### PR TITLE
Refactor behavior spec

### DIFF
--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -170,6 +170,7 @@ test-suite tests
     Hydra.NetworkSpec
     Hydra.NodeSpec
     Hydra.OptionSpec
+    Test.Util
   main-is: Main.hs
   type: exitcode-stdio-1.0
   build-depends:

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -118,7 +118,6 @@ library
     , optparse-applicative
     , ouroboros-network-framework
     , prometheus
-    , safe-exceptions
     , serialise
     , shelley-spec-ledger
     , shelley-spec-ledger-test

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -187,6 +187,7 @@ test-suite tests
     , QuickCheck
     , serialise
     , typed-protocols-examples
+    , HUnit
   build-tool-depends:
     hspec-discover:hspec-discover
   ghc-options:

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -55,8 +55,7 @@ import Test.Hspec (
   shouldNotBe,
   shouldReturn,
  )
-import Test.Util (failAfter)
-import Prelude (error)
+import Test.Util (failAfter, failure)
 
 spec :: Spec
 spec = describe "Behavior of one ore more hydra-nodes" $ do
@@ -299,8 +298,7 @@ startHydraNode' snapshotStrategy nodeId connectToChain = do
               atomically $ do
                 st' <- queryLedgerState node
                 check (st == st')
-            -- TODO(SN): use MonadThrow instead?
-            when (isNothing result) $ error ("Expected ledger state of node " <> show nodeId <> " to be " <> show st)
+            when (isNothing result) $ failure ("Expected ledger state of node " <> show nodeId <> " to be " <> show st)
       , nodeId
       , capturedLogs
       }

--- a/hydra-node/test/Hydra/Chain/ZeroMQSpec.hs
+++ b/hydra-node/test/Hydra/Chain/ZeroMQSpec.hs
@@ -5,12 +5,13 @@ module Hydra.Chain.ZeroMQSpec where
 import Cardano.Prelude
 import qualified Data.Set as Set
 import Data.String (String)
-import Hydra.Ledger (ParticipationToken (..))
-import Hydra.HeadLogic (OnChainTx (InitTx))
 import Hydra.Chain.ZeroMQ (catchUpTransactions, mockChainClient, runChainSync, startChain)
+import Hydra.HeadLogic (OnChainTx (InitTx))
+import Hydra.Ledger (ParticipationToken (..))
 import Hydra.Logging (nullTracer)
 import System.Timeout (timeout)
-import Test.Hspec (Spec, describe, it, shouldReturn)
+import Test.Hspec.Core.Spec (Spec, describe, it)
+import Test.Util (shouldReturn)
 
 spec :: Spec
 spec =

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -10,14 +10,13 @@ import Cardano.Binary (FromCBOR, ToCBOR, fromCBOR, toCBOR)
 import Codec.CBOR.Read (deserialiseFromBytes)
 import Codec.CBOR.Write (toLazyByteString)
 import Codec.Serialise (Serialise, deserialiseOrFail, serialise)
-import Control.Monad.Class.MonadTime (DiffTime)
-import Control.Monad.Class.MonadTimer (timeout)
 import Hydra.HeadLogic (HydraMessage (..), NetworkEvent (MessageReceived, NetworkConnected))
 import Hydra.Logging (nullTracer)
 import Hydra.Network.Ouroboros (broadcast, withOuroborosHydraNetwork)
 import Hydra.Network.ZeroMQ (withZeroMQHydraNetwork)
-import Test.Hspec (Spec, describe, expectationFailure, it, pendingWith, shouldReturn)
+import Test.Hspec (Spec, describe, it, pendingWith, shouldReturn)
 import Test.QuickCheck (Arbitrary (..), Positive (getPositive), arbitrary, oneof, property)
+import Test.Util (failAfter)
 
 type MockTx = ()
 
@@ -118,9 +117,3 @@ prop_canRoundtripCBOREncoding ::
 prop_canRoundtripCBOREncoding a =
   let encoded = toLazyByteString $ toCBOR a
    in (snd <$> deserialiseFromBytes fromCBOR encoded) == Right a
-
-failAfter :: HasCallStack => DiffTime -> IO () -> IO ()
-failAfter seconds action =
-  timeout seconds action >>= \case
-    Nothing -> expectationFailure $ "Test timed out after " <> show seconds <> " seconds"
-    Just _ -> pure ()

--- a/hydra-node/test/Test/Util.hs
+++ b/hydra-node/test/Test/Util.hs
@@ -1,12 +1,12 @@
 module Test.Util where
 
 import Cardano.Prelude
-import Control.Monad.Class.MonadTime (DiffTime)
-import Control.Monad.Class.MonadTimer (timeout)
-import Test.Hspec (expectationFailure)
+import Control.Monad.Class.MonadTimer (DiffTime, MonadTimer, timeout)
+import Prelude (error)
 
-failAfter :: HasCallStack => DiffTime -> IO () -> IO ()
+failAfter :: (HasCallStack, MonadTimer m) => DiffTime -> m () -> m ()
 failAfter seconds action =
   timeout seconds action >>= \case
-    Nothing -> expectationFailure $ "Test timed out after " <> show seconds <> " seconds"
+    -- TODO(SN): use MonadThrow instead?
+    Nothing -> error $ "Test timed out after " <> show seconds <> " seconds"
     Just _ -> pure ()

--- a/hydra-node/test/Test/Util.hs
+++ b/hydra-node/test/Test/Util.hs
@@ -1,0 +1,12 @@
+module Test.Util where
+
+import Cardano.Prelude
+import Control.Monad.Class.MonadTime (DiffTime)
+import Control.Monad.Class.MonadTimer (timeout)
+import Test.Hspec (expectationFailure)
+
+failAfter :: HasCallStack => DiffTime -> IO () -> IO ()
+failAfter seconds action =
+  timeout seconds action >>= \case
+    Nothing -> expectationFailure $ "Test timed out after " <> show seconds <> " seconds"
+    Just _ -> pure ()

--- a/hydra-node/test/Test/Util.hs
+++ b/hydra-node/test/Test/Util.hs
@@ -1,12 +1,22 @@
 module Test.Util where
 
-import Cardano.Prelude
+import Cardano.Prelude hiding (callStack, throwIO)
+import Control.Monad.Class.MonadThrow (MonadThrow (throwIO))
 import Control.Monad.Class.MonadTimer (DiffTime, MonadTimer, timeout)
-import Prelude (error)
+import Data.String (String)
+import GHC.Stack (callStack)
+import Test.HUnit.Lang (FailureReason (Reason), HUnitFailure (HUnitFailure))
 
-failAfter :: (HasCallStack, MonadTimer m) => DiffTime -> m () -> m ()
+failure :: (HasCallStack, MonadThrow m) => String -> m a
+failure msg =
+  throwIO (HUnitFailure location $ Reason msg)
+ where
+  location = case reverse $ getCallStack callStack of
+    (_, loc) : _ -> Just loc
+    _ -> Nothing
+
+failAfter :: (HasCallStack, MonadTimer m, MonadThrow m) => DiffTime -> m () -> m ()
 failAfter seconds action =
   timeout seconds action >>= \case
-    -- TODO(SN): use MonadThrow instead?
-    Nothing -> error $ "Test timed out after " <> show seconds <> " seconds"
+    Nothing -> failure $ "Test timed out after " <> show seconds <> " seconds"
     Just _ -> pure ()

--- a/hydra-node/test/Test/Util.hs
+++ b/hydra-node/test/Test/Util.hs
@@ -25,10 +25,10 @@ failAfter seconds action =
     Just _ -> pure ()
 
 -- | Run given 'action' in 'IOSim' and fail on exceptions.
-shouldRunInSim :: HasCallStack => (forall s. IOSim s ()) -> IO ()
+shouldRunInSim :: HasCallStack => (forall s. IOSim s a) -> IO a
 shouldRunInSim action =
   case runSim action of
-    Right () -> pure ()
+    Right x -> pure x
     Left f -> failure $ "Failed in io-sim: " <> show f
 
 -- | Lifted variant of Hspec's 'shouldBe'.

--- a/hydra-node/test/Test/Util.hs
+++ b/hydra-node/test/Test/Util.hs
@@ -1,22 +1,35 @@
 module Test.Util where
 
-import Cardano.Prelude hiding (callStack, throwIO)
+import Cardano.Prelude hiding (SrcLoc, callStack, throwIO)
 import Control.Monad.Class.MonadThrow (MonadThrow (throwIO))
 import Control.Monad.Class.MonadTimer (DiffTime, MonadTimer, timeout)
 import Data.String (String)
-import GHC.Stack (callStack)
-import Test.HUnit.Lang (FailureReason (Reason), HUnitFailure (HUnitFailure))
+import GHC.Stack (SrcLoc, callStack)
+import Test.HUnit.Lang (FailureReason (ExpectedButGot, Reason), HUnitFailure (HUnitFailure))
 
 failure :: (HasCallStack, MonadThrow m) => String -> m a
 failure msg =
   throwIO (HUnitFailure location $ Reason msg)
- where
-  location = case reverse $ getCallStack callStack of
-    (_, loc) : _ -> Just loc
-    _ -> Nothing
+
+location :: HasCallStack => Maybe SrcLoc
+location = case reverse $ getCallStack callStack of
+  (_, loc) : _ -> Just loc
+  _ -> Nothing
 
 failAfter :: (HasCallStack, MonadTimer m, MonadThrow m) => DiffTime -> m () -> m ()
 failAfter seconds action =
   timeout seconds action >>= \case
     Nothing -> failure $ "Test timed out after " <> show seconds <> " seconds"
     Just _ -> pure ()
+
+-- | Lifted variant of Hspec's 'shouldBe'.
+shouldBe :: (HasCallStack, MonadThrow m, Eq a, Show a) => a -> a -> m ()
+shouldBe actual expected =
+  unless (actual == expected) $
+    throwIO $ HUnitFailure location reason
+ where
+  reason = ExpectedButGot Nothing (show expected) (show actual)
+
+-- | Lifted variant of Hspec's 'shouldReturn'.
+shouldReturn :: (HasCallStack, MonadThrow m, Eq a, Show a) => m a -> a -> m ()
+shouldReturn ma expected = ma >>= (`shouldBe` expected)


### PR DESCRIPTION
Run `BehaviorSpec` (and `FireForgetSpec`) in `IOSim`

This is primarily to deal with longer contestationPeriods.

Next steps:
* Use `runSimStrictShutdown` and ensure proper thread clean-up in `BehaviorSpec` -> most threads are cleaned up, but not all
* Get rid of `HydraProcess` (and use `HydraNode` instead) -> could not get rid of it fully