### PR TITLE
Show network logs on failure in Network specs.

### DIFF
--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -190,6 +190,7 @@ test-suite tests
     , io-sim-classes
     , QuickCheck
     , quickcheck-instances
+    , say
     , typed-protocols-examples
     , HUnit
   build-tool-depends:

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -4,18 +4,25 @@
 -- | Test the real networking layer
 module Hydra.NetworkSpec where
 
-import Cardano.Prelude hiding (threadDelay)
+import Cardano.Prelude hiding (atomically, onException, threadDelay)
 
 import Cardano.Binary (FromCBOR, ToCBOR, fromCBOR, toCBOR)
 import Codec.CBOR.Read (deserialiseFromBytes)
 import Codec.CBOR.Write (toLazyByteString)
 import Control.Monad.Class.MonadAsync (concurrently_)
+import Control.Monad.Class.MonadSTM (
+  MonadSTM (..),
+  newTVarIO,
+  readTVar,
+ )
+import Control.Monad.Class.MonadThrow (MonadCatch, onException)
 import Hydra.HeadLogic (HydraMessage (..), Snapshot (..))
 import Hydra.Ledger.Mock (MockTx (..))
-import Hydra.Logging (nullTracer)
+import Hydra.Logging (Tracer, traceInTVar)
 import Hydra.Network (Network)
 import Hydra.Network.Ouroboros (broadcast, withOuroborosNetwork)
 import Hydra.Network.ZeroMQ (withZeroMQNetwork)
+import Say (say)
 import Test.HUnit.Lang (HUnitFailure)
 import Test.Hspec (Spec, describe, it, shouldReturn)
 import Test.QuickCheck (
@@ -37,10 +44,9 @@ spec = describe "Networking layer" $ do
   describe "Ouroboros Network" $ do
     it "broadcasts messages to single connected peer" $ do
       received <- newEmptyMVar
-      failAfter 10 $ do
-        -- TODO(MB): Capture the trace and print it on failures.
-        withOuroborosNetwork nullTracer (lo, 45678) [(lo, 45679)] (const @_ @(HydraMessage MockTx) $ pure ()) $ \hn1 ->
-          withOuroborosNetwork @(HydraMessage MockTx) nullTracer (lo, 45679) [(lo, 45678)] (putMVar received) $ \_ -> do
+      showLogsOnFailure $ \tracer -> failAfter 10 $ do
+        withOuroborosNetwork tracer (lo, 45678) [(lo, 45679)] (const @_ @(HydraMessage MockTx) $ pure ()) $ \hn1 ->
+          withOuroborosNetwork @(HydraMessage MockTx) tracer (lo, 45679) [(lo, 45678)] (putMVar received) $ \_ -> do
             broadcast hn1 requestTx
             takeMVar received `shouldReturn` requestTx
 
@@ -48,11 +54,10 @@ spec = describe "Networking layer" $ do
       node1received <- newEmptyMVar
       node2received <- newEmptyMVar
       node3received <- newEmptyMVar
-      failAfter 10 $ do
-        -- TODO(MB): Capture the trace and print it on failures.
-        withOuroborosNetwork @(HydraMessage MockTx) nullTracer (lo, 45678) [(lo, 45679), (lo, 45680)] (putMVar node1received) $ \hn1 ->
-          withOuroborosNetwork nullTracer (lo, 45679) [(lo, 45678), (lo, 45680)] (putMVar node2received) $ \hn2 -> do
-            withOuroborosNetwork nullTracer (lo, 45680) [(lo, 45678), (lo, 45679)] (putMVar node3received) $ \hn3 -> do
+      showLogsOnFailure $ \tracer -> failAfter 10 $ do
+        withOuroborosNetwork @(HydraMessage MockTx) tracer (lo, 45678) [(lo, 45679), (lo, 45680)] (putMVar node1received) $ \hn1 ->
+          withOuroborosNetwork tracer (lo, 45679) [(lo, 45678), (lo, 45680)] (putMVar node2received) $ \hn2 -> do
+            withOuroborosNetwork tracer (lo, 45680) [(lo, 45678), (lo, 45679)] (putMVar node3received) $ \hn3 -> do
               concurrently_ (assertBroadcastFrom requestTx hn1 [node2received, node3received]) $
                 concurrently_
                   (assertBroadcastFrom requestTx hn2 [node1received, node3received])
@@ -63,11 +68,10 @@ spec = describe "Networking layer" $ do
       node1received <- newEmptyMVar
       node2received <- newEmptyMVar
       node3received <- newEmptyMVar
-      failAfter 10 $ do
-        -- TODO(MB): Capture the trace and print it on failures.
-        withZeroMQNetwork nullTracer (lo, 55677) [(lo, 55678), (lo, 55679)] (putMVar node1received) $ \hn1 ->
-          withZeroMQNetwork nullTracer (lo, 55678) [(lo, 55677), (lo, 55679)] (putMVar node2received) $ \hn2 ->
-            withZeroMQNetwork nullTracer (lo, 55679) [(lo, 55677), (lo, 55678)] (putMVar node3received) $ \hn3 -> do
+      showLogsOnFailure $ \tracer -> failAfter 10 $ do
+        withZeroMQNetwork tracer (lo, 55677) [(lo, 55678), (lo, 55679)] (putMVar node1received) $ \hn1 ->
+          withZeroMQNetwork tracer (lo, 55678) [(lo, 55677), (lo, 55679)] (putMVar node2received) $ \hn2 ->
+            withZeroMQNetwork tracer (lo, 55679) [(lo, 55677), (lo, 55678)] (putMVar node3received) $ \hn3 -> do
               concurrently_ (assertBroadcastFrom requestTx hn1 [node2received, node3received]) $
                 concurrently_
                   (assertBroadcastFrom requestTx hn2 [node1received, node3received])
@@ -83,6 +87,16 @@ assertBroadcastFrom requestTx network receivers =
   tryBroadcast = do
     broadcast network requestTx
     forM_ receivers $ \var -> failAfter 1 $ takeMVar var `shouldReturn` requestTx
+
+-- TODO(MB): Possibly relocate this function for re-use?
+showLogsOnFailure ::
+  (MonadSTM m, MonadCatch m, MonadIO m, Show msg) =>
+  (Tracer m msg -> m a) ->
+  m a
+showLogsOnFailure action = do
+  tvar <- newTVarIO []
+  action (traceInTVar tvar)
+    `onException` (atomically (readTVar tvar) >>= mapM_ (say . show))
 
 instance Arbitrary (HydraMessage MockTx) where
   arbitrary =


### PR DESCRIPTION
_Addressing some TODOs left as part of #19_

With artificially injected failures:

```
TraceSubscriptions IPs: 127.0.0.1:0 [127.0.0.1:45679] Closed socket to 127.0.0.1:45679
TraceSubscriptions IPs: 127.0.0.1:0 [127.0.0.1:45679] Application Exception: 127.0.0.1:45679 SubscriberError {seType = SubscriberWorkerCancelled, seMessage = "SubscriptionWorker exiting", seStack = []}
TraceSubscriptions IPs: 127.0.0.1:0 [127.0.0.1:45678] Closed socket to 127.0.0.1:45678
TraceSubscriptions IPs: 127.0.0.1:0 [127.0.0.1:45678] Application Exception: 127.0.0.1:45678 SubscriberError {seType = SubscriberWorkerCancelled, seMessage = "SubscriptionWorker exiting", seStack = []}
TraceHandshake (WithMuxBearer (ConnectionId {localAddress = 127.0.0.1:42471, remoteAddress = 127.0.0.1:45678}) Recv (ServerAgency TokConfirm,MsgAcceptVersion UnversionedProtocol TNull))
TraceHandshake (WithMuxBearer (ConnectionId {localAddress = 127.0.0.1:40645, remoteAddress = 127.0.0.1:45679}) Recv (ServerAgency TokConfirm,MsgAcceptVersion UnversionedProtocol TNull))
TraceHandshake (WithMuxBearer (ConnectionId {localAddress = 127.0.0.1:45678, remoteAddress = 127.0.0.1:42471}) Send (ServerAgency TokConfirm,MsgAcceptVersion UnversionedProtocol TNull))
TraceHandshake (WithMuxBearer (ConnectionId {localAddress = 127.0.0.1:45678, remoteAddress = 127.0.0.1:42471}) Recv (ClientAgency TokPropose,MsgProposeVersions (fromList [(UnversionedProtocol,TNull)])))
TraceHandshake (WithMuxBearer (ConnectionId {localAddress = 127.0.0.1:45679, remoteAddress = 127.0.0.1:40645}) Send (ServerAgency TokConfirm,MsgAcceptVersion UnversionedProtocol TNull))
TraceHandshake (WithMuxBearer (ConnectionId {localAddress = 127.0.0.1:45679, remoteAddress = 127.0.0.1:40645}) Recv (ClientAgency TokPropose,MsgProposeVersions (fromList [(UnversionedProtocol,TNull)])))
TraceHandshake (WithMuxBearer (ConnectionId {localAddress = 127.0.0.1:40645, remoteAddress = 127.0.0.1:45679}) Send (ClientAgency TokPropose,MsgProposeVersions (fromList [(UnversionedProtocol,TNull)])))
TraceSubscriptions IPs: 127.0.0.1:0 [127.0.0.1:45679] Connection Attempt End, destination 127.0.0.1:45679 outcome: ConnectSuccess
TraceHandshake (WithMuxBearer (ConnectionId {localAddress = 127.0.0.1:42471, remoteAddress = 127.0.0.1:45678}) Send (ClientAgency TokPropose,MsgProposeVersions (fromList [(UnversionedProtocol,TNull)])))
TraceSubscriptions IPs: 127.0.0.1:0 [127.0.0.1:45678] Connection Attempt End, destination 127.0.0.1:45678 outcome: ConnectSuccess
TraceSubscriptions IPs: 127.0.0.1:0 [127.0.0.1:45679] Allocate socket to 127.0.0.1:45679
TraceSubscriptions IPs: 127.0.0.1:0 [127.0.0.1:45679] Connection Attempt Start, destination 127.0.0.1:45679
TraceSubscriptions IPs: 127.0.0.1:0 [127.0.0.1:45678] Waiting 0.025s before attempting a new connection
TraceSubscriptions IPs: 127.0.0.1:0 [127.0.0.1:45678] Allocate socket to 127.0.0.1:45678
TraceSubscriptions IPs: 127.0.0.1:0 [127.0.0.1:45678] Connection Attempt Start, destination 127.0.0.1:45678
TraceSubscriptions IPs: 127.0.0.1:0 [127.0.0.1:45679] Waiting 0.025s before attempting a new connection
TraceSubscriptions IPs: 127.0.0.1:0 [127.0.0.1:45679] Trying to connect to 127.0.0.1:45679
TraceSubscriptions IPs: 127.0.0.1:0 [127.0.0.1:45679] Starting Subscription Worker, valency 7
TraceSubscriptions IPs: 127.0.0.1:0 [127.0.0.1:45678] Trying to connect to 127.0.0.1:45678
TraceSubscriptions IPs: 127.0.0.1:0 [127.0.0.1:45678] Starting Subscription Worker, valency 7
      broadcasts messages to single connected peer FAILED [1]
      broadcasts messages between 3 connected peers

Failures:

  test/Hydra/NetworkSpec.hs:45:5: 
  1) Hydra.Network, Networking layer, Ouroboros Network, broadcasts messages to single connected peer
       uncaught exception: FatalError
       FatalError {fatalErrorMessage = "Make it fail"}

    0MQ Network
LogMessageReceived "ReqTx (ValidTx 1)"
LogMessageReceived "ReqTx (ValidTx 1)"
LogMessageReceived "ReqTx (ValidTx 1)"
LogMessageReceived "ReqTx (ValidTx 1)"
MessageSent "eReqTx\193\SOH"
MessageSent "eReqTx\193\SOH"
LogMessageReceived "ReqTx (ValidTx 1)"
MessageSent "eReqTx\193\SOH"
MessageSent "eReqTx\193\SOH"
MessageSent "eReqTx\193\SOH"
SubscribedTo ["tcp://127.0.0.1:55677","tcp://127.0.0.1:55678"]
PublisherStarted ("127.0.0.1",55679)
SubscribedTo ["tcp://127.0.0.1:55677","tcp://127.0.0.1:55679"]
SubscribedTo ["tcp://127.0.0.1:55678","tcp://127.0.0.1:55679"]
PublisherStarted ("127.0.0.1",55678)
PublisherStarted ("127.0.0.1",55677)
      broadcasts messages between 3 connected peers FAILED [1]

Failures:

  test/Hydra/NetworkSpec.hs:90:31: 
  1) Hydra.Network, Networking layer, 0MQ Network, broadcasts messages between 3 connected peers
       Test timed out after 1s seconds
```