### PR TITLE
Use structured JSON for interfacing with 'ClientRequest' / 'ClientResponse'

### DIFF
--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -103,6 +103,7 @@ library
     Paths_hydra_node
   build-depends: base
     , aeson
+    , base16
     , cardano-binary
     , cardano-crypto-class
     , cardano-ledger-core

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -103,7 +103,6 @@ library
     Paths_hydra_node
   build-depends: base
     , aeson
-    , base16
     , cardano-binary
     , cardano-crypto-class
     , cardano-ledger-core

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -101,9 +101,8 @@ library
     Hydra.Options
   other-modules:
     Paths_hydra_node
-  build-depends:
-      aeson
-    , base
+  build-depends: base
+    , aeson
     , cardano-binary
     , cardano-crypto-class
     , cardano-ledger-core
@@ -188,8 +187,8 @@ test-suite tests
     Test.Util
   main-is: Main.hs
   type: exitcode-stdio-1.0
-  build-depends:
-      base
+  build-depends: base
+    , aeson
     , cardano-binary
     , cardano-crypto-class
     , cborg

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -103,7 +103,6 @@ library
     Paths_hydra_node
   build-depends:
       aeson
-    , aeson-casing
     , base
     , cardano-binary
     , cardano-crypto-class

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -103,6 +103,7 @@ library
     Paths_hydra_node
   build-depends:
       aeson
+    , aeson-casing
     , base
     , cardano-binary
     , cardano-crypto-class

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -13,8 +13,8 @@ import qualified Control.Concurrent.STM as STM
 import Control.Concurrent.STM.TChan (newBroadcastTChanIO, writeTChan)
 import qualified Data.Aeson as Aeson
 import Hydra.HeadLogic (
-  ClientRequest,
-  ClientResponse,
+  ClientInput,
+  ServerOutput,
  )
 import Hydra.Ledger (Tx (..))
 import Hydra.Logging (Tracer, traceWith)
@@ -34,8 +34,8 @@ withAPIServer ::
   IP ->
   PortNumber ->
   Tracer IO APIServerLog ->
-  (ClientRequest tx -> IO ()) ->
-  ((ClientResponse tx -> IO ()) -> IO ()) ->
+  (ClientInput tx -> IO ()) ->
+  ((ServerOutput tx -> IO ()) -> IO ()) ->
   IO ()
 withAPIServer host port tracer requests continuation = do
   responseChannel <- newBroadcastTChanIO
@@ -49,8 +49,8 @@ runAPIServer ::
   IP ->
   PortNumber ->
   Tracer IO APIServerLog ->
-  (ClientRequest tx -> IO ()) ->
-  TChan (ClientResponse tx) ->
+  (ClientInput tx -> IO ()) ->
+  TChan (ServerOutput tx) ->
   IO ()
 runAPIServer host port tracer requestHandler responseChannel = do
   traceWith tracer (APIServerStarted port)

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -11,7 +11,7 @@ import Hydra.Prelude
 import Control.Concurrent.STM (TChan, dupTChan, readTChan)
 import qualified Control.Concurrent.STM as STM
 import Control.Concurrent.STM.TChan (newBroadcastTChanIO, writeTChan)
-import Data.Aeson (FromJSON, eitherDecode)
+import Data.Aeson (eitherDecode)
 import Hydra.HeadLogic (
   ClientRequest,
   ClientResponse,
@@ -30,7 +30,7 @@ data APIServerLog
   deriving (Eq, Show)
 
 withAPIServer ::
-  (Tx tx, FromJSON tx, FromJSON (UTxO tx)) =>
+  Tx tx =>
   IP ->
   PortNumber ->
   Tracer IO APIServerLog ->
@@ -45,7 +45,7 @@ withAPIServer host port tracer requests continuation = do
     (continuation sendResponse)
 
 runAPIServer ::
-  (Tx tx, FromJSON tx, FromJSON (UTxO tx)) =>
+  Tx tx =>
   IP ->
   PortNumber ->
   Tracer IO APIServerLog ->

--- a/hydra-node/src/Hydra/Chain/ExternalPAB.hs
+++ b/hydra-node/src/Hydra/Chain/ExternalPAB.hs
@@ -5,7 +5,7 @@ module Hydra.Chain.ExternalPAB where
 import Hydra.Prelude
 
 import Control.Monad.Class.MonadSay (say)
-import Data.Aeson (Result (Error, Success), ToJSON, eitherDecodeStrict)
+import Data.Aeson (Result (Error, Success), eitherDecodeStrict)
 import Data.Aeson.Types (fromJSON)
 import qualified Data.Map as Map
 import Hydra.Chain (Chain (Chain, postTx))

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -208,7 +208,9 @@ instance (FromJSON tx, FromJSON (Snapshot tx), FromJSON (UTxO tx)) => FromJSON (
     tag <- obj .: "response"
     case tag of
       "peerConnected" ->
-        PeerConnected <$> (obj .: "host")
+        PeerConnected <$> (obj .: "peer")
+      "peerDisconnected" ->
+        PeerDisconnected <$> (obj .: "peer")
       "readyToCommit" ->
         ReadyToCommit <$> (obj .: "parties")
       "headIsOpen" ->

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -6,16 +6,8 @@ module Hydra.HeadLogic where
 
 import Hydra.Prelude
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Crypto.Util (SignableRepresentation (..))
-import Data.Aeson (
-  FromJSON (..),
-  ToJSON (..),
-  object,
-  withObject,
-  (.:),
-  (.=),
- )
+import Data.Aeson (object, withObject, (.:), (.=))
 import qualified Data.Aeson as Aeson
 import Data.List (elemIndex, (\\))
 import qualified Data.Map.Strict as Map
@@ -77,7 +69,7 @@ instance (ToJSON tx, ToJSON (UTxO tx)) => ToJSON (ClientRequest tx) where
     s = Aeson.String
     tagFieldName = "request"
 
-instance (FromJSON tx, FromJSON (UTxO tx)) => FromJSON (ClientRequest tx) where
+instance Tx tx => FromJSON (ClientRequest tx) where
   parseJSON = withObject "ClientRequest" $ \obj -> do
     tag <- obj .: "request"
     case tag of
@@ -110,7 +102,7 @@ deriving instance Tx tx => Read (Snapshot tx)
 instance Tx tx => SignableRepresentation (Snapshot tx) where
   getSignableRepresentation = encodeUtf8 . show @Text
 
-instance (ToJSON tx, ToJSON (UTxO tx)) => ToJSON (Snapshot tx) where
+instance Tx tx => ToJSON (Snapshot tx) where
   toJSON s =
     object
       [ "snapshotNumber" .= number s
@@ -118,7 +110,7 @@ instance (ToJSON tx, ToJSON (UTxO tx)) => ToJSON (Snapshot tx) where
       , "confirmedTransactions" .= confirmed s
       ]
 
-instance (FromJSON tx, FromJSON (UTxO tx)) => FromJSON (Snapshot tx) where
+instance Tx tx => FromJSON (Snapshot tx) where
   parseJSON = withObject "Snapshot" $ \obj ->
     Snapshot
       <$> (obj .: "snapshotNumber")

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -58,6 +58,10 @@ data ClientRequest tx
   | Contest
   deriving (Generic)
 
+deriving instance Tx tx => Eq (ClientRequest tx)
+deriving instance Tx tx => Show (ClientRequest tx)
+deriving instance Tx tx => Read (ClientRequest tx)
+
 instance (ToJSON tx, ToJSON (UTxO tx)) => ToJSON (ClientRequest tx) where
   toJSON = \case
     Init ->
@@ -90,10 +94,6 @@ instance (FromJSON tx, FromJSON (UTxO tx)) => FromJSON (ClientRequest tx) where
         pure Contest
       _ ->
         fail $ "unknown request type: " <> toString @Text tag
-
-deriving instance Tx tx => Eq (ClientRequest tx)
-deriving instance Tx tx => Show (ClientRequest tx)
-deriving instance Tx tx => Read (ClientRequest tx)
 
 type SnapshotNumber = Natural
 

--- a/hydra-node/src/Hydra/Ledger.hs
+++ b/hydra-node/src/Hydra/Ledger.hs
@@ -15,7 +15,7 @@ import Data.ByteString.Base16 (decodeBase16, encodeBase16)
 
 -- | Identifies a party in a Hydra head.
 newtype Party = UnsafeParty (VerKeyDSIGN MockDSIGN)
-  deriving (Eq)
+  deriving stock (Eq, Generic)
   deriving newtype (Show, Read, Num)
 
 deriving instance Read (VerKeyDSIGN MockDSIGN)
@@ -23,6 +23,9 @@ deriving instance Read (VerKeyDSIGN MockDSIGN)
 instance Ord Party where
   (UnsafeParty a) <= (UnsafeParty b) =
     rawSerialiseVerKeyDSIGN a <= rawSerialiseVerKeyDSIGN b
+
+instance Arbitrary Party where
+  arbitrary = deriveParty . generateKey <$> arbitrary
 
 instance ToJSON Party where
   toJSON (UnsafeParty vk) = toJSON (encodeBase16 $ rawSerialiseVerKeyDSIGN vk)

--- a/hydra-node/src/Hydra/Ledger.hs
+++ b/hydra-node/src/Hydra/Ledger.hs
@@ -5,10 +5,9 @@ module Hydra.Ledger where
 
 import Hydra.Prelude
 
-import Cardano.Binary (FromCBOR (fromCBOR), ToCBOR (toCBOR))
 import Cardano.Crypto.DSIGN (DSIGNAlgorithm (..), MockDSIGN, SignKeyDSIGN, VerKeyDSIGN (VerKeyMockDSIGN), signDSIGN)
 import Cardano.Crypto.Util (SignableRepresentation)
-import Data.Aeson (FromJSON (..), ToJSON (..), withText)
+import Data.Aeson (withText)
 import Data.ByteString.Base16 (decodeBase16, encodeBase16)
 
 -- NOTE(MB): We probably want to move these common types somewhere else. Putting
@@ -86,6 +85,10 @@ class
   , Read (UTxO tx)
   , Monoid (UTxO tx)
   , Typeable tx
+  , FromJSON tx
+  , FromJSON (UTxO tx)
+  , ToJSON tx
+  , ToJSON (UTxO tx)
   ) =>
   Tx tx
   where

--- a/hydra-node/src/Hydra/Ledger/MaryTest.hs
+++ b/hydra-node/src/Hydra/Ledger/MaryTest.hs
@@ -71,6 +71,18 @@ instance Read MaryTestTx where
 instance Read (Ledger.UTxO era) where
   readPrec = error "Read: Ledger.UTxO"
 
+instance ToJSON MaryTestTx where
+  toJSON = error "toJSON: MaryTestTx"
+
+instance ToJSON (Ledger.UTxO era) where
+  toJSON = error "toJSON: Ledger.UTxO"
+
+instance FromJSON MaryTestTx where
+  parseJSON = error "parseJSON: MaryTestTx"
+
+instance FromJSON (Ledger.UTxO era) where
+  parseJSON = error "parseJSON: Ledger.UTxO"
+
 cardanoLedger :: Ledger.LedgerEnv MaryTest -> Ledger (Ledger.Tx MaryTest)
 cardanoLedger env =
   Ledger

--- a/hydra-node/src/Hydra/Ledger/Simple.hs
+++ b/hydra-node/src/Hydra/Ledger/Simple.hs
@@ -11,10 +11,7 @@ module Hydra.Ledger.Simple where
 
 import Hydra.Prelude
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Data.Aeson (
-  FromJSON (..),
-  ToJSON (..),
   object,
   withObject,
   (.:),

--- a/hydra-node/src/Hydra/Ledger/Simple.hs
+++ b/hydra-node/src/Hydra/Ledger/Simple.hs
@@ -13,13 +13,13 @@ import Hydra.Prelude
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Data.Aeson (
-  FromJSON,
-  ToJSON,
-  genericParseJSON,
-  genericToJSON,
+  FromJSON (..),
+  ToJSON (..),
+  object,
+  withObject,
+  (.:),
+  (.=),
  )
-import qualified Data.Aeson as Aeson
-import Data.Aeson.Casing (aesonPrefix, camelCase)
 import qualified Data.Set as Set
 import Hydra.Ledger
 
@@ -36,10 +36,19 @@ data SimpleTx = SimpleTx
   deriving stock (Eq, Ord, Generic, Read, Show)
 
 instance ToJSON SimpleTx where
-  toJSON = genericToJSON (aesonPrefix camelCase)
+  toJSON tx =
+    object
+      [ "id" .= txId tx
+      , "inputs" .= txInputs tx
+      , "outputs" .= txOutputs tx
+      ]
 
 instance FromJSON SimpleTx where
-  parseJSON = genericParseJSON (aesonPrefix camelCase)
+  parseJSON = withObject "SimpleTx" $ \obj ->
+    SimpleTx
+      <$> (obj .: "id")
+      <*> (obj .: "inputs")
+      <*> (obj .: "outputs")
 
 instance ToCBOR SimpleTx where
   toCBOR (SimpleTx txid inputs outputs) =

--- a/hydra-node/src/Hydra/Ledger/Simple.hs
+++ b/hydra-node/src/Hydra/Ledger/Simple.hs
@@ -12,6 +12,14 @@ module Hydra.Ledger.Simple where
 import Hydra.Prelude
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import Data.Aeson (
+  FromJSON,
+  ToJSON,
+  genericParseJSON,
+  genericToJSON,
+ )
+import qualified Data.Aeson as Aeson
+import Data.Aeson.Casing (aesonPrefix, camelCase)
 import qualified Data.Set as Set
 import Hydra.Ledger
 
@@ -27,6 +35,12 @@ data SimpleTx = SimpleTx
   }
   deriving stock (Eq, Ord, Generic, Read, Show)
 
+instance ToJSON SimpleTx where
+  toJSON = genericToJSON (aesonPrefix camelCase)
+
+instance FromJSON SimpleTx where
+  parseJSON = genericParseJSON (aesonPrefix camelCase)
+
 instance ToCBOR SimpleTx where
   toCBOR (SimpleTx txid inputs outputs) =
     toCBOR txid <> toCBOR inputs <> toCBOR outputs
@@ -38,7 +52,7 @@ type TxId = Integer
 
 -- |An identifier for a single output of a 'SimpleTx'.
 newtype TxIn = TxIn {unTxIn :: Integer}
-  deriving newtype (Eq, Ord, Read, Show)
+  deriving newtype (Eq, Ord, Read, Show, ToJSON, FromJSON)
 
 instance ToCBOR TxIn where
   toCBOR (TxIn inId) = toCBOR inId

--- a/hydra-node/src/Hydra/Ledger/Simple.hs
+++ b/hydra-node/src/Hydra/Ledger/Simple.hs
@@ -32,6 +32,10 @@ data SimpleTx = SimpleTx
   }
   deriving stock (Eq, Ord, Generic, Read, Show)
 
+instance Arbitrary SimpleTx where
+  shrink = genericShrink
+  arbitrary = genericArbitrary
+
 instance ToJSON SimpleTx where
   toJSON tx =
     object
@@ -58,7 +62,12 @@ type TxId = Integer
 
 -- |An identifier for a single output of a 'SimpleTx'.
 newtype TxIn = TxIn {unTxIn :: Integer}
+  deriving stock (Generic)
   deriving newtype (Eq, Ord, Read, Show, ToJSON, FromJSON)
+
+instance Arbitrary TxIn where
+  shrink = genericShrink
+  arbitrary = genericArbitrary
 
 instance ToCBOR TxIn where
   toCBOR (TxIn inId) = toCBOR inId

--- a/hydra-node/src/Hydra/Network.hs
+++ b/hydra-node/src/Hydra/Network.hs
@@ -27,6 +27,7 @@ module Hydra.Network (
 import Hydra.Prelude hiding (show)
 
 import Cardano.Binary (FromCBOR (fromCBOR), ToCBOR (toCBOR))
+import Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.:), (.=))
 import Data.IP (IP)
 import Data.Text (pack, unpack)
 import Network.Socket (PortNumber, close)
@@ -66,6 +67,19 @@ instance Read Host where
   readsPrec _ s = case readHost s of
     Just h -> [(h, "")]
     Nothing -> []
+
+instance ToJSON Host where
+  toJSON h =
+    object
+      [ "hostname" .= hostName h
+      , "portNumber" .= fromIntegral @_ @Integer (portNumber h)
+      ]
+
+instance FromJSON Host where
+  parseJSON = withObject "Host" $ \obj ->
+    Host
+      <$> (obj .: "hostname")
+      <*> (fromIntegral @Integer <$> (obj .: "portNumber"))
 
 instance ToCBOR Host where
   toCBOR Host{hostName, portNumber} = toCBOR hostName <> toCBOR (toInteger portNumber)

--- a/hydra-node/src/Hydra/Network.hs
+++ b/hydra-node/src/Hydra/Network.hs
@@ -26,9 +26,8 @@ module Hydra.Network (
 
 import Hydra.Prelude hiding (show)
 
-import Cardano.Binary (FromCBOR (fromCBOR), ToCBOR (toCBOR))
-import Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.:), (.=))
-import Data.IP (IP)
+import Data.Aeson (object, withObject, (.:), (.=))
+import Data.IP (IP, toIPv4w)
 import Data.Text (pack, unpack)
 import Network.Socket (PortNumber, close)
 import Network.TypedProtocol.Pipelined ()

--- a/hydra-node/src/Hydra/Network.hs
+++ b/hydra-node/src/Hydra/Network.hs
@@ -57,7 +57,7 @@ data Host = Host
   { hostName :: Text
   , portNumber :: PortNumber
   }
-  deriving (Eq)
+  deriving (Generic, Eq)
 
 instance Show Host where
   show = showHost
@@ -67,27 +67,41 @@ instance Read Host where
     Just h -> [(h, "")]
     Nothing -> []
 
+instance Arbitrary Host where
+  arbitrary = do
+    ip <- toIPv4w <$> arbitrary
+    port <- fromIntegral @Word16 <$> arbitrary
+    pure $ Host (toText $ show ip) port
+
 instance ToJSON Host where
   toJSON h =
     object
       [ "hostname" .= hostName h
-      , "portNumber" .= fromIntegral @_ @Integer (portNumber h)
+      , "portNumber" .= toInteger (portNumber h)
       ]
 
 instance FromJSON Host where
   parseJSON = withObject "Host" $ \obj ->
     Host
       <$> (obj .: "hostname")
-      <*> (fromIntegral @Integer <$> (obj .: "portNumber"))
+      <*> (fromInteger <$> (obj .: "portNumber"))
 
 instance ToCBOR Host where
-  toCBOR Host{hostName, portNumber} = toCBOR hostName <> toCBOR (toInteger portNumber)
+  toCBOR Host{hostName, portNumber} =
+    mconcat
+      [ toCBOR hostName
+      , toCBOR (toInteger portNumber)
+      ]
 
 instance FromCBOR Host where
-  fromCBOR = Host <$> fromCBOR <*> (fromInteger <$> fromCBOR)
+  fromCBOR =
+    Host
+      <$> fromCBOR
+      <*> (fromInteger <$> fromCBOR)
 
 showHost :: Host -> String
-showHost Host{hostName, portNumber} = unpack hostName <> "@" <> show portNumber
+showHost Host{hostName, portNumber} =
+  unpack hostName <> "@" <> show portNumber
 
 readHost :: String -> Maybe Host
 readHost s =

--- a/hydra-node/src/Hydra/Network/Heartbeat.hs
+++ b/hydra-node/src/Hydra/Network/Heartbeat.hs
@@ -21,7 +21,6 @@ module Hydra.Network.Heartbeat where
 
 import Hydra.Prelude
 
-import Cardano.Binary (FromCBOR (fromCBOR), ToCBOR (..))
 import Control.Monad.Class.MonadSTM (modifyTVar', newTVarIO, readTVarIO)
 import qualified Data.Map as Map
 import qualified Data.Set as Set

--- a/hydra-node/src/Hydra/Network/Ouroboros.hs
+++ b/hydra-node/src/Hydra/Network/Ouroboros.hs
@@ -7,7 +7,6 @@ module Hydra.Network.Ouroboros (
 
 import Hydra.Prelude
 
-import Cardano.Binary (FromCBOR, ToCBOR)
 import qualified Codec.CBOR.Term as CBOR
 import Control.Concurrent.STM (
   TChan,

--- a/hydra-node/src/Hydra/Network/Ouroboros/Type.hs
+++ b/hydra-node/src/Hydra/Network/Ouroboros/Type.hs
@@ -6,7 +6,6 @@ module Hydra.Network.Ouroboros.Type where
 
 import Hydra.Prelude
 
-import Cardano.Binary (FromCBOR, ToCBOR, fromCBOR, toCBOR)
 import qualified Cardano.Binary as CBOR
 import qualified Codec.CBOR.Read as CBOR
 import GHC.Show (Show (show))

--- a/hydra-node/src/Hydra/Network/ZeroMQ.hs
+++ b/hydra-node/src/Hydra/Network/ZeroMQ.hs
@@ -4,10 +4,6 @@ module Hydra.Network.ZeroMQ where
 
 import Hydra.Prelude
 
-import Cardano.Binary (
-  FromCBOR (..),
-  ToCBOR (..),
- )
 import qualified Codec.CBOR.Read as CBOR
 import qualified Codec.CBOR.Write as CBOR
 import Control.Monad.Class.MonadSTM (newEmptyTMVarIO, putTMVar, takeTMVar)

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -12,8 +12,7 @@ import Control.Monad.Class.MonadAsync (async)
 import Control.Monad.Class.MonadSTM (newTQueue, newTVarIO, readTQueue, stateTVar, writeTQueue)
 import Hydra.Chain (Chain (..))
 import Hydra.HeadLogic (
-  ClientRequest (..),
-  ClientResponse (..),
+  ClientInput (..),
   Effect (..),
   Environment (..),
   Event (..),
@@ -22,6 +21,7 @@ import Hydra.HeadLogic (
   LogicError (..),
   OnChainTx (..),
   Outcome (..),
+  ServerOutput (..),
   SnapshotStrategy (SnapshotAfterEachTx),
  )
 import qualified Hydra.HeadLogic as Logic
@@ -65,7 +65,7 @@ data HydraNode tx m = HydraNode
   , hn :: Network m (HydraMessage tx)
   , hh :: HydraHead tx m
   , oc :: Chain tx m
-  , sendResponse :: ClientResponse tx -> m ()
+  , sendResponse :: ServerOutput tx -> m ()
   , env :: Environment
   }
 
@@ -77,8 +77,8 @@ data HydraNodeLog tx
   | ProcessedEffect Party (Effect tx)
   deriving (Eq, Show)
 
-handleClientRequest :: HydraNode tx m -> ClientRequest tx -> m ()
-handleClientRequest HydraNode{eq} = putEvent eq . ClientEvent
+handleClientInput :: HydraNode tx m -> ClientInput tx -> m ()
+handleClientInput HydraNode{eq} = putEvent eq . ClientEvent
 
 handleChainTx :: HydraNode tx m -> OnChainTx tx -> m ()
 handleChainTx HydraNode{eq} = putEvent eq . OnChainEvent

--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -14,7 +14,7 @@ import Control.Monad.Class.MonadSTM (
  )
 import qualified Data.Aeson as Aeson
 import Hydra.API.Server (withAPIServer)
-import Hydra.HeadLogic (ClientResponse (..))
+import Hydra.HeadLogic (ServerOutput (..))
 import Hydra.Ledger.Simple (SimpleTx)
 import Hydra.Logging (nullTracer)
 import Hydra.Network.Ports (withFreePort)
@@ -43,7 +43,7 @@ spec = describe "API Server" $ do
 noop :: Applicative m => a -> m ()
 noop = const $ pure ()
 
-testClient :: HasCallStack => Int -> TQueue IO (ClientResponse SimpleTx) -> TVar IO Int -> IO ()
+testClient :: HasCallStack => Int -> TQueue IO (ServerOutput SimpleTx) -> TVar IO Int -> IO ()
 testClient port queue semaphore =
   failAfter 5 tryClient
  where

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -18,12 +18,12 @@ import Control.Monad.Class.MonadTimer (timeout)
 import Control.Monad.IOSim (IOSim, runSimTrace, selectTraceEventsDynamic)
 import Hydra.Chain (Chain (..))
 import Hydra.HeadLogic (
-  ClientRequest (..),
-  ClientResponse (..),
+  ClientInput (..),
   Effect (ClientEffect),
   Environment (..),
   Event (ClientEvent),
   HeadParameters (..),
+  ServerOutput (..),
   Snapshot (..),
   SnapshotStrategy (..),
   createHeadState,
@@ -38,7 +38,7 @@ import Hydra.Node (
   createEventQueue,
   createHydraHead,
   handleChainTx,
-  handleClientRequest,
+  handleClientInput,
   handleMessage,
   runHydraNode,
  )
@@ -238,8 +238,8 @@ sendRequestAndWaitFor ::
   , Tx tx
   ) =>
   TestHydraNode tx m ->
-  ClientRequest tx ->
-  ClientResponse tx ->
+  ClientInput tx ->
+  ServerOutput tx ->
   m ()
 sendRequestAndWaitFor node req expected = do
   sendRequest node req
@@ -247,8 +247,8 @@ sendRequestAndWaitFor node req expected = do
 
 -- | A thin layer around 'HydraNode' to be able to 'waitForResponse'.
 data TestHydraNode tx m = TestHydraNode
-  { sendRequest :: ClientRequest tx -> m ()
-  , waitForResponse :: m (ClientResponse tx)
+  { sendRequest :: ClientInput tx -> m ()
+  , waitForResponse :: m (ServerOutput tx)
   }
 
 type ConnectToChain tx m = (HydraNode tx m -> m (HydraNode tx m))
@@ -306,7 +306,7 @@ withHydraNode signingKey otherParties snapshotStrategy connectToChain action = d
   withAsync (runHydraNode traceInIOSim node) $ \_ ->
     action $
       TestHydraNode
-        { sendRequest = handleClientRequest node
+        { sendRequest = handleClientInput node
         , waitForResponse = atomically $ readTQueue response
         }
  where

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -8,7 +8,6 @@ module Hydra.HeadLogicSpec where
 
 import Hydra.Prelude
 
-import Data.Aeson (FromJSON, ToJSON)
 import qualified Data.Aeson as Aeson
 import qualified Data.List as List
 import qualified Data.Set as Set

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -12,8 +12,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.List as List
 import qualified Data.Set as Set
 import Hydra.HeadLogic (
-  ClientRequest (..),
-  ClientResponse (..),
+  ClientInput (..),
   CoordinatedHeadState (..),
   Effect (ClientEffect, NetworkEffect),
   Environment (..),
@@ -25,6 +24,7 @@ import Hydra.HeadLogic (
   LogicError (..),
   OnChainTx (..),
   Outcome (..),
+  ServerOutput (..),
   Snapshot (..),
   SnapshotStrategy (..),
   update,
@@ -210,10 +210,10 @@ spec = describe "Hydra Coordinated Head Protocol" $ do
 
   -- TOOD: Replace with: https://hackage.haskell.org/package/hspec-golden-aeson
   describe "JSON instances" $ do
-    prop "ClientRequest - JSON roundtrips" $
-      prop_roundtripJSON (Proxy @(ClientRequest SimpleTx))
-    prop "ClientResponse - JSON roundtrips" $
-      prop_roundtripJSON (Proxy @(ClientResponse SimpleTx))
+    prop "ClientInput - JSON roundtrips" $
+      prop_roundtripJSON (Proxy @(ClientInput SimpleTx))
+    prop "ServerOutput - JSON roundtrips" $
+      prop_roundtripJSON (Proxy @(ServerOutput SimpleTx))
 
 prop_roundtripJSON ::
   forall a.

--- a/hydra-node/test/Hydra/Ledger/SimpleSpec.hs
+++ b/hydra-node/test/Hydra/Ledger/SimpleSpec.hs
@@ -8,7 +8,7 @@ import Hydra.Ledger (UTxO, applyTransactions)
 import Hydra.Ledger.Simple
 import Test.Hspec (Spec, describe)
 import Test.Hspec.QuickCheck (prop)
-import Test.QuickCheck (Property, arbitrary, forAllShrink, getNonEmpty, shrinkList, sublistOf)
+import Test.QuickCheck (Property, forAllShrink, shrinkList, sublistOf)
 import Test.QuickCheck.Gen (Gen, choose)
 
 spec :: Spec
@@ -37,16 +37,6 @@ newTx :: (Integer, UTxO SimpleTx, [SimpleTx]) -> Integer -> Gen (Integer, UTxO S
 newTx (maxId, utxo, txs) txid = do
   (newMax, ins, outs) <- genInputsAndOutputs maxId utxo
   pure (newMax, (utxo Set.\\ ins) `Set.union` outs, SimpleTx txid ins outs : txs)
-
-genUtxo :: Gen (UTxO SimpleTx)
-genUtxo = Set.fromList . fmap TxIn . getNonEmpty <$> arbitrary
-
-genSimpleTx :: Gen SimpleTx
-genSimpleTx = do
-  utxo <- genUtxo
-  (_, ins, outs) <- genInputsAndOutputs (unTxIn $ maximum utxo) utxo
-  txid <- arbitrary
-  pure $ SimpleTx txid ins outs
 
 genInputsAndOutputs :: Integer -> Set TxIn -> Gen (Integer, Set TxIn, Set TxIn)
 genInputsAndOutputs maxId utxo = do

--- a/hydra-node/test/Test/Util.hs
+++ b/hydra-node/test/Test/Util.hs
@@ -5,13 +5,12 @@ module Test.Util where
 import Hydra.Prelude
 
 import Control.Monad.Class.MonadTimer (timeout)
-import Control.Monad.IOSim (IOSim, runSim, traceM, Failure (FailureException))
+import Control.Monad.IOSim (Failure (FailureException), IOSim, runSim, traceM)
+import Control.Tracer (Tracer (Tracer))
 import Data.List (isInfixOf)
+import Data.Typeable (cast)
 import GHC.Stack (SrcLoc)
 import Test.HUnit.Lang (FailureReason (ExpectedButGot, Reason), HUnitFailure (HUnitFailure), formatFailureReason)
-import Test.QuickCheck (Gen, Positive (getPositive), arbitrary)
-import Control.Tracer (Tracer(Tracer))
-import Data.Typeable (cast)
 
 failure :: (HasCallStack, MonadThrow m) => String -> m a
 failure msg =
@@ -70,9 +69,6 @@ shouldContain :: (HasCallStack, MonadThrow m, Eq a, Show a) => [a] -> [a] -> m (
 shouldContain actual expected
   | expected `isInfixOf` actual = pure ()
   | otherwise = failure $ show actual <> " does not contain " <> show expected
-
-arbitraryNatural :: Gen Natural
-arbitraryNatural = fromIntegral . getPositive <$> arbitrary @(Positive Integer)
 
 -- | A 'Tracer' that works in 'IOSim' monad.
 -- This tracer uses the 'Output' event which uses converts value traced to 'Dynamic'

--- a/hydra-plutus/src/Hydra/Contract/PAB.hs
+++ b/hydra-plutus/src/Hydra/Contract/PAB.hs
@@ -1,7 +1,7 @@
 module Hydra.Contract.PAB where
 
 import Hydra.Prelude
-import Data.Aeson (ToJSON, FromJSON)
+
 import Data.Text.Prettyprint.Doc (Pretty (..), viaShow)
 
 data PABContract

--- a/hydra-prelude/hydra-prelude.cabal
+++ b/hydra-prelude/hydra-prelude.cabal
@@ -23,14 +23,20 @@ library
     Hydra.Prelude
     Hydra.Network.Ports
   build-depends:
+    aeson,
     base,
-    relude,
+    cardano-binary,
+    generic-random,
     io-sim-classes,
     network,
-    warp,
+    QuickCheck,
+    quickcheck-instances,
     random-shuffle,
+    relude,
+    warp,
   default-extensions:
     NoImplicitPrelude
+    FlexibleContexts
   ghc-options:
     -Wall
     -Wcompat

--- a/hydra-prelude/src/Hydra/Prelude.hs
+++ b/hydra-prelude/src/Hydra/Prelude.hs
@@ -8,8 +8,19 @@ module Hydra.Prelude (
   module Control.Monad.Class.MonadTimer,
   module Control.Monad.Class.MonadFork,
   module Control.Monad.Class.MonadThrow,
+  FromCBOR (..),
+  ToCBOR (..),
+  FromJSON (..),
+  ToJSON (..),
+  Arbitrary (..),
+  genericArbitrary,
+  genericShrink,
 ) where
 
+import Cardano.Binary (
+  FromCBOR (..),
+  ToCBOR (..),
+ )
 import Control.Monad.Class.MonadAsync (
   MonadAsync (concurrently, concurrently_, race, race_, withAsync),
  )
@@ -55,6 +66,13 @@ import Control.Monad.Class.MonadTimer (
   MonadDelay (..),
   MonadTimer,
  )
+import Data.Aeson (
+  FromJSON (..),
+  ToJSON (..),
+ )
+import GHC.Generics (Rep)
+import qualified Generic.Random as Random
+import qualified Generic.Random.Internal.Generic as Random
 import Relude hiding (
   MVar,
   Nat,
@@ -95,3 +113,22 @@ import Relude hiding (
   tryTakeTMVar,
   writeTVar,
  )
+import Test.QuickCheck (
+  Arbitrary (..),
+  Gen,
+  genericShrink,
+ )
+import Test.QuickCheck.Instances ()
+
+-- | Provides a sensible way of automatically deriving generic 'Arbitrary'
+-- instances for data-types. In the case where more advanced or tailored
+-- generators are needed, custom hand-written generators should be used with
+-- functions such as `forAll` or `forAllShrink`.
+genericArbitrary ::
+  ( Generic a
+  , Random.GA Random.UnsizedOpts (Rep a)
+  , Random.UniformWeight (Random.Weights_ (Rep a))
+  ) =>
+  Gen a
+genericArbitrary =
+  Random.genericArbitrary Random.uniform

--- a/local-cluster/local-cluster.cabal
+++ b/local-cluster/local-cluster.cabal
@@ -123,6 +123,7 @@ test-suite integration
     Test.LocalClusterSpec
   build-depends:
       base >=4.7 && <5
+    , aeson
     , bytestring
     , cardano-crypto-class
     , hspec

--- a/local-cluster/src/CardanoNode.hs
+++ b/local-cluster/src/CardanoNode.hs
@@ -12,7 +12,7 @@ import Control.Tracer (
   Tracer,
   traceWith,
  )
-import Data.Aeson (FromJSON (..), ToJSON (..), (.=))
+import Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.HashMap.Strict as HM
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime, utcTimeToPOSIXSeconds)

--- a/local-cluster/src/HydraNode.hs
+++ b/local-cluster/src/HydraNode.hs
@@ -219,7 +219,7 @@ waitForNodeConnected n@HydraNode{hydraNodeId} =
       ( \party ->
           object
             [ "response" .= String "peerConnected"
-            , "peer" .= party * 10
+            , "peer" .= (party * 10)
             ]
       )
       (filter (/= hydraNodeId) allNodeIds)

--- a/local-cluster/src/HydraNode.hs
+++ b/local-cluster/src/HydraNode.hs
@@ -27,6 +27,7 @@ import Control.Concurrent.Async (
   forConcurrently_,
  )
 import Control.Exception (IOException)
+import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import Data.List (delete)
 import Data.Text.IO (hPutStrLn)
@@ -56,10 +57,10 @@ data HydraNode = HydraNode
   , nodeStdout :: Handle
   }
 
-sendRequest :: HydraNode -> Text -> IO ()
+sendRequest :: HydraNode -> Aeson.Value -> IO ()
 sendRequest HydraNode{hydraNodeId, connection, nodeStdout} request = do
   hPutStrLn nodeStdout ("Tester sending to " <> show hydraNodeId <> ": " <> show request)
-  sendTextData connection request
+  sendTextData connection (Aeson.encode request)
 
 data WaitForResponseTimeout = WaitForResponseTimeout
   { nodeId :: Int

--- a/local-cluster/src/HydraNode.hs
+++ b/local-cluster/src/HydraNode.hs
@@ -218,7 +218,7 @@ waitForNodeConnected n@HydraNode{hydraNodeId} =
     fmap
       ( \party ->
           object
-            [ "response" .= String "peerConnected"
+            [ "output" .= String "peerConnected"
             , "peer" .= (party * 10)
             ]
       )

--- a/local-cluster/src/HydraNode.hs
+++ b/local-cluster/src/HydraNode.hs
@@ -27,14 +27,16 @@ import Control.Concurrent.Async (
   forConcurrently_,
  )
 import Control.Exception (IOException)
+import Data.Aeson (Value (String), object, (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import Data.List (delete)
+import qualified Data.Text as T
 import Data.Text.IO (hPutStrLn)
 import GHC.IO.Handle (hDuplicate)
 import Network.HTTP.Conduit (HttpExceptionContent (ConnectionFailure), parseRequest)
 import Network.HTTP.Simple (HttpException (HttpExceptionRequest), Response, getResponseBody, getResponseStatusCode, httpBS)
-import Network.WebSockets (Connection, DataMessage (Binary, Text), receiveDataMessage, runClient, sendClose, sendTextData)
+import Network.WebSockets (Connection, receiveData, runClient, sendClose, sendTextData)
 import Say (say)
 import System.Exit (ExitCode (..))
 import System.FilePath ((</>))
@@ -62,15 +64,6 @@ sendRequest HydraNode{hydraNodeId, connection, nodeStdout} request = do
   hPutStrLn nodeStdout ("Tester sending to " <> show hydraNodeId <> ": " <> show request)
   sendTextData connection (Aeson.encode request)
 
-data WaitForResponseTimeout = WaitForResponseTimeout
-  { nodeId :: Int
-  , expectedResponse :: Text
-  , actualMessages :: [Text]
-  }
-  deriving (Show)
-
-instance Exception WaitForResponseTimeout
-
 failAfter :: HasCallStack => Natural -> IO a -> IO a
 failAfter seconds action =
   timeout (fromIntegral seconds * 1_000_000) action >>= \case
@@ -80,13 +73,13 @@ failAfter seconds action =
 -- | Wait some time for a single response from each of given nodes.
 -- This function waits for @delay@ seconds for message @expected@  to be seen by all
 -- given @nodes@.
-waitForResponse :: HasCallStack => Natural -> [HydraNode] -> Text -> IO ()
+waitForResponse :: HasCallStack => Natural -> [HydraNode] -> Aeson.Value -> IO ()
 waitForResponse delay nodes expected = waitForResponses delay nodes [expected]
 
 -- |Wait some time for a list of responses from each of given nodes.
 -- This function is the generalised version of 'waitForResponse', allowing several messages
 -- to be waited for and received in /any order/.
-waitForResponses :: HasCallStack => Natural -> [HydraNode] -> [Text] -> IO ()
+waitForResponses :: HasCallStack => Natural -> [HydraNode] -> [Aeson.Value] -> IO ()
 waitForResponses delay nodes expected = do
   forConcurrently_ nodes $ \HydraNode{hydraNodeId, connection} -> do
     msgs <- newIORef []
@@ -96,14 +89,27 @@ waitForResponses delay nodes expected = do
       Just x -> pure x
       Nothing -> do
         actualMsgs <- readIORef msgs
-        expectationFailure $ show $ WaitForResponseTimeout hydraNodeId (show expected) actualMsgs
+        expectationFailure $
+          toString $
+            unlines
+              [ "waitForResponse... timeout!"
+              , padRight " " 20 "  nodeId:"
+                  <> show hydraNodeId
+              , padRight " " 20 "  expected:"
+                  <> unlines (align 20 (decodeUtf8 . Aeson.encode <$> expected))
+              , padRight " " 20 "  seen messages:"
+                  <> unlines (align 20 (decodeUtf8 . Aeson.encode <$> actualMsgs))
+              ]
  where
+  padRight c n str = T.take n (str <> T.replicate n c)
+  align _ [] = []
+  align n (h : q) = h : fmap (T.replicate n " " <>) q
   tryNext _ [] _ = pure ()
   tryNext msgs stillExpected c = do
-    msg <-
-      receiveDataMessage c >>= \case
-        Text b _mt -> pure $ decodeUtf8 b
-        Binary b -> pure $ decodeUtf8 b
+    bytes <- receiveData c
+    msg <- case Aeson.decode' bytes of
+      Nothing -> fail $ "received non-JSON message from the server: " <> show bytes
+      Just m -> pure m
     modifyIORef' msgs (msg :)
     tryNext msgs (delete msg stillExpected) c
 
@@ -210,5 +216,10 @@ waitForNodeConnected n@HydraNode{hydraNodeId} =
   -- party identifiers everywhere
   waitForResponses 10 [n] $
     fmap
-      (\party -> "PeerConnected (VerKeyMockDSIGN " <> show (party * 10) <> ")")
+      ( \party ->
+          object
+            [ "response" .= String "peerConnected"
+            , "peer" .= party * 10
+            ]
+      )
       (filter (/= hydraNodeId) allNodeIds)

--- a/local-cluster/test/Test/EndToEndSpec.hs
+++ b/local-cluster/test/Test/EndToEndSpec.hs
@@ -57,31 +57,31 @@ spec = describe "End-to-end test using a mocked chain though" $ do
                 waitForNodesConnected [n1, n2, n3]
                 let contestationPeriod = 3 -- TODO: Should be part of init
                 sendRequest n1 $
-                  request "init" []
+                  input "init" []
                 waitForResponse 3 [n1, n2, n3] $
-                  response "readyToCommit" ["parties" .= [10, 20, 30 :: Int]]
+                  output "readyToCommit" ["parties" .= [10, 20, 30 :: Int]]
                 sendRequest n1 $
-                  request "commit" ["utxo" .= [1 :: Int]]
+                  input "commit" ["utxo" .= [1 :: Int]]
                 sendRequest n2 $
-                  request "commit" ["utxo" .= [2 :: Int]]
+                  input "commit" ["utxo" .= [2 :: Int]]
                 sendRequest n3 $
-                  request "commit" ["utxo" .= [3 :: Int]]
+                  input "commit" ["utxo" .= [3 :: Int]]
 
                 waitForResponse 3 [n1, n2, n3] $
-                  response "headIsOpen" ["utxo" .= [1, 2, 3 :: Int]]
+                  output "headIsOpen" ["utxo" .= [1, 2, 3 :: Int]]
 
                 let tx = object ["id" .= (42 :: Int), "inputs" .= [1 :: Int], "outputs" .= [4 :: Int]]
                 sendRequest n1 $
-                  request "newTransaction" ["transaction" .= tx]
+                  input "newTransaction" ["transaction" .= tx]
 
                 waitForResponse 10 [n1, n2, n3] $
-                  response "transactionSeen" ["transaction" .= tx]
+                  output "transactionSeen" ["transaction" .= tx]
                 waitForResponse 10 [n1, n2, n3] $
-                  response "snapshotConfirmed" ["snapshotNumber" .= (1 :: Int)]
+                  output "snapshotConfirmed" ["snapshotNumber" .= (1 :: Int)]
                 sendRequest n1 $
-                  request "close" []
+                  input "close" []
                 waitForResponse 3 [n1] $
-                  response
+                  output
                     "headIsClosed"
                     [ "contestationPeriod" .= contestationPeriod
                     , "latestSnapshot"
@@ -92,7 +92,7 @@ spec = describe "End-to-end test using a mocked chain though" $ do
                           ]
                     ]
                 waitForResponse (contestationPeriod + 3) [n1] $
-                  response "headIsFinalized" ["utxo" .= [2, 3, 4 :: Int]]
+                  output "headIsFinalized" ["utxo" .= [2, 3, 4 :: Int]]
 
   describe "Monitoring" $ do
     it "Node exposes Prometheus metrics on port 6001" $ do
@@ -102,8 +102,8 @@ spec = describe "End-to-end test using a mocked chain though" $ do
             withHydraNode 2 bobSk [aliceVk, carolVk] $ \_n2 ->
               withHydraNode 3 carolSk [aliceVk, bobVk] $ \_n3 -> do
                 waitForNodesConnected [n1]
-                sendRequest n1 $ request "init" []
-                waitForResponse 3 [n1] $ response "readyToCommit" ["parties" .= [10, 20, 30 :: Int]]
+                sendRequest n1 $ input "init" []
+                waitForResponse 3 [n1] $ output "readyToCommit" ["parties" .= [10, 20, 30 :: Int]]
                 metrics <- getMetrics n1
                 metrics `shouldSatisfy` ("hydra_head_events  4" `BS.isInfixOf`)
 
@@ -117,8 +117,8 @@ spec = describe "End-to-end test using a mocked chain though" $ do
 -- Helpers
 --
 
-request :: Text -> [Pair] -> Value
-request tag pairs = object $ ("request" .= tag) : pairs
+input :: Text -> [Pair] -> Value
+input tag pairs = object $ ("input" .= tag) : pairs
 
-response :: Text -> [Pair] -> Value
-response tag pairs = object $ ("response" .= tag) : pairs
+output :: Text -> [Pair] -> Value
+output tag pairs = object $ ("output" .= tag) : pairs

--- a/local-cluster/test/Test/EndToEndSpec.hs
+++ b/local-cluster/test/Test/EndToEndSpec.hs
@@ -4,7 +4,7 @@
 
 module Test.EndToEndSpec where
 
-import Hydra.Prelude (Num ((+)), String, ($))
+import Hydra.Prelude
 
 import Cardano.Crypto.DSIGN (
   DSIGNAlgorithm (deriveVerKeyDSIGN),

--- a/local-cluster/test/Test/EndToEndSpec.hs
+++ b/local-cluster/test/Test/EndToEndSpec.hs
@@ -56,29 +56,43 @@ spec = describe "End-to-end test using a mocked chain though" $ do
               withHydraNode 3 carolSk [aliceVk, bobVk] $ \n3 -> do
                 waitForNodesConnected [n1, n2, n3]
                 let contestationPeriod = 3 -- TODO: Should be part of init
-                sendRequest n1 $ request "init" []
-                waitForResponse 3 [n1, n2, n3] "ReadyToCommit [VerKeyMockDSIGN 10,VerKeyMockDSIGN 20,VerKeyMockDSIGN 30]"
-                sendRequest n1 $ request "commit" ["utxo" .= [1 :: Int]]
-                sendRequest n2 $ request "commit" ["utxo" .= [2 :: Int]]
-                sendRequest n3 $ request "commit" ["utxo" .= [3 :: Int]]
-
-                waitForResponse 3 [n1, n2, n3] "HeadIsOpen (fromList [1,2,3])"
-
                 sendRequest n1 $
-                  request
-                    "newTransaction"
-                    [ "transaction"
+                  request "init" []
+                waitForResponse 3 [n1, n2, n3] $
+                  response "readyToCommit" ["parties" .= [10, 20, 30 :: Int]]
+                sendRequest n1 $
+                  request "commit" ["utxo" .= [1 :: Int]]
+                sendRequest n2 $
+                  request "commit" ["utxo" .= [2 :: Int]]
+                sendRequest n3 $
+                  request "commit" ["utxo" .= [3 :: Int]]
+
+                waitForResponse 3 [n1, n2, n3] $
+                  response "headIsOpen" ["utxo" .= [1, 2, 3 :: Int]]
+
+                let tx = object ["id" .= (42 :: Int), "inputs" .= [1 :: Int], "outputs" .= [4 :: Int]]
+                sendRequest n1 $
+                  request "newTransaction" ["transaction" .= tx]
+
+                waitForResponse 10 [n1, n2, n3] $
+                  response "transactionSeen" ["transaction" .= tx]
+                waitForResponse 10 [n1, n2, n3] $
+                  response "snapshotConfirmed" ["snapshotNumber" .= (1 :: Int)]
+                sendRequest n1 $
+                  request "close" []
+                waitForResponse 3 [n1] $
+                  response
+                    "headIsClosed"
+                    [ "contestationPeriod" .= contestationPeriod
+                    , "latestSnapshot"
                         .= object
-                          [ "id" .= (42 :: Int)
-                          , "inputs" .= [1 :: Int]
-                          , "outputs" .= [4 :: Int]
+                          [ "snapshotNumber" .= (1 :: Int)
+                          , "utxo" .= [2, 3, 4 :: Int]
+                          , "confirmedTransactions" .= [tx]
                           ]
                     ]
-                waitForResponse 10 [n1, n2, n3] "TxSeen (SimpleTx {txId = 42, txInputs = fromList [1], txOutputs = fromList [4]})"
-                waitForResponse 10 [n1, n2, n3] "SnapshotConfirmed 1"
-                sendRequest n1 $ request "close" []
-                waitForResponse 3 [n1] "HeadIsClosed 3s (Snapshot {number = 1, utxo = fromList [2,3,4], confirmed = [SimpleTx {txId = 42, txInputs = fromList [1], txOutputs = fromList [4]}]})"
-                waitForResponse (contestationPeriod + 3) [n1] "HeadIsFinalized (fromList [2,3,4])"
+                waitForResponse (contestationPeriod + 3) [n1] $
+                  response "headIsFinalized" ["utxo" .= [2, 3, 4 :: Int]]
 
   describe "Monitoring" $ do
     it "Node exposes Prometheus metrics on port 6001" $ do
@@ -89,8 +103,7 @@ spec = describe "End-to-end test using a mocked chain though" $ do
               withHydraNode 3 carolSk [aliceVk, bobVk] $ \_n3 -> do
                 waitForNodesConnected [n1]
                 sendRequest n1 $ request "init" []
-                waitForResponse 3 [n1] "ReadyToCommit [VerKeyMockDSIGN 10,VerKeyMockDSIGN 20,VerKeyMockDSIGN 30]"
-
+                waitForResponse 3 [n1] $ response "readyToCommit" ["parties" .= [10, 20, 30 :: Int]]
                 metrics <- getMetrics n1
                 metrics `shouldSatisfy` ("hydra_head_events  4" `BS.isInfixOf`)
 
@@ -100,5 +113,12 @@ spec = describe "End-to-end test using a mocked chain though" $ do
         version <- readCreateProcess (hydraNodeProcess ["--version"]) ""
         version `shouldSatisfy` (=~ ("[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9]+)?" :: String))
 
+--
+-- Helpers
+--
+
 request :: Text -> [Pair] -> Value
 request tag pairs = object $ ("request" .= tag) : pairs
+
+response :: Text -> [Pair] -> Value
+response tag pairs = object $ ("response" .= tag) : pairs

--- a/local-cluster/test/Test/EndToEndSpec.hs
+++ b/local-cluster/test/Test/EndToEndSpec.hs
@@ -11,10 +11,8 @@ import Cardano.Crypto.DSIGN (
   MockDSIGN,
   SignKeyDSIGN,
   VerKeyDSIGN,
-)
-import Data.Aeson.QQ.Simple (
-  aesonQQ,
  )
+import Data.Aeson (Value (String), object, (.=))
 import qualified Data.ByteString as BS
 import HydraNode (
   failAfter,
@@ -57,18 +55,27 @@ spec = describe "End-to-end test using a mocked chain though" $ do
               withHydraNode 3 carolSk [aliceVk, bobVk] $ \n3 -> do
                 waitForNodesConnected [n1, n2, n3]
                 let contestationPeriod = 3 -- TODO: Should be part of init
-                sendRequest n1 [aesonQQ|{"req": "init"}|]
+                sendRequest n1 $ object ["req" .= String "init"]
                 waitForResponse 3 [n1, n2, n3] "ReadyToCommit [VerKeyMockDSIGN 10,VerKeyMockDSIGN 20,VerKeyMockDSIGN 30]"
-                sendRequest n1 [aesonQQ|{"req": "commit", "args": [1] }|]
-                sendRequest n2 [aesonQQ|{"req": "commit", "args": [2] }|]
-                sendRequest n3 [aesonQQ|{"req": "commit", "args": [3] }|]
+                sendRequest n1 $ object ["req" .= String "commit", "utxo" .= [1 :: Int]]
+                sendRequest n2 $ object ["req" .= String "commit", "utxo" .= [2 :: Int]]
+                sendRequest n3 $ object ["req" .= String "commit", "utxo" .= [3 :: Int]]
 
                 waitForResponse 3 [n1, n2, n3] "HeadIsOpen (fromList [1,2,3])"
 
-                sendRequest n1 [aesonQQ|{"req": "newTx", "args": {"id": 42, "inputs": [1], "outputs": [4]}}|]
+                sendRequest n1 $
+                  object
+                    [ "req" .= String "new-tx"
+                    , "transaction"
+                        .= object
+                          [ "id" .= (42 :: Int)
+                          , "inputs" .= [1 :: Int]
+                          , "outputs" .= [4 :: Int]
+                          ]
+                    ]
                 waitForResponse 10 [n1, n2, n3] "TxSeen (SimpleTx {txId = 42, txInputs = fromList [1], txOutputs = fromList [4]})"
                 waitForResponse 10 [n1, n2, n3] "SnapshotConfirmed 1"
-                sendRequest n1 [aesonQQ|{"req": "close"}|]
+                sendRequest n1 $ object ["req" .= String "close"]
                 waitForResponse 3 [n1] "HeadIsClosed 3s (Snapshot {number = 1, utxo = fromList [2,3,4], confirmed = [SimpleTx {txId = 42, txInputs = fromList [1], txOutputs = fromList [4]}]})"
                 waitForResponse (contestationPeriod + 3) [n1] "HeadIsFinalized (fromList [2,3,4])"
 
@@ -80,7 +87,7 @@ spec = describe "End-to-end test using a mocked chain though" $ do
             withHydraNode 2 bobSk [aliceVk, carolVk] $ \_n2 ->
               withHydraNode 3 carolSk [aliceVk, bobVk] $ \_n3 -> do
                 waitForNodesConnected [n1]
-                sendRequest n1 [aesonQQ|{"req": "init"}|]
+                sendRequest n1 $ object ["req" .= String "init"]
                 waitForResponse 3 [n1] "ReadyToCommit [VerKeyMockDSIGN 10,VerKeyMockDSIGN 20,VerKeyMockDSIGN 30]"
 
                 metrics <- getMetrics n1

--- a/local-cluster/test/Test/EndToEndSpec.hs
+++ b/local-cluster/test/Test/EndToEndSpec.hs
@@ -55,17 +55,17 @@ spec = describe "End-to-end test using a mocked chain though" $ do
               withHydraNode 3 carolSk [aliceVk, bobVk] $ \n3 -> do
                 waitForNodesConnected [n1, n2, n3]
                 let contestationPeriod = 3 -- TODO: Should be part of init
-                sendRequest n1 $ object ["req" .= String "init"]
+                sendRequest n1 $ object ["request" .= String "init"]
                 waitForResponse 3 [n1, n2, n3] "ReadyToCommit [VerKeyMockDSIGN 10,VerKeyMockDSIGN 20,VerKeyMockDSIGN 30]"
-                sendRequest n1 $ object ["req" .= String "commit", "utxo" .= [1 :: Int]]
-                sendRequest n2 $ object ["req" .= String "commit", "utxo" .= [2 :: Int]]
-                sendRequest n3 $ object ["req" .= String "commit", "utxo" .= [3 :: Int]]
+                sendRequest n1 $ object ["request" .= String "commit", "utxo" .= [1 :: Int]]
+                sendRequest n2 $ object ["request" .= String "commit", "utxo" .= [2 :: Int]]
+                sendRequest n3 $ object ["request" .= String "commit", "utxo" .= [3 :: Int]]
 
                 waitForResponse 3 [n1, n2, n3] "HeadIsOpen (fromList [1,2,3])"
 
                 sendRequest n1 $
                   object
-                    [ "req" .= String "new-tx"
+                    [ "request" .= String "newTransaction"
                     , "transaction"
                         .= object
                           [ "id" .= (42 :: Int)
@@ -75,7 +75,7 @@ spec = describe "End-to-end test using a mocked chain though" $ do
                     ]
                 waitForResponse 10 [n1, n2, n3] "TxSeen (SimpleTx {txId = 42, txInputs = fromList [1], txOutputs = fromList [4]})"
                 waitForResponse 10 [n1, n2, n3] "SnapshotConfirmed 1"
-                sendRequest n1 $ object ["req" .= String "close"]
+                sendRequest n1 $ object ["request" .= String "close"]
                 waitForResponse 3 [n1] "HeadIsClosed 3s (Snapshot {number = 1, utxo = fromList [2,3,4], confirmed = [SimpleTx {txId = 42, txInputs = fromList [1], txOutputs = fromList [4]}]})"
                 waitForResponse (contestationPeriod + 3) [n1] "HeadIsFinalized (fromList [2,3,4])"
 
@@ -87,7 +87,7 @@ spec = describe "End-to-end test using a mocked chain though" $ do
             withHydraNode 2 bobSk [aliceVk, carolVk] $ \_n2 ->
               withHydraNode 3 carolSk [aliceVk, bobVk] $ \_n3 -> do
                 waitForNodesConnected [n1]
-                sendRequest n1 $ object ["req" .= String "init"]
+                sendRequest n1 $ object ["request" .= String "init"]
                 waitForResponse 3 [n1] "ReadyToCommit [VerKeyMockDSIGN 10,VerKeyMockDSIGN 20,VerKeyMockDSIGN 30]"
 
                 metrics <- getMetrics n1


### PR DESCRIPTION
- :round_pushpin: **Use structured JSON for interfacing with 'ClientRequest'**

- :round_pushpin: **Remove use of aeson-casing**
    Instead, favor hand-written JSON instances over generic with options.
  The rationale being that generic deriving with options and other
  meta-programming are often hard to read and easy to shoot oneself in
  the foot.

  Instead, using JSON builder makes for transparent definitions at the
  cost of a small maintainance burden when changing data-types.

- :round_pushpin: **Replace use of aesonQQ with builders**
    QuasiQuoters don't make unanimity, but builders do despite being
  perhaps a bit _too polymorphic_.

- :round_pushpin: **Write JSON roundtrip properties for `ClientRequest`**
    This was slightly more annoying than I initially thought because of
  the shrinkers. I thought I could get away with `genericShrink` and a
  `Generic` instance on `ClientRequest`, but this requires the subtypes
  to have `Arbitrary` instances, which is pretty annoying since we're
  trying to precisely avoid those.

  Ended up writing the shrinker by hand, not sure if it's worth it given
  that the model is small enough in practice anyway...

- :round_pushpin: **Write JSON instances for 'ClientResponse'**

- :round_pushpin: **Add {From,To}JSON / {From,To}CBOR / Arbitrary instances to hydra-prelude**
    All used pervasively across the codebase. So good candidates to be factored out in the prelude.

- :round_pushpin: **Define Arbitrary instances for base data-types in lib code**
    After discussion, we concluded that it is pretty useful to have
  generic Arbitrary instances readily available for base data-types, and
  only provide hand-written generators on a case-by-case. This leverages
  the generic-random package for generating arbitrary instances, and
  quickcheck for shrinkers when possible.

- :round_pushpin: **Refactor End-to-End to use smart-constructors for building JSON requests.**

- :round_pushpin: **Reply with structured JSON instead of mere 'show'**

- :round_pushpin: **Rework 'waitForResponse' expectation failure message**
    Enhance readability, as a big unformatted show is like looking for a needle in a haystack. Not good for quick debugging.

- :round_pushpin: **Represent 'Party' as JSON integers**
    The 'real' implementation should likely be more like it was before
  this commit, a base16 or bech32 encoding of the key. But with the mock
  cryptos, keys are basically just numbers and it's easier to read than
  long bytestring in end-to-end tests. Arguably, the end-to-end
  interface should not change when we change the crypto, so this may be
  only midly correct...

- :round_pushpin: **Rename 'ClientRequest' -> 'ClientInput', 'ClientResponse' -> 'ServerOutput'**

