### PR TITLE
Refactor behavior spec

### DIFF
--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -5,6 +5,7 @@ module Hydra.BehaviorSpec where
 
 import Hydra.Prelude
 
+import Control.Monad.Class.MonadAsync (forConcurrently_)
 import Control.Monad.Class.MonadSTM (
   modifyTVar,
   modifyTVar',
@@ -43,8 +44,7 @@ import Hydra.Node (
   runHydraNode,
  )
 import Test.Hspec (Spec, describe, it, shouldContain, shouldThrow)
-import Test.Util (failAfter, shouldNotBe, shouldReturn, shouldRunInSim, traceInIOSim, failure)
-import Control.Monad.Class.MonadAsync (forConcurrently_)
+import Test.Util (failAfter, failure, shouldNotBe, shouldReturn, shouldRunInSim, traceInIOSim)
 
 spec :: Spec
 spec = describe "Behavior of one ore more hydra nodes" $ do
@@ -123,12 +123,10 @@ spec = describe "Behavior of one ore more hydra nodes" $ do
         withHydraNode 1 [2] NoSnapshots chain $ \n1 ->
           withHydraNode 2 [1] NoSnapshots chain $ \n2 -> do
             send n1 Init
-            waitFor [n1] $ ReadyToCommit [1, 2]
-            waitFor [n2] $ ReadyToCommit [1, 2]
+            waitFor [n1, n2] $ ReadyToCommit [1, 2]
 
             send n1 (Commit (utxoRef 1))
-            waitFor [n1] $ Committed 1 (utxoRef 1)
-            waitFor [n2] $ Committed 1 (utxoRef 1)
+            waitFor [n1, n2] $ Committed 1 (utxoRef 1)
 
             send n2 (Commit (utxoRef 2))
             waitFor [n2] $ Committed 2 (utxoRef 2)
@@ -142,27 +140,20 @@ spec = describe "Behavior of one ore more hydra nodes" $ do
         withHydraNode 1 [2] NoSnapshots chain $ \n1 ->
           withHydraNode 2 [1] NoSnapshots chain $ \n2 -> do
             send n1 Init
-            waitFor [n1] $ ReadyToCommit [1, 2]
+            waitFor [n1, n2] $ ReadyToCommit [1, 2]
             send n1 (Commit (utxoRef 1))
-            waitFor [n2] $ ReadyToCommit [1, 2]
             send n2 (Commit (utxoRef 2))
-            do
-              waitFor [n1] $ Committed 1 (utxoRef 1)
-              waitFor [n2] $ Committed 1 (utxoRef 1)
-              waitFor [n1] $ Committed 2 (utxoRef 2)
-              waitFor [n2] $ Committed 2 (utxoRef 2)
-              waitFor [n1] $ HeadIsOpen (utxoRefs [1, 2])
-              waitFor [n2] $ HeadIsOpen (utxoRefs [1, 2])
+            waitFor [n1, n2] $ Committed 1 (utxoRef 1)
+            waitFor [n1, n2] $ Committed 2 (utxoRef 2)
+            waitFor [n1, n2] $ HeadIsOpen (utxoRefs [1, 2])
             -- XXX(SN): ^^ Boilerplate!
 
             let firstTx = SimpleTx 3 (utxoRef 1) (utxoRef 3)
                 secondTx = SimpleTx 4 (utxoRef 3) (utxoRef 4)
-
             send n2 (NewTx secondTx)
             send n1 (NewTx firstTx)
-            do
-              waitFor [n1] $ TxSeen firstTx
-              waitFor [n1] $ TxSeen secondTx
+            waitFor [n1] $ TxSeen firstTx
+            waitFor [n1] $ TxSeen secondTx
 
     it "sees the head closed by other nodes" $
       shouldRunInSim $ do
@@ -170,20 +161,14 @@ spec = describe "Behavior of one ore more hydra nodes" $ do
         withHydraNode 1 [2] NoSnapshots chain $ \n1 ->
           withHydraNode 2 [1] NoSnapshots chain $ \n2 -> do
             send n1 Init
-            waitFor [n1] $ ReadyToCommit [1, 2]
+            waitFor [n1, n2] $ ReadyToCommit [1, 2]
             send n1 (Commit (utxoRef 1))
-            waitFor [n1] $ Committed 1 (utxoRef 1)
-
-            waitFor [n2] $ ReadyToCommit [1, 2]
-            waitFor [n2] $ Committed 1 (utxoRef 1)
+            waitFor [n1, n2] $ Committed 1 (utxoRef 1)
             send n2 (Commit (utxoRef 2))
-            waitFor [n2] $ Committed 2 (utxoRef 2)
-            waitFor [n2] $ HeadIsOpen (utxoRefs [1, 2])
+            waitFor [n1, n2] $ Committed 2 (utxoRef 2)
+            waitFor [n1, n2] $ HeadIsOpen (utxoRefs [1, 2])
 
-            waitFor [n1] $ Committed 2 (utxoRef 2)
-            waitFor [n1] $ HeadIsOpen (utxoRefs [1, 2])
             send n1 Close
-
             waitFor [n2] $ HeadIsClosed testContestationPeriod (Snapshot 0 (utxoRefs [1, 2]) [])
 
     it "only opens the head after all nodes committed" $
@@ -192,12 +177,13 @@ spec = describe "Behavior of one ore more hydra nodes" $ do
         withHydraNode 1 [2] NoSnapshots chain $ \n1 ->
           withHydraNode 2 [1] NoSnapshots chain $ \n2 -> do
             send n1 Init
-            waitFor [n1] $ ReadyToCommit [1, 2]
+            waitFor [n1, n2] $ ReadyToCommit [1, 2]
+
             send n1 (Commit (utxoRef 1))
             waitFor [n1] $ Committed 1 (utxoRef 1)
-            timeout 1 (waitForNext n1) >>= (`shouldNotBe` Just (HeadIsOpen (utxoRef 1)))
+            let veryLong = timeout 1000
+            veryLong (waitForNext n1) >>= (`shouldNotBe` Just (HeadIsOpen (utxoRef 1)))
 
-            waitFor [n2] $ ReadyToCommit [1, 2]
             send n2 (Commit (utxoRef 2))
             waitFor [n1] $ Committed 2 (utxoRef 2)
             waitFor [n1] $ HeadIsOpen (utxoRefs [1, 2])
@@ -208,21 +194,16 @@ spec = describe "Behavior of one ore more hydra nodes" $ do
         withHydraNode 1 [2] NoSnapshots chain $ \n1 ->
           withHydraNode 2 [1] NoSnapshots chain $ \n2 -> do
             send n1 Init
-            waitFor [n1] $ ReadyToCommit [1, 2]
+            waitFor [n1, n2] $ ReadyToCommit [1, 2]
             send n1 (Commit (utxoRef 1))
-            waitFor [n1] $ Committed 1 (utxoRef 1)
-            waitFor [n2] $ ReadyToCommit [1, 2]
-            waitFor [n2] $ Committed 1 (utxoRef 1)
+            waitFor [n1, n2] $ Committed 1 (utxoRef 1)
             send n2 (Commit (utxoRef 2))
-            waitFor [n2] $ Committed 2 (utxoRef 2)
-            waitFor [n2] $ HeadIsOpen (utxoRefs [1, 2])
-            waitFor [n1] $ Committed 2 (utxoRef 2)
-            waitFor [n1] $ HeadIsOpen (utxoRefs [1, 2])
+            waitFor [n1, n2] $ Committed 2 (utxoRef 2)
+            waitFor [n1, n2] $ HeadIsOpen (utxoRefs [1, 2])
             -- XXX(SN): ^^ Boilerplate!
 
             send n1 (NewTx (aValidTx 42))
-            waitFor [n1] $ TxSeen (aValidTx 42)
-            waitFor [n2] $ TxSeen (aValidTx 42)
+            waitFor [n1, n2] $ TxSeen (aValidTx 42)
 
     it "valid new transactions get snapshotted" $
       shouldRunInSim $ do
@@ -230,33 +211,27 @@ spec = describe "Behavior of one ore more hydra nodes" $ do
         withHydraNode 1 [2] SnapshotAfterEachTx chain $ \n1 ->
           withHydraNode 2 [1] NoSnapshots chain $ \n2 -> do
             send n1 Init
-            waitFor [n1] $ ReadyToCommit [1, 2]
+            waitFor [n1, n2] $ ReadyToCommit [1, 2]
             send n1 (Commit (utxoRef 1))
-            waitFor [n1] $ Committed 1 (utxoRef 1)
-            waitFor [n2] $ ReadyToCommit [1, 2]
-            waitFor [n2] $ Committed 1 (utxoRef 1)
+            waitFor [n1, n2] $ Committed 1 (utxoRef 1)
             send n2 (Commit (utxoRef 2))
-            waitFor [n2] $ Committed 2 (utxoRef 2)
-            waitFor [n2] $ HeadIsOpen (utxoRefs [1, 2])
-            waitFor [n1] $ Committed 2 (utxoRef 2)
-            waitFor [n1] $ HeadIsOpen (utxoRefs [1, 2])
+            waitFor [n1, n2] $ Committed 2 (utxoRef 2)
+            waitFor [n1, n2] $ HeadIsOpen (utxoRefs [1, 2])
             -- XXX(SN): ^^ Boilerplate!
 
             send n1 (NewTx (aValidTx 42))
-            waitFor [n1] $ TxSeen (aValidTx 42)
-            waitFor [n2] $ TxSeen (aValidTx 42)
+            waitFor [n1, n2] $ TxSeen (aValidTx 42)
 
             waitFor [n1] $ SnapshotConfirmed 1
 
             send n1 Close
-            do
-              let expectedSnapshot =
-                    Snapshot
-                      { number = 1
-                      , utxo = utxoRefs [42, 1, 2]
-                      , confirmed = [aValidTx 42]
-                      }
-              waitFor [n1] $ HeadIsClosed testContestationPeriod expectedSnapshot
+            let expectedSnapshot =
+                  Snapshot
+                    { number = 1
+                    , utxo = utxoRefs [42, 1, 2]
+                    , confirmed = [aValidTx 42]
+                    }
+            waitFor [n1] $ HeadIsClosed testContestationPeriod expectedSnapshot
 
   describe "Hydra Node Logging" $ do
     it "traces processing of events" $ do

--- a/hydra-node/test/Test/Util.hs
+++ b/hydra-node/test/Test/Util.hs
@@ -37,7 +37,7 @@ shouldRunInSim action =
       case cast ex of
         Just f@HUnitFailure{} -> throwIO f
         _ -> failure $ "Exception in io-sim: " <> show ex
-    Left f -> failure $ "Other error in io-sim: " <> show f
+    Left f -> throwIO f
 
 -- | Lifted variant of Hspec's 'shouldBe'.
 shouldBe :: (HasCallStack, MonadThrow m, Eq a, Show a) => a -> a -> m ()


### PR DESCRIPTION
Mostly "on the surface" improvements of the behavior spec.

I debated of not using `failAfter` anymore as `shouldRunInSim` does correctly detect deadlocks and throws in that case, but kept a `failAfter 1` in the commonly used `waitFor` to have better error messages with location.

I refrained from adding a "wait until this output is seen" assertion (yet), but it might further improve stating the right thing, i.e. in some test cases where you don't bother (anymore) which exact output sequence is observed.. up to a specific point.