### PR TITLE
Refactor HeadState to make invalid states unrepresentable

### DIFF
--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -9,7 +9,7 @@ import Hydra.Chain.ZeroMQ (withMockChain)
 import Hydra.HeadLogic (
   Environment (party),
   Event (..),
-  createHeadState,
+  HeadState(ReadyState),
  )
 import qualified Hydra.Ledger.Simple as Ledger
 import Hydra.Logging (Verbosity (..), withTracer)
@@ -36,8 +36,7 @@ main = do
   withTracer verbosity $ \tracer' ->
     withMonitoring monitoringPort tracer' $ \tracer -> do
       eq <- createEventQueue
-      let headState = createHeadState 10
-      hh <- createHydraHead headState Ledger.simpleLedger
+      hh <- createHydraHead ReadyState Ledger.simpleLedger
       withMockChain (contramap MockChain tracer) mockChainPorts (putEvent eq . OnChainEvent) $ \oc ->
         withNetwork (contramap Network tracer) (party env) host port peers (putEvent eq . NetworkEvent) $ \hn ->
           withAPIServer apiHost apiPort (contramap APIServer tracer) (putEvent eq . ClientEvent) $ \sendOutput ->

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -5,10 +5,10 @@ module Main where
 import Hydra.Prelude
 
 import Hydra.API.Server (withAPIServer)
+import Hydra.Chain.ZeroMQ (withMockChain)
 import Hydra.HeadLogic (
   Environment (party),
   Event (..),
-  HeadParameters (..),
   createHeadState,
  )
 import qualified Hydra.Ledger.Simple as Ledger
@@ -28,7 +28,6 @@ import Hydra.Node (
   runHydraNode,
  )
 import Hydra.Options (Options (..), parseHydraOptions)
-import Hydra.Chain.ZeroMQ (withMockChain)
 
 main :: IO ()
 main = do
@@ -37,8 +36,7 @@ main = do
   withTracer verbosity $ \tracer' ->
     withMonitoring monitoringPort tracer' $ \tracer -> do
       eq <- createEventQueue
-      -- XXX(SN): this is soo weird, [] and mempty are both `parties`
-      let headState = createHeadState [] (HeadParameters 10 mempty)
+      let headState = createHeadState 10
       hh <- createHydraHead headState Ledger.simpleLedger
       withMockChain (contramap MockChain tracer) mockChainPorts (putEvent eq . OnChainEvent) $ \oc ->
         withNetwork (contramap Network tracer) (party env) host port peers (putEvent eq . NetworkEvent) $ \hn ->

--- a/hydra-node/src/Hydra/Chain.hs
+++ b/hydra-node/src/Hydra/Chain.hs
@@ -7,6 +7,17 @@ import Control.Monad.Class.MonadThrow (MonadThrow)
 import Data.Aeson (FromJSON, ToJSON)
 import Hydra.Ledger (Party, Tx, UTxO)
 import Hydra.Snapshot (Snapshot)
+import Data.Time (DiffTime)
+
+-- | Contains the head's parameters as established in the initial transaction.
+data HeadParameters = HeadParameters
+  { contestationPeriod :: DiffTime
+  , parties :: [Party] -- NOTE(SN): The order of this list is important for leader selection.
+  }
+  deriving stock (Eq, Read, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+type ContestationPeriod = DiffTime
 
 -- NOTE(SN): Might not be symmetric in a real chain client, i.e. posting
 -- transactions could be parameterized using such data types, but they are not
@@ -14,7 +25,7 @@ import Hydra.Snapshot (Snapshot)
 -- REVIEW(SN): There is a similarly named type in plutus-ledger, so we might
 -- want to rename this
 data OnChainTx tx
-  = InitTx [Party] -- NOTE(SN): The order of this list is important for leader selection.
+  = InitTx HeadParameters
   | CommitTx Party (UTxO tx)
   | AbortTx (UTxO tx)
   | CollectComTx (UTxO tx)

--- a/hydra-node/src/Hydra/Chain/ExternalPAB.hs
+++ b/hydra-node/src/Hydra/Chain/ExternalPAB.hs
@@ -8,7 +8,7 @@ import Control.Monad.Class.MonadSay (say)
 import Data.Aeson (Result (Error, Success), eitherDecodeStrict)
 import Data.Aeson.Types (fromJSON)
 import qualified Data.Map as Map
-import Hydra.Chain (Chain (Chain, postTx), OnChainTx (InitTx), ChainComponent)
+import Hydra.Chain (Chain (Chain, postTx), ChainComponent, HeadParameters (..), OnChainTx (InitTx))
 import Hydra.Contract.PAB (PABContract (GetUtxos, Setup, WatchInit))
 import Hydra.Ledger (Party, Tx)
 import Hydra.Logging (Tracer)
@@ -52,7 +52,7 @@ withExternalPAB walletId _tracer callback action = do
       action $ Chain{postTx = postTx}
  where
   postTx = \case
-    InitTx parties -> do
+    InitTx HeadParameters{parties} -> do
       cid <- activateContract Setup wallet
       postInitTx cid $
         PostInitParams
@@ -128,8 +128,9 @@ initTxSubscriber wallet callback = do
             Nothing -> pure ()
             Just (parties :: [Party]) -> do
               say $ "Observed Init tx with datums (parties): " ++ show parties
-              -- TODO(SN): pack hydra verification keys into metadata and callback with these
-              callback $ InitTx parties
+              -- TODO(SN): pack hydra verification keys and contestation period
+              -- into metadata and callback with these
+              callback $ InitTx (HeadParameters 42 parties)
       Right _ -> pure ()
       Left err -> say $ "error decoding msg: " <> show err
 

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -60,6 +60,20 @@ deriving instance Tx tx => Show (HeadState tx)
 deriving instance Tx tx => ToJSON (HeadState tx)
 deriving instance Tx tx => FromJSON (HeadState tx)
 
+-- | Contains at least the contestation period and other things.
+data HeadParameters = HeadParameters
+  { contestationPeriod :: DiffTime
+  , parties :: [Party]
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+type ContestationPeriod = DiffTime
+
+createHeadState :: ContestationPeriod -> HeadState tx
+createHeadState contestationPeriod =
+  HeadState (HeadParameters{contestationPeriod, parties = mempty}) ReadyState
+
 data HeadStatus tx
   = ReadyState
   | InitialState PendingCommits (Committed tx)
@@ -88,22 +102,9 @@ deriving instance Tx tx => FromJSON (CoordinatedHeadState tx)
 
 type PendingCommits = Set Party
 
--- | Contains at least the contestation period and other things.
-data HeadParameters = HeadParameters
-  { contestationPeriod :: DiffTime
-  , parties :: [Party]
-  }
-  deriving stock (Eq, Show, Generic)
-  deriving anyclass (ToJSON, FromJSON)
-
 -- | Decides if snapshots should be done, or not.
 data SnapshotStrategy = NoSnapshots | SnapshotAfterEachTx
   deriving (Eq)
-
--- | Assume: We know the party members and their verification keys. These need
--- to be exchanged somehow, eventually.
-createHeadState :: [Party] -> HeadParameters -> HeadState tx
-createHeadState _ parameters = HeadState parameters ReadyState
 
 -- | Preliminary type for collecting errors occurring during 'update'. Might
 -- make sense to merge this (back) into 'Outcome'.

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -41,6 +41,7 @@ initEnvironment Options{me, parties} = do
       { party = UnsafeParty vk
       , signingKey = sk
       , otherParties = UnsafeParty <$> otherVKeys
+      , contestationPeriod = 10
       , snapshotStrategy = SnapshotAfterEachTx
       }
  where

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -23,8 +23,7 @@ import Hydra.HeadLogic (
   Effect (ClientEffect),
   Environment (..),
   Event (ClientEvent),
-  SnapshotStrategy (..),
-  createHeadState,
+  SnapshotStrategy (..), HeadState (ReadyState)
  )
 import Hydra.Ledger (Party, SigningKey, Tx, deriveParty)
 import Hydra.Ledger.Simple (SimpleTx (..), aValidTx, simpleLedger, utxoRef, utxoRefs)
@@ -416,11 +415,11 @@ withHydraNode signingKey otherParties snapshotStrategy connectToChain action = d
             { party
             , signingKey
             , otherParties
+            , contestationPeriod = testContestationPeriod
             , snapshotStrategy
             }
     eq <- createEventQueue
-    let headState = createHeadState testContestationPeriod
-    hh <- createHydraHead headState simpleLedger
+    hh <- createHydraHead ReadyState simpleLedger
     let hn' = Network{broadcast = const $ pure ()}
     let node =
           HydraNode

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -23,7 +23,6 @@ import Hydra.HeadLogic (
   Effect (ClientEffect),
   Environment (..),
   Event (ClientEvent),
-  HeadParameters (..),
   SnapshotStrategy (..),
   createHeadState,
  )
@@ -386,7 +385,7 @@ simulatedChainAndNetwork = do
 
   broadcast nodes msg = readTVarIO nodes >>= mapM_ (`handleMessage` msg)
 
--- NOTE(SN): Deliberately not configurable via 'startHydraNode'
+-- NOTE(SN): Deliberately not configurable via 'withHydraNode'
 testContestationPeriod :: DiffTime
 testContestationPeriod = 3600
 
@@ -420,7 +419,7 @@ withHydraNode signingKey otherParties snapshotStrategy connectToChain action = d
             , snapshotStrategy
             }
     eq <- createEventQueue
-    let headState = createHeadState [] (HeadParameters testContestationPeriod mempty)
+    let headState = createHeadState testContestationPeriod
     hh <- createHydraHead headState simpleLedger
     let hn' = Network{broadcast = const $ pure ()}
     let node =

--- a/hydra-node/test/Hydra/Chain/ExternalPABSpec.hs
+++ b/hydra-node/test/Hydra/Chain/ExternalPABSpec.hs
@@ -7,7 +7,7 @@ import Hydra.Prelude
 
 import Cardano.Crypto.DSIGN (DSIGNAlgorithm (deriveVerKeyDSIGN), MockDSIGN, SignKeyDSIGN, VerKeyDSIGN)
 import Control.Concurrent (newEmptyMVar, putMVar, takeMVar)
-import Hydra.Chain (Chain (..), OnChainTx (InitTx))
+import Hydra.Chain (Chain (..), OnChainTx (InitTx), HeadParameters (HeadParameters, contestationPeriod))
 import Hydra.Chain.ExternalPAB (withExternalPAB)
 import Hydra.Ledger (Party (UnsafeParty))
 import Hydra.Ledger.Simple (SimpleTx)
@@ -28,9 +28,10 @@ spec =
           -- hard-coded in 'withExternalPAB'!
           withExternalPAB @SimpleTx 1 nullTracer (putMVar calledBack) $ \_ ->
             withExternalPAB 2 nullTracer (const $ pure ()) $ \Chain{postTx} -> do
-              let parties = [alice, bob, carol]
-              postTx $ InitTx @SimpleTx parties
-              takeMVar calledBack `shouldReturn` InitTx parties
+              let parameters = HeadParameters 42 [alice, bob, carol]
+              -- HACK(SN): contestationPeriod = 42 is currently hard-coded!
+              postTx $ InitTx @SimpleTx parameters
+              takeMVar calledBack `shouldReturn` InitTx parameters
 
 alice, bob, carol :: Party
 alice = UnsafeParty aliceVk

--- a/hydra-node/test/Hydra/Chain/ZeroMQSpec.hs
+++ b/hydra-node/test/Hydra/Chain/ZeroMQSpec.hs
@@ -7,7 +7,7 @@ import Hydra.Prelude
 import Control.Concurrent (newChan, readChan, writeChan)
 import Control.Monad.Class.MonadSTM (newEmptyTMVarIO, putTMVar, takeTMVar)
 import Control.Monad.Class.MonadTimer (timeout)
-import Hydra.Chain (OnChainTx (InitTx))
+import Hydra.Chain (OnChainTx (InitTx), HeadParameters (HeadParameters))
 import Hydra.Chain.ZeroMQ (catchUpTransactions, mockChainClient, runChainSync, startChain)
 import Hydra.Ledger.Simple (SimpleTx)
 import Hydra.Logging (nullTracer)
@@ -17,7 +17,7 @@ import Test.Util (shouldReturn)
 spec :: Spec
 spec =
   describe "Mock 0MQ-Based Chain" $ do
-    let tx = InitTx [1, 2]
+    let tx = InitTx (HeadParameters 10 [1, 2])
         numberOfTxs :: Int
         numberOfTxs = 3
 


### PR DESCRIPTION
* It was possible to have a `ReadyState` with `parties`, which is necessarily an invalid state as no `InitTx` was seen yet

* One type less at the cost of more positional arguments

* Naturally led to also having the `contestationPeriod` in the InitTx (in line with the paper) -> also moved the `HeadParameters` type into `Hydra.Chain` module

* Includes a hard-coded contestationPeriod for the ExternalPABSpec