### PR TITLE
Experiment: move lifted params to datums

### DIFF
--- a/hydra-node/test/Hydra/Chain/ExternalPABSpec.hs
+++ b/hydra-node/test/Hydra/Chain/ExternalPABSpec.hs
@@ -10,7 +10,7 @@ import Control.Concurrent (newEmptyMVar, putMVar, takeMVar)
 import qualified Data.Aeson as Aeson
 import Hydra.Chain (Chain (..), HeadParameters (HeadParameters, contestationPeriod), OnChainTx (InitTx))
 import Hydra.Chain.ExternalPAB (PostInitParams, withExternalPAB)
-import qualified Hydra.ContractSM as OnChain
+import qualified Hydra.Contract.PAB as PAB
 import Hydra.Ledger (Party (UnsafeParty))
 import Hydra.Ledger.Simple (SimpleTx)
 import Hydra.Logging (nullTracer)
@@ -32,10 +32,10 @@ spec = do
        in counterexample (decodeUtf8 bytes) $ case Aeson.eitherDecode bytes of
             Left e ->
               counterexample ("Failed to decode: " <> show e) $ property False
-            Right (_ :: OnChain.InitParams) ->
+            Right (_ :: PAB.InitParams) ->
               property True
 
-    prop "HeadParameters <- Onchain.InitialParams" $ \(params :: OnChain.InitialParams) ->
+    prop "HeadParameters <- Onchain.InitialParams" $ \(params :: PAB.InitialParams) ->
       let bytes = Aeson.encode params
        in counterexample (decodeUtf8 bytes) $ case Aeson.eitherDecode bytes of
             Left e ->

--- a/hydra-plutus/exe/inspect-scripts/Main.hs
+++ b/hydra-plutus/exe/inspect-scripts/Main.hs
@@ -3,13 +3,10 @@ module Main where
 import Prelude
 
 import Codec.Serialise
-import Data.Maybe (fromJust)
-import Data.Text.Prettyprint.Doc (pretty)
 import Hydra.Contract.Initial as Initial
 import Hydra.Contract.OnChain
 import Ledger.Typed.Scripts
 import Ledger.Value
-import PlutusTx (getPir)
 
 import qualified Data.ByteString.Lazy as BL
 import qualified Hydra.ContractSM as HydraSM
@@ -22,7 +19,6 @@ main = do
   putStrLn $ ""
   putStrLn $ "Hydra Script (SM):  " <> sizeInKb hydraScriptSM
   putStrLn $ "Initial Script (2): " <> sizeInKb initialScript'
-  print $ pretty $ fromJust $ getPir $ Initial.compiledValidator
  where
   sizeInKb = (<> " KB") . show . (`div` 1024) . BL.length
 

--- a/hydra-plutus/exe/inspect-scripts/Main.hs
+++ b/hydra-plutus/exe/inspect-scripts/Main.hs
@@ -1,0 +1,41 @@
+module Main where
+
+import Prelude
+
+import Codec.Serialise
+import Data.Maybe (fromJust)
+import Data.Text.Prettyprint.Doc (pretty)
+import Hydra.Contract.Initial as Initial
+import Hydra.Contract.OnChain
+import Ledger.Typed.Scripts
+import Ledger.Value
+import PlutusTx (getPir)
+
+import qualified Data.ByteString.Lazy as BL
+import qualified Hydra.ContractSM as HydraSM
+
+main :: IO ()
+main = do
+  putStrLn $ "Hydra Script:       " <> sizeInKb hydraScript
+  putStrLn $ "Initial Script:     " <> sizeInKb initialScript
+  putStrLn $ "Commit Script:      " <> sizeInKb commitScript
+  putStrLn $ ""
+  putStrLn $ "Hydra Script (SM):  " <> sizeInKb hydraScriptSM
+  putStrLn $ "Initial Script (2): " <> sizeInKb initialScript'
+  print $ pretty $ fromJust $ getPir $ Initial.compiledValidator
+ where
+  sizeInKb = (<> " KB") . show . (`div` 1024) . BL.length
+
+  hydraScript =
+    serialise $ validatorScript hydraTypedValidator
+  initialScript =
+    serialise $ validatorScript initialTypedValidator
+  commitScript =
+    serialise $ validatorScript commitTypedValidator
+
+  initialScript' =
+    serialise $ validatorScript Initial.typedValidator
+  hydraScriptSM =
+    serialise $ validatorScript $ HydraSM.typedValidator asset
+   where
+    asset = assetClass (CurrencySymbol mempty) (TokenName mempty)

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -82,11 +82,12 @@ library
   import: project-config
   exposed-modules:
       Hydra.Contract.ContestationPeriod
-      Hydra.Contract.OnChain
+      Hydra.Contract.Initial
       Hydra.Contract.OffChain
+      Hydra.Contract.OnChain
+      Hydra.Contract.PAB
       Hydra.Contract.Party
       Hydra.ContractSM
-      Hydra.Contract.PAB
   hs-source-dirs: src
   build-depends:
       aeson
@@ -171,3 +172,13 @@ executable hydra-pab
   ghc-options:
     -threaded
     -rtsopts
+
+executable inspect-scripts
+  import: project-config
+  hs-source-dirs: exe/inspect-scripts
+  main-is: Main.hs
+  build-depends: base
+    , bytestring
+    , hydra-plutus
+    , plutus-ledger
+    , serialise

--- a/hydra-plutus/src/Hydra/Contract/Initial.hs
+++ b/hydra-plutus/src/Hydra/Contract/Initial.hs
@@ -5,13 +5,15 @@
 -- | Contract for Hydra controlling the redemption of participation tokens.
 module Hydra.Contract.Initial where
 
-import Ledger
+import Ledger hiding (validatorHash)
 import PlutusTx.Prelude
 
+import Ledger.Constraints.TxConstraints (TxConstraints, mustPayToOtherScript)
 import Ledger.Typed.Scripts (ValidatorType, ValidatorTypes (..))
 import qualified Ledger.Typed.Scripts as Scripts
 import PlutusTx (CompiledCode)
 import qualified PlutusTx
+import PlutusTx.IsData.Class (ToData (..))
 
 data Initial
 
@@ -38,3 +40,15 @@ typedValidator = Scripts.mkTypedValidator @Initial
  where
   wrap = Scripts.wrapValidator @(DatumType Initial) @(RedeemerType Initial)
 {- ORMOLU_ENABLE -}
+
+validatorHash :: ValidatorHash
+validatorHash = Scripts.validatorHash typedValidator
+
+datum :: Datum
+datum = Datum (toBuiltinData ())
+
+address :: Address
+address = scriptHashAddress validatorHash
+
+mustPayToScript :: forall i o. Value -> TxConstraints i o
+mustPayToScript = mustPayToOtherScript validatorHash datum

--- a/hydra-plutus/src/Hydra/Contract/Initial.hs
+++ b/hydra-plutus/src/Hydra/Contract/Initial.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-specialize #-}
+
+-- | Contract for Hydra controlling the redemption of participation tokens.
+module Hydra.Contract.Initial where
+
+import Ledger
+import PlutusTx.Prelude
+
+import Ledger.Typed.Scripts (ValidatorType, ValidatorTypes (..))
+import qualified Ledger.Typed.Scripts as Scripts
+import PlutusTx (CompiledCode)
+import qualified PlutusTx
+
+data Initial
+
+instance Scripts.ValidatorTypes Initial where
+  type DatumType Initial = ()
+  type RedeemerType Initial = ()
+
+validator ::
+  () ->
+  () ->
+  ScriptContext ->
+  Bool
+validator _ _ _ctx =
+  True
+
+compiledValidator :: CompiledCode (ValidatorType Initial)
+compiledValidator = $$(PlutusTx.compile [||validator||])
+
+{- ORMOLU_DISABLE -}
+typedValidator :: Scripts.TypedValidator Initial
+typedValidator = Scripts.mkTypedValidator @Initial
+  compiledValidator
+  $$(PlutusTx.compile [|| wrap ||])
+ where
+  wrap = Scripts.wrapValidator @(DatumType Initial) @(RedeemerType Initial)
+{- ORMOLU_ENABLE -}

--- a/hydra-plutus/src/Hydra/Contract/OnChain.hs
+++ b/hydra-plutus/src/Hydra/Contract/OnChain.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-specialize #-}
@@ -40,6 +41,7 @@ data HeadParameters = HeadParameters
   , policyId :: MintingPolicyHash
   }
 
+PlutusTx.unstableMakeIsData ''HeadParameters
 PlutusTx.makeLift ''HeadParameters
 
 --
@@ -69,128 +71,32 @@ instance Scripts.ValidatorTypes Hydra where
   type DatumType Hydra = State
   type RedeemerType Hydra = Transition
 
-hydraValidator ::
-  HeadParameters ->
-  State ->
-  Transition ->
-  ScriptContext ->
-  Bool
-hydraValidator HeadParameters{participants, policyId} s i ctx =
-  case (s, i) of
-    (Initial, CollectCom) ->
-      let collectComUtxos =
-            snd <$> filterInputs (hasParty policyId) ctx
-          committedOutputs =
-            mapMaybe decodeCommit collectComUtxos
-          newState =
-            Open committedOutputs
-          amountPaid =
-            foldMap txOutValue collectComUtxos
-       in and
-            [ mustBeSignedByOneOf participants ctx
-            , all (mustForwardParty ctx policyId) participants
-            , checkScriptContext @(RedeemerType Hydra) @(DatumType Hydra)
-                (mustPayToTheScript newState amountPaid)
-                ctx
-            ]
-    (Initial, Abort) ->
-      let newState =
-            Final
-          amountPaid =
-            lovelaceValueOf 0
-       in and
-            [ mustBeSignedByOneOf participants ctx
-            , all (mustBurnParty ctx policyId) participants
-            , checkScriptContext @(RedeemerType Hydra) @(DatumType Hydra)
-                (mustPayToTheScript newState amountPaid)
-                ctx
-            ]
-    _ ->
-      False
- where
-  decodeCommit =
-    txOutDatumHash
-      >=> (`findDatum` scriptContextTxInfo ctx)
-      >=> (fromBuiltinData @(DatumType Commit) . getDatum)
-
-{- ORMOLU_DISABLE -}
-hydraTypedValidator
-  :: HeadParameters
-  -> Scripts.TypedValidator Hydra
-hydraTypedValidator params = Scripts.mkTypedValidator @Hydra
-    ( $$(PlutusTx.compile [|| hydraValidator ||])
-      `PlutusTx.applyCode` PlutusTx.liftCode params
-    )
-    $$(PlutusTx.compile [|| wrap ||])
-    where
-        wrap = Scripts.wrapValidator @(DatumType Hydra) @(RedeemerType Hydra)
-{- ORMOLU_ENABLE -}
-
-hydraValidatorHash :: HeadParameters -> ValidatorHash
-hydraValidatorHash = Scripts.validatorHash . hydraTypedValidator
-{-# INLINEABLE hydraValidatorHash #-}
-
 --
 -- Initial Validator
 --
 
 data Initial
 instance Scripts.ValidatorTypes Initial where
-  type DatumType Initial = PubKeyHash
+  type DatumType Initial = DatumInitial
   type RedeemerType Initial = TxOutRef
 
--- | The Validator 'initial' ensures that the input is consumed by a commit or
--- an abort transaction.
-initialValidator ::
+data DatumInitial = DatumInitial
+  { policyId :: MintingPolicyHash
+  , hydraScript :: ValidatorHash
+  , commitScript :: ValidatorHash
+  , vk :: PubKeyHash
+  }
+
+PlutusTx.unstableMakeIsData ''DatumInitial
+
+mkDatumInitial ::
   HeadParameters ->
-  ValidatorHash ->
-  ValidatorHash ->
   PubKeyHash ->
-  TxOutRef ->
-  ScriptContext ->
-  Bool
-initialValidator HeadParameters{policyId} hydraScript commitScript vk ref ctx =
-  consumedByCommit || consumedByAbort
- where
-  -- A commit transaction, identified by:
-  --    (a) A signature that verifies as valid with verification key defined as datum
-  --    (b) Spending a UTxO also referenced as redeemer.
-  --    (c) Having the commit validator in its only output, with a valid
-  --        participation token for the associated key, and the total value of the
-  --        committed UTxO.
-  consumedByCommit =
-    case findUtxo ref ctx of
-      Nothing ->
-        False
-      Just utxo ->
-        let commitDatum = asDatum @(DatumType Commit) (snd utxo)
-            commitValue = txOutValue (snd utxo) <> mkParty policyId vk
-         in checkScriptContext @(RedeemerType Initial) @(DatumType Initial)
-              ( mconcat
-                  [ mustBeSignedBy vk
-                  , mustSpendPubKeyOutput (fst utxo)
-                  , mustPayToOtherScript commitScript commitDatum commitValue
-                  ]
-              )
-              ctx
-
-  consumedByAbort =
-    mustRunContract hydraScript Abort ctx
-
-{- ORMOLU_DISABLE -}
-initialTypedValidator
-  :: HeadParameters
-  -> Scripts.TypedValidator Initial
-initialTypedValidator policyId = Scripts.mkTypedValidator @Initial
-  ($$(PlutusTx.compile [|| initialValidator ||])
-      `PlutusTx.applyCode` PlutusTx.liftCode policyId
-      `PlutusTx.applyCode` PlutusTx.liftCode (hydraValidatorHash policyId)
-      `PlutusTx.applyCode` PlutusTx.liftCode (commitValidatorHash policyId)
-  )
-  $$(PlutusTx.compile [|| wrap ||])
- where
-  wrap = Scripts.wrapValidator @(DatumType Initial) @(RedeemerType Initial)
-{- ORMOLU_ENABLE -}
+  DatumType Initial
+mkDatumInitial headParams@HeadParameters{policyId} vk =
+  let hydraScript = hydraValidatorHash headParams
+      commitScript = commitValidatorHash headParams
+   in DatumInitial{policyId, hydraScript, commitScript, vk}
 
 --
 -- Commit Validator
@@ -200,53 +106,6 @@ data Commit
 instance Scripts.ValidatorTypes Commit where
   type DatumType Commit = TxOut
   type RedeemerType Commit = ()
-
--- |  To lock outputs for a Hydra head, the ith head member will attach a commit
--- transaction to the i-th output of the initial transaction.
--- Validator 'commit' ensures that the commit transaction correctly records the
--- partial UTxO set Ui committed by the party.
---
--- The data field of the output of the commit transaction is
---
---     Ui = makeUTxO(o_1 , . . . , o_m),
---
--- where the o_j are the outputs referenced by the commit transaction’s inputs
--- and makeUTxO stores pairs (out-ref_j , o_j) of outputs o_j with the
--- corresponding output reference out-ref_j .
-commitValidator ::
-  ValidatorHash ->
-  TxOut ->
-  () ->
-  ScriptContext ->
-  Bool
-commitValidator hydraScript committedOut () ctx =
-  consumedByCollectCom || consumedByAbort
- where
-  consumedByCollectCom =
-    mustRunContract hydraScript CollectCom ctx
-
-  consumedByAbort =
-    and
-      [ mustRunContract hydraScript Abort ctx
-      , mustReimburse committedOut ctx
-      ]
-
-{- ORMOLU_DISABLE -}
-commitTypedValidator
-  :: HeadParameters
-  -> Scripts.TypedValidator Commit
-commitTypedValidator params = Scripts.mkTypedValidator @Commit
-  ($$(PlutusTx.compile [|| commitValidator ||])
-    `PlutusTx.applyCode` PlutusTx.liftCode (hydraValidatorHash params)
-  )
-  $$(PlutusTx.compile [|| wrap ||])
- where
-  wrap = Scripts.wrapValidator @(DatumType Commit) @(RedeemerType Commit)
-{- ORMOLU_ENABLE -}
-
-commitValidatorHash :: HeadParameters -> ValidatorHash
-commitValidatorHash = Scripts.validatorHash . commitTypedValidator
-{-# INLINEABLE commitValidatorHash #-}
 
 --
 -- Monetary Policy
@@ -467,3 +326,161 @@ symbols = foldr normalize [] . Map.toList . Value.getValue
       let elems = snd <$> Map.toList tokens
        in if sum elems == 0 then acc else currency : acc
 {-# INLINEABLE symbols #-}
+
+--
+-- Validators
+--
+
+hydraValidator ::
+  HeadParameters ->
+  State ->
+  Transition ->
+  ScriptContext ->
+  Bool
+hydraValidator HeadParameters{participants, policyId} s i ctx =
+  case (s, i) of
+    (Initial, CollectCom) ->
+      let collectComUtxos =
+            snd <$> filterInputs (hasParty policyId) ctx
+          committedOutputs =
+            mapMaybe decodeCommit collectComUtxos
+          newState =
+            Open committedOutputs
+          amountPaid =
+            foldMap txOutValue collectComUtxos
+       in and
+            [ mustBeSignedByOneOf participants ctx
+            , all (mustForwardParty ctx policyId) participants
+            , checkScriptContext @(RedeemerType Hydra) @(DatumType Hydra)
+                (mustPayToTheScript newState amountPaid)
+                ctx
+            ]
+    (Initial, Abort) ->
+      let newState =
+            Final
+          amountPaid =
+            lovelaceValueOf 0
+       in and
+            [ mustBeSignedByOneOf participants ctx
+            , all (mustBurnParty ctx policyId) participants
+            , checkScriptContext @(RedeemerType Hydra) @(DatumType Hydra)
+                (mustPayToTheScript newState amountPaid)
+                ctx
+            ]
+    _ ->
+      False
+ where
+  decodeCommit =
+    txOutDatumHash
+      >=> (`findDatum` scriptContextTxInfo ctx)
+      >=> (fromBuiltinData @(DatumType Commit) . getDatum)
+
+{- ORMOLU_DISABLE -}
+hydraTypedValidator
+  :: HeadParameters
+  -> Scripts.TypedValidator Hydra
+hydraTypedValidator params = Scripts.mkTypedValidator @Hydra
+    ( $$(PlutusTx.compile [|| hydraValidator ||])
+      `PlutusTx.applyCode` PlutusTx.liftCode params
+    )
+    $$(PlutusTx.compile [|| wrap ||])
+    where
+        wrap = Scripts.wrapValidator @(DatumType Hydra) @(RedeemerType Hydra)
+{- ORMOLU_ENABLE -}
+
+hydraValidatorHash :: HeadParameters -> ValidatorHash
+hydraValidatorHash = Scripts.validatorHash . hydraTypedValidator
+{-# INLINEABLE hydraValidatorHash #-}
+
+-- | The Validator 'initial' ensures that the input is consumed by a commit or
+-- an abort transaction.
+initialValidator ::
+  DatumInitial ->
+  TxOutRef ->
+  ScriptContext ->
+  Bool
+initialValidator DatumInitial{policyId, hydraScript, commitScript, vk} ref ctx =
+  consumedByCommit || consumedByAbort
+ where
+  -- A commit transaction, identified by:
+  --    (a) A signature that verifies as valid with verification key defined as datum
+  --    (b) Spending a UTxO also referenced as redeemer.
+  --    (c) Having the commit validator in its only output, with a valid
+  --        participation token for the associated key, and the total value of the
+  --        committed UTxO.
+  consumedByCommit =
+    case findUtxo ref ctx of
+      Nothing ->
+        False
+      Just utxo ->
+        let commitDatum = asDatum @(DatumType Commit) (snd utxo)
+            commitValue = txOutValue (snd utxo) <> mkParty policyId vk
+         in checkScriptContext @(RedeemerType Initial) @(DatumType Initial)
+              ( mconcat
+                  [ mustBeSignedBy vk
+                  , mustSpendPubKeyOutput (fst utxo)
+                  , mustPayToOtherScript commitScript commitDatum commitValue
+                  ]
+              )
+              ctx
+
+  consumedByAbort =
+    mustRunContract hydraScript Abort ctx
+
+{- ORMOLU_DISABLE -}
+initialTypedValidator
+  :: HeadParameters
+  -> Scripts.TypedValidator Initial
+initialTypedValidator policyId = Scripts.mkTypedValidator @Initial
+  $$(PlutusTx.compile [|| initialValidator ||])
+  $$(PlutusTx.compile [|| wrap ||])
+ where
+  wrap = Scripts.wrapValidator @(DatumType Initial) @(RedeemerType Initial)
+{- ORMOLU_ENABLE -}
+
+-- |  To lock outputs for a Hydra head, the ith head member will attach a commit
+-- transaction to the i-th output of the initial transaction.
+-- Validator 'commit' ensures that the commit transaction correctly records the
+-- partial UTxO set Ui committed by the party.
+--
+-- The data field of the output of the commit transaction is
+--
+--     Ui = makeUTxO(o_1 , . . . , o_m),
+--
+-- where the o_j are the outputs referenced by the commit transaction’s inputs
+-- and makeUTxO stores pairs (out-ref_j , o_j) of outputs o_j with the
+-- corresponding output reference out-ref_j .
+commitValidator ::
+  ValidatorHash ->
+  TxOut ->
+  () ->
+  ScriptContext ->
+  Bool
+commitValidator hydraScript committedOut () ctx =
+  consumedByCollectCom || consumedByAbort
+ where
+  consumedByCollectCom =
+    mustRunContract hydraScript CollectCom ctx
+
+  consumedByAbort =
+    and
+      [ mustRunContract hydraScript Abort ctx
+      , mustReimburse committedOut ctx
+      ]
+
+{- ORMOLU_DISABLE -}
+commitTypedValidator
+  :: HeadParameters
+  -> Scripts.TypedValidator Commit
+commitTypedValidator params = Scripts.mkTypedValidator @Commit
+  ($$(PlutusTx.compile [|| commitValidator ||])
+    `PlutusTx.applyCode` PlutusTx.liftCode (hydraValidatorHash params)
+  )
+  $$(PlutusTx.compile [|| wrap ||])
+ where
+  wrap = Scripts.wrapValidator @(DatumType Commit) @(RedeemerType Commit)
+{- ORMOLU_ENABLE -}
+
+commitValidatorHash :: HeadParameters -> ValidatorHash
+commitValidatorHash = Scripts.validatorHash . commitTypedValidator
+{-# INLINEABLE commitValidatorHash #-}

--- a/hydra-plutus/src/Hydra/Contract/PAB.hs
+++ b/hydra-plutus/src/Hydra/Contract/PAB.hs
@@ -16,7 +16,7 @@ import Ledger (CurrencySymbol, PubKeyHash (..), TxOut (txOutValue), TxOutTx (txO
 import Ledger.AddressMap (UtxoMap, outputsMapFromTxForAddress)
 import qualified Ledger.Typed.Scripts as Scripts
 import Ledger.Typed.Tx (tyTxOutData, typeScriptTxOut)
-import Ledger.Value (AssetClass, TokenName (..), assetClass, flattenValue, singleton)
+import Ledger.Value (AssetClass, TokenName (..), assetClass, flattenValue)
 import Plutus.Contract (
   AsContractError (..),
   Contract,
@@ -92,17 +92,13 @@ setup = do
   ownPK <- pubKeyHash <$> ownPubKey
   symbol <- Currency.currencySymbol <$> Currency.mintContract ownPK tokens
   let threadToken = mkThreadToken symbol
-      tokenValues = map (uncurry (singleton symbol)) participationTokens
+  -- tokenValues = map (uncurry (singleton symbol)) participationTokens
 
   logInfo $ "Done, our currency symbol: " <> show @String symbol
 
   let client = machineClient threadToken
-  void $ SM.runInitialise client ContractSM.Setup mempty
+  void $ SM.runInitialise client (ContractSM.Initial contestationPeriod hydraParties) mempty
 
-  void $
-    SM.runStep
-      client
-      (ContractSM.Init contestationPeriod (zip cardanoPubKeys tokenValues) hydraParties)
   logInfo $ "Triggered Init " <> show @String cardanoPubKeys
 
 --

--- a/hydra-plutus/src/Hydra/Contract/PAB.hs
+++ b/hydra-plutus/src/Hydra/Contract/PAB.hs
@@ -1,15 +1,209 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Hydra.Contract.PAB where
 
 import Hydra.Prelude
 
+import Control.Lens (makeClassyPrisms)
+import qualified Data.Map as Map
 import Data.Text.Prettyprint.Doc (Pretty (..), viaShow)
+import Hydra.Contract.ContestationPeriod (ContestationPeriod)
+import Hydra.Contract.Party (Party)
 import qualified Hydra.ContractSM as ContractSM
-import Ledger (pubKeyAddress)
-import Ledger.AddressMap (UtxoMap)
-import Plutus.Contract (Contract, ContractError, Empty, logInfo, ownPubKey, tell, utxoAt, waitNSlots)
+import Ledger (CurrencySymbol, PubKeyHash (..), TxOut (txOutValue), TxOutTx (txOutTxOut), pubKeyAddress, pubKeyHash)
+import Ledger.AddressMap (UtxoMap, outputsMapFromTxForAddress)
+import qualified Ledger.Typed.Scripts as Scripts
+import Ledger.Typed.Tx (tyTxOutData, typeScriptTxOut)
+import Ledger.Value (AssetClass, TokenName (..), assetClass, flattenValue, singleton)
+import Plutus.Contract (
+  AsContractError (..),
+  Contract,
+  ContractError (..),
+  Empty,
+  Endpoint,
+  currentSlot,
+  endpoint,
+  logInfo,
+  nextTransactionsAt,
+  ownPubKey,
+  tell,
+  throwError,
+  utxoAt,
+  waitNSlots,
+ )
+import Plutus.Contract.StateMachine (StateMachineClient, WaitingResult (..))
+import qualified Plutus.Contract.StateMachine as SM
+import qualified Plutus.Contracts.Currency as Currency
 import Plutus.PAB.Effects.Contract.Builtin (HasDefinitions (..), SomeBuiltin (..))
+
+data HydraPlutusError
+  = -- | State machine operation failed
+    SMError SM.SMContractError
+  | -- | Endpoint, coin selection, etc. failed
+    PlutusError ContractError
+  | -- | Thread token could not be created
+    ThreadTokenError Currency.CurrencyError
+  | -- | Arbitrary error
+    HydraError String
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+makeClassyPrisms ''HydraPlutusError
+
+instance AsContractError HydraPlutusError where
+  _ContractError = _PlutusError
+
+instance SM.AsSMContractError HydraPlutusError where
+  _SMContractError = _SMError
+
+instance Currency.AsCurrencyError HydraPlutusError where
+  _CurrencyError = _ThreadTokenError
+
+--
+-- Setup
+--
+
+-- | Parameters for starting a head.
+-- NOTE: kinda makes sense to have them separate because it couuld be the
+-- case that the parties (hdyra nodes taking part in the head consensus) and th
+-- participants (people commiting UTxOs) and posting transaction in the head
+-- are different
+data InitParams = InitParams
+  { contestationPeriod :: ContestationPeriod
+  , cardanoPubKeys :: [PubKeyHash]
+  , hydraParties :: [Party]
+  }
+  deriving (Generic, Show, FromJSON, ToJSON)
+
+setup :: Contract () (Endpoint "init" InitParams) HydraPlutusError ()
+setup = do
+  -- NOTE: These are the cardano/chain keys to send PTs to
+  InitParams{contestationPeriod, cardanoPubKeys, hydraParties} <-
+    endpoint @"init" @InitParams
+
+  let stateThreadToken = (threadTokenName, 1)
+      participationTokens = map ((,1) . participationTokenName) cardanoPubKeys
+      tokens = stateThreadToken : participationTokens
+
+  -- TODO(SN): replace with SM.getThreadToken
+  logInfo $ "Forging tokens: " <> show @String tokens
+  ownPK <- pubKeyHash <$> ownPubKey
+  symbol <- Currency.currencySymbol <$> Currency.mintContract ownPK tokens
+  let threadToken = mkThreadToken symbol
+      tokenValues = map (uncurry (singleton symbol)) participationTokens
+
+  logInfo $ "Done, our currency symbol: " <> show @String symbol
+
+  let client = machineClient threadToken
+  void $ SM.runInitialise client ContractSM.Setup mempty
+
+  void $
+    SM.runStep
+      client
+      (ContractSM.Init contestationPeriod (zip cardanoPubKeys tokenValues) hydraParties)
+  logInfo $ "Triggered Init " <> show @String cardanoPubKeys
+
+--
+-- GetUtxos
+--
+
+getUtxo :: Contract (Last UtxoMap) Empty ContractError ()
+getUtxo = do
+  logInfo @Text $ "getUtxo: Starting to get and report utxo map every slot"
+  address <- pubKeyAddress <$> ownPubKey
+  loop address
+ where
+  loop address = do
+    utxos <- utxoAt address
+    tell . Last $ Just utxos
+    void $ waitNSlots 1
+    loop address
+
+--
+-- WatchInit
+--
+
+-- | Parameters as they are available in the 'Initial' state.
+data InitialParams = InitialParams
+  { contestationPeriod :: ContestationPeriod
+  , parties :: [Party]
+  }
+  deriving (Generic, Show, FromJSON, ToJSON)
+
+instance Arbitrary InitialParams where
+  shrink = genericShrink
+  arbitrary = genericArbitrary
+
+-- | Watch 'initialAddress' (with hard-coded parameters) and report all datums
+-- seen on each run.
+watchInit :: Contract (Last InitialParams) Empty ContractError ()
+watchInit = do
+  logInfo @String $ "watchInit: Looking for an init tx and it's parties"
+  pubKey <- ownPubKey
+  let address = pubKeyAddress pubKey
+      pkh = pubKeyHash pubKey
+  forever $ do
+    txs <- nextTransactionsAt address
+    let foundTokens = txs >>= mapMaybe (findToken pkh) . Map.elems . outputsMapFromTxForAddress address
+    logInfo $ "found tokens: " <> show @String foundTokens
+    case foundTokens of
+      [token] -> do
+        let datums = txs >>= rights . fmap (lookupDatum token) . Map.elems . outputsMapFromTxForAddress (scriptAddress token)
+        logInfo @String $ "found init tx(s) with datums: " <> show datums
+        case datums of
+          [ContractSM.Initial contestationPeriod parties] ->
+            tell . Last . Just $ InitialParams{contestationPeriod, parties}
+          _ -> pure ()
+      _ -> pure ()
+ where
+  -- Find candidates for a Hydra Head threadToken 'AssetClass', that is if the
+  -- 'TokenName' matches our public key
+  findToken :: PubKeyHash -> TxOutTx -> Maybe AssetClass
+  findToken pkh txout =
+    let value = txOutValue $ txOutTxOut txout
+        flat = flattenValue value
+        mres = find (\(_, tokenName, amount) -> amount == 1 && tokenName == participationTokenName pkh) flat
+     in case mres of
+          Just (symbol, _, _) -> Just $ mkThreadToken symbol
+          Nothing -> Nothing
+
+  scriptAddress =
+    Scripts.validatorAddress . ContractSM.typedValidator
+
+  lookupDatum token txOutTx =
+    tyTxOutData <$> typeScriptTxOut (ContractSM.typedValidator token) txOutTx
+
+-- | Wait for 'Init' transaction to appear on chain and return the observed state of the state machine
+--
+--
+-- TODO: This code is unused?
+watchStateMachine :: AssetClass -> Contract () Empty HydraPlutusError ContractSM.State
+watchStateMachine threadToken = do
+  logInfo @String $ "watchStateMachine: Looking for transitions of SM: " <> show threadToken
+  let client = machineClient threadToken
+  sl <- currentSlot
+  SM.waitForUpdateUntilSlot client (sl + 10) >>= \case
+    (Timeout _s) -> throwError $ HydraError "Timed out waiting for transaction"
+    ContractEnded -> throwError $ HydraError "Contract ended"
+    (WaitingResult s) -> pure s
+
+-- | The machine client of the hydra state machine. It contains both, the script
+-- instance with the on-chain code, and the Haskell definition of the state
+-- machine for off-chain use.
+machineClient ::
+  -- | Thread token of the instance
+  AssetClass ->
+  StateMachineClient ContractSM.State ContractSM.Input
+machineClient threadToken =
+  let machine = ContractSM.hydraStateMachine threadToken
+      inst = ContractSM.typedValidator threadToken
+   in SM.mkStateMachineClient (SM.StateMachineInstance machine inst)
+
+--
+-- PAB Contract
+--
 
 -- | Enumeration of contracts available in the PAB.
 data PABContract
@@ -34,18 +228,20 @@ instance HasDefinitions PABContract where
   getSchema = const []
 
   getContract = \case
-    Setup -> SomeBuiltin ContractSM.setup
+    Setup -> SomeBuiltin setup
     GetUtxos -> SomeBuiltin getUtxo
-    WatchInit -> SomeBuiltin ContractSM.watchInit
+    WatchInit -> SomeBuiltin watchInit
 
-getUtxo :: Contract (Last UtxoMap) Empty ContractError ()
-getUtxo = do
-  logInfo @Text $ "getUtxo: Starting to get and report utxo map every slot"
-  address <- pubKeyAddress <$> ownPubKey
-  loop address
- where
-  loop address = do
-    utxos <- utxoAt address
-    tell . Last $ Just utxos
-    void $ waitNSlots 1
-    loop address
+--
+-- Helpers
+--
+
+mkThreadToken :: CurrencySymbol -> AssetClass
+mkThreadToken symbol =
+  assetClass symbol threadTokenName
+
+threadTokenName :: TokenName
+threadTokenName = "thread token"
+
+participationTokenName :: PubKeyHash -> TokenName
+participationTokenName = TokenName . getPubKeyHash

--- a/hydra-plutus/src/Hydra/ContractSM.hs
+++ b/hydra-plutus/src/Hydra/ContractSM.hs
@@ -13,8 +13,6 @@ import GHC.Generics (Generic)
 import GHC.Show (Show)
 import Hydra.Contract.ContestationPeriod (ContestationPeriod)
 import Hydra.Contract.Party (Party)
-import Ledger (PubKeyHash, Value)
-import Ledger.Constraints (mustPayToPubKey)
 import qualified Ledger.Typed.Scripts as Scripts
 import Ledger.Value (AssetClass)
 import Plutus.Contract.StateMachine (StateMachine)
@@ -22,8 +20,7 @@ import qualified Plutus.Contract.StateMachine as SM
 import qualified PlutusTx
 
 data State
-  = Setup
-  | Initial ContestationPeriod [Party]
+  = Initial ContestationPeriod [Party]
   | Open
   | Final
   deriving stock (Generic, Show)
@@ -32,8 +29,7 @@ data State
 PlutusTx.unstableMakeIsData ''State
 
 data Input
-  = Init ContestationPeriod [(PubKeyHash, Value)] [Party]
-  | CollectCom
+  = CollectCom
   | Abort
   deriving (Generic, Show)
 
@@ -56,10 +52,6 @@ hydraStateMachine _threadToken =
 hydraTransition :: SM.State State -> Input -> Maybe (SM.TxConstraints SM.Void SM.Void, SM.State State)
 hydraTransition oldState input =
   case (SM.stateData oldState, input) of
-    (Setup, Init contestationPeriod participationTokens parties) ->
-      Just (constraints, oldState{SM.stateData = Initial contestationPeriod parties})
-     where
-      constraints = foldMap (\(a, b) -> mustPayToPubKey a b) participationTokens
     _ -> Nothing
 
 -- | The script instance of the auction state machine. It contains the state

--- a/hydra-plutus/src/Hydra/ContractSM.hs
+++ b/hydra-plutus/src/Hydra/ContractSM.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-specialize #-}
@@ -7,36 +6,19 @@
 -- between Node and Chain
 module Hydra.ContractSM where
 
-import Hydra.Prelude hiding (State, find, fmap, foldMap, map, mapMaybe, mempty, pure, zip, ($), (&&), (+), (<$>), (<>), (==))
-import PlutusTx.Prelude hiding (Eq)
+import PlutusTx.Prelude
 
-import Control.Lens (makeClassyPrisms)
-import qualified Data.Map as Map
+import Data.Aeson (FromJSON, ToJSON)
+import GHC.Generics (Generic)
+import GHC.Show (Show)
 import Hydra.Contract.ContestationPeriod (ContestationPeriod)
 import Hydra.Contract.Party (Party)
-import Ledger (CurrencySymbol, PubKeyHash (..), TxOut (txOutValue), TxOutTx (txOutTxOut), Value, pubKeyAddress, pubKeyHash)
-import Ledger.AddressMap (outputsMapFromTxForAddress)
+import Ledger (PubKeyHash, Value)
 import Ledger.Constraints (mustPayToPubKey)
 import qualified Ledger.Typed.Scripts as Scripts
-import Ledger.Typed.Tx (tyTxOutData, typeScriptTxOut)
-import Ledger.Value (AssetClass, TokenName (..), assetClass, flattenValue, singleton)
-import Plutus.Contract (
-  AsContractError (..),
-  Contract,
-  ContractError (..),
-  Empty,
-  Endpoint,
-  currentSlot,
-  endpoint,
-  logInfo,
-  nextTransactionsAt,
-  ownPubKey,
-  tell,
-  throwError,
- )
-import Plutus.Contract.StateMachine (StateMachine, StateMachineClient, WaitingResult (..))
+import Ledger.Value (AssetClass)
+import Plutus.Contract.StateMachine (StateMachine)
 import qualified Plutus.Contract.StateMachine as SM
-import qualified Plutus.Contracts.Currency as Currency
 import qualified PlutusTx
 
 data State
@@ -56,29 +38,6 @@ data Input
   deriving (Generic, Show)
 
 PlutusTx.unstableMakeIsData ''Input
-
-data HydraPlutusError
-  = -- | State machine operation failed
-    SMError SM.SMContractError
-  | -- | Endpoint, coin selection, etc. failed
-    PlutusError ContractError
-  | -- | Thread token could not be created
-    ThreadTokenError Currency.CurrencyError
-  | -- | Arbitrary error
-    HydraError String
-  deriving stock (Eq, Show, Generic)
-  deriving anyclass (ToJSON, FromJSON)
-
-makeClassyPrisms ''HydraPlutusError
-
-instance AsContractError HydraPlutusError where
-  _ContractError = _PlutusError
-
-instance SM.AsSMContractError HydraPlutusError where
-  _SMContractError = _SMError
-
-instance Currency.AsCurrencyError HydraPlutusError where
-  _CurrencyError = _ThreadTokenError
 
 {-# INLINEABLE hydraStateMachine #-}
 hydraStateMachine :: AssetClass -> StateMachine State Input
@@ -100,7 +59,7 @@ hydraTransition oldState input =
     (Setup, Init contestationPeriod participationTokens parties) ->
       Just (constraints, oldState{SM.stateData = Initial contestationPeriod parties})
      where
-      constraints = foldMap (uncurry mustPayToPubKey) participationTokens
+      constraints = foldMap (\(a, b) -> mustPayToPubKey a b) participationTokens
     _ -> Nothing
 
 -- | The script instance of the auction state machine. It contains the state
@@ -123,121 +82,3 @@ typedValidator threadToken =
    in Scripts.mkTypedValidator @(StateMachine State Input)
         val
         $$(PlutusTx.compile [||wrap||])
-
--- | The machine client of the hydra state machine. It contains both, the script
--- instance with the on-chain code, and the Haskell definition of the state
--- machine for off-chain use.
-machineClient ::
-  -- | Thread token of the instance
-  AssetClass ->
-  StateMachineClient State Input
-machineClient threadToken =
-  let machine = hydraStateMachine threadToken
-      inst = typedValidator threadToken
-   in SM.mkStateMachineClient (SM.StateMachineInstance machine inst)
-
-participationTokenName :: PubKeyHash -> TokenName
-participationTokenName = TokenName . getPubKeyHash
-
-threadTokenName :: TokenName
-threadTokenName = "thread token"
-
-mkThreadToken :: CurrencySymbol -> AssetClass
-mkThreadToken symbol =
-  assetClass symbol threadTokenName
-
--- | Parameters for starting a head.
--- NOTE: kinda makes sense to have them separate because it couuld be the
--- case that the parties (hdyra nodes taking part in the head consensus) and th
--- participants (people commiting UTxOs) and posting transaction in the head
--- are different
-data InitParams = InitParams
-  { contestationPeriod :: ContestationPeriod
-  , cardanoPubKeys :: [PubKeyHash]
-  , hydraParties :: [Party]
-  }
-  deriving (Generic, Show, FromJSON, ToJSON)
-
-setup :: Contract () (Endpoint "init" InitParams) HydraPlutusError ()
-setup = do
-  -- NOTE: These are the cardano/chain keys to send PTs to
-  InitParams{contestationPeriod, cardanoPubKeys, hydraParties} <-
-    endpoint @"init" @InitParams
-
-  let stateThreadToken = (threadTokenName, 1)
-      participationTokens = map ((,1) . participationTokenName) cardanoPubKeys
-      tokens = stateThreadToken : participationTokens
-
-  -- TODO(SN): replace with SM.getThreadToken
-  logInfo $ "Forging tokens: " <> show @String tokens
-  ownPK <- pubKeyHash <$> ownPubKey
-  symbol <- Currency.currencySymbol <$> Currency.mintContract ownPK tokens
-  let threadToken = mkThreadToken symbol
-      tokenValues = map (uncurry (singleton symbol)) participationTokens
-
-  logInfo $ "Done, our currency symbol: " <> show @String symbol
-
-  let client = machineClient threadToken
-  void $ SM.runInitialise client Setup mempty
-
-  void $ SM.runStep client (Init contestationPeriod (zip cardanoPubKeys tokenValues) hydraParties)
-  logInfo $ "Triggered Init " <> show @String cardanoPubKeys
-
--- | Parameters as they are available in the 'Initial' state.
-data InitialParams = InitialParams
-  { contestationPeriod :: ContestationPeriod
-  , parties :: [Party]
-  }
-  deriving (Generic, Show, FromJSON, ToJSON)
-
-instance Arbitrary InitialParams where
-  shrink = genericShrink
-  arbitrary = genericArbitrary
-
--- | Watch 'initialAddress' (with hard-coded parameters) and report all datums
--- seen on each run.
-watchInit :: Contract (Last InitialParams) Empty ContractError ()
-watchInit = do
-  logInfo @String $ "watchInit: Looking for an init tx and it's parties"
-  pubKey <- ownPubKey
-  let address = pubKeyAddress pubKey
-      pkh = pubKeyHash pubKey
-  forever $ do
-    txs <- nextTransactionsAt address
-    let foundTokens = txs >>= mapMaybe (findToken pkh) . Map.elems . outputsMapFromTxForAddress address
-    logInfo $ "found tokens: " <> show @String foundTokens
-    case foundTokens of
-      [token] -> do
-        let datums = txs >>= rights . fmap (lookupDatum token) . Map.elems . outputsMapFromTxForAddress (scriptAddress token)
-        logInfo @String $ "found init tx(s) with datums: " <> show datums
-        case datums of
-          [Initial contestationPeriod parties] ->
-            tell . Last . Just $ InitialParams{contestationPeriod, parties}
-          _ -> pure ()
-      _ -> pure ()
- where
-  -- Find candidates for a Hydra Head threadToken 'AssetClass', that is if the
-  -- 'TokenName' matches our public key
-  findToken :: PubKeyHash -> TxOutTx -> Maybe AssetClass
-  findToken pkh txout =
-    let value = txOutValue $ txOutTxOut txout
-        flat = flattenValue value
-        mres = find (\(_, tokenName, amount) -> amount == 1 && tokenName == participationTokenName pkh) flat
-     in case mres of
-          Just (symbol, _, _) -> Just $ mkThreadToken symbol
-          Nothing -> Nothing
-
-  scriptAddress = Scripts.validatorAddress . typedValidator
-
-  lookupDatum token txOutTx = tyTxOutData <$> typeScriptTxOut (typedValidator token) txOutTx
-
--- | Wait for 'Init' transaction to appear on chain and return the observed state of the state machine
-watchStateMachine :: AssetClass -> Contract () Empty HydraPlutusError State
-watchStateMachine threadToken = do
-  logInfo @String $ "watchStateMachine: Looking for transitions of SM: " <> show threadToken
-  let client = machineClient threadToken
-  sl <- currentSlot
-  SM.waitForUpdateUntilSlot client (sl + 10) >>= \case
-    (Timeout _s) -> throwError $ HydraError "Timed out waiting for transaction"
-    ContractEnded -> throwError $ HydraError "Contract ended"
-    (WaitingResult s) -> pure s


### PR DESCRIPTION
**Why?**

Lifted params are fine for simple contracts with a single participant. However, different params will change the contract code and therefore, yield a different contract address, which then makes it more difficult / not feasible for some other participant to watch a contract (since only the one who initiate the contract fully knows its address). 

Yet, such parameters can be stored as datum such that we live the contract address unchanged. 