### PR TITLE
Fix busy loop in Hydra.Logging

### DIFF
--- a/hydra-node/src/Hydra/Logging.hs
+++ b/hydra-node/src/Hydra/Logging.hs
@@ -77,7 +77,9 @@ withTracer (Verbose name) action = do
         , "message" .= msg
         ]
 
-  logMessagesToStdout queue = forever $ flushLogs queue
+  logMessagesToStdout queue =
+    forever $
+      flushLogs queue >> threadDelay 0.1
 
   flushLogs queue = do
     entries <- atomically $ flushTBQueue queue

--- a/hydra-node/src/Hydra/Logging.hs
+++ b/hydra-node/src/Hydra/Logging.hs
@@ -34,9 +34,7 @@ import Control.Tracer (
   traceWith,
  )
 import Data.Aeson (Value, encode, object, (.=))
-import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text as Text
-import qualified Data.Text.IO as TIO
 
 data Verbosity = Quiet | Verbose Text
   deriving (Eq, Show)


### PR DESCRIPTION
This was leading to 100% cpu utilization as `flushTBQueue` seems not to block