### PR TITLE
Format failures in bench-e2e

### DIFF
--- a/hydra-test-utils/src/Test/Hydra/Prelude.hs
+++ b/hydra-test-utils/src/Test/Hydra/Prelude.hs
@@ -22,10 +22,9 @@ import GHC.Exception (SrcLoc (..))
 import System.IO.Temp (createTempDirectory, getCanonicalTemporaryDirectory)
 import Test.HSpec.JUnit (junitFormat)
 import Test.HUnit.Lang (FailureReason (Reason), HUnitFailure (HUnitFailure))
-import qualified Test.HUnit.Lang as HUnit
-import Test.Hspec.Core.Format (Event (ItemDone), Format, FormatConfig (..), Item (..), Location (..), Result (Failure))
-import qualified Test.Hspec.Core.Format as Hspec
+import Test.Hspec.Core.Format (Format, FormatConfig (..))
 import Test.Hspec.Core.Formatters (formatterToFormat, specdoc)
+import Test.Hspec.Runner (defaultConfig, evaluateSummary, runSpec)
 
 -- | Create a unique temporary directory.
 createSystemTempDirectory :: String -> IO FilePath
@@ -70,46 +69,8 @@ dualFormatter suiteName config = do
   docSpec <- formatterToFormat specdoc config
   pure $ \e -> junit e >> docSpec e
 
--- | Format any 'failure' ('HUnitFailure' exceptions) like 'hspec' inside a given context.
-formatFailure :: String -> IO a -> IO a
+-- | Format any 'failure' ('HUnitFailure' exceptions) using 'hspec' inside a
+-- given context.
+formatFailure :: String -> IO () -> IO ()
 formatFailure ctx action = do
-  action `catch` go
- where
-  go :: HUnitFailure -> IO a
-  go e = do
-    format <- formatterToFormat specdoc config
-    format $ failureEvent e
-    print e
-    exitFailure
-
-  failureEvent :: HUnitFailure -> Event
-  failureEvent (HUnitFailure mloc reason) =
-    ItemDone ([], ctx) $
-      Item
-        { itemLocation = convertLoc <$> mloc
-        , itemDuration = 0 -- TODO(SN): measure duration of 'action'?
-        , itemInfo = ""
-        , itemResult = Failure (convertLoc <$> mloc) (convertReason reason)
-        }
-
-  convertLoc loc =
-    Location
-      { locationFile = srcLocFile loc
-      , locationLine = srcLocStartLine loc
-      , locationColumn = srcLocStartCol loc
-      }
-
-  convertReason = \case
-    HUnit.Reason s -> Hspec.Reason s
-    HUnit.ExpectedButGot ms e a -> Hspec.ExpectedButGot ms e a
-
-  config =
-    FormatConfig
-      { formatConfigUseColor = True
-      , formatConfigUseDiff = True
-      , formatConfigPrintTimes = True
-      , formatConfigHtmlOutput = False
-      , formatConfigPrintCpuTime = False
-      , formatConfigUsedSeed = 0 -- XXX(SN): pass this here?
-      , formatConfigItemCount = 0 -- XXX(SN): required?
-      }
+  runSpec (it ctx action) defaultConfig >>= evaluateSummary

--- a/hydra-test-utils/src/Test/Hydra/Prelude.hs
+++ b/hydra-test-utils/src/Test/Hydra/Prelude.hs
@@ -6,7 +6,6 @@ module Test.Hydra.Prelude (
   location,
   failAfter,
   dualFormatter,
-  formatFailure,
 
   -- * HSpec re-exports
   module Test.Hspec,
@@ -24,7 +23,6 @@ import Test.HSpec.JUnit (junitFormat)
 import Test.HUnit.Lang (FailureReason (Reason), HUnitFailure (HUnitFailure))
 import Test.Hspec.Core.Format (Format, FormatConfig (..))
 import Test.Hspec.Core.Formatters (formatterToFormat, specdoc)
-import Test.Hspec.Runner (defaultConfig, evaluateSummary, runSpec)
 
 -- | Create a unique temporary directory.
 createSystemTempDirectory :: String -> IO FilePath
@@ -68,9 +66,3 @@ dualFormatter suiteName config = do
   junit <- junitFormat "test-results.xml" suiteName config
   docSpec <- formatterToFormat specdoc config
   pure $ \e -> junit e >> docSpec e
-
--- | Format any 'failure' ('HUnitFailure' exceptions) using 'hspec' inside a
--- given context.
-formatFailure :: String -> IO () -> IO ()
-formatFailure ctx action = do
-  runSpec (it ctx action) defaultConfig >>= evaluateSummary

--- a/local-cluster/bench/Bench/EndToEnd.hs
+++ b/local-cluster/bench/Bench/EndToEnd.hs
@@ -56,9 +56,9 @@ data Event = Event
   }
   deriving (Generic, Eq, Show, ToJSON)
 
-bench :: FilePath -> Utxo CardanoTx -> [CardanoTx] -> IO ()
+bench :: FilePath -> Utxo CardanoTx -> [CardanoTx] -> Spec
 bench workDir initialUtxo txs =
-  formatFailure "Benchmark three local nodes" $ do
+  it ("Benchmarks three local nodes in " <> workDir) $ do
     registry <- newTVarIO mempty :: IO (TVar IO (Map.Map (TxId CardanoTx) Event))
     showLogsOnFailure $ \tracer ->
       failAfter 300 $ do

--- a/local-cluster/bench/Main.hs
+++ b/local-cluster/bench/Main.hs
@@ -1,13 +1,14 @@
 module Main where
 
 import Hydra.Prelude
+import Test.Hydra.Prelude
 
 import Bench.EndToEnd (bench)
 import Data.Aeson (eitherDecodeFileStrict', encodeFile)
 import Hydra.Ledger (applyTransactions)
 import Hydra.Ledger.Cardano (cardanoLedger, genSequenceOfValidTransactions, genUtxo)
+import System.Environment (withArgs)
 import System.FilePath (takeDirectory, (</>))
-import Test.Hydra.Prelude (createSystemTempDirectory)
 import Test.QuickCheck (generate, scale)
 
 main :: IO ()
@@ -21,7 +22,7 @@ main =
               (Right txs, Right utxos) -> do
                 putStrLn $ "Using transactions from: " <> txsFile
                 putStrLn $ "Using UTxOs from: " <> utxosFile
-                bench (takeDirectory txsFile) utxos txs
+                run (takeDirectory txsFile) utxos txs
               err -> die (show err)
     _ -> do
       tmpDir <- createSystemTempDirectory "bench"
@@ -34,8 +35,11 @@ main =
         Right _ -> do
           saveTransactions tmpDir txs
           saveUtxos tmpDir initialUtxo
-          bench tmpDir initialUtxo txs
+          run tmpDir initialUtxo txs
  where
+  run fp utxo txs =
+    withArgs [] . hspec $ bench fp utxo txs
+
   saveTransactions tmpDir txs = do
     let txsFile = tmpDir </> "txs.json"
     putStrLn $ "Writing transactions to: " <> txsFile

--- a/local-cluster/local-cluster.cabal
+++ b/local-cluster/local-cluster.cabal
@@ -166,6 +166,7 @@ benchmark bench-e2e
     , cardano-crypto-class
     , containers
     , filepath
+    , hspec
     , hydra-node
     , hydra-prelude
     , hydra-test-utils


### PR DESCRIPTION
This turned out to be quite simple.. after a detour via `hspec`'s `Format`.

Maybe a next step should be to make the `bench :: ... -> Spec` and somehow integrate the utxo/tx generation with `prop`?