### PR TITLE
Use 'Party' for creating txs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -29,7 +29,7 @@ pkgs.haskell-nix.project {
   compiler-nix-name = compiler;
 
   # Fixed output derivation for plan-nix
-  plan-sha256 = "00afs6g5nhddzy2y0bm83pvvb4add41nj89ksk998p9ymzd0x3q7";
+  plan-sha256 = "13lzy3an81n8bcank6snfsg7y29c2rrf0ygpl782g661hcql0an0";
   materialized = ./nix/hydra-poc.materialized;
   # Enable this and nix-build one of the project components to get the new
   # plan-sha256 and materialization update scripts:

--- a/hydra-node/api.yaml
+++ b/hydra-node/api.yaml
@@ -297,6 +297,22 @@ properties:
           input:
             type: string
 
+      - title: Greetings
+        description: >-
+          A friendly welcome message which tells a client something about the
+          node. Currently used for knowing what signing key the server uses (it
+          only knows one).
+        type: object
+        required:
+        - tag
+        - me
+        properties:
+          tag:
+            type: string
+            enum: ["Greetings"]
+          me:
+            $ref: "#/definitions/Party"
+
   utxo:
     type: array
     items:

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -21,7 +21,8 @@ import Hydra.ClientInput (ClientInput)
 import Hydra.Ledger (Tx (..))
 import Hydra.Logging (Tracer, traceWith)
 import Hydra.Network (IP, PortNumber)
-import Hydra.ServerOutput (ServerOutput (InvalidInput))
+import Hydra.Party (Party)
+import Hydra.ServerOutput (ServerOutput (Greetings, InvalidInput))
 import Network.WebSockets (
   acceptRequest,
   receiveData,
@@ -59,11 +60,12 @@ withAPIServer ::
   Tx tx =>
   IP ->
   PortNumber ->
+  Party ->
   Tracer IO APIServerLog ->
   ServerComponent tx IO ()
-withAPIServer host port tracer callback action = do
+withAPIServer host port party tracer callback action = do
   responseChannel <- newBroadcastTChanIO
-  history <- newTVarIO []
+  history <- newTVarIO [Greetings party]
   race_
     (runAPIServer host port tracer history callback responseChannel)
     . action

--- a/hydra-node/src/Hydra/ServerOutput.hs
+++ b/hydra-node/src/Hydra/ServerOutput.hs
@@ -25,6 +25,10 @@ data ServerOutput tx
   | SnapshotConfirmed {snapshot :: Snapshot tx}
   | Utxo {utxo :: Utxo tx}
   | InvalidInput {reason :: String, input :: Text}
+  | -- | A friendly welcome message which tells a client something about the
+    -- node. Currently used for knowing what signing key the server uses (it
+    -- only knows one).
+    Greetings {me :: Party}
   deriving (Generic)
 
 deriving instance Tx tx => Eq (ServerOutput tx)
@@ -52,3 +56,4 @@ instance (Arbitrary tx, Arbitrary (Utxo tx)) => Arbitrary (ServerOutput tx) wher
     SnapshotConfirmed s -> SnapshotConfirmed <$> shrink s
     Utxo u -> Utxo <$> shrink u
     InvalidInput r i -> InvalidInput <$> shrink r <*> shrink i
+    Greetings me -> Greetings <$> shrink me

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -190,6 +190,8 @@ handleAppEvent s = \case
     s & clientStateL .~ Connected
   ClientDisconnected ->
     s & clientStateL .~ Disconnected
+  Update Greetings{me} ->
+    s & meL ?~ me
   Update (PeerConnected p) ->
     s & peersL %~ \cp -> nub $ cp <> [p]
   Update (PeerDisconnected p) ->
@@ -367,16 +369,27 @@ draw s =
       vBox
         [ padLeftRight 1 tuiVersion
         , padLeftRight 1 nodeStatus
+        , hBorder
+        , padLeftRight 1 ownParty
         , padLeftRight 1 ownAddress
-        , hBorder <=> padLeftRight 1 drawPeers
-        , hBorder <=> padLeftRight 1 drawParties
+        , hBorder
+        , padLeftRight 1 drawPeers
+        , hBorder
+        , padLeftRight 1 drawParties
         ]
    where
     tuiVersion = str "Hydra TUI  " <+> withAttr info (str (showVersion version))
+
+    ownParty =
+      case s ^. meL of
+        Nothing -> emptyWidget
+        Just me -> str "Party " <+> txt (show me)
+
     ownAddress =
       case s ^. meL of
         Nothing -> emptyWidget
         Just me -> str "Address " <+> withAttr info (txt $ encodeAddress (getAddress me))
+
     nodeStatus =
       case s ^. clientStateL of
         Disconnected -> withAttr negative $ str $ "Connecting to " <> show (s ^. nodeHostL)

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -64,6 +64,10 @@ data State = State
   , feedback :: Maybe UserFeedback
   }
 
+-- XXX(SN): This is what I had tried to avoid in the past.. refactor back into a
+-- "make impossible states unrepresentable". Allowing 'Disconnected' + other
+-- info we still have around in the 'State' brings us into the uncomfortable
+-- situation of needing to decide which of the values are not stale.
 data ClientState = Connected | Disconnected
 
 data DialogState where
@@ -365,9 +369,9 @@ draw s =
     tuiVersion = str "Hydra TUI  " <+> withAttr info (str (showVersion version))
     ownAddress = str "Address " <+> withAttr info (str $ toString $ encodeAddress (getAddress (s ^. meL)))
     nodeStatus =
-      str "Node " <+> case s ^. clientStateL of
-        Disconnected -> withAttr negative $ str $ show (s ^. meL)
-        Connected -> withAttr positive $ str $ show (s ^. meL)
+      case s ^. clientStateL of
+        Disconnected -> withAttr negative $ str $ "Connecting to " <> show (s ^. meL)
+        Connected -> withAttr positive $ str $ "Connected to " <> show (s ^. meL)
 
   drawRightPanel =
     case s ^? dialogStateL of

--- a/nix/hydra-poc.materialized/.plan.nix/hydra-node.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/hydra-node.nix
@@ -51,6 +51,7 @@
           (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
           (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
           (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+          (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
           (hsPkgs."gitrev" or (errorHandler.buildDepError "gitrev"))
           (hsPkgs."hydra-plutus" or (errorHandler.buildDepError "hydra-plutus"))
           (hsPkgs."hydra-prelude" or (errorHandler.buildDepError "hydra-prelude"))
@@ -105,6 +106,7 @@
           "Hydra/Node"
           "Hydra/Node/Version"
           "Hydra/Options"
+          "Hydra/Party"
           "Hydra/ServerOutput"
           "Hydra/Snapshot"
           ];
@@ -203,6 +205,7 @@
             "Hydra/NetworkSpec"
             "Hydra/NodeSpec"
             "Hydra/OptionsSpec"
+            "Hydra/PartySpec"
             "Hydra/ServerOutputSpec"
             "Hydra/SnapshotStrategySpec"
             "Paths_hydra_node"

--- a/nix/hydra-poc.materialized/.plan.nix/hydra-plutus.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/hydra-plutus.nix
@@ -35,6 +35,7 @@
         depends = [
           (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."base16-bytestring" or (errorHandler.buildDepError "base16-bytestring"))
           (hsPkgs."cardano-crypto-class" or (errorHandler.buildDepError "cardano-crypto-class"))
           (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
           (hsPkgs."directory" or (errorHandler.buildDepError "directory"))

--- a/nix/hydra-poc.materialized/default.nix
+++ b/nix/hydra-poc.materialized/default.nix
@@ -894,7 +894,7 @@
           "cardano-crypto-praos" = {
             flags = {
               "development" = lib.mkOverride 900 false;
-              "external-libsodium-vrf" = lib.mkOverride 900 false;
+              "external-libsodium-vrf" = lib.mkOverride 900 true;
               };
             };
           "monoidal-synchronisation" = { flags = {}; };
@@ -909,7 +909,7 @@
             flags = { "defer-plugin-errors" = lib.mkOverride 900 false; };
             };
           "local-cluster" = {
-            flags = { "development" = lib.mkOverride 900 false; };
+            flags = { "development" = lib.mkOverride 900 true; };
             };
           "typed-protocols-examples" = { flags = {}; };
           "cardano-crypto-tests" = {
@@ -971,13 +971,13 @@
               };
             };
           "hydra-tui" = {
-            flags = { "development" = lib.mkOverride 900 false; };
+            flags = { "development" = lib.mkOverride 900 true; };
             };
           "ouroboros-consensus-byron" = {
             flags = { "asserts" = lib.mkOverride 900 false; };
             };
           "hydra-node" = {
-            flags = { "development" = lib.mkOverride 900 false; };
+            flags = { "development" = lib.mkOverride 900 true; };
             };
           "contra-tracer" = { flags = {}; };
           "orphans-deriving-via" = {


### PR DESCRIPTION
Based on https://github.com/input-output-hk/hydra-poc/pull/83

This changes the TUI to construct transactions (and Utxos) from a `Party` instead of a `Host` (or rather it's port), such that we can now send some value to a `bob@0000000000000033` instead of `127.0.0.1:5002`.

Although it requires the additional knowledge of which party is `me`, the transaction construction feels more natural (to me at least) and only "conflates" Hydra keys with Cardano / In-Head keys. I moved exactly this conversion / short-cut into `Hydra.Ledger.Cardano` because it requires some internal knowledge of `Party` to effectively perform `Party -> CardanoKeyPair` etc.

This is how an Open Head is rendered (yellow are "own" keys/addresses):
![image](https://user-images.githubusercontent.com/2621189/133164505-a9a8041d-08b4-4da3-9afe-58f1855d08bd.png)

And this is now the changed pick a recipient:
![image](https://user-images.githubusercontent.com/2621189/133164581-cad07404-385b-4bdb-9b5e-74a41a18175e.png)
