### PR TITLE
InitTx roundtrip of posting and observing

### DIFF
--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -230,6 +230,7 @@ test-suite tests
     , cardano-ledger-alonzo
     , cardano-ledger-alonzo-test
     , cardano-ledger-core
+    , cardano-ledger-shelley-ma
     , cardano-ledger-shelley-ma-test
     , cborg
     , containers

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -146,6 +146,7 @@ library
     , ouroboros-network-framework
     , plutus-contract
     , plutus-ledger
+    , plutus-ledger-api
     , plutus-pab
     , prometheus
     , QuickCheck
@@ -226,6 +227,7 @@ test-suite tests
     , bytestring
     , cardano-binary
     , cardano-crypto-class
+    , cardano-ledger-alonzo
     , cardano-ledger-alonzo-test
     , cardano-ledger-core
     , cardano-ledger-shelley-ma-test
@@ -250,6 +252,7 @@ test-suite tests
     , lens-aeson
     , network
     , ouroboros-network-framework
+    , plutus-ledger-api
     , process
     , QuickCheck
     , quickcheck-instances

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -112,7 +112,6 @@ library
     , bech32-th
     , bytestring
     , cardano-api
-    , cardano-api:gen
     , cardano-binary
     , cardano-crypto-class
     , cardano-ledger-alonzo
@@ -224,10 +223,10 @@ test-suite tests
   build-depends:
     , aeson
     , base
-    , cardano-api
-    , cardano-api:gen
+    , bytestring
     , cardano-binary
     , cardano-crypto-class
+    , cardano-ledger-alonzo-test
     , cardano-ledger-core
     , cardano-ledger-shelley-ma-test
     , cborg
@@ -236,7 +235,6 @@ test-suite tests
     , cryptonite
     , data-default
     , filepath
-    , hedgehog-quickcheck
     , hspec
     , hspec-core
     , hspec-golden-aeson

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -11,8 +11,6 @@ module Hydra.Chain.Direct (
 
 import Hydra.Prelude
 
-import Cardano.Api (TxBodyError, makeTransactionBody, signShelleyTransaction)
-import qualified Cardano.Api.Shelley as Api
 import Cardano.Chain.Slotting (EpochSlots (..))
 import Cardano.Ledger.Alonzo.Tx (ValidatedTx)
 import Cardano.Ledger.Alonzo.TxSeq (txSeqTxns)
@@ -32,7 +30,6 @@ import Data.Map.Strict ((!))
 import qualified Data.Map.Strict as Map
 import Data.Sequence.Strict (StrictSeq)
 import qualified Data.Sequence.Strict as StrictSeq
-import Gen.Cardano.Api.Typed (genTxIn)
 import Hydra.Chain (
   Chain (..),
   ChainCallback,
@@ -40,7 +37,7 @@ import Hydra.Chain (
   OnChainTx (..),
   PostChainTx (..),
  )
-import Hydra.Chain.Direct.Tx (constructTx)
+import Hydra.Chain.Direct.Tx (constructTx, mkUnsignedTx)
 import Hydra.Ledger.Cardano (generateWith)
 import Hydra.Logging (Tracer)
 import Ouroboros.Consensus.Byron.Ledger.Config (CodecConfig (..))
@@ -126,7 +123,6 @@ import Ouroboros.Network.Server.RateLimiting (AcceptedConnectionsLimit (..))
 import Ouroboros.Network.Socket (SomeResponderApplication (..), withServerNode)
 import qualified Shelley.Spec.Ledger.API as Ledger
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
-import Test.QuickCheck.Hedgehog (hedgehog)
 
 withDirectChain ::
   -- | Tracer for logging
@@ -259,9 +255,7 @@ txSubmissionClient queue =
   clientStIdle :: m (LocalTxClientStIdle (GenTx Block) (ApplyTxErr Block) m ())
   clientStIdle = do
     tx <- atomically $ readTQueue queue
-    case fromPostChainTx tx of
-      Left err -> error $ "failed to construct transaction: " <> show err
-      Right genTx -> pure $ SendMsgSubmitTx genTx (const clientStIdle)
+    pure $ SendMsgSubmitTx (fromPostChainTx tx) (const clientStIdle)
 
   -- FIXME
   -- This is where we need signatures and client credentials. Ideally, we would
@@ -269,14 +263,12 @@ txSubmissionClient queue =
   -- The hydra node could provide a pre-filled transaction body, and let the
   -- client submit a signed transaction.
   --
-  -- For now, it simply does not signs with no keys..
-  fromPostChainTx :: PostChainTx tx -> Either TxBodyError (GenTx Block)
+  -- For now, it simply does not sign..
+  fromPostChainTx :: PostChainTx tx -> GenTx Block
   fromPostChainTx postChainTx = do
-    let txIn = generateWith (hedgehog genTxIn) 42
-        txBodyContents = constructTx txIn postChainTx
-    makeTransactionBody txBodyContents <&> \txBody ->
-      case signShelleyTransaction txBody [] of
-        (Api.ShelleyTx _ tx) -> GenTxAlonzo $ mkShelleyTx tx
+    let txIn = generateWith arbitrary 42
+        body = constructTx txIn postChainTx
+    GenTxAlonzo $ mkShelleyTx $ mkUnsignedTx body
 
 --
 -- Mock Server

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -37,7 +37,7 @@ import Hydra.Chain (
   OnChainTx (..),
   PostChainTx (..),
  )
-import Hydra.Chain.Direct.Tx (constructTx, mkUnsignedTx)
+import Hydra.Chain.Direct.Tx (constructTx)
 import Hydra.Ledger.Cardano (generateWith)
 import Hydra.Logging (Tracer)
 import Ouroboros.Consensus.Byron.Ledger.Config (CodecConfig (..))
@@ -267,8 +267,8 @@ txSubmissionClient queue =
   fromPostChainTx :: PostChainTx tx -> GenTx Block
   fromPostChainTx postChainTx = do
     let txIn = generateWith arbitrary 42
-        body = constructTx txIn postChainTx
-    GenTxAlonzo $ mkShelleyTx $ mkUnsignedTx body
+        unsignedTx = constructTx txIn postChainTx
+    GenTxAlonzo $ mkShelleyTx unsignedTx
 
 --
 -- Mock Server

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -34,7 +34,6 @@ import Hydra.Chain (
   Chain (..),
   ChainCallback,
   ChainComponent,
-  OnChainTx (..),
   PostChainTx (..),
  )
 import Hydra.Chain.Direct.Tx (constructTx, observeTx)

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -8,107 +8,78 @@ module Hydra.Chain.Direct.Tx where
 
 import Hydra.Prelude
 
-import Cardano.Api (
-  AlonzoEra,
-  BuildTx,
-  BuildTxWith (..),
-  KeyWitnessInCtx (..),
-  MultiAssetSupportedInEra (MultiAssetInAlonzoEra),
-  NetworkId (Testnet),
-  NetworkMagic (NetworkMagic),
-  PaymentCredential (PaymentCredentialByScript),
-  PlutusScriptVersion (PlutusScriptV1),
-  Script (PlutusScript),
-  ScriptData (ScriptDataNumber),
-  ScriptDataSupportedInEra (ScriptDataInAlonzoEra),
-  StakeAddressReference (NoStakeAddress),
-  TxAuxScripts (..),
-  TxBodyContent (..),
-  TxCertificates (..),
-  TxExtraKeyWitnesses (..),
-  TxExtraScriptData (..),
-  TxFee (TxFeeExplicit),
-  TxFeesExplicitInEra (..),
-  TxIn,
-  TxInsCollateral (..),
-  TxMetadataInEra (..),
-  TxMintValue (..),
-  TxOut (TxOut),
-  TxOutDatumHash (TxOutDatumHash),
-  TxOutValue (TxOutValue),
-  TxScriptValidity (..),
-  TxUpdateProposal (..),
-  TxValidityLowerBound (..),
-  TxValidityUpperBound (..),
-  TxWithdrawals (..),
-  ValidityNoUpperBoundSupportedInEra (..),
-  WitCtx (WitCtxTxIn),
-  Witness (KeyWitness),
-  examplePlutusScriptAlwaysSucceeds,
-  hashScript,
-  hashScriptData,
-  lovelaceToValue,
-  makeShelleyAddressInEra,
- )
+import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Alonzo.Tx (IsValid (IsValid), ValidatedTx (..))
+import Cardano.Ledger.Alonzo.TxBody (TxBody (..))
+import Cardano.Ledger.Alonzo.TxWitness (Redeemers (..), TxDats (..), TxWitness (..))
+import Cardano.Ledger.Crypto (StandardCrypto)
+import Cardano.Ledger.ShelleyMA.Timelocks (ValidityInterval (..))
+import qualified Data.Set as Set
 import Hydra.Chain (HeadParameters, PostChainTx (InitTx))
+import Shelley.Spec.Ledger.API (Coin (..), StrictMaybe (..), TxIn, Wdrl (Wdrl))
 
 -- * Hydra Head transactions
 
--- TODO(SN) parameterize this
-networkId :: NetworkId
-networkId = Testnet $ NetworkMagic 42
+mkUnsignedTx :: TxBody (AlonzoEra StandardCrypto) -> ValidatedTx (AlonzoEra StandardCrypto)
+mkUnsignedTx body =
+  ValidatedTx
+    { body
+    , wits =
+        TxWitness
+          mempty -- txwitsVKey
+          mempty -- txwitsBoot
+          mempty --txscripts
+          (TxDats mempty) -- txdats
+          (Redeemers mempty) -- txrdmrs
+    , isValid = IsValid True -- REVIEW(SN): no idea of the semantics of this
+    , auxiliaryData = SNothing
+    }
 
-constructTx :: TxIn -> PostChainTx tx -> TxBodyContent BuildTx AlonzoEra
+constructTx :: TxIn StandardCrypto -> PostChainTx tx -> TxBody (AlonzoEra StandardCrypto)
 constructTx txIn = \case
   InitTx p -> initTx p txIn
   _ -> error "not implemented"
 
--- | Smart constructors for 'TxBodyContent' which should be used with
--- 'makeTransactionBodyAutoBalance' to balance and account for fees accordingly.
-
 -- | Create the init transaction from some 'HeadParameters' and a single UTXO
 -- which will be used for minting NFTs.
-initTx :: HeadParameters -> TxIn -> TxBodyContent BuildTx AlonzoEra
+initTx :: HeadParameters -> TxIn StandardCrypto -> TxBody (AlonzoEra StandardCrypto)
 initTx _ txIn =
-  TxBodyContent
-    { txIns = [(txIn, BuildTxWith (KeyWitness KeyWitnessForSpending))]
-    , txInsCollateral = TxInsCollateralNone
-    , txOuts = [headOut]
-    , txFee = TxFeeExplicit TxFeesExplicitInAlonzoEra 0
-    , txValidityRange = (TxValidityNoLowerBound, TxValidityNoUpperBound ValidityNoUpperBoundInAlonzoEra)
-    , txMetadata = TxMetadataNone
-    , txAuxScripts = TxAuxScriptsNone
-    , txExtraScriptData = BuildTxWith TxExtraScriptDataNone
-    , txExtraKeyWits = TxExtraKeyWitnessesNone
-    , txProtocolParams = BuildTxWith Nothing
-    , txWithdrawals = TxWithdrawalsNone
-    , txCertificates = TxCertificatesNone
-    , txUpdateProposal = TxUpdateProposalNone
-    , txMintValue = TxMintNone
-    , txScriptValidity = BuildTxWith TxScriptValidityNone
-    }
- where
-  headOut = TxOut headAddress headValue headDatumHash
+  TxBody
+    (Set.singleton txIn) -- inputs
+    mempty -- collateral
+    mempty -- outputs
+    mempty -- txcerts
+    (Wdrl mempty) -- txwdrls
+    (Coin 0) -- txfee
+    (ValidityInterval SNothing SNothing) -- txvldt
+    SNothing -- txUpdates
+    mempty -- reqSignerHashes
+    mempty -- mint
+    SNothing -- scriptIntegrityHash
+    SNothing -- adHash
+    SNothing -- txnetworkid
+    -- where
+    --  headOut = TxOut headAddress headValue headDatumHash
 
-  -- TODO(SN): The main Hydra Head script address. Will be parameterized by the
-  -- thread token eventually. For now, this is just some arbitrary address, as
-  -- it is also later quite arbitrary/different per Head.
-  headAddress =
-    makeShelleyAddressInEra
-      networkId
-      (PaymentCredentialByScript $ hashScript headScript)
-      -- REVIEW(SN): stake head funds?
-      NoStakeAddress
+--  -- TODO(SN): The main Hydra Head script address. Will be parameterized by the
+--  -- thread token eventually. For now, this is just some arbitrary address, as
+--  -- it is also later quite arbitrary/different per Head.
+--  headAddress =
+--    makeShelleyAddressInEra
+--      networkId
+--      (PaymentCredentialByScript $ hashScript headScript)
+--      -- REVIEW(SN): stake head funds?
+--      NoStakeAddress
 
-  headScript =
-    PlutusScript PlutusScriptV1 $
-      examplePlutusScriptAlwaysSucceeds WitCtxTxIn
+--  headScript =
+--    PlutusScript PlutusScriptV1 $
+--      examplePlutusScriptAlwaysSucceeds WitCtxTxIn
 
-  -- REVIEW(SN): do we need to consider min utxo value? that would also depend
-  -- on how many assets present in an output
-  headValue = TxOutValue MultiAssetInAlonzoEra $ lovelaceToValue 10
+--  -- REVIEW(SN): do we need to consider min utxo value? that would also depend
+--  -- on how many assets present in an output
+--  headValue = TxOutValue MultiAssetInAlonzoEra $ lovelaceToValue 10
 
-  headDatumHash = TxOutDatumHash ScriptDataInAlonzoEra $ hashScriptData headDatum
+--  headDatumHash = TxOutDatumHash ScriptDataInAlonzoEra $ hashScriptData headDatum
 
-  -- TODO(SN): how to convert plutus 'Datum' to 'cardano-api' re-/serialize?
-  headDatum = ScriptDataNumber 1337
+--  -- TODO(SN): how to convert plutus 'Datum' to 'cardano-api' re-/serialize?
+--  headDatum = ScriptDataNumber 1337

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -55,28 +55,29 @@ constructTx txIn = \case
   InitTx p -> initTx p txIn
   _ -> error "not implemented"
 
--- | Create the init transaction from some 'HeadParameters' and a single UTXO
--- which will be used for minting NFTs.
+-- | Create the init transaction from some 'HeadParameters' and a single TxIn
+-- which will be used as unique parameter for minting NFTs.
 initTx :: HeadParameters -> TxIn StandardCrypto -> ValidatedTx (AlonzoEra StandardCrypto)
 initTx HeadParameters{contestationPeriod, parties} txIn =
   mkUnsignedTx body dats
  where
   body =
     TxBody
-      (Set.singleton txIn) -- inputs
-      mempty -- collateral
-      (StrictSeq.singleton headOut) -- outputs
-      mempty -- txcerts
-      (Wdrl mempty) -- txwdrls
-      (Coin 0) -- txfee
-      (ValidityInterval SNothing SNothing) -- txvldt
-      SNothing -- txUpdates
-      mempty -- reqSignerHashes
-      mempty -- mint
-      SNothing -- scriptIntegrityHash
-      SNothing -- adHash
-      SNothing -- txnetworkid
-      --
+      { inputs = Set.singleton txIn
+      , collateral = mempty
+      , outputs = StrictSeq.singleton headOut
+      , txcerts = mempty
+      , txwdrls = Wdrl mempty
+      , txfee = Coin 0
+      , txvldt = ValidityInterval SNothing SNothing
+      , txUpdates = SNothing
+      , reqSignerHashes = mempty
+      , mint = mempty
+      , scriptIntegrityHash = SNothing
+      , adHash = SNothing
+      , txnetworkid = SNothing
+      }
+
   dats = TxDats $ Map.singleton headDatumHash headDatum
 
   headOut = TxOut headAddress headValue (SJust headDatumHash)

--- a/hydra-node/src/Hydra/Party.hs
+++ b/hydra-node/src/Hydra/Party.hs
@@ -90,6 +90,12 @@ instance Num Party where
   signum = error "Party is not a proper Num"
   (-) = error "Party is not a proper Num"
 
+anonymousParty :: VerificationKey -> Party
+anonymousParty = Party Nothing
+
+deriveParty :: SigningKey -> Party
+deriveParty = anonymousParty . deriveVerKeyDSIGN
+
 type VerificationKey = VerKeyDSIGN MockDSIGN
 
 instance ToJSON VerificationKey where
@@ -105,9 +111,6 @@ showVerificationKey :: VerificationKey -> Text
 showVerificationKey = decodeUtf8 . Base16.encode . rawSerialiseVerKeyDSIGN
 
 type SigningKey = SignKeyDSIGN MockDSIGN
-
-deriveParty :: SigningKey -> Party
-deriveParty = Party Nothing . deriveVerKeyDSIGN
 
 generateKey :: Integer -> SigningKey
 generateKey = fromInteger

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -6,37 +6,26 @@ import Hydra.Prelude
 import Test.Hydra.Prelude
 
 import Cardano.Binary (serialize)
+import Cardano.Ledger.Alonzo.Tx (ValidatedTx (ValidatedTx, wits))
+import Cardano.Ledger.Alonzo.TxWitness (TxWitness (TxWitness, txdats), nullDats, unTxDats)
 import qualified Data.ByteString.Lazy as LBS
-import Hydra.Chain.Direct.Tx (initTx, mkUnsignedTx)
+import Hydra.Chain.Direct.Tx (initTx)
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
-import Test.QuickCheck (counterexample)
+import Test.QuickCheck (Testable (property), counterexample)
 
 spec :: Spec
 spec =
   parallel $
     describe "initTx" $ do
-      prop "can construct & serialize unsigned initTx" $ \params txIn ->
-        let tx = mkUnsignedTx $ initTx params txIn
+      prop "can construct & serialize unsigned initTx" $ \txIn params ->
+        let tx = initTx params txIn
             cbor = serialize tx
             len = LBS.length cbor
          in counterexample ("Tx: " <> show tx) $
               counterexample ("Cbor: " <> show cbor) $ len > 0
 
---       prop "contains HeadParameters as datum" $ \params ->
---         forAll (hedgehog genTxIn) $ \txIn ->
---           case makeTransactionBody $ initTx params txIn of
---             Left err -> counterexample ("TxBodyError: " <> show err) False
---             Right (TxBody content) ->
---               let outs = txOuts content
---                   datumHashes = mapMaybe datumHash outs
---                in counterexample ("txOuts: " <> show outs) $
---                     counterexample ("datumHashes: " <> show datumHashes) $
---                       -- TODO(SN): we could check that the hash corresponds to
---                       -- what we expect here, but the Tx won't contain the
---                       -- `Datum` itself.. so no point in continuing here
---                       length datumHashes == 1
-
--- datumHash :: TxOut AlonzoEra -> Maybe (Hash ScriptData)
--- datumHash = \case
---   (TxOut _ _ (TxOutDatumHash _ h)) -> Just h
---   _ -> Nothing
+      prop "contains some datums" $ \txIn params ->
+        let ValidatedTx{wits} = initTx params txIn
+            dats = txdats wits
+         in counterexample ("TxDats: " <> show dats) $
+              not $ nullDats dats

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TypeApplications #-}
+
 -- | Unit tests for our "hand-rolled" transactions as they are used in the
 -- "direct" chain component.
 module Hydra.Chain.Direct.TxSpec where
@@ -8,7 +9,7 @@ import Test.Hydra.Prelude
 
 import Cardano.Binary (serialize)
 import Cardano.Ledger.Alonzo.Data (Data (Data))
-import Cardano.Ledger.Alonzo.Tx (ValidatedTx (ValidatedTx, wits))
+import Cardano.Ledger.Alonzo.Tx (ValidatedTx (ValidatedTx, wits, body), outputs)
 import Cardano.Ledger.Alonzo.TxWitness (TxWitness (txdats), nullDats, unTxDats)
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map as Map
@@ -22,6 +23,11 @@ import Plutus.V1.Ledger.Api (toBuiltinData, toData)
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
 import Test.QuickCheck (counterexample, (===))
 import Hydra.Ledger.Simple (SimpleTx)
+import Hydra.Chain.Direct (Era)
+import Cardano.Ledger.Mary.Value (Value(Value), PolicyID, AssetName)
+import Cardano.Ledger.Alonzo (TxOut)
+import Cardano.Ledger.Alonzo.TxBody (TxOut(TxOut))
+import Cardano.Ledger.Crypto (StandardCrypto)
 
 spec :: Spec
 spec =
@@ -52,3 +58,24 @@ spec =
             onChainParties = map (partyFromVerKey . vkey) parties
             datum = Initial onChainPeriod onChainParties
          in Map.elems (unTxDats dats) === [Data . toData $ toBuiltinData datum]
+
+      -- TODO(SN): assert monetary policy?
+      prop "distributes participation tokens" $ \txIn params ->
+        let ValidatedTx{body} = initTx params txIn
+            nfts = foldMap txOutNFT $ outputs body
+         in counterexample ("NFTs: " <> show nfts) $
+            length nfts == length (parties params)
+
+-- | Extract NFT candidates. any single quantity assets not being ADA is a
+-- candidate.
+txOutNFT :: TxOut Era -> [(PolicyID StandardCrypto, AssetName)]
+txOutNFT (TxOut _ value _ ) =
+  mapMaybe findUnitAssets $ Map.toList assets
+ where
+  (Value _ assets) = value
+
+  findUnitAssets (policy, as) = do
+    (name, _q) <- find unitQuantity $ Map.toList as
+    pure (policy, name)
+
+  unitQuantity (_name,q) = q == 1

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -26,7 +26,7 @@ import Hydra.Ledger.Simple (SimpleTx)
 spec :: Spec
 spec =
   parallel $ do
-    prop "observeTx . constructTx rountrip" $ \postTx txIn time ->
+    prop "observeTx . constructTx roundtrip" $ \postTx txIn time ->
       observeTx (constructTx txIn postTx) === Just (toOnChainTx @SimpleTx time postTx)
 
     describe "initTx" $ do

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -6,9 +6,17 @@ import Hydra.Prelude
 import Test.Hydra.Prelude
 
 import Cardano.Api (
+  AlonzoEra,
+  Hash,
+  ScriptData,
+  TxBody (TxBody),
+  TxBodyContent (txOuts),
+  TxOut (TxOut),
+  TxOutDatumHash (TxOutDatumHash),
   makeTransactionBody,
  )
 import Gen.Cardano.Api.Typed (genTxIn)
+import Hydra.Chain (HeadParameters (HeadParameters, parties))
 import Hydra.Chain.Direct.Tx (initTx)
 import Test.QuickCheck (counterexample, forAll, property)
 import Test.QuickCheck.Hedgehog (hedgehog)
@@ -22,3 +30,22 @@ spec =
           case makeTransactionBody $ initTx params txIn of
             Left err -> counterexample ("TxBodyError: " <> show err) False
             Right _ -> property True
+
+      prop "contains HeadParameters as datum" $ \params ->
+        forAll (hedgehog genTxIn) $ \txIn ->
+          case makeTransactionBody $ initTx params txIn of
+            Left err -> counterexample ("TxBodyError: " <> show err) False
+            Right (TxBody content) ->
+              let outs = txOuts content
+                  datumHashes = mapMaybe datumHash outs
+               in counterexample ("txOuts: " <> show outs) $
+                    counterexample ("datumHashes: " <> show datumHashes) $
+                      -- TODO(SN): we could check that the hash corresponds to
+                      -- what we expect here, but the Tx won't contain the
+                      -- `Datum` itself.. so no point in continuing here
+                      length datumHashes == 1
+
+datumHash :: TxOut AlonzoEra -> Maybe (Hash ScriptData)
+datumHash = \case
+  (TxOut _ _ (TxOutDatumHash _ h)) -> Just h
+  _ -> Nothing

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeApplications #-}
 -- | Unit tests for our "hand-rolled" transactions as they are used in the
 -- "direct" chain component.
 module Hydra.Chain.Direct.TxSpec where
@@ -11,8 +12,8 @@ import Cardano.Ledger.Alonzo.Tx (ValidatedTx (ValidatedTx, wits))
 import Cardano.Ledger.Alonzo.TxWitness (TxWitness (txdats), nullDats, unTxDats)
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map as Map
-import Hydra.Chain (HeadParameters (..))
-import Hydra.Chain.Direct.Tx (initTx)
+import Hydra.Chain (HeadParameters (..), toOnChainTx)
+import Hydra.Chain.Direct.Tx (initTx, observeTx, constructTx)
 import Hydra.Contract.ContestationPeriod (contestationPeriodFromDiffTime)
 import Hydra.Contract.Head (State (Initial))
 import Hydra.Contract.Party (partyFromVerKey)
@@ -20,17 +21,22 @@ import Hydra.Party (vkey)
 import Plutus.V1.Ledger.Api (toBuiltinData, toData)
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
 import Test.QuickCheck (counterexample, (===))
+import Hydra.Ledger.Simple (SimpleTx)
 
 spec :: Spec
 spec =
-  parallel $
+  parallel $ do
+    prop "observeTx . constructTx rountrip" $ \postTx txIn time ->
+      observeTx (constructTx txIn postTx) === Just (toOnChainTx @SimpleTx time postTx)
+
     describe "initTx" $ do
       prop "can construct & serialize unsigned initTx" $ \txIn params ->
         let tx = initTx params txIn
             cbor = serialize tx
             len = LBS.length cbor
          in counterexample ("Tx: " <> show tx) $
-              counterexample ("Cbor: " <> show cbor) $ len > 0
+              counterexample ("Tx serialized size: " <> show len) $
+                len < 16000 -- TODO(SN): use real max tx size
 
       prop "contains some datums" $ \txIn params ->
         let ValidatedTx{wits} = initTx params txIn

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -5,47 +5,38 @@ module Hydra.Chain.Direct.TxSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import Cardano.Api (
-  AlonzoEra,
-  Hash,
-  ScriptData,
-  TxBody (TxBody),
-  TxBodyContent (txOuts),
-  TxOut (TxOut),
-  TxOutDatumHash (TxOutDatumHash),
-  makeTransactionBody,
- )
-import Gen.Cardano.Api.Typed (genTxIn)
-import Hydra.Chain (HeadParameters (HeadParameters, parties))
-import Hydra.Chain.Direct.Tx (initTx)
-import Test.QuickCheck (counterexample, forAll, property)
-import Test.QuickCheck.Hedgehog (hedgehog)
+import Cardano.Binary (serialize)
+import qualified Data.ByteString.Lazy as LBS
+import Hydra.Chain.Direct.Tx (initTx, mkUnsignedTx)
+import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
+import Test.QuickCheck (counterexample)
 
 spec :: Spec
 spec =
   parallel $
     describe "initTx" $ do
-      prop "can be used to construct a non-balanced TxBody" $ \params ->
-        forAll (hedgehog genTxIn) $ \txIn ->
-          case makeTransactionBody $ initTx params txIn of
-            Left err -> counterexample ("TxBodyError: " <> show err) False
-            Right _ -> property True
+      prop "can construct & serialize unsigned initTx" $ \params txIn ->
+        let tx = mkUnsignedTx $ initTx params txIn
+            cbor = serialize tx
+            len = LBS.length cbor
+         in counterexample ("Tx: " <> show tx) $
+              counterexample ("Cbor: " <> show cbor) $ len > 0
 
-      prop "contains HeadParameters as datum" $ \params ->
-        forAll (hedgehog genTxIn) $ \txIn ->
-          case makeTransactionBody $ initTx params txIn of
-            Left err -> counterexample ("TxBodyError: " <> show err) False
-            Right (TxBody content) ->
-              let outs = txOuts content
-                  datumHashes = mapMaybe datumHash outs
-               in counterexample ("txOuts: " <> show outs) $
-                    counterexample ("datumHashes: " <> show datumHashes) $
-                      -- TODO(SN): we could check that the hash corresponds to
-                      -- what we expect here, but the Tx won't contain the
-                      -- `Datum` itself.. so no point in continuing here
-                      length datumHashes == 1
+--       prop "contains HeadParameters as datum" $ \params ->
+--         forAll (hedgehog genTxIn) $ \txIn ->
+--           case makeTransactionBody $ initTx params txIn of
+--             Left err -> counterexample ("TxBodyError: " <> show err) False
+--             Right (TxBody content) ->
+--               let outs = txOuts content
+--                   datumHashes = mapMaybe datumHash outs
+--                in counterexample ("txOuts: " <> show outs) $
+--                     counterexample ("datumHashes: " <> show datumHashes) $
+--                       -- TODO(SN): we could check that the hash corresponds to
+--                       -- what we expect here, but the Tx won't contain the
+--                       -- `Datum` itself.. so no point in continuing here
+--                       length datumHashes == 1
 
-datumHash :: TxOut AlonzoEra -> Maybe (Hash ScriptData)
-datumHash = \case
-  (TxOut _ _ (TxOutDatumHash _ h)) -> Just h
-  _ -> Nothing
+-- datumHash :: TxOut AlonzoEra -> Maybe (Hash ScriptData)
+-- datumHash = \case
+--   (TxOut _ _ (TxOutDatumHash _ h)) -> Just h
+--   _ -> Nothing

--- a/hydra-node/test/Hydra/Chain/DirectSpec.hs
+++ b/hydra-node/test/Hydra/Chain/DirectSpec.hs
@@ -38,17 +38,12 @@ spec = parallel $ do
         withDirectChain nullTracer networkMagic socket (putMVar calledBackAlice) $ \Chain{postTx} -> do
           calledBackBob <- newEmptyMVar
           withDirectChain nullTracer networkMagic socket (putMVar calledBackBob) $ \_ -> do
-            -- TODO: The server is still a mock at the moment, and returns
-            -- dummy data, but ideally we should have something like:
-            --
-            --   let paramaeters = HeadParameters 100 [alice, bob, carol]
-            --
-            let parameters = HeadParameters 42 []
+            let parameters = HeadParameters 100 [alice, bob, carol]
             postTx $ InitTx @SimpleTx parameters
             failAfter 5 $
-              takeMVar calledBackAlice `shouldReturn` OnInitTx 42 []
+              takeMVar calledBackAlice `shouldReturn` OnInitTx 100 [alice, bob, carol]
             failAfter 5 $
-              takeMVar calledBackBob `shouldReturn` OnInitTx @SimpleTx 42 []
+              takeMVar calledBackBob `shouldReturn` OnInitTx @SimpleTx 100 [alice, bob, carol]
 
 -- | Mock implementation of for a Node-to-Client protocol server which should be
 -- accepting transactions and responding with new blocks containing them.

--- a/hydra-plutus/src/Hydra/Contract/ContestationPeriod.hs
+++ b/hydra-plutus/src/Hydra/Contract/ContestationPeriod.hs
@@ -25,3 +25,6 @@ instance FromJSON ContestationPeriod where
 instance ToJSON ContestationPeriod where
   toJSON =
     toJSON . picosecondsToDiffTime . picoseconds
+
+contestationPeriodFromDiffTime :: DiffTime -> ContestationPeriod
+contestationPeriodFromDiffTime = UnsafeContestationPeriod . diffTimeToPicoseconds

--- a/hydra-plutus/src/Hydra/Contract/ContestationPeriod.hs
+++ b/hydra-plutus/src/Hydra/Contract/ContestationPeriod.hs
@@ -28,3 +28,7 @@ instance ToJSON ContestationPeriod where
 
 contestationPeriodFromDiffTime :: DiffTime -> ContestationPeriod
 contestationPeriodFromDiffTime = UnsafeContestationPeriod . diffTimeToPicoseconds
+
+contestationPeriodToDiffTime :: ContestationPeriod -> DiffTime
+contestationPeriodToDiffTime cp =
+  picosecondsToDiffTime $ picoseconds cp

--- a/hydra-plutus/src/Hydra/Contract/Party.hs
+++ b/hydra-plutus/src/Hydra/Contract/Party.hs
@@ -37,8 +37,8 @@ instance FromJSON Party where
   parseJSON = withObject "Party" $ \o -> do
     vkeyHex :: Text <- o .: "vkey"
     vkeyBytes <- either fail pure . Base16.decode $ encodeUtf8 vkeyHex
-    (VerKeyMockDSIGN w) <- maybe (fail "deserialize verification key") pure $ rawDeserialiseVerKeyDSIGN vkeyBytes
-    pure $ UnsafeParty $ fromIntegral w
+    verKey <- maybe (fail "deserialize verification key") pure $ rawDeserialiseVerKeyDSIGN vkeyBytes
+    pure $ partyFromVerKey verKey
 
 instance ToSchema Party where
   toSchema = FormSchemaUnsupported "Party"
@@ -51,3 +51,6 @@ instance PlutusTx.FromData Party where
 
 instance PlutusTx.UnsafeFromData Party where
   unsafeFromBuiltinData = fromInteger . unsafeFromBuiltinData
+
+partyFromVerKey :: VerKeyDSIGN MockDSIGN -> Party
+partyFromVerKey (VerKeyMockDSIGN w) = UnsafeParty $ fromIntegral w


### PR DESCRIPTION
As expected, the tests asserting transaction structure feel like re-stating the implementation. The roundtrip property is a good start though. That + some property for running the validator (in haskell) against the `ValidatedTx` should do the trick though (assuming we test validators somewhere else?)