### PR TITLE
Revive the ExternalPAB by fixing it

### DIFF
--- a/hydra-node/src/Hydra/Chain/ExternalPAB.hs
+++ b/hydra-node/src/Hydra/Chain/ExternalPAB.hs
@@ -9,7 +9,7 @@ import Hydra.Prelude
 
 import Control.Monad.Class.MonadSTM (MonadSTMTx (takeTMVar, tryReadTMVar), newEmptyTMVarIO, putTMVar)
 import Control.Monad.Class.MonadSay (say)
-import Data.Aeson (Result (Error, Success), Value, eitherDecodeStrict)
+import Data.Aeson (Result (Error, Success), eitherDecodeStrict)
 import Data.Aeson.Types (fromJSON)
 import qualified Data.Map as Map
 import Hydra.Chain (
@@ -20,7 +20,7 @@ import Hydra.Chain (
   OnChainTx (..),
   PostChainTx (..),
  )
-import Hydra.Contract.PAB (ObservedTx (), PabContract (..), pabPort)
+import Hydra.Contract.PAB (PabContract (..), pabPort)
 import Hydra.Ledger (Tx, Utxo)
 import Hydra.Logging (Tracer)
 import Hydra.Party (Party)
@@ -144,7 +144,6 @@ postAbortTx wallet threadToken _utxo = do
   -- XXX(SN): stop contract instances?
   (ContractInstanceId cid) <- activateContract Abort wallet
   retryOnAnyHttpException $ do
-    say "send abort http request"
     runReq defaultHttpConfig $ do
       res <-
         req
@@ -174,7 +173,6 @@ initTxSubscriber wallet threadToken callback = do
   (ContractInstanceId cid) <- activateContract WatchInit wallet
   runClient "127.0.0.1" pabPort ("/ws/" <> show cid) $ \con -> forever $ do
     msg <- receiveData con
-    print msg
     case eitherDecodeStrict msg of
       Right (NewObservableState val) -> do
         case fromJSON val of

--- a/hydra-node/test/Hydra/Chain/ExternalPABSpec.hs
+++ b/hydra-node/test/Hydra/Chain/ExternalPABSpec.hs
@@ -18,7 +18,7 @@ import System.Process (CreateProcess (std_in, std_out), StdStream (CreatePipe, U
 import Test.QuickCheck (counterexample, property)
 
 spec :: Spec
-spec = parallel $ do
+spec = do
   -- We use slightly different types in off-chain and on-chain code, BUT, they
   -- have identical wire formats. We use (JSON) serialization as a mean to turn
   -- one into the other.

--- a/hydra-node/test/Hydra/Chain/ExternalPABSpec.hs
+++ b/hydra-node/test/Hydra/Chain/ExternalPABSpec.hs
@@ -41,7 +41,6 @@ spec = parallel $ do
 
   describe "ExternalPAB" $ do
     it "publishes init tx using wallet 1 and observes it also" $ do
-      pendingWith "fails currently"
       failAfter 40 $
         withHydraPab $ do
           calledBack1 <- newEmptyMVar
@@ -57,7 +56,6 @@ spec = parallel $ do
               takeMVar calledBack2 `shouldReturn` OnInitTx 100 [alice, bob, carol]
 
     it "publishes init tx, observes it and abort" $ do
-      pendingWith "fails currently"
       failAfter 40 $
         withHydraPab $ do
           calledBack1 <- newEmptyMVar

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -18,13 +18,6 @@ flag development
   default:     False
   manual:      True
 
-flag defer-plutus-plugin-errors
-  description:
-    Defer errors from the plugin, useful for things like Haddock that can't handle it.
-
-  default:     False
-  manual:      True
-
 common project-config
   default-extensions:
     NoImplicitPrelude
@@ -111,7 +104,8 @@ library
     , text
     , time
 
-  if flag(defer-plutus-plugin-errors)
+  if flag(development)
+    -- NOTE(SN): should fix HLS choking on PlutusTx plugin
     ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
 
 test-suite hydra-plutus-test

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -92,6 +92,7 @@ library
     , hydra-prelude
     , lens
     , playground-common
+    , plutus-chain-index
     , plutus-contract
     , plutus-core
     , plutus-ledger

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -44,7 +44,9 @@ hydraStateMachine _threadToken =
   -- want as we need additional tokens being forged as well (see 'watchInit').
   SM.mkStateMachine Nothing hydraTransition isFinal
  where
-  isFinal Final{} = True
+  -- XXX(SN): This is currently required to be able to observe the 'Abort'
+  -- transition!?
+  -- isFinal Final{} = True
   isFinal _ = False
 
 {-# INLINEABLE hydraTransition #-}


### PR DESCRIPTION
Made existing tests pass by following the plan laid out last time:

* The contract observing an init tx communicates back the `threadToken` to the client side
* The client side can then use this to
  1. start observing any SM progress via `watchHead`
  2. invoke `abort`

  Both require a `threadToken` as the `Head` validator is currently parameterized by this (should be plutus' `ThreadToken` later I suppose)