### PR TITLE
Resurrect on-chain validators as standalone modules.

### DIFF
--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -71,6 +71,7 @@ common project-config
 library
   import:          project-config
   exposed-modules:
+    Hydra.Contract.Commit
     Hydra.Contract.Head
     Hydra.Contract.Initial
     Hydra.Data.ContestationPeriod

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -79,6 +79,7 @@ library
     Hydra.Data.Party
     Hydra.Depreciated.OffChain
     Hydra.Depreciated.OnChain
+    Hydra.OnChain.Util
     Hydra.PAB
 
   hs-source-dirs:  src

--- a/hydra-plutus/src/Hydra/Contract/Commit.hs
+++ b/hydra-plutus/src/Hydra/Contract/Commit.hs
@@ -8,24 +8,44 @@ module Hydra.Contract.Commit where
 import Ledger hiding (validatorHash)
 import PlutusTx.Prelude
 
+import Hydra.Contract.Head (Head, Input (..))
+import Hydra.OnChain.Util (mustReimburse, mustRunContract)
 import Ledger.Typed.Scripts (TypedValidator, ValidatorType, ValidatorTypes (..))
 import qualified Ledger.Typed.Scripts as Scripts
 import PlutusTx (CompiledCode)
 import qualified PlutusTx
+import PlutusTx.IsData.Class (ToData (..))
 
 data Commit
 
 instance Scripts.ValidatorTypes Commit where
-  type DatumType Commit = TxOut
+  type DatumType Commit = (Dependencies, TxOut)
   type RedeemerType Commit = ()
 
+-- See note on Hydra.Contract.Initial#Dependencies
+data Dependencies = Dependencies
+  { headScript :: ValidatorHash
+  }
+
+PlutusTx.makeLift ''Dependencies
+PlutusTx.unstableMakeIsData ''Dependencies
+
 validator ::
-  TxOut ->
+  (Dependencies, TxOut) ->
   () ->
   ScriptContext ->
   Bool
-validator _commit () _ctx =
-  True
+validator (Dependencies{headScript}, committedOut) () ctx =
+  consumedByCollectCom || consumedByAbort
+ where
+  consumedByCollectCom =
+    mustRunContract @(RedeemerType Head) headScript CollectCom ctx
+
+  consumedByAbort =
+    and
+      [ mustRunContract @(RedeemerType Head) headScript Abort ctx
+      , mustReimburse committedOut ctx
+      ]
 
 compiledValidator :: CompiledCode (ValidatorType Commit)
 compiledValidator = $$(PlutusTx.compile [||validator||])
@@ -41,3 +61,9 @@ typedValidator = Scripts.mkTypedValidator @Commit
 
 validatorHash :: ValidatorHash
 validatorHash = Scripts.validatorHash typedValidator
+
+datum :: DatumType Commit -> Datum
+datum a = Datum (toBuiltinData a)
+
+address :: Address
+address = scriptHashAddress validatorHash

--- a/hydra-plutus/src/Hydra/Contract/Commit.hs
+++ b/hydra-plutus/src/Hydra/Contract/Commit.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-specialize #-}
+
+-- | Contract for Hydra controlling the redemption of commits from participants.
+module Hydra.Contract.Commit where
+
+import Ledger hiding (validatorHash)
+import PlutusTx.Prelude
+
+import Ledger.Typed.Scripts (TypedValidator, ValidatorType, ValidatorTypes (..))
+import qualified Ledger.Typed.Scripts as Scripts
+import PlutusTx (CompiledCode)
+import qualified PlutusTx
+
+data Commit
+
+instance Scripts.ValidatorTypes Commit where
+  type DatumType Commit = TxOut
+  type RedeemerType Commit = ()
+
+validator ::
+  TxOut ->
+  () ->
+  ScriptContext ->
+  Bool
+validator _commit () _ctx =
+  True
+
+compiledValidator :: CompiledCode (ValidatorType Commit)
+compiledValidator = $$(PlutusTx.compile [||validator||])
+
+{- ORMOLU_DISABLE -}
+typedValidator :: TypedValidator Commit
+typedValidator = Scripts.mkTypedValidator @Commit
+  compiledValidator
+  $$(PlutusTx.compile [|| wrap ||])
+ where
+  wrap = Scripts.wrapValidator @(DatumType Commit) @(RedeemerType Commit)
+{- ORMOLU_ENABLE -}
+
+validatorHash :: ValidatorHash
+validatorHash = Scripts.validatorHash typedValidator

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -36,6 +36,8 @@ data Input
 
 PlutusTx.unstableMakeIsData ''Input
 
+type Head = StateMachine State Input
+
 {-# INLINEABLE hydraStateMachine #-}
 hydraStateMachine :: MintingPolicyHash -> StateMachine State Input
 hydraStateMachine _policyId =

--- a/hydra-plutus/src/Hydra/OnChain/Util.hs
+++ b/hydra-plutus/src/Hydra/OnChain/Util.hs
@@ -64,6 +64,12 @@ mustReimburse txOut =
   elem txOut . txInfoOutputs . scriptContextTxInfo
 {-# INLINEABLE mustReimburse #-}
 
+-- /!\ IMPORTANT NOTICE /!\
+--
+-- This function does not check that a particular validator is executed with a
+-- known datum. That means, for validators that are not unique (e.g. the Hydra
+-- head contract parameterized with a unique policy ID), there's no guarantee
+-- that this executes the _right_ validator. To consider only with great care
 mustRunContract ::
   forall redeemer.
   (ToData redeemer) =>

--- a/hydra-plutus/src/Hydra/OnChain/Util.hs
+++ b/hydra-plutus/src/Hydra/OnChain/Util.hs
@@ -1,0 +1,188 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-specialize #-}
+
+module Hydra.OnChain.Util where
+
+import Ledger
+import PlutusTx.Prelude
+
+import Ledger.Constraints (checkScriptContext)
+import Ledger.Constraints.TxConstraints (
+  mustBeSignedBy,
+  mustMintCurrency,
+  mustSpendScriptOutput,
+ )
+import Ledger.Credential (Credential (..))
+import Ledger.Value (TokenName (..), assetClass, assetClassValueOf, mpsSymbol)
+import qualified Ledger.Value as Value
+import PlutusTx.AssocMap (Map)
+import qualified PlutusTx.AssocMap as Map
+import PlutusTx.IsData.Class (ToData (..))
+
+-- | This function can be rather unsafe and should *always* be used with a type
+-- annotation to avoid silly mistakes and hours of debugging.
+--
+-- So prefer:
+--
+-- >>> asDatum @(DatumType MyContract) val
+--
+-- over
+--
+-- >>> asDatum val
+--
+-- A 'Datum' is an opaque type, and type information is lost when turning into a
+-- a 'Data'. Hence, various functions of the Plutus Tx framework that rely on
+-- 'Datum' or 'Redeemer' are basically stringly-typed function with no guarantee
+-- whatsoever that the 'IsData a' being passed will correspond to what's
+-- expected by the underlying script. So, save you some hours of debugging and
+-- always explicitly specify the source type when using this function,
+-- preferably using the data-family from the 'ValidatorTypes' instance.
+asDatum :: ToData a => a -> Datum
+asDatum = Datum . toBuiltinData
+{-# INLINEABLE asDatum #-}
+
+-- | Always use with explicit type-annotation, See warnings on 'asDatum'.
+asRedeemer :: ToData a => a -> Redeemer
+asRedeemer = Redeemer . toBuiltinData
+{-# INLINEABLE asRedeemer #-}
+
+mustBeSignedByOneOf ::
+  [PubKeyHash] ->
+  ScriptContext ->
+  Bool
+mustBeSignedByOneOf vks ctx =
+  or ((`checkScriptContext` ctx) . mustBeSignedBy @() @() <$> vks)
+{-# INLINEABLE mustBeSignedByOneOf #-}
+
+mustReimburse ::
+  TxOut ->
+  ScriptContext ->
+  Bool
+mustReimburse txOut =
+  elem txOut . txInfoOutputs . scriptContextTxInfo
+{-# INLINEABLE mustReimburse #-}
+
+mustRunContract ::
+  forall redeemer.
+  (ToData redeemer) =>
+  ValidatorHash ->
+  redeemer ->
+  ScriptContext ->
+  Bool
+mustRunContract script redeemer ctx =
+  case findContractInput script ctx of
+    Nothing ->
+      False
+    Just contractRef ->
+      checkScriptContext @() @()
+        ( mconcat
+            [ mustSpendScriptOutput contractRef (asRedeemer redeemer)
+            ]
+        )
+        ctx
+{-# INLINEABLE mustRunContract #-}
+
+mustForwardParty ::
+  ScriptContext ->
+  MintingPolicyHash ->
+  PubKeyHash ->
+  Bool
+mustForwardParty ctx policyId vk =
+  traceIfFalse "PT not spent" mustSpendToken
+    && traceIfFalse "PT not produced" mustProduceToken
+ where
+  info = scriptContextTxInfo ctx
+
+  mustSpendToken =
+    assetClassValueOf (valueSpent info) participationToken == 1
+
+  mustProduceToken =
+    assetClassValueOf (valueProduced info) participationToken == 1
+
+  participationToken = assetClass (mpsSymbol policyId) (mkPartyName vk)
+{-# INLINEABLE mustForwardParty #-}
+
+mustBurnParty ::
+  ScriptContext ->
+  MintingPolicyHash ->
+  PubKeyHash ->
+  Bool
+mustBurnParty ctx policyId vk =
+  let assetName = mkPartyName vk
+   in checkScriptContext @() @() (mustMintCurrency policyId assetName (-1)) ctx
+{-# INLINEABLE mustBurnParty #-}
+
+mkParty ::
+  MintingPolicyHash ->
+  PubKeyHash ->
+  Value
+mkParty policyId vk =
+  Value.singleton (Value.mpsSymbol policyId) (mkPartyName vk) 1
+{-# INLINEABLE mkParty #-}
+
+mkPartyName ::
+  PubKeyHash ->
+  TokenName
+mkPartyName =
+  TokenName . getPubKeyHash
+{-# INLINEABLE mkPartyName #-}
+
+hasParty :: MintingPolicyHash -> TxInInfo -> Bool
+hasParty policyId input =
+  let currency = Value.mpsSymbol policyId
+   in currency `elem` symbols (txOutValue $ txInInfoResolved input)
+{-# INLINEABLE hasParty #-}
+
+filterInputs :: (TxInInfo -> Bool) -> ScriptContext -> [(TxOutRef, TxOut)]
+filterInputs predicate =
+  mapMaybe fn . txInfoInputs . scriptContextTxInfo
+ where
+  fn info
+    | predicate info = Just (txInInfoOutRef info, txInInfoResolved info)
+    | otherwise = Nothing
+{-# INLINEABLE filterInputs #-}
+
+findUtxo :: TxOutRef -> ScriptContext -> Maybe (TxOutRef, TxOut)
+findUtxo ref ctx =
+  case filterInputs (\input -> ref == txInInfoOutRef input) ctx of
+    [utxo] -> Just utxo
+    _ -> Nothing
+{-# INLINEABLE findUtxo #-}
+
+findContractInput :: ValidatorHash -> ScriptContext -> Maybe TxOutRef
+findContractInput script ctx =
+  case filterInputs (matchScript . txInInfoResolved) ctx of
+    [utxo] -> Just (fst utxo)
+    _ -> Nothing
+ where
+  matchScript :: TxOut -> Bool
+  matchScript txOut =
+    case txOutAddress txOut of
+      Address (ScriptCredential script') _ -> script == script'
+      _ -> False
+{-# INLINEABLE findContractInput #-}
+
+-- NOTE: Not using `Value.symbols` because it is broken. In fact, a 'Value' may
+-- carry null quantities of some particular tokens, leading to weird situation
+-- where both:
+--
+--   - value == lovelaceValueOf n
+--   - symbols value /= [adaSymbol]
+--
+-- are true at the same time. The equality makes no difference between the
+-- absence of a certain symbol/token, and a null quantity of that symbol. Such
+-- null quantities are probably constructed when moving values around but they
+-- don't really mean anything so they should be discarded from views of the
+-- value itself, like 'symbols'
+symbols :: Value -> [CurrencySymbol]
+symbols = foldr normalize [] . Map.toList . Value.getValue
+ where
+  normalize :: (CurrencySymbol, Map TokenName Integer) -> [CurrencySymbol] -> [CurrencySymbol]
+  normalize (currency, tokens) acc
+    | currency `elem` acc = acc
+    | otherwise =
+      let elems = snd <$> Map.toList tokens
+       in if sum elems == 0 then acc else currency : acc
+{-# INLINEABLE symbols #-}


### PR DESCRIPTION
- :round_pushpin: **Implement dummy Commit contract.**
  
- :round_pushpin: **Move on-chain utility functions in dedicated module.**
  
- :round_pushpin: **Replace dummy Initial validator with real one.**
  
- :round_pushpin: **Parameterize Contract.Head by policy id instead of asset class.**
    And also, make the module a bit more structurally consistent with
  others (with top-level 'address', 'validatorHash', etc ..).

- :round_pushpin: **Provide real implementation for the Commit validator**