### PR TITLE
ExternalPAB can observe multiple life cycles of the Head

### DIFF
--- a/hydra-node/test/Hydra/Chain/ExternalPABSpec.hs
+++ b/hydra-node/test/Hydra/Chain/ExternalPABSpec.hs
@@ -83,6 +83,8 @@ spec = do
           takeMVar calledBack1 `shouldReturn` OnAbortTx
           postTx client1 $ InitTx @SimpleTx $ HeadParameters 100 [alice, bob]
           takeMVar calledBack1 `shouldReturn` OnInitTx 100 [alice, bob]
+          postTx client1 $ AbortTx @SimpleTx mempty
+          takeMVar calledBack1 `shouldReturn` OnAbortTx
 
 alice, bob, carol :: Party
 alice = deriveParty $ generateKey 10


### PR DESCRIPTION
Doing the state handling for the thread token (+ observer client threads) a bit less crude as it was before. Still feels a bit clunky though.

Especially the fact that the "latest" known Head is used to post txs, e.g. `AbortTx` is not entirely correct, but good enough for now.

Eventually we would like to have some kind of Head identifier (policy id?) in the Head logic and thus also in the `PostChainTx`