### PR TITLE
Open Head with Direct chain

### DIFF
--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -266,13 +266,15 @@ txSubmissionClient tracer queue callback cardanoKeys headState TinyWallet{getUtx
     -- XXX(SN): This is a bit too much stair-casing (caused by the atomically and ad-hoc Maybe's)
     res <- atomically $ do
       tx <- readTQueue queue
-      partialTx <- fromPostChainTx tx
-      utxo <- knownUtxo <$> readTVar headState
-      coverFee utxo partialTx >>= \case
-        Left e ->
-          error ("failed to cover fee for transaction: " <> show e <> ", " <> show partialTx)
-        Right validatedTx -> do
-          pure $ Just (tx, sign validatedTx)
+      fromPostChainTx tx >>= \case
+        Nothing -> pure Nothing
+        Just partialTx -> do
+          utxo <- knownUtxo <$> readTVar headState
+          coverFee utxo partialTx >>= \case
+            Left e ->
+              error ("failed to cover fee for transaction: " <> show e <> ", " <> show partialTx)
+            Right validatedTx -> do
+              pure $ Just (tx, sign validatedTx)
 
     case res of
       Nothing -> do
@@ -287,29 +289,29 @@ txSubmissionClient tracer queue callback cardanoKeys headState TinyWallet{getUtx
                 SubmitSuccess -> clientStIdle
             )
 
-  fromPostChainTx :: PostChainTx tx -> STM m (ValidatedTx Era)
+  fromPostChainTx :: PostChainTx tx -> STM m (Maybe (ValidatedTx Era))
   fromPostChainTx = \case
     InitTx params -> do
       txIns <- keys <$> getUtxo
       case txIns of
-        (seedInput : _) -> pure $ initTx cardanoKeys params seedInput
+        (seedInput : _) -> pure . Just $ initTx cardanoKeys params seedInput
         [] -> error "cannot find a seed input to pass to Init transaction"
     AbortTx _utxo ->
       readTVar headState >>= \case
         Initial{threadOutput = (i, _, tk, hp), initials} ->
-          pure $ abortTx (i, tk, hp) (map (\(txIn, _, pkh) -> (txIn, pkh)) initials)
-        st -> error $ "cannot post AbortTx, invalid state: " <> show st
+          pure . Just $ abortTx (i, tk, hp) (map (\(txIn, _, pkh) -> (txIn, pkh)) initials)
+        _st -> pure Nothing
     CommitTx party utxo ->
       readTVar headState >>= \case
         Initial{initials} -> case ownInitial verificationKey initials of
           Nothing -> error $ "no ownInitial: " <> show initials
           Just initial ->
-            pure $ commitTx @tx party utxo initial
+            pure . Just $ commitTx @tx party utxo initial
         st -> error $ "cannot post CommitTx, invalid state: " <> show st
     CollectComTx utxo ->
       readTVar headState >>= \case
-        Initial{threadOutput = (i, _, _, hp)} ->
-          pure $ collectComTx @tx utxo (i, hp)
+        Initial{threadOutput = (i, _, _, _)} ->
+          pure . Just $ collectComTx utxo (i, undefined)
         st -> error $ "cannot post CollectComTx, invalid state: " <> show st
     _ -> error "not implemented"
 

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -298,8 +298,8 @@ txSubmissionClient tracer queue callback cardanoKeys headState TinyWallet{getUtx
         [] -> error "cannot find a seed input to pass to Init transaction"
     AbortTx _utxo ->
       readTVar headState >>= \case
-        Initial{threadOutput = (i, _, dat), initials} ->
-          pure . Just $ abortTx (i, dat) (map (\(txIn, _, pkh) -> (txIn, pkh)) initials)
+        Initial{threadOutput, initials} ->
+          pure . Just $ abortTx (convertTuple threadOutput) (map convertTuple initials)
         _st -> pure Nothing
     CommitTx party utxo ->
       readTVar headState >>= \case
@@ -310,10 +310,12 @@ txSubmissionClient tracer queue callback cardanoKeys headState TinyWallet{getUtx
         st -> error $ "cannot post CommitTx, invalid state: " <> show st
     CollectComTx utxo ->
       readTVar headState >>= \case
-        Initial{threadOutput = (i, _, dat)} ->
-          pure . Just $ collectComTx @tx utxo (i, dat)
+        Initial{threadOutput} ->
+          pure . Just $ collectComTx @tx utxo (convertTuple threadOutput)
         st -> error $ "cannot post CollectComTx, invalid state: " <> show st
     _ -> error "not implemented"
+
+  convertTuple (i, _, dat) = (i, dat)
 
 --
 -- Helpers

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -298,8 +298,8 @@ txSubmissionClient tracer queue callback cardanoKeys headState TinyWallet{getUtx
         [] -> error "cannot find a seed input to pass to Init transaction"
     AbortTx _utxo ->
       readTVar headState >>= \case
-        Initial{threadOutput = (i, _, tk, hp), initials} ->
-          pure . Just $ abortTx (i, tk, hp) (map (\(txIn, _, pkh) -> (txIn, pkh)) initials)
+        Initial{threadOutput = (i, _, dat), initials} ->
+          pure . Just $ abortTx (i, dat) (map (\(txIn, _, pkh) -> (txIn, pkh)) initials)
         _st -> pure Nothing
     CommitTx party utxo ->
       readTVar headState >>= \case
@@ -310,8 +310,8 @@ txSubmissionClient tracer queue callback cardanoKeys headState TinyWallet{getUtx
         st -> error $ "cannot post CommitTx, invalid state: " <> show st
     CollectComTx utxo ->
       readTVar headState >>= \case
-        Initial{threadOutput = (i, _, _, _)} ->
-          pure . Just $ collectComTx utxo (i, undefined)
+        Initial{threadOutput = (i, _, dat)} ->
+          pure . Just $ collectComTx @tx utxo (i, dat)
         st -> error $ "cannot post CollectComTx, invalid state: " <> show st
     _ -> error "not implemented"
 

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -226,6 +226,19 @@ commitTx party utxo (initialIn, pkh) =
 
   commitUtxo = fromByteString $ toStrict $ Aeson.encode utxo
 
+-- | Create a transaction collecting all "committed" utxo and opening a Head,
+-- i.e. driving the Head script state.
+-- FIXME(SN): Right now, this is ignoring the actually committed utxo and not
+-- collecting anything.
+collectComTx ::
+  -- | Total UTXO to be made available in the Head.
+  Utxo tx ->
+  -- | Everything needed to spend the Head state-machine output.
+  -- FIXME(SN): should also contain some Head identifier/address and stored Value (maybe the TxOut + Data?)
+  (TxIn StandardCrypto, HeadParameters) ->
+  ValidatedTx Era
+collectComTx _utxo (_headInput, _headParams) = undefined
+
 -- | Create transaction which aborts by spending one input. This is currently
 -- only possible if this is governed by the initial script and only for a single
 -- input. Of course, the Head protocol specifies we need to spend ALL the Utxo

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -366,8 +366,9 @@ runOnChainTxs party headState = fmap reverse . atomically . foldM runOnChainTx [
     -- TODO(SN): We should be only looking for abort,commit etc. when we have a headId/policyId
     let res =
           observeInitTx party tx
-            <|> observeAbortTx utxo tx
             <|> ((,onChainHeadState) <$> observeCommitTx tx)
+            <|> observeCollectComTx utxo tx
+            <|> observeAbortTx utxo tx
     case res of
       Just (onChainTx, newOnChainHeadState) -> do
         writeTVar headState newOnChainHeadState

--- a/hydra-node/test/Hydra/Chain/Direct/Fixture.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Fixture.hs
@@ -17,12 +17,11 @@ import Data.Default (def)
 import qualified Data.Map as Map
 import Data.Maybe (fromJust)
 import Data.Ratio ((%))
-import Hydra.Chain.Direct.Tx (OnChainHeadState (..), threadToken)
 import Hydra.Chain.Direct.Util (Era)
 import Plutus.V1.Ledger.Api (PubKeyHash (PubKeyHash), toBuiltin)
 import Test.Cardano.Ledger.Alonzo.PlutusScripts (defaultCostModel)
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
-import Test.QuickCheck (Gen, listOf, oneof)
+import Test.QuickCheck (Gen)
 import Test.QuickCheck.Instances ()
 
 maxTxSize :: Int64
@@ -42,12 +41,6 @@ pparams =
           , prSteps = fromJust $ boundRational $ 577 % 10000
           }
     }
-
-instance Arbitrary OnChainHeadState where
-  arbitrary = oneof [pure Closed, Initial <$> threadOutput <*> listOf initialOutput]
-   where
-    threadOutput = (,,,) <$> arbitrary <*> arbitrary <*> pure threadToken <*> arbitrary
-    initialOutput = (,,) <$> arbitrary <*> arbitrary <*> arbitrary
 
 instance Arbitrary PubKeyHash where
   arbitrary = PubKeyHash . toBuiltin <$> (arbitrary :: Gen ByteString)


### PR DESCRIPTION
Continuing further on the full life-cycle of a Hydra Head without proper validators.

This is also covering the `collectComTx`, but fully trusting the off-chain `utxo` passed in `CollectComTx` which is simply put into the datum.