### PR TITLE
[Experiment] Plutus hacks to improve mainchain interaction performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ result*
 *.hi
 *.o
 test-results.xml
+
+### auto-generated Plutus files ###
+*.data
+*.plutus

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ test-results.xml
 ### auto-generated Plutus files ###
 *.data
 *.plutus
+*.flat

--- a/cabal.project
+++ b/cabal.project
@@ -51,19 +51,16 @@ allow-newer:
 
 source-repository-package
   type: git
-  location: https://github.com/input-output-hk/plutus.git
+  location: https://github.com/input-output-hk/plutus-apps
   subdir:
     freer-extras
-    plutus-core
+    plutus-chain-index
+    plutus-chain-index-core
+    plutus-contract
     plutus-ledger
-    plutus-ledger-api
-    plutus-tx
-    plutus-tx-plugin
-    prettyprinter-configurable
     quickcheck-dynamic
-    word-array
-  tag: 5ffcfa6c0451b3b937c4b69d2575cd55adebe88b
-  --sha256: 0zd1axm4a7si1z3ssb45hzjcd2aldywm6vxfgv4bdmkz85sl638p
+  tag: c3676cfe11bcd8512d7353ee337de8e84c7f2278
+  --sha256: 0zhysnl5c5r9yadx15sn7x2iamizydqdhdaksmjydn572nls8g5j
 
 -- The following sections are copied from the 'plutus' repository cabal.project at the revision
 -- given above.
@@ -145,9 +142,34 @@ source-repository-package
 
 source-repository-package
   type: git
+  location: https://github.com/input-output-hk/cardano-addresses
+  tag: d2f86caa085402a953920c6714a0de6a50b655ec
+  --sha256: 0p6jbnd7ky2yf7bwb1350k8880py8dgqg39k49q02a6ij4ld01ay
+  subdir:
+    core
+    command-line
+
+source-repository-package
+  type: git
+  location: https://github.com/j-mueller/cardano-wallet
+  tag: 6be73ab852c0592713dfe78218856d4a8a0ee69e
+  --sha256: 0rx5hvmbdv5dwb4qq39vyhisj0v75j21jbiivn3s3q9za6m6x1p4
+  subdir:
+    lib/text-class
+    lib/strict-non-empty-containers
+    lib/core
+    lib/test-utils
+    lib/numeric
+    lib/launcher
+    lib/core-integration
+    lib/cli
+    lib/shelley
+
+source-repository-package
+  type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 94782e5ca52f234ff8eeddc6322a46cca0b69c0e
-  --sha256: 1da3pka4pn6sjf6w19d957aryjc9ip1a3g0vz7jz66pjri3v2n0j
+  tag: 1f4973f36f689d6da75b5d351fb124d66ef1057d
+  --sha256: 186056rvzdzy4jhvamjjbcmjyr94hs5hcyr8x6a0ch21hv5f014p
   subdir:
     monoidal-synchronisation
     typed-protocols
@@ -163,6 +185,7 @@ source-repository-package
     io-sim
     io-classes
     network-mux
+    ntp-client
 
 source-repository-package
   type: git
@@ -246,3 +269,20 @@ source-repository-package
   location: https://github.com/input-output-hk/goblins
   tag: cde90a2b27f79187ca8310b6549331e59595e7ba
   --sha256: 17c88rbva3iw82yg9srlxjv2ia5wjb9cyqw44hik565f5v9svnyg
+
+-- A lot of plutus-apps dependencies have to be syncronized with the dependencies of
+-- plutus. If you update plutus, please make sure that all dependencies of plutus
+-- are also updated
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/plutus
+  tag: 1f31e640e8a258185db01fa899da63f9018c0e85
+  --sha256: 0nd0na0ydcy8yahqzymakvmbs1yqdrzwz83k7dk8vka9r10pad3v
+  subdir:
+    plutus-core
+    plutus-ledger-api
+    plutus-tx
+    plutus-tx-plugin
+    prettyprinter-configurable
+    stubs/plutus-ghc-stub
+    word-array

--- a/default.nix
+++ b/default.nix
@@ -29,7 +29,7 @@ pkgs.haskell-nix.project {
   compiler-nix-name = compiler;
 
   # Fixed output derivation for plan-nix
-  plan-sha256 = "1nchnhz3q2jpzcbzc9wk2dc5x4ml13j5bn3akzi435xcmy3j58a2";
+  plan-sha256 = "13gj6bsjrfcbnnyy325wxfvbpp7l5p648mml4sxlv20b3lbx7483";
   materialized = ./nix/hydra-poc.materialized;
   # Enable this and nix-build one of the project components to get the new
   # plan-sha256 and materialization update scripts:

--- a/hydra-plutus/exe/inspect-script/Main.hs
+++ b/hydra-plutus/exe/inspect-script/Main.hs
@@ -10,7 +10,6 @@ import Data.Text (pack)
 import Hydra.Contract.Commit as Commit
 import Hydra.Contract.Head as Head
 import Hydra.Contract.Initial as Initial
-import Hydra.Contract.MockHead as MockHead
 import Ledger (Datum (..), datumHash)
 import Ledger.Scripts (Script, toCardanoApiScript)
 import Ledger.Value
@@ -63,14 +62,11 @@ main = do
 
   scripts policyId =
     [ (headScript policyId, "headScript")
-    , (mockHeadScript policyId, "mockHeadScript")
     , (initialScript, "initialScript")
     , (commitScript, "commitScript")
     ]
 
   headScript policyId = Head.validatorScript policyId
-
-  mockHeadScript policyId = MockHead.validatorScript policyId
 
   commitScript = Commit.validatorScript
 

--- a/hydra-plutus/exe/inspect-script/Main.hs
+++ b/hydra-plutus/exe/inspect-script/Main.hs
@@ -15,6 +15,11 @@ import Ledger.Scripts (Script, toCardanoApiScript)
 import Ledger.Value
 import Plutus.V1.Ledger.Api (Data, dataToBuiltinData, toData)
 
+-- FIXME: This is just an experiment
+import Data.Default
+import Ledger.Index
+import Plutus.Trace
+
 -- | Serialise Hydra scripts to files for submission through cardano-cli.
 -- This small utility is useful to manually construct transactions payload for Hydra on-chain
 -- protocol. It takes as arguments the currency and token name to be used as unique Head
@@ -41,6 +46,13 @@ main = do
   putTextLn "Datum hashes:"
   forM_ datums $ \(aDatum, datumName) ->
     putTextLn $ toText $ datumName <> ": " <> show (datumHash $ Datum $ dataToBuiltinData $ aDatum)
+
+  -- FIXME: This is just an experiment
+  print =<< writeScriptsTo
+        (ScriptsConfig "." (Scripts UnappliedValidators))
+        "Initial"
+        Initial.initialTrace
+        def
  where
   writeScripts :: [(Script, String)] -> IO ()
   writeScripts plutus =

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -98,6 +98,7 @@ library
     , hydra-prelude
     , lens
     , openapi3
+    , plutus-contract
     , plutus-core
     , plutus-ledger
     , plutus-tx
@@ -126,6 +127,7 @@ executable inspect-script
     , hydra-plutus
     , hydra-prelude
     , optparse-applicative
+    , plutus-contract
     , plutus-ledger
     , plutus-ledger-api
     , serialise

--- a/hydra-plutus/src/Hydra/Contract/Initial.hs
+++ b/hydra-plutus/src/Hydra/Contract/Initial.hs
@@ -5,24 +5,40 @@
 -- | Contract for Hydra controlling the redemption of participation tokens.
 module Hydra.Contract.Initial where
 
-import Ledger hiding (validatorHash)
-import PlutusTx.Prelude
-
+import Control.Monad (forM_, void)
+import qualified Data.Map as M
 import qualified Hydra.Contract.Commit as Commit
-import Hydra.Contract.Head (Head, Input (..))
+import qualified Hydra.Contract.Head as Head
 import Hydra.OnChain.Util (findUtxo, mkParty, mustRunContract)
-import Ledger.Constraints (checkScriptContext)
+import Ledger hiding (validatorHash, unspentOutputs)
+import qualified Ledger.Ada as Ada
+import Ledger.Constraints (
+  checkScriptContext,
+  mintingPolicy,
+  otherScript,
+  typedValidatorLookups,
+  unspentOutputs
+ )
 import Ledger.Constraints.TxConstraints (
   TxConstraints,
   mustBeSignedBy,
+  mustMintValue,
   mustPayToOtherScript,
+  mustPayToTheScript,
+  mustPayToPubKey,
   mustSpendPubKeyOutput,
+  mustSpendScriptOutput
  )
 import Ledger.Typed.Scripts (TypedValidator, ValidatorType, ValidatorTypes (..))
 import qualified Ledger.Typed.Scripts as Scripts
+import Plutus.Contract
+import qualified Plutus.Trace.Emulator as Trace
 import PlutusTx (CompiledCode)
 import qualified PlutusTx
+import PlutusTx.Prelude hiding (Semigroup (..))
 import PlutusTx.IsData.Class (ToData (..))
+import Prelude (Int, Semigroup (..))
+import Wallet.Emulator (knownWallet)
 
 data Initial
 
@@ -48,7 +64,11 @@ validator ::
   ScriptContext ->
   Bool
 validator (policyId, Dependencies{headScript, commitScript}, vk) mref ctx =
-  consumedByCommit || consumedByAbort
+  -- if-then-else is cheaper!
+  if consumedByCommit then True else consumedByAbort
+
+  -- || is more expensive!
+  -- consumedByCommit || consumedByAbort
  where
   -- A commit transaction, identified by:
   --    (a) A signature that verifies as valid with verification key defined as datum
@@ -73,7 +93,7 @@ validator (policyId, Dependencies{headScript, commitScript}, vk) mref ctx =
               ctx
 
   consumedByAbort =
-    mustRunContract @(RedeemerType Head) headScript Abort ctx
+    mustRunContract @(RedeemerType Head.Head) headScript Head.Abort ctx
 
 compiledValidator :: CompiledCode (ValidatorType Initial)
 compiledValidator = $$(PlutusTx.compile [||validator||])
@@ -115,3 +135,122 @@ mustPayToScript policyId dependencies pubKey =
 -- transactions.
 validatorScript :: Script
 validatorScript = unValidatorScript $ Scripts.validatorScript typedValidator
+
+-- FIXME: Drunk code for the lazy-condition experiment only
+-- A always-true fake minting policy for testing
+{-# INLINEABLE fakeMintingValidator #-}
+fakeMintingValidator :: () -> ScriptContext -> Bool
+fakeMintingValidator _ _ = True
+
+fakeMintingPolicy :: MintingPolicy
+fakeMintingPolicy =
+  mkMintingPolicyScript
+    $$(PlutusTx.compile [||Scripts.wrapMintingPolicy fakeMintingValidator||])
+
+fakeMintingPolicyHash :: MintingPolicyHash
+fakeMintingPolicyHash = mintingPolicyHash fakeMintingPolicy
+
+headValidatorHash :: ValidatorHash
+headValidatorHash = Head.validatorHash fakeMintingPolicyHash
+
+-- Setup: prepare the UTXOs and scripts in a state that is suitable for tracing.
+-- Commit: consume an Initial UTXO to commit a UTXO to the Commit script.
+-- Abort: consume an Initial UTXO with a Head UTXO to abort.
+type InitialSchema = Endpoint "Setup" () .\/ Endpoint "Commit" () .\/ Endpoint "Abort" ()
+
+initialEndpoints :: Contract () InitialSchema ContractError ()
+initialEndpoints = selectList [s, c, a] >> initialEndpoints
+  where s = endpoint @"Setup" $ \_ -> handleError logError setup
+        c = endpoint @"Commit" $ \_ -> handleError logError commit
+        a = endpoint @"Abort" $ \_ -> handleError logError abort
+
+-------------------------------------------------------------------------------
+
+setup :: Contract w s ContractError ()
+setup = do
+  pkh <- ownPubKeyHash
+  let datumInitial =
+        ( fakeMintingPolicyHash,
+          Dependencies headValidatorHash Commit.validatorHash,
+          pkh
+        )
+
+  -- Prepare two Initial UTXOs.
+  -- One for the commit trace, one for the abort trace.
+  forM_ ([1 .. 2] :: [Int]) $
+    const $
+      awaitTxConfirmed . getCardanoTxId
+        =<< submitTxConstraintsWith
+          (typedValidatorLookups typedValidator)
+          (mustPayToTheScript datumInitial (Ada.lovelaceValueOf 8))
+
+  -- Initialize a Head for the abort trace.
+  awaitTxConfirmed . getCardanoTxId
+    =<< submitTxConstraintsWith
+      (typedValidatorLookups (Head.typedValidator fakeMintingPolicyHash))
+      (mustPayToTheScript (Head.Initial 8 []) (Ada.lovelaceValueOf 8))
+
+  -- Break down the initial UTXO to have two.
+  -- One to commit away, one to pay fees and all.
+  awaitTxConfirmed . getCardanoTxId
+    =<< submitTx
+      (mustPayToPubKey pkh (Ada.lovelaceValueOf 8888888))
+
+-------------------------------------------------------------------------------
+
+commit :: Contract w s ContractError ()
+commit = do
+  -- Find an arbitrary user UTXO to commit through an arbitrary Initial UTXO.
+  pkh <- ownPubKeyHash
+  (soref, so) <- head . M.toList <$> utxosAt (scriptHashAddress validatorHash)
+  (uoref, uo) <- head . M.toList <$> utxosAt (pubKeyHashAddress pkh)
+  let datumCommit = Commit.datum (Commit.Dependencies headValidatorHash, toTxOut uo)
+      lookups =
+        typedValidatorLookups Commit.typedValidator
+          <> otherScript (Scripts.validatorScript typedValidator)
+          <> mintingPolicy fakeMintingPolicy
+          <> unspentOutputs (M.fromList [(soref, so), (uoref, uo)])
+      party = mkParty fakeMintingPolicyHash pkh
+      commitVal = txOutValue (toTxOut uo) <> party
+      -- This shouldn't match the final wanted behavior.
+      -- Just a minimal setup to run traces.
+      tx =
+        mustPayToOtherScript Commit.validatorHash datumCommit commitVal
+          <> mustMintValue party
+          <> mustSpendScriptOutput soref (redeemer (Just uoref))
+          <> mustSpendPubKeyOutput uoref
+  awaitTxConfirmed . getCardanoTxId =<< submitTxConstraintsWith lookups tx
+
+-------------------------------------------------------------------------------
+
+abort :: Contract w s ContractError ()
+abort = do
+  -- Abort an arbitrary Initial and Head pair of UTXOs.
+  pkh <- ownPubKeyHash
+  (ioref, io) <- head . M.toList <$> utxosAt (scriptHashAddress validatorHash)
+  (horef, ho) <- head . M.toList <$> utxosAt (scriptHashAddress headValidatorHash)
+  let lookups =
+        otherScript (Scripts.validatorScript typedValidator)
+          <> otherScript (Scripts.validatorScript (Head.typedValidator fakeMintingPolicyHash))
+          <> unspentOutputs (M.fromList [(ioref, io), (horef, ho)])
+      -- This shouldn't match the final wanted behavior.
+      -- Just a minimal setup to run traces.
+      tx =
+        mustSpendScriptOutput ioref (redeemer Nothing)
+          <> mustSpendScriptOutput horef (Redeemer (PlutusTx.toBuiltinData Head.Abort))
+          <> mustPayToPubKey pkh (txOutValue (toTxOut io))
+          <> mustPayToOtherScript headValidatorHash (Datum (PlutusTx.toBuiltinData Head.Final)) (txOutValue (toTxOut ho))
+  awaitTxConfirmed . getCardanoTxId =<< submitTxConstraintsWith @Scripts.Any lookups tx
+
+-------------------------------------------------------------------------------
+
+initialTrace :: Trace.EmulatorTrace ()
+initialTrace = do
+  hdl <- Trace.activateContractWallet (knownWallet 1) initialEndpoints
+  void $ Trace.waitNSlots 8
+  Trace.callEndpoint @"Setup" hdl ()
+  void $ Trace.waitNSlots 8
+  Trace.callEndpoint @"Commit" hdl ()
+  void $ Trace.waitNSlots 8
+  Trace.callEndpoint @"Abort" hdl ()
+  void $ Trace.waitNSlots 8

--- a/nix/hydra-poc.materialized/.plan.nix/Win32-network.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/Win32-network.nix
@@ -110,11 +110,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "12";
+      url = "14";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "12";
+      url = "14";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/byron-spec-chain.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/byron-spec-chain.nix
@@ -86,11 +86,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/byron-spec-ledger.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/byron-spec-ledger.nix
@@ -105,11 +105,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-addresses-cli.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-addresses-cli.nix
@@ -1,0 +1,170 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  ({
+    flags = { release = false; };
+    package = {
+      specVersion = "1.12";
+      identifier = { name = "cardano-addresses-cli"; version = "3.6.0"; };
+      license = "Apache-2.0";
+      copyright = "2021 IOHK";
+      maintainer = "operations@iohk.io";
+      author = "IOHK";
+      homepage = "https://github.com/input-output-hk/cardano-addresses#readme";
+      url = "";
+      synopsis = "Utils for constructing a command-line on top of cardano-addresses.";
+      description = "Please see the README on GitHub at <https://github.com/input-output-hk/cardano-addresses>";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [ "./schemas/address-inspect.json" ];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+          (hsPkgs."aeson-pretty" or (errorHandler.buildDepError "aeson-pretty"))
+          (hsPkgs."ansi-terminal" or (errorHandler.buildDepError "ansi-terminal"))
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."bech32" or (errorHandler.buildDepError "bech32"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
+          (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
+          (hsPkgs."code-page" or (errorHandler.buildDepError "code-page"))
+          (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+          (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
+          (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+          (hsPkgs."process" or (errorHandler.buildDepError "process"))
+          (hsPkgs."safe" or (errorHandler.buildDepError "safe"))
+          (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          ];
+        buildable = true;
+        modules = [
+          "Paths_cardano_addresses_cli"
+          "Command"
+          "Command/Address"
+          "Command/Address/Bootstrap"
+          "Command/Address/Delegation"
+          "Command/Address/Inspect"
+          "Command/Address/Payment"
+          "Command/Address/Pointer"
+          "Command/Address/Reward"
+          "Command/Key"
+          "Command/Key/Child"
+          "Command/Key/FromRecoveryPhrase"
+          "Command/Key/Hash"
+          "Command/Key/Inspect"
+          "Command/Key/Public"
+          "Command/RecoveryPhrase"
+          "Command/RecoveryPhrase/Generate"
+          "Command/Script"
+          "Command/Script/Hash"
+          "Command/Script/Preimage"
+          "Command/Script/Validation"
+          "Command/Version"
+          "Options/Applicative/Credential"
+          "Options/Applicative/Derivation"
+          "Options/Applicative/Discrimination"
+          "Options/Applicative/MnemonicSize"
+          "Options/Applicative/Public"
+          "Options/Applicative/Script"
+          "Options/Applicative/Style"
+          "System/Git/TH"
+          "System/IO/Extra"
+          ];
+        hsSourceDirs = [ "lib" ];
+        };
+      exes = {
+        "cardano-address" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
+            (hsPkgs."cardano-addresses-cli" or (errorHandler.buildDepError "cardano-addresses-cli"))
+            ];
+          buildable = true;
+          modules = [ "Paths_cardano_addresses_cli" ];
+          hsSourceDirs = [ "exe" ];
+          mainPath = [
+            "Main.hs"
+            ] ++ (pkgs.lib).optional (flags.release && !(compiler.isGhcjs && true) && !system.isGhcjs) "";
+          };
+        };
+      tests = {
+        "unit" = {
+          depends = [
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bech32" or (errorHandler.buildDepError "bech32"))
+            (hsPkgs."bech32-th" or (errorHandler.buildDepError "bech32-th"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
+            (hsPkgs."cardano-addresses-cli" or (errorHandler.buildDepError "cardano-addresses-cli"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."process" or (errorHandler.buildDepError "process"))
+            (hsPkgs."string-interpolate" or (errorHandler.buildDepError "string-interpolate"))
+            (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."hjsonschema" or (errorHandler.buildDepError "hjsonschema"));
+          build-tools = [
+            (hsPkgs.buildPackages.hspec-discover.components.exes.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover:hspec-discover")))
+            (hsPkgs.buildPackages.cardano-address.components.exes.cardano-address or (pkgs.buildPackages.cardano-address or (errorHandler.buildToolDepError "cardano-address:cardano-address")))
+            ];
+          buildable = true;
+          modules = [
+            "AutoDiscover"
+            "Command/Address/BootstrapSpec"
+            "Command/Address/DelegationSpec"
+            "Command/Address/InspectSpec"
+            "Command/Address/PaymentSpec"
+            "Command/Address/PointerSpec"
+            "Command/Address/RewardSpec"
+            "Command/Key/ChildSpec"
+            "Command/Key/FromRecoveryPhraseSpec"
+            "Command/Key/HashSpec"
+            "Command/Key/InspectSpec"
+            "Command/Key/PublicSpec"
+            "Command/KeySpec"
+            "Command/RecoveryPhrase/GenerateSpec"
+            "Command/RecoveryPhraseSpec"
+            "Command/Script/HashSpec"
+            "Command/Script/PreimageSpec"
+            "Command/Script/ValidationSpec"
+            "CommandSpec"
+            "Options/Applicative/DerivationSpec"
+            "System/IO/ExtraSpec"
+            "Test/Arbitrary"
+            "Test/Utils"
+            "Paths_cardano_addresses_cli"
+            ];
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Main.hs" ];
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "7";
+      rev = "minimal";
+      sha256 = "";
+      }) // {
+      url = "7";
+      rev = "minimal";
+      sha256 = "";
+      };
+    postUnpack = "sourceRoot+=/command-line; echo source root reset to \$sourceRoot";
+    }) // { cabal-generator = "hpack"; }

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-addresses.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-addresses.nix
@@ -1,0 +1,136 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  ({
+    flags = { release = false; };
+    package = {
+      specVersion = "1.12";
+      identifier = { name = "cardano-addresses"; version = "3.6.0"; };
+      license = "Apache-2.0";
+      copyright = "2021 IOHK";
+      maintainer = "operations@iohk.io";
+      author = "IOHK";
+      homepage = "https://github.com/input-output-hk/cardano-addresses#readme";
+      url = "";
+      synopsis = "Library utilities for mnemonic generation and address derivation.";
+      description = "Please see the README on GitHub at <https://github.com/input-output-hk/cardano-addresses>";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."base58-bytestring" or (errorHandler.buildDepError "base58-bytestring"))
+          (hsPkgs."basement" or (errorHandler.buildDepError "basement"))
+          (hsPkgs."bech32" or (errorHandler.buildDepError "bech32"))
+          (hsPkgs."bech32-th" or (errorHandler.buildDepError "bech32-th"))
+          (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
+          (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
+          (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+          (hsPkgs."digest" or (errorHandler.buildDepError "digest"))
+          (hsPkgs."either" or (errorHandler.buildDepError "either"))
+          (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+          (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+          (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
+          (hsPkgs."hashable" or (errorHandler.buildDepError "hashable"))
+          (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."unordered-containers" or (errorHandler.buildDepError "unordered-containers"))
+          ] ++ (pkgs.lib).optional (compiler.isGhcjs && true || system.isGhcjs) (hsPkgs."cardano-addresses-jsbits" or (errorHandler.buildDepError "cardano-addresses-jsbits"));
+        buildable = true;
+        modules = [
+          "Paths_cardano_addresses"
+          "Cardano/Address"
+          "Cardano/Address/Compat"
+          "Cardano/Address/Derivation"
+          "Cardano/Address/Internal"
+          "Cardano/Address/Script"
+          "Cardano/Address/Script/Parser"
+          "Cardano/Address/Style/Byron"
+          "Cardano/Address/Style/Icarus"
+          "Cardano/Address/Style/Shared"
+          "Cardano/Address/Style/Shelley"
+          "Cardano/Codec/Bech32/Prefixes"
+          "Cardano/Codec/Cbor"
+          "Cardano/Mnemonic"
+          "Codec/Binary/Encoding"
+          "Data/Word7"
+          ];
+        hsSourceDirs = [ "lib" ];
+        };
+      tests = {
+        "unit" = {
+          depends = [
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."aeson-pretty" or (errorHandler.buildDepError "aeson-pretty"))
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bech32" or (errorHandler.buildDepError "bech32"))
+            (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
+            (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."hspec-golden" or (errorHandler.buildDepError "hspec-golden"))
+            (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
+            (hsPkgs."pretty-simple" or (errorHandler.buildDepError "pretty-simple"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.hspec-discover.components.exes.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover:hspec-discover")))
+            ];
+          buildable = true;
+          modules = [
+            "AutoDiscover"
+            "Cardano/Address/DerivationSpec"
+            "Cardano/Address/Script/ParserSpec"
+            "Cardano/Address/ScriptSpec"
+            "Cardano/Address/Style/ByronSpec"
+            "Cardano/Address/Style/IcarusSpec"
+            "Cardano/Address/Style/SharedSpec"
+            "Cardano/Address/Style/ShelleySpec"
+            "Cardano/AddressSpec"
+            "Cardano/Codec/CborSpec"
+            "Cardano/MnemonicSpec"
+            "Codec/Binary/EncodingSpec"
+            "Data/Word7Spec"
+            "Test/Arbitrary"
+            "Paths_cardano_addresses"
+            ];
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Main.hs" ];
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "7";
+      rev = "minimal";
+      sha256 = "";
+      }) // {
+      url = "7";
+      rev = "minimal";
+      sha256 = "";
+      };
+    postUnpack = "sourceRoot+=/core; echo source root reset to \$sourceRoot";
+    }) // { cabal-generator = "hpack"; }

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-api.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-api.nix
@@ -236,11 +236,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "10";
+      url = "12";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "10";
+      url = "12";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-cli.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-cli.nix
@@ -276,11 +276,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "10";
+      url = "12";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "10";
+      url = "12";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-config.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-config.nix
@@ -47,11 +47,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "10";
+      url = "12";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "10";
+      url = "12";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-crypto-test.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-crypto-test.nix
@@ -58,11 +58,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-crypto-wrapper.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-crypto-wrapper.nix
@@ -119,11 +119,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-ledger-alonzo-test.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-ledger-alonzo-test.nix
@@ -123,11 +123,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-ledger-alonzo.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-ledger-alonzo.nix
@@ -92,11 +92,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-ledger-byron-test.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-ledger-byron-test.nix
@@ -122,11 +122,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-ledger-byron.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-ledger-byron.nix
@@ -286,11 +286,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-ledger-core.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-ledger-core.nix
@@ -91,11 +91,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-ledger-pretty.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-ledger-pretty.nix
@@ -64,11 +64,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-ledger-shelley-ma-test.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-ledger-shelley-ma-test.nix
@@ -127,11 +127,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-ledger-shelley-ma.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-ledger-shelley-ma.nix
@@ -76,11 +76,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-ledger-shelley-test.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-ledger-shelley-test.nix
@@ -242,11 +242,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-ledger-shelley.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-ledger-shelley.nix
@@ -136,11 +136,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-ledger-test.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-ledger-test.nix
@@ -142,11 +142,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-node.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-node.nix
@@ -181,11 +181,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "10";
+      url = "12";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "10";
+      url = "12";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-numeric.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-numeric.nix
@@ -1,0 +1,73 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = { release = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "cardano-numeric"; version = "2020.12.8"; };
+      license = "Apache-2.0";
+      copyright = "2018-2020 IOHK";
+      maintainer = "operations@iohk.io";
+      author = "IOHK Engineering Team";
+      homepage = "https://github.com/input-output-hk/cardano-wallet";
+      url = "";
+      synopsis = "Types and functions for performing numerical calculations.";
+      description = "";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."lattices" or (errorHandler.buildDepError "lattices"))
+          (hsPkgs."safe" or (errorHandler.buildDepError "safe"))
+          ];
+        buildable = true;
+        modules = [ "Cardano/Numeric/Util" ];
+        hsSourceDirs = [ "src" ];
+        };
+      tests = {
+        "unit" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."cardano-numeric" or (errorHandler.buildDepError "cardano-numeric"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.hspec-discover.components.exes.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover:hspec-discover")))
+            ];
+          buildable = true;
+          modules = [ "Cardano/Numeric/UtilSpec" ];
+          hsSourceDirs = [ "test/unit" ];
+          mainPath = [ "numeric-unit-test.hs" ];
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "8";
+      rev = "minimal";
+      sha256 = "";
+      }) // {
+      url = "8";
+      rev = "minimal";
+      sha256 = "";
+      };
+    postUnpack = "sourceRoot+=/lib/numeric; echo source root reset to \$sourceRoot";
+    }

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-protocol-tpraos.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-protocol-tpraos.nix
@@ -64,11 +64,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-wallet-cli.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-wallet-cli.nix
@@ -1,0 +1,98 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = { release = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "cardano-wallet-cli"; version = "2021.9.29"; };
+      license = "Apache-2.0";
+      copyright = "2018-2020 IOHK";
+      maintainer = "operations@iohk.io";
+      author = "IOHK Engineering Team";
+      homepage = "https://github.com/input-output-hk/cardano-wallet";
+      url = "";
+      synopsis = "Utilities for a building Command-Line Interfaces";
+      description = "";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+          (hsPkgs."aeson-pretty" or (errorHandler.buildDepError "aeson-pretty"))
+          (hsPkgs."ansi-terminal" or (errorHandler.buildDepError "ansi-terminal"))
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
+          (hsPkgs."cardano-addresses-cli" or (errorHandler.buildDepError "cardano-addresses-cli"))
+          (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
+          (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+          (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+          (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
+          (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
+          (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+          (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
+          (hsPkgs."servant-client-core" or (errorHandler.buildDepError "servant-client-core"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
+          (hsPkgs."time" or (errorHandler.buildDepError "time"))
+          (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
+          ];
+        buildable = true;
+        modules = [ "Cardano/CLI" ];
+        hsSourceDirs = [ "src" ];
+        };
+      tests = {
+        "unit" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."cardano-wallet-cli" or (errorHandler.buildDepError "cardano-wallet-cli"))
+            (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
+            (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
+            (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.hspec-discover.components.exes.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover:hspec-discover")))
+            ];
+          buildable = true;
+          modules = [ "Cardano/CLISpec" ];
+          hsSourceDirs = [ "test/unit" ];
+          mainPath = [ "cli-unit-test.hs" ];
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "8";
+      rev = "minimal";
+      sha256 = "";
+      }) // {
+      url = "8";
+      rev = "minimal";
+      sha256 = "";
+      };
+    postUnpack = "sourceRoot+=/lib/cli; echo source root reset to \$sourceRoot";
+    }

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-wallet-core-integration.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-wallet-core-integration.nix
@@ -1,0 +1,151 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = { release = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = {
+        name = "cardano-wallet-core-integration";
+        version = "2021.9.29";
+        };
+      license = "Apache-2.0";
+      copyright = "2018-2020 IOHK";
+      maintainer = "operations@iohk.io";
+      author = "IOHK Engineering Team";
+      homepage = "https://github.com/input-output-hk/cardano-wallet";
+      url = "";
+      synopsis = "Core integration test library.";
+      description = "Shared core functionality for our integration test suites.";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."HUnit" or (errorHandler.buildDepError "HUnit"))
+          (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+          (hsPkgs."aeson-qq" or (errorHandler.buildDepError "aeson-qq"))
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."base58-bytestring" or (errorHandler.buildDepError "base58-bytestring"))
+          (hsPkgs."bech32" or (errorHandler.buildDepError "bech32"))
+          (hsPkgs."bech32-th" or (errorHandler.buildDepError "bech32-th"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+          (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
+          (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+          (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
+          (hsPkgs."cardano-crypto-class" or (errorHandler.buildDepError "cardano-crypto-class"))
+          (hsPkgs."cardano-ledger-alonzo" or (errorHandler.buildDepError "cardano-ledger-alonzo"))
+          (hsPkgs."cardano-ledger-core" or (errorHandler.buildDepError "cardano-ledger-core"))
+          (hsPkgs."cardano-wallet-cli" or (errorHandler.buildDepError "cardano-wallet-cli"))
+          (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
+          (hsPkgs."cardano-wallet-launcher" or (errorHandler.buildDepError "cardano-wallet-launcher"))
+          (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
+          (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
+          (hsPkgs."command" or (errorHandler.buildDepError "command"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."criterion-measurement" or (errorHandler.buildDepError "criterion-measurement"))
+          (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
+          (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+          (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+          (hsPkgs."either" or (errorHandler.buildDepError "either"))
+          (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+          (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+          (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
+          (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
+          (hsPkgs."generic-lens-core" or (errorHandler.buildDepError "generic-lens-core"))
+          (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+          (hsPkgs."hspec-expectations-lifted" or (errorHandler.buildDepError "hspec-expectations-lifted"))
+          (hsPkgs."http-api-data" or (errorHandler.buildDepError "http-api-data"))
+          (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
+          (hsPkgs."http-types" or (errorHandler.buildDepError "http-types"))
+          (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+          (hsPkgs."lens-aeson" or (errorHandler.buildDepError "lens-aeson"))
+          (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
+          (hsPkgs."microstache" or (errorHandler.buildDepError "microstache"))
+          (hsPkgs."network-uri" or (errorHandler.buildDepError "network-uri"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+          (hsPkgs."process" or (errorHandler.buildDepError "process"))
+          (hsPkgs."resourcet" or (errorHandler.buildDepError "resourcet"))
+          (hsPkgs."retry" or (errorHandler.buildDepError "retry"))
+          (hsPkgs."say" or (errorHandler.buildDepError "say"))
+          (hsPkgs."scrypt" or (errorHandler.buildDepError "scrypt"))
+          (hsPkgs."string-interpolate" or (errorHandler.buildDepError "string-interpolate"))
+          (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
+          (hsPkgs."time" or (errorHandler.buildDepError "time"))
+          (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
+          (hsPkgs."unliftio-core" or (errorHandler.buildDepError "unliftio-core"))
+          (hsPkgs."unordered-containers" or (errorHandler.buildDepError "unordered-containers"))
+          ];
+        buildable = true;
+        modules = [
+          "Test/Integration/Faucet"
+          "Test/Integration/Framework/Context"
+          "Test/Integration/Framework/DSL"
+          "Test/Integration/Framework/Request"
+          "Test/Integration/Framework/TestData"
+          "Test/Integration/Plutus"
+          "Test/Integration/Scenario/API/Byron/Wallets"
+          "Test/Integration/Scenario/API/Byron/HWWallets"
+          "Test/Integration/Scenario/API/Byron/Addresses"
+          "Test/Integration/Scenario/API/Byron/CoinSelections"
+          "Test/Integration/Scenario/API/Byron/Transactions"
+          "Test/Integration/Scenario/API/Byron/TransactionsNew"
+          "Test/Integration/Scenario/API/Byron/Migrations"
+          "Test/Integration/Scenario/API/Byron/Network"
+          "Test/Integration/Scenario/API/Shelley/Addresses"
+          "Test/Integration/Scenario/API/Shelley/CoinSelections"
+          "Test/Integration/Scenario/API/Shelley/HWWallets"
+          "Test/Integration/Scenario/API/Shelley/Network"
+          "Test/Integration/Scenario/API/Shelley/Settings"
+          "Test/Integration/Scenario/API/Shelley/StakePools"
+          "Test/Integration/Scenario/API/Shelley/Transactions"
+          "Test/Integration/Scenario/API/Shelley/TransactionsNew"
+          "Test/Integration/Scenario/API/Shelley/Migrations"
+          "Test/Integration/Scenario/API/Shelley/Wallets"
+          "Test/Integration/Scenario/API/Shared/Wallets"
+          "Test/Integration/Scenario/API/Shared/Addresses"
+          "Test/Integration/Scenario/API/Network"
+          "Test/Integration/Scenario/CLI/Byron/Wallets"
+          "Test/Integration/Scenario/CLI/Byron/Addresses"
+          "Test/Integration/Scenario/CLI/Shelley/Addresses"
+          "Test/Integration/Scenario/CLI/Shelley/HWWallets"
+          "Test/Integration/Scenario/CLI/Shelley/Transactions"
+          "Test/Integration/Scenario/CLI/Shelley/Wallets"
+          "Test/Integration/Scenario/CLI/Miscellaneous"
+          "Test/Integration/Scenario/CLI/Network"
+          "Test/Integration/Scenario/CLI/Port"
+          "Cardano/Wallet/LatencyBenchShared"
+          "Cardano/Wallet/BenchShared"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "8";
+      rev = "minimal";
+      sha256 = "";
+      }) // {
+      url = "8";
+      rev = "minimal";
+      sha256 = "";
+      };
+    postUnpack = "sourceRoot+=/lib/core-integration; echo source root reset to \$sourceRoot";
+    }

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-wallet-core.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-wallet-core.nix
@@ -1,0 +1,474 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = { release = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "cardano-wallet-core"; version = "2021.9.29"; };
+      license = "Apache-2.0";
+      copyright = "2018-2020 IOHK";
+      maintainer = "operations@iohk.io";
+      author = "IOHK Engineering Team";
+      homepage = "https://github.com/input-output-hk/cardano-wallet";
+      url = "";
+      synopsis = "The Wallet Backend for a Cardano node.";
+      description = "Please see README.md";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [ "specifications/api/swagger.yaml" ];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+          (hsPkgs."async" or (errorHandler.buildDepError "async"))
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."base16-bytestring" or (errorHandler.buildDepError "base16-bytestring"))
+          (hsPkgs."bech32" or (errorHandler.buildDepError "bech32"))
+          (hsPkgs."bech32-th" or (errorHandler.buildDepError "bech32-th"))
+          (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
+          (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+          (hsPkgs."cardano-binary" or (errorHandler.buildDepError "cardano-binary"))
+          (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
+          (hsPkgs."cardano-crypto-class" or (errorHandler.buildDepError "cardano-crypto-class"))
+          (hsPkgs."cardano-crypto-test" or (errorHandler.buildDepError "cardano-crypto-test"))
+          (hsPkgs."cardano-numeric" or (errorHandler.buildDepError "cardano-numeric"))
+          (hsPkgs."cardano-ledger-core" or (errorHandler.buildDepError "cardano-ledger-core"))
+          (hsPkgs."cardano-ledger-byron-test" or (errorHandler.buildDepError "cardano-ledger-byron-test"))
+          (hsPkgs."cardano-ledger-alonzo" or (errorHandler.buildDepError "cardano-ledger-alonzo"))
+          (hsPkgs."cardano-slotting" or (errorHandler.buildDepError "cardano-slotting"))
+          (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+          (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
+          (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+          (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+          (hsPkgs."digest" or (errorHandler.buildDepError "digest"))
+          (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+          (hsPkgs."either" or (errorHandler.buildDepError "either"))
+          (hsPkgs."errors" or (errorHandler.buildDepError "errors"))
+          (hsPkgs."exact-combinatorics" or (errorHandler.buildDepError "exact-combinatorics"))
+          (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+          (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+          (hsPkgs."fast-logger" or (errorHandler.buildDepError "fast-logger"))
+          (hsPkgs."file-embed" or (errorHandler.buildDepError "file-embed"))
+          (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+          (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
+          (hsPkgs."foldl" or (errorHandler.buildDepError "foldl"))
+          (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
+          (hsPkgs."generic-arbitrary" or (errorHandler.buildDepError "generic-arbitrary"))
+          (hsPkgs."hashable" or (errorHandler.buildDepError "hashable"))
+          (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
+          (hsPkgs."hedgehog-quickcheck" or (errorHandler.buildDepError "hedgehog-quickcheck"))
+          (hsPkgs."http-api-data" or (errorHandler.buildDepError "http-api-data"))
+          (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
+          (hsPkgs."http-client-tls" or (errorHandler.buildDepError "http-client-tls"))
+          (hsPkgs."http-media" or (errorHandler.buildDepError "http-media"))
+          (hsPkgs."http-types" or (errorHandler.buildDepError "http-types"))
+          (hsPkgs."int-cast" or (errorHandler.buildDepError "int-cast"))
+          (hsPkgs."io-classes" or (errorHandler.buildDepError "io-classes"))
+          (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+          (hsPkgs."lattices" or (errorHandler.buildDepError "lattices"))
+          (hsPkgs."math-functions" or (errorHandler.buildDepError "math-functions"))
+          (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
+          (hsPkgs."MonadRandom" or (errorHandler.buildDepError "MonadRandom"))
+          (hsPkgs."monad-logger" or (errorHandler.buildDepError "monad-logger"))
+          (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+          (hsPkgs."network" or (errorHandler.buildDepError "network"))
+          (hsPkgs."network-uri" or (errorHandler.buildDepError "network-uri"))
+          (hsPkgs."nothunks" or (errorHandler.buildDepError "nothunks"))
+          (hsPkgs."ntp-client" or (errorHandler.buildDepError "ntp-client"))
+          (hsPkgs."OddWord" or (errorHandler.buildDepError "OddWord"))
+          (hsPkgs."ouroboros-consensus" or (errorHandler.buildDepError "ouroboros-consensus"))
+          (hsPkgs."ouroboros-network" or (errorHandler.buildDepError "ouroboros-network"))
+          (hsPkgs."path-pieces" or (errorHandler.buildDepError "path-pieces"))
+          (hsPkgs."persistent" or (errorHandler.buildDepError "persistent"))
+          (hsPkgs."persistent-sqlite" or (errorHandler.buildDepError "persistent-sqlite"))
+          (hsPkgs."persistent-template" or (errorHandler.buildDepError "persistent-template"))
+          (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
+          (hsPkgs."pretty-simple" or (errorHandler.buildDepError "pretty-simple"))
+          (hsPkgs."profunctors" or (errorHandler.buildDepError "profunctors"))
+          (hsPkgs."quiet" or (errorHandler.buildDepError "quiet"))
+          (hsPkgs."random" or (errorHandler.buildDepError "random"))
+          (hsPkgs."random-shuffle" or (errorHandler.buildDepError "random-shuffle"))
+          (hsPkgs."resource-pool" or (errorHandler.buildDepError "resource-pool"))
+          (hsPkgs."retry" or (errorHandler.buildDepError "retry"))
+          (hsPkgs."safe" or (errorHandler.buildDepError "safe"))
+          (hsPkgs."scientific" or (errorHandler.buildDepError "scientific"))
+          (hsPkgs."scrypt" or (errorHandler.buildDepError "scrypt"))
+          (hsPkgs."servant" or (errorHandler.buildDepError "servant"))
+          (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
+          (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
+          (hsPkgs."shelley-spec-ledger" or (errorHandler.buildDepError "shelley-spec-ledger"))
+          (hsPkgs."shelley-spec-ledger-test" or (errorHandler.buildDepError "shelley-spec-ledger-test"))
+          (hsPkgs."split" or (errorHandler.buildDepError "split"))
+          (hsPkgs."splitmix" or (errorHandler.buildDepError "splitmix"))
+          (hsPkgs."statistics" or (errorHandler.buildDepError "statistics"))
+          (hsPkgs."streaming-commons" or (errorHandler.buildDepError "streaming-commons"))
+          (hsPkgs."strict-containers" or (errorHandler.buildDepError "strict-containers"))
+          (hsPkgs."strict-non-empty-containers" or (errorHandler.buildDepError "strict-non-empty-containers"))
+          (hsPkgs."string-interpolate" or (errorHandler.buildDepError "string-interpolate"))
+          (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
+          (hsPkgs."time" or (errorHandler.buildDepError "time"))
+          (hsPkgs."tls" or (errorHandler.buildDepError "tls"))
+          (hsPkgs."tracer-transformers" or (errorHandler.buildDepError "tracer-transformers"))
+          (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+          (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
+          (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
+          (hsPkgs."unliftio-core" or (errorHandler.buildDepError "unliftio-core"))
+          (hsPkgs."unordered-containers" or (errorHandler.buildDepError "unordered-containers"))
+          (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
+          (hsPkgs."wai" or (errorHandler.buildDepError "wai"))
+          (hsPkgs."warp" or (errorHandler.buildDepError "warp"))
+          (hsPkgs."warp-tls" or (errorHandler.buildDepError "warp-tls"))
+          (hsPkgs."x509" or (errorHandler.buildDepError "x509"))
+          (hsPkgs."x509-store" or (errorHandler.buildDepError "x509-store"))
+          (hsPkgs."x509-validation" or (errorHandler.buildDepError "x509-validation"))
+          (hsPkgs."Win32-network" or (errorHandler.buildDepError "Win32-network"))
+          (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+          (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
+          ];
+        buildable = true;
+        modules = [
+          "Paths_cardano_wallet_core"
+          "Cardano/Byron/Codec/Cbor"
+          "Cardano/DB/Sqlite"
+          "Cardano/DB/Sqlite/Delete"
+          "Cardano/Pool/DB"
+          "Cardano/Pool/DB/Log"
+          "Cardano/Pool/DB/MVar"
+          "Cardano/Pool/DB/Model"
+          "Cardano/Pool/DB/Sqlite"
+          "Cardano/Pool/DB/Sqlite/TH"
+          "Cardano/Pool/Metadata"
+          "Cardano/Wallet"
+          "Cardano/Wallet/Api"
+          "Cardano/Wallet/Api/Client"
+          "Cardano/Wallet/Api/Link"
+          "Cardano/Wallet/Api/Server"
+          "Cardano/Wallet/Api/Server/Tls"
+          "Cardano/Wallet/Api/Types"
+          "Cardano/Wallet/Compat"
+          "Cardano/Wallet/DB"
+          "Cardano/Wallet/DB/MVar"
+          "Cardano/Wallet/DB/Model"
+          "Cardano/Wallet/DB/Sqlite"
+          "Cardano/Wallet/DB/Sqlite/TH"
+          "Cardano/Wallet/DB/Sqlite/Types"
+          "Cardano/Wallet/Logging"
+          "Cardano/Wallet/Network"
+          "Cardano/Wallet/Network/Ports"
+          "Cardano/Wallet/Orphans"
+          "Cardano/Wallet/TokenMetadata"
+          "Cardano/Wallet/Primitive/AddressDerivation"
+          "Cardano/Wallet/Primitive/AddressDerivation/Byron"
+          "Cardano/Wallet/Primitive/AddressDerivation/Icarus"
+          "Cardano/Wallet/Primitive/AddressDerivation/MintBurn"
+          "Cardano/Wallet/Primitive/AddressDerivation/Shared"
+          "Cardano/Wallet/Primitive/AddressDerivation/SharedKey"
+          "Cardano/Wallet/Primitive/AddressDerivation/Shelley"
+          "Cardano/Wallet/Primitive/AddressDiscovery"
+          "Cardano/Wallet/Primitive/Slotting"
+          "Cardano/Wallet/Primitive/AddressDiscovery/Random"
+          "Cardano/Wallet/Primitive/Delegation/State"
+          "Cardano/Wallet/Primitive/AddressDiscovery/Sequential"
+          "Cardano/Wallet/Primitive/AddressDiscovery/Shared"
+          "Cardano/Wallet/Primitive/SyncProgress"
+          "Cardano/Wallet/Primitive/CoinSelection"
+          "Cardano/Wallet/Primitive/CoinSelection/Balance"
+          "Cardano/Wallet/Primitive/CoinSelection/Collateral"
+          "Cardano/Wallet/Primitive/Collateral"
+          "Cardano/Wallet/Primitive/Delegation/UTxO"
+          "Cardano/Wallet/Primitive/Migration"
+          "Cardano/Wallet/Primitive/Migration/Planning"
+          "Cardano/Wallet/Primitive/Migration/Selection"
+          "Cardano/Wallet/Primitive/Model"
+          "Cardano/Wallet/Primitive/Types"
+          "Cardano/Wallet/Primitive/Types/Address"
+          "Cardano/Wallet/Primitive/Types/Coin"
+          "Cardano/Wallet/Primitive/Types/Hash"
+          "Cardano/Wallet/Primitive/Types/Redeemer"
+          "Cardano/Wallet/Primitive/Types/RewardAccount"
+          "Cardano/Wallet/Primitive/Types/TokenBundle"
+          "Cardano/Wallet/Primitive/Types/TokenMap"
+          "Cardano/Wallet/Primitive/Types/TokenPolicy"
+          "Cardano/Wallet/Primitive/Types/TokenQuantity"
+          "Cardano/Wallet/Primitive/Types/Tx"
+          "Cardano/Wallet/Primitive/Types/UTxO"
+          "Cardano/Wallet/Primitive/Types/UTxOIndex"
+          "Cardano/Wallet/Primitive/Types/UTxOIndex/Internal"
+          "Cardano/Wallet/Primitive/Types/UTxOSelection"
+          "Cardano/Wallet/Registry"
+          "Cardano/Wallet/TokenMetadata/MockServer"
+          "Cardano/Wallet/Transaction"
+          "Cardano/Wallet/Unsafe"
+          "Cardano/Wallet/Util"
+          "Cardano/Wallet/Version"
+          "Cardano/Wallet/Version/TH"
+          "Control/Concurrent/Concierge"
+          "Crypto/Hash/Utils"
+          "Data/Function/Utils"
+          "Data/Time/Text"
+          "Data/Time/Utils"
+          "Data/Quantity"
+          "Data/Vector/Shuffle"
+          "Network/Ntp"
+          "Network/Wai/Middleware/ServerError"
+          "Network/Wai/Middleware/Logging"
+          "Ouroboros/Network/Client/Wallet"
+          "UnliftIO/Compat"
+          "Cardano/Wallet/Primitive/CoinSelection/Balance/Gen"
+          "Cardano/Wallet/Primitive/Types/Address/Gen"
+          "Cardano/Wallet/Primitive/Types/Coin/Gen"
+          "Cardano/Wallet/Primitive/Types/RewardAccount/Gen"
+          "Cardano/Wallet/Primitive/Types/TokenBundle/Gen"
+          "Cardano/Wallet/Primitive/Types/TokenMap/Gen"
+          "Cardano/Wallet/Primitive/Types/TokenPolicy/Gen"
+          "Cardano/Wallet/Primitive/Types/TokenQuantity/Gen"
+          "Cardano/Wallet/Primitive/Types/Tx/Gen"
+          "Cardano/Wallet/Primitive/Types/UTxO/Gen"
+          "Cardano/Wallet/Primitive/Types/UTxOIndex/Gen"
+          "Cardano/Wallet/Primitive/Types/UTxOSelection/Gen"
+          "Cardano/Wallet/Gen"
+          "Cardano/Api/Gen"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      tests = {
+        "unit" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."aeson-qq" or (errorHandler.buildDepError "aeson-qq"))
+            (hsPkgs."base58-bytestring" or (errorHandler.buildDepError "base58-bytestring"))
+            (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
+            (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+            (hsPkgs."cardano-binary" or (errorHandler.buildDepError "cardano-binary"))
+            (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
+            (hsPkgs."cardano-crypto-class" or (errorHandler.buildDepError "cardano-crypto-class"))
+            (hsPkgs."cardano-numeric" or (errorHandler.buildDepError "cardano-numeric"))
+            (hsPkgs."cardano-ledger-byron" or (errorHandler.buildDepError "cardano-ledger-byron"))
+            (hsPkgs."cardano-ledger-byron-test" or (errorHandler.buildDepError "cardano-ledger-byron-test"))
+            (hsPkgs."cardano-ledger-core" or (errorHandler.buildDepError "cardano-ledger-core"))
+            (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
+            (hsPkgs."cardano-wallet-launcher" or (errorHandler.buildDepError "cardano-wallet-launcher"))
+            (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
+            (hsPkgs."cardano-sl-x509" or (errorHandler.buildDepError "cardano-sl-x509"))
+            (hsPkgs."cardano-slotting" or (errorHandler.buildDepError "cardano-slotting"))
+            (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
+            (hsPkgs."connection" or (errorHandler.buildDepError "connection"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+            (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
+            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+            (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+            (hsPkgs."file-embed" or (errorHandler.buildDepError "file-embed"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
+            (hsPkgs."foldl" or (errorHandler.buildDepError "foldl"))
+            (hsPkgs."generic-arbitrary" or (errorHandler.buildDepError "generic-arbitrary"))
+            (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
+            (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
+            (hsPkgs."hedgehog-quickcheck" or (errorHandler.buildDepError "hedgehog-quickcheck"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."hspec-core" or (errorHandler.buildDepError "hspec-core"))
+            (hsPkgs."hspec-hedgehog" or (errorHandler.buildDepError "hspec-hedgehog"))
+            (hsPkgs."http-api-data" or (errorHandler.buildDepError "http-api-data"))
+            (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
+            (hsPkgs."http-client-tls" or (errorHandler.buildDepError "http-client-tls"))
+            (hsPkgs."http-media" or (errorHandler.buildDepError "http-media"))
+            (hsPkgs."http-types" or (errorHandler.buildDepError "http-types"))
+            (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+            (hsPkgs."io-classes" or (errorHandler.buildDepError "io-classes"))
+            (hsPkgs."io-sim" or (errorHandler.buildDepError "io-sim"))
+            (hsPkgs."lattices" or (errorHandler.buildDepError "lattices"))
+            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+            (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
+            (hsPkgs."MonadRandom" or (errorHandler.buildDepError "MonadRandom"))
+            (hsPkgs."network" or (errorHandler.buildDepError "network"))
+            (hsPkgs."network-uri" or (errorHandler.buildDepError "network-uri"))
+            (hsPkgs."nothunks" or (errorHandler.buildDepError "nothunks"))
+            (hsPkgs."persistent" or (errorHandler.buildDepError "persistent"))
+            (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
+            (hsPkgs."pretty-simple" or (errorHandler.buildDepError "pretty-simple"))
+            (hsPkgs."regex-pcre-builtin" or (errorHandler.buildDepError "regex-pcre-builtin"))
+            (hsPkgs."shelley-spec-ledger" or (errorHandler.buildDepError "shelley-spec-ledger"))
+            (hsPkgs."OddWord" or (errorHandler.buildDepError "OddWord"))
+            (hsPkgs."ouroboros-consensus" or (errorHandler.buildDepError "ouroboros-consensus"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."quickcheck-classes" or (errorHandler.buildDepError "quickcheck-classes"))
+            (hsPkgs."quickcheck-state-machine" or (errorHandler.buildDepError "quickcheck-state-machine"))
+            (hsPkgs."quiet" or (errorHandler.buildDepError "quiet"))
+            (hsPkgs."random" or (errorHandler.buildDepError "random"))
+            (hsPkgs."retry" or (errorHandler.buildDepError "retry"))
+            (hsPkgs."safe" or (errorHandler.buildDepError "safe"))
+            (hsPkgs."scrypt" or (errorHandler.buildDepError "scrypt"))
+            (hsPkgs."servant" or (errorHandler.buildDepError "servant"))
+            (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
+            (hsPkgs."shelley-spec-ledger-test" or (errorHandler.buildDepError "shelley-spec-ledger-test"))
+            (hsPkgs."should-not-typecheck" or (errorHandler.buildDepError "should-not-typecheck"))
+            (hsPkgs."splitmix" or (errorHandler.buildDepError "splitmix"))
+            (hsPkgs."strict-non-empty-containers" or (errorHandler.buildDepError "strict-non-empty-containers"))
+            (hsPkgs."openapi3" or (errorHandler.buildDepError "openapi3"))
+            (hsPkgs."servant-openapi3" or (errorHandler.buildDepError "servant-openapi3"))
+            (hsPkgs."string-qq" or (errorHandler.buildDepError "string-qq"))
+            (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
+            (hsPkgs."tls" or (errorHandler.buildDepError "tls"))
+            (hsPkgs."time" or (errorHandler.buildDepError "time"))
+            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            (hsPkgs."tree-diff" or (errorHandler.buildDepError "tree-diff"))
+            (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
+            (hsPkgs."unliftio-core" or (errorHandler.buildDepError "unliftio-core"))
+            (hsPkgs."unordered-containers" or (errorHandler.buildDepError "unordered-containers"))
+            (hsPkgs."x509" or (errorHandler.buildDepError "x509"))
+            (hsPkgs."x509-store" or (errorHandler.buildDepError "x509-store"))
+            (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))
+            (hsPkgs."wai" or (errorHandler.buildDepError "wai"))
+            (hsPkgs."wai-extra" or (errorHandler.buildDepError "wai-extra"))
+            (hsPkgs."warp" or (errorHandler.buildDepError "warp"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.hspec-discover.components.exes.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover:hspec-discover")))
+            ];
+          buildable = true;
+          modules = [
+            "Cardano/Api/GenSpec"
+            "Cardano/Byron/Codec/CborSpec"
+            "Cardano/DB/Sqlite/DeleteSpec"
+            "Cardano/Pool/DB/Arbitrary"
+            "Cardano/Pool/DB/MVarSpec"
+            "Cardano/Pool/DB/Properties"
+            "Cardano/Pool/DB/SqliteSpec"
+            "Cardano/Wallet/Api/Malformed"
+            "Cardano/Wallet/Api/Server/TlsSpec"
+            "Cardano/Wallet/Api/ServerSpec"
+            "Cardano/Wallet/Api/TypesSpec"
+            "Cardano/Wallet/ApiSpec"
+            "Cardano/Wallet/DB/Arbitrary"
+            "Cardano/Wallet/DB/MVarSpec"
+            "Cardano/Wallet/DB/Properties"
+            "Cardano/Wallet/DB/SqliteSpec"
+            "Cardano/Wallet/DB/Sqlite/TypesSpec"
+            "Cardano/Wallet/DB/StateMachine"
+            "Cardano/Wallet/DummyTarget/Primitive/Types"
+            "Cardano/Wallet/Network/PortsSpec"
+            "Cardano/Wallet/NetworkSpec"
+            "Cardano/Wallet/Primitive/AddressDerivation/ByronSpec"
+            "Cardano/Wallet/Primitive/AddressDerivation/IcarusSpec"
+            "Cardano/Wallet/Primitive/AddressDerivation/MintBurnSpec"
+            "Cardano/Wallet/Primitive/AddressDerivationSpec"
+            "Cardano/Wallet/Primitive/AddressDiscovery/RandomSpec"
+            "Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec"
+            "Cardano/Wallet/Primitive/AddressDiscovery/SharedSpec"
+            "Cardano/Wallet/Primitive/Delegation/StateSpec"
+            "Cardano/Wallet/Primitive/AddressDiscoverySpec"
+            "Cardano/Wallet/Primitive/CoinSelectionSpec"
+            "Cardano/Wallet/Primitive/CoinSelection/BalanceSpec"
+            "Cardano/Wallet/Primitive/CoinSelection/CollateralSpec"
+            "Cardano/Wallet/Primitive/CollateralSpec"
+            "Cardano/Wallet/Primitive/MigrationSpec"
+            "Cardano/Wallet/Primitive/Migration/PlanningSpec"
+            "Cardano/Wallet/Primitive/Migration/SelectionSpec"
+            "Cardano/Wallet/Primitive/ModelSpec"
+            "Cardano/Wallet/Primitive/Slotting/Legacy"
+            "Cardano/Wallet/Primitive/SlottingSpec"
+            "Cardano/Wallet/Primitive/SyncProgressSpec"
+            "Cardano/Wallet/Primitive/Types/AddressSpec"
+            "Cardano/Wallet/Primitive/Types/CoinSpec"
+            "Cardano/Wallet/Primitive/Types/HashSpec"
+            "Cardano/Wallet/Primitive/Types/TokenBundleSpec"
+            "Cardano/Wallet/Primitive/Types/TokenMapSpec"
+            "Cardano/Wallet/Primitive/Types/TokenMapSpec/TypeErrorSpec"
+            "Cardano/Wallet/Primitive/Types/TokenPolicySpec"
+            "Cardano/Wallet/Primitive/Types/TokenQuantitySpec"
+            "Cardano/Wallet/Primitive/Types/TxSpec"
+            "Cardano/Wallet/Primitive/Types/UTxOSpec"
+            "Cardano/Wallet/Primitive/Types/UTxOIndexSpec"
+            "Cardano/Wallet/Primitive/Types/UTxOIndex/TypeErrorSpec"
+            "Cardano/Wallet/Primitive/Types/UTxOSelectionSpec"
+            "Cardano/Wallet/Primitive/Types/UTxOSelectionSpec/TypeErrorSpec"
+            "Cardano/Wallet/Primitive/TypesSpec"
+            "Cardano/Wallet/TokenMetadataSpec"
+            "Cardano/Wallet/RegistrySpec"
+            "Cardano/WalletSpec"
+            "Control/Concurrent/ConciergeSpec"
+            "Data/Function/UtilsSpec"
+            "Data/QuantitySpec"
+            "Data/Time/TextSpec"
+            "Data/Time/UtilsSpec"
+            "Data/Vector/ShuffleSpec"
+            "Network/Wai/Middleware/LoggingSpec"
+            "Spec"
+            ];
+          hsSourceDirs = [ "test-common" "test/unit" ];
+          mainPath = [ "core-unit-test.hs" ];
+          };
+        };
+      benchmarks = {
+        "db" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
+            (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
+            (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
+            (hsPkgs."cardano-wallet-launcher" or (errorHandler.buildDepError "cardano-wallet-launcher"))
+            (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+            (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
+            (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
+            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
+            (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+            (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
+            (hsPkgs."random" or (errorHandler.buildDepError "random"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
+            (hsPkgs."time" or (errorHandler.buildDepError "time"))
+            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
+            ];
+          buildable = true;
+          modules = [ "Cardano/Wallet/DummyTarget/Primitive/Types" ];
+          hsSourceDirs = [ "bench" "test-common" ];
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "8";
+      rev = "minimal";
+      sha256 = "";
+      }) // {
+      url = "8";
+      rev = "minimal";
+      sha256 = "";
+      };
+    postUnpack = "sourceRoot+=/lib/core; echo source root reset to \$sourceRoot";
+    }

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-wallet-launcher.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-wallet-launcher.nix
@@ -1,0 +1,104 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = { release = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "cardano-wallet-launcher"; version = "2021.9.29"; };
+      license = "Apache-2.0";
+      copyright = "2018-2020 IOHK";
+      maintainer = "operations@iohk.io";
+      author = "IOHK Engineering Team";
+      homepage = "https://github.com/input-output-hk/cardano-wallet";
+      url = "";
+      synopsis = "Utilities for a building commands launcher";
+      description = "";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."code-page" or (errorHandler.buildDepError "code-page"))
+          (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+          (hsPkgs."either" or (errorHandler.buildDepError "either"))
+          (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+          (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+          (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
+          (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+          (hsPkgs."process" or (errorHandler.buildDepError "process"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
+          (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
+          (hsPkgs."unliftio-core" or (errorHandler.buildDepError "unliftio-core"))
+          ] ++ (if system.isWindows
+          then [ (hsPkgs."Win32" or (errorHandler.buildDepError "Win32")) ]
+          else [ (hsPkgs."unix" or (errorHandler.buildDepError "unix")) ]);
+        buildable = true;
+        modules = [
+          "Cardano/Launcher"
+          "Cardano/Launcher/Node"
+          "Cardano/Startup"
+          ] ++ (if system.isWindows
+          then [ "Cardano/Startup/Windows" ]
+          else [ "Cardano/Startup/POSIX" ]);
+        hsSourceDirs = [ "src" ];
+        };
+      tests = {
+        "unit" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."cardano-wallet-launcher" or (errorHandler.buildDepError "cardano-wallet-launcher"))
+            (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
+            (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+            (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."hspec-core" or (errorHandler.buildDepError "hspec-core"))
+            (hsPkgs."hspec-expectations" or (errorHandler.buildDepError "hspec-expectations"))
+            (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+            (hsPkgs."process" or (errorHandler.buildDepError "process"))
+            (hsPkgs."retry" or (errorHandler.buildDepError "retry"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
+            (hsPkgs."time" or (errorHandler.buildDepError "time"))
+            (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.hspec-discover.components.exes.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover:hspec-discover")))
+            ];
+          buildable = true;
+          modules = [ "Cardano/LauncherSpec" "Cardano/StartupSpec" ];
+          hsSourceDirs = [ "test/unit" ];
+          mainPath = [ "launcher-unit-test.hs" ];
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "8";
+      rev = "minimal";
+      sha256 = "";
+      }) // {
+      url = "8";
+      rev = "minimal";
+      sha256 = "";
+      };
+    postUnpack = "sourceRoot+=/lib/launcher; echo source root reset to \$sourceRoot";
+    }

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-wallet-test-utils.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-wallet-test-utils.nix
@@ -1,0 +1,128 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = { release = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = {
+        name = "cardano-wallet-test-utils";
+        version = "2021.9.29";
+        };
+      license = "Apache-2.0";
+      copyright = "2018-2020 IOHK";
+      maintainer = "operations@iohk.io";
+      author = "IOHK Engineering Team";
+      homepage = "https://github.com/input-output-hk/cardano-wallet";
+      url = "";
+      synopsis = "Shared utilities for writing unit and property tests.";
+      description = "Shared utilities for writing unit and property tests.";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+          (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+          (hsPkgs."file-embed" or (errorHandler.buildDepError "file-embed"))
+          (hsPkgs."formatting" or (errorHandler.buildDepError "formatting"))
+          (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+          (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+          (hsPkgs."either" or (errorHandler.buildDepError "either"))
+          (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
+          (hsPkgs."hspec-core" or (errorHandler.buildDepError "hspec-core"))
+          (hsPkgs."hspec-expectations" or (errorHandler.buildDepError "hspec-expectations"))
+          (hsPkgs."hspec-golden-aeson" or (errorHandler.buildDepError "hspec-golden-aeson"))
+          (hsPkgs."http-api-data" or (errorHandler.buildDepError "http-api-data"))
+          (hsPkgs."HUnit" or (errorHandler.buildDepError "HUnit"))
+          (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+          (hsPkgs."int-cast" or (errorHandler.buildDepError "int-cast"))
+          (hsPkgs."lattices" or (errorHandler.buildDepError "lattices"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+          (hsPkgs."pretty-simple" or (errorHandler.buildDepError "pretty-simple"))
+          (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+          (hsPkgs."quickcheck-classes" or (errorHandler.buildDepError "quickcheck-classes"))
+          (hsPkgs."say" or (errorHandler.buildDepError "say"))
+          (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
+          (hsPkgs."time" or (errorHandler.buildDepError "time"))
+          (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
+          (hsPkgs."unliftio-core" or (errorHandler.buildDepError "unliftio-core"))
+          (hsPkgs."wai-app-static" or (errorHandler.buildDepError "wai-app-static"))
+          (hsPkgs."warp" or (errorHandler.buildDepError "warp"))
+          ];
+        buildable = true;
+        modules = [
+          "Test/Hspec/Extra"
+          "Test/Hspec/Goldens"
+          "Test/QuickCheck/Extra"
+          "Test/Utils/Env"
+          "Test/Utils/FilePath"
+          "Test/Utils/Laws"
+          "Test/Utils/Laws/PartialOrd"
+          "Test/Utils/Paths"
+          "Test/Utils/Pretty"
+          "Test/Utils/Roundtrip"
+          "Test/Utils/Resource"
+          "Test/Utils/Platform"
+          "Test/Utils/Startup"
+          "Test/Utils/StaticServer"
+          "Test/Utils/Time"
+          "Test/Utils/Trace"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      tests = {
+        "unit" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
+            (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."hspec-core" or (errorHandler.buildDepError "hspec-core"))
+            (hsPkgs."hspec-expectations-lifted" or (errorHandler.buildDepError "hspec-expectations-lifted"))
+            (hsPkgs."silently" or (errorHandler.buildDepError "silently"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
+            (hsPkgs."unliftio-core" or (errorHandler.buildDepError "unliftio-core"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.hspec-discover.components.exes.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover:hspec-discover")))
+            ];
+          buildable = true;
+          modules = [ "Test/Hspec/ExtraSpec" ];
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "test-utils-unit-test.hs" ];
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "8";
+      rev = "minimal";
+      sha256 = "";
+      }) // {
+      url = "8";
+      rev = "minimal";
+      sha256 = "";
+      };
+    postUnpack = "sourceRoot+=/lib/test-utils; echo source root reset to \$sourceRoot";
+    }

--- a/nix/hydra-poc.materialized/.plan.nix/cardano-wallet.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/cardano-wallet.nix
@@ -1,0 +1,328 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = { release = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "cardano-wallet"; version = "2021.9.29"; };
+      license = "Apache-2.0";
+      copyright = "2020 IOHK";
+      maintainer = "operations@iohk.io";
+      author = "IOHK Engineering Team";
+      homepage = "https://github.com/input-output-hk/cardano-wallet";
+      url = "";
+      synopsis = "Wallet backend protocol-specific bits implemented using Shelley nodes";
+      description = "Please see README.md";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+          (hsPkgs."array" or (errorHandler.buildDepError "array"))
+          (hsPkgs."base58-bytestring" or (errorHandler.buildDepError "base58-bytestring"))
+          (hsPkgs."bech32" or (errorHandler.buildDepError "bech32"))
+          (hsPkgs."bech32-th" or (errorHandler.buildDepError "bech32-th"))
+          (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
+          (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+          (hsPkgs."cardano-binary" or (errorHandler.buildDepError "cardano-binary"))
+          (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
+          (hsPkgs."cardano-crypto-class" or (errorHandler.buildDepError "cardano-crypto-class"))
+          (hsPkgs."cardano-crypto-wrapper" or (errorHandler.buildDepError "cardano-crypto-wrapper"))
+          (hsPkgs."cardano-wallet-launcher" or (errorHandler.buildDepError "cardano-wallet-launcher"))
+          (hsPkgs."cardano-ledger-byron" or (errorHandler.buildDepError "cardano-ledger-byron"))
+          (hsPkgs."cardano-ledger-core" or (errorHandler.buildDepError "cardano-ledger-core"))
+          (hsPkgs."cardano-ledger-shelley" or (errorHandler.buildDepError "cardano-ledger-shelley"))
+          (hsPkgs."cardano-ledger-shelley-ma" or (errorHandler.buildDepError "cardano-ledger-shelley-ma"))
+          (hsPkgs."cardano-ledger-alonzo" or (errorHandler.buildDepError "cardano-ledger-alonzo"))
+          (hsPkgs."cardano-slotting" or (errorHandler.buildDepError "cardano-slotting"))
+          (hsPkgs."cardano-wallet-cli" or (errorHandler.buildDepError "cardano-wallet-cli"))
+          (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
+          (hsPkgs."cardano-wallet-launcher" or (errorHandler.buildDepError "cardano-wallet-launcher"))
+          (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
+          (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+          (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+          (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+          (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+          (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
+          (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
+          (hsPkgs."io-classes" or (errorHandler.buildDepError "io-classes"))
+          (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+          (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
+          (hsPkgs."network" or (errorHandler.buildDepError "network"))
+          (hsPkgs."network-mux" or (errorHandler.buildDepError "network-mux"))
+          (hsPkgs."network-uri" or (errorHandler.buildDepError "network-uri"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+          (hsPkgs."ouroboros-consensus" or (errorHandler.buildDepError "ouroboros-consensus"))
+          (hsPkgs."ouroboros-consensus-byron" or (errorHandler.buildDepError "ouroboros-consensus-byron"))
+          (hsPkgs."ouroboros-consensus-cardano" or (errorHandler.buildDepError "ouroboros-consensus-cardano"))
+          (hsPkgs."ouroboros-consensus-shelley" or (errorHandler.buildDepError "ouroboros-consensus-shelley"))
+          (hsPkgs."ouroboros-network" or (errorHandler.buildDepError "ouroboros-network"))
+          (hsPkgs."ouroboros-network-framework" or (errorHandler.buildDepError "ouroboros-network-framework"))
+          (hsPkgs."random" or (errorHandler.buildDepError "random"))
+          (hsPkgs."retry" or (errorHandler.buildDepError "retry"))
+          (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
+          (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
+          (hsPkgs."shelley-spec-ledger" or (errorHandler.buildDepError "shelley-spec-ledger"))
+          (hsPkgs."strict-containers" or (errorHandler.buildDepError "strict-containers"))
+          (hsPkgs."strict-non-empty-containers" or (errorHandler.buildDepError "strict-non-empty-containers"))
+          (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
+          (hsPkgs."time" or (errorHandler.buildDepError "time"))
+          (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+          (hsPkgs."typed-process" or (errorHandler.buildDepError "typed-process"))
+          (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
+          (hsPkgs."unliftio-core" or (errorHandler.buildDepError "unliftio-core"))
+          (hsPkgs."unordered-containers" or (errorHandler.buildDepError "unordered-containers"))
+          (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
+          (hsPkgs."warp" or (errorHandler.buildDepError "warp"))
+          (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))
+          (hsPkgs."Win32-network" or (errorHandler.buildDepError "Win32-network"))
+          ];
+        buildable = true;
+        modules = [
+          "Cardano/Wallet/Byron/Compatibility"
+          "Cardano/Wallet/Shelley"
+          "Cardano/Wallet/Shelley/Api/Server"
+          "Cardano/Wallet/Shelley/Compatibility"
+          "Cardano/Wallet/Shelley/Compatibility/Ledger"
+          "Cardano/Wallet/Shelley/Network"
+          "Cardano/Wallet/Shelley/Transaction"
+          "Cardano/Wallet/Shelley/Launch"
+          "Cardano/Wallet/Shelley/Launch/Cluster"
+          "Cardano/Wallet/Shelley/Pools"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      exes = {
+        "cardano-wallet" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."cardano-wallet-cli" or (errorHandler.buildDepError "cardano-wallet-cli"))
+            (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
+            (hsPkgs."cardano-wallet-launcher" or (errorHandler.buildDepError "cardano-wallet-launcher"))
+            (hsPkgs."cardano-wallet" or (errorHandler.buildDepError "cardano-wallet"))
+            (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+            (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+            (hsPkgs."lobemo-backend-ekg" or (errorHandler.buildDepError "lobemo-backend-ekg"))
+            (hsPkgs."network-uri" or (errorHandler.buildDepError "network-uri"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
+            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "exe" ];
+          mainPath = [
+            "cardano-wallet.hs"
+            ] ++ (pkgs.lib).optional (flags.release) "";
+          };
+        "local-cluster" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."cardano-wallet-cli" or (errorHandler.buildDepError "cardano-wallet-cli"))
+            (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
+            (hsPkgs."cardano-wallet-core-integration" or (errorHandler.buildDepError "cardano-wallet-core-integration"))
+            (hsPkgs."cardano-wallet-launcher" or (errorHandler.buildDepError "cardano-wallet-launcher"))
+            (hsPkgs."cardano-wallet" or (errorHandler.buildDepError "cardano-wallet"))
+            (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+            (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            (hsPkgs."lobemo-backend-ekg" or (errorHandler.buildDepError "lobemo-backend-ekg"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "exe" ];
+          mainPath = [
+            "local-cluster.hs"
+            ] ++ (pkgs.lib).optional (flags.release) "";
+          };
+        "mock-token-metadata-server" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."ansi-wl-pprint" or (errorHandler.buildDepError "ansi-wl-pprint"))
+            (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."wai-extra" or (errorHandler.buildDepError "wai-extra"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "exe" ];
+          mainPath = [
+            "mock-token-metadata-server.hs"
+            ] ++ (pkgs.lib).optional (flags.release) "";
+          };
+        };
+      tests = {
+        "unit" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."base58-bytestring" or (errorHandler.buildDepError "base58-bytestring"))
+            (hsPkgs."bech32" or (errorHandler.buildDepError "bech32"))
+            (hsPkgs."bech32-th" or (errorHandler.buildDepError "bech32-th"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
+            (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+            (hsPkgs."cardano-crypto-class" or (errorHandler.buildDepError "cardano-crypto-class"))
+            (hsPkgs."cardano-ledger-alonzo" or (errorHandler.buildDepError "cardano-ledger-alonzo"))
+            (hsPkgs."cardano-ledger-core" or (errorHandler.buildDepError "cardano-ledger-core"))
+            (hsPkgs."cardano-wallet" or (errorHandler.buildDepError "cardano-wallet"))
+            (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
+            (hsPkgs."cardano-wallet-launcher" or (errorHandler.buildDepError "cardano-wallet-launcher"))
+            (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
+            (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
+            (hsPkgs."hspec-core" or (errorHandler.buildDepError "hspec-core"))
+            (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."hspec-core" or (errorHandler.buildDepError "hspec-core"))
+            (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
+            (hsPkgs."MonadRandom" or (errorHandler.buildDepError "MonadRandom"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."ouroboros-consensus-shelley" or (errorHandler.buildDepError "ouroboros-consensus-shelley"))
+            (hsPkgs."ouroboros-network" or (errorHandler.buildDepError "ouroboros-network"))
+            (hsPkgs."shelley-spec-ledger" or (errorHandler.buildDepError "shelley-spec-ledger"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
+            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.hspec-discover.components.exes.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover:hspec-discover")))
+            ];
+          buildable = true;
+          modules = [
+            "Cardano/Wallet/Shelley/CompatibilitySpec"
+            "Cardano/Wallet/Shelley/Compatibility/LedgerSpec"
+            "Cardano/Wallet/Shelley/LaunchSpec"
+            "Cardano/Wallet/Shelley/NetworkSpec"
+            "Cardano/Wallet/Shelley/TransactionSpec"
+            "Spec"
+            ];
+          hsSourceDirs = [ "test/unit" ];
+          mainPath = [ "shelley-unit-test.hs" ];
+          };
+        "integration" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."cardano-wallet-cli" or (errorHandler.buildDepError "cardano-wallet-cli"))
+            (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
+            (hsPkgs."cardano-wallet-core-integration" or (errorHandler.buildDepError "cardano-wallet-core-integration"))
+            (hsPkgs."cardano-wallet-launcher" or (errorHandler.buildDepError "cardano-wallet-launcher"))
+            (hsPkgs."cardano-wallet" or (errorHandler.buildDepError "cardano-wallet"))
+            (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
+            (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+            (hsPkgs."either" or (errorHandler.buildDepError "either"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."hspec-core" or (errorHandler.buildDepError "hspec-core"))
+            (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
+            (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+            (hsPkgs."lobemo-backend-ekg" or (errorHandler.buildDepError "lobemo-backend-ekg"))
+            (hsPkgs."network-uri" or (errorHandler.buildDepError "network-uri"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
+            (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.cardano-wallet.components.exes.cardano-wallet or (pkgs.buildPackages.cardano-wallet or (errorHandler.buildToolDepError "cardano-wallet:cardano-wallet")))
+            ];
+          buildable = true;
+          modules = [ "Cardano/Wallet/Shelley/Faucet" ];
+          hsSourceDirs = [ "test/integration" ];
+          mainPath = [ "shelley-integration-test.hs" ];
+          };
+        };
+      benchmarks = {
+        "restore" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
+            (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
+            (hsPkgs."cardano-wallet-core-integration" or (errorHandler.buildDepError "cardano-wallet-core-integration"))
+            (hsPkgs."cardano-wallet" or (errorHandler.buildDepError "cardano-wallet"))
+            (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
+            (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
+            (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+            (hsPkgs."say" or (errorHandler.buildDepError "say"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
+            (hsPkgs."time" or (errorHandler.buildDepError "time"))
+            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "bench" ];
+          };
+        "latency" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."cardano-wallet-cli" or (errorHandler.buildDepError "cardano-wallet-cli"))
+            (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
+            (hsPkgs."cardano-wallet-core-integration" or (errorHandler.buildDepError "cardano-wallet-core-integration"))
+            (hsPkgs."cardano-wallet" or (errorHandler.buildDepError "cardano-wallet"))
+            (hsPkgs."cardano-wallet-launcher" or (errorHandler.buildDepError "cardano-wallet-launcher"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
+            (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
+            (hsPkgs."http-types" or (errorHandler.buildDepError "http-types"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
+            ];
+          buildable = true;
+          modules = [ "Cardano/Wallet/Shelley/Faucet" ];
+          hsSourceDirs = [ "bench" "test/integration" ];
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "8";
+      rev = "minimal";
+      sha256 = "";
+      }) // {
+      url = "8";
+      rev = "minimal";
+      sha256 = "";
+      };
+    postUnpack = "sourceRoot+=/lib/shelley; echo source root reset to \$sourceRoot";
+    }

--- a/nix/hydra-poc.materialized/.plan.nix/contra-tracer.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/contra-tracer.nix
@@ -42,11 +42,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "8";
+      url = "10";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "8";
+      url = "10";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/goblins.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/goblins.nix
@@ -82,11 +82,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "14";
+      url = "16";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "14";
+      url = "16";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/hedgehog-extras.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/hedgehog-extras.nix
@@ -89,11 +89,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "13";
+      url = "15";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "13";
+      url = "15";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/hydra-plutus.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/hydra-plutus.nix
@@ -44,6 +44,7 @@
           (hsPkgs."hydra-prelude" or (errorHandler.buildDepError "hydra-prelude"))
           (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
           (hsPkgs."openapi3" or (errorHandler.buildDepError "openapi3"))
+          (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
           (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
           (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
           (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
@@ -59,9 +60,11 @@
           "Hydra/Contract/Head"
           "Hydra/Contract/Initial"
           "Hydra/Contract/MockCommit"
+          "Hydra/Contract/MockInitial"
           "Hydra/Data/ContestationPeriod"
           "Hydra/Data/HeadParameters"
           "Hydra/Data/Party"
+          "Hydra/Data/Utxo"
           "Hydra/OnChain/Util"
           "Plutus/Contract/StateMachine/MintingPolarity"
           "Plutus/Contract/StateMachine/OnChain"

--- a/nix/hydra-poc.materialized/.plan.nix/io-classes.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/io-classes.nix
@@ -73,11 +73,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/io-sim.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/io-sim.nix
@@ -71,11 +71,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/iohk-monitoring.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/iohk-monitoring.nix
@@ -180,11 +180,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "8";
+      url = "10";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "8";
+      url = "10";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/lobemo-backend-aggregation.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/lobemo-backend-aggregation.nix
@@ -55,11 +55,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "8";
+      url = "10";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "8";
+      url = "10";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/lobemo-backend-ekg.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/lobemo-backend-ekg.nix
@@ -58,11 +58,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "8";
+      url = "10";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "8";
+      url = "10";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/lobemo-backend-monitoring.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/lobemo-backend-monitoring.nix
@@ -94,11 +94,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "8";
+      url = "10";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "8";
+      url = "10";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/lobemo-backend-trace-forwarder.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/lobemo-backend-trace-forwarder.nix
@@ -55,11 +55,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "8";
+      url = "10";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "8";
+      url = "10";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/monoidal-synchronisation.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/monoidal-synchronisation.nix
@@ -57,11 +57,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/network-mux.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/network-mux.nix
@@ -114,6 +114,7 @@
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             ];
           buildable = if system.isWindows then false else true;
+          modules = [ "Linger" ];
           hsSourceDirs = [ "demo" ];
           mainPath = [ "cardano-ping.hs" ] ++ [ "" ];
           };
@@ -149,11 +150,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/non-integral.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/non-integral.nix
@@ -53,11 +53,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/ntp-client.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/ntp-client.nix
@@ -1,0 +1,96 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = { demo = true; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "ntp-client"; version = "0.0.1"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "";
+      author = "";
+      homepage = "";
+      url = "";
+      synopsis = "";
+      description = "";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [ "README.md" ];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."async" or (errorHandler.buildDepError "async"))
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+          (hsPkgs."network" or (errorHandler.buildDepError "network"))
+          (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+          (hsPkgs."time" or (errorHandler.buildDepError "time"))
+          (hsPkgs."Win32-network" or (errorHandler.buildDepError "Win32-network"))
+          ];
+        buildable = true;
+        modules = [
+          "Network/NTP/Client/Packet"
+          "Network/NTP/Client/Query"
+          "Network/NTP/Client"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      exes = {
+        "demo-ntp-client" = {
+          depends = [
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+            (hsPkgs."Win32-network" or (errorHandler.buildDepError "Win32-network"))
+            (hsPkgs."ntp-client" or (errorHandler.buildDepError "ntp-client"))
+            ];
+          buildable = if flags.demo then true else false;
+          hsSourceDirs = [ "demo" ];
+          mainPath = [ "Main.hs" ] ++ [ "" ];
+          };
+        };
+      tests = {
+        "test" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
+            (hsPkgs."time" or (errorHandler.buildDepError "time"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
+            ];
+          buildable = true;
+          modules = [ "Network/NTP/Client/Packet" ];
+          hsSourceDirs = [ "test" "src" ];
+          mainPath = [ "Test.hs" ];
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "9";
+      rev = "minimal";
+      sha256 = "";
+      }) // {
+      url = "9";
+      rev = "minimal";
+      sha256 = "";
+      };
+    postUnpack = "sourceRoot+=/ntp-client; echo source root reset to \$sourceRoot";
+    }

--- a/nix/hydra-poc.materialized/.plan.nix/optparse-applicative-fork.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/optparse-applicative-fork.nix
@@ -111,11 +111,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "11";
+      url = "13";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "11";
+      url = "13";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/ouroboros-consensus-byron.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/ouroboros-consensus-byron.nix
@@ -103,11 +103,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/ouroboros-consensus-cardano.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/ouroboros-consensus-cardano.nix
@@ -112,11 +112,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/ouroboros-consensus-shelley.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/ouroboros-consensus-shelley.nix
@@ -92,11 +92,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/ouroboros-consensus.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/ouroboros-consensus.nix
@@ -297,11 +297,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/ouroboros-network-framework.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/ouroboros-network-framework.nix
@@ -164,11 +164,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/ouroboros-network-testing.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/ouroboros-network-testing.nix
@@ -52,11 +52,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/ouroboros-network.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/ouroboros-network.nix
@@ -345,11 +345,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/plutus-chain-index-core.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/plutus-chain-index-core.nix
@@ -1,0 +1,160 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.2";
+      identifier = { name = "plutus-chain-index-core"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "sjoerd.visscher@iohk.io";
+      author = "Sjoerd Visscher";
+      homepage = "https://github.com/iohk/plutus#readme";
+      url = "";
+      synopsis = "";
+      description = "Please see the README on GitHub at <https://github.com/input-output-hk/plutus#readme>";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
+          (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
+          (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+          (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
+          (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."beam-core" or (errorHandler.buildDepError "beam-core"))
+          (hsPkgs."beam-sqlite" or (errorHandler.buildDepError "beam-sqlite"))
+          (hsPkgs."beam-migrate" or (errorHandler.buildDepError "beam-migrate"))
+          (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+          (hsPkgs."cardano-ledger-byron" or (errorHandler.buildDepError "cardano-ledger-byron"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+          (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
+          (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+          (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+          (hsPkgs."fingertree" or (errorHandler.buildDepError "fingertree"))
+          (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
+          (hsPkgs."io-classes" or (errorHandler.buildDepError "io-classes"))
+          (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+          (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+          (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
+          (hsPkgs."nothunks" or (errorHandler.buildDepError "nothunks"))
+          (hsPkgs."ouroboros-network" or (errorHandler.buildDepError "ouroboros-network"))
+          (hsPkgs."ouroboros-network-framework" or (errorHandler.buildDepError "ouroboros-network-framework"))
+          (hsPkgs."ouroboros-consensus" or (errorHandler.buildDepError "ouroboros-consensus"))
+          (hsPkgs."ouroboros-consensus-byron" or (errorHandler.buildDepError "ouroboros-consensus-byron"))
+          (hsPkgs."ouroboros-consensus-cardano" or (errorHandler.buildDepError "ouroboros-consensus-cardano"))
+          (hsPkgs."ouroboros-consensus-shelley" or (errorHandler.buildDepError "ouroboros-consensus-shelley"))
+          (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
+          (hsPkgs."retry" or (errorHandler.buildDepError "retry"))
+          (hsPkgs."semigroups" or (errorHandler.buildDepError "semigroups"))
+          (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
+          (hsPkgs."sqlite-simple" or (errorHandler.buildDepError "sqlite-simple"))
+          (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
+          (hsPkgs."unordered-containers" or (errorHandler.buildDepError "unordered-containers"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."servant" or (errorHandler.buildDepError "servant"))
+          (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
+          (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+          (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+          (hsPkgs."warp" or (errorHandler.buildDepError "warp"))
+          (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
+          (hsPkgs."servant-client-core" or (errorHandler.buildDepError "servant-client-core"))
+          (hsPkgs."http-types" or (errorHandler.buildDepError "http-types"))
+          (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
+          ];
+        buildable = true;
+        modules = [
+          "Plutus/ChainIndex"
+          "Plutus/ChainIndex/Api"
+          "Plutus/ChainIndex/ChainIndexError"
+          "Plutus/ChainIndex/ChainIndexLog"
+          "Plutus/ChainIndex/Client"
+          "Plutus/ChainIndex/DbSchema"
+          "Plutus/ChainIndex/Effects"
+          "Plutus/ChainIndex/Emulator"
+          "Plutus/ChainIndex/Emulator/DiskState"
+          "Plutus/ChainIndex/Emulator/Handlers"
+          "Plutus/ChainIndex/Emulator/Server"
+          "Plutus/ChainIndex/Handlers"
+          "Plutus/ChainIndex/Server"
+          "Plutus/ChainIndex/Tx"
+          "Plutus/ChainIndex/TxIdState"
+          "Plutus/ChainIndex/TxOutBalance"
+          "Plutus/ChainIndex/TxUtxoBalance"
+          "Plutus/ChainIndex/Types"
+          "Plutus/ChainIndex/UtxoState"
+          "Plutus/Monitoring/Util"
+          "Cardano/Protocol/Socket/Type"
+          "Cardano/Protocol/Socket/Client"
+          "Plutus/ChainIndex/Compatibility"
+          "Plutus/Contract/CardanoAPI"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      tests = {
+        "plutus-chain-index-test" = {
+          depends = [
+            (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
+            (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+            (hsPkgs."plutus-chain-index-core" or (errorHandler.buildDepError "plutus-chain-index-core"))
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."beam-migrate" or (errorHandler.buildDepError "beam-migrate"))
+            (hsPkgs."beam-sqlite" or (errorHandler.buildDepError "beam-sqlite"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+            (hsPkgs."fingertree" or (errorHandler.buildDepError "fingertree"))
+            (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
+            (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
+            (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
+            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
+            (hsPkgs."sqlite-simple" or (errorHandler.buildDepError "sqlite-simple"))
+            (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError "tasty-hedgehog"))
+            ];
+          buildable = true;
+          modules = [
+            "Generators"
+            "Plutus/ChainIndex/Emulator/DiskStateSpec"
+            "Plutus/ChainIndex/Emulator/HandlersSpec"
+            "Plutus/ChainIndex/HandlersSpec"
+            ];
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "0";
+      rev = "minimal";
+      sha256 = "";
+      }) // {
+      url = "0";
+      rev = "minimal";
+      sha256 = "";
+      };
+    postUnpack = "sourceRoot+=/plutus-chain-index-core; echo source root reset to \$sourceRoot";
+    }

--- a/nix/hydra-poc.materialized/.plan.nix/plutus-chain-index.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/plutus-chain-index.nix
@@ -1,0 +1,89 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.2";
+      identifier = { name = "plutus-chain-index"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "sjoerd.visscher@iohk.io";
+      author = "Sjoerd Visscher";
+      homepage = "https://github.com/iohk/plutus#readme";
+      url = "";
+      synopsis = "";
+      description = "Please see the README on GitHub at <https://github.com/input-output-hk/plutus#readme>";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
+          (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
+          (hsPkgs."plutus-chain-index-core" or (errorHandler.buildDepError "plutus-chain-index-core"))
+          (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
+          (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."beam-sqlite" or (errorHandler.buildDepError "beam-sqlite"))
+          (hsPkgs."beam-migrate" or (errorHandler.buildDepError "beam-migrate"))
+          (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+          (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
+          (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+          (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+          (hsPkgs."ouroboros-network" or (errorHandler.buildDepError "ouroboros-network"))
+          (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
+          (hsPkgs."sqlite-simple" or (errorHandler.buildDepError "sqlite-simple"))
+          (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+          (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+          ];
+        buildable = true;
+        modules = [
+          "Plutus/ChainIndex/App"
+          "Plutus/ChainIndex/CommandLine"
+          "Plutus/ChainIndex/Config"
+          "Plutus/ChainIndex/Logging"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      exes = {
+        "plutus-chain-index" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-chain-index" or (errorHandler.buildDepError "plutus-chain-index"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "app" ];
+          mainPath = [ "Main.hs" ];
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "0";
+      rev = "minimal";
+      sha256 = "";
+      }) // {
+      url = "0";
+      rev = "minimal";
+      sha256 = "";
+      };
+    postUnpack = "sourceRoot+=/plutus-chain-index; echo source root reset to \$sourceRoot";
+    }

--- a/nix/hydra-poc.materialized/.plan.nix/plutus-contract.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/plutus-contract.nix
@@ -1,0 +1,209 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = { defer-plugin-errors = false; };
+    package = {
+      specVersion = "2.2";
+      identifier = { name = "plutus-contract"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "jann.mueller@iohk.io";
+      author = "Jann Müller";
+      homepage = "https://github.com/iohk/plutus#readme";
+      url = "";
+      synopsis = "";
+      description = "Please see the README on GitHub at <https://github.com/input-output-hk/plutus#readme>";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = ([
+          (hsPkgs."plutus-chain-index-core" or (errorHandler.buildDepError "plutus-chain-index-core"))
+          (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+          (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
+          (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
+          (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+          (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
+          (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+          (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
+          (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+          (hsPkgs."aeson-pretty" or (errorHandler.buildDepError "aeson-pretty"))
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
+          (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+          (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+          (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+          (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+          (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
+          (hsPkgs."foldl" or (errorHandler.buildDepError "foldl"))
+          (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
+          (hsPkgs."hashable" or (errorHandler.buildDepError "hashable"))
+          (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
+          (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+          (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
+          (hsPkgs."mmorph" or (errorHandler.buildDepError "mmorph"))
+          (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+          (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
+          (hsPkgs."profunctors" or (errorHandler.buildDepError "profunctors"))
+          (hsPkgs."quickcheck-dynamic" or (errorHandler.buildDepError "quickcheck-dynamic"))
+          (hsPkgs."row-types" or (errorHandler.buildDepError "row-types"))
+          (hsPkgs."semigroupoids" or (errorHandler.buildDepError "semigroupoids"))
+          (hsPkgs."servant" or (errorHandler.buildDepError "servant"))
+          (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
+          (hsPkgs."streaming" or (errorHandler.buildDepError "streaming"))
+          (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+          (hsPkgs."unordered-containers" or (errorHandler.buildDepError "unordered-containers"))
+          (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
+          (hsPkgs."IntervalMap" or (errorHandler.buildDepError "IntervalMap"))
+          (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+          (hsPkgs."openapi3" or (errorHandler.buildDepError "openapi3"))
+          (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
+          (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
+          ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))) ++ (pkgs.lib).optionals (!(compiler.isGhcjs && true || system.isGhcjs || system.isWindows)) [
+          (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+          (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+          (hsPkgs."tasty-golden" or (errorHandler.buildDepError "tasty-golden"))
+          ];
+        buildable = true;
+        modules = [
+          "Data/Row/Extras"
+          "Data/Text/Extras"
+          "Data/UUID/Extras"
+          "Plutus/Contract"
+          "Plutus/Contract/Effects"
+          "Plutus/Contract/Request"
+          "Plutus/Contract/Checkpoint"
+          "Plutus/Contract/Constraints"
+          "Plutus/Contract/State"
+          "Plutus/Contract/Schema"
+          "Plutus/Contract/Trace"
+          "Plutus/Contract/Trace/RequestHandler"
+          "Plutus/Contract/Resumable"
+          "Plutus/Contract/StateMachine"
+          "Plutus/Contract/StateMachine/OnChain"
+          "Plutus/Contract/StateMachine/MintingPolarity"
+          "Plutus/Contract/StateMachine/ThreadToken"
+          "Plutus/Contract/Tx"
+          "Plutus/Contract/Types"
+          "Plutus/Contract/Util"
+          "Plutus/Contract/Wallet"
+          "Plutus/Contract/Typed/Tx"
+          "Plutus/Contract/Secrets"
+          "Wallet/Emulator"
+          "Wallet/Emulator/Types"
+          "Wallet/Emulator/Chain"
+          "Wallet/Emulator/Error"
+          "Wallet/Emulator/Folds"
+          "Wallet/Emulator/LogMessages"
+          "Wallet/Emulator/NodeClient"
+          "Wallet/Emulator/MultiAgent"
+          "Wallet/Emulator/Stream"
+          "Wallet/Emulator/Wallet"
+          "Wallet/Rollup"
+          "Wallet/Rollup/Types"
+          "Wallet/Rollup/Render"
+          "Wallet"
+          "Wallet/API"
+          "Wallet/Effects"
+          "Wallet/Graph"
+          "Wallet/Types"
+          "Plutus/Trace"
+          "Plutus/Trace/Effects/Assert"
+          "Plutus/Trace/Effects/ContractInstanceId"
+          "Plutus/Trace/Effects/RunContract"
+          "Plutus/Trace/Effects/RunContractPlayground"
+          "Plutus/Trace/Effects/EmulatedWalletAPI"
+          "Plutus/Trace/Effects/EmulatorControl"
+          "Plutus/Trace/Effects/Waiting"
+          "Plutus/Trace/Emulator"
+          "Plutus/Trace/Emulator/ContractInstance"
+          "Plutus/Trace/Emulator/Extract"
+          "Plutus/Trace/Emulator/System"
+          "Plutus/Trace/Emulator/Types"
+          "Plutus/Trace/Playground"
+          "Plutus/Trace/Scheduler"
+          "Plutus/Trace/Tag"
+          ] ++ (pkgs.lib).optionals (!(compiler.isGhcjs && true || system.isGhcjs || system.isWindows)) [
+          "Plutus/Contract/Test"
+          "Plutus/Contract/Test/ContractModel"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      tests = {
+        "plutus-contract-test" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+            (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
+            (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-golden" or (errorHandler.buildDepError "tasty-golden"))
+            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
+            (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError "tasty-hedgehog"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
+            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            (hsPkgs."extensible-effects" or (errorHandler.buildDepError "extensible-effects"))
+            (hsPkgs."plutus-chain-index-core" or (errorHandler.buildDepError "plutus-chain-index-core"))
+            (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))
+            (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+            (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
+            (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."semigroupoids" or (errorHandler.buildDepError "semigroupoids"))
+            (hsPkgs."row-types" or (errorHandler.buildDepError "row-types"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"));
+          buildable = true;
+          modules = [
+            "Spec/Contract"
+            "Spec/ErrorChecking"
+            "Spec/Emulator"
+            "Spec/Rows"
+            "Spec/State"
+            "Spec/ThreadToken"
+            "Spec/Secrets"
+            ];
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "0";
+      rev = "minimal";
+      sha256 = "";
+      }) // {
+      url = "0";
+      rev = "minimal";
+      sha256 = "";
+      };
+    postUnpack = "sourceRoot+=/plutus-contract; echo source root reset to \$sourceRoot";
+    }

--- a/nix/hydra-poc.materialized/.plan.nix/plutus-core.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/plutus-core.nix
@@ -31,6 +31,7 @@
         "cost-model/data/cekMachineCosts.json"
         "cost-model/data/benching.csv"
         "cost-model/data/*.R"
+        "plutus-core/test/CostModelInterface/defaultCostModelParams.json"
         ];
       extraTmpFiles = [];
       extraDocFiles = [ "README.md" ];
@@ -110,6 +111,7 @@
         modules = [
           "PlutusCore/Analysis/Definitions"
           "PlutusCore/Constant/Function"
+          "PlutusCore/Constant/Kinded"
           "PlutusCore/Constant/Meaning"
           "PlutusCore/Constant/Typed"
           "PlutusCore/Core/Instance"
@@ -191,6 +193,7 @@
           "PlutusCore/Check/Uniques"
           "PlutusCore/Check/Value"
           "PlutusCore/Constant"
+          "PlutusCore/Constant/Debug"
           "PlutusCore/Constant/Dynamic/Emit"
           "PlutusCore/Core"
           "PlutusCore/Data"
@@ -299,7 +302,7 @@
           "Crypto"
           "Data/ByteString/Hash"
           "Data/SatInt"
-          "Data/Text/Prettyprint/Doc/Custom"
+          "Prettyprinter/Custom"
           "ErrorCode"
           "PlcTestUtils"
           "PlutusPrelude"
@@ -391,6 +394,20 @@
           hsSourceDirs = [ "executables" ];
           mainPath = [ "pir/Main.hs" ];
           };
+        "traceToStacks" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."cassava" or (errorHandler.buildDepError "cassava"))
+            (hsPkgs."integer-gmp" or (errorHandler.buildDepError "integer-gmp"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "executables/traceToStacks" ];
+          mainPath = [ "Main.hs" ];
+          };
         };
       tests = {
         "satint-test" = {
@@ -425,6 +442,10 @@
             (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+            (hsPkgs."th-lift-instances" or (errorHandler.buildDepError "th-lift-instances"))
+            (hsPkgs."th-utilities" or (errorHandler.buildDepError "th-utilities"))
             ];
           buildable = true;
           modules = [
@@ -522,10 +543,29 @@
             (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
             (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."quickcheck-instances" or (errorHandler.buildDepError "quickcheck-instances"))
             (hsPkgs."random" or (errorHandler.buildDepError "random"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
             ];
           buildable = true;
-          modules = [ "CriterionExtensions" "Nops" ];
+          modules = [
+            "Common"
+            "CriterionExtensions"
+            "Generators"
+            "Benchmarks/Bool"
+            "Benchmarks/ByteStrings"
+            "Benchmarks/CryptoAndHashes"
+            "Benchmarks/Data"
+            "Benchmarks/Integers"
+            "Benchmarks/Lists"
+            "Benchmarks/Misc"
+            "Benchmarks/Nops"
+            "Benchmarks/Pairs"
+            "Benchmarks/Strings"
+            "Benchmarks/Tracing"
+            "Benchmarks/Unit"
+            ];
           hsSourceDirs = [ "cost-model/budgeting-bench" ];
           };
         "update-cost-model" = {
@@ -580,11 +620,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "0";
+      url = "17";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "0";
+      url = "17";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/plutus-ghc-stub.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/plutus-ghc-stub.nix
@@ -1,0 +1,76 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "plutus-ghc-stub"; version = "8.6.5"; };
+      license = "BSD-3-Clause";
+      copyright = "";
+      maintainer = "glasgow-haskell-users@haskell.org";
+      author = "The GHC Team";
+      homepage = "http://www.haskell.org/ghc/";
+      url = "";
+      synopsis = "The GHC API";
+      description = "Stub functionality for the Plutus plugin, for cross compilers that\ndon't have a GHC library installed, like GHCJS\nThis should contain all the types and functions that the Plutus\ncompiler uses.\nFor technical reasons (Cabal), we need to be able to compile the plutus-tx\ncompiler for the host platform, even if we are going to load the plugin\nfrom the build platform libraries.";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" ];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."ghc-boot" or (errorHandler.buildDepError "ghc-boot"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+          ];
+        buildable = true;
+        modules = [
+          "StubTypes"
+          "Plugins"
+          "GhcPlugins"
+          "FamInstEnv"
+          "Panic"
+          "LoadIface"
+          "Finder"
+          "OccName"
+          "TcRnTypes"
+          "CoreSyn"
+          "Kind"
+          "TysPrim"
+          "PrimOp"
+          "Class"
+          "FV"
+          "MkId"
+          "PrelNames"
+          "TcRnMonad"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "17";
+      rev = "minimal";
+      sha256 = "";
+      }) // {
+      url = "17";
+      rev = "minimal";
+      sha256 = "";
+      };
+    postUnpack = "sourceRoot+=/stubs/plutus-ghc-stub; echo source root reset to \$sourceRoot";
+    }

--- a/nix/hydra-poc.materialized/.plan.nix/plutus-ledger-api.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/plutus-ledger-api.nix
@@ -60,7 +60,7 @@
         modules = [
           "Data/Aeson/Extras"
           "Data/Either/Extras"
-          "Data/Text/Prettyprint/Doc/Extras"
+          "Prettyprinter/Extras"
           "Plutus/V1/Ledger/Address"
           "Plutus/V1/Ledger/Ada"
           "Plutus/V1/Ledger/Api"
@@ -93,6 +93,7 @@
             (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
             (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError "tasty-hedgehog"))
             (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
             ];
           buildable = true;
           modules = [ "Spec/Interval" "Spec/Time" ];
@@ -103,11 +104,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "0";
+      url = "17";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "0";
+      url = "17";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/plutus-ledger.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/plutus-ledger.nix
@@ -35,49 +35,57 @@
         depends = [
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
-          (hsPkgs."base16-bytestring" or (errorHandler.buildDepError "base16-bytestring"))
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
+          (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+          (hsPkgs."cardano-api".components.sublibs.gen or (errorHandler.buildDepError "cardano-api:gen"))
+          (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
+          (hsPkgs."cardano-crypto-class" or (errorHandler.buildDepError "cardano-crypto-class"))
+          (hsPkgs."cardano-ledger-alonzo" or (errorHandler.buildDepError "cardano-ledger-alonzo"))
+          (hsPkgs."cardano-ledger-byron" or (errorHandler.buildDepError "cardano-ledger-byron"))
+          (hsPkgs."cardano-ledger-core" or (errorHandler.buildDepError "cardano-ledger-core"))
+          (hsPkgs."cardano-ledger-shelley" or (errorHandler.buildDepError "cardano-ledger-shelley"))
+          (hsPkgs."cardano-ledger-shelley-ma" or (errorHandler.buildDepError "cardano-ledger-shelley-ma"))
+          (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
+          (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
           (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
           (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
           (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
           (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
-          (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
           (hsPkgs."hashable" or (errorHandler.buildDepError "hashable"))
           (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
+          (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
           (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
           (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
           (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
           (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+          (hsPkgs."ouroboros-consensus-shelley" or (errorHandler.buildDepError "ouroboros-consensus-shelley"))
           (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
           (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
           (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
           (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
           (hsPkgs."scientific" or (errorHandler.buildDepError "scientific"))
+          (hsPkgs."strict-containers" or (errorHandler.buildDepError "strict-containers"))
           (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           (hsPkgs."time" or (errorHandler.buildDepError "time"))
           (hsPkgs."time-units" or (errorHandler.buildDepError "time-units"))
           (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
-          (hsPkgs."recursion-schemes" or (errorHandler.buildDepError "recursion-schemes"))
           (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
-          (hsPkgs."newtype-generics" or (errorHandler.buildDepError "newtype-generics"))
           (hsPkgs."http-api-data" or (errorHandler.buildDepError "http-api-data"))
-          (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
-          (hsPkgs."cardano-api".components.sublibs.gen or (errorHandler.buildDepError "cardano-api:gen"))
-          (hsPkgs."cardano-binary" or (errorHandler.buildDepError "cardano-binary"))
-          (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
-          (hsPkgs."cardano-crypto-class" or (errorHandler.buildDepError "cardano-crypto-class"))
-          (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+          (hsPkgs."servant" or (errorHandler.buildDepError "servant"))
           (hsPkgs."openapi3" or (errorHandler.buildDepError "openapi3"))
           (hsPkgs."freer-extras" or (errorHandler.buildDepError "freer-extras"))
           ];
         buildable = true;
         modules = [
+          "Ledger/Tx/CardanoAPITemp"
           "Data/Time/Units/Extra"
           "Ledger"
           "Ledger/Address"
           "Ledger/AddressMap"
           "Ledger/Blockchain"
+          "Ledger/CardanoWallet"
           "Ledger/Constraints"
           "Ledger/Constraints/OffChain"
           "Ledger/Constraints/OnChain"
@@ -93,6 +101,7 @@
           "Ledger/TimeSlot"
           "Ledger/Tokens"
           "Ledger/Tx"
+          "Ledger/Tx/CardanoAPI"
           "Ledger/Typed/Scripts"
           "Ledger/Typed/Scripts/MonetaryPolicies"
           "Ledger/Typed/Scripts/StakeValidators"

--- a/nix/hydra-poc.materialized/.plan.nix/plutus-tx-plugin.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/plutus-tx-plugin.nix
@@ -70,40 +70,6 @@
           ];
         hsSourceDirs = [ "src" ];
         };
-      exes = {
-        "logToStacks" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."flat" or (errorHandler.buildDepError "flat"))
-            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
-            (hsPkgs."integer-gmp" or (errorHandler.buildDepError "integer-gmp"))
-            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
-            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
-            (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
-            (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
-            (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
-            (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
-            (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            (hsPkgs."time" or (errorHandler.buildDepError "time"))
-            (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
-            ];
-          buildable = true;
-          modules = [
-            "Lib"
-            "Plugin/Lib"
-            "Plugin/Basic/Spec"
-            "Plugin/Data/Spec"
-            "Plugin/Functions/Spec"
-            "Plugin/Typeclasses/Lib"
-            "Plugin/Typeclasses/Spec"
-            "TH/TestTH"
-            ];
-          hsSourceDirs = [ "executables/profile" "test" ];
-          mainPath = [ "Main.hs" ];
-          };
-        };
       tests = {
         "plutus-tx-tests" = {
           depends = [
@@ -117,11 +83,8 @@
             (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
             (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
             (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
             (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
             (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
-            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
             (hsPkgs."tasty-hedgehog" or (errorHandler.buildDepError "tasty-hedgehog"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."hedgehog" or (errorHandler.buildDepError "hedgehog"))
@@ -157,11 +120,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "0";
+      url = "17";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "0";
+      url = "17";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/plutus-tx.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/plutus-tx.nix
@@ -124,11 +124,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "0";
+      url = "17";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "0";
+      url = "17";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/prettyprinter-configurable.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/prettyprinter-configurable.nix
@@ -10,7 +10,7 @@
   {
     flags = {};
     package = {
-      specVersion = "1.10";
+      specVersion = "2.4";
       identifier = {
         name = "prettyprinter-configurable";
         version = "0.1.0.0";
@@ -83,7 +83,6 @@
           };
         "prettyprinter-configurable-doctest" = {
           depends = [
-            (hsPkgs."prettyprinter-configurable" or (errorHandler.buildDepError "prettyprinter-configurable"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."doctest" or (errorHandler.buildDepError "doctest"))
             ];
@@ -95,11 +94,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "0";
+      url = "17";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "0";
+      url = "17";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/quickcheck-dynamic.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/quickcheck-dynamic.nix
@@ -35,7 +35,6 @@
         depends = [
           (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
-          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
           (hsPkgs."random" or (errorHandler.buildDepError "random"))
           ];
         buildable = true;
@@ -53,11 +52,8 @@
           depends = [
             (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."random" or (errorHandler.buildDepError "random"))
             (hsPkgs."quickcheck-dynamic" or (errorHandler.buildDepError "quickcheck-dynamic"))
             (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
-            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
             (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
             ];
           buildable = true;

--- a/nix/hydra-poc.materialized/.plan.nix/shelley-spec-ledger-test.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/shelley-spec-ledger-test.nix
@@ -74,11 +74,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/shelley-spec-ledger.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/shelley-spec-ledger.nix
@@ -107,11 +107,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/shelley-spec-non-integral.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/shelley-spec-non-integral.nix
@@ -43,11 +43,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/small-steps-test.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/small-steps-test.nix
@@ -88,11 +88,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/small-steps.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/small-steps.nix
@@ -74,11 +74,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "9";
+      url = "11";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/strict-non-empty-containers.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/strict-non-empty-containers.nix
@@ -1,0 +1,89 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = { release = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = {
+        name = "strict-non-empty-containers";
+        version = "2020.12.8";
+        };
+      license = "Apache-2.0";
+      copyright = "2018-2020 IOHK";
+      maintainer = "operations@iohk.io";
+      author = "IOHK Engineering Team";
+      homepage = "https://github.com/input-output-hk/cardano-wallet";
+      url = "";
+      synopsis = "Strict non-empty container types";
+      description = "";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+          (hsPkgs."hashable" or (errorHandler.buildDepError "hashable"))
+          ];
+        buildable = true;
+        modules = [
+          "Data/Map/Strict/NonEmptyMap"
+          "Data/Map/Strict/NonEmptyMap/Internal"
+          "Data/Set/Strict/NonEmptySet"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      tests = {
+        "unit" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."hspec-core" or (errorHandler.buildDepError "hspec-core"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."quickcheck-classes" or (errorHandler.buildDepError "quickcheck-classes"))
+            (hsPkgs."should-not-typecheck" or (errorHandler.buildDepError "should-not-typecheck"))
+            (hsPkgs."strict-non-empty-containers" or (errorHandler.buildDepError "strict-non-empty-containers"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.hspec-discover.components.exes.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover:hspec-discover")))
+            ];
+          buildable = true;
+          modules = [
+            "Data/Map/Strict/NonEmptyMapSpec"
+            "Data/Map/Strict/NonEmptyMap/TypeErrorSpec"
+            ];
+          hsSourceDirs = [ "test/unit" ];
+          mainPath = [ "Main.hs" ];
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "8";
+      rev = "minimal";
+      sha256 = "";
+      }) // {
+      url = "8";
+      rev = "minimal";
+      sha256 = "";
+      };
+    postUnpack = "sourceRoot+=/lib/strict-non-empty-containers; echo source root reset to \$sourceRoot";
+    }

--- a/nix/hydra-poc.materialized/.plan.nix/text-class.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/text-class.nix
@@ -1,0 +1,81 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = { release = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "text-class"; version = "2021.9.29"; };
+      license = "Apache-2.0";
+      copyright = "2018-2020 IOHK";
+      maintainer = "operations@iohk.io";
+      author = "IOHK Engineering Team";
+      homepage = "https://github.com/input-output-hk/cardano-wallet";
+      url = "";
+      synopsis = "Extra helpers to convert data-types to and from Text";
+      description = "";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."casing" or (errorHandler.buildDepError "casing"))
+          (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+          (hsPkgs."formatting" or (errorHandler.buildDepError "formatting"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."time" or (errorHandler.buildDepError "time"))
+          (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+          (hsPkgs."OddWord" or (errorHandler.buildDepError "OddWord"))
+          (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+          ];
+        buildable = true;
+        modules = [ "Data/Text/Class" "Test/Text/Roundtrip" ];
+        hsSourceDirs = [ "src" ];
+        };
+      tests = {
+        "unit" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
+            (hsPkgs."time" or (errorHandler.buildDepError "time"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.hspec-discover.components.exes.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover:hspec-discover")))
+            ];
+          buildable = true;
+          modules = [ "Data/Text/ClassSpec" ];
+          hsSourceDirs = [ "test/unit" ];
+          mainPath = [ "text-class-unit-test.hs" ];
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "8";
+      rev = "minimal";
+      sha256 = "";
+      }) // {
+      url = "8";
+      rev = "minimal";
+      sha256 = "";
+      };
+    postUnpack = "sourceRoot+=/lib/text-class; echo source root reset to \$sourceRoot";
+    }

--- a/nix/hydra-poc.materialized/.plan.nix/tracer-transformers.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/tracer-transformers.nix
@@ -73,11 +73,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "8";
+      url = "10";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "8";
+      url = "10";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/typed-protocols-cborg.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/typed-protocols-cborg.nix
@@ -46,11 +46,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/typed-protocols-examples.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/typed-protocols-examples.nix
@@ -89,11 +89,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/typed-protocols.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/typed-protocols.nix
@@ -50,11 +50,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "7";
+      url = "9";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/.plan.nix/word-array.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/word-array.nix
@@ -62,11 +62,9 @@
         "bench" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
             (hsPkgs."tasty-bench" or (errorHandler.buildDepError "tasty-bench"))
             (hsPkgs."word-array" or (errorHandler.buildDepError "word-array"))
             (hsPkgs."primitive" or (errorHandler.buildDepError "primitive"))
-            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
             ];
           buildable = true;
           hsSourceDirs = [ "bench" ];
@@ -75,11 +73,11 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "0";
+      url = "17";
       rev = "minimal";
       sha256 = "";
       }) // {
-      url = "0";
+      url = "17";
       rev = "minimal";
       sha256 = "";
       };

--- a/nix/hydra-poc.materialized/default.nix
+++ b/nix/hydra-poc.materialized/default.nix
@@ -13,6 +13,7 @@
         "binary".revision = (((hackage."binary")."0.8.8.0").revisions).default;
         "beam-migrate".revision = (((hackage."beam-migrate")."0.5.1.0").revisions).default;
         "beam-migrate".flags.werror = false;
+        "universe-reverse-instances".revision = (((hackage."universe-reverse-instances")."1.1.1").revisions).default;
         "openapi3".revision = (((hackage."openapi3")."3.1.0").revisions).default;
         "serialise".revision = (((hackage."serialise")."0.2.3.0").revisions).default;
         "serialise".flags.newtime15 = true;
@@ -22,6 +23,7 @@
         "ghc-boot".revision = (((hackage."ghc-boot")."8.10.7").revisions).default;
         "streaming-commons".revision = (((hackage."streaming-commons")."0.2.2.1").revisions).default;
         "streaming-commons".flags.use-bytestring-builder = false;
+        "fmt".revision = (((hackage."fmt")."0.6.2.0").revisions).default;
         "old-time".revision = (((hackage."old-time")."1.1.0.3").revisions).default;
         "relude".revision = (((hackage."relude")."1.0.0.1").revisions).default;
         "authenticate-oauth".revision = (((hackage."authenticate-oauth")."1.7").revisions).default;
@@ -37,6 +39,7 @@
         "haskell-lexer".revision = (((hackage."haskell-lexer")."1.1").revisions).default;
         "ghc-prim".revision = (((hackage."ghc-prim")."0.6.1").revisions).default;
         "wl-pprint-text".revision = (((hackage."wl-pprint-text")."1.2.0.1").revisions).default;
+        "command".revision = (((hackage."command")."0.1.1").revisions).default;
         "formatting".revision = (((hackage."formatting")."7.1.3").revisions).default;
         "regex-tdfa".revision = (((hackage."regex-tdfa")."1.3.1.1").revisions).default;
         "regex-tdfa".flags.force-o2 = false;
@@ -49,6 +52,7 @@
         "monad-par".flags.newgeneric = false;
         "boring".revision = (((hackage."boring")."0.2").revisions).default;
         "boring".flags.tagged = true;
+        "cryptohash-sha1".revision = (((hackage."cryptohash-sha1")."0.11.100.1").revisions).default;
         "socks".revision = (((hackage."socks")."0.6.1").revisions).default;
         "Stream".revision = (((hackage."Stream")."0.4.7.2").revisions).default;
         "string-conv".revision = (((hackage."string-conv")."0.1.2").revisions).default;
@@ -103,6 +107,8 @@
         "mtl-compat".flags.two-point-one = false;
         "bech32-th".revision = (((hackage."bech32-th")."1.1.1").revisions).default;
         "bech32-th".flags.release = false;
+        "time-locale-compat".revision = (((hackage."time-locale-compat")."0.1.1.5").revisions).default;
+        "time-locale-compat".flags.old-locale = false;
         "yaml".revision = (((hackage."yaml")."0.11.5.0").revisions).default;
         "yaml".flags.no-exe = true;
         "yaml".flags.no-examples = true;
@@ -117,6 +123,7 @@
         "size-based".revision = (((hackage."size-based")."0.1.2.0").revisions).default;
         "integer-gmp".revision = (((hackage."integer-gmp")."1.0.3.0").revisions).default;
         "psqueues".revision = (((hackage."psqueues")."0.2.7.2").revisions).default;
+        "path-pieces".revision = (((hackage."path-pieces")."0.2.1").revisions).default;
         "mono-traversable".revision = (((hackage."mono-traversable")."1.0.15.1").revisions).default;
         "conduit-extra".revision = (((hackage."conduit-extra")."1.3.5").revisions).default;
         "fast-logger".revision = (((hackage."fast-logger")."3.0.5").revisions).default;
@@ -144,6 +151,9 @@
         "word8".revision = (((hackage."word8")."0.1.3").revisions).default;
         "network".revision = (((hackage."network")."3.1.2.2").revisions).default;
         "network".flags.devel = false;
+        "quickcheck-classes-base".revision = (((hackage."quickcheck-classes-base")."0.6.2.0").revisions).default;
+        "quickcheck-classes-base".flags.unary-laws = true;
+        "quickcheck-classes-base".flags.binary-laws = true;
         "HUnit".revision = (((hackage."HUnit")."1.6.2.0").revisions).default;
         "wai-app-static".revision = (((hackage."wai-app-static")."3.1.7.2").revisions).default;
         "wai-app-static".flags.print = false;
@@ -175,6 +185,7 @@
         "criterion".flags.fast = false;
         "newtype-generics".revision = (((hackage."newtype-generics")."0.6").revisions).default;
         "half".revision = (((hackage."half")."0.3.1").revisions).default;
+        "int-cast".revision = (((hackage."int-cast")."0.2.0.0").revisions).default;
         "auto-update".revision = (((hackage."auto-update")."0.1.6").revisions).default;
         "http-conduit".revision = (((hackage."http-conduit")."2.3.8").revisions).default;
         "http-conduit".flags.aeson = true;
@@ -183,6 +194,7 @@
         "random".revision = (((hackage."random")."1.2.0").revisions).default;
         "code-page".revision = (((hackage."code-page")."0.2.1").revisions).default;
         "string-conversions".revision = (((hackage."string-conversions")."0.4.0.1").revisions).default;
+        "errors".revision = (((hackage."errors")."2.3.0").revisions).default;
         "unix-compat".revision = (((hackage."unix-compat")."0.5.3").revisions).default;
         "unix-compat".flags.old-time = false;
         "generics-sop".revision = (((hackage."generics-sop")."0.5.1.0").revisions).default;
@@ -199,15 +211,21 @@
         "QuickCheck".flags.old-random = false;
         "QuickCheck".flags.templatehaskell = true;
         "uuid-types".revision = (((hackage."uuid-types")."1.0.5").revisions).default;
+        "haskell-src-meta".revision = (((hackage."haskell-src-meta")."0.8.7").revisions).default;
+        "servant-client-core".revision = (((hackage."servant-client-core")."0.18.3").revisions).default;
         "scientific".revision = (((hackage."scientific")."0.3.7.0").revisions).default;
         "scientific".flags.integer-simple = false;
         "scientific".flags.bytestring-builder = false;
+        "resource-pool".revision = (((hackage."resource-pool")."0.2.3.2").revisions).default;
+        "resource-pool".flags.developer = false;
         "monad-loops".revision = (((hackage."monad-loops")."0.4.3").revisions).default;
         "monad-loops".flags.base4 = true;
+        "aeson-qq".revision = (((hackage."aeson-qq")."0.8.3").revisions).default;
         "entropy".revision = (((hackage."entropy")."0.4.1.6").revisions).default;
         "entropy".flags.halvm = false;
         "hpc".revision = (((hackage."hpc")."0.6.1.0").revisions).default;
         "binary-orphans".revision = (((hackage."binary-orphans")."1.0.1").revisions).default;
+        "text-conversions".revision = (((hackage."text-conversions")."0.3.1").revisions).default;
         "tls".revision = (((hackage."tls")."1.5.5").revisions).default;
         "tls".flags.compat = true;
         "tls".flags.network = true;
@@ -236,6 +254,7 @@
         "iproute".revision = (((hackage."iproute")."1.7.11").revisions).default;
         "data-default-instances-containers".revision = (((hackage."data-default-instances-containers")."0.0.1").revisions).default;
         "stm-chans".revision = (((hackage."stm-chans")."3.0.0.4").revisions).default;
+        "cryptohash-md5".revision = (((hackage."cryptohash-md5")."0.11.100.1").revisions).default;
         "generic-deriving".revision = (((hackage."generic-deriving")."1.13.1").revisions).default;
         "generic-deriving".flags.base-4-9 = true;
         "hspec-golden-aeson".revision = (((hackage."hspec-golden-aeson")."0.9.0.0").revisions).default;
@@ -278,18 +297,24 @@
         "aeson-pretty".flags.lib-only = false;
         "tasty-golden".revision = (((hackage."tasty-golden")."2.3.4").revisions).default;
         "tasty-golden".flags.build-example = false;
+        "persistent".revision = (((hackage."persistent")."2.13.1.1").revisions).default;
         "mtl".revision = (((hackage."mtl")."2.2.2").revisions).default;
         "time".revision = (((hackage."time")."1.9.3").revisions).default;
         "bech32".revision = (((hackage."bech32")."1.1.1").revisions).default;
         "bech32".flags.static = false;
         "bech32".flags.release = false;
+        "servant-client".revision = (((hackage."servant-client")."0.18.3").revisions).default;
         "optics-extra".revision = (((hackage."optics-extra")."0.3").revisions).default;
+        "uuid".revision = (((hackage."uuid")."1.3.15").revisions).default;
         "unordered-containers".revision = (((hackage."unordered-containers")."0.2.14.0").revisions).default;
         "unordered-containers".flags.debug = false;
         "easy-file".revision = (((hackage."easy-file")."0.2.2").revisions).default;
         "data-default-class".revision = (((hackage."data-default-class")."0.1.2.0").revisions).default;
         "parser-combinators".revision = (((hackage."parser-combinators")."1.3.0").revisions).default;
         "parser-combinators".flags.dev = false;
+        "pretty-simple".revision = (((hackage."pretty-simple")."4.0.0.0").revisions).default;
+        "pretty-simple".flags.buildexe = false;
+        "pretty-simple".flags.buildexample = false;
         "indexed-list-literals".revision = (((hackage."indexed-list-literals")."0.2.1.3").revisions).default;
         "time-units".revision = (((hackage."time-units")."1.0.0").revisions).default;
         "snap-core".revision = (((hackage."snap-core")."1.0.4.2").revisions).default;
@@ -318,6 +343,7 @@
         "case-insensitive".revision = (((hackage."case-insensitive")."1.2.1.0").revisions).default;
         "constraints-extras".revision = (((hackage."constraints-extras")."0.3.1.0").revisions).default;
         "constraints-extras".flags.build-readme = true;
+        "hspec-expectations-lifted".revision = (((hackage."hspec-expectations-lifted")."0.10.0").revisions).default;
         "network-byte-order".revision = (((hackage."network-byte-order")."0.1.6").revisions).default;
         "optparse-generic".revision = (((hackage."optparse-generic")."1.4.4").revisions).default;
         "base58-bytestring".revision = (((hackage."base58-bytestring")."0.1.0").revisions).default;
@@ -335,6 +361,7 @@
         "canonical-json".revision = (((hackage."canonical-json")."0.6.0.0").revisions).default;
         "witherable".revision = (((hackage."witherable")."0.4.1").revisions).default;
         "pipes".revision = (((hackage."pipes")."4.3.16").revisions).default;
+        "primitive-addr".revision = (((hackage."primitive-addr")."0.1.0.2").revisions).default;
         "lens-aeson".revision = (((hackage."lens-aeson")."1.1.1").revisions).default;
         "ansi-wl-pprint".revision = (((hackage."ansi-wl-pprint")."0.6.9").revisions).default;
         "ansi-wl-pprint".flags.example = false;
@@ -342,6 +369,10 @@
         "reflection".flags.slow = false;
         "reflection".flags.template-haskell = true;
         "th-utilities".revision = (((hackage."th-utilities")."0.2.4.1").revisions).default;
+        "string-interpolate".revision = (((hackage."string-interpolate")."0.3.1.1").revisions).default;
+        "string-interpolate".flags.text-builder = false;
+        "string-interpolate".flags.extended-benchmarks = false;
+        "string-interpolate".flags.bytestring-builder = false;
         "hostname".revision = (((hackage."hostname")."1.0").revisions).default;
         "basement".revision = (((hackage."basement")."0.0.12").revisions).default;
         "process-extras".revision = (((hackage."process-extras")."0.7.4").revisions).default;
@@ -349,6 +380,7 @@
         "ekg-core".revision = (((hackage."ekg-core")."0.1.1.7").revisions).default;
         "either".revision = (((hackage."either")."5.0.1.1").revisions).default;
         "setenv".revision = (((hackage."setenv")."0.1.1.3").revisions).default;
+        "scrypt".revision = (((hackage."scrypt")."0.5.0").revisions).default;
         "integer-logarithms".revision = (((hackage."integer-logarithms")."1.0.3.1").revisions).default;
         "integer-logarithms".flags.check-bounds = false;
         "integer-logarithms".flags.integer-gmp = true;
@@ -404,6 +436,7 @@
         "quickcheck-instances".revision = (((hackage."quickcheck-instances")."0.3.25.2").revisions).default;
         "quickcheck-instances".flags.bytestring-builder = false;
         "streaming".revision = (((hackage."streaming")."0.2.3.0").revisions).default;
+        "row-types".revision = (((hackage."row-types")."1.0.1.0").revisions).default;
         "silently".revision = (((hackage."silently")."1.2.5.1").revisions).default;
         "criterion-measurement".revision = (((hackage."criterion-measurement")."0.1.3.0").revisions).default;
         "criterion-measurement".flags.fast = false;
@@ -411,11 +444,15 @@
         "show-combinators".revision = (((hackage."show-combinators")."0.2.0.0").revisions).default;
         "base-orphans".revision = (((hackage."base-orphans")."0.8.4").revisions).default;
         "fin".revision = (((hackage."fin")."0.1.1").revisions).default;
+        "casing".revision = (((hackage."casing")."0.1.4.1").revisions).default;
+        "prettyprinter-ansi-terminal".revision = (((hackage."prettyprinter-ansi-terminal")."1.1.2").revisions).default;
         "primitive".revision = (((hackage."primitive")."0.7.2.0").revisions).default;
         "servant-server".revision = (((hackage."servant-server")."0.18.3").revisions).default;
         "pqueue".revision = (((hackage."pqueue")."1.4.1.3").revisions).default;
+        "lattices".revision = (((hackage."lattices")."2.0.2").revisions).default;
         "brick".revision = (((hackage."brick")."0.62").revisions).default;
         "brick".flags.demos = false;
+        "OddWord".revision = (((hackage."OddWord")."1.0.2.0").revisions).default;
         "dns".revision = (((hackage."dns")."3.0.4").revisions).default;
         "directory".revision = (((hackage."directory")."1.3.6.0").revisions).default;
         "hspec-junit-formatter".revision = (((hackage."hspec-junit-formatter")."1.0.1.0").revisions).default;
@@ -440,8 +477,19 @@
         "config-ini".revision = (((hackage."config-ini")."0.2.4.0").revisions).default;
         "config-ini".flags.enable-doctests = false;
         "microlens".revision = (((hackage."microlens")."0.4.12.0").revisions).default;
+        "tls-session-manager".revision = (((hackage."tls-session-manager")."0.0.4").revisions).default;
         "microlens-mtl".revision = (((hackage."microlens-mtl")."0.2.0.1").revisions).default;
         "resourcet".revision = (((hackage."resourcet")."1.2.4.3").revisions).default;
+        "persistent-sqlite".revision = (((hackage."persistent-sqlite")."2.13.0.3").revisions).default;
+        "persistent-sqlite".flags.use-stat3 = false;
+        "persistent-sqlite".flags.uri-filenames = true;
+        "persistent-sqlite".flags.use-stat4 = true;
+        "persistent-sqlite".flags.have-usleep = true;
+        "persistent-sqlite".flags.json1 = true;
+        "persistent-sqlite".flags.build-sanity-exe = false;
+        "persistent-sqlite".flags.use-pkgconfig = false;
+        "persistent-sqlite".flags.full-text-search = true;
+        "persistent-sqlite".flags.systemlib = false;
         "aeson".revision = (((hackage."aeson")."1.5.6.0").revisions).default;
         "aeson".flags.developer = false;
         "aeson".flags.bytestring-builder = false;
@@ -452,6 +500,13 @@
         "cabal-doctest".revision = (((hackage."cabal-doctest")."1.0.8").revisions).default;
         "crypto-api".revision = (((hackage."crypto-api")."0.13.3").revisions).default;
         "crypto-api".flags.all_cpolys = false;
+        "quickcheck-classes".revision = (((hackage."quickcheck-classes")."0.6.5.0").revisions).default;
+        "quickcheck-classes".flags.semirings = true;
+        "quickcheck-classes".flags.unary-laws = true;
+        "quickcheck-classes".flags.semigroupoids = true;
+        "quickcheck-classes".flags.vector = true;
+        "quickcheck-classes".flags.aeson = true;
+        "quickcheck-classes".flags.binary-laws = true;
         "data-default".revision = (((hackage."data-default")."0.7.1.1").revisions).default;
         "quickcheck-arbitrary-adt".revision = (((hackage."quickcheck-arbitrary-adt")."0.3.1.0").revisions).default;
         "connection".revision = (((hackage."connection")."0.3.1").revisions).default;
@@ -477,6 +532,7 @@
         "libyaml".flags.no-unicode = false;
         "servant-subscriber".revision = (((hackage."servant-subscriber")."0.7.0.0").revisions).default;
         "servant-subscriber".flags.websockets_0_11 = true;
+        "generic-lens-core".revision = (((hackage."generic-lens-core")."2.2.0.0").revisions).default;
         "splitmix".revision = (((hackage."splitmix")."0.1.0.3").revisions).default;
         "splitmix".flags.optimised-mixer = false;
         "x509-store".revision = (((hackage."x509-store")."1.6.7").revisions).default;
@@ -486,8 +542,12 @@
         "nothunks".flags.bytestring = true;
         "nothunks".flags.vector = true;
         "nothunks".flags.text = true;
+        "IntervalMap".revision = (((hackage."IntervalMap")."0.6.1.2").revisions).default;
         "zeromq4-haskell".revision = (((hackage."zeromq4-haskell")."0.8.0").revisions).default;
         "hedgehog".revision = (((hackage."hedgehog")."1.0.5").revisions).default;
+        "semirings".revision = (((hackage."semirings")."0.6").revisions).default;
+        "semirings".flags.containers = true;
+        "semirings".flags.unordered-containers = true;
         "system-filepath".revision = (((hackage."system-filepath")."0.4.14").revisions).default;
         "recursion-schemes".revision = (((hackage."recursion-schemes")."5.1.3").revisions).default;
         "recursion-schemes".flags.template-haskell = true;
@@ -496,6 +556,7 @@
         "hspec-core".revision = (((hackage."hspec-core")."2.8.3").revisions).default;
         "asn1-types".revision = (((hackage."asn1-types")."0.3.4").revisions).default;
         "say".revision = (((hackage."say")."0.1.0.1").revisions).default;
+        "exact-combinatorics".revision = (((hackage."exact-combinatorics")."0.2.0.9").revisions).default;
         "filepath".revision = (((hackage."filepath")."1.4.2.1").revisions).default;
         "asn1-encoding".revision = (((hackage."asn1-encoding")."0.9.6").revisions).default;
         "list-t".revision = (((hackage."list-t")."1.0.4").revisions).default;
@@ -525,6 +586,8 @@
         "http-api-data".flags.use-text-show = false;
         "attoparsec".revision = (((hackage."attoparsec")."0.13.2.5").revisions).default;
         "attoparsec".flags.developer = false;
+        "persistent-template".revision = (((hackage."persistent-template")."2.12.0.0").revisions).default;
+        "generic-lens".revision = (((hackage."generic-lens")."2.2.0.0").revisions).default;
         "unix-bytestring".revision = (((hackage."unix-bytestring")."0.3.7.3").revisions).default;
         "monad-logger".revision = (((hackage."monad-logger")."0.3.36").revisions).default;
         "monad-logger".flags.template_haskell = true;
@@ -550,6 +613,7 @@
         "blaze-html".revision = (((hackage."blaze-html")."0.9.1.2").revisions).default;
         "invariant".revision = (((hackage."invariant")."0.5.3").revisions).default;
         "dependent-map".revision = (((hackage."dependent-map")."0.4.0.0").revisions).default;
+        "generic-arbitrary".revision = (((hackage."generic-arbitrary")."0.2.0").revisions).default;
         "genvalidity-scientific".revision = (((hackage."genvalidity-scientific")."0.2.1.1").revisions).default;
         "hashable".revision = (((hackage."hashable")."1.3.2.0").revisions).default;
         "hashable".flags.integer-gmp = true;
@@ -570,6 +634,7 @@
         "ghci".revision = (((hackage."ghci")."8.10.7").revisions).default;
         "assoc".revision = (((hackage."assoc")."1.0.2").revisions).default;
         "statistics".revision = (((hackage."statistics")."0.15.2.0").revisions).default;
+        "universe-base".revision = (((hackage."universe-base")."1.1.2").revisions).default;
         "sqlite-simple".revision = (((hackage."sqlite-simple")."0.4.18.0").revisions).default;
         "asn1-parse".revision = (((hackage."asn1-parse")."0.9.5").revisions).default;
         "base64-bytestring".revision = (((hackage."base64-bytestring")."1.2.1.0").revisions).default;
@@ -597,6 +662,7 @@
         "cryptonite".flags.integer-gmp = true;
         "cryptonite".flags.check_alignment = false;
         "hedgehog-quickcheck".revision = (((hackage."hedgehog-quickcheck")."0.1.1").revisions).default;
+        "network-info".revision = (((hackage."network-info")."0.2.0.10").revisions).default;
         "th-compat".revision = (((hackage."th-compat")."0.1.2").revisions).default;
         "mmorph".revision = (((hackage."mmorph")."1.1.5").revisions).default;
         "indexed-traversable".revision = (((hackage."indexed-traversable")."0.1.1").revisions).default;
@@ -612,12 +678,14 @@
         "testing-type-modifiers".revision = (((hackage."testing-type-modifiers")."0.1.0.1").revisions).default;
         "mime-types".revision = (((hackage."mime-types")."0.1.0.9").revisions).default;
         "prometheus".revision = (((hackage."prometheus")."2.2.2").revisions).default;
+        "lift-type".revision = (((hackage."lift-type")."0.1.0.1").revisions).default;
         "http2".revision = (((hackage."http2")."3.0.2").revisions).default;
         "http2".flags.devel = false;
         "http2".flags.h2spec = false;
         "http2".flags.doc = false;
         "generic-monoid".revision = (((hackage."generic-monoid")."0.1.0.1").revisions).default;
         "data-default-instances-dlist".revision = (((hackage."data-default-instances-dlist")."0.0.1").revisions).default;
+        "warp-tls".revision = (((hackage."warp-tls")."3.3.1").revisions).default;
         "microstache".revision = (((hackage."microstache")."1.0.1.2").revisions).default;
         "unix-time".revision = (((hackage."unix-time")."0.4.7").revisions).default;
         "base-compat-batteries".revision = (((hackage."base-compat-batteries")."0.11.2").revisions).default;
@@ -681,6 +749,7 @@
       packages = {
         ouroboros-network = ./.plan.nix/ouroboros-network.nix;
         flat = ./.plan.nix/flat.nix;
+        plutus-ghc-stub = ./.plan.nix/plutus-ghc-stub.nix;
         cardano-cli = ./.plan.nix/cardano-cli.nix;
         purescript-bridge = ./.plan.nix/purescript-bridge.nix;
         cardano-ledger-pretty = ./.plan.nix/cardano-ledger-pretty.nix;
@@ -689,12 +758,15 @@
         hydra-prelude = ./.plan.nix/hydra-prelude.nix;
         typed-protocols = ./.plan.nix/typed-protocols.nix;
         ouroboros-network-testing = ./.plan.nix/ouroboros-network-testing.nix;
+        cardano-addresses = ./.plan.nix/cardano-addresses.nix;
         servant-purescript = ./.plan.nix/servant-purescript.nix;
         ouroboros-consensus-shelley = ./.plan.nix/ouroboros-consensus-shelley.nix;
         cardano-slotting = ./.plan.nix/cardano-slotting.nix;
         cardano-node = ./.plan.nix/cardano-node.nix;
+        cardano-wallet-launcher = ./.plan.nix/cardano-wallet-launcher.nix;
         cardano-protocol-tpraos = ./.plan.nix/cardano-protocol-tpraos.nix;
         cardano-crypto-class = ./.plan.nix/cardano-crypto-class.nix;
+        cardano-wallet = ./.plan.nix/cardano-wallet.nix;
         lobemo-backend-monitoring = ./.plan.nix/lobemo-backend-monitoring.nix;
         tracer-transformers = ./.plan.nix/tracer-transformers.nix;
         plutus-tx-plugin = ./.plan.nix/plutus-tx-plugin.nix;
@@ -705,11 +777,14 @@
         network-mux = ./.plan.nix/network-mux.nix;
         lobemo-backend-ekg = ./.plan.nix/lobemo-backend-ekg.nix;
         small-steps = ./.plan.nix/small-steps.nix;
+        cardano-wallet-core-integration = ./.plan.nix/cardano-wallet-core-integration.nix;
         cardano-ledger-shelley = ./.plan.nix/cardano-ledger-shelley.nix;
         byron-spec-ledger = ./.plan.nix/byron-spec-ledger.nix;
+        cardano-wallet-core = ./.plan.nix/cardano-wallet-core.nix;
         byron-spec-chain = ./.plan.nix/byron-spec-chain.nix;
         cardano-crypto-praos = ./.plan.nix/cardano-crypto-praos.nix;
         monoidal-synchronisation = ./.plan.nix/monoidal-synchronisation.nix;
+        cardano-wallet-cli = ./.plan.nix/cardano-wallet-cli.nix;
         cardano-binary-test = ./.plan.nix/cardano-binary-test.nix;
         plutus-core = ./.plan.nix/plutus-core.nix;
         cardano-prelude-test = ./.plan.nix/cardano-prelude-test.nix;
@@ -720,10 +795,12 @@
         cardano-ledger-byron-test = ./.plan.nix/cardano-ledger-byron-test.nix;
         plutus-tx = ./.plan.nix/plutus-tx.nix;
         hedgehog-extras = ./.plan.nix/hedgehog-extras.nix;
+        cardano-wallet-test-utils = ./.plan.nix/cardano-wallet-test-utils.nix;
         cardano-ledger-test = ./.plan.nix/cardano-ledger-test.nix;
         hydra-test-utils = ./.plan.nix/hydra-test-utils.nix;
         base-deriving-via = ./.plan.nix/base-deriving-via.nix;
         non-integral = ./.plan.nix/non-integral.nix;
+        plutus-contract = ./.plan.nix/plutus-contract.nix;
         iohk-monitoring = ./.plan.nix/iohk-monitoring.nix;
         io-sim = ./.plan.nix/io-sim.nix;
         cardano-ledger-shelley-ma-test = ./.plan.nix/cardano-ledger-shelley-ma-test.nix;
@@ -735,8 +812,11 @@
         cardano-binary = ./.plan.nix/cardano-binary.nix;
         cardano-prelude = ./.plan.nix/cardano-prelude.nix;
         optparse-applicative-fork = ./.plan.nix/optparse-applicative-fork.nix;
+        ntp-client = ./.plan.nix/ntp-client.nix;
+        text-class = ./.plan.nix/text-class.nix;
         ouroboros-network-framework = ./.plan.nix/ouroboros-network-framework.nix;
         lobemo-backend-aggregation = ./.plan.nix/lobemo-backend-aggregation.nix;
+        plutus-chain-index-core = ./.plan.nix/plutus-chain-index-core.nix;
         plutus-ledger-api = ./.plan.nix/plutus-ledger-api.nix;
         io-classes = ./.plan.nix/io-classes.nix;
         cardano-ledger-alonzo-test = ./.plan.nix/cardano-ledger-alonzo-test.nix;
@@ -751,13 +831,17 @@
         small-steps-test = ./.plan.nix/small-steps-test.nix;
         hydra-plutus = ./.plan.nix/hydra-plutus.nix;
         cardano-ledger-shelley-test = ./.plan.nix/cardano-ledger-shelley-test.nix;
+        strict-non-empty-containers = ./.plan.nix/strict-non-empty-containers.nix;
+        plutus-chain-index = ./.plan.nix/plutus-chain-index.nix;
         typed-protocols-cborg = ./.plan.nix/typed-protocols-cborg.nix;
         Win32-network = ./.plan.nix/Win32-network.nix;
         cardano-ledger-core = ./.plan.nix/cardano-ledger-core.nix;
         cardano-ledger-shelley-ma = ./.plan.nix/cardano-ledger-shelley-ma.nix;
         goblins = ./.plan.nix/goblins.nix;
         lobemo-backend-trace-forwarder = ./.plan.nix/lobemo-backend-trace-forwarder.nix;
+        cardano-addresses-cli = ./.plan.nix/cardano-addresses-cli.nix;
         prettyprinter-configurable = ./.plan.nix/prettyprinter-configurable.nix;
+        cardano-numeric = ./.plan.nix/cardano-numeric.nix;
         cardano-crypto = ./.plan.nix/cardano-crypto.nix;
         shelley-spec-ledger = ./.plan.nix/shelley-spec-ledger.nix;
         strict-containers = ./.plan.nix/strict-containers.nix;
@@ -776,6 +860,7 @@
               };
             };
           "flat" = { flags = {}; };
+          "plutus-ghc-stub" = { flags = {}; };
           "cardano-cli" = {
             flags = { "unexpected_thunks" = lib.mkOverride 900 false; };
             };
@@ -788,6 +873,9 @@
           "hydra-prelude" = { flags = {}; };
           "typed-protocols" = { flags = {}; };
           "ouroboros-network-testing" = { flags = {}; };
+          "cardano-addresses" = {
+            flags = { "release" = lib.mkOverride 900 false; };
+            };
           "servant-purescript" = { flags = {}; };
           "ouroboros-consensus-shelley" = {
             flags = { "asserts" = lib.mkOverride 900 false; };
@@ -801,9 +889,15 @@
               "systemd" = lib.mkOverride 900 false;
               };
             };
+          "cardano-wallet-launcher" = {
+            flags = { "release" = lib.mkOverride 900 false; };
+            };
           "cardano-protocol-tpraos" = { flags = {}; };
           "cardano-crypto-class" = {
             flags = { "development" = lib.mkOverride 900 false; };
+            };
+          "cardano-wallet" = {
+            flags = { "release" = lib.mkOverride 900 false; };
             };
           "lobemo-backend-monitoring" = { flags = {}; };
           "tracer-transformers" = { flags = {}; };
@@ -830,8 +924,14 @@
           "small-steps" = {
             flags = { "sts_assert" = lib.mkOverride 900 false; };
             };
+          "cardano-wallet-core-integration" = {
+            flags = { "release" = lib.mkOverride 900 false; };
+            };
           "cardano-ledger-shelley" = { flags = {}; };
           "byron-spec-ledger" = { flags = {}; };
+          "cardano-wallet-core" = {
+            flags = { "release" = lib.mkOverride 900 false; };
+            };
           "byron-spec-chain" = { flags = {}; };
           "cardano-crypto-praos" = {
             flags = {
@@ -840,6 +940,9 @@
               };
             };
           "monoidal-synchronisation" = { flags = {}; };
+          "cardano-wallet-cli" = {
+            flags = { "release" = lib.mkOverride 900 false; };
+            };
           "cardano-binary-test" = {
             flags = { "development" = lib.mkOverride 900 false; };
             };
@@ -848,7 +951,7 @@
             flags = { "development" = lib.mkOverride 900 false; };
             };
           "local-cluster" = {
-            flags = { "hydra-development" = lib.mkOverride 900 true; };
+            flags = { "hydra-development" = lib.mkOverride 900 false; };
             };
           "typed-protocols-examples" = { flags = {}; };
           "cardano-crypto-tests" = {
@@ -858,12 +961,18 @@
           "cardano-ledger-byron-test" = { flags = {}; };
           "plutus-tx" = { flags = {}; };
           "hedgehog-extras" = { flags = {}; };
+          "cardano-wallet-test-utils" = {
+            flags = { "release" = lib.mkOverride 900 false; };
+            };
           "cardano-ledger-test" = { flags = {}; };
           "hydra-test-utils" = { flags = {}; };
           "base-deriving-via" = {
             flags = { "development" = lib.mkOverride 900 false; };
             };
           "non-integral" = { flags = {}; };
+          "plutus-contract" = {
+            flags = { "defer-plugin-errors" = lib.mkOverride 900 false; };
+            };
           "iohk-monitoring" = {
             flags = {
               "performance-test-queue" = lib.mkOverride 900 false;
@@ -890,8 +999,11 @@
           "optparse-applicative-fork" = {
             flags = { "process" = lib.mkOverride 900 true; };
             };
+          "ntp-client" = { flags = { "demo" = lib.mkOverride 900 true; }; };
+          "text-class" = { flags = { "release" = lib.mkOverride 900 false; }; };
           "ouroboros-network-framework" = { flags = {}; };
           "lobemo-backend-aggregation" = { flags = {}; };
+          "plutus-chain-index-core" = { flags = {}; };
           "plutus-ledger-api" = { flags = {}; };
           "io-classes" = {
             flags = {
@@ -901,13 +1013,13 @@
             };
           "cardano-ledger-alonzo-test" = { flags = {}; };
           "hydra-tui" = {
-            flags = { "hydra-development" = lib.mkOverride 900 true; };
+            flags = { "hydra-development" = lib.mkOverride 900 false; };
             };
           "ouroboros-consensus-byron" = {
             flags = { "asserts" = lib.mkOverride 900 false; };
             };
           "hydra-node" = {
-            flags = { "hydra-development" = lib.mkOverride 900 true; };
+            flags = { "hydra-development" = lib.mkOverride 900 false; };
             };
           "contra-tracer" = { flags = {}; };
           "orphans-deriving-via" = {
@@ -920,9 +1032,13 @@
           "cardano-ledger-alonzo" = { flags = {}; };
           "small-steps-test" = { flags = {}; };
           "hydra-plutus" = {
-            flags = { "hydra-development" = lib.mkOverride 900 true; };
+            flags = { "hydra-development" = lib.mkOverride 900 false; };
             };
           "cardano-ledger-shelley-test" = { flags = {}; };
+          "strict-non-empty-containers" = {
+            flags = { "release" = lib.mkOverride 900 false; };
+            };
+          "plutus-chain-index" = { flags = {}; };
           "typed-protocols-cborg" = { flags = {}; };
           "Win32-network" = { flags = { "demo" = lib.mkOverride 900 false; }; };
           "cardano-ledger-core" = { flags = {}; };
@@ -931,7 +1047,13 @@
             flags = { "development" = lib.mkOverride 900 false; };
             };
           "lobemo-backend-trace-forwarder" = { flags = {}; };
+          "cardano-addresses-cli" = {
+            flags = { "release" = lib.mkOverride 900 false; };
+            };
           "prettyprinter-configurable" = { flags = {}; };
+          "cardano-numeric" = {
+            flags = { "release" = lib.mkOverride 900 false; };
+            };
           "cardano-crypto" = {
             flags = {
               "golden-tests-exe" = lib.mkOverride 900 false;
@@ -964,9 +1086,11 @@
           "math-functions".components.library.planned = lib.mkOverride 900 true;
           "byteorder".components.library.planned = lib.mkOverride 900 true;
           "vty".components.exes."vty-demo".planned = lib.mkOverride 900 true;
+          "ntp-client".components.exes."demo-ntp-client".planned = lib.mkOverride 900 true;
           "ekg-json".components.library.planned = lib.mkOverride 900 true;
           "tracer-transformers".components.exes."tracer-transfomers-example1".planned = lib.mkOverride 900 true;
           "semigroupoids".components.setup.planned = lib.mkOverride 900 true;
+          "row-types".components.library.planned = lib.mkOverride 900 true;
           "streaming".components.library.planned = lib.mkOverride 900 true;
           "containers".components.library.planned = lib.mkOverride 900 true;
           "lens".components.library.planned = lib.mkOverride 900 true;
@@ -982,18 +1106,22 @@
           "Win32-network".components.exes."named-pipe-demo".planned = lib.mkOverride 900 true;
           "criterion-measurement".components.library.planned = lib.mkOverride 900 true;
           "silently".components.library.planned = lib.mkOverride 900 true;
+          "plutus-contract".components.library.planned = lib.mkOverride 900 true;
           "cardano-ledger-test".components.library.planned = lib.mkOverride 900 true;
           "wl-pprint-text".components.library.planned = lib.mkOverride 900 true;
           "bifunctors".components.library.planned = lib.mkOverride 900 true;
+          "cardano-wallet-test-utils".components.library.planned = lib.mkOverride 900 true;
           "ral".components.library.planned = lib.mkOverride 900 true;
           "katip".components.library.planned = lib.mkOverride 900 true;
           "streaming-commons".components.library.planned = lib.mkOverride 900 true;
+          "fmt".components.library.planned = lib.mkOverride 900 true;
           "relude".components.library.planned = lib.mkOverride 900 true;
           "old-time".components.library.planned = lib.mkOverride 900 true;
           "authenticate-oauth".components.library.planned = lib.mkOverride 900 true;
           "base-deriving-via".components.library.planned = lib.mkOverride 900 true;
           "beam-migrate".components.library.planned = lib.mkOverride 900 true;
           "openapi3".components.library.planned = lib.mkOverride 900 true;
+          "universe-reverse-instances".components.library.planned = lib.mkOverride 900 true;
           "dependent-sum".components.library.planned = lib.mkOverride 900 true;
           "generic-random".components.library.planned = lib.mkOverride 900 true;
           "ghc-boot".components.library.planned = lib.mkOverride 900 true;
@@ -1008,7 +1136,9 @@
           "these".components.library.planned = lib.mkOverride 900 true;
           "openapi3".components.setup.planned = lib.mkOverride 900 true;
           "socks".components.library.planned = lib.mkOverride 900 true;
+          "cryptohash-sha1".components.library.planned = lib.mkOverride 900 true;
           "hydra-test-utils".components.library.planned = lib.mkOverride 900 true;
+          "command".components.library.planned = lib.mkOverride 900 true;
           "regex-tdfa".components.library.planned = lib.mkOverride 900 true;
           "formatting".components.library.planned = lib.mkOverride 900 true;
           "network-mux".components.exes."mux-demo".planned = lib.mkOverride 900 true;
@@ -1038,6 +1168,7 @@
           "x509-validation".components.library.planned = lib.mkOverride 900 true;
           "typed-protocols-cborg".components.library.planned = lib.mkOverride 900 true;
           "dec".components.library.planned = lib.mkOverride 900 true;
+          "cardano-addresses-cli".components.library.planned = lib.mkOverride 900 true;
           "extra".components.library.planned = lib.mkOverride 900 true;
           "base-compat-batteries".components.library.planned = lib.mkOverride 900 true;
           "lobemo-backend-trace-forwarder".components.library.planned = lib.mkOverride 900 true;
@@ -1047,6 +1178,7 @@
           "strict-containers".components.library.planned = lib.mkOverride 900 true;
           "vty".components.exes."vty-mode-demo".planned = lib.mkOverride 900 true;
           "cardano-ledger-shelley-ma".components.library.planned = lib.mkOverride 900 true;
+          "cardano-numeric".components.library.planned = lib.mkOverride 900 true;
           "hydra-node".components.exes."hydra-node".planned = lib.mkOverride 900 true;
           "ouroboros-consensus-byron".components.exes."db-converter".planned = lib.mkOverride 900 true;
           "cardano-cli".components.exes."cardano-cli".planned = lib.mkOverride 900 true;
@@ -1055,6 +1187,7 @@
           "data-default-instances-dlist".components.library.planned = lib.mkOverride 900 true;
           "microstache".components.library.planned = lib.mkOverride 900 true;
           "hydra-node".components.tests."tests".planned = lib.mkOverride 900 true;
+          "warp-tls".components.library.planned = lib.mkOverride 900 true;
           "mime-types".components.library.planned = lib.mkOverride 900 true;
           "prettyprinter-configurable".components.library.planned = lib.mkOverride 900 true;
           "shelley-spec-ledger".components.library.planned = lib.mkOverride 900 true;
@@ -1066,6 +1199,7 @@
           "generic-monoid".components.library.planned = lib.mkOverride 900 true;
           "hydra-tui".components.exes."hydra-tui".planned = lib.mkOverride 900 true;
           "happy".components.exes."happy".planned = lib.mkOverride 900 true;
+          "lift-type".components.library.planned = lib.mkOverride 900 true;
           "hourglass".components.library.planned = lib.mkOverride 900 true;
           "indexed-traversable-instances".components.library.planned = lib.mkOverride 900 true;
           "appar".components.library.planned = lib.mkOverride 900 true;
@@ -1078,6 +1212,7 @@
           "indexed-traversable".components.library.planned = lib.mkOverride 900 true;
           "th-compat".components.library.planned = lib.mkOverride 900 true;
           "assoc".components.library.planned = lib.mkOverride 900 true;
+          "universe-base".components.library.planned = lib.mkOverride 900 true;
           "statistics".components.library.planned = lib.mkOverride 900 true;
           "sqlite-simple".components.library.planned = lib.mkOverride 900 true;
           "lifted-async".components.library.planned = lib.mkOverride 900 true;
@@ -1091,6 +1226,7 @@
           "cryptonite".components.library.planned = lib.mkOverride 900 true;
           "hspec".components.library.planned = lib.mkOverride 900 true;
           "hedgehog-quickcheck".components.library.planned = lib.mkOverride 900 true;
+          "network-info".components.library.planned = lib.mkOverride 900 true;
           "deriving-compat".components.library.planned = lib.mkOverride 900 true;
           "Cabal".components.library.planned = lib.mkOverride 900 true;
           "tasty-quickcheck".components.library.planned = lib.mkOverride 900 true;
@@ -1098,6 +1234,7 @@
           "ghci".components.library.planned = lib.mkOverride 900 true;
           "monoidal-synchronisation".components.library.planned = lib.mkOverride 900 true;
           "dictionary-sharing".components.library.planned = lib.mkOverride 900 true;
+          "cardano-wallet-cli".components.library.planned = lib.mkOverride 900 true;
           "cardano-prelude-test".components.library.planned = lib.mkOverride 900 true;
           "base64-bytestring".components.library.planned = lib.mkOverride 900 true;
           "cardano-binary-test".components.library.planned = lib.mkOverride 900 true;
@@ -1105,16 +1242,21 @@
           "regex-base".components.library.planned = lib.mkOverride 900 true;
           "asn1-parse".components.library.planned = lib.mkOverride 900 true;
           "plutus-core".components.library.planned = lib.mkOverride 900 true;
+          "cardano-wallet".components.exes."mock-token-metadata-server".planned = lib.mkOverride 900 true;
           "adjunctions".components.library.planned = lib.mkOverride 900 true;
           "http-api-data".components.library.planned = lib.mkOverride 900 true;
+          "plutus-chain-index".components.library.planned = lib.mkOverride 900 true;
           "pem".components.library.planned = lib.mkOverride 900 true;
+          "strict-non-empty-containers".components.library.planned = lib.mkOverride 900 true;
           "small-steps-test".components.library.planned = lib.mkOverride 900 true;
           "clock".components.library.planned = lib.mkOverride 900 true;
           "hashable".components.library.planned = lib.mkOverride 900 true;
           "retry".components.library.planned = lib.mkOverride 900 true;
           "attoparsec".components.library.planned = lib.mkOverride 900 true;
           "cardano-ledger-shelley-test".components.library.planned = lib.mkOverride 900 true;
+          "persistent-template".components.library.planned = lib.mkOverride 900 true;
           "unix-bytestring".components.library.planned = lib.mkOverride 900 true;
+          "generic-lens".components.library.planned = lib.mkOverride 900 true;
           "double-conversion".components.library.planned = lib.mkOverride 900 true;
           "file-embed".components.library.planned = lib.mkOverride 900 true;
           "colour".components.library.planned = lib.mkOverride 900 true;
@@ -1125,6 +1267,7 @@
           "syb".components.library.planned = lib.mkOverride 900 true;
           "transformers".components.library.planned = lib.mkOverride 900 true;
           "monad-logger".components.library.planned = lib.mkOverride 900 true;
+          "plutus-core".components.exes."traceToStacks".planned = lib.mkOverride 900 true;
           "hydra-plutus".components.library.planned = lib.mkOverride 900 true;
           "partial-order".components.library.planned = lib.mkOverride 900 true;
           "crypto-pubkey-types".components.library.planned = lib.mkOverride 900 true;
@@ -1135,12 +1278,14 @@
           "genvalidity-scientific".components.library.planned = lib.mkOverride 900 true;
           "invariant".components.library.planned = lib.mkOverride 900 true;
           "cardano-ledger-alonzo".components.library.planned = lib.mkOverride 900 true;
+          "generic-arbitrary".components.library.planned = lib.mkOverride 900 true;
           "bytestring-builder".components.library.planned = lib.mkOverride 900 true;
           "entropy".components.setup.planned = lib.mkOverride 900 true;
           "parallel".components.library.planned = lib.mkOverride 900 true;
           "hydra-node".components.exes."mock-chain".planned = lib.mkOverride 900 true;
           "uuid-types".components.library.planned = lib.mkOverride 900 true;
           "QuickCheck".components.library.planned = lib.mkOverride 900 true;
+          "haskell-src-meta".components.library.planned = lib.mkOverride 900 true;
           "shelley-spec-non-integral".components.library.planned = lib.mkOverride 900 true;
           "cborg".components.library.planned = lib.mkOverride 900 true;
           "time-manager".components.library.planned = lib.mkOverride 900 true;
@@ -1150,12 +1295,14 @@
           "string-conversions".components.library.planned = lib.mkOverride 900 true;
           "plutus-ledger".components.library.planned = lib.mkOverride 900 true;
           "unix-compat".components.library.planned = lib.mkOverride 900 true;
+          "errors".components.library.planned = lib.mkOverride 900 true;
           "generics-sop".components.library.planned = lib.mkOverride 900 true;
           "vty".components.library.planned = lib.mkOverride 900 true;
           "monad-control".components.library.planned = lib.mkOverride 900 true;
           "random".components.library.planned = lib.mkOverride 900 true;
           "code-page".components.library.planned = lib.mkOverride 900 true;
           "hydra-tui".components.library.planned = lib.mkOverride 900 true;
+          "int-cast".components.library.planned = lib.mkOverride 900 true;
           "auto-update".components.library.planned = lib.mkOverride 900 true;
           "http-conduit".components.library.planned = lib.mkOverride 900 true;
           "ouroboros-consensus-byron".components.library.planned = lib.mkOverride 900 true;
@@ -1168,10 +1315,14 @@
           "hpc".components.library.planned = lib.mkOverride 900 true;
           "cardano-ledger-alonzo-test".components.library.planned = lib.mkOverride 900 true;
           "binary-orphans".components.library.planned = lib.mkOverride 900 true;
+          "text-conversions".components.library.planned = lib.mkOverride 900 true;
+          "servant-client-core".components.library.planned = lib.mkOverride 900 true;
           "hydra-node".components.library.planned = lib.mkOverride 900 true;
+          "aeson-qq".components.library.planned = lib.mkOverride 900 true;
           "entropy".components.library.planned = lib.mkOverride 900 true;
           "monad-loops".components.library.planned = lib.mkOverride 900 true;
           "scientific".components.library.planned = lib.mkOverride 900 true;
+          "resource-pool".components.library.planned = lib.mkOverride 900 true;
           "io-classes".components.library.planned = lib.mkOverride 900 true;
           "th-reify-many".components.library.planned = lib.mkOverride 900 true;
           "streaming-bytestring".components.library.planned = lib.mkOverride 900 true;
@@ -1189,6 +1340,7 @@
           "algebraic-graphs".components.library.planned = lib.mkOverride 900 true;
           "constraints".components.library.planned = lib.mkOverride 900 true;
           "network".components.library.planned = lib.mkOverride 900 true;
+          "quickcheck-classes-base".components.library.planned = lib.mkOverride 900 true;
           "word8".components.library.planned = lib.mkOverride 900 true;
           "plutus-tx-plugin".components.library.planned = lib.mkOverride 900 true;
           "tracer-transformers".components.library.planned = lib.mkOverride 900 true;
@@ -1200,6 +1352,7 @@
           "wai-app-static".components.library.planned = lib.mkOverride 900 true;
           "HUnit".components.library.planned = lib.mkOverride 900 true;
           "tree-diff".components.library.planned = lib.mkOverride 900 true;
+          "cardano-wallet".components.library.planned = lib.mkOverride 900 true;
           "fast-logger".components.library.planned = lib.mkOverride 900 true;
           "vty".components.exes."vty-build-width-table".planned = lib.mkOverride 900 true;
           "vector".components.library.planned = lib.mkOverride 900 true;
@@ -1207,6 +1360,7 @@
           "http-date".components.library.planned = lib.mkOverride 900 true;
           "concurrent-output".components.library.planned = lib.mkOverride 900 true;
           "ouroboros-network-framework".components.exes."demo-ping-pong".planned = lib.mkOverride 900 true;
+          "path-pieces".components.library.planned = lib.mkOverride 900 true;
           "hydra-tui".components.tests."unit".planned = lib.mkOverride 900 true;
           "mono-traversable".components.library.planned = lib.mkOverride 900 true;
           "integer-gmp".components.library.planned = lib.mkOverride 900 true;
@@ -1221,6 +1375,7 @@
           "cardano-ledger-byron".components.library.planned = lib.mkOverride 900 true;
           "erf".components.library.planned = lib.mkOverride 900 true;
           "yaml".components.library.planned = lib.mkOverride 900 true;
+          "time-locale-compat".components.library.planned = lib.mkOverride 900 true;
           "shelley-spec-ledger-test".components.library.planned = lib.mkOverride 900 true;
           "ekg".components.library.planned = lib.mkOverride 900 true;
           "th-lift-instances".components.library.planned = lib.mkOverride 900 true;
@@ -1272,12 +1427,16 @@
           "generic-data".components.library.planned = lib.mkOverride 900 true;
           "ouroboros-network".components.exes."demo-chain-sync".planned = lib.mkOverride 900 true;
           "data-clist".components.library.planned = lib.mkOverride 900 true;
+          "primitive-addr".components.library.planned = lib.mkOverride 900 true;
           "lens-aeson".components.library.planned = lib.mkOverride 900 true;
           "pipes".components.library.planned = lib.mkOverride 900 true;
           "ouroboros-network".components.library.planned = lib.mkOverride 900 true;
+          "string-interpolate".components.library.planned = lib.mkOverride 900 true;
           "hostname".components.library.planned = lib.mkOverride 900 true;
           "basement".components.library.planned = lib.mkOverride 900 true;
+          "scrypt".components.library.planned = lib.mkOverride 900 true;
           "setenv".components.library.planned = lib.mkOverride 900 true;
+          "cardano-addresses-cli".components.exes."cardano-address".planned = lib.mkOverride 900 true;
           "ouroboros-consensus-cardano".components.library.planned = lib.mkOverride 900 true;
           "integer-logarithms".components.library.planned = lib.mkOverride 900 true;
           "utf8-string".components.library.planned = lib.mkOverride 900 true;
@@ -1288,6 +1447,7 @@
           "cardano-ledger-pretty".components.library.planned = lib.mkOverride 900 true;
           "flat".components.library.planned = lib.mkOverride 900 true;
           "mwc-random".components.library.planned = lib.mkOverride 900 true;
+          "plutus-ghc-stub".components.library.planned = lib.mkOverride 900 true;
           "fingertree".components.library.planned = lib.mkOverride 900 true;
           "word-wrap".components.library.planned = lib.mkOverride 900 true;
           "microlens-th".components.library.planned = lib.mkOverride 900 true;
@@ -1303,6 +1463,7 @@
           "witherable".components.library.planned = lib.mkOverride 900 true;
           "snap-core".components.library.planned = lib.mkOverride 900 true;
           "cardano-crypto-tests".components.library.planned = lib.mkOverride 900 true;
+          "cardano-wallet".components.exes."cardano-wallet".planned = lib.mkOverride 900 true;
           "servant-foreign".components.library.planned = lib.mkOverride 900 true;
           "contravariant".components.library.planned = lib.mkOverride 900 true;
           "optparse-generic".components.library.planned = lib.mkOverride 900 true;
@@ -1310,6 +1471,7 @@
           "typed-protocols-examples".components.library.planned = lib.mkOverride 900 true;
           "srcloc".components.library.planned = lib.mkOverride 900 true;
           "case-insensitive".components.library.planned = lib.mkOverride 900 true;
+          "plutus-chain-index".components.exes."plutus-chain-index".planned = lib.mkOverride 900 true;
           "data-fix".components.library.planned = lib.mkOverride 900 true;
           "dependent-sum-template".components.library.planned = lib.mkOverride 900 true;
           "sop-core".components.library.planned = lib.mkOverride 900 true;
@@ -1332,6 +1494,7 @@
           "alex".components.exes."alex".planned = lib.mkOverride 900 true;
           "constraints-extras".components.library.planned = lib.mkOverride 900 true;
           "network-byte-order".components.library.planned = lib.mkOverride 900 true;
+          "hspec-expectations-lifted".components.library.planned = lib.mkOverride 900 true;
           "text".components.library.planned = lib.mkOverride 900 true;
           "beam-core".components.library.planned = lib.mkOverride 900 true;
           "aeson-pretty".components.library.planned = lib.mkOverride 900 true;
@@ -1344,32 +1507,39 @@
           "cmdargs".components.library.planned = lib.mkOverride 900 true;
           "moo".components.library.planned = lib.mkOverride 900 true;
           "unordered-containers".components.library.planned = lib.mkOverride 900 true;
+          "uuid".components.library.planned = lib.mkOverride 900 true;
           "regex-posix".components.library.planned = lib.mkOverride 900 true;
           "openapi3".components.exes."example".planned = lib.mkOverride 900 true;
           "network-uri".components.library.planned = lib.mkOverride 900 true;
           "foldl".components.library.planned = lib.mkOverride 900 true;
           "tasty-golden".components.library.planned = lib.mkOverride 900 true;
+          "persistent".components.library.planned = lib.mkOverride 900 true;
           "data-default-class".components.library.planned = lib.mkOverride 900 true;
           "easy-file".components.library.planned = lib.mkOverride 900 true;
           "time-units".components.library.planned = lib.mkOverride 900 true;
           "parser-combinators".components.library.planned = lib.mkOverride 900 true;
+          "pretty-simple".components.library.planned = lib.mkOverride 900 true;
           "plutus-core".components.exes."uplc".planned = lib.mkOverride 900 true;
           "indexed-list-literals".components.library.planned = lib.mkOverride 900 true;
           "bech32".components.library.planned = lib.mkOverride 900 true;
+          "servant-client".components.library.planned = lib.mkOverride 900 true;
           "optics-extra".components.library.planned = lib.mkOverride 900 true;
           "lazy-search".components.library.planned = lib.mkOverride 900 true;
           "abstract-deque".components.library.planned = lib.mkOverride 900 true;
           "mtl".components.library.planned = lib.mkOverride 900 true;
           "time".components.library.planned = lib.mkOverride 900 true;
+          "pretty-simple".components.setup.planned = lib.mkOverride 900 true;
           "iproute".components.library.planned = lib.mkOverride 900 true;
           "stm-chans".components.library.planned = lib.mkOverride 900 true;
           "RSA".components.library.planned = lib.mkOverride 900 true;
           "wai-app-static".components.exes."warp".planned = lib.mkOverride 900 true;
           "data-default-instances-containers".components.library.planned = lib.mkOverride 900 true;
+          "cardano-wallet-core".components.library.planned = lib.mkOverride 900 true;
           "prettyprinter".components.library.planned = lib.mkOverride 900 true;
           "wai-extra".components.library.planned = lib.mkOverride 900 true;
           "base16-bytestring".components.library.planned = lib.mkOverride 900 true;
           "transformers-base".components.library.planned = lib.mkOverride 900 true;
+          "cryptohash-md5".components.library.planned = lib.mkOverride 900 true;
           "pretty-show".components.library.planned = lib.mkOverride 900 true;
           "distributive".components.library.planned = lib.mkOverride 900 true;
           "tasty-hunit".components.library.planned = lib.mkOverride 900 true;
@@ -1389,6 +1559,7 @@
           "base64-bytestring-type".components.library.planned = lib.mkOverride 900 true;
           "hspec-golden-aeson".components.library.planned = lib.mkOverride 900 true;
           "generic-deriving".components.library.planned = lib.mkOverride 900 true;
+          "IntervalMap".components.library.planned = lib.mkOverride 900 true;
           "zeromq4-haskell".components.library.planned = lib.mkOverride 900 true;
           "deepseq".components.library.planned = lib.mkOverride 900 true;
           "network-mux".components.library.planned = lib.mkOverride 900 true;
@@ -1396,6 +1567,7 @@
           "statistics-linreg".components.library.planned = lib.mkOverride 900 true;
           "tasty".components.library.planned = lib.mkOverride 900 true;
           "say".components.library.planned = lib.mkOverride 900 true;
+          "exact-combinatorics".components.library.planned = lib.mkOverride 900 true;
           "small-steps".components.library.planned = lib.mkOverride 900 true;
           "filepath".components.library.planned = lib.mkOverride 900 true;
           "recursion-schemes".components.library.planned = lib.mkOverride 900 true;
@@ -1404,6 +1576,7 @@
           "monad-par-extras".components.library.planned = lib.mkOverride 900 true;
           "cardano-ledger-shelley".components.library.planned = lib.mkOverride 900 true;
           "merkle-patricia-tree".components.library.planned = lib.mkOverride 900 true;
+          "semirings".components.library.planned = lib.mkOverride 900 true;
           "system-filepath".components.library.planned = lib.mkOverride 900 true;
           "list-t".components.library.planned = lib.mkOverride 900 true;
           "cardano-config".components.library.planned = lib.mkOverride 900 true;
@@ -1413,6 +1586,7 @@
           "indexed-profunctors".components.library.planned = lib.mkOverride 900 true;
           "lobemo-backend-ekg".components.library.planned = lib.mkOverride 900 true;
           "kan-extensions".components.library.planned = lib.mkOverride 900 true;
+          "cardano-wallet-core-integration".components.library.planned = lib.mkOverride 900 true;
           "strict".components.library.planned = lib.mkOverride 900 true;
           "temporary".components.library.planned = lib.mkOverride 900 true;
           "dom-lt".components.library.planned = lib.mkOverride 900 true;
@@ -1424,11 +1598,13 @@
           "foundation".components.library.planned = lib.mkOverride 900 true;
           "asn1-encoding".components.library.planned = lib.mkOverride 900 true;
           "servant-subscriber".components.exes."subscriber-psGenerator".planned = lib.mkOverride 900 true;
+          "persistent-sqlite".components.library.planned = lib.mkOverride 900 true;
           "finite-typelits".components.library.planned = lib.mkOverride 900 true;
+          "plutus-chain-index-core".components.library.planned = lib.mkOverride 900 true;
           "quickcheck-arbitrary-adt".components.library.planned = lib.mkOverride 900 true;
           "connection".components.library.planned = lib.mkOverride 900 true;
-          "plutus-tx-plugin".components.exes."logToStacks".planned = lib.mkOverride 900 true;
           "splitmix".components.library.planned = lib.mkOverride 900 true;
+          "generic-lens-core".components.library.planned = lib.mkOverride 900 true;
           "websockets".components.library.planned = lib.mkOverride 900 true;
           "x509-store".components.library.planned = lib.mkOverride 900 true;
           "aeson".components.library.planned = lib.mkOverride 900 true;
@@ -1436,6 +1612,7 @@
           "streaming-binary".components.library.planned = lib.mkOverride 900 true;
           "cardano-prelude".components.library.planned = lib.mkOverride 900 true;
           "ouroboros-consensus".components.library.planned = lib.mkOverride 900 true;
+          "ntp-client".components.library.planned = lib.mkOverride 900 true;
           "servant-subscriber".components.library.planned = lib.mkOverride 900 true;
           "semigroups".components.library.planned = lib.mkOverride 900 true;
           "plutus-ledger-api".components.library.planned = lib.mkOverride 900 true;
@@ -1445,23 +1622,32 @@
           "ouroboros-network-framework".components.library.planned = lib.mkOverride 900 true;
           "nothunks".components.library.planned = lib.mkOverride 900 true;
           "typerep-map".components.library.planned = lib.mkOverride 900 true;
+          "quickcheck-classes".components.library.planned = lib.mkOverride 900 true;
           "lobemo-backend-aggregation".components.library.planned = lib.mkOverride 900 true;
           "crypto-api".components.library.planned = lib.mkOverride 900 true;
+          "cardano-wallet".components.exes."local-cluster".planned = lib.mkOverride 900 true;
           "data-default".components.library.planned = lib.mkOverride 900 true;
           "genvalidity".components.library.planned = lib.mkOverride 900 true;
+          "text-class".components.library.planned = lib.mkOverride 900 true;
           "libyaml".components.library.planned = lib.mkOverride 900 true;
           "cabal-doctest".components.library.planned = lib.mkOverride 900 true;
           "optparse-applicative-fork".components.library.planned = lib.mkOverride 900 true;
+          "tls-session-manager".components.library.planned = lib.mkOverride 900 true;
           "resourcet".components.library.planned = lib.mkOverride 900 true;
           "microlens-mtl".components.library.planned = lib.mkOverride 900 true;
           "microlens".components.library.planned = lib.mkOverride 900 true;
+          "OddWord".components.library.planned = lib.mkOverride 900 true;
           "profunctors".components.library.planned = lib.mkOverride 900 true;
           "servant-server".components.library.planned = lib.mkOverride 900 true;
           "pqueue".components.library.planned = lib.mkOverride 900 true;
+          "lattices".components.library.planned = lib.mkOverride 900 true;
           "brick".components.library.planned = lib.mkOverride 900 true;
           "show-combinators".components.library.planned = lib.mkOverride 900 true;
           "fin".components.library.planned = lib.mkOverride 900 true;
           "base-orphans".components.library.planned = lib.mkOverride 900 true;
+          "casing".components.library.planned = lib.mkOverride 900 true;
+          "cardano-addresses".components.library.planned = lib.mkOverride 900 true;
+          "prettyprinter-ansi-terminal".components.library.planned = lib.mkOverride 900 true;
           "local-cluster".components.exes."log-filter".planned = lib.mkOverride 900 true;
           "directory".components.library.planned = lib.mkOverride 900 true;
           "ouroboros-network".components.sublibs."ouroboros-protocol-tests".planned = lib.mkOverride 900 true;
@@ -1476,6 +1662,7 @@
           "config-ini".components.library.planned = lib.mkOverride 900 true;
           "primitive".components.library.planned = lib.mkOverride 900 true;
           "ouroboros-consensus-shelley".components.library.planned = lib.mkOverride 900 true;
+          "cardano-wallet-launcher".components.library.planned = lib.mkOverride 900 true;
           "plutus-core".components.sublibs."index-envs".planned = lib.mkOverride 900 true;
           "transformers-compat".components.library.planned = lib.mkOverride 900 true;
           "fmlist".components.library.planned = lib.mkOverride 900 true;


### PR DESCRIPTION
This branch is a curious experiment to see how resource requirements change with different Plutus code styles on Hydra. The goal is to have another compelling study case for at least https://github.com/input-output-hk/plutus/issues/4114, and perhaps also https://github.com/input-output-hk/plutus/issues/4174. The first two commits are only for setup; we will try to keep a clean history from the third one for others to go through commits like that.

For now, the only experiment we have is to try different combinations of `Hydra.Contract.Initial (validator)`.
https://github.com/input-output-hk/hydra-poc/blob/2056b8c9ba441aebc396a4fe0f50a419d6ee7be3/hydra-plutus/src/Hydra/Contract/Initial.hs#L45-L51

As per https://github.com/input-output-hk/plutus/issues/4174, the above code has strict semantics, in that the validator script evaluates the second condition even when the first condition was already confirmed. This behaviour leads to wasteful resources and higher fees for end-users. With a minimal off-chain `Trace` setup, we could calculate the resource requirements using `writeScriptsTo` as documented in the official [how-to](https://playground.plutus.iohkdev.io/doc/plutus/howtos/analysing-scripts.html).
```haskell
print =<< writeScriptsTo
      (ScriptsConfig "." (Scripts UnappliedValidators))
      "Initial"
      Initial.initialTrace
      def
```

To be run with:
```bash
nix-shell
cd hydra-plutus
cabal run inspect-script -f hydra-development test test
```

Here are the initial results:
### Commit only.
With `||`:
```
Writing script: ./Initial-1-unapplied.flat (Size: 7.3kB, Cost: ExCPU 757929757, ExMemory 2144728)
Writing script: ./Initial-2-unapplied.flat (Size: 2.1kB, Cost: ExCPU 299359363, ExMemory 674576)
(Sum {getSum = 9582},ExBudget {exBudgetCPU = ExCPU 1057289120, exBudgetMemory = ExMemory 2819304})
```

With `if-then-else`:
```
Writing script: ./Initial-1-unapplied.flat (Size: 7.3kB, Cost: ExCPU 742869051, ExMemory 2094994)
Writing script: ./Initial-2-unapplied.flat (Size: 2.1kB, Cost: ExCPU 299359363, ExMemory 674576)
(Sum {getSum = 9583},ExBudget {exBudgetCPU = ExCPU 1042228414, exBudgetMemory = ExMemory 2769570})
```

Curiously, the `if-then-else` way is one louder in volume. The gains in CPU and memory are only around 1.4%-1.8%.

### Abort only.
With `||`:
```
Writing script: ./Initial-1-unapplied.flat (Size: 7.3kB, Cost: ExCPU 417623296, ExMemory 1032754)
Writing script: ./Initial-2-unapplied.flat (Size: 7.0kB, Cost: ExCPU 628376757, ExMemory 1733944)
(Sum {getSum = 14652},ExBudget {exBudgetCPU = ExCPU 1046000053, exBudgetMemory = ExMemory 2766698})
```

With `if-then-else`:
```
Writing script: ./Initial-1-unapplied.flat (Size: 7.0kB, Cost: ExCPU 628376757, ExMemory 1733944)
Writing script: ./Initial-2-unapplied.flat (Size: 7.3kB, Cost: ExCPU 417355339, ExMemory 1031854)
(Sum {getSum = 14653},ExBudget {exBudgetCPU = ExCPU 1045732096, exBudgetMemory = ExMemory 2765798})
```

Again, one louder in size with a wholesome gain in resource usage of 0.03-0.06%. I guess the notable observation here is how intense state machines are. This minimal innocent-looking transition:
https://github.com/input-output-hk/hydra-poc/blob/2056b8c9ba441aebc396a4fe0f50a419d6ee7be3/hydra-plutus/src/Hydra/Contract/Head.hs#L62-L63

Requires much more resources than this raw rule on the `Initial` side:
https://github.com/input-output-hk/hydra-poc/blob/2056b8c9ba441aebc396a4fe0f50a419d6ee7be3/hydra-plutus/src/Hydra/Contract/Initial.hs#L75-L76

That, in turn, call many more functions, for example:
https://github.com/input-output-hk/hydra-poc/blob/6ff282a107f5ffe0d4a95a8c999ed224d748c40f/hydra-plutus/src/Hydra/OnChain/Util.hs#L80-L91

Even though we love state machines and are determined to help make them more practical, we are afraid it is simply a no-go at the moment for performance-driven applications. I wonder how intense is Hydra on this end? I guess the main priority is the off-chain part, to minimize these on-chain interactions in the first place?

### Abort, but abort first!?
We actually get a bit better gains if we bring the abort check in front. The `||` way stays the same, with new stats only for `if-then-else`:
```
Writing script: ./Initial-1-unapplied.flat (Size: 7.3kB, Cost: ExCPU 416223965, ExMemory 1028054)
Writing script: ./Initial-2-unapplied.flat (Size: 7.0kB, Cost: ExCPU 628376757, ExMemory 1733944)
(Sum {getSum = 14652},ExBudget {exBudgetCPU = ExCPU 1044600722, exBudgetMemory = ExMemory 2761998}
```
The gains now go to around 0.13-0.17% with no more one-louder (interesting). Of course, it is now slightly slower for commit transactions. The amusing thing about short-circuit evaluations is that we have to decide beforehand which one to check first. Intuitively, we would want to check the more minor things first, but one could also argue that we should prioritize the most common types of transactions first. However, I wonder if an early `case` on the redeemer would improve both types' performance for this specific instance.

While the numbers being shown here are very modest, we believe it could grow quite fast alongside the script, which is still relatively minimal at the moment. As they grow, we are curious to monitor their size and resource usage carefully. We did find a more complex validator where a quick `if-then-else` rewrite reduces 2.7 times (we cheated a bit not counting the script context for both cases) the applied size and more than 1.5 times the resource usage [here](https://github.com/input-output-hk/plutus/issues/4114#issuecomment-959813949).

Let us see where we can go from there, especially with the reducing script size endeavour!