### PR TITLE
Iteration on fanout transaction size property

### DIFF
--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -627,6 +627,17 @@ genOneUtxoFor vk = do
   output <- scale (const 1) $ genOutput vk
   pure $ Utxo $ Map.singleton (fromShelleyTxIn input) output
 
+-- | Generate UTXO entries that do not contain any assets. Useful to test /
+-- measure cases where
+genAdaOnlyUtxo :: Gen Utxo
+genAdaOnlyUtxo = do
+  fmap adaOnly <$> arbitrary
+ where
+  adaOnly :: TxOut CtxUTxO AlonzoEra -> TxOut CtxUTxO AlonzoEra
+  adaOnly = \case
+    TxOut addr value datum ->
+      TxOut addr (lovelaceToTxOutValue $ txOutValueToLovelace value) datum
+
 shrinkUtxo :: Utxo -> [Utxo]
 shrinkUtxo = shrinkMapBy (Utxo . fromList) utxoPairs (shrinkList shrinkOne)
  where

--- a/hydra-node/test/Hydra/Chain/Direct/Fixture.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Fixture.hs
@@ -24,7 +24,7 @@ import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
 import Test.QuickCheck.Instances ()
 
 maxTxSize :: Int64
-maxTxSize = 1 `shift` 15 -- FIXME: current value on mainnet is 2 ^ 14 but this is not enough for SM based Head Script
+maxTxSize = 1 `shift` 14
 
 pparams :: PParams Era
 pparams =

--- a/hydra-prelude/hydra-prelude.cabal
+++ b/hydra-prelude/hydra-prelude.cabal
@@ -18,6 +18,7 @@ library
   exposed-modules:    Hydra.Prelude
   build-depends:
     , aeson
+    , aeson-pretty
     , base
     , cardano-binary
     , generic-random

--- a/hydra-prelude/src/Hydra/Prelude.hs
+++ b/hydra-prelude/src/Hydra/Prelude.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE LambdaCase #-}
+
 module Hydra.Prelude (
   module Relude,
   module Control.Monad.Class.MonadSTM,
@@ -21,6 +23,7 @@ module Hydra.Prelude (
   genericArbitrary,
   genericShrink,
   generateWith,
+  shrinkListAggressively,
 ) where
 
 import Cardano.Binary (
@@ -151,3 +154,12 @@ genericArbitrary =
 generateWith :: Gen a -> Int -> a
 generateWith (MkGen runGen) seed =
   runGen (mkQCGen seed) 30
+
+-- | Like 'shrinkList', but more aggressive :)
+--
+-- Useful for shrinking large nested Map or Lists where the shrinker "don't have
+-- time" to go through many cases.
+shrinkListAggressively :: [a] -> [[a]]
+shrinkListAggressively = \case
+  [] -> []
+  xs -> [[], take (length xs `div` 2) xs, drop 1 xs]

--- a/hydra-prelude/src/Hydra/Prelude.hs
+++ b/hydra-prelude/src/Hydra/Prelude.hs
@@ -18,6 +18,7 @@ module Hydra.Prelude (
   ToCBOR (..),
   FromJSON (..),
   ToJSON (..),
+  encodePretty,
   Gen,
   Arbitrary (..),
   genericArbitrary,
@@ -78,6 +79,9 @@ import Control.Monad.Class.MonadTimer (
 import Data.Aeson (
   FromJSON (..),
   ToJSON (..),
+ )
+import Data.Aeson.Encode.Pretty (
+  encodePretty,
  )
 import GHC.Generics (Rep)
 import qualified Generic.Random as Random


### PR DESCRIPTION
- :round_pushpin: **Add 'describeCardanoTx' for debugging**
    Printing a whole 30KB+ transaction via 'Show' on a property failure is unreadable. Most of the time, we are interested in synthetic informations about generated values, especially transactions or UTXO maps (e.g. number of inputs, number of assets, max value, min value, etc..). This function does just that.

- :round_pushpin: **Add shrinker for UTXO**
    Make test failures more approachable :), properties on lists / maps without shrinkers can be quite noisy.

- :round_pushpin: **Address FIXME regarding 'maxTxSize'**
    I was puzzled as for why the shrinker wasn't shrinking further, that was because of an 'overly large max size'. The goal of those properties is really to check that we are indeed producing transactions that are somewhat realistic for the mainnet / public testnet. Thus, it makes sense to stick with the current protocol parameters.

- :round_pushpin: **Write new generator for UTXO, generating ada-only UTXOs.**
    The rationale for such generator is to enable properties in a context of 'payment-only' Hydra heads, showing that this particular use-case can be viable. Of course, it doesn't preclude testing with actual arbitrary UTXO to catch other classes of bugs.

- :round_pushpin: **Add aeson-pretty's 'encodePretty' to hydra-prelude.**
    This is a very handy function to output nicely formatted JSON, which I find interesting to have easily at reach; in particular in test code.

- :round_pushpin: **Fix and improve fanout size property**
    - Adding/using a shrinker for UTXO
  - Adding a label for the UTXO's size
  - Adding two versions of the property with different generators:
    ada-only UTXOs and fully arbitrary ones. The former passes, the
    latter fails.
  - Pretty print UTXO as JSON on failures, instead of 'Show'
  - Pretty print transaction using 'describeCardanoTx' instead of 'Show'

  Overall, property executions now look like:

  ```
  Hydra.Chain.Direct.Tx
    fanoutTx
      size is below limit for small number of UTXO
        +++ OK, passed 100 tests:
        61% 10-49 entries
        26% 00-10 entries
        13% 50-99 entries

        30% 8KB
        28% 7KB
        17% 9KB
        12% 10KB
         5% 11KB
         3% 12KB
         3% 13KB
         2% 14KB

      size is above limit for UTXO
        +++ OK, failed as expected. Falsified (after 23 tests and 15 shrinks):
        TxInCompact (TxId {_unTxId = SafeHash "09d34606abdcd0b10ebc89307cbfa0b469f9144194137b45b7a04b273961add8"}) 926
        Tx serialized size: 16386
        "e9e3ea49dddad0f8b7ee3dbed47f244a44d613a3dea118b250963d87b80faa79"
          Inputs (1)
          Outputs (15)
            total number of assets: 195
          Scripts (1)
            total size (bytes):  7378
    ```
