### PR TITLE
Fix JSON-schema properties (and specifications!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ documentation](./docs), which is also published online at
 https://input-output-hk.github.io/hydra-poc.
 
 API Documentation is available for:
-* The [WebSocket API](https://input-output-hk.github.io/json-schema-viewer/#/?url=https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/hydra-node/api.yaml)
-* The [Log API](https://input-output-hk.github.io/json-schema-viewer/#/?url=https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/hydra-node/api-log.yaml)
+* The [WebSocket API](https://input-output-hk.github.io/json-schema-viewer/#/?url=https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/hydra-node/json-schemas/api.yaml)
+* The [Log API](https://input-output-hk.github.io/json-schema-viewer/#/?url=https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/hydra-node/json-schemas/logs.yaml)
 
 [Haddock](https://www.haskell.org/haddock/) documentation is also published for each package:
 * [hydra-prelude](https://input-output-hk.github.io/hydra-poc/haddock/hydra-prelude/index.html)

--- a/default.nix
+++ b/default.nix
@@ -29,11 +29,11 @@ pkgs.haskell-nix.project {
   compiler-nix-name = compiler;
 
   # Fixed output derivation for plan-nix
-  plan-sha256 = "1fdshl7rcd67w1jcwn88ascjmgbx9jbv9dbsvlfn3pv5sd4byy8h";
+  plan-sha256 = "1fz2dwp9yb2bhsv29pqk1hjm59m72as44kh6m2vdpv2lkbpbd2am";
   materialized = ./nix/hydra-poc.materialized;
   # Enable this and nix-build one of the project components to get the new
   # plan-sha256 and materialization update scripts:
-  checkMaterialization = false;
+  # checkMaterialization = true;
 
   modules = [{
     packages = {

--- a/hydra-node/api-log.yaml
+++ b/hydra-node/api-log.yaml
@@ -1,6 +1,5 @@
 ---
 "$schema": http://json-schema.org/draft/2020-12/schema
-"$id": https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/docs/api-log.json
 "$comment": A description of the log items produced by a Hydra node
 title: Hydra Log API
 description: >
@@ -9,132 +8,99 @@ description: >
   separated by a newline which makes it easy to ingest by thirdparty tools and
   services.
 
-required:
-- namespace
-- timestamp
-- thread
-- message
+type: object
+additionalProperties: false
+
 properties:
-  namespace:
-    type: string
-    description: >-
-      An arbitrary string identifying the tracer generating this entry. For a
-      node, this is always 'HydraNode'.
+  messages:
+    type: array
+    additionalItems: false
+    items:
+      type: object
+      required:
+      - namespace
+      - timestamp
+      - threadId
+      - message
+      properties:
+        namespace:
+          type: string
+          description: >-
+            An arbitrary string identifying the tracer generating this entry. For a
+            node, this is always 'HydraNode'.
 
-  timestamp:
-    type: string
-    format: "date-time"
-    description: >-
-      Timestamp denoting the wall-clock time at which this log entry was
-      recorded.
+        timestamp:
+          type: string
+          format: "date-time"
+          description: >-
+            Timestamp denoting the wall-clock time at which this log entry was
+            recorded.
 
-  thread:
-    type: integer
-    description: >-
-      The id of the thread which produced the log entry.
+        threadId:
+          type: integer
+          description: >-
+            The id of the thread which produced the log entry.
 
-  message:
-    oneOf:
-      - title: APIServer
-        type: object
-        required:
-        - tag
-        - api
-        description: >-
-          A log entry produced by the API server.
-        properties:
-          tag:
-            type: string
-            enum: ["APIServer"]
-          api:
-            $ref: "#/definitions/APIServer"
-      - title: Node
-        type: object
-        required:
-        - tag
-        - node
-        description: >-
-          A log entry denoting events and effects processed by the Node as part
-          of the Head protocol.
-        properties:
-          tag:
-            type: string
-            enum: ["Node"]
-          node:
-            $ref: "#/definitions/Node"
+        message:
+          oneOf:
+          - title: APIServer
+            type: object
+            required:
+            - tag
+            - api
+            description: >-
+              A log entry produced by the API server.
+            properties:
+              tag:
+                type: string
+                enum: ["APIServer"]
+              api:
+                $ref: "#/definitions/APIServer"
+
+          - title: Node
+            type: object
+            required:
+            - tag
+            - node
+            description: >-
+              A log entry denoting events and effects processed by the Node as part
+              of the Head protocol.
+            properties:
+              tag:
+                type: string
+                enum: ["Node"]
+              node:
+                $ref: "#/definitions/Node"
+
+          - title: DirectChain
+            type: object
+            required:
+            - tag
+            - directChain
+            description: >-
+              A log entry produced by the chain component watching the chain.
+            properties:
+              tag:
+                type: string
+                enum: ["DirectChain"]
+              directChain:
+                $ref: "#/definitions/DirectChain"
+
+          - title: Network
+            type: object
+            required:
+            - tag
+            - network
+            description: >-
+              A log entry from the Hydra network (i.e. the layer-two network between Hydra nodes).
+            properties:
+              tag:
+                type: string
+                enum: ["Network"]
+              network:
+                $ref: "#/definitions/Network"
 
 definitions:
-  Node:
-    oneOf:
-    - title: ErrorHandlingEvent
-      # This should be removed from the Log's description as soon as we have some proper
-      # error handling strategy in place, be it simply "Close the head" and bail out.
-      description: >-
-        Some error happened while processing an event, provides enough context
-        information to troubleshoot the origin of the error.
-      type: object
-      required:
-      - by
-      - event
-      - reason
-      properties:
-        by:
-          description: >-
-            The Party emitting the log entry.
-          $ref: "#/definitions/Party"
-        event:
-          description: >-
-            The event causing the error.
-          $ref: "#/definitions/Event"
-        reason:
-          description: >-
-            Structured description of the cause of the error.
-          $ref: "#/definitions/LogicError"
-    - title: ProcessingEvent
-      description: >-
-        Head has started processing an event drawn from some pool or queue of
-        events to process.
-      type: object
-      required:
-      - by
-      - event
-      properties:
-        by:
-          description: >-
-            The Party emitting the log entry.
-          $ref: "#/definitions/Party"
-        event:
-          $ref: "#/definitions/Event"
-    - title: ProcessedEvent
-      description: >-
-        Head has succesfully finished processing an event.
-      type: object
-      required:
-      - by
-      - event
-      properties:
-        by:
-          description: >-
-            The Party emitting the log entry.
-          $ref: "#/definitions/Party"
-        event:
-          $ref: "#/definitions/Event"
-    - title: ProcessingEffect
-      description: >-
-        Head has started processing an effect produced by some transition in the
-        protocol.
-      type: object
-      required:
-      - by
-      - effect
-      properties:
-        by:
-          description: >-
-            The Party emitting the log entry.
-          $ref: "#/definitions/Party"
-        event:
-          $ref: "#/definitions/Effect"
-
   APIServer:
     oneOf:
     - title: APIServerStarted
@@ -185,7 +151,9 @@ definitions:
           type: string
           enum: ["APIInputReceived"]
         receivedInput:
-          type: object
+          oneOf:
+            - type: "null"
+            - type: object
     - title: APIInvalidInput
       description: >-
         Some input sent by a client is invalid.
@@ -208,16 +176,105 @@ definitions:
             hence it's potentially invalid JSON so we just encode it as a proper
             JSON string. Note that if the input contained invalid UTF-8
             characters they will be ignored.
+
+  # TODO: Fill the gap!
+  DirectChain: {}
+
+  # TODO: Fill the gap!
+  Network: {}
+
+  Node:
+    oneOf:
+    - title: ErrorHandlingEvent
+      # This should be removed from the Log's description as soon as we have some proper
+      # error handling strategy in place, be it simply "Close the head" and bail out.
+      description: >-
+        Some error happened while processing an event, provides enough context
+        information to troubleshoot the origin of the error.
+      type: object
+      required:
+      - tag
+      properties:
+        tag:
+          type: string
+          enum: [ "ErrorHandlingEvent" ]
+            # by:
+            #   description: >-
+            #     The Party emitting the log entry.
+            #   $ref: "#/definitions/Party"
+            # event:
+            #   description: >-
+            #     The event causing the error.
+            #   $ref: "#/definitions/Event"
+            # reason:
+            #   description: >-
+            #     Structured description of the cause of the error.
+            #   $ref: "#/definitions/LogicError"
+            # - title: ProcessingEvent
+            #   description: >-
+            #     Head has started processing an event drawn from some pool or queue of
+            #     events to process.
+            #   type: object
+            #   required:
+            #   - by
+            #   - event
+            #   properties:
+            #     by:
+            #       description: >-
+            #         The Party emitting the log entry.
+            #       $ref: "#/definitions/Party"
+            #     event:
+            #       $ref: "#/definitions/Event"
+            # - title: ProcessedEvent
+            #   description: >-
+            #     Head has succesfully finished processing an event.
+            #   type: object
+            #   required:
+            #   - by
+            #   - event
+            #   properties:
+            #     by:
+            #       description: >-
+            #         The Party emitting the log entry.
+            #       $ref: "#/definitions/Party"
+            #     event:
+            #       $ref: "#/definitions/Event"
+            # - title: ProcessingEffect
+            #   description: >-
+            #     Head has started processing an effect produced by some transition in the
+            #     protocol.
+            #   type: object
+            #   required:
+            #   - by
+            #   - effect
+            #   properties:
+            #     by:
+            #       description: >-
+            #         The Party emitting the log entry.
+            #       $ref: "#/definitions/Party"
+            #     event:
+            #       $ref: "#/definitions/Effect"
+    - type: object
+
+  # TODO: Fill the gap!
+  LogicError:
+    type: object
+
   Party:
-    type: integer
-    # Signing is currently implemented using mock crypto hence party is just an integer
+    type: object
     description: >-
-      The verification key for some Party in the Head protocol, uniquely
-      identifying it.
+      The verification key for some Party in the Head protocol, uniquely identifying it.
+    additionalProperties: false
+    required:
+      - vkey
+    properties:
+      vkey:
+        type: string
+        contentEncoding: base16
     examples:
-      - 10
-      - 20
-      - 30
+      - { "vkey": "0000000000000000" }
+      - { "vkey": "0000000000000001" }
+      - { "vkey": "0000000000000002" }
 
   Event:
     description: >-
@@ -239,7 +296,7 @@ definitions:
           type: string
           enum: ["ClientEvent"]
         clientInput:
-          $ref: "https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/hydra-node/api.yaml#/definitions/ClientInput"
+          $ref: "#/definitions/ClientInput"
     - title: NetworkEvent
       type: object
       required:
@@ -299,7 +356,7 @@ definitions:
           party:
             $ref: "#/definitions/Party"
           transaction:
-            $ref: "https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/hydra-node/api.yaml#/definitions/Transaction"
+            $ref: "#/definitions/Transaction"
       - title: ReqSn
         type: object
         required:
@@ -322,7 +379,7 @@ definitions:
           transactions:
             type: array
             items:
-              $ref: "https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/hydra-node/api.yaml#/definitions/Transaction"
+              $ref: "#/definitions/Transaction"
       - title: AckSn
         type: object
         required:
@@ -373,6 +430,7 @@ definitions:
             enum: ["Disconnected"]
           party:
             $ref: "#/definitions/Party"
+
   OnChainTx:
     description: >-
       On-Chain transactions for the Head protocol. These data structures
@@ -417,8 +475,7 @@ definitions:
           party:
             $ref: "#/definitions/Party"
           committed:
-            $ref: "https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/hydra-node/api.ya
-ml#/definitions/Utxo"
+            $ref: "#/definitions/Utxo"
       - title: OnAbortTx
         type: object
         required:
@@ -483,7 +540,7 @@ ml#/definitions/Utxo"
           type: string
           enum: ["ClientEffect"]
         clientInput:
-          $ref: "https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/hydra-node/api.yaml#/definitions/ServerOutput"
+          $ref: "#/definitions/ClientInput"
     - title: NetworkEffect
       type: object
       required:
@@ -572,7 +629,7 @@ ml#/definitions/Utxo"
           party:
             $ref: "#/definitions/Party"
           committed:
-            $ref: "https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/hydra-node/api.yaml#/definitions/Utxo"
+            $ref: "#/definitions/Utxo"
       - title: AbortTx
         type: object
         required:
@@ -585,7 +642,7 @@ ml#/definitions/Utxo"
             type: string
             enum: ["AbortTx"]
           committed:
-            $ref: "https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/hydra-node/api.yaml#/definitions/Utxo"
+            $ref: "#/definitions/Utxo"
       - title: CollectComTx
         type: object
         required:
@@ -599,7 +656,7 @@ ml#/definitions/Utxo"
             type: string
             enum: ["CollectComTx"]
           utxos:
-            $ref: "https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/hydra-node/api.yaml#/definitions/Utxo"
+            $ref: "#/definitions/Utxo"
       - title: CloseTx
         type: object
         required:
@@ -612,7 +669,7 @@ ml#/definitions/Utxo"
             type: string
             enum: ["CloseTx"]
           snapshot:
-            $ref: "https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/hydra-node/api.yaml#/definitions/Snapshot"
+            $ref: "#/definitions/Snapshot"
       - title: ContestTx
         type: object
         required:
@@ -626,7 +683,7 @@ ml#/definitions/Utxo"
             type: string
             enum: ["ContestTx"]
           snapshot:
-            $ref: "https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/hydra-node/api.yaml#/definitions/Snapshot"
+            $ref: "#/definitions/Snapshot"
       - title: FanoutTx
         type: object
         required:
@@ -639,4 +696,15 @@ ml#/definitions/Utxo"
             type: string
             enum: ["FanoutTx"]
           utxos:
-            $ref: "https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/hydra-node/api.yaml#/definitions/Utxo"
+            $ref: "#/definitions/Utxo"
+
+  ClientInput:
+    $ref: ./api.yaml#/properties/inputs/items
+  ServerOutput:
+    $ref: ./api.yaml#/properties/outputs/items
+  Snapshot:
+    $ref: ./api.yaml#/definitions/Snapshot
+  Utxo:
+    $ref: ./api.yaml#/definitions/Utxo
+  Transaction:
+    $ref: ./api.yaml#/definitions/Transaction

--- a/hydra-node/api.yaml
+++ b/hydra-node/api.yaml
@@ -1,6 +1,5 @@
 ---
 "$schema": http://json-schema.org/draft/2020-12/schema
-"$id": https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/docs/api.json
 "$comment": A synthetic description of the WebSocket API for Hydra Head nodes.
 title: Hydra WebSocket API
 description: >

--- a/hydra-node/api.yaml
+++ b/hydra-node/api.yaml
@@ -16,6 +16,9 @@ description: >
   and is fully asynchronous: Inputs from the client are queued for later processing on
   the server-side, and outputs can occur at any time.
 
+type: object
+additionalProperties: false
+
 properties:
   inputs:
     type: array
@@ -313,18 +316,6 @@ properties:
           me:
             $ref: "#/definitions/Party"
 
-  utxo:
-    type: array
-    items:
-      $ref: "#/definitions/Utxo"
-    additionalItems: false
-
-  txs:
-    type: array
-    items:
-      $ref: "#/definitions/Transaction"
-    additionalItems: false
-
 definitions:
   Peer:
     type: object
@@ -382,19 +373,19 @@ definitions:
       whose grammar is described using CDDL here: https://github.com/input-output-hk/cardano-ledger-specs/blob/master/shelley-ma/shelley-ma-test/cddl-files/shelley-ma.cddl#L13
     required:
     - id
+    - isValid
     - body
-    - witnesses
-    - auxiliaryData
+    additionalProperties: false
     properties:
       id:
         $ref: "#/definitions/TxId"
+      isValid:
+          type: boolean
       body:
         $ref: "#/definitions/TxBody"
       witnesses:
         type: object
-        required:
-        - keys
-        - scripts
+        additionalProperties: false
         properties:
           keys:
             type: array
@@ -409,14 +400,23 @@ definitions:
             patternProperties:
               "[0-9a-f]+":
                 $ref: "#/definitions/Cbor"
-
+          redeemers:
+            <<: { $ref: "#/definitions/Cbor" }
+            description: >-
+              An hex-encoded, CBOR-serialised, mapping of redeemer hashes to their definition.
+          datums:
+            type: object
+            description: >-
+              An object mapping datum hashes to their definition, encoded in CBOR
+            patternProperties:
+              "[0-9a-f]+":
+                $ref: "#/definitions/Cbor"
       auxiliaryData:
+        <<:
+          $ref: "#/definitions/Cbor"
         description: >-
           Hex-encoding of CBOR encoding of auxiliary data attached to this transaction. Can be null if
           there's no auxiliary data
-        oneOf:
-        - type: "null"
-        - $ref: "#/definitions/Cbor"
 
   TxId:
     type: string
@@ -432,11 +432,18 @@ definitions:
     required:
     - inputs
     - outputs
+    additionalProperties: false
     properties:
       inputs:
         type: array
         description: >-
           A list of inputs for this transaction. Technically, this is actually a Set, eg. the order of elements does not matter and they must be unique.
+        items:
+          $ref: "#/definitions/TxIn"
+      collateral:
+        type: array
+        description: >-
+          A list of collateral inputs for this transaction.
         items:
           $ref: "#/definitions/TxIn"
       outputs:
@@ -457,12 +464,12 @@ definitions:
         description: >-
           An array of withdrawal.
         items:
-          $ref: "#/definitions/Wdrl"
+          $ref: "#/definitions/Withdrawal"
       fees:
-        type: number
+        type: integer
         minimum: 0
         description: >-
-          Fees paid for this transaction, in ADA
+          Fees paid for this transaction, in lovelace.
       validity:
         type: object
         description: >-
@@ -474,7 +481,8 @@ definitions:
           notAfter:
             type: integer
       auxiliaryDataHash:
-        type: [ "string", "null"]
+        type: string
+        encoding: base16
         description: >-
           Hex-encoding of the hash of auxiliary data section of the transactions.
         examples:
@@ -483,6 +491,25 @@ definitions:
         description: >-
           Values minted by this transaction
         $ref: "#/definitions/Value"
+      networkId:
+          type: string
+          enum:
+            - Mainnet
+            - Testnet
+      scriptIntegrityHash:
+        type: string
+        encoding: base16
+        description: >-
+          Hex-encoding of the hash of script data section of the transaction.
+        examples:
+        - "9b258583229a324c3021d036e83f3c1e69ca4a586a91fad0bc9e4ce79f7411e0"
+      requiredSignatures:
+        type: array
+        items:
+          type: string
+          encoding: base16
+          description: >-
+            Hex-encoding of the hash of verification keys identifying extra expected signers.
 
   TxIn:
     type: string
@@ -501,11 +528,15 @@ definitions:
     required:
     - address
     - value
+    additionalProperties: false
     properties:
       address:
         $ref: "#/definitions/Address"
       value:
         $ref: "#/definitions/Value"
+      datumhash:
+        type: string
+        encoding: base16
 
   Address:
     type: string
@@ -526,68 +557,42 @@ definitions:
 
       Assets represent native tokens available on the Cardano blockchain,
       including Non-Fungible Tokens.
-    required:
-    - lovelace
+    additionalProperties:
+      type: object
+      description: >-
+        A map of 'asset names' to integral values. The key is
+        the hex-encoded name of the asset.
+      minProperties: 1
+      patternProperties:
+        "[0-9a-f]*":
+          type: integer
+          minimum: 0
+          description: >-
+            Some positive number of some 'coin'.
     properties:
       lovelace:
         type: integer
         minimum: 0
         description: >-
           A (positive) amount of lovelace
-      assets:
-        type: object
+
+  Withdrawal:
+    type: object
+    description: >-
+      A withdrawal of some number of coins to some reward address.
+    additionalProperties: false
+    patternProperties:
+      "[0-9a-f]+":
+        type: integer
+        minimum: 0
         description: >-
-          A map from monetary policy id to assets. A policy id is a
-          hex-encoded string of some arbitrary bytes.
-        patternProperties:
-          "[0-9a-f]+":
-            type: object
-            description: >-
-              A map of 'asset names' to integral values. The key is
-              the hex-encoded name of the asset.
-            patternProperties:
-              "[0-9a-f]*":
-                type: integer
-                minimum: 0
-                description: >-
-                  Some positive number of some 'coin'.
+          Some non-negative lovelace value.
 
   Cbor:
     type: string
+    encoding: base16
+    format: cbor
     description: >-
       The hex-encoding of the CBOR encoding of some binary data
     examples:
       - "820082582089ff4f3ff4a6052ec9d073b3be68b5e7596bd74a04e7b74504a8302fb2278cd95840f66eb3cd160372d617411408792c0ebd9791968e9948112894e2706697a55c10296b04019ed2f146f4d81e8ab17b9d14cf99569a2f85cbfa32320127831db202"
-
-  Wdrl:
-    type: array
-    description: >-
-      A withdrawal of some number of coins to some reward address, expressed as a pair.
-    prefixItems:
-    - type: object
-      required:
-      - network
-      - credential
-      properties:
-        network:
-          type: string
-          description: >-
-            Identification of the network the address is valid for
-          enum: ["Mainnet", "Testnet"]
-        credential:
-          type: object
-          minProperties: 1
-          maxProperties: 1
-          properties:
-            "script hash":
-              type: string
-              description: >-
-                Hexadecimal string of the hash of a script
-            "key hash":
-              type: string
-              description: >-
-                Hexadecimal string of the hash of a public key
-    - type: integer
-      minimum: 0
-      description:  >-
-        Number of ADAs withdrawn to the given address

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -236,6 +236,7 @@ test-suite tests
     , contra-tracer
     , cryptonite
     , data-default
+    , directory
     , filepath
     , hspec
     , hspec-core

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -12,6 +12,7 @@ license-files:
 extra-source-files: README.md
 data-files:
   json-schemas/api.yaml
+  json-schemas/common.yaml
   json-schemas/logs.yaml
 
 source-repository head

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -10,7 +10,9 @@ license-files:
   NOTICE
 
 extra-source-files: README.md
-data-files:         api.yaml
+data-files:
+  json-schemas/api.yaml
+  json-schemas/logs.yaml
 
 source-repository head
   type:     git

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -1,5 +1,5 @@
 ---
-"$id": https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/hydra-node/
+"$id": https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/hydra-node/json-schemas/
 "$schema": http://json-schema.org/draft/2020-12/schema
 "$comment": A synthetic description of the WebSocket API for Hydra Head nodes.
 title: Hydra WebSocket API
@@ -317,291 +317,29 @@ properties:
             $ref: "#/definitions/Party"
 
 definitions:
-  Peer:
-    type: object
-    properties:
-      hostname:
-        type: string
-        format: hostname
-      port:
-        type: number
-    examples:
-      - hostname: "10.0.0.10"
-        port: 5001
-
-  Party:
-    type: object
-    description: >-
-      The verification key for some Party in the Head protocol, uniquely identifying it.
-    additionalProperties: false
-    required:
-      - vkey
-    properties:
-      vkey:
-        type: string
-        contentEncoding: base16
-    examples:
-      - { "vkey": "0000000000000000" }
-      - { "vkey": "0000000000000001" }
-      - { "vkey": "0000000000000002" }
-
-  Snapshot:
-    type: object
-    required:
-    - snapshotNumber
-    - utxo
-    - confirmedTransactions
-    properties:
-      snapshotNumber:
-        type: integer
-      utxo:
-        $ref: "#/definitions/Utxo"
-      confirmedTransactions:
-        type: array
-        items:
-          $ref: "#/definitions/Transaction"
-
-  Utxo:
-    type: object
-    description: >-
-      Cardano Unspent transaction outputs (Utxo), mapping from TxId#index to TxOut
-    items:
-      $ref: "#/definitions/TxOut"
-    propertyNames:
-      pattern: "^[0-9a-f]{64}#[0-9]+$"
-    examples:
-      - "09d34606abdcd0b10ebc89307cbfa0b469f9144194137b45b7a04b273961add8#687":
-          "address": "addr1w9htvds89a78ex2uls5y969ttry9s3k9etww0staxzndwlgmzuul5"
-          "value":
-            "lovelace": 7620669
-
-  Transaction:
-    type: object
-    description: >-
-      A full Mary-era Cardano transaction. This is a simplification over the full definition of a Cardano Transaction,
-      whose grammar is described using CDDL here: https://github.com/input-output-hk/cardano-ledger-specs/blob/master/shelley-ma/shelley-ma-test/cddl-files/shelley-ma.cddl#L13
-    required:
-    - id
-    - isValid
-    - body
-    additionalProperties: false
-    properties:
-      id:
-        $ref: "#/definitions/TxId"
-      isValid:
-          type: boolean
-      body:
-        $ref: "#/definitions/TxBody"
-      witnesses:
-        type: object
-        additionalProperties: false
-        properties:
-          keys:
-            type: array
-            description: >-
-              List of public keys witnessing pay-to-pubkey inputs.
-            items:
-              $ref: "#/definitions/Cbor"
-          scripts:
-            type: object
-            description: >-
-              An object mapping script hashes to script definitions, encoded in CBOR.
-            patternProperties:
-              "[0-9a-f]+":
-                $ref: "#/definitions/Cbor"
-          redeemers:
-            <<: { $ref: "#/definitions/Cbor" }
-            description: >-
-              An hex-encoded, CBOR-serialised, mapping of redeemer hashes to their definition.
-          datums:
-            type: object
-            description: >-
-              An object mapping datum hashes to their definition, encoded in CBOR
-            patternProperties:
-              "[0-9a-f]+":
-                $ref: "#/definitions/Cbor"
-      auxiliaryData:
-        <<:
-          $ref: "#/definitions/Cbor"
-        description: >-
-          Hex-encoding of CBOR encoding of auxiliary data attached to this transaction. Can be null if
-          there's no auxiliary data
-
-  TxId:
-    type: string
-    pattern: "^[0-9a-f]{64}"
-    description: >-
-      A Cardano transaction identifier. This is the hex-encoded hash of the
-      transaction's body.
-    examples:
-      - "8df1616d4337ede40bbad2914f12977815234b83951bcce3bfcd735aed3f63e4"
-
-  TxBody:
-    type: object
-    required:
-    - inputs
-    - outputs
-    additionalProperties: false
-    properties:
-      inputs:
-        type: array
-        description: >-
-          A list of inputs for this transaction. Technically, this is actually a Set, eg. the order of elements does not matter and they must be unique.
-        items:
-          $ref: "#/definitions/TxIn"
-      collateral:
-        type: array
-        description: >-
-          A list of collateral inputs for this transaction.
-        items:
-          $ref: "#/definitions/TxIn"
-      outputs:
-        type: array
-        description: >-
-          A list of outputs. Ordering is important here because a TxOut is referenced by its
-          position in the inputs of subsequent transactions.
-        items:
-          $ref: "#/definitions/TxOut"
-      certificates:
-        type: array
-        description: >-
-          An array of certificates, encoded as hexadecimal representation of CBOR serialisation.
-        items:
-          $ref: "#/definitions/Cbor"
-      withdrawals:
-        type: array
-        description: >-
-          An array of withdrawal.
-        items:
-          $ref: "#/definitions/Withdrawal"
-      fees:
-        type: integer
-        minimum: 0
-        description: >-
-          Fees paid for this transaction, in lovelace.
-      validity:
-        type: object
-        description: >-
-          Validity interval of this transaction. Both bounds can be omitted in which case the transaction
-          has unlimited validity. Each bound is a slot number.
-        properties:
-          notBefore:
-            type: integer
-          notAfter:
-            type: integer
-      auxiliaryDataHash:
-        type: string
-        contentEncoding: base16
-        description: >-
-          Hex-encoding of the hash of auxiliary data section of the transactions.
-        examples:
-        - "9b258583229a324c3021d036e83f3c1e69ca4a586a91fad0bc9e4ce79f7411e0"
-      mint:
-        description: >-
-          Values minted by this transaction
-        $ref: "#/definitions/Value"
-      networkId:
-          type: string
-          enum:
-            - Mainnet
-            - Testnet
-      scriptIntegrityHash:
-        type: string
-        contentEncoding: base16
-        description: >-
-          Hex-encoding of the hash of script data section of the transaction.
-        examples:
-        - "9b258583229a324c3021d036e83f3c1e69ca4a586a91fad0bc9e4ce79f7411e0"
-      requiredSignatures:
-        type: array
-        items:
-          type: string
-          contentEncoding: base16
-          description: >-
-            Hex-encoding of the hash of verification keys identifying extra expected signers.
-
-  TxIn:
-    type: string
-    pattern: "^[0-9a-f]{64}#[0-9]+$"
-    description: >-
-      A reference to a Cardano transaction output, commonly used as transaction
-      input and thus named TxIn. Constructed from the transaction's id and
-      the ouput index, separated by a '#'.
-    examples:
-      - "03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314#4"
-
-  TxOut:
-    type: object
-    description: >-
-      A single transaction output
-    required:
-    - address
-    - value
-    additionalProperties: false
-    properties:
-      address:
-        $ref: "#/definitions/Address"
-      value:
-        $ref: "#/definitions/Value"
-      datumhash:
-        type: string
-        contentEncoding: base16
-
   Address:
-    type: string
-    description: >-
-      A bech-32 encoded Cardano address, see
-      https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#Bech32s and
-      https://github.com/cardano-foundation/CIPs/blob/master/CIP-0005/CIP-0005.md
-    examples:
-      - "addr1w9htvds89a78ex2uls5y969ttry9s3k9etww0staxzndwlgmzuul5"
-      - "addr_test1gpr87kyn9d2fzpvy5r5w5fdzyhsx59znpvhfd6fcc5ar7g5yl33cdg0cq24ewdshsutgm"
-
-  Value:
-    type: object
-    description: >-
-      A Mary-era Cardano value. This is an object containing a number of lovelaces, and
-      optional assets, mapping some monetary policy identifier to a
-      mapping of coin (arbitrary strings) to some integer value.
-
-      Assets represent native tokens available on the Cardano blockchain,
-      including Non-Fungible Tokens.
-    additionalProperties:
-      type: object
-      description: >-
-        A map of 'asset names' to integral values. The key is
-        the hex-encoded name of the asset.
-      minProperties: 1
-      patternProperties:
-        "[0-9a-f]*":
-          type: integer
-          minimum: 0
-          description: >-
-            Some positive number of some 'coin'.
-    properties:
-      lovelace:
-        type: integer
-        minimum: 0
-        description: >-
-          A (positive) amount of lovelace
-
-  Withdrawal:
-    type: object
-    description: >-
-      A withdrawal of some number of coins to some reward address.
-    additionalProperties: false
-    patternProperties:
-      "[0-9a-f]+":
-        type: integer
-        minimum: 0
-        description: >-
-          Some non-negative lovelace value.
-
+    $ref: "common.json#/definitions/Address"
   Cbor:
-    type: string
-    contentEncoding: base16
-    format: cbor
-    description: >-
-      The hex-encoding of the CBOR encoding of some binary data
-    examples:
-      - "820082582089ff4f3ff4a6052ec9d073b3be68b5e7596bd74a04e7b74504a8302fb2278cd95840f66eb3cd160372d617411408792c0ebd9791968e9948112894e2706697a55c10296b04019ed2f146f4d81e8ab17b9d14cf99569a2f85cbfa32320127831db202"
+    $ref: "common.json#/definitions/Cbor"
+  Party:
+    $ref: "common.json#/definitions/Party"
+  Peer:
+    $ref: "common.json#/definitions/Peer"
+  Snapshot:
+    $ref: "common.json#/definitions/Snapshot"
+  Transaction:
+    $ref: "common.json#/definitions/Transaction"
+  TxBody:
+    $ref: "common.json#/definitions/TxBody"
+  TxId:
+    $ref: "common.json#/definitions/TxId"
+  TxIn:
+    $ref: "common.json#/definitions/TxIn"
+  TxOut:
+    $ref: "common.json#/definitions/TxOut"
+  Utxo:
+    $ref: "common.json#/definitions/Utxo"
+  Value:
+    $ref: "common.json#/definitions/Value"
+  Withdrawal:
+    $ref: "common.json#/definitions/Withdrawal"

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -1,4 +1,5 @@
 ---
+"$id": https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/hydra-node/
 "$schema": http://json-schema.org/draft/2020-12/schema
 "$comment": A synthetic description of the WebSocket API for Hydra Head nodes.
 title: Hydra WebSocket API

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -481,7 +481,7 @@ definitions:
             type: integer
       auxiliaryDataHash:
         type: string
-        encoding: base16
+        contentEncoding: base16
         description: >-
           Hex-encoding of the hash of auxiliary data section of the transactions.
         examples:
@@ -497,7 +497,7 @@ definitions:
             - Testnet
       scriptIntegrityHash:
         type: string
-        encoding: base16
+        contentEncoding: base16
         description: >-
           Hex-encoding of the hash of script data section of the transaction.
         examples:
@@ -506,7 +506,7 @@ definitions:
         type: array
         items:
           type: string
-          encoding: base16
+          contentEncoding: base16
           description: >-
             Hex-encoding of the hash of verification keys identifying extra expected signers.
 
@@ -535,7 +535,7 @@ definitions:
         $ref: "#/definitions/Value"
       datumhash:
         type: string
-        encoding: base16
+        contentEncoding: base16
 
   Address:
     type: string
@@ -589,7 +589,7 @@ definitions:
 
   Cbor:
     type: string
-    encoding: base16
+    contentEncoding: base16
     format: cbor
     description: >-
       The hex-encoding of the CBOR encoding of some binary data

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -329,11 +329,20 @@ definitions:
         port: 5001
 
   Party:
-    type: integer
+    type: object
+    description: >-
+      The verification key for some Party in the Head protocol, uniquely identifying it.
+    additionalProperties: false
+    required:
+      - vkey
+    properties:
+      vkey:
+        type: string
+        contentEncoding: base16
     examples:
-      - 1
-      - 2
-      - 3
+      - { "vkey": "0000000000000000" }
+      - { "vkey": "0000000000000001" }
+      - { "vkey": "0000000000000002" }
 
   Snapshot:
     type: object

--- a/hydra-node/json-schemas/common.yaml
+++ b/hydra-node/json-schemas/common.yaml
@@ -1,0 +1,292 @@
+---
+"$id": https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/hydra-node/json-schemas/
+"$schema": http://json-schema.org/draft/2020-12/schema
+"$comment": Common object definitions used across the WebSocket API and Logging API.
+title: Common Definitions
+definitions:
+  Address:
+    type: string
+    description: >-
+      A bech-32 encoded Cardano address, see
+      https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#Bech32s and
+      https://github.com/cardano-foundation/CIPs/blob/master/CIP-0005/CIP-0005.md
+    examples:
+      - "addr1w9htvds89a78ex2uls5y969ttry9s3k9etww0staxzndwlgmzuul5"
+      - "addr_test1gpr87kyn9d2fzpvy5r5w5fdzyhsx59znpvhfd6fcc5ar7g5yl33cdg0cq24ewdshsutgm"
+
+  Cbor:
+    type: string
+    contentEncoding: base16
+    format: cbor
+    description: >-
+      The hex-encoding of the CBOR encoding of some binary data
+    examples:
+      - "820082582089ff4f3ff4a6052ec9d073b3be68b5e7596bd74a04e7b74504a8302fb2278cd95840f66eb3cd160372d617411408792c0ebd9791968e9948112894e2706697a55c10296b04019ed2f146f4d81e8ab17b9d14cf99569a2f85cbfa32320127831db202"
+
+  Peer:
+    type: object
+    properties:
+      hostname:
+        type: string
+        format: hostname
+      port:
+        type: number
+    examples:
+      - hostname: "10.0.0.10"
+        port: 5001
+
+  Party:
+    type: object
+    description: >-
+      The verification key for some Party in the Head protocol, uniquely identifying it.
+    additionalProperties: false
+    required:
+      - vkey
+    properties:
+      vkey:
+        type: string
+        contentEncoding: base16
+    examples:
+      - { "vkey": "0000000000000000" }
+      - { "vkey": "0000000000000001" }
+      - { "vkey": "0000000000000002" }
+
+  Snapshot:
+    type: object
+    required:
+    - snapshotNumber
+    - utxo
+    - confirmedTransactions
+    properties:
+      snapshotNumber:
+        type: integer
+      utxo:
+        $ref: "#/definitions/Utxo"
+      confirmedTransactions:
+        type: array
+        items:
+          $ref: "#/definitions/Transaction"
+
+  Transaction:
+    type: object
+    description: >-
+      A full Mary-era Cardano transaction. This is a simplification over the full definition of a Cardano Transaction,
+      whose grammar is described using CDDL here: https://github.com/input-output-hk/cardano-ledger-specs/blob/master/shelley-ma/shelley-ma-test/cddl-files/shelley-ma.cddl#L13
+    required:
+    - id
+    - isValid
+    - body
+    additionalProperties: false
+    properties:
+      id:
+        $ref: "#/definitions/TxId"
+      isValid:
+          type: boolean
+      body:
+        $ref: "#/definitions/TxBody"
+      witnesses:
+        type: object
+        additionalProperties: false
+        properties:
+          keys:
+            type: array
+            description: >-
+              List of public keys witnessing pay-to-pubkey inputs.
+            items:
+              $ref: "#/definitions/Cbor"
+          scripts:
+            type: object
+            description: >-
+              An object mapping script hashes to script definitions, encoded in CBOR.
+            patternProperties:
+              "[0-9a-f]+":
+                $ref: "#/definitions/Cbor"
+          redeemers:
+            <<: { $ref: "#/definitions/Cbor" }
+            description: >-
+              An hex-encoded, CBOR-serialised, mapping of redeemer hashes to their definition.
+          datums:
+            type: object
+            description: >-
+              An object mapping datum hashes to their definition, encoded in CBOR
+            patternProperties:
+              "[0-9a-f]+":
+                $ref: "#/definitions/Cbor"
+      auxiliaryData:
+        <<:
+          $ref: "#/definitions/Cbor"
+        description: >-
+          Hex-encoding of CBOR encoding of auxiliary data attached to this transaction. Can be null if
+          there's no auxiliary data
+
+  TxBody:
+    type: object
+    required:
+    - inputs
+    - outputs
+    additionalProperties: false
+    properties:
+      inputs:
+        type: array
+        description: >-
+          A list of inputs for this transaction. Technically, this is actually a Set, eg. the order of elements does not matter and they must be unique.
+        items:
+          $ref: "#/definitions/TxIn"
+      collateral:
+        type: array
+        description: >-
+          A list of collateral inputs for this transaction.
+        items:
+          $ref: "#/definitions/TxIn"
+      outputs:
+        type: array
+        description: >-
+          A list of outputs. Ordering is important here because a TxOut is referenced by its
+          position in the inputs of subsequent transactions.
+        items:
+          $ref: "#/definitions/TxOut"
+      certificates:
+        type: array
+        description: >-
+          An array of certificates, encoded as hexadecimal representation of CBOR serialisation.
+        items:
+          $ref: "#/definitions/Cbor"
+      withdrawals:
+        type: array
+        description: >-
+          An array of withdrawal.
+        items:
+          $ref: "#/definitions/Withdrawal"
+      fees:
+        type: integer
+        minimum: 0
+        description: >-
+          Fees paid for this transaction, in lovelace.
+      validity:
+        type: object
+        description: >-
+          Validity interval of this transaction. Both bounds can be omitted in which case the transaction
+          has unlimited validity. Each bound is a slot number.
+        properties:
+          notBefore:
+            type: integer
+          notAfter:
+            type: integer
+      auxiliaryDataHash:
+        type: string
+        contentEncoding: base16
+        description: >-
+          Hex-encoding of the hash of auxiliary data section of the transactions.
+        examples:
+        - "9b258583229a324c3021d036e83f3c1e69ca4a586a91fad0bc9e4ce79f7411e0"
+      mint:
+        description: >-
+          Values minted by this transaction
+        $ref: "#/definitions/Value"
+      networkId:
+          type: string
+          enum:
+            - Mainnet
+            - Testnet
+      scriptIntegrityHash:
+        type: string
+        contentEncoding: base16
+        description: >-
+          Hex-encoding of the hash of script data section of the transaction.
+        examples:
+        - "9b258583229a324c3021d036e83f3c1e69ca4a586a91fad0bc9e4ce79f7411e0"
+      requiredSignatures:
+        type: array
+        items:
+          type: string
+          contentEncoding: base16
+          description: >-
+            Hex-encoding of the hash of verification keys identifying extra expected signers.
+
+  TxId:
+    type: string
+    pattern: "^[0-9a-f]{64}"
+    description: >-
+      A Cardano transaction identifier. This is the hex-encoded hash of the
+      transaction's body.
+    examples:
+      - "8df1616d4337ede40bbad2914f12977815234b83951bcce3bfcd735aed3f63e4"
+
+  TxIn:
+    type: string
+    pattern: "^[0-9a-f]{64}#[0-9]+$"
+    description: >-
+      A reference to a Cardano transaction output, commonly used as transaction
+      input and thus named TxIn. Constructed from the transaction's id and
+      the ouput index, separated by a '#'.
+    examples:
+      - "03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314#4"
+
+  TxOut:
+    type: object
+    description: >-
+      A single transaction output
+    required:
+    - address
+    - value
+    additionalProperties: false
+    properties:
+      address:
+        $ref: "#/definitions/Address"
+      value:
+        $ref: "#/definitions/Value"
+      datumhash:
+        type: string
+        contentEncoding: base16
+
+  Utxo:
+    type: object
+    description: >-
+      Cardano Unspent transaction outputs (Utxo), mapping from TxId#index to TxOut
+    items:
+      $ref: "#/definitions/TxOut"
+    propertyNames:
+      pattern: "^[0-9a-f]{64}#[0-9]+$"
+    examples:
+      - "09d34606abdcd0b10ebc89307cbfa0b469f9144194137b45b7a04b273961add8#687":
+          "address": "addr1w9htvds89a78ex2uls5y969ttry9s3k9etww0staxzndwlgmzuul5"
+          "value":
+            "lovelace": 7620669
+
+  Value:
+    type: object
+    description: >-
+      A Mary-era Cardano value. This is an object containing a number of lovelaces, and
+      optional assets, mapping some monetary policy identifier to a
+      mapping of coin (arbitrary strings) to some integer value.
+      Assets represent native tokens available on the Cardano blockchain, including Non-Fungible Tokens.
+    additionalProperties:
+      type: object
+      description: >-
+        A map of 'asset names' to integral values. The key is
+        the hex-encoded name of the asset.
+      minProperties: 1
+      patternProperties:
+        "[0-9a-f]*":
+          type: integer
+          minimum: 0
+          description: >-
+            Some positive number of some 'coin'.
+    properties:
+      lovelace:
+        type: integer
+        minimum: 0
+        description: >-
+          A (positive) amount of lovelace
+
+  Withdrawal:
+    type: object
+    description: >-
+      A withdrawal of some number of coins to some reward address.
+    additionalProperties: false
+    patternProperties:
+      "[0-9a-f]+":
+        type: integer
+        minimum: 0
+        description: >-
+          Some non-negative lovelace value.

--- a/hydra-node/json-schemas/common.yaml
+++ b/hydra-node/json-schemas/common.yaml
@@ -23,17 +23,19 @@ definitions:
     examples:
       - "820082582089ff4f3ff4a6052ec9d073b3be68b5e7596bd74a04e7b74504a8302fb2278cd95840f66eb3cd160372d617411408792c0ebd9791968e9948112894e2706697a55c10296b04019ed2f146f4d81e8ab17b9d14cf99569a2f85cbfa32320127831db202"
 
-  Peer:
+  HeadParameters:
     type: object
+    additionalProperties: false
+    required:
+      - contestationPeriod
+      - parties
     properties:
-      hostname:
-        type: string
-        format: hostname
-      port:
-        type: number
-    examples:
-      - hostname: "10.0.0.10"
-        port: 5001
+      contestationPeriod:
+        type: integer
+      parties:
+        type: array
+        items:
+          $ref: "#/definitions/Party"
 
   Party:
     type: object
@@ -51,6 +53,74 @@ definitions:
       - { "vkey": "0000000000000001" }
       - { "vkey": "0000000000000002" }
 
+  Peer:
+    type: object
+    properties:
+      hostname:
+        type: string
+        format: hostname
+      port:
+        type: number
+    examples:
+      - hostname: "10.0.0.10"
+        port: 5001
+
+  Point:
+    oneOf:
+    - title: Origin
+      type: string
+      enum: ["Origin"]
+
+    - title: "Any"
+      type: object
+      required:
+        - slot
+        - hash
+      properties:
+        slot:
+          type: integer
+        hash:
+          type: string
+          contentEncoding: base16
+
+  SeenSnapshot:
+    oneOf:
+    - title: NoSeenSnapshot
+      type: object
+      additionalProperties: false
+      required:
+        - tag
+      properties:
+        tag:
+          type: string
+          enum: ["NoSeenSnapshot"]
+    - title: RequestedSnapshot
+      type: object
+      additionalProperties: false
+      required:
+        - tag
+      properties:
+        tag:
+          type: string
+          enum: ["RequestedSnapshot"]
+    - title: SeenSnapshot
+      type: object
+      additionalProperties: false
+      required:
+        - tag
+        - snapshot
+        - signatories
+      properties:
+        tag:
+          type: string
+          enum: ["SeenSnapshot"]
+        snapshot:
+          $ref: "#/definitions/Snapshot"
+        signatories:
+          type: array
+          items:
+            $ref: "#/definitions/Party"
+
   Snapshot:
     type: object
     required:
@@ -59,13 +129,17 @@ definitions:
     - confirmedTransactions
     properties:
       snapshotNumber:
-        type: integer
+        $ref: "#/definitions/SnapshotNumber"
       utxo:
         $ref: "#/definitions/Utxo"
       confirmedTransactions:
         type: array
         items:
           $ref: "#/definitions/Transaction"
+
+  SnapshotNumber:
+    type: integer
+    minimum: 0
 
   Transaction:
     type: object

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -291,22 +291,6 @@ definitions:
   LogicError:
     type: object
 
-  Party:
-    type: object
-    description: >-
-      The verification key for some Party in the Head protocol, uniquely identifying it.
-    additionalProperties: false
-    required:
-      - vkey
-    properties:
-      vkey:
-        type: string
-        contentEncoding: base16
-    examples:
-      - { "vkey": "0000000000000000" }
-      - { "vkey": "0000000000000001" }
-      - { "vkey": "0000000000000002" }
-
   Event:
     description: >-
       Events (with Effects) are the atomic elements of the Hydra Head protocol
@@ -749,5 +733,7 @@ definitions:
     $ref: "api.json#/definitions/Utxo"
   Transaction:
     $ref: "api.json#/definitions/Transaction"
+  Party:
+    $ref: "api.json#/definitions/Party"
   Peer:
     $ref: "api.json#/definitions/Peer"

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -1,4 +1,5 @@
 ---
+"$id": https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/hydra-node/
 "$schema": http://json-schema.org/draft/2020-12/schema
 "$comment": A description of the log items produced by a Hydra node
 title: Hydra Log API

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -18,6 +18,7 @@ properties:
     additionalItems: false
     items:
       type: object
+      additionalProperties: false
       required:
       - namespace
       - timestamp
@@ -46,6 +47,7 @@ properties:
           oneOf:
           - title: APIServer
             type: object
+            additionalProperties: false
             required:
             - tag
             - api
@@ -60,6 +62,7 @@ properties:
 
           - title: Node
             type: object
+            additionalProperties: false
             required:
             - tag
             - node
@@ -75,6 +78,7 @@ properties:
 
           - title: DirectChain
             type: object
+            additionalProperties: false
             required:
             - tag
             - directChain
@@ -89,6 +93,7 @@ properties:
 
           - title: Network
             type: object
+            additionalProperties: false
             required:
             - tag
             - network
@@ -109,6 +114,7 @@ definitions:
         API Server has started and is ready, listening for incoming client
         connections on given port.
       type: object
+      additionalProperties: false
       required:
       - tag
       - listeningPort
@@ -123,6 +129,7 @@ definitions:
     - title: NewAPIConnection
       description: >-
         A new client has connected to the API Server.
+      additionalProperties: false
       required:
       - tag
       properties:
@@ -132,6 +139,7 @@ definitions:
     - title: APIOutputSent
       description: >-
         Some output has been sent to a client.
+      additionalProperties: false
       required:
       - tag
       - sentOutput
@@ -144,6 +152,7 @@ definitions:
     - title: APIInputReceived
       description: >-
         Some input has been received from a client.
+      additionalProperties: false
       required:
       - tag
       - receivedInput
@@ -158,6 +167,7 @@ definitions:
     - title: APIInvalidInput
       description: >-
         Some input sent by a client is invalid.
+      additionalProperties: false
       required:
       - tag
       - reason
@@ -178,8 +188,124 @@ definitions:
             JSON string. Note that if the input contained invalid UTF-8
             characters they will be ignored.
 
-  # TODO: Fill the gap!
-  DirectChain: {}
+  DirectChain:
+    oneOf:
+    - title: ToPost
+      description: >-
+        A logical representation of the transaction to be posted on-chain.
+      type: object
+      additionalProperties: false
+      required:
+        - tag
+        - toPost
+      properties:
+        tag:
+          type: string
+          enum: ["ToPost"]
+        toPost:
+          $ref: "#/definitions/PostChainTx"
+    - title: PostedTx
+      description: >-
+        Actual on-chain representation of a transaction posted to the network.
+      type: object
+      additionalProperties: false
+      required:
+        - tag
+        - postedTx
+      properties:
+        tag:
+          type: string
+          enum: ["PostedTx"]
+        postedTx:
+          type: array
+          prefixItems:
+            - $ref: "#/definitions/TxId"
+            - $ref: "#/definitions/Transaction"
+    - title: ReceivedTxs
+      description: >-
+        Logical and actual representation of received / observed transactions on-chain.
+      type: object
+      additionalProperties: false
+      required:
+        - tag
+        - onChainTxs
+        - receivedTxs
+      properties:
+        tag:
+          type: string
+          enum: ["ReceivedTxs"]
+        onChainTxs:
+          type: array
+          items:
+            $ref: "#/definitions/OnChainTx"
+        receivedTxs:
+          type: array
+          items:
+            type: integer
+    - title: RolledBackward
+      description: >-
+        Observation of a rollback.
+      type: object
+      additionalProperties: false
+      required:
+        - tag
+        - point
+      properties:
+        tag:
+          type: string
+          enum: ["RolledBackward"]
+        point:
+          $ref: "#/definitions/Point"
+    - title: Wallet
+      description: >-
+        Logs coming from the wallet.
+      type: object
+      additionalProperties: false
+      required:
+        - tag
+        - contents
+      properties:
+        tag:
+          type: string
+          enum: ["Wallet"]
+        contents:
+          $ref: "#/definitions/Wallet"
+
+  Wallet:
+    oneOf:
+    - title: InitializingWallet
+      description: >-
+        The wallet has been initialized to some point on the chain and will start syncing block by block from there.
+      type: object
+      additionalProperties: false
+      required:
+      - tag
+      - point
+      - initialUtxo
+      properties:
+        tag:
+          type: string
+          enum: ["InitializingWallet"]
+        point:
+          $ref: "#/definitions/Point"
+        initialUtxo:
+          $ref: "#/definitions/Utxo"
+    - title: ApplyBlock
+      description: >-
+        The wallet has discovered and applied a new block of interest.
+      additionalProperties: false
+      required:
+      - tag
+      - before
+      - after
+      properties:
+        tag:
+          type: string
+          enum: ["ApplyBlock"]
+        before:
+          $ref: "#/definitions/Utxo"
+        after:
+          $ref: "#/definitions/Utxo"
 
   # TODO: Fill the gap!
   Network: {}
@@ -193,6 +319,7 @@ definitions:
         Some error happened while processing an event, provides enough context
         information to troubleshoot the origin of the error.
       type: object
+      additionalProperties: false
       required:
       - tag
       - by
@@ -218,6 +345,7 @@ definitions:
         Head has started processing an event drawn from some pool or queue of
         events to process.
       type: object
+      additionalProperties: false
       required:
       - tag
       - by
@@ -236,6 +364,7 @@ definitions:
       description: >-
         Head has succesfully finished processing an event.
       type: object
+      additionalProperties: false
       required:
       - tag
       - by
@@ -255,6 +384,7 @@ definitions:
         Head has started processing an effect produced by some transition in the
         protocol.
       type: object
+      additionalProperties: false
       required:
       - tag
       - by
@@ -267,12 +397,13 @@ definitions:
           <<: { "$ref": "#/definitions/Party" }
           description: >-
             The Party emitting the log entry.
-        event:
+        effect:
           $ref: "#/definitions/Effect"
     - title: ProcessedEffect
       description: >-
         Head has finished processing an effect produced by some transition in the protocol.
       type: object
+      additionalProperties: false
       required:
       - tag
       - by
@@ -285,12 +416,149 @@ definitions:
           <<: { "$ref": "#/definitions/Party" }
           description: >-
             The Party emitting the log entry.
-        event:
+        effect:
           $ref: "#/definitions/Effect"
 
-  # TODO: Fill the gap!
   LogicError:
+    oneOf:
+    - title: InvalidEvent
+      additionalProperties: false
+      required:
+        - tag
+        - contents
+      properties:
+        tag:
+          type: string
+          enum: [ "InvalidEvent" ]
+        contents:
+          type: array
+          prefixItems:
+            - $ref: "#/definitions/Event"
+            - $ref: "#/definitions/HeadState"
+    - title: InvalidState
+      additionalProperties: false
+      required:
+        - tag
+        - contents
+      properties:
+        tag:
+          type: string
+          enum: [ "InvalidState" ]
+        contents:
+          $ref: "#/definitions/HeadState"
+    - title: InvalidSnapshot
+      additionalProperties: false
+      required:
+      - tag
+      - expected
+      - actual
+      properties:
+        tag:
+          type: string
+          enum: [ "InvalidSnapshot" ]
+        expected:
+          $ref: "#/definitions/SnapshotNumber"
+        actual:
+          $ref: "#/definitions/SnapshotNumber"
+    - title: LedgerError
+      additionalProperties: false
+      required:
+        - tag
+        - contents
+      properties:
+        tag:
+          type: string
+          enum: [ "LedgerError" ]
+        contents:
+          $ref: "#/definitions/ValidationError"
+
+  ValidationError:
     type: object
+    additionalProperties: false
+    required:
+      - reason
+    properties:
+      reason:
+        type: string
+
+  HeadState:
+    oneOf:
+    - title: "ReadyState"
+      additionalProperties: false
+      required:
+        - tag
+      properties:
+        tag:
+          type: string
+          enum: [ "ReadyState" ]
+    - title: "InitialState"
+      additionalProperties: false
+      required:
+        - tag
+        - pendingCommits
+        - committed
+      properties:
+        tag:
+          type: string
+          enum: [ "InitialState" ]
+        parameters:
+          $ref: "#/definitions/HeadParameters"
+        pendingCommits:
+          type: array
+          items:
+            $ref: "#/definitions/Party"
+        committed:
+          type: array
+          items:
+            $ref: "#/definitions/Party"
+    - title: "OpenState"
+      additionalProperties: false
+      required:
+        - tag
+        - parameters
+        - coordinatedHeadState
+      properties:
+        tag:
+          type: string
+          enum: [ "OpenState" ]
+        parameters:
+          $ref: "#/definitions/HeadParameters"
+        coordinatedHeadState:
+          $ref: "#/definitions/CoordinatedHeadState"
+    - title: "ClosedState"
+      additionalProperties: false
+      required:
+        - tag
+        - parameters
+        - utxos
+      properties:
+        tag:
+          type: string
+          enum: [ "ClosedState" ]
+        parameters:
+          $ref: "#/definitions/HeadParameters"
+        utxos:
+          $ref: "#/definitions/Utxo"
+
+  CoordinatedHeadState:
+    type: object
+    additionalProperties: false
+    required:
+    - seenUtxo
+    - seenTxs
+    - confirmedSnapshot
+    - seenSnapshot
+    properties:
+      seenUtxo:
+        $ref: "#/definitions/Utxo"
+      seenTxs:
+        type: array
+        items:
+          $ref: "#/definitions/Transaction"
+      confirmedSnapshot:
+        $ref: "#/definitions/Snapshot"
+      seenSnapshot:
+        $ref: "#/definitions/SeenSnapshot"
 
   Event:
     description: >-
@@ -302,6 +570,7 @@ definitions:
     oneOf:
     - title: ClientEvent
       type: object
+      additionalProperties: false
       required:
       - tag
       - clientInput
@@ -315,6 +584,7 @@ definitions:
           $ref: "#/definitions/ClientInput"
     - title: NetworkEvent
       type: object
+      additionalProperties: false
       required:
       - tag
       - message
@@ -328,6 +598,7 @@ definitions:
           $ref: "#/definitions/Message"
     - title: OnChainEvent
       type: object
+      additionalProperties: false
       required:
       - tag
       - onChainTx
@@ -342,6 +613,7 @@ definitions:
           $ref: "#/definitions/OnChainTx"
     - title: ShouldPostFanout
       type: object
+      additionalProperties: false
       required:
       - tag
       description: >-
@@ -358,6 +630,7 @@ definitions:
     oneOf:
       - title: ReqTx
         type: object
+        additionalProperties: false
         required:
         - tag
         - party
@@ -375,6 +648,7 @@ definitions:
             $ref: "#/definitions/Transaction"
       - title: ReqSn
         type: object
+        additionalProperties: false
         required:
         - tag
         - party
@@ -390,14 +664,14 @@ definitions:
           party:
             $ref: "#/definitions/Party"
           snapshotNumber:
-            type: integer
-            minimum: 0
+            $ref: "#/definitions/SnapshotNumber"
           transactions:
             type: array
             items:
               $ref: "#/definitions/Transaction"
       - title: AckSn
         type: object
+        additionalProperties: false
         required:
         - tag
         - party
@@ -422,6 +696,7 @@ definitions:
               the signature are hex-encoded.
       - title: Connected
         type: object
+        additionalProperties: false
         required:
         - tag
         - peer
@@ -435,6 +710,7 @@ definitions:
             $ref: "#/definitions/Peer"
       - title: Disconnected
         type: object
+        additionalProperties: false
         required:
         - tag
         - peer
@@ -455,6 +731,7 @@ definitions:
     oneOf:
       - title: OnInitTx
         type: object
+        additionalProperties: false
         required:
         - tag
         - contestationPeriod
@@ -477,6 +754,7 @@ definitions:
               $ref: "#/definitions/Party"
       - title: OnCommitTx
         type: object
+        additionalProperties: false
         required:
         - tag
         - party
@@ -494,6 +772,7 @@ definitions:
             $ref: "#/definitions/Utxo"
       - title: OnAbortTx
         type: object
+        additionalProperties: false
         required:
         - tag
         properties:
@@ -502,6 +781,7 @@ definitions:
             enum: ["OnAbortTx"]
       - title: OnCollectComTx
         type: object
+        additionalProperties: false
         required:
         - tag
         properties:
@@ -510,9 +790,11 @@ definitions:
             enum: ["OnCollectComTx"]
       - title: OnCloseTx
         type: object
+        additionalProperties: false
         required:
         - tag
         - snapshotNumber
+        - contestationDeadline
         properties:
           tag:
             type: string
@@ -520,8 +802,12 @@ definitions:
           snapshotNumber:
             type: integer
             minimum: 0
+          contestationDeadline:
+            type: string
+            format: date-time
       - title: OnContestTx
         type: object
+        additionalProperties: false
         required:
         - tag
         properties:
@@ -530,6 +816,7 @@ definitions:
             enum: ["OnContestTx"]
       - title: OnFanoutTx
         type: object
+        additionalProperties: false
         required:
         - tag
         properties:
@@ -538,6 +825,7 @@ definitions:
             enum: ["OnFanoutTx"]
       - title: PostTxFailed
         type: object
+        additionalProperties: false
         required:
         - tag
         description: >-
@@ -556,6 +844,7 @@ definitions:
     oneOf:
     - title: ClientEffect
       type: object
+      additionalProperties: false
       required:
       - tag
       - serverOutput
@@ -565,10 +854,11 @@ definitions:
         tag:
           type: string
           enum: ["ClientEffect"]
-        clientInput:
-          $ref: "#/definitions/ClientInput"
+        serverOutput:
+          $ref: "#/definitions/ServerOutput"
     - title: NetworkEffect
       type: object
+      additionalProperties: false
       required:
       - tag
       - message
@@ -583,6 +873,7 @@ definitions:
           $ref: "#/definitions/Message"
     - title: OnChainEffect
       type: object
+      additionalProperties: false
       required:
       - tag
       - onChainTx
@@ -598,6 +889,7 @@ definitions:
           $ref: "#/definitions/PostChainTx"
     - title: Delay
       type: object
+      additionalProperties: false
       required:
       - tag
       - delay
@@ -629,6 +921,7 @@ definitions:
     oneOf:
       - title: InitTx
         type: object
+        additionalProperties: false
         required:
         - tag
         - headParameters
@@ -642,6 +935,7 @@ definitions:
             $ref: "#/definitions/HeadParameters"
       - title: CommitTx
         type: object
+        additionalProperties: false
         required:
         - tag
         - party
@@ -658,22 +952,24 @@ definitions:
             $ref: "#/definitions/Utxo"
       - title: AbortTx
         type: object
+        additionalProperties: false
         required:
         - tag
-        - utxos
+        - utxo
         description: >-
           Abort the opening of the Head process.
         properties:
           tag:
             type: string
             enum: ["AbortTx"]
-          committed:
+          utxo:
             $ref: "#/definitions/Utxo"
       - title: CollectComTx
         type: object
+        additionalProperties: false
         required:
         - tag
-        - utxos
+        - utxo
         description: >-
           Confirm the opening of the Head collecting the committed UTxO set
           combined from all individual commits.
@@ -681,10 +977,11 @@ definitions:
           tag:
             type: string
             enum: ["CollectComTx"]
-          utxos:
+          utxo:
             $ref: "#/definitions/Utxo"
       - title: CloseTx
         type: object
+        additionalProperties: false
         required:
         - tag
         - snapshot
@@ -698,6 +995,7 @@ definitions:
             $ref: "#/definitions/Snapshot"
       - title: ContestTx
         type: object
+        additionalProperties: false
         required:
         - tag
         - snapshot
@@ -712,29 +1010,40 @@ definitions:
             $ref: "#/definitions/Snapshot"
       - title: FanoutTx
         type: object
+        additionalProperties: false
         required:
         - tag
-        - utxos
+        - utxo
         description: >-
           Finalise the Head posting all UTxO from the Head on-chain.
         properties:
           tag:
             type: string
             enum: ["FanoutTx"]
-          utxos:
+          utxo:
             $ref: "#/definitions/Utxo"
 
   ClientInput:
     $ref: "api.json#/properties/inputs/items"
   ServerOutput:
     $ref: "api.json#/properties/outputs/items"
+  HeadParameters:
+    $ref: "common.json#/definitions/HeadParameters"
   Party:
     $ref: "common.json#/definitions/Party"
   Peer:
     $ref: "common.json#/definitions/Peer"
+  Point:
+    $ref: "common.json#/definitions/Point"
+  SeenSnapshot:
+    $ref: "common.json#/definitions/SeenSnapshot"
   Snapshot:
     $ref: "common.json#/definitions/Snapshot"
+  SnapshotNumber:
+    $ref: "common.json#/definitions/SnapshotNumber"
   Transaction:
     $ref: "common.json#/definitions/Transaction"
+  TxId:
+    $ref: "common.json#/definitions/TxId"
   Utxo:
     $ref: "common.json#/definitions/Utxo"

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -1,5 +1,5 @@
 ---
-"$id": https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/hydra-node/
+"$id": https://raw.githubusercontent.com/input-output-hk/hydra-poc/master/hydra-node/json-schemas/
 "$schema": http://json-schema.org/draft/2020-12/schema
 "$comment": A description of the log items produced by a Hydra node
 title: Hydra Log API
@@ -728,13 +728,13 @@ definitions:
     $ref: "api.json#/properties/inputs/items"
   ServerOutput:
     $ref: "api.json#/properties/outputs/items"
-  Snapshot:
-    $ref: "api.json#/definitions/Snapshot"
-  Utxo:
-    $ref: "api.json#/definitions/Utxo"
-  Transaction:
-    $ref: "api.json#/definitions/Transaction"
   Party:
-    $ref: "api.json#/definitions/Party"
+    $ref: "common.json#/definitions/Party"
   Peer:
-    $ref: "api.json#/definitions/Peer"
+    $ref: "common.json#/definitions/Peer"
+  Snapshot:
+    $ref: "common.json#/definitions/Snapshot"
+  Transaction:
+    $ref: "common.json#/definitions/Transaction"
+  Utxo:
+    $ref: "common.json#/definitions/Utxo"

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -194,67 +194,98 @@ definitions:
       type: object
       required:
       - tag
+      - by
+      - event
       properties:
         tag:
           type: string
           enum: [ "ErrorHandlingEvent" ]
-            # by:
-            #   description: >-
-            #     The Party emitting the log entry.
-            #   $ref: "#/definitions/Party"
-            # event:
-            #   description: >-
-            #     The event causing the error.
-            #   $ref: "#/definitions/Event"
-            # reason:
-            #   description: >-
-            #     Structured description of the cause of the error.
-            #   $ref: "#/definitions/LogicError"
-            # - title: ProcessingEvent
-            #   description: >-
-            #     Head has started processing an event drawn from some pool or queue of
-            #     events to process.
-            #   type: object
-            #   required:
-            #   - by
-            #   - event
-            #   properties:
-            #     by:
-            #       description: >-
-            #         The Party emitting the log entry.
-            #       $ref: "#/definitions/Party"
-            #     event:
-            #       $ref: "#/definitions/Event"
-            # - title: ProcessedEvent
-            #   description: >-
-            #     Head has succesfully finished processing an event.
-            #   type: object
-            #   required:
-            #   - by
-            #   - event
-            #   properties:
-            #     by:
-            #       description: >-
-            #         The Party emitting the log entry.
-            #       $ref: "#/definitions/Party"
-            #     event:
-            #       $ref: "#/definitions/Event"
-            # - title: ProcessingEffect
-            #   description: >-
-            #     Head has started processing an effect produced by some transition in the
-            #     protocol.
-            #   type: object
-            #   required:
-            #   - by
-            #   - effect
-            #   properties:
-            #     by:
-            #       description: >-
-            #         The Party emitting the log entry.
-            #       $ref: "#/definitions/Party"
-            #     event:
-            #       $ref: "#/definitions/Effect"
-    - type: object
+        by:
+          <<: { "$ref": "#/definitions/Party" }
+          description: >-
+            The Party emitting the log entry.
+        event:
+          <<: { "$ref": "#/definitions/Event" }
+          description: >-
+            The event causing the error.
+        reason:
+          <<: { "$ref": "#/definitions/LogicError" }
+          description: >-
+            Structured description of the cause of the error.
+    - title: ProcessingEvent
+      description: >-
+        Head has started processing an event drawn from some pool or queue of
+        events to process.
+      type: object
+      required:
+      - tag
+      - by
+      - event
+      properties:
+        tag:
+          type: string
+          enum: [ "ProcessingEvent" ]
+        by:
+          <<: { "$ref": "#/definitions/Party" }
+          description: >-
+            The Party emitting the log entry.
+        event:
+          <<: { "$ref": "#/definitions/Event" }
+    - title: ProcessedEvent
+      description: >-
+        Head has succesfully finished processing an event.
+      type: object
+      required:
+      - tag
+      - by
+      - event
+      properties:
+        tag:
+          type: string
+          enum: [ "ProcessedEvent" ]
+        by:
+          <<: { "$ref": "#/definitions/Party" }
+          description: >-
+            The Party emitting the log entry.
+        event:
+          $ref: "#/definitions/Event"
+    - title: ProcessingEffect
+      description: >-
+        Head has started processing an effect produced by some transition in the
+        protocol.
+      type: object
+      required:
+      - tag
+      - by
+      - effect
+      properties:
+        tag:
+          type: string
+          enum: [ "ProcessingEffect" ]
+        by:
+          <<: { "$ref": "#/definitions/Party" }
+          description: >-
+            The Party emitting the log entry.
+        event:
+          $ref: "#/definitions/Effect"
+    - title: ProcessedEffect
+      description: >-
+        Head has finished processing an effect produced by some transition in the protocol.
+      type: object
+      required:
+      - tag
+      - by
+      - effect
+      properties:
+        tag:
+          type: string
+          enum: [ "ProcessedEffect" ]
+        by:
+          <<: { "$ref": "#/definitions/Party" }
+          description: >-
+            The Party emitting the log entry.
+        event:
+          $ref: "#/definitions/Effect"
 
   # TODO: Fill the gap!
   LogicError:
@@ -408,28 +439,28 @@ definitions:
         type: object
         required:
         - tag
-        - party
+        - peer
         description: >-
           Given party is known to be connected to the network.
         properties:
           tag:
             type: string
             enum: ["Connected"]
-          party:
-            $ref: "#/definitions/Party"
+          peer:
+            $ref: "#/definitions/Peer"
       - title: Disconnected
         type: object
         required:
         - tag
-        - party
+        - peer
         description: >-
-          Given party is probably disconnected from the network.
+          Given peer is probably disconnected from the network.
         properties:
           tag:
             type: string
             enum: ["Disconnected"]
-          party:
-            $ref: "#/definitions/Party"
+          peer:
+            $ref: "#/definitions/Peer"
 
   OnChainTx:
     description: >-
@@ -520,6 +551,16 @@ definitions:
           tag:
             type: string
             enum: ["OnFanoutTx"]
+      - title: PostTxFailed
+        type: object
+        required:
+        - tag
+        description: >-
+          Submitted transaction was ill-formed.
+        properties:
+          tag:
+            type: string
+            enum: ["PostTxFailed"]
 
   Effect:
     description: >-
@@ -699,12 +740,14 @@ definitions:
             $ref: "#/definitions/Utxo"
 
   ClientInput:
-    $ref: ./api.yaml#/properties/inputs/items
+    $ref: "api.json#/properties/inputs/items"
   ServerOutput:
-    $ref: ./api.yaml#/properties/outputs/items
+    $ref: "api.json#/properties/outputs/items"
   Snapshot:
-    $ref: ./api.yaml#/definitions/Snapshot
+    $ref: "api.json#/definitions/Snapshot"
   Utxo:
-    $ref: ./api.yaml#/definitions/Utxo
+    $ref: "api.json#/definitions/Utxo"
   Transaction:
-    $ref: ./api.yaml#/definitions/Transaction
+    $ref: "api.json#/definitions/Transaction"
+  Peer:
+    $ref: "api.json#/definitions/Peer"

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -46,8 +46,8 @@ instance Arbitrary APIServerLog where
     oneof
       [ APIServerStarted <$> arbitrary
       , pure NewAPIConnection
-      , pure $ APIOutputSent Aeson.Null
-      , pure $ APIInputReceived Aeson.Null
+      , pure $ APIOutputSent (Aeson.Object mempty)
+      , pure $ APIInputReceived (Aeson.Object mempty)
       , APIInvalidInput <$> arbitrary <*> arbitrary
       ]
 

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -56,7 +56,8 @@ data HeadState tx
   = ReadyState
   | InitialState {parameters :: HeadParameters, pendingCommits :: PendingCommits, committed :: Committed tx}
   | OpenState {parameters :: HeadParameters, coordinatedHeadState :: CoordinatedHeadState tx}
-  | ClosedState {parameters :: HeadParameters, utxos :: UtxoType tx}
+  | -- TODO: rename utxos -> utxo
+    ClosedState {parameters :: HeadParameters, utxos :: UtxoType tx}
   deriving stock (Generic)
 
 instance (Arbitrary (UtxoType tx), Arbitrary tx) => Arbitrary (HeadState tx) where

--- a/hydra-node/test/Hydra/APISpec.hs
+++ b/hydra-node/test/Hydra/APISpec.hs
@@ -17,18 +17,18 @@ import Test.QuickCheck.Property (conjoin, withMaxSuccess)
 spec :: Spec
 spec = parallel $ do
   context "validates JSON representations against API specification" $ do
-    aroundAll (withJsonSpecifications "api.yaml") $ do
-      specify "ClientInput" $ \(specs, tmp) ->
+    aroundAll (withJsonSpecifications ["api.yaml"]) $ do
+      specify "ClientInput" $ \dir ->
         withMaxSuccess 1 $
           conjoin
-            [ prop_validateToJSON @(ClientInput CardanoTx) specs "inputs" (tmp </> "ClientInput")
-            , prop_specIsComplete @(ClientInput CardanoTx) specs (apiSpecificationSelector "inputs")
+            [ prop_validateToJSON @(ClientInput CardanoTx) (dir </> "api.json") "inputs" (dir </> "ClientInput")
+            , prop_specIsComplete @(ClientInput CardanoTx) (dir </> "api.json") (apiSpecificationSelector "inputs")
             ]
-      specify "ServerOutput" $ \(specs, tmp) ->
+      specify "ServerOutput" $ \dir ->
         withMaxSuccess 1 $
           conjoin
-            [ prop_validateToJSON @(ServerOutput CardanoTx) specs "outputs" (tmp </> "ServerOutput")
-            , prop_specIsComplete @(ServerOutput CardanoTx) specs (apiSpecificationSelector "outputs")
+            [ prop_validateToJSON @(ServerOutput CardanoTx) (dir </> "api.json") "outputs" (dir </> "ServerOutput")
+            , prop_specIsComplete @(ServerOutput CardanoTx) (dir </> "api.json") (apiSpecificationSelector "outputs")
             ]
 
 apiSpecificationSelector ::

--- a/hydra-node/test/Hydra/APISpec.hs
+++ b/hydra-node/test/Hydra/APISpec.hs
@@ -17,7 +17,7 @@ import Test.QuickCheck.Property (conjoin, withMaxSuccess)
 spec :: Spec
 spec = parallel $ do
   context "validates JSON representations against API specification" $ do
-    aroundAll (withJsonSpecifications ["api.yaml"]) $ do
+    aroundAll withJsonSpecifications $ do
       specify "ClientInput" $ \dir ->
         withMaxSuccess 1 $
           conjoin

--- a/hydra-node/test/Hydra/APISpec.hs
+++ b/hydra-node/test/Hydra/APISpec.hs
@@ -9,7 +9,7 @@ import Test.Hydra.Prelude
 import Data.Aeson.Lens (key)
 import Hydra.ClientInput (ClientInput)
 import Hydra.JSONSchema (SpecificationSelector, prop_specIsComplete, prop_validateToJSON, withJsonSpecifications)
-import Hydra.Ledger.Cardano (CardanoTx, Utxo)
+import Hydra.Ledger.Cardano (CardanoTx)
 import Hydra.ServerOutput (ServerOutput)
 import System.FilePath ((</>))
 import Test.QuickCheck.Property (conjoin, withMaxSuccess)
@@ -21,19 +21,15 @@ spec = parallel $ do
       specify "ClientInput" $ \(specs, tmp) ->
         withMaxSuccess 1 $
           conjoin
-            [ prop_validateToJSON @(ClientInput CardanoTx) specs (tmp </> "ClientInput")
+            [ prop_validateToJSON @(ClientInput CardanoTx) specs "inputs" (tmp </> "ClientInput")
             , prop_specIsComplete @(ClientInput CardanoTx) specs (apiSpecificationSelector "inputs")
             ]
       specify "ServerOutput" $ \(specs, tmp) ->
         withMaxSuccess 1 $
           conjoin
-            [ prop_validateToJSON @(ServerOutput CardanoTx) specs (tmp </> "ServerOutput")
+            [ prop_validateToJSON @(ServerOutput CardanoTx) specs "outputs" (tmp </> "ServerOutput")
             , prop_specIsComplete @(ServerOutput CardanoTx) specs (apiSpecificationSelector "outputs")
             ]
-      specify "Utxo" $ \(specs, tmp) ->
-        withMaxSuccess 1 $ prop_validateToJSON @Utxo specs (tmp </> "Utxo")
-      specify "CardanoTx" $ \(specs, tmp) ->
-        withMaxSuccess 1 $ prop_validateToJSON @CardanoTx specs (tmp </> "CardanoTx")
 
 apiSpecificationSelector ::
   Text -> SpecificationSelector

--- a/hydra-node/test/Hydra/JSONSchema.hs
+++ b/hydra-node/test/Hydra/JSONSchema.hs
@@ -131,10 +131,9 @@ type SpecificationSelector = Traversal' Aeson.Value Aeson.Value
 -- But tools (and in particular jsonschema) only works from JSON, so this
 -- function makes sure to also convert our local yaml into JSON.
 withJsonSpecifications ::
-  [FilePath] ->
   (FilePath -> IO ()) ->
   IO ()
-withJsonSpecifications _specFiles action = do
+withJsonSpecifications action = do
   specDir <- (</> "json-schemas") . normalise <$> Pkg.getDataDir
   specFiles <- listDirectory specDir
   dir <- createSystemTempDirectory "Hydra_APISpec"

--- a/hydra-node/test/Hydra/LoggingSpec.hs
+++ b/hydra-node/test/Hydra/LoggingSpec.hs
@@ -8,7 +8,7 @@ import Test.Hydra.Prelude
 import Data.Aeson (object, (.=))
 import Data.Aeson.Lens (key)
 import Hydra.JSONSchema (SpecificationSelector, prop_specIsComplete, prop_validateToJSON, withJsonSpecifications)
-import Hydra.Ledger.Simple (SimpleTx)
+import Hydra.Ledger.Cardano (CardanoTx)
 import Hydra.Logging (Envelope (..), Verbosity (Verbose), traceWith, withTracer)
 import Hydra.Logging.Messages (HydraLog)
 import System.FilePath ((</>))
@@ -24,13 +24,13 @@ spec = do
 
     captured `shouldContain` "{\"foo\":42}"
 
-  aroundAll (withJsonSpecifications "api-log.yaml") $ do
-    specify "HydraLog" $ \(specs, tmp) -> do
+  aroundAll (withJsonSpecifications ["logs.yaml", "api.yaml"]) $ do
+    specify "HydraLog" $ \dir -> do
       property $
         withMaxSuccess 1 $
           conjoin
-            [ prop_validateToJSON @(Envelope (HydraLog SimpleTx ())) specs "messages" (tmp </> "HydraLog")
-            , prop_specIsComplete @(HydraLog SimpleTx ()) specs apiSpecificationSelector
+            [ prop_validateToJSON @(Envelope (HydraLog CardanoTx ())) (dir </> "logs.json") "messages" (dir </> "HydraLog")
+            , prop_specIsComplete @(HydraLog CardanoTx ()) (dir </> "logs.json") apiSpecificationSelector
             ]
 
 apiSpecificationSelector :: SpecificationSelector

--- a/hydra-node/test/Hydra/LoggingSpec.hs
+++ b/hydra-node/test/Hydra/LoggingSpec.hs
@@ -24,7 +24,7 @@ spec = do
 
     captured `shouldContain` "{\"foo\":42}"
 
-  aroundAll (withJsonSpecifications ["logs.yaml", "api.yaml"]) $ do
+  aroundAll withJsonSpecifications $ do
     specify "HydraLog" $ \dir -> do
       property $
         withMaxSuccess 1 $

--- a/hydra-node/test/Hydra/LoggingSpec.hs
+++ b/hydra-node/test/Hydra/LoggingSpec.hs
@@ -29,7 +29,7 @@ spec = do
       property $
         withMaxSuccess 1 $
           conjoin
-            [ prop_validateToJSON @(Envelope (HydraLog SimpleTx ())) specs (tmp </> "HydraLog")
+            [ prop_validateToJSON @(Envelope (HydraLog SimpleTx ())) specs "messages" (tmp </> "HydraLog")
             , prop_specIsComplete @(HydraLog SimpleTx ()) specs apiSpecificationSelector
             ]
 

--- a/nix/hydra-poc.materialized/.plan.nix/hydra-node.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/hydra-node.nix
@@ -25,7 +25,11 @@
       detailLevel = "FullDetails";
       licenseFiles = [ "LICENSE" "NOTICE" ];
       dataDir = ".";
-      dataFiles = [ "api.yaml" ];
+      dataFiles = [
+        "json-schemas/api.yaml"
+        "json-schemas/common.yaml"
+        "json-schemas/logs.yaml"
+        ];
       extraSrcFiles = [ "README.md" ];
       extraTmpFiles = [];
       extraDocFiles = [];
@@ -165,6 +169,7 @@
             (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
             (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
             (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
             (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
             (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
             (hsPkgs."hspec-core" or (errorHandler.buildDepError "hspec-core"))

--- a/nix/hydra-poc.materialized/.plan.nix/local-cluster.nix
+++ b/nix/hydra-poc.materialized/.plan.nix/local-cluster.nix
@@ -84,22 +84,6 @@
         hsSourceDirs = [ "src" ];
         };
       exes = {
-        "local-cluster" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."cardano-cli" or (errorHandler.buildDepError "cardano-cli"))
-            (hsPkgs."cardano-node" or (errorHandler.buildDepError "cardano-node"))
-            (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
-            (hsPkgs."hydra-prelude" or (errorHandler.buildDepError "hydra-prelude"))
-            (hsPkgs."local-cluster" or (errorHandler.buildDepError "local-cluster"))
-            (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
-            ];
-          buildable = true;
-          hsSourceDirs = [ "exe" ];
-          mainPath = [
-            "local-cluster.hs"
-            ] ++ (pkgs.lib).optional (!flags.hydra-development) "";
-          };
         "log-filter" = {
           depends = [
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))

--- a/nix/hydra-poc.materialized/default.nix
+++ b/nix/hydra-poc.materialized/default.nix
@@ -788,7 +788,7 @@
           "cardano-crypto-praos" = {
             flags = {
               "development" = lib.mkOverride 900 false;
-              "external-libsodium-vrf" = lib.mkOverride 900 true;
+              "external-libsodium-vrf" = lib.mkOverride 900 false;
               };
             };
           "monoidal-synchronisation" = { flags = {}; };
@@ -800,7 +800,7 @@
             flags = { "development" = lib.mkOverride 900 false; };
             };
           "local-cluster" = {
-            flags = { "hydra-development" = lib.mkOverride 900 true; };
+            flags = { "hydra-development" = lib.mkOverride 900 false; };
             };
           "typed-protocols-examples" = { flags = {}; };
           "cardano-crypto-tests" = {
@@ -854,13 +854,13 @@
             };
           "cardano-ledger-alonzo-test" = { flags = {}; };
           "hydra-tui" = {
-            flags = { "hydra-development" = lib.mkOverride 900 true; };
+            flags = { "hydra-development" = lib.mkOverride 900 false; };
             };
           "ouroboros-consensus-byron" = {
             flags = { "asserts" = lib.mkOverride 900 false; };
             };
           "hydra-node" = {
-            flags = { "hydra-development" = lib.mkOverride 900 true; };
+            flags = { "hydra-development" = lib.mkOverride 900 false; };
             };
           "contra-tracer" = { flags = {}; };
           "orphans-deriving-via" = {
@@ -873,7 +873,7 @@
           "cardano-ledger-alonzo" = { flags = {}; };
           "small-steps-test" = { flags = {}; };
           "hydra-plutus" = {
-            flags = { "hydra-development" = lib.mkOverride 900 true; };
+            flags = { "hydra-development" = lib.mkOverride 900 false; };
             };
           "cardano-ledger-shelley-test" = { flags = {}; };
           "typed-protocols-cborg" = { flags = {}; };
@@ -978,7 +978,6 @@
           "atomic-primops".components.library.planned = lib.mkOverride 900 true;
           "composition-prelude".components.library.planned = lib.mkOverride 900 true;
           "stm".components.library.planned = lib.mkOverride 900 true;
-          "local-cluster".components.exes."local-cluster".planned = lib.mkOverride 900 true;
           "old-locale".components.library.planned = lib.mkOverride 900 true;
           "SHA".components.library.planned = lib.mkOverride 900 true;
           "split".components.library.planned = lib.mkOverride 900 true;


### PR DESCRIPTION
- :round_pushpin: **Fix prop_validateToJSON to correctly wrap generated arbitrary JSON.**
  
- :round_pushpin: **Fix api.yaml JSON-schema specification.**
    After fixing the property, it started to fail and raise a few errors.

- :round_pushpin: **Start fixing api-log.yaml...**
  
- :round_pushpin: **Move json-schemas into dedicated directory.**
  
- :round_pushpin: **Reduce duplication in specs file and make references work.**
  
- :round_pushpin: **Remove now redundant list of filepaths from 'withJsonSpecifications'**
  
- :round_pushpin: **Move common JSON schema definitions into a separate file.**