### PR TITLE
Continue absorbing cardano-api in Direct.Tx, baby steps -- albeit big baby. 

### DIFF
--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -156,6 +156,7 @@ library
     , prometheus
     , QuickCheck
     , req
+    , serialise
     , shelley-spec-ledger
     , shelley-spec-ledger-test
     , small-steps

--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -260,18 +260,32 @@ instance Exception InvalidTransactionException
 
 -- | An empty 'TxBodyContent' with all empty/zero values to be extended using
 -- record updates.
+--
+-- FIXME: 'makeTransactionBody' throws when one tries to build a transaction
+-- with scripts but no collaterals. This is unfortunate because collaterals are
+-- currently added after by out integrated wallet... We may want to revisit our
+-- flow to avoid this exception and have the wallet work from a TxBuilder instead
+-- of fiddling with a sealed 'CardanoTx'.
+--
+-- Similarly, 'makeTransactionBody' throws when building a transaction
+-- with scripts and no protocol parameters (needed to compute the script
+-- integrity hash). This is also added by our wallet at the moment so
+-- hopefully, this ugly work-around will be removed eventually.
+--
+-- So we currently bypass this by having default but seemingly innofensive
+-- values for collaterals and protocol params in the 'empty' value
 emptyTxBody :: TxBuilder
 emptyTxBody =
   TxBodyContent
     mempty
-    TxInsCollateralNone
+    (TxInsCollateral CollateralInAlonzoEra mempty)
     mempty
     (TxFeeExplicit TxFeesExplicitInAlonzoEra 0)
     (TxValidityNoLowerBound, TxValidityNoUpperBound ValidityNoUpperBoundInAlonzoEra)
     TxMetadataNone
     TxAuxScriptsNone
     TxExtraKeyWitnessesNone
-    (BuildTxWith Nothing)
+    (BuildTxWith $ Just $ fromLedgerPParams ShelleyBasedEraAlonzo def) -- FIXME
     TxWithdrawalsNone
     TxCertificatesNone
     TxUpdateProposalNone

--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -683,8 +683,8 @@ fromLedgerTxWitness wits =
 -- Value
 --
 
-liftValue :: Value -> TxOutValue Era
-liftValue =
+mkTxOutValue :: Value -> TxOutValue Era
+mkTxOutValue =
   TxOutValue MultiAssetInAlonzoEra
 
 fromLedgerValue :: Ledger.Mary.Value Ledger.StandardCrypto -> Value


### PR DESCRIPTION
- :round_pushpin: **Add smart-constructors and utilities to Hydra.Ledger.Cardano**
  
- :round_pushpin: **Define extra helpers for building transactions in steps.**
  Co-authored-by: ch1bo <sebastian.nagel@ncoding.at>

- :round_pushpin: **Make use of the new transaction builder API for 'initTx'**
  Co-authored-by: ch1bo <sebastian.nagel@ncoding.at>

- :round_pushpin: **Make use of the transaction builder API for 'commitTx'**
    Keeping the same strategy as for initTx and leaving the signature untouched. Note that this currently fails because 'unsafeBuildTransaction' throws with 'TxBodyEmptyTxInsCollateral'; looks like cardano-api does this extra verification and requires collateral to be set when creating the transaction... which is unfortunate as we do set the collateral only during transaction balancing.

- :round_pushpin: **Work around guards of 'makeTransactionBody' to keep the ball rolling :grimacing:**
    The proper way to fix this (and we'll get there eventually) will be to get the tiny wallet work with a 'TxBuilder' instead of a plain 'CardanoTx', so that 'unsafeBuildTransaction' is only called when the transaction is actually ready to be built. Right now, we do however return full transaction (albeit not passing phase-1 validations...) in order to test their execution. So, having 'initTx', 'commitTx', 'abortTx'... return a 'TxBuilder' is probably what we want (then bypassing the guards only in the relevant test code) but it's a bit too much of a step right now.