### PR TITLE
More cardano-api rewrites. 

### DIFF
--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -410,7 +410,7 @@ fromPostChainTx TinyWallet{getUtxo, verificationKey} networkId headState cardano
   AbortTx _utxo ->
     readTVar headState >>= \case
       Initial{threadOutput, initials} ->
-        case abortTx (convertTuple threadOutput) (Map.fromList $ map convertTuple initials) of
+        case abortTx networkId (convertTuple threadOutput) (Map.fromList $ map convertTuple initials) of
           Left err -> error $ show err
           Right tx -> pure $ Just tx
       _st -> pure Nothing

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -440,7 +440,7 @@ fromPostChainTx TinyWallet{getUtxo, verificationKey} networkId headState cardano
   FanoutTx{utxo} ->
     readTVar headState >>= \case
       OpenOrClosed{threadOutput} ->
-        pure . Just $ fanoutTx utxo (convertTuple threadOutput)
+        pure . Just $ fanoutTx networkId utxo (convertTuple threadOutput)
       st -> error $ "cannot post FanOutTx, invalid state: " <> show st
   _ -> error "not implemented"
  where

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -193,7 +193,7 @@ initTx networkId cardanoKeys HeadParameters{contestationPeriod, parties} txIn =
   headOutput =
     Api.TxOut headAddress headValue headDatum
   headScript =
-    Api.fromPlutusScript $ MockHead.validatorScript policyId
+    Api.fromPlutusScript Api.AsPlutusScriptV1 $ MockHead.validatorScript policyId
   headAddress =
     Api.mkScriptAddress networkId headScript
   headValue =
@@ -207,7 +207,7 @@ initTx networkId cardanoKeys HeadParameters{contestationPeriod, parties} txIn =
   mkInitialOutput (Api.toPlutusKeyHash . Api.verificationKeyHash -> vkh) =
     Api.TxOut initialAddress initialValue (mkInitialDatum vkh)
   initialScript =
-    Api.fromPlutusScript MockInitial.validatorScript
+    Api.fromPlutusScript Api.AsPlutusScriptV1 MockInitial.validatorScript
   -- FIXME: should really be the minted PTs plus some ADA to make the ledger happy
   initialValue =
     Api.lovelaceToTxOutValue $ Api.Lovelace 2_000_000
@@ -246,7 +246,7 @@ commitTx networkId party utxo (initialInput, vkh) =
   initialWitness =
     Api.BuildTxWith $ Api.mkScriptWitness initialScript initialDatum initialRedeemer
   initialScript =
-    Api.fromPlutusScript' MockInitial.validatorScript
+    Api.fromPlutusScript Api.AsPlutusScriptV1 MockInitial.validatorScript
   initialDatum =
     Api.mkDatumForTxIn $ MockInitial.datum vkh
   initialRedeemer =
@@ -255,7 +255,7 @@ commitTx networkId party utxo (initialInput, vkh) =
   commitOutput =
     Api.TxOut commitAddress commitValue commitDatum
   commitScript =
-    Api.fromPlutusScript MockCommit.validatorScript
+    Api.fromPlutusScript Api.AsPlutusScriptV1 MockCommit.validatorScript
   commitAddress =
     Api.mkScriptAddress networkId commitScript
   -- FIXME: We should add the value from the initialIn too because it contains the PTs
@@ -302,7 +302,7 @@ collectComTx networkId _utxo (Api.fromLedgerTxIn -> headInput, Api.fromLedgerDat
   headWitness =
     Api.BuildTxWith $ Api.mkScriptWitness headScript headDatumBefore headRedeemer
   headScript =
-    Api.fromPlutusScript' $ MockHead.validatorScript policyId
+    Api.fromPlutusScript Api.AsPlutusScriptV1 $ MockHead.validatorScript policyId
   headRedeemer =
     Api.mkRedeemerForTxIn $ MockHead.CollectCom $ Api.toPlutusValue commitValue
 
@@ -323,7 +323,7 @@ collectComTx networkId _utxo (Api.fromLedgerTxIn -> headInput, Api.fromLedgerDat
   commitValue =
     mconcat $ Api.txOutValue . Api.fromLedgerTxOut . fst <$> Map.elems commits
   commitScript =
-    Api.fromPlutusScript' MockCommit.validatorScript
+    Api.fromPlutusScript Api.AsPlutusScriptV1 MockCommit.validatorScript
   commitRedeemer =
     Api.mkRedeemerForTxIn MockCommit.redeemer
 
@@ -346,7 +346,7 @@ closeTx snapshotNumber _utxo (Api.fromLedgerTxIn -> headInput, Api.fromLedgerTxO
   headWitness =
     Api.BuildTxWith $ Api.mkScriptWitness headScript headDatumBefore headRedeemer
   headScript =
-    Api.fromPlutusScript' $ MockHead.validatorScript policyId
+    Api.fromPlutusScript Api.AsPlutusScriptV1 $ MockHead.validatorScript policyId
   headRedeemer =
     Api.mkRedeemerForTxIn $ MockHead.Close (fromIntegral snapshotNumber)
 
@@ -374,7 +374,7 @@ fanoutTx networkId utxo (Api.fromLedgerTxIn -> headInput, Api.fromLedgerData -> 
   headWitness =
     Api.BuildTxWith $ Api.mkScriptWitness headScript headDatumBefore headRedeemer
   headScript =
-    Api.fromPlutusScript' $ MockHead.validatorScript policyId
+    Api.fromPlutusScript Api.AsPlutusScriptV1 $ MockHead.validatorScript policyId
   headRedeemer =
     Api.mkRedeemerForTxIn MockHead.Fanout
 
@@ -418,7 +418,7 @@ abortTx networkId (Api.fromLedgerTxIn -> headInput, Api.fromLedgerData -> headDa
   headWitness =
     Api.BuildTxWith $ Api.mkScriptWitness headScript headDatumBefore headRedeemer
   headScript =
-    Api.fromPlutusScript' $ MockHead.validatorScript policyId
+    Api.fromPlutusScript Api.AsPlutusScriptV1 $ MockHead.validatorScript policyId
   headRedeemer =
     Api.mkRedeemerForTxIn MockHead.Abort
 
@@ -442,7 +442,7 @@ abortTx networkId (Api.fromLedgerTxIn -> headInput, Api.fromLedgerData -> headDa
   mkAbortWitness initialDatum =
     Api.BuildTxWith $ Api.mkScriptWitness initialScript initialDatum initialRedeemer
   initialScript =
-    Api.fromPlutusScript' MockInitial.validatorScript
+    Api.fromPlutusScript Api.AsPlutusScriptV1 MockInitial.validatorScript
   initialRedeemer =
     Api.mkRedeemerForTxIn $ MockInitial.redeemer ()
 

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -193,9 +193,9 @@ initTx networkId cardanoKeys HeadParameters{contestationPeriod, parties} txIn =
   headOutput =
     Api.TxOut headAddress headValue headDatum
   headScript =
-    Api.fromPlutusScript Api.AsPlutusScriptV1 $ MockHead.validatorScript policyId
+    Api.fromPlutusScript $ MockHead.validatorScript policyId
   headAddress =
-    Api.mkScriptAddress networkId headScript
+    Api.mkScriptAddress @Api.PlutusScriptV1 networkId headScript
   headValue =
     Api.lovelaceToTxOutValue $ Api.Lovelace 2_000_000
   headDatum =
@@ -207,12 +207,12 @@ initTx networkId cardanoKeys HeadParameters{contestationPeriod, parties} txIn =
   mkInitialOutput (Api.toPlutusKeyHash . Api.verificationKeyHash -> vkh) =
     Api.TxOut initialAddress initialValue (mkInitialDatum vkh)
   initialScript =
-    Api.fromPlutusScript Api.AsPlutusScriptV1 MockInitial.validatorScript
+    Api.fromPlutusScript MockInitial.validatorScript
   -- FIXME: should really be the minted PTs plus some ADA to make the ledger happy
   initialValue =
     Api.lovelaceToTxOutValue $ Api.Lovelace 2_000_000
   initialAddress =
-    Api.mkScriptAddress networkId initialScript
+    Api.mkScriptAddress @Api.PlutusScriptV1 networkId initialScript
   mkInitialDatum =
     Api.mkTxOutDatum . MockInitial.datum
 
@@ -246,7 +246,7 @@ commitTx networkId party utxo (initialInput, vkh) =
   initialWitness =
     Api.BuildTxWith $ Api.mkScriptWitness initialScript initialDatum initialRedeemer
   initialScript =
-    Api.fromPlutusScript Api.AsPlutusScriptV1 MockInitial.validatorScript
+    Api.fromPlutusScript MockInitial.validatorScript
   initialDatum =
     Api.mkDatumForTxIn $ MockInitial.datum vkh
   initialRedeemer =
@@ -255,9 +255,9 @@ commitTx networkId party utxo (initialInput, vkh) =
   commitOutput =
     Api.TxOut commitAddress commitValue commitDatum
   commitScript =
-    Api.fromPlutusScript Api.AsPlutusScriptV1 MockCommit.validatorScript
+    Api.fromPlutusScript MockCommit.validatorScript
   commitAddress =
-    Api.mkScriptAddress networkId commitScript
+    Api.mkScriptAddress @Api.PlutusScriptV1 networkId commitScript
   -- FIXME: We should add the value from the initialIn too because it contains the PTs
   commitValue =
     Api.mkTxOutValue $
@@ -302,13 +302,13 @@ collectComTx networkId _utxo (Api.fromLedgerTxIn -> headInput, Api.fromLedgerDat
   headWitness =
     Api.BuildTxWith $ Api.mkScriptWitness headScript headDatumBefore headRedeemer
   headScript =
-    Api.fromPlutusScript Api.AsPlutusScriptV1 $ MockHead.validatorScript policyId
+    Api.fromPlutusScript $ MockHead.validatorScript policyId
   headRedeemer =
     Api.mkRedeemerForTxIn $ MockHead.CollectCom $ Api.toPlutusValue commitValue
 
   headOutput =
     Api.TxOut
-      (Api.mkScriptAddress networkId $ Api.asScript headScript)
+      (Api.mkScriptAddress @Api.PlutusScriptV1 networkId headScript)
       (Api.mkTxOutValue $ Api.lovelaceToValue 2_000_000 <> commitValue)
       headDatumAfter
   headDatumAfter =
@@ -323,7 +323,7 @@ collectComTx networkId _utxo (Api.fromLedgerTxIn -> headInput, Api.fromLedgerDat
   commitValue =
     mconcat $ Api.txOutValue . Api.fromLedgerTxOut . fst <$> Map.elems commits
   commitScript =
-    Api.fromPlutusScript Api.AsPlutusScriptV1 MockCommit.validatorScript
+    Api.fromPlutusScript MockCommit.validatorScript
   commitRedeemer =
     Api.mkRedeemerForTxIn MockCommit.redeemer
 
@@ -346,7 +346,7 @@ closeTx snapshotNumber _utxo (Api.fromLedgerTxIn -> headInput, Api.fromLedgerTxO
   headWitness =
     Api.BuildTxWith $ Api.mkScriptWitness headScript headDatumBefore headRedeemer
   headScript =
-    Api.fromPlutusScript Api.AsPlutusScriptV1 $ MockHead.validatorScript policyId
+    Api.fromPlutusScript $ MockHead.validatorScript policyId
   headRedeemer =
     Api.mkRedeemerForTxIn $ MockHead.Close (fromIntegral snapshotNumber)
 
@@ -374,14 +374,14 @@ fanoutTx networkId utxo (Api.fromLedgerTxIn -> headInput, Api.fromLedgerData -> 
   headWitness =
     Api.BuildTxWith $ Api.mkScriptWitness headScript headDatumBefore headRedeemer
   headScript =
-    Api.fromPlutusScript Api.AsPlutusScriptV1 $ MockHead.validatorScript policyId
+    Api.fromPlutusScript $ MockHead.validatorScript policyId
   headRedeemer =
     Api.mkRedeemerForTxIn MockHead.Fanout
 
   -- TODO: we probably don't need an output for the head SM which we don't use anyway
   headOutput =
     Api.TxOut
-      (Api.mkScriptAddress networkId $ Api.asScript headScript)
+      (Api.mkScriptAddress @Api.PlutusScriptV1 networkId headScript)
       (Api.mkTxOutValue $ Api.lovelaceToValue 2_000_000)
       headDatumAfter
   headDatumAfter =
@@ -418,7 +418,7 @@ abortTx networkId (Api.fromLedgerTxIn -> headInput, Api.fromLedgerData -> headDa
   headWitness =
     Api.BuildTxWith $ Api.mkScriptWitness headScript headDatumBefore headRedeemer
   headScript =
-    Api.fromPlutusScript Api.AsPlutusScriptV1 $ MockHead.validatorScript policyId
+    Api.fromPlutusScript $ MockHead.validatorScript policyId
   headRedeemer =
     Api.mkRedeemerForTxIn MockHead.Abort
 
@@ -427,7 +427,7 @@ abortTx networkId (Api.fromLedgerTxIn -> headInput, Api.fromLedgerData -> headDa
   -- (b) There's in principle no need to output any SM output here, it's over.
   headOutput =
     Api.TxOut
-      (Api.mkScriptAddress networkId $ Api.asScript headScript)
+      (Api.mkScriptAddress @Api.PlutusScriptV1 networkId headScript)
       (Api.mkTxOutValue $ Api.lovelaceToValue 2_000_000)
       headDatumAfter
   headDatumAfter =
@@ -442,7 +442,7 @@ abortTx networkId (Api.fromLedgerTxIn -> headInput, Api.fromLedgerData -> headDa
   mkAbortWitness initialDatum =
     Api.BuildTxWith $ Api.mkScriptWitness initialScript initialDatum initialRedeemer
   initialScript =
-    Api.fromPlutusScript Api.AsPlutusScriptV1 MockInitial.validatorScript
+    Api.fromPlutusScript MockInitial.validatorScript
   initialRedeemer =
     Api.mkRedeemerForTxIn $ MockInitial.redeemer ()
 

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -388,7 +388,7 @@ fanoutTx networkId utxo (Api.fromLedgerTxIn -> headInput, Api.fromLedgerData -> 
     Api.mkTxOutDatum MockHead.Final
 
   fanoutOutputs =
-    foldr ((:) . Api.useForBuildingTx) [] utxo
+    foldr ((:) . Api.toTxContext) [] utxo
 
 data AbortTxError = OverlappingInputs
   deriving (Show)

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -388,7 +388,7 @@ fanoutTx networkId utxo (Api.fromLedgerTxIn -> headInput, Api.fromLedgerData -> 
     Api.mkTxOutDatum MockHead.Final
 
   fanoutOutputs =
-    foldr ((:) . Api.toCtxTx) [] utxo
+    foldr ((:) . Api.useForBuildingTx) [] utxo
 
 data AbortTxError = OverlappingInputs
   deriving (Show)

--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -321,7 +321,10 @@ mkSimpleCardanoTx (txin, TxOut owner txOutValueIn datum) (recipient, valueOut) s
 
   txOuts =
     TxOut @CtxTx recipient (TxOutValue MultiAssetInAlonzoEra valueOut) TxOutDatumNone :
-      [ TxOut @CtxTx owner (TxOutValue MultiAssetInAlonzoEra $ valueIn <> negateValue valueOut) (toCtxTx datum)
+      [ TxOut @CtxTx
+        owner
+        (TxOutValue MultiAssetInAlonzoEra $ valueIn <> negateValue valueOut)
+        (useForBuildingTx datum)
       | valueOut /= valueIn
       ]
 
@@ -512,17 +515,17 @@ signWith (TxId h) (PaymentVerificationKey vk, PaymentSigningKey sk) =
 -- * Extra
 
 -- TODO: Could be offered upstream.
-class ToCtxTx f where
-  toCtxTx :: f CtxUTxO Era -> f CtxTx Era
+class UseForBuildingTx f where
+  useForBuildingTx :: f CtxUTxO Era -> f CtxTx Era
 
-instance ToCtxTx TxOutDatum where
-  toCtxTx = \case
+instance UseForBuildingTx TxOutDatum where
+  useForBuildingTx = \case
     TxOutDatumNone -> TxOutDatumNone
     TxOutDatumHash era h -> TxOutDatumHash era h
 
-instance ToCtxTx TxOut where
-  toCtxTx =
-    modifyTxOutDatum toCtxTx
+instance UseForBuildingTx TxOut where
+  useForBuildingTx =
+    modifyTxOutDatum useForBuildingTx
 
 -- * Generators
 

--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -324,7 +324,7 @@ mkSimpleCardanoTx (txin, TxOut owner txOutValueIn datum) (recipient, valueOut) s
       [ TxOut @CtxTx
         owner
         (TxOutValue MultiAssetInAlonzoEra $ valueIn <> negateValue valueOut)
-        (useForBuildingTx datum)
+        (toTxContext datum)
       | valueOut /= valueIn
       ]
 
@@ -515,17 +515,17 @@ signWith (TxId h) (PaymentVerificationKey vk, PaymentSigningKey sk) =
 -- * Extra
 
 -- TODO: Could be offered upstream.
-class UseForBuildingTx f where
-  useForBuildingTx :: f CtxUTxO Era -> f CtxTx Era
+class ToTxContext f where
+  toTxContext :: f CtxUTxO Era -> f CtxTx Era
 
-instance UseForBuildingTx TxOutDatum where
-  useForBuildingTx = \case
+instance ToTxContext TxOutDatum where
+  toTxContext = \case
     TxOutDatumNone -> TxOutDatumNone
     TxOutDatumHash era h -> TxOutDatumHash era h
 
-instance UseForBuildingTx TxOut where
-  useForBuildingTx =
-    modifyTxOutDatum useForBuildingTx
+instance ToTxContext TxOut where
+  toTxContext =
+    modifyTxOutDatum toTxContext
 
 -- * Generators
 

--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -346,6 +346,9 @@ mkTxOutValue :: Value -> TxOutValue Era
 mkTxOutValue =
   TxOutValue MultiAssetInAlonzoEra
 
+setTxOutDatum :: TxOutDatum ctx Era -> TxOut ctx Era -> TxOut ctx Era
+setTxOutDatum dat (TxOut addr value _dat') =
+  TxOut addr value dat
 -- ** Value
 
 -- TODO: Maybe consider using 'renderValue' from cardano-api instead?

--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -154,15 +154,18 @@ mkVkAddress networkId vk =
 --
 -- TODO: See remark on 'mkVkAddress' about 'NetworkId'
 mkScriptAddress ::
-  IsShelleyBasedEra era =>
+  forall lang era.
+  (IsShelleyBasedEra era, HasPlutusScriptVersion lang) =>
   NetworkId ->
-  Script lang ->
+  PlutusScript lang ->
   AddressInEra era
 mkScriptAddress networkId script =
   makeShelleyAddressInEra
     networkId
-    (PaymentCredentialByScript $ hashScript script)
+    (PaymentCredentialByScript $ hashScript $ PlutusScript version script)
     NoStakeAddress
+ where
+  version = plutusScriptVersion (proxyToAsType $ Proxy @lang)
 
 -- ** Datum / Redeemer
 
@@ -183,11 +186,6 @@ mkDatumForTxIn =
 mkRedeemerForTxIn :: Plutus.ToData a => a -> ScriptRedeemer
 mkRedeemerForTxIn =
   fromPlutusData . Plutus.toData
-
--- ** Script
-
-asScript :: PlutusScript PlutusScriptV1 -> Script PlutusScriptV1
-asScript = PlutusScript PlutusScriptV1
 
 -- ** Tx
 

--- a/hydra-node/src/Hydra/Ledger/Cardano/Isomorphism.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano/Isomorphism.hs
@@ -81,28 +81,18 @@ fromLedgerData = ScriptDatumForTxIn . fromAlonzoData
 
 -- ** Script
 
--- TODO: Possibly move upstream?
-class FromPlutusScript (script :: Type -> Type) where
-  fromPlutusScript :: IsPlutusScriptVersion lang => AsType lang -> Plutus.Script -> script lang
-
-instance FromPlutusScript PlutusScript where
-  fromPlutusScript _ script =
-    PlutusScriptSerialised bytes
-   where
-    bytes = toShort . fromLazy . serialise $ script
-
-instance FromPlutusScript Script where
-  fromPlutusScript lang =
-    PlutusScript (plutusScriptVersion lang) . fromPlutusScript lang
+fromPlutusScript :: Plutus.Script -> PlutusScript lang
+fromPlutusScript =
+  PlutusScriptSerialised . toShort . fromLazy . serialise
 
 -- TODO: Move upstream.
-class IsPlutusScriptVersion lang where
+class HasTypeProxy lang => HasPlutusScriptVersion lang where
   plutusScriptVersion :: AsType lang -> PlutusScriptVersion lang
 
-instance IsPlutusScriptVersion PlutusScriptV1 where
+instance HasPlutusScriptVersion PlutusScriptV1 where
   plutusScriptVersion _ = PlutusScriptV1
 
-instance IsPlutusScriptVersion PlutusScriptV2 where
+instance HasPlutusScriptVersion PlutusScriptV2 where
   plutusScriptVersion _ = PlutusScriptV2
 
 -- ** ScriptValidity

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -282,7 +282,7 @@ spec =
       -- NOTE(AB): This property fails if initials are too big
       prop "transaction size below limit" $ \txIn cperiod parties (ReasonablySized initials) ->
         let headDatum = Data . toData $ MockHead.Initial cperiod parties
-         in case abortTx (txIn, headDatum) (Map.fromList initials) of
+         in case abortTx testNetworkId (txIn, headDatum) (Map.fromList initials) of
               Left err -> property False & counterexample ("AbortTx construction failed: " <> show err)
               Right tx ->
                 let cbor = serialize tx
@@ -296,7 +296,7 @@ spec =
         let headOutput = mkHeadOutput SNothing -- will be SJust, but not covered by this test
             headDatum = Data . toData $ MockHead.Initial cperiod parties
             utxo = Map.singleton txIn headOutput
-         in case abortTx (txIn, headDatum) initials of
+         in case abortTx testNetworkId (txIn, headDatum) initials of
               Left err -> property False & counterexample ("AbortTx construction failed: " <> show err)
               Right tx ->
                 let res = observeAbortTx utxo tx
@@ -321,7 +321,7 @@ spec =
               initials = Map.map (Data . toData . MockInitial.datum) initialsPkh
               initialsUtxo = map (\(i, pkh) -> mkMockInitialTxOut (i, pkh)) $ Map.toList initialsPkh
               utxo = UTxO $ Map.fromList (headUtxo : initialsUtxo)
-           in checkCoverage $ case abortTx (txIn, headDatum) initials of
+           in checkCoverage $ case abortTx testNetworkId (txIn, headDatum) initials of
                 Left OverlappingInputs ->
                   property (isJust $ txIn `Map.lookup` initials)
                 Right tx ->
@@ -351,7 +351,7 @@ spec =
               -- Finally we can create the abortTx and have it processed by the wallet
               lookupUtxo = Map.fromList (headUtxo : initialUtxo)
               utxo = UTxO $ walletUtxo <> lookupUtxo
-           in case abortTx (headInput, headDatum) (Map.fromList initials) of
+           in case abortTx testNetworkId (headInput, headDatum) (Map.fromList initials) of
                 Left err ->
                   property False & counterexample ("AbortTx construction failed: " <> show err)
                 Right txAbort ->

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -237,7 +237,7 @@ spec =
     describe "fanoutTx" $ do
       let prop_fanoutTxSize :: Utxo -> TxIn StandardCrypto -> Property
           prop_fanoutTxSize utxo headIn =
-            let tx = fanoutTx utxo (headIn, headDatum)
+            let tx = fanoutTx testNetworkId utxo (headIn, headDatum)
                 headDatum = Data $ toData MockHead.Closed
                 cbor = serialize tx
                 len = LBS.length cbor
@@ -269,7 +269,7 @@ spec =
             expectFailure . prop_fanoutTxSize utxo
 
       prop "is observed" $ \utxo headInput ->
-        let tx = fanoutTx utxo (headInput, headDatum)
+        let tx = fanoutTx testNetworkId utxo (headInput, headDatum)
             headOutput = mkHeadOutput SNothing
             headDatum = Data $ toData MockHead.Closed
             lookupUtxo = Map.singleton headInput headOutput


### PR DESCRIPTION
- :round_pushpin: **Rewrite 'clostTx' to use cardano-api.**
  
- :round_pushpin: **Rewrite 'fanoutTx' to use cardano-api.**
  
- :round_pushpin: **Rewrite 'abortTx' to use cardano-api.**
  
- :round_pushpin: **Fix commitTx consumes initials spec.**
    Once again, because of the low-entropy generators that we use for TxIn, it can happen on rare occasion that the 'singleUtxo' generated actually overlaps with the 'initials', causing the property to fail weirdly.

- :round_pushpin: **rename 'ToCtxCtx' -> 'UseForBuildingTx'**
   Less cryptic and more transparent as for what is this context change.

- :round_pushpin: **Rename 'useForBuildingTx' to 'toTxContext'**
  
- :round_pushpin: **Unify fromPlutusScript & fromPlutusScript'**
    Also, doing so, I've made it easier to switch to PlutusScriptV2 right away.

- :round_pushpin: **unify mkScriptAddress with other API to avoid polymorphic 'fromPlutusScript'.**
