### PR TITLE
Use multiple docker images and directly tag them

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -33,7 +33,7 @@ jobs:
         images: |
           ghcr.io/${{ github.repository_owner }}/{{ matrix.target }}
         flavor: |
-          latest=auto
+          latest=true
         tags: |
           type=semver,pattern={{version}}
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -32,9 +32,8 @@ jobs:
       with:
         images: |
           ghcr.io/${{ github.repository_owner }}/{{ matrix.target }}
-        flavor: |
-          latest=true
         tags: |
+          latest
           type=semver,pattern={{version}}
 
     - name: 🔨 Build and push

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -31,7 +31,7 @@ jobs:
       uses: docker/metadata-action@v3
       with:
         images: |
-          ghcr.io/${{ github.repository_owner }}/{{ matrix.target }}
+          ghcr.io/${{ github.repository_owner }}/${{ matrix.target }}
         tags: |
           latest
           type=semver,pattern={{version}}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -24,6 +24,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: 📝 Prepare docker image metadata
       id: meta

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -2,7 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "ch1bo/multiple-docker-images" ]
     tags: [ "*.*.*" ]
 
 jobs:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,5 +1,7 @@
 name: Docker
 
+# NOTE: This workflow builds & tags docker images always as 'latest', so ensure
+# it only runs on events we want to have as 'latest' image on the registry.
 on:
   push:
     branches: [ "master", "ch1bo/multiple-docker-images" ]

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -4,7 +4,7 @@ name: Docker
 # it only runs on events we want to have as 'latest' image on the registry.
 on:
   push:
-    branches: [ "master", "ch1bo/multiple-docker-images" ]
+    branches: [ "master" ]
     tags: [ "*.*.*" ]
 
 jobs:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -9,11 +9,9 @@ jobs:
   docker:
     strategy:
       matrix:
-        os: [ ubuntu-20.04 ]
-        repository: [ inputoutput ]
         target: [ hydra-node, hydra-tui ]
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
     - name: 📥 Checkout repository
       uses: actions/checkout@v2.3.3
@@ -21,35 +19,30 @@ jobs:
     - name: 🧰 Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
 
-    - name: 🐳 Login to DockerHub
+    - name: 🐳 Login to GitHub Container Registry
       uses: docker/login-action@v1
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+
+    - name: 📝 Prepare docker image metadata
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: |
+          ghcr.io/${{ github.repository_owner }}/{{ matrix.target }}
+        flavor: |
+          latest=auto
+        tags: |
+          type=semver,pattern={{version}}
 
     - name: 🔨 Build and push
       uses: docker/build-push-action@v2
       with:
         context: .
         push: true
-        tags: ${{ matrix.repository }}/{{ matrix.target }}:latest
         target: ${{ matrix.target }}
-        cache-from: type=registry,ref=${{ matrix.repository }}/${{ matrix.target }}:latest
-        cache-to: type=inline
-
-    - name: 📝 Variables
-      if: ${{ startsWith(github.ref, 'refs/tags') }}
-      id: variables
-      run: |
-        echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
-
-    - name: 🏷️ Build and push (tag)
-      if: ${{ startsWith(github.ref, 'refs/tags') }}
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        push: true
-        tags: ${{ matrix.repository }}/{{ matrix.target }}:${{ steps.variables.outputs.tag }}
-        target: ${{ matrix.target }}
-        cache-from: type=registry,ref=${{ matrix.repository }}/${{ matrix.target }}:latest
-        cache-to: type=inline
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
-        repository: [ inputoutput/hydra ]
+        repository: [ inputoutput ]
         target: [ hydra-node, hydra-tui ]
 
     runs-on: ${{ matrix.os }}
@@ -32,9 +32,9 @@ jobs:
       with:
         context: .
         push: true
-        tags: ${{ matrix.repository }}:${{ matrix.target }}-latest
+        tags: ${{ matrix.repository }}/{{ matrix.target }}:latest
         target: ${{ matrix.target }}
-        cache-from: type=registry,ref=${{ matrix.repository }}:${{ matrix.target }}-latest
+        cache-from: type=registry,ref=${{ matrix.repository }}/${{ matrix.target }}:latest
         cache-to: type=inline
 
     - name: 📝 Variables
@@ -49,7 +49,7 @@ jobs:
       with:
         context: .
         push: true
-        tags: ${{ matrix.repository }}:${{ matrix.target }}-${{ steps.variables.outputs.tag }}
+        tags: ${{ matrix.repository }}/{{ matrix.target }}:${{ steps.variables.outputs.tag }}
         target: ${{ matrix.target }}
-        cache-from: type=registry,ref=${{ matrix.repository }}:${{ matrix.target }}-latest
+        cache-from: type=registry,ref=${{ matrix.repository }}/${{ matrix.target }}:latest
         cache-to: type=inline

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <div align="center">
   <p>A home to our colorful experiments and prototypes.</p>
   <a href='https://github.com/input-output-hk/hydra-poc/actions'><img src="https://img.shields.io/github/workflow/status/input-output-hk/hydra-poc/CI?label=Tests&style=for-the-badge" /></a>
-  <a href='https://hub.docker.com/r/inputoutput/hydra/tags'><img src="https://img.shields.io/github/workflow/status/input-output-hk/hydra-poc/Docker?label=Docker&style=for-the-badge" /></a>
+  <a href='https://hub.docker.com/r/inputoutput/hydra-node/tags'><img src="https://img.shields.io/github/workflow/status/input-output-hk/hydra-poc/Docker?label=Docker&style=for-the-badge" /></a>
 </div>
 
 ## :sunrise_over_mountains: Introduction
@@ -54,11 +54,11 @@ Later:
 ## :rocket: Getting started
 
 The quickest way to get a `hydra-node` running is to use our [docker
-images](https://hub.docker.com/r/inputoutput/hydra/tags).
+images](https://hub.docker.com/r/inputoutput/hydra-node/tags).
 
 ```sh
-docker pull inputoutput/hydra:hydra-node-latest
-docker run --rm inputoutput/hydra:hydra-node-latest --help
+docker pull inputoutput/hydra-node
+docker run --rm inputoutput/hydra-node --help
 ```
 
 A full example scenario with three nodes connected off-chain and three Head

--- a/demo/README.md
+++ b/demo/README.md
@@ -14,7 +14,8 @@ times are too far in the past and you should update them e.g. using the
 
 # Building Docker Images
 
-The CI automatically pushes docker images built from latest `master` branch to a [docker hub repository](https://hub.docker.com/r/inputoutput/hydra), hence
+The CI automatically pushes docker images built from latest `master` branch to a
+[docker hub repository](https://hub.docker.com/r/inputoutput/hydra-node), hence
 running the demo only requires pulling those images.
 
 To build the images locally, do:

--- a/demo/docker-compose.yaml
+++ b/demo/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
       ]
 
   hydra-node-1:
-    image: inputoutput/hydra:hydra-node-latest
+    image: inputoutput/hydra-node:latest
     build:
       context: ../
       target: hydra-node
@@ -52,7 +52,7 @@ services:
     restart: always
 
   hydra-node-2:
-    image: inputoutput/hydra:hydra-node-latest
+    image: inputoutput/hydra-node:latest
     build:
       context: ../
       target: hydra-node
@@ -84,7 +84,7 @@ services:
     restart: always
 
   hydra-node-3:
-    image: inputoutput/hydra:hydra-node-latest
+    image: inputoutput/hydra-node:latest
     build:
       context: ../
       target: hydra-node
@@ -116,7 +116,7 @@ services:
     restart: always
 
   hydra-tui-1:
-    image: inputoutput/hydra:hydra-tui-latest
+    image: inputoutput/hydra-tui:latest
     build:
        context: ../
        target: hydra-tui
@@ -136,7 +136,7 @@ services:
         ipv4_address: 172.16.238.11
 
   hydra-tui-2:
-    image: inputoutput/hydra:hydra-tui-latest
+    image: inputoutput/hydra-tui:latest
     build:
        context: ../
        target: hydra-tui
@@ -156,7 +156,7 @@ services:
         ipv4_address: 172.16.238.21
 
   hydra-tui-3:
-    image: inputoutput/hydra:hydra-tui-latest
+    image: inputoutput/hydra-tui:latest
     build:
        context: ../
        target: hydra-tui


### PR DESCRIPTION
This results in inputoutput/hydra-node and inputoutput/hydra-tui being
the images and for example inputoutput/hydra-node:0.2.0 a tagged version.

Saw the tags step only after changing things so I kept it this way and wanted to see what you guys think.

IMO having the tag == the git tag is nice and having two images for two different components seems more docker idiomatic to me, but not entirely sure.