### PR TITLE
Check coverage of mutations

### DIFF
--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -243,6 +243,7 @@ test-suite tests
     , data-default
     , directory
     , filepath
+    , generic-lens
     , hspec
     , hspec-core
     , hspec-golden-aeson

--- a/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
@@ -21,6 +21,7 @@ import Cardano.Ledger.Alonzo.Tools (
 import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr)
 import qualified Cardano.Ledger.Alonzo.TxWitness as Ledger
 import qualified Cardano.Ledger.Shelley.API as Ledger
+import Control.Lens ((^.))
 import qualified Data.ByteString as BS
 import Data.Generics.Product.Typed (HasType (..))
 import qualified Data.Map as Map

--- a/hydra-prelude/src/Hydra/Prelude.hs
+++ b/hydra-prelude/src/Hydra/Prelude.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE LambdaCase #-}
 
 module Hydra.Prelude (
@@ -26,6 +27,7 @@ module Hydra.Prelude (
   generateWith,
   shrinkListAggressively,
   padLeft,
+  GenericData,
 ) where
 
 import Cardano.Binary (
@@ -83,6 +85,9 @@ import Data.Aeson (
  )
 import Data.Aeson.Encode.Pretty (
   encodePretty,
+ )
+import Data.Data (
+  Data,
  )
 import qualified Data.Text as T
 import GHC.Generics (Rep)
@@ -142,6 +147,10 @@ import Test.QuickCheck (
 import Test.QuickCheck.Gen (Gen (..))
 import Test.QuickCheck.Instances ()
 import Test.QuickCheck.Random (mkQCGen)
+
+-- NOTE: Not re-exporting as 'Data' to avoid conflict with Cardano
+-- already-overloaded 'Data' type.
+type GenericData = Data
 
 -- | Provides a sensible way of automatically deriving generic 'Arbitrary'
 -- instances for data-types. In the case where more advanced or tailored

--- a/hydra-prelude/src/Hydra/Prelude.hs
+++ b/hydra-prelude/src/Hydra/Prelude.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Hydra.Prelude (
   module Relude,
@@ -27,7 +28,8 @@ module Hydra.Prelude (
   generateWith,
   shrinkListAggressively,
   padLeft,
-  GenericData,
+  (^.),
+  (.~),
 ) where
 
 import Cardano.Binary (
@@ -86,9 +88,6 @@ import Data.Aeson (
 import Data.Aeson.Encode.Pretty (
   encodePretty,
  )
-import Data.Data (
-  Data,
- )
 import qualified Data.Text as T
 import GHC.Generics (Rep)
 import qualified Generic.Random as Random
@@ -133,6 +132,10 @@ import Relude hiding (
   tryTakeTMVar,
   writeTVar,
  )
+import Relude.Extra.Lens (
+  (.~),
+  (^.),
+ )
 import Relude.Extra.Map (
   DynamicMap (..),
   StaticMap (..),
@@ -147,10 +150,6 @@ import Test.QuickCheck (
 import Test.QuickCheck.Gen (Gen (..))
 import Test.QuickCheck.Instances ()
 import Test.QuickCheck.Random (mkQCGen)
-
--- NOTE: Not re-exporting as 'Data' to avoid conflict with Cardano
--- already-overloaded 'Data' type.
-type GenericData = Data
 
 -- | Provides a sensible way of automatically deriving generic 'Arbitrary'
 -- instances for data-types. In the case where more advanced or tailored

--- a/hydra-prelude/src/Hydra/Prelude.hs
+++ b/hydra-prelude/src/Hydra/Prelude.hs
@@ -28,8 +28,6 @@ module Hydra.Prelude (
   generateWith,
   shrinkListAggressively,
   padLeft,
-  (^.),
-  (.~),
 ) where
 
 import Cardano.Binary (
@@ -131,10 +129,6 @@ import Relude hiding (
   tryTakeMVar,
   tryTakeTMVar,
   writeTVar,
- )
-import Relude.Extra.Lens (
-  (.~),
-  (^.),
  )
 import Relude.Extra.Map (
   DynamicMap (..),


### PR DESCRIPTION
  Make sure that we do actually tests all mutations with enough
  coverage. This makes heavy use of generics to make it easy to maintain
  (i.e. add/remove mutations) and produces nice output for free:

  ```
  does not survive random adversarial mutations
    +++ OK, passed 800 tests.

    CloseMutation (800 in total):
    50.7% MutateParties
    17.4% MutateSnapshotNumberButNotSignature
    16.4% MutateSnapshotToIllFormedValue
    15.5% MutateSignatureButNotSnapshotNumber
  ```