### PR TITLE
Seperate label/mutation again to use derived Enum/Bounded enumeration

### DIFF
--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -243,7 +243,6 @@ test-suite tests
     , data-default
     , directory
     , filepath
-    , generic-lens
     , hspec
     , hspec-core
     , hspec-golden-aeson

--- a/hydra-test-utils/src/Test/Hydra/Prelude.hs
+++ b/hydra-test-utils/src/Test/Hydra/Prelude.hs
@@ -152,10 +152,10 @@ newtype ReasonablySized a = ReasonablySized a
 instance Arbitrary a => Arbitrary (ReasonablySized a) where
   arbitrary = ReasonablySized <$> reasonablySized arbitrary
 
--- Like 'coverTable', but construct the weight requirements generically from the
--- label type-representation.
+-- | Like 'coverTable', but construct the weight requirements generically from
+-- the provided label.
 --
---     data MyCoverLabel = Case1 Int | Case2 Bool deriving (Generic, Data, Show)
+--     data MyCoverLabel = Case1 | Case2 deriving (Enum, Bounded, Show)
 --
 --     forAll arbitrary $ \a ->
 --         myProp a
@@ -170,6 +170,15 @@ instance Arbitrary a => Arbitrary (ReasonablySized a) where
 --        & tabulate "MyCoverTable" [head $ words $ show a]
 --        & checkCoverage
 --
+-- If 'myProp' should take some data, use a product type around 'MyCoverLabel',
+-- for example:
+--
+--     type WithLabel a = (MyCoverLabel, a)
+--
+--     forAll arbitrary $ \(label, input) ->
+--         myProp input
+--         & genericCoverTable [label]
+--         & checkCoverage
 genericCoverTable ::
   forall a prop.
   ( Show a


### PR DESCRIPTION
This is a more "boring" Haskell approach to the genericCoverTable function.

Not sure if we should rather opt for this. It's less code, but separates labels/values and the genericCoverTable function is less powerfull then.

Also, I have not updated the documentation of it and just wanted to try this out first :)