### PR TITLE
Another small step to refactor towards cardano-api types

### DIFF
--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -350,6 +350,12 @@ mkSimpleCardanoTx (txin, TxOut owner txOutValueIn datum) (recipient, valueOut) s
 
   fee = Lovelace 0
 
+-- ** TxIn
+
+-- | Create a 'TxIn' from a transaction body and index.
+mkTxIn :: TxBody era -> Word -> TxIn
+mkTxIn txBody index = TxIn (getTxId txBody) (TxIx index)
+
 -- ** TxOut
 
 -- XXX(SN): replace with Cardano.Api.TxBody.lovelaceToTxOutValue when available
@@ -375,6 +381,17 @@ modifyTxOutDatum ::
   TxOut ctx1 Era
 modifyTxOutDatum fn (TxOut addr value dat) =
   TxOut addr value (fn dat)
+
+-- | Find first 'TxOut' which pays to given address and also return the
+-- corresponding 'TxIn' to reference it.
+findTxOutByAddress :: AddressInEra era -> TxBody era -> Maybe (TxIn, TxOut CtxTx era)
+findTxOutByAddress address body =
+  flip find indexedOutputs $ \(_, TxOut addr _ _) -> addr == address
+ where
+  indexedOutputs = zip [mkTxIn body ix | ix <- [0 ..]] txOuts
+
+  TxBody TxBodyContent{txOuts} = body
+
 -- ** Value
 
 -- TODO: Maybe consider using 'renderValue' from cardano-api instead?

--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -180,11 +180,6 @@ mkTxOutDatum :: Plutus.ToData a => a -> TxOutDatum CtxTx Era
 mkTxOutDatum =
   TxOutDatum ScriptDataInAlonzoEra . fromPlutusData . Plutus.toData
 
-toTxDatum :: TxOutDatum CtxUTxO Era -> TxOutDatum CtxTx Era
-toTxDatum = \case
-  TxOutDatumNone -> TxOutDatumNone
-  TxOutDatumHash sdsie ha -> TxOutDatumHash sdsie ha
-
 mkTxOutDatumHash :: Plutus.ToData a => a -> TxOutDatum CtxUTxO Era
 mkTxOutDatumHash =
   TxOutDatumHash ScriptDataInAlonzoEra . hashScriptData . fromPlutusData . Plutus.toData
@@ -368,6 +363,11 @@ txOutValue (TxOut _ value _) =
 mkTxOutValue :: Value -> TxOutValue Era
 mkTxOutValue =
   TxOutValue MultiAssetInAlonzoEra
+
+getDatum :: TxOut CtxTx era -> Maybe ScriptData
+getDatum (TxOut _ _ d) = case d of
+  TxOutDatum _ dat -> Just dat
+  _ -> Nothing
 
 modifyTxOutDatum ::
   (TxOutDatum ctx0 Era -> TxOutDatum ctx1 Era) ->


### PR DESCRIPTION
:snowflake: Rewritten `observeInitTx` and `observeCommitTx`

:snowflake: Added some helper functions to `Hydra.Ledger.Cardano` along the way.

:snowflake: Hard-coded `observeNetworkId` to not change the interface right now. Problem also is, that we would only need to know whether `Mainnet | Testnet` according to the comment on `mkScriptAddress`, but this `NetworkId` ripples alot.