### PR TITLE
Spike: costs of hashing

### DIFF
--- a/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
@@ -1,5 +1,5 @@
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Hydra.Chain.Direct.ContractSpec where
@@ -24,30 +24,47 @@ import qualified Cardano.Ledger.Shelley.API as Ledger
 import qualified Data.ByteString as BS
 import qualified Data.Map as Map
 import Data.Maybe.Strict (StrictMaybe (..))
+import Hydra.Chain.Direct.Fixture (testNetworkId)
 import qualified Hydra.Chain.Direct.Fixture as Fixture
 import Hydra.Chain.Direct.Tx (closeRedeemer, closeTx, policyId)
 import Hydra.Chain.Direct.TxSpec (mkHeadOutput)
+import qualified Hydra.Contract.Hash as Hash
 import Hydra.Contract.MockHead (naturalToCBOR, verifyPartySignature, verifySnapshotSignature)
 import qualified Hydra.Contract.MockHead as MockHead
 import Hydra.Data.Party (partyFromVerKey)
 import Hydra.Ledger.Cardano (
   AlonzoEra,
+  BuildTxWith (BuildTxWith),
   CardanoTx,
   CtxUTxO,
   Era,
   LedgerCrypto,
   LedgerEra,
+  PlutusScriptV1,
   Tx (Tx),
   TxBody (ShelleyTxBody),
   TxBodyScriptData (TxBodyNoScriptData, TxBodyScriptData),
   TxOut (..),
   Utxo,
+  Utxo' (Utxo),
+  addInputs,
   describeCardanoTx,
+  emptyTxBody,
+  fromAlonzoExUnits,
   fromLedgerTx,
   fromLedgerUtxo,
+  fromPlutusScript,
+  lovelaceToTxOutValue,
+  mkDatumForTxIn,
+  mkRedeemerForTxIn,
+  mkScriptAddress,
+  mkScriptWitness,
+  mkTxOutDatum,
   mkTxOutDatumHash,
+  toCtxUTxOTxOut,
   toLedgerTx,
   toLedgerUtxo,
+  unsafeBuildTransaction,
  )
 import qualified Hydra.Ledger.Cardano as Api
 import Hydra.Ledger.Simple (SimpleTx)
@@ -78,10 +95,11 @@ import Test.QuickCheck (
   property,
   suchThat,
  )
+import qualified Test.QuickCheck as QC
 import Test.QuickCheck.Instances ()
 
 spec :: Spec
-spec = describe "On-chain contracts" $ do
+spec = do
   prop "correctly encode 'small' integer to CBOR" prop_encode16BitsNaturalToCBOROnChain
   describe "Signature validator" $ do
     prop
@@ -99,6 +117,33 @@ spec = describe "On-chain contracts" $ do
       propTransactionValidates healthyCloseTx
     prop "does not survive random adversarial mutations" $
       propMutation healthyCloseTx genCloseMutation
+
+  describe "Hash" $
+    prop "execution units" $ \input algorithm ->
+      let output = toCtxUTxOTxOut $ TxOut address value (mkTxOutDatum datum)
+          value = lovelaceToTxOutValue 1_000_000
+          address = mkScriptAddress @PlutusScriptV1 testNetworkId script
+          tx = unsafeBuildTransaction $ emptyTxBody & addInputs [(input, witness)]
+          utxo = Utxo $ Map.singleton input output
+          witness = BuildTxWith $ mkScriptWitness script (mkDatumForTxIn datum) redeemer
+          script = fromPlutusScript Hash.validatorScript
+          bytes = fold $ replicate 10000 ("a" :: ByteString)
+          datum = Hash.datum $ toBuiltin bytes
+          redeemer = mkRedeemerForTxIn $ Hash.redeemer algorithm
+       in case evaluateTx tx utxo of
+            Left basicFailure ->
+              property False
+                & counterexample ("Basic failure: " <> show basicFailure)
+            Right report ->
+              case Map.elems report of
+                [Right units] ->
+                  property True
+                    & counterexample ("Redeemer report: " <> show report)
+                    & counterexample ("Tx: " <> show tx)
+                    & QC.label (show algorithm <> ":" <> show (fromAlonzoExUnits units))
+                _ ->
+                  property False
+                    & counterexample ("Too many redeemers in report: " <> show report)
 
 --
 -- Properties

--- a/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
@@ -119,12 +119,14 @@ spec = do
       propMutation healthyCloseTx genCloseMutation
 
   describe "Hash" $
-    it "measure execution units" $ do
-      for_ [1, 10, 100, 1000, 10000] $ \n -> do
-        putTextLn @IO $ "n = " <> show n
+    it "runs with these ^ execution units" $ do
+      for_ [0 .. 5] $ \(power :: Integer) -> do
+        let n = 8 ^ power
+            s = n `quot` 8
+        putTextLn @IO $ "    n = " <> show n <> ", s = " <> show s
         for_ [minBound .. maxBound] $ \algorithm -> do
           let units = calculateHashExUnits n algorithm
-          putTextLn $ "  " <> show algorithm <> ":" <> show units
+          putTextLn $ "      " <> show algorithm <> ":" <> show units
 
 calculateHashExUnits :: Int -> Hash.HashAlgorithm -> ExecutionUnits
 calculateHashExUnits n algorithm =

--- a/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
@@ -126,19 +126,21 @@ spec = do
         putTextLn @IO $ "    n = " <> show n <> ", s = " <> show s
         for_ [minBound .. maxBound] $ \algorithm -> do
           let ExecutionUnits
-                { executionSteps = baselineCpu
-                , executionMemory = baselineMem
-                } = calculateHashExUnits n Hash.Baseline
-              ExecutionUnits
+                { executionSteps = baseCpu
+                , executionMemory = baseMem
+                } = calculateHashExUnits n Hash.Base
+              units@ExecutionUnits
                 { executionSteps = cpu
                 , executionMemory = mem
                 } = calculateHashExUnits n algorithm
           putTextLn $
             "      " <> show algorithm
-              <> ": cpu="
-              <> show (toInteger cpu - toInteger baselineCpu)
-              <> ", mem="
-              <> show (toInteger mem - toInteger baselineMem)
+              <> ": "
+              <> show units
+              <> " Δcpu="
+              <> show (toInteger cpu - toInteger baseCpu)
+              <> " Δmem="
+              <> show (toInteger mem - toInteger baseMem)
 
 calculateHashExUnits :: Int -> Hash.HashAlgorithm -> ExecutionUnits
 calculateHashExUnits n algorithm =

--- a/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
@@ -38,7 +38,7 @@ import Hydra.Ledger.Cardano (
   CardanoTx,
   CtxUTxO,
   Era,
-  ExecutionUnits,
+  ExecutionUnits (ExecutionUnits),
   LedgerCrypto,
   LedgerEra,
   PlutusScriptV1,
@@ -119,14 +119,26 @@ spec = do
       propMutation healthyCloseTx genCloseMutation
 
   describe "Hash" $
-    it "runs with these ^ execution units" $ do
+    it "runs with these ^ execution units over Baseline" $ do
       for_ [0 .. 5] $ \(power :: Integer) -> do
         let n = 8 ^ power
             s = n `quot` 8
         putTextLn @IO $ "    n = " <> show n <> ", s = " <> show s
         for_ [minBound .. maxBound] $ \algorithm -> do
-          let units = calculateHashExUnits n algorithm
-          putTextLn $ "      " <> show algorithm <> ":" <> show units
+          let ExecutionUnits
+                { executionSteps = baselineCpu
+                , executionMemory = baselineMem
+                } = calculateHashExUnits n Hash.Baseline
+              ExecutionUnits
+                { executionSteps = cpu
+                , executionMemory = mem
+                } = calculateHashExUnits n algorithm
+          putTextLn $
+            "      " <> show algorithm
+              <> ": cpu="
+              <> show (toInteger cpu - toInteger baselineCpu)
+              <> ", mem="
+              <> show (toInteger mem - toInteger baselineMem)
 
 calculateHashExUnits :: Int -> Hash.HashAlgorithm -> ExecutionUnits
 calculateHashExUnits n algorithm =

--- a/hydra-plutus/exe/inspect-script/Main.hs
+++ b/hydra-plutus/exe/inspect-script/Main.hs
@@ -8,6 +8,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as BL
 import Data.Text (pack)
 import Hydra.Contract.Commit as Commit
+import qualified Hydra.Contract.Hash as Hash
 import Hydra.Contract.Initial as Initial
 import Hydra.Contract.MockHead as MockHead
 import Ledger (Datum (..), datumHash)
@@ -64,6 +65,7 @@ main = do
     [ (headScript policyId, "headScript")
     , (initialScript, "initialScript")
     , (commitScript, "commitScript")
+    , (hashScript, "hashScript")
     ]
 
   headScript policyId = MockHead.validatorScript policyId
@@ -71,6 +73,8 @@ main = do
   commitScript = Commit.validatorScript
 
   initialScript = Initial.validatorScript
+
+  hashScript = Hash.validatorScript
 
   datums =
     [ (headDatum, "headDatum")

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -72,6 +72,7 @@ library
   import:          project-config
   exposed-modules:
     Hydra.Contract.Commit
+    Hydra.Contract.Hash
     Hydra.Contract.Initial
     Hydra.Contract.MockCommit
     Hydra.Contract.MockHead

--- a/hydra-plutus/src/Hydra/Contract/Hash.hs
+++ b/hydra-plutus/src/Hydra/Contract/Hash.hs
@@ -9,7 +9,7 @@ module Hydra.Contract.Hash where
 import Ledger hiding (validatorHash)
 import PlutusTx.Prelude
 
-import Hydra.Prelude (Arbitrary (arbitrary), Generic, Show, genericArbitrary)
+import qualified Hydra.Prelude as Haskell
 
 import Ledger.Typed.Scripts (TypedValidator, ValidatorType, ValidatorTypes (..))
 import qualified Ledger.Typed.Scripts as Scripts
@@ -25,12 +25,12 @@ data HashAlgorithm
   | SHA2
   | SHA3
   -- Blake2b
-  deriving (Show, Generic)
+  deriving (Haskell.Show, Haskell.Generic, Haskell.Enum, Haskell.Bounded)
 
 PlutusTx.unstableMakeIsData ''HashAlgorithm
 
-instance Arbitrary HashAlgorithm where
-  arbitrary = genericArbitrary
+instance Haskell.Arbitrary HashAlgorithm where
+  arbitrary = Haskell.genericArbitrary
 
 instance Scripts.ValidatorTypes Hash where
   type DatumType Hash = BuiltinByteString
@@ -40,7 +40,7 @@ instance Scripts.ValidatorTypes Hash where
 validator :: DatumType Hash -> RedeemerType Hash -> ScriptContext -> Bool
 validator bytes algorithm _ctx =
   case algorithm of
-    Baseline -> not $ equalsByteString "" "1"
+    Baseline -> not $ equalsByteString "" bytes
     SHA2 -> not . equalsByteString "" $ sha2_256 bytes
     SHA3 -> not . equalsByteString "" $ sha3_256 bytes
 

--- a/hydra-plutus/src/Hydra/Contract/Hash.hs
+++ b/hydra-plutus/src/Hydra/Contract/Hash.hs
@@ -40,9 +40,9 @@ instance Scripts.ValidatorTypes Hash where
 validator :: DatumType Hash -> RedeemerType Hash -> ScriptContext -> Bool
 validator bytes algorithm _ctx =
   case algorithm of
-    Baseline -> True
-    SHA2 -> not . equalsByteString "" $ sha2_256 bytes
-    SHA3 -> not . equalsByteString "" $ sha3_256 bytes
+    Baseline -> equalsByteString bytes bytes
+    SHA2 -> not . equalsByteString bytes $ sha2_256 bytes
+    SHA3 -> not . equalsByteString bytes $ sha3_256 bytes
 
 -- Blake2b -> not . equalsByteString "" $ blake2b_256 bytes
 

--- a/hydra-plutus/src/Hydra/Contract/Hash.hs
+++ b/hydra-plutus/src/Hydra/Contract/Hash.hs
@@ -21,7 +21,7 @@ import PlutusTx.IsData.Class (ToData (..))
 data Hash
 
 data HashAlgorithm
-  = Baseline
+  = Base
   | SHA2
   | SHA3
   -- Blake2b
@@ -40,7 +40,7 @@ instance Scripts.ValidatorTypes Hash where
 validator :: DatumType Hash -> RedeemerType Hash -> ScriptContext -> Bool
 validator bytes algorithm _ctx =
   case algorithm of
-    Baseline -> equalsByteString bytes bytes
+    Base -> equalsByteString bytes bytes
     SHA2 -> not . equalsByteString bytes $ sha2_256 bytes
     SHA3 -> not . equalsByteString bytes $ sha3_256 bytes
 

--- a/hydra-plutus/src/Hydra/Contract/Hash.hs
+++ b/hydra-plutus/src/Hydra/Contract/Hash.hs
@@ -40,7 +40,7 @@ instance Scripts.ValidatorTypes Hash where
 validator :: DatumType Hash -> RedeemerType Hash -> ScriptContext -> Bool
 validator bytes algorithm _ctx =
   case algorithm of
-    Baseline -> not $ equalsByteString "" bytes
+    Baseline -> True
     SHA2 -> not . equalsByteString "" $ sha2_256 bytes
     SHA3 -> not . equalsByteString "" $ sha3_256 bytes
 

--- a/hydra-plutus/src/Hydra/Contract/Hash.hs
+++ b/hydra-plutus/src/Hydra/Contract/Hash.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-specialize #-}
+
+-- | An experimental validator which simply hashes a bytestring stored in the
+-- datum using one of three supported algorithms.
+module Hydra.Contract.Hash where
+
+import Ledger hiding (validatorHash)
+import PlutusTx.Prelude
+
+import Ledger.Typed.Scripts (TypedValidator, ValidatorType, ValidatorTypes (..))
+import qualified Ledger.Typed.Scripts as Scripts
+import PlutusTx (CompiledCode)
+import qualified PlutusTx
+import PlutusTx.Builtins (blake2b_256)
+import PlutusTx.IsData.Class (ToData (..))
+
+data Hash
+
+data HashAlgorithm
+  = SHA2
+  | SHA3
+  | Blake2b
+
+PlutusTx.unstableMakeIsData ''HashAlgorithm
+
+instance Scripts.ValidatorTypes Hash where
+  type DatumType Hash = BuiltinByteString
+  type RedeemerType Hash = HashAlgorithm
+
+-- NOTE: Plutus is strict, thus this still occurs cost for hashing
+validator :: DatumType Hash -> RedeemerType Hash -> ScriptContext -> Bool
+validator bytes algorithm _ctx =
+  case algorithm of
+    SHA2 -> let _x = sha2_256 bytes in True
+    SHA3 -> let _x = sha3_256 bytes in True
+    Blake2b -> let _x = blake2b_256 bytes in True
+
+compiledValidator :: CompiledCode (ValidatorType Hash)
+compiledValidator = $$(PlutusTx.compile [||validator||])
+
+{- ORMOLU_DISABLE -}
+typedValidator :: TypedValidator Hash
+typedValidator = Scripts.mkTypedValidator @Hash
+  compiledValidator
+  $$(PlutusTx.compile [|| wrap ||])
+ where
+  wrap = Scripts.wrapValidator @(DatumType Hash) @(RedeemerType Hash)
+{- ORMOLU_ENABLE -}
+
+-- | Get the actual plutus script. Mainly used to serialize and use in
+-- transactions.
+validatorScript :: Script
+validatorScript = unValidatorScript $ Scripts.validatorScript typedValidator
+
+validatorHash :: ValidatorHash
+validatorHash = Scripts.validatorHash typedValidator
+
+datum :: DatumType Hash -> Datum
+datum a = Datum (toBuiltinData a)
+
+redeemer :: RedeemerType Hash -> Redeemer
+redeemer a = Redeemer (toBuiltinData a)
+
+address :: Address
+address = scriptHashAddress validatorHash


### PR DESCRIPTION
:snowflake: Indeed the formula `s * slope + intercept` where `s = number of Word64` is used to calculate builtin hash function costs in the cost model

- Builtin cost model lists all three hashing functions as `ModelOneArgument` https://github.com/input-output-hk/plutus/blob/1efbb276ef1a10ca6961d0fd32e6141e9798bd11/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/BuiltinCostModel.hs#L111-L113
- `runOneArgumentModel` function shows a linear multiplication of `s * slope + intercept` with a single `ExMemory` argument
https://github.com/input-output-hk/plutus/blob/1efbb276ef1a10ca6961d0fd32e6141e9798bd11/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/BuiltinCostModel.hs#L208-L223
- Via some not-so-sure (fancy haskell) steps, it seems that `makeBuiltinMeaning` does determine the `ExMemory` cost of the provided function's argument. For hashing it's always a `BuiltinBytestring` and thus the length of the `Bytestring` in 8-byte / 64bit words is `s`. https://github.com/input-output-hk/plutus/blob/1efbb276ef1a10ca6961d0fd32e6141e9798bd11/plutus-core/plutus-core/src/PlutusCore/Evaluation/Machine/ExMemory.hs#L149-L150

:snowflake: Given the cost model parameters in [`mainnet-alonzo-genesis.json`](https://github.com/input-output-hk/cardano-node/tree/e747a7694d55bfd262f82af51b46610d2c1c54cf/configuration/cardano/mainnet-alonzo-genesis.json)
```json
"blake2b-cpu-arguments-intercept": 2477736,
"blake2b-cpu-arguments-slope": 29175,
"blake2b-memory-arguments": 4,
"sha2_256-cpu-arguments-intercept": 2477736,
"sha2_256-cpu-arguments-slope": 29175,
"sha2_256-memory-arguments": 4,
"sha3_256-cpu-arguments-intercept": 0,
"sha3_256-cpu-arguments-slope": 82363,
"sha3_256-memory-arguments": 4,
```
we expect
- memory costs to be constant `ModelOneArgumentConstantCost == 4`
- cpu costs with some number of words lengths (`org-mode` table)
```
|             | slope | intercept | s= |       1 |       8 |      64 |      512 |
|-------------+-------+-----------+----+---------+---------+---------+----------|
| blake2b_256 | 29175 |   2477736 |    | 2506911 | 2711136 | 4344936 | 17415336 |
| sha2_256    | 29175 |   2477736 |    | 2506911 | 2711136 | 4344936 | 17415336 |
| sha3_256    | 82363 |         0 |    |   82363 |  658904 | 5271232 | 42169856 |
#+TBLFM: @2$5..@4$8=@1*$2+$3
```

:snowflake: Add a `Hash` contract to hash a given datum using supported hashing algorithms

:snowflake: Add test to `ContractSpec` which calculates units for multiple bytes lengths and all algorithms

:snowflake: The observed execution unit (deltas) output of `cabal test hydra-node --test-options '--match "Contract/Hash"'`

![image](https://user-images.githubusercontent.com/2621189/148117392-68de0f92-5c01-4b23-8266-21f71af6cf61.png)

show that **memory usage is constant** and **somewhat confirms the expected cpu usage** values with an additional offset between `[-20k..-200k]` and `[-870k..-1M]` units for SHA2 and SHA3 respectively. It seems like the baseline is not good enough or maybe there had been some tweaks on the cost model?
