### PR TITLE
On-chain CBOR encoding experiments - part II

### DIFF
--- a/plutus-cbor/plutus-cbor.cabal
+++ b/plutus-cbor/plutus-cbor.cabal
@@ -97,7 +97,6 @@ test-suite unit
     , hspec
     , hydra-prelude
     , hydra-test-utils
-    , memory
     , plutus-cbor
     , plutus-ledger
     , plutus-ledger-api

--- a/plutus-cbor/plutus-cbor.cabal
+++ b/plutus-cbor/plutus-cbor.cabal
@@ -60,9 +60,8 @@ common project-config
     ViewPatterns
 
   ghc-options:
-    -Wall -Wcompat -Widentities -Wincomplete-record-updates
-    -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
-    -fprint-potential-instances
+    -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
+    -fno-ignore-interface-pragmas -fno-omit-interface-pragmas -fno-strictness -fprint-potential-instances
 
   if !flag(hydra-development)
     ghc-options: -Werror
@@ -85,11 +84,7 @@ test-suite unit
   import:             project-config
   type:               exitcode-stdio-1.0
   hs-source-dirs:     test
-  ghc-options:
-    -threaded -rtsopts
-    -Wall -Wcompat -Widentities -Wincomplete-record-updates
-    -Wincomplete-uni-patterns -Wredundant-constraints
-    -fprint-potential-instances
+  ghc-options:        -threaded -rtsopts
   build-tool-depends: hspec-discover:hspec-discover -any
   build-depends:
     , base

--- a/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
+++ b/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
@@ -2,6 +2,7 @@ module Plutus.Codec.CBOR.Encoding (
   Encoding,
   encodingToBuiltinByteString,
   encodeInteger,
+  encodeByteString,
 ) where
 
 import PlutusTx.Prelude
@@ -25,6 +26,11 @@ encodeInteger n
   | otherwise =
     Encoding (encodeUnsigned 0 n emptyByteString)
 {-# INLINEABLE encodeInteger #-}
+
+encodeByteString :: BuiltinByteString -> Encoding
+encodeByteString bytes =
+  Encoding (encodeUnsigned 2 (lengthOfByteString bytes) bytes)
+{-# INLINEABLE encodeByteString #-}
 
 -- * Internal
 

--- a/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
+++ b/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-specialize #-}
+
 module Plutus.Codec.CBOR.Encoding (
   Encoding,
   encodingToBuiltinByteString,

--- a/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
+++ b/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
@@ -6,6 +6,7 @@ module Plutus.Codec.CBOR.Encoding (
   encodeInteger,
   encodeByteString,
   encodeList,
+  encodeMap,
 ) where
 
 import PlutusTx.Prelude
@@ -43,10 +44,20 @@ encodeList xs =
   Encoding $ \next ->
     encodeUnsigned 4 (length xs) $
       foldr
-        (\(Encoding runEncoder) bytes -> runEncoder bytes)
+        (\(Encoding runEncoder) -> runEncoder)
         next
         xs
 {-# INLINEABLE encodeList #-}
+
+encodeMap :: [(Encoding, Encoding)] -> Encoding
+encodeMap xs =
+  Encoding $ \next ->
+    encodeUnsigned 5 (length xs) $
+      foldr
+        (\(Encoding encodeKey, Encoding encodeValue) -> encodeKey . encodeValue)
+        next
+        xs
+{-# INLINEABLE encodeMap #-}
 
 -- * Internal
 

--- a/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
+++ b/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
@@ -39,7 +39,7 @@ encodeByteString bytes =
 encodeList :: [Encoding] -> Encoding
 encodeList xs =
   Encoding $ \next ->
-    withMajorType 4 (length xs) $
+    encodeUnsigned 4 (length xs) $
       foldr
         (\(Encoding runEncoder) bytes -> runEncoder bytes)
         next

--- a/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
+++ b/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
@@ -5,10 +5,12 @@ module Plutus.Codec.CBOR.Encoding (
   encodingToBuiltinByteString,
   encodeInteger,
   encodeByteString,
+  encodeNull,
   encodeListLen,
   encodeList,
   encodeMapLen,
   encodeMap,
+  encodeMaybe,
 ) where
 
 import PlutusTx.Prelude
@@ -47,6 +49,11 @@ encodeByteString bytes =
   Encoding (encodeUnsigned 2 (lengthOfByteString bytes) . appendByteString bytes)
 {-# INLINEABLE encodeByteString #-}
 
+encodeNull :: Encoding
+encodeNull =
+  Encoding (consByteString 246)
+{-# INLINEABLE encodeNull #-}
+
 -- * Data-Structure
 
 -- | Declare a list of fixed size. Then, provide each element of the list
@@ -63,6 +70,12 @@ encodeList encodeElem es =
   encodeListLen (length es)
     <> foldr (\e -> (encodeElem e <>)) mempty es
 {-# INLINEABLE encodeList #-}
+
+encodeMaybe :: (a -> Encoding) -> Maybe a -> Encoding
+encodeMaybe encode = \case
+  Nothing -> encodeNull
+  Just a -> encode a
+{-# INLINEABLE encodeMaybe #-}
 
 -- | Declare a map of fixed size. Then, provide each key/value pair of the map
 -- separately via appending them ('Encoding' is a 'Semigroup').

--- a/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
+++ b/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
@@ -10,10 +10,10 @@ import PlutusTx.Builtins (subtractInteger)
 
 -- * Encoding
 
-type Encoding = BuiltinByteString
+newtype Encoding = Encoding BuiltinByteString
 
 encodingToBuiltinByteString :: Encoding -> BuiltinByteString
-encodingToBuiltinByteString = id
+encodingToBuiltinByteString (Encoding bytes) = bytes
 {-# INLINEABLE encodingToBuiltinByteString #-}
 
 -- * Basic types

--- a/plutus-cbor/test/Plutus/Codec/CBOR/EncodingSpec.hs
+++ b/plutus-cbor/test/Plutus/Codec/CBOR/EncodingSpec.hs
@@ -110,7 +110,7 @@ propCostIsSmall tolerance (ExUnits maxMemUnits maxStepsUnits) (encode, validator
           <> ")"
       )
  where
-  n = BS.length $ convert $ encode a
+  n = BS.length $ convert $ encodingToBuiltinByteString $ encode a
   ExUnits mem steps =
     distanceExUnits
       (evaluateScriptExecutionUnits emptyValidator ())

--- a/plutus-cbor/test/Plutus/Codec/CBOR/EncodingSpec.hs
+++ b/plutus-cbor/test/Plutus/Codec/CBOR/EncodingSpec.hs
@@ -30,6 +30,7 @@ import Test.Plutus.Codec.CBOR.Encoding.Validators (
   emptyValidator,
   encodeByteStringValidator,
   encodeIntegerValidator,
+  encodeListValidator,
  )
 import Test.Plutus.Validator (
   ExUnits (..),
@@ -84,6 +85,14 @@ spec = do
           defaultMaxExecutionUnits
           (encodeByteString, encodeByteStringValidator)
           . convert
+    prop "for all (x :: [ByteString]), < (0.5% + 0.5% * n)" $
+      forAllBlind (genList (convert <$> genByteString)) $ \xs ->
+        let n = fromIntegral (length xs)
+         in propCostIsSmall
+              (50 % 10_000 + n * 50 % 10_000)
+              defaultMaxExecutionUnits
+              (encodeList . fmap encodeByteString, encodeListValidator)
+              xs
 
 -- | Compare encoding a value 'x' with our own encoder and a reference
 -- implementation. Counterexamples shows both encoded values, but in a pretty /

--- a/plutus-cbor/test/Test/Plutus/Codec/CBOR/Encoding/Validators.hs
+++ b/plutus-cbor/test/Test/Plutus/Codec/CBOR/Encoding/Validators.hs
@@ -11,6 +11,7 @@ import Plutus.Codec.CBOR.Encoding (
   encodeByteString,
   encodeInteger,
   encodeList,
+  encodeMap,
   encodingToBuiltinByteString,
  )
 import qualified PlutusTx as Plutus
@@ -80,3 +81,24 @@ encodeListValidator =
     $$(Plutus.compile [||wrap||])
  where
   wrap = Scripts.wrapValidator @() @[BuiltinByteString]
+
+encodeMapValidator :: Scripts.TypedValidator (EncodeValidator [(BuiltinByteString, BuiltinByteString)])
+encodeMapValidator =
+  Scripts.mkTypedValidator @(EncodeValidator [(BuiltinByteString, BuiltinByteString)])
+    $$( Plutus.compile
+          [||
+          \() m _ctx ->
+            let bytes =
+                  encodingToBuiltinByteString
+                    ( encodeMap $
+                        ( \(a, b) ->
+                            (encodeByteString a, encodeByteString b)
+                        )
+                          <$> m
+                    )
+             in lengthOfByteString bytes > 0
+          ||]
+      )
+    $$(Plutus.compile [||wrap||])
+ where
+  wrap = Scripts.wrapValidator @() @[(BuiltinByteString, BuiltinByteString)]

--- a/plutus-cbor/test/Test/Plutus/Codec/CBOR/Encoding/Validators.hs
+++ b/plutus-cbor/test/Test/Plutus/Codec/CBOR/Encoding/Validators.hs
@@ -7,7 +7,10 @@ module Test.Plutus.Codec.CBOR.Encoding.Validators where
 import PlutusTx.Prelude
 
 import qualified Ledger.Typed.Scripts as Scripts
-import Plutus.Codec.CBOR.Encoding (encodeInteger)
+import Plutus.Codec.CBOR.Encoding (
+  encodeInteger,
+  encodingToBuiltinByteString,
+ )
 import qualified PlutusTx as Plutus
 
 -- | A baseline validator which does nothing but returning 'True'. We use it as
@@ -40,7 +43,7 @@ encodeIntegerValidator =
     $$( Plutus.compile
           [||
           \() a _ctx ->
-            lengthOfByteString (encodeInteger a) > 0
+            lengthOfByteString (encodingToBuiltinByteString (encodeInteger a)) > 0
           ||]
       )
     $$(Plutus.compile [||wrap||])

--- a/plutus-cbor/test/Test/Plutus/Codec/CBOR/Encoding/Validators.hs
+++ b/plutus-cbor/test/Test/Plutus/Codec/CBOR/Encoding/Validators.hs
@@ -8,6 +8,7 @@ import PlutusTx.Prelude
 
 import qualified Ledger.Typed.Scripts as Scripts
 import Plutus.Codec.CBOR.Encoding (
+  encodeByteString,
   encodeInteger,
   encodingToBuiltinByteString,
  )
@@ -43,9 +44,24 @@ encodeIntegerValidator =
     $$( Plutus.compile
           [||
           \() a _ctx ->
-            lengthOfByteString (encodingToBuiltinByteString (encodeInteger a)) > 0
+            let bytes = encodingToBuiltinByteString (encodeInteger a)
+             in lengthOfByteString bytes > 0
           ||]
       )
     $$(Plutus.compile [||wrap||])
  where
   wrap = Scripts.wrapValidator @() @Integer
+
+encodeByteStringValidator :: Scripts.TypedValidator (EncodeValidator BuiltinByteString)
+encodeByteStringValidator =
+  Scripts.mkTypedValidator @(EncodeValidator BuiltinByteString)
+    $$( Plutus.compile
+          [||
+          \() a _ctx ->
+            let bytes = encodingToBuiltinByteString (encodeByteString a)
+             in lengthOfByteString bytes > 0
+          ||]
+      )
+    $$(Plutus.compile [||wrap||])
+ where
+  wrap = Scripts.wrapValidator @() @BuiltinByteString

--- a/plutus-cbor/test/Test/Plutus/Codec/CBOR/Encoding/Validators.hs
+++ b/plutus-cbor/test/Test/Plutus/Codec/CBOR/Encoding/Validators.hs
@@ -10,6 +10,7 @@ import qualified Ledger.Typed.Scripts as Scripts
 import Plutus.Codec.CBOR.Encoding (
   encodeByteString,
   encodeInteger,
+  encodeList,
   encodingToBuiltinByteString,
  )
 import qualified PlutusTx as Plutus
@@ -65,3 +66,17 @@ encodeByteStringValidator =
     $$(Plutus.compile [||wrap||])
  where
   wrap = Scripts.wrapValidator @() @BuiltinByteString
+
+encodeListValidator :: Scripts.TypedValidator (EncodeValidator [BuiltinByteString])
+encodeListValidator =
+  Scripts.mkTypedValidator @(EncodeValidator [BuiltinByteString])
+    $$( Plutus.compile
+          [||
+          \() xs _ctx ->
+            let bytes = encodingToBuiltinByteString (encodeList (encodeByteString <$> xs))
+             in lengthOfByteString bytes > 0
+          ||]
+      )
+    $$(Plutus.compile [||wrap||])
+ where
+  wrap = Scripts.wrapValidator @() @[BuiltinByteString]

--- a/plutus-merkle-tree/exe/contract-cost/Main.hs
+++ b/plutus-merkle-tree/exe/contract-cost/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TypeApplications #-}
+
 import Hydra.Prelude
 
 import qualified Data.ByteString as BS
@@ -5,7 +7,11 @@ import Data.Maybe (fromJust)
 import qualified Plutus.MerkleTree as MT
 import Plutus.MerkleTreeValidator (merkleTreeValidator)
 import qualified PlutusTx.Builtins as Plutus
-import Test.Plutus.Validator (ExUnits (ExUnits), evaluateScriptExecutionUnits)
+import Test.Plutus.Validator (
+  ExUnits (ExUnits),
+  defaultMaxExecutionUnits,
+  evaluateScriptExecutionUnits,
+ )
 import Test.QuickCheck (generate, vectorOf)
 
 main :: IO ()
@@ -20,12 +26,15 @@ main =
 
         (totalMem, totalCpu) = foldr accumulateCost (0, 0) utxo
 
+    let ExUnits (fromIntegral @_ @Double -> maxMem) (fromIntegral @_ @Double -> maxCpu) =
+          defaultMaxExecutionUnits
+
     putTextLn $
       show numElems
         <> "\t"
-        <> show (fromIntegral totalMem `div` numElems)
+        <> show (100 * fromIntegral (fromIntegral totalMem `div` numElems) / maxMem)
         <> "\t"
-        <> show (fromIntegral totalCpu `div` numElems)
+        <> show (100 * fromIntegral (fromIntegral totalCpu `div` numElems) / maxCpu)
  where
   -- NOTE: assume size of a UTXO is around  60
   genFakeUtxos numElems = generate (vectorOf numElems $ BS.pack <$> vectorOf 60 arbitrary)

--- a/plutus-merkle-tree/src/Plutus/MerkleTree.hs
+++ b/plutus-merkle-tree/src/Plutus/MerkleTree.hs
@@ -6,7 +6,7 @@ import Data.ByteString.Base16 (encodeBase16)
 import qualified Data.Text as Text
 import PlutusPrelude ((<|>))
 import qualified PlutusTx
-import PlutusTx.Builtins (subtractInteger)
+import PlutusTx.Builtins (divideInteger, subtractInteger)
 import qualified PlutusTx.List as List
 import PlutusTx.Prelude hiding (toList)
 import qualified Prelude as Haskell
@@ -90,27 +90,19 @@ fromList =
     [e] -> MerkleLeaf (hash e) e
     es ->
       let len = length es
-          cutoff = infPowerOf2 len
+          cutoff = len `divideInteger` 2
           (l, r) = (List.take cutoff es, drop cutoff es)
           lnode = fromList l
           rnode = fromList r
        in MerkleNode (combineHash (rootHash lnode) (rootHash rnode)) len lnode rnode
 
 -- | Plutus Tx version of 'Data.List.drop'.
+--
 -- TODO: move into plutus
 drop :: Integer -> [a] -> [a]
 drop n rs | n <= 0 = rs
 drop n (_ : xs) = drop (subtractInteger n 1) xs
 drop _ [] = []
-
-infPowerOf2 :: Integer -> Integer
-infPowerOf2 n
-  | n <= 0 = 0
-  | otherwise = go 0 1
- where
-  go i k
-    | k > n = i - 1
-    | otherwise = go (i + 1) (k * 2)
 
 toList :: MerkleTree -> [BuiltinByteString]
 toList = go

--- a/plutus-merkle-tree/test/Plutus/MerkleTreeSpec.hs
+++ b/plutus-merkle-tree/test/Plutus/MerkleTreeSpec.hs
@@ -7,11 +7,10 @@ import Test.Hydra.Prelude
 
 import qualified Data.ByteString as BS
 import Data.Maybe (fromJust)
-import Plutus.MerkleTree (MerkleTree, infPowerOf2)
+import Plutus.MerkleTree (MerkleTree)
 import qualified Plutus.MerkleTree as MT
 import qualified PlutusTx.Builtins as Plutus
 import Test.QuickCheck (
-  Positive (Positive),
   Property,
   Testable,
   checkCoverage,
@@ -28,7 +27,6 @@ spec :: Spec
 spec = do
   prop "fromList . toList roundtrips MT" prop_roundtripFromToList
   prop "can check membership of an element" prop_member
-  prop "inf power of 2 bound" prop_infPowerOf2
   prop "tree is balanced" prop_treeIsBalanced
 
 prop_roundtripFromToList :: Property
@@ -44,19 +42,13 @@ prop_member =
     MT.member e (MT.rootHash tree) proof
       & counterexample ("Proof: " <> show proof)
 
-prop_infPowerOf2 :: Positive Integer -> Property
-prop_infPowerOf2 (Positive n) =
-  let p = infPowerOf2 n
-   in floor (logBase @Double 2 (fromIntegral n)) === p
-
 prop_treeIsBalanced :: Property
 prop_treeIsBalanced =
   forAllNonEmptyMerkleTree $ \(tree, _, proof) ->
     let treeSize = MT.size tree
         treeDepthUpperBound = floor (logBase @Double 2 (fromIntegral treeSize)) + 1
      in length proof <= fromIntegral treeSize
-          & cover 50 (length proof <= treeDepthUpperBound) "proofs are in log(n) size of tree"
-          & cover 95 (length proof <= 2 * treeDepthUpperBound) "proofs are no larger than twice log(n) size of tree"
+          & cover 100 (length proof <= treeDepthUpperBound) "proofs are in log(n) size of tree"
           & counterexample ("proof: " <> show proof)
           & counterexample ("tree size: " <> show treeSize)
           & counterexample ("max tree depth: " <> show treeDepthUpperBound)


### PR DESCRIPTION
- :round_pushpin: **Make 'Encoding' a proper newtype to force API use.**
  
- :round_pushpin: **Use continuation passing style to avoid use of 'appendByteString'**
    This is slightly more efficient for this bytestrings of that length. On large integers, we save up to 3M execution units that way.

- :round_pushpin: **Add CBOR encoding for ByteString.**
  
- :round_pushpin: **Split measurement property for integers.**
  
- :round_pushpin: **WIP: encodeList**
  
- :round_pushpin: **Generalize the roundtrip property to allow combining values together.**
  
- :round_pushpin: **Measure cost of execution of 'encodeList'**
  
- :round_pushpin: **Implement on-chain CBOR encoder for maps.**
  
- :round_pushpin: **Measure cost of execution of 'encodeMap'**
  
- :round_pushpin: **Slightly optimize encodeMap and encodeList**
     + also make the API work with AssocMap for Map, since this is likely what we'll use for TxOut and values.

- :round_pushpin: **Measure cost of encoding a TxOut on-chain.**
    Results aren't much encouraging as for whether this is a viable
  solution ....

  ```
  for all (x :: TxOut), ada-only
    +++ OK, passed 100 tests (100% of mem units < 2.5%, and steps units < 1.5%).

  for all (x :: TxOut), with up to 10 assets
    +++ OK, passed 100 tests (100% of mem units < 15.0%, and steps units < 6.0%).

  for all (x :: TxOut), with up to 75 assets
    +++ OK, passed 100 tests (100% of mem units < 100.0%, and steps units < 40.0%).
  ```

  For ada only transactions, we run out of memory after 40 transactions,
  and it's not even counting the rest of the script. For assets, it's
  even worse as we may not even be able to handle an output with more
  than 75 assets (whereas the protocol technically allows for up to ~140
  assets with the current parameters).
