### PR TITLE
Cache /nix/store

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
     - name: Import nix-shell.closure from cache
       run: |
         [[ -e nix-shell.closure ]] && nix-store --import < nix-shell.closure || echo "No nix-shell cache found"
-        nix-store --verify
+        nix-store --verify --check-contents --repair
 
     - name: Github cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
       uses: actions/cache@v2.1.5
@@ -48,15 +48,9 @@ jobs:
         restore-keys: |
             ${{ runner.os }}-key
 
-    - run: |
-        nix-store --verify --check-contents --repair
-
     - name: Prepare nix-shell
       run: |
         nix-build shell.nix
-
-    - run: |
-        nix-store --verify-path /nix/store/5d821pjgzb90lw4zbg6xwxs7llm335wr-libunistring-0.9.10
 
     - name: Export shell.nix for later caching
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Prepare nix-shell
       # Creates a ./result symlink -> useful for collect-garbage
-      run: nix build -f shell.nix
+      run: nix-build shell.nix
 
     - name: Cabal build, test & haddock in nix-shell
       run: nix-shell --run 'build-ci.sh'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Import nix-shell.closure from cache
       run: |
-        [[ -f nix-shell.closure ]] && nix-store --import < nix-shell.closure
+        nix-store --import < nix-shell.closure || true
 
     - name: Build & export shell.nix for later caching
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
             ${{ runner.os }}-key
 
     - run: |
-        nix-store --repair-path /nix/store/5d821pjgzb90lw4zbg6xwxs7llm335wr-libunistring-0.9.10
+        nix-store --verify --check-contents --repair
 
     - name: Prepare nix-shell
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
         path: nix-shell.closure
         key:
           nix-shell-closure-${{ hashFiles('shell.nix', 'default.nix') }}
-        restore-key:
+        restore-keys: |
           nix-shell-closure
 
     - name: Import nix-shell.closure from cache
@@ -50,8 +50,8 @@ jobs:
           dist-newstyle
         key:
           cabal-${{ runner.os }}-${{ hashFiles('cabal.project') }}
-        restore-keys:
-          ${{ runner.os }}-${{ hashFiles('cabal.project') }}
+        restore-keys: |
+          cabal-${{ runner.os }}
 
     - name: Prepare nix-shell
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
           substituters = https://cache.nixos.org https://hydra.iohk.io https://iohk.cachix.org
 
     - name: Chown /nix/store
-      # This is primarily done to cache & restore /nix/store
+      # This is primarily done to be able to restore /nix/store
       run: sudo chown --verbose "$USER:" /nix
 
     - name: Cachix cache of nix derivations

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Chown /nix/store
       # This is done to be able to restore /nix/store
-      run: sudo chown --verbose "$USER:" /nix
+      run: sudo chown -R --verbose "$USER:" /nix
 
     - name: Cachix cache of nix derivations
       uses: cachix/cachix-action@v10

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,10 +12,6 @@ jobs:
         repository: input-output-hk/hydra-poc
         token: ${{ secrets.MY_TOKEN || github.token }}
 
-    - name: Workaround for single-user-install
-      run: mkdir -p /run/systemd/system
-      # depends on https://github.com/cachix/install-nix-action/blob/1199b02395e5f71e4bd52f325f2d453bb44d4c8b/lib/install-nix.sh#L37
-
     - name: Prepare nix
       uses: cachix/install-nix-action@v13
       with:
@@ -24,16 +20,14 @@ jobs:
           trusted-public-keys = iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           substituters = https://cache.nixos.org https://hydra.iohk.io https://iohk.cachix.org
 
-    - name: Chown /nix/store
-      # This is done to be able to restore /nix/store
-      run: sudo chown -R --verbose "$USER:" /nix
-
-    - name: Github cache of /nix/store
+    - name: Github cache of nix-shell.closure
       uses: actions/cache@v2.1.5
       with:
-        path: |
-          /nix/store
-        key: nix-store
+        path: nix-shell.closure
+        key: nix-shell-closure
+
+    - name: Import nix-shell.closure from cache
+      run: [[ -f nix-shell.closure ]] && nix-store --import < nix-shell.closure
 
     - name: Github cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
       uses: actions/cache@v2.1.5
@@ -59,6 +53,9 @@ jobs:
       shell: 'script -q -e -c "bash {0}"'
       env:
         TERM: "xterm"
+
+    - name: Export nix-shell.closure for cache
+      run: [[ -f nix-shell.closure ]] && nix-store --import < nix-shell.closure
 
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,8 @@ jobs:
 
     - name: Build & export shell.nix for later caching
       run: |
-        nix-store --export $(nix-store -qR $(nix-build shell.nix)) > nix-shell.closure
+        SHELL_DRV=$(nix-build shell.nix)
+        nix-store --export $(nix-store -qR ${SHELL_DRV}) > nix-shell.closure
 
     - name: Github cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
       uses: actions/cache@v2.1.5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,10 +46,6 @@ jobs:
           /nix/store
         key: nix-store
 
-    - name: Prepare nix-shell
-      # Creates a ./result symlink -> useful for collect-garbage
-      run: nix-build shell.nix
-
     - name: Cabal build, test & haddock in nix-shell
       run: nix-shell --run 'build-ci.sh'
       # https://giters.com/gfx/example-github-actions-with-tty
@@ -57,11 +53,6 @@ jobs:
       shell: 'script -q -e -c "bash {0}"'
       env:
         TERM: "xterm"
-
-    - name: Cleanup /nix/store for cache
-      # The nix build above installs a result symlink which prevents purging the
-      # current nix-shell derivations
-      run: nix-collect-garbage
 
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
           substituters = https://cache.nixos.org https://hydra.iohk.io https://iohk.cachix.org
 
     - name: Chown /nix/store
-      # This is primarily done to be able to restore /nix/store
+      # This is done to be able to restore /nix/store
       run: sudo chown --verbose "$USER:" /nix
 
     - name: Cachix cache of nix derivations

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,9 @@ jobs:
         restore-keys: |
             ${{ runner.os }}-key
 
+    - run: |
+        nix-store --repair-path /nix/store/5d821pjgzb90lw4zbg6xwxs7llm335wr-libunistring-0.9.10
+
     - name: Prepare nix-shell
       run: |
         nix-build shell.nix

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,13 @@ jobs:
         restore-keys: |
             ${{ runner.os }}-key
 
+    - uses: actions/cache@v2.1.5
+      name: Github cache of /nix/store
+      with:
+        path: |
+          /nix/store
+        key: nix-store
+
     - run: nix-shell --run 'build-ci.sh'
       # https://giters.com/gfx/example-github-actions-with-tty
       # The default shell does not allocate a TTY which breaks some tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,12 @@ jobs:
           trusted-public-keys = iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           substituters = https://cache.nixos.org https://hydra.iohk.io https://iohk.cachix.org
 
+    - name: Cachix cache of nix derivations
+      uses: cachix/cachix-action@v10
+      with:
+        name: hydra-node
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
     - name: Github cache of nix-shell.closure
       uses: actions/cache@v2.1.5
       with:
@@ -27,7 +33,12 @@ jobs:
         key: nix-shell-closure
 
     - name: Import nix-shell.closure from cache
-      run: [[ -f nix-shell.closure ]] && nix-store --import < nix-shell.closure
+      run: |
+        [[ -f nix-shell.closure ]] && nix-store --import < nix-shell.closure
+
+    - name: Build & export shell.nix for later caching
+      run: |
+        nix-store --export $(nix-store -qR $(nix-build shell.nix)) > nix-shell.closure
 
     - name: Github cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
       uses: actions/cache@v2.1.5
@@ -40,12 +51,6 @@ jobs:
         restore-keys: |
             ${{ runner.os }}-key
 
-    - name: Cachix cache of nix derivations
-      uses: cachix/cachix-action@v10
-      with:
-        name: hydra-node
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-
     - name: Cabal build, test & haddock in nix-shell
       run: nix-shell --run 'build-ci.sh'
       # https://giters.com/gfx/example-github-actions-with-tty
@@ -53,9 +58,6 @@ jobs:
       shell: 'script -q -e -c "bash {0}"'
       env:
         TERM: "xterm"
-
-    - name: Export nix-shell.closure for cache
-      run: [[ -f nix-shell.closure ]] && nix-store --import < nix-shell.closure
 
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,19 +8,24 @@ jobs:
       with:
         repository: input-output-hk/hydra-poc
         token: ${{ secrets.MY_TOKEN || github.token }}
-    - uses: cachix/install-nix-action@v13
+
+    - name: Prepare nix
+      uses: cachix/install-nix-action@v13
       with:
         skip_adding_nixpkgs_channel: true
         install_options: '--no-daemon'
         extra_nix_config: |
           trusted-public-keys = iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           substituters = https://cache.nixos.org https://hydra.iohk.io https://iohk.cachix.org
-    - uses: cachix/cachix-action@v10
+
+    - name: Cachix cache of nix derivations
+      uses: cachix/cachix-action@v10
       with:
         name: hydra-node
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - uses: actions/cache@v2.1.5
-      name: Cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
+
+    - name: Github cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
+      uses: actions/cache@v2.1.5
       with:
         path: |
           ~/.cabal/packages
@@ -30,27 +35,37 @@ jobs:
         restore-keys: |
             ${{ runner.os }}-key
 
-    - uses: actions/cache@v2.1.5
-      name: Github cache of /nix/store
+    - name: Github cache of /nix/store
+      uses: actions/cache@v2.1.5
       with:
         path: |
           /nix/store
         key: nix-store
 
-    - run: nix-shell --run 'build-ci.sh'
+    - name: Prepare nix-shell
+      # Creates a ./result symlink -> useful for collect-garbage
+      run: nix build -f shell.nix
+
+    - name: Cabal build, test & haddock in nix-shell
+      run: nix-shell --run 'build-ci.sh'
       # https://giters.com/gfx/example-github-actions-with-tty
       # The default shell does not allocate a TTY which breaks some tests
       shell: 'script -q -e -c "bash {0}"'
       env:
         TERM: "xterm"
 
+    - name: Cleanup /nix/store for cache
+      # The nix build above installs a result symlink which prevents purging the
+      # current nix-shell derivations
+      run: nix-collect-garbage
+
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action@v1
       with:
         files: ./**/test-results.xml
 
-    - uses: peaceiris/actions-gh-pages@v3
-      name: Publish Documentation
+    - name: Publish Documentation
+      uses: peaceiris/actions-gh-pages@v3
       if: github.event_name == 'push'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN || github.token }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,10 @@ jobs:
       uses: actions/cache@v2.1.5
       with:
         path: nix-shell.closure
-        key: nix-shell-closure
+        key:
+          nix-shell-closure-${{ hashFiles('shell.nix', 'default.nix') }}
+        restore-key:
+          nix-shell-closure
 
     - name: Import nix-shell.closure from cache
       # TODO: nix-store --import is very verbose
@@ -45,15 +48,16 @@ jobs:
           ~/.cabal/packages
           ~/.cabal/store
           dist-newstyle
-        key: ${{ runner.os }}-${{ hashFiles('cabal.project') }}
-        restore-keys: |
-            ${{ runner.os }}-key
+        key:
+          cabal-${{ runner.os }}-${{ hashFiles('cabal.project') }}
+        restore-keys:
+          ${{ runner.os }}-${{ hashFiles('cabal.project') }}
 
     - name: Prepare nix-shell
       run: |
         nix-build shell.nix
 
-    - name: Export shell.nix for later caching
+    - name: Export nix-shell derivations for later caching
       run: |
         nix-store --export $(nix-store -qR --include-outputs $(nix-instantiate shell.nix)) > nix-shell.closure
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,11 +25,12 @@ jobs:
       # This is done to be able to restore /nix/store
       run: sudo chown -R --verbose "$USER:" /nix
 
-    - name: Cachix cache of nix derivations
-      uses: cachix/cachix-action@v10
+    - name: Github cache of /nix/store
+      uses: actions/cache@v2.1.5
       with:
-        name: hydra-node
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        path: |
+          /nix/store
+        key: nix-store
 
     - name: Github cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
       uses: actions/cache@v2.1.5
@@ -42,12 +43,11 @@ jobs:
         restore-keys: |
             ${{ runner.os }}-key
 
-    - name: Github cache of /nix/store
-      uses: actions/cache@v2.1.5
+    - name: Cachix cache of nix derivations
+      uses: cachix/cachix-action@v10
       with:
-        path: |
-          /nix/store
-        key: nix-store
+        name: hydra-node
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
     - name: Cabal build, test & haddock in nix-shell
       run: nix-shell --run 'build-ci.sh'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,7 @@ jobs:
         key: nix-shell-closure
 
     - name: Import nix-shell.closure from cache
+      # TODO: nix-store --import is very verbose
       run: |
         [[ -e nix-shell.closure ]] && nix-store --import < nix-shell.closure || echo "No nix-shell cache found"
         nix-store --verify --check-contents --repair
@@ -54,7 +55,7 @@ jobs:
 
     - name: Export shell.nix for later caching
       run: |
-        nix-store --export $(nix-store -qR $(nix-instantiate shell.nix)) > nix-shell.closure
+        nix-store --export $(nix-store -qR --include-outputs $(nix-instantiate shell.nix)) > nix-shell.closure
 
     - name: Cabal build, test & haddock in nix-shell
       run: nix-shell --run 'build-ci.sh'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,11 +12,14 @@ jobs:
         repository: input-output-hk/hydra-poc
         token: ${{ secrets.MY_TOKEN || github.token }}
 
+    - name: Workaround for single-user-install
+      run: mkdir -p /run/systemd/system
+      # depends on https://github.com/cachix/install-nix-action/blob/1199b02395e5f71e4bd52f325f2d453bb44d4c8b/lib/install-nix.sh#L37
+
     - name: Prepare nix
       uses: cachix/install-nix-action@v13
       with:
         skip_adding_nixpkgs_channel: true
-        install_options: '--no-daemon'
         extra_nix_config: |
           trusted-public-keys = iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           substituters = https://cache.nixos.org https://hydra.iohk.io https://iohk.cachix.org

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,17 @@ jobs:
         restore-keys: |
             ${{ runner.os }}-key
 
+    - name: Prepare nix-shell
+      run: |
+        nix-build shell.nix
+
+    - run: |
+        nix-store --verify-path /nix/store/5d821pjgzb90lw4zbg6xwxs7llm335wr-libunistring-0.9.10
+
+    - name: Export shell.nix for later caching
+      run: |
+        nix-store --export $(nix-store -qR $(nix-instantiate shell.nix)) > nix-shell.closure
+
     - name: Cabal build, test & haddock in nix-shell
       run: nix-shell --run 'build-ci.sh'
       # https://giters.com/gfx/example-github-actions-with-tty
@@ -55,12 +66,6 @@ jobs:
       shell: 'script -q -e -c "bash {0}"'
       env:
         TERM: "xterm"
-
-    - name: Build & export shell.nix for later caching
-      run: |
-        SHELL_DRV=$(nix-build shell.nix)
-        echo ${SHELL_DRV}
-        nix-store --export $(nix-store -qR ${SHELL_DRV}) > nix-shell.closure
 
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,10 @@ jobs:
           trusted-public-keys = iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           substituters = https://cache.nixos.org https://hydra.iohk.io https://iohk.cachix.org
 
+    - name: Chown /nix/store
+      # This is primarily done to cache & restore /nix/store
+      run: sudo chown --verbose "$USER:" /nix
+
     - name: Cachix cache of nix derivations
       uses: cachix/cachix-action@v10
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: "CI"
-on: [push, pull_request]
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,12 +34,8 @@ jobs:
 
     - name: Import nix-shell.closure from cache
       run: |
-        nix-store --import < nix-shell.closure || true
-
-    - name: Build & export shell.nix for later caching
-      run: |
-        SHELL_DRV=$(nix-build shell.nix)
-        nix-store --export $(nix-store -qR ${SHELL_DRV}) > nix-shell.closure
+        [[ -e nix-shell.closure ]] && nix-store --import < nix-shell.closure || echo "No nix-shell cache found"
+        nix-store --verify
 
     - name: Github cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
       uses: actions/cache@v2.1.5
@@ -59,6 +55,12 @@ jobs:
       shell: 'script -q -e -c "bash {0}"'
       env:
         TERM: "xterm"
+
+    - name: Build & export shell.nix for later caching
+      run: |
+        SHELL_DRV=$(nix-build shell.nix)
+        echo ${SHELL_DRV}
+        nix-store --export $(nix-store -qR ${SHELL_DRV}) > nix-shell.closure
 
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action@v1


### PR DESCRIPTION
Opening a PR to only close it again -> this is not possible right now.

Reason: the `/nix/store` is not writable by the Github cache action / user when restoring the cache.

It's definitely not possible to have `/nix/store` be somewhere else.
Maybe it's possible to change permissions or give the cache action / the user permissions to write it.