### PR TITLE
Plutus cbor optimization / test rework

### DIFF
--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -130,16 +130,14 @@ waitForAll tracer delay nodes expected = do
           toString $
             unlines
               [ "waitFor... timeout!"
-              , padRight " " 20 "  nodeId:"
+              , padRight ' ' 20 "  nodeId:"
                   <> show hydraNodeId
-              , padRight " " 20 "  expected:"
+              , padRight ' ' 20 "  expected:"
                   <> unlines (align 20 (decodeUtf8 . Aeson.encode <$> expected))
-              , padRight " " 20 "  seen messages:"
+              , padRight ' ' 20 "  seen messages:"
                   <> unlines (align 20 (decodeUtf8 . Aeson.encode <$> actualMsgs))
               ]
  where
-  padRight c n str = T.take n (str <> T.replicate n c)
-
   align _ [] = []
   align n (h : q) = h : fmap (T.replicate n " " <>) q
 

--- a/hydra-prelude/src/Hydra/Prelude.hs
+++ b/hydra-prelude/src/Hydra/Prelude.hs
@@ -28,6 +28,7 @@ module Hydra.Prelude (
   generateWith,
   shrinkListAggressively,
   padLeft,
+  padRight,
 ) where
 
 import Cardano.Binary (
@@ -178,3 +179,10 @@ shrinkListAggressively = \case
 -- NOTE: Truncate the string if longer than the given length.
 padLeft :: Char -> Int -> Text -> Text
 padLeft c n str = T.takeEnd n (T.replicate n (T.singleton c) <> str)
+
+-- | Pad a text-string to right with the given character until it reaches the given
+-- length.
+--
+-- NOTE: Truncate the string if longer than the given length.
+padRight :: Char -> Int -> Text -> Text
+padRight c n str = T.take n (str <> T.replicate n (T.singleton c))

--- a/plutus-cbor/exe/encoding-cost/Main.hs
+++ b/plutus-cbor/exe/encoding-cost/Main.hs
@@ -1,0 +1,148 @@
+{-# LANGUAGE TypeApplications #-}
+
+import Hydra.Prelude hiding (label)
+
+import Data.Binary.Builder (toLazyByteString)
+import qualified Data.ByteString as BS
+import Data.ByteString.Builder.Scientific (FPFormat (Fixed), formatScientificBuilder)
+import Data.Ratio ((%))
+import Data.Scientific (unsafeFromRational)
+import qualified Ledger.Typed.Scripts as Scripts
+import Plutus.Codec.CBOR.Encoding.Validator (
+  EncodeValidator,
+  ValidatorKind (..),
+  encodeTxOutValidator,
+  encodeTxOutsValidator,
+ )
+import qualified Plutus.V1.Ledger.Api as Plutus
+import qualified PlutusTx.AssocMap as Plutus.Map
+import Test.Plutus.Validator (
+  ExUnits (..),
+  defaultMaxExecutionUnits,
+  distanceExUnits,
+  evaluateScriptExecutionUnits,
+ )
+import Test.QuickCheck (
+  choose,
+  oneof,
+  vector,
+  vectorOf,
+ )
+
+main :: IO ()
+main = do
+  putTextLn "List of ADA-only TxOut, by list size."
+  forM_ [1 .. 50] $ \n -> do
+    let x = generateWith (vectorOf n genAdaOnlyTxOut) 42
+    let (mem, cpu) = relativeCostOf x defaultMaxExecutionUnits encodeTxOutsValidator
+    putTextLn @IO $
+      unwords
+        [ padLeft ' ' 2 (show n)
+        , rationalToPercent mem
+        , rationalToPercent cpu
+        ]
+
+  putTextLn ""
+  putTextLn "Single multi-asset TxOut, by asset number."
+  forM_ [1 .. 50] $ \n -> do
+    let x = generateWith (genTxOut n) 42
+    let (mem, cpu) = relativeCostOf x defaultMaxExecutionUnits encodeTxOutValidator
+    putTextLn @IO $
+      unwords
+        [ padLeft ' ' 2 (show n)
+        , rationalToPercent mem
+        , rationalToPercent cpu
+        ]
+
+relativeCostOf ::
+  (Plutus.ToData a) =>
+  a ->
+  ExUnits ->
+  (ValidatorKind -> Scripts.TypedValidator (EncodeValidator a)) ->
+  (Rational, Rational)
+relativeCostOf a (ExUnits maxMem maxCpu) validator =
+  (relativeMemCost, relativeCpuCost)
+ where
+  ExUnits mem cpu =
+    distanceExUnits
+      (evaluateScriptExecutionUnits (validator BaselineValidator) a)
+      (evaluateScriptExecutionUnits (validator RealValidator) a)
+
+  (relativeMemCost, relativeCpuCost) =
+    ( toInteger mem % toInteger maxMem
+    , toInteger cpu % toInteger maxCpu
+    )
+
+--
+-- Helpers
+--
+
+rationalToPercent :: Rational -> Text
+rationalToPercent r =
+  padLeft ' ' 5 $ decodeUtf8 (toLazyByteString $ toFixedDecimals 2 $ 100 * r)
+ where
+  toFixedDecimals n = formatScientificBuilder Fixed (Just n) . unsafeFromRational
+
+--
+-- Generators
+--
+
+genTxOut :: Int -> Gen Plutus.TxOut
+genTxOut n = do
+  Plutus.TxOut
+    <$> genAddress
+    <*> fmap mconcat (vectorOf n genValue)
+    <*> oneof [pure Nothing, Just <$> genDatumHash]
+
+genAdaOnlyTxOut :: Gen Plutus.TxOut
+genAdaOnlyTxOut =
+  Plutus.TxOut
+    <$> genAddress
+    <*> genAdaOnlyValue
+    <*> oneof [pure Nothing, Just <$> genDatumHash]
+
+genAddress :: Gen Plutus.Address
+genAddress =
+  Plutus.Address
+    <$> fmap (Plutus.PubKeyCredential . Plutus.PubKeyHash . Plutus.toBuiltin) (genByteStringOf 28)
+    <*> pure Nothing
+
+genValue :: Gen Plutus.Value
+genValue = do
+  n <- genAssetQuantity
+  policyId <- genCurrencySymbol
+  assetName <- genTokenName
+  pure $
+    Plutus.Value $
+      Plutus.Map.fromList
+        [(policyId, Plutus.Map.fromList [(assetName, n)])]
+
+genAdaOnlyValue :: Gen Plutus.Value
+genAdaOnlyValue = do
+  n <- genAssetQuantity
+  pure $
+    Plutus.Value $
+      Plutus.Map.fromList
+        [(Plutus.adaSymbol, Plutus.Map.fromList [(Plutus.adaToken, n)])]
+
+genAssetQuantity :: Gen Integer
+genAssetQuantity = choose (1, 4_294_967_296) -- NOTE: 2**32
+
+genCurrencySymbol :: Gen Plutus.CurrencySymbol
+genCurrencySymbol =
+  Plutus.CurrencySymbol
+    <$> fmap Plutus.toBuiltin (genByteStringOf 32)
+
+genTokenName :: Gen Plutus.TokenName
+genTokenName =
+  Plutus.TokenName
+    <$> fmap Plutus.toBuiltin (genByteStringOf =<< choose (0, 32))
+
+genDatumHash :: Gen Plutus.DatumHash
+genDatumHash =
+  Plutus.DatumHash
+    <$> fmap Plutus.toBuiltin (genByteStringOf 32)
+
+genByteStringOf :: Int -> Gen ByteString
+genByteStringOf n =
+  BS.pack <$> vector n

--- a/plutus-cbor/exe/encoding-cost/Plutus/Codec/CBOR/Encoding/Validator.hs
+++ b/plutus-cbor/exe/encoding-cost/Plutus/Codec/CBOR/Encoding/Validator.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-specialize #-}
 
-module Test.Plutus.Codec.CBOR.Encoding.Validators where
+module Plutus.Codec.CBOR.Encoding.Validator where
 
 import PlutusTx.Prelude
 

--- a/plutus-cbor/plutus-cbor.cabal
+++ b/plutus-cbor/plutus-cbor.cabal
@@ -70,9 +70,6 @@ library
   import:          project-config
   hs-source-dirs:  src
   ghc-options:     -haddock
-  if flag(hydra-development)
-    -- NOTE(SN): should fix HLS choking on PlutusTx plugin
-    ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
   build-depends:
       plutus-core
     , plutus-tx
@@ -91,8 +88,32 @@ test-suite unit
     , base16
     , binary
     , bytestring
-    , cardano-ledger-alonzo
     , cborg
+    , containers
+    , hspec
+    , hydra-prelude
+    , hydra-test-utils
+    , plutus-cbor
+    , plutus-tx
+    , plutus-ledger
+    , plutus-ledger-api
+    , QuickCheck
+  other-modules:
+    Plutus.Codec.CBOR.EncodingSpec
+    Spec
+  main-is:            Main.hs
+
+executable encoding-cost
+  import:         project-config
+  hs-source-dirs: exe/encoding-cost
+  main-is:        Main.hs
+  other-modules:  Plutus.Codec.CBOR.Encoding.Validator
+  build-depends:
+    , base
+    , base16
+    , binary
+    , bytestring
+    , cardano-ledger-alonzo
     , containers
     , hspec
     , hydra-prelude
@@ -104,8 +125,7 @@ test-suite unit
     , plutus-tx-plugin
     , scientific
     , QuickCheck
-  other-modules:
-    Plutus.Codec.CBOR.EncodingSpec
-    Test.Plutus.Codec.CBOR.Encoding.Validators
-    Spec
-  main-is:            Main.hs
+  if flag(hydra-development)
+    -- NOTE(SN): should fix HLS choking on PlutusTx plugin
+    ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
+  ghc-options:    -threaded -rtsopts

--- a/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
+++ b/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
@@ -74,9 +74,9 @@ encodeList :: (a -> Encoding) -> [a] -> Encoding
 encodeList encodeElem =
   step 0 mempty
  where
-  step !n !bs = \case
+  step n bs = \case
     [] -> encodeListLen n <> bs
-    (e : q) -> step (n+1) (bs <> encodeElem e) q
+    (e : q) -> step (n + 1) (bs <> encodeElem e) q
 {-# INLINEABLE encodeList #-}
 
 encodeListIndef :: (a -> Encoding) -> [a] -> Encoding
@@ -117,7 +117,7 @@ encodeMap encodeKey encodeValue =
  where
   step n bs = \case
     [] -> encodeMapLen n <> bs
-    ((k,v) : q) -> step (n+1) (bs <> encodeKey k <> encodeValue v) q
+    ((k, v) : q) -> step (n + 1) (bs <> encodeKey k <> encodeValue v) q
 {-# INLINEABLE encodeMap #-}
 
 encodeMapIndef :: (k -> Encoding) -> (v -> Encoding) -> Map k v -> Encoding
@@ -126,7 +126,7 @@ encodeMapIndef encodeKey encodeValue m =
  where
   step = \case
     [] -> encodeBreak
-    ((k,v) : q) -> encodeKey k <> encodeValue v <> step q
+    ((k, v) : q) -> encodeKey k <> encodeValue v <> step q
 {-# INLINEABLE encodeMapIndef #-}
 
 encodeBeginMap :: Encoding

--- a/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
+++ b/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
@@ -71,13 +71,21 @@ encodeListLen = Encoding . encodeUnsigned 4
 {-# INLINEABLE encodeListLen #-}
 
 encodeList :: (a -> Encoding) -> [a] -> Encoding
-encodeList encodeElem es =
-  encodeListLen (length es) <> foldMap encodeElem es
+encodeList encodeElem =
+  step 0 mempty
+ where
+  step !n !bs = \case
+    [] -> encodeListLen n <> bs
+    (e : q) -> step (n+1) (bs <> encodeElem e) q
 {-# INLINEABLE encodeList #-}
 
 encodeListIndef :: (a -> Encoding) -> [a] -> Encoding
 encodeListIndef encodeElem es =
-  encodeBeginList <> foldMap encodeElem es <> encodeBreak
+  encodeBeginList <> step es
+ where
+  step = \case
+    [] -> encodeBreak
+    (e : q) -> encodeElem e <> step q
 {-# INLINEABLE encodeListIndef #-}
 
 encodeBeginList :: Encoding
@@ -104,15 +112,21 @@ encodeMapLen = Encoding . encodeUnsigned 5
 {-# INLINEABLE encodeMapLen #-}
 
 encodeMap :: (k -> Encoding) -> (v -> Encoding) -> Map k v -> Encoding
-encodeMap encodeKey encodeValue m =
-  encodeMapLen (length m) <> foldMap (\(k, v) -> encodeKey k <> encodeValue v) (Map.toList m)
+encodeMap encodeKey encodeValue =
+  step 0 mempty . Map.toList
+ where
+  step n bs = \case
+    [] -> encodeMapLen n <> bs
+    ((k,v) : q) -> step (n+1) (bs <> encodeKey k <> encodeValue v) q
 {-# INLINEABLE encodeMap #-}
 
 encodeMapIndef :: (k -> Encoding) -> (v -> Encoding) -> Map k v -> Encoding
 encodeMapIndef encodeKey encodeValue m =
-  encodeBeginMap
-    <> foldMap (\(k, v) -> encodeKey k <> encodeValue v) (Map.toList m)
-    <> encodeBreak
+  encodeBeginMap <> step (Map.toList m)
+ where
+  step = \case
+    [] -> encodeBreak
+    ((k,v) : q) -> encodeKey k <> encodeValue v <> step q
 {-# INLINEABLE encodeMapIndef #-}
 
 encodeBeginMap :: Encoding

--- a/plutus-cbor/test/Plutus/Codec/CBOR/EncodingSpec.hs
+++ b/plutus-cbor/test/Plutus/Codec/CBOR/EncodingSpec.hs
@@ -36,6 +36,7 @@ import Test.Plutus.Codec.CBOR.Encoding.Validators (
   encodeIntegerValidator,
   encodeListValidator,
   encodeTxOutValidator,
+  encodeTxOutsValidator,
  )
 import Test.Plutus.Validator (
   ExUnits (..),
@@ -102,7 +103,18 @@ spec = do
             , rationalToPercent cpu
             ]
 
-    it "TxOut" $ do
+    it "[TxOut] (ada-only)" $ do
+      forM_ [1 .. 50] $ \n -> do
+        let x = generateWith (vectorOf n genAdaOnlyTxOut) 42
+        let (mem, cpu) = relativeCostOf x defaultMaxExecutionUnits encodeTxOutsValidator
+        putTextLn @IO $
+          unwords
+            [ padLeft ' ' 2 (show n)
+            , rationalToPercent mem
+            , rationalToPercent cpu
+            ]
+
+    it "TxOut (multi-asset)" $ do
       forM_ [1 .. 50] $ \n -> do
         let x = generateWith (genTxOut n) 42
         let (mem, cpu) = relativeCostOf x defaultMaxExecutionUnits encodeTxOutValidator
@@ -353,7 +365,7 @@ genValue = do
 
 genAdaOnlyValue :: Gen Plutus.Value
 genAdaOnlyValue = do
-  n <- genInteger `suchThat` (> 0)
+  n <- genInteger `suchThat` (\x -> x > 0 && x < 45_000_000_000)
   pure $
     Plutus.Value $
       Plutus.Map.fromList

--- a/plutus-cbor/test/Plutus/Codec/CBOR/EncodingSpec.hs
+++ b/plutus-cbor/test/Plutus/Codec/CBOR/EncodingSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Plutus.Codec.CBOR.EncodingSpec where
@@ -9,13 +8,8 @@ import Test.Hydra.Prelude
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Pretty as CBOR
 import qualified Codec.CBOR.Write as CBOR
-import Data.Binary.Builder (toLazyByteString)
 import qualified Data.ByteString as BS
 import Data.ByteString.Base16 (encodeBase16)
-import Data.ByteString.Builder.Scientific (FPFormat (Fixed), formatScientificBuilder)
-import Data.Ratio ((%))
-import Data.Scientific (unsafeFromRational)
-import qualified Ledger.Typed.Scripts as Scripts
 import Plutus.Codec.CBOR.Encoding (
   Encoding,
   encodeByteString,
@@ -29,21 +23,6 @@ import Plutus.Codec.CBOR.Encoding (
  )
 import qualified Plutus.V1.Ledger.Api as Plutus
 import qualified PlutusTx.AssocMap as Plutus.Map
-import Test.Plutus.Codec.CBOR.Encoding.Validators (
-  EncodeValidator,
-  ValidatorKind (..),
-  encodeByteStringValidator,
-  encodeIntegerValidator,
-  encodeListValidator,
-  encodeTxOutValidator,
-  encodeTxOutsValidator,
- )
-import Test.Plutus.Validator (
-  ExUnits (..),
-  defaultMaxExecutionUnits,
-  distanceExUnits,
-  evaluateScriptExecutionUnits,
- )
 import Test.QuickCheck (
   Property,
   choose,
@@ -53,7 +32,6 @@ import Test.QuickCheck (
   liftShrink2,
   oneof,
   shrinkList,
-  suchThat,
   vector,
   vectorOf,
   withMaxSuccess,
@@ -68,62 +46,6 @@ spec = do
       withMaxSuccess 1000 $
         forAllShrink genSomeValue shrinkSomeValue $ \(SomeValue x _ encode encode') ->
           propCompareWithOracle encode encode' x
-
-  describe "can plot (mem & cpu) cost of encoding" $ do
-    it "Integer" $ do
-      forM_ (sort $ generateWith (vectorOf 100 genInteger) 42) $ \i -> do
-        let (mem, cpu) = relativeCostOf i defaultMaxExecutionUnits encodeIntegerValidator
-        putTextLn @IO $
-          unwords
-            [ padRight ' ' 25 (show i)
-            , rationalToPercent mem
-            , rationalToPercent cpu
-            ]
-
-    it "ByteString" $ do
-      forM_ [1 .. 32] $ \n -> do
-        let x = Plutus.toBuiltin $ generateWith (genByteStringOf n) 42
-        let (mem, cpu) = relativeCostOf x defaultMaxExecutionUnits encodeByteStringValidator
-        putTextLn @IO $
-          unwords
-            [ padLeft ' ' 2 (show n)
-            , rationalToPercent mem
-            , rationalToPercent cpu
-            ]
-
-    it "[ByteSting]" $ do
-      forM_ [2, 4 .. 100] $ \n -> do
-        let bs = Plutus.toBuiltin $ generateWith (genByteStringOf 32) 42
-        let x = replicate n bs
-        let (mem, cpu) = relativeCostOf x defaultMaxExecutionUnits encodeListValidator
-        putTextLn @IO $
-          unwords
-            [ padLeft ' ' 3 (show n)
-            , rationalToPercent mem
-            , rationalToPercent cpu
-            ]
-
-    it "[TxOut] (ada-only)" $ do
-      forM_ [1 .. 50] $ \n -> do
-        let x = generateWith (vectorOf n genAdaOnlyTxOut) 42
-        let (mem, cpu) = relativeCostOf x defaultMaxExecutionUnits encodeTxOutsValidator
-        putTextLn @IO $
-          unwords
-            [ padLeft ' ' 2 (show n)
-            , rationalToPercent mem
-            , rationalToPercent cpu
-            ]
-
-    it "TxOut (multi-asset)" $ do
-      forM_ [1 .. 50] $ \n -> do
-        let x = generateWith (genTxOut n) 42
-        let (mem, cpu) = relativeCostOf x defaultMaxExecutionUnits encodeTxOutValidator
-        putTextLn @IO $
-          unwords
-            [ padLeft ' ' 2 (show n)
-            , rationalToPercent mem
-            , rationalToPercent cpu
-            ]
 
 -- | Compare encoding a value 'x' with our own encoder and a reference
 -- implementation. Counterexamples shows both encoded values, but in a pretty /
@@ -143,35 +65,6 @@ propCompareWithOracle encodeOracle encodeOurs x =
  where
   oracle = encodeOracle x
   ours = encodingToBuiltinByteString (encodeOurs x)
-
-relativeCostOf ::
-  (Plutus.ToData a) =>
-  a ->
-  ExUnits ->
-  (ValidatorKind -> Scripts.TypedValidator (EncodeValidator a)) ->
-  (Rational, Rational)
-relativeCostOf a (ExUnits maxMem maxCpu) validator =
-  (relativeMemCost, relativeCpuCost)
- where
-  ExUnits mem cpu =
-    distanceExUnits
-      (evaluateScriptExecutionUnits (validator BaselineValidator) a)
-      (evaluateScriptExecutionUnits (validator RealValidator) a)
-
-  (relativeMemCost, relativeCpuCost) =
-    ( toInteger mem % toInteger maxMem
-    , toInteger cpu % toInteger maxCpu
-    )
-
---
--- Helpers
---
-
-rationalToPercent :: Rational -> Text
-rationalToPercent r =
-  padLeft ' ' 5 $ decodeUtf8 (toLazyByteString $ toFixedDecimals 2 $ 100 * r)
- where
-  toFixedDecimals n = formatScientificBuilder Fixed (Just n) . unsafeFromRational
 
 --
 -- SomeValue
@@ -313,11 +206,7 @@ genInteger =
 
 genByteString :: Gen ByteString
 genByteString = do
-  genByteStringOf =<< elements [0, 8, 16, 28, 32]
-
-genByteStringOf :: Int -> Gen ByteString
-genByteStringOf n =
-  BS.pack <$> vector n
+  (\n -> BS.pack <$> vector n) =<< elements [0, 8, 16, 28, 32]
 
 shrinkByteString :: ByteString -> [ByteString]
 shrinkByteString =
@@ -332,56 +221,3 @@ genMap :: Gen k -> Gen v -> Gen [(k, v)]
 genMap genKey genVal = do
   n <- elements [0, 1, 5, 25]
   zip <$> vectorOf n genKey <*> vectorOf n genVal
-
-genTxOut :: Int -> Gen Plutus.TxOut
-genTxOut n = do
-  Plutus.TxOut
-    <$> genAddress
-    <*> fmap mconcat (vectorOf n genValue)
-    <*> oneof [pure Nothing, Just <$> genDatumHash]
-
-genAdaOnlyTxOut :: Gen Plutus.TxOut
-genAdaOnlyTxOut =
-  Plutus.TxOut
-    <$> genAddress
-    <*> genAdaOnlyValue
-    <*> oneof [pure Nothing, Just <$> genDatumHash]
-
-genAddress :: Gen Plutus.Address
-genAddress =
-  Plutus.Address
-    <$> fmap (Plutus.PubKeyCredential . Plutus.PubKeyHash . Plutus.toBuiltin) (genByteStringOf 28)
-    <*> pure Nothing
-
-genValue :: Gen Plutus.Value
-genValue = do
-  n <- genInteger `suchThat` (> 0)
-  policyId <- genCurrencySymbol
-  assetName <- genTokenName
-  pure $
-    Plutus.Value $
-      Plutus.Map.fromList
-        [(policyId, Plutus.Map.fromList [(assetName, n)])]
-
-genAdaOnlyValue :: Gen Plutus.Value
-genAdaOnlyValue = do
-  n <- genInteger `suchThat` (\x -> x > 0 && x < 45_000_000_000)
-  pure $
-    Plutus.Value $
-      Plutus.Map.fromList
-        [(Plutus.adaSymbol, Plutus.Map.fromList [(Plutus.adaToken, n)])]
-
-genCurrencySymbol :: Gen Plutus.CurrencySymbol
-genCurrencySymbol =
-  Plutus.CurrencySymbol
-    <$> fmap Plutus.toBuiltin (genByteStringOf 32)
-
-genTokenName :: Gen Plutus.TokenName
-genTokenName =
-  Plutus.TokenName
-    <$> fmap Plutus.toBuiltin (genByteStringOf =<< choose (0, 32))
-
-genDatumHash :: Gen Plutus.DatumHash
-genDatumHash =
-  Plutus.DatumHash
-    <$> fmap Plutus.toBuiltin (genByteStringOf 32)

--- a/plutus-cbor/test/Test/Plutus/Codec/CBOR/Encoding/Validators.hs
+++ b/plutus-cbor/test/Test/Plutus/Codec/CBOR/Encoding/Validators.hs
@@ -120,34 +120,57 @@ encodeTxOutValidator = \case
  where
   wrap = Scripts.wrapValidator @() @TxOut
 
-  encodeTxOut :: TxOut -> Encoding
-  encodeTxOut (TxOut addr value datum) =
-    encodeListLen 3
-      <> encodeAddress addr
-      <> encodeValue value
-      <> encodeDatum datum
+encodeTxOutsValidator :: ValidatorKind -> Scripts.TypedValidator (EncodeValidator [TxOut])
+encodeTxOutsValidator = \case
+  BaselineValidator ->
+    Scripts.mkTypedValidator @(EncodeValidator [TxOut])
+      $$(Plutus.compile [||\() _ _ctx -> True||])
+      $$(Plutus.compile [||wrap||])
+  RealValidator ->
+    Scripts.mkTypedValidator @(EncodeValidator [TxOut])
+      $$( Plutus.compile
+            [||
+            \() xs _ctx ->
+              let bytes = encodingToBuiltinByteString (encodeList encodeTxOut xs)
+               in lengthOfByteString bytes > 0
+            ||]
+        )
+      $$(Plutus.compile [||wrap||])
+ where
+  wrap = Scripts.wrapValidator @() @[TxOut]
 
-  -- NOTE 1: This is missing the header byte with network discrimination. For the
-  -- sake of getting an order of magnitude and moving forward, it is fine.
-  --
-  -- NOTE 2: This is ignoring any stake reference and assuming that all addresses
-  -- are plain script or payment addresses with no delegation whatsoever. Again,
-  -- see NOTE #1.
-  encodeAddress :: Address -> Encoding
-  encodeAddress Address{addressCredential} =
-    encodeByteString (credentialToBytes addressCredential)
-   where
-    credentialToBytes = \case
-      PubKeyCredential (PubKeyHash h) -> h
-      ScriptCredential (ValidatorHash h) -> h
+encodeTxOut :: TxOut -> Encoding
+encodeTxOut (TxOut addr value datum) =
+  encodeListLen 3
+    <> encodeAddress addr
+    <> encodeValue value
+    <> encodeDatum datum
+{-# INLINEABLE encodeTxOut #-}
 
-  encodeValue :: Value -> Encoding
-  encodeValue =
-    encodeMap encodeCurrencySymbol (encodeMap encodeTokenName encodeInteger) . getValue
-   where
-    encodeCurrencySymbol (CurrencySymbol symbol) = encodeByteString symbol
-    encodeTokenName (TokenName token) = encodeByteString token
+-- NOTE 1: This is missing the header byte with network discrimination. For the
+-- sake of getting an order of magnitude and moving forward, it is fine.
+--
+-- NOTE 2: This is ignoring any stake reference and assuming that all addresses
+-- are plain script or payment addresses with no delegation whatsoever. Again,
+-- see NOTE #1.
+encodeAddress :: Address -> Encoding
+encodeAddress Address{addressCredential} =
+  encodeByteString (credentialToBytes addressCredential)
+ where
+  credentialToBytes = \case
+    PubKeyCredential (PubKeyHash h) -> h
+    ScriptCredential (ValidatorHash h) -> h
+{-# INLINEABLE encodeAddress #-}
 
-  encodeDatum :: Maybe DatumHash -> Encoding
-  encodeDatum =
-    encodeMaybe (\(DatumHash h) -> encodeByteString h)
+encodeValue :: Value -> Encoding
+encodeValue =
+  encodeMap encodeCurrencySymbol (encodeMap encodeTokenName encodeInteger) . getValue
+ where
+  encodeCurrencySymbol (CurrencySymbol symbol) = encodeByteString symbol
+  encodeTokenName (TokenName token) = encodeByteString token
+{-# INLINEABLE encodeValue #-}
+
+encodeDatum :: Maybe DatumHash -> Encoding
+encodeDatum =
+  encodeMaybe (\(DatumHash h) -> encodeByteString h)
+{-# INLINEABLE encodeDatum #-}

--- a/plutus-cbor/test/Test/Plutus/Codec/CBOR/Encoding/Validators.hs
+++ b/plutus-cbor/test/Test/Plutus/Codec/CBOR/Encoding/Validators.hs
@@ -29,7 +29,6 @@ import Plutus.V1.Ledger.Api (
   Value (..),
  )
 import qualified PlutusTx as Plutus
-import PlutusTx.AssocMap (Map)
 
 -- | A validator for measuring cost of encoding values. The validator is
 -- parameterized by the type of value.
@@ -101,27 +100,6 @@ encodeListValidator = \case
       $$(Plutus.compile [||wrap||])
  where
   wrap = Scripts.wrapValidator @() @[BuiltinByteString]
-
-encodeMapValidator :: ValidatorKind -> Scripts.TypedValidator (EncodeValidator (Map BuiltinByteString BuiltinByteString))
-encodeMapValidator = \case
-  BaselineValidator ->
-    Scripts.mkTypedValidator @(EncodeValidator (Map BuiltinByteString BuiltinByteString))
-      $$(Plutus.compile [||\() _ _ctx -> True||])
-      $$(Plutus.compile [||wrap||])
-  RealValidator ->
-    Scripts.mkTypedValidator @(EncodeValidator (Map BuiltinByteString BuiltinByteString))
-      $$( Plutus.compile
-            [||
-            \() m _ctx ->
-              let bytes =
-                    encodingToBuiltinByteString $
-                      encodeMap encodeByteString encodeByteString m
-               in lengthOfByteString bytes > 0
-            ||]
-        )
-      $$(Plutus.compile [||wrap||])
- where
-  wrap = Scripts.wrapValidator @() @(Map BuiltinByteString BuiltinByteString)
 
 encodeTxOutValidator :: ValidatorKind -> Scripts.TypedValidator (EncodeValidator TxOut)
 encodeTxOutValidator = \case


### PR DESCRIPTION
- :round_pushpin: **Write more optimized version of encodingList / encodeMap**
    Seems like using the builtin 'length' and 'foldMap' is twice the cost of using raw recursion.

- :round_pushpin: **Rewrite test to print read-to-plot costs vs size of data.**
  
- :round_pushpin: **add plots for ada-only txout.**
