### PR TITLE
More cardano-api uses in Direct.Tx

### DIFF
--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -314,7 +314,7 @@ chainSyncClient tracer networkMagic callback party headState =
   runOnChainTx :: [OnChainTx CardanoTx] -> ValidatedTx Era -> STM m [OnChainTx CardanoTx]
   runOnChainTx observed tx = do
     onChainHeadState <- readTVar headState
-    let utxo = knownUtxo onChainHeadState
+    let utxo = Ledger.UTxO (knownUtxo onChainHeadState)
     -- TODO(SN): We should be only looking for abort,commit etc. when we have a headId/policyId
     let res =
           observeInitTx networkId party tx

--- a/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
@@ -65,7 +65,6 @@ import qualified Data.List as List
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
-import Hydra.Chain.Direct.Tx (redeemersFromList)
 import Hydra.Chain.Direct.Util (
   Block,
   Era,

--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -32,16 +32,15 @@ import qualified Cardano.Ledger.Alonzo.PParams as Ledger.Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Ledger.Alonzo
 import qualified Cardano.Ledger.Alonzo.Tx as Ledger.Alonzo
 import qualified Cardano.Ledger.Alonzo.TxBody as Ledger.Alonzo
-import Cardano.Ledger.Alonzo.TxWitness (TxDats (TxDats), unRedeemers)
 import qualified Cardano.Ledger.Alonzo.TxWitness as Ledger.Alonzo
 import qualified Cardano.Ledger.BaseTypes as Ledger
 import qualified Cardano.Ledger.Core as Ledger
+import qualified Cardano.Ledger.Credential as Ledger
 import qualified Cardano.Ledger.Crypto as Ledger (StandardCrypto)
 import qualified Cardano.Ledger.Era as Ledger
 import qualified Cardano.Ledger.Keys as Ledger
 import qualified Cardano.Ledger.Mary as Ledger.Mary hiding (Value)
 import qualified Cardano.Ledger.Mary.Value as Ledger.Mary
-import Cardano.Ledger.Shelley.API (StakeReference (StakeRefNull, StakeRefPtr))
 import qualified Cardano.Ledger.Shelley.API.Mempool as Ledger
 import qualified Cardano.Ledger.Shelley.Genesis as Ledger
 import qualified Cardano.Ledger.Shelley.LedgerState as Ledger
@@ -325,7 +324,7 @@ describeCardanoTx (Tx body _wits) =
 
   datums = case scriptsData of
     TxBodyNoScriptData -> []
-    (TxBodyScriptData _ (TxDats dats) _) ->
+    (TxBodyScriptData _ (Ledger.Alonzo.TxDats dats) _) ->
       "  Datums (" <> show (length dats) <> ")" :
       (("    " <>) . showDatumAndHash <$> Map.toList dats)
 
@@ -334,7 +333,7 @@ describeCardanoTx (Tx body _wits) =
   redeemers = case scriptsData of
     TxBodyNoScriptData -> []
     (TxBodyScriptData _ _ re) ->
-      let rdmrs = Map.elems $ unRedeemers re
+      let rdmrs = Map.elems $ Ledger.Alonzo.unRedeemers re
        in "  Redeemers (" <> show (length rdmrs) <> ")" :
           (("    " <>) . show . fst <$> rdmrs)
 
@@ -743,8 +742,8 @@ simplifyUtxo = Utxo . Map.fromList . map tweakAddress . filter notByronAddress .
   tweakAddress out@(txin, TxOut addr val dat) = case addr of
     AddressInEra er@(ShelleyAddressInEra _) (ShelleyAddress _ cre sr) ->
       case sr of
-        StakeRefPtr _ ->
-          (txin, TxOut (AddressInEra er (ShelleyAddress Ledger.Testnet cre StakeRefNull)) val dat)
+        Ledger.StakeRefPtr _ ->
+          (txin, TxOut (AddressInEra er (ShelleyAddress Ledger.Testnet cre Ledger.StakeRefNull)) val dat)
         _ ->
           (txin, TxOut (AddressInEra er (ShelleyAddress Ledger.Testnet cre sr)) val dat)
     _ -> out

--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -195,6 +195,10 @@ mkRedeemerForTxIn =
   fromPlutusData . Plutus.toData
 
 -- | Lookup and decode redeemer which is spending a given 'TxIn'.
+--
+-- TODO: This should probably return a list, to force downstream consumer to
+-- pattern match and expect singleton when they do. Otherwise, we may silently
+-- introduce tricky-to-debug errors.
 findRedeemerSpending ::
   Plutus.FromData a =>
   TxBody Era ->


### PR DESCRIPTION
- :round_pushpin: **Define 'findRedeemerSpending' in Ledger.Cardano**
    This will come as a replacement for 'getRedeemerSpending' in the Direct.Tx module.

- :round_pushpin: **Remove dead-code and unused imports in Direct.Tx**
  
- :round_pushpin: **Use 'findRedeemerSpending' in direct tx.**
    baby steps towards the cardano-api...

- :round_pushpin: **Define 'findScriptOutput' using the cardano-api.**
  
- :round_pushpin: **Convert 'findScriptOutput' to cardano-api's version.**
