### PR TITLE
Complete commit validator in CollectCom context

### DIFF
--- a/hydra-cluster/test/Test/LocalClusterSpec.hs
+++ b/hydra-cluster/test/Test/LocalClusterSpec.hs
@@ -38,6 +38,7 @@ import CardanoNode (ChainTip (..), RunningNode (..), cliQueryTip)
 import qualified Data.Map as Map
 import Hydra.Chain.Direct.Tx (policyId)
 import qualified Hydra.Contract.Head as Head
+import qualified Hydra.Contract.HeadState as Head
 import Hydra.Logging (Tracer, showLogsOnFailure)
 import Ledger (toCardanoApiScript)
 import Plutus.V1.Ledger.Api (toData)

--- a/hydra-node/exe/tx-cost/Main.hs
+++ b/hydra-node/exe/tx-cost/Main.hs
@@ -18,6 +18,7 @@ import Data.Maybe.Strict (StrictMaybe (..))
 import Hydra.Chain.Direct.Tx (fanoutTx, plutusScript, policyId, scriptAddr)
 import qualified Hydra.Contract.Hash as Hash
 import qualified Hydra.Contract.Head as Head
+import qualified Hydra.Contract.HeadState as Head
 import Hydra.Ledger.Cardano (
   BuildTxWith (BuildTxWith),
   CardanoTx,

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -278,7 +278,7 @@ collectComTx networkId (Api.fromLedgerTxIn -> headInput, Api.fromLedgerData -> h
   commitScript =
     Api.fromPlutusScript Commit.validatorScript
   commitRedeemer =
-    Api.mkRedeemerForTxIn $ Commit.redeemer Commit.Collect
+    Api.mkRedeemerForTxIn ()
 
 -- | Create a transaction closing a head with given snapshot number and utxo.
 closeTx ::

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -42,6 +42,7 @@ import Hydra.Chain (HeadParameters (..), OnChainTx (..))
 import Hydra.Chain.Direct.Util (Era)
 import qualified Hydra.Contract.Commit as Commit
 import qualified Hydra.Contract.Head as Head
+import qualified Hydra.Contract.HeadState as Head
 import qualified Hydra.Contract.Initial as Initial
 import Hydra.Data.ContestationPeriod (contestationPeriodFromDiffTime, contestationPeriodToDiffTime)
 import Hydra.Data.Party (partyFromVerKey, partyToVerKey)

--- a/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
@@ -369,7 +369,7 @@ healthyCommitOutput party committed =
     mkTxOutValue $
       lovelaceToValue 2_000_000 <> (txOutValue . snd) committed
   commitDatum =
-    mkCommitDatum party (Just committed)
+    mkCommitDatum party (Head.validatorHash policyId) (Just committed)
 
 data CollectComMutation
   = MutateOpenOutputValue

--- a/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
 
 module Hydra.Chain.Direct.ContractSpec where
 
@@ -112,6 +114,7 @@ import Test.QuickCheck (
   elements,
   forAll,
   forAllShrink,
+  generate,
   oneof,
   property,
   suchThat,
@@ -142,12 +145,15 @@ spec = do
       propTransactionValidates healthyCollectComTx
     prop "does not survive random adversarial mutations" $
       propMutation healthyCollectComTx genCollectComMutation
+    it "check trans" $ do
+      SomeMutation _ mut <- generate $ genCollectComMutation healthyCollectComTx
+      let (tx, utxo) = applyMutation mut healthyCollectComTx
+      evaluateTx tx utxo `shouldSatisfy` isLeft
   describe "Close" $ do
     prop "is healthy" $
       propTransactionValidates healthyCloseTx
     prop "does not survive random adversarial mutations" $
       propMutation healthyCloseTx genCloseMutation
-
   describe "Fanout" $ do
     prop "is healthy" $
       propTransactionValidates healthyFanoutTx

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -42,6 +42,7 @@ import Hydra.Chain.Direct.Util (Era)
 import Hydra.Chain.Direct.Wallet (ErrCoverFee (..), coverFee_)
 import qualified Hydra.Contract.Commit as Commit
 import qualified Hydra.Contract.Head as Head
+import qualified Hydra.Contract.HeadState as Head
 import qualified Hydra.Contract.Initial as Initial
 import Hydra.Data.ContestationPeriod (contestationPeriodFromDiffTime)
 import Hydra.Data.Party (partyFromVerKey)

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -151,7 +151,7 @@ spec =
             commitOutput = TxOut @Era commitAddress commitValue (SJust $ hashData commitDatum)
             commitAddress = scriptAddr $ plutusScript Commit.validatorScript
             commitValue = inject (Coin 2_000_000) <> maybe (inject (Coin 0)) (toLedgerValue . txOutValue . snd) singleUtxo
-            commitDatum = Ledger.Data . toData $ mkCommitDatum party singleUtxo
+            commitDatum = Ledger.Data . toData $ mkCommitDatum party (Head.validatorHash policyId) singleUtxo
             expectedOutput = (TxIn (Ledger.TxId (SafeHash.hashAnnotated $ body tx)) 0, commitOutput, commitDatum)
             committedUtxo = maybe mempty singletonUtxo singleUtxo
          in observeCommitTx testNetworkId tx
@@ -170,7 +170,7 @@ spec =
             commitOutput = TxOut @Era commitAddress commitValue (SJust $ hashData commitDatum)
             commitAddress = scriptAddr $ plutusScript Commit.validatorScript
             commitValue = inject (Coin 2_000_000) <> toMaryValue (balance @CardanoTx committedUtxo)
-            commitDatum = Ledger.Data . toData $ mkCommitDatum party $ Just singleUtxo
+            commitDatum = Ledger.Data . toData $ mkCommitDatum party (Head.validatorHash policyId) $ Just singleUtxo
             commitInput = TxIn (txid $ body tx) 0
             onChainState =
               Initial
@@ -528,7 +528,7 @@ generateCommitUtxos parties = do
     commitValue = inject (Coin 2000000) <> maybe (inject $ Coin 0) (getValue . snd) utxo
     getValue (Api.TxOut _ val _) = toMaryValue $ Api.txOutValueToValue val
     commitScript = plutusScript Commit.validatorScript
-    commitDatum = Data . toData $ mkCommitDatum party utxo
+    commitDatum = Data . toData $ mkCommitDatum party (Head.validatorHash policyId) utxo
 
 executionCost :: PParams Era -> ValidatedTx Era -> Coin
 executionCost PParams{_prices} ValidatedTx{wits} =

--- a/hydra-plutus/exe/inspect-script/Main.hs
+++ b/hydra-plutus/exe/inspect-script/Main.hs
@@ -7,14 +7,19 @@ import Cardano.Api.Shelley (fromPlutusData)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as BL
 import Data.Text (pack)
+import Data.Text.Prettyprint.Doc.Extras (pretty)
 import Hydra.Contract.Commit as Commit
 import qualified Hydra.Contract.Hash as Hash
-import Hydra.Contract.Initial as Initial
 import Hydra.Contract.Head as Head
+import Hydra.Contract.Initial as Initial
 import Ledger (Datum (..), datumHash)
 import Ledger.Scripts (Script, toCardanoApiScript)
 import Ledger.Value
 import Plutus.V1.Ledger.Api (Data, dataToBuiltinData, toData)
+import PlutusTx (getPlc)
+import PlutusTx.Code (CompiledCode)
+import Prettyprinter (defaultLayoutOptions, layoutPretty)
+import Prettyprinter.Render.Text (renderStrict)
 
 -- | Serialise Hydra scripts to files for submission through cardano-cli.
 -- This small utility is useful to manually construct transactions payload for Hydra on-chain
@@ -33,6 +38,9 @@ main = do
   putTextLn "Serialise scripts:"
   writeScripts (scripts policyId)
 
+  putTextLn "Compile scripts:"
+  writePlc (compiledScripts policyId)
+
   putTextLn "Serialise datums:"
   writeData datums
 
@@ -48,6 +56,14 @@ main = do
     forM_ plutus $ \(item, itemName) -> do
       let itemFile = itemName <> ".plutus"
           serialised = Aeson.encode $ serialiseToTextEnvelope (Just $ fromString itemName) $ toCardanoApiScript item
+      BL.writeFile itemFile serialised
+      putTextLn $ "  " <> pack itemFile <> ":     " <> sizeInKb serialised
+
+  writePlc :: [(Compiled, String)] -> IO ()
+  writePlc plutus =
+    forM_ plutus $ \(Compiled item, itemName) -> do
+      let itemFile = itemName <> ".plc"
+          serialised = encodeUtf8 $ renderStrict $ layoutPretty defaultLayoutOptions $ pretty $ getPlc item
       BL.writeFile itemFile serialised
       putTextLn $ "  " <> pack itemFile <> ":     " <> sizeInKb serialised
 
@@ -76,6 +92,12 @@ main = do
 
   hashScript = Hash.validatorScript
 
+  compiledScripts policyId =
+    [ (Compiled $ Head.compiledValidator policyId, "headScript")
+    , (Compiled Initial.compiledValidator, "initialScript")
+    , (Compiled Commit.compiledValidator, "commitScript")
+    ]
+
   datums =
     [ (headDatum, "headDatum")
     , (abortDatum, "abortDatum")
@@ -88,3 +110,5 @@ main = do
   redeemers = [(headRedeemer, "headRedeemer")]
 
   headRedeemer = toData Head.Abort
+
+data Compiled = forall a. Compiled {compiledCode :: CompiledCode a}

--- a/hydra-plutus/exe/inspect-script/Main.hs
+++ b/hydra-plutus/exe/inspect-script/Main.hs
@@ -11,6 +11,7 @@ import Data.Text.Prettyprint.Doc.Extras (pretty)
 import Hydra.Contract.Commit as Commit
 import qualified Hydra.Contract.Hash as Hash
 import Hydra.Contract.Head as Head
+import Hydra.Contract.HeadState as Head
 import Hydra.Contract.Initial as Initial
 import Ledger (Datum (..), datumHash)
 import Ledger.Scripts (Script, toCardanoApiScript)

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -75,6 +75,7 @@ library
     Hydra.Contract.Encoding
     Hydra.Contract.Hash
     Hydra.Contract.Head
+    Hydra.Contract.HeadState
     Hydra.Contract.Initial
     Hydra.Data.ContestationPeriod
     Hydra.Data.HeadParameters

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -130,6 +130,8 @@ executable inspect-script
     , optparse-applicative
     , plutus-ledger
     , plutus-ledger-api
+    , plutus-tx
+    , prettyprinter
     , serialise
     , text
 

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -8,11 +8,10 @@ module Hydra.Contract.Head where
 import Ledger hiding (txOutDatum, validatorHash)
 import PlutusTx.Prelude
 
-import Data.Aeson (FromJSON, ToJSON)
-import GHC.Generics (Generic)
 import Hydra.Contract.Commit (Commit, SerializedTxOut (..))
 import qualified Hydra.Contract.Commit as Commit
 import Hydra.Contract.Encoding (serialiseTxOuts)
+import Hydra.Contract.HeadState (Input (..), SnapshotNumber, State (..))
 import Hydra.Data.ContestationPeriod (ContestationPeriod)
 import Hydra.Data.Party (Party (UnsafeParty))
 import Ledger.Typed.Scripts (TypedValidator, ValidatorType, ValidatorTypes (RedeemerType))
@@ -28,34 +27,6 @@ import Plutus.Codec.CBOR.Encoding (
 import PlutusTx (fromBuiltinData, toBuiltinData)
 import qualified PlutusTx
 import PlutusTx.Code (CompiledCode)
-import Text.Show (Show)
-
-type SnapshotNumber = Integer
-
-type Hash = BuiltinByteString
-
-data State
-  = Initial {contestationPeriod :: ContestationPeriod, parties :: [Party]}
-  | Open {parties :: [Party], utxoHash :: Hash}
-  | Closed {snapshotNumber :: SnapshotNumber, utxoHash :: Hash}
-  | Final
-  deriving stock (Generic, Show)
-  deriving anyclass (FromJSON, ToJSON)
-
-PlutusTx.unstableMakeIsData ''State
-
-data Input
-  = CollectCom
-  | Close
-      { snapshotNumber :: SnapshotNumber
-      , utxoHash :: Hash
-      , signature :: [Signature]
-      }
-  | Abort
-  | Fanout {numberOfFanoutOutputs :: Integer}
-  deriving (Generic, Show)
-
-PlutusTx.unstableMakeIsData ''Input
 
 data Head
 

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -160,9 +160,9 @@ checkCollectCom commitAddress (_, parties) context@ScriptContext{scriptContextTx
   lookupCommit h = do
     d <- getDatum <$> findDatum h txInfo
     case fromBuiltinData @(DatumType Commit) d of
-      Just (_p, Just (_, o)) ->
+      Just (_p, _, Just (_, o)) ->
         Just o
-      Just (_p, Nothing) ->
+      Just (_p, _, Nothing) ->
         Nothing
       Nothing ->
         traceError "fromBuiltinData failed"

--- a/hydra-plutus/src/Hydra/Contract/HeadState.hs
+++ b/hydra-plutus/src/Hydra/Contract/HeadState.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-specialize #-}
+
+module Hydra.Contract.HeadState where
+
+import Ledger hiding (txOutDatum, validatorHash)
+import PlutusTx.Prelude
+
+import Data.Aeson (FromJSON, ToJSON)
+import GHC.Generics (Generic)
+import Hydra.Data.ContestationPeriod (ContestationPeriod)
+import Hydra.Data.Party (Party)
+import qualified PlutusTx
+import Text.Show (Show)
+
+type SnapshotNumber = Integer
+
+type Hash = BuiltinByteString
+
+data State
+  = Initial {contestationPeriod :: ContestationPeriod, parties :: [Party]}
+  | Open {parties :: [Party], utxoHash :: Hash}
+  | Closed {snapshotNumber :: SnapshotNumber, utxoHash :: Hash}
+  | Final
+  deriving stock (Generic, Show)
+  deriving anyclass (FromJSON, ToJSON)
+
+PlutusTx.unstableMakeIsData ''State
+
+data Input
+  = CollectCom
+  | Close
+      { snapshotNumber :: SnapshotNumber
+      , utxoHash :: Hash
+      , signature :: [Signature]
+      }
+  | Abort
+  | Fanout {numberOfFanoutOutputs :: Integer}
+  deriving (Generic, Show)
+
+PlutusTx.unstableMakeIsData ''Input


### PR DESCRIPTION
This PR ensures the `v_commit` contract checks the state of the Head script. Note it does not seem to be possible to retrieve the redeemer for _another_ validator so the script checks the state instead, which is fine as the `Abort` and `CollectCom` redeemers should only work in the `Initial` state anyway.

It also fixes 2 issues with our mutators:
* The `ChangeHeadRedeemer` was actually changing _any_ redeemer that looked like a `Head.Input` redeemer which broke other scripts,
* The `ChangeHeadDatum` was not updating the transaction's `TxDats` map which made the scripts fail for the wrong reason. 