### PR TITLE
cardano-api in Direct.Chain modules, finally.

### DIFF
--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -11,35 +11,13 @@
 -- thus we have not yet "reached" 'isomorphism'.
 module Hydra.Chain.Direct.Tx where
 
+import Hydra.Ledger.Cardano
 import Hydra.Prelude
 
-import Cardano.Api (NetworkId)
-import Cardano.Binary (decodeFull', serialize, serialize')
-import Cardano.Ledger.Address (Addr (Addr))
-import Cardano.Ledger.Alonzo (Script)
-import Cardano.Ledger.Alonzo.Data (Data, getPlutusData)
-import Cardano.Ledger.Alonzo.Language (Language (PlutusV1))
-import Cardano.Ledger.Alonzo.Scripts (Script (PlutusScript))
-import Cardano.Ledger.Alonzo.Tx (ValidatedTx (..))
-import Cardano.Ledger.Alonzo.TxBody (TxBody (..), TxOut (TxOut))
-import Cardano.Ledger.Alonzo.TxInfo (transKeyHash)
-import Cardano.Ledger.Alonzo.TxWitness (TxWitness (..), unTxDats)
-import Cardano.Ledger.Crypto (StandardCrypto)
-import Cardano.Ledger.Era (hashScript)
-import Cardano.Ledger.Shelley.API (
-  Credential (ScriptHashObj),
-  Network (Testnet),
-  StakeReference (StakeRefNull),
-  StrictMaybe (..),
-  TxIn,
-  hashKey,
- )
-import Cardano.Ledger.Shelley.UTxO (UTxO (..))
+import Cardano.Binary (decodeFull', serialize')
 import qualified Data.Map as Map
-import qualified Data.Set as Set
 import Data.Time (Day (ModifiedJulianDay), UTCTime (UTCTime))
 import Hydra.Chain (HeadParameters (..), OnChainTx (..))
-import Hydra.Chain.Direct.Util (Era)
 import qualified Hydra.Contract.Commit as Commit
 import qualified Hydra.Contract.Head as Head
 import qualified Hydra.Contract.HeadState as Head
@@ -47,36 +25,16 @@ import qualified Hydra.Contract.Initial as Initial
 import Hydra.Data.ContestationPeriod (contestationPeriodFromDiffTime, contestationPeriodToDiffTime)
 import Hydra.Data.Party (partyFromVerKey, partyToVerKey)
 import qualified Hydra.Data.Party as OnChain
-import Hydra.Ledger.Cardano (
-  CardanoTx,
-  PaymentKey,
-  Utxo,
-  VerificationKey (PaymentVerificationKey),
-  fromLedgerTx,
-  fromPlutusScript,
-  getDatum,
-  hashTxOuts,
-  mkScriptAddress,
-  toAlonzoData,
-  toCtxUTxOTxOut,
-  toLedgerTxIn,
-  toLedgerTxOut,
-  toPlutusData,
- )
 import qualified Hydra.Ledger.Cardano as Api
 import Hydra.Party (MultiSigned, Party (Party), toPlutusSignatures, vkey)
 import Hydra.Snapshot (Snapshot (..))
 import Ledger.Typed.Scripts (DatumType)
 import Ledger.Value (AssetClass (..), currencyMPSHash)
 import Ouroboros.Consensus.Util (eitherToMaybe)
-import Plutus.V1.Ledger.Api (MintingPolicyHash, PubKeyHash (..), fromBuiltin, fromData)
+import Plutus.V1.Ledger.Api (MintingPolicyHash, fromBuiltin, fromData)
 import qualified Plutus.V1.Ledger.Api as Plutus
 import Plutus.V1.Ledger.Value (assetClass, currencySymbol, tokenName)
 import Plutus.V2.Ledger.Api (toBuiltin)
-
--- FIXME: parameterize
-network :: Network
-network = Testnet
 
 -- * Post Hydra Head transactions
 
@@ -90,9 +48,9 @@ data OnChainHeadState
         -- transactions.
         -- NOTE(SN): The Head's identifier is somewhat encoded in the TxOut's address
         -- XXX(SN): Data and [OnChain.Party] are overlapping
-        threadOutput :: (TxIn StandardCrypto, TxOut Era, Data Era, [OnChain.Party])
-      , initials :: [(TxIn StandardCrypto, TxOut Era, Data Era)]
-      , commits :: [(TxIn StandardCrypto, TxOut Era, Data Era)]
+        threadOutput :: (TxIn, TxOut CtxUTxO Era, ScriptData, [OnChain.Party])
+      , initials :: [(TxIn, TxOut CtxUTxO Era, ScriptData)]
+      , commits :: [(TxIn, TxOut CtxUTxO Era, ScriptData)]
       }
   | OpenOrClosed
       { -- | The state machine UTxO produced by the Init transaction
@@ -100,7 +58,7 @@ data OnChainHeadState
         -- transactions.
         -- NOTE(SN): The Head's identifier is somewhat encoded in the TxOut's address
         -- XXX(SN): Data and [OnChain.Party] are overlapping
-        threadOutput :: (TxIn StandardCrypto, TxOut Era, Data Era, [OnChain.Party])
+        threadOutput :: (TxIn, TxOut CtxUTxO Era, ScriptData, [OnChain.Party])
       }
   | Final
   deriving (Eq, Show, Generic)
@@ -115,53 +73,44 @@ policyId :: MintingPolicyHash
 
 -- | Create the init transaction from some 'HeadParameters' and a single TxIn
 -- which will be used as unique parameter for minting NFTs.
---
--- TODO: Remove all the qualified 'Api' once the refactoring is over and there's
--- no more import clash with 'cardano-ledger'.
---
--- TODO: Get rid of Ledger types in the signature and fully rely on Cardano.Api
 initTx ::
   NetworkId ->
   -- | Participant's cardano public keys.
   [VerificationKey PaymentKey] ->
   HeadParameters ->
-  TxIn StandardCrypto ->
-  ValidatedTx Era
+  TxIn ->
+  CardanoTx
 initTx networkId cardanoKeys HeadParameters{contestationPeriod, parties} txIn =
-  Api.toLedgerTx $
-    Api.unsafeBuildTransaction $
-      Api.emptyTxBody
-        & Api.addVkInputs [Api.fromLedgerTxIn txIn]
-        & Api.addOutputs (headOutput : map mkInitialOutput cardanoKeys)
+  unsafeBuildTransaction $
+    emptyTxBody
+      & addVkInputs [txIn]
+      & addOutputs (headOutput : map mkInitialOutput cardanoKeys)
  where
   headOutput =
-    Api.TxOut headAddress headValue headDatum
+    TxOut headAddress headValue headDatum
   headScript =
-    Api.fromPlutusScript $ Head.validatorScript policyId
+    fromPlutusScript $ Head.validatorScript policyId
   headAddress =
-    Api.mkScriptAddress @Api.PlutusScriptV1 networkId headScript
+    mkScriptAddress @PlutusScriptV1 networkId headScript
   headValue =
-    Api.lovelaceToTxOutValue $ Api.Lovelace 2_000_000
+    lovelaceToTxOutValue $ Lovelace 2_000_000
   headDatum =
-    Api.mkTxOutDatum $
+    mkTxOutDatum $
       Head.Initial
         (contestationPeriodFromDiffTime contestationPeriod)
         (map (partyFromVerKey . vkey) parties)
 
-  mkInitialOutput (Api.toPlutusKeyHash . Api.verificationKeyHash -> vkh) =
-    Api.TxOut initialAddress initialValue (mkInitialDatum vkh)
+  mkInitialOutput (toPlutusKeyHash . verificationKeyHash -> vkh) =
+    TxOut initialAddress initialValue (mkInitialDatum vkh)
   initialScript =
-    Api.fromPlutusScript Initial.validatorScript
+    fromPlutusScript Initial.validatorScript
   -- FIXME: should really be the minted PTs plus some ADA to make the ledger happy
   initialValue =
-    Api.lovelaceToTxOutValue $ Api.Lovelace 2_000_000
+    lovelaceToTxOutValue $ Lovelace 2_000_000
   initialAddress =
-    Api.mkScriptAddress @Api.PlutusScriptV1 networkId initialScript
+    mkScriptAddress @PlutusScriptV1 networkId initialScript
   mkInitialDatum =
-    Api.mkTxOutDatum . Initial.datum
-
-pubKeyHash :: VerificationKey PaymentKey -> PubKeyHash
-pubKeyHash (PaymentVerificationKey vkey) = transKeyHash $ hashKey @StandardCrypto $ vkey
+    mkTxOutDatum . Initial.datum
 
 -- | Craft a commit transaction which includes the "committed" utxo as a datum.
 --
@@ -174,40 +123,39 @@ commitTx ::
   Party ->
   -- | A single UTxO to commit to the Head
   -- We currently limit committing one UTxO to the head because of size limitations.
-  Maybe (Api.TxIn, Api.TxOut Api.CtxUTxO Api.Era) ->
+  Maybe (TxIn, TxOut CtxUTxO Era) ->
   -- | The inital output (sent to each party) which should contain the PT and is
   -- locked by initial script
-  (TxIn StandardCrypto, PubKeyHash) ->
-  ValidatedTx Era
+  (TxIn, Hash PaymentKey) ->
+  Tx Era
 commitTx networkId party utxo (initialInput, vkh) =
-  Api.toLedgerTx $
-    Api.unsafeBuildTransaction $
-      Api.emptyTxBody
-        & Api.addInputs [(Api.fromLedgerTxIn initialInput, initialWitness)]
-        & Api.addVkInputs [commit | Just (commit, _) <- [utxo]]
-        & Api.addOutputs [commitOutput]
+  unsafeBuildTransaction $
+    emptyTxBody
+      & addInputs [(initialInput, initialWitness)]
+      & addVkInputs [commit | Just (commit, _) <- [utxo]]
+      & addOutputs [commitOutput]
  where
   initialWitness =
-    Api.BuildTxWith $ Api.mkScriptWitness initialScript initialDatum initialRedeemer
+    BuildTxWith $ mkScriptWitness initialScript initialDatum initialRedeemer
   initialScript =
-    Api.fromPlutusScript Initial.validatorScript
+    fromPlutusScript Initial.validatorScript
   initialDatum =
-    Api.mkDatumForTxIn $ Initial.datum vkh
+    mkDatumForTxIn $ Initial.datum $ toPlutusKeyHash vkh
   initialRedeemer =
-    Api.mkRedeemerForTxIn $ Initial.redeemer ()
+    mkRedeemerForTxIn $ Initial.redeemer ()
 
   commitOutput =
-    Api.TxOut commitAddress commitValue commitDatum
+    TxOut commitAddress commitValue commitDatum
   commitScript =
-    Api.fromPlutusScript Commit.validatorScript
+    fromPlutusScript Commit.validatorScript
   commitAddress =
-    Api.mkScriptAddress @Api.PlutusScriptV1 networkId commitScript
+    mkScriptAddress @PlutusScriptV1 networkId commitScript
   -- FIXME: We should add the value from the initialIn too because it contains the PTs
   commitValue =
-    Api.mkTxOutValue $
-      Api.lovelaceToValue 2_000_000 <> maybe mempty (Api.txOutValue . snd) utxo
+    mkTxOutValue $
+      lovelaceToValue 2_000_000 <> maybe mempty (txOutValue . snd) utxo
   commitDatum =
-    Api.mkTxOutDatum $ mkCommitDatum party (Head.validatorHash policyId) utxo
+    mkTxOutDatum $ mkCommitDatum party (Head.validatorHash policyId) utxo
 
 -- FIXME: WIP
 mkCommitDatum :: Party -> Plutus.ValidatorHash -> Maybe (Api.TxIn, Api.TxOut Api.CtxUTxO Api.Era) -> Plutus.Datum
@@ -229,39 +177,38 @@ collectComTx ::
   NetworkId ->
   -- | Everything needed to spend the Head state-machine output.
   -- FIXME(SN): should also contain some Head identifier/address and stored Value (maybe the TxOut + Data?)
-  (TxIn StandardCrypto, Data Era, [OnChain.Party]) ->
+  (TxIn, ScriptData, [OnChain.Party]) ->
   -- | Data needed to spend the commit output produced by each party.
   -- Should contain the PT and is locked by @ν_commit@ script.
-  Map (TxIn StandardCrypto) (TxOut Era, Data Era) ->
-  ValidatedTx Era
+  Map TxIn (TxOut CtxUTxO Era, ScriptData) ->
+  CardanoTx
 -- TODO(SN): utxo unused means other participants would not "see" the opened
 -- utxo when observing. Right now, they would be trusting the OCV checks this
 -- and construct their "world view" from observed commit txs in the HeadLogic
-collectComTx networkId (Api.fromLedgerTxIn -> headInput, Api.fromLedgerData -> headDatumBefore, parties) commits =
-  Api.toLedgerTx $
-    Api.unsafeBuildTransaction $
-      Api.emptyTxBody
-        & Api.addInputs ((headInput, headWitness) : (mkCommit <$> Map.toList commits))
-        & Api.addOutputs [headOutput]
+collectComTx networkId (headInput, ScriptDatumForTxIn -> headDatumBefore, parties) commits =
+  unsafeBuildTransaction $
+    emptyTxBody
+      & addInputs ((headInput, headWitness) : (mkCommit <$> Map.toList commits))
+      & addOutputs [headOutput]
  where
   headWitness =
-    Api.BuildTxWith $ Api.mkScriptWitness headScript headDatumBefore headRedeemer
+    BuildTxWith $ mkScriptWitness headScript headDatumBefore headRedeemer
   headScript =
-    Api.fromPlutusScript $ Head.validatorScript policyId
+    fromPlutusScript $ Head.validatorScript policyId
   headRedeemer =
-    Api.mkRedeemerForTxIn Head.CollectCom
+    mkRedeemerForTxIn Head.CollectCom
   headOutput =
-    Api.TxOut
-      (Api.mkScriptAddress @Api.PlutusScriptV1 networkId headScript)
-      (Api.mkTxOutValue $ Api.lovelaceToValue 2_000_000 <> commitValue)
+    TxOut
+      (mkScriptAddress @PlutusScriptV1 networkId headScript)
+      (mkTxOutValue $ lovelaceToValue 2_000_000 <> commitValue)
       headDatumAfter
   headDatumAfter =
-    Api.mkTxOutDatum Head.Open{Head.parties = parties, utxoHash}
+    mkTxOutDatum Head.Open{Head.parties = parties, utxoHash}
   -- NOTE: We hash tx outs in an order that is recoverable on-chain.
   -- The simplest thing to do, is to make sure commit inputs are in the same
   -- order as their corresponding committed utxo.
   extractSerialisedTxOut d =
-    case fromData $ getPlutusData d of
+    case fromData $ toPlutusData d of
       Nothing -> error "SNAFU"
       Just ((_, _, Just (_, o)) :: DatumType Commit.Commit) -> Just o
       _ -> Nothing
@@ -269,17 +216,17 @@ collectComTx networkId (Api.fromLedgerTxIn -> headInput, Api.fromLedgerData -> h
     Head.hashPreSerializedCommits $
       mapMaybe (extractSerialisedTxOut . snd . snd) $ sortOn fst $ Map.toList commits
   mkCommit (commitInput, (_commitOutput, commitDatum)) =
-    ( Api.fromLedgerTxIn commitInput
+    ( commitInput
     , mkCommitWitness commitDatum
     )
-  mkCommitWitness (Api.fromLedgerData -> commitDatum) =
-    Api.BuildTxWith $ Api.mkScriptWitness commitScript commitDatum commitRedeemer
+  mkCommitWitness (ScriptDatumForTxIn -> commitDatum) =
+    BuildTxWith $ mkScriptWitness commitScript commitDatum commitRedeemer
   commitValue =
-    mconcat $ Api.txOutValue . Api.fromLedgerTxOut . fst <$> Map.elems commits
+    mconcat $ txOutValue . fst <$> Map.elems commits
   commitScript =
-    Api.fromPlutusScript Commit.validatorScript
+    fromPlutusScript Commit.validatorScript
   commitRedeemer =
-    Api.mkRedeemerForTxIn ()
+    mkRedeemerForTxIn ()
 
 -- | Create a transaction closing a head with given snapshot number and utxo.
 closeTx ::
@@ -288,30 +235,29 @@ closeTx ::
   MultiSigned (Snapshot CardanoTx) ->
   -- | Everything needed to spend the Head state-machine output.
   -- FIXME(SN): should also contain some Head identifier/address and stored Value (maybe the TxOut + Data?)
-  (TxIn StandardCrypto, TxOut Era, Data Era) ->
-  ValidatedTx Era
-closeTx Snapshot{number, utxo} sig (Api.fromLedgerTxIn -> headInput, Api.fromLedgerTxOut -> headOutputBefore, Api.fromLedgerData -> headDatumBefore) =
-  Api.toLedgerTx $
-    Api.unsafeBuildTransaction $
-      Api.emptyTxBody
-        & Api.addInputs [(headInput, headWitness)]
-        & Api.addOutputs [headOutputAfter]
+  (TxIn, TxOut CtxUTxO Era, ScriptData) ->
+  Tx Era
+closeTx Snapshot{number, utxo} sig (headInput, headOutputBefore, ScriptDatumForTxIn -> headDatumBefore) =
+  unsafeBuildTransaction $
+    emptyTxBody
+      & addInputs [(headInput, headWitness)]
+      & addOutputs [headOutputAfter]
  where
   headWitness =
-    Api.BuildTxWith $ Api.mkScriptWitness headScript headDatumBefore headRedeemer
+    BuildTxWith $ mkScriptWitness headScript headDatumBefore headRedeemer
   headScript =
-    Api.fromPlutusScript $ Head.validatorScript policyId
+    fromPlutusScript $ Head.validatorScript policyId
   headRedeemer =
-    Api.mkRedeemerForTxIn
+    mkRedeemerForTxIn
       Head.Close
         { snapshotNumber = toInteger number
         , signature = toPlutusSignatures sig
         , utxoHash
         }
   headOutputAfter =
-    Api.modifyTxOutDatum (const headDatumAfter) headOutputBefore
+    modifyTxOutDatum (const headDatumAfter) headOutputBefore
   headDatumAfter =
-    Api.mkTxOutDatum
+    mkTxOutDatum
       Head.Closed
         { snapshotNumber = toInteger number
         , utxoHash
@@ -323,24 +269,23 @@ fanoutTx ::
   Utxo ->
   -- | Everything needed to spend the Head state-machine output.
   -- FIXME(SN): should also contain some Head identifier/address and stored Value (maybe the TxOut + Data?)
-  (TxIn StandardCrypto, Data Era) ->
-  ValidatedTx Era
-fanoutTx utxo (Api.fromLedgerTxIn -> headInput, Api.fromLedgerData -> headDatumBefore) =
-  Api.toLedgerTx $
-    Api.unsafeBuildTransaction $
-      Api.emptyTxBody
-        & Api.addInputs [(headInput, headWitness)]
-        & Api.addOutputs fanoutOutputs
+  (TxIn, ScriptData) ->
+  Tx Era
+fanoutTx utxo (headInput, ScriptDatumForTxIn -> headDatumBefore) =
+  unsafeBuildTransaction $
+    emptyTxBody
+      & addInputs [(headInput, headWitness)]
+      & addOutputs fanoutOutputs
  where
   headWitness =
-    Api.BuildTxWith $ Api.mkScriptWitness headScript headDatumBefore headRedeemer
+    BuildTxWith $ mkScriptWitness headScript headDatumBefore headRedeemer
   headScript =
-    Api.fromPlutusScript $ Head.validatorScript policyId
+    fromPlutusScript $ Head.validatorScript policyId
   headRedeemer =
-    Api.mkRedeemerForTxIn (Head.Fanout $ fromIntegral $ length utxo)
+    mkRedeemerForTxIn (Head.Fanout $ fromIntegral $ length utxo)
 
   fanoutOutputs =
-    foldr ((:) . Api.toTxContext) [] utxo
+    foldr ((:) . toTxContext) [] utxo
 
 data AbortTxError = OverlappingInputs
   deriving (Show)
@@ -351,63 +296,62 @@ abortTx ::
   -- | Network identifier for address discrimination
   NetworkId ->
   -- | Everything needed to spend the Head state-machine output.
-  (TxIn StandardCrypto, Data Era) ->
+  (TxIn, ScriptData) ->
   -- | Data needed to spend the inital output sent to each party to the Head
   -- which should contain the PT and is locked by initial script.
-  Map (TxIn StandardCrypto) (Data Era) ->
-  Either AbortTxError (ValidatedTx Era)
-abortTx networkId (Api.fromLedgerTxIn -> headInput, Api.fromLedgerData -> headDatumBefore) initialInputs
-  | isJust (lookup (Api.toLedgerTxIn headInput) initialInputs) =
+  Map TxIn ScriptData ->
+  Either AbortTxError CardanoTx
+abortTx networkId (headInput, ScriptDatumForTxIn -> headDatumBefore) initialInputs
+  | isJust (lookup headInput initialInputs) =
     Left OverlappingInputs
   | otherwise =
     Right $
-      Api.toLedgerTx $
-        Api.unsafeBuildTransaction $
-          Api.emptyTxBody
-            & Api.addInputs ((headInput, headWitness) : (mkAbort <$> Map.toList initialInputs))
-            & Api.addOutputs [headOutput]
+      unsafeBuildTransaction $
+        emptyTxBody
+          & addInputs ((headInput, headWitness) : (mkAbort <$> Map.toList initialInputs))
+          & addOutputs [headOutput]
  where
   headWitness =
-    Api.BuildTxWith $ Api.mkScriptWitness headScript headDatumBefore headRedeemer
+    BuildTxWith $ mkScriptWitness headScript headDatumBefore headRedeemer
   headScript =
-    Api.fromPlutusScript $ Head.validatorScript policyId
+    fromPlutusScript $ Head.validatorScript policyId
   headRedeemer =
-    Api.mkRedeemerForTxIn Head.Abort
+    mkRedeemerForTxIn Head.Abort
 
   -- FIXME:
   -- (a) Abort need to reimburse participants that have committed!
   -- (b) There's in principle no need to output any SM output here, it's over.
   headOutput =
-    Api.TxOut
-      (Api.mkScriptAddress @Api.PlutusScriptV1 networkId headScript)
-      (Api.mkTxOutValue $ Api.lovelaceToValue 2_000_000)
+    TxOut
+      (mkScriptAddress @PlutusScriptV1 networkId headScript)
+      (mkTxOutValue $ lovelaceToValue 2_000_000)
       headDatumAfter
   headDatumAfter =
-    Api.mkTxOutDatum Head.Final
+    mkTxOutDatum Head.Final
 
   -- NOTE: Abort datums contain the datum of the spent state-machine input, but
   -- also, the datum of the created output which is necessary for the
   -- state-machine on-chain validator to control the correctness of the
   -- transition.
-  mkAbort (Api.fromLedgerTxIn -> initialInput, Api.fromLedgerData -> initialDatum) =
+  mkAbort (initialInput, ScriptDatumForTxIn -> initialDatum) =
     (initialInput, mkAbortWitness initialDatum)
   mkAbortWitness initialDatum =
-    Api.BuildTxWith $ Api.mkScriptWitness initialScript initialDatum initialRedeemer
+    BuildTxWith $ mkScriptWitness initialScript initialDatum initialRedeemer
   initialScript =
-    Api.fromPlutusScript Initial.validatorScript
+    fromPlutusScript Initial.validatorScript
   initialRedeemer =
-    Api.mkRedeemerForTxIn $ Initial.redeemer ()
+    mkRedeemerForTxIn $ Initial.redeemer ()
 
 -- * Observe Hydra Head transactions
 
 -- XXX(SN): We should log decisions why a tx is not an initTx etc. instead of
 -- only returning a Maybe, i.e. 'Either Reason (OnChainTx tx, OnChainHeadState)'
 observeInitTx ::
-  Api.NetworkId ->
+  NetworkId ->
   Party ->
-  ValidatedTx Era ->
+  CardanoTx ->
   Maybe (OnChainTx CardanoTx, OnChainHeadState)
-observeInitTx networkId party (Api.getTxBody . fromLedgerTx -> txBody) = do
+observeInitTx networkId party (getTxBody -> txBody) = do
   (ix, headOut, headData, Head.Initial cp ps) <- findFirst headOutput indexedOutputs
   let parties = map convertParty ps
   let cperiod = contestationPeriodToDiffTime cp
@@ -416,9 +360,9 @@ observeInitTx networkId party (Api.getTxBody . fromLedgerTx -> txBody) = do
     ( OnInitTx cperiod parties
     , Initial
         { threadOutput =
-            ( toLedgerTxIn $ Api.mkTxIn txBody ix
-            , toLedgerTxOut $ toCtxUTxOTxOut headOut
-            , headData
+            ( mkTxIn txBody ix
+            , toCtxUTxOTxOut headOut
+            , fromAlonzoData headData
             , ps
             )
         , initials
@@ -426,11 +370,11 @@ observeInitTx networkId party (Api.getTxBody . fromLedgerTx -> txBody) = do
         }
     )
  where
-  Api.TxBody Api.TxBodyContent{txOuts} = txBody
+  TxBody TxBodyContent{txOuts} = txBody
 
   headOutput = \case
-    (ix, out@(Api.TxOut _ _ (Api.TxOutDatum _ d))) ->
-      (ix,out,Api.toAlonzoData d,) <$> fromData (Api.toPlutusData d)
+    (ix, out@(TxOut _ _ (TxOutDatum _ d))) ->
+      (ix,out,toAlonzoData d,) <$> fromData (toPlutusData d)
     _ -> Nothing
 
   indexedOutputs = zip [0 ..] txOuts
@@ -440,14 +384,14 @@ observeInitTx networkId party (Api.getTxBody . fromLedgerTx -> txBody) = do
   initials =
     mapMaybe
       ( \(i, o) -> do
-          dat <- toAlonzoData <$> getDatum o
-          pure (toLedgerTxIn $ Api.mkTxIn txBody i, toLedgerTxOut $ toCtxUTxOTxOut o, dat)
+          dat <- getDatum o
+          pure (mkTxIn txBody i, toCtxUTxOTxOut o, dat)
       )
       initialOutputs
 
-  isInitial (Api.TxOut addr _ _) = addr == initialAddress
+  isInitial (TxOut addr _ _) = addr == initialAddress
 
-  initialAddress = mkScriptAddress @Api.PlutusScriptV1 networkId initialScript
+  initialAddress = mkScriptAddress @PlutusScriptV1 networkId initialScript
 
   initialScript = fromPlutusScript Initial.validatorScript
 
@@ -456,23 +400,16 @@ convertParty = Party . partyToVerKey
 
 -- | Identify a commit tx by looking for an output which pays to v_commit.
 observeCommitTx ::
-  Api.NetworkId ->
-  ValidatedTx Era ->
-  Maybe (OnChainTx CardanoTx, (TxIn StandardCrypto, TxOut Era, Data Era))
-observeCommitTx networkId (Api.getTxBody . fromLedgerTx -> txBody) = do
-  (commitIn, commitOut) <- Api.findTxOutByAddress commitAddress txBody
+  NetworkId ->
+  CardanoTx ->
+  Maybe (OnChainTx CardanoTx, (TxIn, TxOut CtxUTxO Era, ScriptData))
+observeCommitTx networkId (getTxBody -> txBody) = do
+  (commitIn, commitOut) <- findTxOutByAddress commitAddress txBody
   dat <- getDatum commitOut
   (party, _, committedUtxo) <- fromData @(DatumType Commit.Commit) $ toPlutusData dat
   convertedUtxo <- convertUtxo committedUtxo
   let onChainTx = OnCommitTx (convertParty party) convertedUtxo
-  pure
-    ( onChainTx
-    ,
-      ( toLedgerTxIn commitIn
-      , toLedgerTxOut $ toCtxUTxOTxOut commitOut
-      , toAlonzoData dat
-      )
-    )
+  pure (onChainTx, (commitIn, toCtxUTxOTxOut commitOut, dat))
  where
   convertUtxo :: Maybe (Commit.SerializedTxOutRef, Commit.SerializedTxOut) -> Maybe Utxo
   convertUtxo = \case
@@ -481,19 +418,19 @@ observeCommitTx networkId (Api.getTxBody . fromLedgerTx -> txBody) = do
       -- XXX(SN): these errors might be more severe and we could throw an
       -- exception here?
       eitherToMaybe $ do
-        txIn <- Api.fromLedgerTxIn <$> decodeFull' (fromBuiltin inBytes)
-        txOut <- Api.fromLedgerTxOut <$> decodeFull' (fromBuiltin outBytes)
-        pure $ Api.singletonUtxo (txIn, txOut)
+        txIn <- fromLedgerTxIn <$> decodeFull' (fromBuiltin inBytes)
+        txOut <- fromLedgerTxOut <$> decodeFull' (fromBuiltin outBytes)
+        pure $ singletonUtxo (txIn, txOut)
 
-  commitAddress = mkScriptAddress @Api.PlutusScriptV1 networkId commitScript
+  commitAddress = mkScriptAddress @PlutusScriptV1 networkId commitScript
 
   commitScript = fromPlutusScript Commit.validatorScript
 
 -- REVIEW(SN): Is this really specific to commit only, or wouldn't we be able to
 -- filter all 'knownUtxo' after observing any protocol tx?
 observeCommit ::
-  Api.NetworkId ->
-  ValidatedTx Era ->
+  NetworkId ->
+  CardanoTx ->
   OnChainHeadState ->
   Maybe (OnChainTx CardanoTx, OnChainHeadState)
 observeCommit networkId tx = \case
@@ -501,8 +438,8 @@ observeCommit networkId tx = \case
     (onChainTx, commitTriple) <- observeCommitTx networkId tx
     -- NOTE(SN): A commit tx has been observed and thus we can remove all it's
     -- inputs from our tracked initials
-    let commitIns = inputs $ body tx
-    let initials' = filter (\(i, _, _) -> i `Set.notMember` commitIns) initials
+    let commitIns = inputs tx
+    let initials' = filter (\(i, _, _) -> i `notElem` commitIns) initials
     let commits' = commitTriple : commits
     pure
       ( onChainTx
@@ -520,27 +457,24 @@ observeCommit networkId tx = \case
 -- and decoding its redeemer.
 observeCollectComTx ::
   -- | A Utxo set to lookup tx inputs
-  UTxO Era ->
-  ValidatedTx Era ->
+  Utxo ->
+  CardanoTx ->
   Maybe (OnChainTx CardanoTx, OnChainHeadState)
 observeCollectComTx utxo tx = do
-  (headInput, headOutput) <- Api.findScriptOutput @Api.PlutusScriptV1 (Api.fromLedgerUtxo utxo) headScript
-  redeemer <-
-    Api.findRedeemerSpending
-      (Api.getTxBody $ Api.fromLedgerTx tx)
-      headInput
-  oldHeadDatum <- lookupDatum (wits tx) (Api.toLedgerTxOut headOutput)
-  datum <- fromData $ getPlutusData oldHeadDatum
+  (headInput, headOutput) <- findScriptOutput @PlutusScriptV1 utxo headScript
+  redeemer <- findRedeemerSpending (getTxBody tx) headInput
+  oldHeadDatum <- lookupDatum tx headOutput
+  datum <- fromData $ toPlutusData oldHeadDatum
   case (datum, redeemer) of
     (Head.Initial{parties}, Head.CollectCom) -> do
-      (newHeadInput, newHeadOutput) <- Api.findScriptOutput @Api.PlutusScriptV1 (Api.utxoFromTx $ Api.fromLedgerTx tx) headScript
-      newHeadDatum <- lookupDatum (wits tx) (Api.toLedgerTxOut newHeadOutput)
+      (newHeadInput, newHeadOutput) <- findScriptOutput @PlutusScriptV1 (utxoFromTx tx) headScript
+      newHeadDatum <- lookupDatum tx newHeadOutput
       pure
         ( OnCollectComTx
         , OpenOrClosed
             { threadOutput =
-                ( Api.toLedgerTxIn newHeadInput
-                , Api.toLedgerTxOut newHeadOutput
+                ( newHeadInput
+                , newHeadOutput
                 , newHeadDatum
                 , parties
                 )
@@ -548,34 +482,31 @@ observeCollectComTx utxo tx = do
         )
     _ -> Nothing
  where
-  headScript = Api.fromPlutusScript $ Head.validatorScript policyId
+  headScript = fromPlutusScript $ Head.validatorScript policyId
 
 -- | Identify a close tx by lookup up the input spending the Head output and
 -- decoding its redeemer.
 observeCloseTx ::
   -- | A Utxo set to lookup tx inputs
-  UTxO Era ->
-  ValidatedTx Era ->
+  Utxo ->
+  CardanoTx ->
   Maybe (OnChainTx CardanoTx, OnChainHeadState)
 observeCloseTx utxo tx = do
-  (headInput, headOutput) <- Api.findScriptOutput @Api.PlutusScriptV1 (Api.fromLedgerUtxo utxo) headScript
-  redeemer <-
-    Api.findRedeemerSpending
-      (Api.getTxBody $ Api.fromLedgerTx tx)
-      headInput
-  oldHeadDatum <- lookupDatum (wits tx) (Api.toLedgerTxOut headOutput)
-  datum <- fromData $ getPlutusData oldHeadDatum
+  (headInput, headOutput) <- findScriptOutput @PlutusScriptV1 utxo headScript
+  redeemer <- findRedeemerSpending (getTxBody tx) headInput
+  oldHeadDatum <- lookupDatum tx headOutput
+  datum <- fromData $ toPlutusData oldHeadDatum
   case (datum, redeemer) of
     (Head.Open{parties}, Head.Close{snapshotNumber = onChainSnapshotNumber}) -> do
-      (newHeadInput, newHeadOutput) <- Api.findScriptOutput @Api.PlutusScriptV1 (Api.utxoFromTx $ Api.fromLedgerTx tx) headScript
-      newHeadDatum <- lookupDatum (wits tx) (Api.toLedgerTxOut newHeadOutput)
+      (newHeadInput, newHeadOutput) <- findScriptOutput @PlutusScriptV1 (utxoFromTx tx) headScript
+      newHeadDatum <- lookupDatum tx newHeadOutput
       snapshotNumber <- integerToNatural onChainSnapshotNumber
       pure
         ( OnCloseTx{contestationDeadline, snapshotNumber}
         , OpenOrClosed
             { threadOutput =
-                ( Api.toLedgerTxIn newHeadInput
-                , Api.toLedgerTxOut newHeadOutput
+                ( newHeadInput
+                , newHeadOutput
                 , newHeadDatum
                 , parties
                 )
@@ -583,7 +514,7 @@ observeCloseTx utxo tx = do
         )
     _ -> Nothing
  where
-  headScript = Api.fromPlutusScript $ Head.validatorScript policyId
+  headScript = fromPlutusScript $ Head.validatorScript policyId
 
   -- FIXME(SN): store in/read from datum
   contestationDeadline = UTCTime (ModifiedJulianDay 0) 0
@@ -596,45 +527,40 @@ observeCloseTx utxo tx = do
 -- from a known script (the head state machine script) with a "fanout" redeemer.
 observeFanoutTx ::
   -- | A Utxo set to lookup tx inputs
-  UTxO Era ->
-  ValidatedTx Era ->
+  Utxo ->
+  CardanoTx ->
   Maybe (OnChainTx CardanoTx, OnChainHeadState)
 observeFanoutTx utxo tx = do
-  headInput <- fst <$> Api.findScriptOutput @Api.PlutusScriptV1 (Api.fromLedgerUtxo utxo) headScript
-  Api.findRedeemerSpending
-    (Api.getTxBody $ Api.fromLedgerTx tx)
-    headInput
+  headInput <- fst <$> findScriptOutput @PlutusScriptV1 utxo headScript
+  findRedeemerSpending (getTxBody tx) headInput
     >>= \case
       Head.Fanout{} -> pure (OnFanoutTx, Final)
       _ -> Nothing
  where
-  headScript = Api.fromPlutusScript $ Head.validatorScript policyId
+  headScript = fromPlutusScript $ Head.validatorScript policyId
 
 -- | Identify an abort tx by looking up the input spending the Head output and
 -- decoding its redeemer.
 observeAbortTx ::
   -- | A Utxo set to lookup tx inputs
-  UTxO Era ->
-  ValidatedTx Era ->
+  Utxo ->
+  CardanoTx ->
   Maybe (OnChainTx CardanoTx, OnChainHeadState)
-observeAbortTx utxo tx = do
-  headInput <- fst <$> Api.findScriptOutput @Api.PlutusScriptV1 (Api.fromLedgerUtxo utxo) headScript
-  Api.findRedeemerSpending
-    (Api.getTxBody $ Api.fromLedgerTx tx)
-    headInput
-    >>= \case
-      Head.Abort -> pure (OnAbortTx, Final)
-      _ -> Nothing
+observeAbortTx utxo (Tx body _) = do
+  headInput <- fst <$> findScriptOutput @PlutusScriptV1 utxo headScript
+  findRedeemerSpending body headInput >>= \case
+    Head.Abort -> pure (OnAbortTx, Final)
+    _ -> Nothing
  where
   -- FIXME(SN): make sure this is aborting "the right head / your head" by not hard-coding policyId
-  headScript = Api.fromPlutusScript $ Head.validatorScript policyId
+  headScript = fromPlutusScript $ Head.validatorScript policyId
 
 -- * Functions related to OnChainHeadState
 
 -- | Provide a UTXO map for given OnChainHeadState. Used by the TinyWallet and
 -- the direct chain component to lookup inputs for balancing / constructing txs.
 -- XXX(SN): This is a hint that we might want to track the Utxo directly?
-knownUtxo :: OnChainHeadState -> Map (TxIn StandardCrypto) (TxOut Era)
+knownUtxo :: OnChainHeadState -> Map TxIn (TxOut CtxUTxO Era)
 knownUtxo = \case
   Initial{threadOutput, initials, commits} ->
     Map.fromList $ take2 threadOutput : (take2' <$> (initials <> commits))
@@ -647,35 +573,29 @@ knownUtxo = \case
   take2' (i, o, _) = (i, o)
 
 -- | Look for the "initial" which corresponds to given cardano verification key.
-ownInitial :: VerificationKey PaymentKey -> [(TxIn StandardCrypto, TxOut Era, Data Era)] -> Maybe (TxIn StandardCrypto, PubKeyHash)
+ownInitial ::
+  VerificationKey PaymentKey ->
+  [(TxIn, TxOut CtxUTxO Era, ScriptData)] ->
+  Maybe (TxIn, Hash PaymentKey)
 ownInitial vkey =
   foldl' go Nothing
  where
   go (Just x) _ = Just x
   go Nothing (i, _, dat) = do
-    pkh <- fromData (getPlutusData dat)
-    guard $ pkh == pubKeyHash vkey
-    pure (i, pkh)
+    let vkh = verificationKeyHash vkey
+    pkh <- fromData (toPlutusData dat)
+    guard $ pkh == toPlutusKeyHash vkh
+    pure (i, vkh)
 
 -- * Helpers
 
--- | Get the ledger address for a given plutus script.
-scriptAddr :: Script Era -> Addr StandardCrypto
-scriptAddr script =
-  Addr
-    network
-    (ScriptHashObj $ hashScript @Era script)
-    -- REVIEW(SN): stake head funds?
-    StakeRefNull
-
-plutusScript :: Plutus.Script -> Script Era
-plutusScript = PlutusScript PlutusV1 . toShort . fromLazy . serialize
-
 -- | Lookup included datum of given 'TxOut'.
-lookupDatum :: TxWitness Era -> TxOut Era -> Maybe (Data Era)
-lookupDatum wits = \case
-  (TxOut _ _ (SJust datumHash)) -> Map.lookup datumHash . unTxDats $ txdats wits
-  _ -> Nothing
+lookupDatum :: CardanoTx -> TxOut CtxUTxO Era -> Maybe ScriptData
+lookupDatum _wits = undefined
+
+--  \case
+--  (TxOut _ _ (SJust datumHash)) -> Map.lookup datumHash . unTxDats $ txdats wits
+--  _ -> Nothing
 
 -- | Find first occurrence including a transformation.
 findFirst :: Foldable t => (a -> Maybe b) -> t a -> Maybe b

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -589,14 +589,6 @@ ownInitial vkey =
 
 -- * Helpers
 
--- | Lookup included datum of given 'TxOut'.
-lookupDatum :: CardanoTx -> TxOut CtxUTxO Era -> Maybe ScriptData
-lookupDatum _wits = undefined
-
---  \case
---  (TxOut _ _ (SJust datumHash)) -> Map.lookup datumHash . unTxDats $ txdats wits
---  _ -> Nothing
-
 -- | Find first occurrence including a transformation.
 findFirst :: Foldable t => (a -> Maybe b) -> t a -> Maybe b
 findFirst fn = getFirst . foldMap (First . fn)

--- a/hydra-node/src/Hydra/Ledger/Cardano/Isomorphism.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano/Isomorphism.hs
@@ -39,6 +39,7 @@ import qualified Cardano.Ledger.Alonzo.Tx as Ledger.Alonzo
 import qualified Cardano.Ledger.Alonzo.TxInfo as Ledger
 import qualified Cardano.Ledger.Alonzo.TxWitness as Ledger.Alonzo
 import qualified Cardano.Ledger.BaseTypes as Ledger
+import qualified Cardano.Ledger.Coin as Ledger
 import qualified Cardano.Ledger.Core as Ledger
 import qualified Cardano.Ledger.Credential as Ledger
 import qualified Cardano.Ledger.Crypto as Ledger (StandardCrypto)
@@ -126,6 +127,11 @@ fromPlutusAddress Plutus.Address{Plutus.addressCredential = credential, Plutus.a
           (Ledger.StakeRefPtr $ Ledger.Ptr (SlotNo $ fromInteger a) (fromInteger b) (fromInteger c))
  where
   network = Ledger.Testnet
+
+-- ** Coin
+
+fromLedgerCoin :: Ledger.Coin -> Lovelace
+fromLedgerCoin (Ledger.Coin n) = Lovelace n
 
 -- ** Key
 


### PR DESCRIPTION
Work in progress, still updating the TxSpec, halfway through it. 

- :round_pushpin: **Fully embrace cardano-api in Chain.Direct.Tx. Finally.**
  
- :round_pushpin: **Fully embrace cardano-api in Hydra.Chain.**
  
- :round_pushpin: **Ripple changes from adopting cardano-api in the direct chain to tx-cost executable.**
  
- :round_pushpin: **Start updating Chain.Direct.TxSpec to work with cardano-api.**
