### PR TITLE
Refine cardano-node executable dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,10 +46,10 @@ jobs:
         nix-build shell.nix
 
     - name: Build
-      run: nix-shell --run '.github/workflows/ci-build.sh'
+      run: nix-shell --pure --run '.github/workflows/ci-build.sh'
 
     - name: Test
-      run: nix-shell --run '.github/workflows/ci-test.sh'
+      run: nix-shell --pure --run '.github/workflows/ci-test.sh'
       # https://giters.com/gfx/example-github-actions-with-tty
       # The default shell does not allocate a TTY which breaks some tests
       shell: 'script -q -e -c "bash {0}"'
@@ -58,7 +58,7 @@ jobs:
 
     - name: Documentation (Haddock)
       run: |
-        nix-shell --run '.github/workflows/ci-haddock.sh'
+        nix-shell --pure --run '.github/workflows/ci-haddock.sh'
 
     - name: Setup Node.js
       uses: actions/setup-node@v3

--- a/cabal.project
+++ b/cabal.project
@@ -38,7 +38,7 @@ package plutus-merkle-tree
 -- Always show detailed output for tests
 test-show-details: direct
 
--- NOTE(SN): The following is taken from cardano-node v1.31.0
+-- NOTE(SN): The following is taken from cardano-node v1.32.0-rc2
 
 source-repository-package
   type: git
@@ -48,7 +48,6 @@ source-repository-package
   subdir:
     cardano-api
     cardano-node
-    cardano-cli
 
 -- NOTE(SN): These source-repository-package tags are copied from the
 -- 'cardano-node' repository cabal.project at the revision given above. Make
@@ -191,12 +190,6 @@ source-repository-package
     prettyprinter-configurable
     stubs/plutus-ghc-stub
     word-array
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ekg-forward
-  tag: 2adc8b698443bb10154304b24f6c1d6913bb65b9
-  --sha256: 0cyixq3jmq43zs1yzrycqw1klyjy0zxf1vifknnr1k9d6sc3zf6b
 
 source-repository-package
   type: git

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -63,7 +63,7 @@ You can also use `nix-build` to build the project and all executables. You will 
     Do not confuse `lzma` with `liblzma-dev`, those are 2 existing package!
 
 1. Install forked libsodium
-    
+
     ````mdx-code-block
     <TerminalWindow>
 
@@ -78,6 +78,8 @@ You can also use `nix-build` to build the project and all executables. You will 
 
     </TerminalWindow>
     ````
+
+1. To run integration tests, we need to install `cardano-node` & `cardano-cli` v1.32.0-rc2 to path. For example, see the official doc [here](https://developers.cardano.org/docs/get-started/installing-cardano-node).
 
 1. Build and test everything:
 

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -230,8 +230,7 @@ test-suite integration
     , text
 
   build-tool-depends:
-    hspec-discover:hspec-discover -any, hydra-node:hydra-node -any,
-    cardano-node:cardano-node -any, cardano-cli:cardano-cli -any
+    hspec-discover:hspec-discover -any, hydra-node:hydra-node -any
 
   ghc-options:        -threaded -rtsopts
 
@@ -267,6 +266,6 @@ benchmark bench-e2e
     , time
 
   build-tool-depends:
-    hydra-node:hydra-node -any, cardano-node:cardano-node -any
+    hydra-node:hydra-node -any
 
   ghc-options:        -threaded -rtsopts

--- a/hydra-tui/hydra-tui.cabal
+++ b/hydra-tui/hydra-tui.cabal
@@ -141,7 +141,6 @@ test-suite tests
     , vty
 
   build-tool-depends:
-    hspec-discover:hspec-discover -any, hydra-node:hydra-node -any,
-    cardano-node:cardano-node -any
+    hspec-discover:hspec-discover -any, hydra-node:hydra-node -any
 
   ghc-options:        -threaded -rtsopts


### PR DESCRIPTION
Previously we were building `cardano-node` & `cardano-cli` executables from source with `cabal`. This is not very nice because:
- It builds the executables with this codebase's `cabal.project`, forcing the codebase to follow `cardano-node`'s `cabal.project` as tightly as possible, which is error-prone and inflexible. For instance, bumping the commit of `plutus` in our `cabal.project` to get smaller script sizes (new compiler optimizations or something) risks building an untested version of the node with a new `plutus-ledger-api` leading to failed tests and unexpected behaviors.
- It is slow as it doesn't reuse most of `cardano-node`'s Nix cache and adds extra overheads to our own Cabal caches.
- It complicates our own Cabal setup with dependencies we don't even use for Hydra, like `ekg-forward`. In fact, if we remove `cardano-node` (only keep `cardano-api`) from `cabal.project` for good then we'll be able to get rid of `optparse-applicative`, `hedgehog-extras`, and `cardano-config`. The trade-off is to (re)define a few orphan instances (only for tracing) in `Hydra.Network.Ouroboros`, which I guess is acceptable? 

As a solution, this PR avoids building the `cardano-node` executables from source with our own `cabal.project`, and populates more standard ones to the default `nix-shell` for convenience. Outside of it, we should advise people to get a stable binary directly, build from source, etc.

Reference: https://github.com/input-output-hk/plutus-apps/pull/213.