### PR TITLE
Remove era-binding parameters from cardano-api types

### DIFF
--- a/hydra-cardano-api/hydra-cardano-api.cabal
+++ b/hydra-cardano-api/hydra-cardano-api.cabal
@@ -78,6 +78,7 @@ library
     Hydra.Cardano.Api.AddressInEra
     Hydra.Cardano.Api.CtxTx
     Hydra.Cardano.Api.CtxUTxO
+    Hydra.Cardano.Api.ExecutionUnits
     Hydra.Cardano.Api.Hash
     Hydra.Cardano.Api.KeyWitness
     Hydra.Cardano.Api.Lovelace

--- a/hydra-cardano-api/src/Hydra/Cardano/Api.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api.hs
@@ -2,33 +2,7 @@
 
 module Hydra.Cardano.Api (
   module Hydra.Cardano.Api,
-  module Cardano.Api,
-  module Cardano.Api.Byron,
-  module Cardano.Api.Shelley,
-  module Hydra.Cardano.Api.AddressInEra,
-  module Hydra.Cardano.Api.CtxTx,
-  module Hydra.Cardano.Api.CtxUTxO,
-  module Hydra.Cardano.Api.ExecutionUnits,
-  module Hydra.Cardano.Api.Hash,
-  module Hydra.Cardano.Api.KeyWitness,
-  module Hydra.Cardano.Api.Lovelace,
-  module Hydra.Cardano.Api.PlutusScript,
-  module Hydra.Cardano.Api.PlutusScriptVersion,
-  module Hydra.Cardano.Api.ScriptData,
-  module Hydra.Cardano.Api.ScriptDatum,
-  module Hydra.Cardano.Api.ScriptHash,
-  module Hydra.Cardano.Api.ScriptWitnessInCtx,
-  module Hydra.Cardano.Api.Tx,
-  module Hydra.Cardano.Api.TxBody,
-  module Hydra.Cardano.Api.TxId,
-  module Hydra.Cardano.Api.TxIn,
-  module Hydra.Cardano.Api.TxOut,
-  module Hydra.Cardano.Api.TxOutDatum,
-  module Hydra.Cardano.Api.TxOutValue,
-  module Hydra.Cardano.Api.TxScriptValidity,
-  module Hydra.Cardano.Api.UTxO,
-  module Hydra.Cardano.Api.Value,
-  module Hydra.Cardano.Api.Witness,
+  module X,
   UTxO,
   UTxO' (UTxO),
   StandardCrypto,
@@ -38,7 +12,7 @@ module Hydra.Cardano.Api (
 
 import Hydra.Prelude
 
-import Cardano.Api hiding (
+import Cardano.Api as X hiding (
   AddressInEra (..),
   AddressTypeInEra (..),
   BalancedTxBody (..),
@@ -65,25 +39,56 @@ import Cardano.Api hiding (
   Witness (..),
   toLedgerUTxO,
  )
-import qualified Cardano.Api
-import Cardano.Api.Byron (
+import Cardano.Api.Byron as X (
   Address (..),
  )
-import Cardano.Api.Shelley (
+import Cardano.Api.Shelley as X (
   Address (..),
   PoolId,
   ProtocolParameters (..),
-  ShelleyBasedEra (..),
   ShelleyGenesis (..),
   ShelleyLedgerEra,
-  SigningKey (..),
   VerificationKey (..),
-  fromLedgerPParams,
   fromPlutusData,
   toPlutusData,
  )
+import Cardano.Api.UTxO (
+  UTxO,
+  UTxO' (..),
+ )
+import Hydra.Cardano.Api.Prelude (
+  Era,
+  LedgerEra,
+  StandardCrypto,
+ )
+
+import Hydra.Cardano.Api.AddressInEra as X
+import Hydra.Cardano.Api.CtxTx as X
+import Hydra.Cardano.Api.CtxUTxO as X
+import Hydra.Cardano.Api.ExecutionUnits as X
+import Hydra.Cardano.Api.Hash as X
+import Hydra.Cardano.Api.KeyWitness as X
+import Hydra.Cardano.Api.Lovelace as X
+import Hydra.Cardano.Api.PlutusScript as X
+import Hydra.Cardano.Api.PlutusScriptVersion as X
+import Hydra.Cardano.Api.ScriptData as X
+import Hydra.Cardano.Api.ScriptDatum as X
+import Hydra.Cardano.Api.ScriptHash as X
+import Hydra.Cardano.Api.ScriptWitnessInCtx as X
+import Hydra.Cardano.Api.Tx as X
+import Hydra.Cardano.Api.TxBody as X
+import Hydra.Cardano.Api.TxId as X
+import Hydra.Cardano.Api.TxIn as X
+import Hydra.Cardano.Api.TxOut as X
+import Hydra.Cardano.Api.TxOutDatum as X
+import Hydra.Cardano.Api.TxOutValue as X
+import Hydra.Cardano.Api.TxScriptValidity as X
+import Hydra.Cardano.Api.UTxO as X
+import Hydra.Cardano.Api.Value as X
+import Hydra.Cardano.Api.Witness as X
+
+import qualified Cardano.Api
 import qualified Cardano.Api.Shelley
-import Cardano.Api.UTxO (UTxO, UTxO' (..))
 import qualified Cardano.Ledger.Alonzo.Data as Ledger
 import qualified Cardano.Ledger.Alonzo.Scripts as Ledger
 import qualified Cardano.Ledger.Alonzo.TxBody as Ledger
@@ -91,36 +96,6 @@ import qualified Cardano.Ledger.Alonzo.TxWitness as Ledger
 import qualified Cardano.Ledger.Keys as Ledger
 import qualified Cardano.Ledger.Shelley.Address.Bootstrap as Ledger
 import qualified Cardano.Ledger.Shelley.Tx as Ledger hiding (TxBody)
-import Hydra.Cardano.Api.Prelude (
-  Era,
-  LedgerEra,
-  StandardCrypto,
- )
-
-import Hydra.Cardano.Api.AddressInEra
-import Hydra.Cardano.Api.CtxTx
-import Hydra.Cardano.Api.CtxUTxO
-import Hydra.Cardano.Api.ExecutionUnits
-import Hydra.Cardano.Api.Hash
-import Hydra.Cardano.Api.KeyWitness
-import Hydra.Cardano.Api.Lovelace
-import Hydra.Cardano.Api.PlutusScript
-import Hydra.Cardano.Api.PlutusScriptVersion
-import Hydra.Cardano.Api.ScriptData
-import Hydra.Cardano.Api.ScriptDatum
-import Hydra.Cardano.Api.ScriptHash
-import Hydra.Cardano.Api.ScriptWitnessInCtx
-import Hydra.Cardano.Api.Tx
-import Hydra.Cardano.Api.TxBody
-import Hydra.Cardano.Api.TxId
-import Hydra.Cardano.Api.TxIn
-import Hydra.Cardano.Api.TxOut
-import Hydra.Cardano.Api.TxOutDatum
-import Hydra.Cardano.Api.TxOutValue
-import Hydra.Cardano.Api.TxScriptValidity
-import Hydra.Cardano.Api.UTxO
-import Hydra.Cardano.Api.Value
-import Hydra.Cardano.Api.Witness
 
 -- NOTE: We always use the latest era available in our codebase, so to ease type
 -- signatures and notations, we specialize any type of the cardano-api normally

--- a/hydra-cardano-api/src/Hydra/Cardano/Api.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api.hs
@@ -1,10 +1,14 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module Hydra.Cardano.Api (
+  module Hydra.Cardano.Api,
   module Cardano.Api,
   module Cardano.Api.Byron,
   module Cardano.Api.Shelley,
   module Hydra.Cardano.Api.AddressInEra,
   module Hydra.Cardano.Api.CtxTx,
   module Hydra.Cardano.Api.CtxUTxO,
+  module Hydra.Cardano.Api.ExecutionUnits,
   module Hydra.Cardano.Api.Hash,
   module Hydra.Cardano.Api.KeyWitness,
   module Hydra.Cardano.Api.Lovelace,
@@ -32,20 +36,71 @@ module Hydra.Cardano.Api (
   LedgerEra,
 ) where
 
+import Hydra.Prelude
+
+import Cardano.Api hiding (
+  AddressInEra (..),
+  AddressTypeInEra (..),
+  BalancedTxBody (..),
+  KeyWitness,
+  PlutusScript,
+  Script (..),
+  ScriptInEra (..),
+  ScriptLanguage (..),
+  ScriptWitness (..),
+  Tx (..),
+  TxAuxScripts (..),
+  TxBody (..),
+  TxBodyContent (..),
+  TxBodyScriptData (..),
+  TxExtraKeyWitnesses (..),
+  TxFee (..),
+  TxInsCollateral (..),
+  TxMetadataInEra (..),
+  TxMintValue (..),
+  TxOut (..),
+  TxOutDatum (..),
+  TxScriptValidity (..),
+  UTxO (..),
+  Witness (..),
+  toLedgerUTxO,
+ )
+import qualified Cardano.Api
+import Cardano.Api.Byron (
+  Address (..),
+ )
+import Cardano.Api.Shelley (
+  Address (..),
+  PoolId,
+  ProtocolParameters (..),
+  ShelleyBasedEra (..),
+  ShelleyGenesis (..),
+  ShelleyLedgerEra,
+  SigningKey (..),
+  VerificationKey (..),
+  fromLedgerPParams,
+  fromPlutusData,
+  toPlutusData,
+ )
+import qualified Cardano.Api.Shelley
+import Cardano.Api.UTxO (UTxO, UTxO' (..))
+import qualified Cardano.Ledger.Alonzo.Data as Ledger
+import qualified Cardano.Ledger.Alonzo.Scripts as Ledger
+import qualified Cardano.Ledger.Alonzo.TxBody as Ledger
+import qualified Cardano.Ledger.Alonzo.TxWitness as Ledger
+import qualified Cardano.Ledger.Keys as Ledger
+import qualified Cardano.Ledger.Shelley.Address.Bootstrap as Ledger
+import qualified Cardano.Ledger.Shelley.Tx as Ledger hiding (TxBody)
 import Hydra.Cardano.Api.Prelude (
   Era,
   LedgerEra,
   StandardCrypto,
  )
 
-import Cardano.Api hiding (UTxO, toLedgerUTxO)
-import Cardano.Api.Byron hiding (UTxO, toLedgerUTxO)
-import Cardano.Api.Shelley hiding (UTxO, toLedgerUTxO)
-import Cardano.Api.UTxO (UTxO, UTxO' (..))
-
 import Hydra.Cardano.Api.AddressInEra
 import Hydra.Cardano.Api.CtxTx
 import Hydra.Cardano.Api.CtxUTxO
+import Hydra.Cardano.Api.ExecutionUnits
 import Hydra.Cardano.Api.Hash
 import Hydra.Cardano.Api.KeyWitness
 import Hydra.Cardano.Api.Lovelace
@@ -66,3 +121,451 @@ import Hydra.Cardano.Api.TxScriptValidity
 import Hydra.Cardano.Api.UTxO
 import Hydra.Cardano.Api.Value
 import Hydra.Cardano.Api.Witness
+
+-- NOTE: We always use the latest era available in our codebase, so to ease type
+-- signatures and notations, we specialize any type of the cardano-api normally
+-- parameterized by an era to the latest era 'Era'.
+
+-- AddressInEra
+
+type AddressInEra = Cardano.Api.AddressInEra Era
+{-# COMPLETE AddressInEra #-}
+
+pattern AddressInEra :: AddressTypeInEra addrtype -> Address addrtype -> AddressInEra
+pattern AddressInEra{addressTypeInEra, address} <-
+  Cardano.Api.AddressInEra addressTypeInEra address
+  where
+    AddressInEra =
+      Cardano.Api.AddressInEra
+
+-- AddressTypeInEra
+
+type AddressTypeInEra addrType = Cardano.Api.AddressTypeInEra addrType Era
+{-# COMPLETE ByronAddressInAnyEra, ShelleyAddressInAnyEra #-}
+
+pattern ByronAddressInAnyEra :: AddressTypeInEra ByronAddr
+pattern ByronAddressInAnyEra <-
+  Cardano.Api.ByronAddressInAnyEra
+  where
+    ByronAddressInAnyEra =
+      Cardano.Api.ByronAddressInAnyEra
+
+pattern ShelleyAddressInAnyEra :: AddressTypeInEra ShelleyAddr
+pattern ShelleyAddressInAnyEra <-
+  Cardano.Api.ShelleyAddressInEra _
+  where
+    ShelleyAddressInAnyEra =
+      Cardano.Api.ShelleyAddressInEra ShelleyBasedEraAlonzo
+
+-- BalancedTxBody
+
+type BalancedTxBody = Cardano.Api.BalancedTxBody Era
+{-# COMPLETE BalancedTxBody #-}
+
+pattern BalancedTxBody :: TxBody -> TxOut CtxTx -> Lovelace -> BalancedTxBody
+pattern BalancedTxBody{balancedTxBody, balancedTxChangeOutput, balancedTxFee} <-
+  Cardano.Api.BalancedTxBody balancedTxBody balancedTxChangeOutput balancedTxFee
+  where
+    BalancedTxBody =
+      Cardano.Api.BalancedTxBody
+
+-- KeyWitness
+
+type KeyWitness = Cardano.Api.KeyWitness Era
+{-# COMPLETE ShelleyBootstrapWitness, ShelleyKeyWitness #-}
+
+pattern ShelleyBootstrapWitness :: Ledger.BootstrapWitness StandardCrypto -> KeyWitness
+pattern ShelleyBootstrapWitness{shelleyBootstrapWitness} <-
+  Cardano.Api.Shelley.ShelleyBootstrapWitness _ shelleyBootstrapWitness
+  where
+    ShelleyBootstrapWitness =
+      Cardano.Api.Shelley.ShelleyBootstrapWitness ShelleyBasedEraAlonzo
+
+pattern ShelleyKeyWitness :: Ledger.WitVKey 'Ledger.Witness StandardCrypto -> KeyWitness
+pattern ShelleyKeyWitness{shelleyKeyWitness} <-
+  Cardano.Api.Shelley.ShelleyKeyWitness _ shelleyKeyWitness
+  where
+    ShelleyKeyWitness =
+      Cardano.Api.Shelley.ShelleyKeyWitness ShelleyBasedEraAlonzo
+
+-- PlutusScript
+
+type PlutusScript = Cardano.Api.PlutusScript PlutusScriptV1
+{-# COMPLETE PlutusScriptSerialised #-}
+
+pattern PlutusScriptSerialised :: ShortByteString -> PlutusScript
+pattern PlutusScriptSerialised{plutusScriptSerialised} <-
+  Cardano.Api.Shelley.PlutusScriptSerialised plutusScriptSerialised
+  where
+    PlutusScriptSerialised =
+      Cardano.Api.Shelley.PlutusScriptSerialised
+
+-- Script
+
+type Script = Cardano.Api.Script PlutusScriptV1
+{-# COMPLETE PlutusScript #-}
+
+pattern PlutusScript :: PlutusScript -> Script
+pattern PlutusScript{plutusScript} <-
+  Cardano.Api.Shelley.PlutusScript _ plutusScript
+  where
+    PlutusScript =
+      Cardano.Api.Shelley.PlutusScript PlutusScriptV1
+
+-- ScriptInEra
+
+type ScriptInEra = Cardano.Api.ScriptInEra Era
+
+-- ScriptLanguage
+
+type ScriptLanguage = Cardano.Api.ScriptLanguage PlutusScriptV1
+{-# COMPLETE PlutusScriptLanguage #-}
+
+pattern PlutusScriptLanguage :: ScriptLanguage
+pattern PlutusScriptLanguage <-
+  Cardano.Api.Shelley.PlutusScriptLanguage _
+  where
+    PlutusScriptLanguage =
+      Cardano.Api.Shelley.PlutusScriptLanguage PlutusScriptV1
+
+-- ScriptWitness
+
+type ScriptWitness witCtx = Cardano.Api.ScriptWitness witCtx Era
+{-# COMPLETE PlutusScriptWitness #-}
+
+pattern PlutusScriptWitness ::
+  PlutusScript ->
+  ScriptDatum witctx ->
+  ScriptRedeemer ->
+  ExecutionUnits ->
+  ScriptWitness witctx
+pattern PlutusScriptWitness
+  { plutusScriptWitnessScript
+  , plutusScriptWitnessDatum
+  , plutusScriptWitnessRedeemer
+  , plutusScriptWitnessExecutionUnits
+  } <-
+  Cardano.Api.PlutusScriptWitness
+    PlutusScriptV1InAlonzo
+    PlutusScriptV1
+    plutusScriptWitnessScript
+    plutusScriptWitnessDatum
+    plutusScriptWitnessRedeemer
+    plutusScriptWitnessExecutionUnits
+  where
+    PlutusScriptWitness =
+      Cardano.Api.PlutusScriptWitness
+        PlutusScriptV1InAlonzo
+        PlutusScriptV1
+
+-- Tx
+
+type Tx = Cardano.Api.Tx Era
+{-# COMPLETE Tx #-}
+{-# COMPLETE ShelleyTxBody #-}
+
+pattern Tx :: TxBody -> [KeyWitness] -> Tx
+pattern Tx{txBody, txKeyWitnesses} <-
+  Cardano.Api.Tx txBody txKeyWitnesses
+  where
+    Tx =
+      Cardano.Api.Tx
+
+pattern ShelleyTxBody ::
+  Ledger.TxBody LedgerEra ->
+  [Ledger.Script LedgerEra] ->
+  TxBodyScriptData ->
+  Maybe (Ledger.AuxiliaryData LedgerEra) ->
+  TxScriptValidity ->
+  TxBody
+pattern ShelleyTxBody
+  { txBodyLedgerTxBody
+  , txBodyScripts
+  , txBodyScriptData
+  , txBodyAuxiliaryData
+  , txBodyScriptValidity
+  } <-
+  Cardano.Api.Shelley.ShelleyTxBody
+    _
+    txBodyLedgerTxBody
+    txBodyScripts
+    txBodyScriptData
+    txBodyAuxiliaryData
+    txBodyScriptValidity
+  where
+    ShelleyTxBody =
+      Cardano.Api.Shelley.ShelleyTxBody ShelleyBasedEraAlonzo
+
+-- TxAuxScripts
+
+type TxAuxScripts = Cardano.Api.TxAuxScripts Era
+{-# COMPLETE TxAuxScriptsNone, TxAuxScripts #-}
+
+pattern TxAuxScriptsNone :: TxAuxScripts
+pattern TxAuxScriptsNone <-
+  Cardano.Api.TxAuxScriptsNone
+  where
+    TxAuxScriptsNone =
+      Cardano.Api.TxAuxScriptsNone
+
+pattern TxAuxScripts :: [ScriptInEra] -> TxAuxScripts
+pattern TxAuxScripts{txAuxScripts'} <-
+  Cardano.Api.TxAuxScripts _ txAuxScripts'
+  where
+    TxAuxScripts =
+      Cardano.Api.TxAuxScripts AuxScriptsInAlonzoEra
+
+-- TxBody
+
+type TxBody = Cardano.Api.TxBody Era
+{-# COMPLETE TxBody #-}
+
+pattern TxBody :: TxBodyContent ViewTx -> TxBody
+pattern TxBody{txBodyContent} <-
+  Cardano.Api.TxBody txBodyContent
+{-# COMPLETE TxBody #-}
+
+-- TxBodyContent
+
+type TxBodyContent build = Cardano.Api.TxBodyContent build Era
+{-# COMPLETE TxBodyContent #-}
+
+pattern TxBodyContent ::
+  TxIns build ->
+  TxInsCollateral ->
+  [TxOut CtxTx] ->
+  TxFee ->
+  (TxValidityLowerBound Era, TxValidityUpperBound Era) ->
+  TxMetadataInEra ->
+  TxAuxScripts ->
+  TxExtraKeyWitnesses ->
+  BuildTxWith build (Maybe ProtocolParameters) ->
+  TxWithdrawals build Era ->
+  TxCertificates build Era ->
+  TxUpdateProposal Era ->
+  TxMintValue build ->
+  TxScriptValidity ->
+  TxBodyContent build
+pattern TxBodyContent
+  { txIns
+  , txInsCollateral
+  , txOuts
+  , txFee
+  , txValidityRange
+  , txMetadata
+  , txAuxScripts
+  , txExtraKeyWits
+  , txProtocolParams
+  , txWithdrawals
+  , txCertificates
+  , txUpdateProposal
+  , txMintValue
+  , txScriptValidity
+  } <-
+  Cardano.Api.TxBodyContent
+    txIns
+    txInsCollateral
+    txOuts
+    txFee
+    txValidityRange
+    txMetadata
+    txAuxScripts
+    txExtraKeyWits
+    txProtocolParams
+    txWithdrawals
+    txCertificates
+    txUpdateProposal
+    txMintValue
+    txScriptValidity
+  where
+    TxBodyContent = Cardano.Api.TxBodyContent
+
+-- TxBodyScriptData
+
+type TxBodyScriptData = Cardano.Api.TxBodyScriptData Era
+{-# COMPLETE TxBodyNoScriptData, TxBodyScriptData #-}
+
+pattern TxBodyNoScriptData :: TxBodyScriptData
+pattern TxBodyNoScriptData <-
+  Cardano.Api.TxBodyNoScriptData
+  where
+    TxBodyNoScriptData =
+      Cardano.Api.TxBodyNoScriptData
+
+pattern TxBodyScriptData ::
+  Ledger.TxDats (ShelleyLedgerEra Era) ->
+  Ledger.Redeemers (ShelleyLedgerEra Era) ->
+  TxBodyScriptData
+pattern TxBodyScriptData{txBodyScriptDatums, txBodyScriptRedeemers} <-
+  Cardano.Api.TxBodyScriptData _ txBodyScriptDatums txBodyScriptRedeemers
+  where
+    TxBodyScriptData =
+      Cardano.Api.TxBodyScriptData ScriptDataInAlonzoEra
+
+-- TxExtraKeyWitnesses
+
+type TxExtraKeyWitnesses = Cardano.Api.TxExtraKeyWitnesses Era
+{-# COMPLETE TxExtraKeyWitnessesNone, TxExtraKeyWitnesses #-}
+
+pattern TxExtraKeyWitnessesNone :: TxExtraKeyWitnesses
+pattern TxExtraKeyWitnessesNone <-
+  Cardano.Api.TxExtraKeyWitnessesNone
+  where
+    TxExtraKeyWitnessesNone = Cardano.Api.TxExtraKeyWitnessesNone
+
+pattern TxExtraKeyWitnesses :: [Hash PaymentKey] -> TxExtraKeyWitnesses
+pattern TxExtraKeyWitnesses{txExtraKeyWitnesses} <-
+  Cardano.Api.TxExtraKeyWitnesses _ txExtraKeyWitnesses
+  where
+    TxExtraKeyWitnesses =
+      Cardano.Api.TxExtraKeyWitnesses ExtraKeyWitnessesInAlonzoEra
+
+-- TxFee
+
+type TxFee = Cardano.Api.TxFee Era
+{-# COMPLETE TxFeeExplicit #-}
+
+pattern TxFeeExplicit :: Lovelace -> TxFee
+pattern TxFeeExplicit{txFeeExplicit} <-
+  Cardano.Api.TxFeeExplicit _ txFeeExplicit
+  where
+    TxFeeExplicit =
+      Cardano.Api.TxFeeExplicit TxFeesExplicitInAlonzoEra
+
+-- TxIns
+
+type TxIns build = [(TxIn, BuildTxWith build (Cardano.Api.Witness WitCtxTxIn Era))]
+
+-- TxInsCollateral
+
+type TxInsCollateral = Cardano.Api.TxInsCollateral Era
+{-# COMPLETE TxInsCollateralNone, TxInsCollateral #-}
+
+pattern TxInsCollateralNone :: TxInsCollateral
+pattern TxInsCollateralNone <-
+  Cardano.Api.TxInsCollateralNone
+  where
+    TxInsCollateralNone =
+      Cardano.Api.TxInsCollateralNone
+
+pattern TxInsCollateral :: [TxIn] -> TxInsCollateral
+pattern TxInsCollateral{txInsCollateral'} <-
+  Cardano.Api.TxInsCollateral _ txInsCollateral'
+  where
+    TxInsCollateral =
+      Cardano.Api.TxInsCollateral CollateralInAlonzoEra
+
+-- TxMetadataInEra
+
+type TxMetadataInEra = Cardano.Api.TxMetadataInEra Era
+{-# COMPLETE TxMetadataNone, TxMetadataInEra #-}
+
+pattern TxMetadataNone :: TxMetadataInEra
+pattern TxMetadataNone <-
+  Cardano.Api.TxMetadataNone
+  where
+    TxMetadataNone =
+      Cardano.Api.TxMetadataNone
+
+pattern TxMetadataInEra :: TxMetadata -> TxMetadataInEra
+pattern TxMetadataInEra{txMetadataInEra} <-
+  Cardano.Api.TxMetadataInEra _ txMetadataInEra
+  where
+    TxMetadataInEra =
+      Cardano.Api.TxMetadataInEra TxMetadataInAlonzoEra
+
+-- TxMintValue
+
+type TxMintValue build = Cardano.Api.TxMintValue build Era
+{-# COMPLETE TxMintValueNone, TxMintValue #-}
+
+pattern TxMintValueNone :: TxMintValue build
+pattern TxMintValueNone <-
+  Cardano.Api.TxMintNone
+  where
+    TxMintValueNone =
+      Cardano.Api.TxMintNone
+
+pattern TxMintValue ::
+  Value ->
+  BuildTxWith build (Map PolicyId (ScriptWitness WitCtxMint)) ->
+  TxMintValue build
+pattern TxMintValue{txMintValueInEra, txMintValueScriptWitnesses} <-
+  Cardano.Api.TxMintValue _ txMintValueInEra txMintValueScriptWitnesses
+  where
+    TxMintValue =
+      Cardano.Api.TxMintValue MultiAssetInAlonzoEra
+
+-- TxOut
+
+type TxOut ctx = Cardano.Api.TxOut ctx Era
+{-# COMPLETE TxOut #-}
+
+pattern TxOut :: AddressInEra -> Value -> TxOutDatum ctx -> TxOut ctx
+pattern TxOut{txOutAddress, txOutValue, txOutDatum} <-
+  Cardano.Api.TxOut txOutAddress (TxOutValue MultiAssetInAlonzoEra txOutValue) txOutDatum
+  where
+    TxOut addr =
+      Cardano.Api.TxOut addr . TxOutValue MultiAssetInAlonzoEra
+
+-- TxOutDatum
+
+type TxOutDatum ctx = Cardano.Api.TxOutDatum ctx Era
+{-# COMPLETE TxOutDatumNone, TxOutDatumHash, TxOutDatum #-}
+
+pattern TxOutDatumNone :: TxOutDatum ctx
+pattern TxOutDatumNone <-
+  Cardano.Api.TxOutDatumNone
+  where
+    TxOutDatumNone =
+      Cardano.Api.TxOutDatumNone
+
+pattern TxOutDatumHash :: Hash ScriptData -> TxOutDatum ctx
+pattern TxOutDatumHash{txOutDatumHash} <-
+  Cardano.Api.TxOutDatumHash _ txOutDatumHash
+  where
+    TxOutDatumHash =
+      Cardano.Api.TxOutDatumHash ScriptDataInAlonzoEra
+
+pattern TxOutDatum :: ScriptData -> TxOutDatum CtxTx
+pattern TxOutDatum{txOutDatumScriptData} <-
+  Cardano.Api.TxOutDatum _ txOutDatumScriptData
+  where
+    TxOutDatum =
+      Cardano.Api.TxOutDatum ScriptDataInAlonzoEra
+
+-- TxScriptValidity
+
+type TxScriptValidity = Cardano.Api.TxScriptValidity Era
+{-# COMPLETE TxScriptValidityNone, TxScriptValidity #-}
+
+pattern TxScriptValidityNone :: TxScriptValidity
+pattern TxScriptValidityNone <-
+  Cardano.Api.TxScriptValidityNone
+  where
+    TxScriptValidityNone =
+      Cardano.Api.TxScriptValidityNone
+
+pattern TxScriptValidity :: ScriptValidity -> TxScriptValidity
+pattern TxScriptValidity{txScriptValidity'} <-
+  Cardano.Api.TxScriptValidity _ txScriptValidity'
+  where
+    TxScriptValidity =
+      Cardano.Api.TxScriptValidity TxScriptValiditySupportedInAlonzoEra
+
+-- Witness
+
+type Witness witCtx = Cardano.Api.Witness witCtx Era
+{-# COMPLETE ScriptWitness, KeyWitness #-}
+
+pattern KeyWitness :: KeyWitnessInCtx ctx -> Witness ctx
+pattern KeyWitness keyWitnessInCtx <-
+  Cardano.Api.KeyWitness keyWitnessInCtx
+  where
+    KeyWitness = Cardano.Api.KeyWitness
+
+pattern ScriptWitness :: ScriptWitnessInCtx ctx -> ScriptWitness ctx -> Witness ctx
+pattern ScriptWitness scriptWitnessInCtx scriptWitness <-
+  Cardano.Api.ScriptWitness scriptWitnessInCtx scriptWitness
+  where
+    ScriptWitness = Cardano.Api.ScriptWitness

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/AddressInEra.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/AddressInEra.hs
@@ -45,11 +45,6 @@ mkScriptAddress networkId script =
  where
   version = plutusScriptVersion (proxyToAsType $ Proxy @lang)
 
--- | Get the address associated with some 'TxOut'
-txOutAddress :: TxOut ctx Era -> AddressInEra Era
-txOutAddress (TxOut addr _ _) =
-  addr
-
 -- * Type Conversions
 
 -- | From a ledger 'Addr' to an api 'AddressInEra'

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/ExecutionUnits.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/ExecutionUnits.hs
@@ -1,0 +1,15 @@
+module Hydra.Cardano.Api.ExecutionUnits where
+
+import Hydra.Cardano.Api.Prelude
+
+import qualified Cardano.Ledger.Alonzo.Scripts as Ledger
+
+-- * Type Conversions
+
+-- | Convert a cardano-api's 'ExecutionUnits' into a cardano-ledger's 'ExUnits'
+toLedgerExUnits :: ExecutionUnits -> Ledger.ExUnits
+toLedgerExUnits = toAlonzoExUnits
+
+-- | Convert a cardano-ledger's 'ExUnits' into a cardano-api's 'ExecutionUnits'
+fromLedgerExUnits :: Ledger.ExUnits -> ExecutionUnits
+fromLedgerExUnits = fromAlonzoExUnits

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/ScriptData.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/ScriptData.hs
@@ -7,6 +7,8 @@ import qualified Cardano.Ledger.Alonzo.TxWitness as Ledger
 import qualified Data.Map as Map
 import qualified Plutus.V1.Ledger.Api as Plutus
 
+-- * Extras
+
 -- | Data-types that can be marshalled into a generic 'ScriptData' structure.
 type ToScriptData a = Plutus.ToData a
 
@@ -18,11 +20,6 @@ toScriptData :: (ToScriptData a) => a -> ScriptData
 toScriptData =
   fromPlutusData . Plutus.toData
 
-{-# DEPRECATED mkRedeemerForTxIn "use 'asScriptData' instead." #-}
-mkRedeemerForTxIn :: (ToScriptData a) => a -> ScriptRedeemer
-mkRedeemerForTxIn =
-  toScriptData
-
 -- | Get the 'ScriptData' associated to the a 'TxOut'. Note that this requires
 -- the 'CtxTx' context. To get script data in a 'CtxUTxO' context, see
 -- 'lookupScriptData'.
@@ -31,10 +28,6 @@ getScriptData (TxOut _ _ d) =
   case d of
     TxOutDatum _ dat -> Just dat
     _ -> Nothing
-
-{-# DEPRECATED getDatum "use 'getScriptData' instead." #-}
-getDatum :: TxOut CtxTx era -> Maybe ScriptData
-getDatum = getScriptData
 
 -- | Lookup included datum of given 'TxOut'.
 lookupScriptData :: Tx Era -> TxOut CtxUTxO Era -> Maybe ScriptData
@@ -47,10 +40,6 @@ lookupScriptData (Tx (ShelleyTxBody _ _ _ scriptsData _ _) _) = \case
   datums = case scriptsData of
     TxBodyNoScriptData -> mempty
     TxBodyScriptData _ (Ledger.TxDats m) _ -> m
-
-{-# DEPRECATED lookupDatum "use 'lookupScriptData' instead." #-}
-lookupDatum :: Tx Era -> TxOut CtxUTxO Era -> Maybe ScriptData
-lookupDatum = lookupScriptData
 
 -- * Type Conversions
 

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/ScriptData.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/ScriptData.hs
@@ -51,3 +51,15 @@ lookupScriptData (Tx (ShelleyTxBody _ _ _ scriptsData _ _) _) = \case
 {-# DEPRECATED lookupDatum "use 'lookupScriptData' instead." #-}
 lookupDatum :: Tx Era -> TxOut CtxUTxO Era -> Maybe ScriptData
 lookupDatum = lookupScriptData
+
+-- * Type Conversions
+
+-- | Convert a cardano-ledger's script 'Data' into a cardano-api's 'ScriptDatum'.
+fromLedgerData :: Ledger.Data LedgerEra -> ScriptData
+fromLedgerData =
+  fromAlonzoData
+
+-- | Convert a cardano-api's 'ScriptData' into a cardano-ledger's script 'Data'.
+toLedgerData :: ScriptData -> Ledger.Data LedgerEra
+toLedgerData =
+  toAlonzoData

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/ScriptDatum.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/ScriptDatum.hs
@@ -4,8 +4,6 @@ import Hydra.Cardano.Api.Prelude
 
 import Hydra.Cardano.Api.ScriptData (ToScriptData, toScriptData)
 
-import qualified Cardano.Ledger.Alonzo.Data as Ledger
-
 -- * Extras
 
 -- | Construct a 'ScriptDatum' for use as transaction witness.
@@ -17,10 +15,3 @@ mkScriptDatum =
 mkDatumForTxIn :: (ToScriptData a) => a -> ScriptDatum WitCtxTxIn
 mkDatumForTxIn =
   mkScriptDatum
-
--- * Type Conversions
-
--- | Convert a cardano-ledger's script 'Data' into a cardano-api's 'ScriptDatum'.
-fromLedgerData :: Ledger.Data LedgerEra -> ScriptDatum WitCtxTxIn
-fromLedgerData =
-  ScriptDatumForTxIn . fromAlonzoData

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/ScriptDatum.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/ScriptDatum.hs
@@ -10,8 +10,3 @@ import Hydra.Cardano.Api.ScriptData (ToScriptData, toScriptData)
 mkScriptDatum :: (ToScriptData a) => a -> ScriptDatum WitCtxTxIn
 mkScriptDatum =
   ScriptDatumForTxIn . toScriptData
-
-{-# DEPRECATED mkDatumForTxIn "use 'mkScriptDatum' instead." #-}
-mkDatumForTxIn :: (ToScriptData a) => a -> ScriptDatum WitCtxTxIn
-mkDatumForTxIn =
-  mkScriptDatum

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Tx.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Tx.hs
@@ -23,7 +23,7 @@ import qualified Data.ByteString.Lazy as BL
 import qualified Data.Map as Map
 import Data.Maybe.Strict (maybeToStrictMaybe, strictMaybeToMaybe)
 
--- * Extra
+-- * Extras
 
 -- | Get explicit fees allocated to a transaction.
 --
@@ -34,10 +34,6 @@ txFee' (getTxBody -> TxBody body) =
   case txFee body of
     TxFeeExplicit TxFeesExplicitInAlonzoEra fee -> fee
     TxFeeImplicit _ -> error "impossible: TxFeeImplicit on non-Byron transaction."
-
-{-# DEPRECATED getFee "use txFee' instead." #-}
-getFee :: Tx Era -> Lovelace
-getFee = txFee'
 
 -- | Calculate the total execution cost of a transaction, according to the
 -- budget assigned to each redeemer.
@@ -50,13 +46,6 @@ totalExecutionCost pparams tx =
  where
   executionUnits = foldMap snd $ Ledger.unRedeemers $ Ledger.txrdmrs wits
   Ledger.ValidatedTx{Ledger.wits = wits} = toLedgerTx tx
-
-executionCost ::
-  Ledger.PParams LedgerEra ->
-  Tx Era ->
-  Lovelace
-executionCost = totalExecutionCost
-{-# DEPRECATED executionCost "use totalExecutionCost instead." #-}
 
 -- | Obtain a human-readable pretty text representation of a transaction.
 renderTx :: Tx Era -> Text
@@ -116,10 +105,6 @@ renderTx (Tx body _wits) =
       let rdmrs = Map.elems $ Ledger.unRedeemers re
        in "  Redeemers (" <> show (length rdmrs) <> ")" :
           (("    - " <>) . show . fst <$> rdmrs)
-
-{-# DEPRECATED describeCardanoTx "use 'renderTx' instead." #-}
-describeCardanoTx :: Tx Era -> Text
-describeCardanoTx = renderTx
 
 -- * Type Conversions
 

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Tx.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Tx.hs
@@ -9,7 +9,6 @@ import Hydra.Cardano.Api.KeyWitness (
  )
 import Hydra.Cardano.Api.Lovelace (fromLedgerCoin)
 import Hydra.Cardano.Api.TxScriptValidity (toLedgerScriptValidity)
-import Hydra.Cardano.Api.Value (txOutValue)
 
 import Cardano.Binary (serialize)
 import qualified Cardano.Ledger.Alonzo as Ledger
@@ -83,6 +82,9 @@ renderTx (Tx body _wits) =
     , "    total number of assets: " <> show totalNumberOfAssets
     ]
       <> (("    - " <>) . renderValue . txOutValue <$> txOuts)
+
+  txOutValue (TxOut _ value _) =
+    txOutValueToValue value
 
   totalNumberOfAssets =
     sum $

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/TxOut.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/TxOut.hs
@@ -16,11 +16,6 @@ txOuts' (getTxBody -> txBody) =
   let TxBody TxBodyContent{txOuts} = txBody
    in txOuts
 
-{-# DEPRECATED getOutputs "use txOuts' instead." #-}
-getOutputs :: Tx Era -> [TxOut CtxTx Era]
-getOutputs =
-  txOuts'
-
 -- | Alter the address of a 'TxOut' with the given transformation.
 modifyTxOutAddress ::
   (AddressInEra Era -> AddressInEra Era) ->

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Value.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Value.hs
@@ -6,12 +6,6 @@ import qualified Cardano.Ledger.Alonzo.TxInfo as Ledger
 import qualified Cardano.Ledger.Mary.Value as Ledger
 import qualified Plutus.V1.Ledger.Api as Plutus
 
--- * Extra
-
-txOutValue :: TxOut ctx Era -> Value
-txOutValue (TxOut _ value _) =
-  txOutValueToValue value
-
 -- * Type Conversions
 
 -- | Convert a cardano-ledger's 'Value'  into a cardano-api's 'Value'

--- a/hydra-cluster/exe/seed-network.hs
+++ b/hydra-cluster/exe/seed-network.hs
@@ -9,6 +9,7 @@ import CardanoClient (
 import CardanoCluster (asSigningKey, availableInitialFunds, defaultNetworkId)
 import Hydra.Cardano.Api (Lovelace, getVerificationKey)
 import Hydra.Chain.Direct.Util (readFileTextEnvelopeThrow)
+import Hydra.Ledger.Cardano ()
 import Hydra.Prelude
 import Options.Applicative (
   Parser,

--- a/hydra-cluster/test/Test/DirectChainSpec.hs
+++ b/hydra-cluster/test/Test/DirectChainSpec.hs
@@ -43,7 +43,7 @@ import Hydra.Chain.Direct (
   withIOManager,
  )
 import Hydra.Ledger (IsTx (..))
-import Hydra.Ledger.Cardano (CardanoTx, genOneUTxOFor)
+import Hydra.Ledger.Cardano (Tx, genOneUTxOFor)
 import Hydra.Logging (nullTracer, showLogsOnFailure)
 import Hydra.Party (Party, SigningKey, aggregate, deriveParty, generateKey, sign)
 import Hydra.Snapshot (ConfirmedSnapshot (..), Snapshot (..))
@@ -132,7 +132,7 @@ spec = around showLogsOnFailure $ do
               alicesCallback `observesInTime` OnInitTx 100 [alice, carol]
 
               bobPostTx (AbortTx mempty)
-                `shouldThrow` (== InvalidStateToPost @CardanoTx (AbortTx mempty))
+                `shouldThrow` (== InvalidStateToPost @Tx (AbortTx mempty))
 
   it "can commit" $ \tracer -> do
     alicesCallback <- newEmptyMVar
@@ -153,11 +153,11 @@ spec = around showLogsOnFailure $ do
             someUTxOB <- generate $ genOneUTxOFor aliceCardanoVk
 
             postTx (CommitTx alice (someUTxOA <> someUTxOB))
-              `shouldThrow` (== MoreThanOneUTxOCommitted @CardanoTx)
+              `shouldThrow` (== MoreThanOneUTxOCommitted @Tx)
 
             postTx (CommitTx alice someUTxOA)
               `shouldThrow` \case
-                (CannotSpendInput{} :: PostTxError CardanoTx) -> True
+                (CannotSpendInput{} :: PostTxError Tx) -> True
                 _ -> False
 
             aliceUTxO <- generatePaymentToCommit defaultNetworkId node aliceCardanoSk aliceCardanoVk 1_000_000

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -35,7 +35,6 @@ import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Hydra.Cardano.Api (
   AddressInEra,
-  Era,
   NetworkId (Testnet),
   NetworkMagic (NetworkMagic),
   PaymentKey,
@@ -47,9 +46,7 @@ import Hydra.Cardano.Api (
   serialiseAddress,
  )
 import Hydra.Ledger (txId)
-import Hydra.Ledger.Cardano (
-  mkSimpleCardanoTx,
- )
+import Hydra.Ledger.Cardano (mkSimpleTx)
 import Hydra.Logging (showLogsOnFailure)
 import Hydra.Party (Party, deriveParty)
 import HydraNode (
@@ -112,7 +109,7 @@ spec = around showLogsOnFailure $
                     -- NOTE(AB): this is partial and will fail if we are not able to generate a payment
                     let firstCommittedUTxO = Prelude.head $ UTxO.pairs committedUTxO
                     let Right tx =
-                          mkSimpleCardanoTx
+                          mkSimpleTx
                             firstCommittedUTxO
                             (inHeadAddress bobCardanoVk, lovelaceToValue paymentFromAliceToBob)
                             aliceCardanoSk
@@ -226,7 +223,7 @@ carol = deriveParty carolSk
 someTxId :: IsString s => s
 someTxId = "9fdc525c20bc00d9dfa9d14904b65e01910c0dfe3bb39865523c1e20eaeb0903"
 
-inHeadAddress :: VerificationKey PaymentKey -> AddressInEra Era
+inHeadAddress :: VerificationKey PaymentKey -> AddressInEra
 inHeadAddress =
   mkVkAddress network
  where

--- a/hydra-cluster/test/Test/GeneratorSpec.hs
+++ b/hydra-cluster/test/Test/GeneratorSpec.hs
@@ -10,7 +10,7 @@ import Data.Text (unpack)
 import Hydra.Cardano.Api (UTxO, utxoFromTx)
 import Hydra.Generator (Dataset (..), defaultProtocolParameters, genConstantUTxODataset)
 import Hydra.Ledger (applyTransactions, balance)
-import Hydra.Ledger.Cardano (CardanoTx, cardanoLedger, genUTxO)
+import Hydra.Ledger.Cardano (Tx, cardanoLedger, genUTxO)
 import Test.Aeson.GenericSpecs (roundtripSpecs)
 import Test.QuickCheck (Positive (Positive), Property, counterexample, forAll)
 
@@ -23,7 +23,7 @@ spec = parallel $ do
 prop_computeValueFromUTxO :: Property
 prop_computeValueFromUTxO =
   forAll genUTxO $ \utxo ->
-    balance @CardanoTx utxo /= mempty
+    balance @Tx utxo /= mempty
 
 prop_keepsUTxOConstant :: Property
 prop_keepsUTxOConstant =
@@ -35,7 +35,7 @@ prop_keepsUTxOConstant =
             & counterexample ("\ntransactions: " <> jsonString transactionsSequence)
             & counterexample ("\nutxo: " <> jsonString initialUTxO)
 
-apply :: UTxO -> CardanoTx -> UTxO
+apply :: UTxO -> Tx -> UTxO
 apply utxo tx =
   case applyTransactions cardanoLedger utxo [tx] of
     Left err -> error $ "invalid generated data set" <> show err

--- a/hydra-cluster/test/Test/LogFilterSpec.hs
+++ b/hydra-cluster/test/Test/LogFilterSpec.hs
@@ -10,7 +10,7 @@ import Control.Lens ((^?))
 import Data.Aeson (Value (..), decode, encode)
 import Data.Aeson.Lens (key)
 import qualified Data.ByteString.Lazy as LBS
-import Hydra.Ledger.Cardano (CardanoTx)
+import Hydra.Ledger.Cardano (Tx)
 import Hydra.LogFilter (filterLog)
 import Hydra.Logging (Envelope)
 import Hydra.Logging.Messages (HydraLog)
@@ -38,7 +38,7 @@ spec = parallel $ do
       `shouldBe` Just (Array [String "6cba5394ec8a1a1161758a33089661383143283d0121e4a293ed51a0272cfbc4"])
 
   prop "significantly reduces standard log messages size" $ \(ReasonablySized (NonEmpty logs)) ->
-    let jsonLogs = map toJSON (logs :: [Envelope (HydraLog CardanoTx Text)])
+    let jsonLogs = map toJSON (logs :: [Envelope (HydraLog Tx Text)])
         bytes = mconcat $ map encode jsonLogs
         filtered = encode $ mapMaybe filterLog jsonLogs
         sizeRatio = fromIntegral (LBS.length filtered) * (100.0 :: Double) / fromIntegral (LBS.length bytes)

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -10,7 +10,7 @@ import Hydra.Chain (Chain, ChainCallback)
 import Hydra.Chain.Direct (withDirectChain)
 import Hydra.Chain.Direct.Util (readKeyPair, readVerificationKey)
 import Hydra.HeadLogic (Environment (..), Event (..))
-import Hydra.Ledger.Cardano (CardanoTx)
+import Hydra.Ledger.Cardano (Tx)
 import qualified Hydra.Ledger.Cardano as Ledger
 import Hydra.Logging (Tracer, Verbosity (..), withTracer)
 import Hydra.Logging.Messages (HydraLog (..))
@@ -45,11 +45,11 @@ main = do
      in withHeartbeat localhost $ withOuroborosNetwork tracer localhost peers
 
 withChain ::
-  Tracer IO (HydraLog CardanoTx net) ->
+  Tracer IO (HydraLog Tx net) ->
   Party ->
-  ChainCallback CardanoTx IO ->
+  ChainCallback Tx IO ->
   ChainConfig ->
-  (Chain CardanoTx IO -> IO ()) ->
+  (Chain Tx IO -> IO ()) ->
   IO ()
 withChain tracer party callback config action = do
   keyPair@(vk, _) <- readKeyPair cardanoSigningKey

--- a/hydra-node/exe/tx-cost/Main.hs
+++ b/hydra-node/exe/tx-cost/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TypeApplications #-}
 
 import Hydra.Prelude
@@ -26,26 +27,26 @@ import Hydra.Cardano.Api (
   NetworkMagic (NetworkMagic),
   PlutusScriptV1,
   StandardCrypto,
-  TxOut (..),
+  Tx,
   UTxO,
-  fromAlonzoExUnits,
+  fromLedgerExUnits,
   fromLedgerTxOut,
   fromPlutusData,
   fromPlutusScript,
-  lovelaceToTxOutValue,
+  lovelaceToValue,
   mkScriptAddress,
   mkScriptDatum,
   mkScriptWitness,
   mkTxOutDatum,
   toCtxUTxOTxOut,
   toScriptData,
+  pattern TxOut,
  )
 import Hydra.Chain.Direct.Tx (fanoutTx, policyId)
 import qualified Hydra.Contract.Hash as Hash
 import qualified Hydra.Contract.Head as Head
 import qualified Hydra.Contract.HeadState as Head
 import Hydra.Ledger.Cardano (
-  CardanoTx,
   adaOnly,
   addInputs,
   emptyTxBody,
@@ -101,7 +102,7 @@ showPad n x =
  where
   len = length $ show @String x
 
-mkFanoutTx :: UTxO -> (CardanoTx, UTxO)
+mkFanoutTx :: UTxO -> (Tx, UTxO)
 mkFanoutTx utxo =
   (tx, lookupUTxO)
  where
@@ -205,7 +206,7 @@ calculateHashExUnits n algorithm =
     Right report ->
       case Map.elems report of
         [Right units] ->
-          fromAlonzoExUnits units
+          fromLedgerExUnits units
         _ ->
           error $ "Too many redeemers in report: " <> show report
  where
@@ -213,7 +214,7 @@ calculateHashExUnits n algorithm =
   utxo = UTxO.singleton (input, output)
   input = generateWith arbitrary 42
   output = toCtxUTxOTxOut $ TxOut address value (mkTxOutDatum datum)
-  value = lovelaceToTxOutValue 1_000_000
+  value = lovelaceToValue 1_000_000
   address = mkScriptAddress @PlutusScriptV1 (Testnet $ NetworkMagic 42) script
   witness = BuildTxWith $ mkScriptWitness script (mkScriptDatum datum) redeemer
   script = fromPlutusScript Hash.validatorScript

--- a/hydra-node/src/Hydra/Chain/Direct/Util.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Util.hs
@@ -174,7 +174,7 @@ retry predicate action =
 markerDatum :: Data
 markerDatum = toData $ toBuiltinData ("Hydra Head Payment" :: BuiltinByteString)
 
-isMarkedOutput :: TxOut CtxUTxO era -> Bool
+isMarkedOutput :: TxOut CtxUTxO -> Bool
 isMarkedOutput = \case
-  (TxOut _ _ (TxOutDatumHash _ ha)) -> ha == hashScriptData (Shelley.fromPlutusData markerDatum)
+  (TxOut _ _ (TxOutDatumHash ha)) -> ha == hashScriptData (Shelley.fromPlutusData markerDatum)
   _ -> False

--- a/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
@@ -78,8 +78,8 @@ import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
 import GHC.Ix (Ix)
 import Hydra.Cardano.Api (
-  AddressInEra (..),
-  AddressTypeInEra (..),
+  AddressInEra,
+  AddressTypeInEra,
   NetworkId (Testnet),
   PaymentKey,
   SigningKey,

--- a/hydra-node/src/Hydra/Ledger/Cardano/Builder.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano/Builder.hs
@@ -9,10 +9,7 @@ import Hydra.Cardano.Api
 
 -- * Types
 
-type TxBuilder = TxBodyContent BuildTx AlonzoEra
-
--- TODO: This is copied straight from 'cardano-api', could be exposed upstream.
-type TxIns build era = [(TxIn, BuildTxWith build (Witness WitCtxTxIn era))]
+type TxBuilder = TxBodyContent BuildTx
 
 -- * Executing
 
@@ -23,7 +20,7 @@ type TxIns build era = [(TxIn, BuildTxWith build (Witness WitCtxTxIn era))]
 --
 -- We use the builder only internally for on-chain transaction crafted in the
 -- context of Hydra.
-unsafeBuildTransaction :: HasCallStack => TxBuilder -> Tx AlonzoEra
+unsafeBuildTransaction :: HasCallStack => TxBuilder -> Tx
 unsafeBuildTransaction builder =
   either
     (\txBodyError -> bug $ InvalidTransactionException{txBodyError, builder})
@@ -63,9 +60,9 @@ emptyTxBody :: TxBuilder
 emptyTxBody =
   TxBodyContent
     mempty
-    (TxInsCollateral CollateralInAlonzoEra mempty)
+    (TxInsCollateral mempty)
     mempty
-    (TxFeeExplicit TxFeesExplicitInAlonzoEra 0)
+    (TxFeeExplicit 0)
     (TxValidityNoLowerBound, TxValidityNoUpperBound ValidityNoUpperBoundInAlonzoEra)
     TxMetadataNone
     TxAuxScriptsNone
@@ -74,11 +71,11 @@ emptyTxBody =
     TxWithdrawalsNone
     TxCertificatesNone
     TxUpdateProposalNone
-    TxMintNone
+    TxMintValueNone
     TxScriptValidityNone
 
 -- | Add new inputs to an ongoing builder.
-addInputs :: TxIns BuildTx AlonzoEra -> TxBuilder -> TxBuilder
+addInputs :: TxIns BuildTx -> TxBuilder -> TxBuilder
 addInputs ins tx =
   tx{txIns = txIns tx <> ins}
 
@@ -88,6 +85,6 @@ addVkInputs ins =
   addInputs ((,BuildTxWith $ KeyWitness KeyWitnessForSpending) <$> ins)
 
 -- | Append new outputs to an ongoing builder.
-addOutputs :: [TxOut CtxTx AlonzoEra] -> TxBuilder -> TxBuilder
+addOutputs :: [TxOut CtxTx] -> TxBuilder -> TxBuilder
 addOutputs outputs tx =
   tx{txOuts = txOuts tx <> outputs}

--- a/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs
@@ -26,15 +26,14 @@ import qualified Data.Map as Map
 import Data.Maybe (fromJust)
 import Data.Ratio ((%))
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
-import Hydra.Cardano.Api (StandardCrypto, UTxO, toLedgerTx, toLedgerUTxO)
+import Hydra.Cardano.Api (StandardCrypto, Tx, UTxO, toLedgerTx, toLedgerUTxO)
 import Hydra.Chain.Direct.Util (Era)
-import Hydra.Ledger.Cardano (CardanoTx)
 
 type RedeemerReport =
   (Map RdmrPtr (Either (ScriptFailure StandardCrypto) ExUnits))
 
 evaluateTx ::
-  CardanoTx ->
+  Tx ->
   UTxO ->
   Either (BasicFailure StandardCrypto) RedeemerReport
 evaluateTx tx utxo =

--- a/hydra-node/src/Hydra/Ledger/Cardano/Json.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano/Json.hs
@@ -271,15 +271,15 @@ instance ToJSON (Ledger.Alonzo.TxBody StandardAlonzo) where
   toJSON b =
     object $
       mconcat
-        [ onlyIf (const True) "inputs" (Set.map fromShelleyTxIn (Ledger.Alonzo.inputs' b))
-        , onlyIf (not . null) "collateral" (Set.map fromShelleyTxIn (Ledger.Alonzo.collateral' b))
-        , onlyIf (const True) "outputs" (fromShelleyTxOut ShelleyBasedEraAlonzo <$> Ledger.Alonzo.outputs' b)
+        [ onlyIf (const True) "inputs" (Set.map fromLedgerTxIn (Ledger.Alonzo.inputs' b))
+        , onlyIf (not . null) "collateral" (Set.map fromLedgerTxIn (Ledger.Alonzo.collateral' b))
+        , onlyIf (const True) "outputs" (fromLedgerTxOut <$> Ledger.Alonzo.outputs' b)
         , onlyIf (not . null) "certificates" (Ledger.Alonzo.certs' b)
         , onlyIf (not . null . Ledger.unWdrl) "withdrawals" (Ledger.Alonzo.wdrls' b)
         , onlyIf (const True) "fees" (Ledger.Alonzo.txfee' b)
         , onlyIf (not . isOpenInterval) "validity" (Ledger.Alonzo.vldt' b)
         , onlyIf (not . null) "requiredSignatures" (Ledger.Alonzo.reqSignerHashes' b)
-        , onlyIf ((/=) mempty) "mint" (fromMaryValue (Ledger.Alonzo.mint' b))
+        , onlyIf ((/=) mempty) "mint" (fromLedgerValue (Ledger.Alonzo.mint' b))
         , onlyIf isSJust "scriptIntegrityHash" (Ledger.Alonzo.scriptIntegrityHash' b)
         , onlyIf isSJust "auxiliaryDataHash" (Ledger.Alonzo.adHash' b)
         , onlyIf isSJust "networkId" (Ledger.Alonzo.txnetworkid' b)
@@ -372,7 +372,7 @@ txIdFromText = fmap Ledger.TxId . safeHashFromText
 --
 
 instance FromJSON (Ledger.TxIn StandardCrypto) where
-  parseJSON = fmap toShelleyTxIn . parseJSON
+  parseJSON = fmap toLedgerTxIn . parseJSON
 
 txInFromText :: (Crypto crypto, MonadFail m) => Text -> m (Ledger.TxIn crypto)
 txInFromText t = do
@@ -388,14 +388,14 @@ txInFromText t = do
       (decode (encodeUtf8 $ Text.drop 1 txIxText))
 
 instance FromJSONKey TxIn where
-  fromJSONKey = FromJSONKeyTextParser (fmap fromShelleyTxIn . txInFromText)
+  fromJSONKey = FromJSONKeyTextParser (fmap fromLedgerTxIn . txInFromText)
 
 --
 -- TxOut
 --
 
 instance FromJSON (Ledger.Alonzo.TxOut StandardAlonzo) where
-  parseJSON = fmap (toShelleyTxOut ShelleyBasedEraAlonzo) . parseJSON
+  parseJSON = fmap toLedgerTxOut . parseJSON
 
 --
 -- TxWitness
@@ -495,7 +495,7 @@ instance FromJSON Ledger.Mary.ValidityInterval where
 --
 
 instance FromJSON (Ledger.Mary.Value StandardCrypto) where
-  parseJSON = fmap toMaryValue . parseJSON
+  parseJSON = fmap toLedgerValue . parseJSON
 
 --
 -- Wdrl

--- a/hydra-node/test/Hydra/APISpec.hs
+++ b/hydra-node/test/Hydra/APISpec.hs
@@ -9,7 +9,7 @@ import Test.Hydra.Prelude
 import Data.Aeson.Lens (key)
 import Hydra.ClientInput (ClientInput)
 import Hydra.JSONSchema (SpecificationSelector, prop_specIsComplete, prop_validateToJSON, withJsonSpecifications)
-import Hydra.Ledger.Cardano (CardanoTx)
+import Hydra.Ledger.Cardano (Tx)
 import Hydra.ServerOutput (ServerOutput)
 import System.FilePath ((</>))
 import Test.QuickCheck.Property (conjoin, withMaxSuccess)
@@ -21,14 +21,14 @@ spec = parallel $ do
       specify "ClientInput" $ \dir ->
         withMaxSuccess 1 $
           conjoin
-            [ prop_validateToJSON @(ClientInput CardanoTx) (dir </> "api.yaml") "inputs" (dir </> "ClientInput")
-            , prop_specIsComplete @(ClientInput CardanoTx) (dir </> "api.yaml") (apiSpecificationSelector "inputs")
+            [ prop_validateToJSON @(ClientInput Tx) (dir </> "api.yaml") "inputs" (dir </> "ClientInput")
+            , prop_specIsComplete @(ClientInput Tx) (dir </> "api.yaml") (apiSpecificationSelector "inputs")
             ]
       specify "ServerOutput" $ \dir ->
         withMaxSuccess 1 $
           conjoin
-            [ prop_validateToJSON @(ServerOutput CardanoTx) (dir </> "api.yaml") "outputs" (dir </> "ServerOutput")
-            , prop_specIsComplete @(ServerOutput CardanoTx) (dir </> "api.yaml") (apiSpecificationSelector "outputs")
+            [ prop_validateToJSON @(ServerOutput Tx) (dir </> "api.yaml") "outputs" (dir </> "ServerOutput")
+            , prop_specIsComplete @(ServerOutput Tx) (dir </> "api.yaml") (apiSpecificationSelector "outputs")
             ]
 
 apiSpecificationSelector ::

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -14,7 +14,6 @@ import Hydra.Chain.Direct.Tx (closeTx, mkHeadOutput)
 import qualified Hydra.Contract.HeadState as Head
 import Hydra.Data.Party (partyFromVerKey)
 import qualified Hydra.Data.Party as OnChain
-import Hydra.Ledger.Cardano (CardanoTx)
 import Hydra.Party (
   MultiSigned (MultiSigned),
   SigningKey,
@@ -33,7 +32,7 @@ import Test.QuickCheck.Instances ()
 -- CloseTx
 --
 
-healthyCloseTx :: (CardanoTx, UTxO)
+healthyCloseTx :: (Tx, UTxO)
 healthyCloseTx =
   (tx, lookupUTxO)
  where
@@ -43,7 +42,7 @@ healthyCloseTx =
   headDatum = fromPlutusData $ toData healthyCloseDatum
   lookupUTxO = UTxO.singleton (headInput, headOutput)
 
-healthySnapshot :: Snapshot CardanoTx
+healthySnapshot :: Snapshot Tx
 healthySnapshot =
   Snapshot
     { number = healthySnapshotNumber
@@ -67,7 +66,7 @@ healthyCloseParties = partyFromVerKey . vkey . deriveParty <$> healthyPartyCrede
 healthyPartyCredentials :: [SigningKey]
 healthyPartyCredentials = [1, 2, 3]
 
-healthySignature :: SnapshotNumber -> MultiSigned (Snapshot CardanoTx)
+healthySignature :: SnapshotNumber -> MultiSigned (Snapshot Tx)
 healthySignature number = MultiSigned [sign sk snapshot | sk <- healthyPartyCredentials]
  where
   snapshot = healthySnapshot{number}
@@ -79,7 +78,7 @@ data CloseMutation
   | MutateParties
   deriving (Generic, Show, Enum, Bounded)
 
-genCloseMutation :: (CardanoTx, UTxO) -> Gen SomeMutation
+genCloseMutation :: (Tx, UTxO) -> Gen SomeMutation
 genCloseMutation (_tx, _utxo) =
   -- FIXME: using 'closeRedeemer' here is actually too high-level and reduces
   -- the power of the mutators, we should test at the level of the validator.

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/FanOut.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/FanOut.hs
@@ -12,7 +12,6 @@ import Hydra.Chain.Direct.Fixture (testNetworkId)
 import Hydra.Chain.Direct.Tx (fanoutTx, mkHeadOutput)
 import qualified Hydra.Contract.HeadState as Head
 import Hydra.Ledger.Cardano (
-  CardanoTx,
   adaOnly,
   genOutput,
   genUTxOWithSimplifiedAddresses,
@@ -24,7 +23,7 @@ import Plutus.V1.Ledger.Api (toBuiltin, toData)
 import Test.QuickCheck (elements, oneof, suchThat)
 import Test.QuickCheck.Instances ()
 
-healthyFanoutTx :: (CardanoTx, UTxO)
+healthyFanoutTx :: (Tx, UTxO)
 healthyFanoutTx =
   (tx, lookupUTxO)
  where
@@ -49,7 +48,7 @@ data FanoutMutation
   | MutateChangeOutputValue
   deriving (Generic, Show, Enum, Bounded)
 
-genFanoutMutation :: (CardanoTx, UTxO) -> Gen SomeMutation
+genFanoutMutation :: (Tx, UTxO) -> Gen SomeMutation
 genFanoutMutation (tx, _utxo) =
   oneof
     [ SomeMutation MutateAddUnexpectedOutput . PrependOutput <$> do

--- a/hydra-node/test/Hydra/Chain/DirectSpec.hs
+++ b/hydra-node/test/Hydra/Chain/DirectSpec.hs
@@ -26,7 +26,7 @@ import Hydra.Chain.Direct (DirectChainLog, withDirectChain)
 import Hydra.Chain.Direct.MockServer (withMockServer)
 import Hydra.Chain.Direct.Util (Era, retry)
 import Hydra.Chain.Direct.WalletSpec (genPaymentTo)
-import Hydra.Ledger.Cardano (CardanoTx, genKeyPair)
+import Hydra.Ledger.Cardano (Tx, genKeyPair)
 import Hydra.Logging (showLogsOnFailure)
 import Hydra.Party (Party, deriveParty, generateKey)
 import Test.QuickCheck (generate)
@@ -48,7 +48,7 @@ spec = do
               let parameters = HeadParameters 100 [alice, bob, carol]
               mkSeedPayment magic aliceVk submitTx
 
-              retry (== NoSeedInput @CardanoTx) $ postTx $ InitTx parameters
+              retry (== NoSeedInput @Tx) $ postTx $ InitTx parameters
               takeMVar calledBackAlice `shouldReturn` OnInitTx 100 [alice, bob, carol]
               takeMVar calledBackBob `shouldReturn` OnInitTx 100 [alice, bob, carol]
 

--- a/hydra-node/test/Hydra/LoggingSpec.hs
+++ b/hydra-node/test/Hydra/LoggingSpec.hs
@@ -8,7 +8,7 @@ import Test.Hydra.Prelude
 import Data.Aeson (object, (.=))
 import Data.Aeson.Lens (key)
 import Hydra.JSONSchema (SpecificationSelector, prop_specIsComplete, prop_validateToJSON, withJsonSpecifications)
-import Hydra.Ledger.Cardano (CardanoTx)
+import Hydra.Ledger.Cardano (Tx)
 import Hydra.Logging (Envelope (..), Verbosity (Verbose), traceWith, withTracer)
 import Hydra.Logging.Messages (HydraLog)
 import System.FilePath ((</>))
@@ -29,8 +29,8 @@ spec = do
       property $
         withMaxSuccess 1 $
           conjoin
-            [ prop_validateToJSON @(Envelope (HydraLog CardanoTx ())) (dir </> "logs.yaml") "messages" (dir </> "HydraLog")
-            , prop_specIsComplete @(HydraLog CardanoTx ()) (dir </> "logs.yaml") apiSpecificationSelector
+            [ prop_validateToJSON @(Envelope (HydraLog Tx ())) (dir </> "logs.yaml") "messages" (dir </> "HydraLog")
+            , prop_specIsComplete @(HydraLog Tx ()) (dir </> "logs.yaml") apiSpecificationSelector
             ]
 
 apiSpecificationSelector :: SpecificationSelector


### PR DESCRIPTION
  This initially started as simple type aliases with re-exports to get
  rid of various 'Era' in type signatures; and went down a rabbit hole a
  bit.

  Thing is, we can't hide types and keep re-export only constructors.
  So, the only (relatively) transparent way of doing this is by defining
  pattern synonyms for constructors which are now hidden.

  This has a nice side-effect of allowing us to also get rid of some of
  the proxy-type-carrying types 'XXXInEra' in most constructors and
  patterns! So it cleans up the API nicely, at the cost of having to
  define pattern synonyms for *all* re-exported constructors.