### PR TITLE
Benchmark plutus-cbor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,27 +1,30 @@
-### Cabal ###
+# Cabal
 .ghc.environment.*
 /cabal.project.diff
 /cabal.project.local
 /cabal.project.old
 /dist-newstyle/
 
-### Haskell ###
+# Haskell
 *.eventlog
 *.hp
 *.prof
 
-### Nix ###
+# Nix
 result*
 
-### Direnv ###
+# Direnv
 .direnv/
 *~
 
-### hydra-node ###
+# hydra-node
 .history
 *.hi
 *.o
 test-results.xml
+
+# Benchmark results
+*.html
 
 # Getting started / demo instructions
 devnet/

--- a/plutus-cbor/README.md
+++ b/plutus-cbor/README.md
@@ -36,3 +36,10 @@ encodeAssets m
   | otherwise = encodeMapIndef encodeCurrencySymbol encodeSingleAsset m
 {-# INLINEABLE encodeAssets #-}
 ```
+
+## Running the benchmark
+
+To run the benchmark and produce an HTML output in the package directory:
+```
+cabal bench --benchmark-options "-o bench.html"
+```

--- a/plutus-cbor/bench/Main.hs
+++ b/plutus-cbor/bench/Main.hs
@@ -1,0 +1,96 @@
+module Main where
+
+import Hydra.Prelude
+
+import Criterion.Main (bench, bgroup, defaultMain, whnf)
+import qualified Data.ByteString as BS
+import Plutus.V1.Ledger.Api (BuiltinByteString, Data, toData)
+import qualified Plutus.V1.Ledger.Api as Plutus
+import qualified PlutusTx.AssocMap as Plutus.Map
+import Test.QuickCheck (choose, oneof, vector, vectorOf)
+
+main :: IO ()
+main =
+  defaultMain
+    [ bgroup
+        "TxOut serialization in Haskell"
+        [ bgroup
+            "ada only"
+            [ bench "plutus-cbor" $ whnf plutusSerialize txOutAdaOnly
+            , bench "cborg" $ whnf cborgSerialize txOutAdaOnly
+            ]
+        ]
+    ]
+
+cborgSerialize :: Data -> BuiltinByteString
+cborgSerialize = const ""
+
+-- | Serialize a 'TxOut' to cbor using a simplified encoder.
+plutusSerialize :: Data -> BuiltinByteString
+plutusSerialize = const ""
+
+-- * Benchmark values
+
+txOutAdaOnly :: Data
+txOutAdaOnly =
+  toData $ generateWith genAdaOnlyTxOut 42
+
+genTxOut :: Int -> Gen Plutus.TxOut
+genTxOut n = do
+  Plutus.TxOut
+    <$> genAddress
+    <*> fmap mconcat (vectorOf n genValue)
+    <*> oneof [pure Nothing, Just <$> genDatumHash]
+
+genAdaOnlyTxOut :: Gen Plutus.TxOut
+genAdaOnlyTxOut =
+  Plutus.TxOut
+    <$> genAddress
+    <*> genAdaOnlyValue
+    <*> oneof [pure Nothing, Just <$> genDatumHash]
+
+genAddress :: Gen Plutus.Address
+genAddress =
+  Plutus.Address
+    <$> fmap (Plutus.PubKeyCredential . Plutus.PubKeyHash . Plutus.toBuiltin) (genByteStringOf 28)
+    <*> pure Nothing
+
+genValue :: Gen Plutus.Value
+genValue = do
+  n <- genAssetQuantity
+  policyId <- genCurrencySymbol
+  assetName <- genTokenName
+  pure $
+    Plutus.Value $
+      Plutus.Map.fromList
+        [(policyId, Plutus.Map.fromList [(assetName, n)])]
+
+genAdaOnlyValue :: Gen Plutus.Value
+genAdaOnlyValue = do
+  n <- genAssetQuantity
+  pure $
+    Plutus.Value $
+      Plutus.Map.fromList
+        [(Plutus.adaSymbol, Plutus.Map.fromList [(Plutus.adaToken, n)])]
+
+genAssetQuantity :: Gen Integer
+genAssetQuantity = choose (1, 4_294_967_296) -- NOTE: 2**32
+
+genCurrencySymbol :: Gen Plutus.CurrencySymbol
+genCurrencySymbol =
+  Plutus.CurrencySymbol
+    <$> fmap Plutus.toBuiltin (genByteStringOf 32)
+
+genTokenName :: Gen Plutus.TokenName
+genTokenName =
+  Plutus.TokenName
+    <$> fmap Plutus.toBuiltin (genByteStringOf =<< choose (0, 32))
+
+genDatumHash :: Gen Plutus.DatumHash
+genDatumHash =
+  Plutus.DatumHash
+    <$> fmap Plutus.toBuiltin (genByteStringOf 32)
+
+genByteStringOf :: Int -> Gen ByteString
+genByteStringOf n =
+  BS.pack <$> vector n

--- a/plutus-cbor/plutus-cbor.cabal
+++ b/plutus-cbor/plutus-cbor.cabal
@@ -83,6 +83,7 @@ test-suite unit
   import:             project-config
   type:               exitcode-stdio-1.0
   hs-source-dirs:     test
+  main-is:            Main.hs
   ghc-options:        -threaded -rtsopts
   build-tool-depends: hspec-discover:hspec-discover -any
   build-depends:
@@ -106,7 +107,24 @@ test-suite unit
     Plutus.Codec.CBOR.EncodingSpec
     Spec
 
+benchmark bench
+  import:             project-config
+  type:               exitcode-stdio-1.0
+  hs-source-dirs:     bench
   main-is:            Main.hs
+  ghc-options:        -threaded -rtsopts
+  build-tool-depends: hspec-discover:hspec-discover -any
+  build-depends:
+    , base
+    , bytestring
+    , cborg
+    , criterion
+    , hydra-prelude
+    , plutus-cbor
+    , plutus-core
+    , plutus-ledger-api
+    , plutus-tx
+    , QuickCheck
 
 executable encoding-cost
   import:         project-config

--- a/plutus-cbor/plutus-cbor.cabal
+++ b/plutus-cbor/plutus-cbor.cabal
@@ -125,6 +125,7 @@ benchmark bench
     , plutus-ledger-api
     , plutus-tx
     , QuickCheck
+    , serialise
 
 executable encoding-cost
   import:         project-config


### PR DESCRIPTION
In course of formulating a CIP for `serialiseData` we created this benchmark to compare serialization of our basic on-chain encoder for `TxOut`s (run via Haskell on the host of course) with the more optimized `cborg` encoder used via `serialise` package for `Data`.

Here is the gist of it:
* Ada-only outputs are not bad
* 20 and definitely 100 asset outputs are serialized much less efficiently
* Makes sense, as those lead to much more `appendBytestring` calls, which is the builtin used at the core of `plutus-cbor`

![image](https://user-images.githubusercontent.com/2621189/153183494-61d45ebb-9130-4bef-ac2c-136871bf53d7.png)

To reproduce these results on your machine: https://github.com/input-output-hk/hydra-poc/blob/8d0a20510a1e0fb007044a3c7aa8ecbf45ddd49c/plutus-cbor/README.md#L40-L45
