### PR TITLE
Strict plutus-cbor

### DIFF
--- a/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
+++ b/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
@@ -87,7 +87,7 @@ import PlutusTx.Builtins (subtractInteger)
 newtype Encoding = Encoding (BuiltinByteString -> BuiltinByteString)
 
 instance Semigroup Encoding where
-  (Encoding a) <> (Encoding b) = Encoding (a . b)
+  (Encoding f) <> (Encoding g) = Encoding (\(!x) -> f $ g x)
 
 instance Monoid Encoding where
   mempty = Encoding id

--- a/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
+++ b/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
@@ -246,7 +246,7 @@ encodeMap :: (k -> Encoding) -> (v -> Encoding) -> Map k v -> Encoding
 encodeMap encodeKey encodeValue =
   step 0 mempty . Map.toList
  where
-  step !n bs = \case
+  step !n !bs = \case
     [] -> encodeMapLen n <> bs
     ((k, v) : q) -> step (n + 1) (bs <> encodeKey k <> encodeValue v) q
 {-# INLINEABLE encodeMap #-}

--- a/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
+++ b/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
@@ -246,7 +246,7 @@ encodeMap :: (k -> Encoding) -> (v -> Encoding) -> Map k v -> Encoding
 encodeMap encodeKey encodeValue =
   step 0 mempty . Map.toList
  where
-  step n bs = \case
+  step !n bs = \case
     [] -> encodeMapLen n <> bs
     ((k, v) : q) -> step (n + 1) (bs <> encodeKey k <> encodeValue v) q
 {-# INLINEABLE encodeMap #-}

--- a/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
+++ b/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
@@ -189,7 +189,7 @@ encodeList :: (a -> Encoding) -> [a] -> Encoding
 encodeList encodeElem =
   step 0 mempty
  where
-  step n bs = \case
+  step !n !bs = \case
     [] -> encodeListLen n <> bs
     (e : q) -> step (n + 1) (bs <> encodeElem e) q
 {-# INLINEABLE encodeList #-}

--- a/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
+++ b/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# OPTIONS_GHC -fno-specialize #-}
 {-# OPTIONS_HADDOCK prune #-}
 
@@ -310,12 +311,12 @@ unsafeEncodeRaw =
 -- * Internal
 
 withMajorType :: Integer -> Integer -> BuiltinByteString -> BuiltinByteString
-withMajorType major n =
-  consByteString (32 * major + n)
+withMajorType major n !next =
+  consByteString (32 * major + n) next
 {-# INLINEABLE withMajorType #-}
 
 encodeUnsigned :: Integer -> Integer -> BuiltinByteString -> BuiltinByteString
-encodeUnsigned major n next
+encodeUnsigned major n !next
   | n < 24 =
     withMajorType major n next
   | n < 256 =
@@ -329,20 +330,20 @@ encodeUnsigned major n next
 {-# INLINEABLE encodeUnsigned #-}
 
 encodeUnsigned8 :: Integer -> BuiltinByteString -> BuiltinByteString
-encodeUnsigned8 = consByteString
+encodeUnsigned8 n !next = consByteString n next
 {-# INLINEABLE encodeUnsigned8 #-}
 
 encodeUnsigned16 :: Integer -> BuiltinByteString -> BuiltinByteString
-encodeUnsigned16 n =
-  encodeUnsigned8 (quotient n 256) . encodeUnsigned8 (remainder n 256)
+encodeUnsigned16 n !next =
+  encodeUnsigned8 (quotient n 256) $ encodeUnsigned8 (remainder n 256) next
 {-# INLINEABLE encodeUnsigned16 #-}
 
 encodeUnsigned32 :: Integer -> BuiltinByteString -> BuiltinByteString
-encodeUnsigned32 n =
-  encodeUnsigned16 (quotient n 65536) . encodeUnsigned16 (remainder n 65536)
+encodeUnsigned32 n !next =
+  encodeUnsigned16 (quotient n 65536) $ encodeUnsigned16 (remainder n 65536) next
 {-# INLINEABLE encodeUnsigned32 #-}
 
 encodeUnsigned64 :: Integer -> BuiltinByteString -> BuiltinByteString
-encodeUnsigned64 n =
-  encodeUnsigned32 (quotient n 4294967296) . encodeUnsigned32 (remainder n 4294967296)
+encodeUnsigned64 n !next =
+  encodeUnsigned32 (quotient n 4294967296) $ encodeUnsigned32 (remainder n 4294967296) next
 {-# INLINEABLE encodeUnsigned64 #-}

--- a/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
+++ b/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
@@ -116,7 +116,7 @@ encodeBool = \case
 --
 -- Note (2): This can only encode numbers up to @2^64 - 1@ and down to @-2^63@
 encodeInteger :: Integer -> Encoding
-encodeInteger n
+encodeInteger !n
   | n < 0 =
     Encoding (encodeUnsigned 1 (subtractInteger 0 n - 1))
   | otherwise =
@@ -125,14 +125,15 @@ encodeInteger n
 
 -- | Encode a 'BuiltinByteString' as a CBOR type-02 major type.
 encodeByteString :: BuiltinByteString -> Encoding
-encodeByteString bytes =
+encodeByteString !bytes =
   Encoding (encodeUnsigned 2 (lengthOfByteString bytes) . appendByteString bytes)
 {-# INLINEABLE encodeByteString #-}
 
 -- | Encode a 'BuiltinString' as a CBOR type-03 major type.
 encodeString :: BuiltinString -> Encoding
-encodeString (encodeUtf8 -> bytes) =
-  Encoding (encodeUnsigned 3 (lengthOfByteString bytes) . appendByteString bytes)
+encodeString bytes =
+  let encoded = encodeUtf8 bytes
+   in Encoding (encodeUnsigned 3 (lengthOfByteString encoded) . appendByteString encoded)
 {-# INLINEABLE encodeString #-}
 
 -- | Encode a null character, useful to encode optional values.
@@ -162,7 +163,7 @@ encodeBreak = Encoding (consByteString 0xFF)
 --   <> encodeInteger 42
 -- @
 encodeListLen :: Integer -> Encoding
-encodeListLen = Encoding . encodeUnsigned 4
+encodeListLen !n = Encoding (encodeUnsigned 4 n)
 {-# INLINEABLE encodeListLen #-}
 
 -- | Declare a list of indefinite size. Each element of the list must then be
@@ -219,7 +220,7 @@ encodeListIndef encodeElem es =
 --   <> encodeInteger 42 <> encodeByteString "0000"
 -- @
 encodeMapLen :: Integer -> Encoding
-encodeMapLen = Encoding . encodeUnsigned 5
+encodeMapLen !n = Encoding (encodeUnsigned 5 n)
 {-# INLINEABLE encodeMapLen #-}
 
 -- | Declare a map of indefinite size. Each key/value pair of the map must then
@@ -295,8 +296,8 @@ encodeMaybe encode = \case
 --
 -- For more tags, have a look at [iana's Concise Binary Object Representation (CBOR) Tags list](https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml).
 encodeTag :: Integer -> Encoding
-encodeTag =
-  Encoding . encodeUnsigned 6
+encodeTag !n =
+  Encoding (encodeUnsigned 6 n)
 
 -- * Backdoor
 
@@ -304,8 +305,8 @@ encodeTag =
 -- unless you know what you're doing, this may creates an 'Encoding' not
 -- compliant with the CBOR specification.
 unsafeEncodeRaw :: BuiltinByteString -> Encoding
-unsafeEncodeRaw =
-  Encoding . appendByteString
+unsafeEncodeRaw !bs =
+  Encoding (appendByteString bs)
 {-# INLINEABLE unsafeEncodeRaw #-}
 
 -- * Internal

--- a/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
+++ b/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
@@ -311,12 +311,12 @@ unsafeEncodeRaw =
 -- * Internal
 
 withMajorType :: Integer -> Integer -> BuiltinByteString -> BuiltinByteString
-withMajorType major n !next =
+withMajorType !major !n !next =
   consByteString (32 * major + n) next
 {-# INLINEABLE withMajorType #-}
 
 encodeUnsigned :: Integer -> Integer -> BuiltinByteString -> BuiltinByteString
-encodeUnsigned major n !next
+encodeUnsigned !major !n !next
   | n < 24 =
     withMajorType major n next
   | n < 256 =
@@ -330,20 +330,20 @@ encodeUnsigned major n !next
 {-# INLINEABLE encodeUnsigned #-}
 
 encodeUnsigned8 :: Integer -> BuiltinByteString -> BuiltinByteString
-encodeUnsigned8 n !next = consByteString n next
+encodeUnsigned8 !n !next = consByteString n next
 {-# INLINEABLE encodeUnsigned8 #-}
 
 encodeUnsigned16 :: Integer -> BuiltinByteString -> BuiltinByteString
-encodeUnsigned16 n !next =
+encodeUnsigned16 !n !next =
   encodeUnsigned8 (quotient n 256) $ encodeUnsigned8 (remainder n 256) next
 {-# INLINEABLE encodeUnsigned16 #-}
 
 encodeUnsigned32 :: Integer -> BuiltinByteString -> BuiltinByteString
-encodeUnsigned32 n !next =
+encodeUnsigned32 !n !next =
   encodeUnsigned16 (quotient n 65536) $ encodeUnsigned16 (remainder n 65536) next
 {-# INLINEABLE encodeUnsigned32 #-}
 
 encodeUnsigned64 :: Integer -> BuiltinByteString -> BuiltinByteString
-encodeUnsigned64 n !next =
+encodeUnsigned64 !n !next =
   encodeUnsigned32 (quotient n 4294967296) $ encodeUnsigned32 (remainder n 4294967296) next
 {-# INLINEABLE encodeUnsigned64 #-}


### PR DESCRIPTION
Introducing more strictness to plutus-cbor

Could shave off about 30% on computation time on the expensive 100 asset case, but still not linear in input data! That means, that benchmarking in Haskell is still vastly different than evaluating & estimating execution costs in plutus.

Before:
![image](https://user-images.githubusercontent.com/2621189/153219511-da0ed9f0-738f-44ac-8d8c-39d09d126b6a.png)

After:
![image](https://user-images.githubusercontent.com/2621189/153219444-b72233d4-fa3b-426a-8f1d-85000058b309.png)
