### PR TITLE
Make subscription valency dependent on number of peers

### DIFF
--- a/hydra-node/src/Hydra/Network/Ouroboros.hs
+++ b/hydra-node/src/Hydra/Network/Ouroboros.hs
@@ -167,7 +167,7 @@ withOuroborosNetwork tracer localHost remoteHosts networkCallback between = do
       { spLocalAddresses = LocalAddresses (Just localAddr) Nothing Nothing
       , spConnectionAttemptDelay = const Nothing
       , spErrorPolicies = nullErrorPolicies
-      , spSubscriptionTarget = IPSubscriptionTarget remoteAddrs 7
+      , spSubscriptionTarget = IPSubscriptionTarget remoteAddrs (length remoteAddrs)
       }
 
   actualConnect iomgr chanPool app sn = do


### PR DESCRIPTION
We had a hardcoded value for the valency of Ouroboros subscriptions, which meant the network engine would stop connecting to peers once it reached the target valency, thus preventing us from scaling to more than 7 peers.
The benchmark is still not working properly with 10 nodes as it now fails to post the `CollectCom` transaction on-chain...