### PR TITLE
Attempt at refactoring & decoupling the OnChainHeadState logic

### DIFF
--- a/hydra-cardano-api/src/Cardano/Api/UTxO.hs
+++ b/hydra-cardano-api/src/Cardano/Api/UTxO.hs
@@ -43,6 +43,10 @@ singleton (i, o) = UTxO $ Map.singleton i o
 pairs :: UTxO' out -> [(TxIn, out)]
 pairs = Map.toList . toMap
 
+-- | Get the 'UTxO' domain input's set
+inputSet :: UTxO' out -> Set TxIn
+inputSet = Map.keysSet . toMap
+
 -- | Get a human-readable pretty text representation of a UTxO.
 render :: (TxIn, TxOut ctx era) -> Text
 render (k, TxOut _ (txOutValueToValue -> v) _) =

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/TxIn.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/TxIn.hs
@@ -4,6 +4,7 @@ import Hydra.Cardano.Api.Prelude
 
 import qualified Cardano.Ledger.Alonzo.TxInfo as Ledger
 import qualified Cardano.Ledger.TxIn as Ledger
+import qualified Data.Set as Set
 import qualified Plutus.V1.Ledger.Api as Plutus
 
 -- * Extras
@@ -18,6 +19,10 @@ txIns' :: Tx era -> [TxIn]
 txIns' (getTxBody -> txBody) =
   let TxBody TxBodyContent{txIns} = txBody
    in fst <$> txIns
+
+-- | Access inputs of a transaction, as an ordered set.
+txInputSet :: Tx era -> Set TxIn
+txInputSet = Set.fromList . txIns'
 
 -- * Type Conversions
 

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -80,6 +80,7 @@ library
     Hydra.API.Server
     Hydra.Chain
     Hydra.Chain.Direct
+    Hydra.Chain.Direct.State
     Hydra.Chain.Direct.Tx
     Hydra.Chain.Direct.Util
     Hydra.Chain.Direct.Wallet

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -237,6 +237,7 @@ test-suite tests
     Hydra.Chain.Direct.ContractSpec
     Hydra.Chain.Direct.Fixture
     Hydra.Chain.Direct.MockServer
+    Hydra.Chain.Direct.StateSpec
     Hydra.Chain.Direct.TxSpec
     Hydra.Chain.Direct.WalletSpec
     Hydra.Chain.DirectSpec

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -14,7 +14,6 @@ module Hydra.Chain.Direct (
 
 import Hydra.Prelude
 
-import qualified Cardano.Api.UTxO as UTxO
 import Cardano.Ledger.Alonzo.Language (Language (PlutusV1))
 import Cardano.Ledger.Alonzo.Rules.Utxo (UtxoPredicateFailure (UtxosFailure))
 import Cardano.Ledger.Alonzo.Rules.Utxos (TagMismatchDescription (FailedUnexpectedly), UtxosPredicateFailure (ValidationTagMismatch))
@@ -33,17 +32,14 @@ import Control.Monad.Class.MonadSTM (newTQueueIO, newTVarIO, readTQueue, retry, 
 import Control.Monad.Class.MonadTimer (timeout)
 import Control.Tracer (nullTracer)
 import Data.Aeson (Value (String), object, (.=))
-import qualified Data.Map.Strict as Map
 import Data.Sequence.Strict (StrictSeq)
 import Hydra.Cardano.Api (
   NetworkId (Testnet),
   PaymentKey,
   SigningKey,
   Tx,
-  UTxO' (..),
   VerificationKey,
   fromLedgerTx,
-  fromLedgerTxIn,
   fromLedgerUTxO,
   toLedgerTx,
   toLedgerUTxO,
@@ -57,8 +53,6 @@ import Hydra.Chain (
   PostTxError (..),
  )
 import Hydra.Chain.Direct.State (
-  HeadStateKind (..),
-  OnChainHeadState,
   SomeOnChainHeadState (..),
   TokHeadState (..),
   abort,
@@ -89,7 +83,6 @@ import Hydra.Chain.Direct.Wallet (
  )
 import Hydra.Logging (Tracer, traceWith)
 import Hydra.Party (Party)
-import Hydra.Snapshot (ConfirmedSnapshot (..))
 import Ouroboros.Consensus.Cardano.Block (GenTx (..), HardForkApplyTxErr (ApplyTxErrAlonzo), HardForkBlock (BlockAlonzo))
 import Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr)
 import Ouroboros.Consensus.Network.NodeToClient (Codecs' (..))

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -329,7 +329,7 @@ chainSyncClient tracer callback headState =
   runOnChainTx :: [OnChainTx Tx] -> ValidatedTx Era -> STM m [OnChainTx Tx]
   runOnChainTx observed (fromLedgerTx -> tx) = do
     SomeOnChainHeadState st <- readTVar headState
-    observeTx tx st >>= \case
+    case observeTx tx st of
       Just (onChainTx, st') -> do
         writeTVar headState st'
         pure $ onChainTx : observed

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -24,6 +24,7 @@ module Hydra.Chain.Direct.State (
   fanout,
 
   -- ** Observing transitions
+  HasTransition,
   observeTx,
 ) where
 
@@ -63,6 +64,7 @@ data OnChainHeadState (st :: HeadStateKind) = OnChainHeadState
   , ownParty :: Party
   , stateMachine :: HydraStateMachine st
   }
+  deriving (Show)
 
 -- NOTE (1): The state machine UTxO produced by the Init transaction (a.k.a
 -- 'threadOutput') is always present and 'threaded' across all transactions.
@@ -89,6 +91,8 @@ data HydraStateMachine (st :: HeadStateKind) where
     { closedThreadOutput :: (TxIn, TxOut CtxUTxO, ScriptData, [OnChain.Party])
     } ->
     HydraStateMachine 'StClosed
+
+deriving instance Show (HydraStateMachine st)
 
 getKnownUTxO ::
   OnChainHeadState st ->

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -97,7 +97,11 @@ getKnownUTxO =
 -- | An existential wrapping /some/ 'OnChainHeadState' into a value that carry
 -- no type-level information about the state.
 data SomeOnChainHeadState m where
-  SomeOnChainHeadState :: forall st m. OnChainHeadState m st -> SomeOnChainHeadState m
+  SomeOnChainHeadState ::
+    forall st m.
+    HasTransition st =>
+    OnChainHeadState m st ->
+    SomeOnChainHeadState m
 
 -- | Some Kind for witnessing Hydra state-machine's states at the type-level.
 --
@@ -203,28 +207,22 @@ fanout =
 
 -- Observing Transitions
 
-class HasTransition st st' where
+class HasTransition st where
   observeTx ::
     Tx ->
     OnChainHeadState m st ->
-    m (Maybe (OnChainTx Tx, OnChainHeadState m st'))
+    STM m (Maybe (OnChainTx Tx, SomeOnChainHeadState m))
 
-instance HasTransition 'StIdle 'StInitialized where
+instance HasTransition 'StIdle where
   observeTx = undefined
 
-instance HasTransition 'StInitialized 'StIdle where
+instance HasTransition 'StInitialized where
   observeTx = undefined
 
-instance HasTransition 'StInitialized 'StInitialized where
+instance HasTransition 'StOpen where
   observeTx = undefined
 
-instance HasTransition 'StInitialized 'StOpen where
-  observeTx = undefined
-
-instance HasTransition 'StOpen 'StClosed where
-  observeTx = undefined
-
-instance HasTransition 'StClosed 'StIdle where
+instance HasTransition 'StClosed where
   observeTx = undefined
 
 --

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -1,0 +1,226 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Hydra.Chain.Direct.State (
+  -- * OnChainHeadState'
+  OnChainHeadState',
+  HeadStateKind (..),
+
+  -- ** Common
+  commitAddress,
+
+  -- ** Idle
+  idleOnChainHeadState',
+
+  -- ** Initialized
+  initialOutputRef,
+  mkCommitOutput,
+  findInitialRedeemer,
+  putCommit,
+
+  -- ** Open
+
+  -- ** Closed
+) where
+
+import Hydra.Cardano.Api
+import Hydra.Prelude
+
+import Cardano.Binary (serialize')
+import qualified Hydra.Contract.Commit as Commit
+import qualified Hydra.Contract.Head as Head
+import Hydra.Contract.Initial (Initial)
+import qualified Hydra.Contract.Initial as Initial
+import Hydra.Data.Party (partyFromVerKey)
+import qualified Hydra.Data.Party as OnChain
+import Hydra.Party (Party, vkey)
+import Ledger.Typed.Scripts (ValidatorTypes (..))
+import Ledger.Value (AssetClass (..), currencyMPSHash)
+import Plutus.V1.Ledger.Api (
+  Datum,
+  MintingPolicyHash,
+  ValidatorHash,
+  fromData,
+  toBuiltin,
+ )
+import Plutus.V1.Ledger.Value (assetClass, currencySymbol, tokenName)
+
+-- | An opaque on-chain head state, which records information and events
+-- happening on the layer-1 for a given Hydra head.
+data OnChainHeadState' (st :: HeadStateKind) = OnChainHeadState'
+  { networkId :: NetworkId
+  , ownVerificationKey :: VerificationKey PaymentKey
+  , ownParty :: Party
+  , stateMachine :: HydraStateMachine st
+  }
+
+-- NOTE (1): The state machine UTxO produced by the Init transaction (a.k.a
+-- 'threadOutput') is always present and 'threaded' across all transactions.
+--
+-- NOTE (2): The Head's identifier is somewhat encoded in the TxOut's address
+--
+-- TODO: Data and [OnChain.Party] are overlapping
+--
+-- TODO: There are better ways to model this to avoid duplicating common fields
+-- across all branches!
+data HydraStateMachine (st :: HeadStateKind) where
+  Idle :: HydraStateMachine 'StIdle
+  Initial ::
+    { initialThreadOutput :: (TxIn, TxOut CtxUTxO, ScriptData, [OnChain.Party])
+    , initialInitials :: [UTxOWithScript]
+    , initialCommits :: [UTxOWithScript]
+    } ->
+    HydraStateMachine 'StInitialized
+  Open ::
+    { openThreadOutput :: (TxIn, TxOut CtxUTxO, ScriptData, [OnChain.Party])
+    } ->
+    HydraStateMachine 'StOpen
+  Closed ::
+    { closedThreadOutput :: (TxIn, TxOut CtxUTxO, ScriptData, [OnChain.Party])
+    } ->
+    HydraStateMachine 'StClosed
+
+-- | Some Kind for witnessing Hydra state-machine's states at the type-level.
+--
+-- This is useful to
+--
+-- (a) Reads code evolving the state machine, as it makes transition more
+-- obvious from type-signatures;
+-- (b) Pattern-match on the 'HydraStateMachine' without having to bother with
+-- non-reachable cases.
+data HeadStateKind = StIdle | StInitialized | StOpen | StClosed
+
+-- Common
+
+commitAddress :: OnChainHeadState' st -> AddressInEra
+commitAddress OnChainHeadState'{networkId} =
+  mkScriptAddress @PlutusScriptV1 networkId commitScript
+ where
+  commitScript = fromPlutusScript Commit.validatorScript
+
+-- Idle
+
+-- | Initialize a new 'OnChainHeadState''.
+idleOnChainHeadState' ::
+  NetworkId ->
+  VerificationKey PaymentKey ->
+  Party ->
+  OnChainHeadState' 'StIdle
+idleOnChainHeadState' networkId ownVerificationKey ownParty =
+  OnChainHeadState'
+    { networkId
+    , ownVerificationKey
+    , ownParty
+    , stateMachine = Idle
+    }
+
+-- Initialized
+
+-- | Retrieve the initial output reference (i.e. locked by an initial script)
+-- and a corresponding spending witness.
+initialOutputRef ::
+  Maybe (TxIn, TxOut CtxUTxO) ->
+  OnChainHeadState' 'StInitialized ->
+  Maybe (TxIn, BuildTxWith BuildTx (Witness WitCtxTxIn))
+initialOutputRef utxo OnChainHeadState'{ownVerificationKey, stateMachine} = do
+  (outRef, vkh) <- ownInitial ownVerificationKey initialInitials
+  let initialScript =
+        fromPlutusScript @PlutusScriptV1 Initial.validatorScript
+  let initialDatum =
+        mkScriptDatum $ Initial.datum $ toPlutusKeyHash vkh
+  let initialRedeemer =
+        toScriptData . Initial.redeemer $
+          Initial.Commit (toPlutusTxOutRef . fst <$> utxo)
+  return
+    ( outRef
+    , BuildTxWith $ mkScriptWitness initialScript initialDatum initialRedeemer
+    )
+ where
+  Initial{initialInitials} = stateMachine
+
+mkCommitOutput ::
+  Maybe (TxIn, TxOut CtxUTxO) ->
+  OnChainHeadState' 'StInitialized ->
+  TxOut CtxTx
+mkCommitOutput mUTxO st@OnChainHeadState'{ownParty} =
+  TxOut (commitAddress st) commitValue commitDatum
+ where
+  -- FIXME: We should add the value from the initialIn too because it contains the PTs
+  commitValue =
+    headValue <> maybe mempty (txOutValue . snd) mUTxO
+  commitDatum =
+    mkTxOutDatum $ mkCommitDatum ownParty (Head.validatorHash policyId) mUTxO
+
+findInitialRedeemer ::
+  Tx ->
+  OnChainHeadState' 'StInitialized ->
+  Maybe (RedeemerType Initial)
+findInitialRedeemer tx OnChainHeadState'{stateMachine} = do
+  findInitialOutputRef >>= findRedeemerSpending tx
+ where
+  Initial{initialInitials} = stateMachine
+
+  findInitialOutputRef =
+    case filter (`elem` (fst3 <$> initialInitials)) (txIns' tx) of
+      [input] -> Just input
+      _ -> Nothing
+
+putCommit ::
+  UTxOWithScript ->
+  OnChainHeadState' 'StInitialized ->
+  OnChainHeadState' 'StInitialized
+putCommit commit st@OnChainHeadState'{stateMachine} =
+  st
+    { stateMachine =
+        stateMachine
+          { initialCommits = commit : initialCommits
+          }
+    }
+ where
+  Initial{initialCommits} = stateMachine
+
+--
+-- Helpers
+--
+
+type UTxOWithScript = (TxIn, TxOut CtxUTxO, ScriptData)
+
+fst3 :: (a, b, c) -> a
+fst3 (a, _b, _c) = a
+
+-- FIXME: should not be hardcoded but come from the previous state!
+headValue :: Value
+headValue = lovelaceToValue (Lovelace 2_000_000)
+
+-- FIXME: should not be hardcoded, for testing purposes only
+threadToken :: AssetClass
+threadToken = assetClass (currencySymbol "hydra") (tokenName "token")
+
+-- FIXME: This should be part of the OnChainHeadState
+policyId :: MintingPolicyHash
+(policyId, _) = first currencyMPSHash (unAssetClass threadToken)
+
+mkCommitDatum :: Party -> ValidatorHash -> Maybe (TxIn, TxOut CtxUTxO) -> Datum
+mkCommitDatum (partyFromVerKey . vkey -> party) headValidatorHash utxo =
+  Commit.datum (party, headValidatorHash, serializedUTxO)
+ where
+  serializedUTxO = case utxo of
+    Nothing ->
+      Nothing
+    Just (_i, o) ->
+      Just $ Commit.SerializedTxOut (toBuiltin $ serialize' $ toLedgerTxOut o)
+
+-- | Look for the "initial" which corresponds to given cardano verification key.
+ownInitial ::
+  VerificationKey PaymentKey ->
+  [UTxOWithScript] ->
+  Maybe (TxIn, Hash PaymentKey)
+ownInitial vkey =
+  foldl' go Nothing
+ where
+  go (Just x) _ = Just x
+  go Nothing (i, _, dat) = do
+    let vkh = verificationKeyHash vkey
+    pkh <- fromData (toPlutusData dat)
+    guard $ pkh == toPlutusKeyHash vkh
+    pure (i, vkh)

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -366,6 +366,7 @@ data InitObservation = InitObservation
   , initials :: [UTxOWithScript]
   , commits :: [UTxOWithScript]
   }
+  deriving (Show, Eq)
 
 -- XXX(SN): We should log decisions why a tx is not an initTx etc. instead of
 -- only returning a Maybe, i.e. 'Either Reason (OnChainTx tx, OnChainHeadState)'
@@ -489,6 +490,7 @@ convertTxOut = \case
 data CollectComObservation = CollectComObservation
   { threadOutput :: (TxIn, TxOut CtxUTxO, ScriptData, [OnChain.Party])
   }
+  deriving (Show, Eq)
 
 -- | Identify a collectCom tx by lookup up the input spending the Head output
 -- and decoding its redeemer.
@@ -524,6 +526,7 @@ observeCollectComTx utxo tx = do
 data CloseObservation = CloseObservation
   { threadOutput :: (TxIn, TxOut CtxUTxO, ScriptData, [OnChain.Party])
   }
+  deriving (Show, Eq)
 
 -- | Identify a close tx by lookup up the input spending the Head output and
 -- decoding its redeemer.

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -19,6 +19,15 @@ import Cardano.Binary (decodeFull', serialize')
 import qualified Data.Map as Map
 import Data.Time (Day (ModifiedJulianDay), UTCTime (UTCTime))
 import Hydra.Chain (HeadParameters (..), OnChainTx (..))
+import Hydra.Chain.Direct.State (
+  HeadStateKind (..),
+  OnChainHeadState',
+  commitAddress,
+  findInitialRedeemer,
+  initialOutputRef,
+  mkCommitOutput,
+  putCommit,
+ )
 import qualified Hydra.Contract.Commit as Commit
 import qualified Hydra.Contract.Head as Head
 import qualified Hydra.Contract.HeadState as Head
@@ -147,11 +156,11 @@ commitTx ::
 commitTx networkId party utxo (initialInput, vkh) =
   unsafeBuildTransaction $
     emptyTxBody
-      & addInputs [(initialInput, initialWitness)]
+      & addInputs [(initialInput, initialWitness_)]
       & addVkInputs (maybeToList mCommittedInput)
       & addOutputs [commitOutput]
  where
-  initialWitness =
+  initialWitness_ =
     BuildTxWith $ mkScriptWitness initialScript initialDatum initialRedeemer
   initialScript =
     fromPlutusScript @PlutusScriptV1 Initial.validatorScript
@@ -173,6 +182,23 @@ commitTx networkId party utxo (initialInput, vkh) =
     headValue <> maybe mempty (txOutValue . snd) utxo
   commitDatum =
     mkTxOutDatum $ mkCommitDatum party (Head.validatorHash policyId) utxo
+
+-- | Craft a commit transaction which includes the "committed" utxo as datum.
+commitTx' ::
+  OnChainHeadState' 'StInitialized ->
+  -- | A single UTxO to commit to the Head
+  -- We currently limit committing one UTxO to the head because of size limitations.
+  Maybe (TxIn, TxOut CtxUTxO) ->
+  -- | Zero-or-one UTXO entry to commit.
+  Maybe Tx
+commitTx' st utxo = do
+  initialInput <- initialOutputRef utxo st
+  return $
+    unsafeBuildTransaction $
+      emptyTxBody
+        & addInputs [initialInput]
+        & addVkInputs [i | Just (i, _) <- [utxo]]
+        & addOutputs [mkCommitOutput utxo st]
 
 mkCommitDatum :: Party -> Plutus.ValidatorHash -> Maybe (TxIn, TxOut CtxUTxO) -> Plutus.Datum
 mkCommitDatum (partyFromVerKey . vkey -> party) headValidatorHash utxo =
@@ -432,6 +458,34 @@ observeInitTx networkId party tx = do
 
 convertParty :: OnChain.Party -> Party
 convertParty = Party . partyToVerKey
+
+observeCommitTx' ::
+  Tx ->
+  OnChainHeadState' 'StInitialized ->
+  Maybe (OnChainTx Tx, OnChainHeadState' 'StInitialized)
+observeCommitTx' tx st = do
+  findInitialRedeemer tx st >>= \case
+    Initial.Abort -> do
+      Nothing
+    Initial.Commit{committedRef} -> do
+      let mCommittedTxIn = fromPlutusTxOutRef <$> committedRef
+      (commitIn, commitOut) <- findTxOutByAddress (commitAddress st) tx
+      dat <- getScriptData commitOut
+      -- TODO: This 'party' would be available from the spent 'initial' utxo (PT eventually)
+      (party, _, serializedTxOut) <- fromData @(DatumType Commit.Commit) $ toPlutusData dat
+      let mCommittedTxOut = convertTxOut serializedTxOut
+
+      comittedUTxO <-
+        case (mCommittedTxIn, mCommittedTxOut) of
+          (Nothing, Nothing) -> Just mempty
+          (Just i, Just o) -> Just $ UTxO.singleton (i, o)
+          (Nothing, Just{}) -> error "found commit with no redeemer out ref but with serialized output."
+          (Just{}, Nothing) -> error "found commit with redeemer out ref but with no serialized output."
+
+      return
+        ( OnCommitTx (convertParty party) comittedUTxO
+        , putCommit (commitIn, toUTxOContext commitOut, dat) st
+        )
 
 -- | Identify a commit tx by:
 --

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -1,0 +1,105 @@
+module Hydra.Chain.Direct.StateSpec where
+
+import Hydra.Cardano.Api
+import Hydra.Prelude
+import Test.Hydra.Prelude
+
+import qualified Cardano.Api.UTxO as UTxO
+import qualified Data.Set as Set
+import Hydra.Chain (HeadParameters (..))
+import Hydra.Chain.Direct.State (
+  HeadStateKind (..),
+  OnChainHeadState,
+  SomeOnChainHeadState (..),
+  TokHeadState (..),
+  commit,
+  getKnownUTxO,
+  idleOnChainHeadState,
+  initialize,
+  observeTx,
+  reifyState,
+ )
+import Hydra.Ledger.Cardano (genOneUTxOFor, genTxIn, genVerificationKey)
+import Hydra.Party (Party)
+import Test.QuickCheck (choose, elements, forAll, property, vector)
+
+spec :: Spec
+spec =
+  describe "commit" $ do
+    prop "consumes all inputs that are committed." $
+      forAll genHydraContext $ \ctx ->
+        forAll (genStInitialized ctx) $ \stInitialized ->
+          forAll genSingleUTxO $ \utxo ->
+            let tx = unsafeCommit utxo stInitialized
+             in case observeTx tx stInitialized of
+                  Just (_, SomeOnChainHeadState st') ->
+                    let knownInputs = UTxO.inputSet (getKnownUTxO st')
+                     in property (knownInputs `Set.disjoint` txInputSet tx)
+                  Nothing ->
+                    property False
+
+--
+-- Generators
+--
+
+-- Some 'global' (to all generator) context from which generators can pick
+-- values for generation. This allows to write fairly independent generators
+-- which however still make sense with one another within the context of a head.
+--
+-- For example, one can generate a head's _party_ from that global list, whereas
+-- other functions may rely on all parties and thus, we need both generation to
+-- be coherent.
+data HydraContext = HydraContext
+  { ctxVerificationKeys :: [VerificationKey PaymentKey]
+  , ctxParties :: [Party]
+  , ctxNetworkId :: NetworkId
+  , ctxContestationPeriod :: DiffTime
+  }
+  deriving (Show)
+
+genHydraContext :: Gen HydraContext
+genHydraContext = do
+  n <- choose (1, 10)
+  ctxVerificationKeys <- replicateM n genVerificationKey
+  ctxParties <- vector n
+  ctxNetworkId <- Testnet . NetworkMagic <$> arbitrary
+  ctxContestationPeriod <- arbitrary
+  pure $
+    HydraContext
+      { ctxVerificationKeys
+      , ctxParties
+      , ctxNetworkId
+      , ctxContestationPeriod
+      }
+
+genStIdle :: HydraContext -> Gen (OnChainHeadState 'StIdle)
+genStIdle HydraContext{ctxVerificationKeys, ctxNetworkId, ctxParties} = do
+  ownParty <- elements ctxParties
+  ownVerificationKey <- elements ctxVerificationKeys
+  pure $ idleOnChainHeadState ctxNetworkId ownVerificationKey ownParty
+
+genStInitialized :: HydraContext -> Gen (OnChainHeadState 'StInitialized)
+genStInitialized ctx@HydraContext{ctxParties, ctxContestationPeriod, ctxVerificationKeys} = do
+  stIdle <- genStIdle ctx
+  let headParameters = HeadParameters ctxContestationPeriod ctxParties
+  seedInput <- genTxIn
+  case observeTx (initialize headParameters ctxVerificationKeys seedInput stIdle) stIdle of
+    Nothing -> error "failed to observe arbitrarily generated init tx?"
+    Just (_, SomeOnChainHeadState st) ->
+      case reifyState st of
+        TkInitialized ->
+          pure st
+        _ ->
+          error "expected 'Initialized' state after observing init but got something else!"
+
+genSingleUTxO :: Gen UTxO
+genSingleUTxO =
+  genVerificationKey >>= genOneUTxOFor
+
+--
+-- Helpers
+--
+
+unsafeCommit :: HasCallStack => UTxO -> OnChainHeadState 'StInitialized -> Tx
+unsafeCommit u =
+  either (error . show) id . commit u


### PR DESCRIPTION
## History

- :round_pushpin: **Cleanup Direct.Tx module from previous approach.**
    We discussed that, rather to be in that direction, the dependency should be the other way around. That is, we want the 'State' module to sit in between the direct-chain component and the low-level transaction construction. Hence, it is the 'State' module which will use the 'Direct.Tx' module down the line to construct and observe the transitions.

- :round_pushpin: **Type-drive refactoring of the Hydra.Chain.Direct module.**
     We start from the type, which outlines the interface that we want. And from there, write implementation. It's a very top-down approach where we goes more and more into details with the goal of making the module hierarchy a clearer: that is, the Chain.Direct is fairly ignorant to (a) what's the internal state and (b) how it is represented. This allows to write functions in a generic way, to decouple from implementation details and therefore, make testing easier (since bottom parts can be tested independently and in depth, while upper layers can focus on integration only).

- :round_pushpin: **re-implement 'fromPostChainTx' using the new 'State' interface.**
    Much cleaner :D. And now, we can test each transition independently, which is great (although still yet to do :grimacing:).

- :round_pushpin: **re-implement 'runOnChainTx' in the Chain.Direct module.**
    This is now in principle, all that is needed in the Chain.Direct module which is now very generic about the state and the transitions. It can observe the chain and keep track of /some state/ but the representation of that state is unknown to it (implementation detail of the lower layers).

- :round_pushpin: **Cleanup Hydra.Chain.Direct.**
  
- :round_pushpin: **re-implement initialize, abort, commit, collect, close and fanout as independently testable functions.**
    Note that they should not be in STM, as per note.

- :round_pushpin: **re-implement 'observeTx' for all transitions.**
  
- :round_pushpin: **Revert putting TinyWallet in Direct.State.**

## Remarks

- Tests don't compile yet since I _slightly_ changed the interface of the low-level tx construction functions (which no longer return an `OnChainHeadState` but instead, returns _observations_. Need to be done, but not if we end up dropping this whole approach. 

- This refactoring does not simplify anything about the low-level tx construction or observation. Rather, it introduces an indirection between those low-level details and the higher direct-chain component which is now manipulating _some_ opaque state. This buys us mainly two things:
   -  It gives us more freedom in changing the internal representation of the on-chain head state, without impacting the rest of the code; 
   - It makes the state transitions function testable independently!  

- From there, a next logical step is to get rid of the `TVar` storing the on-chain state, and move it inside the head logic. We can achieve this by yielding new states as part of `OnChainTx` events and, providing it back as part of `PostChainTx` commands, which effectively make the chain-component stateless (the state is within the requests/responses!). 

- In parallel, we can also work on simplifying the low-level building and observing of transactions by introducing an embedded DSL similar to the Plutus constraints. the main guiding principle for the DSL should be that we ought to be able to write one description of each transaction and either interpret it to build a transaction from a known context or, to observe it from a given tx. This would reduce a lot of the duplications between construction/observation and gives us one declarative and consistent approach for both constructing and observing.

- Finally, once the on-chain state is part of the head logic's state, we can consider representing the head logic not as an aggregate state, but as sequence of states instead (folding only on-demand) to cope with rollbacks in an easy way! 