### PR TITLE
Typed transitions

### DIFF
--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -329,7 +329,7 @@ chainSyncClient tracer callback headState =
 
   runOnChainTx :: [OnChainTx Tx] -> ValidatedTx Era -> STM m [OnChainTx Tx]
   runOnChainTx observed (fromLedgerTx -> tx) = do
-    SomeOnChainHeadState st <- readTVar headState
+    st <- readTVar headState
     case observeTx tx st of
       Just (onChainTx, st') -> do
         writeTVar headState st'

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -65,7 +65,7 @@ import Hydra.Chain.Direct.State (
   getKnownUTxO,
   idleOnChainHeadState,
   initialize,
-  observeTx,
+  observeSomeTx,
   reifyState,
  )
 import Hydra.Chain.Direct.Util (
@@ -330,7 +330,7 @@ chainSyncClient tracer callback headState =
   runOnChainTx :: [OnChainTx Tx] -> ValidatedTx Era -> STM m [OnChainTx Tx]
   runOnChainTx observed (fromLedgerTx -> tx) = do
     st <- readTVar headState
-    case observeTx tx st of
+    case observeSomeTx tx st of
       Just (onChainTx, st') -> do
         writeTVar headState st'
         pure $ onChainTx : observed

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -492,13 +492,11 @@ data TransitionFrom st where
     TransitionFrom st
 
 instance Show (TransitionFrom st) where
-  show (TransitionTo proxy) =
-    "Transition "
-    <> show (headStateKindVal (Proxy @st))
-    <> " -> "
-    <> show (headStateKindVal proxy)
-
-
+  show (TransitionTo proxy) = mconcat
+    [ show (headStateKindVal (Proxy @st))
+    , " -> "
+    , show (headStateKindVal proxy)
+    ]
 
 instance Eq (TransitionFrom st) where
   (TransitionTo proxy) == (TransitionTo proxy') =

--- a/hydra-node/src/Hydra/Snapshot.hs
+++ b/hydra-node/src/Hydra/Snapshot.hs
@@ -97,5 +97,12 @@ getSnapshot = \case
   InitialSnapshot{snapshot} -> snapshot
   ConfirmedSnapshot{snapshot} -> snapshot
 
+-- | Tell whether a snapshot is the initial snapshot coming from the collect-com
+-- transaction.
+isInitialSnapshot :: ConfirmedSnapshot tx -> Bool
+isInitialSnapshot = \case
+  InitialSnapshot{} -> True
+  ConfirmedSnapshot{} -> False
+
 instance (Arbitrary tx, Arbitrary (UTxOType tx)) => Arbitrary (ConfirmedSnapshot tx) where
   arbitrary = genericArbitrary

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -240,21 +240,6 @@ genCommit =
     ]
 
 --
--- Helpers
---
-
-forAll2
-  :: (Testable property, Show a, Show b)
-  => Gen a
-  -> Gen b
-  -> ((a, b) -> property)
-  -> Property
-forAll2 genA genB action =
-  forAll genA $ \a ->
-    forAll genB $ \b ->
-      action (a, b)
-
---
 -- Wrapping Transition for easy labelling
 --
 

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -18,10 +18,9 @@ import qualified Cardano.Ledger.Alonzo.Scripts as Ledger
 import qualified Cardano.Ledger.Alonzo.Tools as Ledger
 import qualified Cardano.Ledger.Alonzo.TxWitness as Ledger
 import qualified Data.ByteString.Lazy as LBS
-import Data.List (nub, (\\))
 import qualified Data.Map as Map
 import qualified Data.Text as T
-import Hydra.Chain (HeadParameters (..), OnChainTx (..))
+import Hydra.Chain (HeadParameters (..))
 import Hydra.Chain.Direct.Fixture (
   costModels,
   epochInfo,
@@ -48,18 +47,15 @@ import Hydra.Ledger.Cardano (
   shrinkUTxO,
  )
 import Hydra.Party (Party, vkey)
-import Hydra.Snapshot (number)
 import Plutus.V1.Ledger.Api (toBuiltin, toData)
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
 import Test.QuickCheck (
-  NonEmptyList (NonEmpty),
   Property,
   checkCoverage,
   choose,
   conjoin,
   counterexample,
   cover,
-  elements,
   expectFailure,
   forAll,
   forAllShrinkBlind,
@@ -69,47 +65,12 @@ import Test.QuickCheck (
   property,
   vectorOf,
   withMaxSuccess,
-  (.&&.),
-  (===),
  )
 import Test.QuickCheck.Instances ()
 
 spec :: Spec
 spec =
   parallel $ do
-    describe "initTx" $ do
-      prop "is observed" $ \txIn cperiod (party :| parties) cardanoKeys ->
-        let params = HeadParameters cperiod (party : parties)
-            tx = initTx testNetworkId cardanoKeys params txIn
-            observed = observeInitTx testNetworkId party tx
-         in case observed of
-              Just (octx, _) -> octx === OnInitTx @Tx cperiod (party : parties)
-              _ -> property False
-              & counterexample ("Observed: " <> show observed)
-
-      prop "is not observed if not invited" $ \txIn cperiod (NonEmpty parties) cardanoKeys ->
-        forAll (elements parties) $ \notInvited ->
-          let invited = nub parties \\ [notInvited]
-              tx = initTx testNetworkId cardanoKeys (HeadParameters cperiod invited) txIn
-           in isNothing (observeInitTx testNetworkId notInvited tx)
-                & counterexample ("observing as: " <> show notInvited)
-                & counterexample ("invited: " <> show invited)
-
-      prop "updates on-chain state to 'Initial'" $ \txIn cperiod (me :| others) ->
-        let params = HeadParameters cperiod parties
-            parties = fst <$> me : others
-            cardanoKeys = snd <$> me : others
-            tx = initTx testNetworkId cardanoKeys params txIn
-            res = observeInitTx testNetworkId (fst me) tx
-         in case res of
-              Just (OnInitTx cp ps, InitObservation{initials}) ->
-                cp === cperiod
-                  .&&. ps === parties
-                  .&&. length initials === length cardanoKeys
-              _ -> property False
-              & counterexample ("Observe result: " <> show res)
-              & counterexample ("Tx: " <> show tx)
-
     describe "commitTx" $ do
       prop "transaction size for single commit utxo below limit" $ \party (ReasonablySized singleUTxO) initialIn ->
         let tx = commitTx testNetworkId party (Just singleUTxO) initialIn
@@ -119,21 +80,6 @@ spec =
               & label (show (len `div` 1024) <> "kB")
               & counterexample ("Tx: " <> show tx)
               & counterexample ("Tx serialized size: " <> show len)
-
-      prop "is observed" $ \party singleUTxO initialIn ->
-        let tx = commitTx testNetworkId party singleUTxO initialIn
-            commitAddress = mkScriptAddress @PlutusScriptV1 testNetworkId $ fromPlutusScript Commit.validatorScript
-            commitValue = headValue <> maybe mempty (txOutValue . snd) singleUTxO
-            commitDatum = mkCommitDatum party (Head.validatorHash policyId) singleUTxO
-            expectedOutput =
-              ( TxIn (getTxId (getTxBody tx)) (TxIx 0)
-              , toUTxOContext $ TxOut commitAddress commitValue (mkTxOutDatum commitDatum)
-              , fromPlutusData (toData commitDatum)
-              )
-            committedUTxO = maybe mempty UTxO.singleton singleUTxO
-         in observeCommitTx testNetworkId [fst initialIn] tx
-              === Just (OnCommitTx{party, committed = committedUTxO}, expectedOutput)
-              & counterexample ("Tx: " <> show tx)
 
     describe "collectComTx" $ do
       prop "transaction size below limit" $ \(ReasonablySized parties) headIn cperiod ->
@@ -148,27 +94,6 @@ spec =
                 & label (show (len `div` 1024) <> "kB")
                 & counterexample ("Tx: " <> show tx)
                 & counterexample ("Tx serialized size: " <> show len)
-
-      prop "is observed" $ \(ReasonablySized parties) headInput cperiod ->
-        forAll (generateCommitUTxOs parties) $ \commitsUTxO ->
-          let committedValue = foldMap (txOutValue . fst) commitsUTxO
-              headOutput = mkHeadOutput testNetworkId testPolicyId $ toUTxOContext $ mkTxOutDatum headDatum
-              headTotalValue = txOutValue headOutput <> committedValue
-              onChainParties = partyFromVerKey . vkey <$> parties
-              headDatum = Head.Initial cperiod onChainParties
-              lookupUTxO = UTxO.singleton (headInput, headOutput)
-              tx =
-                collectComTx
-                  testNetworkId
-                  (headInput, headOutput, fromPlutusData $ toData headDatum, onChainParties)
-                  commitsUTxO
-              res = observeCollectComTx lookupUTxO tx
-           in case res of
-                Just (OnCollectComTx, CollectComObservation{threadOutput}) ->
-                  txOutValue ((\(_, b, _, _) -> b) threadOutput) === headTotalValue
-                _ -> property False
-                & counterexample ("Observe result: " <> show res)
-                & counterexample ("Tx: " <> show tx)
 
       modifyMaxSuccess (const 10) $
         prop "validates" $ \headInput cperiod ->
@@ -207,19 +132,6 @@ spec =
               & counterexample ("Tx: " <> show tx)
               & counterexample ("Tx serialized size: " <> show len)
 
-      prop "is observed" $ \parties headInput snapshot msig ->
-        let headOutput = mkHeadOutput testNetworkId testPolicyId $ toUTxOContext $ mkTxOutDatum headDatum
-            headDatum = Head.Open{parties, utxoHash = ""}
-            lookupUTxO = UTxO.singleton (headInput, headOutput)
-            -- NOTE(SN): deliberately uses an arbitrary multi-signature
-            tx = closeTx snapshot msig (headInput, headOutput, fromPlutusData $ toData headDatum)
-            res = observeCloseTx lookupUTxO tx
-         in case res of
-              Just (OnCloseTx{snapshotNumber}, CloseObservation{}) -> snapshotNumber === number snapshot
-              _ -> property False
-              & counterexample ("Observe result: " <> show res)
-              & counterexample ("Tx: " <> show tx)
-
     describe "fanoutTx" $ do
       let prop_fanoutTxSize :: UTxO -> TxIn -> Property
           prop_fanoutTxSize utxo headIn =
@@ -253,16 +165,6 @@ spec =
         forAllShrinkBlind arbitrary shrinkUTxO $ \utxo ->
           forAll arbitrary $
             expectFailure . prop_fanoutTxSize utxo
-
-      prop "is observed" $ \utxo headInput ->
-        let tx = fanoutTx utxo (headInput, headDatum) (mkHeadTokenScript testSeedInput)
-            headOutput = mkHeadOutput testNetworkId testPolicyId TxOutDatumNone
-            headDatum = fromPlutusData $ toData $ Head.Closed{snapshotNumber = 1, utxoHash = ""}
-            lookupUTxO = UTxO.singleton (headInput, headOutput)
-            res = observeFanoutTx lookupUTxO tx
-         in res === Just (OnFanoutTx, ())
-              & counterexample ("Tx: " <> show tx)
-              & counterexample ("UTxO map: " <> show lookupUTxO)
 
       prop "validates" $ \headInput ->
         forAll (reasonablySized genUTxOWithSimplifiedAddresses) $ \inHeadUTxO ->
@@ -311,25 +213,6 @@ spec =
                             & label (show (len `div` 1024) <> "kB")
                             & counterexample ("Tx: " <> show tx)
                             & counterexample ("Tx serialized size: " <> show len)
-
-      prop "is observed" $
-        \txIn cperiod parties -> forAll (genAbortableOutputs parties) $
-          \(fmap drop2nd -> initials, commits) ->
-            let headOutput = mkHeadOutput testNetworkId testPolicyId TxOutDatumNone -- will be SJust, but not covered by this test
-                headDatum = fromPlutusData $ toData $ Head.Initial cperiod onChainParties
-                onChainParties = partyFromVerKey . vkey <$> parties
-                utxo = UTxO.singleton (txIn, headOutput)
-             in case abortTx testNetworkId (txIn, headOutput, headDatum) (Map.fromList initials) (Map.fromList $ map tripleToPair commits) of
-                  Left err -> property False & counterexample ("AbortTx construction failed: " <> show err)
-                  Right tx ->
-                    let res = observeAbortTx utxo tx
-                     in case res of
-                          Just (_, ()) ->
-                            property True
-                          _ ->
-                            property False
-                              & counterexample ("Result: " <> show res)
-                              & counterexample ("Tx: " <> show tx)
 
       prop "validates" $
         \txIn contestationPeriod (ReasonablySized parties) -> forAll (genAbortableOutputs parties) $

--- a/hydra-test-utils/src/Test/Hydra/Prelude.hs
+++ b/hydra-test-utils/src/Test/Hydra/Prelude.hs
@@ -5,14 +5,11 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 
 module Test.Hydra.Prelude (
   createSystemTempDirectory,
@@ -23,6 +20,7 @@ module Test.Hydra.Prelude (
   reasonablySized,
   ReasonablySized (..),
   genericCoverTable,
+  forAll2,
 
   -- * HSpec re-exports
   module Test.Hspec,
@@ -42,14 +40,14 @@ import Data.Typeable (typeRep)
 import GHC.Exception (SrcLoc (..))
 import System.Directory (removePathForcibly)
 import System.Exit (ExitCode (..))
-import System.Info (os)
 import System.IO.Temp (createTempDirectory, getCanonicalTemporaryDirectory)
+import System.Info (os)
 import System.Process (ProcessHandle, waitForProcess)
 import Test.HSpec.JUnit (junitFormat)
 import Test.HUnit.Lang (FailureReason (Reason), HUnitFailure (HUnitFailure))
 import Test.Hspec.Core.Format (Format, FormatConfig (..))
 import Test.Hspec.Core.Formatters (formatterToFormat, specdoc)
-import Test.QuickCheck (Property, Testable, coverTable, scale, tabulate)
+import Test.QuickCheck (Property, Testable, coverTable, forAll, scale, tabulate)
 
 -- | Create a unique temporary directory.
 createSystemTempDirectory :: String -> IO FilePath
@@ -205,3 +203,15 @@ genericCoverTable xs =
   allLabels = enumerate :: [a]
   enumerate = [minBound .. maxBound]
   lengthI = toInteger . length
+
+-- | Shorthand for using 2 generated values in a property.
+forAll2 ::
+  (Testable property, Show a, Show b) =>
+  Gen a ->
+  Gen b ->
+  ((a, b) -> property) ->
+  Property
+forAll2 genA genB action =
+  forAll genA $ \a ->
+    forAll genB $ \b ->
+      action (a, b)


### PR DESCRIPTION
(Opening for the sake of discussion... the two last commits are probably salvageable but the first one is up to debate :grimacing:).

- :round_pushpin: **Make transitions visible at the type-level.**
    Not sure I want to commit that as this is venturing more and more in
  the lands of dependent-types... therefore adding complexity to the
  code for actually here little gain apart from a more descriptive
  module API.

  What motivated this change initially was an attempt at simplifying the
  underlying test-code where we do know exactly what transition we want
  to do. Thus, getting back an opaque 'SomeOnChainHeadState' forces some
  needless unwrapping via reify state. It ain't much, as we are really
  just talking about one case/pattern-match but still... that was the
  initial motivation. With this new approach, we can remove that extra
  pattern match on call-sites by using `transition` directly, with some
  type annotation as for the transition we expect and tada! Yet.. the
  definitions are a bit more complex now as I added a new type-class and
  some glue to make things work :/

- :round_pushpin: **write another property on commit transition.**
    can only apply/observe the same commit once.

- :round_pushpin: **dry a bit the StateSpec: define forAllCommit.**

- :round_pushpin: **Add property tests for 'init' at the Direct.State level.**
  
- :round_pushpin: **Add property test for observing a CollectCom tx from the 'State' module perspective.**
  
- :round_pushpin: **Rename 'transition' -> 'observeTx'**
  
- :round_pushpin: **Minor cosmetic adjustments to StateSpec.**
  
- :round_pushpin: **Write a generic property for observing all possible transitions.**
    Instead of writing the same 'is observed' property for each individual transitions.

- :round_pushpin: **Provide Eq / Show instances for Transition to enable generic coverage via QuickCheck.**
    This is slightly involved but we get automatic coverage generation for free, telling us what transitions aren't covered by tests.

- :round_pushpin: **Move 'forAll2' to the test prelude.**
  
- :round_pushpin: **Add chain state tests for remaining transitions**
    Enforced by code coverage!

  ```
  observeTx
    All valid transitions for all possible states can be observed.
      +++ OK, passed 400 tests.

      Transition (400 in total):
      19.0% StOpen -> StClosed
      18.2% StClosed -> StIdle
      17.0% StIdle -> StInitialized
      16.0% StInitialized -> StIdle
      15.0% StInitialized -> StInitialized
      14.8% StInitialized -> StOpen
  ```

- :round_pushpin: **Add classification for interesting scenarios to the generic state observation tests.**
  
- :round_pushpin: **Remove now redundant/obsolete tests from TxSpec.**
  
- :round_pushpin: **Also move the size specs to the chain state spec module.**

---

```
Hydra.Chain.Direct.State
  observeTx
    All valid transitions for all possible states can be observed.
      +++ OK, passed 400 tests:
      17.0% Non-empty commit
      14.2% 2+ parties
      13.2% Abort after some (but not all) commits
       9.0% Close with initial snapshot
       8.5% Close with multi-signed snapshot
       1.8% 1 party
       1.0% Empty commit
       0.8% Abort immediately, after 0 commits
       0.5% Abort after all commits
      
      13.5% Fanout size: > 100
       4.0% Fanout size: 50-99
       0.8% Fanout size: 10-49
      
      Transition (400 in total):
      18.2% StClosed -> StIdle
      18.0% StInitialized -> StInitialized
      17.5% StOpen -> StClosed
      16.0% StIdle -> StInitialized
      15.8% StInitialized -> StOpen
      14.5% StInitialized -> StIdle
  init
    is not observed if not invited
      +++ OK, passed 100 tests; 86 discarded.
  commit
    is below the network size limit
      +++ OK, passed 100 tests:
      92% Non-empty commit
       8% Empty commit
      
      93% 6kB
       7% 7kB
    consumes all inputs that are committed
      +++ OK, passed 100 tests:
      92% Non-empty commit
       8% Empty commit
    can only be applied / observed once
      +++ OK, passed 100 tests:
      92% Non-empty commit
       8% Empty commit
  abort
    is below the network size limit
      +++ OK, passed 100 tests:
      76% Abort after some (but not all) commits
      13% Abort after all commits
      11% Abort immediately, after 0 commits
      
      41% 20kB
      24% 19kB
      12% 13kB
      12% 14kB
       7% 21kB
       4% 22kB
  collectCom
    is below the network size limit
      +++ OK, passed 100 tests:
      35% 13kB
      31% 15kB
      28% 14kB
       5% 16kB
       1% 12kB
  close
    is below the network size limit
      +++ OK, passed 100 tests:
      52% Close with multi-signed snapshot
      48% Close with initial snapshot
      
      78% 8kB
      19% 9kB
       2% 7kB
       1% 10kB
  fanout
    is below the network size limit
      +++ OK, passed 100 tests:
      61% Fanout size: > 100
      29% Fanout size: 50-99
      10% Fanout size: 10-49
      
      18% 16kB
      17% 17kB
      16% 18kB
      12% 13kB
       9% 14kB
       6% 19kB
       5% 12kB
       5% 15kB
       5% 21kB
       4% 20kB
       3% 11kB
```

