### PR TITLE
Re-add explicit packages in nix-shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -46,6 +46,20 @@ let
   ];
 
   haskellNixShell = hsPkgs.shellFor {
+    # NOTE: Explicit list of local packages as hoogle would not work otherwise.
+    # Make sure these are consistent with the packages in cabal.project.
+    packages = ps: with ps; [
+      hydra-cluster
+      hydra-node
+      hydra-plutus
+      hydra-prelude
+      hydra-test-utils
+      hydra-tui
+      hydra-cardano-api
+      merkle-patricia-tree
+      plutus-cbor
+      plutus-merkle-tree
+    ];
 
     # Haskell.nix managed tools (via hackage)
     tools = {


### PR DESCRIPTION
It seems like haddock/hoogle is not working with the implicit package
selection. Pinged the haskell.nix people for this, but until then the
explicit packages list will make do.
