### PR TITLE
Stateless Observe

### DIFF
--- a/hydra-cardano-api/hydra-cardano-api.cabal
+++ b/hydra-cardano-api/hydra-cardano-api.cabal
@@ -88,6 +88,7 @@ library
     Hydra.Cardano.Api.PlutusScriptVersion
     Hydra.Cardano.Api.PolicyId
     Hydra.Cardano.Api.Prelude
+    Hydra.Cardano.Api.RdmrTag
     Hydra.Cardano.Api.ScriptData
     Hydra.Cardano.Api.ScriptDataSupportedInEra
     Hydra.Cardano.Api.ScriptDatum

--- a/hydra-cardano-api/src/Hydra/Cardano/Api.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api.hs
@@ -97,6 +97,7 @@ import Hydra.Cardano.Api.MultiAssetSupportedInEra as Extras
 import Hydra.Cardano.Api.PlutusScript as Extras
 import Hydra.Cardano.Api.PlutusScriptVersion as Extras
 import Hydra.Cardano.Api.PolicyId as Extras
+import Hydra.Cardano.Api.RdmrTag as Extras
 import Hydra.Cardano.Api.ScriptData as Extras
 import Hydra.Cardano.Api.ScriptDataSupportedInEra as Extras
 import Hydra.Cardano.Api.ScriptDatum as Extras

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/RdmrTag.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/RdmrTag.hs
@@ -1,0 +1,36 @@
+module Hydra.Cardano.Api.RdmrTag where
+
+import Hydra.Cardano.Api.Prelude
+
+import qualified Cardano.Ledger.Alonzo.Scripts as Ledger
+
+-- * Extras
+
+-- | A redeemer tag used to qualify the purpose of a redeemer.
+data RdmrTag
+  = -- | Validates spending a script-locked UTxO
+    Spend
+  | -- | Validates minting new tokens
+    Mint
+  | -- | Validates certificate transactions
+    Cert
+  | -- | Validates withdrawl from a reward account
+    Rewrd
+  deriving (Eq, Generic, Ord, Show, Enum, Bounded)
+
+-- * Type Conversions
+
+-- | Convert a cardano-ledger's 'Tag' into a cardano-api's 'RdmrTag'
+fromLedgerTag :: Ledger.Tag -> RdmrTag
+fromLedgerTag = \case
+  Ledger.Spend -> Spend
+  Ledger.Mint -> Mint
+  Ledger.Cert -> Cert
+  Ledger.Rewrd -> Rewrd
+
+toLedgerTag :: RdmrTag -> Ledger.Tag
+toLedgerTag = \case
+  Spend -> Ledger.Spend
+  Mint -> Ledger.Mint
+  Cert -> Ledger.Cert
+  Rewrd -> Ledger.Rewrd

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/ScriptData.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/ScriptData.hs
@@ -13,13 +13,18 @@ import qualified Plutus.V1.Ledger.Api as Plutus
 -- | Data-types that can be marshalled into a generic 'ScriptData' structure.
 type ToScriptData a = Plutus.ToData a
 
--- | Data-types that can be unmarshalled from a generic 'ScriptData' structure.
-type FromScriptData a = Plutus.FromData a
-
 -- | Serialise some type into a generic 'ScriptData' structure.
 toScriptData :: (ToScriptData a) => a -> ScriptData
 toScriptData =
   fromPlutusData . Plutus.toData
+
+-- | Data-types that can be unmarshalled from a generic 'ScriptData' structure.
+type FromScriptData a = Plutus.FromData a
+
+-- | Interpret a script data as some type.
+fromScriptData :: (FromScriptData a) => ScriptData -> Maybe a
+fromScriptData =
+  Plutus.fromData . Ledger.getPlutusData . toLedgerData
 
 -- | Get the 'ScriptData' associated to the a 'TxOut'. Note that this requires
 -- the 'CtxTx' context. To get script data in a 'CtxUTxO' context, see

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/TxBody.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/TxBody.hs
@@ -2,9 +2,11 @@ module Hydra.Cardano.Api.TxBody where
 
 import Hydra.Cardano.Api.Prelude
 
+import Hydra.Cardano.Api.ExecutionUnits (fromLedgerExUnits)
 import Hydra.Cardano.Api.PlutusScript (fromLedgerScript)
 import Hydra.Cardano.Api.PolicyId (toLedgerScriptHash)
-import Hydra.Cardano.Api.ScriptData (FromScriptData)
+import Hydra.Cardano.Api.RdmrTag (RdmrTag (..), fromLedgerTag)
+import Hydra.Cardano.Api.ScriptData (FromScriptData, fromLedgerData)
 import Hydra.Cardano.Api.TxIn (toLedgerTxIn)
 
 import qualified Cardano.Ledger.Alonzo.Data as Ledger
@@ -62,6 +64,32 @@ findScriptMinting (getTxBody -> ShelleyTxBody _ body scripts _ _ _) policyId = d
  where
   needle = toLedgerScriptHash policyId
   haystack = getField @"minted" body :: Set (Ledger.ScriptHash StandardCrypto)
+
+foldRedeemers ::
+  Tx AlonzoEra ->
+  result ->
+  (RdmrTag -> Word64 -> ScriptData -> ExecutionUnits -> result -> result) ->
+  result
+foldRedeemers (getTxBody -> ShelleyTxBody _ _ _ scriptData _ _) result0 step =
+  Map.foldrWithKey
+    ( \(Ledger.RdmrPtr tag ix) (d, ex) ->
+        step (fromLedgerTag tag) ix (fromLedgerData d) (fromLedgerExUnits ex)
+    )
+    result0
+    redeemers
+ where
+  redeemers = case scriptData of
+    TxBodyNoScriptData ->
+      mempty
+    TxBodyScriptData _ _ (Ledger.Redeemers rs) ->
+      rs
+
+hasScript ::
+  Tx AlonzoEra ->
+  PlutusScript lang ->
+  Bool
+hasScript (getTxBody -> ShelleyTxBody _ _ scripts _ _ _) script =
+  script `elem` (fromLedgerScript <$> scripts)
 
 --
 -- Internals

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -348,8 +348,8 @@ instance HasTransition 'StInitialized where
 
 instance ObserveTx 'StInitialized 'StInitialized where
   observeTx tx st@OnChainHeadState{networkId, stateMachine} = do
-    let initials = fst3 <$> initialInitials
-    (event, newCommit) <- observeCommitTx networkId initials tx
+    (event, newCommit) <- observeCommitTx networkId tx
+    guard (newCommit `notElem` initialCommits)
     let st' =
           st
             { stateMachine =


### PR DESCRIPTION
- :round_pushpin: **Add extra helpers to hydra-cardano-api.**
  
- :round_pushpin: **Make 'observeCommitTx' stateless**
    This drops the 'initials' argument from an observeCommitTx to allow
  observing a commit transaction from just a transaction. This changes
  slightly alter the semantic of the _what we consider a commit_ and
  makes the assumption that a commit is a transaction which carries only
  one script (an initial script) and has an input locked by such script.

  Yet, the current transaction format does not allow us to express the
  relation "is locked by" because we do not have a full resolution of
  inputs. Inputs are just (TxIn, Ix).

  It'd be possible to get rid of this assumption if we had access to
  fully resolved inputs, in which case we could look for THE input that
  is locked by an initial script. However, this is likely good enough
  for now.
