### PR TITLE
Refactor genSequenceOfValidTransactions

### DIFF
--- a/hydra-node/src/Hydra/Ledger.hs
+++ b/hydra-node/src/Hydra/Ledger.hs
@@ -43,6 +43,8 @@ class
 data Ledger tx = Ledger
   { -- | Apply a set of transaction to a given UTXO set. Returns the new UTXO or
     -- validation failures returned from the ledger.
+    -- TODO: 'ValidationError' should also include the UTxO, which is not
+    -- necessarily the same as the given UTxO after some transactions
     applyTransactions ::
       UTxOType tx ->
       [tx] ->

--- a/hydra-node/src/Hydra/Ledger.hs
+++ b/hydra-node/src/Hydra/Ledger.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Hydra.Ledger where
 

--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -265,7 +265,7 @@ genFixedSizeSequenceOfValidTransactions globals ledgerEnv numTxs = do
   initialUTxO <- genUTxO
   if initialUTxO == mempty
     then pure (initialUTxO, [])
-    else second reverse <$> foldM newTx (initialUTxO, []) [1 .. numTxs]
+    else (initialUTxO,) . reverse . snd <$> foldM newTx (initialUTxO, []) [1 .. numTxs]
  where
   newTx (utxos, acc) _ = do
     tx <- genTx ledgerEnv utxos

--- a/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
+++ b/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
@@ -19,12 +19,10 @@ import Hydra.Ledger (applyTransactions)
 import Hydra.Ledger.Cardano (
   cardanoLedger,
   genSequenceOfValidTransactions,
-  genUTxO,
  )
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
 import Test.Cardano.Ledger.MaryEraGen ()
-import Test.QuickCheck (Property, counterexample, forAllBlind, forAllShrink, property, (.&&.), (===))
-import Test.QuickCheck.Property (forAll)
+import Test.QuickCheck (Property, counterexample, forAllBlind, property, (.&&.), (===))
 
 spec :: Spec
 spec =

--- a/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
+++ b/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
@@ -23,7 +23,7 @@ import Hydra.Ledger.Cardano (
  )
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
 import Test.Cardano.Ledger.MaryEraGen ()
-import Test.QuickCheck (Property, counterexample, forAllShrink, property, (.&&.), (===))
+import Test.QuickCheck (Property, counterexample, forAllBlind, forAllShrink, property, (.&&.), (===))
 import Test.QuickCheck.Property (forAll)
 
 spec :: Spec
@@ -109,11 +109,7 @@ appliesValidTransactionFromJSON =
   forAllBlind (genSequenceOfValidTransactions defaultGlobals defaultLedgerEnv) $ \(utxo, txs) ->
     let encoded = encode txs
         result = eitherDecode encoded >>= first show . applyTransactions (cardanoLedger defaultGlobals defaultLedgerEnv) utxo
-     in case result of
-          Right _ -> property True
-          Left (tx, err) ->
-            property False
-              & counterexample ("Error: " <> show err)
-              & counterexample ("Failing tx: " <> toString (renderTx tx))
-              & counterexample ("All txs: " <> unpack (decodeUtf8With lenientDecode $ prettyPrintJSON txs))
-              & counterexample ("Initial UTxO: " <> unpack (decodeUtf8With lenientDecode $ prettyPrintJSON utxo))
+     in isRight result
+          & counterexample ("Result: " <> show result)
+          & counterexample ("All txs: " <> unpack (decodeUtf8With lenientDecode $ prettyPrintJSON txs))
+          & counterexample ("Initial UTxO: " <> unpack (decodeUtf8With lenientDecode $ prettyPrintJSON utxo))


### PR DESCRIPTION
:snowflake: Refactor genSequenceOfValidTransctions to be a Gen (UTxO, [Tx])

This removes the need to use a `genUTxO` which is compatible with the included `genTx` and allows further refactoring of `genUTxO` and our `Arbitrary UTxO` instance.

:snowflake: Improve error output of `applyTransactions` tests
