### PR TITLE
Remove the Party from the Commit Datum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ changes.
 - `hydra-tui` to show form focus, indicate invalid fields in dialogs and only allow valid values
   to be submitted [#224](https://github.com/input-output-hk/hydra-poc/issues/224).
 
+## Known issues
+
+- `cardano-verification-key` need to be in the same order on all `hydra-node` instances of the same Head.
+
 ## [0.3.0] - 2022-02-22
 
 #### Added

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -150,6 +150,7 @@ withDirectChain tracer networkId iocp socketPath keyPair party cardanoKeys callb
             networkId
             (verificationKey wallet)
             party
+            cardanoKeys
     race_
       ( do
           -- FIXME: There's currently a race-condition with the actual client

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -208,16 +208,16 @@ commit ::
   UTxO ->
   OnChainHeadState 'StInitialized ->
   Either (PostTxError Tx) Tx
-commit utxo st@OnChainHeadState{networkId, ownParty, ownVerificationKey, stateMachine} = do
+commit utxo st@OnChainHeadState{networkId, ownVerificationKey, stateMachine} = do
   case ownInitial initialHeadTokenScript ownVerificationKey initialInitials of
     Nothing ->
       Left (CannotFindOwnInitial{knownUTxO = getKnownUTxO st})
     Just initial ->
       case UTxO.pairs utxo of
         [aUTxO] -> do
-          Right $ commitTx networkId ownParty (Just aUTxO) initial
+          Right $ commitTx networkId (Just aUTxO) initial
         [] -> do
-          Right $ commitTx networkId ownParty Nothing initial
+          Right $ commitTx networkId Nothing initial
         _ ->
           Left (MoreThanOneUTxOCommitted @Tx)
  where

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -475,7 +475,7 @@ observeCommitTx ::
   [TxIn] ->
   Tx ->
   Maybe (OnChainTx Tx, CommitObservation)
-observeCommitTx networkId headScript _partyTable initials tx = do
+observeCommitTx networkId headScript partyTable initials tx = do
   initialTxIn <- findInitialTxIn
   mCommittedTxIn <- decodeInitialRedeemer initialTxIn
 
@@ -521,7 +521,7 @@ observeCommitTx networkId headScript _partyTable initials tx = do
       _ -> Nothing
 
   partyFromAsset :: AssetName -> Maybe Party
-  partyFromAsset an = assetNameToVKH an >>= lookupVKHParty undefined
+  partyFromAsset an = assetNameToVKH an >>= lookupVKHParty partyTable
 
 convertTxOut :: Maybe Commit.SerializedTxOut -> Maybe (TxOut CtxUTxO)
 convertTxOut = \case
@@ -691,8 +691,11 @@ mkHeadId =
 newtype PartyTable = PartyTable (Map (Hash PaymentKey) Party)
   deriving (Show)
 
+-- FIXME: This results in a known issue where we need all
+-- --cardano-verification-key options on all hydra-nodes need to be in the same
+-- order :(
 mkPartyTable :: [VerificationKey PaymentKey] -> [Party] -> PartyTable
-mkPartyTable = undefined
+mkPartyTable vks ps = PartyTable $ Map.fromList (zip (map verificationKeyHash vks) ps)
 
 -- | Map a chain-specific credential (Hash PaymentKey) to the hydra-credential
 -- (Party). This function actually connects the chain layer to the logic layer.

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -386,6 +386,7 @@ data InitObservation = InitObservation
   , commits :: [UTxOWithScript]
   , headId :: HeadId
   , headTokenScript :: PlutusScript
+  , parties :: [Party]
   }
   deriving (Show, Eq)
 
@@ -418,6 +419,7 @@ observeInitTx networkId party tx = do
         , commits = []
         , headId = mkHeadId headTokenPolicyId
         , headTokenScript
+        , parties
         }
     )
  where
@@ -686,7 +688,8 @@ mkHeadId =
 -- actually all be tracked inside `Party`, such that `HeadParameters` suffice to
 -- do this lookup.
 
-data PartyTable = PartyTable (Map (Hash PaymentKey) Party)
+newtype PartyTable = PartyTable (Map (Hash PaymentKey) Party)
+  deriving (Show)
 
 mkPartyTable :: [VerificationKey PaymentKey] -> [Party] -> PartyTable
 mkPartyTable = undefined

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -131,7 +131,7 @@ healthyCommitOutput party committed =
         [ (AssetId testPolicyId (assetNameFromVerificationKey cardanoVk), 1)
         ]
   commitDatum =
-    mkCommitDatum party Head.validatorHash (Just committed)
+    mkCommitDatum Head.validatorHash (Just committed)
 
 data CollectComMutation
   = MutateOpenOutputValue

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
@@ -22,7 +22,6 @@ import Hydra.Ledger.Cardano (
   genValue,
   genVerificationKey,
  )
-import Hydra.Party (Party)
 import Test.QuickCheck (oneof, suchThat)
 
 --
@@ -39,7 +38,6 @@ healthyCommitTx =
   tx =
     commitTx
       Fixture.testNetworkId
-      commitParty
       (Just healthyCommittedUTxO)
       (initialInput, toUTxOContext initialOutput, initialPubKeyHash)
 
@@ -53,9 +51,6 @@ healthyCommitTx =
 
   commitVerificationKey :: VerificationKey PaymentKey
   commitVerificationKey = generateWith arbitrary 42
-
-  commitParty :: Party
-  commitParty = generateWith arbitrary 42
 
 -- NOTE: An 8₳ output which is currently addressed to some arbitrary key.
 healthyCommittedUTxO :: (TxIn, TxOut CtxUTxO)

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -303,7 +303,7 @@ genStIdle ::
 genStIdle HydraContext{ctxVerificationKeys, ctxNetworkId, ctxParties} = do
   ownParty <- elements ctxParties
   ownVerificationKey <- elements ctxVerificationKeys
-  pure $ idleOnChainHeadState ctxNetworkId ownVerificationKey ownParty
+  pure $ idleOnChainHeadState ctxNetworkId ownVerificationKey ownParty ctxVerificationKeys
 
 genStInitialized ::
   HydraContext ->
@@ -351,7 +351,7 @@ genCommits ::
   Gen [Tx]
 genCommits ctx initTx = do
   forM (zip (ctxVerificationKeys ctx) (ctxParties ctx)) $ \(p, vk) -> do
-    let stIdle = idleOnChainHeadState (ctxNetworkId ctx) p vk
+    let stIdle = idleOnChainHeadState (ctxNetworkId ctx) p vk (ctxVerificationKeys ctx)
     let (_, stInitialized) = unsafeObserveTx @_ @'StInitialized initTx stIdle
     utxo <- genCommit
     pure $ unsafeCommit utxo stInitialized

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -245,6 +245,7 @@ spec =
 
 -- | Generate a UTXO representing /commit/ outputs for a given list of `Party`.
 -- FIXME: This function is very complicated and it's hard to understand it after a while
+-- XXX: [Party] is only used for the length of the list
 generateCommitUTxOs :: [Party] -> Gen (Map.Map TxIn (TxOut CtxUTxO, ScriptData))
 generateCommitUTxOs parties = do
   txins <- vectorOf (length parties) (arbitrary @TxIn)
@@ -259,11 +260,11 @@ generateCommitUTxOs parties = do
         ]
   let commitUTxO =
         zip txins $
-          uncurry mkCommitUTxO <$> zip (zip vks parties) committedUTxO
+          uncurry mkCommitUTxO <$> zip vks committedUTxO
   pure $ Map.fromList commitUTxO
  where
-  mkCommitUTxO :: (VerificationKey PaymentKey, Party) -> Maybe (TxIn, TxOut CtxUTxO) -> (TxOut CtxUTxO, ScriptData)
-  mkCommitUTxO (vk, party) utxo =
+  mkCommitUTxO :: VerificationKey PaymentKey -> Maybe (TxIn, TxOut CtxUTxO) -> (TxOut CtxUTxO, ScriptData)
+  mkCommitUTxO vk utxo =
     ( toUTxOContext $
         TxOut
           (mkScriptAddress @PlutusScriptV1 testNetworkId commitScript)
@@ -281,7 +282,7 @@ generateCommitUTxOs parties = do
             ]
         ]
     commitScript = fromPlutusScript Commit.validatorScript
-    commitDatum = mkCommitDatum party Head.validatorHash utxo
+    commitDatum = mkCommitDatum Head.validatorHash utxo
 
 -- | Evaluate all plutus scripts and return execution budgets of a given
 -- transaction (any included budgets are ignored).

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -183,9 +183,9 @@ checkCollectCom commitAddress (_, parties) context@ScriptContext{scriptContextTx
   lookupCommit h = do
     d <- getDatum <$> findDatum h txInfo
     case fromBuiltinData @(DatumType Commit) d of
-      Just (_p, _, Just o) ->
+      Just (_, Just o) ->
         Just o
-      Just (_p, _, Nothing) ->
+      Just (_, Nothing) ->
         Nothing
       Nothing ->
         traceError "fromBuiltinData failed"

--- a/hydra-plutus/src/Hydra/Contract/Initial.hs
+++ b/hydra-plutus/src/Hydra/Contract/Initial.hs
@@ -131,7 +131,7 @@ checkCommit commitValidator committedRef context@ScriptContext{scriptContextTxIn
           (Just da) ->
             case fromBuiltinData @(DatumType Commit.Commit) da of
               Nothing -> traceError "expected commit datum type, got something else"
-              Just (_party, _headScriptHash, mSerializedTxOut) ->
+              Just (_headScriptHash, mSerializedTxOut) ->
                 mSerializedTxOut
       _ -> traceError "expected single commit output"
 


### PR DESCRIPTION
First step of #242

This became messy because at some point, some code needs to determine from which party (hydra credential) a commit came from (as our Head logic is tracking parties in deciding when to open the Head), but the only thing we see on chain is now a `Hash PaymentKey`.

We discussed a lot and somewhat agree that it would be best if the return type of `observeCommitTx` would NOT contain a `Party`, but only the chain-specific credential info (e.g. by changing `OnChainTx` contain only the `Hash PaymentKey`), but ripples far and we have not really been settled on where the `Hash PaymentKey` -> `Party` lookup would be made. In general, if `Party` would contain both, many pitfalls (like taking two lists which need to be consistent in `mkPartyTable`) could be avoided (https://github.com/input-output-hk/hydra-poc/pull/258/commits/2c1359c0e1ab490d5fbfd019ae8e274b2d458ecf)