### PR TITLE
Test suite & generator grooming

### DIFF
--- a/hydra-cardano-api/src/Cardano/Api/UTxO.hs
+++ b/hydra-cardano-api/src/Cardano/Api/UTxO.hs
@@ -35,6 +35,10 @@ newtype UTxO' out = UTxO
 instance Traversable UTxO' where
   traverse fn (UTxO m) = UTxO <$> traverse fn m
 
+-- | Create a 'UTxO' from a list of 'TxIn' and 'out' pairs.
+fromPairs :: [(TxIn, out)] -> UTxO' out
+fromPairs = UTxO . Map.fromList
+
 -- | Create a 'UTxO' from a single unspent transaction output.
 singleton :: (TxIn, TxOut CtxUTxO AlonzoEra) -> UTxO
 singleton (i, o) = UTxO $ Map.singleton i o

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Value.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Value.hs
@@ -6,6 +6,12 @@ import qualified Cardano.Ledger.Alonzo.TxInfo as Ledger
 import qualified Cardano.Ledger.Mary.Value as Ledger
 import qualified Plutus.V1.Ledger.Api as Plutus
 
+-- * Extras
+
+-- | Count number of assets in a 'Value'.
+valueSize :: Value -> Int
+valueSize = length . valueToList
+
 -- * Type Conversions
 
 -- | Convert a cardano-ledger's 'Value'  into a cardano-api's 'Value'

--- a/hydra-cluster/test/Test/GeneratorSpec.hs
+++ b/hydra-cluster/test/Test/GeneratorSpec.hs
@@ -15,8 +15,8 @@ import Hydra.Generator (
   defaultProtocolParameters,
   genDatasetConstantUTxO,
  )
-import Hydra.Ledger (applyTransactions, balance)
-import Hydra.Ledger.Cardano (Tx, cardanoLedger, genUTxO)
+import Hydra.Ledger (applyTransactions)
+import Hydra.Ledger.Cardano (Tx, cardanoLedger)
 import Hydra.Ledger.Cardano.Configuration (
   Globals,
   LedgerEnv,
@@ -32,13 +32,7 @@ import Test.QuickCheck (Positive (Positive), Property, counterexample, forAll, i
 spec :: Spec
 spec = parallel $ do
   roundtripSpecs (Proxy @Dataset)
-  prop "compute values from UTXO set" prop_computeValueFromUTxO
   prop "generates a Dataset that keeps UTXO constant" prop_keepsUTxOConstant
-
-prop_computeValueFromUTxO :: Property
-prop_computeValueFromUTxO =
-  forAll genUTxO $ \utxo ->
-    balance @Tx utxo /= mempty
 
 prop_keepsUTxOConstant :: Property
 prop_keepsUTxOConstant =

--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -19,10 +19,13 @@ import qualified Cardano.Crypto.DSIGN as CC
 import Cardano.Crypto.Hash (SHA256, digest)
 import qualified Cardano.Ledger.Alonzo.PParams as Ledger.Alonzo
 import qualified Cardano.Ledger.Alonzo.Tx as Ledger.Alonzo
+import qualified Cardano.Ledger.Alonzo.TxBody as Ledger.Alonzo
 import qualified Cardano.Ledger.BaseTypes as Ledger
 import qualified Cardano.Ledger.Core as Ledger
 import qualified Cardano.Ledger.Credential as Ledger
 import qualified Cardano.Ledger.Crypto as Ledger (StandardCrypto)
+import qualified Cardano.Ledger.Mary as Ledger.Mary
+import qualified Cardano.Ledger.Shelley.API as Ledger.Shelley
 import qualified Cardano.Ledger.Shelley.API.Mempool as Ledger
 import qualified Cardano.Ledger.Shelley.Genesis as Ledger
 import qualified Cardano.Ledger.Shelley.LedgerState as Ledger
@@ -296,6 +299,19 @@ genUTxO =
     Ledger.TxIn Ledger.StandardCrypto ->
     Ledger.TxIn Ledger.StandardCrypto
   setTxId baseId (Ledger.TxIn _ti wo) = Ledger.TxIn baseId wo
+
+genUTxOMultiAsset :: Gen UTxO
+genUTxOMultiAsset =
+  fmap
+    (fromLedgerUTxO . Ledger.UTxO . Map.map fromMaryTxOut . Ledger.unUTxO)
+    arbitrary
+ where
+  fromMaryTxOut ::
+    Ledger.Mary.TxOut (Ledger.Mary.MaryEra Ledger.StandardCrypto) ->
+    Ledger.TxOut LedgerEra
+  fromMaryTxOut = \case
+    Ledger.Shelley.TxOutCompact addr value ->
+      Ledger.Alonzo.TxOutCompact addr value
 
 -- | Generate utxos owned by the given cardano key.
 genUTxOFor :: VerificationKey PaymentKey -> Gen UTxO

--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -291,6 +291,7 @@ genTxIn =
     <$> fmap (unsafeDeserialize' . BS.pack . ([88, 32] <>)) (vectorOf 32 arbitrary)
     <*> fmap fromIntegral (choose @Int (0, 99))
 
+-- | Generate some 'UTxO'. NOTE: This seems to be generating Ada-only 'TxOut'.
 genUTxO :: Gen UTxO
 genUTxO = do
   genesisTxId <- arbitrary

--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -Wno-missing-methods #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Hydra.Ledger.Cardano (
@@ -23,17 +21,14 @@ import qualified Cardano.Crypto.DSIGN as CC
 import Cardano.Crypto.Hash (SHA256, digest)
 import qualified Cardano.Ledger.Alonzo.PParams as Ledger.Alonzo
 import qualified Cardano.Ledger.Alonzo.Tx as Ledger.Alonzo
-import qualified Cardano.Ledger.Alonzo.TxBody as Ledger.Alonzo
 import qualified Cardano.Ledger.BaseTypes as Ledger
 import qualified Cardano.Ledger.Core as Ledger
 import qualified Cardano.Ledger.Credential as Ledger
 import qualified Cardano.Ledger.Crypto as Ledger (StandardCrypto)
-import qualified Cardano.Ledger.Mary as Ledger.Mary hiding (Value)
 import qualified Cardano.Ledger.Shelley.API.Mempool as Ledger
 import qualified Cardano.Ledger.Shelley.Genesis as Ledger
 import qualified Cardano.Ledger.Shelley.LedgerState as Ledger
 import qualified Cardano.Ledger.Shelley.Rules.Ledger as Ledger
-import qualified Cardano.Ledger.Shelley.Tx as Ledger.Shelley
 import qualified Cardano.Ledger.Shelley.UTxO as Ledger
 import qualified Cardano.Ledger.TxIn as Ledger
 import qualified Codec.CBOR.Decoding as CBOR
@@ -191,21 +186,9 @@ instance FromCBOR UTxO where
   fromCBOR = fromLedgerUTxO <$> fromCBOR
   label _ = label (Proxy @(Ledger.UTxO LedgerEra))
 
--- TODO: Use Alonzo generators!
--- probably: import Test.Cardano.Ledger.Alonzo.AlonzoEraGen ()
 instance Arbitrary UTxO where
   shrink = shrinkUTxO
-  arbitrary =
-    fmap
-      (fromLedgerUTxO . Ledger.UTxO . Map.map fromMaryTxOut . Ledger.unUTxO)
-      arbitrary
-   where
-    fromMaryTxOut ::
-      Ledger.Mary.TxOut (Ledger.Mary.MaryEra Ledger.StandardCrypto) ->
-      Ledger.TxOut LedgerEra
-    fromMaryTxOut = \case
-      Ledger.Shelley.TxOutCompact addr value ->
-        Ledger.Alonzo.TxOutCompact addr value
+  arbitrary = genUTxO
 
 -- * Generators
 

--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -276,16 +276,22 @@ genTxIn =
     <$> fmap (unsafeDeserialize' . BS.pack . ([88, 32] <>)) (vectorOf 32 arbitrary)
     <*> fmap fromIntegral (choose @Int (0, 99))
 
--- | Generate some number of 'UTxO'. NOTE: This seems to be generating Ada-only 'TxOut'.
+-- | Generate some number of 'UTxO'.
 genUTxO :: Gen UTxO
 genUTxO =
+  genUTxOAlonzo
+
+-- | Generate 'Alonzo' era 'UTxO', which has Ada-only 'TxOut' addressed to
+-- public keys and scripts.
+genUTxOAlonzo :: Gen UTxO
+genUTxOAlonzo =
   fromLedgerUTxO <$> arbitrary
 
--- | Generate a 'Mary' era which may contain arbitrary assets in 'TxOut's. NOTE:
--- This is not reducing size when generating assets in 'TxOut's, so will end up
--- regularly with 300+ assets with generator size 30.
-genUTxOMultiAsset :: Gen UTxO
-genUTxOMultiAsset =
+-- | Generate 'Mary' era 'UTxO', which may contain arbitrary assets in 'TxOut's.
+-- NOTE: This is not reducing size when generating assets in 'TxOut's, so will
+-- end up regularly with 300+ assets with generator size 30.
+genUTxOMary :: Gen UTxO
+genUTxOMary =
   convertFromMaryUTxO <$> arbitrary
  where
   convertFromMaryUTxO = fromLedgerUTxO . Ledger.UTxO . Map.map fromMaryTxOut . Ledger.unUTxO

--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -281,7 +281,9 @@ genUTxO :: Gen UTxO
 genUTxO =
   fromLedgerUTxO <$> arbitrary
 
--- | Generate a 'Mary' era which may contain arbitrary assets in 'TxOut's.
+-- | Generate a 'Mary' era which may contain arbitrary assets in 'TxOut's. NOTE:
+-- This is not reducing size when generating assets in 'TxOut's, so will end up
+-- regularly with 300+ assets with generator size 30.
 genUTxOMultiAsset :: Gen UTxO
 genUTxOMultiAsset =
   convertFromMaryUTxO <$> arbitrary

--- a/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs
@@ -34,7 +34,7 @@ import qualified Data.Map as Map
 import Data.Maybe (fromJust)
 import Data.Ratio ((%))
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
-import Hydra.Cardano.Api (StandardCrypto, Tx, UTxO, toLedgerTx, toLedgerUTxO)
+import Hydra.Cardano.Api (ExecutionUnits, StandardCrypto, Tx, UTxO, toLedgerExUnits, toLedgerTx, toLedgerUTxO)
 import Hydra.Chain.Direct.Util (Era)
 
 type RedeemerReport =
@@ -48,6 +48,22 @@ evaluateTx tx utxo =
   runIdentity $
     evaluateTransactionExecutionUnits
       pparams
+      (toLedgerTx tx)
+      (toLedgerUTxO utxo)
+      epochInfo
+      systemStart
+      costModels
+
+evaluateTx' ::
+  -- | Max tx execution units.
+  ExecutionUnits ->
+  Tx ->
+  UTxO ->
+  Either (BasicFailure StandardCrypto) RedeemerReport
+evaluateTx' maxTxExUnits tx utxo =
+  runIdentity $
+    evaluateTransactionExecutionUnits
+      pparams{_maxTxExUnits = toLedgerExUnits maxTxExUnits}
       (toLedgerTx tx)
       (toLedgerUTxO utxo)
       epochInfo

--- a/hydra-node/test/Hydra/Chain/Direct/Fixture.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Fixture.hs
@@ -54,7 +54,7 @@ testSeedInput :: TxIn
 testSeedInput = generateWith arbitrary 42
 
 maxTxSize :: Int64
-maxTxSize = 1 `shift` 15
+maxTxSize = 1 `shift` 14 -- 16kB
 
 instance Arbitrary PubKeyHash where
   arbitrary = PubKeyHash . toBuiltin <$> (arbitrary :: Gen ByteString)

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -331,11 +331,7 @@ genStClosed ::
   HydraContext ->
   Gen (OnChainHeadState 'StClosed)
 genStClosed ctx = do
-  initTx <- genInitTx ctx
-  commits <- genCommits ctx initTx
-  stInitialized <- executeCommits initTx commits <$> genStIdle ctx
-  let collectComTx = collect stInitialized
-  let stOpen = snd $ unsafeObserveTx @_ @'StOpen collectComTx stInitialized
+  stOpen <- genStOpen ctx
   snapshot <- arbitrary
   let closeTx = close snapshot stOpen
   pure $ snd $ unsafeObserveTx @_ @'StClosed closeTx stOpen

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -39,9 +39,10 @@ import Hydra.Data.Party (partyFromVerKey)
 import Hydra.Ledger.Cardano (
   adaOnly,
   genOneUTxOFor,
-  genUTxOWithSimplifiedAddresses,
+  genUTxO,
   genVerificationKey,
   hashTxOuts,
+  simplifyUTxO,
  )
 import Hydra.Party (Party, vkey)
 import Plutus.V1.Ledger.Api (toBuiltin, toData)
@@ -94,7 +95,7 @@ spec =
 
     describe "fanoutTx" $ do
       prop "validates" $ \headInput ->
-        forAll (resize 50 genUTxOWithSimplifiedAddresses) $ \inHeadUTxO ->
+        forAll (resize 70 $ simplifyUTxO <$> genUTxO) $ \inHeadUTxO ->
           let tx =
                 fanoutTx
                   inHeadUTxO
@@ -128,6 +129,7 @@ spec =
                         & counterexample "Wrong count of mint redeemer(s)"
                     ]
                     & label (show (length inHeadUTxO) <> " UTXO")
+                    & label (show (valueSize $ foldMap txOutValue inHeadUTxO) <> " Assets")
                     & counterexample ("Redeemer report: " <> show redeemerReport)
                     & counterexample ("Tx: " <> toString (renderTx tx))
                     & cover 0.8 True "Success"

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -58,12 +58,12 @@ import Test.QuickCheck (
   conjoin,
   counterexample,
   cover,
-  expectFailure,
   forAll,
   forAllShrinkBlind,
   label,
   oneof,
   property,
+  resize,
   suchThat,
   vectorOf,
   withMaxSuccess,
@@ -129,7 +129,7 @@ spec =
             prop_fanoutTxSize utxo
 
       prop "validates" $ \headInput ->
-        forAll (reasonablySized genUTxOWithSimplifiedAddresses) $ \inHeadUTxO ->
+        forAll (resize 50 genUTxOWithSimplifiedAddresses) $ \inHeadUTxO ->
           let tx =
                 fanoutTx
                   inHeadUTxO
@@ -164,7 +164,7 @@ spec =
                     ]
                     & label (show (length inHeadUTxO) <> " UTXO")
                     & counterexample ("Redeemer report: " <> show redeemerReport)
-                    & counterexample ("Tx: " <> show tx)
+                    & counterexample ("Tx: " <> toString (renderTx tx))
                     & cover 0.8 True "Success"
 
     describe "abortTx" $ do

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -42,6 +42,7 @@ import Hydra.Data.Party (partyFromVerKey)
 import Hydra.Ledger.Cardano (
   adaOnly,
   genOneUTxOFor,
+  genUTxO,
   genUTxOWithSimplifiedAddresses,
   genVerificationKey,
   hashTxOuts,
@@ -105,7 +106,7 @@ spec =
                 headDatum = fromPlutusData $ toData Head.Closed{snapshotNumber = 1, utxoHash = ""}
                 cbor = serialize tx
                 len = LBS.length cbor
-             in len < maxTxSize
+             in len < (2 * maxTxSize)
                   & label (show (len `div` 1024) <> "KB")
                   & label (prettyLength utxo <> " entries")
                   & counterexample (toString (renderTx tx))
@@ -123,9 +124,9 @@ spec =
       -- (fanout splitting) or find a better property to capture what is
       -- actually 'expectable' from the function, given arbitrary UTXO entries.
       prop "size is above limit for UTXO" $
-        forAllShrinkBlind arbitrary shrinkUTxO $ \utxo ->
+        forAllShrinkBlind genUTxO shrinkUTxO $ \utxo ->
           forAll arbitrary $
-            expectFailure . prop_fanoutTxSize utxo
+            prop_fanoutTxSize utxo
 
       prop "validates" $ \headInput ->
         forAll (reasonablySized genUTxOWithSimplifiedAddresses) $ \inHeadUTxO ->


### PR DESCRIPTION
:snowflake: Add some `fromPairs` and `valueSize` utilities to `hydra-cardano-api`

:snowflake: Consolidate `genUtxo0` and `genTx` into `genSequenceOfValidTransactions`

:snowflake: Add a `propIsValid` which takes an `ExecutionUnits` argument

:snowflake: Make `propBelowSizeLimit` configurable with `maxTxSize`

:snowflake: Remove now redundant `TxSpec` "validates" tests