### PR TITLE
Update without-docker.md -- fix the node.socket location.

### DIFF
--- a/docs/docs/getting-started/demo/without-docker.md
+++ b/docs/docs/getting-started/demo/without-docker.md
@@ -28,6 +28,7 @@ First, let's prepare and start an ad-hoc, single `cardano-node` devnet using our
 ```
 ./prepare-devnet.sh
 cd devnet
+mkdir ipc
 cabal exec cardano-node -- run \
   --config cardano-node.json \
   --topology topology.json \


### PR DESCRIPTION
The current version does not run correctly as is. The `/devnet/ipc/` directory is not create. A fix is to replace the node.socket location to the default `/devnet/db`location. Another fix is to create the `/devnet/ipc` directory and use the previous command (this is easier and more compatible with the other documentation.