### PR TITLE
Fix/update fanout tests and benchmark

### DIFF
--- a/hydra-node/exe/tx-cost/Main.hs
+++ b/hydra-node/exe/tx-cost/Main.hs
@@ -240,7 +240,7 @@ costOfFanOut = markdownFanOutCost <$> computeFanOutCost
  where
   markdownFanOutCost stats =
     unlines $
-      [ "## Cost of FanOut validator"
+      [ "## Cost of FanOut Transaction (spend Head + burn HeadTokens)"
       , ""
       , "| UTXO  | Tx. size | % max Mem |   % max CPU |"
       , "| :---- | -------: | --------: | ----------: |"

--- a/hydra-node/exe/tx-cost/TxCost.hs
+++ b/hydra-node/exe/tx-cost/TxCost.hs
@@ -8,36 +8,22 @@ import Hydra.Prelude hiding (catch)
 
 import qualified Cardano.Api.UTxO as UTxO
 import Cardano.Binary (serialize)
-import qualified Cardano.Ledger.Alonzo as Ledger.Alonzo
-import qualified Cardano.Ledger.Alonzo.Data as Ledger
-import Cardano.Ledger.Alonzo.Language (Language (..))
 import qualified Cardano.Ledger.Alonzo.PParams as Ledger
 import qualified Cardano.Ledger.Alonzo.Scripts as Ledger
-import qualified Cardano.Ledger.Alonzo.TxBody as Ledger.Alonzo
-import Cardano.Ledger.Era (hashScript)
-import qualified Cardano.Ledger.Shelley.API as API
-import qualified Cardano.Ledger.Val as Ledger
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import Data.Fixed (E2, Fixed)
 import qualified Data.Map as Map
 import Data.Maybe (fromJust)
-import Data.Maybe.Strict (StrictMaybe (..))
 import Hydra.Cardano.Api (
   BuildTxWith (BuildTxWith),
   ExecutionUnits (..),
-  LedgerEra,
   NetworkId (Testnet),
   NetworkMagic (NetworkMagic),
   PlutusScriptV1,
-  StandardCrypto,
-  Tx,
   UTxO,
   fromLedgerExUnits,
-  fromLedgerScript,
-  fromLedgerTxOut,
   fromLedgerValue,
-  fromPlutusData,
   fromPlutusScript,
   lovelaceToValue,
   mkScriptAddress,
@@ -58,21 +44,21 @@ import Hydra.Chain.Direct.Context (
   genCloseTx,
   genCollectComTx,
   genCommits,
+  genHydraContext,
   genHydraContextFor,
   genInitTx,
+  genStClosed,
   genStIdle,
   genStInitialized,
  )
 import Hydra.Chain.Direct.State (
   abort,
   commit,
+  fanout,
   getKnownUTxO,
   initialize,
  )
-import Hydra.Chain.Direct.Tx (fanoutTx)
 import qualified Hydra.Contract.Hash as Hash
-import qualified Hydra.Contract.Head as Head
-import qualified Hydra.Contract.HeadState as Head
 import Hydra.Ledger.Cardano (
   adaOnly,
   addInputs,
@@ -80,7 +66,6 @@ import Hydra.Ledger.Cardano (
   genKeyPair,
   genOneUTxOFor,
   genTxIn,
-  hashTxOuts,
   simplifyUTxO,
   unsafeBuildTransaction,
  )
@@ -88,7 +73,7 @@ import Hydra.Ledger.Cardano.Evaluate (evaluateTx, pparams)
 import Plutus.MerkleTree (rootHash)
 import qualified Plutus.MerkleTree as MT
 import Plutus.Orphans ()
-import Plutus.V1.Ledger.Api (toBuiltin, toData)
+import Plutus.V1.Ledger.Api (toBuiltin)
 import qualified Plutus.V1.Ledger.Api as Plutus
 import Test.Plutus.Validator (
   ExUnits (ExUnits),
@@ -248,14 +233,19 @@ computeFanOutCost =
     <$> forM
       [1 .. 100]
       ( \numElems -> do
-          utxo <- generate (genSimpleUTxOOfSize numElems)
-          let (tx, lookupUTxO) = mkFanoutTx utxo
-          case evaluateTx tx lookupUTxO of
+          (tx, knownUtxo) <- generate $ genFanoutTx numElems
+          case evaluateTx tx knownUtxo of
             (Right (toList -> [Right (Ledger.ExUnits mem cpu)])) ->
               pure (Just (NumUTxO numElems, TxSize $ LBS.length $ serialize tx, MemUnit mem, CpuUnit cpu))
             _ ->
               pure Nothing
       )
+ where
+  genFanoutTx numOutputs = do
+    ctx <- genHydraContext 3
+    stClosed <- genStClosed ctx
+    utxo <- genSimpleUTxOOfSize numOutputs
+    pure (fanout utxo stClosed, getKnownUTxO stClosed)
 
 genSimpleUTxOOfSize :: Int -> Gen UTxO
 genSimpleUTxOOfSize numUTxO =
@@ -264,28 +254,6 @@ genSimpleUTxOOfSize numUTxO =
       numUTxO
       ( genKeyPair >>= fmap (fmap adaOnly) . genOneUTxOFor . fst
       )
-
-mkFanoutTx :: UTxO -> (Tx, UTxO)
-mkFanoutTx utxo =
-  (tx, lookupUTxO)
- where
-  tx = fanoutTx utxo (headInput, headOutput, fromPlutusData headDatum) (fromLedgerScript headScript)
-  headInput = generateWith arbitrary 42
-  headScript = plutusScript Head.validatorScript
-  headOutput = fromLedgerTxOut $ mkHeadOutput (SJust $ Ledger.Data headDatum)
-  headDatum =
-    toData $
-      Head.Closed 1 (toBuiltin $ hashTxOuts $ toList utxo)
-
-  lookupUTxO = UTxO.singleton (headInput, headOutput)
-
-mkHeadOutput :: StrictMaybe (Ledger.Data LedgerEra) -> Ledger.Alonzo.TxOut LedgerEra
-mkHeadOutput headDatum =
-  Ledger.Alonzo.TxOut headAddress headValue headDatumHash
- where
-  headAddress = scriptAddr $ plutusScript Head.validatorScript
-  headValue = Ledger.inject (API.Coin 2_000_000)
-  headDatumHash = Ledger.hashData @LedgerEra <$> headDatum
 
 computeMerkleTreeCost :: IO [(Int, MemUnit, CpuUnit, MemUnit, CpuUnit)]
 computeMerkleTreeCost =
@@ -357,24 +325,16 @@ calculateHashExUnits n algorithm =
   input = generateWith arbitrary 42
   output = toCtxUTxOTxOut $ TxOut address value (mkTxOutDatum datum)
   value = lovelaceToValue 1_000_000
-  address = mkScriptAddress @PlutusScriptV1 (Testnet $ NetworkMagic 42) script
+  address = mkScriptAddress @PlutusScriptV1 networkId script
   witness = BuildTxWith $ ScriptWitness scriptWitnessCtx $ mkScriptWitness script (mkScriptDatum datum) redeemer
   script = fromPlutusScript @PlutusScriptV1 Hash.validatorScript
   datum = Hash.datum $ toBuiltin bytes
   redeemer = toScriptData $ Hash.redeemer algorithm
   bytes = fold $ replicate n ("0" :: ByteString)
 
--- | Get the ledger address for a given plutus script.
-scriptAddr :: Ledger.Script LedgerEra -> API.Addr StandardCrypto
-scriptAddr script =
-  API.Addr
-    API.Testnet
-    (API.ScriptHashObj $ hashScript @LedgerEra script)
-    API.StakeRefNull
-
-plutusScript :: Plutus.Script -> Ledger.Script LedgerEra
-plutusScript = Ledger.PlutusScript PlutusV1 . toShort . fromLazy . serialize
-
 maxMem, maxCpu :: Fixed E2
 Ledger.ExUnits (fromIntegral @_ @(Fixed E2) -> maxMem) (fromIntegral @_ @(Fixed E2) -> maxCpu) =
   Ledger._maxTxExUnits pparams
+
+networkId :: NetworkId
+networkId = Testnet $ NetworkMagic 42

--- a/hydra-node/src/Hydra/Chain/Direct/Context.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Context.hs
@@ -28,7 +28,7 @@ import Hydra.Chain.Direct.State (
 import qualified Hydra.Crypto as Hydra
 import Hydra.Ledger.Cardano (genOneUTxOFor, genTxIn, genVerificationKey, renderTx)
 import Hydra.Party (Party, deriveParty)
-import Hydra.Snapshot (genConfirmedSnapshot)
+import Hydra.Snapshot (ConfirmedSnapshot (..), Snapshot (..), genConfirmedSnapshot, getSnapshot)
 import Test.QuickCheck (choose, elements, frequency, vector)
 
 -- | Define some 'global' context from which generators can pick
@@ -153,10 +153,13 @@ genStOpen ctx = do
 
 genStClosed ::
   HydraContext ->
+  UTxO ->
   Gen (OnChainHeadState 'StClosed)
-genStClosed ctx = do
+genStClosed ctx utxo = do
   stOpen <- genStOpen ctx
-  snapshot <- arbitrary
+  -- Any confirmed snapshot suffices here, no signatures are checked
+  confirmed <- arbitrary
+  let snapshot = confirmed{snapshot = (getSnapshot confirmed){utxo = utxo}}
   let closeTx = close snapshot stOpen
   pure $ snd $ unsafeObserveTx @_ @ 'StClosed closeTx stOpen
 

--- a/hydra-node/src/Hydra/Chain/Direct/Context.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Context.hs
@@ -151,6 +151,15 @@ genStOpen ctx = do
   let collectComTx = collect stInitialized
   pure $ snd $ unsafeObserveTx @_ @ 'StOpen collectComTx stInitialized
 
+genStClosed ::
+  HydraContext ->
+  Gen (OnChainHeadState 'StClosed)
+genStClosed ctx = do
+  stOpen <- genStOpen ctx
+  snapshot <- arbitrary
+  let closeTx = close snapshot stOpen
+  pure $ snd $ unsafeObserveTx @_ @ 'StClosed closeTx stOpen
+
 --
 -- Here be dragons
 --

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -55,9 +55,9 @@ import Hydra.Chain.Direct.Context (
   genCommits,
   genHydraContext,
   genInitTx,
+  genStClosed,
   genStIdle,
   genStInitialized,
-  genStOpen,
   unsafeCommit,
   unsafeObserveTx,
  )
@@ -71,7 +71,6 @@ import Hydra.Chain.Direct.State (
   SomeOnChainHeadState (..),
   TransitionFrom (..),
   abort,
-  close,
   commit,
   fanout,
   getKnownUTxO,
@@ -538,15 +537,6 @@ genByronCommit = do
   addr <- ByronAddressInEra <$> arbitrary
   value <- genValue
   pure $ UTxO.singleton (input, TxOut addr value TxOutDatumNone)
-
-genStClosed ::
-  HydraContext ->
-  Gen (OnChainHeadState 'StClosed)
-genStClosed ctx = do
-  stOpen <- genStOpen ctx
-  snapshot <- arbitrary
-  let closeTx = close snapshot stOpen
-  pure $ snd $ unsafeObserveTx @_ @ 'StClosed closeTx stOpen
 
 genBlockAt :: SlotNo -> [Tx] -> Gen Block
 genBlockAt sl txs = do

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -109,7 +109,6 @@ import Test.QuickCheck (
   classify,
   counterexample,
   elements,
-  expectFailure,
   forAll,
   forAllBlind,
   forAllShow,
@@ -182,8 +181,8 @@ spec = parallel $ do
     propBelowSizeLimit (2 * maxTxSize) forAllAbort
 
   describe "collectCom" $ do
-    propBelowSizeLimit (2 * maxTxSize) forAllCollectCom
-    propIsValid tenTimesTxExecutionUnits forAllCollectCom
+    propBelowSizeLimit maxTxSize forAllCollectCom
+    propIsValid maxTxExecutionUnits forAllCollectCom
 
   describe "close" $ do
     propBelowSizeLimit maxTxSize forAllClose
@@ -191,8 +190,7 @@ spec = parallel $ do
 
   describe "fanout" $ do
     propBelowSizeLimit maxTxSize forAllFanout
-    -- TODO: look into why this is failing
-    propIsValid maxTxExecutionUnits (expectFailure . forAllFanout)
+    propIsValid maxTxExecutionUnits forAllFanout
 
   describe "ChainSyncHandler" $ do
     prop "yields observed transactions rolling forward" $ do
@@ -327,13 +325,6 @@ genSequenceOfObservableBlocks = do
     let commitTx = unsafeCommit utxo stInitialized
     putNextBlock commitTx
     pure $ snd $ unsafeObserveTx @_ @StInitialized commitTx stInitialized
-
-tenTimesTxExecutionUnits :: ExecutionUnits
-tenTimesTxExecutionUnits =
-  ExecutionUnits
-    { executionMemory = 100_000_000
-    , executionSteps = 100_000_000_000
-    }
 
 stAtGenesis :: SomeOnChainHeadState -> SomeOnChainHeadStateAt
 stAtGenesis currentOnChainHeadState =
@@ -512,8 +503,8 @@ forAllFanout ::
   Property
 forAllFanout action = do
   forAll (genHydraContext 3) $ \ctx ->
-    forAll (genStClosed ctx) $ \stClosed ->
-      forAllShow (resize maxAssetsSupported $ simplifyUTxO <$> genUTxO) renderUTxO $ \utxo ->
+    forAllShow (resize maxAssetsSupported $ simplifyUTxO <$> genUTxO) renderUTxO $ \utxo ->
+      forAll (genStClosed ctx utxo) $ \stClosed ->
         action stClosed (fanout utxo stClosed)
           & label ("Fanout size: " <> prettyLength (assetsInUtxo utxo))
  where


### PR DESCRIPTION
Not really fix in the context of `master`, but I updated it to not use `cardano-ledger` apis when doing #330 and it would be interesting to see whether the cost changes compared to this state.

Note that the `cardano-ledger` based version was *not* burning tokens, but this version now does .. as it is correctly benchmarking the tx construction logic we actually use! 