### PR TITLE
Change --version and add a --script-info to hydra-node

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,11 @@ jobs:
       with:
         repository: input-output-hk/hydra-poc
         token: ${{ secrets.MY_TOKEN || github.token }}
+        # On pull_request events, we want to check out the latest commit of the
+        # PR, which is different to github.ref (the default, which would point
+        # to a "fake merge" commit). On push events, the default is fine as it
+        # refers to the pushed commit.
+        ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
     - name: Prepare nix
       uses: cachix/install-nix-action@v13

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,8 @@ jobs:
         # to a "fake merge" commit). On push events, the default is fine as it
         # refers to the pushed commit.
         ref: ${{ github.event.pull_request.head.sha || github.ref }}
+        # Also ensure we have all history with all tags
+        fetch-depth: 0
 
     - name: Prepare nix
       uses: cachix/install-nix-action@v13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ changes.
 - New architectural decision records:
   + [ADR-0017: UDP for Hydra networking](https://hydra.family/head-protocol/adr/17)
   + [ADR-0018: Single state in Hydra.Node](https://hydra.family/head-protocol/adr/18)
+  
+- Improved `hydra-node --version` to show an easier to understand and accurate revision based on `git describe`
+
+- Added `hydra-node --script-info` to check hashes of plutus scripts available in a `hydra-node`.
+  + This can also be seen as the "script version" and should stabilize as we progress in maturity of the codebase.
 
 #### Changed
 
@@ -43,7 +48,7 @@ changes.
 - **BREAKING** Renamed server output `UTxO -> GetUTxOResponse`
   + This should be a better name for the response of `GetUTxO` client input on our API :)
 
-- Updated our dependencies (`plutus`, `cardano-ledger`, ..) to most recent released versions making scripts smaller and Head transactions slighly cheaper already, see benchmarks for current limits.
+- Updated our dependencies (`plutus`, `cardano-ledger`, etc.) to most recent released versions making scripts smaller and Head transactions slighly cheaper already, see benchmarks for current limits.
 
 #### Fixed
 

--- a/hydra-node/exe/tx-cost/Main.hs
+++ b/hydra-node/exe/tx-cost/Main.hs
@@ -145,7 +145,7 @@ costOfCommit = markdownCommitCost <$> computeCommitCost
   markdownCommitCost stats =
     unlines $
       [ "## Cost of Commit Transaction"
-      , " Uses ada-only UTxO for better comparability."
+      , " Currently only one UTxO per commit allowed (this is about to change soon)"
       , ""
       , "| UTxO | Tx size | % max Mem | % max CPU |"
       , "| :--- | ------: | --------: | --------: |"

--- a/hydra-node/exe/tx-cost/TxCost.hs
+++ b/hydra-node/exe/tx-cost/TxCost.hs
@@ -85,7 +85,7 @@ computeInitCost = do
 computeCommitCost :: IO [(NumUTxO, TxSize, MemUnit, CpuUnit)]
 computeCommitCost = do
   interesting <- catMaybes <$> mapM compute [1, 2, 3, 5, 10, 50, 100]
-  limit <- maybeToList . getFirst <$> foldMapM (fmap First . compute) [100 .. 500]
+  limit <- maybeToList . getFirst <$> foldMapM (fmap First . compute) [500, 499 .. 101]
   pure $ interesting <> limit
  where
   compute numUTxO = do
@@ -127,7 +127,7 @@ computeCollectComCost =
 computeCloseCost :: IO [(NumParties, TxSize, MemUnit, CpuUnit)]
 computeCloseCost = do
   interesting <- catMaybes <$> mapM compute [1, 2, 3, 5, 10, 30]
-  limit <- maybeToList . getFirst <$> foldMapM (fmap First . compute) [100, 99 .. 30]
+  limit <- maybeToList . getFirst <$> foldMapM (fmap First . compute) [100, 99 .. 31]
   pure $ interesting <> limit
  where
   compute numParties = do
@@ -170,7 +170,7 @@ computeAbortCost =
 computeFanOutCost :: IO [(NumUTxO, TxSize, MemUnit, CpuUnit)]
 computeFanOutCost = do
   interesting <- catMaybes <$> mapM compute [1, 2, 3, 5, 10, 50, 100]
-  limit <- maybeToList . getFirst <$> foldMapM (fmap First . compute) [100 .. 500]
+  limit <- maybeToList . getFirst <$> foldMapM (fmap First . compute) [500, 499 .. 101]
   pure $ interesting <> limit
  where
   compute numElems = do

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -188,9 +188,7 @@ benchmark tx-cost
   import:         project-config
   hs-source-dirs: exe/tx-cost
   main-is:        Main.hs
-  other-modules:
-    TxCost
-
+  other-modules:  TxCost
   type:           exitcode-stdio-1.0
   build-depends:
     , base

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -17,6 +17,7 @@ import Hydra.Prelude
 import qualified Data.ByteString as BS
 import Data.IP (IP (IPv4), toIPv4w)
 import qualified Data.Text as T
+import Data.Version (showVersion)
 import Hydra.Cardano.Api (
   ChainPoint (..),
   NetworkId (..),
@@ -30,7 +31,7 @@ import Hydra.Cardano.Api (
  )
 import Hydra.Logging (Verbosity (..))
 import Hydra.Network (Host, PortNumber, readHost, readPort)
-import Hydra.Node.Version (gitRevision, showFullVersion, version)
+import Hydra.Node.Version (gitDescribe)
 import Options.Applicative (
   Parser,
   ParserInfo,
@@ -59,6 +60,7 @@ import Options.Applicative (
   value,
  )
 import Options.Applicative.Builder (str)
+import Paths_hydra_node (version)
 import Test.QuickCheck (elements, listOf, listOf1, oneof, vectorOf)
 
 data Options = Options
@@ -396,15 +398,15 @@ startChainFromParser =
 hydraNodeOptions :: ParserInfo Options
 hydraNodeOptions =
   info
-    (hydraNodeParser <**> helper <**> displayVersion)
+    (hydraNodeParser <**> helper <**> versionInfo)
     ( fullDesc
         <> progDesc "Starts a Hydra Node"
         <> header "hydra-node - A prototype of Hydra Head protocol"
     )
  where
-  displayVersion =
+  versionInfo =
     infoOption
-      (showFullVersion version gitRevision)
+      (fromMaybe (showVersion version) gitDescribe)
       (long "version" <> help "Show version")
 
 -- | Parse command-line arguments into a `Option` or exit with failure and error message.
@@ -469,16 +471,14 @@ toArgs
       Testnet (NetworkMagic magic) -> show magic
 
     argsChainConfig =
-      mempty
-        <> ["--network-id", toArgNetworkId networkId]
+      ["--network-id", toArgNetworkId networkId]
         <> ["--node-socket", nodeSocket]
         <> ["--cardano-signing-key", cardanoSigningKey]
         <> concatMap (\vk -> ["--cardano-verification-key", vk]) cardanoVerificationKeys
         <> toArgStartChainFrom startChainFrom
 
     argsLedgerConfig =
-      mempty
-        <> ["--ledger-genesis", cardanoLedgerGenesisFile]
+      ["--ledger-genesis", cardanoLedgerGenesisFile]
         <> ["--ledger-protocol-parameters", cardanoLedgerProtocolParametersFile]
 
     CardanoLedgerConfig

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -29,6 +29,7 @@ import Hydra.Cardano.Api (
   proxyToAsType,
   serialiseToRawBytesHexText,
  )
+import qualified Hydra.Contract as Contract
 import Hydra.Logging (Verbosity (..))
 import Hydra.Network (Host, PortNumber, readHost, readPort)
 import Hydra.Node.Version (gitDescribe)
@@ -398,7 +399,7 @@ startChainFromParser =
 hydraNodeOptions :: ParserInfo Options
 hydraNodeOptions =
   info
-    (hydraNodeParser <**> helper <**> versionInfo)
+    (hydraNodeParser <**> helper <**> versionInfo <**> scriptInfo)
     ( fullDesc
         <> progDesc "Starts a Hydra Node"
         <> header "hydra-node - A prototype of Hydra Head protocol"
@@ -408,6 +409,11 @@ hydraNodeOptions =
     infoOption
       (fromMaybe (showVersion version) gitDescribe)
       (long "version" <> help "Show version")
+
+  scriptInfo =
+    infoOption
+      (decodeUtf8 $ encodePretty Contract.scriptInfo)
+      (long "script-info" <> help "Dump script info as JSON")
 
 -- | Parse command-line arguments into a `Option` or exit with failure and error message.
 parseHydraOptions :: IO Options

--- a/hydra-plutus/exe/inspect-script/Main.hs
+++ b/hydra-plutus/exe/inspect-script/Main.hs
@@ -11,6 +11,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as BL
 import Data.Text (pack)
 import Hydra.Cardano.Api (PlutusScriptV1, fromPlutusScript, hashScriptData)
+import Hydra.Contract (scriptInfo)
 import Hydra.Contract.Commit as Commit
 import qualified Hydra.Contract.Hash as Hash
 import Hydra.Contract.Head as Head
@@ -27,6 +28,9 @@ import Prettyprinter.Render.Text (renderStrict)
 -- protocol.
 main :: IO ()
 main = do
+  putTextLn "Script info:"
+  putLBSLn $ encodePretty scriptInfo
+
   putTextLn "Serialise scripts:"
   writeScripts scripts
 

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -72,6 +72,7 @@ common project-config
 library
   import:          project-config
   exposed-modules:
+    Hydra.Contract
     Hydra.Contract.Commit
     Hydra.Contract.Encoding
     Hydra.Contract.Hash

--- a/hydra-plutus/src/Hydra/Contract.hs
+++ b/hydra-plutus/src/Hydra/Contract.hs
@@ -1,0 +1,27 @@
+-- | Things related to the Hydra smart contracts / script validators.
+module Hydra.Contract where
+
+import Hydra.Prelude
+
+import qualified Hydra.Contract.Commit as Commit
+import qualified Hydra.Contract.Head as Head
+import qualified Hydra.Contract.Initial as Initial
+import Plutus.V1.Ledger.Api (ValidatorHash)
+
+-- | Information about relevant Hydra scripts.
+data ScriptInfo = ScriptInfo
+  { initialScriptHash :: ValidatorHash
+  , commitScriptHash :: ValidatorHash
+  , headScriptHash :: ValidatorHash
+  }
+  deriving (Eq, Show, Generic, ToJSON)
+
+-- | Gather 'ScriptInfo' from the current Hydra scripts. This is useful to
+-- determine changes in between version of 'hydra-plutus'.
+scriptInfo :: ScriptInfo
+scriptInfo =
+  ScriptInfo
+    { initialScriptHash = Initial.validatorHash
+    , commitScriptHash = Commit.validatorHash
+    , headScriptHash = Head.validatorHash
+    }

--- a/hydra-plutus/src/Hydra/Contract/HeadTokens.hs
+++ b/hydra-plutus/src/Hydra/Contract/HeadTokens.hs
@@ -10,7 +10,7 @@ import qualified Hydra.Contract.Head as Head
 import qualified Hydra.Contract.HeadState as Head
 import qualified Hydra.Contract.Initial as Initial
 import Hydra.Contract.MintAction (MintAction (Burn, Mint))
-import Plutus.Extras (wrapMintingPolicy)
+import Plutus.Extras (scriptValidatorHash, wrapMintingPolicy)
 import Plutus.V1.Ledger.Api (
   CurrencySymbol,
   Datum (getDatum),
@@ -141,3 +141,6 @@ mintingPolicy txOutRef =
 
 validatorScript :: TxOutRef -> Script
 validatorScript = getMintingPolicy . mintingPolicy
+
+validatorHash :: TxOutRef -> ValidatorHash
+validatorHash = scriptValidatorHash . validatorScript


### PR DESCRIPTION
:snowflake: [Use "git describe" for hydra-node --version](https://github.com/input-output-hk/hydra-poc/commit/96f26ced3058b5c3baa21cec2336de6fc6a32e1f)
> This is more accurate and robust in determining which version we are on.


:snowflake: [Add --script-info to retrieve script hashes](https://github.com/input-output-hk/hydra-poc/commit/3e6dca52214041c0f56d87a61b6bd1aafe6466ff)

> This allows us to detect unwanted regressions in future, non-major version bumps.

BONUS :snowflake: Fix enumerations in `tx-cost`and provide an explanation why there is only `1 UTXO` for commit transaction cost.