### PR TITLE
Remove -T option from cp as this is not supported outside GNU cp

### DIFF
--- a/demo/prepare-devnet.sh
+++ b/demo/prepare-devnet.sh
@@ -9,7 +9,7 @@ TARGETDIR="devnet"
 
 [ -d "$TARGETDIR" ] && { echo "Cleaning up directory $TARGETDIR" ; sudo rm -r $TARGETDIR ; }
 
-cp -afT "$BASEDIR/hydra-cluster/config" "$TARGETDIR"
+cp -af "$BASEDIR/hydra-cluster/config/." "$TARGETDIR"
 find $TARGETDIR -type f -exec chmod 0400 {} \;
 
 echo '{"Producers": []}' > "$TARGETDIR/topology.json"


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Giovanni Garufi <giovanni@mlabs.city>