### PR TITLE
Check tx sizes in all tx-cost and require ALL redeemers to be Right

### DIFF
--- a/hydra-node/exe/tx-cost/TxCost.hs
+++ b/hydra-node/exe/tx-cost/TxCost.hs
@@ -1,19 +1,20 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
 module TxCost where
 
 import Hydra.Prelude hiding (catch)
 
+import qualified Cardano.Api.UTxO as UTxO
 import Cardano.Binary (serialize)
 import qualified Cardano.Ledger.Alonzo.PParams as Ledger
 import qualified Cardano.Ledger.Alonzo.Scripts as Ledger
 import qualified Data.ByteString.Lazy as LBS
-import Data.Fixed (E2, Fixed)
+import Data.Fixed
 import qualified Data.Map as Map
 import Hydra.Cardano.Api (
   NetworkId (Testnet),
   NetworkMagic (NetworkMagic),
+  Tx,
   UTxO,
  )
 import Hydra.Chain.Direct.Context (
@@ -41,6 +42,7 @@ import Hydra.Ledger.Cardano (
   adaOnly,
   genKeyPair,
   genOneUTxOFor,
+  genOutput,
   genTxIn,
   simplifyUTxO,
  )
@@ -48,39 +50,27 @@ import Hydra.Ledger.Cardano.Evaluate (evaluateTx, pparams)
 import Plutus.Orphans ()
 import Test.QuickCheck (generate, sublistOf, vectorOf)
 
-newtype NumParties = NumParties Int
-  deriving newtype (Eq, Show, Ord, Num, Real, Enum, Integral)
-
-newtype NumUTxO = NumUTxO Int
-  deriving newtype (Eq, Show, Ord, Num, Real, Enum, Integral)
-
-newtype TxSize = TxSize Int64
-  deriving newtype (Eq, Show, Ord, Num, Real, Enum, Integral)
-
-newtype MemUnit = MemUnit Natural
-  deriving newtype (Eq, Show, Ord, Num, Real, Enum, Integral)
-
-newtype CpuUnit = CpuUnit Natural
-  deriving newtype (Eq, Show, Ord, Num, Real, Enum, Integral)
-
-computeInitCost :: IO [(NumParties, TxSize)]
+computeInitCost :: IO [(NumParties, TxSize, MemUnit, CpuUnit)]
 computeInitCost = do
   interesting <- catMaybes <$> mapM compute [1, 2, 3, 5, 10, 30]
   limit <- maybeToList . getFirst <$> foldMapM (fmap First . compute) [100, 99 .. 30]
   pure $ interesting <> limit
  where
   compute numParties = do
-    tx <- generate $ genInitTx' numParties
-    let txSize = LBS.length $ serialize tx
-    if txSize < fromIntegral (Ledger._maxTxSize pparams)
-      then pure (Just (NumParties numParties, TxSize txSize))
-      else pure Nothing
+    (tx, knownUtxo) <- generate $ genInitTx' numParties
+    case checkSizeAndEvaluate tx knownUtxo of
+      Just (txSize, memUnit, cpuUnit) ->
+        pure $ Just (NumParties numParties, txSize, memUnit, cpuUnit)
+      Nothing ->
+        pure Nothing
 
   genInitTx' numParties = do
-    genHydraContextFor numParties >>= \ctx ->
-      genStIdle ctx >>= \stIdle ->
-        genTxIn >>= \seedInput ->
-          pure $ initialize (ctxHeadParameters ctx) (ctxVerificationKeys ctx) seedInput stIdle
+    ctx <- genHydraContextFor numParties
+    stIdle <- genStIdle ctx
+    seedInput <- genTxIn
+    seedOutput <- genOutput =<< arbitrary
+    let utxo = UTxO.singleton (seedInput, seedOutput)
+    pure (initialize (ctxHeadParameters ctx) (ctxVerificationKeys ctx) seedInput stIdle, utxo)
 
 computeCommitCost :: IO [(NumUTxO, TxSize, MemUnit, CpuUnit)]
 computeCommitCost = do
@@ -93,14 +83,12 @@ computeCommitCost = do
     (commitTx, knownUtxo) <- generate $ genCommitTx utxo
     case commitTx of
       Left _ -> pure Nothing
-      Right tx -> do
-        let txSize = LBS.length $ serialize tx
-        if txSize < fromIntegral (Ledger._maxTxSize pparams)
-          then case evaluateTx tx (utxo <> knownUtxo) of
-            (Right (toList -> [Right (Ledger.ExUnits mem cpu)])) ->
-              pure $ Just (NumUTxO $ length utxo, TxSize txSize, MemUnit mem, CpuUnit cpu)
-            _ -> pure Nothing
-          else pure Nothing
+      Right tx ->
+        case checkSizeAndEvaluate tx (utxo <> knownUtxo) of
+          Just (txSize, memUnit, cpuUnit) ->
+            pure $ Just (NumUTxO $ length utxo, txSize, memUnit, cpuUnit)
+          Nothing ->
+            pure Nothing
 
   genCommitTx utxo = do
     -- NOTE: number of parties is irrelevant for commit tx
@@ -115,14 +103,11 @@ computeCollectComCost =
   compute numParties = do
     (st, tx) <- generate $ genCollectComTx numParties
     let utxo = getKnownUTxO st
-    let txSize = LBS.length $ serialize tx
-    if txSize < fromIntegral (Ledger._maxTxSize pparams)
-      then case evaluateTx tx utxo of
-        (Right (mconcat . rights . Map.elems -> (Ledger.ExUnits mem cpu)))
-          | fromIntegral mem <= maxMem && fromIntegral cpu <= maxCpu ->
-            pure $ Just (NumParties numParties, TxSize txSize, MemUnit mem, CpuUnit cpu)
-        _ -> pure Nothing
-      else pure Nothing
+    case checkSizeAndEvaluate tx utxo of
+      Just (txSize, memUnit, cpuUnit) ->
+        pure $ Just (NumParties numParties, txSize, memUnit, cpuUnit)
+      Nothing ->
+        pure Nothing
 
 computeCloseCost :: IO [(NumParties, TxSize, MemUnit, CpuUnit)]
 computeCloseCost = do
@@ -133,14 +118,11 @@ computeCloseCost = do
   compute numParties = do
     (st, tx) <- generate $ genCloseTx numParties
     let utxo = getKnownUTxO st
-    let txSize = LBS.length $ serialize tx
-    if txSize < fromIntegral (Ledger._maxTxSize pparams)
-      then case evaluateTx tx utxo of
-        (Right (mconcat . rights . Map.elems -> (Ledger.ExUnits mem cpu)))
-          | fromIntegral mem <= maxMem && fromIntegral cpu <= maxCpu ->
-            pure $ Just (NumParties numParties, TxSize txSize, MemUnit mem, CpuUnit cpu)
-        _ -> pure Nothing
-      else pure Nothing
+    case checkSizeAndEvaluate tx utxo of
+      Just (txSize, memUnit, cpuUnit) ->
+        pure $ Just (NumParties numParties, txSize, memUnit, cpuUnit)
+      Nothing ->
+        pure Nothing
 
 computeAbortCost :: IO [(NumParties, TxSize, MemUnit, CpuUnit)]
 computeAbortCost =
@@ -150,14 +132,11 @@ computeAbortCost =
  where
   compute numParties = do
     (tx, knownUtxo) <- generate $ genAbortTx numParties
-    let txSize = LBS.length $ serialize tx
-    if txSize < fromIntegral (Ledger._maxTxSize pparams)
-      then case evaluateTx tx knownUtxo of
-        (Right (mconcat . rights . Map.elems -> (Ledger.ExUnits mem cpu)))
-          | fromIntegral mem <= maxMem && fromIntegral cpu <= maxCpu ->
-            pure $ Just (NumParties numParties, TxSize txSize, MemUnit mem, CpuUnit cpu)
-        _ -> pure Nothing
-      else pure Nothing
+    case checkSizeAndEvaluate tx knownUtxo of
+      Just (txSize, memUnit, cpuUnit) ->
+        pure $ Just (NumParties numParties, txSize, memUnit, cpuUnit)
+      Nothing ->
+        pure Nothing
 
   genAbortTx numParties =
     genHydraContextFor numParties >>= \ctx ->
@@ -169,23 +148,22 @@ computeAbortCost =
 
 computeFanOutCost :: IO [(NumUTxO, TxSize, MemUnit, CpuUnit)]
 computeFanOutCost = do
-  interesting <- catMaybes <$> mapM compute [1, 2, 3, 5, 10, 50, 100]
-  limit <- maybeToList . getFirst <$> foldMapM (fmap First . compute) [500, 499 .. 101]
+  interesting <- catMaybes <$> mapM compute [1, 2, 3, 5, 10, 50]
+  limit <- maybeToList . getFirst <$> foldMapM (fmap First . compute) [500, 499 .. 51]
   pure $ interesting <> limit
  where
   compute numElems = do
     (tx, knownUtxo) <- generate $ genFanoutTx numElems
-    let txSize = LBS.length $ serialize tx
-    case evaluateTx tx knownUtxo of
-      (Right (mconcat . rights . Map.elems -> (Ledger.ExUnits mem cpu)))
-        | fromIntegral mem <= maxMem && fromIntegral cpu <= maxCpu ->
-          pure (Just (NumUTxO numElems, TxSize txSize, MemUnit mem, CpuUnit cpu))
-      _ -> pure Nothing
+    case checkSizeAndEvaluate tx knownUtxo of
+      Just (txSize, memUnit, cpuUnit) ->
+        pure $ Just (NumUTxO numElems, txSize, memUnit, cpuUnit)
+      Nothing ->
+        pure Nothing
 
   genFanoutTx numOutputs = do
     ctx <- genHydraContext 3
-    utxo <- genSimpleUTxOOfSize numOutputs
-    (_,stClosed) <- genStClosed ctx utxo
+    let utxo = genSimpleUTxOOfSize numOutputs `generateWith` 42
+    (_, stClosed) <- genStClosed ctx utxo
     pure (fanout utxo stClosed, getKnownUTxO stClosed)
 
 genSimpleUTxOOfSize :: Int -> Gen UTxO
@@ -195,6 +173,39 @@ genSimpleUTxOOfSize numUTxO =
       numUTxO
       ( genKeyPair >>= fmap (fmap adaOnly) . genOneUTxOFor . fst
       )
+
+newtype NumParties = NumParties Int
+  deriving newtype (Eq, Show, Ord, Num, Real, Enum, Integral)
+
+newtype NumUTxO = NumUTxO Int
+  deriving newtype (Eq, Show, Ord, Num, Real, Enum, Integral)
+
+newtype TxSize = TxSize Natural
+  deriving newtype (Eq, Show, Ord, Num, Real, Enum, Integral)
+
+newtype MemUnit = MemUnit Natural
+  deriving newtype (Eq, Show, Ord, Num, Real, Enum, Integral)
+
+newtype CpuUnit = CpuUnit Natural
+  deriving newtype (Eq, Show, Ord, Num, Real, Enum, Integral)
+
+checkSizeAndEvaluate :: Tx -> UTxO -> Maybe (TxSize, MemUnit, CpuUnit)
+checkSizeAndEvaluate tx knownUTxO = do
+  guard $ txSize < maxTxSize
+  case evaluateTx tx knownUTxO of
+    (Right report) -> do
+      let results = Map.elems report
+      guard $ all isRight results
+      let (Ledger.ExUnits mem cpu) = mconcat $ rights results
+      guard $ fromIntegral mem <= maxMem
+      guard $ fromIntegral cpu <= maxCpu
+      Just (TxSize txSize, MemUnit mem, CpuUnit cpu)
+    _ -> Nothing
+ where
+  txSize = fromIntegral $ LBS.length $ serialize tx
+
+maxTxSize :: Natural
+maxTxSize = Ledger._maxTxSize pparams
 
 maxMem, maxCpu :: Fixed E2
 Ledger.ExUnits (fromIntegral @_ @(Fixed E2) -> maxMem) (fromIntegral @_ @(Fixed E2) -> maxCpu) =


### PR DESCRIPTION
We had been summing up only the Right redeemer report results and had
partially validating transactions in our benchmark numbers!

This also evaluates init transactions now, whose minting policies might fail
and do cost evaluation units as well!