### PR TITLE
Fix fanout tx-cost benchmark

### DIFF
--- a/hydra-node/src/Hydra/Chain/Direct/Context.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Context.hs
@@ -29,11 +29,11 @@ import Hydra.Chain.Direct.State (
   observeTx,
  )
 import qualified Hydra.Crypto as Hydra
-import Hydra.Ledger.Cardano (genOneUTxOFor, genTxIn, genUTxO, genVerificationKey, renderTx, simplifyUTxO)
+import Hydra.Ledger.Cardano (genOneUTxOFor, genTxIn, genUTxOAdaOnlyOfSize, genVerificationKey, renderTx)
 import Hydra.Ledger.Cardano.Evaluate (genPointInTime, slotNoToPOSIXTime)
 import Hydra.Party (Party, deriveParty)
 import Hydra.Snapshot (ConfirmedSnapshot (..), Snapshot (..), SnapshotNumber, genConfirmedSnapshot)
-import Test.QuickCheck (choose, elements, frequency, resize, suchThat, vector)
+import Test.QuickCheck (choose, elements, frequency, suchThat, vector)
 
 -- | Define some 'global' context from which generators can pick
 -- values for generation. This allows to write fairly independent generators
@@ -158,11 +158,10 @@ genContestTx numParties = do
       slotNoToPOSIXTime slot < getContestationDeadline stClosed
   pure (stClosed, contest snapshot pointInTime stClosed)
 
-genFanoutTx :: Int -> Gen (OnChainHeadState 'StClosed, Tx)
-genFanoutTx numParties = do
+genFanoutTx :: Int -> Int -> Gen (OnChainHeadState 'StClosed, Tx)
+genFanoutTx numParties numOutputs = do
   ctx <- genHydraContext numParties
-  let maxAssetsSupported = 1
-  utxo <- resize maxAssetsSupported $ simplifyUTxO <$> genUTxO
+  utxo <- genUTxOAdaOnlyOfSize numOutputs
   (_, toFanout, stClosed) <- genStClosed ctx utxo
   pointInTime <-
     genPointInTime `suchThat` \(slot, _) ->

--- a/hydra-node/src/Hydra/Snapshot.hs
+++ b/hydra-node/src/Hydra/Snapshot.hs
@@ -137,6 +137,7 @@ genConfirmedSnapshot minSn utxo sks
   confirmedSnapshot = do
     -- FIXME: This is another nail in the coffin to our current modeling of
     -- snapshots
-    snapshot <- arbitrary `suchThat` \Snapshot{number} -> number > minSn
+    number <- arbitrary `suchThat` (> minSn)
+    let snapshot = Snapshot{number, utxo, confirmed = []}
     let signatures = Hydra.aggregate $ fmap (`Hydra.sign` snapshot) sks
     pure $ ConfirmedSnapshot{snapshot, signatures}


### PR DESCRIPTION
Re-using the `genStClosed` was problematic as it would sometimes pick closing with an `InitialSnapshot` and this obviously fakes the benchmark results. That's why we saw fanout with > 100 outputs being valid.

This PR also makes another attempt at a more well-behaved `genUTxOAdaOnlyOfSize` generator.