### PR TITLE
Fix pointInTime generators

### DIFF
--- a/hydra-node/exe/tx-cost/TxCost.hs
+++ b/hydra-node/exe/tx-cost/TxCost.hs
@@ -48,10 +48,10 @@ import Hydra.Ledger.Cardano (
   genTxIn,
   genUTxOAdaOnlyOfSize,
  )
-import Hydra.Ledger.Cardano.Evaluate (evaluateTx, genPointInTime, pparams, slotNoToPOSIXTime)
+import Hydra.Ledger.Cardano.Evaluate (evaluateTx, genPointInTime, genPointInTimeAfter, pparams)
 import Hydra.Snapshot (genConfirmedSnapshot)
 import Plutus.Orphans ()
-import Test.QuickCheck (generate, sublistOf, suchThat)
+import Test.QuickCheck (generate, sublistOf)
 
 computeInitCost :: IO [(NumParties, TxSize, MemUnit, CpuUnit)]
 computeInitCost = do
@@ -187,9 +187,7 @@ computeFanOutCost = do
     closePoint <- genPointInTime
     let closeTx = close snapshot closePoint stOpen
     let stClosed = snd $ unsafeObserveTx @_ @ 'StClosed closeTx stOpen
-    fanoutPoint <-
-      genPointInTime `suchThat` \(slot, _) ->
-        slotNoToPOSIXTime slot > getContestationDeadline stClosed
+    fanoutPoint <- genPointInTimeAfter (getContestationDeadline stClosed)
     pure (getKnownUTxO stClosed, fanout utxo fanoutPoint stClosed)
 
 newtype NumParties = NumParties Int

--- a/hydra-node/src/Hydra/Chain/Direct/Context.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Context.hs
@@ -30,7 +30,7 @@ import Hydra.Chain.Direct.State (
  )
 import qualified Hydra.Crypto as Hydra
 import Hydra.Ledger.Cardano (genOneUTxOFor, genTxIn, genUTxOAdaOnlyOfSize, genVerificationKey, renderTx)
-import Hydra.Ledger.Cardano.Evaluate (genPointInTime, slotNoToPOSIXTime)
+import Hydra.Ledger.Cardano.Evaluate (genPointInTime, genPointInTimeBefore, slotNoToPOSIXTime)
 import Hydra.Party (Party, deriveParty)
 import Hydra.Snapshot (ConfirmedSnapshot (..), Snapshot (..), SnapshotNumber, genConfirmedSnapshot)
 import Test.QuickCheck (choose, elements, frequency, suchThat, vector)
@@ -153,9 +153,7 @@ genContestTx numParties = do
   utxo <- arbitrary
   (closedSnapshotNumber, _, stClosed) <- genStClosed ctx utxo
   snapshot <- genConfirmedSnapshot (succ closedSnapshotNumber) utxo (ctxHydraSigningKeys ctx)
-  pointInTime <-
-    genPointInTime `suchThat` \(slot, _) ->
-      slotNoToPOSIXTime slot < getContestationDeadline stClosed
+  pointInTime <- genPointInTimeBefore (getContestationDeadline stClosed)
   pure (stClosed, contest snapshot pointInTime stClosed)
 
 genFanoutTx :: Int -> Int -> Gen (OnChainHeadState 'StClosed, Tx)

--- a/hydra-node/src/Hydra/Chain/Direct/Context.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Context.hs
@@ -30,10 +30,10 @@ import Hydra.Chain.Direct.State (
  )
 import qualified Hydra.Crypto as Hydra
 import Hydra.Ledger.Cardano (genOneUTxOFor, genTxIn, genUTxOAdaOnlyOfSize, genVerificationKey, renderTx)
-import Hydra.Ledger.Cardano.Evaluate (genPointInTime, genPointInTimeBefore, slotNoToPOSIXTime)
+import Hydra.Ledger.Cardano.Evaluate (genPointInTime, genPointInTimeAfter, genPointInTimeBefore)
 import Hydra.Party (Party, deriveParty)
 import Hydra.Snapshot (ConfirmedSnapshot (..), Snapshot (..), SnapshotNumber, genConfirmedSnapshot)
-import Test.QuickCheck (choose, elements, frequency, suchThat, vector)
+import Test.QuickCheck (choose, elements, frequency, vector)
 
 -- | Define some 'global' context from which generators can pick
 -- values for generation. This allows to write fairly independent generators
@@ -161,9 +161,7 @@ genFanoutTx numParties numOutputs = do
   ctx <- genHydraContext numParties
   utxo <- genUTxOAdaOnlyOfSize numOutputs
   (_, toFanout, stClosed) <- genStClosed ctx utxo
-  pointInTime <-
-    genPointInTime `suchThat` \(slot, _) ->
-      slotNoToPOSIXTime slot > getContestationDeadline stClosed
+  pointInTime <- genPointInTimeAfter (getContestationDeadline stClosed)
   pure (stClosed, fanout toFanout pointInTime stClosed)
 
 genStOpen ::

--- a/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs
@@ -102,7 +102,6 @@ slotLength = mkSlotLength 1
 systemStart :: SystemStart
 systemStart = SystemStart $ posixSecondsToUTCTime 0
 
--- | Only for use in the context of `evaluateTx`.
 genPointInTime :: Gen (SlotNo, Plutus.POSIXTime)
 genPointInTime = do
   slot <- arbitrary
@@ -112,6 +111,12 @@ genPointInTimeBefore :: Plutus.POSIXTime -> Gen (SlotNo, Plutus.POSIXTime)
 genPointInTimeBefore deadline = do
   let SlotNo slotDeadline = slotNoFromPOSIXTime deadline
   slot <- SlotNo <$> choose (0, slotDeadline)
+  pure (slot, slotNoToPOSIXTime slot)
+
+genPointInTimeAfter :: Plutus.POSIXTime -> Gen (SlotNo, Plutus.POSIXTime)
+genPointInTimeAfter deadline = do
+  let SlotNo slotDeadline = slotNoFromPOSIXTime deadline
+  slot <- SlotNo <$> choose (slotDeadline, maxBound)
   pure (slot, slotNoToPOSIXTime slot)
 
 -- | Using hard-coded systemStart and slotLength, do not use in production!

--- a/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs
@@ -23,7 +23,7 @@ import Cardano.Ledger.Alonzo.TxWitness (RdmrPtr)
 import Cardano.Ledger.BaseTypes (ProtVer (..), boundRational)
 import Cardano.Slotting.EpochInfo (EpochInfo, fixedEpochInfo)
 import Cardano.Slotting.Slot (EpochSize (EpochSize))
-import Cardano.Slotting.Time (SystemStart (SystemStart), mkSlotLength)
+import Cardano.Slotting.Time (SystemStart (SystemStart), mkSlotLength, toRelativeTime)
 import Data.Array (Array, array)
 import Data.Bits (shift)
 import Data.Default (def)
@@ -33,6 +33,7 @@ import Data.Ratio ((%))
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Hydra.Cardano.Api (ExecutionUnits, SlotNo, StandardCrypto, Tx, UTxO, fromLedgerExUnits, toLedgerExUnits, toLedgerTx, toLedgerUTxO)
 import Hydra.Chain.Direct.Util (Era)
+import Ouroboros.Consensus.HardFork.History (wallclockToSlot)
 import qualified Plutus.V1.Ledger.Api as PV1
 import qualified Plutus.V1.Ledger.Api as Plutus
 import qualified Plutus.V2.Ledger.Api as PV2
@@ -103,6 +104,18 @@ genPointInTime :: Gen (SlotNo, Plutus.POSIXTime)
 genPointInTime = do
   slot <- arbitrary
   pure (slot, slotNoToPOSIXTime slot)
+
+genPointInTimeBefore :: Plutus.POSIXTime -> Gen (SlotNo, Plutus.POSIXTime)
+genPointInTimeBefore deadline = do
+  undefined $ slotNoFromPOSIXTime deadline
+
+slotNoFromPOSIXTime :: Plutus.POSIXTime -> SlotNo
+slotNoFromPOSIXTime posixTime =
+  undefined $ wallclockToSlot relativeTime
+ where
+  relativeTime = toRelativeTime systemStart utcTime
+
+  utcTime = undefined posixTime
 
 -- | Using hard-coded defaults above
 slotNoToPOSIXTime :: SlotNo -> Plutus.POSIXTime

--- a/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs
@@ -114,6 +114,7 @@ genPointInTimeBefore deadline = do
   slot <- SlotNo <$> choose (0, slotDeadline)
   pure (slot, slotNoToPOSIXTime slot)
 
+-- | Using hard-coded systemStart and slotLength, do not use in production!
 slotNoFromPOSIXTime :: Plutus.POSIXTime -> SlotNo
 slotNoFromPOSIXTime posixTime =
   SlotNo $ truncate (relativeTime / getSlotLength slotLength)
@@ -127,7 +128,7 @@ slotNoFromPOSIXTime posixTime =
         (`div` 1000) $
           Plutus.getPOSIXTime posixTime
 
--- | Using hard-coded defaults above
+-- | Using hard-coded epochInfo and systemStart, do not use in production!
 slotNoToPOSIXTime :: SlotNo -> Plutus.POSIXTime
 slotNoToPOSIXTime =
   runIdentity

--- a/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
+++ b/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
@@ -21,6 +21,7 @@ import Hydra.Ledger.Cardano (
   genSequenceOfValidTransactions,
   renderTx,
  )
+import Hydra.Ledger.Cardano.Evaluate (slotNoFromPOSIXTime, slotNoToPOSIXTime)
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
 import Test.Cardano.Ledger.MaryEraGen ()
 import Test.QuickCheck (Property, counterexample, forAll, forAllBlind, property, withMaxSuccess, (.&&.), (===))
@@ -68,6 +69,10 @@ spec =
       propCollisionResistant "arbitrary TxId" (arbitrary @TxId)
       propCollisionResistant "arbitrary VerificationKey" (arbitrary @(VerificationKey PaymentKey))
       propCollisionResistant "arbitrary Hash" (arbitrary @(Hash PaymentKey))
+
+    describe "Evaluate helpers" $ do
+      prop "slotNoFromPOSIXTime . slotNoToPOSIXTime === id" $ \slot ->
+        slotNoFromPOSIXTime (slotNoToPOSIXTime slot) === slot
 
 shouldParseJSONAs :: forall a. FromJSON a => LByteString -> Expectation
 shouldParseJSONAs bs =


### PR DESCRIPTION
We have been using `suchThat` which had these generators block _sometimes_. Now we use the choose within a range of slots to make generation stable.