### PR TITLE
Use testnet epochLength and securityParam on devnets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@ test-results.xml
 !index.html
 
 # Getting started / demo instructions
-devnet/
+/demo/devnet/

--- a/hydra-cluster/config/genesis-shelley.json
+++ b/hydra-cluster/config/genesis-shelley.json
@@ -1,8 +1,8 @@
 {
-    "epochLength": 500,
+    "epochLength": 432000,
     "activeSlotsCoeff": 1.0,
     "slotLength": 0.1,
-    "securityParam": 100,
+    "securityParam": 2160,
     "genDelegs": {},
     "initialFunds": {
         "00813c32c92aad21770ff8001de0918f598df8c06775f77f8e8839d2a0074a515f7f32bf31a4f41c7417a8136e8152bfb42f06d71b389a6896": 900000000000,


### PR DESCRIPTION
This keeps only the slotLength 10x faster than the testnet and results in
* less problems with `PasthHorizonExceptions` (trying to resolve contestation deadlines past 2 epochs?) and
* makes the range in which we can `--start-from-point` bigger and not
get `AcquireFailurePointTooOld` (related to `k` - not exactly how long into the past)