### PR TITLE
fix(tui): remaining contestation period time format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,6 @@ changes.
 #### Fixed
 
 - Head contract check UTxO hash upon closing the head [#338](https://github.com/input-output-hk/hydra-poc/pull/338). This prevents closing the head with arbitrary UTxO.
-
-## [0.6.1] - 2022-07-22
-
-#### Fixed
 - Remaining contestation period displayed in `hydra-tui` [#437](https://github.com/input-output-hk/hydra-poc/pull/437). Previously it was displaying 'total whole values' instead of 'relative whole values'.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ changes.
 
 - Head contract check UTxO hash upon closing the head [#338](https://github.com/input-output-hk/hydra-poc/pull/338). This prevents closing the head with arbitrary UTxO.
 
+## [0.6.1] - 2022-07-22
+
+#### Fixed
+- Remaining contestation period displayed in `hydra-tui` [#437](https://github.com/input-output-hk/hydra-poc/pull/437). Previously it was displaying 'total whole values' instead of 'relative whole values'.
+
+
 ## [0.6.0] - 2022-06-22
 
 #### Added

--- a/hydra-tui/hydra-tui.cabal
+++ b/hydra-tui/hydra-tui.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          hydra-tui
-version:       0.6.1
+version:       0.7.0
 synopsis:      TUI for managing a Hydra node
 description:   TUI for managing a Hydra node
 author:        IOG

--- a/hydra-tui/hydra-tui.cabal
+++ b/hydra-tui/hydra-tui.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          hydra-tui
-version:       0.6.0
+version:       0.6.1
 synopsis:      TUI for managing a Hydra node
 description:   TUI for managing a Hydra node
 author:        IOG

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -624,8 +624,10 @@ draw Client{sk} CardanoClient{networkId} s =
   drawShow :: forall a n. Show a => a -> Widget n
   drawShow = txt . (" - " <>) . show
 
-renderTime :: (FormatTime t) => t -> String
-renderTime = formatTime defaultTimeLocale "%dd %Hh %Mm %Ss"
+renderTime :: (Ord t, Num t, FormatTime t) => t -> String
+renderTime r
+  | r < 0 = "-" <> renderTime (negate r)
+  | otherwise = formatTime defaultTimeLocale "%dd %Hh %Mm %Ss" r
 
 -- HACK(SN): This might be too expensive for a general case and we should move
 -- this somehwere.

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -625,7 +625,7 @@ draw Client{sk} CardanoClient{networkId} s =
   drawShow = txt . (" - " <>) . show
 
 renderTime :: (FormatTime t) => t -> String
-renderTime r = formatTime defaultTimeLocale "%Dd %Hh %Mm %Ss" r
+renderTime r = formatTime defaultTimeLocale "%dd %Hh %Mm %Ss" r
 
 -- HACK(SN): This might be too expensive for a general case and we should move
 -- this somehwere.

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -20,6 +20,7 @@ import Data.List (nub, (\\))
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
 import Data.Time (defaultTimeLocale, formatTime)
+import Data.Time.Format (FormatTime)
 import Data.Version (showVersion)
 import Graphics.Vty (
   Event (EvKey),
@@ -432,6 +433,8 @@ handleNewTxEvent Client{sendInput, sk} CardanoClient{networkId} s = case s ^? he
 --
 -- View
 --
+timeFormatted :: (FormatTime t) => t -> String
+timeFormatted r = formatTime defaultTimeLocale "%Dd %Hh %Mm %Ss" r
 
 draw :: Client Tx m -> CardanoClient -> State -> [Widget Name]
 draw Client{sk} CardanoClient{networkId} s =
@@ -551,7 +554,7 @@ draw Client{sk} CardanoClient{networkId} s =
     | remaining > 0 =
       padLeftRight 1 $
         txt "Remaining time to contest: "
-          <+> str (formatTime defaultTimeLocale "%dd %hh %mm %ss" remaining)
+          <+> str (timeFormatted remaining)
     | otherwise =
       txt "Contestation period passed, ready to fan out."
 

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -625,7 +625,7 @@ draw Client{sk} CardanoClient{networkId} s =
   drawShow = txt . (" - " <>) . show
 
 renderTime :: (FormatTime t) => t -> String
-renderTime r = formatTime defaultTimeLocale "%dd %Hh %Mm %Ss" r
+renderTime = formatTime defaultTimeLocale "%dd %Hh %Mm %Ss"
 
 -- HACK(SN): This might be too expensive for a general case and we should move
 -- this somehwere.

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -433,8 +433,6 @@ handleNewTxEvent Client{sendInput, sk} CardanoClient{networkId} s = case s ^? he
 --
 -- View
 --
-timeFormatted :: (FormatTime t) => t -> String
-timeFormatted r = formatTime defaultTimeLocale "%Dd %Hh %Mm %Ss" r
 
 draw :: Client Tx m -> CardanoClient -> State -> [Widget Name]
 draw Client{sk} CardanoClient{networkId} s =
@@ -554,7 +552,7 @@ draw Client{sk} CardanoClient{networkId} s =
     | remaining > 0 =
       padLeftRight 1 $
         txt "Remaining time to contest: "
-          <+> str (timeFormatted remaining)
+          <+> str (renderTime remaining)
     | otherwise =
       txt "Contestation period passed, ready to fan out."
 
@@ -625,6 +623,9 @@ draw Client{sk} CardanoClient{networkId} s =
 
   drawShow :: forall a n. Show a => a -> Widget n
   drawShow = txt . (" - " <>) . show
+
+renderTime :: (FormatTime t) => t -> String
+renderTime r = formatTime defaultTimeLocale "%Dd %Hh %Mm %Ss" r
 
 -- HACK(SN): This might be too expensive for a general case and we should move
 -- this somehwere.

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -40,7 +40,7 @@ import Hydra.ContestationPeriod (toNominalDiffTime)
 import Hydra.Logging (showLogsOnFailure)
 import Hydra.Network (Host (..))
 import Hydra.Options (ChainConfig (..))
-import Hydra.TUI (runWithVty, timeFormatted, tuiContestationPeriod)
+import Hydra.TUI (renderTime, runWithVty, tuiContestationPeriod)
 import Hydra.TUI.Options (Options (..))
 import HydraNode (EndToEndLog, HydraClient (HydraClient, hydraNodeId), withHydraNode)
 import System.Posix (OpenMode (WriteOnly), closeFd, defaultFileFlags, openFd)
@@ -98,7 +98,7 @@ spec =
             sendInputEvent $ EvKey (KChar 'q') []
     it "should format time with whole values for every unit, not total values" $ do
       let time = (3675 :: NominalDiffTime)
-      timeFormatted time `shouldBe` "0d 1h 1m 15s"
+      renderTime time `shouldBe` "0d 1h 1m 15s"
 
 -- XXX: The same hack as in EndToEndSpec
 gracePeriod :: NominalDiffTime

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -104,7 +104,10 @@ spec = do
         days = hours * 24  
         time = 10 * days + 1 * hours + 1 * minutes + 15 * seconds
       renderTime (time :: NominalDiffTime) `shouldBe` "10d 1h 1m 15s"
-      renderTime (-time :: NominalDiffTime) `shouldBe` "-10d -1h -1m -15s"
+      renderTime (-time :: NominalDiffTime) `shouldBe` "-10d 1h 1m 15s"
+      let 
+        time' = 1 * hours + 1 * minutes + 15 * seconds
+      renderTime (-time' :: NominalDiffTime) `shouldBe` "-0d 1h 1m 15s"
 
 -- XXX: The same hack as in EndToEndSpec
 gracePeriod :: NominalDiffTime

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -40,61 +40,65 @@ import Hydra.ContestationPeriod (toNominalDiffTime)
 import Hydra.Logging (showLogsOnFailure)
 import Hydra.Network (Host (..))
 import Hydra.Options (ChainConfig (..))
-import Hydra.TUI (runWithVty, tuiContestationPeriod)
+import Hydra.TUI (runWithVty, timeFormatted, tuiContestationPeriod)
 import Hydra.TUI.Options (Options (..))
 import HydraNode (EndToEndLog, HydraClient (HydraClient, hydraNodeId), withHydraNode)
 import System.Posix (OpenMode (WriteOnly), closeFd, defaultFileFlags, openFd)
 
 spec :: Spec
 spec =
-  around setupNodeAndTUI $
-    context "end-to-end smoke tests" $ do
-      it "starts & renders" $
-        \TUITest{sendInputEvent, shouldRender} -> do
-          threadDelay 1
-          shouldRender "TUI"
-          -- Using hex representation of aliceSk's HydraVerificationKey
-          shouldRender "Party 38088e4c2ae82"
-          sendInputEvent $ EvKey (KChar 'q') []
+  describe "Terminal User Interface" $ do
+    around setupNodeAndTUI $
+      context "end-to-end smoke tests" $ do
+        it "starts & renders" $
+          \TUITest{sendInputEvent, shouldRender} -> do
+            threadDelay 1
+            shouldRender "TUI"
+            -- Using hex representation of aliceSk's HydraVerificationKey
+            shouldRender "Party 38088e4c2ae82"
+            sendInputEvent $ EvKey (KChar 'q') []
 
-      it "supports the init & abort Head life cycle" $
-        \TUITest{sendInputEvent, shouldRender} -> do
-          threadDelay 1
-          shouldRender "connected"
-          shouldRender "Idle"
-          sendInputEvent $ EvKey (KChar 'i') []
-          threadDelay 1
-          shouldRender "Initializing"
-          sendInputEvent $ EvKey (KChar 'a') []
-          threadDelay 1
-          shouldRender "Idle"
-          sendInputEvent $ EvKey (KChar 'q') []
+        it "supports the init & abort Head life cycle" $
+          \TUITest{sendInputEvent, shouldRender} -> do
+            threadDelay 1
+            shouldRender "connected"
+            shouldRender "Idle"
+            sendInputEvent $ EvKey (KChar 'i') []
+            threadDelay 1
+            shouldRender "Initializing"
+            sendInputEvent $ EvKey (KChar 'a') []
+            threadDelay 1
+            shouldRender "Idle"
+            sendInputEvent $ EvKey (KChar 'q') []
 
-      it "supports the full Head life cycle" $
-        \TUITest{sendInputEvent, shouldRender} -> do
-          threadDelay 1
-          shouldRender "connected"
-          shouldRender "Idle"
-          sendInputEvent $ EvKey (KChar 'i') []
-          threadDelay 1
-          shouldRender "Initializing"
-          sendInputEvent $ EvKey (KChar 'c') []
-          threadDelay 1
-          shouldRender "42000000 lovelace"
-          sendInputEvent $ EvKey (KChar ' ') []
-          sendInputEvent $ EvKey KEnter []
-          threadDelay 1
-          shouldRender "Open"
-          sendInputEvent $ EvKey (KChar 'c') []
-          threadDelay 1
-          shouldRender "Closed"
-          shouldRender "Remaining time to contest"
-          threadDelay (realToFrac $ toNominalDiffTime tuiContestationPeriod + gracePeriod + someTime)
-          sendInputEvent $ EvKey (KChar 'f') []
-          threadDelay 1
-          shouldRender "Final"
-          shouldRender "42000000 lovelace"
-          sendInputEvent $ EvKey (KChar 'q') []
+        it "supports the full Head life cycle" $
+          \TUITest{sendInputEvent, shouldRender} -> do
+            threadDelay 1
+            shouldRender "connected"
+            shouldRender "Idle"
+            sendInputEvent $ EvKey (KChar 'i') []
+            threadDelay 1
+            shouldRender "Initializing"
+            sendInputEvent $ EvKey (KChar 'c') []
+            threadDelay 1
+            shouldRender "42000000 lovelace"
+            sendInputEvent $ EvKey (KChar ' ') []
+            sendInputEvent $ EvKey KEnter []
+            threadDelay 1
+            shouldRender "Open"
+            sendInputEvent $ EvKey (KChar 'c') []
+            threadDelay 1
+            shouldRender "Closed"
+            shouldRender "Remaining time to contest"
+            threadDelay (realToFrac $ toNominalDiffTime tuiContestationPeriod + gracePeriod + someTime)
+            sendInputEvent $ EvKey (KChar 'f') []
+            threadDelay 1
+            shouldRender "Final"
+            shouldRender "42000000 lovelace"
+            sendInputEvent $ EvKey (KChar 'q') []
+    it "should format time with whole values for every unit, not total values" $ do
+      let time = (3675 :: NominalDiffTime)
+      timeFormatted time `shouldBe` "0d 1h 1m 15s"
 
 -- XXX: The same hack as in EndToEndSpec
 gracePeriod :: NominalDiffTime

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -46,56 +46,56 @@ import HydraNode (EndToEndLog, HydraClient (HydraClient, hydraNodeId), withHydra
 import System.Posix (OpenMode (WriteOnly), closeFd, defaultFileFlags, openFd)
 
 spec :: Spec
-spec =
-  describe "Terminal User Interface" $ do
-    around setupNodeAndTUI $
-      context "end-to-end smoke tests" $ do
-        it "starts & renders" $
-          \TUITest{sendInputEvent, shouldRender} -> do
-            threadDelay 1
-            shouldRender "TUI"
-            -- Using hex representation of aliceSk's HydraVerificationKey
-            shouldRender "Party 38088e4c2ae82"
-            sendInputEvent $ EvKey (KChar 'q') []
+spec = do
+  context "end-to-end smoke tests" $ do
+    around setupNodeAndTUI $ do
+      it "starts & renders" $
+        \TUITest{sendInputEvent, shouldRender} -> do
+          threadDelay 1
+          shouldRender "TUI"
+          -- Using hex representation of aliceSk's HydraVerificationKey
+          shouldRender "Party 38088e4c2ae82"
+          sendInputEvent $ EvKey (KChar 'q') []
 
-        it "supports the init & abort Head life cycle" $
-          \TUITest{sendInputEvent, shouldRender} -> do
-            threadDelay 1
-            shouldRender "connected"
-            shouldRender "Idle"
-            sendInputEvent $ EvKey (KChar 'i') []
-            threadDelay 1
-            shouldRender "Initializing"
-            sendInputEvent $ EvKey (KChar 'a') []
-            threadDelay 1
-            shouldRender "Idle"
-            sendInputEvent $ EvKey (KChar 'q') []
+      it "supports the init & abort Head life cycle" $
+        \TUITest{sendInputEvent, shouldRender} -> do
+          threadDelay 1
+          shouldRender "connected"
+          shouldRender "Idle"
+          sendInputEvent $ EvKey (KChar 'i') []
+          threadDelay 1
+          shouldRender "Initializing"
+          sendInputEvent $ EvKey (KChar 'a') []
+          threadDelay 1
+          shouldRender "Idle"
+          sendInputEvent $ EvKey (KChar 'q') []
 
-        it "supports the full Head life cycle" $
-          \TUITest{sendInputEvent, shouldRender} -> do
-            threadDelay 1
-            shouldRender "connected"
-            shouldRender "Idle"
-            sendInputEvent $ EvKey (KChar 'i') []
-            threadDelay 1
-            shouldRender "Initializing"
-            sendInputEvent $ EvKey (KChar 'c') []
-            threadDelay 1
-            shouldRender "42000000 lovelace"
-            sendInputEvent $ EvKey (KChar ' ') []
-            sendInputEvent $ EvKey KEnter []
-            threadDelay 1
-            shouldRender "Open"
-            sendInputEvent $ EvKey (KChar 'c') []
-            threadDelay 1
-            shouldRender "Closed"
-            shouldRender "Remaining time to contest"
-            threadDelay (realToFrac $ toNominalDiffTime tuiContestationPeriod + gracePeriod + someTime)
-            sendInputEvent $ EvKey (KChar 'f') []
-            threadDelay 1
-            shouldRender "Final"
-            shouldRender "42000000 lovelace"
-            sendInputEvent $ EvKey (KChar 'q') []
+      it "supports the full Head life cycle" $
+        \TUITest{sendInputEvent, shouldRender} -> do
+          threadDelay 1
+          shouldRender "connected"
+          shouldRender "Idle"
+          sendInputEvent $ EvKey (KChar 'i') []
+          threadDelay 1
+          shouldRender "Initializing"
+          sendInputEvent $ EvKey (KChar 'c') []
+          threadDelay 1
+          shouldRender "42000000 lovelace"
+          sendInputEvent $ EvKey (KChar ' ') []
+          sendInputEvent $ EvKey KEnter []
+          threadDelay 1
+          shouldRender "Open"
+          sendInputEvent $ EvKey (KChar 'c') []
+          threadDelay 1
+          shouldRender "Closed"
+          shouldRender "Remaining time to contest"
+          threadDelay (realToFrac $ toNominalDiffTime tuiContestationPeriod + gracePeriod + someTime)
+          sendInputEvent $ EvKey (KChar 'f') []
+          threadDelay 1
+          shouldRender "Final"
+          shouldRender "42000000 lovelace"
+          sendInputEvent $ EvKey (KChar 'q') []
+  context "text rendering tests" $ do
     it "should format time with whole values for every unit, not total values" $ do
       let time = (3675 :: NominalDiffTime)
       renderTime time `shouldBe` "0d 1h 1m 15s"

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -104,6 +104,7 @@ spec = do
         days = hours * 24  
         time = 10 * days + 1 * hours + 1 * minutes + 15 * seconds
       renderTime (time :: NominalDiffTime) `shouldBe` "10d 1h 1m 15s"
+      renderTime (-time :: NominalDiffTime) `shouldBe` "-10d -1h -1m -15s"
 
 -- XXX: The same hack as in EndToEndSpec
 gracePeriod :: NominalDiffTime

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -97,8 +97,13 @@ spec = do
           sendInputEvent $ EvKey (KChar 'q') []
   context "text rendering tests" $ do
     it "should format time with whole values for every unit, not total values" $ do
-      let time = (3675 :: NominalDiffTime)
-      renderTime time `shouldBe` "0d 1h 1m 15s"
+      let
+        seconds = 1
+        minutes = seconds * 60
+        hours = minutes * 60
+        days = hours * 24  
+        time = 10 * days + 1 * hours + 1 * minutes + 15 * seconds
+      renderTime (time :: NominalDiffTime) `shouldBe` "10d 1h 1m 15s"
 
 -- XXX: The same hack as in EndToEndSpec
 gracePeriod :: NominalDiffTime


### PR DESCRIPTION
Due to the time formatting logic was using modifiers to show the `total whole value` for every time unit, instead of `elapsed time`, making the display confusing.

i.e.:
if the remaining contestation period was 3675
then the tui was displaying: "0d 1h 61m 3675s"
instead of current result: "0d 1h 1m 15s"

Fixes https://github.com/input-output-hk/hydra-poc/issues/434