### PR TITLE
Use deadline in fanout tx

### DIFF
--- a/hydra-node/exe/tx-cost/TxCost.hs
+++ b/hydra-node/exe/tx-cost/TxCost.hs
@@ -51,11 +51,11 @@ import Hydra.Ledger.Cardano (
 import Hydra.Ledger.Cardano.Evaluate (
   evaluateTx,
   genPointInTime,
-  genPointInTimeAfter,
   genPointInTimeBefore,
   maxCpu,
   maxMem,
   maxTxSize,
+  slotNoFromPOSIXTime,
  )
 import Hydra.Snapshot (genConfirmedSnapshot)
 import Plutus.Orphans ()
@@ -211,8 +211,8 @@ computeFanOutCost = do
     closePoint <- genPointInTime
     let closeTx = close snapshot closePoint stOpen
     let stClosed = snd $ unsafeObserveTx @_ @ 'StClosed closeTx stOpen
-    fanoutPoint <- genPointInTimeAfter (getContestationDeadline stClosed)
-    pure (getKnownUTxO stClosed, fanout utxo fanoutPoint stClosed)
+    let deadlineSlotNo = slotNoFromPOSIXTime (getContestationDeadline stClosed)
+    pure (getKnownUTxO stClosed, fanout utxo deadlineSlotNo stClosed)
 
 newtype NumParties = NumParties Int
   deriving newtype (Eq, Show, Ord, Num, Real, Enum, Integral)

--- a/hydra-node/src/Hydra/Chain/Direct/Context.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Context.hs
@@ -31,7 +31,7 @@ import Hydra.Chain.Direct.State (
 import Hydra.ContestationPeriod (ContestationPeriod)
 import Hydra.Crypto (HydraKey, generateSigningKey)
 import Hydra.Ledger.Cardano (genOneUTxOFor, genTxIn, genUTxOAdaOnlyOfSize, genVerificationKey, renderTx)
-import Hydra.Ledger.Cardano.Evaluate (genPointInTime, genPointInTimeAfter)
+import Hydra.Ledger.Cardano.Evaluate (genPointInTime, slotNoFromPOSIXTime)
 import Hydra.Party (Party, deriveParty)
 import Hydra.Snapshot (ConfirmedSnapshot (..), Snapshot (..), SnapshotNumber, genConfirmedSnapshot)
 import Test.QuickCheck (choose, elements, frequency, vector)
@@ -143,8 +143,8 @@ genFanoutTx numParties numOutputs = do
   ctx <- genHydraContext numParties
   utxo <- genUTxOAdaOnlyOfSize numOutputs
   (_, toFanout, stClosed) <- genStClosed ctx utxo
-  pointInTime <- genPointInTimeAfter (getContestationDeadline stClosed)
-  pure (stClosed, fanout toFanout pointInTime stClosed)
+  let deadlineSlotNo = slotNoFromPOSIXTime (getContestationDeadline stClosed)
+  pure (stClosed, fanout toFanout deadlineSlotNo stClosed)
 
 genStOpen ::
   HydraContext ->

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -311,7 +311,7 @@ fromPostChainTx timeHandle cardanoKeys wallet someHeadState tx = do
       shifted <- throwLeft $ adjustPointInTime closeGraceTime pointInTime
       pure (contest confirmedSnapshot shifted st)
     (FanoutTx{utxo}, TkClosed) -> do
-      -- NOTE: It's a bit weir that we inspect the state here, but handing
+      -- NOTE: It's a bit weird that we inspect the state here, but handling
       -- errors around while we want the possibly failing "time -> slot"
       -- conversion to be done here is not prettier.
       deadlineSlot <- throwLeft . slotFromPOSIXTime $ getContestationDeadline st

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -347,14 +347,16 @@ contest confirmedSnapshot pointInTime OnChainHeadState{ownVerificationKey, state
 
 fanout ::
   UTxO ->
-  PointInTime ->
+  -- | Contestation deadline as SlotNo, used to set lower tx validity bound.
+  SlotNo ->
   OnChainHeadState 'StClosed ->
   Tx
-fanout utxo pointInTime OnChainHeadState{stateMachine} = do
-  let ClosedThreadOutput{closedThreadUTxO = (i, o, dat)} = closedThreadOutput
-   in fanoutTx utxo (i, o, dat) pointInTime closedHeadTokenScript
+fanout utxo deadlineSlotNo OnChainHeadState{stateMachine} = do
+  fanoutTx utxo (i, o, dat) deadlineSlotNo closedHeadTokenScript
  where
   Closed{closedThreadOutput, closedHeadTokenScript} = stateMachine
+
+  ClosedThreadOutput{closedThreadUTxO = (i, o, dat)} = closedThreadOutput
 
 -- Observing Transitions
 

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -390,19 +390,18 @@ fanoutTx ::
   UTxO ->
   -- | Everything needed to spend the Head state-machine output.
   UTxOWithScript ->
-  -- | Point in time at which this transaction is posted, used to set
-  -- lower bound.
-  PointInTime ->
+  -- | Contestation deadline as SlotNo, used to set lower tx validity bound.
+  SlotNo ->
   -- | Minting Policy script, made from initial seed
   PlutusScript ->
   Tx
-fanoutTx utxo (headInput, headOutput, ScriptDatumForTxIn -> headDatumBefore) (slotNo, _) headTokenScript =
+fanoutTx utxo (headInput, headOutput, ScriptDatumForTxIn -> headDatumBefore) deadlineSlotNo headTokenScript =
   unsafeBuildTransaction $
     emptyTxBody
       & addInputs [(headInput, headWitness)]
       & addOutputs orderedTxOutsToFanout
       & burnTokens headTokenScript Burn headTokens
-      & setValidityLowerBound slotNo
+      & setValidityLowerBound (deadlineSlotNo + 1)
  where
   headWitness =
     BuildTxWith $ ScriptWitness scriptWitnessCtx $ mkScriptWitness headScript headDatumBefore headRedeemer

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -385,6 +385,9 @@ contestTx vk Snapshot{number, utxo} sig (slotNo, _) ClosedThreadOutput{closedThr
         }
   utxoHash = toBuiltin $ hashUTxO @Tx utxo
 
+-- | Create the fanout transaction, which distributes the closed state
+-- accordingly. The head validator allows fanout only > deadline, so we need
+-- to set the lower bound to be deadline + 1 slot.
 fanoutTx ::
   -- | Snapshotted UTxO to fanout on layer 1
   UTxO ->

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/FanOut.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/FanOut.hs
@@ -35,7 +35,7 @@ healthyFanoutTx =
     fanoutTx
       healthyFanoutUTxO
       (headInput, headOutput, headDatum)
-      (healthySlotNo, slotNoToPOSIXTime healthySlotNo)
+      healthySlotNo
       headTokenScript
 
   headInput = generateWith arbitrary 42


### PR DESCRIPTION
:palm_tree: Introduce a `slotFromPOSIXTime`into the TimeHandle

This may fail outside the safe zone, but is required to convert the
contestation deadline back into a slot number.

:palm_tree: Use deadline slot in fanout tx construction

Using the current point in time for the transaction lower bound makes it
tricky to not submit the transaction too early. A more robust and still
correct way to create fanout transactions is to use the contestation
deadline `slot + 1` for a lower transaction bound.