### PR TITLE
Fix faucet race

### DIFF
--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -201,11 +201,13 @@ test-suite integration
     Test.DirectChainSpec
     Test.EndToEndSpec
     Test.GeneratorSpec
+    Test.Hydra.Cluster.FaucetSpec
     Test.Ledger.Cardano.ConfigurationSpec
     Test.LogFilterSpec
 
   build-depends:
     , aeson
+    , async
     , base                       >=4.7 && <5
     , base16-bytestring
     , bytestring

--- a/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
@@ -1,22 +1,23 @@
 module Test.Hydra.Cluster.FaucetSpec where
 
+import Hydra.Prelude
+import Test.Hydra.Prelude
+
 import CardanoNode (withCardanoNodeDevnet)
 import Control.Concurrent.Async (replicateConcurrently_)
 import Hydra.Cluster.Faucet (Marked (Normal), seedFromFaucet_)
 import Hydra.Ledger.Cardano (genVerificationKey)
 import Hydra.Logging (showLogsOnFailure)
-import Hydra.Prelude
-import HydraNode (EndToEndLog (FromCardanoNode))
-import Test.Hydra.Prelude
 import Test.QuickCheck (generate)
 
 spec :: Spec
-spec = around showLogsOnFailure $ do
-  describe "seed from faucet" $ do
-    it "should work concurrently" $ \tracer -> do
-      failAfter 30 $
-        withTempDir "end-to-end-cardano-node" $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node -> do
-            replicateConcurrently_ 10 $ do
-              vk <- generate genVerificationKey
-              seedFromFaucet_ node vk 1_000_000 Normal
+spec =
+  describe "seed from faucet" $
+    it "should work concurrently" $
+      showLogsOnFailure $ \tracer ->
+        failAfter 30 $
+          withTempDir "end-to-end-cardano-node" $ \tmpDir ->
+            withCardanoNodeDevnet tracer tmpDir $ \node ->
+              replicateConcurrently_ 10 $ do
+                vk <- generate genVerificationKey
+                seedFromFaucet_ node vk 1_000_000 Normal

--- a/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
@@ -1,9 +1,22 @@
 module Test.Hydra.Cluster.FaucetSpec where
 
+import CardanoNode (withCardanoNodeDevnet)
+import Control.Concurrent.Async (replicateConcurrently_)
+import Hydra.Cluster.Faucet (Marked (Normal), seedFromFaucet_)
+import Hydra.Ledger.Cardano (genVerificationKey)
+import Hydra.Logging (showLogsOnFailure)
 import Hydra.Prelude
+import HydraNode (EndToEndLog (FromCardanoNode))
 import Test.Hydra.Prelude
+import Test.QuickCheck (generate)
 
 spec :: Spec
-spec = do
-    it "should be true" $ do
-      True `shouldBe` True
+spec = around showLogsOnFailure $ do
+  describe "seed from faucet" $ do
+    it "should work concurrently" $ \tracer -> do
+      failAfter 30 $
+        withTempDir "end-to-end-cardano-node" $ \tmpDir -> do
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node -> do
+            replicateConcurrently_ 10 $ do
+              vk <- generate genVerificationKey
+              seedFromFaucet_ node vk 1_000_000 Normal

--- a/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
@@ -1,0 +1,9 @@
+module Test.Hydra.Cluster.FaucetSpec where
+
+import Hydra.Prelude
+import Test.Hydra.Prelude
+
+spec :: Spec
+spec = do
+    it "should be true" $ do
+      True `shouldBe` True


### PR DESCRIPTION
Added a test for concurrently seeding funds from the faucet, which happens in some of our end to end tests.

The fix for this is to not query utxos again to avoid build errors and instead see any double spends as proper client exceptions, which we retry in `seedFromFaucet`.