### PR TITLE
Try to fix hydra CI by using https-based submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "testnet/cardano-configurations"]
 	path = hydra-cluster/config/cardano-configurations
-	url = git@github.com:input-output-hk/cardano-configurations.git
+	url = https://github.com/input-output-hk/cardano-configurations.git


### PR DESCRIPTION
This seems to have worked and Hydra CI builds our codebase again (no reporting, only caching)

https://hydra.iohk.io/jobset/Cardano/hydra-poc-pr-446#tabs-evaluations