### PR TITLE
Evaluate transactions using cardano-api functions

### DIFF
--- a/hydra-node/exe/tx-cost/Main.hs
+++ b/hydra-node/exe/tx-cost/Main.hs
@@ -1,6 +1,7 @@
 import Hydra.Prelude hiding (catch)
 
 import Data.ByteString (hPut)
+import Data.Fixed (Centi)
 import Hydra.Ledger.Cardano.Evaluate (maxCpu, maxMem, maxTxSize)
 import Options.Applicative (
   Parser,
@@ -134,9 +135,9 @@ costOfInit = markdownInitCost <$> computeInitCost
                 <> "| "
                 <> show txSize
                 <> " | "
-                <> show (100 * fromIntegral mem / maxMem)
+                <> show (mem `percentOf` maxMem)
                 <> " | "
-                <> show (100 * fromIntegral cpu / maxCpu)
+                <> show (cpu `percentOf` maxCpu)
                 <> " |"
           )
           stats
@@ -158,9 +159,9 @@ costOfCommit = markdownCommitCost <$> computeCommitCost
                 <> "| "
                 <> show txSize
                 <> " | "
-                <> show (100 * fromIntegral mem / maxMem)
+                <> show (mem `percentOf` maxMem)
                 <> " | "
-                <> show (100 * fromIntegral cpu / maxCpu)
+                <> show (cpu `percentOf` maxCpu)
                 <> " |"
           )
           stats
@@ -181,9 +182,9 @@ costOfCollectCom = markdownCollectComCost <$> computeCollectComCost
                 <> "| "
                 <> show txSize
                 <> " | "
-                <> show (100 * fromIntegral mem / maxMem)
+                <> show (mem `percentOf` maxMem)
                 <> " | "
-                <> show (100 * fromIntegral cpu / maxCpu)
+                <> show (cpu `percentOf` maxCpu)
                 <> " |"
           )
           stats
@@ -204,9 +205,9 @@ costOfClose = markdownClose <$> computeCloseCost
                 <> "| "
                 <> show txSize
                 <> " | "
-                <> show (100 * fromIntegral mem / maxMem)
+                <> show (mem `percentOf` maxMem)
                 <> " | "
-                <> show (100 * fromIntegral cpu / maxCpu)
+                <> show (cpu `percentOf` maxCpu)
                 <> " |"
           )
           stats
@@ -227,9 +228,9 @@ costOfContest = markdownContest <$> computeContestCost
                 <> "| "
                 <> show txSize
                 <> " | "
-                <> show (100 * fromIntegral mem / maxMem)
+                <> show (mem `percentOf` maxMem)
                 <> " | "
-                <> show (100 * fromIntegral cpu / maxCpu)
+                <> show (cpu `percentOf` maxCpu)
                 <> " |"
           )
           stats
@@ -250,9 +251,9 @@ costOfAbort = markdownAbortCost <$> computeAbortCost
                 <> "| "
                 <> show txSize
                 <> " | "
-                <> show (100 * fromIntegral mem / maxMem)
+                <> show (mem `percentOf` maxMem)
                 <> " | "
-                <> show (100 * fromIntegral cpu / maxCpu)
+                <> show (cpu `percentOf` maxCpu)
                 <> " |"
           )
           stats
@@ -274,9 +275,13 @@ costOfFanOut = markdownFanOutCost <$> computeFanOutCost
                 <> "| "
                 <> show txSize
                 <> " | "
-                <> show (100 * fromIntegral mem / maxMem)
+                <> show (mem `percentOf` maxMem)
                 <> " | "
-                <> show (100 * fromIntegral cpu / maxCpu)
+                <> show (cpu `percentOf` maxCpu)
                 <> " |"
           )
           stats
+
+percentOf :: (Real a, Real b) => a -> b -> Centi
+part `percentOf` total =
+  100 * realToFrac part / realToFrac total

--- a/hydra-node/test/Hydra/Chain/Direct/Fixture.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Fixture.hs
@@ -1,9 +1,12 @@
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Hydra.Chain.Direct.Fixture (
   module Hydra.Chain.Direct.Fixture,
   pparams,
+  systemStart,
+  epochInfo,
 ) where
 
 import Hydra.Prelude
@@ -12,24 +15,24 @@ import Cardano.Crypto.Hash (hashToBytes)
 import Cardano.Ledger.BaseTypes (TxIx (TxIx))
 import qualified Cardano.Ledger.BaseTypes as Ledger
 import qualified Cardano.Ledger.Shelley.Rules.Ledger as Ledger
-import Cardano.Slotting.EpochInfo (EpochInfo, fixedEpochInfo)
-import Cardano.Slotting.Slot (EpochSize (EpochSize))
-import Cardano.Slotting.Time (SlotLength, SystemStart (SystemStart), mkSlotLength)
 import qualified Cardano.Slotting.Time as Slotting
 import Codec.CBOR.Magic (uintegerFromBytes)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Hydra.Cardano.Api (
+  Era,
   LedgerEra,
   NetworkId (Testnet),
   NetworkMagic (NetworkMagic),
   PolicyId,
   SlotNo (..),
   TxIn,
+  shelleyBasedEra,
+  toLedgerPParams,
   verificationKeyHash,
  )
 import Hydra.Chain.Direct.Tx (headPolicyId)
 import Hydra.Crypto (Hash (HydraKeyHash))
-import Hydra.Ledger.Cardano.Evaluate (pparams)
+import Hydra.Ledger.Cardano.Evaluate (epochInfo, pparams, systemStart)
 import Hydra.Party (Party (..))
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
 import Test.Cardano.Ledger.Generic.ModelState (accountStateZero)
@@ -63,25 +66,12 @@ testPolicyId = headPolicyId testSeedInput
 testSeedInput :: TxIn
 testSeedInput = generateWith arbitrary 42
 
--- REVIEW(SN): taken from 'testGlobals'
-epochInfo :: Monad m => EpochInfo m
-epochInfo = fixedEpochInfo epochSize slotLength
-
-systemStart :: SystemStart
-systemStart = SystemStart $ posixSecondsToUTCTime 0
-
-epochSize :: EpochSize
-epochSize = EpochSize 100
-
-slotLength :: SlotLength
-slotLength = mkSlotLength 1
-
 defaultLedgerEnv :: Ledger.LedgerEnv LedgerEra
 defaultLedgerEnv =
   Ledger.LedgerEnv
     { Ledger.ledgerSlotNo = SlotNo 1
     , Ledger.ledgerIx = TxIx 0
-    , Ledger.ledgerPp = pparams
+    , Ledger.ledgerPp = toLedgerPParams (shelleyBasedEra @Era) pparams
     , Ledger.ledgerAccount = accountStateZero
     }
 

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -97,7 +97,7 @@ import Hydra.Ledger.Cardano.Evaluate (
   genPointInTimeBefore,
   maxTxExecutionUnits,
   maxTxSize,
-  renderRedeemerReportFailures,
+  renderEvaluationReportFailures,
  )
 import Hydra.Snapshot (genConfirmedSnapshot, getSnapshot, number)
 import Ouroboros.Consensus.Block (Point, blockPoint)
@@ -406,14 +406,14 @@ propIsValid forAllTx =
     forAllTx $ \st tx -> do
       let lookupUTxO = getKnownUTxO st
       case evaluateTx' maxTxExecutionUnits tx lookupUTxO of
-        Left basicFailure ->
+        Left validityError ->
           property False
             & counterexample ("Tx: " <> renderTxWithUTxO lookupUTxO tx)
-            & counterexample ("Phase-1 validation failed: " <> show basicFailure)
-        Right redeemerReport ->
-          all isRight (Map.elems redeemerReport)
+            & counterexample ("Evaluation failed: " <> show validityError)
+        Right evaluationReport ->
+          all isRight (Map.elems evaluationReport)
             & counterexample ("Tx: " <> renderTxWithUTxO lookupUTxO tx)
-            & counterexample (toString $ "Redeemer report: " <> renderRedeemerReportFailures redeemerReport)
+            & counterexample (toString $ "Failures: " <> renderEvaluationReportFailures evaluationReport)
             & counterexample "Phase-2 validation failed"
 
 --


### PR DESCRIPTION
:tropical_drink: Replace the ledger functions with their cardano-api equivalent.

:tropical_drink: The `EraHistory` needed some convincing, but otherwise this was quite straight-forward.

:tropical_drink: Now only the `Hydra.Chain.Direct.Wallet` is using the ledger types directly.