### PR TITLE
Smoke test with existing scripts

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -13,6 +13,10 @@ on:
         - preview
         - preprod
 
+      hydra-scripts-tx-id:
+        description: "TxId of already published scripts (leave empty to publish)"
+        required: false
+
 jobs:
   smoke-test:
     name: "Smoke test on ${{inputs.network}}"
@@ -49,7 +53,11 @@ jobs:
 
     - name: Run hydra-cluster 
       run: |
-        nix-shell -A exes --run "hydra-cluster --${{inputs.network}} --state-directory state-${{inputs.network}}"
+        if [ -n "${{inputs.hydra-scripts-tx-id}}" ]; then
+          nix-shell -A exes --run "hydra-cluster --${{inputs.network}} --hydra-scripts-tx-id ${{inputs.hydra-scripts-tx-id}} --state-directory state-${{inputs.network}}"
+        else
+          nix-shell -A exes --run "hydra-cluster --${{inputs.network}} --publish-scripts --state-directory state-${{inputs.network}}"
+        fi
 
     - name: Archive logs
       if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 As a minor extension, we also keep a semantic version for the `UNRELEASED`
 changes.
 
+## [0.8.0] - UNRELEASED
+
+- The `hydra-cluster` does require `--publish-scripts` or `--hydra-scripts-tx-id` now as it may be provided with pre-published hydra scripts.
+
 ## [0.7.0] - 2022-08-23
 
 - **BREAKING** Switch to `BabbageEra` and `PlutusV2`.

--- a/default.nix
+++ b/default.nix
@@ -49,8 +49,8 @@ let
   cardano-node = import
     (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "1.35.3-testnetonly";
-      sha256 = "0vg5775z683wf421asxjm7g2b6yxmgprpylhs9ryb035id83slp2";
+      rev = "1.35.3";
+      sha256 = "020fwimsm24yblr1fmnwx240wj8r3x715p89cpjgnnd8axwf32p0";
     })
     { };
 in

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               hydra-cluster
-version:            0.7.0
+version:            0.8.0
 synopsis:
   Integration test suite using a local cluster of cardano and hydra nodes
 

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -189,6 +189,7 @@ data EndToEndLog
   | RefueledFunds {actor :: String, refuelingAmount :: Lovelace, fuelUTxO :: UTxO}
   | RemainingFunds {actor :: String, fuelUTxO :: UTxO, otherUTxO :: UTxO}
   | PublishedHydraScriptsAt {hydraScriptsTxId :: TxId}
+  | UsingHydraScriptsAt {hydraScriptsTxId :: TxId}
   deriving (Eq, Show, Generic, ToJSON, FromJSON, ToObject)
 
 -- XXX: The two lists need to be of same length. Also the verification keys can

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -86,8 +86,9 @@ spec = around showLogsOnFailure $ do
     describe "single party hydra head" $ do
       it "full head life-cycle" $ \tracer -> do
         withTempDir "hydra-cluster-end-to-end" $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $
-            singlePartyHeadFullLifeCycle tracer tmpDir
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
+            publishHydraScriptsAs node Faucet
+              >>= singlePartyHeadFullLifeCycle tracer tmpDir node
 
     describe "three hydra nodes scenario" $ do
       it "inits a Head, processes a single Cardano transaction and closes it again" $ \tracer ->

--- a/testnets/squash-utxo.sh
+++ b/testnets/squash-utxo.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Squash all fuel utxo of a signing key into a single output and mark it as fuel.
+# Squash all utxo of a signing key into a single output and mark it as fuel.
 set -e
 
 function usage() {
@@ -31,7 +31,7 @@ utxo=$(cardano-cli query utxo \
     --cardano-mode --epoch-slots 21600 \
     --testnet-magic ${magic} \
     --address ${addr} \
-    --out-file /dev/stdout | jq ". | select(.[].datumhash == \"${fuelMarker}\")")
+    --out-file /dev/stdout)
 inputs=($(echo ${utxo} | jq -r '. | keys | @sh' | tr -d "'"))
 totalLovelace=$(echo ${utxo} | jq -r 'reduce .[] as $item (0; . + $item.value.lovelace)')
 


### PR DESCRIPTION
:ear_of_rice: Add a `--publish-scripts` and `--hydra-scripts-tx-id` to `hydra-cluster`, one needs to be provided

:ear_of_rice: Update the smoke-test workflow to take an optional tx id for already published scripts