### PR TITLE
Refactor Hydra.Chain.Direct.State

### DIFF
--- a/hydra-node/exe/tx-cost/TxCost.hs
+++ b/hydra-node/exe/tx-cost/TxCost.hs
@@ -28,7 +28,7 @@ import Hydra.Chain.Direct.Context (
   genInitTx,
   genStClosed,
   genStIdle,
-  genStInitialized,
+  genStInitial,
   genStOpen,
   unsafeObserveTx,
  )
@@ -106,7 +106,7 @@ computeCommitCost = do
   genCommitTx utxo = do
     -- NOTE: number of parties is irrelevant for commit tx
     ctx <- genHydraContextFor 1
-    stInitialized <- genStInitialized ctx
+    stInitialized <- genStInitial ctx
     pure (commit utxo stInitialized, getKnownUTxO stInitialized)
 
 computeCollectComCost :: IO [(NumParties, TxSize, MemUnit, CpuUnit, Lovelace)]

--- a/hydra-node/exe/tx-cost/TxCost.hs
+++ b/hydra-node/exe/tx-cost/TxCost.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TypeApplications #-}
-
 module TxCost where
 
 import Hydra.Prelude hiding (catch)
@@ -8,6 +6,7 @@ import qualified Cardano.Api.UTxO as UTxO
 import Cardano.Binary (serialize)
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map as Map
+import Data.Maybe (fromJust)
 import Hydra.Cardano.Api (
   ExecutionUnits (..),
   Lovelace,
@@ -17,23 +16,20 @@ import Hydra.Cardano.Api (
   UTxO,
  )
 import Hydra.Chain.Direct.Context (
-  HydraContext (ctxVerificationKeys),
   ctxHeadParameters,
   ctxHydraSigningKeys,
-  executeCommits,
   genCloseTx,
   genCommits,
   genHydraContext,
   genHydraContextFor,
   genInitTx,
   genStClosed,
-  genStIdle,
   genStInitial,
   genStOpen,
-  unsafeObserveTx,
+  pickChainContext,
+  unsafeObserveInitAndCommits,
  )
 import Hydra.Chain.Direct.State (
-  HeadStateKind (StClosed),
   abort,
   close,
   collect,
@@ -43,6 +39,7 @@ import Hydra.Chain.Direct.State (
   getContestationDeadline,
   getKnownUTxO,
   initialize,
+  observeClose,
  )
 import Hydra.Ledger.Cardano (
   genOutput,
@@ -79,11 +76,11 @@ computeInitCost = do
 
   genInitTx' numParties = do
     ctx <- genHydraContextFor numParties
-    stIdle <- genStIdle ctx
+    cctx <- pickChainContext ctx
     seedInput <- genTxIn
     seedOutput <- genOutput =<< arbitrary
     let utxo = UTxO.singleton (seedInput, seedOutput)
-    pure (initialize (ctxHeadParameters ctx) (ctxVerificationKeys ctx) seedInput stIdle, utxo)
+    pure (initialize cctx (ctxHeadParameters ctx) seedInput, utxo)
 
 computeCommitCost :: IO [(NumUTxO, TxSize, MemUnit, CpuUnit, Lovelace)]
 computeCommitCost = do
@@ -106,8 +103,8 @@ computeCommitCost = do
   genCommitTx utxo = do
     -- NOTE: number of parties is irrelevant for commit tx
     ctx <- genHydraContextFor 1
-    stInitialized <- genStInitial ctx
-    pure (commit utxo stInitialized, getKnownUTxO stInitialized)
+    stInitial <- genStInitial ctx
+    pure (commit stInitial utxo, getKnownUTxO stInitial)
 
 computeCollectComCost :: IO [(NumParties, TxSize, MemUnit, CpuUnit, Lovelace)]
 computeCollectComCost =
@@ -124,10 +121,10 @@ computeCollectComCost =
 
   genCollectComTx numParties = do
     ctx <- genHydraContextFor numParties
+    cctx <- pickChainContext ctx
     initTx <- genInitTx ctx
     commits <- genCommits ctx initTx
-    stIdle <- genStIdle ctx
-    let (_, stInitialized) = executeCommits initTx commits stIdle
+    let (_, stInitialized) = unsafeObserveInitAndCommits cctx initTx commits
     pure (stInitialized, collect stInitialized)
 
 computeCloseCost :: IO [(NumParties, TxSize, MemUnit, CpuUnit, Lovelace)]
@@ -166,7 +163,7 @@ computeContestCost = do
     (closedSnapshotNumber, _, stClosed) <- genStClosed ctx utxo
     snapshot <- genConfirmedSnapshot (succ closedSnapshotNumber) utxo (ctxHydraSigningKeys ctx)
     pointInTime <- genPointInTimeBefore (getContestationDeadline stClosed)
-    pure (stClosed, contest snapshot pointInTime stClosed)
+    pure (stClosed, contest stClosed snapshot pointInTime)
 
 computeAbortCost :: IO [(NumParties, TxSize, MemUnit, CpuUnit, Lovelace)]
 computeAbortCost =
@@ -186,8 +183,8 @@ computeAbortCost =
     ctx <- genHydraContextFor numParties
     initTx <- genInitTx ctx
     commits <- sublistOf =<< genCommits ctx initTx
-    stIdle <- genStIdle ctx
-    let (_, stInitialized) = executeCommits initTx commits stIdle
+    cctx <- pickChainContext ctx
+    let (_, stInitialized) = unsafeObserveInitAndCommits cctx initTx commits
     pure (abort stInitialized, getKnownUTxO stInitialized)
 
 computeFanOutCost :: IO [(NumUTxO, TxSize, MemUnit, CpuUnit, Lovelace)]
@@ -211,10 +208,10 @@ computeFanOutCost = do
     (_committed, stOpen) <- genStOpen ctx
     snapshot <- genConfirmedSnapshot 1 utxo [] -- We do not validate the signatures
     closePoint <- genPointInTime
-    let closeTx = close snapshot closePoint stOpen
-    let stClosed = snd $ unsafeObserveTx @_ @ 'StClosed closeTx stOpen
+    let closeTx = close stOpen snapshot closePoint
+    let stClosed = snd . fromJust $ observeClose stOpen closeTx
     let deadlineSlotNo = slotNoFromPOSIXTime (getContestationDeadline stClosed)
-    pure (getKnownUTxO stClosed, fanout utxo deadlineSlotNo stClosed)
+    pure (getKnownUTxO stClosed, fanout stClosed utxo deadlineSlotNo)
 
 newtype NumParties = NumParties Int
   deriving newtype (Eq, Show, Ord, Num, Real, Enum, Integral)

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -79,6 +79,7 @@ import Hydra.Chain.Direct.Handlers (
  )
 import Hydra.Chain.Direct.ScriptRegistry (queryScriptRegistry)
 import Hydra.Chain.Direct.State (
+  ChainContext (..),
   SomeOnChainHeadState (..),
   idleOnChainHeadState,
  )
@@ -172,6 +173,15 @@ withDirectChain tracer networkId iocp socketPath keyPair party cardanoKeys point
               idleOnChainHeadState networkId (cardanoKeys \\ [vk]) vk party scriptRegistry
         , recordedAt = AtStart
         }
+
+  let chainContext =
+        ChainContext
+          { networkId
+          , peerVerificationKeys = cardanoKeys \\ [vk]
+          , ownVerificationKey = vk
+          , ownParty = party
+          , scriptRegistry
+          }
   res <-
     race
       ( do
@@ -183,6 +193,7 @@ withDirectChain tracer networkId iocp socketPath keyPair party cardanoKeys point
           action $
             mkChain
               tracer
+              chainContext
               (queryTimeHandle networkId socketPath)
               cardanoKeys
               wallet

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -195,7 +195,6 @@ withDirectChain tracer networkId iocp socketPath keyPair party cardanoKeys point
               tracer
               chainContext
               (queryTimeHandle networkId socketPath)
-              cardanoKeys
               wallet
               headState
               (submitTx queue)

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -80,7 +80,7 @@ import Hydra.Chain.Direct.Handlers (
 import Hydra.Chain.Direct.ScriptRegistry (queryScriptRegistry)
 import Hydra.Chain.Direct.State (
   ChainContext (..),
-  IdleState (IdleState, ctx),
+  IdleState (..),
   SomeOnChainHeadState (..),
  )
 import Hydra.Chain.Direct.TimeHandle (queryTimeHandle)

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -80,8 +80,8 @@ import Hydra.Chain.Direct.Handlers (
 import Hydra.Chain.Direct.ScriptRegistry (queryScriptRegistry)
 import Hydra.Chain.Direct.State (
   ChainContext (..),
+  IdleState (IdleState),
   SomeOnChainHeadState (..),
-  idleOnChainHeadState,
  )
 import Hydra.Chain.Direct.TimeHandle (queryTimeHandle)
 import Hydra.Chain.Direct.Util (
@@ -168,12 +168,9 @@ withDirectChain tracer networkId iocp socketPath keyPair party cardanoKeys point
   headState <-
     newTVarIO $
       SomeOnChainHeadStateAt
-        { currentOnChainHeadState =
-            SomeOnChainHeadState $
-              idleOnChainHeadState networkId (cardanoKeys \\ [vk]) vk party scriptRegistry
+        { currentOnChainHeadState = SomeOnChainHeadState IdleState
         , recordedAt = AtStart
         }
-
   let chainContext =
         ChainContext
           { networkId

--- a/hydra-node/src/Hydra/Chain/Direct/Context.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Context.hs
@@ -94,7 +94,7 @@ genHydraContextFor n = do
 -- 'ctxVerificationKeys' and 'ctxHydraSigningKeys'.
 pickChainContext :: HydraContext -> Gen ChainContext
 pickChainContext ctx = do
-  ourIndex <- choose (0, length ctxHydraSigningKeys)
+  ourIndex <- choose (0, length ctxHydraSigningKeys - 1)
   let ownVerificationKey = ctxVerificationKeys !! ourIndex
       ownParty = deriveParty $ ctxHydraSigningKeys !! ourIndex
   scriptRegistry <- genScriptRegistry

--- a/hydra-node/src/Hydra/Chain/Direct/Context.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Context.hs
@@ -122,11 +122,10 @@ pickChainContext :: HydraContext -> Gen ChainContext
 pickChainContext ctx =
   deriveChainContexts ctx >>= elements
 
--- TODO: rename
-genStInitialized ::
+genStInitial ::
   HydraContext ->
   Gen InitialState
-genStInitialized ctx = do
+genStInitial ctx = do
   seedInput <- genTxIn
   cctx <- pickChainContext ctx
   let initTx = initialize cctx (ctxHeadParameters ctx) seedInput

--- a/hydra-node/src/Hydra/Chain/Direct/Context.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Context.hs
@@ -208,23 +208,6 @@ genStClosed ctx utxo = do
 -- Here be dragons
 --
 
--- REVIEW: see whether we need this ported or not?
--- unsafeObserveTx ::
---   forall st st'.
---   (ObserveTx st st', HasCallStack) =>
---   Tx ->
---   OnChainHeadState st ->
---   (OnChainTx Tx, OnChainHeadState st')
--- unsafeObserveTx tx st =
---   fromMaybe (error hopefullyInformativeMessage) (observeTx @st @st' tx st)
---  where
---   hopefullyInformativeMessage =
---     "unsafeObserveTx:"
---       <> "\n  From:\n    "
---       <> show st
---       <> "\n  Via:\n    "
---       <> renderTx tx
-
 unsafeCommit ::
   HasCallStack =>
   InitialState ->

--- a/hydra-node/src/Hydra/Chain/Direct/Context.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Context.hs
@@ -89,11 +89,11 @@ genHydraContextFor n = do
       , ctxContestationPeriod
       }
 
--- | Derive and generate a peer-specific ChainContext from a HydraContext. NOTE:
--- This assumes that 'HydraContext' has same length 'ctxVerificationKeys' and
--- 'ctxHydraSigningKeys'.
-genChainContext :: HydraContext -> Gen ChainContext
-genChainContext ctx = do
+-- | Pick one of the participants and derive the peer-specific ChainContext from
+-- a HydraContext. NOTE: This assumes that 'HydraContext' has same length
+-- 'ctxVerificationKeys' and 'ctxHydraSigningKeys'.
+pickChainContext :: HydraContext -> Gen ChainContext
+pickChainContext ctx = do
   ourIndex <- choose (0, length ctxHydraSigningKeys)
   let ownVerificationKey = ctxVerificationKeys !! ourIndex
       ownParty = deriveParty $ ctxHydraSigningKeys !! ourIndex
@@ -129,7 +129,7 @@ genStInitialized ::
 genStInitialized ctx = do
   stIdle <- genStIdle ctx
   seedInput <- genTxIn
-  cctx <- genChainContext ctx
+  cctx <- pickChainContext ctx
   let initTx = initialize cctx (ctxHeadParameters ctx) seedInput
   pure $ snd $ unsafeObserveTx @_ @ 'StInitialized initTx stIdle
 
@@ -137,7 +137,7 @@ genInitTx ::
   HydraContext ->
   Gen Tx
 genInitTx ctx = do
-  cctx <- genChainContext ctx
+  cctx <- pickChainContext ctx
   initialize cctx (ctxHeadParameters ctx) <$> genTxIn
 
 genCommits ::

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -103,15 +103,16 @@ mkChain tracer queryTimeHandle wallet headState submitTx =
         timeHandle <- queryTimeHandle
         vtx <-
           atomically
-            ( -- FIXME (MB): 'cardanoKeys' should really not be here (its in
-              -- ChainContext). They are only required for the init transaction
-              -- and ought to come from the _client_ and be part of the init
-              -- request altogether. This goes in the direction of 'dynamic
-              -- heads' where participants aren't known upfront but provided via
-              -- the API. Ultimately, an init request from a client would
-              -- contain all the details needed to establish connection to the
-              -- other peers and to bootstrap the init transaction. For now, we
-              -- bear with it and keep the static keys in context.
+            ( -- FIXME (MB): cardano keys should really not be here (as this
+              -- point they are in the 'headState' stored in the 'ChainContext')
+              -- . They are only required for the init transaction and ought to
+              -- come from the _client_ and be part of the init request
+              -- altogether. This goes in the direction of 'dynamic heads' where
+              -- participants aren't known upfront but provided via the API.
+              -- Ultimately, an init request from a client would contain all the
+              -- details needed to establish connection to the other peers and
+              -- to bootstrap the init transaction. For now, we bear with it and
+              -- keep the static keys in context.
               fromPostChainTx timeHandle wallet headState tx
                 >>= finalizeTx wallet headState . toLedgerTx
             )

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -327,8 +327,8 @@ fromPostChainTx timeHandle wallet someHeadState tx = do
         Nothing -> throwIO $ InvalidStateToPost tx -- TODO: dry
         Just st@ClosedState{} -> do
           -- NOTE: It's a bit weird that we inspect the state here, but handling
-          -- errors around while we want the possibly failing "time -> slot"
-          -- conversion to be done here is not prettier.
+          -- errors of the possibly failing "time -> slot" conversion is better
+          -- done here.
           deadlineSlot <- throwLeft . slotFromPOSIXTime $ getContestationDeadline st
           pure (fanout st utxo deadlineSlot)
  where

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Hydra.Chain.Direct.State (
+  HasUTxO (..),
   ChainContext (..),
   genChainContext,
 
@@ -84,6 +85,12 @@ import Plutus.V2.Ledger.Api (POSIXTime)
 import Test.QuickCheck (choose, sized)
 import qualified Text.Show
 
+-- | A class for accessing the 'UTxO' set in a type.
+class HasUTxO a where
+  getUTxO :: a -> UTxO
+
+-- * States
+
 -- | Read-only chain-specific data. This is different to 'HydraContext' as it
 -- only provide contains data known to single peer.
 data ChainContext = ChainContext
@@ -94,6 +101,9 @@ data ChainContext = ChainContext
   , scriptRegistry :: ScriptRegistry
   }
   deriving (Show, Eq)
+
+instance HasUTxO ChainContext where
+  getUTxO = mempty
 
 instance Arbitrary ChainContext where
   arbitrary = sized $ \n -> choose (0, n) >>= genChainContext

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -1,62 +1,20 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Hydra.Chain.Direct.State (
-  HasKnownUTxO (..),
-  ChainContext (..),
-  genChainContext,
-  allVerificationKeys,
-
-  -- * OnChainHeadState
-  OnChainHeadState,
-  HeadStateKind (..),
-  HeadStateKindVal (..),
-
-  -- ** Working with opaque states
-  SomeOnChainHeadState (..),
-  TokHeadState (..),
-  reifyState,
-
-  -- ** Initializing
-  idleOnChainHeadState,
-
-  -- ** Constructing transitions
-  initialize,
-  abort,
-  commit,
-  collect,
-  close,
-  contest,
-  fanout,
-
-  -- ** Observing transitions
-  observeSomeTx,
-  observeInit,
-
-  -- *** Internal API
-  ObserveTx (..),
-  HasTransition (..),
-  TransitionFrom (..),
-  getContestationDeadline,
-) where
+module Hydra.Chain.Direct.State where
 
 import Hydra.Cardano.Api
 import Hydra.Prelude hiding (init)
 
 import qualified Cardano.Api.UTxO as UTxO
 import qualified Data.Map as Map
+import Data.Typeable (typeRep)
 import Hydra.Chain (HeadId (..), HeadParameters, OnChainTx (..), PostTxError (..))
-import Hydra.Chain.Direct.ScriptRegistry (ScriptRegistry (..), genScriptRegistry, registryUTxO)
+import Hydra.Chain.Direct.ScriptRegistry (ScriptRegistry (..), genScriptRegistry)
 import Hydra.Chain.Direct.TimeHandle (PointInTime)
 import Hydra.Chain.Direct.Tx (
-  AbortObservation (..),
-  CloseObservation (..),
   ClosedThreadOutput (..),
   ClosingSnapshot (..),
-  CollectComObservation (..),
-  CommitObservation (..),
-  ContestObservation (..),
-  FanoutObservation (..),
   InitObservation (..),
   InitialThreadOutput (..),
   OpenThreadOutput (..),
@@ -68,12 +26,6 @@ import Hydra.Chain.Direct.Tx (
   contestTx,
   fanoutTx,
   initTx,
-  observeAbortTx,
-  observeCloseTx,
-  observeCollectComTx,
-  observeCommitTx,
-  observeContestTx,
-  observeFanoutTx,
   observeInitTx,
   ownInitial,
  )
@@ -130,6 +82,10 @@ allVerificationKeys :: ChainContext -> [VerificationKey PaymentKey]
 allVerificationKeys ChainContext{peerVerificationKeys, ownVerificationKey} =
   ownVerificationKey : peerVerificationKeys
 
+-- | The idle state does not contain any head-specific information and exists to
+-- be used as a starting and terminal state.
+data IdleState = IdleState
+
 data InitialState = InitialState
   { initialThreadOutput :: InitialThreadOutput
   , initialInitials :: [UTxOWithScript]
@@ -139,6 +95,9 @@ data InitialState = InitialState
   }
   deriving (Show, Eq)
 
+instance HasKnownUTxO InitialState where
+  getKnownUTxO = mempty -- TODO
+
 data OpenState = OpenState
   { openThreadOutput :: OpenThreadOutput
   , openHeadId :: HeadId
@@ -147,6 +106,9 @@ data OpenState = OpenState
   }
   deriving (Show, Eq)
 
+instance HasKnownUTxO OpenState where
+  getKnownUTxO = mempty -- TODO
+
 data ClosedState = ClosedState
   { closedThreadOutput :: ClosedThreadOutput
   , closedHeadId :: HeadId
@@ -154,178 +116,44 @@ data ClosedState = ClosedState
   }
   deriving (Show, Eq)
 
--- * Old state type
+instance HasKnownUTxO ClosedState where
+  getKnownUTxO = mempty -- TODO
 
--- | An opaque on-chain head state, which records information and events
--- happening on the layer-1 for a given Hydra head.
-data OnChainHeadState (st :: HeadStateKind) = OnChainHeadState
-  { networkId :: NetworkId
-  , peerVerificationKeys :: [VerificationKey PaymentKey]
-  , ownVerificationKey :: VerificationKey PaymentKey
-  , ownParty :: Party
-  , stateMachine :: HydraStateMachine st
-  , scriptRegistry :: ScriptRegistry
-  }
-  deriving (Eq, Show)
-
--- NOTE (1): The state machine UTxO produced by the Init transaction (a.k.a
--- 'threadOutput') is always present and 'threaded' across all transactions.
---
--- NOTE (2): The Head's identifier is somewhat encoded in the TxOut's address
---
--- TODO: Data and [OnChain.Party] are overlapping
---
--- TODO: There are better ways to model this to avoid duplicating common fields
--- across all branches!
-data HydraStateMachine (st :: HeadStateKind) where
-  Idle :: HydraStateMachine 'StIdle
-  Initialized ::
-    { initialThreadOutput :: InitialThreadOutput
-    , initialInitials :: [UTxOWithScript]
-    , initialCommits :: [UTxOWithScript]
-    , initialHeadId :: HeadId
-    , initialHeadTokenScript :: PlutusScript
-    } ->
-    HydraStateMachine 'StInitialized
-  Open ::
-    { openThreadOutput :: OpenThreadOutput
-    , openHeadId :: HeadId
-    , openHeadTokenScript :: PlutusScript
-    , openUtxoHash :: ByteString
-    } ->
-    HydraStateMachine 'StOpen
-  Closed ::
-    { closedThreadOutput :: ClosedThreadOutput
-    , closedHeadId :: HeadId
-    , closedHeadTokenScript :: PlutusScript
-    } ->
-    HydraStateMachine 'StClosed
-
-deriving instance Show (HydraStateMachine st)
-deriving instance Eq (HydraStateMachine st)
-
-instance HasKnownUTxO (OnChainHeadState 'StIdle) where
-  getKnownUTxO OnChainHeadState{scriptRegistry} =
-    registryUTxO scriptRegistry
-
-instance HasKnownUTxO (OnChainHeadState 'StInitialized) where
-  getKnownUTxO OnChainHeadState{stateMachine, scriptRegistry} =
-    registryUTxO scriptRegistry <> headUtxo
-   where
-    Initialized{initialThreadOutput = InitialThreadOutput{initialThreadUTxO}, initialInitials, initialCommits} = stateMachine
-    headUtxo =
-      UTxO $
-        Map.fromList $
-          take2Of3 initialThreadUTxO : (take2Of3 <$> (initialInitials <> initialCommits))
-
-instance HasKnownUTxO (OnChainHeadState 'StOpen) where
-  getKnownUTxO OnChainHeadState{stateMachine, scriptRegistry} =
-    registryUTxO scriptRegistry <> UTxO.singleton (i, o)
-   where
-    Open{openThreadOutput = OpenThreadOutput{openThreadUTxO = (i, o, _)}} = stateMachine
-
-instance HasKnownUTxO (OnChainHeadState 'StClosed) where
-  getKnownUTxO OnChainHeadState{stateMachine, scriptRegistry} =
-    registryUTxO scriptRegistry <> UTxO.singleton (i, o)
-   where
-    Closed{closedThreadOutput = ClosedThreadOutput{closedThreadUTxO = (i, o, _)}} = stateMachine
-
-getContestationDeadline :: OnChainHeadState 'StClosed -> POSIXTime
+getContestationDeadline :: ClosedState -> POSIXTime
 getContestationDeadline
-  OnChainHeadState{stateMachine = Closed{closedThreadOutput = ClosedThreadOutput{closedContestationDeadline}}} =
+  ClosedState{closedThreadOutput = ClosedThreadOutput{closedContestationDeadline}} =
     closedContestationDeadline
 
 -- Working with opaque states
 
--- | An existential wrapping /some/ 'OnChainHeadState' into a value that carry
--- no type-level information about the state.
+-- | An existential wrapping /some/ on-chain head state into a value that carry
+-- no type-level information about the state except that is 'HasTransitions' and 'HasKnownUTxO'.
 data SomeOnChainHeadState where
   SomeOnChainHeadState ::
     forall st.
-    (HasTransition st, HasKnownUTxO (OnChainHeadState st)) =>
-    OnChainHeadState st ->
+    (Show st, HasTransitions st, HasKnownUTxO st) =>
+    st ->
     SomeOnChainHeadState
 
 instance Show SomeOnChainHeadState where
   show (SomeOnChainHeadState st) = show st
 
-instance Eq SomeOnChainHeadState where
-  (SomeOnChainHeadState st) == (SomeOnChainHeadState st') =
-    case (reifyState st, reifyState st') of
-      (TkIdle, TkIdle) ->
-        st == st'
-      (TkInitialized, TkInitialized) ->
-        st == st'
-      (TkOpen, TkOpen) ->
-        st == st'
-      (TkClosed, TkClosed) ->
-        st == st'
-      _ ->
-        False
+-- TODO: Use Typable for equality
+-- instance Eq SomeOnChainHeadState where
+--   (SomeOnChainHeadState st) == (SomeOnChainHeadState st') =
+--     case (reifyState st, reifyState st') of
+--       (TkIdle, TkIdle) ->
+--         st == st'
+--       (TkInitialized, TkInitialized) ->
+--         st == st'
+--       (TkOpen, TkOpen) ->
+--         st == st'
+--       (TkClosed, TkClosed) ->
+--         st == st'
+--       _ ->
+--         False
 
--- | Some Kind for witnessing Hydra state-machine's states at the type-level.
---
--- This is useful to
---
--- (a) Reads code evolving the state machine, as it makes transition more
--- obvious from type-signatures;
--- (b) Pattern-match on the 'HydraStateMachine' without having to bother with
--- non-reachable cases.
-data HeadStateKind = StIdle | StInitialized | StOpen | StClosed
-  deriving (Eq, Show, Enum, Bounded)
-
-class HeadStateKindVal (st :: HeadStateKind) where
-  headStateKindVal :: Proxy st -> HeadStateKind
-
-instance HeadStateKindVal 'StIdle where
-  headStateKindVal _ = StIdle
-instance HeadStateKindVal 'StInitialized where
-  headStateKindVal _ = StInitialized
-instance HeadStateKindVal 'StOpen where
-  headStateKindVal _ = StOpen
-instance HeadStateKindVal 'StClosed where
-  headStateKindVal _ = StClosed
-
--- | A token witnessing the state's type of an 'OnChainHeadState'. See 'reifyState'
-data TokHeadState (st :: HeadStateKind) where
-  TkIdle :: TokHeadState 'StIdle
-  TkInitialized :: TokHeadState 'StInitialized
-  TkOpen :: TokHeadState 'StOpen
-  TkClosed :: TokHeadState 'StClosed
-
-deriving instance Show (TokHeadState st)
-
--- | Reify a 'HeadStateKind' kind into a value to enable pattern-matching on
--- existentials.
-reifyState :: forall st. OnChainHeadState st -> TokHeadState st
-reifyState OnChainHeadState{stateMachine} =
-  case stateMachine of
-    Idle{} -> TkIdle
-    Initialized{} -> TkInitialized
-    Open{} -> TkOpen
-    Closed{} -> TkClosed
-
--- Initialization
-
--- | Initialize a new 'OnChainHeadState'.
-idleOnChainHeadState ::
-  NetworkId ->
-  [VerificationKey PaymentKey] ->
-  VerificationKey PaymentKey ->
-  Party ->
-  ScriptRegistry ->
-  OnChainHeadState 'StIdle
-idleOnChainHeadState networkId peerVerificationKeys ownVerificationKey ownParty scriptRegistry =
-  OnChainHeadState
-    { networkId
-    , peerVerificationKeys
-    , ownVerificationKey
-    , ownParty
-    , scriptRegistry
-    , stateMachine = Idle
-    }
-
--- Constructing Transitions
+-- * Constructing transactions
 
 -- | A thin wrapper around 'initTx'. The seed input will determine the head identifier.
 initialize ::
@@ -340,10 +168,11 @@ initialize ctx =
   ChainContext{networkId} = ctx
 
 commit ::
+  ChainContext ->
+  InitialState ->
   UTxO ->
-  OnChainHeadState 'StInitialized ->
   Either (PostTxError Tx) Tx
-commit utxo st@OnChainHeadState{networkId, ownParty, ownVerificationKey, stateMachine} = do
+commit ctx st utxo = do
   case ownInitial initialHeadTokenScript ownVerificationKey initialInitials of
     Nothing ->
       Left (CannotFindOwnInitial{knownUTxO = getKnownUTxO st})
@@ -357,10 +186,9 @@ commit utxo st@OnChainHeadState{networkId, ownParty, ownVerificationKey, stateMa
         _ ->
           Left (MoreThanOneUTxOCommitted @Tx)
  where
-  Initialized
-    { initialInitials
-    , initialHeadTokenScript
-    } = stateMachine
+  ChainContext{networkId, ownParty, ownVerificationKey} = ctx
+
+  InitialState{initialInitials, initialHeadTokenScript} = st
 
   rejectByronAddress :: (TxIn, TxOut CtxUTxO) -> Either (PostTxError Tx) ()
   rejectByronAddress = \case
@@ -371,9 +199,10 @@ commit utxo st@OnChainHeadState{networkId, ownParty, ownVerificationKey, stateMa
 
 abort ::
   HasCallStack =>
-  OnChainHeadState 'StInitialized ->
+  ChainContext ->
+  InitialState ->
   Tx
-abort OnChainHeadState{ownVerificationKey, stateMachine, scriptRegistry} = do
+abort ctx st = do
   let InitialThreadOutput{initialThreadUTxO = (i, o, dat)} = initialThreadOutput
       initials = Map.fromList $ map tripleToPair initialInitials
       commits = Map.fromList $ map tripleToPair initialCommits
@@ -384,31 +213,37 @@ abort OnChainHeadState{ownVerificationKey, stateMachine, scriptRegistry} = do
         Right tx ->
           tx
  where
-  Initialized
+  ChainContext{ownVerificationKey, scriptRegistry} = ctx
+
+  InitialState
     { initialThreadOutput
     , initialInitials
     , initialCommits
     , initialHeadTokenScript
-    } = stateMachine
+    } = st
 
 collect ::
-  OnChainHeadState 'StInitialized ->
+  ChainContext ->
+  InitialState ->
   Tx
-collect OnChainHeadState{networkId, ownVerificationKey, stateMachine} = do
+collect ctx st = do
   let commits = Map.fromList $ fmap tripleToPair initialCommits
    in collectComTx networkId ownVerificationKey initialThreadOutput commits
  where
-  Initialized
+  ChainContext{networkId, ownVerificationKey} = ctx
+
+  InitialState
     { initialThreadOutput
     , initialCommits
-    } = stateMachine
+    } = st
 
 close ::
+  ChainContext ->
+  OpenState ->
   ConfirmedSnapshot Tx ->
   PointInTime ->
-  OnChainHeadState 'StOpen ->
   Tx
-close confirmedSnapshot pointInTime OnChainHeadState{ownVerificationKey, stateMachine} =
+close ctx st confirmedSnapshot pointInTime =
   closeTx ownVerificationKey closingSnapshot pointInTime openThreadOutput
  where
   closingSnapshot = case confirmedSnapshot of
@@ -422,14 +257,17 @@ close confirmedSnapshot pointInTime OnChainHeadState{ownVerificationKey, stateMa
         , signatures
         }
 
-  Open{openThreadOutput, openUtxoHash} = stateMachine
+  ChainContext{ownVerificationKey} = ctx
+
+  OpenState{openThreadOutput, openUtxoHash} = st
 
 contest ::
+  ChainContext ->
+  ClosedState ->
   ConfirmedSnapshot Tx ->
   PointInTime ->
-  OnChainHeadState 'StClosed ->
   Tx
-contest confirmedSnapshot pointInTime OnChainHeadState{ownVerificationKey, stateMachine} = do
+contest ctx st confirmedSnapshot pointInTime = do
   contestTx ownVerificationKey sn sigs pointInTime closedThreadOutput
  where
   (sn, sigs) =
@@ -437,84 +275,72 @@ contest confirmedSnapshot pointInTime OnChainHeadState{ownVerificationKey, state
       ConfirmedSnapshot{snapshot, signatures} -> (snapshot, signatures)
       InitialSnapshot{snapshot} -> (snapshot, mempty)
 
-  Closed{closedThreadOutput} = stateMachine
+  ChainContext{ownVerificationKey} = ctx
 
+  ClosedState{closedThreadOutput} = st
+
+-- | Construct a fanout transaction based on the 'ClosedState' and known 'UTxO'
+-- set to fan out.
 fanout ::
+  ClosedState ->
   UTxO ->
   -- | Contestation deadline as SlotNo, used to set lower tx validity bound.
   SlotNo ->
-  OnChainHeadState 'StClosed ->
   Tx
-fanout utxo deadlineSlotNo OnChainHeadState{stateMachine} = do
+fanout st utxo deadlineSlotNo = do
   fanoutTx utxo (i, o, dat) deadlineSlotNo closedHeadTokenScript
  where
-  Closed{closedThreadOutput, closedHeadTokenScript} = stateMachine
+  ClosedState{closedThreadOutput, closedHeadTokenScript} = st
 
   ClosedThreadOutput{closedThreadUTxO = (i, o, dat)} = closedThreadOutput
 
--- Observing Transitions
+-- * Observing Transitions
 
--- | A class for describing a Hydra transition from a state to another.
---
--- The transition is encoded at the type-level through the `HeadStateKind` and
--- the function `transition` overloaded for all transitions.
-class
-  HasTransition st =>
-  ObserveTx (st :: HeadStateKind) (st' :: HeadStateKind)
-  where
+-- | A class for observing a transition from a state to another given the right
+-- transaction.
+class ObserveTx st st' where
   observeTx ::
+    ChainContext ->
+    st ->
     Tx ->
-    OnChainHeadState st ->
-    Maybe (OnChainTx Tx, OnChainHeadState st')
+    Maybe (OnChainTx Tx, st')
 
 -- | A convenient class to declare all possible transitions from a given
--- starting state 'st'. This is useful to embed 'OnChainHeadState' with an
--- existential that carries some capabilities in the form of transitions (e.g.
--- 'SomeOnChainHeadState').
-class HasTransition (st :: HeadStateKind) where
-  transitions ::
-    Proxy st -> [TransitionFrom st]
+-- starting state 'st'.
+class HasTransitions st where
+  transitions :: Proxy st -> [TransitionFrom st]
 
---
--- StIdle
---
+-- | An existential to be used in 'HasTransitions'.
+data TransitionFrom st where
+  TransitionTo ::
+    forall st st'.
+    (Typeable st, Typeable st', ObserveTx st st') =>
+    String ->
+    Proxy st' ->
+    TransitionFrom st
 
-instance HasTransition 'StIdle where
+instance Show (TransitionFrom st) where
+  show (TransitionTo name proxy) =
+    mconcat
+      [ show (typeRep (Proxy @st))
+      , " -> "
+      , show (typeRep proxy)
+      , ": " <> name
+      ]
+
+instance Eq (TransitionFrom st) where
+  (TransitionTo name proxy) == (TransitionTo name' proxy') =
+    name == name'
+      && typeRep proxy == typeRep proxy'
+
+-- ** IdleState transitions
+
+instance HasTransitions IdleState where
   transitions _ =
-    [ TransitionTo (Proxy @ 'StInitialized)
-    ]
+    [TransitionTo "init" (Proxy @InitialState)]
 
-instance ObserveTx 'StIdle 'StInitialized where
-  observeTx tx OnChainHeadState{networkId, peerVerificationKeys, ownParty, ownVerificationKey, scriptRegistry} = do
-    let allVerificationKeys = ownVerificationKey : peerVerificationKeys
-    observation <- observeInitTx networkId allVerificationKeys ownParty tx
-    let InitObservation
-          { threadOutput
-          , initials
-          , commits
-          , headId
-          , headTokenScript
-          , contestationPeriod
-          , parties
-          } = observation
-    let event = OnInitTx{contestationPeriod, parties}
-    let st' =
-          OnChainHeadState
-            { networkId
-            , ownParty
-            , ownVerificationKey
-            , peerVerificationKeys
-            , scriptRegistry
-            , stateMachine =
-                Initialized
-                  { initialThreadOutput = threadOutput
-                  , initialInitials = initials
-                  , initialCommits = commits
-                  , initialHeadId = headId
-                  , initialHeadTokenScript = headTokenScript
-                  }
-            }
-    pure (event, st')
+instance ObserveTx IdleState InitialState where
+  observeTx ctx IdleState tx = observeInit ctx tx
 
 observeInit ::
   ChainContext ->
@@ -540,227 +366,196 @@ observeInit ctx tx = do
     { networkId
     , ownParty
     } = ctx
+-- ** InitialState transitions
 
---
--- StInitialized
---
+instance HasTransitions InitialState where
+  transitions _ = [] -- TODO
+  -- [ TransitionTo "commit" (Proxy @InitialState)
+  -- , TransitionTo "collect" (Proxy @OpenState)
+  -- , TransitionTo "abort" (Proxy @IdleState)
+  -- ]
 
-instance HasTransition 'StInitialized where
-  transitions _ =
-    [ TransitionTo (Proxy @ 'StInitialized)
-    , TransitionTo (Proxy @ 'StOpen)
-    , TransitionTo (Proxy @ 'StIdle)
-    ]
+-- instance ObserveTx 'StInitialized 'StInitialized where
+--   observeTx tx st@OnChainHeadState{networkId, stateMachine} = do
+--     let initials = fst3 <$> initialInitials
+--     observation <- observeCommitTx networkId initials tx
+--     let CommitObservation{commitOutput, party, committed} = observation
+--     let event = OnCommitTx{party, committed}
+--     let st' =
+--           st
+--             { stateMachine =
+--                 stateMachine
+--                   { initialInitials =
+--                       -- NOTE: A commit tx has been observed and thus we can
+--                       -- remove all it's inputs from our tracked initials
+--                       filter ((`notElem` txIns' tx) . fst3) initialInitials
+--                   , initialCommits =
+--                       commitOutput : initialCommits
+--                   }
+--             }
+--     pure (event, st')
+--    where
+--     Initialized
+--       { initialCommits
+--       , initialInitials
+--       } = stateMachine
 
-instance ObserveTx 'StInitialized 'StInitialized where
-  observeTx tx st@OnChainHeadState{networkId, stateMachine} = do
-    let initials = fst3 <$> initialInitials
-    observation <- observeCommitTx networkId initials tx
-    let CommitObservation{commitOutput, party, committed} = observation
-    let event = OnCommitTx{party, committed}
-    let st' =
-          st
-            { stateMachine =
-                stateMachine
-                  { initialInitials =
-                      -- NOTE: A commit tx has been observed and thus we can
-                      -- remove all it's inputs from our tracked initials
-                      filter ((`notElem` txIns' tx) . fst3) initialInitials
-                  , initialCommits =
-                      commitOutput : initialCommits
-                  }
-            }
-    pure (event, st')
-   where
-    Initialized
-      { initialCommits
-      , initialInitials
-      } = stateMachine
+-- instance ObserveTx 'StInitialized 'StOpen where
+--   observeTx tx st@OnChainHeadState{networkId, peerVerificationKeys, ownVerificationKey, ownParty, stateMachine, scriptRegistry} = do
+--     let utxo = getKnownUTxO st
+--     observation <- observeCollectComTx utxo tx
+--     let CollectComObservation{threadOutput, headId, utxoHash} = observation
+--     guard (headId == initialHeadId)
+--     let event = OnCollectComTx
+--     let st' =
+--           OnChainHeadState
+--             { networkId
+--             , peerVerificationKeys
+--             , ownVerificationKey
+--             , ownParty
+--             , scriptRegistry
+--             , stateMachine =
+--                 Open
+--                   { openThreadOutput = threadOutput
+--                   , openHeadId = initialHeadId
+--                   , openHeadTokenScript = initialHeadTokenScript
+--                   , openUtxoHash = utxoHash
+--                   }
+--             }
+--     pure (event, st')
+--    where
+--     Initialized
+--       { initialHeadId
+--       , initialHeadTokenScript
+--       } = stateMachine
 
-instance ObserveTx 'StInitialized 'StOpen where
-  observeTx tx st@OnChainHeadState{networkId, peerVerificationKeys, ownVerificationKey, ownParty, stateMachine, scriptRegistry} = do
-    let utxo = getKnownUTxO st
-    observation <- observeCollectComTx utxo tx
-    let CollectComObservation{threadOutput, headId, utxoHash} = observation
-    guard (headId == initialHeadId)
-    let event = OnCollectComTx
-    let st' =
-          OnChainHeadState
-            { networkId
-            , peerVerificationKeys
-            , ownVerificationKey
-            , ownParty
-            , scriptRegistry
-            , stateMachine =
-                Open
-                  { openThreadOutput = threadOutput
-                  , openHeadId = initialHeadId
-                  , openHeadTokenScript = initialHeadTokenScript
-                  , openUtxoHash = utxoHash
-                  }
-            }
-    pure (event, st')
-   where
-    Initialized
-      { initialHeadId
-      , initialHeadTokenScript
-      } = stateMachine
-
-instance ObserveTx 'StInitialized 'StIdle where
-  observeTx tx st@OnChainHeadState{networkId, peerVerificationKeys, ownVerificationKey, ownParty, scriptRegistry} = do
-    let utxo = getKnownUTxO st
-    AbortObservation <- observeAbortTx utxo tx
-    let event = OnAbortTx
-    let st' =
-          OnChainHeadState
-            { networkId
-            , peerVerificationKeys
-            , ownVerificationKey
-            , ownParty
-            , scriptRegistry
-            , stateMachine = Idle
-            }
-    pure (event, st')
+-- instance ObserveTx 'StInitialized 'StIdle where
+--   observeTx tx st@OnChainHeadState{networkId, peerVerificationKeys, ownVerificationKey, ownParty, scriptRegistry} = do
+--     let utxo = getKnownUTxO st
+--     AbortObservation <- observeAbortTx utxo tx
+--     let event = OnAbortTx
+--     let st' =
+--           OnChainHeadState
+--             { networkId
+--             , peerVerificationKeys
+--             , ownVerificationKey
+--             , ownParty
+--             , scriptRegistry
+--             , stateMachine = Idle
+--             }
+--     pure (event, st')
 
 --
 -- StOpen
 --
 
-instance HasTransition 'StOpen where
-  transitions _ =
-    [ TransitionTo (Proxy @ 'StClosed)
-    ]
+instance HasTransitions OpenState where
+  transitions _ = [] -- TODO:
+  -- [ TransitionTo "close" (Proxy @ClosedState)
+  -- ]
 
-instance ObserveTx 'StOpen 'StClosed where
-  observeTx tx st@OnChainHeadState{networkId, peerVerificationKeys, ownVerificationKey, ownParty, stateMachine, scriptRegistry} = do
-    let utxo = getKnownUTxO st
-    observation <- observeCloseTx utxo tx
-    let CloseObservation{threadOutput, headId, snapshotNumber} = observation
-    guard (headId == openHeadId)
-    -- FIXME: The 0 here is a wart. We are in a pure function so we cannot easily compute with
-    -- time. We tried passing the current time from the caller but given the current machinery
-    -- around `observeSomeTx` this is actually not straightforward and quite ugly.
-    let event = OnCloseTx{snapshotNumber, remainingContestationPeriod = 0}
-    let st' =
-          OnChainHeadState
-            { networkId
-            , peerVerificationKeys
-            , ownVerificationKey
-            , ownParty
-            , scriptRegistry
-            , stateMachine =
-                Closed
-                  { closedThreadOutput = threadOutput
-                  , closedHeadId = headId
-                  , closedHeadTokenScript = openHeadTokenScript
-                  }
-            }
-    pure (event, st')
-   where
-    Open
-      { openHeadId
-      , openHeadTokenScript
-      } = stateMachine
+-- instance ObserveTx 'StOpen 'StClosed where
+--   observeTx tx st@OnChainHeadState{networkId, peerVerificationKeys, ownVerificationKey, ownParty, stateMachine, scriptRegistry} = do
+--     let utxo = getKnownUTxO st
+--     observation <- observeCloseTx utxo tx
+--     let CloseObservation{threadOutput, headId, snapshotNumber} = observation
+--     guard (headId == openHeadId)
+--     -- FIXME: The 0 here is a wart. We are in a pure function so we cannot easily compute with
+--     -- time. We tried passing the current time from the caller but given the current machinery
+--     -- around `observeSomeTx` this is actually not straightforward and quite ugly.
+--     let event = OnCloseTx{snapshotNumber, remainingContestationPeriod = 0}
+--     let st' =
+--           OnChainHeadState
+--             { networkId
+--             , peerVerificationKeys
+--             , ownVerificationKey
+--             , ownParty
+--             , scriptRegistry
+--             , stateMachine =
+--                 Closed
+--                   { closedThreadOutput = threadOutput
+--                   , closedHeadId = headId
+--                   , closedHeadTokenScript = openHeadTokenScript
+--                   }
+--             }
+--     pure (event, st')
+--    where
+--     Open
+--       { openHeadId
+--       , openHeadTokenScript
+--       } = stateMachine
 
 --
 -- StClosed
 --
 
-instance HasTransition 'StClosed where
-  transitions _ =
-    [ TransitionTo (Proxy @ 'StIdle)
-    , TransitionTo (Proxy @ 'StClosed)
-    ]
+instance HasTransitions ClosedState where
+  transitions _ = [] -- TODO
+  -- [ TransitionTo "contest" (Proxy @ClosedState)
+  -- , TransitionTo "fanout" (Proxy @IdleState)
+  -- ]
 
-instance ObserveTx 'StClosed 'StIdle where
-  observeTx tx st@OnChainHeadState{networkId, peerVerificationKeys, ownVerificationKey, ownParty, scriptRegistry} = do
-    let utxo = getKnownUTxO st
-    FanoutObservation <- observeFanoutTx utxo tx
-    let event = OnFanoutTx
-    let st' =
-          OnChainHeadState
-            { networkId
-            , peerVerificationKeys
-            , ownVerificationKey
-            , ownParty
-            , scriptRegistry
-            , stateMachine = Idle
-            }
-    pure (event, st')
+-- instance ObserveTx 'StClosed 'StIdle where
+--   observeTx tx st@OnChainHeadState{networkId, peerVerificationKeys, ownVerificationKey, ownParty, scriptRegistry} = do
+--     let utxo = getKnownUTxO st
+--     FanoutObservation <- observeFanoutTx utxo tx
+--     let event = OnFanoutTx
+--     let st' =
+--           OnChainHeadState
+--             { networkId
+--             , peerVerificationKeys
+--             , ownVerificationKey
+--             , ownParty
+--             , scriptRegistry
+--             , stateMachine = Idle
+--             }
+--     pure (event, st')
 
-instance ObserveTx 'StClosed 'StClosed where
-  observeTx tx st@OnChainHeadState{networkId, peerVerificationKeys, ownVerificationKey, ownParty, stateMachine, scriptRegistry} = do
-    let utxo = getKnownUTxO st
-    observation <- observeContestTx utxo tx
-    let ContestObservation{contestedThreadOutput, headId, snapshotNumber} = observation
-    guard (headId == closedHeadId)
-    let event = OnContestTx{snapshotNumber}
-    let st' =
-          OnChainHeadState
-            { networkId
-            , peerVerificationKeys
-            , ownVerificationKey
-            , ownParty
-            , scriptRegistry
-            , stateMachine =
-                Closed
-                  { closedThreadOutput = closedThreadOutput{closedThreadUTxO = contestedThreadOutput}
-                  , closedHeadId
-                  , closedHeadTokenScript
-                  }
-            }
-    pure (event, st')
-   where
-    Closed
-      { closedHeadId
-      , closedHeadTokenScript
-      , closedThreadOutput
-      } = stateMachine
+-- instance ObserveTx 'StClosed 'StClosed where
+--   observeTx tx st@OnChainHeadState{networkId, peerVerificationKeys, ownVerificationKey, ownParty, stateMachine, scriptRegistry} = do
+--     let utxo = getKnownUTxO st
+--     observation <- observeContestTx utxo tx
+--     let ContestObservation{contestedThreadOutput, headId, snapshotNumber} = observation
+--     guard (headId == closedHeadId)
+--     let event = OnContestTx{snapshotNumber}
+--     let st' =
+--           OnChainHeadState
+--             { networkId
+--             , peerVerificationKeys
+--             , ownVerificationKey
+--             , ownParty
+--             , scriptRegistry
+--             , stateMachine =
+--                 Closed
+--                   { closedThreadOutput = closedThreadOutput{closedThreadUTxO = contestedThreadOutput}
+--                   , closedHeadId
+--                   , closedHeadTokenScript
+--                   }
+--             }
+--     pure (event, st')
+--    where
+--     Closed
+--       { closedHeadId
+--       , closedHeadTokenScript
+--       , closedThreadOutput
+--       } = stateMachine
 
 -- | A convenient way to apply transition to 'SomeOnChainHeadState' without
 -- bothering about the internal details.
-observeSomeTx ::
-  Tx ->
-  SomeOnChainHeadState ->
-  Maybe (OnChainTx Tx, SomeOnChainHeadState)
-observeSomeTx tx (SomeOnChainHeadState (st :: OnChainHeadState st)) =
-  asum $ (\(TransitionTo st') -> observeSome st') <$> transitions (Proxy @st)
- where
-  observeSome ::
-    forall st'.
-    (ObserveTx st st', HasTransition st', HasKnownUTxO (OnChainHeadState st')) =>
-    Proxy st' ->
-    Maybe (OnChainTx Tx, SomeOnChainHeadState)
-  observeSome _ =
-    second SomeOnChainHeadState <$> observeTx @st @st' tx st
-
---
--- TransitionFrom
---
-
-data TransitionFrom st where
-  TransitionTo ::
-    forall st st'.
-    ( ObserveTx st st'
-    , HasTransition st'
-    , HeadStateKindVal st
-    , HeadStateKindVal st'
-    , HasKnownUTxO (OnChainHeadState st')
-    ) =>
-    Proxy st' ->
-    TransitionFrom st
-
-instance Show (TransitionFrom st) where
-  show (TransitionTo proxy) =
-    mconcat
-      [ show (headStateKindVal (Proxy @st))
-      , " -> "
-      , show (headStateKindVal proxy)
-      ]
-
-instance Eq (TransitionFrom st) where
-  (TransitionTo proxy) == (TransitionTo proxy') =
-    headStateKindVal proxy == headStateKindVal proxy'
+-- observeSomeTx ::
+--   Tx ->
+--   SomeOnChainHeadState ->
+--   Maybe (OnChainTx Tx, SomeOnChainHeadState)
+-- observeSomeTx tx (SomeOnChainHeadState (st :: OnChainHeadState st)) =
+--   asum $ (\(Proxy :: Proxy st') -> observeSome) <$> transitions (Proxy @st)
+--  where
+--   observeSome ::
+--     forall st st'.
+--     (ObserveTx st st', HasTransitions st', HasKnownUTxO st') =>
+--     Proxy st' ->
+--     Maybe (OnChainTx Tx, SomeOnChainHeadState)
+--   observeSome _ =
+--     second SomeOnChainHeadState <$> observeTx @st @st' tx st
 
 --
 -- Helpers

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -138,7 +138,7 @@ getContestationDeadline
 data SomeOnChainHeadState where
   SomeOnChainHeadState ::
     forall st.
-    (Eq st, Typeable st, Show st, HasTransitions st, HasKnownUTxO st) =>
+    (Eq st, Typeable st, Show st, HasKnownUTxO st) =>
     st ->
     SomeOnChainHeadState
 
@@ -440,6 +440,12 @@ observeCollect = error "TODO observeCollect"
 --       { initialHeadId
 --       , initialHeadTokenScript
 --       } = stateMachine
+
+observeAbort ::
+  InitialState ->
+  Tx ->
+  Maybe (OnChainTx Tx, IdleState)
+observeAbort = error "TODO observeAbort"
 
 -- instance ObserveTx 'StInitialized 'StIdle where
 --   observeTx tx st@OnChainHeadState{networkId, peerVerificationKeys, ownVerificationKey, ownParty, scriptRegistry} = do

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -85,6 +85,10 @@ allVerificationKeys ChainContext{peerVerificationKeys, ownVerificationKey} =
 -- | The idle state does not contain any head-specific information and exists to
 -- be used as a starting and terminal state.
 data IdleState = IdleState
+  deriving (Show, Eq)
+
+instance HasKnownUTxO IdleState where
+  getKnownUTxO = mempty -- TODO
 
 data InitialState = InitialState
   { initialThreadOutput :: InitialThreadOutput
@@ -537,10 +541,12 @@ instance HasTransitions ClosedState where
 
 -- | A convenient way to apply transition to 'SomeOnChainHeadState' without
 -- bothering about the internal details.
--- observeSomeTx ::
---   Tx ->
---   SomeOnChainHeadState ->
---   Maybe (OnChainTx Tx, SomeOnChainHeadState)
+observeSomeTx ::
+  Tx ->
+  SomeOnChainHeadState ->
+  Maybe (OnChainTx Tx, SomeOnChainHeadState)
+observeSomeTx = error "TODO: enumerate transitions - do we even need this?"
+
 -- observeSomeTx tx (SomeOnChainHeadState (st :: OnChainHeadState st)) =
 --   asum $ (\(Proxy :: Proxy st') -> observeSome) <$> transitions (Proxy @st)
 --  where

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -525,10 +525,10 @@ instance ObserveTx OpenState ClosedState where
 --
 
 instance HasTransitions ClosedState where
-  transitions _ = [] -- TODO
-  -- [ TransitionTo "contest" (Proxy @ClosedState)
-  -- , TransitionTo "fanout" (Proxy @IdleState)
-  -- ]
+  transitions _ =
+    [ TransitionTo "contest" (Proxy @ClosedState)
+    , TransitionTo "fanout" (Proxy @IdleState)
+    ]
 
 observeContest ::
   ClosedState ->
@@ -548,6 +548,9 @@ observeContest st tx = do
     , closedThreadOutput
     } = st
 
+instance ObserveTx ClosedState ClosedState where
+  observeTx = observeContest
+
 observeFanout ::
   ClosedState ->
   Tx ->
@@ -558,6 +561,9 @@ observeFanout st tx = do
   pure (OnFanoutTx, IdleState{ctx})
  where
   ClosedState{ctx} = st
+
+instance ObserveTx ClosedState IdleState where
+  observeTx = observeFanout
 
 -- | A convenient way to apply transition to 'SomeOnChainHeadState' without
 -- known the starting or ending state. This function does enumerate and try all

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -44,7 +44,7 @@ import Hydra.Ledger.Cardano (genVerificationKey)
 import Hydra.Party (Party)
 import Hydra.Snapshot (ConfirmedSnapshot (..), Snapshot (..))
 import Plutus.V2.Ledger.Api (POSIXTime)
-import Test.QuickCheck (choose, sized)
+import Test.QuickCheck (sized)
 import qualified Text.Show
 
 -- | A class for accessing the known 'UTxO' set in a type.
@@ -65,24 +65,20 @@ data ChainContext = ChainContext
   deriving (Show, Eq)
 
 instance Arbitrary ChainContext where
-  arbitrary = sized $ \n -> choose (0, n) >>= genChainContext
-
--- | Generate a 'HydraContext' for a given number of parties.
-genChainContext :: Int -> Gen ChainContext
-genChainContext n = do
-  networkId <- Testnet . NetworkMagic <$> arbitrary
-  peerVerificationKeys <- replicateM n genVerificationKey
-  ownVerificationKey <- genVerificationKey
-  ownParty <- arbitrary
-  scriptRegistry <- genScriptRegistry
-  pure
-    ChainContext
-      { networkId
-      , peerVerificationKeys
-      , ownVerificationKey
-      , ownParty
-      , scriptRegistry
-      }
+  arbitrary = sized $ \n -> do
+    networkId <- Testnet . NetworkMagic <$> arbitrary
+    peerVerificationKeys <- replicateM n genVerificationKey
+    ownVerificationKey <- genVerificationKey
+    ownParty <- arbitrary
+    scriptRegistry <- genScriptRegistry
+    pure
+      ChainContext
+        { networkId
+        , peerVerificationKeys
+        , ownVerificationKey
+        , ownParty
+        , scriptRegistry
+        }
 
 -- | Get all cardano verification kesy known in the chain context.
 allVerificationKeys :: ChainContext -> [VerificationKey PaymentKey]

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -367,7 +367,7 @@ class ObserveTx st st' where
 -- | A convenient class to declare all possible transitions from a given
 -- starting state 'st'.
 class HasTransitions st where
-  transitions :: proxy st -> [TransitionFrom st]
+  transitions :: [TransitionFrom st]
 
 -- | An existential to be used in 'HasTransitions'.
 data TransitionFrom st where
@@ -395,8 +395,7 @@ instance Eq (TransitionFrom st) where
 -- ** IdleState transitions
 
 instance HasTransitions IdleState where
-  transitions _ =
-    [TransitionTo "init" (Proxy @InitialState)]
+  transitions = [TransitionTo "init" (Proxy @InitialState)]
 
 observeInit ::
   ChainContext ->
@@ -430,7 +429,7 @@ instance ObserveTx IdleState InitialState where
 -- ** InitialState transitions
 
 instance HasTransitions InitialState where
-  transitions _ =
+  transitions =
     [ TransitionTo "commit" (Proxy @InitialState)
     , TransitionTo "collect" (Proxy @OpenState)
     , TransitionTo "abort" (Proxy @IdleState)
@@ -513,7 +512,7 @@ instance ObserveTx InitialState IdleState where
 -- ** OpenState transitions
 
 instance HasTransitions OpenState where
-  transitions _ =
+  transitions =
     [ TransitionTo "close" (Proxy @ClosedState)
     ]
 
@@ -551,7 +550,7 @@ instance ObserveTx OpenState ClosedState where
 -- ** ClosedState transitions
 
 instance HasTransitions ClosedState where
-  transitions _ =
+  transitions =
     [ TransitionTo "contest" (Proxy @ClosedState)
     , TransitionTo "fanout" (Proxy @IdleState)
     ]
@@ -602,7 +601,7 @@ observeSomeTx ::
   SomeOnChainHeadState ->
   Maybe (OnChainTx Tx, SomeOnChainHeadState)
 observeSomeTx tx (SomeOnChainHeadState (st :: st)) =
-  asum $ (\(TransitionTo _ p) -> observeSome p) <$> transitions (Proxy :: Proxy st)
+  asum $ (\(TransitionTo _ p) -> observeSome p) <$> transitions @st
  where
   observeSome ::
     forall st'.

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -355,7 +355,7 @@ instance Show (TransitionFrom st) where
       [ show (typeRep (Proxy @st))
       , " -> "
       , show (typeRep proxy)
-      , ": " <> name
+      , " : " <> name
       ]
 
 instance Eq (TransitionFrom st) where

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -374,6 +374,13 @@ instance HasTransitions InitialState where
   -- , TransitionTo "abort" (Proxy @IdleState)
   -- ]
 
+observeCommit ::
+  ChainContext ->
+  InitialState ->
+  Tx ->
+  Maybe (OnChainTx Tx, InitialState)
+observeCommit = error "TODO observeCommit"
+
 -- instance ObserveTx 'StInitialized 'StInitialized where
 --   observeTx tx st@OnChainHeadState{networkId, stateMachine} = do
 --     let initials = fst3 <$> initialInitials
@@ -398,6 +405,13 @@ instance HasTransitions InitialState where
 --       { initialCommits
 --       , initialInitials
 --       } = stateMachine
+
+observeCollect ::
+  ChainContext ->
+  InitialState ->
+  Tx ->
+  Maybe (OnChainTx Tx, OpenState)
+observeCollect = error "TODO observeCollect"
 
 -- instance ObserveTx 'StInitialized 'StOpen where
 --   observeTx tx st@OnChainHeadState{networkId, peerVerificationKeys, ownVerificationKey, ownParty, stateMachine, scriptRegistry} = do
@@ -452,6 +466,13 @@ instance HasTransitions OpenState where
   transitions _ = [] -- TODO:
   -- [ TransitionTo "close" (Proxy @ClosedState)
   -- ]
+
+observeClose ::
+  ChainContext ->
+  OpenState ->
+  Tx ->
+  Maybe (OnChainTx Tx, ClosedState)
+observeClose = error "TODO observeClose"
 
 -- instance ObserveTx 'StOpen 'StClosed where
 --   observeTx tx st@OnChainHeadState{networkId, peerVerificationKeys, ownVerificationKey, ownParty, stateMachine, scriptRegistry} = do

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -8,7 +8,7 @@ import Hydra.Prelude hiding (init)
 
 import qualified Cardano.Api.UTxO as UTxO
 import qualified Data.Map as Map
-import Data.Typeable (typeRep)
+import Data.Typeable (cast, typeRep)
 import Hydra.Chain (HeadId (..), HeadParameters, OnChainTx (..), PostTxError (..))
 import Hydra.Chain.Direct.ScriptRegistry (ScriptRegistry (..), genScriptRegistry)
 import Hydra.Chain.Direct.TimeHandle (PointInTime)
@@ -131,7 +131,7 @@ getContestationDeadline
 data SomeOnChainHeadState where
   SomeOnChainHeadState ::
     forall st.
-    (Show st, HasTransitions st, HasKnownUTxO st) =>
+    (Typeable st, Show st, HasTransitions st, HasKnownUTxO st) =>
     st ->
     SomeOnChainHeadState
 
@@ -152,6 +152,10 @@ instance Show SomeOnChainHeadState where
 --         st == st'
 --       _ ->
 --         False
+
+-- | Access the actual head state in the existential given it is of type 'st'.
+castHeadState :: Typeable st => SomeOnChainHeadState -> Maybe st
+castHeadState (SomeOnChainHeadState x) = cast x
 
 -- * Constructing transactions
 

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -398,11 +398,11 @@ observeInit ctx tx = do
 -- ** InitialState transitions
 
 instance HasTransitions InitialState where
-  transitions _ = [] -- TODO
-  -- [ TransitionTo "commit" (Proxy @InitialState)
-  -- , TransitionTo "collect" (Proxy @OpenState)
-  -- , TransitionTo "abort" (Proxy @IdleState)
-  -- ]
+  transitions _ =
+    [ TransitionTo "commit" (Proxy @InitialState)
+    , TransitionTo "collect" (Proxy @OpenState)
+    , TransitionTo "abort" (Proxy @IdleState)
+    ]
 
 observeCommit ::
   InitialState ->

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -81,7 +81,8 @@ import Hydra.Snapshot (ConfirmedSnapshot (..), Snapshot (..))
 import Plutus.V2.Ledger.Api (POSIXTime)
 import qualified Text.Show
 
--- | Read-only chain-specific data.
+-- | Read-only chain-specific data. This is different to 'HydraContext' as it
+-- only provide contains data known to single peer.
 data ChainContext = ChainContext
   { networkId :: NetworkId
   , peerVerificationKeys :: [VerificationKey PaymentKey]

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -847,34 +847,11 @@ observeAbortTx utxo tx = do
  where
   headScript = fromPlutusScript Head.validatorScript
 
--- * Functions related to OnChainHeadState
-
--- | Look for the "initial" which corresponds to given cardano verification key.
-ownInitial ::
-  PlutusScript ->
-  VerificationKey PaymentKey ->
-  [UTxOWithScript] ->
-  Maybe (TxIn, TxOut CtxUTxO, Hash PaymentKey)
-ownInitial headTokenScript vkey =
-  foldl' go Nothing
- where
-  go (Just x) _ = Just x
-  go Nothing (i, out, _) = do
-    let vkh = verificationKeyHash vkey
-    guard $ hasMatchingPT vkh (txOutValue out)
-    pure (i, out, vkh)
-
-  hasMatchingPT :: Hash PaymentKey -> Value -> Bool
-  hasMatchingPT vkh val =
-    case headTokensFromValue headTokenScript val of
-      [(AssetName bs, 1)] -> bs == serialiseToRawBytes vkh
-      _ -> False
+-- * Helpers
 
 mkHeadId :: PolicyId -> HeadId
 mkHeadId =
   HeadId . serialiseToRawBytes
-
--- * Helpers
 
 headTokensFromValue :: PlutusScript -> Value -> [(AssetName, Quantity)]
 headTokensFromValue headTokenScript v =

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -95,7 +95,7 @@ headValue = lovelaceToValue (Lovelace 2_000_000)
 -- which will be used as unique parameter for minting NFTs.
 initTx ::
   NetworkId ->
-  -- | Participant's cardano public keys.
+  -- | All participants cardano keys.
   [VerificationKey PaymentKey] ->
   HeadParameters ->
   TxIn ->

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Init.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Init.hs
@@ -6,7 +6,6 @@ import Hydra.Cardano.Api
 import Hydra.Prelude
 
 import qualified Cardano.Api.UTxO as UTxO
-import Data.List ((\\))
 import Hydra.Chain (HeadParameters (..))
 import Hydra.Chain.Direct.Contract.Mutation (
   Mutation (..),
@@ -15,8 +14,6 @@ import Hydra.Chain.Direct.Contract.Mutation (
   changeMintedValueQuantityFrom,
  )
 import Hydra.Chain.Direct.Fixture (genForParty, testNetworkId)
-import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry)
-import Hydra.Chain.Direct.State (HeadStateKind (..), OnChainHeadState, idleOnChainHeadState)
 import Hydra.Chain.Direct.Tx (hydraHeadV1AssetName, initTx)
 import Hydra.Ledger.Cardano (genOneUTxOFor, genValue, genVerificationKey)
 import Hydra.Party (Party)
@@ -61,13 +58,6 @@ healthyLookupUTxO :: UTxO
 healthyLookupUTxO =
   generateWith (genOneUTxOFor (Prelude.head healthyCardanoKeys)) 42
 
-genHealthyIdleSt :: Gen (OnChainHeadState 'StIdle)
-genHealthyIdleSt = do
-  party <- elements healthyParties
-  let vk = genVerificationKey `genForParty` party
-  scriptRegistry <- genScriptRegistry
-  pure $ idleOnChainHeadState testNetworkId (healthyCardanoKeys \\ [vk]) vk party scriptRegistry
-
 data InitMutation
   = MutateThreadTokenQuantity
   | MutateAddAnotherPT
@@ -96,6 +86,9 @@ genInitMutation (tx, _utxo) =
     , SomeMutation MutateDropSeedInput <$> do
         pure $ RemoveInput healthySeedInput
     ]
+
+-- REVIEW: This is odd and should not be needed? If we can remove this, then we
+-- could simplify the machinery and drop propMutationOffChain
 
 -- These are mutations we expect to be valid from an on-chain standpoint, yet
 -- invalid for the off-chain observation. There's mainly only the `init`

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Init.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Init.hs
@@ -6,6 +6,7 @@ import Hydra.Cardano.Api
 import Hydra.Prelude
 
 import qualified Cardano.Api.UTxO as UTxO
+import Data.List ((\\))
 import Hydra.Chain (HeadParameters (..))
 import Hydra.Chain.Direct.Contract.Mutation (
   Mutation (..),
@@ -14,6 +15,8 @@ import Hydra.Chain.Direct.Contract.Mutation (
   changeMintedValueQuantityFrom,
  )
 import Hydra.Chain.Direct.Fixture (genForParty, testNetworkId)
+import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry)
+import Hydra.Chain.Direct.State (ChainContext (..), IdleState (IdleState))
 import Hydra.Chain.Direct.Tx (hydraHeadV1AssetName, initTx)
 import Hydra.Ledger.Cardano (genOneUTxOFor, genValue, genVerificationKey)
 import Hydra.Party (Party)
@@ -57,6 +60,21 @@ healthyCardanoKeys =
 healthyLookupUTxO :: UTxO
 healthyLookupUTxO =
   generateWith (genOneUTxOFor (Prelude.head healthyCardanoKeys)) 42
+
+genHealthyIdleState :: Gen IdleState
+genHealthyIdleState = do
+  party <- elements healthyParties
+  let vk = genVerificationKey `genForParty` party
+  scriptRegistry <- genScriptRegistry
+  pure $
+    IdleState
+      ChainContext
+        { networkId = testNetworkId
+        , peerVerificationKeys = healthyCardanoKeys \\ [vk]
+        , ownVerificationKey = vk
+        , ownParty = party
+        , scriptRegistry
+        }
 
 data InitMutation
   = MutateThreadTokenQuantity

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
@@ -143,9 +143,10 @@ import qualified Data.List as List
 import qualified Data.Map as Map
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
+import Data.Typeable (typeOf)
 import Hydra.Chain.Direct.Fixture (genForParty, testPolicyId)
 import qualified Hydra.Chain.Direct.Fixture as Fixture
-import Hydra.Chain.Direct.State (SomeOnChainHeadState (..), observeSomeTx, reifyState)
+import Hydra.Chain.Direct.State (SomeOnChainHeadState (..), observeSomeTx)
 import Hydra.Chain.Direct.Tx (assetNameFromVerificationKey)
 import qualified Hydra.Contract.Head as Head
 import qualified Hydra.Contract.HeadState as Head
@@ -247,7 +248,7 @@ propTransactionIsNotObserved (tx, _) st =
     Just (onChainTx, SomeOnChainHeadState st') ->
       property False
         & counterexample ("Observed tx: " <> strawmanGetConstr onChainTx)
-        & counterexample ("New head state: " <> show (reifyState st'))
+        & counterexample ("New head state: " <> show (typeOf st'))
  where
   strawmanGetConstr = toString . Prelude.head . words . show
 

--- a/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
@@ -91,7 +91,7 @@ spec = parallel $ do
     prop "does not survive random adversarial mutations (on-chain)" $
       propMutationOnChain healthyInitTx genInitMutation
     prop "does not survive random adversarial mutations (off-chain)" $
-      propMutationOffChain healthyInitTx genObserveInitMutation (SomeOnChainHeadState <$> genHealthyIdleSt)
+      propMutationOffChain healthyInitTx genObserveInitMutation (SomeOnChainHeadState IdleState)
 
   describe "Abort" $ do
     prop "is healthy" $

--- a/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
@@ -25,7 +25,7 @@ import Hydra.Chain.Direct.Contract.CollectCom (genCollectComMutation, healthyCol
 import Hydra.Chain.Direct.Contract.Commit (genCommitMutation, healthyCommitTx)
 import Hydra.Chain.Direct.Contract.Contest (genContestMutation, healthyContestTx)
 import Hydra.Chain.Direct.Contract.FanOut (genFanoutMutation, healthyFanoutTx)
-import Hydra.Chain.Direct.Contract.Init (genHealthyIdleSt, genInitMutation, genObserveInitMutation, healthyInitTx)
+import Hydra.Chain.Direct.Contract.Init (genHealthyIdleState, genInitMutation, genObserveInitMutation, healthyInitTx)
 import Hydra.Chain.Direct.Contract.Mutation (
   propMutationOffChain,
   propMutationOnChain,
@@ -91,7 +91,7 @@ spec = parallel $ do
     prop "does not survive random adversarial mutations (on-chain)" $
       propMutationOnChain healthyInitTx genInitMutation
     prop "does not survive random adversarial mutations (off-chain)" $
-      propMutationOffChain healthyInitTx genObserveInitMutation (SomeOnChainHeadState IdleState)
+      propMutationOffChain healthyInitTx genObserveInitMutation (SomeOnChainHeadState <$> genHealthyIdleState)
 
   describe "Abort" $ do
     prop "is healthy" $

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -464,14 +464,14 @@ forAllSt action =
           ( forAllClose action
           , Transition @OpenState (TransitionTo "close" (Proxy @ClosedState))
           )
-          -- ,
-          --   ( forAllContest action
-          --   , Transition @ClosedState (TransitionTo "contest" (Proxy @ClosedState))
-          --   )
-          -- ,
-          --   ( forAllFanout action
-          --   , Transition @ClosedState (TransitionTo "fanout" (Proxy @IdleState))
-          --   )
+        ,
+          ( forAllContest action
+          , Transition @ClosedState (TransitionTo "contest" (Proxy @ClosedState))
+          )
+        ,
+          ( forAllFanout action
+          , Transition @ClosedState (TransitionTo "fanout" (Proxy @IdleState))
+          )
         ]
     )
     $ \(p, lbl) ->

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -57,6 +57,7 @@ import Hydra.Chain.Direct.Context (
   unsafeCommit,
   unsafeObserveTx,
  )
+import Hydra.Chain.Direct.Fixture (testNetworkId)
 import Hydra.Chain.Direct.Handlers (
   ChainSyncHandler (..),
   RecordedAt (..),
@@ -80,7 +81,9 @@ import Hydra.Chain.Direct.State (
   getContestationDeadline,
   getKnownUTxO,
   idleOnChainHeadState,
+  init,
   initialize,
+  observeInit,
   observeSomeTx,
  )
 import Hydra.Chain.Direct.Util (Block)
@@ -154,6 +157,10 @@ spec = parallel $ do
           isJust (observeSomeTx tx (SomeOnChainHeadState st))
 
   describe "init" $ do
+    prop "new interface" $ \headParameters vks seedTxIn ->
+      let tx = initialize testNetworkId headParameters vks seedTxIn
+       in isJust $ observeInit tx
+
     prop "is not observed if not invited" $
       forAll2 (genHydraContext 3) (genHydraContext 3) $ \(ctxA, ctxB) ->
         null (ctxParties ctxA `intersect` ctxParties ctxB)

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -162,14 +162,8 @@ spec = parallel $ do
             & counterexample "observeSomeTx returned Nothing"
 
   describe "init" $ do
-    prop "new interface" $ \seedTxIn ->
-      forAllBlind (genHydraContext 3) $ \ctx ->
-        forAllBlind (pickChainContext ctx) $ \cctx ->
-          let params = ctxHeadParameters ctx
-              tx = initialize cctx params seedTxIn
-           in property (isJust $ observeInit cctx tx)
-                & counterexample ("tx: " <> renderTx tx)
-                & counterexample ("params: " <> show params)
+    propBelowSizeLimit maxTxSize forAllInit
+    -- propIsValid forAllInit XXX: not possible because it spends an "outside" UTxO
 
     prop "is not observed if not invited" $
       forAll2 (genHydraContext 3) (genHydraContext 3) $ \(ctxA, ctxB) ->
@@ -182,6 +176,7 @@ spec = parallel $ do
 
   describe "commit" $ do
     propBelowSizeLimit maxTxSize forAllCommit
+    -- propIsValid forAllCommit XXX: not possible because it spends an "outside" UTxO
 
     prop "consumes all inputs that are committed" $
       forAllCommit $ \st tx ->

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -152,11 +152,11 @@ import qualified Prelude
 
 spec :: Spec
 spec = parallel $ do
-  -- describe "observeTx" $ do
-  --   prop "All valid transitions for all possible states can be observed." $
-  --     checkCoverage $
-  --       forAllSt $ \st tx ->
-  --         isJust (observeSomeTx tx (SomeOnChainHeadState st))
+  describe "observeTx" $ do
+    prop "All valid transitions for all possible states can be observed." $
+      checkCoverage $
+        forAllSt $ \st tx ->
+          isJust (observeSomeTx tx (SomeOnChainHeadState st))
 
   describe "init" $ do
     prop "new interface" $ \ctx headParameters seedTxIn ->
@@ -233,21 +233,21 @@ spec = parallel $ do
     propIsValid forAllFanout
 
   describe "ChainSyncHandler" $ do
-    -- prop "yields observed transactions rolling forward" $ do
-    --   forAllSt $ \(SomeOnChainHeadState -> st) tx -> do
-    --     let callback = \case
-    --           Rollback{} ->
-    --             fail "rolled back but expected roll forward."
-    --           Observation OnCloseTx{snapshotNumber} ->
-    --             -- FIXME: Special case for `OnCloseTx` because we don't directly observe the remaining contestation period,
-    --             -- it's the result of a computation that involves current time
-    --             fst <$> observeSomeTx tx st `shouldBe` Just OnCloseTx{snapshotNumber, remainingContestationPeriod = 0}
-    --           Observation onChainTx ->
-    --             fst <$> observeSomeTx tx st `shouldBe` Just onChainTx
-    --     forAllBlind (genBlockAt 1 [tx]) $ \blk -> monadicIO $ do
-    --       headState <- run $ newTVarIO $ stAtGenesis st
-    --       let handler = chainSyncHandler nullTracer callback headState
-    --       run $ onRollForward handler blk
+    prop "yields observed transactions rolling forward" $ do
+      forAllSt $ \(SomeOnChainHeadState -> st) tx -> do
+        let callback = \case
+              Rollback{} ->
+                fail "rolled back but expected roll forward."
+              Observation OnCloseTx{snapshotNumber} ->
+                -- FIXME: Special case for `OnCloseTx` because we don't directly observe the remaining contestation period,
+                -- it's the result of a computation that involves current time
+                fst <$> observeSomeTx tx st `shouldBe` Just OnCloseTx{snapshotNumber, remainingContestationPeriod = 0}
+              Observation onChainTx ->
+                fst <$> observeSomeTx tx st `shouldBe` Just onChainTx
+        forAllBlind (genBlockAt 1 [tx]) $ \blk -> monadicIO $ do
+          headState <- run $ newTVarIO $ stAtGenesis st
+          let handler = chainSyncHandler nullTracer callback headState
+          run $ onRollForward handler blk
 
     prop "can replay chain on (benign) rollback" $
       forAllBlind genSequenceOfObservableBlocks $ \(st, blks) ->
@@ -424,44 +424,44 @@ propIsValid forAllTx =
 -- XXX: This is very fancy, but does not prevent us of not aligning forAll
 -- generators with Transition labels. Ideally we would would use the actual
 -- states/transactions or observed states/transactions for labeling.
--- forAllSt ::
---   (Testable property) =>
---   (forall st. (HasTransition st) => OnChainHeadState st -> Tx -> property) ->
---   Property
--- forAllSt action =
---   forAllBlind
---     ( elements
---         [
---           ( forAllInit action
---           , Transition @ 'StIdle (TransitionTo (Proxy @ 'StInitialized))
---           )
---         ,
---           ( forAllCommit action
---           , Transition @ 'StInitialized (TransitionTo (Proxy @ 'StInitialized))
---           )
---         ,
---           ( forAllAbort action
---           , Transition @ 'StInitialized (TransitionTo (Proxy @ 'StIdle))
---           )
---         ,
---           ( forAllCollectCom action
---           , Transition @ 'StInitialized (TransitionTo (Proxy @ 'StOpen))
---           )
---         ,
---           ( forAllClose action
---           , Transition @ 'StOpen (TransitionTo (Proxy @ 'StClosed))
---           )
---         ,
---           ( forAllContest action
---           , Transition @ 'StClosed (TransitionTo (Proxy @ 'StClosed))
---           )
---         ,
---           ( forAllFanout action
---           , Transition @ 'StClosed (TransitionTo (Proxy @ 'StIdle))
---           )
---         ]
---     )
---     (\(p, lbl) -> genericCoverTable [lbl] p)
+forAllSt ::
+  (Testable property) =>
+  (forall a. HasTransition a => a -> Tx -> property) ->
+  Property
+forAllSt action =
+  forAllBlind
+    ( elements
+        [
+          ( forAllInit action
+          , Transition @ 'StIdle (TransitionTo (Proxy @ 'StInitialized))
+          )
+        ,
+          ( forAllCommit action
+          , Transition @ 'StInitialized (TransitionTo (Proxy @ 'StInitialized))
+          )
+        ,
+          ( forAllAbort action
+          , Transition @ 'StInitialized (TransitionTo (Proxy @ 'StIdle))
+          )
+        ,
+          ( forAllCollectCom action
+          , Transition @ 'StInitialized (TransitionTo (Proxy @ 'StOpen))
+          )
+        ,
+          ( forAllClose action
+          , Transition @ 'StOpen (TransitionTo (Proxy @ 'StClosed))
+          )
+        ,
+          ( forAllContest action
+          , Transition @ 'StClosed (TransitionTo (Proxy @ 'StClosed))
+          )
+        ,
+          ( forAllFanout action
+          , Transition @ 'StClosed (TransitionTo (Proxy @ 'StIdle))
+          )
+        ]
+    )
+    (\(p, lbl) -> genericCoverTable [lbl] p)
 
 forAllInit ::
   (Testable property) =>

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -68,6 +68,7 @@ import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry)
 import Hydra.Chain.Direct.State (
   ChainContext (peerVerificationKeys),
   HasTransition (..),
+  HasUTxO (getUTxO),
   HeadStateKind (..),
   HeadStateKindVal (..),
   ObserveTx (..),
@@ -405,13 +406,13 @@ propBelowSizeLimit txSizeLimit forAllTx =
 
 -- TODO: DRY with Hydra.Chain.Direct.Contract.Mutation.propTransactionValidates?
 propIsValid ::
-  forall st.
-  ((OnChainHeadState st -> Tx -> Property) -> Property) ->
+  HasUTxO a =>
+  ((a -> Tx -> Property) -> Property) ->
   SpecWith ()
 propIsValid forAllTx =
   prop "validates within maxTxExecutionUnits" $
     forAllTx $ \st tx -> do
-      let lookupUTxO = getKnownUTxO st
+      let lookupUTxO = getUTxO st
       case evaluateTx' maxTxExecutionUnits tx lookupUTxO of
         Left validityError ->
           property False

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -152,6 +152,7 @@ spec = parallel $ do
       checkCoverage $
         forAllSt $ \st tx ->
           isJust (observeSomeTx tx (SomeOnChainHeadState st))
+            & counterexample "observeSomeTx returned Nothing"
 
   describe "init" $ do
     prop "new interface" $ \seedTxIn ->

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -662,10 +662,10 @@ genBlockAt sl txs = do
 allTransitions :: [Transition]
 allTransitions =
   mconcat
-    [ Transition <$> transitions (Proxy @IdleState)
-    , Transition <$> transitions (Proxy @InitialState)
-    , Transition <$> transitions (Proxy @OpenState)
-    , Transition <$> transitions (Proxy @ClosedState)
+    [ Transition <$> transitions @IdleState
+    , Transition <$> transitions @InitialState
+    , Transition <$> transitions @OpenState
+    , Transition <$> transitions @ClosedState
     ]
 
 data Transition where

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -178,8 +178,8 @@ spec = parallel $ do
     propBelowSizeLimit maxTxSize forAllCommit
 
     prop "consumes all inputs that are committed" $
-      forAllCommit $ \InitialState{ctx} tx ->
-        case observeInit ctx tx of
+      forAllCommit $ \st tx ->
+        case observeCommit st tx of
           Just (_, st') ->
             let knownInputs = UTxO.inputSet (getKnownUTxO st')
              in knownInputs `Set.disjoint` txInputSet tx

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -35,7 +35,13 @@ import Hydra.Cardano.Api (
   pattern TxOut,
   pattern TxOutDatumNone,
  )
-import Hydra.Chain (ChainEvent (..), HeadParameters, OnChainTx (OnCloseTx, remainingContestationPeriod), PostTxError (..), snapshotNumber)
+import Hydra.Chain (
+  ChainEvent (..),
+  HeadParameters,
+  OnChainTx (OnCloseTx, remainingContestationPeriod),
+  PostTxError (..),
+  snapshotNumber,
+ )
 import Hydra.Chain.Direct.Context (
   HydraContext (..),
   ctxHeadParameters,


### PR DESCRIPTION
:pineapple: A fairly direct re-write of the State module to not use GADTs and higher-kinded types, but instead distinct types (`OnChainHeadState 'StIninitialized` becomes `InitialState`)

:pineapple: Introduce a `ChainContext` type for the peer-specific, read-only, always available portion of the state

:pineapple: Small quality of life improvements like adding a transition name to `TransitionFrom`

This in itself does not fix any of the pre-existing `XXX`, `TODO` or `FIXME` items. I will follow-up PR on some of the things and/or discussions are needed :)