### PR TITLE
Boring chain state

### DIFF
--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -68,10 +68,10 @@ import Hydra.Chain.CardanoClient (
   queryUTxO,
  )
 import Hydra.Chain.Direct.Handlers (
+  ChainStateAt (..),
   ChainSyncHandler,
   DirectChainLog (..),
   RecordedAt (..),
-  SomeOnChainHeadStateAt (..),
   chainSyncHandler,
   mkChain,
   onRollBackward,
@@ -175,8 +175,8 @@ withDirectChain tracer networkId iocp socketPath keyPair party cardanoKeys point
           }
   headState <-
     newTVarIO $
-      SomeOnChainHeadStateAt
-        { currentOnChainHeadState = Idle IdleState{ctx}
+      ChainStateAt
+        { currentChainState = Idle IdleState{ctx}
         , recordedAt = AtStart
         }
   res <-

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -80,8 +80,8 @@ import Hydra.Chain.Direct.Handlers (
 import Hydra.Chain.Direct.ScriptRegistry (queryScriptRegistry)
 import Hydra.Chain.Direct.State (
   ChainContext (..),
+  ChainState (Idle),
   IdleState (..),
-  SomeOnChainHeadState (..),
  )
 import Hydra.Chain.Direct.TimeHandle (queryTimeHandle)
 import Hydra.Chain.Direct.Util (
@@ -176,7 +176,7 @@ withDirectChain tracer networkId iocp socketPath keyPair party cardanoKeys point
   headState <-
     newTVarIO $
       SomeOnChainHeadStateAt
-        { currentOnChainHeadState = SomeOnChainHeadState IdleState{ctx}
+        { currentOnChainHeadState = Idle IdleState{ctx}
         , recordedAt = AtStart
         }
   res <-

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -50,7 +50,7 @@ import Hydra.Chain.Direct.State (
   getContestationDeadline,
   getKnownUTxO,
   initialize,
-  observeAllTx,
+  observeSomeTx,
  )
 import Hydra.Chain.Direct.TimeHandle (TimeHandle (..))
 import Hydra.Chain.Direct.Util (Block, SomePoint (..))
@@ -223,7 +223,7 @@ chainSyncHandler tracer callback headState =
   withNextTx :: UTCTime -> Point Block -> [OnChainTx Tx] -> ValidatedTx LedgerEra -> STM m [OnChainTx Tx]
   withNextTx now point observed (fromLedgerTx -> tx) = do
     st <- readTVar headState
-    case observeAllTx tx (currentChainState st) of
+    case observeSomeTx tx (currentChainState st) of
       Just (onChainTx, st') -> do
         writeTVar headState $
           ChainStateAt

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -128,7 +128,7 @@ finalizeTx ::
   STM m (ValidatedTx LedgerEra)
 finalizeTx TinyWallet{sign, getUTxO, coverFee} headState partialTx = do
   someSt <- currentOnChainHeadState <$> readTVar headState
-  let headUTxO = (\(SomeOnChainHeadState st) -> getKnownUTxO st) someSt
+  let headUTxO = getKnownUTxO someSt
   walletUTxO <- fromLedgerUTxO . Ledger.UTxO <$> getUTxO
   coverFee (Ledger.unUTxO $ toLedgerUTxO headUTxO) partialTx >>= \case
     Left ErrUnknownInput{input} -> do

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -539,7 +539,10 @@ observeAllTx tx = \case
     second Initial <$> observeCommit st tx
       <|> second Idle <$> observeAbort st tx
       <|> second Open <$> observeCollect st tx
-  _ -> error "TODO"
+  Open st -> second Closed <$> observeClose st tx
+  Closed st ->
+    second Closed <$> observeContest st tx
+      <|> second Idle <$> observeFanout st tx
 
 -- * Helpers
 

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -162,6 +162,30 @@ getContestationDeadline
   ClosedState{closedThreadOutput = ClosedThreadOutput{closedContestationDeadline}} =
     closedContestationDeadline
 
+-- | An enumeration of all possible chain states. This can be kept around in
+-- memory.
+data ChainState
+  = Idle IdleState
+  | Initial InitialState
+  | Open OpenState
+  | Closed ClosedState
+
+genChainState :: Gen ChainState
+genChainState = undefined
+
+genChainStateWithTx :: Gen (ChainState, Tx)
+genChainStateWithTx = undefined
+
+observeAllTx :: Tx -> ChainState -> Maybe (OnChainTx Tx, ChainState)
+observeAllTx tx = \case
+  Idle IdleState{ctx} ->
+    second Initial <$> observeInit ctx tx
+  Initial st ->
+    second Initial <$> observeCommit st tx
+      <|> second Idle <$> observeAbort st tx
+      <|> second Open <$> observeCollect st tx
+  _ -> error "TODO"
+
 -- | An existential wrapping /some/ on-chain head state into a value that carry
 -- information about the state except that it 'HasTransitions' and
 -- 'HasKnownUTxO'.

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -169,6 +169,7 @@ data ChainState
   | Initial InitialState
   | Open OpenState
   | Closed ClosedState
+  deriving (Eq, Show)
 
 genChainState :: Gen ChainState
 genChainState = undefined

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -179,21 +179,13 @@ instance HasKnownUTxO ChainState where
     Open st -> getKnownUTxO st
     Closed st -> getKnownUTxO st
 
+-- TODO: basically Arbitrary ChainState, ensure it covers all cases
 genChainState :: Gen ChainState
 genChainState = undefined
 
+-- TODO: an alternative to forAllSt
 genChainStateWithTx :: Gen (ChainState, Tx)
 genChainStateWithTx = undefined
-
-observeAllTx :: Tx -> ChainState -> Maybe (OnChainTx Tx, ChainState)
-observeAllTx tx = \case
-  Idle IdleState{ctx} ->
-    second Initial <$> observeInit ctx tx
-  Initial st ->
-    second Initial <$> observeCommit st tx
-      <|> second Idle <$> observeAbort st tx
-      <|> second Open <$> observeCollect st tx
-  _ -> error "TODO"
 
 -- | An existential wrapping /some/ on-chain head state into a value that carry
 -- information about the state except that it 'HasTransitions' and
@@ -624,6 +616,16 @@ instance ObserveTx ClosedState IdleState where
   observeTx = observeFanout
 
 -- * Observe any transition
+
+observeAllTx :: Tx -> ChainState -> Maybe (OnChainTx Tx, ChainState)
+observeAllTx tx = \case
+  Idle IdleState{ctx} ->
+    second Initial <$> observeInit ctx tx
+  Initial st ->
+    second Initial <$> observeCommit st tx
+      <|> second Idle <$> observeAbort st tx
+      <|> second Open <$> observeCollect st tx
+  _ -> error "TODO"
 
 -- | Observe a transition without knowing the starting or ending state. This
 -- function does enumerate and try all 'transitions' of some given

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -171,6 +171,14 @@ data ChainState
   | Closed ClosedState
   deriving (Eq, Show)
 
+instance HasKnownUTxO ChainState where
+  getKnownUTxO :: ChainState -> UTxO
+  getKnownUTxO = \case
+    Idle st -> getKnownUTxO st
+    Initial st -> getKnownUTxO st
+    Open st -> getKnownUTxO st
+    Closed st -> getKnownUTxO st
+
 genChainState :: Gen ChainState
 genChainState = undefined
 

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -179,13 +179,15 @@ instance HasKnownUTxO ChainState where
     Open st -> getKnownUTxO st
     Closed st -> getKnownUTxO st
 
--- TODO: basically Arbitrary ChainState, ensure it covers all cases
-genChainState :: Gen ChainState
-genChainState = undefined
-
--- TODO: an alternative to forAllSt
-genChainStateWithTx :: Gen (ChainState, Tx)
-genChainStateWithTx = undefined
+-- | An enumeration of all transitions. Can be used as labels for checking coverage.
+data ChainTransition
+  = Init
+  | Commit
+  | Collect
+  | Close
+  | Contest
+  | Fanout
+  deriving (Eq, Show, Enum, Bounded)
 
 -- | An existential wrapping /some/ on-chain head state into a value that carry
 -- information about the state except that it 'HasTransitions' and

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -8,7 +8,6 @@ import Hydra.Prelude hiding (init)
 
 import qualified Cardano.Api.UTxO as UTxO
 import qualified Data.Map as Map
-import Data.Typeable (cast, eqT, typeRep, type (:~:) (Refl))
 import Hydra.Chain (HeadId (..), HeadParameters, OnChainTx (..), PostTxError (..))
 import Hydra.Chain.Direct.ScriptRegistry (ScriptRegistry (..), genScriptRegistry, registryUTxO)
 import Hydra.Chain.Direct.TimeHandle (PointInTime)
@@ -47,7 +46,6 @@ import Hydra.Party (Party)
 import Hydra.Snapshot (ConfirmedSnapshot (..), Snapshot (..))
 import Plutus.V2.Ledger.Api (POSIXTime)
 import Test.QuickCheck (sized)
-import qualified Text.Show
 
 -- | A class for accessing the known 'UTxO' set in a type.
 class HasKnownUTxO a where
@@ -171,6 +169,7 @@ data ChainState
   | Closed ClosedState
   deriving (Eq, Show)
 
+-- TODO: No type class needed for this
 instance HasKnownUTxO ChainState where
   getKnownUTxO :: ChainState -> UTxO
   getKnownUTxO = \case
@@ -188,29 +187,6 @@ data ChainTransition
   | Contest
   | Fanout
   deriving (Eq, Show, Enum, Bounded)
-
--- | An existential wrapping /some/ on-chain head state into a value that carry
--- information about the state except that it 'HasTransitions' and
--- 'HasKnownUTxO'.
-data SomeOnChainHeadState where
-  SomeOnChainHeadState ::
-    forall st.
-    (Eq st, Typeable st, Show st, HasKnownUTxO st, HasTransitions st) =>
-    st ->
-    SomeOnChainHeadState
-
-instance Show SomeOnChainHeadState where
-  show (SomeOnChainHeadState st) = show st
-
-instance Eq SomeOnChainHeadState where
-  (SomeOnChainHeadState (st :: a)) == (SomeOnChainHeadState (st' :: b)) =
-    case eqT @a @b of
-      Just Refl -> st == st'
-      Nothing -> False
-
--- | Access the actual head state in the existential given it is of type 'st'.
-castHeadState :: Typeable st => SomeOnChainHeadState -> Maybe st
-castHeadState (SomeOnChainHeadState x) = cast x
 
 -- * Constructing transactions
 
@@ -383,47 +359,9 @@ fanout st utxo deadlineSlotNo = do
 
 -- * Observing Transitions
 
--- | A class for observing a transition from a state to another given the right
--- transaction.
-class ObserveTx st st' where
-  observeTx ::
-    st ->
-    Tx ->
-    Maybe (OnChainTx Tx, st')
-
--- | A convenient class to declare all possible transitions from a given
--- starting state 'st'.
-class HasTransitions st where
-  transitions :: [TransitionFrom st]
-
--- | An existential to be used in 'HasTransitions'.
-data TransitionFrom st where
-  TransitionTo ::
-    forall st st'.
-    (Typeable st, Typeable st', ObserveTx st st', Eq st', Show st', HasKnownUTxO st', HasTransitions st') =>
-    String ->
-    Proxy st' ->
-    TransitionFrom st
-
-instance Show (TransitionFrom st) where
-  show (TransitionTo name proxy) =
-    mconcat
-      [ show (typeRep (Proxy @st))
-      , " -> "
-      , show (typeRep proxy)
-      , " : " <> name
-      ]
-
-instance Eq (TransitionFrom st) where
-  (TransitionTo name proxy) == (TransitionTo name' proxy') =
-    name == name'
-      && typeRep proxy == typeRep proxy'
-
 -- ** IdleState transitions
 
-instance HasTransitions IdleState where
-  transitions = [TransitionTo "init" (Proxy @InitialState)]
-
+-- | Observe an init transition using a 'InitialState' and 'observeInitTx'.
 observeInit ::
   ChainContext ->
   Tx ->
@@ -450,18 +388,9 @@ observeInit ctx tx = do
     , ownParty
     } = ctx
 
-instance ObserveTx IdleState InitialState where
-  observeTx IdleState{ctx} = observeInit ctx
-
 -- ** InitialState transitions
 
-instance HasTransitions InitialState where
-  transitions =
-    [ TransitionTo "commit" (Proxy @InitialState)
-    , TransitionTo "collect" (Proxy @OpenState)
-    , TransitionTo "abort" (Proxy @IdleState)
-    ]
-
+-- | Observe an commit transition using a 'InitialState' and 'observeCommitTx'.
 observeCommit ::
   InitialState ->
   Tx ->
@@ -488,9 +417,8 @@ observeCommit st tx = do
     , initialInitials
     } = st
 
-instance ObserveTx InitialState InitialState where
-  observeTx = observeCommit
-
+-- | Observe an collect transition using a 'InitialState' and 'observeCollectComTx'.
+-- This function checks the head id and ignores if not relevant.
 observeCollect ::
   InitialState ->
   Tx ->
@@ -517,9 +445,8 @@ observeCollect st tx = do
     , initialHeadTokenScript
     } = st
 
-instance ObserveTx InitialState OpenState where
-  observeTx = observeCollect
-
+-- | Observe an abort transition using a 'InitialState' and 'observeAbortTx'.
+-- This function checks the head id and ignores if not relevant.
 observeAbort ::
   InitialState ->
   Tx ->
@@ -533,16 +460,10 @@ observeAbort st tx = do
  where
   InitialState{ctx} = st
 
-instance ObserveTx InitialState IdleState where
-  observeTx = observeAbort
-
 -- ** OpenState transitions
 
-instance HasTransitions OpenState where
-  transitions =
-    [ TransitionTo "close" (Proxy @ClosedState)
-    ]
-
+-- | Observe a close transition using a 'OpenState' and 'observeCloseTx'.
+-- This function checks the head id and ignores if not relevant.
 observeClose ::
   OpenState ->
   Tx ->
@@ -571,17 +492,10 @@ observeClose st tx = do
     , openHeadTokenScript
     } = st
 
-instance ObserveTx OpenState ClosedState where
-  observeTx = observeClose
-
 -- ** ClosedState transitions
 
-instance HasTransitions ClosedState where
-  transitions =
-    [ TransitionTo "contest" (Proxy @ClosedState)
-    , TransitionTo "fanout" (Proxy @IdleState)
-    ]
-
+-- | Observe a fanout transition using a 'ClosedState' and 'observeContestTx'.
+-- This function checks the head id and ignores if not relevant.
 observeContest ::
   ClosedState ->
   Tx ->
@@ -600,9 +514,7 @@ observeContest st tx = do
     , closedThreadOutput
     } = st
 
-instance ObserveTx ClosedState ClosedState where
-  observeTx = observeContest
-
+-- | Observe a fanout transition using a 'ClosedState' and 'observeFanoutTx'.
 observeFanout ::
   ClosedState ->
   Tx ->
@@ -614,11 +526,11 @@ observeFanout st tx = do
  where
   ClosedState{ctx} = st
 
-instance ObserveTx ClosedState IdleState where
-  observeTx = observeFanout
-
 -- * Observe any transition
 
+-- | Observe a transition without knowing the starting or ending state. This
+-- function should try to observe all relevant transitions given some
+-- 'ChainState'.
 observeAllTx :: Tx -> ChainState -> Maybe (OnChainTx Tx, ChainState)
 observeAllTx tx = \case
   Idle IdleState{ctx} ->
@@ -628,25 +540,6 @@ observeAllTx tx = \case
       <|> second Idle <$> observeAbort st tx
       <|> second Open <$> observeCollect st tx
   _ -> error "TODO"
-
--- | Observe a transition without knowing the starting or ending state. This
--- function does enumerate and try all 'transitions' of some given
--- 'SomeOnChainHeadState'. To do that, this function uses the 'HasTransitions'
--- and 'ObserveTx' type classes.
-observeSomeTx ::
-  Tx ->
-  SomeOnChainHeadState ->
-  Maybe (OnChainTx Tx, SomeOnChainHeadState)
-observeSomeTx tx (SomeOnChainHeadState (st :: st)) =
-  asum $ (\(TransitionTo _ p) -> observeSome p) <$> transitions @st
- where
-  observeSome ::
-    forall st'.
-    (ObserveTx st st', Typeable st', Eq st', Show st', HasTransitions st', HasKnownUTxO st') =>
-    Proxy st' ->
-    Maybe (OnChainTx Tx, SomeOnChainHeadState)
-  observeSome _ =
-    second SomeOnChainHeadState <$> observeTx @st @st' st tx
 
 -- * Helpers
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
@@ -146,7 +146,7 @@ import qualified Data.Set as Set
 import Data.Typeable (typeOf)
 import Hydra.Chain.Direct.Fixture (genForParty, testPolicyId)
 import qualified Hydra.Chain.Direct.Fixture as Fixture
-import Hydra.Chain.Direct.State (ChainState (..), observeAllTx)
+import Hydra.Chain.Direct.State (ChainState (..), observeSomeTx)
 import Hydra.Chain.Direct.Tx (assetNameFromVerificationKey)
 import qualified Hydra.Contract.Head as Head
 import qualified Hydra.Contract.HeadState as Head
@@ -242,7 +242,7 @@ propTransactionValidates (tx, lookupUTxO) =
 -- properly observe given a configuration.
 propTransactionIsNotObserved :: (Tx, UTxO) -> ChainState -> Property
 propTransactionIsNotObserved (tx, _) st =
-  case observeAllTx tx st of
+  case observeSomeTx tx st of
     Nothing ->
       property True
     Just (onChainTx, st') ->

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
@@ -146,7 +146,7 @@ import qualified Data.Set as Set
 import Data.Typeable (typeOf)
 import Hydra.Chain.Direct.Fixture (genForParty, testPolicyId)
 import qualified Hydra.Chain.Direct.Fixture as Fixture
-import Hydra.Chain.Direct.State (SomeOnChainHeadState (..), observeSomeTx)
+import Hydra.Chain.Direct.State (ChainState (..), observeAllTx)
 import Hydra.Chain.Direct.Tx (assetNameFromVerificationKey)
 import qualified Hydra.Contract.Head as Head
 import qualified Hydra.Contract.HeadState as Head
@@ -192,7 +192,7 @@ propMutationOnChain (tx, utxo) genMutation =
 propMutationOffChain ::
   (Tx, UTxO) ->
   ((Tx, UTxO) -> Gen SomeMutation) ->
-  Gen SomeOnChainHeadState ->
+  Gen ChainState ->
   Property
 propMutationOffChain (tx, utxo) genMutation genSt =
   forAll @_ @Property (genMutation (tx, utxo)) $ \SomeMutation{label, mutation} ->
@@ -240,12 +240,12 @@ propTransactionValidates (tx, lookupUTxO) =
 
 -- | A 'Property' checking some (on-chain valid) (transaction, UTxO) is not
 -- properly observe given a configuration.
-propTransactionIsNotObserved :: (Tx, UTxO) -> SomeOnChainHeadState -> Property
+propTransactionIsNotObserved :: (Tx, UTxO) -> ChainState -> Property
 propTransactionIsNotObserved (tx, _) st =
-  case observeSomeTx tx st of
+  case observeAllTx tx st of
     Nothing ->
       property True
-    Just (onChainTx, SomeOnChainHeadState st') ->
+    Just (onChainTx, st') ->
       property False
         & counterexample ("Observed tx: " <> strawmanGetConstr onChainTx)
         & counterexample ("New head state: " <> show (typeOf st'))

--- a/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
@@ -31,7 +31,7 @@ import Hydra.Chain.Direct.Contract.Mutation (
   propMutationOnChain,
   propTransactionValidates,
  )
-import Hydra.Chain.Direct.State (SomeOnChainHeadState (..))
+import Hydra.Chain.Direct.State (ChainState (Idle))
 import qualified Hydra.Contract.Commit as Commit
 import Hydra.Contract.Head (
   verifyPartySignature,
@@ -91,7 +91,7 @@ spec = parallel $ do
     prop "does not survive random adversarial mutations (on-chain)" $
       propMutationOnChain healthyInitTx genInitMutation
     prop "does not survive random adversarial mutations (off-chain)" $
-      propMutationOffChain healthyInitTx genObserveInitMutation (SomeOnChainHeadState <$> genHealthyIdleState)
+      propMutationOffChain healthyInitTx genObserveInitMutation (Idle <$> genHealthyIdleState)
 
   describe "Abort" $ do
     prop "is healthy" $

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -75,7 +75,6 @@ import Hydra.Chain.Direct.State (
   IdleState (..),
   InitialState (..),
   OpenState,
-  SomeOnChainHeadState (..),
   TransitionFrom (TransitionTo),
   abort,
   close,
@@ -91,7 +90,6 @@ import Hydra.Chain.Direct.State (
   observeClose,
   observeCommit,
   observeInit,
-  observeSomeTx,
  )
 import Hydra.Chain.Direct.Util (Block)
 import Hydra.ContestationPeriod (toNominalDiffTime)
@@ -159,10 +157,10 @@ spec :: Spec
 spec = parallel $ do
   describe "observeTx" $ do
     prop "All valid transitions for all possible states can be observed." $
-      checkCoverage $
-        forAllSt $ \st tx ->
-          isJust (observeSomeTx tx (SomeOnChainHeadState st))
-            & counterexample "observeSomeTx returned Nothing"
+      checkCoverage $ -- TODO: use genericCoverTable on some transition type
+        forAll genChainStateWithTx $ \(st, tx) ->
+          isJust (observeAllTx tx st)
+            & counterexample "observeAllTx returned Nothing"
 
   describe "init" $ do
     propBelowSizeLimit maxTxSize forAllInit
@@ -424,6 +422,7 @@ propIsValid forAllTx =
 -- QuickCheck Extras
 --
 
+-- TODO: unused
 -- XXX: This does not prevent us of not aligning forAll generators with
 -- Transition labels. Ideally we would would use the actual states/transactions
 -- or observed states/transactions for labeling.


### PR DESCRIPTION
:watermelon: This is now a fully boring Hydra.Chain.Direct.State without the need for higher-kinded types or existentials

:watermelon: The `ChainState` sum-type is required to keep any of them in the TVar in `Hydra.Direct.Chain`

:watermelon: The `ChainTransition` sum-type is used to check coverage of generated cases in `genChainStateWithTx`.

:watermelon: Note that there are some TODOs still in this PR. I will address them, but wanted to put it out for a first round of review.


This depends on #475 