### PR TITLE
fix(tui): increase feedbacks display time

### DIFF
--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -625,7 +625,7 @@ draw Client{sk} CardanoClient{networkId} s =
   drawFeedback =
     case s ^? (feedbackL . _head) of
       Just UserFeedback{message, severity, time} ->
-        withAttr (severityToAttr severity) $ str (toString (show time <> ":" <> message))
+        withAttr (severityToAttr severity) $ str (toString (show time <> " | " <> message))
       Nothing ->
         -- Reserves the space and not have this area collapse
         str " "

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -177,12 +177,10 @@ warn :: Text -> State -> State
 warn = report Error
 
 report :: Severity -> Text -> State -> State
-report typ msg st = case st of
-  Connected{me, nodeHost, peers, headState, dialogState, feedback, now} ->
-    Connected{me, nodeHost, peers, headState, dialogState, feedback = userFeedback : feedback, now}
-   where
-    userFeedback = UserFeedback typ msg now
-  disconnected -> disconnected
+report typ msg s =
+  s & feedbackL %~ (userFeedback :)
+ where
+  userFeedback = UserFeedback typ msg (s ^. nowL)
 
 --
 -- Update

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -6,7 +6,7 @@
 
 module Hydra.TUI where
 
-import Hydra.Prelude hiding (State, padLeft, splitAt)
+import Hydra.Prelude hiding (State, padLeft)
 
 import Brick
 import Hydra.Cardano.Api
@@ -28,11 +28,10 @@ import Brick.Forms (
  )
 import Brick.Widgets.Border (hBorder, vBorder)
 import Brick.Widgets.Border.Style (ascii)
-import Brick.Widgets.List (Splittable (splitAt))
 import qualified Cardano.Api.UTxO as UTxO
 import Data.List (nub, (\\))
-import qualified Data.Map.Strict as Map hiding (splitAt)
-import qualified Data.Text as Text hiding (splitAt)
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as Text
 import Data.Time (defaultTimeLocale, formatTime)
 import Data.Time.Format (FormatTime)
 import Data.Version (showVersion)
@@ -70,9 +69,6 @@ import qualified Prelude
 -- TODO(SN): hardcoded contestation period used by the tui
 tuiContestationPeriod :: ContestationPeriod
 tuiContestationPeriod = UnsafeContestationPeriod 10
-
-instance Splittable [] where
-  splitAt = Prelude.splitAt
 
 --
 -- Model

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -43,7 +43,7 @@ import Hydra.Network (Host (..))
 import Hydra.Options (ChainConfig (..))
 import Hydra.TUI (renderTime, runWithVty, tuiContestationPeriod)
 import Hydra.TUI.Options (Options (..))
-import HydraNode (EndToEndLog, HydraClient (HydraClient, hydraNodeId), withHydraNode)
+import HydraNode (EndToEndLog (FromFaucet), HydraClient (HydraClient, hydraNodeId), withHydraNode)
 import System.Posix (OpenMode (WriteOnly), closeFd, defaultFileFlags, openFd)
 
 spec :: Spec
@@ -143,9 +143,9 @@ setupNodeAndTUI action =
         let nodeId = 1
         withHydraNode (contramap FromHydra tracer) chainConfig tmpDir nodeId aliceSk [] [nodeId] hydraScriptsTxId $ \HydraClient{hydraNodeId} -> do
           -- Fuel to pay hydra transactions
-          seedFromFaucet_ node aliceCardanoVk 100_000_000 Fuel
+          seedFromFaucet_ node aliceCardanoVk 100_000_000 Fuel (contramap FromFaucet tracer)
           -- Some ADA to commit
-          seedFromFaucet_ node aliceCardanoVk 42_000_000 Normal
+          seedFromFaucet_ node aliceCardanoVk 42_000_000 Normal (contramap FromFaucet tracer)
 
           withTUITest (150, 10) $ \brickTest@TUITest{buildVty} -> do
             race_

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -43,7 +43,7 @@ import Hydra.Network (Host (..))
 import Hydra.Options (ChainConfig (..))
 import Hydra.TUI (renderTime, runWithVty, tuiContestationPeriod)
 import Hydra.TUI.Options (Options (..))
-import HydraNode (EndToEndLog (FromFaucet), HydraClient (HydraClient, hydraNodeId), withHydraNode)
+import HydraNode (EndToEndLog, HydraClient (HydraClient, hydraNodeId), withHydraNode)
 import System.Posix (OpenMode (WriteOnly), closeFd, defaultFileFlags, openFd)
 
 spec :: Spec
@@ -143,9 +143,9 @@ setupNodeAndTUI action =
         let nodeId = 1
         withHydraNode (contramap FromHydra tracer) chainConfig tmpDir nodeId aliceSk [] [nodeId] hydraScriptsTxId $ \HydraClient{hydraNodeId} -> do
           -- Fuel to pay hydra transactions
-          seedFromFaucet_ node aliceCardanoVk 100_000_000 Fuel (contramap FromFaucet tracer)
+          seedFromFaucet_ node aliceCardanoVk 100_000_000 Fuel
           -- Some ADA to commit
-          seedFromFaucet_ node aliceCardanoVk 42_000_000 Normal (contramap FromFaucet tracer)
+          seedFromFaucet_ node aliceCardanoVk 42_000_000 Normal
 
           withTUITest (150, 10) $ \brickTest@TUITest{buildVty} -> do
             race_

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -57,8 +57,8 @@ spec = do
           -- Using hex representation of aliceSk's HydraVerificationKey
           shouldRender "Party d5bf4a3fcce71"
           sendInputEvent $ EvKey (KChar 'q') []
-      it "displays errors long enough" $
-        \TUITest{sendInputEvent, shouldRender, shouldNotRender} -> do
+      it "report feedback for ever" $
+        \TUITest{sendInputEvent, shouldRender} -> do
           threadDelay 1
           shouldRender "connected"
           shouldRender "Idle"
@@ -69,8 +69,6 @@ spec = do
           shouldRender "Invalid command: Fanout"
           threadDelay 1
           shouldRender "Invalid command: Fanout"
-          threadDelay 1
-          shouldNotRender "Invalid command: Fanout"
       it "supports the init & abort Head life cycle" $
         \TUITest{sendInputEvent, shouldRender} -> do
           threadDelay 1

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -57,7 +57,16 @@ spec = do
           -- Using hex representation of aliceSk's HydraVerificationKey
           shouldRender "Party d5bf4a3fcce71"
           sendInputEvent $ EvKey (KChar 'q') []
-
+      it "displays errors long enough" $
+        \TUITest{sendInputEvent, shouldRender} -> do
+          threadDelay 1
+          shouldRender "connected"
+          shouldRender "Idle"
+          sendInputEvent $ EvKey (KChar 'f') []
+          threadDelay 1
+          shouldRender "Invalid command: Fanout"
+          threadDelay 1
+          shouldRender "Invalid command: Fanout"
       it "supports the init & abort Head life cycle" $
         \TUITest{sendInputEvent, shouldRender} -> do
           threadDelay 1


### PR DESCRIPTION
Fixes  #484 

🏓 Refactor State to have a list of feedback instead of a maybe value.

🏓 Feedback will always be visible, displaying the last error which occurs.

🏓 Extra: added `shouldNotRender` helper, as it is convenient during development.