### PR TITLE
Use wss: when serving hydraw via https:

### DIFF
--- a/hydraw/bundle.js
+++ b/hydraw/bundle.js
@@ -1,4 +1,5 @@
-const client = new WebSocket("ws://" + window.location.host);
+const protocol = window.location.protocol == "https:" ? "wss:" : "ws:";
+const client = new WebSocket(protocol + "//" + window.location.host);
 
 const metadataLabel = 14;
 const query = (window.location.search || "?")


### PR DESCRIPTION
Will also build `hydraw` image and push it if this is merged.

Reviewer could also try accessing `https://hydraw.fk.ncoding.at`