### PR TITLE
Introduce a pending state in the TUI

### DIFF
--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -204,6 +204,7 @@ handleEvent client@Client{sendInput} cardanoClient s = \case
             | c `elem` ['q', 'Q'] ->
               halt s
             | c `elem` ['i', 'I'] ->
+              -- TODO: don't do this when something pending already
               liftIO (sendInput $ Init tuiContestationPeriod) >> continue s
             | c `elem` ['a', 'A'] ->
               liftIO (sendInput Abort) >> continue s

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -206,14 +206,19 @@ handleEvent client@Client{sendInput} cardanoClient s = \case
             | c `elem` ['q', 'Q'] ->
               halt s
             | c `elem` ['i', 'I'] -> do
-              unless (s ^? pendingL == Just True) $  
+              unless (s ^? pendingL == Just True) $
                 liftIO (sendInput $ Init tuiContestationPeriod)
-              continue (s & pendingL .~ True)
+              continue $
+                s & pendingL .~ True
+                  & info "Transition already pending"
             | c `elem` ['a', 'A'] ->
+              -- TODO: add pending logic
               liftIO (sendInput Abort) >> continue s
             | c `elem` ['f', 'F'] ->
+              -- TODO: add pending logic
               liftIO (sendInput Fanout) >> continue s
             | c `elem` ['c', 'C'] ->
+              -- TODO: add pending logic
               case s ^? headStateL of
                 Just Initializing{} ->
                   handleCommitEvent client cardanoClient s

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -214,17 +214,17 @@ handleEvent client cardanoClient s = \case
             | c `elem` ['q', 'Q'] ->
               halt s
             | c `elem` ['i', 'I'] ->
-              doSendInputAndTransitionIfNotPending client s (Init tuiContestationPeriod)
+              sendInputAndTransition client s (Init tuiContestationPeriod)
             | c `elem` ['a', 'A'] ->
-              doSendInputAndTransitionIfNotPending client s Abort
+              sendInputAndTransition client s Abort
             | c `elem` ['f', 'F'] ->
-              doSendInputAndTransitionIfNotPending client s Fanout
+              sendInputAndTransition client s Fanout
             | c `elem` ['c', 'C'] ->
               case s ^? headStateL of
                 Just Initializing{} ->
                   showCommitDialog client cardanoClient s
                 Just Open{} ->
-                  doSendInputAndTransitionIfNotPending client s Close
+                  sendInputAndTransition client s Close
                 _ ->
                   continue s
             | c `elem` ['n', 'N'] ->
@@ -242,8 +242,8 @@ handleEvent client cardanoClient s = \case
   e ->
     continue $ s & warn ("unhandled event: " <> show e)
 
-doSendInputAndTransitionIfNotPending :: Client tx IO -> State -> ClientInput tx -> EventM n (Next State)
-doSendInputAndTransitionIfNotPending Client{sendInput} s input = case s ^? pendingL of
+sendInputAndTransition :: Client tx IO -> State -> ClientInput tx -> EventM n (Next State)
+sendInputAndTransition Client{sendInput} s input = case s ^? pendingL of
   Just Pending -> do
     continue $ s & info "Transition already pending"
   Just NotPending -> do
@@ -416,7 +416,7 @@ showCommitDialog client@Client{sk} CardanoClient{queryUTxOByAddress, networkId} 
               & warn "Cannot commit more than 1 entry."
               & dialogStateL .~ NoDialog
         else do
-          doSendInputAndTransitionIfNotPending client (s' & dialogStateL .~ NoDialog) (Commit commitUTxO)
+          sendInputAndTransition client (s' & dialogStateL .~ NoDialog) (Commit commitUTxO)
 
 handleNewTxEvent ::
   Client Tx IO ->

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -133,6 +133,7 @@ makeLensesFor
   , ("dialogState", "dialogStateL")
   , ("feedback", "feedbackL")
   , ("now", "nowL")
+  , ("pending", "pendingL")
   ]
   ''State
 
@@ -204,9 +205,10 @@ handleEvent client@Client{sendInput} cardanoClient s = \case
         if
             | c `elem` ['q', 'Q'] ->
               halt s
-            | c `elem` ['i', 'I'] ->
-              -- TODO: don't do this when something pending already
-              liftIO (sendInput $ Init tuiContestationPeriod) >> continue s
+            | c `elem` ['i', 'I'] -> do
+              unless (s ^? pendingL == Just True) $  
+                liftIO (sendInput $ Init tuiContestationPeriod)
+              continue (s & pendingL .~ True)
             | c `elem` ['a', 'A'] ->
               liftIO (sendInput Abort) >> continue s
             | c `elem` ['f', 'F'] ->

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -582,7 +582,10 @@ draw Client{sk} CardanoClient{networkId} s =
     Disconnected{} -> emptyWidget
     Connected{headState} ->
       vBox
-        [ padLeftRight 1 $ txt "Head status: " <+> withAttr infoA (txt $ Prelude.head (words $ show headState))
+        [ padLeftRight 1 $
+            txt "Head status: "
+              <+> withAttr infoA (txt $ Prelude.head (words $ show headState))
+              <+> txt " (Transition pending)"
         , hBorder
         ]
 

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -87,6 +87,7 @@ data State
       , dialogState :: DialogState
       , feedback :: [UserFeedback]
       , now :: UTCTime
+      , pending :: Bool
       }
 
 data UserFeedback = UserFeedback
@@ -247,6 +248,7 @@ handleAppEvent s = \case
       , dialogState = NoDialog
       , feedback = []
       , now = s ^. nowL
+      , pending = False
       }
   ClientDisconnected ->
     Disconnected
@@ -581,12 +583,12 @@ draw Client{sk} CardanoClient{networkId} s =
 
   drawHeadState = case s of
     Disconnected{} -> emptyWidget
-    Connected{headState} ->
+    Connected{headState, pending} ->
       vBox
         [ padLeftRight 1 $
             txt "Head status: "
               <+> withAttr infoA (txt $ Prelude.head (words $ show headState))
-              <+> txt " (Transition pending)"
+              <+> if pending then txt " (Transition pending)" else txt ""
         , hBorder
         ]
 

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -283,8 +283,9 @@ handleAppEvent s = \case
   Update Committed{party, utxo} ->
     s & headStateL %~ partyCommitted [party] utxo
       & info (show party <> " committed " <> renderValue (balance @Tx utxo))
-      -- TODO: only unblock when we committed
-      & pendingL .~ False
+      & if Just (Just party) == s ^? meL
+        then pendingL .~ False
+        else id
   Update HeadIsOpen{utxo} ->
     s & headStateL %~ headIsOpen utxo
       & info "Head is now open!"

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -46,6 +46,7 @@ import Hydra.TUI (renderTime, runWithVty, tuiContestationPeriod)
 import Hydra.TUI.Options (Options (..))
 import HydraNode (EndToEndLog, HydraClient (HydraClient, hydraNodeId), withHydraNode)
 import System.Posix (OpenMode (WriteOnly), closeFd, defaultFileFlags, openFd)
+import Hydra.Chain (PostTxError(NoSeedInput))
 
 spec :: Spec
 spec = do
@@ -127,9 +128,12 @@ spec = do
           shouldRender "Idle"
           shouldNotRender "pending"
           sendInputEvent $ EvKey (KChar 'i') []
+          threadDelay 0.05
           shouldRender "pending"
+          -- we expect the application to prevent this and also to inform us about it
           sendInputEvent $ EvKey (KChar 'i') []
-          shouldNotRender "PostTxOnChainFailed"
+          threadDelay 0.05
+          shouldNotRender "An error happened"
           shouldRender "Transition already pending"
 
   context "text rendering tests" $ do

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -125,11 +125,13 @@ spec = do
         \TUITest{sendInputEvent, shouldRender, shouldNotRender} -> do
           threadDelay 1
           shouldRender "Idle"
+          shouldNotRender "pending"
           sendInputEvent $ EvKey (KChar 'i') []
-          shouldRender "Pending"
+          shouldRender "pending"
           sendInputEvent $ EvKey (KChar 'i') []
           shouldNotRender "PostTxOnChainFailed"
-       
+          shouldRender "Transition already pending"
+
   context "text rendering tests" $ do
     it "should format time with whole values for every unit, not total values" $ do
       let seconds = 1

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -58,7 +58,7 @@ spec = do
           -- Using hex representation of aliceSk's HydraVerificationKey
           shouldRender "Party d5bf4a3fcce71"
           sendInputEvent $ EvKey (KChar 'q') []
-      it "report feedback for ever" $
+      it "display feedback long enough" $
         \TUITest{sendInputEvent, shouldRender} -> do
           threadDelay 1
           shouldRender "connected"
@@ -120,6 +120,16 @@ spec = do
           shouldRender "Final"
           shouldRender "42000000 lovelace"
           sendInputEvent $ EvKey (KChar 'q') []
+
+      it "doesn't allow multiple initializations" $
+        \TUITest{sendInputEvent, shouldRender, shouldNotRender} -> do
+          threadDelay 1
+          shouldRender "Idle"
+          sendInputEvent $ EvKey (KChar 'i') []
+          shouldRender "Pending"
+          sendInputEvent $ EvKey (KChar 'i') []
+          shouldNotRender "PostTxOnChainFailed"
+       
   context "text rendering tests" $ do
     it "should format time with whole values for every unit, not total values" $ do
       let seconds = 1

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -46,7 +46,6 @@ import Hydra.TUI (renderTime, runWithVty, tuiContestationPeriod)
 import Hydra.TUI.Options (Options (..))
 import HydraNode (EndToEndLog, HydraClient (HydraClient, hydraNodeId), withHydraNode)
 import System.Posix (OpenMode (WriteOnly), closeFd, defaultFileFlags, openFd)
-import Hydra.Chain (PostTxError(NoSeedInput))
 
 spec :: Spec
 spec = do
@@ -128,13 +127,19 @@ spec = do
           shouldRender "Idle"
           shouldNotRender "pending"
           sendInputEvent $ EvKey (KChar 'i') []
-          threadDelay 0.05
+          -- NOTE: The timing is important here as it needs to be faster than
+          -- the devnet block production
+          threadDelay 0.01
           shouldRender "pending"
           -- we expect the application to prevent this and also to inform us about it
           sendInputEvent $ EvKey (KChar 'i') []
-          threadDelay 0.05
-          shouldNotRender "An error happened"
+          threadDelay 0.01
           shouldRender "Transition already pending"
+          shouldNotRender "An error happened"
+          -- Eventualy the first Init should be successful
+          threadDelay 1
+          shouldRender "Initializing"
+          shouldNotRender "pending"
 
   context "text rendering tests" $ do
     it "should format time with whole values for every unit, not total values" $ do

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -131,6 +131,7 @@ spec = do
           -- the devnet block production
           threadDelay 0.01
           shouldRender "pending"
+          shouldNotRender "Transition already pending"
           -- we expect the application to prevent this and also to inform us about it
           sendInputEvent $ EvKey (KChar 'i') []
           threadDelay 0.01


### PR DESCRIPTION
:t-rex: Show a pending state in the TUI

:t-rex: Don't allow state transitioning commands while pending


![image](https://user-images.githubusercontent.com/2621189/192761269-5376aeb4-a81d-46c9-a1a0-1dd2e242bc27.png)

:t-rex: Known issue: The commit pending state update / display seems not to do well with the commit dialog

![image](https://user-images.githubusercontent.com/2621189/192761507-e27878fe-d80d-4aad-aa75-813301876eaa.png)
 (Maybe this is also because commit can still be done while the node is actually already opening the head with the `CollectComTx` under the hood)