### PR TITLE
Not update wallet utxo on coverFee

### DIFF
--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -181,7 +181,7 @@ spec =
                                           ErrScriptExecutionFailed{} -> "Script(s) execution failed"
                                           ErrTranslationError{} -> "Transaction context translation error"
                                       )
-                                Right (_, fromLedgerTx -> txAbortWithFees) ->
+                                Right (fromLedgerTx -> txAbortWithFees) ->
                                   let actualExecutionCost = totalExecutionCost ledgerPParams txAbortWithFees
                                       fee = txFee' txAbortWithFees
                                    in actualExecutionCost > Lovelace 0 && fee > actualExecutionCost

--- a/hydra-node/test/Hydra/Chain/Direct/WalletSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/WalletSpec.hs
@@ -90,7 +90,7 @@ spec = parallel $ do
 
   describe "coverFee" $ do
     prop "balances transaction with fees" prop_balanceTransaction
-    prop "transaction's inputs are removed from wallet" prop_removeUsedInputs
+    prop "returns used UTxO" prop_returnsUsedUTxO
 
   describe "newTinyWallet" $ do
     prop "initialises wallet by querying UTxO" $
@@ -221,9 +221,9 @@ isBalanced utxo originalTx balancedTx =
         & counterexample ("Outputs after:   " <> show (coin out'))
         & counterexample ("Outputs before:  " <> show (coin out))
 
-prop_removeUsedInputs ::
+prop_returnsUsedUTxO ::
   Property
-prop_removeUsedInputs =
+prop_returnsUsedUTxO =
   forAllBlind (reasonablySized genValidatedTx) $ \tx ->
     forAllBlind (reasonablySized $ genOutputsForInputs tx) $ \txUTxO ->
       forAllBlind genMarkedUTxO $ \extraUTxO ->


### PR DESCRIPTION
We do not optimistically remove these UTxOs anymore and instead accept re-use should we 'coverFee' multiple times before seeing the outputs spent.

This should fix a weird behavior we saw that the node does not see fuel outputs (in presence of submission failures) and even some flakyness on our test suites.