### PR TITLE
Use a consistent chain point for TinyWallet

### DIFF
--- a/hydra-cardano-api/src/Hydra/Cardano/Api.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api.hs
@@ -73,6 +73,7 @@ import Cardano.Api.Byron as X (
  )
 import Cardano.Api.Shelley as X (
   Address (..),
+  Hash (HeaderHash),
   Key (..),
   PlutusScriptOrReferenceInput (PScript),
   PoolId,

--- a/hydra-cardano-api/src/Hydra/Cardano/Api.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api.hs
@@ -72,6 +72,7 @@ import Cardano.Api.Byron as X (
   Address (..),
  )
 import Cardano.Api.Shelley as X (
+  AcquireFailure (..),
   Address (..),
   Hash (HeaderHash),
   Key (..),

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -205,14 +205,7 @@ withDirectChain tracer networkId iocp socketPath keyPair party cardanoKeys mpoin
             (versions networkId client)
             socketPath
       )
-      ( do
-          -- FIXME: There's currently a race-condition with the actual client
-          -- which will only see transactions after it has established
-          -- connection with the server's tip. So any transaction submitted
-          -- before that tip will be missed.
-          threadDelay 2
-          action chainHandle
-      )
+      (action chainHandle)
   case res of
     Left () -> error "'connectTo' cannot terminate but did?"
     Right a -> pure a


### PR DESCRIPTION
As we made the wallet "interleaved", where we provide it with blocks through 'update', we need to also give it a starting point from where it queries.

![image](https://user-images.githubusercontent.com/2621189/193521227-a4b1a911-b83b-48be-9be7-1dfcca7fcd02.png)

The fact that it still uses the local state query to get the initial utxo is another problem not solved in this. Related issue #439 