### PR TITLE
fix(node): do not discard InitObservation when some keys don't match

### DIFF
--- a/hydra-node/src/Hydra/Chain/CardanoClient.hs
+++ b/hydra-node/src/Hydra/Chain/CardanoClient.hs
@@ -12,6 +12,7 @@ import qualified Cardano.Api.UTxO as UTxO
 import Cardano.Slotting.Time (SystemStart)
 import qualified Data.Set as Set
 import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (EraMismatch)
+import Ouroboros.Network.Protocol.LocalStateQuery.Type (AcquireFailure)
 import Ouroboros.Network.Protocol.LocalTxSubmission.Client (SubmitResult (..))
 import Test.QuickCheck (oneof)
 

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -386,7 +386,7 @@ observeInit ::
   Tx ->
   Maybe (OnChainTx Tx, InitialState)
 observeInit ctx tx = do
-  observation <- observeInitTx networkId (allVerificationKeys ctx) ownParty tx
+  observation <- observeInitTx networkId ownParty tx
   pure (toEvent observation, toState observation)
  where
   toEvent InitObservation{contestationPeriod, parties} =

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -386,7 +386,7 @@ observeInit ::
   Tx ->
   Maybe (OnChainTx Tx, InitialState)
 observeInit ctx tx = do
-  observation <- observeInitTx networkId ownParty tx
+  observation <- observeInitTx networkId (ownVerificationKey ctx) ownParty tx
   pure (toEvent observation, toState observation)
  where
   toEvent InitObservation{contestationPeriod, parties} =

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
@@ -144,6 +144,7 @@ import qualified Data.Map as Map
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
 import Data.Typeable (typeOf)
+import Hydra.Chain (OnChainTx (OnInitTx))
 import Hydra.Chain.Direct.Fixture (genForParty, testPolicyId)
 import qualified Hydra.Chain.Direct.Fixture as Fixture
 import Hydra.Chain.Direct.State (ChainState (..), observeSomeTx)
@@ -244,6 +245,8 @@ propTransactionIsNotObserved :: (Tx, UTxO) -> ChainState -> Property
 propTransactionIsNotObserved (tx, _) st =
   case observeSomeTx tx st of
     Nothing ->
+      property True
+    Just (OnInitTx{}, _) ->
       property True
     Just (onChainTx, st') ->
       property False

--- a/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
@@ -90,7 +90,7 @@ spec = parallel $ do
       propTransactionValidates healthyInitTx
     prop "does not survive random adversarial mutations (on-chain)" $
       propMutationOnChain healthyInitTx genInitMutation
-    prop "does not survive random adversarial mutations (off-chain)" $
+    prop "pepe does not survive random adversarial mutations (off-chain)" $
       propMutationOffChain healthyInitTx genObserveInitMutation (Idle <$> genHealthyIdleState)
 
   describe "Abort" $ do

--- a/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
@@ -90,7 +90,7 @@ spec = parallel $ do
       propTransactionValidates healthyInitTx
     prop "does not survive random adversarial mutations (on-chain)" $
       propMutationOnChain healthyInitTx genInitMutation
-    prop "pepe does not survive random adversarial mutations (off-chain)" $
+    prop "does not survive random adversarial mutations (off-chain)" $
       propMutationOffChain healthyInitTx genObserveInitMutation (Idle <$> genHealthyIdleState)
 
   describe "Abort" $ do

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -149,12 +149,12 @@ spec =
                               & cover 80 True "Success"
 
       prop "cover fee correctly handles redeemers" $
-        withMaxSuccess 60 $ \txIn cperiod (party :| parties) cardanoKeys walletUTxO ->
+        withMaxSuccess 60 $ \txIn cperiod (party :| parties) (ownKey :| cardanoKeys) walletUTxO ->
           forAll (genForParty genVerificationKey <$> elements (party : parties)) $ \signer ->
             forAll genScriptRegistry $ \scriptRegistry ->
               let params = HeadParameters cperiod (party : parties)
                   tx = initTx testNetworkId cardanoKeys params txIn
-               in case observeInitTx testNetworkId party tx of
+               in case observeInitTx testNetworkId ownKey party tx of
                     Just InitObservation{initials, threadOutput} -> do
                       let InitialThreadOutput{initialThreadUTxO = (headInput, headOutput, headDatum)} = threadOutput
                           initials' = Map.fromList [(a, (b, c)) | (a, b, c) <- initials]

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -154,7 +154,7 @@ spec =
             forAll genScriptRegistry $ \scriptRegistry ->
               let params = HeadParameters cperiod (party : parties)
                   tx = initTx testNetworkId cardanoKeys params txIn
-               in case observeInitTx testNetworkId cardanoKeys party tx of
+               in case observeInitTx testNetworkId party tx of
                     Just InitObservation{initials, threadOutput} -> do
                       let InitialThreadOutput{initialThreadUTxO = (headInput, headOutput, headDatum)} = threadOutput
                           initials' = Map.fromList [(a, (b, c)) | (a, b, c) <- initials]


### PR DESCRIPTION
Fixes #529 

⛵ Make InitTx observable, by being less strict on the discarding rule.

⛵ Now we only discard in case the party tokens are not found in the minted assets for the InitTx.

⛵This should make it easier to see if a Head has been initialized or if there is a misconfiguration.
