### PR TITLE
Refactor ConfirmedSnapshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ result*
 *.hi
 *.o
 test-results.xml
+hydra-node/golden/*.faulty.*
 
 # Benchmark results
 *.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ changes.
 
 - **BREAKING** The `hydra-cluster` executable (our smoke test) does require `--publish-scripts` or `--hydra-scripts-tx-id` now as it may be provided with pre-published hydra scripts.
 
+- **BREAKING** The `InitialSnapshot` only contains the `initialUTxO` as the rest of the information was useless.
+
 - Added a `hydra-tools` executable, which provides basic commands to help working with Hydra Heads:
   + Generate a pair of Hydra keys
   + Output the marker datum hash

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -358,6 +358,7 @@ test-suite tests
     , typed-protocols-examples
     , websockets
     , yaml
+    , versions
 
   build-tool-depends: hspec-discover:hspec-discover -any
   ghc-options:        -threaded -rtsopts

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -611,11 +611,11 @@ components:
         type: object
         additionalProperties: false
         required:
-          - snapshot
+          - initialUTxO
           - tag
         properties:
-          snapshot:
-            $ref: "#/components/schemas/Snapshot"
+          initialUTxO:
+            $ref: "#/components/schemas/UTxO"
           tag:
             type: string
             enum: ["InitialSnapshot"]

--- a/hydra-node/src/Hydra/Chain/Direct/Context.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Context.hs
@@ -197,14 +197,16 @@ genStClosed ctx utxo = do
   (u0, stOpen) <- genStOpen ctx
   confirmed <- arbitrary
   let (sn, snapshot, toFanout) = case confirmed of
-        cf@InitialSnapshot{snapshot = s} ->
+        InitialSnapshot{} ->
           ( 0
-          , cf{snapshot = s{utxo = u0}}
+          , InitialSnapshot {initialUtxo = u0}
           , u0
           )
-        cf@ConfirmedSnapshot{snapshot = s} ->
-          ( number s
-          , cf{snapshot = s{utxo = utxo}}
+        ConfirmedSnapshot{snapshot = snap, signatures} ->
+          ( number snap
+          , ConfirmedSnapshot
+            { snapshot = snap { utxo = utxo }
+            , signatures}
           , utxo
           )
   pointInTime <- genPointInTime

--- a/hydra-node/src/Hydra/Chain/Direct/Context.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Context.hs
@@ -199,7 +199,7 @@ genStClosed ctx utxo = do
   let (sn, snapshot, toFanout) = case confirmed of
         InitialSnapshot{} ->
           ( 0
-          , InitialSnapshot {initialUtxo = u0}
+          , InitialSnapshot {initialUTxO = u0}
           , u0
           )
         ConfirmedSnapshot{snapshot = snap, signatures} ->

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -45,7 +45,7 @@ import Hydra.Data.ContestationPeriod (posixToUTCTime)
 import Hydra.Ledger (IsTx (hashUTxO))
 import Hydra.Ledger.Cardano (genVerificationKey)
 import Hydra.Party (Party)
-import Hydra.Snapshot (ConfirmedSnapshot (..), Snapshot (..))
+import Hydra.Snapshot (ConfirmedSnapshot (..), Snapshot (..), getSnapshot)
 import Test.QuickCheck (sized)
 
 -- | A class for accessing the known 'UTxO' set in a type. This is useful to get
@@ -335,10 +335,10 @@ contest ::
 contest st confirmedSnapshot pointInTime = do
   contestTx ownVerificationKey sn sigs pointInTime closedThreadOutput
  where
-  (sn, sigs) =
+  (sn, sigs) = 
     case confirmedSnapshot of
-      ConfirmedSnapshot{snapshot, signatures} -> (snapshot, signatures)
-      InitialSnapshot{snapshot} -> (snapshot, mempty)
+      ConfirmedSnapshot{signatures} -> (getSnapshot confirmedSnapshot, signatures)
+      _ -> (getSnapshot confirmedSnapshot, mempty)
 
   ClosedState
     { ctx = ChainContext{ownVerificationKey}

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -368,7 +368,7 @@ onInitialChainCollectTx previousRecoverableState parameters committed =
   -- For example, we do expect `null remainingParties` but what happens if
   -- it's untrue?
   let u0 = fold committed
-      initialSnapshot = InitialSnapshot $ Snapshot 0 u0 mempty
+      initialSnapshot = InitialSnapshot u0
    in NewState
         ( OpenState
             { parameters

--- a/hydra-node/src/Hydra/Snapshot.hs
+++ b/hydra-node/src/Hydra/Snapshot.hs
@@ -70,7 +70,7 @@ instance (FromCBOR tx, FromCBOR (UTxOType tx)) => FromCBOR (Snapshot tx) where
 
 -- | A snapshot that can be used to close a head with. Either the initial one, or when it was signed by all parties, i.e. it is confirmed.
 data ConfirmedSnapshot tx
-  = InitialSnapshot { initialUtxo :: UTxOType tx }
+  = InitialSnapshot { initialUTxO :: UTxOType tx }
   | ConfirmedSnapshot
       { snapshot :: Snapshot tx
       , signatures :: MultiSignature (Snapshot tx)
@@ -86,10 +86,10 @@ data ConfirmedSnapshot tx
 -- | Safely get a 'Snapshot' from a confirmed snapshot.
 getSnapshot :: ConfirmedSnapshot tx -> Snapshot tx
 getSnapshot = \case
-  InitialSnapshot{initialUtxo} ->
+  InitialSnapshot{initialUTxO} ->
     Snapshot
     { number = 0
-    , utxo = initialUtxo
+    , utxo = initialUTxO
     , confirmed = []
     }
   ConfirmedSnapshot{snapshot} -> snapshot

--- a/hydra-node/src/Hydra/Snapshot.hs
+++ b/hydra-node/src/Hydra/Snapshot.hs
@@ -68,7 +68,7 @@ instance (ToCBOR tx, ToCBOR (UTxOType tx)) => ToCBOR (Snapshot tx) where
 instance (FromCBOR tx, FromCBOR (UTxOType tx)) => FromCBOR (Snapshot tx) where
   fromCBOR = Snapshot <$> fromCBOR <*> fromCBOR <*> fromCBOR
 
--- | Snapshot when it was signed by all parties, i.e. it is confirmed.
+-- | A snapshot that can be used to close a head with. Either the initial one, or when it was signed by all parties, i.e. it is confirmed.
 data ConfirmedSnapshot tx
   = InitialSnapshot { initialUtxo :: UTxOType tx }
   | ConfirmedSnapshot

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -337,7 +337,7 @@ inOpenState parties Ledger{initUTxO} =
   inOpenState' parties $ CoordinatedHeadState u0 mempty snapshot0 NoSeenSnapshot
  where
   u0 = initUTxO
-  snapshot0 = InitialSnapshot $ Snapshot 0 u0 mempty
+  snapshot0 = InitialSnapshot u0
 
 inOpenState' ::
   [Party] ->
@@ -359,7 +359,7 @@ inClosedState :: [Party] -> HeadState SimpleTx
 inClosedState parties = inClosedState' parties snapshot0
  where
   u0 = initUTxO simpleLedger
-  snapshot0 = InitialSnapshot $ Snapshot 0 u0 mempty
+  snapshot0 = InitialSnapshot u0
 
 inClosedState' :: [Party] -> ConfirmedSnapshot SimpleTx -> HeadState SimpleTx
 inClosedState' parties confirmedSnapshot =

--- a/hydra-node/test/Hydra/JSONSchema.hs
+++ b/hydra-node/test/Hydra/JSONSchema.hs
@@ -22,10 +22,12 @@ import System.Exit (ExitCode (..))
 import System.FilePath (normalise, takeBaseName, takeExtension, (<.>), (</>))
 import System.Process (readProcessWithExitCode)
 import Test.Hspec (pendingWith)
-import Test.Hydra.Prelude (createSystemTempDirectory)
+import Test.Hydra.Prelude (createSystemTempDirectory, failure)
 import Test.QuickCheck (Property, conjoin, counterexample, forAllBlind, forAllShrink, vectorOf, withMaxSuccess)
 import Test.QuickCheck.Monadic (assert, monadicIO, monitor, run)
 import qualified Prelude
+import System.IO.Error (IOError, ioeGetErrorType)
+import GHC.IO.Exception (IOErrorType(OtherError))
 
 -- | Generate arbitrary serializable (JSON) value, and check their validity
 -- against a known JSON schema.
@@ -158,12 +160,17 @@ ensureSystemRequirements ::
   IO ()
 ensureSystemRequirements = do
   getToolVersion >>= \case
-    Just "3.2.0" -> pure ()
-    _ -> pendingWith "This test requires the python library 'jsonschema==3.2.0' to be in scope."
+    Right "3.2.0" -> pure ()
+    Right _ -> failure "This test requires the python library 'jsonschema==3.2.0' to be in scope."
+    Left errorMsg -> failure errorMsg
  where
   -- Returns 'Nothing' when not available and 'Just <version number>' otherwise.
   getToolVersion ::
-    IO (Maybe String)
+    IO (Either String String)
   getToolVersion = do
-    (exitCode, out, _) <- readProcessWithExitCode "jsonschema" ["--version"] mempty
-    pure (dropWhileEnd isSpace out <$ guard (exitCode == ExitSuccess))
+    try (readProcessWithExitCode "jsonschema" ["--version"] mempty) >>= \case
+      Right (exitCode, out, _) -> pure (dropWhileEnd isSpace out <$ guard (exitCode == ExitSuccess))
+      Left (err :: IOError)
+        | ioeGetErrorType err == OtherError ->
+            pure (Left $ "Check jsonschema is installed and in $PATH")
+      Left err -> pure (Left $ show err)

--- a/hydra-node/test/Hydra/SnapshotStrategySpec.hs
+++ b/hydra-node/test/Hydra/SnapshotStrategySpec.hs
@@ -51,7 +51,7 @@ spec = do
               CoordinatedHeadState
                 { seenUTxO = initUTxO
                 , seenTxs = [tx]
-                , confirmedSnapshot = InitialSnapshot $ Snapshot 0 initUTxO mempty
+                , confirmedSnapshot = InitialSnapshot initUTxO
                 , seenSnapshot = NoSeenSnapshot
                 }
         newSn (envFor aliceSk) params st `shouldBe` ShouldSnapshot 1 [tx]
@@ -66,7 +66,7 @@ spec = do
               CoordinatedHeadState
                 { seenUTxO = initUTxO
                 , seenTxs = [tx]
-                , confirmedSnapshot = InitialSnapshot $ Snapshot 0 initUTxO mempty
+                , confirmedSnapshot = InitialSnapshot initUTxO
                 , seenSnapshot = NoSeenSnapshot
                 }
         newSn (envFor bobSk) params st `shouldBe` ShouldNotSnapshot (NotLeader 1)
@@ -77,7 +77,7 @@ spec = do
               CoordinatedHeadState
                 { seenUTxO = initUTxO
                 , seenTxs = mempty
-                , confirmedSnapshot = InitialSnapshot $ Snapshot 0 initUTxO mempty
+                , confirmedSnapshot = InitialSnapshot initUTxO
                 , seenSnapshot = SeenSnapshot sn1 mempty
                 }
         newSn (envFor aliceSk) params st `shouldBe` ShouldNotSnapshot (SnapshotInFlight 1)
@@ -87,7 +87,7 @@ spec = do
               CoordinatedHeadState
                 { seenUTxO = initUTxO
                 , seenTxs = mempty
-                , confirmedSnapshot = InitialSnapshot $ Snapshot 0 initUTxO mempty
+                , confirmedSnapshot = InitialSnapshot initUTxO
                 , seenSnapshot = NoSeenSnapshot
                 } ::
                 CoordinatedHeadState SimpleTx
@@ -100,7 +100,7 @@ spec = do
                 CoordinatedHeadState
                   { seenUTxO = initUTxO
                   , seenTxs = [tx]
-                  , confirmedSnapshot = InitialSnapshot $ Snapshot 0 initUTxO mempty
+                  , confirmedSnapshot = InitialSnapshot initUTxO
                   , seenSnapshot = NoSeenSnapshot
                   }
               st =


### PR DESCRIPTION
An InitialSnapshot always has number 0 and an empty list of confirmed transactions.
So we make it explicit in the type system to avoid issues with that.