### PR TITLE
fix(docs): update hydra-node-options section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ changes.
 
 - Prevent transactions from being resubmitted for application over and over [#485](https://github.com/input-output-hk/hydra-poc/issues/485)
 
+- Update [hydra-node-options](https://hydra.family/head-protocol/docs/getting-started/quickstart/#hydra-node-options) section in docs.
+
 ## [0.7.0] - 2022-08-23
 
 - **BREAKING** Switch to `BabbageEra` and `PlutusV2`.

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -26,11 +26,11 @@ Options                                                       | Description
 ---                                                           | ---
 `--node-id`                                                   | The Hydra node identifier, serving as identifier within the Head network.
 `--host` <br/> `--port`                                       | This Hydra node host and port, to which peers from the Hydra network can connect to.
-`--peer`                                                      | The Hydra network peers address. Must be provided multiple time, one for each peer.
-`--hydra-verification-key` <br/> `--cardano-verification-key` | The Cardano and Hydra credentials for peers. Those options may also be provided multiple times depending on the number of peers.
+`--peer`                                                      | The Hydra network peers address.<br />Must be provided multiple time, one for each peer.
+`--hydra-verification-key` <br/> `--cardano-verification-key` | The Cardano and Hydra credentials for peers.<br />Those options must also be provided multiple times, depending on the number of peers.
 `--hydra-signing-key` <br/> `--cardano-signing-key`           | The Cardano and Hydra credentials for the node itself.
-`--hydra-scripts-tx-id`                                       | A transaction id referencing Hydra's Plutus scripts. See release notes.
-`--node-socket`                                               | The Cardano node's IPC socket filepath, used for inter-process communication with the node.
+`--hydra-scripts-tx-id`                                       | A transaction id referencing Hydra's Plutus scripts.<br />See release notes.
+`--node-socket`                                               | The Cardano node's IPC socket filepath.<br />Used for inter-process communication with the node.
 `--ledger-genesis` <br/> `--ledger-protocol-parameters`       | The Hydra ledger rules and parameters for the head.
 
 Also, optionally:
@@ -39,9 +39,9 @@ Options                         | Description
 ---                             | ---
 `--verbosity`                   | Turn on/off logging. Default is on. Turn off by passing 'quiet' as value.
 `--api-host` <br/> `--api-port` | The Hydra API host and port, to interact with the [WebSocket API](/api-reference).
-`--monitoring-port`             | The port this node listens on for monitoring and metrics via Prometheus. If left empty, monitoring server is not started.
+`--monitoring-port`             | The port this node listens on for monitoring and metrics via Prometheus.<br /> If left empty, monitoring server is not started.
 `--network-id`                  | The id of a test network to conect, with the given network magic.
-`--start-chain-from`            | The id of the block we want to start observing the ledger from. Composed by the slot number, a saparor (".") and the hash of the block header (i.e.: 52970883.d36a9936ae7a07f5f4bdc9ad0b23761cb7b14f35007e54947e27a1510f897f04)
+`--start-chain-from`            | The id of the block we want to start observing the ledger from.<br /> Composed by the slot number, a saparor (".") and the hash of the block header <br /> (i.e.: 52970883.d36a9936ae7a07f5f4bdc9ad0b23761cb7b14f35007e54947e27a1510f897f04)
 
 :::info  Dynamic Configuration
 

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -39,9 +39,9 @@ Options                         | Description
 ---                             | ---
 `--verbosity`                   | Turn on/off logging. Default is on. Turn off by passing 'quiet' as value.
 `--api-host` <br/> `--api-port` | The Hydra API host and port, to interact with the [WebSocket API](/api-reference).
-`--monitoring-port`             | The port this node listens on for monitoring and metrics via Prometheus.<br /> If left empty, monitoring server is not started.
+`--monitoring-port`             | The port this node listens on for monitoring and metrics via Prometheus.<br />If left empty, monitoring server is not started.
 `--network-id`                  | The id of a test network to conect, with the given network magic.
-`--start-chain-from`            | The id of the block we want to start observing the ledger from.<br /> Composed by the slot number, a saparor (".") and the hash of the block header <br /> (i.e.: 52970883.d36a9936ae7a07f5f4bdc9ad0b23761cb7b14f35007e54947e27a1510f897f04)
+`--start-chain-from`            | The id of the block we want to start observing the ledger from.<br />Composed by the slot number, a saparor (".") and the hash of the block header.<br />(i.e.: 52970883.d36a9936ae7a07f5f4bdc9ad0b23761cb7b14f35007e54947e27a1510f897f04)
 
 :::info  Dynamic Configuration
 

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -37,7 +37,7 @@ Also, optionally:
 
 Options                         | Description
 ---                             | ---
-`--verbosity`                   | Turn on/off logging. Default is on. Turn off by passing 'quiet' as value.
+`--quiet`                   | Turn off logging when given, default is on.
 `--api-host` <br/> `--api-port` | The Hydra API host and port, to interact with the [WebSocket API](/api-reference).
 `--monitoring-port`             | The port this node listens on for monitoring and metrics via Prometheus.<br />If left empty, monitoring server is not started.
 `--network-id`                  | The id of a test network to conect, with the given network magic.

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -41,7 +41,7 @@ Options                         | Description
 `--api-host` <br/> `--api-port` | The Hydra API host and port, to interact with the [WebSocket API](/api-reference).
 `--monitoring-port`             | The port this node listens on for monitoring and metrics via Prometheus.<br />If left empty, monitoring server is not started.
 `--network-id`                  | The id of a test network to conect, with the given network magic.
-`--start-chain-from`            | The id of the block we want to start observing the ledger from.<br />Composed by the slot number, a saparor (".") and the hash of the block header.<br />(i.e.: 52970883.d36a9936ae7a07f5f4bdc9ad0b23761cb7b14f35007e54947e27a1510f897f04)
+`--start-chain-from`            | The id of the block we want to start observing the ledger from.<br />Composed by the slot number, a separator (".") and the hash of the block header. For example: 52970883.d36a9936ae7a07f5f4bdc9ad0b23761cb7b14f35007e54947e27a1510f897f04
 
 :::info  Dynamic Configuration
 

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -22,22 +22,26 @@ This image contains both `cardano-node` and `cardano-cli`. The latter is handy t
 
 So far, the `hydra-node` command-line provide a single command only for starting a node. The entire configuration is provided through command-line options and is fully static. Options are used to configured various elements, and can be summarized as follows (note however that reference documentation for those options is available under the `--help` flag):
 
-Options                                                 | Description
----                                                     | ---
-`--node-id`                                             | The Hydra node identifier, serving as identifier within the Head network.
-`--peer`                                                | The Hydra network peers address. Must be provided multiple time, one for each peer.
-`--host` <br/> `--port`                                 | This Hydra node host and port, to which peers from the Hydra network can connect to.
-`--node-socket`                                         | The Cardano node's IPC socket filepath, used for inter-process communication with the node.
-`--ledger-genesis` <br/> `--ledger-protocol-parameters` | The Hydra ledger rules and parameters for the head.
-`--hydra-scripts-tx-id`                                 | A transaction id referencing Hydra's Plutus scripts. See release notes.
-`--hydra-signing-key` <br/> `--cardano-signing-key` <br/> `--hydra-verification-key` <br/> `--cardano-verification-key` | The Cardano and Hydra credentials for peers and the node itself. Those options may also be provided multiple times depending on the number of peers.
+Options                                                       | Description
+---                                                           | ---
+`--node-id`                                                   | The Hydra node identifier, serving as identifier within the Head network.
+`--host` <br/> `--port`                                       | This Hydra node host and port, to which peers from the Hydra network can connect to.
+`--peer`                                                      | The Hydra network peers address. Must be provided multiple time, one for each peer.
+`--hydra-verification-key` <br/> `--cardano-verification-key` | The Cardano and Hydra credentials for peers. Those options may also be provided multiple times depending on the number of peers.
+`--hydra-signing-key` <br/> `--cardano-signing-key`           | The Cardano and Hydra credentials for the node itself.
+`--hydra-scripts-tx-id`                                       | A transaction id referencing Hydra's Plutus scripts. See release notes.
+`--node-socket`                                               | The Cardano node's IPC socket filepath, used for inter-process communication with the node.
+`--ledger-genesis` <br/> `--ledger-protocol-parameters`       | The Hydra ledger rules and parameters for the head.
 
 Also, optionally:
 
 Options                         | Description
 ---                             | ---
+`--verbosity`                   | Turn on/off logging. Default is on. Turn off by passing 'quiet' as value.
 `--api-host` <br/> `--api-port` | The Hydra API host and port, to interact with the [WebSocket API](/api-reference).
 `--monitoring-port`             | The port this node listens on for monitoring and metrics via Prometheus. If left empty, monitoring server is not started.
+`--network-id`                  | The id of a test network to conect, with the given network magic.
+`--start-chain-from`            | The id of the block we want to start observing the ledger from. Composed by the slot number, a saparor (".") and the hash of the block header (i.e.: 52970883.d36a9936ae7a07f5f4bdc9ad0b23761cb7b14f35007e54947e27a1510f897f04)
 
 :::info  Dynamic Configuration
 


### PR DESCRIPTION
Fixes #542 

🔧  Update [hydra-node-options](https://hydra.family/head-protocol/docs/getting-started/quickstart#hydra-node-options) section in docs to reflect the latest changes.

🔧 Reorder items in the section to better match with `RunOptions`. 

🔧 Keep **peers** related config as close as possible to improve readability.

🔧 Split **key** arguments (in peers and itself ) for the same reason above.

🔧 Add break lines in descriptions to improve cells spacing.

To check before merging:
* [X] CHANGELOG is up to date