### PR TITLE
538 the ping hostnames are overlapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ result*
 *.o
 test-results.xml
 hydra-node/golden/*.faulty.*
+hspec-results.md
 
 # Benchmark results
 *.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,15 +30,15 @@ changes.
   +  Take a look at the [example] (https://github.com/input-output-hk/hydra-poc/blob/master/docs/docs/getting-started/quickstart.md#hydra-keys)
   +  on how to use `hydra-tools` to generate necessary hydra keys.
 
+- **BREAKING** hydra-node command line flag `--node-id` is now mandatory.
+  + Instead of `Host` we are using the `node-id` in the server messages like + `PeerConnected/Disconnected` which are also used in
+  + the TUI to distinguish between different connected peers.
+
 - Added a `hydra-tools` executable, which provides basic commands to help working with Hydra Heads:
   + Generate a pair of Hydra keys
   + Output the marker datum hash
 
 - Added some sample Terraform-based configuration files to spin up GCP and AWS Hydra node
-
-- hydra-node command line flag `--node-id` is converted from `INT` to `TEXT`. Instead of `Host` we are using the `node-id`
-  in the server messages like `PeerConnected/Disconnected` which is also used in the TUI to
-  distinguish between different connected peers.
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ changes.
 
 - Added some sample Terraform-based configuration files to spin up GCP and AWS Hydra node
 
+- hydra-node command line flag `--node-id` is converted from `INT` to `TEXT`. Instead of `Host` we are using the `node-id`
+  in the server messages like `PeerConnected/Disconnected` which is also used in the TUI to
+  distinguish between different connected peers.
+
 #### Fixed
 
 - Prevent transactions from being resubmitted for application over and over [#485](https://github.com/input-output-hk/hydra-poc/issues/485)

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -33,6 +33,7 @@ import Data.Aeson (Value (String), object, (.=))
 import qualified Data.Aeson as Aeson
 import Data.Aeson.Types (Pair)
 import qualified Data.List as List
+import Data.Text (pack)
 import qualified Data.Text as T
 import qualified Data.Text as Text
 import Hydra.Cluster.Faucet (FaucetLog)
@@ -361,11 +362,7 @@ waitForNodesConnected tracer clients =
         ( \nodeId ->
             object
               [ "tag" .= String "PeerConnected"
-              , "peer"
-                  .= object
-                    [ "hostname" .= ("127.0.0.1" :: Text)
-                    , "port" .= (5000 + nodeId)
-                    ]
+              , "peer" .= String (pack $ show nodeId)
               ]
         )
         (filter (/= hydraNodeId) allNodeIds)

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -35,13 +35,12 @@ import Data.Aeson.Types (Pair)
 import qualified Data.List as List
 import Data.Text (pack)
 import qualified Data.Text as T
-import qualified Data.Text as Text
 import Hydra.Cluster.Faucet (FaucetLog)
 import Hydra.Cluster.Util (readConfigFile)
 import Hydra.Crypto (HydraKey)
 import Hydra.Ledger.Cardano ()
 import Hydra.Logging (Tracer, Verbosity (..), traceWith)
-import Hydra.Network (Host (Host))
+import Hydra.Network (Host (Host), NodeId (NodeId))
 import qualified Hydra.Network as Network
 import Hydra.Options (ChainConfig (..), LedgerConfig (..), RunOptions (..), defaultChainConfig, toArgs)
 import Network.HTTP.Conduit (HttpExceptionContent (ConnectionFailure), parseRequest)
@@ -285,7 +284,7 @@ withHydraNode tracer chainConfig workDir hydraNodeId hydraSKey hydraVKeys allNod
             ( hydraNodeProcess $
                 RunOptions
                   { verbosity = Verbose "HydraNode"
-                  , nodeId = Text.pack . show $ hydraNodeId
+                  , nodeId = NodeId $ show hydraNodeId
                   , host = "127.0.0.1"
                   , port = fromIntegral $ 5000 + hydraNodeId
                   , peers

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -34,6 +34,7 @@ import qualified Data.Aeson as Aeson
 import Data.Aeson.Types (Pair)
 import qualified Data.List as List
 import qualified Data.Text as T
+import qualified Data.Text as Text
 import Hydra.Cluster.Faucet (FaucetLog)
 import Hydra.Cluster.Util (readConfigFile)
 import Hydra.Crypto (HydraKey)
@@ -283,7 +284,7 @@ withHydraNode tracer chainConfig workDir hydraNodeId hydraSKey hydraVKeys allNod
             ( hydraNodeProcess $
                 RunOptions
                   { verbosity = Verbose "HydraNode"
-                  , nodeId = fromIntegral hydraNodeId
+                  , nodeId = Text.pack . show $ hydraNodeId
                   , host = "127.0.0.1"
                   , port = fromIntegral $ 5000 + hydraNodeId
                   , peers

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -23,7 +23,7 @@ import Hydra.Ledger.Cardano.Configuration (
 import Hydra.Logging (Tracer, Verbosity (..), withTracer)
 import Hydra.Logging.Messages (HydraLog (..))
 import Hydra.Logging.Monitoring (withMonitoring)
-import Hydra.Network (Host (..))
+import Hydra.Network (Host (..), HydraNodeId (HydraNodeId))
 import Hydra.Network.Heartbeat (withHeartbeat)
 import Hydra.Network.Ouroboros (withIOManager, withOuroborosNetwork)
 import Hydra.Node (
@@ -77,7 +77,7 @@ main = do
 
   withNetwork tracer host port peers nodeId =
     let localhost = Host{hostname = show host, port}
-     in withHeartbeat nodeId $ withOuroborosNetwork tracer localhost peers
+     in withHeartbeat (HydraNodeId nodeId) $ withOuroborosNetwork tracer localhost peers
 
   withCardanoLedger ledgerConfig action = do
     globals <-

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -23,7 +23,7 @@ import Hydra.Ledger.Cardano.Configuration (
 import Hydra.Logging (Tracer, Verbosity (..), withTracer)
 import Hydra.Logging.Messages (HydraLog (..))
 import Hydra.Logging.Monitoring (withMonitoring)
-import Hydra.Network (Host (..), HydraNodeId (HydraNodeId))
+import Hydra.Network (Host (..), NodeId (NodeId))
 import Hydra.Network.Heartbeat (withHeartbeat)
 import Hydra.Network.Ouroboros (withIOManager, withOuroborosNetwork)
 import Hydra.Node (
@@ -77,7 +77,7 @@ main = do
 
   withNetwork tracer host port peers nodeId =
     let localhost = Host{hostname = show host, port}
-     in withHeartbeat (HydraNodeId nodeId) $ withOuroborosNetwork tracer localhost peers
+     in withHeartbeat (NodeId nodeId) $ withOuroborosNetwork tracer localhost peers
 
   withCardanoLedger ledgerConfig action = do
     globals <-

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -23,7 +23,7 @@ import Hydra.Ledger.Cardano.Configuration (
 import Hydra.Logging (Tracer, Verbosity (..), withTracer)
 import Hydra.Logging.Messages (HydraLog (..))
 import Hydra.Logging.Monitoring (withMonitoring)
-import Hydra.Network (Host (..), NodeId (NodeId))
+import Hydra.Network (Host (..))
 import Hydra.Network.Heartbeat (withHeartbeat)
 import Hydra.Network.Ouroboros (withIOManager, withOuroborosNetwork)
 import Hydra.Node (
@@ -77,7 +77,7 @@ main = do
 
   withNetwork tracer host port peers nodeId =
     let localhost = Host{hostname = show host, port}
-     in withHeartbeat (NodeId nodeId) $ withOuroborosNetwork tracer localhost peers
+     in withHeartbeat nodeId $ withOuroborosNetwork tracer localhost peers
 
   withCardanoLedger ledgerConfig action = do
     globals <-

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -60,8 +60,8 @@ main = do
         eq <- createEventQueue
         let RunOptions{hydraScriptsTxId, chainConfig} = opts
         withChain tracer party (putEvent eq . OnChainEvent) hydraScriptsTxId chainConfig $ \oc -> do
-          let RunOptions{host, port, peers} = opts
-          withNetwork (contramap Network tracer) host port peers (putEvent eq . NetworkEvent defaultTTL) $ \hn -> do
+          let RunOptions{host, port, peers, nodeId} = opts
+          withNetwork (contramap Network tracer) host port peers nodeId (putEvent eq . NetworkEvent defaultTTL) $ \hn -> do
             let RunOptions{apiHost, apiPort} = opts
             withAPIServer apiHost apiPort party (contramap APIServer tracer) (putEvent eq . ClientEvent) $ \server -> do
               let RunOptions{ledgerConfig} = opts
@@ -75,9 +75,9 @@ main = do
     txId <- publishHydraScripts networkId nodeSocket sk
     putStrLn (decodeUtf8 (serialiseToRawBytesHex txId))
 
-  withNetwork tracer host port peers =
+  withNetwork tracer host port peers nodeId =
     let localhost = Host{hostname = show host, port}
-     in withHeartbeat localhost $ withOuroborosNetwork tracer localhost peers
+     in withHeartbeat nodeId $ withOuroborosNetwork tracer localhost peers
 
   withCardanoLedger ledgerConfig action = do
     globals <-

--- a/hydra-node/golden/Message SimpleTx.json
+++ b/hydra-node/golden/Message SimpleTx.json
@@ -1,31 +1,28 @@
 {
     "samples": [
         {
-            "peer": {
-                "hostname": "0.0.4.59",
-                "port": 2142
-            },
+            "nodeId": "\u0012Y~𨄈c愱(𤪼\r\u0008l𩦊t`\"􂙨o\u0019nᓚ\u0003ez\u0005㗵ᖐ\n",
             "tag": "Disconnected"
         },
         {
             "party": {
-                "vkey": "86d2b6713d0cd0e4ef92e2ba10850ba53a8501c5fc9132287bd9945a46f9c204"
+                "vkey": "d4a58e92bb48486978c8b0bad4f22de41df6c6e07172105997b0c91b9acf518b"
             },
-            "signed": "25557f3903a1ec633298ec964dfd35fe5a80a97158a2ac50c6b708aa30a6a0f28ad012f1bb08741e9e8bc827dc1a26ea4ff1a46198dc2c474de49746c09d5601",
+            "signed": "35f4bfc9aeda1bd6de6860a0734ce68ee2d46d08d5d519004eaa449fb7f8363dbf55bc62d7e87d1dee3fba79ef4a0bc296caa153030c704466b3505c58fb1a0a",
             "snapshotNumber": 15,
             "tag": "AckSn"
         },
         {
             "party": {
-                "vkey": "fdf3c15d16bcc85eaf6349b96504da21e4197dfff255e369d656781afa9257bc"
+                "vkey": "8ea0d38fa36c03928e4aa86a5f349357ef9e41f4f5d400b6ac71a850fa682ce0"
             },
-            "signed": "991be92e4ac4167610180b644f47d12bb89bace2b4388c269479e51347b8b6353d4d7caa64040c5fc5868bf0f3336c0926fe4610f0719e33df97377179c1e50f",
+            "signed": "13b0f667985871659cfffe73e87652b44454c307a81e4679227bc67a6317a020e978fdc183a52bf2b374f65856e536e702623a49d13a6824e1a63849ee8f150c",
             "snapshotNumber": 26,
             "tag": "AckSn"
         },
         {
             "party": {
-                "vkey": "28b2fb6a709cb4ca07d350a63e2265ec83af1c929fb56921abd5c4475bb84a37"
+                "vkey": "a533e531ad92e81005836a14f87d18e8a26042fb4c450e267bee1b8443fbf5eb"
             },
             "snapshotNumber": 11,
             "tag": "ReqSn",
@@ -75,10 +72,7 @@
             ]
         },
         {
-            "peer": {
-                "hostname": "0.0.74.30",
-                "port": 2658
-            },
+            "nodeId": "\u001dQu_\u001e\u0002h󵏧􂘚󸾱\u001f5r\u0002D@\u0016ᚳ#j",
             "tag": "Connected"
         }
     ],

--- a/hydra-node/golden/ReasonablySized (ServerOutput (Tx BabbageEra)).json
+++ b/hydra-node/golden/ReasonablySized (ServerOutput (Tx BabbageEra)).json
@@ -5039,10 +5039,7 @@
             "tag": "PostTxOnChainFailed"
         },
         {
-            "peer": {
-                "hostname": "0.0.0.3",
-                "port": 3
-            },
+            "peer": "g\r󳴓",
             "tag": "PeerConnected"
         },
         {
@@ -6812,10 +6809,7 @@
             }
         },
         {
-            "peer": {
-                "hostname": "0.0.0.1",
-                "port": 8
-            },
+            "peer": "\u0014",
             "tag": "PeerDisconnected"
         },
         {
@@ -7599,10 +7593,7 @@
             }
         },
         {
-            "peer": {
-                "hostname": "0.0.0.2",
-                "port": 7
-            },
+            "peer": "􇽞󵣩",
             "tag": "PeerConnected"
         },
         {
@@ -7697,10 +7688,7 @@
             }
         },
         {
-            "peer": {
-                "hostname": "0.0.0.2",
-                "port": 6
-            },
+            "peer": "󠄉5",
             "tag": "PeerConnected"
         },
         {
@@ -9250,10 +9238,7 @@
             }
         },
         {
-            "peer": {
-                "hostname": "0.0.0.7",
-                "port": 1
-            },
+            "peer": "󱙹W\u0012!",
             "tag": "PeerDisconnected"
         },
         {
@@ -9593,10 +9578,7 @@
             }
         },
         {
-            "peer": {
-                "hostname": "0.0.0.3",
-                "port": 2
-            },
+            "peer": "C93Z𬵛󵇻",
             "tag": "PeerDisconnected"
         },
         {
@@ -10639,10 +10621,7 @@
             "tag": "HeadIsContested"
         },
         {
-            "peer": {
-                "hostname": "0.0.0.3",
-                "port": 1
-            },
+            "peer": "䖻􎄋菽cv􅺌",
             "tag": "PeerDisconnected"
         },
         {
@@ -10681,10 +10660,7 @@
             "tag": "HeadIsClosed"
         },
         {
-            "peer": {
-                "hostname": "0.0.0.0",
-                "port": 3
-            },
+            "peer": "",
             "tag": "PeerDisconnected"
         },
         {
@@ -12287,10 +12263,7 @@
             }
         },
         {
-            "peer": {
-                "hostname": "0.0.0.7",
-                "port": 7
-            },
+            "peer": "L𐡹ql$",
             "tag": "PeerDisconnected"
         },
         {
@@ -16088,10 +16061,7 @@
             }
         },
         {
-            "peer": {
-                "hostname": "0.0.0.6",
-                "port": 1
-            },
+            "peer": "Zu\u0015[𫏿􈞩",
             "tag": "PeerDisconnected"
         },
         {
@@ -19979,10 +19949,7 @@
             "tag": "HeadIsClosed"
         },
         {
-            "peer": {
-                "hostname": "0.0.0.3",
-                "port": 3
-            },
+            "peer": "\u001f.>",
             "tag": "PeerConnected"
         },
         {
@@ -21688,10 +21655,7 @@
             "tag": "HeadIsContested"
         },
         {
-            "peer": {
-                "hostname": "0.0.0.5",
-                "port": 1
-            },
+            "peer": "\u0013\u0007㲮",
             "tag": "PeerDisconnected"
         },
         {

--- a/hydra-node/golden/ReasonablySized (ServerOutput SimpleTx).json
+++ b/hydra-node/golden/ReasonablySized (ServerOutput SimpleTx).json
@@ -928,10 +928,7 @@
             }
         },
         {
-            "peer": {
-                "hostname": "0.0.0.7",
-                "port": 6
-            },
+            "peer": "grT",
             "tag": "PeerDisconnected"
         },
         {
@@ -1091,10 +1088,7 @@
             }
         },
         {
-            "peer": {
-                "hostname": "0.0.0.4",
-                "port": 2
-            },
+            "peer": "t땆\u0010\u0005",
             "tag": "PeerDisconnected"
         },
         {
@@ -1137,10 +1131,7 @@
             ]
         },
         {
-            "peer": {
-                "hostname": "0.0.0.8",
-                "port": 6
-            },
+            "peer": "",
             "tag": "PeerDisconnected"
         },
         {
@@ -1682,10 +1673,7 @@
             ]
         },
         {
-            "peer": {
-                "hostname": "0.0.0.4",
-                "port": 8
-            },
+            "peer": "t𤾓\u0013\u000b",
             "tag": "PeerDisconnected"
         },
         {
@@ -1867,10 +1855,7 @@
             "tag": "ReadyToFanout"
         },
         {
-            "peer": {
-                "hostname": "0.0.0.1",
-                "port": 5
-            },
+            "peer": " ",
             "tag": "PeerConnected"
         },
         {
@@ -1912,10 +1897,7 @@
             }
         },
         {
-            "peer": {
-                "hostname": "0.0.0.4",
-                "port": 4
-            },
+            "peer": "󱦹]\u0004\u0007",
             "tag": "PeerConnected"
         },
         {
@@ -2154,10 +2136,7 @@
             }
         },
         {
-            "peer": {
-                "hostname": "0.0.0.5",
-                "port": 2
-            },
+            "peer": "\u0007[u􎹕",
             "tag": "PeerDisconnected"
         },
         {
@@ -2184,10 +2163,7 @@
             "tag": "ReadyToCommit"
         },
         {
-            "peer": {
-                "hostname": "0.0.0.4",
-                "port": 1
-            },
+            "peer": "9*\u0016",
             "tag": "PeerConnected"
         },
         {
@@ -2203,10 +2179,7 @@
             ]
         },
         {
-            "peer": {
-                "hostname": "0.0.0.2",
-                "port": 6
-            },
+            "peer": "Ku`WK",
             "tag": "PeerConnected"
         },
         {
@@ -2219,10 +2192,7 @@
             "tag": "Greetings"
         },
         {
-            "peer": {
-                "hostname": "0.0.0.5",
-                "port": 3
-            },
+            "peer": "󽝉<H\u0001",
             "tag": "PeerDisconnected"
         },
         {
@@ -2251,10 +2221,7 @@
             "tag": "HeadIsContested"
         },
         {
-            "peer": {
-                "hostname": "0.0.0.4",
-                "port": 6
-            },
+            "peer": "[>􁓥\u000e",
             "tag": "PeerConnected"
         },
         {

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -235,7 +235,7 @@ components:
             type: string
             enum: ["PeerConnected"]
           peer:
-            $ref: "#/components/schemas/Peer"
+            $ref: "#/components/schemas/HydraNodeId"
 
     PeerDisconnected:
       title: PeerDisconnected
@@ -251,7 +251,7 @@ components:
             type: string
             enum: ["PeerDisconnected"]
           peer:
-            $ref: "#/components/schemas/Peer"
+            $ref: "#/components/schemas/HydraNodeId"
 
     ReadyToCommit:
       title: ReadyToCommit
@@ -699,6 +699,16 @@ components:
             "hostname": "10.0.0.10",
             "port": 5001
         }
+
+    HydraNodeId:
+      type: object
+      description: Hydra Node identifier
+      properties:
+        hydraNodeId:
+          type: string
+      example:
+        { "hydraNodeId" : "some hydra-node id" }
+
 
     Point:
       description: |

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -235,7 +235,7 @@ components:
             type: string
             enum: ["PeerConnected"]
           peer:
-            $ref: "#/components/schemas/HydraNodeId"
+            $ref: "#/components/schemas/NodeId"
 
     PeerDisconnected:
       title: PeerDisconnected
@@ -251,7 +251,7 @@ components:
             type: string
             enum: ["PeerDisconnected"]
           peer:
-            $ref: "#/components/schemas/HydraNodeId"
+            $ref: "#/components/schemas/NodeId"
 
     ReadyToCommit:
       title: ReadyToCommit
@@ -700,15 +700,10 @@ components:
             "port": 5001
         }
 
-    HydraNodeId:
-      type: object
+    NodeId:
+      type: string
       description: Hydra Node identifier
-      properties:
-        hydraNodeId:
-          type: string
-      example:
-        { "hydraNodeId" : "some hydra-node id" }
-
+      example: "some hydra-node id"
 
     Point:
       description: |

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -814,7 +814,7 @@ definitions:
             type: string
             enum: ["Connected"]
           nodeId:
-            $ref: "api.yaml#/components/schemas/HydraNodeId"
+            $ref: "api.yaml#/components/schemas/NodeId"
       - title: Disconnected
         type: object
         additionalProperties: false
@@ -827,8 +827,8 @@ definitions:
           tag:
             type: string
             enum: ["Disconnected"]
-          peer:
-            $ref: "api.yaml#/components/schemas/HydraNodeId"
+          nodeId:
+            $ref: "api.yaml#/components/schemas/NodeId"
 
   OnChainEvent:
     oneOf:

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -806,21 +806,21 @@ definitions:
         additionalProperties: false
         required:
         - tag
-        - peer
+        - nodeId
         description: >-
           Given party is known to be connected to the network.
         properties:
           tag:
             type: string
             enum: ["Connected"]
-          peer:
-            $ref: "api.yaml#/components/schemas/Peer"
+          nodeId:
+            $ref: "api.yaml#/components/schemas/HydraNodeId"
       - title: Disconnected
         type: object
         additionalProperties: false
         required:
         - tag
-        - peer
+        - nodeId
         description: >-
           Given peer is probably disconnected from the network.
         properties:
@@ -828,7 +828,7 @@ definitions:
             type: string
             enum: ["Disconnected"]
           peer:
-            $ref: "api.yaml#/components/schemas/Peer"
+            $ref: "api.yaml#/components/schemas/HydraNodeId"
 
   OnChainEvent:
     oneOf:

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -6,14 +6,14 @@ import Hydra.API.ClientInput (ClientInput (..))
 import Hydra.Chain (PostChainTx, PostTxError)
 import Hydra.Crypto (MultiSignature)
 import Hydra.Ledger (IsTx, UTxOType, ValidationError)
-import Hydra.Network (NodeId)
+import Hydra.Network (HydraNodeId)
 import Hydra.Party (Party)
 import Hydra.Prelude
 import Hydra.Snapshot (Snapshot, SnapshotNumber)
 
 data ServerOutput tx
-  = PeerConnected {peer :: NodeId}
-  | PeerDisconnected {peer :: NodeId}
+  = PeerConnected {peer :: HydraNodeId}
+  | PeerDisconnected {peer :: HydraNodeId}
   | ReadyToCommit {parties :: Set Party}
   | Committed {party :: Party, utxo :: UTxOType tx}
   | HeadIsOpen {utxo :: UTxOType tx}

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -6,14 +6,14 @@ import Hydra.API.ClientInput (ClientInput (..))
 import Hydra.Chain (PostChainTx, PostTxError)
 import Hydra.Crypto (MultiSignature)
 import Hydra.Ledger (IsTx, UTxOType, ValidationError)
-import Hydra.Network (Host)
+import Hydra.Network (NodeId)
 import Hydra.Party (Party)
 import Hydra.Prelude
 import Hydra.Snapshot (Snapshot, SnapshotNumber)
 
 data ServerOutput tx
-  = PeerConnected {peer :: Host}
-  | PeerDisconnected {peer :: Host}
+  = PeerConnected {peer :: NodeId}
+  | PeerDisconnected {peer :: NodeId}
   | ReadyToCommit {parties :: Set Party}
   | Committed {party :: Party, utxo :: UTxOType tx}
   | HeadIsOpen {utxo :: UTxOType tx}

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -6,14 +6,14 @@ import Hydra.API.ClientInput (ClientInput (..))
 import Hydra.Chain (PostChainTx, PostTxError)
 import Hydra.Crypto (MultiSignature)
 import Hydra.Ledger (IsTx, UTxOType, ValidationError)
-import Hydra.Network (HydraNodeId)
+import Hydra.Network (NodeId)
 import Hydra.Party (Party)
 import Hydra.Prelude
 import Hydra.Snapshot (Snapshot, SnapshotNumber)
 
 data ServerOutput tx
-  = PeerConnected {peer :: HydraNodeId}
-  | PeerDisconnected {peer :: HydraNodeId}
+  = PeerConnected {peer :: NodeId}
+  | PeerDisconnected {peer :: NodeId}
   | ReadyToCommit {parties :: Set Party}
   | Committed {party :: Party, utxo :: UTxOType tx}
   | HeadIsOpen {utxo :: UTxOType tx}

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -812,10 +812,10 @@ update Environment{party, signingKey, otherParties} ledger st ev = case (st, ev)
     onCurrentChainRollback currentState n
   (_, OnChainEvent Tick{}) ->
     OnlyEffects []
-  (_, NetworkEvent _ (Connected host)) ->
-    OnlyEffects [ClientEffect $ PeerConnected host]
-  (_, NetworkEvent _ (Disconnected host)) ->
-    OnlyEffects [ClientEffect $ PeerDisconnected host]
+  (_, NetworkEvent _ (Connected nodeId)) ->
+    OnlyEffects [ClientEffect $ PeerConnected nodeId]
+  (_, NetworkEvent _ (Disconnected nodeId)) ->
+    OnlyEffects [ClientEffect $ PeerDisconnected nodeId]
   (_, PostTxError{postChainTx, postTxError}) ->
     OnlyEffects [ClientEffect $ PostTxOnChainFailed{postChainTx, postTxError}]
   (_, ClientEvent{clientInput}) ->

--- a/hydra-node/src/Hydra/Network.hs
+++ b/hydra-node/src/Hydra/Network.hs
@@ -18,7 +18,7 @@ module Hydra.Network (
   NetworkCallback,
   IP,
   Host (..),
-  NodeId,
+  HydraNodeId (..),
   showHost,
   readHost,
   PortNumber,
@@ -34,6 +34,7 @@ import Data.IP (IP, toIPv4w)
 import Data.Text (pack, unpack)
 import Network.Socket (PortNumber, close)
 import Network.TypedProtocol.Pipelined ()
+import Test.QuickCheck.Gen (suchThat)
 import Text.Read (Read (readsPrec))
 import Text.Show (Show (show))
 
@@ -73,7 +74,18 @@ instance ToCBOR PortNumber where
 instance FromCBOR PortNumber where
   fromCBOR = fmap fromInteger fromCBOR
 
-type NodeId = Text
+newtype HydraNodeId = HydraNodeId {hydraNodeId :: Text}
+  deriving newtype (Eq, Show, Ord, ToJSON, FromJSON)
+
+instance Arbitrary HydraNodeId where
+  arbitrary =
+    HydraNodeId . pack <$> suchThat arbitrary (not . null)
+
+instance FromCBOR HydraNodeId where
+  fromCBOR = HydraNodeId <$> fromCBOR
+
+instance ToCBOR HydraNodeId where
+  toCBOR HydraNodeId{hydraNodeId} = toCBOR hydraNodeId
 
 -- ** Host
 

--- a/hydra-node/src/Hydra/Network.hs
+++ b/hydra-node/src/Hydra/Network.hs
@@ -18,7 +18,7 @@ module Hydra.Network (
   NetworkCallback,
   IP,
   Host (..),
-  HydraNodeId (..),
+  NodeId (..),
   showHost,
   readHost,
   PortNumber,
@@ -74,18 +74,18 @@ instance ToCBOR PortNumber where
 instance FromCBOR PortNumber where
   fromCBOR = fmap fromInteger fromCBOR
 
-newtype HydraNodeId = HydraNodeId {hydraNodeId :: Text}
+newtype NodeId = NodeId {nodeId :: Text}
   deriving newtype (Eq, Show, Ord, ToJSON, FromJSON)
 
-instance Arbitrary HydraNodeId where
+instance Arbitrary NodeId where
   arbitrary =
-    HydraNodeId . pack <$> suchThat arbitrary (not . null)
+    NodeId . pack <$> suchThat arbitrary (not . null)
 
-instance FromCBOR HydraNodeId where
-  fromCBOR = HydraNodeId <$> fromCBOR
+instance FromCBOR NodeId where
+  fromCBOR = NodeId <$> fromCBOR
 
-instance ToCBOR HydraNodeId where
-  toCBOR HydraNodeId{hydraNodeId} = toCBOR hydraNodeId
+instance ToCBOR NodeId where
+  toCBOR NodeId{nodeId} = toCBOR nodeId
 
 -- ** Host
 

--- a/hydra-node/src/Hydra/Network.hs
+++ b/hydra-node/src/Hydra/Network.hs
@@ -34,7 +34,7 @@ import Data.IP (IP, toIPv4w)
 import Data.Text (pack, unpack)
 import Network.Socket (PortNumber, close)
 import Network.TypedProtocol.Pipelined ()
-import Test.QuickCheck.Gen (suchThat)
+import Test.QuickCheck (elements, listOf)
 import Text.Read (Read (readsPrec))
 import Text.Show (Show (show))
 
@@ -75,11 +75,13 @@ instance FromCBOR PortNumber where
   fromCBOR = fmap fromInteger fromCBOR
 
 newtype NodeId = NodeId {nodeId :: Text}
-  deriving newtype (Eq, Show, Ord, ToJSON, FromJSON)
+  deriving newtype (Eq, Show, IsString, Read, Ord, ToJSON, FromJSON)
 
 instance Arbitrary NodeId where
   arbitrary =
-    NodeId . pack <$> suchThat arbitrary (not . null)
+    NodeId . pack <$> listOf (elements ['a' .. 'z'])
+
+-- return $ NodeId $ pack c
 
 instance FromCBOR NodeId where
   fromCBOR = NodeId <$> fromCBOR

--- a/hydra-node/src/Hydra/Network.hs
+++ b/hydra-node/src/Hydra/Network.hs
@@ -34,7 +34,7 @@ import Data.IP (IP, toIPv4w)
 import Data.Text (pack, unpack)
 import Network.Socket (PortNumber, close)
 import Network.TypedProtocol.Pipelined ()
-import Test.QuickCheck (elements, listOf)
+import Test.QuickCheck (elements, listOf, suchThat)
 import Text.Read (Read (readsPrec))
 import Text.Show (Show (show))
 
@@ -79,7 +79,7 @@ newtype NodeId = NodeId {nodeId :: Text}
 
 instance Arbitrary NodeId where
   arbitrary =
-    NodeId . pack <$> listOf (elements ['a' .. 'z'])
+    NodeId . pack <$> suchThat (listOf (elements ['a' .. 'z'])) (not . null)
 
 -- return $ NodeId $ pack c
 

--- a/hydra-node/src/Hydra/Network.hs
+++ b/hydra-node/src/Hydra/Network.hs
@@ -18,6 +18,7 @@ module Hydra.Network (
   NetworkCallback,
   IP,
   Host (..),
+  NodeId,
   showHost,
   readHost,
   PortNumber,
@@ -71,6 +72,8 @@ instance ToCBOR PortNumber where
 
 instance FromCBOR PortNumber where
   fromCBOR = fmap fromInteger fromCBOR
+
+type NodeId = Text
 
 -- ** Host
 

--- a/hydra-node/src/Hydra/Network/Heartbeat.hs
+++ b/hydra-node/src/Hydra/Network/Heartbeat.hs
@@ -22,16 +22,16 @@ import Hydra.Prelude
 import Control.Monad.Class.MonadSTM (modifyTVar', newTVarIO, readTVarIO)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
-import Hydra.Network (HydraNodeId, Network (..), NetworkCallback, NetworkComponent)
+import Hydra.Network (Network (..), NetworkCallback, NetworkComponent, NodeId)
 import Hydra.Network.Message (Message (Connected, Disconnected))
 
 data HeartbeatState = HeartbeatState
   { -- | The map of known 'Connected' parties with the last time they've been "seen".
     -- This is updated when we see a message from another 'Host'
-    alive :: Map HydraNodeId Time
+    alive :: Map NodeId Time
   , -- | The set of known parties which might be 'Disconnected'
     -- This is updated after some time no message has been received from a 'Host'.
-    suspected :: Set HydraNodeId
+    suspected :: Set NodeId
   , -- | The timestamp of the last sent message.
     lastSent :: Maybe Time
   }
@@ -41,8 +41,8 @@ initialHeartbeatState :: HeartbeatState
 initialHeartbeatState = HeartbeatState{alive = mempty, suspected = mempty, lastSent = Nothing}
 
 data Heartbeat msg
-  = Data HydraNodeId msg
-  | Ping HydraNodeId
+  = Data NodeId msg
+  | Ping NodeId
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
@@ -72,15 +72,15 @@ withHeartbeat ::
   , MonadDelay m
   , MonadMonotonicTime m
   ) =>
-  HydraNodeId ->
+  NodeId ->
   NetworkComponent m (Heartbeat (Message tx)) a ->
   NetworkComponent m (Message tx) a
-withHeartbeat hydraNodeId withNetwork callback action = do
+withHeartbeat nodeId withNetwork callback action = do
   heartbeat <- newTVarIO initialHeartbeatState
   withNetwork (updateStateFromIncomingMessages heartbeat callback) $ \network ->
     withAsync (checkRemoteParties heartbeat callback) $ \_ ->
-      withAsync (checkHeartbeatState hydraNodeId heartbeat network) $ \_ ->
-        action (updateStateFromOutgoingMessages hydraNodeId heartbeat network)
+      withAsync (checkHeartbeatState nodeId heartbeat network) $ \_ ->
+        action (updateStateFromOutgoingMessages nodeId heartbeat network)
 
 updateStateFromIncomingMessages ::
   (MonadSTM m, MonadMonotonicTime m) =>
@@ -104,15 +104,15 @@ updateStateFromIncomingMessages heartbeatState callback = \case
 
 updateStateFromOutgoingMessages ::
   (MonadSTM m, MonadMonotonicTime m) =>
-  HydraNodeId ->
+  NodeId ->
   TVar m HeartbeatState ->
   Network m (Heartbeat (Message msg)) ->
   Network m (Message msg)
-updateStateFromOutgoingMessages hydraNodeId heartbeatState Network{broadcast} =
+updateStateFromOutgoingMessages nodeId heartbeatState Network{broadcast} =
   Network $ \msg -> do
     now <- getMonotonicTime
     updateLastSent heartbeatState now
-    broadcast (Data hydraNodeId msg)
+    broadcast (Data nodeId msg)
 
 updateLastSent :: MonadSTM m => TVar m HeartbeatState -> Time -> m ()
 updateLastSent heartbeatState now = atomically (modifyTVar' heartbeatState $ \s -> s{lastSent = Just now})
@@ -122,7 +122,7 @@ checkHeartbeatState ::
   , MonadSTM m
   , MonadMonotonicTime m
   ) =>
-  HydraNodeId ->
+  NodeId ->
   TVar m HeartbeatState ->
   Network m (Heartbeat (Message msg)) ->
   m ()
@@ -154,7 +154,7 @@ checkRemoteParties heartbeatState callback =
     updateSuspected heartbeatState now
       >>= mapM_ (callback . Disconnected)
 
-updateSuspected :: MonadSTM m => TVar m HeartbeatState -> Time -> m (Set HydraNodeId)
+updateSuspected :: MonadSTM m => TVar m HeartbeatState -> Time -> m (Set NodeId)
 updateSuspected heartbeatState now =
   atomically $ do
     aliveParties <- alive <$> readTVar heartbeatState

--- a/hydra-node/src/Hydra/Network/Heartbeat.hs
+++ b/hydra-node/src/Hydra/Network/Heartbeat.hs
@@ -27,10 +27,10 @@ import Hydra.Network.Message (Message (Connected, Disconnected))
 
 data HeartbeatState = HeartbeatState
   { -- | The map of known 'Connected' parties with the last time they've been "seen".
-    -- This is updated when we see a message from another 'Host'
+    -- This is updated when we see a message from another node
     alive :: Map NodeId Time
   , -- | The set of known parties which might be 'Disconnected'
-    -- This is updated after some time no message has been received from a 'Host'.
+    -- This is updated after some time no message has been received from a node.
     suspected :: Set NodeId
   , -- | The timestamp of the last sent message.
     lastSent :: Maybe Time

--- a/hydra-node/src/Hydra/Network/Message.hs
+++ b/hydra-node/src/Hydra/Network/Message.hs
@@ -6,7 +6,7 @@ import Hydra.Prelude
 
 import Hydra.Crypto (Signature)
 import Hydra.Ledger (IsTx, UTxOType)
-import Hydra.Network (Host)
+import Hydra.Network (NodeId)
 import Hydra.Party (Party)
 import Hydra.Snapshot (Snapshot, SnapshotNumber)
 
@@ -16,8 +16,8 @@ data Message tx
   = ReqTx {party :: Party, transaction :: tx}
   | ReqSn {party :: Party, snapshotNumber :: SnapshotNumber, transactions :: [tx]}
   | AckSn {party :: Party, signed :: Signature (Snapshot tx), snapshotNumber :: SnapshotNumber}
-  | Connected {peer :: Host}
-  | Disconnected {peer :: Host}
+  | Connected {nodeId :: NodeId}
+  | Disconnected {nodeId :: NodeId}
   deriving stock (Generic, Eq, Show)
   deriving anyclass (ToJSON, FromJSON)
 

--- a/hydra-node/src/Hydra/Network/Message.hs
+++ b/hydra-node/src/Hydra/Network/Message.hs
@@ -6,7 +6,7 @@ import Hydra.Prelude
 
 import Hydra.Crypto (Signature)
 import Hydra.Ledger (IsTx, UTxOType)
-import Hydra.Network (NodeId)
+import Hydra.Network (HydraNodeId)
 import Hydra.Party (Party)
 import Hydra.Snapshot (Snapshot, SnapshotNumber)
 
@@ -16,8 +16,8 @@ data Message tx
   = ReqTx {party :: Party, transaction :: tx}
   | ReqSn {party :: Party, snapshotNumber :: SnapshotNumber, transactions :: [tx]}
   | AckSn {party :: Party, signed :: Signature (Snapshot tx), snapshotNumber :: SnapshotNumber}
-  | Connected {nodeId :: NodeId}
-  | Disconnected {nodeId :: NodeId}
+  | Connected {nodeId :: HydraNodeId}
+  | Disconnected {nodeId :: HydraNodeId}
   deriving stock (Generic, Eq, Show)
   deriving anyclass (ToJSON, FromJSON)
 
@@ -29,8 +29,8 @@ instance (ToCBOR tx, ToCBOR (UTxOType tx)) => ToCBOR (Message tx) where
     ReqTx party tx -> toCBOR ("ReqTx" :: Text) <> toCBOR party <> toCBOR tx
     ReqSn party sn txs -> toCBOR ("ReqSn" :: Text) <> toCBOR party <> toCBOR sn <> toCBOR txs
     AckSn party sig sn -> toCBOR ("AckSn" :: Text) <> toCBOR party <> toCBOR sig <> toCBOR sn
-    Connected host -> toCBOR ("Connected" :: Text) <> toCBOR host
-    Disconnected host -> toCBOR ("Disconnected" :: Text) <> toCBOR host
+    Connected nodeId -> toCBOR ("Connected" :: Text) <> toCBOR nodeId
+    Disconnected nodeId -> toCBOR ("Disconnected" :: Text) <> toCBOR nodeId
 
 instance (FromCBOR tx, FromCBOR (UTxOType tx)) => FromCBOR (Message tx) where
   fromCBOR =

--- a/hydra-node/src/Hydra/Network/Message.hs
+++ b/hydra-node/src/Hydra/Network/Message.hs
@@ -6,7 +6,7 @@ import Hydra.Prelude
 
 import Hydra.Crypto (Signature)
 import Hydra.Ledger (IsTx, UTxOType)
-import Hydra.Network (HydraNodeId)
+import Hydra.Network (NodeId)
 import Hydra.Party (Party)
 import Hydra.Snapshot (Snapshot, SnapshotNumber)
 
@@ -16,8 +16,8 @@ data Message tx
   = ReqTx {party :: Party, transaction :: tx}
   | ReqSn {party :: Party, snapshotNumber :: SnapshotNumber, transactions :: [tx]}
   | AckSn {party :: Party, signed :: Signature (Snapshot tx), snapshotNumber :: SnapshotNumber}
-  | Connected {nodeId :: HydraNodeId}
-  | Disconnected {nodeId :: HydraNodeId}
+  | Connected {nodeId :: NodeId}
+  | Disconnected {nodeId :: NodeId}
   deriving stock (Generic, Eq, Show)
   deriving anyclass (ToJSON, FromJSON)
 

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -28,7 +28,7 @@ import Hydra.Cardano.Api (
 import qualified Hydra.Contract as Contract
 import Hydra.Ledger.Cardano ()
 import Hydra.Logging (Verbosity (..))
-import Hydra.Network (Host, PortNumber, readHost, readPort)
+import Hydra.Network (Host, NodeId, PortNumber, readHost, readPort)
 import Hydra.Node.Version (gitDescribe)
 import Options.Applicative (
   Parser,
@@ -123,7 +123,7 @@ publishOptionsParser =
 
 data RunOptions = RunOptions
   { verbosity :: Verbosity
-  , nodeId :: Text
+  , nodeId :: NodeId
   , -- NOTE: Why not a 'Host'?
     host :: IP
   , port :: PortNumber
@@ -345,15 +345,16 @@ peerParser =
         <> help "A peer address in the form <host>:<port>, where <host> can be an IP address, or a host name"
     )
 
-nodeIdParser :: Parser Text
+nodeIdParser :: Parser NodeId
 nodeIdParser =
   option
     auto
     ( long "node-id"
         <> short 'n'
-        <> value "some_node_id_string"
         <> metavar "TEXT"
-        <> help "Sets this node's id"
+        <> help
+          "Sets the hydra node's id. It is important to have a unique identifiers for hydra-nodes \
+          \ in order to be able distinguish between connected peers in the tui."
     )
 
 verbosityParser :: Parser Verbosity

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -123,7 +123,7 @@ publishOptionsParser =
 
 data RunOptions = RunOptions
   { verbosity :: Verbosity
-  , nodeId :: Natural
+  , nodeId :: Text
   , -- NOTE: Why not a 'Host'?
     host :: IP
   , port :: PortNumber
@@ -345,14 +345,14 @@ peerParser =
         <> help "A peer address in the form <host>:<port>, where <host> can be an IP address, or a host name"
     )
 
-nodeIdParser :: Parser Natural
+nodeIdParser :: Parser Text
 nodeIdParser =
   option
     auto
     ( long "node-id"
         <> short 'n'
-        <> value 1
-        <> metavar "INTEGER"
+        <> value "some_node_id_string"
+        <> metavar "TEXT"
         <> help "Sets this node's id"
     )
 

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -9,6 +9,7 @@ import Control.Arrow (left)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BSC
 import Data.IP (IP (IPv4), toIPv4w)
+import Data.Text (unpack)
 import qualified Data.Text as T
 import Data.Version (showVersion)
 import Hydra.Cardano.Api (
@@ -28,7 +29,7 @@ import Hydra.Cardano.Api (
 import qualified Hydra.Contract as Contract
 import Hydra.Ledger.Cardano ()
 import Hydra.Logging (Verbosity (..))
-import Hydra.Network (Host, NodeId, PortNumber, readHost, readPort)
+import Hydra.Network (Host, NodeId (NodeId), PortNumber, readHost, readPort)
 import Hydra.Node.Version (gitDescribe)
 import Options.Applicative (
   Parser,
@@ -348,10 +349,10 @@ peerParser =
 nodeIdParser :: Parser NodeId
 nodeIdParser =
   option
-    auto
+    str
     ( long "node-id"
         <> short 'n'
-        <> metavar "TEXT"
+        <> metavar "NODE-ID"
         <> help
           "Sets the hydra node's id. It is important to have a unique identifiers for hydra-nodes \
           \ in order to be able distinguish between connected peers in the tui."
@@ -506,19 +507,20 @@ toArgs
     , chainConfig
     , ledgerConfig
     } =
-    isVerbose verbosity
-      <> ["--node-id", show nodeId]
-      <> ["--host", show host]
-      <> ["--port", show port]
-      <> ["--api-host", show apiHost]
-      <> ["--api-port", show apiPort]
-      <> ["--hydra-signing-key", hydraSigningKey]
-      <> concatMap (\vk -> ["--hydra-verification-key", vk]) hydraVerificationKeys
-      <> concatMap toArgPeer peers
-      <> maybe [] (\mport -> ["--monitoring-port", show mport]) monitoringPort
-      <> ["--hydra-scripts-tx-id", toString $ serialiseToRawBytesHexText hydraScriptsTxId]
-      <> argsChainConfig
-      <> argsLedgerConfig
+    let (NodeId nId) = nodeId
+     in isVerbose verbosity
+          <> ["--node-id", unpack nId]
+          <> ["--host", show host]
+          <> ["--port", show port]
+          <> ["--api-host", show apiHost]
+          <> ["--api-port", show apiPort]
+          <> ["--hydra-signing-key", hydraSigningKey]
+          <> concatMap (\vk -> ["--hydra-verification-key", vk]) hydraVerificationKeys
+          <> concatMap toArgPeer peers
+          <> maybe [] (\mport -> ["--monitoring-port", show mport]) monitoringPort
+          <> ["--hydra-scripts-tx-id", toString $ serialiseToRawBytesHexText hydraScriptsTxId]
+          <> argsChainConfig
+          <> argsLedgerConfig
    where
     isVerbose = \case
       Quiet -> ["--quiet"]

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -34,6 +34,7 @@ import Hydra.HeadLogic (
  )
 import Hydra.Ledger (IsTx (..), Ledger (..), ValidationError (..))
 import Hydra.Ledger.Simple (SimpleTx (..), aValidTx, simpleLedger, utxoRef)
+import Hydra.Network (HydraNodeId (HydraNodeId))
 import Hydra.Network.Message (Message (AckSn, Connected, ReqSn, ReqTx))
 import Hydra.Party (Party (..))
 import Hydra.Snapshot (ConfirmedSnapshot (..), Snapshot (..), getSnapshot)
@@ -206,7 +207,7 @@ spec = do
         update bobEnv ledger s0 event `shouldBe` Error (InvalidEvent event s0)
 
       it "notifies client when it receives a ping" $ do
-        let nodeId = "My special node id"
+        let nodeId = HydraNodeId "My special node id"
         update bobEnv ledger (inOpenState threeParties ledger) (NetworkEvent defaultTTL $ Connected nodeId)
           `hasEffect` ClientEffect (PeerConnected nodeId)
 

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -34,7 +34,7 @@ import Hydra.HeadLogic (
  )
 import Hydra.Ledger (IsTx (..), Ledger (..), ValidationError (..))
 import Hydra.Ledger.Simple (SimpleTx (..), aValidTx, simpleLedger, utxoRef)
-import Hydra.Network (HydraNodeId (HydraNodeId))
+import Hydra.Network (NodeId (..))
 import Hydra.Network.Message (Message (AckSn, Connected, ReqSn, ReqTx))
 import Hydra.Party (Party (..))
 import Hydra.Snapshot (ConfirmedSnapshot (..), Snapshot (..), getSnapshot)
@@ -207,7 +207,7 @@ spec = do
         update bobEnv ledger s0 event `shouldBe` Error (InvalidEvent event s0)
 
       it "notifies client when it receives a ping" $ do
-        let nodeId = HydraNodeId "My special node id"
+        let nodeId = NodeId "My special node id"
         update bobEnv ledger (inOpenState threeParties ledger) (NetworkEvent defaultTTL $ Connected nodeId)
           `hasEffect` ClientEffect (PeerConnected nodeId)
 

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -34,7 +34,6 @@ import Hydra.HeadLogic (
  )
 import Hydra.Ledger (IsTx (..), Ledger (..), ValidationError (..))
 import Hydra.Ledger.Simple (SimpleTx (..), aValidTx, simpleLedger, utxoRef)
-import Hydra.Network (Host (..))
 import Hydra.Network.Message (Message (AckSn, Connected, ReqSn, ReqTx))
 import Hydra.Party (Party (..))
 import Hydra.Snapshot (ConfirmedSnapshot (..), Snapshot (..), getSnapshot)
@@ -207,9 +206,9 @@ spec = do
         update bobEnv ledger s0 event `shouldBe` Error (InvalidEvent event s0)
 
       it "notifies client when it receives a ping" $ do
-        let peer = Host{hostname = "1.2.3.4", port = 1}
-        update bobEnv ledger (inOpenState threeParties ledger) (NetworkEvent defaultTTL $ Connected peer)
-          `hasEffect` ClientEffect (PeerConnected peer)
+        let nodeId = "My special node id"
+        update bobEnv ledger (inOpenState threeParties ledger) (NetworkEvent defaultTTL $ Connected nodeId)
+          `hasEffect` ClientEffect (PeerConnected nodeId)
 
       it "cannot observe abort after collect com" $ do
         let s0 = inInitialState threeParties

--- a/hydra-node/test/Hydra/JSONSchema.hs
+++ b/hydra-node/test/Hydra/JSONSchema.hs
@@ -15,21 +15,21 @@ import Data.Aeson.Lens (AsValue, key, _Array, _String)
 import Data.Char (isSpace)
 import Data.List (dropWhileEnd)
 import qualified Data.Map.Strict as Map
+import Data.Text (pack)
+import Data.Versions (SemVer (SemVer), semver)
 import qualified Data.Yaml as Yaml
+import GHC.IO.Exception (IOErrorType (OtherError))
 import qualified Paths_hydra_node as Pkg
 import System.Directory (listDirectory)
 import System.Exit (ExitCode (..))
 import System.FilePath (normalise, takeBaseName, takeExtension, (<.>), (</>))
+import System.IO.Error (IOError, ioeGetErrorType)
 import System.Process (readProcessWithExitCode)
 import Test.Hspec (pendingWith)
 import Test.Hydra.Prelude (createSystemTempDirectory, failure)
 import Test.QuickCheck (Property, conjoin, counterexample, forAllBlind, forAllShrink, vectorOf, withMaxSuccess)
 import Test.QuickCheck.Monadic (assert, monadicIO, monitor, run)
 import qualified Prelude
-import System.IO.Error (IOError, ioeGetErrorType)
-import GHC.IO.Exception (IOErrorType(OtherError))
-import Data.Versions (semver, SemVer (SemVer))
-import Data.Text (pack)
 
 -- | Generate arbitrary serializable (JSON) value, and check their validity
 -- against a known JSON schema.
@@ -165,9 +165,9 @@ ensureSystemRequirements = do
     Right version ->
       case semver (pack version) of
         Right v ->
-          if v >= SemVer 3 2 0 [] Nothing then pure ()
-          else
-            failure $ "jsonschema version " <> version <> " found but >=3.2.0 needed"
+          if v >= SemVer 3 2 0 [] Nothing
+            then pure ()
+            else failure $ "jsonschema version " <> version <> " found but >=3.2.0 needed"
         Left err -> failure $ show err
     Left errorMsg -> failure errorMsg
  where
@@ -180,5 +180,5 @@ ensureSystemRequirements = do
         pure (dropWhileEnd isSpace out <$ guard (exitCode == ExitSuccess))
       Left (err :: IOError)
         | ioeGetErrorType err == OtherError ->
-            pure (Left $ "Check jsonschema is installed and in $PATH")
+          pure (Left $ "Check jsonschema is installed and in $PATH")
       Left err -> pure (Left $ show err)

--- a/hydra-node/test/Hydra/Network/HeartbeatSpec.hs
+++ b/hydra-node/test/Hydra/Network/HeartbeatSpec.hs
@@ -5,7 +5,7 @@ import Test.Hydra.Prelude
 
 import Control.Monad.Class.MonadSTM (MonadSTM (readTVarIO), modifyTVar', newTVarIO)
 import Control.Monad.IOSim (runSimOrThrow)
-import Hydra.Network (Network (..))
+import Hydra.Network (HydraNodeId (HydraNodeId), Network (..))
 import Hydra.Network.Heartbeat (Heartbeat (..), withHeartbeat)
 import Hydra.Network.Message (Message (Connected, Disconnected, ReqTx))
 import Test.Hydra.Fixture (alice, bob)
@@ -19,9 +19,9 @@ spec = parallel $
         captureIncoming receivedMessages msg =
           atomically $ modifyTVar' receivedMessages (msg :)
 
-        nodeId = "node_id-1"
+        nodeId = HydraNodeId "node_id-1"
 
-        otherNodeId = "node_id-2"
+        otherNodeId = HydraNodeId "node_id-2"
 
     it "sends a heartbeat message with local host after 500 ms" $ do
       let sentHeartbeats = runSimOrThrow $ do

--- a/hydra-node/test/Hydra/Network/HeartbeatSpec.hs
+++ b/hydra-node/test/Hydra/Network/HeartbeatSpec.hs
@@ -5,7 +5,7 @@ import Test.Hydra.Prelude
 
 import Control.Monad.Class.MonadSTM (MonadSTM (readTVarIO), modifyTVar', newTVarIO)
 import Control.Monad.IOSim (runSimOrThrow)
-import Hydra.Network (Host (..), Network (..))
+import Hydra.Network (Network (..))
 import Hydra.Network.Heartbeat (Heartbeat (..), withHeartbeat)
 import Hydra.Network.Message (Message (Connected, Disconnected, ReqTx))
 import Test.Hydra.Fixture (alice, bob)
@@ -19,53 +19,53 @@ spec = parallel $
         captureIncoming receivedMessages msg =
           atomically $ modifyTVar' receivedMessages (msg :)
 
-        localhost = Host{hostname = "1.2.3.4", port = 1}
+        nodeId = "node_id-1"
 
-        otherPeer = Host{hostname = "2.3.4.5", port = 1}
+        otherNodeId = "node_id-2"
 
     it "sends a heartbeat message with local host after 500 ms" $ do
       let sentHeartbeats = runSimOrThrow $ do
             sentMessages <- newTVarIO ([] :: [Heartbeat (Message Integer)])
 
-            withHeartbeat localhost (captureOutgoing sentMessages) noop $ \_ ->
+            withHeartbeat nodeId (captureOutgoing sentMessages) noop $ \_ ->
               threadDelay 1.1
 
             readTVarIO sentMessages
 
-      sentHeartbeats `shouldBe` [Ping localhost]
+      sentHeartbeats `shouldBe` [Ping nodeId]
 
     it "sends Connected when Ping received from other peer" $ do
       let receivedHeartbeats = runSimOrThrow $ do
             receivedMessages <- newTVarIO ([] :: [Message Integer])
 
-            withHeartbeat localhost (\incoming _ -> incoming (Ping otherPeer)) (captureIncoming receivedMessages) $ \_ ->
+            withHeartbeat nodeId (\incoming _ -> incoming (Ping otherNodeId)) (captureIncoming receivedMessages) $ \_ ->
               threadDelay 1
 
             readTVarIO receivedMessages
 
-      receivedHeartbeats `shouldBe` [Connected otherPeer]
+      receivedHeartbeats `shouldBe` [Connected otherNodeId]
 
     it "sends Connected when any message received from other party" $ do
       let receivedHeartbeats = runSimOrThrow $ do
             receivedMessages <- newTVarIO ([] :: [Message Integer])
 
-            withHeartbeat localhost (\incoming _ -> incoming (Data otherPeer $ ReqTx bob 1)) (captureIncoming receivedMessages) $ \_ ->
+            withHeartbeat nodeId (\incoming _ -> incoming (Data otherNodeId $ ReqTx bob 1)) (captureIncoming receivedMessages) $ \_ ->
               threadDelay 1
 
             readTVarIO receivedMessages
 
-      receivedHeartbeats `shouldBe` [ReqTx bob 1, Connected otherPeer]
+      receivedHeartbeats `shouldBe` [ReqTx bob 1, Connected otherNodeId]
 
     it "do not send Connected on subsequent messages from already Connected party" $ do
       let receivedHeartbeats = runSimOrThrow $ do
             receivedMessages <- newTVarIO ([] :: [Message Integer])
 
-            withHeartbeat localhost (\incoming _ -> incoming (Data otherPeer $ ReqTx bob 1) >> incoming (Ping otherPeer)) (captureIncoming receivedMessages) $ \_ ->
+            withHeartbeat nodeId (\incoming _ -> incoming (Data otherNodeId $ ReqTx bob 1) >> incoming (Ping otherNodeId)) (captureIncoming receivedMessages) $ \_ ->
               threadDelay 1
 
             readTVarIO receivedMessages
 
-      receivedHeartbeats `shouldBe` [ReqTx bob 1, Connected otherPeer]
+      receivedHeartbeats `shouldBe` [ReqTx bob 1, Connected otherNodeId]
 
     it "sends Disconnected given no messages has been received from known party within twice heartbeat delay" $ do
       let receivedHeartbeats = runSimOrThrow $ do
@@ -74,42 +74,42 @@ spec = parallel $
             let component incoming action =
                   race_
                     (action (Network noop))
-                    (incoming (Ping otherPeer) >> threadDelay 4 >> incoming (Ping otherPeer) >> threadDelay 7)
+                    (incoming (Ping otherNodeId) >> threadDelay 4 >> incoming (Ping otherNodeId) >> threadDelay 7)
 
-            withHeartbeat localhost component (captureIncoming receivedMessages) $ \_ ->
+            withHeartbeat nodeId component (captureIncoming receivedMessages) $ \_ ->
               threadDelay 20
 
             readTVarIO receivedMessages
 
-      receivedHeartbeats `shouldBe` [Disconnected otherPeer, Connected otherPeer]
+      receivedHeartbeats `shouldBe` [Disconnected otherNodeId, Connected otherNodeId]
 
     it "stop sending heartbeat message given action sends a message" $ do
       let someMessage = ReqTx alice 1
           sentHeartbeats = runSimOrThrow $ do
             sentMessages <- newTVarIO ([] :: [Heartbeat (Message Integer)])
 
-            withHeartbeat localhost (captureOutgoing sentMessages) noop $ \Network{broadcast} -> do
+            withHeartbeat nodeId (captureOutgoing sentMessages) noop $ \Network{broadcast} -> do
               threadDelay 0.6
               broadcast someMessage
               threadDelay 1
 
             readTVarIO sentMessages
 
-      sentHeartbeats `shouldBe` [Data localhost someMessage, Ping localhost]
+      sentHeartbeats `shouldBe` [Data nodeId someMessage, Ping nodeId]
 
     it "restart sending heartbeat messages given last message sent is older than heartbeat delay" $ do
       let someMessage = ReqTx alice 1
           sentHeartbeats = runSimOrThrow $ do
             sentMessages <- newTVarIO ([] :: [Heartbeat (Message Integer)])
 
-            withHeartbeat localhost (captureOutgoing sentMessages) noop $ \Network{broadcast} -> do
+            withHeartbeat nodeId (captureOutgoing sentMessages) noop $ \Network{broadcast} -> do
               threadDelay 0.6
               broadcast someMessage
               threadDelay 3.6
 
             readTVarIO sentMessages
 
-      sentHeartbeats `shouldBe` [Ping localhost, Data localhost someMessage, Ping localhost]
+      sentHeartbeats `shouldBe` [Ping nodeId, Data nodeId someMessage, Ping nodeId]
 
 noop :: Monad m => b -> m ()
 noop = const $ pure ()

--- a/hydra-node/test/Hydra/Network/HeartbeatSpec.hs
+++ b/hydra-node/test/Hydra/Network/HeartbeatSpec.hs
@@ -5,7 +5,7 @@ import Test.Hydra.Prelude
 
 import Control.Monad.Class.MonadSTM (MonadSTM (readTVarIO), modifyTVar', newTVarIO)
 import Control.Monad.IOSim (runSimOrThrow)
-import Hydra.Network (HydraNodeId (HydraNodeId), Network (..))
+import Hydra.Network (NodeId (..), Network (..))
 import Hydra.Network.Heartbeat (Heartbeat (..), withHeartbeat)
 import Hydra.Network.Message (Message (Connected, Disconnected, ReqTx))
 import Test.Hydra.Fixture (alice, bob)
@@ -19,9 +19,9 @@ spec = parallel $
         captureIncoming receivedMessages msg =
           atomically $ modifyTVar' receivedMessages (msg :)
 
-        nodeId = HydraNodeId "node_id-1"
+        nodeId = NodeId "node_id-1"
 
-        otherNodeId = HydraNodeId "node_id-2"
+        otherNodeId = NodeId "node_id-2"
 
     it "sends a heartbeat message with local host after 500 ms" $ do
       let sentHeartbeats = runSimOrThrow $ do

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -27,7 +27,7 @@ import Hydra.HeadLogic (
 import Hydra.Ledger (IsTx)
 import Hydra.Ledger.Simple (SimpleTx (..), simpleLedger, utxoRef, utxoRefs)
 import Hydra.Logging (Tracer, showLogsOnFailure)
-import Hydra.Network (Host (..), Network (..))
+import Hydra.Network (Network (..))
 import Hydra.Network.Message (Message (..))
 import Hydra.Node (
   EventQueue (..),
@@ -100,8 +100,8 @@ spec = parallel $ do
   it "notifies client when postTx throws PostTxError" $
     showLogsOnFailure $ \tracer -> do
       let events =
-            [ NetworkEvent{ttl = defaultTTL, message = Connected{peer = Host{hostname = "10.0.0.30", port = 5000}}}
-            , NetworkEvent{ttl = defaultTTL, message = Connected{peer = Host{hostname = "10.0.0.10", port = 5000}}}
+            [ NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = "NodeId1"}}
+            , NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = "NodeId2"}}
             , ClientEvent $ Init cperiod
             ]
       (node, getServerOutputs) <- createHydraNode aliceSk [bob, carol] events >>= throwExceptionOnPostTx NoSeedInput >>= recordServerOutputs
@@ -118,8 +118,8 @@ isReqSn = \case
 
 eventsToOpenHead :: [Event SimpleTx]
 eventsToOpenHead =
-  [ NetworkEvent{ttl = defaultTTL, message = Connected{peer = Host{hostname = "10.0.0.30", port = 5000}}}
-  , NetworkEvent{ttl = defaultTTL, message = Connected{peer = Host{hostname = "10.0.0.10", port = 5000}}}
+  [ NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = "NodeId1"}}
+  , NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = "NodeId2"}}
   , OnChainEvent
       { chainEvent = Observation $ OnInitTx cperiod [alice, bob, carol]
       }

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -27,7 +27,7 @@ import Hydra.HeadLogic (
 import Hydra.Ledger (IsTx)
 import Hydra.Ledger.Simple (SimpleTx (..), simpleLedger, utxoRef, utxoRefs)
 import Hydra.Logging (Tracer, showLogsOnFailure)
-import Hydra.Network (HydraNodeId (HydraNodeId), Network (..))
+import Hydra.Network (NodeId (..), Network (..))
 import Hydra.Network.Message (Message (..))
 import Hydra.Node (
   EventQueue (..),
@@ -100,8 +100,8 @@ spec = parallel $ do
   it "notifies client when postTx throws PostTxError" $
     showLogsOnFailure $ \tracer -> do
       let events =
-            [ NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = HydraNodeId "NodeId1"}}
-            , NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = HydraNodeId "NodeId2"}}
+            [ NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = NodeId "NodeId1"}}
+            , NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = NodeId "NodeId2"}}
             , ClientEvent $ Init cperiod
             ]
       (node, getServerOutputs) <- createHydraNode aliceSk [bob, carol] events >>= throwExceptionOnPostTx NoSeedInput >>= recordServerOutputs
@@ -118,8 +118,8 @@ isReqSn = \case
 
 eventsToOpenHead :: [Event SimpleTx]
 eventsToOpenHead =
-  [ NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = HydraNodeId "NodeId1"}}
-  , NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = HydraNodeId "NodeId2"}}
+  [ NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = NodeId "NodeId1"}}
+  , NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = NodeId "NodeId2"}}
   , OnChainEvent
       { chainEvent = Observation $ OnInitTx cperiod [alice, bob, carol]
       }

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -27,7 +27,7 @@ import Hydra.HeadLogic (
 import Hydra.Ledger (IsTx)
 import Hydra.Ledger.Simple (SimpleTx (..), simpleLedger, utxoRef, utxoRefs)
 import Hydra.Logging (Tracer, showLogsOnFailure)
-import Hydra.Network (Network (..))
+import Hydra.Network (HydraNodeId (HydraNodeId), Network (..))
 import Hydra.Network.Message (Message (..))
 import Hydra.Node (
   EventQueue (..),
@@ -100,8 +100,8 @@ spec = parallel $ do
   it "notifies client when postTx throws PostTxError" $
     showLogsOnFailure $ \tracer -> do
       let events =
-            [ NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = "NodeId1"}}
-            , NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = "NodeId2"}}
+            [ NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = HydraNodeId "NodeId1"}}
+            , NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = HydraNodeId "NodeId2"}}
             , ClientEvent $ Init cperiod
             ]
       (node, getServerOutputs) <- createHydraNode aliceSk [bob, carol] events >>= throwExceptionOnPostTx NoSeedInput >>= recordServerOutputs
@@ -118,8 +118,8 @@ isReqSn = \case
 
 eventsToOpenHead :: [Event SimpleTx]
 eventsToOpenHead =
-  [ NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = "NodeId1"}}
-  , NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = "NodeId2"}}
+  [ NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = HydraNodeId "NodeId1"}}
+  , NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = HydraNodeId "NodeId2"}}
   , OnChainEvent
       { chainEvent = Observation $ OnInitTx cperiod [alice, bob, carol]
       }

--- a/hydra-node/test/Hydra/OptionsSpec.hs
+++ b/hydra-node/test/Hydra/OptionsSpec.hs
@@ -6,7 +6,7 @@ import Test.Hydra.Prelude
 import Hydra.Cardano.Api (ChainPoint (..), NetworkId (..), serialiseToRawBytesHexText, unsafeDeserialiseFromRawBytesBase16)
 import Hydra.Chain.Direct (NetworkMagic (..))
 import Hydra.Logging (Verbosity (..))
-import Hydra.Network (Host (Host))
+import Hydra.Network (Host (Host), NodeId (NodeId))
 import Hydra.Options (
   ChainConfig (..),
   Command (..),
@@ -24,24 +24,26 @@ import Test.QuickCheck (Property, counterexample, forAll, property, (===))
 spec :: Spec
 spec = parallel $
   describe "Hydra Node RunOptions" $ do
-    it "has defaults" $
-      [] `shouldParse` Run defaultRunOptions
+    -- NOTE: --node-id flag needs to be set so we set a default here
+    let setFlags a = ["--node-id", "node-id-1"] <> a
+    it "parses with default node-id set" $
+      setFlags [] `shouldParse` Run defaultRunOptions
 
     it "parses --host option given valid IPv4 and IPv6 addresses" $ do
-      ["--host", "127.0.0.1"]
+      setFlags ["--host", "127.0.0.1"]
         `shouldParse` Run defaultRunOptions{host = "127.0.0.1"}
-      ["--host", "2001:db8:11e:c00::101"]
+      setFlags ["--host", "2001:db8:11e:c00::101"]
         `shouldParse` Run defaultRunOptions{host = "2001:db8:11e:c00::101"}
-      ["--host", "0.0.0.0"]
+      setFlags ["--host", "0.0.0.0"]
         `shouldParse` Run defaultRunOptions{host = "0.0.0.0"}
       shouldNotParse ["--host", "0.0.0"]
       shouldNotParse ["--host", "2001:db8:11e:c00:101"]
 
     it "parses --port option given valid port number" $ do
-      ["--port", "12345"]
+      setFlags ["--port", "12345"]
         `shouldParse` Run defaultRunOptions{port = 12345}
       shouldNotParse ["--port", "123456"]
-      ["--port", "0"]
+      setFlags ["--port", "0"]
         `shouldParse` Run defaultRunOptions{port = 0}
       shouldNotParse ["--port", "-42"]
 
@@ -50,46 +52,46 @@ spec = parallel $
     -- became evident when realizing that the 'hydra-tui' is also relying on this
     -- Read instance for parsing, but in a different command line flag.
     it "parses --peer `<host>:<port>` option" $ do
-      ["--peer", "1.2.3.4:4567"]
+      setFlags ["--peer", "1.2.3.4:4567"]
         `shouldParse` Run defaultRunOptions{peers = [Host "1.2.3.4" 4567]}
-      ["--peer", "1.2.3.4:4567", "--peer", "1.2.3.5:4568"]
+      setFlags ["--peer", "1.2.3.4:4567", "--peer", "1.2.3.5:4568"]
         `shouldParse` Run defaultRunOptions{peers = [Host "1.2.3.4" 4567, Host "1.2.3.5" 4568]}
-      ["--peer", "foo.com:4567"]
+      setFlags ["--peer", "foo.com:4567"]
         `shouldParse` Run defaultRunOptions{peers = [Host "foo.com" 4567]}
       shouldNotParse ["--peer", "foo.com:456789"]
     it "does parse --peer given ipv6 addresses" $ do
       pendingWith "we do not support it"
-      ["--peer", ":::1:4567"]
+      setFlags ["--peer", ":::1:4567"]
         `shouldParse` Run defaultRunOptions{peers = [Host ":::1" 4567]}
 
     it "parses --monitoring-port option given valid port number" $ do
-      []
+      setFlags []
         `shouldParse` Run defaultRunOptions{monitoringPort = Nothing}
-      ["--monitoring-port", "12345"]
+      setFlags ["--monitoring-port", "12345"]
         `shouldParse` Run defaultRunOptions{monitoringPort = Just 12345}
-      ["--monitoring-port", "65535"]
+      setFlags ["--monitoring-port", "65535"]
         `shouldParse` Run defaultRunOptions{monitoringPort = Just 65535}
 
     it "parses --version flag as a parse error" $
       shouldNotParse ["--version"]
 
     it "parses --hydra-verification-key option as a filepath" $ do
-      ["--hydra-verification-key", "./alice.vk"]
+      setFlags ["--hydra-verification-key", "./alice.vk"]
         `shouldParse` Run defaultRunOptions{hydraVerificationKeys = ["./alice.vk"]}
-      ["--hydra-verification-key", "/foo"]
+      setFlags ["--hydra-verification-key", "/foo"]
         `shouldParse` Run defaultRunOptions{hydraVerificationKeys = ["/foo"]}
-      ["--hydra-verification-key", "bar"]
+      setFlags ["--hydra-verification-key", "bar"]
         `shouldParse` Run defaultRunOptions{hydraVerificationKeys = ["bar"]}
-      ["--hydra-verification-key", "alice.vk", "--hydra-verification-key", "bob.vk"]
+      setFlags ["--hydra-verification-key", "alice.vk", "--hydra-verification-key", "bob.vk"]
         `shouldParse` Run defaultRunOptions{hydraVerificationKeys = ["alice.vk", "bob.vk"]}
 
     it "parses --hydra-signing-key option as a filepath" $
-      ["--hydra-signing-key", "./alice.sk"]
+      setFlags ["--hydra-signing-key", "./alice.sk"]
         `shouldParse` Run defaultRunOptions{hydraSigningKey = "./alice.sk"}
 
     it "parses --network-id option as a number" $ do
       shouldNotParse ["--network-id", "abc"]
-      ["--network-id", "0"]
+      setFlags ["--network-id", "0"]
         `shouldParse` Run
           defaultRunOptions
             { chainConfig =
@@ -97,7 +99,7 @@ spec = parallel $
                   { networkId = Testnet (NetworkMagic 0)
                   }
             }
-      ["--network-id", "-1"] -- Word32 overflow expected
+      setFlags ["--network-id", "-1"] -- Word32 overflow expected
         `shouldParse` Run
           defaultRunOptions
             { chainConfig =
@@ -105,7 +107,7 @@ spec = parallel $
                   { networkId = Testnet (NetworkMagic 4294967295)
                   }
             }
-      ["--network-id", "123"]
+      setFlags ["--network-id", "123"]
         `shouldParse` Run
           defaultRunOptions
             { chainConfig =
@@ -118,7 +120,7 @@ spec = parallel $
       shouldNotParse ["--mainnet"]
 
     it "parses --node-socket as a filepath" $
-      ["--node-socket", "foo.sock"]
+      setFlags ["--node-socket", "foo.sock"]
         `shouldParse` Run
           defaultRunOptions
             { chainConfig =
@@ -128,7 +130,7 @@ spec = parallel $
             }
 
     it "parses --cardano-signing-key option as a filepath" $
-      ["--cardano-signing-key", "./alice-cardano.sk"]
+      setFlags ["--cardano-signing-key", "./alice-cardano.sk"]
         `shouldParse` Run
           defaultRunOptions
             { chainConfig =
@@ -138,7 +140,7 @@ spec = parallel $
             }
 
     it "parses --cardano-verification-key option as a filepath" $
-      ["--cardano-verification-key", "./alice-cardano.vk"]
+      setFlags ["--cardano-verification-key", "./alice-cardano.vk"]
         `shouldParse` Run
           defaultRunOptions
             { chainConfig =
@@ -148,7 +150,7 @@ spec = parallel $
             }
 
     it "parses --ledger-genesis-file as a filepath" $
-      ["--ledger-genesis", "my-custom-genesis.json"]
+      setFlags ["--ledger-genesis", "my-custom-genesis.json"]
         `shouldParse` Run
           defaultRunOptions
             { ledgerConfig =
@@ -158,7 +160,7 @@ spec = parallel $
             }
 
     it "parses --ledger-protocol-parameters-file as a filepath" $
-      ["--ledger-protocol-parameters", "my-custom-protocol-parameters.json"]
+      setFlags ["--ledger-protocol-parameters", "my-custom-protocol-parameters.json"]
         `shouldParse` Run
           defaultRunOptions
             { ledgerConfig =
@@ -168,7 +170,7 @@ spec = parallel $
             }
 
     it "parses --start-chain-from as a pair of slot number and block header hash" $
-      ["--start-chain-from", "1000.0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"]
+      setFlags ["--start-chain-from", "1000.0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"]
         `shouldParse` Run
           defaultRunOptions
             { chainConfig =
@@ -183,7 +185,7 @@ spec = parallel $
             }
 
     prop "parses --hydra-scripts-tx-id as a tx id" $ \txId ->
-      ["--hydra-scripts-tx-id", toString $ serialiseToRawBytesHexText txId]
+      setFlags ["--hydra-scripts-tx-id", toString $ serialiseToRawBytesHexText txId]
         `shouldParse` Run
           defaultRunOptions
             { hydraScriptsTxId = txId
@@ -262,7 +264,7 @@ defaultRunOptions :: RunOptions
 defaultRunOptions =
   RunOptions
     { verbosity = Verbose "HydraNode"
-    , nodeId = "some_node_id_string"
+    , nodeId = NodeId "node-id-1"
     , host = "127.0.0.1"
     , port = 5001
     , peers = []

--- a/hydra-node/test/Hydra/OptionsSpec.hs
+++ b/hydra-node/test/Hydra/OptionsSpec.hs
@@ -262,7 +262,7 @@ defaultRunOptions :: RunOptions
 defaultRunOptions =
   RunOptions
     { verbosity = Verbose "HydraNode"
-    , nodeId = "some_node_id"
+    , nodeId = "some_node_id_string"
     , host = "127.0.0.1"
     , port = 5001
     , peers = []

--- a/hydra-node/test/Hydra/OptionsSpec.hs
+++ b/hydra-node/test/Hydra/OptionsSpec.hs
@@ -229,13 +229,12 @@ spec = parallel $
           , ["--network-id", "42"]
           , ["--cardano-signing-key", "bar"]
           ]
-          `shouldParse` ( Publish
-                            PublishOptions
-                              { publishNodeSocket = "foo"
-                              , publishNetworkId = Testnet (NetworkMagic 42)
-                              , publishSigningKey = "bar"
-                              }
-                        )
+          `shouldParse` Publish
+            PublishOptions
+              { publishNodeSocket = "foo"
+              , publishNetworkId = Testnet (NetworkMagic 42)
+              , publishSigningKey = "bar"
+              }
 
 canRoundtripRunOptionsAndPrettyPrinting :: RunOptions -> Property
 canRoundtripRunOptionsAndPrettyPrinting opts =
@@ -263,7 +262,7 @@ defaultRunOptions :: RunOptions
 defaultRunOptions =
   RunOptions
     { verbosity = Verbose "HydraNode"
-    , nodeId = 1
+    , nodeId = "some_node_id"
     , host = "127.0.0.1"
     , port = 5001
     , peers = []

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -57,7 +57,7 @@ import Hydra.Client (Client (..), HydraEvent (..), withClient)
 import Hydra.ContestationPeriod (ContestationPeriod (UnsafeContestationPeriod))
 import Hydra.Ledger (IsTx (..))
 import Hydra.Ledger.Cardano (mkSimpleTx)
-import Hydra.Network (Host (..))
+import Hydra.Network (Host (..), NodeId)
 import Hydra.Party (Party (..))
 import Hydra.Snapshot (Snapshot (..))
 import Hydra.TUI.Options (Options (..))
@@ -82,7 +82,7 @@ data State
   | Connected
       { me :: Maybe Party -- TODO(SN): we could make a nicer type if ClientConnected is only emited of 'Hydra.Client' upon receiving a 'Greeting'
       , nodeHost :: Host
-      , peers :: [Host]
+      , peers :: [NodeId]
       , headState :: HeadState
       , dialogState :: DialogState
       , feedback :: [UserFeedback]
@@ -673,7 +673,7 @@ draw Client{sk} CardanoClient{networkId} s =
 
   drawPeers = case s of
     Disconnected{} -> emptyWidget
-    Connected{peers} -> vBox $ str "Connected peers:" : map drawShow peers
+    Connected{peers} -> vBox $ str "Peers connected to our node:" : map drawShow peers
 
   drawHex :: SerialiseAsRawBytes a => a -> Widget n
   drawHex = txt . (" - " <>) . serialiseToRawBytesHexText


### PR DESCRIPTION
fix #538 

~~I am not so sure that we actually want to merge this after all. It re-uses the same `Host` type to add `nodeId` field so that we can distinguish in the tui the connected peers. Question is: do we want this change - if so we should remove the flag `--node-id` from the cmd line options and specify nodeId in the `--peers` flag.~~

We talked about this in the meeting and decided to go for the option to use the `NodeId` in the `HeartBeat` messages which should propagate to tui.
