### PR TITLE
Flaky model spec

### DIFF
--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -492,11 +492,6 @@ genAddressInEra networkId =
 genValue :: Gen Value
 genValue = fromLedgerValue <$> arbitrary
 
-genAdaValue :: Gen Value
-genAdaValue = filterOutNonAdaAssets <$> genValue
- where
-  filterOutNonAdaAssets = lovelaceToValue . selectLovelace
-
 -- | Generate UTXO entries that do not contain any assets. Useful to test /
 -- measure cases where
 genAdaOnlyUTxO :: Gen UTxO

--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -493,7 +493,9 @@ genValue :: Gen Value
 genValue = fromLedgerValue <$> arbitrary
 
 genAdaValue :: Gen Value
-genAdaValue = lovelaceToValue . selectLovelace <$> genValue
+genAdaValue = filterOutNonAdaAssets <$> genValue
+ where
+  filterOutNonAdaAssets = lovelaceToValue . selectLovelace
 
 -- | Generate UTXO entries that do not contain any assets. Useful to test /
 -- measure cases where

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -55,7 +55,7 @@ import Hydra.ContestationPeriod (ContestationPeriod)
 import Hydra.Crypto (HydraKey)
 import Hydra.HeadLogic (Committed (), PendingCommits)
 import Hydra.Ledger (IsTx (..))
-import Hydra.Ledger.Cardano (cardanoLedger, genAdaValue, genKeyPair, genSigningKey, mkSimpleTx)
+import Hydra.Ledger.Cardano (cardanoLedger, genKeyPair, genSigningKey, genValue, mkSimpleTx)
 import Hydra.Logging (Tracer)
 import Hydra.Node (HydraNodeLog, runHydraNode)
 import Hydra.Party (Party, deriveParty)
@@ -581,6 +581,13 @@ genPayment WorldState{hydraParties, hydraState} =
       (_, to) <- elements hydraParties `suchThat` ((/= from) . snd)
       pure (party, Payment{from, to, value})
     _ -> error $ "genPayment impossible in state: " <> show hydraState
+
+genAdaValue :: Gen Value
+genAdaValue = genNonNullAdaValue
+ where
+  genNonNullAdaValue = genAdaAsset `suchThat` (/= lovelaceToValue 0)
+  genAdaAsset = onlyAdaAssets <$> genValue
+  onlyAdaAssets = lovelaceToValue . selectLovelace
 
 unsafeConstructorName :: (Show a) => a -> String
 unsafeConstructorName = Prelude.head . Prelude.words . show

--- a/hydra-node/test/Hydra/ModelSpec.hs
+++ b/hydra-node/test/Hydra/ModelSpec.hs
@@ -155,6 +155,7 @@ prop_doesNotGenerate0AdaUTxO (Actions actions) =
   contains0AdaUTxO :: Step WorldState -> Bool
   contains0AdaUTxO = \case
     _anyVar := Model.Commit _anyParty utxos -> any contains0Ada utxos
+    _anyVar := Model.NewTx _anyParty Model.Payment{value} -> value == lovelaceToValue 0
     _anyOtherStep -> False
   contains0Ada = (== lovelaceToValue 0) . snd
 

--- a/hydra-node/test/Hydra/ModelSpec.hs
+++ b/hydra-node/test/Hydra/ModelSpec.hs
@@ -72,6 +72,7 @@ import Hydra.API.ClientInput (ClientInput (..))
 import Hydra.API.ServerOutput (ServerOutput (..))
 import Hydra.BehaviorSpec (TestHydraNode (..))
 import Hydra.Chain.Direct.Fixture (testNetworkId)
+import Hydra.Ledger.Cardano (genAdaValue)
 import Hydra.Model (
   Action (ObserveConfirmedTx, Wait),
   GlobalState (..),
@@ -100,6 +101,9 @@ import Test.Util (printTrace, traceInIOSim)
 
 spec :: Spec
 spec = do
+  -- There cannot be a UTxO with no ADAs
+  -- See https://github.com/input-output-hk/cardano-ledger/blob/master/doc/explanations/min-utxo-mary.rst
+  prop "model should not generate 0 Ada UTxO" $ forAll genAdaValue (/= lovelaceToValue 0)
   prop "model generates consistent traces" $ withMaxSuccess 10000 prop_generateTraces
   prop "implementation respects model" $ forAll arbitrary prop_checkModel
   prop "check conflict-free liveness" prop_checkConflictFreeLiveness

--- a/hydra-node/test/Hydra/ModelSpec.hs
+++ b/hydra-node/test/Hydra/ModelSpec.hs
@@ -72,7 +72,6 @@ import Hydra.API.ClientInput (ClientInput (..))
 import Hydra.API.ServerOutput (ServerOutput (..))
 import Hydra.BehaviorSpec (TestHydraNode (..))
 import Hydra.Chain.Direct.Fixture (testNetworkId)
-import Hydra.Ledger.Cardano (genAdaValue)
 import Hydra.Model (
   Action (ObserveConfirmedTx, Wait),
   GlobalState (..),
@@ -96,14 +95,14 @@ import Test.QuickCheck.DynamicLogic (
  )
 import Test.QuickCheck.Gen.Unsafe (Capture (Capture), capture)
 import Test.QuickCheck.Monadic (PropertyM, assert, monadic', monitor, run)
-import Test.QuickCheck.StateModel (Actions, RunModel, runActions, stateAfter, pattern Actions)
+import Test.QuickCheck.StateModel (Actions, RunModel, Step ((:=)), runActions, stateAfter, pattern Actions)
 import Test.Util (printTrace, traceInIOSim)
 
 spec :: Spec
 spec = do
   -- There cannot be a UTxO with no ADAs
   -- See https://github.com/input-output-hk/cardano-ledger/blob/master/doc/explanations/min-utxo-mary.rst
-  prop "model should not generate 0 Ada UTxO" $ forAll genAdaValue (/= lovelaceToValue 0)
+  prop "model should not generate 0 Ada UTxO" $ withMaxSuccess 10000 prop_doesNotGenerate0AdaUTxO
   prop "model generates consistent traces" $ withMaxSuccess 10000 prop_generateTraces
   prop "implementation respects model" $ forAll arbitrary prop_checkModel
   prop "check conflict-free liveness" prop_checkConflictFreeLiveness
@@ -148,6 +147,16 @@ prop_generateTraces actions =
         Actions _ ->
           hydraState st /= Start
             & counterexample ("state: " <> show st)
+
+prop_doesNotGenerate0AdaUTxO :: Actions WorldState -> Bool
+prop_doesNotGenerate0AdaUTxO (Actions actions) =
+  not (any contains0AdaUTxO actions)
+ where
+  contains0AdaUTxO :: Step WorldState -> Bool
+  contains0AdaUTxO = \case
+    _anyVar := Model.Commit _anyParty utxos -> any contains0Ada utxos
+    _anyOtherStep -> False
+  contains0Ada = (== lovelaceToValue 0) . snd
 
 prop_checkModel :: Actions WorldState -> Property
 prop_checkModel actions =


### PR DESCRIPTION
We don't want to generate 0 Ada values in the context of our Model tests as it would make no sense.

This will fix flaky tests that we observed in that kind of situations.

To check before merging:
* [x] CHANGELOG is up to date
* [x] Up to date with master
