### PR TITLE
Let's have a hydra-tools docker image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,7 +17,7 @@ jobs:
   docker:
     strategy:
       matrix:
-        target: [ hydra-node, hydra-tui, hydraw ]
+        target: [ hydra-node, hydra-tui, hydra-tools, hydraw ]
 
     runs-on: ubuntu-latest
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,16 @@ COPY --from=build-hydra-node /build/hydra-node-result/bin/hydra-node /bin/
 STOPSIGNAL SIGINT
 ENTRYPOINT ["hydra-node"]
 
+# hydra-tools
+
+FROM build as build-hydra-tools
+RUN nix-build -A hydra-tools-static -o hydra-tools-result release.nix
+
+FROM alpine as hydra-tools
+COPY --from=build-hydra-tools /build/hydra-tools-result/bin/hydra-tools /bin/
+STOPSIGNAL SIGINT
+ENTRYPOINT ["hydra-tools"]
+
 # hydra-tui
 
 FROM build as build-hydra-tui


### PR DESCRIPTION
If we provide a hydra-node docker image, I think we should also provide a hydra-tools image to provide a better experience to docker users.

To check before merging:
* [x] CHANGELOG is up to date
* [x] Up to date with master
