### PR TITLE
Fix hydra-tui docker image entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ FROM alpine as hydra-tui
 RUN apk update && apk add ncurses-terminfo
 COPY --from=build-hydra-tui /build/hydra-tui-result/bin/hydra-tui /bin/
 STOPSIGNAL SIGINT
-ENTRYPOINT ["sh", "-c", "TERMINFO=/usr/share/terminfo hydra-tui $@"]
+ENTRYPOINT ["sh", "-c", "TERMINFO=/usr/share/terminfo hydra-tui $@", "--"]
 
 # hydraw
 


### PR DESCRIPTION
Without that, command line arguments are sent to `sh` instead of `hydra-tui`

To check before merging:
* [x] CHANGELOG is up to date
* [x] Up to date with master
