### PR TITLE
Use CHaP :robot:

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,8 +65,8 @@ jobs:
 
     - name: 🔨 Build
       run: |
-        nix-shell --pure --arg withoutDevTools true --run 'cabal update'
-        nix-shell --pure --arg withoutDevTools true --run 'cabal build ${{ matrix.package }}'
+        nix-shell --arg withoutDevTools true --run 'cabal update'
+        nix-shell --arg withoutDevTools true --run 'cabal build ${{ matrix.package }}'
 
     - name: ❓ Test
       if: ${{ matrix.package != 'hydra-tui' }}
@@ -83,7 +83,7 @@ jobs:
         TERM: "xterm"
       continue-on-error: true
       run: |
-        nix-shell --pure --arg withoutDevTools true --run 'cabal test ${{ matrix.package }}'
+        nix-shell --arg withoutDevTools true --run 'cabal test ${{ matrix.package }}'
 
     - name: ⁉ Test (TUI, retry)
       if: steps.test_tui.outcome=='failure'
@@ -91,7 +91,7 @@ jobs:
       env:
         TERM: "xterm"
       run: |
-        nix-shell --pure --arg withoutDevTools true --run 'cabal test ${{ matrix.package }}'
+        nix-shell --arg withoutDevTools true --run 'cabal test ${{ matrix.package }}'
 
     - name: 💾 Upload build & test artifacts
       uses: actions/upload-artifact@v3
@@ -211,15 +211,15 @@ jobs:
     - name: ❄ Prepare nix-shell
       run: |
         nix-build --pure --arg withoutDevTools true shell.nix
-        nix-shell --pure --arg withoutDevTools true --run 'cabal update'
+        nix-shell --arg withoutDevTools true --run 'cabal update'
 
     - name: 📈 Benchmark
       run: |
-        nix-shell --pure --arg withoutDevTools true --run 'cabal bench ${{ matrix.bench }} --benchmark-options "${{ matrix.options }}"'
+        nix-shell --arg withoutDevTools true --run 'cabal bench ${{ matrix.bench }} --benchmark-options "${{ matrix.options }}"'
 
     - name: 📚 Documentation (Haddock)
       run: |
-        nix-shell --pure --arg withoutDevTools true --run '.github/workflows/ci-haddock.sh'
+        nix-shell --arg withoutDevTools true --run '.github/workflows/ci-haddock.sh'
 
     - name: 💾 Upload build & test artifacts
       uses: actions/upload-artifact@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,42 @@ something merged we usually require:
 + Change is related to an issue, feature (idea) or bug report - ideally discussed beforehand
 + Well-scoped - we prefer multiple PRs, rather than a big one
 
+### Updating dependencies
+
+#### From Hackage
+
+Updating package dependencies from Hackage should work like normal in a Haskell
+project. The most important thing to note is that we pin the `index-state` of
+the Hackage package index in `cabal.project`. This means that cabal will always
+see Hackage “as if” it was that time, ensuring reproducibility. But it also
+means that if you need a package version that was released *after* that time,
+you need to bump the `index-state` (and to run ``cabal update`` locally).
+
+Because of how we use Nix to manage our Haskell build, whenever you do this you
+will also need to pull in the Nix equivalent of the newer `index-state`. You can
+do this by bumping the `haskellNix` to a newer tag in our `default.nix`.
+
+#### From Cardano Haskell Packages (CHaP)
+
+Many Cardano packages are not on Hackage and are instead in the [Cardano Haskell
+Packages (CHaP)](https://github.com/input-output-hk/cardano-haskell-packages) see the
+README for (lots) more information. Getting new packages from there works much
+like getting them from Hackage. The differences are that it has an independent
+`index-state`, and that there is the `CHaP` expression which you need to bump in
+the `default.nix`.
+
+#### Using unreleased versions of dependencies
+
+Sometimes we need to use an unreleased version of one of our dependencies,
+either to fix an issue in a package that is not under our control, or to
+experiment with a pre-release version of one of our own packages. You can use a
+`source-repository-package` stanza to pull in the unreleased version. Do this
+**only** for a short period of time, and try to get your changes released
+upstream. If that is (really) not possible, we can also release a patched
+version into CHap, see their
+[README](https://github.com/input-output-hk/cardano-haskell-packages) for
+instructions.
+
 ### Versioning & Changelog
 
 During development

--- a/cabal.project
+++ b/cabal.project
@@ -98,7 +98,7 @@ source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node.git
   tag: 2fb29390e080bb27993b3e91399b10673feab8b8
-  --sha256: 0000000000000000000000000000000000000000000000000000
+  --sha256: 151iz6gpz4d3b4rhphnxp7prpi4hc7ym2xg564vp1k5n4zcjsyqi
   subdir:
     cardano-api
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
--- Custom repository for cardano haskell packages, see CONTRIBUTING for more
+-- Custom repository for cardano haskell packages, see CONTRIBUTING.md
 repository cardano-haskell-packages
   url: https://input-output-hk.github.io/cardano-haskell-packages
   secure: True
@@ -10,8 +10,7 @@ repository cardano-haskell-packages
     c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
--- See CONTRIBUTING for information about these, including some Nix commands
--- you need to run if you change them
+-- See CONTRIBUTING.md for information about when and how to update these.
 index-state: 2022-10-21T00:00:00Z
 index-state: cardano-haskell-packages 2022-10-21T00:00:00Z
 
@@ -58,6 +57,8 @@ package hydra-test-utils
 -- Always show detailed output for tests
 test-show-details: direct
 
+-- TODO: These should be fixed upstream, try to remove them whenever upstream
+-- packages have updated their cabal files.
 constraints:
     hedgehog >= 1.0
   , bimap >= 0.4.0
@@ -67,7 +68,6 @@ constraints:
   , HSOpenSSL >= 0.11.7.2
   , algebraic-graphs < 0.7
   , protolude < 0.3.1
-    -- TODO: these should be set in cabal files, but avoiding setting them in lower dependencies for initial CHaP release
   , cardano-prelude == 0.1.0.0
   , base-deriving-via == 0.1.0.0
   , cardano-binary == 1.5.0

--- a/cabal.project
+++ b/cabal.project
@@ -101,11 +101,3 @@ source-repository-package
   --sha256: 151iz6gpz4d3b4rhphnxp7prpi4hc7ym2xg564vp1k5n4zcjsyqi
   subdir:
     cardano-api
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/quickcheck-dynamic
-  tag: 1.1.0
-  --sha256: 17cf58b36db5xpa0h4rbv62i7zdmknhmzz0g0znlb0mglfn7w2aj
-  subdir:
-    quickcheck-dynamic

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,19 @@
+-- Custom repository for cardano haskell packages, see CONTRIBUTING for more
+repository cardano-haskell-packages
+  url: https://input-output-hk.github.io/cardano-haskell-packages
+  secure: True
+  root-keys:
+    3e0cce471cf09815f930210f7827266fd09045445d65923e6d0238a6cd15126f
+    443abb7fb497a134c343faf52f0b659bd7999bc06b7f63fa76dc99d631f9bea1
+    a86a1f6ce86c449c46666bda44268677abf29b5b2d2eb5ec7af903ec2f117a82
+    bcec67e8e99cabfa7764d75ad9b158d72bfacf70ca1d0ec8bc6b4406d1bf8413
+    c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
+    d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
-index-state: 2022-02-22T20:47:03Z
+-- See CONTRIBUTING for information about these, including some Nix commands
+-- you need to run if you change them
+index-state: 2022-10-21T00:00:00Z
+index-state: cardano-haskell-packages 2022-10-21T00:00:00Z
 
 packages:
   hydra-cluster
@@ -44,217 +58,49 @@ package hydra-test-utils
 -- Always show detailed output for tests
 test-show-details: direct
 
--- NOTE: master somewhere ahead of 1.35.x, but holding enough of our upstream
--- contributions to use for us
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-node.git
-  tag: aed8e71339cf6c92847fff83fbd92be61e468174
-  --sha256: 1j8lkrg8xz6gjaq8grx7vc4cynlz5x6n3cd9q4y5w3kzsd89072a
-  subdir:
-    cardano-api
-
--- NOTE(SN): These source-repository-package tags are copied from the
--- 'cardano-node' repository cabal.project at the revision given above. Make
--- sure to update 'tag' and 'sha256' entries when you do an upgrade. Or just
--- copy the whole thing and drop not-required packages and constraints.
-
--- Tracking cardano-node
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/optparse-applicative
-  tag: 7497a29cb998721a9068d5725d49461f2bba0e7a
-  --sha256: 1gvsrg925vynwgqwplgjmp53vj953qyh3wbdf34pw21c8r47w35r
-
--- Tracking cardano-node
-source-repository-package
-  type: git
-  location: https://github.com/vshabanov/ekg-json
-  tag: 00ebe7211c981686e65730b7144fbf5350462608
-  --sha256: 1zvjm3pb38w0ijig5wk5mdkzcszpmlp5d4zxvks2jk1rkypi8gsm
-
--- Tracking cardano-node
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/hedgehog-extras
-  tag: 967d79533c21e33387d0227a5f6cc185203fe658
-  --sha256: 0rbqb7a64aya1qizlr3im06hdydg9zr6sl3i8bvqqlf7kpa647sd
-
--- Tracking cardano-node
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-base
-  tag: a3c13fb11bc41fedff7885ca70a3b33f61fef4b5
-  --sha256: 0h492cz9mvzbsl5yzvp3iq40c0z0j5hmrifdrnnqzzk02g9j9c4b
-  subdir:
-    base-deriving-via
-    binary
-    binary/test
-    cardano-crypto-class
-    cardano-crypto-praos
-    cardano-crypto-tests
-    measures
-    orphans-deriving-via
-    slotting
-    strict-containers
-
--- Tracking cardano-node
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-crypto
-  tag: f73079303f663e028288f9f4a9e08bcca39a923e
-  --sha256: 1n87i15x54s0cjkh3nsxs4r1x016cdw1fypwmr68936n3xxsjn6q
-
--- Tracking cardano-node
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-ledger
-  tag: f49879a79098d9372d63baa13b94a941a56eda34
-  --sha256: 0i9x66yqkrvx2w79dy6lzlya82yxc8567rgjj828vc2d46d6nvx6
-  subdir:
-    eras/alonzo/impl
-    eras/alonzo/test-suite
-    eras/babbage/impl
-    eras/babbage/test-suite
-    eras/byron/chain/executable-spec
-    eras/byron/crypto
-    eras/byron/crypto/test
-    eras/byron/ledger/executable-spec
-    eras/byron/ledger/impl
-    eras/byron/ledger/impl/test
-    eras/shelley/impl
-    eras/shelley/test-suite
-    eras/shelley-ma/impl
-    eras/shelley-ma/test-suite
-    libs/cardano-ledger-core
-    libs/cardano-ledger-pretty
-    libs/cardano-ledger-test
-    libs/cardano-protocol-tpraos
-    libs/cardano-data
-    libs/vector-map
-    libs/set-algebra
-    libs/small-steps
-    libs/small-steps-test
-    libs/non-integral
-
--- Tracking cardano-node
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-prelude
-  tag: 6ea36cf2247ac0bc33e08c327abec34dfd05bd99
-  --sha256: 0z2y3wzppc12bpn9bl48776ms3nszw8j58xfsdxf97nzjgrmd62g
-  subdir:
-    cardano-prelude
-    cardano-prelude-test
-
--- Tracking cardano-node
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/goblins
-  tag: cde90a2b27f79187ca8310b6549331e59595e7ba
-  --sha256: 17c88rbva3iw82yg9srlxjv2ia5wjb9cyqw44hik565f5v9svnyg
-
--- Tracking cardano-node
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 066f7002aac5a0efc20e49643fea45454f226caa
-  --sha256: 0s6x4in11k5ba7nl7la896g28sznf9185xlqg9c604jqz58vj9nj
-  subdir:
-    contra-tracer
-    iohk-monitoring
-    tracer-transformers
-
--- Tracking cardano-node
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/Win32-network
-  tag: 3825d3abf75f83f406c1f7161883c438dac7277d
-  --sha256: 19wahfv726fa3mqajpqdqhnl9ica3xmf68i254q45iyjcpj1psqx
-
--- Tracking cardano-node
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: c764553561bed8978d2c6753d1608dc65449617a
-  --sha256: 0hdh7xdrvxw943r6qr0xr4kwszindh5mnsn1lww6qdnxnmn7wcsc
-  subdir:
-    monoidal-synchronisation
-    network-mux
-    ouroboros-consensus
-    ouroboros-consensus-byron
-    ouroboros-consensus-byronspec
-    ouroboros-consensus-byron-test
-    ouroboros-consensus-cardano
-    ouroboros-consensus-cardano-test
-    ouroboros-consensus-protocol
-    ouroboros-consensus-shelley
-    ouroboros-consensus-shelley-test
-    ouroboros-consensus-test
-    ouroboros-network
-    ouroboros-network-framework
-    ouroboros-network-testing
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/io-sim
-  tag: f4183f274d88d0ad15817c7052df3a6a8b40e6dc
-  --sha256: 0vb2pd9hl89v2y5hrhrsm69yx0jf98vppjmfncj2fraxr3p3lldw
-  subdir:
-    io-classes
-    io-sim
-    strict-stm
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/typed-protocols
-  tag: 181601bc3d9e9d21a671ce01e0b481348b3ca104
-  --sha256: 1lr97b2z7l0rpsmmz92rsv27qzd5vavz10cf7n25svya4kkiysp5
-  subdir:
-    typed-protocols
-    typed-protocols-cborg
-    typed-protocols-examples
-
--- Tracking cardano-node
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ekg-forward
-  tag: 297cd9db5074339a2fb2e5ae7d0780debb670c63
-  --sha256: 1zcwry3y5rmd9lgxy89wsb3k4kpffqji35dc7ghzbz603y1gy24g
-
--- Tracking cardano-node
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/flat
-  tag: ee59880f47ab835dbd73bea0847dab7869fc20d8
-  --sha256: 1lrzknw765pz2j97nvv9ip3l1mcpf2zr4n56hwlz0rk7wq7ls4cm
-
--- Tracking cardano-node
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/plutus
-  tag: f680ac6979e069fcc013e4389ee607ff5fa6672f
-  --sha256: 180jq8hd0jlg48ya7b5yw3bnd2d5czy0b1agy9ng3mgnzpyq747i
-  subdir:
-    plutus-core
-    plutus-ledger-api
-    plutus-tx
-    plutus-tx-plugin
-    prettyprinter-configurable
-    stubs/plutus-ghc-stub
-    word-array
-
 constraints:
     hedgehog >= 1.0
   , bimap >= 0.4.0
   , libsystemd-journal >= 1.4.4
   , systemd >= 2.3.0
   , network >= 3.1.1.0
+  , HSOpenSSL >= 0.11.7.2
+  , algebraic-graphs < 0.7
+  , protolude < 0.3.1
+    -- TODO: these should be set in cabal files, but avoiding setting them in lower dependencies for initial CHaP release
+  , cardano-prelude == 0.1.0.0
+  , base-deriving-via == 0.1.0.0
+  , cardano-binary == 1.5.0
+  , cardano-binary-test == 1.3.0
+  , cardano-crypto-class == 2.0.0
+  , cardano-crypto-praos == 2.0.0
+  , cardano-crypto-tests == 2.0.0
+  , cardano-slotting == 0.1.0.0
+  , measures == 0.1.0.0
+  , orphans-deriving-via == 0.1.0.0
+  , strict-containers == 0.1.0.0
+  , plutus-core == 1.0.0.0
+  , plutus-ledger-api == 1.0.0.0
+  , plutus-tx == 1.0.0.0
+  , plutus-tx-plugin == 1.0.0.0
+  , prettyprinter-configurable == 0.1.0.0
+  , plutus-ghc-stub == 8.6.5
+  , word-array == 0.1.0.0
 
 allow-newer:
   *:aeson,
   monoidal-containers:aeson,
   size-based:template-haskell
+
+-- TODO: Backported our changes onto 1.35.3 (latest in CHaP).
+-- Branch: ch1bo/backport-cardano-api-1.35.3
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-node.git
+  tag: 2fb29390e080bb27993b3e91399b10673feab8b8
+  --sha256: 0000000000000000000000000000000000000000000000000000
+  subdir:
+    cardano-api
 
 source-repository-package
   type: git
@@ -263,10 +109,3 @@ source-repository-package
   --sha256: 17cf58b36db5xpa0h4rbv62i7zdmknhmzz0g0znlb0mglfn7w2aj
   subdir:
     quickcheck-dynamic
-
--- Version with fixed moo.cabal not on hackage yet
-source-repository-package
-  type: git
-  location: https://github.com/astanin/moo
-  tag: dbda5e76ac3b4c72c805ec0cdb9bcdff7bb6247d
-  --sha256: 1mdj218hgh7s5a6b9k14vg9i06zxah0wa42ycdgh245izs8nfv0x

--- a/default.nix
+++ b/default.nix
@@ -4,13 +4,17 @@
 
 , haskellNix ? import
     (builtins.fetchTarball
-      "https://github.com/input-output-hk/haskell.nix/archive/0.0.49.tar.gz")
+      "https://github.com/input-output-hk/haskell.nix/archive/0.0.64.tar.gz")
     { }
 
 , iohkNix ? import
     (builtins.fetchTarball
       "https://github.com/input-output-hk/iohk-nix/archive/d31417fe8c8fbfb697b3ad4c498e17eb046874b9.tar.gz")
     { }
+
+  # NOTE: use the 'repo' branch of CHaP which contains the index
+, CHaP ? (builtins.fetchTarball
+    "https://github.com/input-output-hk/cardano-haskell-packages/archive/ceaae5355c81453d7cb092acadec3441bf57ed11.tar.gz")
 
   # nixpkgs-unstable as also used by cardano-node, cardano-ledger et al
 , nixpkgsSrc ? haskellNix.sources.nixpkgs-unstable
@@ -31,6 +35,8 @@ let
     };
     projectFileName = "cabal.project";
     compiler-nix-name = compiler;
+
+    inputMap = { "https://input-output-hk.github.io/cardano-haskell-packages" = CHaP; };
 
     modules = [
       # Set libsodium-vrf on cardano-crypto-{praos,class}. Otherwise they depend

--- a/hydra-cardano-api/src/Hydra/Cardano/Api.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api.hs
@@ -72,7 +72,6 @@ import Cardano.Api.Byron as X (
   Address (..),
  )
 import Cardano.Api.Shelley as X (
-  AcquireFailure (..),
   Address (..),
   Hash (HeaderHash),
   Key (..),

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -242,6 +242,7 @@ test-suite integration
     , hydra-test-utils
     , lens
     , lens-aeson
+    , ouroboros-network
     , plutus-ledger-api
     , process
     , QuickCheck

--- a/hydra-cluster/test/Test/DirectChainSpec.hs
+++ b/hydra-cluster/test/Test/DirectChainSpec.hs
@@ -20,7 +20,6 @@ import Control.Concurrent (MVar, newEmptyMVar, putMVar, takeMVar)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 import Hydra.Cardano.Api (
-  AcquireFailure (AcquireFailurePointNotOnChain),
   ChainPoint (..),
   lovelaceToValue,
   txOutValue,
@@ -63,6 +62,9 @@ import Hydra.Options (
   toArgNetworkId,
  )
 import Hydra.Snapshot (ConfirmedSnapshot (..), Snapshot (..))
+import Ouroboros.Network.Protocol.LocalStateQuery.Type (
+  AcquireFailure (AcquireFailurePointNotOnChain),
+ )
 import System.Process (proc, readCreateProcess)
 import Test.QuickCheck (generate)
 

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -349,7 +349,7 @@ test-suite tests
     , plutus-ledger-api
     , process
     , QuickCheck
-    , quickcheck-dynamic
+    , quickcheck-dynamic                <2.0.0
     , quickcheck-instances
     , req
     , silently

--- a/hydra-node/src/Hydra/Chain/CardanoClient.hs
+++ b/hydra-node/src/Hydra/Chain/CardanoClient.hs
@@ -12,6 +12,7 @@ import qualified Cardano.Api.UTxO as UTxO
 import Cardano.Slotting.Time (SystemStart)
 import qualified Data.Set as Set
 import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (EraMismatch)
+import Ouroboros.Network.Protocol.LocalStateQuery.Type (AcquireFailure)
 import Ouroboros.Network.Protocol.LocalTxSubmission.Client (SubmitResult (..))
 import Test.QuickCheck (oneof)
 

--- a/hydra-prelude/src/Hydra/Prelude.hs
+++ b/hydra-prelude/src/Hydra/Prelude.hs
@@ -103,7 +103,6 @@ import qualified Generic.Random.Internal.Generic as Random
 import Relude hiding (
   MVar,
   Nat,
-  Option,
   STM,
   TMVar,
   TVar,


### PR DESCRIPTION
:robot: The Cardano Haskell Packages (CHaP) will make our life's simpler by forcing our upstream dependencies to version & release their code, and we don't need to keep `source-repository-package` entries in the `cabal.project`

:robot: Added the CHaP index to `cabal.project` and made it work using nix. The nix shell will now compile (or download) & provide most third-party dependencies to us.

:robot: Only exception: `cardano-api` where only version `1.35.3` is in CHaP, which does not include our upstreamed changes. Needed to backport the two commits and keep the `source-repository-package` stanza for that one.
