### PR TITLE
task(tui): improve tui UX feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ hspec-results.md
 
 # Getting started / demo instructions
 /demo/devnet/
+demo/chainstate
+demo/headstate
 
 # Testnet setups
 testnet/logs/

--- a/docs/docs/getting-started/demo/without-docker.md
+++ b/docs/docs/getting-started/demo/without-docker.md
@@ -96,7 +96,8 @@ source .env && hydra-node \
   --ledger-genesis devnet/genesis-shelley.json \
   --ledger-protocol-parameters devnet/protocol-parameters.json \
   --network-id 42 \
-  --node-socket devnet/node.socket
+  --node-socket devnet/node.socket \
+  --persistence-dir persistence/alice
 ```
 
 </TerminalWindow>
@@ -120,7 +121,8 @@ source .env && hydra-node \
   --ledger-genesis devnet/genesis-shelley.json \
   --ledger-protocol-parameters devnet/protocol-parameters.json \
   --network-id 42 \
-  --node-socket devnet/node.socket
+  --node-socket devnet/node.socket \
+  --persistence-dir persistence/bob
 ```
 
 </TerminalWindow>
@@ -144,7 +146,8 @@ source .env && hydra-node \
   --ledger-genesis devnet/genesis-shelley.json \
   --ledger-protocol-parameters devnet/protocol-parameters.json \
   --network-id 42 \
-  --node-socket devnet/node.socket
+  --node-socket devnet/node.socket \
+  --persistence-dir persistence/carol
 ```
 
 </TerminalWindow>

--- a/docs/docs/getting-started/demo/without-docker.md
+++ b/docs/docs/getting-started/demo/without-docker.md
@@ -163,7 +163,7 @@ Connect to the nodes using hydra-tui. For example, to use Alice's hydra-node and
 <TerminalWindow>
 
 ```
-cabal exec hydra-tui -- \
+hydra-tui \
   --connect 0.0.0.0:4001 \
   --cardano-signing-key devnet/credentials/alice.sk \
   --network-id 42 \

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -393,6 +393,15 @@ handleDialogEvent (title, form, submit) s = \case
     case invalidFields form of
       [] -> submit s (formState form)
       fs -> continue $ s & warn ("Invalid fields: " <> Text.intercalate ", " fs)
+  EvKey (KChar c) _
+    | c `elem` ['<'] ->
+      scroll s Up *> continue s
+    | c `elem` ['>'] ->
+      scroll s Down *> continue s
+    | c `elem` ['h', 'H'] ->
+      continue $ s & feedbackStateL .~ Full
+    | c `elem` ['s', 'S'] ->
+      continue $ s & feedbackStateL .~ Short
   e -> do
     form' <- handleFormEvent (VtyEvent e) form
     continue $ s & dialogStateL .~ Dialog title form' submit

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -493,7 +493,7 @@ draw Client{sk} CardanoClient{networkId} s =
               , drawRightPanel
               ]
           , hBorder
-          , vBox $ padLeftRight 1 <$> drawFeedback
+          , vLimit 10 $ vBox $ padLeftRight 1 <$> drawFeedback
           ]
  where
   vk = getVerificationKey sk

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -548,11 +548,12 @@ draw Client{sk} CardanoClient{networkId} s =
               , "[>] scroll right"
               , "Full [H]istory Mode"
               ]
-         in hBox
-              [ hLimit 120 $ viewport shortFeedbackViewportName Horizontal panel
-              , vBorder
-              , padLeftRight 1 $ vBox (str <$> cmds)
-              ]
+         in vLimit 3 $
+              hBox
+                [ hLimit 120 $ viewport shortFeedbackViewportName Horizontal panel
+                , vBorder
+                , padLeftRight 1 $ vBox (str <$> cmds)
+                ]
       ]
 
   drawInfo =

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -729,11 +729,10 @@ draw Client{sk} CardanoClient{networkId} s =
   drawShortFeedback =
     case s ^? (feedbackL . _head) of
       Just UserFeedback{message, severity, time} ->
-        let errorMessage = withAttr (severityToAttr severity) . txt $ (show time <> " | " <> message)
-         in errorMessage
+        withAttr (severityToAttr severity) . str . toString $ (show time <> " | " <> message)
       Nothing ->
         -- Reserves the space and not have this area collapse
-        txt ""
+        str ""
 
   drawParties =
     case s ^? headStateL . partiesL of

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -215,24 +215,10 @@ handleEvent client cardanoClient s = \case
       -- Commands
       EvKey (KChar c) _ ->
         if
-            | c `elem` ['<'] -> do
-              case s ^? feedbackStateL of
-                Just Full -> do
-                  let vp = viewportScroll fullFeedbackViewportName
-                  vScrollPage vp Up
-                _ -> do
-                  let vp = viewportScroll shortFeedbackViewportName
-                  hScrollPage vp Up
-              continue s
-            | c `elem` ['>'] -> do
-              case s ^? feedbackStateL of
-                Just Full -> do
-                  let vp = viewportScroll fullFeedbackViewportName
-                  vScrollPage vp Down
-                _ -> do
-                  let vp = viewportScroll shortFeedbackViewportName
-                  hScrollPage vp Down
-              continue s
+            | c `elem` ['<'] ->
+              scroll s Up *> continue s
+            | c `elem` ['>'] ->
+              scroll s Down *> continue s
             | c `elem` ['h', 'H'] ->
               continue $ s & feedbackStateL .~ Full
             | c `elem` ['s', 'S'] ->
@@ -511,6 +497,16 @@ fullFeedbackViewportName = "full-feedback-view-port"
 
 shortFeedbackViewportName :: Name
 shortFeedbackViewportName = "short-feedback-view-port"
+
+scroll :: State -> Direction -> EventM Name ()
+scroll s direction =
+  case s ^? feedbackStateL of
+    Just Full -> do
+      let vp = viewportScroll fullFeedbackViewportName
+      vScrollPage vp direction
+    _ -> do
+      let vp = viewportScroll shortFeedbackViewportName
+      hScrollPage vp direction
 
 draw :: Client Tx m -> CardanoClient -> State -> [Widget Name]
 draw Client{sk} CardanoClient{networkId} s =

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -31,6 +31,7 @@ import Brick.Widgets.Border.Style (ascii)
 import qualified Cardano.Api.UTxO as UTxO
 import Data.List (nub, (\\))
 import qualified Data.Map.Strict as Map
+import Data.Text (chunksOf)
 import qualified Data.Text as Text
 import Data.Time (defaultTimeLocale, formatTime)
 import Data.Time.Format (FormatTime)
@@ -492,7 +493,7 @@ draw Client{sk} CardanoClient{networkId} s =
               , drawRightPanel
               ]
           , hBorder
-          , padLeftRight 1 drawFeedback
+          , vBox $ padLeftRight 1 <$> drawFeedback
           ]
  where
   vk = getVerificationKey sk
@@ -656,10 +657,10 @@ draw Client{sk} CardanoClient{networkId} s =
   drawFeedback =
     case s ^? (feedbackL . _head) of
       Just UserFeedback{message, severity, time} ->
-        withAttr (severityToAttr severity) $ str (toString (show time <> " | " <> message))
+        withAttr (severityToAttr severity) . txt <$> chunksOf 120 (show time <> " | " <> message)
       Nothing ->
         -- Reserves the space and not have this area collapse
-        str " "
+        [txt ""]
 
   drawParties =
     case s ^? headStateL . partiesL of

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -533,15 +533,18 @@ draw Client{sk} CardanoClient{networkId} s =
       [ drawHeadState
       , let panel = drawFullFeedback
             cmds =
-              commandList
-                <> [ "[<] scroll up"
-                   , "[>] scroll down"
-                   , "[S]hort Feedback Mode"
-                   ]
+              [ "[<] scroll up"
+              , "[>] scroll down"
+              , "[S]hort Feedback Mode"
+              ]
          in hBox
-              [ hLimit 120 $ viewport fullFeedbackViewportName Vertical (vBox panel)
+              [ hLimit 150 $ viewport fullFeedbackViewportName Vertical (vBox panel)
               , vBorder
-              , padLeftRight 1 . vBox $ (str <$> cmds)
+              , vBox
+                  [ padLeftRight 1 . vBox $ (str <$> commandList)
+                  , hBorder
+                  , padLeftRight 1 . vBox $ (str <$> cmds)
+                  ]
               ]
       ]
 
@@ -561,7 +564,7 @@ draw Client{sk} CardanoClient{networkId} s =
               ]
          in vLimit 3 $
               hBox
-                [ hLimit 120 $ viewport shortFeedbackViewportName Horizontal panel
+                [ hLimit 150 $ viewport shortFeedbackViewportName Horizontal panel
                 , vBorder
                 , padLeftRight 1 . vBox $ (str <$> cmds)
                 ]
@@ -718,7 +721,7 @@ draw Client{sk} CardanoClient{networkId} s =
 
   withCommands panel cmds =
     hBox
-      [ hLimit 70 (vBox panel)
+      [ hLimit 100 (vBox panel)
       , vBorder
       , padLeftRight 1 $ vBox (str <$> cmds)
       ]
@@ -730,7 +733,7 @@ draw Client{sk} CardanoClient{networkId} s =
         feedbackToWidget =
           ( \UserFeedback{message, severity, time} ->
               let feedbackText = show time <> " | " <> message
-                  feedbackChunks = chunksOf 120 feedbackText
+                  feedbackChunks = chunksOf 150 feedbackText
                   feedbackDecorator = withAttr (severityToAttr severity) . txt
                in feedbackDecorator <$> feedbackChunks
           )


### PR DESCRIPTION
Fixes #531 

## Summary

🍭 Refactor the feedback panel to be able to switch between two modes:
- Full [H]istory
- [S]hort Feedback

🍭 Full [H]istory Mode:
- provides the user with a fullscreen view that renders a full history of feedback logs.
- this mode hides the user from the normal dialog panel but it does not prevent the user from continuing to interact with the state through commands.
- this panel is composed of a set of widgets, each containing a chunk of a feedback message.
- because of the above, this view has the possibility to scroll Up (<) and Down (>).
<img width="1790" alt="image" src="https://user-images.githubusercontent.com/14299604/197509236-407b0467-6a5b-4cc3-8a03-8811a6be5779.png">



🍭 [S]hort Feedback Mode:
- provides the user with a single-line view of the last feedback.
- this mode does not hide the user from the normal dialog panel, thus the user can continue to observe the state interactions.
- this view is a single text widget that overflows the screen.
- because of the above, this view has the possibility to scroll Left (<) and Right (>).
<img width="1603" alt="image" src="https://user-images.githubusercontent.com/14299604/197334170-6181985e-b48e-444e-bf32-987e7e988652.png">

## Extras

🍭 Add demo persistent state files to .gitignore

🍭 Fix [with-out-docker demo docs](https://hydra.family/head-protocol/docs/getting-started/demo/without-docker#running-the-clients) on launching hydra-tui and multiple persistence hydra-nodes

To check before merging:
* [ ] CHANGELOG is up to date
* [x] Updated documentation
