### PR TITLE
fix(tui): alter terminal being used during CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,7 +93,6 @@ jobs:
     - name: ❓ Test (TUI)
       id: test_tui
       if: ${{ matrix.package == 'hydra-tui' }}
-      continue-on-error: true
       # https://giters.com/gfx/example-github-actions-with-tty
       # The default shell does not allocate a TTY which breaks some tests
       shell: 'script -q -e -c "bash {0}"'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,7 @@ jobs:
       if: ${{ matrix.package == 'hydra-tui' }}
       # https://giters.com/gfx/example-github-actions-with-tty
       # The default shell does not allocate a TTY which breaks some tests
-      shell: 'script -q -e -c "bash {0}"'
+      shell: 'script -q -e -c "bash -eo pipefail {0}"'
       env:
         TERM: "xterm-color"
       continue-on-error: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,8 +80,7 @@ jobs:
       # The default shell does not allocate a TTY which breaks some tests
       shell: 'script -q -e -c "bash -eo pipefail {0}"'
       env:
-        TERM: "ansi-cup"
-      continue-on-error: true
+        TERM: "xterm-color"
       run: |
         nix-shell --arg withoutDevTools true --run 'cabal test ${{ matrix.package }}'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,7 +102,7 @@ jobs:
         ulimit -c               # should output 0 if disabled
         ulimit -c unlimited
         ulimit -c               # should output 'unlimited' now
-        nix-shell --arg withoutDevTools true --run 'cabal test --test-wrapper strace ${{ matrix.package }}'
+        nix-shell --arg withoutDevTools true --run 'cabal test ${{ matrix.package }}'
 
     - name: 💾 Upload core dumps
       uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,7 @@ jobs:
       if: ${{ matrix.package == 'hydra-tui' }}
       # https://giters.com/gfx/example-github-actions-with-tty
       # The default shell does not allocate a TTY which breaks some tests
-      shell: 'script -q -e -c "bash -eo pipefail {0}"'
+      shell: 'script -q -e -c "bash {0}"'
       env:
         TERM: "xterm-color"
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,6 +84,14 @@ jobs:
       run: |
         nix-shell --arg withoutDevTools true --run 'cabal test ${{ matrix.package }}'
 
+    - name: 💾 Upload failed test artifacts
+      uses: actions/upload-artifact@v3
+      if: failure() && steps.test_tui.outcome != 'success'
+      with:
+        name: test-failed-results
+        path: |
+          ./**/dist-newstyle/build/x86_64-linux/ghc-8.10.7/hydra-tui-0.8.0/t/tests/test/hydra-tui-0.8.0-tests.log
+
     - name: 💾 Upload build & test artifacts
       uses: actions/upload-artifact@v3
       with:
@@ -91,14 +99,6 @@ jobs:
         path: |
           ./**/test-results.xml
           ./**/hspec-results.md
-          
-    - name: 💾 Upload failed test artifacts
-      uses: actions/upload-artifact@v3
-      if: always() && steps.test_tui.outcome != 'success'
-      with:
-        name: test-failed-results
-        path: |
-          ./**/dist-newstyle/build/x86_64-linux/ghc-8.10.7/hydra-tui-0.8.0/t/tests/test/hydra-tui-0.8.0-tests.log
 
   build-executables:
     name: "Build using nix"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,7 +103,7 @@ jobs:
         ulimit -c               # should output 0 if disabled
         ulimit -c unlimited
         ulimit -c               # should output 'unlimited' now
-        nix-shell --arg withoutDevTools true --run 'cabal test ${{ matrix.package }}'
+        nix-shell --arg withoutDevTools true --run 'cabal test --test-wrapper strace ${{ matrix.package }}'
 
     - name: 💾 Upload core dumps
       uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,14 +85,6 @@ jobs:
       run: |
         nix-shell --arg withoutDevTools true --run 'cabal test ${{ matrix.package }}'
 
-    - name: ⁉ Test (TUI, retry)
-      if: steps.test_tui.outcome=='failure'
-      shell: 'script -q -e -c "bash {0}"'
-      env:
-        TERM: "xterm-color"
-      run: |
-        nix-shell --arg withoutDevTools true --run 'cabal test ${{ matrix.package }}'
-
     - name: 💾 Upload build & test artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,19 @@ jobs:
         name: hydra-node
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
+    - name: Checkout actions/cache@v3
+      uses: actions/checkout@v3
+      with:
+        repository: actions/cache
+        ref: v3
+        path: .tmp/actions/cache
+
+    - name: Make actions/cache@v3 run always, not only when job succeeds
+      # Tweak `action.yml` of `actions/cache@v3` to remove its `post-if`
+      # condition, making it default to `post-if: always()`.
+      run: |
+        sed -i -e '/ post-if: /d' .tmp/actions/cache/action.yml
+
     - name: 🔁 Github cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
       uses: actions/cache@v3
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,16 +86,32 @@ jobs:
       run: |
         nix-shell --arg withoutDevTools true --run 'cabal test ${{ matrix.package }}'
 
+    - name: 🔨 Prepare core dump
+      run: |
+        echo "$PWD/cores/corefile-%e-%p-%t" | sudo tee /proc/sys/kernel/core_pattern
+
     - name: ❓ Test (TUI)
       id: test_tui
       if: ${{ matrix.package == 'hydra-tui' }}
+      continue-on-error: true
       # https://giters.com/gfx/example-github-actions-with-tty
       # The default shell does not allocate a TTY which breaks some tests
       shell: 'script -q -e -c "bash {0}"'
       env:
         TERM: "xterm-color"
       run: |
+        ulimit -c               # should output 0 if disabled
+        ulimit -c unlimited
+        ulimit -c               # should output 'unlimited' now
         nix-shell --arg withoutDevTools true --run 'cabal test ${{ matrix.package }}'
+
+    - name: 💾 Upload core dumps
+      uses: actions/upload-artifact@v3
+      if: failure() && steps.test_tui.outcome != 'success'
+      with:
+        name: test-core-dumps
+        path: |
+          "$PWD/cores"
 
     - name: 💾 Upload failed test artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,7 @@ jobs:
       # The default shell does not allocate a TTY which breaks some tests
       shell: 'script -q -e -c "bash {0}"'
       env:
-        TERM: "xterm"
+        TERM: "xterm-color"
       continue-on-error: true
       run: |
         nix-shell --arg withoutDevTools true --run 'cabal test ${{ matrix.package }}'
@@ -89,7 +89,7 @@ jobs:
       if: steps.test_tui.outcome=='failure'
       shell: 'script -q -e -c "bash {0}"'
       env:
-        TERM: "xterm"
+        TERM: "xterm-color"
       run: |
         nix-shell --arg withoutDevTools true --run 'cabal test ${{ matrix.package }}'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,14 +84,6 @@ jobs:
       run: |
         nix-shell --arg withoutDevTools true --run 'cabal test ${{ matrix.package }}'
 
-    - name: 💾 Upload failed test artifacts
-      uses: actions/upload-artifact@v3
-      if: failure() && steps.test_tui.outcome != 'success'
-      with:
-        name: test-failed-results
-        path: |
-          ./**/dist-newstyle/build/x86_64-linux/ghc-8.10.7/hydra-tui-0.8.0/t/tests/test/hydra-tui-0.8.0-tests.log
-
     - name: 💾 Upload build & test artifacts
       uses: actions/upload-artifact@v3
       with:
@@ -99,6 +91,14 @@ jobs:
         path: |
           ./**/test-results.xml
           ./**/hspec-results.md
+          
+    - name: 💾 Upload failed test artifacts
+      uses: actions/upload-artifact@v3
+      if: always() && steps.test_tui.outcome != 'success'
+      with:
+        name: test-failed-results
+        path: |
+          ./**/dist-newstyle/build/x86_64-linux/ghc-8.10.7/hydra-tui-0.8.0/t/tests/test/hydra-tui-0.8.0-tests.log
 
   build-executables:
     name: "Build using nix"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,7 @@ jobs:
       # The default shell does not allocate a TTY which breaks some tests
       shell: 'script -q -e -c "bash -eo pipefail {0}"'
       env:
-        TERM: "xterm-color"
+        TERM: "ansi-cup"
       continue-on-error: true
       run: |
         nix-shell --arg withoutDevTools true --run 'cabal test ${{ matrix.package }}'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,6 +84,14 @@ jobs:
       run: |
         nix-shell --arg withoutDevTools true --run 'cabal test ${{ matrix.package }}'
 
+    - name: 💾 Upload failed test artifacts
+      uses: actions/upload-artifact@v3
+      if: failure() && steps.test_tui.outcome != 'success'
+      with:
+        name: test-failed-results
+        path: |
+          ./**/dist-newstyle/build/x86_64-linux/ghc-8.10.7/hydra-tui-0.8.0/t/tests/test/hydra-tui-0.8.0-tests.log
+
     - name: 💾 Upload build & test artifacts
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/input-output-hk/hydra-poc/issues/590#issuecomment-1297055566)

🥶  This term should allocate a TTY, support colors, and have "cup" capabilities enabled.

> "cup" appears to stand for "cursor position", and is another
terminfo capability used for moving the cursor to an arbitrary location
on the screen. smcup is used to prepare the terminal for cup usage, and
rmcup is used to reset it.

🥶 To select another terminal available, we need to run `toe -a | less` as a  separate CI step.
Here is detailed information about each: https://invisible-island.net/ncurses/terminfo.ti-entries.html
Here is the set of available options:  [term-options-available.txt](https://github.com/input-output-hk/hydra-poc/files/9909364/term-options-available.txt)

🥶 Because we are not using the default term, we manually call bash with options using a shell step as a script.
Here is the link to this strategy: https://github.com/gfx/example-github-actions-with-tty
And the links for the options selected:
  - script options: https://manpages.ubuntu.com/manpages/bionic/en/man1/script.1.html
  - bash options: https://gist.github.com/mohanpedala/1e2ff5661761d3abd0385e8223e16425?permalink_comment_id=3945021

🥶 Remove **"Test (TUI, retry)"** step from CI, as it's no longer needed (we will continue in case of failure on the future PR)

🥶 Add steps to upload artifacts for failed test results.

🥶 Add cache steps in case of failure.

To check before merging:
* [ ] ~CHANGELOG is up to date~
* [ ] ~Documentation updated~
