### PR TITLE
replay events to client upon connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ changes.
   + Include the `chainState` in `InvalidStateToPost` errors.
   + Moved received transaction ids into `RolledForward` log message.
 
+- After restarting `hydra-node`, clients will receive the whole history now.  [#580](https://github.com/input-output-hk/hydra-poc/issues/580)
+  + This history will be kept as `server-output` state in `--persistence-dir`.
+
 - **BREAKING** Changed internal wallet logs to help with debugging [#600](https://github.com/input-output-hk/hydra-poc/pull/600)
   + Split `ApplyBlock` into `BeginUpdate` and `EndUpdate`
   + Split `InitializedWallet` into `BeginInitialize` and `EndInitialize`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ changes.
 
 - After restarting `hydra-node`, clients will receive the whole history now.  [#580](https://github.com/input-output-hk/hydra-poc/issues/580)
   + This history will be kept as `server-output` state in `--persistence-dir`.
+  + Clients should use `Greetings` to identify the end of a restart/replay of events.
 
 - **BREAKING** Changed internal wallet logs to help with debugging [#600](https://github.com/input-output-hk/hydra-poc/pull/600)
   + Split `ApplyBlock` into `BeginUpdate` and `EndUpdate`

--- a/docs/core-concepts/behavior.md
+++ b/docs/core-concepts/behavior.md
@@ -16,3 +16,6 @@ Not pictured is the `CommandFailed` output, which is implicit emitted whenever a
 
 A special case is the `RolledBack` output. This means that the chain rolled back, but it includes no particular information in which state the Hydra Head is now. Frankly, this is quite hard to use - we will improve on this!, but should not invalidate any of the behavioral rules.
 
+## Replay of past server outputs
+
+When a `hydra-node` restarts, it will load it's history from persistence and replay previous server outputs to enable clients to re-establish their state upon re-connection. If that happens, obviously some of these outputs are not relevant anymore. One example of this is the `PeerConnected` and `PeerDisconnected`. To make it possible to determine the end of replayed history, client applications can use the `Greetings`, which will be emitted on every `hydra-node` start. See the `hydra-tui` example client for how this is handled.

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -79,6 +79,28 @@ restartedNodeCanAbort tracer workDir cardanoNode hydraScriptsTxId = do
  where
   RunningNode{nodeSocket, networkId} = cardanoNode
 
+restartedNodeCanReplayEventsToAPIClient :: Tracer IO EndToEndLog -> FilePath -> RunningNode -> TxId -> IO ()
+restartedNodeCanReplayEventsToAPIClient tracer workDir cardanoNode hydraScriptsTxId = do
+  refuelIfNeeded tracer cardanoNode Alice 100_000_000
+  aliceChainConfig <-
+    chainConfigFor Alice workDir nodeSocket []
+      -- we delibelately do not start from a chain point here to highlight the
+      -- need for persistence
+      <&> \config -> config{networkId, startChainFrom = Nothing}
+
+  withHydraNode tracer aliceChainConfig workDir 1 aliceSk [] [1] hydraScriptsTxId $ \n1 -> do
+    let contestationPeriod = 1 :: Natural
+    send n1 $ input "Init" ["contestationPeriod" .= contestationPeriod]
+    -- XXX: might need to tweak the wait time
+    waitFor tracer 10 [n1] $
+      output "ReadyToCommit" ["parties" .= Set.fromList [alice]]
+
+  withHydraNode tracer aliceChainConfig workDir 1 aliceSk [] [1] hydraScriptsTxId $ \n1 -> do
+    waitFor tracer 10 [n1] $
+      output "ReadyToCommit" ["parties" .= Set.fromList [alice]]
+ where
+  RunningNode{nodeSocket, networkId} = cardanoNode
+
 -- | Step through the full life cycle of a Hydra Head with only a single
 -- participant. This scenario is also used by the smoke test run via the
 -- `hydra-cluster` executable.

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -80,7 +80,7 @@ send HydraClient{tracer, hydraNodeId, connection} v = do
 output :: Text -> [Pair] -> Aeson.Value
 output tag pairs = object $ ("tag" .= tag) : pairs
 
--- | Wait some time for a single output from each of given nodes.
+-- | Wait some time for a single API server output from each of given nodes.
 -- This function waits for @delay@ seconds for message @expected@  to be seen by all
 -- given @nodes@.
 waitFor :: HasCallStack => Tracer IO EndToEndLog -> Natural -> [HydraClient] -> Aeson.Value -> IO ()

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -52,6 +52,7 @@ import Hydra.Cluster.Fixture (
 import Hydra.Cluster.Scenarios (
   restartedNodeCanAbort,
   restartedNodeCanObserveCommitTx,
+  restartedNodeCanReplayEventsToAPIClient,
   singlePartyHeadFullLifeCycle,
  )
 import Hydra.Cluster.Util (chainConfigFor, keysFor)
@@ -171,13 +172,13 @@ spec = around showLogsOnFailure $ do
             publishHydraScriptsAs node Faucet
               >>= restartedNodeCanAbort tracer tmpDir node
 
-      fit "can observe a commit tx after a restart, even when a tx happened while down" $ \tracer -> do
+      it "can observe a commit tx after a restart, even when a tx happened while down" $ \tracer -> do
         withTempDir "hydra-cluster-end-to-end" $ \tmpDir -> do
           withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
             publishHydraScriptsAs node Faucet
               >>= restartedNodeCanObserveCommitTx tracer tmpDir node
 
-      it "can replay events to API client after a restart" $ \tracer -> do
+      fit "can replay events to API client after a restart" $ \tracer -> do
         withTempDir "hydra-cluster-end-to-end" $ \tmpDir -> do
           withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
             publishHydraScriptsAs node Faucet

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -52,7 +52,6 @@ import Hydra.Cluster.Fixture (
 import Hydra.Cluster.Scenarios (
   restartedNodeCanAbort,
   restartedNodeCanObserveCommitTx,
-  restartedNodeCanReplayEventsToAPIClient,
   singlePartyHeadFullLifeCycle,
  )
 import Hydra.Cluster.Util (chainConfigFor, keysFor)
@@ -177,12 +176,6 @@ spec = around showLogsOnFailure $ do
           withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
             publishHydraScriptsAs node Faucet
               >>= restartedNodeCanObserveCommitTx tracer tmpDir node
-
-      fit "can replay events to API client after a restart" $ \tracer -> do
-        withTempDir "hydra-cluster-end-to-end" $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-            publishHydraScriptsAs node Faucet
-              >>= restartedNodeCanReplayEventsToAPIClient tracer tmpDir node
 
       it "can start chain from the past and replay on-chain events" $ \tracer ->
         withTempDir "end-to-end-chain-observer" $ \tmp ->

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -171,11 +171,17 @@ spec = around showLogsOnFailure $ do
             publishHydraScriptsAs node Faucet
               >>= restartedNodeCanAbort tracer tmpDir node
 
-      it "can observe a commit tx after a restart, even when a tx happened while down" $ \tracer -> do
+      fit "can observe a commit tx after a restart, even when a tx happened while down" $ \tracer -> do
         withTempDir "hydra-cluster-end-to-end" $ \tmpDir -> do
           withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
             publishHydraScriptsAs node Faucet
               >>= restartedNodeCanObserveCommitTx tracer tmpDir node
+
+      it "can replay events to API client after a restart" $ \tracer -> do
+        withTempDir "hydra-cluster-end-to-end" $ \tmpDir -> do
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
+            publishHydraScriptsAs node Faucet
+              >>= restartedNodeCanReplayEventsToAPIClient tracer tmpDir node
 
       it "can start chain from the past and replay on-chain events" $ \tracer ->
         withTempDir "end-to-end-chain-observer" $ \tmp ->

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -45,7 +45,7 @@ import Hydra.Options (
   parseHydraCommand,
   validateRunOptions,
  )
-import Hydra.Persistence (Persistence (load), createPersistence, createPersistenceClient)
+import Hydra.Persistence (Persistence (load), createPersistence, createPersistenceIncremental)
 
 main :: IO ()
 main = do
@@ -83,7 +83,7 @@ main = do
           withNetwork (contramap Network tracer) host port peers nodeId (putEvent eq . NetworkEvent defaultTTL) $ \hn -> do
             let RunOptions{apiHost, apiPort} = opts
 
-            apiPersistence <- createPersistenceClient Proxy $ persistenceDir <> "/server-output"
+            apiPersistence <- createPersistenceIncremental Proxy $ persistenceDir <> "/server-output"
             withAPIServer apiHost apiPort party apiPersistence (contramap APIServer tracer) (putEvent eq . ClientEvent) $ \server -> do
               let RunOptions{ledgerConfig} = opts
               withCardanoLedger ledgerConfig $ \ledger ->

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -45,7 +45,7 @@ import Hydra.Options (
   parseHydraCommand,
   validateRunOptions,
  )
-import Hydra.Persistence (Persistence (load), createPersistence)
+import Hydra.Persistence (Persistence (load), createPersistence, createPersistenceClient)
 
 main :: IO ()
 main = do
@@ -83,7 +83,7 @@ main = do
           withNetwork (contramap Network tracer) host port peers nodeId (putEvent eq . NetworkEvent defaultTTL) $ \hn -> do
             let RunOptions{apiHost, apiPort} = opts
 
-            apiPersistence <- createPersistence Proxy $ persistenceDir <> "/server-output"
+            apiPersistence <- createPersistenceClient Proxy $ persistenceDir <> "/server-output"
             withAPIServer apiHost apiPort party apiPersistence (contramap APIServer tracer) (putEvent eq . ClientEvent) $ \server -> do
               let RunOptions{ledgerConfig} = opts
               withCardanoLedger ledgerConfig $ \ledger ->

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -66,7 +66,7 @@ main = do
         eq <- createEventQueue
         let RunOptions{hydraScriptsTxId, chainConfig} = opts
         -- Load state from persistence or create new one
-        persistence <- createPersistence Proxy $ persistenceDir <> "/state"
+        persistence <- createPersistence $ persistenceDir <> "/state"
         hs <-
           load persistence >>= \case
             Nothing -> do
@@ -83,7 +83,7 @@ main = do
           withNetwork (contramap Network tracer) host port peers nodeId (putEvent eq . NetworkEvent defaultTTL) $ \hn -> do
             let RunOptions{apiHost, apiPort} = opts
 
-            apiPersistence <- createPersistenceIncremental Proxy $ persistenceDir <> "/server-output"
+            apiPersistence <- createPersistenceIncremental $ persistenceDir <> "/server-output"
             withAPIServer apiHost apiPort party apiPersistence (contramap APIServer tracer) (putEvent eq . ClientEvent) $ \server -> do
               let RunOptions{ledgerConfig} = opts
               withCardanoLedger ledgerConfig $ \ledger ->

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -111,6 +111,7 @@ library
     Hydra.Node.Version
     Hydra.Options
     Hydra.Party
+    Hydra.Persistence
     Hydra.Snapshot
 
   other-modules:   Paths_hydra_node
@@ -289,7 +290,6 @@ test-suite tests
     Hydra.NodeSpec
     Hydra.OptionsSpec
     Hydra.PartySpec
-    Hydra.Persistence
     Hydra.SnapshotStrategySpec
     Paths_hydra_node
     Spec

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -290,6 +290,7 @@ test-suite tests
     Hydra.NodeSpec
     Hydra.OptionsSpec
     Hydra.PartySpec
+    Hydra.PersistenceSpec
     Hydra.SnapshotStrategySpec
     Paths_hydra_node
     Spec

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -289,6 +289,7 @@ test-suite tests
     Hydra.NodeSpec
     Hydra.OptionsSpec
     Hydra.PartySpec
+    Hydra.Persistence
     Hydra.SnapshotStrategySpec
     Paths_hydra_node
     Spec
@@ -361,5 +362,5 @@ test-suite tests
     , websockets
     , yaml
 
-  build-tool-depends: hspec-discover:hspec-discover -any
+  build-tool-depends: hspec-discover:hspec-discover
   ghc-options:        -threaded -rtsopts

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -208,7 +208,7 @@ components:
     Greetings:
       title: Greetings
       description: |
-        A friendly welcome message which tells a client something about the node. Currently used for knowing what Party the server embodies.
+        A friendly welcome message which tells a client something about the node. Currently used for knowing what Party the server embodies. This message produced whenever the hydra-node starts and clients should take consequence of seeing this. For example, we can assume no peers connected when we see 'Greetings'.
       payload:
         type: object
         required:

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -22,8 +22,8 @@ import Hydra.API.ServerOutput (ServerOutput (Greetings, InvalidInput))
 import Hydra.Chain (IsChainState)
 import Hydra.Logging (Tracer, traceWith)
 import Hydra.Network (IP, PortNumber)
-import Hydra.Node (Persistence)
 import Hydra.Party (Party)
+import Hydra.Persistence (Persistence)
 import Network.WebSockets (
   acceptRequest,
   receiveData,

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -Wno-unused-do-bind #-}
 
 module Hydra.API.Server (
   Server (..),

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -22,6 +22,7 @@ import Hydra.API.ServerOutput (ServerOutput (Greetings, InvalidInput))
 import Hydra.Chain (IsChainState)
 import Hydra.Logging (Tracer, traceWith)
 import Hydra.Network (IP, PortNumber)
+import Hydra.Node (Persistence)
 import Hydra.Party (Party)
 import Network.WebSockets (
   acceptRequest,
@@ -69,9 +70,10 @@ withAPIServer ::
   IP ->
   PortNumber ->
   Party ->
+  Persistence [ServerOutput tx] IO ->
   Tracer IO APIServerLog ->
   ServerComponent tx IO ()
-withAPIServer host port party tracer callback action = do
+withAPIServer host port party persistence tracer callback action = do
   responseChannel <- newBroadcastTChanIO
   history <- newTVarIO [Greetings party]
   race_

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -75,11 +75,11 @@ withAPIServer ::
   ServerComponent tx IO ()
 withAPIServer host port party PersistenceIncremental{loadAll, append} tracer callback action = do
   responseChannel <- newBroadcastTChanIO
-  h <-
-    loadAll <&> \case
-      [] -> [Greetings party]
-      as -> as
-  history <- newTVarIO h
+  h <- loadAll
+  -- NOTE: We will add a 'Greetings' message on each API server start. This is
+  -- important to make sure the latest configured 'party' is reaching the
+  -- client.
+  history <- newTVarIO (Greetings party : h)
   race_
     (runAPIServer host port tracer history callback responseChannel)
     . action

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -24,7 +24,7 @@ import Hydra.Chain (IsChainState)
 import Hydra.Logging (Tracer, traceWith)
 import Hydra.Network (IP, PortNumber)
 import Hydra.Party (Party)
-import Hydra.Persistence (PersistenceClient (..))
+import Hydra.Persistence (PersistenceIncremental (..))
 import Network.WebSockets (
   acceptRequest,
   receiveData,
@@ -71,10 +71,10 @@ withAPIServer ::
   IP ->
   PortNumber ->
   Party ->
-  PersistenceClient (ServerOutput tx) IO ->
+  PersistenceIncremental (ServerOutput tx) IO ->
   Tracer IO APIServerLog ->
   ServerComponent tx IO ()
-withAPIServer host port party PersistenceClient{loadAll, append} tracer callback action = do
+withAPIServer host port party PersistenceIncremental{loadAll, append} tracer callback action = do
   responseChannel <- newBroadcastTChanIO
   h <-
     loadAll <&> \case

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -24,7 +24,7 @@ import Hydra.Chain (IsChainState)
 import Hydra.Logging (Tracer, traceWith)
 import Hydra.Network (IP, PortNumber)
 import Hydra.Party (Party)
-import Hydra.Persistence (Persistence (..))
+import Hydra.Persistence (PersistenceClient (..))
 import Network.WebSockets (
   acceptRequest,
   receiveData,
@@ -71,13 +71,13 @@ withAPIServer ::
   IP ->
   PortNumber ->
   Party ->
-  Persistence (ServerOutput tx) IO ->
+  PersistenceClient (ServerOutput tx) IO ->
   Tracer IO APIServerLog ->
   ServerComponent tx IO ()
-withAPIServer host port party Persistence{save, load, append} tracer callback action = do
+withAPIServer host port party PersistenceClient{loadAll, append} tracer callback action = do
   responseChannel <- newBroadcastTChanIO
   h <-
-    load <&> \case
+    loadAll <&> \case
       [] -> [Greetings party]
       as -> as
   history <- newTVarIO h

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -246,38 +246,3 @@ createNodeState initialState = do
       { modifyHeadState = stateTVar tv
       , queryHeadState = readTVar tv
       }
-
--- ** Save and load files
-
--- | Handle to save and load files to/from disk using JSON encoding.
-data Persistence a m = Persistence
-  { save :: ToJSON a => a -> m ()
-  , load :: FromJSON a => m (Maybe a)
-  }
-
-newtype PersistenceException
-  = PersistenceException String
-  deriving (Eq, Show)
-
-instance Exception PersistenceException
-
--- | Initialize persistence handle for given type 'a' at given file path.
-createPersistence :: (MonadIO m, MonadThrow m) => Proxy a -> FilePath -> m (Persistence a m)
-createPersistence _ fp = do
-  liftIO . createDirectoryIfMissing True $ takeDirectory fp
-  pure $
-    Persistence
-      { save = \a -> do
-          writeBinaryFileDurableAtomic fp . toStrict $ Aeson.encode a
-      , load =
-          liftIO (doesFileExist fp) >>= \case
-            False -> pure Nothing
-            True -> do
-              bs <- readFileBS fp
-              -- XXX: This is weird and smelly
-              if BS.null bs
-                then pure Nothing
-                else case Aeson.eitherDecodeStrict' bs of
-                  Left e -> throwIO $ PersistenceException e
-                  Right a -> pure $ Just a
-      }

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -33,8 +33,6 @@ import Control.Monad.Class.MonadSTM (
   stateTVar,
   writeTQueue,
  )
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as BS
 import Hydra.API.Server (Server, sendOutput)
 import Hydra.Cardano.Api (AsType (AsSigningKey, AsVerificationKey))
 import Hydra.Chain (Chain (..), ChainStateType, IsChainState, PostTxError)
@@ -57,9 +55,7 @@ import Hydra.Network (Network (..))
 import Hydra.Network.Message (Message)
 import Hydra.Options (RunOptions (..))
 import Hydra.Party (Party (..), deriveParty)
-import System.Directory (createDirectoryIfMissing, doesFileExist)
-import System.FilePath (takeDirectory)
-import UnliftIO.IO.File (writeBinaryFileDurableAtomic)
+import Hydra.Persistence (Persistence (..))
 
 -- * Environment Handling
 

--- a/hydra-node/src/Hydra/Persistence.hs
+++ b/hydra-node/src/Hydra/Persistence.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DuplicateRecordFields #-}
-
 module Hydra.Persistence where
 
 import Hydra.Prelude

--- a/hydra-node/src/Hydra/Persistence.hs
+++ b/hydra-node/src/Hydra/Persistence.hs
@@ -26,10 +26,9 @@ data Persistence a m = Persistence
 -- | Initialize persistence handle for given type 'a' at given file path.
 createPersistence ::
   (MonadIO m, MonadThrow m) =>
-  Proxy a ->
   FilePath ->
   m (Persistence a m)
-createPersistence _ fp = do
+createPersistence fp = do
   liftIO . createDirectoryIfMissing True $ takeDirectory fp
   pure $
     Persistence
@@ -56,10 +55,9 @@ data PersistenceIncremental a m = PersistenceIncremental
 -- | Initialize persistence handle for given type 'a' at given file path.
 createPersistenceIncremental ::
   (MonadIO m, MonadThrow m) =>
-  Proxy a ->
   FilePath ->
   m (PersistenceIncremental a m)
-createPersistenceIncremental _ fp = do
+createPersistenceIncremental fp = do
   liftIO . createDirectoryIfMissing True $ takeDirectory fp
   pure $
     PersistenceIncremental

--- a/hydra-node/src/Hydra/Persistence.hs
+++ b/hydra-node/src/Hydra/Persistence.hs
@@ -1,5 +1,13 @@
 module Hydra.Persistence where
 
+import Hydra.Prelude
+
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import System.Directory (createDirectoryIfMissing, doesFileExist)
+import System.FilePath (takeDirectory)
+import UnliftIO.IO.File (writeBinaryFileDurableAtomic)
+
 -- ** Save and load files
 
 -- | Handle to save and load files to/from disk using JSON encoding.

--- a/hydra-node/src/Hydra/Persistence.hs
+++ b/hydra-node/src/Hydra/Persistence.hs
@@ -69,6 +69,7 @@ createPersistenceClient _ fp = do
                   Left e -> throwIO $ PersistenceException e
                   Right a -> pure a
       , append = \a -> do
+          -- atomicity in file writing implies a file copy everytime we append something to it
           let bytes = toStrict $ Aeson.encode a
           liftIO $ withBinaryFileDurableAtomic fp AppendMode (`BS.hPut` bytes)
       }

--- a/hydra-node/src/Hydra/Persistence.hs
+++ b/hydra-node/src/Hydra/Persistence.hs
@@ -12,8 +12,9 @@ import UnliftIO.IO.File (writeBinaryFileDurableAtomic)
 
 -- | Handle to save and load files to/from disk using JSON encoding.
 data Persistence a m = Persistence
-  { save :: ToJSON a => a -> m ()
-  , load :: FromJSON a => m (Maybe a)
+  { save :: ToJSON a => [a] -> m ()
+  , load :: FromJSON a => m [a]
+  , append :: ToJSON a => a -> m ()
   }
 
 newtype PersistenceException

--- a/hydra-node/src/Hydra/Persistence.hs
+++ b/hydra-node/src/Hydra/Persistence.hs
@@ -1,0 +1,36 @@
+module Hydra.Persistence where
+
+-- ** Save and load files
+
+-- | Handle to save and load files to/from disk using JSON encoding.
+data Persistence a m = Persistence
+  { save :: ToJSON a => a -> m ()
+  , load :: FromJSON a => m (Maybe a)
+  }
+
+newtype PersistenceException
+  = PersistenceException String
+  deriving (Eq, Show)
+
+instance Exception PersistenceException
+
+-- | Initialize persistence handle for given type 'a' at given file path.
+createPersistence :: (MonadIO m, MonadThrow m) => Proxy a -> FilePath -> m (Persistence a m)
+createPersistence _ fp = do
+  liftIO . createDirectoryIfMissing True $ takeDirectory fp
+  pure $
+    Persistence
+      { save = \a -> do
+          writeBinaryFileDurableAtomic fp . toStrict $ Aeson.encode a
+      , load =
+          liftIO (doesFileExist fp) >>= \case
+            False -> pure Nothing
+            True -> do
+              bs <- readFileBS fp
+              -- XXX: This is weird and smelly
+              if BS.null bs
+                then pure Nothing
+                else case Aeson.eitherDecodeStrict' bs of
+                  Left e -> throwIO $ PersistenceException e
+                  Right a -> pure $ Just a
+      }

--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -20,6 +20,7 @@ import Hydra.API.Server (Server (Server, sendOutput), withAPIServer)
 import Hydra.API.ServerOutput (ServerOutput (Greetings, InvalidInput, ReadyToCommit), input)
 import Hydra.Ledger.Simple (SimpleTx)
 import Hydra.Logging (nullTracer, showLogsOnFailure)
+import Hydra.Persistence (createPersistence)
 import Network.WebSockets (Connection, receiveData, runClient, sendBinaryData)
 import Test.Hydra.Fixture (alice)
 import Test.Network.Ports (withFreePort)
@@ -30,46 +31,52 @@ spec :: Spec
 spec = parallel $ do
   it "greets" $ do
     failAfter 5 $
-      withFreePort $ \port ->
-        withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice nullTracer noop $ \_ -> do
-          withClient port $ \conn -> do
-            received <- receiveData conn
-            case Aeson.eitherDecode received of
-              Right msg -> msg `shouldBe` greeting
-              Left{} -> failure $ "Failed to decode greeting " <> show received
+      withFreePort $ \port -> do
+        withTempDir "server-spec-tmp-dir" $ \tmp -> do
+          apiPersistence <- createPersistence Proxy $ tmp <> "/server-output"
+          withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice apiPersistence nullTracer noop $ \_ -> do
+            withClient port $ \conn -> do
+              received <- receiveData conn
+              case Aeson.eitherDecode received of
+                Right msg -> msg `shouldBe` greeting
+                Left{} -> failure $ "Failed to decode greeting " <> show received
 
   it "sends sendOutput to all connected clients" $ do
     queue <- atomically newTQueue
     showLogsOnFailure $ \tracer -> failAfter 5 $
-      withFreePort $ \port ->
-        withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice tracer noop $ \Server{sendOutput} -> do
-          semaphore <- newTVarIO 0
-          withAsync
-            ( concurrently_
-                (withClient port $ testClient queue semaphore)
-                (withClient port $ testClient queue semaphore)
-            )
-            $ \_ -> do
-              waitForClients semaphore
-              failAfter 1 $ atomically (replicateM 2 (readTQueue queue)) `shouldReturn` [greeting, greeting]
-              let arbitraryMsg = ReadyToCommit mempty
-              sendOutput arbitraryMsg
-              failAfter 1 $ atomically (replicateM 2 (readTQueue queue)) `shouldReturn` [arbitraryMsg, arbitraryMsg]
-              failAfter 1 $ atomically (tryReadTQueue queue) `shouldReturn` Nothing
+      withFreePort $ \port -> do
+        withTempDir "server-spec-tmp-dir" $ \tmp -> do
+          apiPersistence <- createPersistence Proxy $ tmp <> "/server-output"
+          withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice apiPersistence tracer noop $ \Server{sendOutput} -> do
+            semaphore <- newTVarIO 0
+            withAsync
+              ( concurrently_
+                  (withClient port $ testClient queue semaphore)
+                  (withClient port $ testClient queue semaphore)
+              )
+              $ \_ -> do
+                waitForClients semaphore
+                failAfter 1 $ atomically (replicateM 2 (readTQueue queue)) `shouldReturn` [greeting, greeting]
+                let arbitraryMsg = ReadyToCommit mempty
+                sendOutput arbitraryMsg
+                failAfter 1 $ atomically (replicateM 2 (readTQueue queue)) `shouldReturn` [arbitraryMsg, arbitraryMsg]
+                failAfter 1 $ atomically (tryReadTQueue queue) `shouldReturn` Nothing
 
   prop "echoes history (past outputs) to client upon reconnection" $ \msgs -> monadicIO $ do
     monitor $ cover 100 (null msgs) "no message when reconnecting"
     monitor $ cover 100 (length msgs == 1) "only one message when reconnecting"
     monitor $ cover 100 (length msgs > 1) "more than one message when reconnecting"
     run . failAfter 5 $ do
-      withFreePort $ \port ->
-        withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice nullTracer noop $ \Server{sendOutput} -> do
-          mapM_ sendOutput (msgs :: [ServerOutput SimpleTx])
-          withClient port $ \conn -> do
-            received <- replicateM (length msgs + 1) (receiveData conn)
-            case traverse Aeson.eitherDecode received of
-              Right msgs' -> msgs' `shouldBe` greeting : msgs
-              Left{} -> failure $ "Failed to decode messages " <> show msgs
+      withFreePort $ \port -> do
+        withTempDir "server-spec-tmp-dir" $ \tmp -> do
+          apiPersistence <- createPersistence Proxy $ tmp <> "/server-output"
+          withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice apiPersistence nullTracer noop $ \Server{sendOutput} -> do
+            mapM_ sendOutput (msgs :: [ServerOutput SimpleTx])
+            withClient port $ \conn -> do
+              received <- replicateM (length msgs + 1) (receiveData conn)
+              case traverse Aeson.eitherDecode received of
+                Right msgs' -> msgs' `shouldBe` greeting : msgs
+                Left{} -> failure $ "Failed to decode messages " <> show msgs
 
   it "sends an error when input cannot be decoded" $
     failAfter 5 $
@@ -77,14 +84,16 @@ spec = parallel $ do
 
 sendsAnErrorWhenInputCannotBeDecoded :: Int -> Expectation
 sendsAnErrorWhenInputCannotBeDecoded port = do
-  withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice nullTracer noop $ \_server -> do
-    withClient port $ \con -> do
-      _greeting :: ByteString <- receiveData con
-      sendBinaryData con invalidInput
-      msg <- receiveData con
-      case Aeson.eitherDecode @(ServerOutput SimpleTx) msg of
-        Right resp -> resp `shouldSatisfy` isInvalidInput
-        Left{} -> failure $ "Failed to decode output " <> show msg
+  withTempDir "server-spec-tmp-dir" $ \tmp -> do
+    apiPersistence <- createPersistence Proxy $ tmp <> "/server-output"
+    withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice apiPersistence nullTracer noop $ \_server -> do
+      withClient port $ \con -> do
+        _greeting :: ByteString <- receiveData con
+        sendBinaryData con invalidInput
+        msg <- receiveData con
+        case Aeson.eitherDecode @(ServerOutput SimpleTx) msg of
+          Right resp -> resp `shouldSatisfy` isInvalidInput
+          Left{} -> failure $ "Failed to decode output " <> show msg
  where
   invalidInput = "not a valid message"
   isInvalidInput = \case

--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -33,7 +33,7 @@ spec = parallel $ do
     failAfter 5 $
       withFreePort $ \port -> do
         withTempDir "server-spec-tmp-dir" $ \tmp -> do
-          apiPersistence <- createPersistenceIncremental Proxy $ tmp <> "/server-output"
+          apiPersistence <- createPersistenceIncremental $ tmp <> "/server-output"
           withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice apiPersistence nullTracer noop $ \_ -> do
             withClient port $ \conn -> do
               received <- receiveData conn
@@ -46,7 +46,7 @@ spec = parallel $ do
     showLogsOnFailure $ \tracer -> failAfter 5 $
       withFreePort $ \port -> do
         withTempDir "server-spec-tmp-dir" $ \tmp -> do
-          apiPersistence <- createPersistenceIncremental Proxy $ tmp <> "/server-output"
+          apiPersistence <- createPersistenceIncremental $ tmp <> "/server-output"
           withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice apiPersistence tracer noop $ \Server{sendOutput} -> do
             semaphore <- newTVarIO 0
             withAsync
@@ -69,7 +69,7 @@ spec = parallel $ do
     run . failAfter 5 $ do
       withFreePort $ \port -> do
         withTempDir "server-spec-tmp-dir" $ \tmp -> do
-          apiPersistence <- createPersistenceIncremental Proxy $ tmp <> "/server-output"
+          apiPersistence <- createPersistenceIncremental $ tmp <> "/server-output"
           withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice apiPersistence nullTracer noop $ \Server{sendOutput} -> do
             mapM_ sendOutput (msgs :: [ServerOutput SimpleTx])
             withClient port $ \conn -> do
@@ -85,7 +85,7 @@ spec = parallel $ do
 sendsAnErrorWhenInputCannotBeDecoded :: Int -> Expectation
 sendsAnErrorWhenInputCannotBeDecoded port = do
   withTempDir "server-spec-tmp-dir" $ \tmp -> do
-    apiPersistence <- createPersistenceIncremental Proxy $ tmp <> "/server-output"
+    apiPersistence <- createPersistenceIncremental $ tmp <> "/server-output"
     withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice apiPersistence nullTracer noop $ \_server -> do
       withClient port $ \con -> do
         _greeting :: ByteString <- receiveData con

--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -20,7 +20,7 @@ import Hydra.API.Server (Server (Server, sendOutput), withAPIServer)
 import Hydra.API.ServerOutput (ServerOutput (Greetings, InvalidInput, ReadyToCommit), input)
 import Hydra.Ledger.Simple (SimpleTx)
 import Hydra.Logging (nullTracer, showLogsOnFailure)
-import Hydra.Persistence (createPersistence)
+import Hydra.Persistence (createPersistenceClient)
 import Network.WebSockets (Connection, receiveData, runClient, sendBinaryData)
 import Test.Hydra.Fixture (alice)
 import Test.Network.Ports (withFreePort)
@@ -33,7 +33,7 @@ spec = parallel $ do
     failAfter 5 $
       withFreePort $ \port -> do
         withTempDir "server-spec-tmp-dir" $ \tmp -> do
-          apiPersistence <- createPersistence Proxy $ tmp <> "/server-output"
+          apiPersistence <- createPersistenceClient Proxy $ tmp <> "/server-output"
           withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice apiPersistence nullTracer noop $ \_ -> do
             withClient port $ \conn -> do
               received <- receiveData conn
@@ -46,7 +46,7 @@ spec = parallel $ do
     showLogsOnFailure $ \tracer -> failAfter 5 $
       withFreePort $ \port -> do
         withTempDir "server-spec-tmp-dir" $ \tmp -> do
-          apiPersistence <- createPersistence Proxy $ tmp <> "/server-output"
+          apiPersistence <- createPersistenceClient Proxy $ tmp <> "/server-output"
           withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice apiPersistence tracer noop $ \Server{sendOutput} -> do
             semaphore <- newTVarIO 0
             withAsync
@@ -69,7 +69,7 @@ spec = parallel $ do
     run . failAfter 5 $ do
       withFreePort $ \port -> do
         withTempDir "server-spec-tmp-dir" $ \tmp -> do
-          apiPersistence <- createPersistence Proxy $ tmp <> "/server-output"
+          apiPersistence <- createPersistenceClient Proxy $ tmp <> "/server-output"
           withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice apiPersistence nullTracer noop $ \Server{sendOutput} -> do
             mapM_ sendOutput (msgs :: [ServerOutput SimpleTx])
             withClient port $ \conn -> do
@@ -85,7 +85,7 @@ spec = parallel $ do
 sendsAnErrorWhenInputCannotBeDecoded :: Int -> Expectation
 sendsAnErrorWhenInputCannotBeDecoded port = do
   withTempDir "server-spec-tmp-dir" $ \tmp -> do
-    apiPersistence <- createPersistence Proxy $ tmp <> "/server-output"
+    apiPersistence <- createPersistenceClient Proxy $ tmp <> "/server-output"
     withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice apiPersistence nullTracer noop $ \_server -> do
       withClient port $ \con -> do
         _greeting :: ByteString <- receiveData con

--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -20,7 +20,7 @@ import Hydra.API.Server (Server (Server, sendOutput), withAPIServer)
 import Hydra.API.ServerOutput (ServerOutput (Greetings, InvalidInput, ReadyToCommit), input)
 import Hydra.Ledger.Simple (SimpleTx)
 import Hydra.Logging (nullTracer, showLogsOnFailure)
-import Hydra.Persistence (createPersistenceIncremental)
+import Hydra.Persistence (PersistenceIncremental (..))
 import Network.WebSockets (Connection, receiveData, runClient, sendBinaryData)
 import Test.Hydra.Fixture (alice)
 import Test.Network.Ports (withFreePort)
@@ -32,35 +32,31 @@ spec = parallel $ do
   it "greets" $ do
     failAfter 5 $
       withFreePort $ \port -> do
-        withTempDir "server-spec-tmp-dir" $ \tmp -> do
-          apiPersistence <- createPersistenceIncremental $ tmp <> "/server-output"
-          withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice apiPersistence nullTracer noop $ \_ -> do
-            withClient port $ \conn -> do
-              received <- receiveData conn
-              case Aeson.eitherDecode received of
-                Right msg -> msg `shouldBe` greeting
-                Left{} -> failure $ "Failed to decode greeting " <> show received
+        withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice mockPersistence nullTracer noop $ \_ -> do
+          withClient port $ \conn -> do
+            received <- receiveData conn
+            case Aeson.eitherDecode received of
+              Right msg -> msg `shouldBe` greeting
+              Left{} -> failure $ "Failed to decode greeting " <> show received
 
   it "sends sendOutput to all connected clients" $ do
     queue <- atomically newTQueue
     showLogsOnFailure $ \tracer -> failAfter 5 $
       withFreePort $ \port -> do
-        withTempDir "server-spec-tmp-dir" $ \tmp -> do
-          apiPersistence <- createPersistenceIncremental $ tmp <> "/server-output"
-          withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice apiPersistence tracer noop $ \Server{sendOutput} -> do
-            semaphore <- newTVarIO 0
-            withAsync
-              ( concurrently_
-                  (withClient port $ testClient queue semaphore)
-                  (withClient port $ testClient queue semaphore)
-              )
-              $ \_ -> do
-                waitForClients semaphore
-                failAfter 1 $ atomically (replicateM 2 (readTQueue queue)) `shouldReturn` [greeting, greeting]
-                let arbitraryMsg = ReadyToCommit mempty
-                sendOutput arbitraryMsg
-                failAfter 1 $ atomically (replicateM 2 (readTQueue queue)) `shouldReturn` [arbitraryMsg, arbitraryMsg]
-                failAfter 1 $ atomically (tryReadTQueue queue) `shouldReturn` Nothing
+        withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice mockPersistence tracer noop $ \Server{sendOutput} -> do
+          semaphore <- newTVarIO 0
+          withAsync
+            ( concurrently_
+                (withClient port $ testClient queue semaphore)
+                (withClient port $ testClient queue semaphore)
+            )
+            $ \_ -> do
+              waitForClients semaphore
+              failAfter 1 $ atomically (replicateM 2 (readTQueue queue)) `shouldReturn` [greeting, greeting]
+              let arbitraryMsg = ReadyToCommit mempty
+              sendOutput arbitraryMsg
+              failAfter 1 $ atomically (replicateM 2 (readTQueue queue)) `shouldReturn` [arbitraryMsg, arbitraryMsg]
+              failAfter 1 $ atomically (tryReadTQueue queue) `shouldReturn` Nothing
 
   prop "echoes history (past outputs) to client upon reconnection" $ \msgs -> monadicIO $ do
     monitor $ cover 100 (null msgs) "no message when reconnecting"
@@ -68,15 +64,13 @@ spec = parallel $ do
     monitor $ cover 100 (length msgs > 1) "more than one message when reconnecting"
     run . failAfter 5 $ do
       withFreePort $ \port -> do
-        withTempDir "server-spec-tmp-dir" $ \tmp -> do
-          apiPersistence <- createPersistenceIncremental $ tmp <> "/server-output"
-          withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice apiPersistence nullTracer noop $ \Server{sendOutput} -> do
-            mapM_ sendOutput (msgs :: [ServerOutput SimpleTx])
-            withClient port $ \conn -> do
-              received <- replicateM (length msgs + 1) (receiveData conn)
-              case traverse Aeson.eitherDecode received of
-                Right msgs' -> msgs' `shouldBe` greeting : msgs
-                Left{} -> failure $ "Failed to decode messages " <> show msgs
+        withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice mockPersistence nullTracer noop $ \Server{sendOutput} -> do
+          mapM_ sendOutput (msgs :: [ServerOutput SimpleTx])
+          withClient port $ \conn -> do
+            received <- replicateM (length msgs + 1) (receiveData conn)
+            case traverse Aeson.eitherDecode received of
+              Right msgs' -> msgs' `shouldBe` greeting : msgs
+              Left{} -> failure $ "Failed to decode messages " <> show msgs
 
   it "sends an error when input cannot be decoded" $
     failAfter 5 $
@@ -84,16 +78,14 @@ spec = parallel $ do
 
 sendsAnErrorWhenInputCannotBeDecoded :: Int -> Expectation
 sendsAnErrorWhenInputCannotBeDecoded port = do
-  withTempDir "server-spec-tmp-dir" $ \tmp -> do
-    apiPersistence <- createPersistenceIncremental $ tmp <> "/server-output"
-    withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice apiPersistence nullTracer noop $ \_server -> do
-      withClient port $ \con -> do
-        _greeting :: ByteString <- receiveData con
-        sendBinaryData con invalidInput
-        msg <- receiveData con
-        case Aeson.eitherDecode @(ServerOutput SimpleTx) msg of
-          Right resp -> resp `shouldSatisfy` isInvalidInput
-          Left{} -> failure $ "Failed to decode output " <> show msg
+  withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice mockPersistence nullTracer noop $ \_server -> do
+    withClient port $ \con -> do
+      _greeting :: ByteString <- receiveData con
+      sendBinaryData con invalidInput
+      msg <- receiveData con
+      case Aeson.eitherDecode @(ServerOutput SimpleTx) msg of
+        Right resp -> resp `shouldSatisfy` isInvalidInput
+        Left{} -> failure $ "Failed to decode output " <> show msg
  where
   invalidInput = "not a valid message"
   isInvalidInput = \case
@@ -126,3 +118,11 @@ withClient port action = do
   failAfter 5 retry
  where
   retry = runClient "127.0.0.1" port "/" action `catch` \(_ :: IOException) -> retry
+
+-- | Mocked persistence handle which just does nothing.
+mockPersistence :: Applicative m => PersistenceIncremental a m
+mockPersistence =
+  PersistenceIncremental
+    { append = \_ -> pure ()
+    , loadAll = pure []
+    }

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -53,12 +53,12 @@ import Hydra.Node (
   EventQueue (putEvent),
   HydraNode (..),
   HydraNodeLog (..),
-  Persistence (Persistence, load, save),
   createEventQueue,
   createNodeState,
   runHydraNode,
  )
 import Hydra.Party (Party, deriveParty)
+import Hydra.Persistence (Persistence (Persistence, load, save))
 import Hydra.Snapshot (Snapshot (..), SnapshotNumber, getSnapshot)
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
 import Test.Hydra.Fixture (alice, aliceSk, bob, bobSk)
@@ -602,7 +602,7 @@ simulatedChainAndNetwork initialChainState = do
     (toReplay, kept) <- atomically $ do
       (toReplay, kept) <- splitAt (fromIntegral steps) <$> readTVar history
       writeTVar history kept
-      pure $ (reverse toReplay, kept)
+      pure (reverse toReplay, kept)
     -- Determine the new (last kept one) chainstate
     let rolledBackChainState = case kept of
           [] -> initialChainState

--- a/hydra-node/test/Hydra/JSONSchema.hs
+++ b/hydra-node/test/Hydra/JSONSchema.hs
@@ -1,17 +1,15 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-unused-imports #-}
-{-# OPTIONS_GHC -Wno-unused-local-binds #-}
 
 module Hydra.JSONSchema where
 
 import Hydra.Prelude
 
-import Control.Lens (Traversal', at, to, (?~), (^..), (^?))
+import Control.Lens (Traversal', at, (?~), (^..))
 import Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson
-import Data.Aeson.Lens (AsValue, key, _Array, _String)
+import Data.Aeson.Lens (key, _Array, _String)
 import Data.Char (isSpace)
 import Data.List (dropWhileEnd)
 import qualified Data.Map.Strict as Map
@@ -25,9 +23,8 @@ import System.Exit (ExitCode (..))
 import System.FilePath (normalise, takeBaseName, takeExtension, (<.>), (</>))
 import System.IO.Error (IOError, ioeGetErrorType)
 import System.Process (readProcessWithExitCode)
-import Test.Hspec (pendingWith)
 import Test.Hydra.Prelude (createSystemTempDirectory, failure)
-import Test.QuickCheck (Property, conjoin, counterexample, forAllBlind, forAllShrink, vectorOf, withMaxSuccess)
+import Test.QuickCheck (Property, counterexample, forAllBlind, forAllShrink, vectorOf)
 import Test.QuickCheck.Monadic (assert, monadicIO, monitor, run)
 import qualified Prelude
 

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -34,13 +34,13 @@ import Hydra.Node (
   EventQueue (..),
   HydraNode (..),
   HydraNodeLog,
-  Persistence (Persistence, load, save),
   createEventQueue,
   createNodeState,
   isEmpty,
   stepHydraNode,
  )
 import Hydra.Party (Party, deriveParty)
+import Hydra.Persistence (Persistence (Persistence, load, save))
 import Hydra.Snapshot (Snapshot (..))
 import Test.Hydra.Fixture (alice, aliceSk, bob, bobSk, carol, carolSk, cperiod)
 

--- a/hydra-node/test/Hydra/PersistenceSpec.hs
+++ b/hydra-node/test/Hydra/PersistenceSpec.hs
@@ -2,14 +2,14 @@
 
 module Hydra.PersistenceSpec where
 
-import Hydra.Prelude
+import Hydra.Prelude hiding (label)
 import Test.Hydra.Prelude
 
 import Data.Aeson (Value (..))
 import qualified Data.Aeson as Aeson
 import qualified Data.Text as Text
 import Hydra.Persistence (PersistenceIncremental (..), createPersistenceIncremental)
-import Test.QuickCheck (collect, counterexample, elements, oneof, (===))
+import Test.QuickCheck (counterexample, elements, label, oneof, (===))
 import Test.QuickCheck.Gen (listOf)
 import Test.QuickCheck.Monadic (monadicIO, monitor, pick, run)
 
@@ -19,7 +19,7 @@ spec =
     it "is consistent after multiple append calls" $
       monadicIO $ do
         items :: [Aeson.Value] <- pick $ listOf genPersistenceItem
-        monitor (collect items)
+        monitor (label "foo")
         monitor (counterexample $ "items: " <> (show items))
         actualResult <- run $
           withTempDir "hydra-persistence" $ \tmpDir -> do

--- a/hydra-node/test/Hydra/PersistenceSpec.hs
+++ b/hydra-node/test/Hydra/PersistenceSpec.hs
@@ -1,11 +1,15 @@
+{-# OPTIONS_GHC -Wno-unused-do-bind #-}
+
 module Hydra.PersistenceSpec where
 
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
+import Data.Aeson (Value (..))
 import qualified Data.Aeson as Aeson
+import qualified Data.Text as Text
 import Hydra.Persistence (PersistenceIncremental (..), createPersistenceIncremental)
-import Test.QuickCheck (generate, oneof)
+import Test.QuickCheck (elements, generate, oneof)
 import Test.QuickCheck.Gen (listOf)
 
 spec :: Spec
@@ -14,9 +18,19 @@ spec =
     it "is consistent after multiple append calls" $
       withTempDir "hydra-persistence" $ \tmpDir -> do
         items :: [Aeson.Value] <- generate $ listOf genPersistenceItem
+        print items
         PersistenceIncremental{loadAll, append} <- createPersistenceIncremental Proxy $ tmpDir <> "/data"
         forM_ items append
         loadAll `shouldReturn` items
 
 genPersistenceItem :: Gen Aeson.Value
-genPersistenceItem = oneof []
+genPersistenceItem =
+  oneof
+    [ pure Null
+    , String <$> genSomeText
+    ]
+
+genSomeText :: Gen Text
+genSomeText = do
+  let t = ['A' .. 'z'] <> ['\n', '\t', '\r']
+  Text.pack <$> listOf (elements t)

--- a/hydra-node/test/Hydra/PersistenceSpec.hs
+++ b/hydra-node/test/Hydra/PersistenceSpec.hs
@@ -5,7 +5,7 @@ import Test.Hydra.Prelude
 
 import qualified Data.Aeson as Aeson
 import Hydra.Persistence (PersistenceIncremental (..), createPersistenceIncremental)
-import Test.QuickCheck (generate)
+import Test.QuickCheck (generate, oneof)
 import Test.QuickCheck.Gen (listOf)
 
 spec :: Spec
@@ -14,8 +14,9 @@ spec =
     it "is consistent after multiple append calls" $
       withTempDir "hydra-persistence" $ \tmpDir -> do
         items :: [Aeson.Value] <- generate $ listOf genPersistenceItem
-        PersistenceIncremental{} <- createPersistenceIncremental Proxy $ tmpDir <> "/data"
-        pure ()
+        PersistenceIncremental{loadAll, append} <- createPersistenceIncremental Proxy $ tmpDir <> "/data"
+        forM_ items append
+        loadAll `shouldReturn` items
 
 genPersistenceItem :: Gen Aeson.Value
-genPersistenceItem = undefined
+genPersistenceItem = oneof []

--- a/hydra-node/test/Hydra/PersistenceSpec.hs
+++ b/hydra-node/test/Hydra/PersistenceSpec.hs
@@ -1,0 +1,21 @@
+module Hydra.PersistenceSpec where
+
+import Hydra.Prelude
+import Test.Hydra.Prelude
+
+import qualified Data.Aeson as Aeson
+import Hydra.Persistence (PersistenceIncremental (..), createPersistenceIncremental)
+import Test.QuickCheck (generate)
+import Test.QuickCheck.Gen (listOf)
+
+spec :: Spec
+spec =
+  describe "PersistenceIncremental" $
+    it "is consistent after multiple append calls" $
+      withTempDir "hydra-persistence" $ \tmpDir -> do
+        items :: [Aeson.Value] <- generate $ listOf genPersistenceItem
+        PersistenceIncremental{} <- createPersistenceIncremental Proxy $ tmpDir <> "/data"
+        pure ()
+
+genPersistenceItem :: Gen Aeson.Value
+genPersistenceItem = undefined

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -290,6 +290,7 @@ handleAppEvent s = \case
       }
   Update Greetings{me} ->
     s & meL ?~ me
+      & peersL .~ []
   Update (PeerConnected p) ->
     s & peersL %~ \cp -> nub $ cp <> [p]
   Update (PeerDisconnected p) ->


### PR DESCRIPTION
Contributes to #580 

🧃 Added new PersistenceClient handle to `loadAll` and `append` server output events.

🧃 Move Persistence handles to their own module.

To check before merging:
* [x] CHANGELOG is up to date
* [x] ~Documentation is up to date~
