### PR TITLE
FIX history re-ordering issue

### DIFF
--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -58,8 +58,9 @@ spec = parallel $ do
               failAfter 1 $ atomically (replicateM 2 (readTQueue queue)) `shouldReturn` [arbitraryMsg, arbitraryMsg]
               failAfter 1 $ atomically (tryReadTQueue queue) `shouldReturn` Nothing
 
-  fit "sends all sendOutput history to all connected clients after a restart" $ do
-    queue <- atomically newTQueue
+  it "sends all sendOutput history to all connected clients after a restart" $ do
+    queue1 <- atomically newTQueue
+    queue2 <- atomically newTQueue
     showLogsOnFailure $ \tracer -> failAfter 5 $
       withTempDir "ServerSpec" $ \tmpDir -> do
         let persistentFile = tmpDir <> "/history"
@@ -76,15 +77,17 @@ spec = parallel $ do
             semaphore <- newTVarIO 0
             withAsync
               ( concurrently_
-                  (withClient port $ testClient queue semaphore)
-                  (withClient port $ testClient queue semaphore)
+                  (withClient port $ testClient queue1 semaphore)
+                  (withClient port $ testClient queue2 semaphore)
               )
               $ \_ -> do
                 waitForClients semaphore
-                failAfter 1 $ atomically (replicateM 4 (readTQueue queue)) `shouldReturn` [greeting, arbitraryMsg, greeting, greeting, arbitraryMsg, greeting]
+                failAfter 1 $ atomically (replicateM 3 (readTQueue queue1)) `shouldReturn` [greeting, arbitraryMsg, greeting]
+                failAfter 1 $ atomically (replicateM 3 (readTQueue queue2)) `shouldReturn` [greeting, arbitraryMsg, greeting]
                 sendOutput arbitraryMsg
-                failAfter 1 $ atomically (replicateM 2 (readTQueue queue)) `shouldReturn` [arbitraryMsg, arbitraryMsg]
-                failAfter 1 $ atomically (tryReadTQueue queue) `shouldReturn` Nothing
+                failAfter 1 $ atomically (replicateM 1 (readTQueue queue1)) `shouldReturn` [arbitraryMsg]
+                failAfter 1 $ atomically (replicateM 1 (readTQueue queue2)) `shouldReturn` [arbitraryMsg]
+                failAfter 1 $ atomically (tryReadTQueue queue1) `shouldReturn` Nothing
 
   prop "echoes history (past outputs) to client upon reconnection" $ \msgs -> monadicIO $ do
     monitor $ cover 100 (null msgs) "no message when reconnecting"


### PR DESCRIPTION
We validate that all the clients receive all the events after a restart, including `Greetings`.

To check before merging:
* [x] CHANGELOG is up to date
* [x] Up to date with master
