### PR TITLE
New wallet initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ changes.
     `toConsensusPointHF` with `toConsensusPointInMode`.
   + Re-export new `AcquiringFailure` type from `cardano-api`.
 
+- **BREAKING** Change the way the internal wallet initializes its state [#621](https://github.com/input-output-hk/hydra/pull/621)
+  + The internal wallet does now always query ledger state and parameters at the tip.
+  + This should fix the `AcquireFailure` issues.
+  + Changed logs of `BeginInitialize` and `EndInitialize`.
+  + Added `SkipUpdate` constructor to the wallet logs.
+
 ## [0.8.1] - 2022-11-17
 
 - **BREAKING** Implemented [ADR18](https://hydra.family/head-protocol/adr/18) to keep only a single state:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ changes.
     `toConsensusPointHF` with `toConsensusPointInMode`.
   + Re-export new `AcquiringFailure` type from `cardano-api`.
 
-- **BREAKING** Change the way the internal wallet initializes its state [#621](https://github.com/input-output-hk/hydra/pull/621)
+- Change the way the internal wallet initializes its state [#621](https://github.com/input-output-hk/hydra/pull/621)
   + The internal wallet does now always query ledger state and parameters at the tip.
   + This should fix the `AcquireFailure` issues.
   + Changed logs of `BeginInitialize` and `EndInitialize`.

--- a/hydra-cluster/test/Test/DirectChainSpec.hs
+++ b/hydra-cluster/test/Test/DirectChainSpec.hs
@@ -21,7 +21,6 @@ import Control.Concurrent.STM.TVar (writeTVar)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 import Hydra.Cardano.Api (
-  AcquiringFailure (AFPointNotOnChain),
   ChainPoint (..),
   lovelaceToValue,
   txOutValue,

--- a/hydra-cluster/test/Test/DirectChainSpec.hs
+++ b/hydra-cluster/test/Test/DirectChainSpec.hs
@@ -310,7 +310,6 @@ spec = around showLogsOnFailure $ do
 
         action `shouldThrow` \case
           IntersectionNotFound{} -> True
-          _ -> False
 
   it "can publish and query reference scripts in a timely manner" $ \tracer -> do
     withTempDir "direct-chain" $ \tmp -> do

--- a/hydra-cluster/test/Test/DirectChainSpec.hs
+++ b/hydra-cluster/test/Test/DirectChainSpec.hs
@@ -36,7 +36,7 @@ import Hydra.Chain (
   PostChainTx (..),
   PostTxError (..),
  )
-import Hydra.Chain.Direct (initialChainState, loadChainContext, withDirectChain)
+import Hydra.Chain.Direct (IntersectionNotFoundException (..), initialChainState, loadChainContext, withDirectChain)
 import Hydra.Chain.Direct.Handlers (DirectChainLog)
 import Hydra.Chain.Direct.ScriptRegistry (queryScriptRegistry)
 import Hydra.Chain.Direct.State (ChainContext)
@@ -310,7 +310,7 @@ spec = around showLogsOnFailure $ do
               threadDelay 5 >> fail "should not execute main action but did?"
 
         action `shouldThrow` \case
-          QueryAcquireException AFPointNotOnChain -> True
+          IntersectionNotFoundException{} -> True
           _ -> False
 
   it "can publish and query reference scripts in a timely manner" $ \tracer -> do

--- a/hydra-cluster/test/Test/DirectChainSpec.hs
+++ b/hydra-cluster/test/Test/DirectChainSpec.hs
@@ -8,7 +8,6 @@ import Hydra.Prelude
 import Test.Hydra.Prelude
 
 import CardanoClient (
-  QueryException (QueryAcquireException),
   QueryPoint (QueryTip),
   buildAddress,
   queryTip,
@@ -310,7 +309,7 @@ spec = around showLogsOnFailure $ do
               threadDelay 5 >> fail "should not execute main action but did?"
 
         action `shouldThrow` \case
-          IntersectionNotFoundException{} -> True
+          IntersectionNotFound{} -> True
           _ -> False
 
   it "can publish and query reference scripts in a timely manner" $ \tracer -> do

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -345,32 +345,34 @@ definitions:
     oneOf:
       - title: BeginInitialize
         description: >-
-          The wallet (re-)initializes to given point on the chain.
+          The wallet is asked to (re-)initialize and fetch latest information
+          from the cardano-node.
         type: object
         additionalProperties: false
         required:
           - tag
-          - point
         properties:
           tag:
             type: string
             enum: ["BeginInitialize"]
-          point:
-            $ref: "api.yaml#/components/schemas/ChainPoint"
       - title: EndInitialize
         description: >-
-          The wallet has initialized with these UTxOs.
+          The wallet has been initialized with these UTxOs and will skip blocks
+          until reaching the tip.
         type: object
         additionalProperties: false
         required:
           - tag
           - initialUTxO
+          - tip
         properties:
           tag:
             type: string
             enum: ["EndInitialize"]
           initialUTxO:
             $ref: "api.yaml#/components/schemas/UTxO"
+          tip:
+            $ref: "api.yaml#/components/schemas/ChainPoint"
       - title: BeginUpdate
         description: >-
           The wallet has been given a new block to update it's state.
@@ -386,7 +388,8 @@ definitions:
             $ref: "api.yaml#/components/schemas/ChainPoint"
       - title: EndUpdate
         description: >-
-          The wallet updated it's state by applying a block resulting in given UTxOs.
+          The wallet updated it's state by applying a block resulting in given
+          UTxOs.
         additionalProperties: false
         required:
           - tag

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -397,6 +397,20 @@ definitions:
             enum: ["EndUpdate"]
           newUTxO:
             $ref: "api.yaml#/components/schemas/UTxO"
+      - title: SkipUpdate
+        description: >-
+          The wallet has been given a block behind it's last known tip and skips
+          the internal update of UTxOs.
+        additionalProperties: false
+        required:
+          - tag
+          - point
+        properties:
+          tag:
+            type: string
+            enum: ["SkipUpdate"]
+          point:
+            $ref: "api.yaml#/components/schemas/ChainPoint"
 
   # NOTE: We cannot simply describe 'ServerOutput' and re-use it in api.yaml, so
   # we opted to not detail this section here. The outputs documented in api.yaml

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -25,7 +25,6 @@ import Cardano.Ledger.Shelley.Rules.Ledger (LedgerPredicateFailure (UtxowFailure
 import Cardano.Ledger.Shelley.Rules.Utxow (UtxowPredicateFailure (UtxoFailure))
 import Cardano.Ledger.Slot (EpochInfo)
 import Cardano.Slotting.EpochInfo (hoistEpochInfo)
-import CardanoClient (QueryPoint (..))
 import Control.Exception (IOException)
 import Control.Monad.Class.MonadSTM (
   newEmptyTMVar,
@@ -59,6 +58,7 @@ import Hydra.Chain (
   PostTxError (..),
  )
 import Hydra.Chain.CardanoClient (
+  QueryPoint (..),
   queryEraHistory,
   queryProtocolParameters,
   querySystemStart,

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -45,7 +45,6 @@ import Hydra.Cardano.Api (
   NetworkId,
   Tx,
   TxId,
-  fromConsensusPointInMode,
   shelleyBasedEra,
   toConsensusPointInMode,
   toLedgerPParams,
@@ -190,7 +189,7 @@ withDirectChain tracer config ctx persistedPoint callback action = do
     (min <$> startChainFrom <*> persistedPoint)
       <|> persistedPoint
       <|> startChainFrom
-  wallet <- newTinyWallet (contramap Wallet tracer) networkId keyPair chainPoint queryWalletInfo
+  wallet <- newTinyWallet (contramap Wallet tracer) networkId keyPair queryWalletInfo
   let chainHandle =
         mkChain
           tracer
@@ -354,7 +353,7 @@ chainSyncClient handler wallet startingPoint =
           pure clientStIdle
       , recvMsgRollBackward = \point _tip -> ChainSyncClient $ do
           -- Re-initialize the tiny wallet
-          reset wallet $ fromConsensusPointInMode CardanoMode point
+          reset wallet
           -- Rollback main chain sync handler
           onRollBackward handler point
           pure clientStIdle

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -104,20 +104,19 @@ mkChain tracer queryTimeHandle wallet ctx submitTx =
         traceWith tracer $ ToPost{toPost = tx}
         timeHandle <- queryTimeHandle
         vtx <-
-          atomically
-            ( -- FIXME (MB): cardano keys should really not be here (as this
-              -- point they are in the 'chainState' stored in the 'ChainContext')
-              -- . They are only required for the init transaction and ought to
-              -- come from the _client_ and be part of the init request
-              -- altogether. This goes in the direction of 'dynamic heads' where
-              -- participants aren't known upfront but provided via the API.
-              -- Ultimately, an init request from a client would contain all the
-              -- details needed to establish connection to the other peers and
-              -- to bootstrap the init transaction. For now, we bear with it and
-              -- keep the static keys in context.
-              fromPostChainTx timeHandle wallet ctx chainState tx
-            )
-            >>= finalizeTx wallet ctx chainState . toLedgerTx
+          atomically $
+            -- FIXME (MB): cardano keys should really not be here (as this
+            -- point they are in the 'chainState' stored in the 'ChainContext')
+            -- . They are only required for the init transaction and ought to
+            -- come from the _client_ and be part of the init request
+            -- altogether. This goes in the direction of 'dynamic heads' where
+            -- participants aren't known upfront but provided via the API.
+            -- Ultimately, an init request from a client would contain all the
+            -- details needed to establish connection to the other peers and
+            -- to bootstrap the init transaction. For now, we bear with it and
+            -- keep the static keys in context.
+            fromPostChainTx timeHandle wallet ctx chainState tx
+              >>= finalizeTx wallet ctx chainState . toLedgerTx
         submitTx vtx
     }
 

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -116,19 +116,19 @@ mkChain tracer queryTimeHandle wallet ctx submitTx =
               -- to bootstrap the init transaction. For now, we bear with it and
               -- keep the static keys in context.
               fromPostChainTx timeHandle wallet ctx chainState tx
-                >>= finalizeTx wallet ctx chainState . toLedgerTx
             )
+            >>= finalizeTx wallet ctx chainState . toLedgerTx
         submitTx vtx
     }
 
 -- | Balance and sign the given partial transaction.
 finalizeTx ::
-  (MonadSTM m, MonadThrow (STM m)) =>
+  (MonadThrow m) =>
   TinyWallet m ->
   ChainContext ->
   ChainStateType Tx ->
   ValidatedTx LedgerEra ->
-  STM m (ValidatedTx LedgerEra)
+  m (ValidatedTx LedgerEra)
 finalizeTx TinyWallet{sign, coverFee} ctx ChainStateAt{chainState} partialTx = do
   let headUTxO = getKnownUTxO ctx <> getKnownUTxO chainState
   coverFee (Ledger.unUTxO $ toLedgerUTxO headUTxO) partialTx >>= \case

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -104,19 +104,18 @@ mkChain tracer queryTimeHandle wallet ctx submitTx =
         traceWith tracer $ ToPost{toPost = tx}
         timeHandle <- queryTimeHandle
         vtx <-
-          atomically $
-            -- FIXME (MB): cardano keys should really not be here (as this
-            -- point they are in the 'chainState' stored in the 'ChainContext')
-            -- . They are only required for the init transaction and ought to
-            -- come from the _client_ and be part of the init request
-            -- altogether. This goes in the direction of 'dynamic heads' where
-            -- participants aren't known upfront but provided via the API.
-            -- Ultimately, an init request from a client would contain all the
-            -- details needed to establish connection to the other peers and
-            -- to bootstrap the init transaction. For now, we bear with it and
-            -- keep the static keys in context.
-            fromPostChainTx timeHandle wallet ctx chainState tx
-              >>= finalizeTx wallet ctx chainState . toLedgerTx
+          -- FIXME (MB): cardano keys should really not be here (as this
+          -- point they are in the 'chainState' stored in the 'ChainContext')
+          -- . They are only required for the init transaction and ought to
+          -- come from the _client_ and be part of the init request
+          -- altogether. This goes in the direction of 'dynamic heads' where
+          -- participants aren't known upfront but provided via the API.
+          -- Ultimately, an init request from a client would contain all the
+          -- details needed to establish connection to the other peers and
+          -- to bootstrap the init transaction. For now, we bear with it and
+          -- keep the static keys in context.
+          atomically (fromPostChainTx timeHandle wallet ctx chainState tx)
+            >>= finalizeTx wallet ctx chainState . toLedgerTx
         submitTx vtx
     }
 

--- a/hydra-node/test/Hydra/Chain/Direct/WalletSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/WalletSpec.hs
@@ -80,7 +80,7 @@ spec = parallel $ do
   describe "newTinyWallet" $ do
     prop "initialises wallet by querying UTxO" $
       forAll genKeyPair $ \(vk, sk) -> do
-        wallet <- newTinyWallet nullTracer Fixture.testNetworkId (vk, sk) (mockChainQuery vk)
+        wallet <- newTinyWallet nullTracer Fixture.testNetworkId (vk, sk) (mockChainQuery vk) (pure Fixture.epochInfo)
         utxo <- atomically (getUTxO wallet)
         utxo `shouldSatisfy` \m -> Map.size m > 0
 
@@ -88,7 +88,7 @@ spec = parallel $ do
     prop "re-queries UTxO from the tip after reset" $
       forAll genKeyPair $ \(vk, sk) -> do
         (queryFn, assertQueryPoint) <- setupQuery vk
-        wallet <- newTinyWallet nullTracer Fixture.testNetworkId (vk, sk) queryFn
+        wallet <- newTinyWallet nullTracer Fixture.testNetworkId (vk, sk) queryFn (pure Fixture.epochInfo)
         assertQueryPoint QueryTip
         reset wallet
         assertQueryPoint QueryTip

--- a/hydra-node/test/Hydra/Chain/Direct/WalletSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/WalletSpec.hs
@@ -84,8 +84,7 @@ spec = parallel $ do
         utxo <- atomically (getUTxO wallet)
         utxo `shouldSatisfy` \m -> Map.size m > 0
 
-    -- TODO: This test has become a bit pointless
-    prop "re-queries UTxO from the tip after reset" $
+    prop "re-queries UTxO from the tip, even on reset" $
       forAll genKeyPair $ \(vk, sk) -> do
         (queryFn, assertQueryPoint) <- setupQuery vk
         wallet <- newTinyWallet nullTracer Fixture.testNetworkId (vk, sk) queryFn (pure Fixture.epochInfo)


### PR DESCRIPTION
Do not query at point, but instead always use the tip to query parameters, era history and utxo to initialize the wallet. When "digesting" blocks, we only use them to update the inernal wallet's utxo state once we reached the queried point.

This will make the wallet not try to query at "too old" points and hopefully also not query points "not on chain" (i.e. on a fork). Hence, I believe this will close #439 and #560. 

On master with a node synched on `preview`:
```
λ cabal exec hydra-node -- --node-id "sebastian-testnets-preview" --node-socket "preview/node.socket" --network-id $(cat preview/db/protocolMagicId) --ledger-genesis preview/genesis/shelley.json --ledger-protocol-parameters ../hydra-cluster/config/protocol-parameters.json --hydra-signing-key "credentials/sebastian.hydra.sk" --cardano-signing-key "credentials/sebastian.cardano.sk" --hydra-scripts-tx-id 4081fab39728fa3c05c0edc4dc7c0e8c45129ca6b2b70bf8600c1203a79d2c6d --start-chain-from "2864083.b92823aa4c4d42b9722b032fcfc9314dfa4ef99a344e690074a04e52217ceb53"
{"timestamp":"2022-11-29T17:25:53.528276429Z","threadId":4,"namespace":"HydraNode-\"sebastian-testnets-preview\"","message":{"runOptions":{"apiHost":{"ipv4":"127.0.0.1","tag":"IPv4"},"apiPort":4001,"chainConfig":{"cardanoSigningKey":"credentials/sebastian.cardano.sk","cardanoVerificationKeys":[],"networkId":{"magic":2,"tag":"Testnet"},"nodeSocket":"preview/node.socket","startChainFrom":{"blockHash":"b92823aa4c4d42b9722b032fcfc9314dfa4ef99a344e690074a04e52217ceb53","slot":2864083,"tag":"ChainPoint"}},"host":{"ipv4":"127.0.0.1","tag":"IPv4"},"hydraScriptsTxId":"4081fab39728fa3c05c0edc4dc7c0e8c45129ca6b2b70bf8600c1203a79d2c6d","hydraSigningKey":"credentials/sebastian.hydra.sk","hydraVerificationKeys":[],"ledgerConfig":{"cardanoLedgerGenesisFile":"preview/genesis/shelley.json","cardanoLedgerProtocolParametersFile":"../hydra-cluster/config/protocol-parameters.json"},"monitoringPort":null,"nodeId":"sebastian-testnets-preview","peers":[],"persistenceDir":"./","port":5001,"verbosity":{"contents":"HydraNode-\"sebastian-testnets-preview\"","tag":"Verbose"}},"tag":"NodeOptions"}}
{"timestamp":"2022-11-29T17:25:53.530667148Z","threadId":4,"namespace":"HydraNode-\"sebastian-testnets-preview\"","message":{"tag":"LoadedState"}}
hydra-node: QueryAcquireException AcquireFailurePointTooOld
```

On this branch:
```
λ cabal exec hydra-node -- --node-id "sebastian-testnets-preview" --node-socket "preview/node.socket" --network-id $(cat preview/db/protocolMagicId) --ledger-genesis preview/genesis/shelley.json --ledger-protocol-parameters ../hydra-cluster/config/protocol-parameters.json --hydra-signing-key "credentials/sebastian.hydra.sk" --cardano-signing-key "credentials/sebastian.cardano.sk" --hydra-scripts-tx-id 4081fab39728fa3c05c0edc4dc7c0e8c45129ca6b2b70bf8600c1203a79d2c6d --start-chain-from "2864083.b92823aa4c4d42b9722b032fcfc9314dfa4ef99a344e690074a04e52217ceb53"
{"timestamp":"2022-11-29T17:31:26.706662941Z","threadId":4,"namespace":"HydraNode-\"sebastian-testnets-preview\"","message":{"runOptions":{"apiHost":{"ipv4":"127.0.0.1","tag":"IPv4"},"apiPort":4001,"chainConfig":{"cardanoSigningKey":"credentials/sebastian.cardano.sk","cardanoVerificationKeys":[],"networkId":{"magic":2,"tag":"Testnet"},"nodeSocket":"preview/node.socket","startChainFrom":{"blockHash":"b92823aa4c4d42b9722b032fcfc9314dfa4ef99a344e690074a04e52217ceb53","slot":2864083,"tag":"ChainPoint"}},"host":{"ipv4":"127.0.0.1","tag":"IPv4"},"hydraScriptsTxId":"4081fab39728fa3c05c0edc4dc7c0e8c45129ca6b2b70bf8600c1203a79d2c6d","hydraSigningKey":"credentials/sebastian.hydra.sk","hydraVerificationKeys":[],"ledgerConfig":{"cardanoLedgerGenesisFile":"preview/genesis/shelley.json","cardanoLedgerProtocolParametersFile":"../hydra-cluster/config/protocol-parameters.json"},"monitoringPort":null,"nodeId":"sebastian-testnets-preview","peers":[],"persistenceDir":"./","port":5001,"verbosity":{"contents":"HydraNode-\"sebastian-testnets-preview\"","tag":"Verbose"}},"tag":"NodeOptions"}}
{"timestamp":"2022-11-29T17:31:26.708859203Z","threadId":4,"namespace":"HydraNode-\"sebastian-testnets-preview\"","message":{"tag":"LoadedState"}}
{"timestamp":"2022-11-29T17:31:26.779666755Z","threadId":4,"namespace":"HydraNode-\"sebastian-testnets-preview\"","message":{"directChain":{"contents":{"tag":"BeginInitialize"},"tag":"Wallet"},"tag":"DirectChain"}}
{"timestamp":"2022-11-29T17:31:26.868982443Z","threadId":4,"namespace":"HydraNode-\"sebastian-testnets-preview\"","message":{"directChain":{"contents":{"initialUTxO":{"219e4da70e0a26c23456c375f646fdf1868a9be9cdf8244cd2266bc556ab1a4e#TxIx 1":{"address":"6055f528bd5ddb27d3ea7a113009550d7ebfca94cfa75307eb56cce3ac","datum":null,"referenceScript":null,"value":{"lovelace":9832475,"policies":{}}},"219e4da70e0a26c23456c375f646fdf1868a9be9cdf8244cd2266bc556ab1a4e#TxIx 2":{"address":"6055f528bd5ddb27d3ea7a113009550d7ebfca94cfa75307eb56cce3ac","datum":"a654fb60d21c1fed48db2c320aa6df9737ec0204c0ba53b9b94a09fb40e757f3","referenceScript":null,"value":{"lovelace":9843549600,"policies":{}}}},"tag":"EndInitialize","tip":{"blockHash":"aff83045e8d3d2dd9075fa7011a250098bb3136fc6bf5419cd72b19814988234","slot":3087077,"tag":"ChainPoint"}},"tag":"Wallet"},"tag":"DirectChain"}}
{"timestamp":"2022-11-29T17:31:26.869653456Z","threadId":58,"namespace":"HydraNode-\"sebastian-testnets-preview\"","message":{"network":{"data":{"subscriptions":{"dsts":"[]","event":"Starting Subscription Worker, valency 0","src":"LocalAddresses {laIpv4 = Just 127.0.0.1:0, laIpv6 = Nothing, laUnix = Nothing}","tag":"WithIPList"},"tag":"TraceSubscriptions"},"host":{"hostname":"127.0.0.1","port":5001}},"tag":"Network"}}
{"timestamp":"2022-11-29T17:31:26.869674225Z","threadId":58,"namespace":"HydraNode-\"sebastian-testnets-preview\"","message":{"network":{"data":{"subscriptions":{"dsts":"[]","event":"Required subscriptions started","src":"LocalAddresses {laIpv4 = Just 127.0.0.1:0, laIpv6 = Nothing, laUnix = Nothing}","tag":"WithIPList"},"tag":"TraceSubscriptions"},"host":{"hostname":"127.0.0.1","port":5001}},"tag":"Network"}}
{"timestamp":"2022-11-29T17:31:26.880643035Z","threadId":62,"namespace":"HydraNode-\"sebastian-testnets-preview\"","message":{"directChain":{"contents":{"tag":"BeginInitialize"},"tag":"Wallet"},"tag":"DirectChain"}}
{"timestamp":"2022-11-29T17:31:26.882778053Z","threadId":86,"namespace":"HydraNode-\"sebastian-testnets-preview\"","message":{"api":{"listeningPort":4001,"tag":"APIServerStarted"},"tag":"APIServer"}}
{"timestamp":"2022-11-29T17:31:26.956540093Z","threadId":62,"namespace":"HydraNode-\"sebastian-testnets-preview\"","message":{"directChain":{"contents":{"initialUTxO":{"219e4da70e0a26c23456c375f646fdf1868a9be9cdf8244cd2266bc556ab1a4e#TxIx 1":{"address":"6055f528bd5ddb27d3ea7a113009550d7ebfca94cfa75307eb56cce3ac","datum":null,"referenceScript":null,"value":{"lovelace":9832475,"policies":{}}},"219e4da70e0a26c23456c375f646fdf1868a9be9cdf8244cd2266bc556ab1a4e#TxIx 2":{"address":"6055f528bd5ddb27d3ea7a113009550d7ebfca94cfa75307eb56cce3ac","datum":"a654fb60d21c1fed48db2c320aa6df9737ec0204c0ba53b9b94a09fb40e757f3","referenceScript":null,"value":{"lovelace":9843549600,"policies":{}}}},"tag":"EndInitialize","tip":{"blockHash":"aff83045e8d3d2dd9075fa7011a250098bb3136fc6bf5419cd72b19814988234","slot":3087077,"tag":"ChainPoint"}},"tag":"Wallet"},"tag":"DirectChain"}}
{"timestamp":"2022-11-29T17:31:26.956546345Z","threadId":62,"namespace":"HydraNode-\"sebastian-testnets-preview\"","message":{"directChain":{"point":{"blockHash":"b92823aa4c4d42b9722b032fcfc9314dfa4ef99a344e690074a04e52217ceb53","slot":2864083,"tag":"ChainPoint"},"tag":"RolledBackward"},"tag":"DirectChain"}}
{"timestamp":"2022-11-29T17:31:26.956747684Z","threadId":87,"namespace":"HydraNode-\"sebastian-testnets-preview\"","message":{"node":{"by":{"vkey":"43d8ac3fb8e39b355005ed546c8fc9cd80e4909cb254835513a542b1c9a2e3ad"},"event":{"chainEvent":{"contents":2864083,"tag":"Rollback"},"tag":"OnChainEvent"},"tag":"BeginEvent"},"tag":"Node"}}
{"timestamp":"2022-11-29T17:31:26.959278617Z","threadId":62,"namespace":"HydraNode-\"sebastian-testnets-preview\"","message":{"directChain":{"contents":{"point":{"blockHash":"ad7b417cb5a6aa12af11a24de33a817807c529a0dbdbfec0f68860f5f4af2605","slot":2864097,"tag":"ChainPoint"},"tag":"SkipUpdate"},"tag":"Wallet"},"tag":"DirectChain"}}
```

![image](https://user-images.githubusercontent.com/2621189/204600656-c394def7-f155-44f5-a35f-9e6fa3d5caa3.png)
