### PR TITLE
Log HeadLogic Outcome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ changes.
 
 - API server responses now contain a `timestamp` and a monotonic `seq`uence number. [#618](https://github.com/input-output-hk/hydra/pull/618)
 
+- HeadLogic Outcome is now being trace on every protocol step transition.
+
 ## [0.8.1] - 2022-11-17
 
 - **BREAKING** Implemented [ADR18](https://hydra.family/head-protocol/adr/18) to keep only a single state:

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -1133,9 +1133,7 @@ definitions:
 
   Outcome:
     description: >-
-      The result of Head protocol processing Events. Each Outcome
-      represents an action to be taken by the node to transition
-      the protocol.
+      The decision taken by the node logic after processing an Event.
     oneOf:
       - title: OnlyEffects
         type: object

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -516,6 +516,25 @@ definitions:
               The Party emitting the log entry.
           effect:
             $ref: "#/definitions/Effect"
+      - title: LogicOutcome
+        description: >-
+          Outcome produced, to transition the Head protocol, after processing an input event.
+        type: object
+        additionalProperties: false
+        required:
+          - tag
+          - by
+          - outcome
+        properties:
+          tag:
+            type: string
+            enum: ["LogicOutcome"]
+          by:
+            <<: { "$ref": "api.yaml#/components/schemas/Party" }
+            description: >-
+              The Party emitting the log entry.
+          outcome:
+            $ref: "#/definitions/Outcome"
 
   LogicError:
     oneOf:
@@ -1111,6 +1130,85 @@ definitions:
             $ref: "#/definitions/WaitReason"
           event:
             $ref: "#/definitions/Event"
+
+  Outcome:
+    description: >-
+      The result of Head protocol processing Events. Each Outcome
+      represents an action to be taken by the node to transition
+      the protocol.
+    oneOf:
+      - title: OnlyEffects
+        type: object
+        additionalProperties: false
+        required:
+          - tag
+          - effects
+        description: >-
+          An outcome representing the list of actions to be taken by the node 
+          to transition the protocol.
+        properties:
+          tag:
+            type: string
+            enum: ["OnlyEffects"]
+          effects:
+            type: array
+            items:
+              type: object
+              $ref: "#/definitions/Effect"
+      - title: NewState
+        type: object
+        additionalProperties: false
+        required:
+          - tag
+          - headState
+          - effects
+        description: >-
+          An outcome representing the list of actions to be taken by the node 
+          to transition the protocol, and the new resulting state.
+        properties:
+          tag:
+            type: string
+            enum: ["NewState"]
+          headState:
+            type: object
+            $ref: "#/definitions/HeadState"
+          effects:
+            type: array
+            items:
+              type: object
+              $ref: "#/definitions/Effect"
+      - title: Wait
+        type: object
+        additionalProperties: false
+        required:
+          - tag
+          - reason
+        description: >-
+          An outcome representing the time to wait by the node before re-enqueuing
+          the input event to be processed again.
+        properties:
+          tag:
+            type: string
+            enum: ["Wait"]
+          reason:
+            type: object
+            $ref: "#/definitions/WaitReason"
+      - title: Error
+        type: object
+        additionalProperties: false
+        required:
+          - tag
+          - error
+        description: >-
+          An outcome representing an error to be logged by the node after processing
+          an input event.
+        properties:
+          tag:
+            type: string
+            enum: ["Error"]
+          error:
+            type: object
+            $ref: "#/definitions/LogicError"
 
   WaitReason:
     oneOf:

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -409,34 +409,6 @@ definitions:
 
   Node:
     oneOf:
-      - title: ErrorHandlingEvent
-        # This should be removed from the Log's description as soon as we have some proper
-        # error handling strategy in place, be it simply "Close the head" and bail out.
-        description: >-
-          Some error happened while processing an event, provides enough context
-          information to troubleshoot the origin of the error.
-        type: object
-        additionalProperties: false
-        required:
-          - tag
-          - by
-          - event
-        properties:
-          tag:
-            type: string
-            enum: ["ErrorHandlingEvent"]
-          by:
-            <<: { "$ref": "api.yaml#/components/schemas/Party" }
-            description: >-
-              The Party emitting the log entry.
-          event:
-            <<: { "$ref": "#/definitions/Event" }
-            description: >-
-              The event causing the error.
-          reason:
-            <<: { "$ref": "#/definitions/LogicError" }
-            description: >-
-              Structured description of the cause of the error.
       - title: BeginEvent
         description: >-
           Head has started processing an event drawn from some pool or queue of
@@ -518,7 +490,7 @@ definitions:
             $ref: "#/definitions/Effect"
       - title: LogicOutcome
         description: >-
-          Outcome produced, to transition the Head protocol, after processing an input event.
+          An outcome produced is a decision the node took after processing an input event.
         type: object
         additionalProperties: false
         required:
@@ -1182,7 +1154,7 @@ definitions:
           - tag
           - reason
         description: >-
-          An outcome representing the time to wait by the node before re-enqueuing
+          An outcome representing the time that needs to pass before re-enqueuing
           the input event to be processed again.
         properties:
           tag:

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -240,9 +240,15 @@ data Outcome tx
   | NewState (HeadState tx) [Effect tx]
   | Wait WaitReason
   | Error (LogicError tx)
+  deriving stock (Generic)
 
 deriving instance (IsTx tx, IsChainState tx) => Eq (Outcome tx)
 deriving instance (IsTx tx, IsChainState tx) => Show (Outcome tx)
+deriving instance (IsTx tx, IsChainState tx) => ToJSON (Outcome tx)
+deriving instance (IsTx tx, IsChainState tx) => FromJSON (Outcome tx)
+
+instance (IsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (Outcome tx) where
+  arbitrary = genericArbitrary
 
 data WaitReason
   = WaitOnNotApplicableTx {validationError :: ValidationError}

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -236,10 +236,10 @@ deriving instance (ToJSON (Event tx), ToJSON (HeadState tx)) => ToJSON (LogicErr
 deriving instance (FromJSON (Event tx), FromJSON (HeadState tx)) => FromJSON (LogicError tx)
 
 data Outcome tx
-  = OnlyEffects [Effect tx]
-  | NewState (HeadState tx) [Effect tx]
-  | Wait WaitReason
-  | Error (LogicError tx)
+  = OnlyEffects {effects :: [Effect tx]}
+  | NewState {headState :: HeadState tx, effects :: [Effect tx]}
+  | Wait {reason :: WaitReason}
+  | Error {error :: LogicError tx}
   deriving stock (Generic)
 
 deriving instance (IsTx tx, IsChainState tx) => Eq (Outcome tx)

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -247,7 +247,7 @@ deriving instance (IsTx tx, IsChainState tx) => Show (Outcome tx)
 deriving instance (IsTx tx, IsChainState tx) => ToJSON (Outcome tx)
 deriving instance (IsTx tx, IsChainState tx) => FromJSON (Outcome tx)
 
-instance (IsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (Outcome tx) where
+instance (IsTx tx, IsChainState tx) => Arbitrary (Outcome tx) where
   arbitrary = genericArbitrary
 
 data WaitReason

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -247,7 +247,7 @@ deriving instance (IsTx tx, IsChainState tx) => Show (Outcome tx)
 deriving instance (IsTx tx, IsChainState tx) => ToJSON (Outcome tx)
 deriving instance (IsTx tx, IsChainState tx) => FromJSON (Outcome tx)
 
-instance (IsTx tx, IsChainState tx) => Arbitrary (Outcome tx) where
+instance (IsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (Outcome tx) where
   arbitrary = genericArbitrary
 
 data WaitReason

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -129,7 +129,9 @@ stepHydraNode ::
 stepHydraNode tracer node = do
   e <- nextEvent eq
   traceWith tracer $ BeginEvent party e
-  atomically (processNextEvent node e) >>= \case
+  outcome <- atomically (processNextEvent node e)
+  traceWith tracer (LogicOutcome party outcome)
+  case outcome of
     -- TODO(SN): Handling of 'Left' is untested, i.e. the fact that it only
     -- does trace and not throw!
     Error err -> traceWith tracer (ErrorHandlingEvent party e err)

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -43,7 +43,6 @@ import Hydra.HeadLogic (
   Environment (..),
   Event (..),
   HeadState (..),
-  LogicError (..),
   Outcome (..),
   defaultTTL,
   emitSnapshot,
@@ -87,8 +86,7 @@ data HydraNode tx m = HydraNode
   }
 
 data HydraNodeLog tx
-  = ErrorHandlingEvent {by :: Party, event :: Event tx, reason :: LogicError tx}
-  | BeginEvent {by :: Party, event :: Event tx}
+  = BeginEvent {by :: Party, event :: Event tx}
   | EndEvent {by :: Party, event :: Event tx}
   | BeginEffect {by :: Party, effect :: Effect tx}
   | EndEffect {by :: Party, effect :: Effect tx}
@@ -134,14 +132,14 @@ stepHydraNode tracer node = do
   case outcome of
     -- TODO(SN): Handling of 'Left' is untested, i.e. the fact that it only
     -- does trace and not throw!
-    Error err -> traceWith tracer (ErrorHandlingEvent party e err)
-    Wait _reason -> putEventAfter eq 0.1 (decreaseTTL e) >> traceWith tracer (EndEvent party e)
+    Error _ -> return ()
+    Wait _reason -> putEventAfter eq 0.1 (decreaseTTL e)
     NewState s effs -> do
       save s
       forM_ effs (processEffect node tracer)
-      traceWith tracer (EndEvent party e)
     OnlyEffects effs ->
-      forM_ effs (processEffect node tracer) >> traceWith tracer (EndEvent party e)
+      forM_ effs (processEffect node tracer)
+  traceWith tracer (EndEvent party e)
  where
   decreaseTTL =
     \case

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -92,7 +92,7 @@ data HydraNodeLog tx
   | EndEvent {by :: Party, event :: Event tx}
   | BeginEffect {by :: Party, effect :: Effect tx}
   | EndEffect {by :: Party, effect :: Effect tx}
-  | LogicOutcome {outcome :: Outcome tx}
+  | LogicOutcome {by :: Party, outcome :: Outcome tx}
   deriving stock (Generic)
 
 deriving instance (IsTx tx, IsChainState tx) => Eq (HydraNodeLog tx)

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -92,6 +92,7 @@ data HydraNodeLog tx
   | EndEvent {by :: Party, event :: Event tx}
   | BeginEffect {by :: Party, effect :: Effect tx}
   | EndEffect {by :: Party, effect :: Effect tx}
+  | LogicOutcome {outcome :: Outcome tx}
   deriving stock (Generic)
 
 deriving instance (IsTx tx, IsChainState tx) => Eq (HydraNodeLog tx)


### PR DESCRIPTION
Fixes #628 

🌴 Add `LogicOutcome` type to `HydraNodeLog`.

🌴 Trace the `LogicOutcome` on every protocol transition step.

🌴 Alter `Outcome` to use record types.

🌴 Updated logs json schemas.

🌴 Remove `ErrorHandlingEvent` type as it became redundant.

To check before merging:
* [x] CHANGELOG is up to date
* [X] ~Documentation is up to date~