### PR TITLE
Bump cardano-node to 1.35.4

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -59,8 +59,8 @@ let
   cardano-node = import
     (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "1.35.3";
-      sha256 = "020fwimsm24yblr1fmnwx240wj8r3x715p89cpjgnnd8axwf32p0";
+      rev = "1.35.4";
+      sha256 = "1j01m2cp2vdcl26zx9xmipr551v3b2rz9kfn9ik8byfwj1z7652r";
     })
     { };
 in

--- a/hydra-cluster/test/Test/CardanoNodeSpec.hs
+++ b/hydra-cluster/test/Test/CardanoNodeSpec.hs
@@ -20,7 +20,7 @@ spec = do
   -- false positives test errors in case someone uses an "untested" /
   -- different than in shell.nix version of cardano-node and cardano-cli.
   it "has expected cardano-node version available" $
-    getCardanoNodeVersion >>= (`shouldContain` "1.35.3")
+    getCardanoNodeVersion >>= (`shouldContain` "1.35.4")
 
   -- NOTE: We hard-code the expected networkId here to detect any change to the
   -- genesis-shelley.json

--- a/sample-node-config/nixos/hydraw.nix
+++ b/sample-node-config/nixos/hydraw.nix
@@ -6,8 +6,8 @@ let
   cardano-node = import
     (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "1.35.3";
-      sha256 = "020fwimsm24yblr1fmnwx240wj8r3x715p89cpjgnnd8axwf32p0";
+      rev = "1.35.4";
+      sha256 = "1j01m2cp2vdcl26zx9xmipr551v3b2rz9kfn9ik8byfwj1z7652r";
     })
     { };
 in


### PR DESCRIPTION
## Why

- Our smoke-tests are stuck on cardano-node syncing around 63%
- We want to use the latest cardano-node version for the developers using nix

#### Note:
 - This PR updates the cardano-node version in both nix-shell and hydraw
 
 


To check before merging:
* [x] CHANGELOG is up to date
* [x] Up to date with master
