### PR TITLE
Update changelog of plutus-merkle-tree and bump version

### DIFF
--- a/plutus-merkle-tree/CHANGELOG.md
+++ b/plutus-merkle-tree/CHANGELOG.md
@@ -12,6 +12,10 @@ changes.
 >
 > This package is released independently of other `hydra-` packages using `plutus-merkle-tree-x.y.z` tags.
 
+## [1.1.0] - UNRELEASED
+
+- Added `on-chain-cost` benchmark executable.
+
 ## [1.0.0] - 2022-02-11
 
 ### Added

--- a/plutus-merkle-tree/bench/Main.hs
+++ b/plutus-merkle-tree/bench/Main.hs
@@ -87,7 +87,7 @@ costOfMerkleTree = markdownMerkleTreeCost <$> computeMerkleTreeCost
 
 computeMerkleTreeCost :: IO [(Int, MemUnit, CpuUnit, MemUnit, CpuUnit)]
 computeMerkleTreeCost =
-  mapM compute [1, 2, 5, 10, 20, 50, 100, 500]
+  mapM compute [1, 2, 5, 10, 20, 50, 100, 500, 1000, 10000]
  where
   compute numElems = do
     utxo <- fmap Plutus.toBuiltin <$> genFakeUTxOs numElems

--- a/plutus-merkle-tree/plutus-merkle-tree.cabal
+++ b/plutus-merkle-tree/plutus-merkle-tree.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          plutus-merkle-tree
-version:       1.0.0
+version:       1.1.0
 synopsis:      On-Chain Merkle Trees
 author:        IOHK
 copyright:     2022 IOHK


### PR DESCRIPTION
:abacus: We did not bump when we actually added the executable.

:abacus: Also included 1000 and 10000 entries to the benchmark results. 

--- 

# Plutus Merkle-Tree Contract

## Cost of on-chain Merkle-Tree

| Size | % member max mem | % member max cpu | % builder max mem | % builder max cpu |
| :--- | ---------------: | ---------------: | ----------------: | ----------------: |
| 1 | 2.86 | 1.24 | 3.10 | 1.32 |
| 2 | 3.00 | 1.31 | 3.75 | 1.65 |
| 5 | 3.19 | 1.41 | 8.66 | 4.17 |
| 10 | 3.33 | 1.48 | 25.93 | 13.07 |
| 20 | 3.46 | 1.55 | 94.98 | 48.71 |
| 50 | 3.64 | 1.64 | 0.00 | 0.00 |
| 100 | 3.78 | 1.71 | 0.00 | 0.00 |
| 500 | 4.08 | 1.86 | 0.00 | 0.00 |
| 1000 | 4.22 | 1.93 | 0.00 | 0.00 |
| 10000 | 4.68 | 2.17 | 0.00 | 0.00 |
