### PR TITLE
Definitive nix.conf that should work

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,8 +78,8 @@ development.
 Before that, make sure the following caches are listed in your `nix.conf` for a speedy setup and that you have activated flakes:
 
 ```
-substituters = https://cache.nixos.org https://cache.iog.io https://iohk.cachix.org
-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+substituters = https://cache.iog.io https://cache.nixos.org
+trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 experimental-features = nix-command flakes
 ```
 


### PR DESCRIPTION
That's when you think it's so a trivial change that you should do it straight in master that you can remember why it's not a good idea :(

Anyway, after several trials and errors, here is the definitive nix.conf that should work to compile hydra was of today.

To check before merging:
* [x] CHANGELOG is up to date
* [x] Up to date with master
