### PR TITLE
fix abort tx-cost benchmark

### DIFF
--- a/hydra-node/exe/tx-cost/TxCost.hs
+++ b/hydra-node/exe/tx-cost/TxCost.hs
@@ -184,7 +184,7 @@ computeAbortCost =
     commits <- sublistOf =<< genCommits ctx initTx
     cctx <- pickChainContext ctx
     let (_, stInitialized) = unsafeObserveInitAndCommits cctx initTx commits
-    pure (abort cctx stInitialized, getKnownUTxO stInitialized)
+    pure (abort cctx stInitialized, getKnownUTxO stInitialized <> getKnownUTxO cctx)
 
 computeFanOutCost :: IO [(NumUTxO, TxSize, MemUnit, CpuUnit, Lovelace)]
 computeFanOutCost = do


### PR DESCRIPTION
Fixes #631 

## The problem
🎈 [computeAbortCost](https://github.com/input-output-hk/hydra-poc/blob/071e8e3efd92111615b2f1ff36fe0603c67e9f9f/hydra-node/exe/tx-cost/TxCost.hs#L169) was NOT producing a result because of:
```
Left (TransactionValidityTranslationError (TranslationLogicMissingInput (TxIn (TxId {_unTxId = SafeHash "ffae3c9a11bedf780250dc899dae0c755b0234d86136ce6b3c526eac3bf353ce"}) (TxIx 0))))
```
- This output has been obtain by tracing the result from `checkSizeAndEvaluate tx knownUtxo`.
- The error means: there are missing inputs, as part of the `knownUtxo`, which are being referenced on the `aborTx`, 
- This is because, during the computation, we call [evaluateTx](https://github.com/input-output-hk/hydra-poc/blob/071e8e3efd92111615b2f1ff36fe0603c67e9f9f/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs#L78) passing the abort `Tx to evaluate` along with the known set of `UTxO which are spent in this Tx`, and we expect all inputs referenced in the tx exists in the set of known UTxO.
- After calling `renderTxWithUTxO` and tracing the result, we found the missing inputs were reference inputs.

## The solution
🎈 Include reference inputs, from the chain context UTxO registry, as part of the `knownUtxo`.
- The [abortTx](https://github.com/input-output-hk/hydra-poc/blob/071e8e3efd92111615b2f1ff36fe0603c67e9f9f/hydra-node/src/Hydra/Chain/Direct/Tx.hs#L473) is the only transaction which currently requires the reference inputs
- The reference inputs are contained inside the [ScriptRegistry](https://github.com/input-output-hk/hydra/blob/071e8e3efd92111615b2f1ff36fe0603c67e9f9f/hydra-node/src/Hydra/Chain/Direct/ScriptRegistry.hs#L57).
- The registry lives in the [ChainContext](https://github.com/input-output-hk/hydra-poc/blob/071e8e3efd92111615b2f1ff36fe0603c67e9f9f/hydra-node/src/Hydra/Chain/Direct/State.hs#L182).

To check before merging:
* [X] CHANGELOG is up to date
* [X] Documentation is up to date
