### PR TITLE
Reduce cost of commitTx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ changes.
   + Changed logs of `BeginInitialize` and `EndInitialize`.
   + Added `SkipUpdate` constructor to the wallet logs.
 
+- Reduce cost of `commitTx` by using the initial script as input reference.
+
 ## [0.8.1] - 2022-11-17
 
 - **BREAKING** Implemented [ADR18](https://hydra.family/head-protocol/adr/18) to keep only a single state:

--- a/hydra-node/exe/tx-cost/TxCost.hs
+++ b/hydra-node/exe/tx-cost/TxCost.hs
@@ -102,7 +102,7 @@ computeCommitCost = do
     -- NOTE: number of parties is irrelevant for commit tx
     ctx <- genHydraContextFor 1
     (cctx, stInitial) <- genStInitial ctx
-    pure (commit cctx stInitial utxo, getKnownUTxO stInitial)
+    pure (commit cctx stInitial utxo, getKnownUTxO stInitial <> getKnownUTxO cctx)
 
 computeCollectComCost :: IO [(NumParties, TxSize, MemUnit, CpuUnit, Lovelace)]
 computeCollectComCost =

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -25,7 +25,6 @@ import Hydra.Cardano.Api (
   NetworkMagic (NetworkMagic),
   PaymentKey,
   PlutusScript,
-  ScriptData,
   SerialiseAsRawBytes (serialiseToRawBytes),
   SlotNo (SlotNo),
   Tx,
@@ -306,15 +305,15 @@ commit ctx st utxo = do
     , initialHeadTokenScript
     } = st
 
-  ownInitial :: Maybe (TxIn, TxOut CtxUTxO, Hash PaymentKey, ScriptData)
+  ownInitial :: Maybe (TxIn, TxOut CtxUTxO, Hash PaymentKey)
   ownInitial =
     foldl' go Nothing initialInitials
    where
     go (Just x) _ = Just x
-    go Nothing (i, out, sd) = do
+    go Nothing (i, out, _) = do
       let vkh = verificationKeyHash ownVerificationKey
       guard $ hasMatchingPT vkh (txOutValue out)
-      pure (i, out, vkh, sd)
+      pure (i, out, vkh)
 
   hasMatchingPT :: Hash PaymentKey -> Value -> Bool
   hasMatchingPT vkh val =

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -174,9 +174,9 @@ commitTx ::
   Maybe (TxIn, TxOut CtxUTxO) ->
   -- | The initial output (sent to each party) which should contain the PT and is
   -- locked by initial script
-  (TxIn, TxOut CtxUTxO, Hash PaymentKey, ScriptData) ->
+  (TxIn, TxOut CtxUTxO, Hash PaymentKey) ->
   Tx
-commitTx scriptRegistry networkId party utxo (initialInput, out, vkh, sd) =
+commitTx scriptRegistry networkId party utxo (initialInput, out, vkh) =
   unsafeBuildTransaction $
     emptyTxBody
       & addInputs [(initialInput, initialWitness)]
@@ -194,7 +194,7 @@ commitTx scriptRegistry networkId party utxo (initialInput, out, vkh, sd) =
   initialScriptRef =
     fst (initialReference scriptRegistry)
   initialDatum =
-    ScriptDatumForTxIn sd
+    mkScriptDatum $ Initial.datum ()
   initialRedeemer =
     toScriptData . Initial.redeemer $
       Initial.ViaCommit (toPlutusTxOutRef <$> mCommittedInput)

--- a/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
@@ -10,6 +10,7 @@ import Hydra.Prelude
 import Cardano.Crypto.Hash.Class
 import qualified Cardano.Ledger.Address as Ledger
 import Cardano.Ledger.Alonzo.Data (Data (Data))
+import Cardano.Ledger.Alonzo.Language (Language (PlutusV2))
 import Cardano.Ledger.Alonzo.PlutusScriptApi (language)
 import Cardano.Ledger.Alonzo.Scripts (CostModels (CostModels), ExUnits (ExUnits), Tag (Spend), txscriptfee)
 import Cardano.Ledger.Alonzo.Tools (TransactionScriptFailure, evaluateTransactionExecutionUnits)
@@ -258,12 +259,8 @@ coverFee_ pparams systemStart epochInfo lookupUTxO walletUTxO partialTx@Validate
         needlesslyHighFee
 
   let newOutputs = outputs body <> StrictSeq.singleton (mkSized change)
-      langs =
-        [ getLanguageView pparams l
-        | (_hash, script) <- Map.toList (txscripts wits)
-        , (not . isNativeScript @LedgerEra) script
-        , Just l <- [language script]
-        ]
+      -- FIXME: NONONO.. use cardano-api instead of doing hard-coding this here
+      langs = [getLanguageView pparams (PlutusV2)]
       finalBody =
         body
           { inputs = inputs'

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
@@ -15,6 +15,7 @@ import Hydra.Chain.Direct.Contract.Mutation (
   SomeMutation (..),
  )
 import qualified Hydra.Chain.Direct.Fixture as Fixture
+import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry, registryUTxO)
 import Hydra.Chain.Direct.Tx (commitTx, headPolicyId, mkInitialOutput)
 import Hydra.Ledger.Cardano (
   genAddressInEra,
@@ -36,12 +37,18 @@ healthyCommitTx =
   lookupUTxO =
     UTxO.singleton (initialInput, toUTxOContext initialOutput)
       <> UTxO.singleton healthyCommittedUTxO
+      <> registryUTxO scriptRegistry
   tx =
     commitTx
+      scriptRegistry
       Fixture.testNetworkId
       commitParty
       (Just healthyCommittedUTxO)
-      (initialInput, toUTxOContext initialOutput, initialPubKeyHash)
+      (initialInput, toUTxOContext initialOutput, initialPubKeyHash, scriptData)
+
+  scriptData = fromJust . getScriptData $ initialOutput
+
+  scriptRegistry = genScriptRegistry `generateWith` 42
 
   initialInput = generateWith arbitrary 42
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
@@ -44,9 +44,7 @@ healthyCommitTx =
       Fixture.testNetworkId
       commitParty
       (Just healthyCommittedUTxO)
-      (initialInput, toUTxOContext initialOutput, initialPubKeyHash, scriptData)
-
-  scriptData = fromJust . getScriptData $ initialOutput
+      (initialInput, toUTxOContext initialOutput, initialPubKeyHash)
 
   scriptRegistry = genScriptRegistry `generateWith` 42
 


### PR DESCRIPTION
🦚 By making use of the initial script reference as input reference, we can replace the `scripts: v_initial` and reduce the cost of the `commitTx`.

* [x] CHANGELOG is up to date
* [x] Documentation is up to date
