### PR TITLE
Also use cachix cache in docker workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -39,6 +39,12 @@ jobs:
         extra_nix_config: |
           accept-flake-config = true
 
+    - name: ❄ Cachix cache of nix derivations
+      uses: cachix/cachix-action@v12
+      with:
+        name: hydra-node
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
     - name: 🔨 Build images using nix
       run: |
         IMAGE_NAME=ghcr.io/${{github.repository_owner}}/${{matrix.target}}

--- a/hydraw/hydraw.cabal
+++ b/hydraw/hydraw.cabal
@@ -58,7 +58,6 @@ library
     , cardano-ledger-shelley-ma
     , containers
     , hydra-cardano-api
-    , hydra-cluster
     , hydra-node
     , hydra-prelude
     , text


### PR DESCRIPTION
This will yield cachix cache entries of derivations built for the docker images (maybe even the docker image layers) and should speed up the docker workflow.
