### PR TITLE
Tackle a Fixme in the Head minting policy

### DIFF
--- a/hydra-plutus/src/Hydra/Contract/HeadTokens.hs
+++ b/hydra-plutus/src/Hydra/Contract/HeadTokens.hs
@@ -45,10 +45,6 @@ validate initialValidator headValidator seedInput action context =
     Burn -> validateTokensBurning context
 {-# INLINEABLE validate #-}
 
--- FIXME: This doesn't verify that:
---
--- (a) A ST is minted with the right 'HydraHeadV1' name
--- (b) PTs's name have the right shape (i.e. 28 bytes long)
 validateTokensMinting :: ValidatorHash -> ValidatorHash -> TxOutRef -> ScriptContext -> Bool
 validateTokensMinting initialValidator headValidator seedInput context =
   traceIfFalse "minted wrong" $


### PR DESCRIPTION
## Why

PT tokens should be of length 28 and ST token needs to have a correct name. Note: Both tokens use the same currency symbol but the length and token name check is missing from the minting validator.

To check before merging:
* [ ] CHANGELOG is up to date
* [x] Up to date with master
