### PR TITLE
Remove reference to non-existing README file

### DIFF
--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -9,7 +9,6 @@ license-files:
   LICENSE
   NOTICE
 
-extra-source-files: README.md
 data-files:         json-schemas/logs.yaml
 
 source-repository head


### PR DESCRIPTION
The hydra-node cabal file references a non-existing README.md and this was causing my build to fail

To check before merging:
* [ ] CHANGELOG is up to date
* [ ] Up to date with master
