### PR TITLE
check commits are reimbursed in nu head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@ changes.
   + Will make bumping dependencies (e.g. cardano-node) easier.
   + Build commands for binaries and docker images change, see updated [Contribution Guidelines](https://github.com/input-output-hk/hydra/blob/master/CONTRIBUTING.md)
 
-
 - **BREAKING** Change the way tx validity and contestation deadline is constructed for close transactions:
   + There is a new hydra-node flag `--contestation-period` expressed in seconds
     to control the close tx validity bounds as well as determine the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,13 @@ changes.
 
 - HeadLogic Outcome is now being trace on every protocol step transition.
 
-- Check commits are reimbursed in nu head.
 
 - **BREAKING** `hydra-cardano-api` changes:
   + Remove `Hydra.Cardano.Api.SlotNo` module.
   + Replace `fromConsensusPointHF` with `fromConsensusPointInMode` and
     `toConsensusPointHF` with `toConsensusPointInMode`.
   + Re-export new `AcquiringFailure` type from `cardano-api`.
+  + The head validator will check that the commits are reimbursed.
 
 - Change the way the internal wallet initializes its state [#621](https://github.com/input-output-hk/hydra/pull/621)
   + The internal wallet does now always query ledger state and parameters at the tip.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,10 @@ changes.
   + Replace `fromConsensusPointHF` with `fromConsensusPointInMode` and
     `toConsensusPointHF` with `toConsensusPointInMode`.
   + Re-export new `AcquiringFailure` type from `cardano-api`.
-  + The head validator will check that the commits are reimbursed.
+
+- **BREAKING** Addressed short-comings in `hydra-plutus` scripts:
+  + Check presence of state token (ST) and that it's consistent against datum.
+  + Moved check to reimburse commits to head validator.
 
 - Change the way the internal wallet initializes its state [#621](https://github.com/input-output-hk/hydra/pull/621)
   + The internal wallet does now always query ledger state and parameters at the tip.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ changes.
 
 - HeadLogic Outcome is now being trace on every protocol step transition.
 
+- Check commits are reimbursed in nu head.
+
 - **BREAKING** `hydra-cardano-api` changes:
   + Remove `Hydra.Cardano.Api.SlotNo` module.
   + Replace `fromConsensusPointHF` with `fromConsensusPointInMode` and
@@ -39,6 +41,7 @@ changes.
   + Makes configuration of binary-caches easier to discover (you get asked about adding them).
   + Will make bumping dependencies (e.g. cardano-node) easier.
   + Build commands for binaries and docker images change, see updated [Contribution Guidelines](https://github.com/input-output-hk/hydra/blob/master/CONTRIBUTING.md)
+
 
 - **BREAKING** Change the way tx validity and contestation deadline is constructed for close transactions:
   + There is a new hydra-node flag `--contestation-period` expressed in seconds

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
@@ -93,14 +93,13 @@ healthyCommits :: [UTxOWithScript]
   -- TODO: Refactor this to be an AbortTx generator because we actually want
   -- to test healthy abort txs with varied combinations of inital and commit
   -- outputs
-  generateWith (genAbortableOutputs healthyParties `suchThat` thereIsAtLeastOneCommit) 42
-
-thereIsAtLeastOneCommit :: ([UTxOWithScript], [UTxOWithScript]) -> Bool
-thereIsAtLeastOneCommit (is, cs) = not (null cs) && not (null is)
+  generateWith (genAbortableOutputs healthyParties `suchThat` thereIsTwoEach) 42
+ where
+  thereIsTwoEach (is, cs) = length is >= 2 && length cs >= 2
 
 healthyParties :: [Party]
 healthyParties =
-  [ generateWith arbitrary i | i <- [1 .. 3]
+  [ generateWith arbitrary i | i <- [1 .. 4]
   ]
 
 propHasInitial :: (Tx, UTxO) -> Property

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -130,6 +130,7 @@ data HealthyCommit = HealthyCommit
   , txOut :: TxOut CtxUTxO
   , scriptData :: ScriptData
   }
+  deriving (Show)
 
 healthyCommitOutput ::
   Party ->

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -30,6 +30,7 @@ import Hydra.Chain.Direct.Tx (
   mkCommitDatum,
   mkHeadId,
   mkHeadOutput,
+  mkInitialOutput,
  )
 import qualified Hydra.Contract.Commit as Commit
 import qualified Hydra.Contract.Head as Head
@@ -54,27 +55,18 @@ healthyCollectComTx =
   (tx, lookupUTxO)
  where
   lookupUTxO =
-    UTxO.singleton (healthyHeadInput, healthyHeadResolvedInput) <> UTxO (fst <$> commits)
+    UTxO.singleton (healthyHeadInput, healthyHeadResolvedInput) <> UTxO (txOut <$> healthyCommits)
 
   tx =
     collectComTx
       testNetworkId
       somePartyCardanoVerificationKey
       initialThreadOutput
-      commits
+      ((txOut &&& scriptData) <$> healthyCommits)
       (mkHeadId testPolicyId)
 
   somePartyCardanoVerificationKey = flip generateWith 42 $ do
     genForParty genVerificationKey <$> elements healthyParties
-
-  committedUTxO =
-    generateWith
-      (replicateM (length healthyParties) genCommittableTxOut)
-      42
-
-  commits =
-    (uncurry healthyCommitOutput <$> zip healthyParties committedUTxO)
-      & Map.fromList
 
   headDatum = fromPlutusData $ toData healthyCollectComInitialDatum
 
@@ -84,6 +76,16 @@ healthyCollectComTx =
       , initialParties = healthyOnChainParties
       , initialContestationPeriod = healthyContestationPeriod
       }
+
+healthyCommits :: Map TxIn HealthyCommit
+healthyCommits =
+  (uncurry healthyCommitOutput <$> zip healthyParties committedUTxO)
+    & Map.fromList
+ where
+  committedUTxO =
+    generateWith
+      (replicateM (length healthyParties) genCommittableTxOut)
+      42
 
 healthyContestationPeriod :: OnChain.ContestationPeriod
 healthyContestationPeriod =
@@ -123,21 +125,28 @@ genCommittableTxOut :: Gen (TxIn, TxOut CtxUTxO)
 genCommittableTxOut =
   Prelude.head . UTxO.pairs <$> (genAdaOnlyUTxO `suchThat` (\u -> length u > 1))
 
+data HealthyCommit = HealthyCommit
+  { cardanoKey :: VerificationKey PaymentKey
+  , txOut :: TxOut CtxUTxO
+  , scriptData :: ScriptData
+  }
+
 healthyCommitOutput ::
   Party ->
   (TxIn, TxOut CtxUTxO) ->
-  (TxIn, (TxOut CtxUTxO, ScriptData))
+  (TxIn, HealthyCommit)
 healthyCommitOutput party committed =
   ( txIn
-  ,
-    ( toCtxUTxOTxOut (TxOut commitAddress commitValue (mkTxOutDatum commitDatum) ReferenceScriptNone)
-    , fromPlutusData (toData commitDatum)
-    )
+  , HealthyCommit
+      { cardanoKey
+      , txOut = toCtxUTxOTxOut (TxOut commitAddress commitValue (mkTxOutDatum commitDatum) ReferenceScriptNone)
+      , scriptData = fromPlutusData (toData commitDatum)
+      }
   )
  where
   txIn = genTxIn `genForParty` party
 
-  cardanoVk = genVerificationKey `genForParty` party
+  cardanoKey = genVerificationKey `genForParty` party
 
   commitScript =
     fromPlutusScript Commit.validatorScript
@@ -147,13 +156,15 @@ healthyCommitOutput party committed =
     headValue
       <> (txOutValue . snd) committed
       <> valueFromList
-        [ (AssetId testPolicyId (assetNameFromVerificationKey cardanoVk), 1)
+        [ (AssetId testPolicyId (assetNameFromVerificationKey cardanoKey), 1)
         ]
   commitDatum =
     mkCommitDatum party Head.validatorHash (Just committed) (toPlutusCurrencySymbol $ headPolicyId healthyHeadInput)
 
 data CollectComMutation
   = MutateOpenUTxOHash
+  | MutateCommitToInitial
+  | MutateHeadScriptInput
   | MutateHeadTransition
   | -- | NOTE: We want to ccheck CollectCom validator checks there's exactly the
     -- expected number of commits. This is needed because the Head protocol
@@ -199,6 +210,9 @@ genCollectComMutation (tx, _utxo) =
     , SomeMutation MutateRequiredSigner <$> do
         newSigner <- verificationKeyHash <$> genVerificationKey
         pure $ ChangeRequiredSigners [newSigner]
+    , SomeMutation MutateCommitToInitial <$> do
+        (txIn, HealthyCommit{cardanoKey}) <- elements $ Map.toList healthyCommits
+        pure $ ChangeInput txIn (toUTxOContext $ mkInitialOutput testNetworkId testPolicyId cardanoKey) Nothing
     ]
  where
   headTxOut = fromJust $ txOuts' tx !!? 0

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -164,7 +164,6 @@ healthyCommitOutput party committed =
 data CollectComMutation
   = MutateOpenUTxOHash
   | MutateCommitToInitial
-  | MutateHeadScriptInput
   | MutateHeadTransition
   | -- | NOTE: We want to ccheck CollectCom validator checks there's exactly the
     -- expected number of commits. This is needed because the Head protocol

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -163,11 +163,10 @@ healthyCommitOutput party committed =
 
 data CollectComMutation
   = MutateOpenUTxOHash
-  | MutateCommitToInitial
+  | -- | Test that collectCom cannot collect from an initial UTxO.
+    MutateCommitToInitial
   | MutateHeadTransition
-  | -- | NOTE: We want to ccheck CollectCom validator checks there's exactly the
-    -- expected number of commits. This is needed because the Head protocol
-    -- requires to ensure every party has a chance to commit.
+  | -- | Test that every party has a chance to commit.
     MutateNumberOfParties
   | MutateHeadId
   | MutateRequiredSigner

--- a/hydra-plutus/src/Hydra/Contract/Commit.hs
+++ b/hydra-plutus/src/Hydra/Contract/Commit.hs
@@ -20,7 +20,7 @@ import Plutus.V2.Ledger.Api (
   Datum (..),
   Redeemer (Redeemer),
   Script,
-  ScriptContext (ScriptContext, scriptContextTxInfo),
+  ScriptContext (scriptContextTxInfo),
   TxInfo (txInfoMint, txInfoOutputs),
   TxOutRef,
   Validator (getValidator),
@@ -30,7 +30,6 @@ import Plutus.V2.Ledger.Api (
  )
 import PlutusTx (CompiledCode, fromData, toBuiltinData, toData)
 import qualified PlutusTx
-import qualified PlutusTx.Builtins as Builtins
 import qualified Prelude as Haskell
 
 data CommitRedeemer
@@ -88,7 +87,7 @@ type RedeemerType = CommitRedeemer
 --
 --   * spent in a transaction also consuming a v_head output
 validator :: DatumType -> RedeemerType -> ScriptContext -> Bool
-validator (_party, _headScriptHash, commit, headId) r ctx@ScriptContext{scriptContextTxInfo = txInfo} =
+validator (_party, _headScriptHash, _commit, headId) r ctx =
   case r of
     ViaAbort ->
       -- NOTE: In the Abort case the reimbursement of the committed output 'commit' is

--- a/hydra-plutus/src/Hydra/Contract/Commit.hs
+++ b/hydra-plutus/src/Hydra/Contract/Commit.hs
@@ -86,15 +86,17 @@ type RedeemerType = CommitRedeemer
 -- | The v_commit validator verifies that:
 --
 --   * spent in a transaction also consuming a v_head output
+--
+--   * ST token is burned if the redeemer is 'ViaAbort'
+--
+--   * ST token is present in the output if the redeemer is 'ViaCollectCom'
 validator :: DatumType -> RedeemerType -> ScriptContext -> Bool
 validator (_party, _headScriptHash, _commit, headId) r ctx =
   case r of
-    ViaAbort ->
-      -- NOTE: In the Abort case the reimbursement of the committed output 'commit' is
-      -- delegated to the 'head' script who has more information to do it.
-      traceIfFalse "ST not burned" (mustBurnST (txInfoMint $ scriptContextTxInfo ctx) headId)
-    -- NOTE: In the Collectcom case the inclusion of the committed output 'commit' is
+    -- NOTE: The reimbursement of the committed output 'commit' is
     -- delegated to the 'head' script who has more information to do it.
+    ViaAbort ->
+      traceIfFalse "ST not burned" (mustBurnST (txInfoMint $ scriptContextTxInfo ctx) headId)
     ViaCollectCom ->
       traceIfFalse "ST is missing in the output" (hasST headId outputs)
  where

--- a/hydra-plutus/src/Hydra/Contract/Commit.hs
+++ b/hydra-plutus/src/Hydra/Contract/Commit.hs
@@ -103,8 +103,8 @@ validator (_party, _headScriptHash, commit, headId) r ctx@ScriptContext{scriptCo
     -- delegated to the 'CollectCom' script who has more information to do it.
     ViaCollectCom ->
       traceIfFalse "ST is missing in the output" (hasST headId outputs)
--- where
---  outputs = foldMap txOutValue $ txInfoOutputs $ scriptContextTxInfo ctx
+ where
+  outputs = foldMap txOutValue $ txInfoOutputs $ scriptContextTxInfo ctx
 
 compiledValidator :: CompiledCode ValidatorType
 compiledValidator =

--- a/hydra-plutus/src/Hydra/Contract/Commit.hs
+++ b/hydra-plutus/src/Hydra/Contract/Commit.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -fno-specialize #-}
+{-# OPTIONS_GHC -fno-specialize -Wwarn #-}
 
 -- | The validator used to collect & open or abort a Head.
 module Hydra.Contract.Commit where
@@ -94,19 +94,19 @@ validator (_party, _headScriptHash, commit, headId) r ctx@ScriptContext{scriptCo
   case r of
     ViaAbort ->
       traceIfFalse "ST not burned" (mustBurnST (txInfoMint $ scriptContextTxInfo ctx) headId)
-        && case commit of
-          Nothing -> True
-          Just Commit{preSerializedOutput} ->
-            traceIfFalse
-              "cannot find committed output"
-              -- There should be an output in the transaction corresponding to this preSerializedOutput
-              (preSerializedOutput `elem` (Builtins.serialiseData . toBuiltinData <$> txInfoOutputs txInfo))
+    --  && case commit of
+    --    Nothing -> True
+    --    Just Commit{preSerializedOutput} ->
+    --      traceIfFalse
+    --        "cannot find committed output"
+    --        -- There should be an output in the transaction corresponding to this preSerializedOutput
+    --        (preSerializedOutput `elem` (Builtins.serialiseData . toBuiltinData <$> txInfoOutputs txInfo))
     -- NOTE: In the Collectcom case the inclusion of the committed output 'commit' is
     -- delegated to the 'CollectCom' script who has more information to do it.
     ViaCollectCom ->
       traceIfFalse "ST is missing in the output" (hasST headId outputs)
- where
-  outputs = foldMap txOutValue $ txInfoOutputs $ scriptContextTxInfo ctx
+-- where
+--  outputs = foldMap txOutValue $ txInfoOutputs $ scriptContextTxInfo ctx
 
 compiledValidator :: CompiledCode ValidatorType
 compiledValidator =

--- a/hydra-plutus/src/Hydra/Contract/Commit.hs
+++ b/hydra-plutus/src/Hydra/Contract/Commit.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -fno-specialize -Wwarn #-}
+{-# OPTIONS_GHC -fno-specialize #-}
 
 -- | The validator used to collect & open or abort a Head.
 module Hydra.Contract.Commit where
@@ -91,16 +91,11 @@ validator :: DatumType -> RedeemerType -> ScriptContext -> Bool
 validator (_party, _headScriptHash, commit, headId) r ctx@ScriptContext{scriptContextTxInfo = txInfo} =
   case r of
     ViaAbort ->
+      -- NOTE: In the Abort case the reimbursement of the committed output 'commit' is
+      -- delegated to the 'head' script who has more information to do it.
       traceIfFalse "ST not burned" (mustBurnST (txInfoMint $ scriptContextTxInfo ctx) headId)
-    --  && case commit of
-    --    Nothing -> True
-    --    Just Commit{preSerializedOutput} ->
-    --      traceIfFalse
-    --        "cannot find committed output"
-    --        -- There should be an output in the transaction corresponding to this preSerializedOutput
-    --        (preSerializedOutput `elem` (Builtins.serialiseData . toBuiltinData <$> txInfoOutputs txInfo))
     -- NOTE: In the Collectcom case the inclusion of the committed output 'commit' is
-    -- delegated to the 'CollectCom' script who has more information to do it.
+    -- delegated to the 'head' script who has more information to do it.
     ViaCollectCom ->
       traceIfFalse "ST is missing in the output" (hasST headId outputs)
  where

--- a/hydra-plutus/src/Hydra/Contract/Commit.hs
+++ b/hydra-plutus/src/Hydra/Contract/Commit.hs
@@ -87,9 +87,9 @@ type RedeemerType = CommitRedeemer
 --
 --   * spent in a transaction also consuming a v_head output
 --
---   * ST token is burned if the redeemer is 'ViaAbort'
+--   * ST is burned if the redeemer is 'ViaAbort'
 --
---   * ST token is present in the output if the redeemer is 'ViaCollectCom'
+--   * ST is present in the output if the redeemer is 'ViaCollectCom'
 validator :: DatumType -> RedeemerType -> ScriptContext -> Bool
 validator (_party, _headScriptHash, _commit, headId) r ctx =
   case r of

--- a/hydra-plutus/src/Hydra/Contract/Commit.hs
+++ b/hydra-plutus/src/Hydra/Contract/Commit.hs
@@ -87,8 +87,6 @@ type RedeemerType = CommitRedeemer
 -- | The v_commit validator verifies that:
 --
 --   * spent in a transaction also consuming a v_head output
---
---   * on abort, redistribute comitted utxo
 validator :: DatumType -> RedeemerType -> ScriptContext -> Bool
 validator (_party, _headScriptHash, commit, headId) r ctx@ScriptContext{scriptContextTxInfo = txInfo} =
   case r of

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -119,9 +119,9 @@ checkAbort ctx@ScriptContext{scriptContextTxInfo = txInfo} headCurrencySymbol pa
   traverseInputs commits = \case
     [] ->
       commits
-    TxInInfo{txInInfoResolved = input} : rest
-      | hasPT headCurrencySymbol input ->
-        case commitDatum txInfo input of
+    TxInInfo{txInInfoResolved = txOut} : rest
+      | hasPT headCurrencySymbol txOut ->
+        case commitDatum txInfo txOut of
           Just Commit{preSerializedOutput} ->
             traverseInputs
               (preSerializedOutput : commits)

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -114,12 +114,13 @@ checkAbort ctx@ScriptContext{scriptContextTxInfo = txInfo} headCurrencySymbol pa
 
   serialisedOutputs = Builtins.serialiseData . toBuiltinData <$> txInfoOutputs txInfo
 
-  committedUTxOs = traverseInputs [] (txInfoOutputs txInfo)
+  committedUTxOs = traverseInputs [] (txInfoInputs txInfo)
 
+  traverseInputs :: [BuiltinByteString] -> [TxInInfo] -> [BuiltinByteString]
   traverseInputs commits = \case
     [] ->
       commits
-    txOut : rest
+    TxInInfo{txInInfoResolved = txOut} : rest
       | hasPT headContext txOut ->
         case commitDatum txInfo txOut of
           Just Commit{preSerializedOutput} ->

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -213,6 +213,8 @@ checkCollectCom ctx@ScriptContext{scriptContextTxInfo = txInfo} (contestationPer
   isHeadOutput txOut = txOutAddress txOut == headAddress
 {-# INLINEABLE checkCollectCom #-}
 
+-- | Try to find the commit datum in the input and
+-- if it is there return the commited utxo
 commitDatum :: TxInfo -> TxOut -> Maybe Commit
 commitDatum txInfo input = do
   let datum = findTxOutDatum txInfo input
@@ -498,6 +500,7 @@ hashTxOuts =
   sha2_256 . foldMap (Builtins.serialiseData . toBuiltinData)
 {-# INLINEABLE hashTxOuts #-}
 
+-- | Check if 'TxOut' contains the PT token.
 hasPT :: CurrencySymbol -> TxOut -> Bool
 hasPT headCurrencySymbol txOut =
   let pts = findParticipationTokens headCurrencySymbol (txOutValue txOut)

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -219,8 +219,7 @@ commitDatum txInfo input = do
   case fromBuiltinData @Commit.DatumType $ getDatum datum of
     Just (_party, _validatorHash, commit, _headId) ->
       commit
-    Nothing ->
-      traceError "commitDatum failed fromBuiltinData"
+    Nothing -> Nothing
 {-# INLINEABLE commitDatum #-}
 
 -- | The close validator must verify that:

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -160,8 +160,8 @@ checkCollectCom ::
   ScriptContext ->
   (ContestationPeriod, [Party], CurrencySymbol) ->
   Bool
-checkCollectCom ctx@ScriptContext{scriptContextTxInfo = txInfo} Initial{contestationPeriod, parties, initialHeadId} =
-  mustContinueHeadWith ctx expectedChangeValue expectedOutputDatum
+checkCollectCom ctx@ScriptContext{scriptContextTxInfo = txInfo} (contestationPeriod, parties, headId) =
+  mustContinueHeadWith ctx headAddress expectedChangeValue expectedOutputDatum
     && everyoneHasCommitted
     && mustBeSignedByParticipant ctx headId
     && hasST headId outValue

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -120,9 +120,9 @@ checkAbort ctx@ScriptContext{scriptContextTxInfo = txInfo} headCurrencySymbol pa
   traverseInputs commits = \case
     [] ->
       commits
-    TxInInfo{txInInfoResolved = txOut} : rest
-      | hasPT headContext txOut ->
-        case commitDatum txInfo txOut of
+    TxInInfo{txInInfoResolved = input} : rest
+      | hasPT headContext input ->
+        case commitDatum txInfo input of
           Just Commit{preSerializedOutput} ->
             traverseInputs
               (preSerializedOutput : commits)
@@ -234,13 +234,13 @@ hasPT ctx txOut =
 {-# INLINEABLE hasPT #-}
 
 commitDatum :: TxInfo -> TxOut -> Maybe Commit
-commitDatum txInfo o = do
-  let d = findTxOutDatum txInfo o
-  case fromBuiltinData @Commit.DatumType $ getDatum d of
+commitDatum txInfo input = do
+  let datum = findTxOutDatum txInfo input
+  case fromBuiltinData @Commit.DatumType $ getDatum datum of
     Just (_p, _, mCommit) ->
       mCommit
     Nothing ->
-      traceError "commitDatum failed fromBuiltinData"
+      Nothing
 {-# INLINEABLE commitDatum #-}
 
 -- | The close validator must verify that:

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -119,10 +119,10 @@ checkAbort ctx@ScriptContext{scriptContextTxInfo = txInfo} headCurrencySymbol pa
   traverseInputs commits = \case
     [] ->
       commits
-    TxOut{txInInfoResolved} : rest
-      | hasPT txInInfoResolved ->
-        case commitDatum txInInfoResolved of
-          Just commit@Commit{preSerializedOutput} ->
+    txOut : rest
+      | hasPT headContext txOut ->
+        case commitDatum txInfo txOut of
+          Just Commit{preSerializedOutput} ->
             traverseInputs
               (preSerializedOutput : commits)
               rest
@@ -195,8 +195,8 @@ checkCollectCom ctx@ScriptContext{scriptContextTxInfo = txInfo} (contestationPer
         traverseInputs
           (fuel, commits, nCommits)
           rest
-      | hasPT txInInfoResolved ->
-        case commitDatum txInInfoResolved of
+      | hasPT headContext txInInfoResolved ->
+        case commitDatum txInfo txInInfoResolved of
           Just commit@Commit{} ->
             traverseInputs
               (fuel, commit : commits, succ nCommits)
@@ -226,13 +226,14 @@ checkCollectCom ctx@ScriptContext{scriptContextTxInfo = txInfo} (contestationPer
         traceError "commitDatum failed fromBuiltinData"
 {-# INLINEABLE checkCollectCom #-}
 
-hasPT txOut =
-  let pts = findParticipationTokens headCurrencySymbol (txOutValue txOut)
+hasPT :: HeadContext -> TxOut -> Bool
+hasPT ctx txOut =
+  let pts = findParticipationTokens (headCurrencySymbol ctx) (txOutValue txOut)
    in length pts == 1
 {-# INLINEABLE hasPT #-}
 
-commitDatum :: TxOut -> Maybe Commit
-commitDatum o = do
+commitDatum :: TxInfo -> TxOut -> Maybe Commit
+commitDatum txInfo o = do
   let d = findTxOutDatum txInfo o
   case fromBuiltinData @Commit.DatumType $ getDatum d of
     Just (_p, _, mCommit) ->

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -108,6 +108,7 @@ checkAbort ctx@ScriptContext{scriptContextTxInfo = txInfo} headCurrencySymbol pa
       Nothing -> 0
       Just tokenMap -> negate $ sum tokenMap
 
+  -- FIXME: This is prone to identical commits only being reimbursed once.
   mustReimburseCommittedUTxO =
     traceIfFalse "committed UTxO not reimbursed" $
       all (`elem` serialisedOutputs) committedUTxOs


### PR DESCRIPTION
This PR is a step into the right direction but there will be a follow-up one to address a gap in the `checkAbort`  where we should check that two identical commits can not be reimbursed by one output.

To check before merging:
* [x] CHANGELOG is up to date
* [x] ~Documentation is up to date~
