### PR TITLE
check commits are reimbursed in nu head - continuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@ changes.
 
 - **BREAKING** Addressed short-comings in `hydra-plutus` scripts:
   + Check presence of state token (ST) and that it's consistent against datum.
-  + Moved check to reimburse commits to head validator.
   + Reduce cost of `commitTx` by using the initial script as input reference.
+  + Moved check to reimburse commits to head validator and ensure its completeness.
 
 - **BREAKING** Change the way tx validity and contestation deadline is constructed for close transactions:
   + There is a new hydra-node flag `--contestation-period` expressed in seconds

--- a/hydra-cluster/test/Test/DirectChainSpec.hs
+++ b/hydra-cluster/test/Test/DirectChainSpec.hs
@@ -131,7 +131,7 @@ spec = around showLogsOnFailure $ do
                 aliceChain `observesInTime` OnCommitTx alice aliceUTxO
                 bobChain `observesInTime` OnCommitTx alice aliceUTxO
 
-                postTx $ AbortTx mempty
+                postTx $ AbortTx aliceUTxO
 
                 aliceChain `observesInTime` OnAbortTx
                 bobChain `observesInTime` OnAbortTx

--- a/hydra-node/exe/tx-cost/TxCost.hs
+++ b/hydra-node/exe/tx-cost/TxCost.hs
@@ -185,8 +185,8 @@ computeAbortCost =
     initTx <- genInitTx ctx
     commits <- sublistOf =<< genCommits ctx initTx
     cctx <- pickChainContext ctx
-    let (_, stInitialized) = unsafeObserveInitAndCommits cctx initTx commits
-    pure (abort cctx stInitialized, getKnownUTxO stInitialized <> getKnownUTxO cctx)
+    let (committed, stInitialized) = unsafeObserveInitAndCommits cctx initTx commits
+    pure (abort (fold committed) cctx stInitialized, getKnownUTxO stInitialized <> getKnownUTxO cctx)
 
 computeFanOutCost :: IO [(NumUTxO, TxSize, MemUnit, CpuUnit, Lovelace)]
 computeFanOutCost = do

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -247,8 +247,8 @@ prepareTxToPost timeHandle wallet ctx cst@ChainStateAt{chainState} tx =
           pure $ initialize ctx params seedInput
         Nothing ->
           throwIO (NoSeedInput @Tx)
-    (AbortTx{}, Initial st) ->
-      pure $ abort ctx st
+    (AbortTx{utxo}, Initial st) ->
+      pure $ abort utxo ctx st
     -- NOTE / TODO: 'CommitTx' also contains a 'Party' which seems redundant
     -- here. The 'Party' is already part of the state and it is the only party
     -- which can commit from this Hydra node.

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -337,14 +337,16 @@ commit ctx st utxo = do
 -- reimburse all the already committed outputs.
 abort ::
   HasCallStack =>
+  -- | Committed UTxOs to reimburse.
+  UTxO ->
   ChainContext ->
   InitialState ->
   Tx
-abort ctx st = do
+abort committedUTxO ctx st = do
   let InitialThreadOutput{initialThreadUTxO = (i, o, dat)} = initialThreadOutput
       initials = Map.fromList $ map tripleToPair initialInitials
       commits = Map.fromList $ map tripleToPair initialCommits
-   in case abortTx scriptRegistry ownVerificationKey (i, o, dat) initialHeadTokenScript initials commits of
+   in case abortTx committedUTxO scriptRegistry ownVerificationKey (i, o, dat) initialHeadTokenScript initials commits of
         Left OverlappingInputs ->
           -- FIXME: This is a "should not happen" error. We should try to fix
           -- the arguments of abortTx to make it impossible of having

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -115,7 +115,7 @@ initTx networkId cardanoKeys parameters seed =
     emptyTxBody
       & addVkInputs [seed]
       & addOutputs
-        ( mkHeadOutputInitial networkId policyId parameters :
+        ( mkHeadOutputInitial networkId policyId parameters cardanoKeys :
           map (mkInitialOutput networkId policyId) cardanoKeys
         )
       & mintTokens (HeadTokens.mkHeadTokenScript seed) Mint ((hydraHeadV1AssetName, 1) : participationTokens)
@@ -134,8 +134,8 @@ mkHeadOutput networkId tokenPolicyId datum =
  where
   headScript = fromPlutusScript Head.validatorScript
 
-mkHeadOutputInitial :: NetworkId -> PolicyId -> HeadParameters -> TxOut CtxTx
-mkHeadOutputInitial networkId tokenPolicyId HeadParameters{contestationPeriod, parties} =
+mkHeadOutputInitial :: NetworkId -> PolicyId -> HeadParameters -> [VerificationKey PaymentKey] -> TxOut CtxTx
+mkHeadOutputInitial networkId tokenPolicyId HeadParameters{contestationPeriod, parties} cardanoKeys =
   mkHeadOutput networkId tokenPolicyId headDatum
  where
   headDatum =
@@ -144,6 +144,7 @@ mkHeadOutputInitial networkId tokenPolicyId HeadParameters{contestationPeriod, p
         (toChain contestationPeriod)
         (map partyToChain parties)
         (toPlutusCurrencySymbol tokenPolicyId)
+        (Plutus.PubKeyHash . toBuiltin . serialiseToRawBytes . verificationKeyHash <$> cardanoKeys)
 
 mkInitialOutput :: NetworkId -> PolicyId -> VerificationKey PaymentKey -> TxOut CtxTx
 mkInitialOutput networkId tokenPolicyId (verificationKeyHash -> pkh) =
@@ -586,7 +587,7 @@ observeInitTx ::
 observeInitTx networkId cardanoKeys expectedCP party tx = do
   -- FIXME: This is affected by "same structure datum attacks", we should be
   -- using the Head script address instead.
-  (ix, headOut, headData, Head.Initial cp ps _headPolicyId) <- findFirst headOutput indexedOutputs
+  (ix, headOut, headData, Head.Initial cp ps _headPolicyId _cardanoKeys) <- findFirst headOutput indexedOutputs
   parties <- mapM partyFromChain ps
   let contestationPeriod = fromChain cp
   guard $ expectedCP == contestationPeriod

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
@@ -34,7 +34,7 @@ import qualified Hydra.Contract.Initial as Initial
 import Hydra.Ledger.Cardano (genVerificationKey)
 import Hydra.Party (Party, partyToChain)
 import Test.Hydra.Fixture (cperiod)
-import Test.QuickCheck (Property, choose, counterexample, elements, listOf, oneof, shuffle, suchThat)
+import Test.QuickCheck (Property, choose, counterexample, elements, oneof, shuffle, suchThat)
 
 --
 -- AbortTx
@@ -67,7 +67,7 @@ healthyAbortTx =
 
   headTokenScript = mkHeadTokenScript testSeedInput
 
-  headOutput = mkHeadOutputInitial testNetworkId testPolicyId healthyHeadParameters healthyCardanoKeys
+  headOutput = mkHeadOutputInitial testNetworkId testPolicyId healthyHeadParameters
 
   headDatum = unsafeGetDatum headOutput
 
@@ -99,11 +99,6 @@ healthyCommits :: [UTxOWithScript]
 
 healthyParties :: [Party]
 healthyParties =
-  [ generateWith arbitrary i | i <- [1 .. 4]
-  ]
-
-healthyCardanoKeys :: [VerificationKey PaymentKey]
-healthyCardanoKeys =
   [ generateWith arbitrary i | i <- [1 .. 4]
   ]
 
@@ -149,8 +144,7 @@ genAbortMutation (tx, _utxo) =
     [ SomeMutation Nothing MutateParties . ChangeHeadDatum <$> do
         moreParties <- (: healthyParties) <$> arbitrary
         c <- arbitrary
-        cardanoKeys <- arbitrary
-        pure $ Head.Initial c (partyToChain <$> moreParties) (toPlutusCurrencySymbol $ headPolicyId testSeedInput) cardanoKeys
+        pure $ Head.Initial c (partyToChain <$> moreParties) (toPlutusCurrencySymbol $ headPolicyId testSeedInput)
     , SomeMutation Nothing DropOneCommitOutput
         . RemoveOutput
         <$> choose (0, fromIntegral (length (txOuts' tx) - 1))
@@ -161,12 +155,10 @@ genAbortMutation (tx, _utxo) =
         newSigner <- verificationKeyHash <$> genVerificationKey
         pure $ ChangeRequiredSigners [newSigner]
     , SomeMutation Nothing MutateHeadId <$> do
-        cardanoKeys <- listOf genVerificationKey
         illedHeadResolvedInput <-
           mkHeadOutputInitial testNetworkId
             <$> fmap headPolicyId (arbitrary `suchThat` (/= testSeedInput))
             <*> pure healthyHeadParameters
-            <*> pure cardanoKeys
         return $ ChangeInput healthyHeadInput (toUTxOContext illedHeadResolvedInput) (Just $ toScriptData Head.Abort)
     , SomeMutation Nothing UseInputFromOtherHead <$> do
         (input, output, _) <- elements healthyInitials

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
@@ -176,9 +176,9 @@ genAbortMutation (tx, _utxo) =
             [ ChangeInput input (replacePolicyIdWith testPolicyId otherHeadId output) (Just $ toScriptData Initial.ViaAbort)
             , ChangeMintedValue (removePTFromMintedValue output tx)
             ]
-    , SomeMutation Nothing ReorderCommitOutputs <$> do
+    , SomeMutation (Just "hash of committed UTxo do not match hash of outputs") ReorderCommitOutputs <$> do
         let outputs = txOuts' tx
-        outputs' <- shuffle outputs
+        outputs' <- shuffle outputs `suchThat` (/= outputs)
         let reorderedOutputs = uncurry ChangeOutput <$> zip [0 ..] outputs'
         pure $ Changes reorderedOutputs
     ]

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
@@ -168,7 +168,7 @@ genAbortMutation (tx, _utxo) =
             [ ChangeInput input (replacePolicyIdWith testPolicyId otherHeadId output) (Just $ toScriptData Initial.ViaAbort)
             , ChangeMintedValue (removePTFromMintedValue output tx)
             ]
-    , SomeMutation (Just "hash of committed UTxo do not match hash of outputs") ReorderCommitOutputs <$> do
+    , SomeMutation (Just "reimbursed outputs dont match") ReorderCommitOutputs <$> do
         let outputs = txOuts' tx
         outputs' <- shuffle outputs `suchThat` (/= outputs)
         let reorderedOutputs = uncurry ChangeOutput <$> zip [0 ..] outputs'

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -108,7 +108,6 @@ healthyCollectComInitialDatum =
     { contestationPeriod = healthyContestationPeriod
     , parties = healthyOnChainParties
     , headId = toPlutusCurrencySymbol testPolicyId
-    , cardanoVkeys = healthyCardanoKeys
     }
 
 healthyOnChainParties :: [OnChain.Party]
@@ -121,13 +120,6 @@ healthyParties = flip generateWith 42 $ do
   bob <- arbitrary
   carol <- arbitrary
   pure [alice, bob, carol]
-
-healthyCardanoKeys :: [PubKeyHash]
-healthyCardanoKeys = flip generateWith 42 $ do
-  aliceKey <- arbitrary
-  bobKey <- arbitrary
-  carolKey <- arbitrary
-  pure [aliceKey, bobKey, carolKey]
 
 genCommittableTxOut :: Gen (TxIn, TxOut CtxUTxO)
 genCommittableTxOut =
@@ -202,10 +194,9 @@ genCollectComMutation (tx, _utxo) =
         -- be bothered to decode/lookup the current one.
         c <- arbitrary
         moreParties <- (: healthyOnChainParties) <$> arbitrary
-        cardanoVKeys <- arbitrary
         pure $
           Changes
-            [ ChangeHeadDatum $ Head.Initial c moreParties (toPlutusCurrencySymbol testPolicyId) cardanoVKeys
+            [ ChangeHeadDatum $ Head.Initial c moreParties (toPlutusCurrencySymbol testPolicyId)
             , ChangeOutput 0 $ mutatedPartiesHeadTxOut moreParties headTxOut
             ]
     , SomeMutation Nothing MutateHeadId <$> do

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -41,7 +41,7 @@ import qualified Hydra.Data.Party as OnChain
 import Hydra.Ledger.Cardano (genAdaOnlyUTxO, genTxIn, genVerificationKey)
 import Hydra.Party (Party, partyToChain)
 import Plutus.Orphans ()
-import Plutus.V2.Ledger.Api (PubKeyHash, toBuiltin, toData)
+import Plutus.V2.Ledger.Api (toBuiltin, toData)
 import Test.QuickCheck (elements, oneof, suchThat)
 import Test.QuickCheck.Instances ()
 import qualified Prelude

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
@@ -182,7 +182,7 @@ propMutation (tx, utxo) genMutation =
       & propTransactionDoesNotValidate expectedError
       & genericCoverTable [label]
       & checkCoverage
-      & counterexample ("Original transaction: \n" <> renderTxWithUTxO utxo tx)
+      & counterexample ("Original transaction: " <> renderTxWithUTxO utxo tx)
 
 -- | A 'Property' checking some (transaction, UTxO) pair is invalid.
 propTransactionDoesNotValidate :: Maybe Text -> (Tx, UTxO) -> Property

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
@@ -191,19 +191,19 @@ propTransactionDoesNotValidate mExpectedError (tx, lookupUTxO) =
    in case result of
         Left basicFailure ->
           property False
-            & counterexample ("Tx: " <> renderTxWithUTxO lookupUTxO tx)
+            & counterexample ("Mutated transaction: " <> renderTxWithUTxO lookupUTxO tx)
             & counterexample ("Phase-1 validation failed: " <> show basicFailure)
         Right redeemerReport ->
           let errors = lefts $ Map.elems redeemerReport
            in case mExpectedError of
                 Nothing ->
                   not (null errors)
-                    & counterexample ("Tx: " <> renderTxWithUTxO lookupUTxO tx)
+                    & counterexample ("Mutated transaction: " <> renderTxWithUTxO lookupUTxO tx)
                     & counterexample ("Redeemer report: " <> show redeemerReport)
                     & counterexample "Phase-2 validation should have failed"
                 Just expectedError ->
                   any (matchesErrorMessage expectedError) errors
-                    & counterexample ("Tx: " <> renderTxWithUTxO lookupUTxO tx)
+                    & counterexample ("Mutated transaction: " <> renderTxWithUTxO lookupUTxO tx)
                     & counterexample ("Redeemer report: " <> show redeemerReport)
                     & counterexample ("Phase-2 validation should have failed with error message: " <> show expectedError)
  where
@@ -218,11 +218,11 @@ propTransactionValidates (tx, lookupUTxO) =
    in case result of
         Left basicFailure ->
           property False
-            & counterexample ("Tx: " <> renderTxWithUTxO lookupUTxO tx)
+            & counterexample ("Mutated transaction: " <> renderTxWithUTxO lookupUTxO tx)
             & counterexample ("Phase-1 validation failed: " <> show basicFailure)
         Right redeemerReport ->
           all isRight (Map.elems redeemerReport)
-            & counterexample ("Tx: " <> renderTxWithUTxO lookupUTxO tx)
+            & counterexample ("Mutated transaction: " <> renderTxWithUTxO lookupUTxO tx)
             & counterexample ("Redeemer report: " <> show redeemerReport)
             & counterexample "Phase-2 validation failed"
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
@@ -182,6 +182,7 @@ propMutation (tx, utxo) genMutation =
       & propTransactionDoesNotValidate expectedError
       & genericCoverTable [label]
       & checkCoverage
+      & counterexample ("Original transaction: \n" <> renderTxWithUTxO utxo tx)
 
 -- | A 'Property' checking some (transaction, UTxO) pair is invalid.
 propTransactionDoesNotValidate :: Maybe Text -> (Tx, UTxO) -> Property

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -173,8 +173,8 @@ spec = parallel $ do
             when (h1 == h2) discard
             pure ((ctx1, st1), (ctx2, st2))
       forAll twoDistinctHeads $ \((ctx1, stHead1), (ctx2, stHead2)) ->
-        let observedIn1 = observeAbort stHead1 (abort ctx1 stHead1)
-            observedIn2 = observeAbort stHead2 (abort ctx2 stHead1)
+        let observedIn1 = observeAbort stHead1 (abort mempty ctx1 stHead1)
+            observedIn2 = observeAbort stHead2 (abort mempty ctx2 stHead1)
          in conjoin
               [ observedIn1 =/= Nothing
               , observedIn2 === Nothing
@@ -306,9 +306,9 @@ forAllAbort action = do
     forAll (pickChainContext ctx) $ \cctx ->
       forAllBlind (genInitTx ctx) $ \initTx -> do
         forAllBlind (sublistOf =<< genCommits ctx initTx) $ \commits ->
-          let (_, stInitialized) = unsafeObserveInitAndCommits cctx initTx commits
+          let (committed, stInitialized) = unsafeObserveInitAndCommits cctx initTx commits
               utxo = getKnownUTxO stInitialized <> getKnownUTxO cctx
-           in action utxo (abort cctx stInitialized)
+           in action utxo (abort (fold committed) cctx stInitialized)
                 & classify
                   (null commits)
                   "Abort immediately, after 0 commits"

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -389,7 +389,7 @@ forAllFanout action =
        in action utxo tx
             & label ("Fanout size: " <> prettyLength (countAssets $ txOuts' tx))
  where
-  maxSupported = 70
+  maxSupported = 67
 
   countAssets = getSum . foldMap (Sum . valueSize . txOutValue)
 

--- a/hydra-plutus/exe/inspect-script/Main.hs
+++ b/hydra-plutus/exe/inspect-script/Main.hs
@@ -102,7 +102,7 @@ main = do
     , (abortDatum, "abortDatum")
     ]
 
-  headDatum = toData $ Head.Initial 1_000_000_000_000 [] (toPlutusCurrencySymbol $ HeadTokens.headPolicyId $ someTxIn) []
+  headDatum = toData $ Head.Initial 1_000_000_000_000 [] (toPlutusCurrencySymbol $ HeadTokens.headPolicyId $ someTxIn)
 
   someTxIn = TxIn (TxId $ unsafeHashFromBytes "01234567890123456789012345678901") (TxIx 1)
 

--- a/hydra-plutus/exe/inspect-script/Main.hs
+++ b/hydra-plutus/exe/inspect-script/Main.hs
@@ -102,7 +102,7 @@ main = do
     , (abortDatum, "abortDatum")
     ]
 
-  headDatum = toData $ Head.Initial 1_000_000_000_000 [] (toPlutusCurrencySymbol $ HeadTokens.headPolicyId $ someTxIn)
+  headDatum = toData $ Head.Initial 1_000_000_000_000 [] (toPlutusCurrencySymbol $ HeadTokens.headPolicyId $ someTxIn) []
 
   someTxIn = TxIn (TxId $ unsafeHashFromBytes "01234567890123456789012345678901") (TxIx 1)
 

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -115,7 +115,9 @@ checkAbort ctx@ScriptContext{scriptContextTxInfo = txInfo} headCurrencySymbol pa
 
   serialisedOutputs = Builtins.serialiseData . toBuiltinData <$> txInfoOutputs txInfo
 
-  committedUTxOs = traverseInputs [] (txInfoInputs txInfo)
+  committedUTxOs =
+    hashPreSerializedCommits $
+      traverseInputs [] (txInfoInputs txInfo)
 
   traverseInputs commits = \case
     [] ->
@@ -123,9 +125,9 @@ checkAbort ctx@ScriptContext{scriptContextTxInfo = txInfo} headCurrencySymbol pa
     TxInInfo{txInInfoResolved = txOut} : rest
       | hasPT headCurrencySymbol txOut ->
         case commitDatum txInfo txOut of
-          Just Commit{preSerializedOutput} ->
+          Just commit ->
             traverseInputs
-              (preSerializedOutput : commits)
+              (commit : commits)
               rest
           Nothing ->
             traverseInputs

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -113,10 +113,16 @@ checkAbort ctx@ScriptContext{scriptContextTxInfo = txInfo} headCurrencySymbol pa
       hashOfCommittedUTxO == hashOfOutputs
 
   hashOfOutputs =
-    hashTxOuts $ txInfoOutputs txInfo
+    -- NOTE: It is enough to just _take_ the same number of outputs
+    -- that correspond to the number of commit inputs to make sure
+    -- everything is reimbursed because the two are already sorted
+    -- and there are no other outputs a part from change.
+    hashTxOuts $ take (length commited) (txInfoOutputs txInfo)
 
   hashOfCommittedUTxO =
-    hashPreSerializedCommits $ committedUTxO [] (txInfoInputs txInfo)
+    hashPreSerializedCommits commited
+
+  commited = committedUTxO [] (txInfoInputs txInfo)
 
   committedUTxO commits = \case
     [] ->

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -109,7 +109,7 @@ checkAbort ctx@ScriptContext{scriptContextTxInfo = txInfo} headCurrencySymbol pa
       Just tokenMap -> negate $ sum tokenMap
 
   mustReimburseCommittedUTxO =
-    traceIfFalse "hash of committed UTxo do not match hash of outputs" $
+    traceIfFalse "reimbursed outputs dont match" $
       hashOfCommittedUTxO == hashOfOutputs
 
   hashOfOutputs =

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -113,10 +113,10 @@ checkAbort ctx@ScriptContext{scriptContextTxInfo = txInfo} headCurrencySymbol pa
       hashOfCommittedUTxO == hashOfOutputs
 
   hashOfOutputs =
-    -- NOTE: It is enough to just _take_ the same number of outputs
-    -- that correspond to the number of commit inputs to make sure
-    -- everything is reimbursed because the two are already sorted
-    -- and there are no other outputs a part from change.
+    -- NOTE: It is enough to just _take_ the same number of outputs that
+    -- correspond to the number of commit inputs to make sure everything is
+    -- reimbursed because we assume the outputs are correctly sorted with
+    -- reimbursed commits coming first
     hashTxOuts $ take (length commited) (txInfoOutputs txInfo)
 
   hashOfCommittedUTxO =

--- a/hydra-plutus/src/Hydra/Contract/HeadState.hs
+++ b/hydra-plutus/src/Hydra/Contract/HeadState.hs
@@ -10,7 +10,7 @@ import PlutusTx.Prelude
 import GHC.Generics (Generic)
 import Hydra.Data.ContestationPeriod (ContestationPeriod)
 import Hydra.Data.Party (Party)
-import Plutus.V1.Ledger.Api (CurrencySymbol, POSIXTime)
+import Plutus.V2.Ledger.Api (CurrencySymbol, POSIXTime, PubKeyHash)
 import qualified PlutusTx
 import Text.Show (Show)
 
@@ -25,6 +25,7 @@ data State
       { contestationPeriod :: ContestationPeriod
       , parties :: [Party]
       , headId :: CurrencySymbol
+      , cardanoVkeys :: [PubKeyHash]
       }
   | Open
       { contestationPeriod :: ContestationPeriod

--- a/hydra-plutus/src/Hydra/Contract/HeadState.hs
+++ b/hydra-plutus/src/Hydra/Contract/HeadState.hs
@@ -10,7 +10,7 @@ import PlutusTx.Prelude
 import GHC.Generics (Generic)
 import Hydra.Data.ContestationPeriod (ContestationPeriod)
 import Hydra.Data.Party (Party)
-import Plutus.V2.Ledger.Api (CurrencySymbol, POSIXTime, PubKeyHash)
+import Plutus.V2.Ledger.Api (CurrencySymbol, POSIXTime)
 import qualified PlutusTx
 import Text.Show (Show)
 
@@ -25,7 +25,6 @@ data State
       { contestationPeriod :: ContestationPeriod
       , parties :: [Party]
       , headId :: CurrencySymbol
-      , cardanoVkeys :: [PubKeyHash]
       }
   | Open
       { contestationPeriod :: ContestationPeriod

--- a/hydra-plutus/src/Plutus/Orphans.hs
+++ b/hydra-plutus/src/Plutus/Orphans.hs
@@ -6,11 +6,9 @@ module Plutus.Orphans where
 
 import Hydra.Prelude
 
-import qualified Data.ByteString as BS
 import Plutus.V2.Ledger.Api (
   CurrencySymbol,
   POSIXTime (..),
-  PubKeyHash (PubKeyHash),
   TokenName,
   UpperBound (..),
   Value,
@@ -18,7 +16,6 @@ import Plutus.V2.Ledger.Api (
  )
 import qualified PlutusTx.AssocMap as AssocMap
 import PlutusTx.Prelude (BuiltinByteString, toBuiltin)
-import Test.QuickCheck (vectorOf)
 import Test.QuickCheck.Instances.ByteString ()
 
 instance Arbitrary BuiltinByteString where
@@ -50,6 +47,3 @@ instance FromJSON POSIXTime where
 
 instance Arbitrary a => Arbitrary (UpperBound a) where
   arbitrary = upperBound <$> arbitrary
-
-instance Arbitrary PubKeyHash where
-  arbitrary = PubKeyHash . toBuiltin . BS.pack <$> vectorOf 28 arbitrary

--- a/hydra-plutus/src/Plutus/Orphans.hs
+++ b/hydra-plutus/src/Plutus/Orphans.hs
@@ -6,9 +6,11 @@ module Plutus.Orphans where
 
 import Hydra.Prelude
 
-import Plutus.V1.Ledger.Api (
+import qualified Data.ByteString as BS
+import Plutus.V2.Ledger.Api (
   CurrencySymbol,
   POSIXTime (..),
+  PubKeyHash (PubKeyHash),
   TokenName,
   UpperBound (..),
   Value,
@@ -16,6 +18,7 @@ import Plutus.V1.Ledger.Api (
  )
 import qualified PlutusTx.AssocMap as AssocMap
 import PlutusTx.Prelude (BuiltinByteString, toBuiltin)
+import Test.QuickCheck (vectorOf)
 import Test.QuickCheck.Instances.ByteString ()
 
 instance Arbitrary BuiltinByteString where
@@ -47,3 +50,6 @@ instance FromJSON POSIXTime where
 
 instance Arbitrary a => Arbitrary (UpperBound a) where
   arbitrary = upperBound <$> arbitrary
+
+instance Arbitrary PubKeyHash where
+  arbitrary = PubKeyHash . toBuiltin . BS.pack <$> vectorOf 28 arbitrary


### PR DESCRIPTION
This pr is rebased off of #679  so it should be merged after that one.

To properly check for reimbursed commits we need to check that hash of the list of commited outputs match the hash of the list of relevant outputs. This assumes an ordering of the commited outputs by `TxRef`. 

Note: There might be more outputs that we don't care about. 

We need to have corresponding mutations that will mutate the outputs in the following way:
- Reorder the outputs (this checks the canonical ordering)
- Add more irrelevant outputs
- Remove one relevant output (make sure that the value is preserved)

To check before merging:
* [x] CHANGELOG is up to date
* [x] Up to date with master
