### PR TITLE
Do not publish merkle tree benchmarks anymore

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,8 +164,6 @@ jobs:
             options: '--output-directory $(pwd)/docs/benchmarks'
           - bench: hydra-cluster
             options: '--scaling-factor 1'
-          - bench: plutus-merkle-tree
-            options: '$(pwd)/docs/benchmarks'
     steps:
     - name: 📥 Checkout repository
       uses: actions/checkout@v3


### PR DESCRIPTION
These are unrelated to the current implementation as we don't use it in our scripts right now.
