### PR TITLE
Add script sizes to tx-cost and --script-info outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ changes.
   + Will make bumping dependencies (e.g. cardano-node) easier.
   + Build commands for binaries and docker images change, see updated [Contribution Guidelines](https://github.com/input-output-hk/hydra/blob/master/CONTRIBUTING.md)
 
+- Add script sizes to `hydra-node --script-info` and published transaction cost benchmarks.
+
 ## [0.8.1] - 2022-11-17
 
 - **BREAKING** Implemented [ADR18](https://hydra.family/head-protocol/adr/18) to keep only a single state:

--- a/hydra-node/exe/tx-cost/Main.hs
+++ b/hydra-node/exe/tx-cost/Main.hs
@@ -2,7 +2,7 @@ import Hydra.Prelude hiding (catch)
 
 import Data.ByteString (hPut)
 import Data.Fixed (Centi)
-import Hydra.Cardano.Api (Lovelace (Lovelace))
+import Hydra.Cardano.Api (Lovelace (Lovelace), serialiseToRawBytesHexText)
 import Hydra.Contract (ScriptInfo (..), scriptInfo)
 import Hydra.Ledger.Cardano.Evaluate (maxCpu, maxMem, maxTxSize)
 import Options.Applicative (
@@ -127,10 +127,10 @@ scriptSizes =
   [ "## Script summary"
   , ""
   , "| Name   | Hash | Size (Bytes) "
-  , "| :----- | ---: | -----------: "
-  , "| " <> "νInitial" <> " | " <> show initialScriptHash <> " | " <> show initialScriptSize <> " | "
-  , "| " <> "νCommit" <> " | " <> show commitScriptHash <> " | " <> show commitScriptSize <> " | "
-  , "| " <> "νHead" <> " | " <> show headScriptHash <> " | " <> show headScriptSize <> " | "
+  , "| :----- | :--- | -----------: "
+  , "| " <> "νInitial" <> " | " <> serialiseToRawBytesHexText initialScriptHash <> " | " <> show initialScriptSize <> " | "
+  , "| " <> "νCommit" <> " | " <> serialiseToRawBytesHexText commitScriptHash <> " | " <> show commitScriptSize <> " | "
+  , "| " <> "νHead" <> " | " <> serialiseToRawBytesHexText headScriptHash <> " | " <> show headScriptSize <> " | "
   ]
  where
   ScriptInfo

--- a/hydra-node/exe/tx-cost/Main.hs
+++ b/hydra-node/exe/tx-cost/Main.hs
@@ -3,6 +3,7 @@ import Hydra.Prelude hiding (catch)
 import Data.ByteString (hPut)
 import Data.Fixed (Centi)
 import Hydra.Cardano.Api (Lovelace (Lovelace))
+import Hydra.Contract (ScriptInfo (..), scriptInfo)
 import Hydra.Ledger.Cardano.Evaluate (maxCpu, maxMem, maxTxSize)
 import Options.Applicative (
   Parser,
@@ -83,6 +84,7 @@ writeTransactionCostMarkdown hdl = do
     encodeUtf8 $
       unlines $
         pageHeader
+          <> scriptSizes
           <> intersperse
             ""
             [ initC
@@ -119,6 +121,26 @@ pageHeader =
 {-# NOINLINE now #-}
 now :: UTCTime
 now = unsafePerformIO getCurrentTime
+
+scriptSizes :: [Text]
+scriptSizes =
+  [ "## Script summary"
+  , ""
+  , "| Name   | Hash | Size (Bytes) "
+  , "| :----- | ---: | -----------: "
+  , "| " <> "νInitial" <> " | " <> show initialScriptHash <> " | " <> show initialScriptSize <> " | "
+  , "| " <> "νCommit" <> " | " <> show commitScriptHash <> " | " <> show commitScriptSize <> " | "
+  , "| " <> "νHead" <> " | " <> show headScriptHash <> " | " <> show headScriptSize <> " | "
+  ]
+ where
+  ScriptInfo
+    { initialScriptHash
+    , initialScriptSize
+    , commitScriptHash
+    , commitScriptSize
+    , headScriptHash
+    , headScriptSize
+    } = scriptInfo
 
 costOfInit :: IO Text
 costOfInit = markdownInitCost <$> computeInitCost

--- a/hydra-plutus/src/Hydra/Contract.hs
+++ b/hydra-plutus/src/Hydra/Contract.hs
@@ -1,11 +1,19 @@
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- | Things related to the Hydra smart contracts / script validators.
 module Hydra.Contract where
 
 import Hydra.Prelude
 
-import Hydra.Cardano.Api (ScriptHash, fromPlutusScript, hashScript, pattern PlutusScript)
+import Codec.Serialise (serialise)
+import qualified Data.ByteString.Lazy as BSL
+import Hydra.Cardano.Api (
+  ScriptHash,
+  fromPlutusScript,
+  hashScript,
+  pattern PlutusScript,
+ )
 import qualified Hydra.Contract.Commit as Commit
 import qualified Hydra.Contract.Head as Head
 import qualified Hydra.Contract.Initial as Initial
@@ -13,8 +21,11 @@ import qualified Hydra.Contract.Initial as Initial
 -- | Information about relevant Hydra scripts.
 data ScriptInfo = ScriptInfo
   { initialScriptHash :: ScriptHash
+  , initialScriptSize :: Int64
   , commitScriptHash :: ScriptHash
+  , commitScriptSize :: Int64
   , headScriptHash :: ScriptHash
+  , headScriptSize :: Int64
   }
   deriving (Eq, Show, Generic, ToJSON)
 
@@ -24,8 +35,14 @@ scriptInfo :: ScriptInfo
 scriptInfo =
   ScriptInfo
     { initialScriptHash = plutusScriptHash Initial.validatorScript
+    , initialScriptSize = scriptSize Initial.validatorScript
     , commitScriptHash = plutusScriptHash Commit.validatorScript
+    , commitScriptSize = scriptSize Commit.validatorScript
     , headScriptHash = plutusScriptHash Head.validatorScript
+    , headScriptSize = scriptSize Head.validatorScript
     }
  where
-  plutusScriptHash = hashScript . PlutusScript . fromPlutusScript
+  plutusScriptHash =
+    hashScript . PlutusScript . fromPlutusScript
+
+  scriptSize = BSL.length . serialise


### PR DESCRIPTION
This will also show up in PRs and we can compare whether a PR impacts the size of the serialized scripts. Also, this will include these numbers to be included in the published benchmark results.

* [x] CHANGELOG is up to date
