### PR TITLE
Mention that hydra-cardano-api is using Babbage and PlutusV2

### DIFF
--- a/hydra-cardano-api/README.md
+++ b/hydra-cardano-api/README.md
@@ -1,10 +1,20 @@
 # Hydra Cardano API
 
-A Haskell API for Cardano, tailored to the Hydra project. This package provides a wrapper around the cardano-ledger, cardano-api and plutus libraries with extra utilities and function commonly used across the Hydra project. 
+A Haskell API for Cardano, tailored to the Hydra project. This package provides
+a wrapper around the cardano-ledger, cardano-api and plutus libraries with extra
+utilities and function commonly used across the Hydra project.
 
-Some of those addition may be likely candidates for upstream change requests, but having this extra space gives us an opportunity to iterate faster and to unify not-always-consistent names / approches across the Cardano ecosystem.
+Some of those addition may be likely candidates for upstream change requests,
+but having this extra space gives us an opportunity to iterate faster and to
+unify not-always-consistent names / approches across the Cardano ecosystem.
 
-In addition, the top-level module `Hydra.Cardano.Api` does re-export only specialized types and constructors for all underlying types. Everything is indeed specialized to the latest era (e.g. Babbage) making the era type parameter redundant in most cases. This also removes the need for extra indirections or, for proxy-values witnessing era types as present in many `cardano-api` constructors. For example, a vanilla usage of the `cardano-api` would looks like the followings:
+In addition, the top-level module `Hydra.Cardano.Api` does re-export only
+specialized types and constructors for all underlying types. Everything is
+indeed specialized to the **latest era** (e.g. `Babbage`) and **latest plutus
+version** (e.g. `PlutusV2`) making the era type parameter redundant in most
+cases. This also removes the need for extra indirections or, for proxy-values
+witnessing era types as present in many `cardano-api` constructors. For example,
+a vanilla usage of the `cardano-api` would looks like the followings:
 
 ```hs
 changeOutput :: Address ShelleyAddr -> TxOut CtxUTxO BabbageEra

--- a/hydra-cardano-api/src/Hydra/Cardano/Api.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api.hs
@@ -6,11 +6,15 @@
 -- @plutus@ libraries with extra utilities and function commonly used across the
 -- Hydra project.
 --
--- NOTE: We always use the latest era available in our codebase, so to ease type
--- signatures and notations, we specialize any type of the @cardano-api@ normally
--- parameterized by an era to the latest era 'Era'. As a consequence, we've
--- defined pattern synonyms for most constructors in the @cardano-api@ to also
--- get rid of era witnesses.
+-- NOTE: We always use the **latest era** available in our codebase, so to ease
+-- type signatures and notations, we specialize any type of the @cardano-api@
+-- normally parameterized by an era to the latest era 'Era'. As a consequence,
+-- we've defined pattern synonyms for most constructors in the @cardano-api@ to
+-- also get rid of era witnesses.
+--
+-- NOTE: This module also uses the **latest plutus version** available
+-- (currently 'PlutusScriptV2'). So make sure that you give it a plutus script
+-- of the right version (e.g. when compiling and serializing plutus-tx).
 module Hydra.Cardano.Api (
   -- * Common type-alias
   StandardCrypto,


### PR DESCRIPTION
Later versions of the package could make this more in the module name or naming things.


This was something that tricked one of our collaborators on the auction project. They were compiling `PlutusV1` scripts from `plutus-tx` and `hydra-cardano-api` is tagging all `Script`s as `PlutusScriptV2`.