### PR TITLE
Check for token minting or burning 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,9 @@ changes.
   + Check presence of state token (ST) and that it's consistent against datum.
   + Reduce cost of `commitTx` by using the initial script as input reference.
   + Moved check to reimburse commits to head validator and ensure its completeness.
-<<<<<<< HEAD
   + Remove snapshot number and utxo hash from Close and Contest reedemer as they
     were already present in Closed datum.
-=======
   + Check no tokens are minted/burnt in v-head for close, contest, commit and collectCom tx.
->>>>>>> 67e6f2daf (Generate better values)
 
 - **BREAKING** Change the way tx validity and contestation deadline is constructed for close transactions:
   + There is a new hydra-node flag `--contestation-period` expressed in seconds
@@ -66,7 +63,6 @@ changes.
 - Add script sizes to `hydra-node --script-info` and published transaction cost benchmarks.
 
 -  `hydra-cluster` executable can be used to provide a local cardano "network" with `--devnet` argument
-
 
 ## [0.8.1] - 2022-11-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,12 @@ changes.
   + Check presence of state token (ST) and that it's consistent against datum.
   + Reduce cost of `commitTx` by using the initial script as input reference.
   + Moved check to reimburse commits to head validator and ensure its completeness.
+<<<<<<< HEAD
   + Remove snapshot number and utxo hash from Close and Contest reedemer as they
     were already present in Closed datum.
+=======
+  + Check no tokens are minted/burnt in v-head for close, contest, commit and collectCom tx.
+>>>>>>> 67e6f2daf (Generate better values)
 
 - **BREAKING** Change the way tx validity and contestation deadline is constructed for close transactions:
   + There is a new hydra-node flag `--contestation-period` expressed in seconds
@@ -63,7 +67,6 @@ changes.
 
 -  `hydra-cluster` executable can be used to provide a local cardano "network" with `--devnet` argument
 
-- Check no tokens are burnt in v-head for close, contest and collectCom tx.
 
 ## [0.8.1] - 2022-11-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ changes.
 
 -  `hydra-cluster` executable can be used to provide a local cardano "network" with `--devnet` argument
 
+- Check no tokens are burnt in v-head for close, contest and collectCom tx.
+
 ## [0.8.1] - 2022-11-17
 
 - **BREAKING** Implemented [ADR18](https://hydra.family/head-protocol/adr/18) to keep only a single state:

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -305,6 +305,7 @@ test-suite tests
     , base
     , base16-bytestring
     , bytestring
+    , cardano-api
     , cardano-binary
     , cardano-crypto-class
     , cardano-ledger-alonzo

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -262,7 +262,7 @@ test-suite tests
     Hydra.Chain.Direct.Contract.CollectCom
     Hydra.Chain.Direct.Contract.Commit
     Hydra.Chain.Direct.Contract.Contest
-    Hydra.Chain.Direct.Contract.ContractGenerators
+    Hydra.Chain.Direct.Contract.Gen
     Hydra.Chain.Direct.Contract.FanOut
     Hydra.Chain.Direct.Contract.Init
     Hydra.Chain.Direct.Contract.Mutation

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -305,7 +305,6 @@ test-suite tests
     , base
     , base16-bytestring
     , bytestring
-    , cardano-api
     , cardano-binary
     , cardano-crypto-class
     , cardano-ledger-alonzo
@@ -364,5 +363,5 @@ test-suite tests
     , websockets
     , yaml
 
-  build-tool-depends: hspec-discover:hspec-discover -any
+  build-tool-depends: hspec-discover:hspec-discover
   ghc-options:        -threaded -rtsopts

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -262,6 +262,7 @@ test-suite tests
     Hydra.Chain.Direct.Contract.CollectCom
     Hydra.Chain.Direct.Contract.Commit
     Hydra.Chain.Direct.Contract.Contest
+    Hydra.Chain.Direct.Contract.ContractGenerators
     Hydra.Chain.Direct.Contract.FanOut
     Hydra.Chain.Direct.Contract.Init
     Hydra.Chain.Direct.Contract.Mutation

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
@@ -12,6 +12,7 @@ import qualified Cardano.Api.UTxO as UTxO
 import qualified Data.Map as Map
 import Data.Maybe (fromJust)
 import Hydra.Chain (HeadParameters (..))
+import Hydra.Chain.Direct.Contract.ContractGenerators (genForParty)
 import Hydra.Chain.Direct.Contract.Mutation (
   Mutation (..),
   SomeMutation (..),
@@ -19,7 +20,7 @@ import Hydra.Chain.Direct.Contract.Mutation (
   changeMintedValueQuantityFrom,
   replacePolicyIdWith,
  )
-import Hydra.Chain.Direct.Fixture (genForParty, testNetworkId, testPolicyId, testSeedInput)
+import Hydra.Chain.Direct.Fixture (testNetworkId, testPolicyId, testSeedInput)
 import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry, registryUTxO)
 import Hydra.Chain.Direct.Tx (
   UTxOWithScript,

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
@@ -12,7 +12,7 @@ import qualified Cardano.Api.UTxO as UTxO
 import qualified Data.Map as Map
 import Data.Maybe (fromJust)
 import Hydra.Chain (HeadParameters (..))
-import Hydra.Chain.Direct.Contract.ContractGenerators (genForParty)
+import Hydra.Chain.Direct.Contract.Gen (genForParty)
 import Hydra.Chain.Direct.Contract.Mutation (
   Mutation (..),
   SomeMutation (..),

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -9,8 +9,21 @@ import Hydra.Prelude hiding (label)
 
 import Cardano.Api.UTxO as UTxO
 import Data.Maybe (fromJust)
-import Hydra.Chain.Direct.Contract.Mutation (Mutation (..), SomeMutation (..), addParticipationTokens, changeHeadOutputDatum, changeMintedTokens, genHash, genMintedOrBurnedValue, replaceContestationDeadline, replaceHeadId, replaceParties, replacePolicyIdWith, replaceSnapshotNumber, replaceUtxoHash)
-import Hydra.Chain.Direct.Fixture (genForParty, testNetworkId)
+import Hydra.Chain.Direct.Contract.ContractGenerators (genForParty, genHash, genMintedOrBurnedValue)
+import Hydra.Chain.Direct.Contract.Mutation (
+  Mutation (..),
+  SomeMutation (..),
+  addParticipationTokens,
+  changeHeadOutputDatum,
+  changeMintedTokens,
+  replaceContestationDeadline,
+  replaceHeadId,
+  replaceParties,
+  replacePolicyIdWith,
+  replaceSnapshotNumber,
+  replaceUtxoHash,
+ )
+import Hydra.Chain.Direct.Fixture (testNetworkId)
 import qualified Hydra.Chain.Direct.Fixture as Fixture
 import Hydra.Chain.Direct.TimeHandle (PointInTime)
 import Hydra.Chain.Direct.Tx (ClosingSnapshot (..), OpenThreadOutput (..), UTxOHash (UTxOHash), closeTx, mkHeadId, mkHeadOutput)

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -9,7 +9,7 @@ import Hydra.Prelude hiding (label)
 
 import Cardano.Api.UTxO as UTxO
 import Data.Maybe (fromJust)
-import Hydra.Chain.Direct.Contract.Mutation (Mutation (..), SomeMutation (..), addParticipationTokens, changeHeadOutputDatum, changeMintedTokens, genHash, replaceContestationDeadline, replaceHeadId, replaceParties, replacePolicyIdWith, replaceSnapshotNumber, replaceUtxoHash)
+import Hydra.Chain.Direct.Contract.Mutation (Mutation (..), SomeMutation (..), addParticipationTokens, changeHeadOutputDatum, changeMintedTokens, genHash, genMintedOrBurnedValue, replaceContestationDeadline, replaceHeadId, replaceParties, replacePolicyIdWith, replaceSnapshotNumber, replaceUtxoHash)
 import Hydra.Chain.Direct.Fixture (genForParty, testNetworkId)
 import qualified Hydra.Chain.Direct.Fixture as Fixture
 import Hydra.Chain.Direct.TimeHandle (PointInTime)
@@ -264,7 +264,7 @@ genCloseMutation (tx, _utxo) =
                 (Just $ toScriptData healthyOpenHeadDatum)
             ]
     , SomeMutation (Just "minting or burning is forbidden") MutateTokenMintingOrBurning
-        <$> changeMintedTokens tx (valueFromList [(AssetId Fixture.testPolicyId "badTokenBurned", Quantity (-1))])
+        <$> (changeMintedTokens tx =<< genMintedOrBurnedValue)
     ]
  where
   genOversizedTransactionValidity = do

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -205,8 +205,8 @@ data CloseMutation
   | -- | See spec: 5.5. rule 5 -> upperBound - lowerBound <= contestationPeriod
     MutateValidityInterval
   | MutateHeadId
-  | -- | Burning of the tokens should not be possible in v_head apart from 'checkAbort' or 'checkFanout'
-    MutateTokenBurning
+  | -- | Minting or burning of the tokens should not be possible in v_head apart from 'checkAbort' or 'checkFanout'
+    MutateTokenMintingOrBurning
   deriving (Generic, Show, Enum, Bounded)
 
 genCloseMutation :: (Tx, UTxO) -> Gen SomeMutation
@@ -263,7 +263,7 @@ genCloseMutation (tx, _utxo) =
                 (replacePolicyIdWith Fixture.testPolicyId otherHeadId healthyOpenHeadTxOut)
                 (Just $ toScriptData healthyOpenHeadDatum)
             ]
-    , SomeMutation (Just "burning is forbidden") MutateTokenBurning
+    , SomeMutation (Just "minting or burning is forbidden") MutateTokenMintingOrBurning
         <$> changeMintedTokens tx (valueFromList [(AssetId Fixture.testPolicyId "badTokenBurned", Quantity (-1))])
     ]
  where

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -9,7 +9,7 @@ import Hydra.Prelude hiding (label)
 
 import Cardano.Api.UTxO as UTxO
 import Data.Maybe (fromJust)
-import Hydra.Chain.Direct.Contract.ContractGenerators (genForParty, genHash, genMintedOrBurnedValue)
+import Hydra.Chain.Direct.Contract.Gen (genForParty, genHash, genMintedOrBurnedValue)
 import Hydra.Chain.Direct.Contract.Mutation (
   Mutation (..),
   SomeMutation (..),

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -205,7 +205,7 @@ data CloseMutation
   | -- | See spec: 5.5. rule 5 -> upperBound - lowerBound <= contestationPeriod
     MutateValidityInterval
   | MutateHeadId
-  | -- | Burning of the tokens should not be possible in v_head a part from 'checkAbort' or 'checkFanout'
+  | -- | Burning of the tokens should not be possible in v_head apart from 'checkAbort' or 'checkFanout'
     MutateTokenBurning
   deriving (Generic, Show, Enum, Bounded)
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -205,7 +205,7 @@ data CloseMutation
   | -- | See spec: 5.5. rule 5 -> upperBound - lowerBound <= contestationPeriod
     MutateValidityInterval
   | MutateHeadId
-  | -- | Burning of the tokens should not be possible in v_head a part from 'checkAbort'
+  | -- | Burning of the tokens should not be possible in v_head a part from 'checkAbort' or 'checkFanout'
     MutateTokenBurning
   deriving (Generic, Show, Enum, Bounded)
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -14,6 +14,7 @@ import Hydra.Chain.Direct.Contract.Mutation (
   Mutation (..),
   SomeMutation (..),
   changeHeadOutputDatum,
+  changeMintedTokens,
   genHash,
  )
 import Hydra.Chain.Direct.Fixture (
@@ -171,6 +172,7 @@ data CollectComMutation
     MutateNumberOfParties
   | MutateHeadId
   | MutateRequiredSigner
+  | MutateTokenBurning
   deriving (Generic, Show, Enum, Bounded)
 
 genCollectComMutation :: (Tx, UTxO) -> Gen SomeMutation
@@ -212,6 +214,8 @@ genCollectComMutation (tx, _utxo) =
     , SomeMutation Nothing MutateCommitToInitial <$> do
         (txIn, HealthyCommit{cardanoKey}) <- elements $ Map.toList healthyCommits
         pure $ ChangeInput txIn (toUTxOContext $ mkInitialOutput testNetworkId testPolicyId cardanoKey) Nothing
+    , SomeMutation (Just "burning is forbidden") MutateTokenBurning
+        <$> changeMintedTokens tx (valueFromList [(AssetId testPolicyId "badTokenBurned", Quantity (-1))])
     ]
  where
   headTxOut = fromJust $ txOuts' tx !!? 0

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -16,6 +16,7 @@ import Hydra.Chain.Direct.Contract.Mutation (
   changeHeadOutputDatum,
   changeMintedTokens,
   genHash,
+  genMintedOrBurnedValue,
  )
 import Hydra.Chain.Direct.Fixture (
   genForParty,
@@ -216,7 +217,7 @@ genCollectComMutation (tx, _utxo) =
         (txIn, HealthyCommit{cardanoKey}) <- elements $ Map.toList healthyCommits
         pure $ ChangeInput txIn (toUTxOContext $ mkInitialOutput testNetworkId testPolicyId cardanoKey) Nothing
     , SomeMutation (Just "minting or burning is forbidden") MutateTokenMintingOrBurning
-        <$> changeMintedTokens tx (valueFromList [(AssetId testPolicyId "badTokenBurned", Quantity (-1))])
+        <$> (changeMintedTokens tx =<< genMintedOrBurnedValue)
     ]
  where
   headTxOut = fromJust $ txOuts' tx !!? 0

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -172,7 +172,8 @@ data CollectComMutation
     MutateNumberOfParties
   | MutateHeadId
   | MutateRequiredSigner
-  | MutateTokenBurning
+  | -- | Burning of the tokens should not be possible in v_head a part from 'checkAbort' or 'checkFanout'
+    MutateTokenBurning
   deriving (Generic, Show, Enum, Bounded)
 
 genCollectComMutation :: (Tx, UTxO) -> Gen SomeMutation

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -10,7 +10,7 @@ import Hydra.Prelude hiding (label)
 import qualified Cardano.Api.UTxO as UTxO
 import qualified Data.Map as Map
 import Data.Maybe (fromJust)
-import Hydra.Chain.Direct.Contract.ContractGenerators (genForParty, genHash, genMintedOrBurnedValue)
+import Hydra.Chain.Direct.Contract.Gen (genForParty, genHash, genMintedOrBurnedValue)
 import Hydra.Chain.Direct.Contract.Mutation (
   Mutation (..),
   SomeMutation (..),

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -172,8 +172,8 @@ data CollectComMutation
     MutateNumberOfParties
   | MutateHeadId
   | MutateRequiredSigner
-  | -- | Burning of the tokens should not be possible in v_head apart from 'checkAbort' or 'checkFanout'
-    MutateTokenBurning
+  | -- | Minting or burning of the tokens should not be possible in v_head apart from 'checkAbort' or 'checkFanout'
+    MutateTokenMintingOrBurning
   deriving (Generic, Show, Enum, Bounded)
 
 genCollectComMutation :: (Tx, UTxO) -> Gen SomeMutation
@@ -215,7 +215,7 @@ genCollectComMutation (tx, _utxo) =
     , SomeMutation Nothing MutateCommitToInitial <$> do
         (txIn, HealthyCommit{cardanoKey}) <- elements $ Map.toList healthyCommits
         pure $ ChangeInput txIn (toUTxOContext $ mkInitialOutput testNetworkId testPolicyId cardanoKey) Nothing
-    , SomeMutation (Just "minting or burning is forbidden") MutateTokenBurning
+    , SomeMutation (Just "minting or burning is forbidden") MutateTokenMintingOrBurning
         <$> changeMintedTokens tx (valueFromList [(AssetId testPolicyId "badTokenBurned", Quantity (-1))])
     ]
  where

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -10,16 +10,14 @@ import Hydra.Prelude hiding (label)
 import qualified Cardano.Api.UTxO as UTxO
 import qualified Data.Map as Map
 import Data.Maybe (fromJust)
+import Hydra.Chain.Direct.Contract.ContractGenerators (genForParty, genHash, genMintedOrBurnedValue)
 import Hydra.Chain.Direct.Contract.Mutation (
   Mutation (..),
   SomeMutation (..),
   changeHeadOutputDatum,
   changeMintedTokens,
-  genHash,
-  genMintedOrBurnedValue,
  )
 import Hydra.Chain.Direct.Fixture (
-  genForParty,
   testNetworkId,
   testPolicyId,
   testSeedInput,

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -172,7 +172,7 @@ data CollectComMutation
     MutateNumberOfParties
   | MutateHeadId
   | MutateRequiredSigner
-  | -- | Burning of the tokens should not be possible in v_head a part from 'checkAbort' or 'checkFanout'
+  | -- | Burning of the tokens should not be possible in v_head apart from 'checkAbort' or 'checkFanout'
     MutateTokenBurning
   deriving (Generic, Show, Enum, Bounded)
 
@@ -215,7 +215,7 @@ genCollectComMutation (tx, _utxo) =
     , SomeMutation Nothing MutateCommitToInitial <$> do
         (txIn, HealthyCommit{cardanoKey}) <- elements $ Map.toList healthyCommits
         pure $ ChangeInput txIn (toUTxOContext $ mkInitialOutput testNetworkId testPolicyId cardanoKey) Nothing
-    , SomeMutation (Just "burning is forbidden") MutateTokenBurning
+    , SomeMutation (Just "minting or burning is forbidden") MutateTokenBurning
         <$> changeMintedTokens tx (valueFromList [(AssetId testPolicyId "badTokenBurned", Quantity (-1))])
     ]
  where

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
@@ -10,11 +10,11 @@ import Hydra.Chain.Direct.TxSpec ()
 
 import qualified Cardano.Api.UTxO as UTxO
 import Data.Maybe (fromJust)
+import Hydra.Chain.Direct.Contract.ContractGenerators (genMintedOrBurnedValue)
 import Hydra.Chain.Direct.Contract.Mutation (
   Mutation (..),
   SomeMutation (..),
   changeMintedTokens,
-  genMintedOrBurnedValue,
   replacePolicyIdWith,
  )
 import qualified Hydra.Chain.Direct.Fixture as Fixture

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
@@ -10,7 +10,7 @@ import Hydra.Chain.Direct.TxSpec ()
 
 import qualified Cardano.Api.UTxO as UTxO
 import Data.Maybe (fromJust)
-import Hydra.Chain.Direct.Contract.ContractGenerators (genMintedOrBurnedValue)
+import Hydra.Chain.Direct.Contract.Gen (genMintedOrBurnedValue)
 import Hydra.Chain.Direct.Contract.Mutation (
   Mutation (..),
   SomeMutation (..),

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
@@ -14,6 +14,7 @@ import Hydra.Chain.Direct.Contract.Mutation (
   Mutation (..),
   SomeMutation (..),
   changeMintedTokens,
+  genMintedOrBurnedValue,
   replacePolicyIdWith,
  )
 import qualified Hydra.Chain.Direct.Fixture as Fixture
@@ -113,7 +114,7 @@ genCommitMutation (tx, _utxo) =
                 (Just $ toScriptData $ Initial.ViaCommit $ Just $ toPlutusTxOutRef committedTxIn)
             ]
     , SomeMutation (Just "minting or burning is forbidden") MutateTokenMintingOrBurning
-        <$> changeMintedTokens tx (valueFromList [(AssetId Fixture.testPolicyId "badTokenBurned", Quantity (-1))])
+        <$> (changeMintedTokens tx =<< genMintedOrBurnedValue)
     ]
  where
   TxOut{txOutValue = commitOutputValue} = commitTxOut

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -169,8 +169,8 @@ data ContestMutation
     MutateValidityPastDeadline
   | -- | Change the head policy id to test the head validators
     MutateHeadId
-  | -- | Burning of the tokens should not be possible in v_head apart from 'checkAbort' or 'checkFanout'
-    MutateTokenBurning
+  | -- | Minting or burning of the tokens should not be possible in v_head apart from 'checkAbort' or 'checkFanout'
+    MutateTokenMintingOrBurning
   deriving (Generic, Show, Enum, Bounded)
 
 genContestMutation :: (Tx, UTxO) -> Gen SomeMutation
@@ -225,7 +225,7 @@ genContestMutation
                   (replacePolicyIdWith testPolicyId otherHeadId healthyClosedHeadTxOut)
                   (Just $ toScriptData healthyClosedState)
               ]
-      , SomeMutation (Just "burning is forbidden") MutateTokenBurning
+      , SomeMutation (Just "minting or burning is forbidden") MutateTokenMintingOrBurning
           <$> changeMintedTokens tx (valueFromList [(AssetId testPolicyId "badTokenBurned", Quantity (-1))])
       ]
    where

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -10,7 +10,7 @@ import Hydra.Prelude hiding (label)
 import Data.Maybe (fromJust)
 
 import Cardano.Api.UTxO as UTxO
-import Hydra.Chain.Direct.Contract.ContractGenerators (genForParty, genHash, genMintedOrBurnedValue)
+import Hydra.Chain.Direct.Contract.Gen (genForParty, genHash, genMintedOrBurnedValue)
 import Hydra.Chain.Direct.Contract.Mutation (
   Mutation (..),
   SomeMutation (..),

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -169,7 +169,7 @@ data ContestMutation
     MutateValidityPastDeadline
   | -- | Change the head policy id to test the head validators
     MutateHeadId
-  | -- | Burning of the tokens should not be possible in v_head a part from 'checkAbort' or 'checkFanout'
+  | -- | Burning of the tokens should not be possible in v_head apart from 'checkAbort' or 'checkFanout'
     MutateTokenBurning
   deriving (Generic, Show, Enum, Bounded)
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -10,20 +10,19 @@ import Hydra.Prelude hiding (label)
 import Data.Maybe (fromJust)
 
 import Cardano.Api.UTxO as UTxO
+import Hydra.Chain.Direct.Contract.ContractGenerators (genForParty, genHash, genMintedOrBurnedValue)
 import Hydra.Chain.Direct.Contract.Mutation (
   Mutation (..),
   SomeMutation (..),
   addParticipationTokens,
   changeHeadOutputDatum,
   changeMintedTokens,
-  genHash,
-  genMintedOrBurnedValue,
   replaceParties,
   replacePolicyIdWith,
   replaceSnapshotNumber,
   replaceUtxoHash,
  )
-import Hydra.Chain.Direct.Fixture (genForParty, testNetworkId, testPolicyId)
+import Hydra.Chain.Direct.Fixture (testNetworkId, testPolicyId)
 import Hydra.Chain.Direct.Tx (ClosedThreadOutput (..), contestTx, mkHeadId, mkHeadOutput)
 import qualified Hydra.Contract.HeadState as Head
 import Hydra.Contract.HeadTokens (headPolicyId)

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -169,7 +169,7 @@ data ContestMutation
     MutateValidityPastDeadline
   | -- | Change the head policy id to test the head validators
     MutateHeadId
-  | -- | Burning of the tokens should not be possible in v_head a part from 'checkAbort'
+  | -- | Burning of the tokens should not be possible in v_head a part from 'checkAbort' or 'checkFanout'
     MutateTokenBurning
   deriving (Generic, Show, Enum, Bounded)
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -15,6 +15,7 @@ import Hydra.Chain.Direct.Contract.Mutation (
   SomeMutation (..),
   addParticipationTokens,
   changeHeadOutputDatum,
+  changeMintedTokens,
   genHash,
   replaceParties,
   replacePolicyIdWith,
@@ -168,6 +169,8 @@ data ContestMutation
     MutateValidityPastDeadline
   | -- | Change the head policy id to test the head validators
     MutateHeadId
+  | -- | Burning of the tokens should not be possible in v_head a part from 'checkAbort'
+    MutateTokenBurning
   deriving (Generic, Show, Enum, Bounded)
 
 genContestMutation :: (Tx, UTxO) -> Gen SomeMutation
@@ -222,6 +225,8 @@ genContestMutation
                   (replacePolicyIdWith testPolicyId otherHeadId healthyClosedHeadTxOut)
                   (Just $ toScriptData healthyClosedState)
               ]
+      , SomeMutation (Just "burning is forbidden") MutateTokenBurning
+          <$> changeMintedTokens tx (valueFromList [(AssetId testPolicyId "badTokenBurned", Quantity (-1))])
       ]
    where
     headTxOut = fromJust $ txOuts' tx !!? 0

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -17,6 +17,7 @@ import Hydra.Chain.Direct.Contract.Mutation (
   changeHeadOutputDatum,
   changeMintedTokens,
   genHash,
+  genMintedOrBurnedValue,
   replaceParties,
   replacePolicyIdWith,
   replaceSnapshotNumber,
@@ -226,7 +227,7 @@ genContestMutation
                   (Just $ toScriptData healthyClosedState)
               ]
       , SomeMutation (Just "minting or burning is forbidden") MutateTokenMintingOrBurning
-          <$> changeMintedTokens tx (valueFromList [(AssetId testPolicyId "badTokenBurned", Quantity (-1))])
+          <$> (changeMintedTokens tx =<< genMintedOrBurnedValue)
       ]
    where
     headTxOut = fromJust $ txOuts' tx !!? 0

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/ContractGenerators.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/ContractGenerators.hs
@@ -1,0 +1,54 @@
+-- | Generators used in mutation testing framework
+module Hydra.Chain.Direct.Contract.ContractGenerators where
+
+import Cardano.Crypto.Hash (hashToBytes)
+import Codec.CBOR.Magic (uintegerFromBytes)
+import qualified Data.ByteString as BS
+import Hydra.Cardano.Api
+import qualified Hydra.Chain.Direct.Fixture as Fixtures
+import Hydra.Contract.HeadTokens (headPolicyId)
+import Hydra.Contract.Util (hydraHeadV1)
+import Hydra.Crypto (Hash (HydraKeyHash))
+import Hydra.Party (Party (..))
+import Hydra.Prelude
+import Plutus.V2.Ledger.Api (fromBuiltin)
+import Test.QuickCheck (oneof, suchThat, vector)
+
+-- * Party / key utilities
+
+-- | Generate some 'a' given the Party as a seed. NOTE: While this is useful to
+-- generate party-specific values, it DOES depend on the generator used. For
+-- example, `genForParty genVerificationKey` and `genForParty (fst <$>
+-- genKeyPair)` do not yield the same verification keys!
+genForParty :: Gen a -> Party -> a
+genForParty gen Party{vkey} =
+  generateWith gen seed
+ where
+  seed =
+    fromIntegral
+      . uintegerFromBytes
+      . hydraKeyHashToBytes
+      $ verificationKeyHash vkey
+
+  hydraKeyHashToBytes (HydraKeyHash h) = hashToBytes h
+
+genBytes :: Gen ByteString
+genBytes = arbitrary
+
+genHash :: Gen ByteString
+genHash = BS.pack <$> vector 32
+
+-- | Generates value such that:
+-- - alters between policy id we use in test fixtures with a random one.
+-- - mixing arbitrary token names with 'hydraHeadV1'
+-- - excluding 0 for quantity to mimic minting/burning
+genMintedOrBurnedValue :: Gen Value
+genMintedOrBurnedValue = do
+  policyId <-
+    oneof
+      [ headPolicyId <$> arbitrary
+      , pure Fixtures.testPolicyId
+      ]
+  tokenName <- oneof [arbitrary, pure (AssetName $ fromBuiltin hydraHeadV1)]
+  quantity <- arbitrary `suchThat` (/= 0)
+  pure $ valueFromList [(AssetId policyId tokenName, Quantity quantity)]

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Gen.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Gen.hs
@@ -1,5 +1,5 @@
 -- | Generators used in mutation testing framework
-module Hydra.Chain.Direct.Contract.ContractGenerators where
+module Hydra.Chain.Direct.Contract.Gen where
 
 import Cardano.Crypto.Hash (hashToBytes)
 import Codec.CBOR.Magic (uintegerFromBytes)

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Init.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Init.hs
@@ -7,13 +7,14 @@ import Hydra.Prelude
 
 import qualified Cardano.Api.UTxO as UTxO
 import Hydra.Chain (HeadParameters (..))
+import Hydra.Chain.Direct.Contract.ContractGenerators (genForParty)
 import Hydra.Chain.Direct.Contract.Mutation (
   Mutation (..),
   SomeMutation (..),
   addPTWithQuantity,
   changeMintedValueQuantityFrom,
  )
-import Hydra.Chain.Direct.Fixture (genForParty, testNetworkId)
+import Hydra.Chain.Direct.Fixture (testNetworkId)
 import Hydra.Chain.Direct.Tx (hydraHeadV1AssetName, initTx)
 import Hydra.Ledger.Cardano (genOneUTxOFor, genValue, genVerificationKey)
 import Hydra.Party (Party)

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Init.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Init.hs
@@ -7,7 +7,7 @@ import Hydra.Prelude
 
 import qualified Cardano.Api.UTxO as UTxO
 import Hydra.Chain (HeadParameters (..))
-import Hydra.Chain.Direct.Contract.ContractGenerators (genForParty)
+import Hydra.Chain.Direct.Contract.Gen (genForParty)
 import Hydra.Chain.Direct.Contract.Mutation (
   Mutation (..),
   SomeMutation (..),

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
@@ -607,7 +607,9 @@ changeMintedValueQuantityFrom tx exclude =
  where
   mintedValue = txMintValue $ txBodyContent $ txBody tx
 
--- | A 'Mutation' that changes the minted/burnt quantity of tokens
+-- | A 'Mutation' that changes the forged quantity of tokens like this:
+-- - when no value is being forged -> add some value to be forged
+-- - when tx is forging values -> add more values on top of that
 changeMintedTokens :: Tx -> Value -> Gen Mutation
 changeMintedTokens tx mintValue =
   ChangeMintedValue

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
@@ -219,11 +219,11 @@ propTransactionValidates (tx, lookupUTxO) =
    in case result of
         Left basicFailure ->
           property False
-            & counterexample ("Mutated transaction: " <> renderTxWithUTxO lookupUTxO tx)
+            & counterexample ("Transaction: " <> renderTxWithUTxO lookupUTxO tx)
             & counterexample ("Phase-1 validation failed: " <> show basicFailure)
         Right redeemerReport ->
           all isRight (Map.elems redeemerReport)
-            & counterexample ("Mutated transaction: " <> renderTxWithUTxO lookupUTxO tx)
+            & counterexample ("Transaction: " <> renderTxWithUTxO lookupUTxO tx)
             & counterexample ("Redeemer report: " <> show redeemerReport)
             & counterexample "Phase-2 validation failed"
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
@@ -140,7 +140,7 @@ import Cardano.Ledger.Serialization (mkSized)
 import qualified Data.Map as Map
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
-import Hydra.Chain.Direct.Contract.ContractGenerators (genForParty)
+import Hydra.Chain.Direct.Contract.Gen (genForParty)
 import Hydra.Chain.Direct.Fixture (testPolicyId)
 import qualified Hydra.Chain.Direct.Fixture as Fixture
 import Hydra.Chain.Direct.Tx (assetNameFromVerificationKey)

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
@@ -205,7 +205,6 @@ propTransactionDoesNotValidate mExpectedError (tx, lookupUTxO) =
                   any (matchesErrorMessage expectedError) errors
                     & counterexample ("Mutated transaction: " <> renderTxWithUTxO lookupUTxO tx)
                     & counterexample ("Redeemer report: " <> show redeemerReport)
-                    & counterexample ("But errors were: " <> show errors)
                     & counterexample ("Phase-2 validation should have failed with error message: " <> show expectedError)
  where
   matchesErrorMessage errMsg = \case

--- a/hydra-node/test/Hydra/Chain/Direct/Fixture.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Fixture.hs
@@ -23,7 +23,6 @@ import Hydra.Cardano.Api (
   PolicyId,
   ProtocolParameters (..),
   TxIn,
-  verificationKeyHash,
  )
 import Hydra.Contract.HeadTokens (headPolicyId)
 import Hydra.Ledger.Cardano ()

--- a/hydra-node/test/Hydra/Chain/Direct/Fixture.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Fixture.hs
@@ -11,11 +11,9 @@ module Hydra.Chain.Direct.Fixture (
 
 import Hydra.Prelude
 
-import Cardano.Crypto.Hash (hashToBytes)
 import qualified Cardano.Ledger.BaseTypes as Ledger
 import qualified Cardano.Ledger.Shelley.Rules.Ledger as Ledger
 import qualified Cardano.Slotting.Time as Slotting
-import Codec.CBOR.Magic (uintegerFromBytes)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Hydra.Cardano.Api (
   ExecutionUnitPrices (ExecutionUnitPrices),
@@ -28,30 +26,10 @@ import Hydra.Cardano.Api (
   verificationKeyHash,
  )
 import Hydra.Contract.HeadTokens (headPolicyId)
-import Hydra.Crypto (Hash (HydraKeyHash))
 import Hydra.Ledger.Cardano ()
 import Hydra.Ledger.Cardano.Configuration (newLedgerEnv)
 import Hydra.Ledger.Cardano.Evaluate (epochInfo, pparams, systemStart)
-import Hydra.Party (Party (..))
 import Test.Cardano.Ledger.Alonzo.Serialisation.Generators ()
-
--- * Party / key utilities
-
--- | Generate some 'a' given the Party as a seed. NOTE: While this is useful to
--- generate party-specific values, it DOES depend on the generator used. For
--- example, `genForParty genVerificationKey` and `genForParty (fst <$>
--- genKeyPair)` do not yield the same verification keys!
-genForParty :: Gen a -> Party -> a
-genForParty gen Party{vkey} =
-  generateWith gen seed
- where
-  seed =
-    fromIntegral
-      . uintegerFromBytes
-      . hydraKeyHashToBytes
-      $ verificationKeyHash vkey
-
-  hydraKeyHashToBytes (HydraKeyHash h) = hashToBytes h
 
 -- * Cardano tx utilities
 

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -389,7 +389,7 @@ forAllFanout action =
        in action utxo tx
             & label ("Fanout size: " <> prettyLength (countAssets $ txOuts' tx))
  where
-  maxSupported = 42
+  maxSupported = 39
 
   countAssets = getSum . foldMap (Sum . valueSize . txOutValue)
 

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -18,7 +18,7 @@ import qualified Data.Map as Map
 import qualified Data.Text as T
 import GHC.Natural (wordToNatural)
 import Hydra.Chain (HeadParameters (..))
-import Hydra.Chain.Direct.Contract.ContractGenerators (genForParty)
+import Hydra.Chain.Direct.Contract.Gen (genForParty)
 import Hydra.Chain.Direct.Fixture (
   epochInfo,
   pparams,

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -18,9 +18,9 @@ import qualified Data.Map as Map
 import qualified Data.Text as T
 import GHC.Natural (wordToNatural)
 import Hydra.Chain (HeadParameters (..))
+import Hydra.Chain.Direct.Contract.ContractGenerators (genForParty)
 import Hydra.Chain.Direct.Fixture (
   epochInfo,
-  genForParty,
   pparams,
   systemStart,
   testNetworkId,

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -177,7 +177,8 @@ checkCollectCom ::
   (ContestationPeriod, [Party], CurrencySymbol) ->
   Bool
 checkCollectCom ctx@ScriptContext{scriptContextTxInfo = txInfo} (contestationPeriod, parties, headId) =
-  mustContinueHeadWith ctx headAddress expectedChangeValue expectedOutputDatum
+  mustNotBurnTokens ctx headId
+    && mustContinueHeadWith ctx headAddress expectedChangeValue expectedOutputDatum
     && everyoneHasCommitted
     && mustBeSignedByParticipant ctx headId
     && hasST headId outValue

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -343,8 +343,9 @@ checkContest ::
   -- | Head id
   CurrencySymbol ->
   Bool
-checkContest ctx@ScriptContext{scriptContextTxInfo} contestationDeadline parties closedSnapshotNumber sig headId =
-  mustBeNewer
+checkContest ctx@ScriptContext{scriptContextTxInfo} contestationDeadline parties closedSnapshotNumber contestSnapshotNumber contestUtxoHash sig headPolicyId =
+  mustNotBurnTokens ctx headPolicyId
+    && mustBeNewer
     && mustBeMultiSigned
     && mustNotChangeParameters
     && mustBeSignedByParticipant ctx headId

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -262,7 +262,7 @@ checkClose ::
   ContestationPeriod ->
   CurrencySymbol ->
   Bool
-checkClose ctx parties initialUtxoHash snapshotNumber closedUtxoHash sig cperiod headPolicyId =
+checkClose ctx parties initialUtxoHash sig cperiod headPolicyId =
   mustNotMintOrBurn txInfo
     && hasBoundedValidity
     && checkDeadline
@@ -344,7 +344,7 @@ checkContest ::
   -- | Head id
   CurrencySymbol ->
   Bool
-checkContest ctx contestationDeadline parties closedSnapshotNumber contestSnapshotNumber contestUtxoHash sig headPolicyId =
+checkContest ctx contestationDeadline parties closedSnapshotNumber sig headId =
   mustNotMintOrBurn txInfo
     && mustBeNewer
     && mustBeMultiSigned

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -21,12 +21,12 @@ import PlutusTx.Prelude
 import Hydra.Contract.Commit (Commit (..))
 import qualified Hydra.Contract.Commit as Commit
 import Hydra.Contract.HeadState (Input (..), Signature, SnapshotNumber, State (..))
-import Hydra.Contract.Util (hasST)
+import Hydra.Contract.Util (hasST, mustNotMintOrBurn)
 import Hydra.Data.ContestationPeriod (ContestationPeriod, addContestationPeriod, milliseconds)
 import Hydra.Data.Party (Party (vkey))
 import Plutus.Extras (ValidatorType, scriptValidatorHash, wrapValidator)
 import Plutus.V1.Ledger.Time (fromMilliSeconds)
-import Plutus.V1.Ledger.Value (assetClass, assetClassValue, isZero, valueOf)
+import Plutus.V1.Ledger.Value (assetClass, assetClassValue, valueOf)
 import Plutus.V2.Ledger.Api (
   Address,
   CurrencySymbol,
@@ -535,12 +535,6 @@ hasPT headCurrencySymbol txOut =
   let pts = findParticipationTokens headCurrencySymbol (txOutValue txOut)
    in length pts == 1
 {-# INLINEABLE hasPT #-}
-
-mustNotMintOrBurn :: TxInfo -> Bool
-mustNotMintOrBurn TxInfo{txInfoMint} =
-  traceIfFalse "minting or burning is forbidden" $
-    isZero txInfoMint
-{-# INLINEABLE mustNotMintOrBurn #-}
 
 verifySnapshotSignature :: [Party] -> SnapshotNumber -> BuiltinByteString -> [Signature] -> Bool
 verifySnapshotSignature parties snapshotNumber utxoHash sigs =

--- a/hydra-plutus/src/Hydra/Contract/Initial.hs
+++ b/hydra-plutus/src/Hydra/Contract/Initial.hs
@@ -9,7 +9,7 @@ import PlutusTx.Prelude
 
 import Hydra.Contract.Commit (Commit (..))
 import qualified Hydra.Contract.Commit as Commit
-import Hydra.Contract.Util (mustBurnST)
+import Hydra.Contract.Util (mustBurnST, mustNotMintOrBurn)
 import Plutus.Extras (ValidatorType, scriptValidatorHash, wrapValidator)
 import Plutus.V1.Ledger.Value (assetClass, assetClassValueOf)
 import Plutus.V2.Ledger.Api (
@@ -106,7 +106,9 @@ checkCommit ::
   ScriptContext ->
   Bool
 checkCommit commitValidator committedRef context@ScriptContext{scriptContextTxInfo = txInfo} =
-  checkCommittedValue && checkLockedCommit
+  mustNotMintOrBurn txInfo
+    && checkCommittedValue
+    && checkLockedCommit
  where
   checkCommittedValue =
     traceIfFalse "lockedValue does not match" $

--- a/hydra-plutus/src/Hydra/Contract/Util.hs
+++ b/hydra-plutus/src/Hydra/Contract/Util.hs
@@ -3,9 +3,11 @@
 
 module Hydra.Contract.Util where
 
+import Plutus.V1.Ledger.Value (isZero)
 import Plutus.V2.Ledger.Api (
   CurrencySymbol,
   TokenName (..),
+  TxInfo (TxInfo, txInfoMint),
   Value (getValue),
  )
 import qualified PlutusTx.AssocMap as Map
@@ -38,3 +40,9 @@ mustBurnST val headCurrencySymbol =
         Nothing -> True
         Just v -> v == negate 1
 {-# INLINEABLE mustBurnST #-}
+
+mustNotMintOrBurn :: TxInfo -> Bool
+mustNotMintOrBurn TxInfo{txInfoMint} =
+  traceIfFalse "minting or burning is forbidden" $
+    isZero txInfoMint
+{-# INLINEABLE mustNotMintOrBurn #-}


### PR DESCRIPTION
## Why

We want to close the identified security gap where we want to prevent minting or burning of tokens in state transitions that are not actually supposed to burn or mint.

## How
🍦 Update `checkClose`, `checkContest`, `checkCommit` and `checkCollectCom` to verify no head token is burnt in v-head.

To check before merging:
* [x] CHANGELOG is up to date
* [x] ~Documentation is up to date~
