### PR TITLE
Head script as reference script

### DIFF
--- a/hydra-node/exe/tx-cost/TxCost.hs
+++ b/hydra-node/exe/tx-cost/TxCost.hs
@@ -220,7 +220,7 @@ computeFanOutCost = do
     let closeTx = close cctx stOpen snapshot startSlot closePoint
     let stClosed = snd . fromJust $ observeClose stOpen closeTx
     let deadlineSlotNo = slotNoFromUTCTime (getContestationDeadline stClosed)
-    pure (utxo, fanout stClosed utxo deadlineSlotNo, getKnownUTxO stClosed)
+    pure (utxo, fanout cctx stClosed utxo deadlineSlotNo, getKnownUTxO stClosed <> getKnownUTxO cctx)
 
 newtype NumParties = NumParties Int
   deriving newtype (Eq, Show, Ord, Num, Real, Enum, Integral)

--- a/hydra-node/exe/tx-cost/TxCost.hs
+++ b/hydra-node/exe/tx-cost/TxCost.hs
@@ -187,7 +187,7 @@ computeAbortCost =
     commits <- genCommits ctx initTx
     cctx <- pickChainContext ctx
     let (committed, stInitialized) = unsafeObserveInitAndCommits cctx initTx commits
-    pure (abort (fold committed) cctx stInitialized, getKnownUTxO stInitialized <> getKnownUTxO cctx)
+    pure (abort cctx stInitialized (fold committed), getKnownUTxO stInitialized <> getKnownUTxO cctx)
 
 computeFanOutCost :: IO [(NumParties, NumUTxO, Natural, TxSize, MemUnit, CpuUnit, Lovelace)]
 computeFanOutCost = do

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -281,7 +281,7 @@ prepareTxToPost timeHandle wallet ctx cst@ChainStateAt{chainState} tx =
       pure (contest ctx st confirmedSnapshot upperBound)
     (FanoutTx{utxo, contestationDeadline}, Closed st) -> do
       deadlineSlot <- throwLeft $ slotFromUTCTime contestationDeadline
-      pure (fanout st utxo deadlineSlot)
+      pure (fanout ctx st utxo deadlineSlot)
     (_, _) -> throwIO $ InvalidStateToPost{txTried = tx, chainState = cst}
  where
   -- XXX: Might want a dedicated exception type here

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -256,7 +256,7 @@ prepareTxToPost timeHandle wallet ctx cst@ChainStateAt{chainState} tx =
         Nothing ->
           throwIO (NoSeedInput @Tx)
     (AbortTx{utxo}, Initial st) ->
-      pure $ abort utxo ctx st
+      pure $ abort ctx st utxo
     -- NOTE / TODO: 'CommitTx' also contains a 'Party' which seems redundant
     -- here. The 'Party' is already part of the state and it is the only party
     -- which can commit from this Hydra node.

--- a/hydra-node/src/Hydra/Chain/Direct/ScriptRegistry.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/ScriptRegistry.hs
@@ -62,6 +62,26 @@ data ScriptRegistry = ScriptRegistry
   }
   deriving (Eq, Show, Generic, ToJSON, FromJSON)
 
+genScriptRegistry :: Gen ScriptRegistry
+genScriptRegistry = do
+  txId <- arbitrary
+  txOut <- genTxOutAdaOnly
+  pure $
+    ScriptRegistry
+      { initialReference =
+          ( TxIn txId (TxIx 0)
+          , txOut{txOutReferenceScript = mkScriptRef Initial.validatorScript}
+          )
+      , commitReference =
+          ( TxIn txId (TxIx 1)
+          , txOut{txOutReferenceScript = mkScriptRef Commit.validatorScript}
+          )
+      , headReference =
+          ( TxIn txId (TxIx 2)
+          , txOut{txOutReferenceScript = mkScriptRef Head.validatorScript}
+          )
+      }
+
 data NewScriptRegistryException = MissingScript
   { scriptName :: Text
   , scriptHash :: ScriptHash
@@ -146,26 +166,6 @@ queryScriptRegistry networkId nodeSocket txId = do
     Right sr -> pure sr
  where
   candidates = [TxIn txId ix | ix <- [TxIx 0 .. TxIx 10]] -- Arbitrary but, high-enough.
-
-genScriptRegistry :: Gen ScriptRegistry
-genScriptRegistry = do
-  txId <- arbitrary
-  txOut <- genTxOutAdaOnly
-  pure $
-    ScriptRegistry
-      { initialReference =
-          ( TxIn txId (TxIx 0)
-          , txOut{txOutReferenceScript = mkScriptRef Initial.validatorScript}
-          )
-      , commitReference =
-          ( TxIn txId (TxIx 1)
-          , txOut{txOutReferenceScript = mkScriptRef Commit.validatorScript}
-          )
-      , headReference =
-          ( TxIn txId (TxIx 2)
-          , txOut{txOutReferenceScript = mkScriptRef Head.validatorScript}
-          )
-      }
 
 publishHydraScripts ::
   -- | Expected network discriminant.

--- a/hydra-node/src/Hydra/Chain/Direct/ScriptRegistry.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/ScriptRegistry.hs
@@ -134,11 +134,12 @@ newScriptRegistry =
 --     newScriptRegistry (registryUTxO r) === Just r
 registryUTxO :: ScriptRegistry -> UTxO
 registryUTxO scriptRegistry =
-  UTxO.fromPairs [initialReference, commitReference]
+  UTxO.fromPairs [initialReference, commitReference, headReference]
  where
   ScriptRegistry
     { initialReference
     , commitReference
+    , headReference
     } = scriptRegistry
 
 -- | Query for 'TxIn's in the search for outputs containing all the reference

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -379,9 +379,9 @@ collect ::
   Tx
 collect ctx st = do
   let commits = Map.fromList $ fmap tripleToPair initialCommits
-   in collectComTx networkId ownVerificationKey initialThreadOutput commits headId
+   in collectComTx networkId scriptRegistry ownVerificationKey initialThreadOutput commits headId
  where
-  ChainContext{networkId, ownVerificationKey} = ctx
+  ChainContext{networkId, ownVerificationKey, scriptRegistry} = ctx
 
   InitialState
     { initialThreadOutput

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -342,12 +342,12 @@ commit ctx st utxo = do
 -- reimburse all the already committed outputs.
 abort ::
   HasCallStack =>
-  -- | Committed UTxOs to reimburse.
-  UTxO ->
   ChainContext ->
   InitialState ->
+  -- | Committed UTxOs to reimburse.
+  UTxO ->
   Tx
-abort committedUTxO ctx st = do
+abort ctx st committedUTxO = do
   let InitialThreadOutput{initialThreadUTxO = (i, o, dat)} = initialThreadOutput
       initials = Map.fromList $ map tripleToPair initialInitials
       commits = Map.fromList $ map tripleToPair initialCommits

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -301,9 +301,9 @@ commit ctx st utxo = do
       case UTxO.pairs utxo of
         [aUTxO] -> do
           rejectByronAddress aUTxO
-          Right $ commitTx scriptRegistry networkId headId ownParty (Just aUTxO) initial
+          Right $ commitTx networkId scriptRegistry headId ownParty (Just aUTxO) initial
         [] -> do
-          Right $ commitTx scriptRegistry networkId headId ownParty Nothing initial
+          Right $ commitTx networkId scriptRegistry headId ownParty Nothing initial
         _ ->
           Left (MoreThanOneUTxOCommitted @Tx)
  where

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -438,14 +438,14 @@ contest ::
   PointInTime ->
   Tx
 contest ctx st confirmedSnapshot pointInTime = do
-  contestTx ownVerificationKey sn sigs pointInTime closedThreadOutput headId contestationPeriod
+  contestTx scriptRegistry ownVerificationKey sn sigs pointInTime closedThreadOutput headId contestationPeriod
  where
   (sn, sigs) =
     case confirmedSnapshot of
       ConfirmedSnapshot{signatures} -> (getSnapshot confirmedSnapshot, signatures)
       _ -> (getSnapshot confirmedSnapshot, mempty)
 
-  ChainContext{contestationPeriod, ownVerificationKey} = ctx
+  ChainContext{contestationPeriod, ownVerificationKey, scriptRegistry} = ctx
 
   ClosedState
     { closedThreadOutput

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -407,7 +407,7 @@ close ::
   PointInTime ->
   Tx
 close ctx st confirmedSnapshot startSlotNo pointInTime =
-  closeTx ownVerificationKey closingSnapshot startSlotNo pointInTime openThreadOutput headId
+  closeTx scriptRegistry ownVerificationKey closingSnapshot startSlotNo pointInTime openThreadOutput headId
  where
   closingSnapshot = case confirmedSnapshot of
     -- XXX: Not needing anything of the 'InitialSnapshot' is another hint that
@@ -420,7 +420,7 @@ close ctx st confirmedSnapshot startSlotNo pointInTime =
         , signatures
         }
 
-  ChainContext{ownVerificationKey} = ctx
+  ChainContext{ownVerificationKey, scriptRegistry} = ctx
 
   OpenState
     { openThreadOutput

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -164,9 +164,9 @@ mkInitialOutput networkId seedTxIn (verificationKeyHash -> pkh) =
 
 -- | Craft a commit transaction which includes the "committed" utxo as a datum.
 commitTx ::
+  NetworkId ->
   -- | Published Hydra scripts to reference.
   ScriptRegistry ->
-  NetworkId ->
   HeadId ->
   Party ->
   -- | A single UTxO to commit to the Head
@@ -176,7 +176,7 @@ commitTx ::
   -- locked by initial script
   (TxIn, TxOut CtxUTxO, Hash PaymentKey) ->
   Tx
-commitTx scriptRegistry networkId headId party utxo (initialInput, out, vkh) =
+commitTx networkId scriptRegistry headId party utxo (initialInput, out, vkh) =
   unsafeBuildTransaction $
     emptyTxBody
       & addInputs [(initialInput, initialWitness)]

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -506,13 +506,17 @@ abortTx committedUTxO scriptRegistry vk (headInput, initialHeadOutput, ScriptDat
       unsafeBuildTransaction $
         emptyTxBody
           & addInputs ((headInput, headWitness) : initialInputs <> commitInputs)
-          & addReferenceInputs [initialScriptRef, commitScriptRef]
+          & addReferenceInputs [initialScriptRef, commitScriptRef, headScriptRef]
           & addOutputs reimbursedOutputs
           & burnTokens headTokenScript Burn headTokens
           & addExtraRequiredSigners [verificationKeyHash vk]
  where
   headWitness =
-    BuildTxWith $ ScriptWitness scriptWitnessCtx $ mkScriptWitness headScript headDatumBefore headRedeemer
+    BuildTxWith $
+      ScriptWitness scriptWitnessCtx $
+        mkScriptReference headScriptRef headScript headDatumBefore headRedeemer
+  headScriptRef =
+    fst (headReference scriptRegistry)
   headScript =
     fromPlutusScript @PlutusScriptV2 Head.validatorScript
   headRedeemer =

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -26,6 +26,7 @@ import Hydra.Chain.Direct.Contract.Mutation (
  )
 import Hydra.Chain.Direct.Fixture (testNetworkId)
 import qualified Hydra.Chain.Direct.Fixture as Fixture
+import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry, registryUTxO)
 import Hydra.Chain.Direct.TimeHandle (PointInTime)
 import Hydra.Chain.Direct.Tx (ClosingSnapshot (..), OpenThreadOutput (..), UTxOHash (UTxOHash), closeTx, mkHeadId, mkHeadOutput)
 import Hydra.ContestationPeriod (fromChain)
@@ -62,10 +63,6 @@ import Test.Hydra.Fixture (aliceSk, bobSk, carolSk)
 import Test.QuickCheck (arbitrarySizedNatural, choose, elements, listOf1, oneof, suchThat)
 import Test.QuickCheck.Instances ()
 
---
--- CloseTx
---
-
 -- | Healthy close transaction for the generic case were we close a head
 --   after one or more snapshot have been agreed upon between the members.
 healthyCloseTx :: (Tx, UTxO)
@@ -74,6 +71,7 @@ healthyCloseTx =
  where
   tx =
     closeTx
+      scriptRegistry
       somePartyCardanoVerificationKey
       closingSnapshot
       healthyCloseLowerBoundSlot
@@ -81,7 +79,11 @@ healthyCloseTx =
       openThreadOutput
       (mkHeadId Fixture.testPolicyId)
 
-  lookupUTxO = UTxO.singleton (healthyOpenHeadTxIn, healthyOpenHeadTxOut)
+  lookupUTxO =
+    UTxO.singleton (healthyOpenHeadTxIn, healthyOpenHeadTxOut)
+      <> registryUTxO scriptRegistry
+
+  scriptRegistry = genScriptRegistry `generateWith` 42
 
   headDatum = fromPlutusData $ toData healthyOpenHeadDatum
 
@@ -108,6 +110,7 @@ healthyCloseInitialTx =
  where
   tx =
     closeTx
+      scriptRegistry
       somePartyCardanoVerificationKey
       closingSnapshot
       healthyCloseLowerBoundSlot
@@ -115,7 +118,11 @@ healthyCloseInitialTx =
       openThreadOutput
       (mkHeadId Fixture.testPolicyId)
 
-  lookupUTxO = UTxO.singleton (healthyOpenHeadTxIn, healthyOpenHeadTxOut)
+  lookupUTxO =
+    UTxO.singleton (healthyOpenHeadTxIn, healthyOpenHeadTxOut)
+      <> registryUTxO scriptRegistry
+
+  scriptRegistry = genScriptRegistry `generateWith` 42
 
   headDatum = fromPlutusData $ toData healthyOpenHeadDatum
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -45,7 +45,6 @@ import Hydra.Contract.Head (
     SignerIsNotAParticipant
   ),
  )
-import qualified Hydra.Contract.Head as Head
 import qualified Hydra.Contract.HeadState as Head
 import Hydra.Contract.HeadTokens (headPolicyId)
 import Hydra.Contract.Util (UtilError (MintingOrBurningIsForbidden))

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -23,6 +23,7 @@ import Hydra.Chain.Direct.Fixture (
   testPolicyId,
   testSeedInput,
  )
+import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry)
 import Hydra.Chain.Direct.Tx (
   InitialThreadOutput (..),
   assetNameFromVerificationKey,
@@ -72,10 +73,13 @@ healthyCollectComTx =
   tx =
     collectComTx
       testNetworkId
+      scriptRegistry
       somePartyCardanoVerificationKey
       initialThreadOutput
       ((txOut &&& scriptData) <$> healthyCommits)
       (mkHeadId testPolicyId)
+
+  scriptRegistry = genScriptRegistry `generateWith` 42
 
   somePartyCardanoVerificationKey = flip generateWith 42 $ do
     genForParty genVerificationKey <$> elements healthyParties

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -179,7 +179,7 @@ healthyCommitOutput party committed =
         [ (AssetId testPolicyId (assetNameFromVerificationKey cardanoKey), 1)
         ]
   commitDatum =
-    mkCommitDatum party Head.validatorHash (Just committed) (toPlutusCurrencySymbol $ headPolicyId healthyHeadInput)
+    mkCommitDatum party (Just committed) (toPlutusCurrencySymbol $ headPolicyId healthyHeadInput)
 
 data CollectComMutation
   = MutateOpenUTxOHash

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -23,7 +23,7 @@ import Hydra.Chain.Direct.Fixture (
   testPolicyId,
   testSeedInput,
  )
-import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry)
+import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry, registryUTxO)
 import Hydra.Chain.Direct.Tx (
   InitialThreadOutput (..),
   assetNameFromVerificationKey,
@@ -68,7 +68,9 @@ healthyCollectComTx =
   (tx, lookupUTxO)
  where
   lookupUTxO =
-    UTxO.singleton (healthyHeadInput, healthyHeadResolvedInput) <> UTxO (txOut <$> healthyCommits)
+    UTxO.singleton (healthyHeadInput, healthyHeadResolvedInput)
+      <> UTxO (txOut <$> healthyCommits)
+      <> registryUTxO scriptRegistry
 
   tx =
     collectComTx

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
@@ -47,8 +47,8 @@ healthyCommitTx =
       <> registryUTxO scriptRegistry
   tx =
     commitTx
-      scriptRegistry
       Fixture.testNetworkId
+      scriptRegistry
       (mkHeadId Fixture.testPolicyId)
       commitParty
       (Just healthyCommittedUTxO)

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -26,6 +26,7 @@ import Hydra.Chain.Direct.Contract.Mutation (
   replaceUtxoHash,
  )
 import Hydra.Chain.Direct.Fixture (testNetworkId, testPolicyId)
+import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry, registryUTxO)
 import Hydra.Chain.Direct.Tx (ClosedThreadOutput (..), contestTx, mkHeadId, mkHeadOutput)
 import Hydra.ContestationPeriod (ContestationPeriod, fromChain)
 import Hydra.Contract.Error (toErrorCode)
@@ -69,8 +70,13 @@ healthyContestTx :: (Tx, UTxO)
 healthyContestTx =
   (tx, lookupUTxO)
  where
+  lookupUTxO =
+    UTxO.singleton (healthyClosedHeadTxIn, healthyClosedHeadTxOut)
+      <> registryUTxO scriptRegistry
+
   tx =
     contestTx
+      scriptRegistry
       healthyContesterVerificationKey
       healthyContestSnapshot
       (healthySignature healthyContestSnapshotNumber)
@@ -79,9 +85,9 @@ healthyContestTx =
       (mkHeadId testPolicyId)
       healthyContestationPeriod
 
-  headDatum = fromPlutusData $ toData healthyClosedState
+  scriptRegistry = genScriptRegistry `generateWith` 42
 
-  lookupUTxO = UTxO.singleton (healthyClosedHeadTxIn, healthyClosedHeadTxOut)
+  headDatum = fromPlutusData $ toData healthyClosedState
 
   closedThreadOutput =
     ClosedThreadOutput

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/FanOut.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/FanOut.hs
@@ -11,6 +11,7 @@ import Hydra.Prelude hiding (label)
 import Cardano.Api.UTxO as UTxO
 import Hydra.Chain.Direct.Contract.Mutation (Mutation (..), SomeMutation (..))
 import Hydra.Chain.Direct.Fixture (testNetworkId, testPolicyId, testSeedInput)
+import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry, registryUTxO)
 import Hydra.Chain.Direct.Tx (fanoutTx, mkHeadOutput)
 import Hydra.Contract.Error (toErrorCode)
 import Hydra.Contract.Head (
@@ -41,12 +42,19 @@ healthyFanoutTx :: (Tx, UTxO)
 healthyFanoutTx =
   (tx, lookupUTxO)
  where
+  lookupUTxO =
+    UTxO.singleton (headInput, headOutput)
+      <> registryUTxO scriptRegistry
+
   tx =
     fanoutTx
+      scriptRegistry
       healthyFanoutUTxO
       (headInput, headOutput, headDatum)
       healthySlotNo
       headTokenScript
+
+  scriptRegistry = genScriptRegistry `generateWith` 42
 
   headInput = generateWith arbitrary 42
 
@@ -67,8 +75,6 @@ healthyFanoutTx =
         parties
 
   headDatum = fromPlutusData $ toData healthyFanoutDatum
-
-  lookupUTxO = UTxO.singleton (headInput, headOutput)
 
 healthyFanoutUTxO :: UTxO
 healthyFanoutUTxO =

--- a/hydra-node/test/Hydra/Chain/Direct/ScriptRegistrySpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/ScriptRegistrySpec.hs
@@ -8,10 +8,10 @@ import Hydra.Chain.Direct.ScriptRegistry (
   newScriptRegistry,
   registryUTxO,
  )
-import Test.QuickCheck (forAll, (===))
+import Test.QuickCheck (forAllBlind, (===))
 
 spec :: Spec
 spec =
   prop "newScriptRegistry (registryUTxO r) === Just r" $
-    forAll genScriptRegistry $ \r ->
+    forAllBlind genScriptRegistry $ \r ->
       newScriptRegistry (registryUTxO r) === Right r

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -242,8 +242,8 @@ spec = parallel $ do
             when (h1 == h2) discard
             pure ((ctx1, st1), (ctx2, st2))
       forAll twoDistinctHeads $ \((ctx1, stHead1), (ctx2, stHead2)) ->
-        let observedIn1 = observeAbort stHead1 (abort mempty ctx1 stHead1)
-            observedIn2 = observeAbort stHead2 (abort mempty ctx2 stHead1)
+        let observedIn1 = observeAbort stHead1 (abort ctx1 stHead1 mempty)
+            observedIn2 = observeAbort stHead2 (abort ctx2 stHead1 mempty)
          in conjoin
               [ observedIn1 =/= Nothing
               , observedIn2 === Nothing
@@ -414,7 +414,7 @@ forAllAbort action = do
         forAllBlind (sublistOf =<< genCommits ctx initTx) $ \commits ->
           let (committed, stInitialized) = unsafeObserveInitAndCommits cctx initTx commits
               utxo = getKnownUTxO stInitialized <> getKnownUTxO cctx
-           in action utxo (abort (fold committed) cctx stInitialized)
+           in action utxo (abort cctx stInitialized (fold committed))
                 & classify
                   (null commits)
                   "Abort immediately, after 0 commits"

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -292,7 +292,7 @@ prop_canCloseFanoutEveryCollect = monadicST $ do
     Just (OnCloseTx{contestationDeadline}, st) -> pure (contestationDeadline, st)
     _ -> fail "not observed close"
   -- Fanout
-  let txFanout = fanout stClosed initialUTxO (Fixture.slotNoFromUTCTime deadline)
+  let txFanout = fanout cctx stClosed initialUTxO (Fixture.slotNoFromUTCTime deadline)
 
   -- Properties
   let collectFails =

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -338,7 +338,8 @@ propIsValid ::
   SpecWith ()
 propIsValid forAllTx =
   prop "validates within maxTxExecutionUnits" $
-    forAllTx $ \utxo tx -> propTransactionEvaluates (tx, utxo)
+    forAllTx $
+      \utxo tx -> propTransactionEvaluates (tx, utxo)
 
 --
 -- QuickCheck Extras
@@ -498,7 +499,7 @@ forAllFanout action =
        in action utxo tx
             & label ("Fanout size: " <> prettyLength (countAssets $ txOuts' tx))
  where
-  maxSupported = 35
+  maxSupported = 58
 
   countAssets = getSum . foldMap (Sum . valueSize . txOutValue)
 

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -32,7 +32,6 @@ import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry, registryUTxO)
 import Hydra.Chain.Direct.Wallet (ErrCoverFee (..), coverFee_)
 import Hydra.ContestationPeriod (ContestationPeriod (UnsafeContestationPeriod))
 import qualified Hydra.Contract.Commit as Commit
-import qualified Hydra.Contract.Head as Head
 import Hydra.Contract.HeadTokens (mkHeadTokenScript)
 import qualified Hydra.Contract.Initial as Initial
 import Hydra.Ledger.Cardano (
@@ -219,7 +218,7 @@ generateCommitUTxOs parties = do
 
     commitScript = fromPlutusScript Commit.validatorScript
 
-    commitDatum = mkCommitDatum party Head.validatorHash utxo (toPlutusCurrencySymbol testPolicyId)
+    commitDatum = mkCommitDatum party utxo (toPlutusCurrencySymbol testPolicyId)
 
 prettyEvaluationReport :: EvaluationReport -> String
 prettyEvaluationReport (Map.toList -> xs) =

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -100,6 +100,7 @@ mockChainAndNetwork tr seedKeys nodes cp = do
                      in ScriptRegistry
                           { initialReference = (txIn, txOut)
                           , commitReference = (txIn, txOut)
+                          , headReference = (txIn, txOut)
                           }
                 , contestationPeriod = cp
                 }

--- a/hydra-plutus/src/Hydra/Contract/Commit.hs
+++ b/hydra-plutus/src/Hydra/Contract/Commit.hs
@@ -82,7 +82,7 @@ deserializeCommit Commit{input, preSerializedOutput} =
 -- TODO: Party is not used on-chain but is needed off-chain while it's still
 -- based on mock crypto. When we move to real crypto we could simply use
 -- the PT's token name to identify the committing party
-type DatumType = (Party, ValidatorHash, Maybe Commit, CurrencySymbol)
+type DatumType = (Party, Maybe Commit, CurrencySymbol)
 type RedeemerType = CommitRedeemer
 
 -- | The v_commit validator verifies that:
@@ -93,7 +93,7 @@ type RedeemerType = CommitRedeemer
 --
 --   * ST is present in the output if the redeemer is 'ViaCollectCom'
 validator :: DatumType -> RedeemerType -> ScriptContext -> Bool
-validator (_party, _headScriptHash, _commit, headId) r ctx =
+validator (_party, _commit, headId) r ctx =
   case r of
     -- NOTE: The reimbursement of the committed output 'commit' is
     -- delegated to the 'head' script who has more information to do it.

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -245,7 +245,7 @@ commitDatum :: TxInfo -> TxOut -> Maybe Commit
 commitDatum txInfo input = do
   let datum = findTxOutDatum txInfo input
   case fromBuiltinData @Commit.DatumType $ getDatum datum of
-    Just (_party, _validatorHash, commit, _headId) ->
+    Just (_party, commit, _headId) ->
       commit
     Nothing -> Nothing
 {-# INLINEABLE commitDatum #-}

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -606,8 +606,6 @@ TxOutRef{txOutRefId, txOutRefIdx} `compareRef` TxOutRef{txOutRefId = id', txOutR
     ord -> ord
 {-# INLINEABLE compareRef #-}
 
--- TODO: Add a NetworkId so that we can properly serialise address hashes
--- see 'encodeAddress' for details
 compiledValidator :: CompiledCode ValidatorType
 compiledValidator =
   $$(PlutusTx.compile [||wrap headValidator||])

--- a/hydra-plutus/src/Hydra/Contract/Initial.hs
+++ b/hydra-plutus/src/Hydra/Contract/Initial.hs
@@ -143,7 +143,7 @@ checkCommit commitValidator headId committedRef context =
               Just da ->
                 case fromBuiltinData @Commit.DatumType $ getDatum da of
                   Nothing -> traceError "I12"
-                  Just (_party, _headScriptHash, mCommit, _headId) ->
+                  Just (_party, mCommit, _headId) ->
                     mCommit
       _ -> traceError "I13"
 

--- a/hydra-plutus/src/Hydra/Contract/Initial.hs
+++ b/hydra-plutus/src/Hydra/Contract/Initial.hs
@@ -12,7 +12,6 @@ import qualified Hydra.Contract.Commit as Commit
 import Hydra.Contract.Util (mustBurnST, mustNotMintOrBurn)
 import Hydra.Prelude (Show)
 import Plutus.Extras (ValidatorType, scriptValidatorHash, wrapValidator)
-import Plutus.V1.Ledger.Value (assetClass, assetClassValueOf)
 import Plutus.V2.Ledger.Api (
   CurrencySymbol,
   Datum (..),
@@ -31,8 +30,6 @@ import Plutus.V2.Ledger.Api (
   Validator (getValidator),
   ValidatorHash,
   Value (getValue),
-  adaSymbol,
-  adaToken,
   mkValidatorScript,
  )
 import Plutus.V2.Ledger.Contexts (findDatum, findOwnInput, findTxInByTxOutRef, scriptOutputsAt, valueLockedBy)
@@ -114,10 +111,7 @@ checkCommit commitValidator committedRef context@ScriptContext{scriptContextTxIn
  where
   checkCommittedValue =
     traceIfFalse "I03" $
-      traceIfFalse ("lockedValue: " `appendString` debugValue lockedValue) $
-        traceIfFalse ("initialValue: " `appendString` debugValue initialValue) $
-          traceIfFalse ("comittedValue: " `appendString` debugValue committedValue) $
-            lockedValue == initialValue + committedValue
+      lockedValue == initialValue + committedValue
 
   checkLockedCommit =
     case (committedTxOut, lockedCommit) of
@@ -159,27 +153,6 @@ checkCommit commitValidator committedRef context@ScriptContext{scriptContextTxIn
                   Just (_party, _headScriptHash, mCommit, _headId) ->
                     mCommit
       _ -> traceError "I13"
-
-  debugValue v =
-    debugInteger . assetClassValueOf v $ assetClass adaSymbol adaToken
-
--- | Show an 'Integer' as decimal number. This is very inefficient and only
--- should be used for debugging.
-debugInteger :: Integer -> BuiltinString
-debugInteger i
-  | i == 0 = "0"
-  | i == 1 = "1"
-  | i == 2 = "2"
-  | i == 3 = "3"
-  | i == 4 = "4"
-  | i == 5 = "5"
-  | i == 6 = "6"
-  | i == 7 = "7"
-  | i == 8 = "8"
-  | i == 9 = "9"
-  | i >= 10 = debugInteger (i `quotient` 10) `appendString` "0"
-  | otherwise = "-" `appendString` debugInteger (negate i)
-{-# INLINEABLE debugInteger #-}
 
 compiledValidator :: CompiledCode ValidatorType
 compiledValidator =


### PR DESCRIPTION
Draft PR to show the difference of when we would publish & reference all the validator scripts into.

This will not pass integration tests as the publishing transaction is too big (obviously).

UPDATE: Recent advancements made it possible to fit all three scripts in one transactions and this is now possible!

---

* :zap: Also publish `vHead` on chain and reference it from all Head transactions. This makes all these transactions about 10kB smaller!

* :zap: Remove some debugging code from `vInitial` and refactor it a bit.

* :zap: Remove unused validator hash from `vCommit` to make it just fit.. barely :package:

* :zap: Increased limits of tests again to `58` UTxOs.

---

<!-- Tick off or strike-through / remove if not applicable -->
* [ ] CHANGELOG updated
* [x] Documentation updated
* [x] Added and/or updated haddocks
* [x] No new TODOs introduced or explained herafter
