### PR TITLE
Check that value is preserved in v_head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ changes.
   + Check no tokens are minted/burnt in v-head for close, contest, commit and collectCom tx.
   + The v_head output must now be the first output of the transaction so that we can make the validator code simpler.
   + Introduce check in head validator to allow contest only once per party.
+  + Check that value is preserved in v_head
 
 - **BREAKING** Change the way tx validity and contestation deadline is constructed for close transactions:
   + There is a new hydra-node flag `--contestation-period` expressed in seconds

--- a/hydra-node/exe/tx-cost/TxCost.hs
+++ b/hydra-node/exe/tx-cost/TxCost.hs
@@ -129,8 +129,8 @@ computeCollectComCost =
 
 computeCloseCost :: IO [(NumParties, TxSize, MemUnit, CpuUnit, Lovelace)]
 computeCloseCost = do
-  interesting <- catMaybes <$> mapM compute [1, 2, 3, 5, 10, 30]
-  limit <- maybeToList . getFirst <$> foldMapM (fmap First . compute) [100, 99 .. 31]
+  interesting <- catMaybes <$> mapM compute [1, 2, 3, 5, 10]
+  limit <- maybeToList . getFirst <$> foldMapM (fmap First . compute) [50, 49 .. 11]
   pure $ interesting <> limit
  where
   compute numParties = do
@@ -144,8 +144,8 @@ computeCloseCost = do
 
 computeContestCost :: IO [(NumParties, TxSize, MemUnit, CpuUnit, Lovelace)]
 computeContestCost = do
-  interesting <- catMaybes <$> mapM compute [1, 2, 3, 5, 10, 30]
-  limit <- maybeToList . getFirst <$> foldMapM (fmap First . compute) [100, 99 .. 31]
+  interesting <- catMaybes <$> mapM compute [1, 2, 3, 5, 10]
+  limit <- maybeToList . getFirst <$> foldMapM (fmap First . compute) [50, 49 .. 11]
   pure $ interesting <> limit
  where
   compute numParties = do

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -28,6 +28,7 @@ import Hydra.Chain.Direct.Fixture (testNetworkId)
 import qualified Hydra.Chain.Direct.Fixture as Fixture
 import Hydra.Chain.Direct.TimeHandle (PointInTime)
 import Hydra.Chain.Direct.Tx (ClosingSnapshot (..), OpenThreadOutput (..), UTxOHash (UTxOHash), closeTx, mkHeadId, mkHeadOutput)
+import Hydra.Chain.Direct.Util (addChangeOutput)
 import Hydra.ContestationPeriod (fromChain)
 import qualified Hydra.Contract.HeadState as Head
 import Hydra.Contract.HeadTokens (headPolicyId)
@@ -58,13 +59,14 @@ healthyCloseTx =
   (tx, lookupUTxO)
  where
   tx =
-    closeTx
-      somePartyCardanoVerificationKey
-      closingSnapshot
-      healthyCloseLowerBoundSlot
-      healthyCloseUpperBoundPointInTime
-      openThreadOutput
-      (mkHeadId Fixture.testPolicyId)
+    addChangeOutput $
+      closeTx
+        somePartyCardanoVerificationKey
+        closingSnapshot
+        healthyCloseLowerBoundSlot
+        healthyCloseUpperBoundPointInTime
+        openThreadOutput
+        (mkHeadId Fixture.testPolicyId)
 
   lookupUTxO = UTxO.singleton (healthyOpenHeadTxIn, healthyOpenHeadTxOut)
 
@@ -92,13 +94,14 @@ healthyCloseInitialTx =
   (tx, lookupUTxO)
  where
   tx =
-    closeTx
-      somePartyCardanoVerificationKey
-      closingSnapshot
-      healthyCloseLowerBoundSlot
-      healthyCloseUpperBoundPointInTime
-      openThreadOutput
-      (mkHeadId Fixture.testPolicyId)
+    addChangeOutput $
+      closeTx
+        somePartyCardanoVerificationKey
+        closingSnapshot
+        healthyCloseLowerBoundSlot
+        healthyCloseUpperBoundPointInTime
+        openThreadOutput
+        (mkHeadId Fixture.testPolicyId)
 
   lookupUTxO = UTxO.singleton (healthyOpenHeadTxIn, healthyOpenHeadTxOut)
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -28,7 +28,6 @@ import Hydra.Chain.Direct.Fixture (testNetworkId)
 import qualified Hydra.Chain.Direct.Fixture as Fixture
 import Hydra.Chain.Direct.TimeHandle (PointInTime)
 import Hydra.Chain.Direct.Tx (ClosingSnapshot (..), OpenThreadOutput (..), UTxOHash (UTxOHash), closeTx, mkHeadId, mkHeadOutput)
-import Hydra.Chain.Direct.Util (addChangeOutput)
 import Hydra.ContestationPeriod (fromChain)
 import qualified Hydra.Contract.HeadState as Head
 import Hydra.Contract.HeadTokens (headPolicyId)
@@ -59,14 +58,13 @@ healthyCloseTx =
   (tx, lookupUTxO)
  where
   tx =
-    addChangeOutput $
-      closeTx
-        somePartyCardanoVerificationKey
-        closingSnapshot
-        healthyCloseLowerBoundSlot
-        healthyCloseUpperBoundPointInTime
-        openThreadOutput
-        (mkHeadId Fixture.testPolicyId)
+    closeTx
+      somePartyCardanoVerificationKey
+      closingSnapshot
+      healthyCloseLowerBoundSlot
+      healthyCloseUpperBoundPointInTime
+      openThreadOutput
+      (mkHeadId Fixture.testPolicyId)
 
   lookupUTxO = UTxO.singleton (healthyOpenHeadTxIn, healthyOpenHeadTxOut)
 
@@ -94,14 +92,13 @@ healthyCloseInitialTx =
   (tx, lookupUTxO)
  where
   tx =
-    addChangeOutput $
-      closeTx
-        somePartyCardanoVerificationKey
-        closingSnapshot
-        healthyCloseLowerBoundSlot
-        healthyCloseUpperBoundPointInTime
-        openThreadOutput
-        (mkHeadId Fixture.testPolicyId)
+    closeTx
+      somePartyCardanoVerificationKey
+      closingSnapshot
+      healthyCloseLowerBoundSlot
+      healthyCloseUpperBoundPointInTime
+      openThreadOutput
+      (mkHeadId Fixture.testPolicyId)
 
   lookupUTxO = UTxO.singleton (healthyOpenHeadTxIn, healthyOpenHeadTxOut)
 

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -398,7 +398,7 @@ forAllFanout action =
        in action utxo tx
             & label ("Fanout size: " <> prettyLength (countAssets $ txOuts' tx))
  where
-  maxSupported = 30
+  maxSupported = 39
 
   countAssets = getSum . foldMap (Sum . valueSize . txOutValue)
 

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -398,7 +398,7 @@ forAllFanout action =
        in action utxo tx
             & label ("Fanout size: " <> prettyLength (countAssets $ txOuts' tx))
  where
-  maxSupported = 39
+  maxSupported = 38
 
   countAssets = getSum . foldMap (Sum . valueSize . txOutValue)
 

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -21,7 +21,7 @@ import PlutusTx.Prelude
 import Hydra.Contract.Commit (Commit (..))
 import qualified Hydra.Contract.Commit as Commit
 import Hydra.Contract.HeadState (Input (..), Signature, SnapshotNumber, State (..))
-import Hydra.Contract.Util (hasST, headOutputValue, mustNotMintOrBurn, mustPreserveValue)
+import Hydra.Contract.Util (hasST, mustNotMintOrBurn, mustPreserveValue)
 import Hydra.Data.ContestationPeriod (ContestationPeriod, addContestationPeriod, milliseconds)
 import Hydra.Data.Party (Party (vkey))
 import Plutus.Extras (ValidatorType, scriptValidatorHash, wrapValidator)
@@ -280,7 +280,7 @@ checkClose ctx parties initialUtxoHash sig cperiod headPolicyId =
     && mustNotChangeParameters
     && mustPreserveValue outValue headOutValue
  where
-  headOutValue = headOutputValue $ txInfoOutputs txInfo
+  headOutValue = txOutValue . head $ txInfoOutputs txInfo
   hasBoundedValidity =
     traceIfFalse "hasBoundedValidity check failed" $
       tMax - tMin <= cp
@@ -377,7 +377,7 @@ checkContest ctx contestationDeadline parties closedSnapshotNumber sig contester
     && mustNotChangeParameters
     && mustPreserveValue outValue headOutValue
  where
-  headOutValue = headOutputValue $ txInfoOutputs txInfo
+  headOutValue = txOutValue . head $ txInfoOutputs txInfo
   outValue =
     maybe mempty (txOutValue . txInInfoResolved) $ findOwnInput ctx
 

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -278,7 +278,16 @@ checkClose ctx parties initialUtxoHash sig cperiod headPolicyId =
     && hasST headPolicyId outValue
     && mustInitializeContesters
     && mustNotChangeParameters
+    && mustPreserveValue
  where
+  mustPreserveValue =
+    traceIfFalse "head value is not preserved" $
+      outValue == headOutputValue
+  headOutputValue =
+    case txInfoOutputs txInfo of
+      [headOutput, _] -> txOutValue headOutput
+      _ -> traceError "does not have exactly two outputs"
+
   hasBoundedValidity =
     traceIfFalse "hasBoundedValidity check failed" $
       tMax - tMin <= cp

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -21,7 +21,7 @@ import PlutusTx.Prelude
 import Hydra.Contract.Commit (Commit (..))
 import qualified Hydra.Contract.Commit as Commit
 import Hydra.Contract.HeadState (Input (..), Signature, SnapshotNumber, State (..))
-import Hydra.Contract.Util (hasST, mustNotMintOrBurn)
+import Hydra.Contract.Util (hasST, headOutputValue, mustNotMintOrBurn, mustPreserveValue)
 import Hydra.Data.ContestationPeriod (ContestationPeriod, addContestationPeriod, milliseconds)
 import Hydra.Data.Party (Party (vkey))
 import Plutus.Extras (ValidatorType, scriptValidatorHash, wrapValidator)
@@ -278,16 +278,9 @@ checkClose ctx parties initialUtxoHash sig cperiod headPolicyId =
     && hasST headPolicyId outValue
     && mustInitializeContesters
     && mustNotChangeParameters
-    && mustPreserveValue
+    && mustPreserveValue outValue headOutValue
  where
-  mustPreserveValue =
-    traceIfFalse "head value is not preserved" $
-      outValue == headOutputValue
-  headOutputValue =
-    case txInfoOutputs txInfo of
-      [headOutput, _] -> txOutValue headOutput
-      _ -> traceError "does not have exactly two outputs"
-
+  headOutValue = headOutputValue $ txInfoOutputs txInfo
   hasBoundedValidity =
     traceIfFalse "hasBoundedValidity check failed" $
       tMax - tMin <= cp
@@ -382,7 +375,9 @@ checkContest ctx contestationDeadline parties closedSnapshotNumber sig contester
     && hasST headId outValue
     && mustUpdateContesters
     && mustNotChangeParameters
+    && mustPreserveValue outValue headOutValue
  where
+  headOutValue = headOutputValue $ txInfoOutputs txInfo
   outValue =
     maybe mempty (txOutValue . txInInfoResolved) $ findOwnInput ctx
 

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -277,15 +277,17 @@ checkClose ctx parties initialUtxoHash sig cperiod headPolicyId =
     && checkDeadline
     && checkSnapshot
     && mustBeSignedByParticipant ctx headPolicyId
-    && hasST headPolicyId val
     && mustInitializeContesters
     && hasST headPolicyId val
-    && mustNotChangeParameters
     && mustPreserveValue
+    && mustNotChangeParameters
  where
-
   mustPreserveValue =
     traceIfFalse "head value is not preserved" $
+      -- XXX: Equality on value is very memory intensive as it's defined on
+      -- associative lists and Map equality is implemented. Instead we should be
+      -- more strict and require EXACTLY the same value and compare using a
+      -- simple fold or even compare the serialised bytes.
       val == val'
 
   val' = txOutValue . head $ txInfoOutputs txInfo
@@ -389,6 +391,10 @@ checkContest ctx contestationDeadline parties closedSnapshotNumber sig contester
  where
   mustPreserveValue =
     traceIfFalse "head value is not preserved" $
+      -- XXX: Equality on value is very memory intensive as it's defined on
+      -- associative lists and Map equality is implemented. Instead we should be
+      -- more strict and require EXACTLY the same value and compare using a
+      -- simple fold or even compare the serialised bytes.
       val == val'
 
   val' = txOutValue . head $ txInfoOutputs txInfo

--- a/hydra-plutus/src/Hydra/Contract/Util.hs
+++ b/hydra-plutus/src/Hydra/Contract/Util.hs
@@ -8,6 +8,7 @@ import Plutus.V2.Ledger.Api (
   CurrencySymbol,
   TokenName (..),
   TxInfo (TxInfo, txInfoMint),
+  TxOut (txOutValue),
   Value (getValue),
  )
 import qualified PlutusTx.AssocMap as Map
@@ -46,3 +47,14 @@ mustNotMintOrBurn TxInfo{txInfoMint} =
   traceIfFalse "minting or burning is forbidden" $
     isZero txInfoMint
 {-# INLINEABLE mustNotMintOrBurn #-}
+
+mustPreserveValue :: Value -> Value -> Bool
+mustPreserveValue outValue headOutValue =
+  traceIfFalse "head value is not preserved" $
+    outValue == headOutValue
+{-# INLINEABLE mustPreserveValue #-}
+
+headOutputValue :: [TxOut] -> Value
+headOutputValue (headOutput : _outputs) = txOutValue headOutput
+headOutputValue _ = traceError "does not have at least head output"
+{-# INLINEABLE headOutputValue #-}

--- a/hydra-plutus/src/Hydra/Contract/Util.hs
+++ b/hydra-plutus/src/Hydra/Contract/Util.hs
@@ -47,8 +47,3 @@ mustNotMintOrBurn TxInfo{txInfoMint} =
     isZero txInfoMint
 {-# INLINEABLE mustNotMintOrBurn #-}
 
-mustPreserveValue :: Value -> Value -> Bool
-mustPreserveValue outValue headOutValue =
-  traceIfFalse "head value is not preserved" $
-    outValue == headOutValue
-{-# INLINEABLE mustPreserveValue #-}

--- a/hydra-plutus/src/Hydra/Contract/Util.hs
+++ b/hydra-plutus/src/Hydra/Contract/Util.hs
@@ -8,7 +8,6 @@ import Plutus.V2.Ledger.Api (
   CurrencySymbol,
   TokenName (..),
   TxInfo (TxInfo, txInfoMint),
-  TxOut (txOutValue),
   Value (getValue),
  )
 import qualified PlutusTx.AssocMap as Map
@@ -53,8 +52,3 @@ mustPreserveValue outValue headOutValue =
   traceIfFalse "head value is not preserved" $
     outValue == headOutValue
 {-# INLINEABLE mustPreserveValue #-}
-
-headOutputValue :: [TxOut] -> Value
-headOutputValue (headOutput : _outputs) = txOutValue headOutput
-headOutputValue _ = traceError "does not have at least head output"
-{-# INLINEABLE headOutputValue #-}


### PR DESCRIPTION

## Why

According to spec `5.5. rule 6 -> value is preserved` there should be a validator check to make sure the head value is preserved. Note that `checkAbort` and `checkFanout` head transitions should not contain this check.

To check before merging:
* [x] CHANGELOG is up to date
* [x] Up to date with master
