### PR TITLE
ADD explicit error expectations for Fanout and CollecCom

### DIFF
--- a/hydra-node/test/Hydra/Chain/Direct/Contract/FanOut.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/FanOut.hs
@@ -94,9 +94,9 @@ data FanoutMutation
 genFanoutMutation :: (Tx, UTxO) -> Gen SomeMutation
 genFanoutMutation (tx, _utxo) =
   oneof
-    [ SomeMutation Nothing MutateAddUnexpectedOutput . PrependOutput <$> do
+    [ SomeMutation (Just "fannedOutUtxoHash /= closedUtxoHash") MutateAddUnexpectedOutput . PrependOutput <$> do
         arbitrary >>= genOutput
-    , SomeMutation Nothing MutateChangeOutputValue <$> do
+    , SomeMutation (Just "fannedOutUtxoHash /= closedUtxoHash") MutateChangeOutputValue <$> do
         let outs = txOuts' tx
         -- NOTE: Assumes the fanout transaction has non-empty outputs, which
         -- might not be always the case when testing unbalanced txs and we need
@@ -104,7 +104,7 @@ genFanoutMutation (tx, _utxo) =
         (ix, out) <- elements (zip [0 .. length outs - 1] outs)
         value' <- genValue `suchThat` (/= txOutValue out)
         pure $ ChangeOutput (fromIntegral ix) (modifyTxOutValue (const value') out)
-    , SomeMutation Nothing MutateValidityBeforeDeadline . ChangeValidityInterval <$> do
+    , SomeMutation (Just "lower bound before contestation deadline") MutateValidityBeforeDeadline . ChangeValidityInterval <$> do
         lb <- arbitrary `suchThat` slotBeforeContestationDeadline
         pure (TxValidityLowerBound lb, TxValidityNoUpperBound)
     ]

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -182,7 +182,7 @@ checkCollectCom ctx@ScriptContext{scriptContextTxInfo = txInfo} (contestationPer
     && mustNotChangeParameters
     && everyoneHasCommitted
     && mustBeSignedByParticipant ctx headId
-    && hasST headId val
+    && traceIfFalse "ST not spent" (hasST headId val)
  where
   mustCollectUtxoHash =
     traceIfFalse "incorrect utxo hash" $


### PR DESCRIPTION
This contributes to moving #705 forward.

To check before merging:
* [x] CHANGELOG is up to date
* [x] Up to date with master
