### PR TITLE
Introduce strict equality check for PlutusTx Value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ changes.
   + The v_head output must now be the first output of the transaction so that we can make the validator code simpler.
   + Introduce check in head validator to allow contest only once per party.
   + Check that value is preserved in v_head
+  + Introduce a function `(===!)` for strict equality check between serialized `Value`.
 
 - **BREAKING** Change the way tx validity and contestation deadline is constructed for close transactions:
   + There is a new hydra-node flag `--contestation-period` expressed in seconds

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -398,7 +398,7 @@ forAllFanout action =
        in action utxo tx
             & label ("Fanout size: " <> prettyLength (countAssets $ txOuts' tx))
  where
-  maxSupported = 38
+  maxSupported = 45
 
   countAssets = getSum . foldMap (Sum . valueSize . txOutValue)
 

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -21,7 +21,7 @@ import PlutusTx.Prelude
 import Hydra.Contract.Commit (Commit (..))
 import qualified Hydra.Contract.Commit as Commit
 import Hydra.Contract.HeadState (Input (..), Signature, SnapshotNumber, State (..))
-import Hydra.Contract.Util (hasST, mustNotMintOrBurn)
+import Hydra.Contract.Util (hasST, mustNotMintOrBurn, (===!))
 import Hydra.Data.ContestationPeriod (ContestationPeriod, addContestationPeriod, milliseconds)
 import Hydra.Data.Party (Party (vkey))
 import Plutus.Extras (ValidatorType, scriptValidatorHash, wrapValidator)
@@ -284,11 +284,7 @@ checkClose ctx parties initialUtxoHash sig cperiod headPolicyId =
  where
   mustPreserveValue =
     traceIfFalse "head value is not preserved" $
-      -- XXX: Equality on value is very memory intensive as it's defined on
-      -- associative lists and Map equality is implemented. Instead we should be
-      -- more strict and require EXACTLY the same value and compare using a
-      -- simple fold or even compare the serialised bytes.
-      val == val'
+      val ===! val'
 
   val' = txOutValue . head $ txInfoOutputs txInfo
 
@@ -391,11 +387,7 @@ checkContest ctx contestationDeadline parties closedSnapshotNumber sig contester
  where
   mustPreserveValue =
     traceIfFalse "head value is not preserved" $
-      -- XXX: Equality on value is very memory intensive as it's defined on
-      -- associative lists and Map equality is implemented. Instead we should be
-      -- more strict and require EXACTLY the same value and compare using a
-      -- simple fold or even compare the serialised bytes.
-      val == val'
+      val ===! val'
 
   val' = txOutValue . head $ txInfoOutputs txInfo
 

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -21,7 +21,7 @@ import PlutusTx.Prelude
 import Hydra.Contract.Commit (Commit (..))
 import qualified Hydra.Contract.Commit as Commit
 import Hydra.Contract.HeadState (Input (..), Signature, SnapshotNumber, State (..))
-import Hydra.Contract.Util (hasST, mustNotMintOrBurn, (===!))
+import Hydra.Contract.Util (hasST, mustNotMintOrBurn, (===))
 import Hydra.Data.ContestationPeriod (ContestationPeriod, addContestationPeriod, milliseconds)
 import Hydra.Data.Party (Party (vkey))
 import Plutus.Extras (ValidatorType, scriptValidatorHash, wrapValidator)
@@ -284,7 +284,7 @@ checkClose ctx parties initialUtxoHash sig cperiod headPolicyId =
  where
   mustPreserveValue =
     traceIfFalse "head value is not preserved" $
-      val ===! val'
+      val === val'
 
   val' = txOutValue . head $ txInfoOutputs txInfo
 
@@ -387,7 +387,7 @@ checkContest ctx contestationDeadline parties closedSnapshotNumber sig contester
  where
   mustPreserveValue =
     traceIfFalse "head value is not preserved" $
-      val ===! val'
+      val === val'
 
   val' = txOutValue . head $ txInfoOutputs txInfo
 

--- a/hydra-plutus/src/Hydra/Contract/Util.hs
+++ b/hydra-plutus/src/Hydra/Contract/Util.hs
@@ -50,13 +50,13 @@ mustNotMintOrBurn TxInfo{txInfoMint} =
 
 
 
-infix 4 ===!
+infix 4 ===
 
 -- | Checks for exact exuality between two serialized values
 -- Equality on value is very memory intensive as it's defined on associative
 -- lists and Map equality is implemented. Instead we can be more strict and
 -- require EXACTLY the same value and compare using the serialised bytes.
-(===!) :: Value -> Value -> Bool
-(===!) val val' =
+(===) :: Value -> Value -> Bool
+(===) val val' =
   serialiseData (toBuiltinData val) == serialiseData (toBuiltinData val')
-{-# INLINEABLE (===!) #-}
+{-# INLINEABLE (===) #-}

--- a/hydra-plutus/src/Hydra/Contract/Util.hs
+++ b/hydra-plutus/src/Hydra/Contract/Util.hs
@@ -8,10 +8,11 @@ import Plutus.V2.Ledger.Api (
   CurrencySymbol,
   TokenName (..),
   TxInfo (TxInfo, txInfoMint),
-  Value (getValue),
+  Value (getValue), toBuiltinData,
  )
 import qualified PlutusTx.AssocMap as Map
 import PlutusTx.Prelude
+import PlutusTx.Builtins (serialiseData)
 
 hydraHeadV1 :: BuiltinByteString
 hydraHeadV1 = "HydraHeadV1"
@@ -47,3 +48,15 @@ mustNotMintOrBurn TxInfo{txInfoMint} =
     isZero txInfoMint
 {-# INLINEABLE mustNotMintOrBurn #-}
 
+
+
+infix 4 ===!
+
+-- | Checks for exact exuality between two serialized values
+-- Equality on value is very memory intensive as it's defined on associative
+-- lists and Map equality is implemented. Instead we can be more strict and
+-- require EXACTLY the same value and compare using the serialised bytes.
+(===!) :: Value -> Value -> Bool
+(===!) val val' =
+  serialiseData (toBuiltinData val) == serialiseData (toBuiltinData val')
+{-# INLINEABLE (===!) #-}


### PR DESCRIPTION
## Why
We found out that equality check `(==)` on `Value` is expensive in `PlutusTx`. Values are implemented as _map of maps_ and _map_ here is just an associative list and this check cares to be able to find the appropriate value for the key anywhere in this list.

Since we know that two values and their order should be the same we can leverage this to serialize the data
and then do equality check on `BuiltinBytestring` which is cheaper.

## What
Introduce a new function to do the _strict_ equality check between serialized representation of two Values.

To check before merging:
* [x] CHANGELOG is up to date
* [x] Up to date with master
