### PR TITLE
No need to check quantity, PT distribution when minting tokens

### DIFF
--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -636,8 +636,9 @@ observeInitTx networkId cardanoKeys expectedCP party tx = do
 
   assetNames headAssetName =
     [ assetName
-    | (AssetId _ assetName, _) <- txMintAssets tx
+    | (AssetId _ assetName, assetQuantity) <- txMintAssets tx
     , assetName /= headAssetName
+    , assetQuantity == 1
     ]
 
 data CommitObservation = CommitObservation

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -149,9 +149,9 @@ spec = parallel $ do
               let wrongCctx =
                     ChainContext
                       { networkId = networkId cctx
-                      , -- Here we use a wrong number of cardano-keys to build the tx
+                      , -- Here we use wrong cardano-keys to build the tx
                         -- as they are used to generate the PT tokens to be minted
-                        peerVerificationKeys = List.tail $ peerVerificationKeys cctx
+                        peerVerificationKeys = ownVerificationKey cctx : List.tail (peerVerificationKeys cctx)
                       , ownVerificationKey = ownVerificationKey cctx
                       , ownParty = ownParty cctx
                       , scriptRegistry = scriptRegistry cctx

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -49,6 +49,7 @@ import Hydra.Chain.Direct.State (
   genContestTx,
   genFanoutTx,
   genHydraContext,
+  genHydraContextFor,
   genInitTx,
   genStInitial,
   getContestationDeadline,
@@ -141,7 +142,7 @@ spec = parallel $ do
                in isNothing (observeInit cctxB tx)
 
     prop "is not observed if wrong number of PT tokens distributed" $
-      forAll (genHydraContext maximumNumberOfParties) $ \ctx ->
+      forAll (genHydraContextFor maximumNumberOfParties) $ \ctx ->
         forAll (pickChainContext ctx) $
           \cctx ->
             forAll genTxIn $ \seedInput ->

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -151,7 +151,7 @@ spec = parallel $ do
                       { networkId = networkId cctx
                       , -- Here we use wrong cardano-keys to build the tx
                         -- as they are used to generate the PT tokens to be minted
-                        peerVerificationKeys = ownVerificationKey cctx : List.tail (peerVerificationKeys cctx)
+                        peerVerificationKeys = List.head (peerVerificationKeys cctx) : peerVerificationKeys cctx
                       , ownVerificationKey = ownVerificationKey cctx
                       , ownParty = ownParty cctx
                       , scriptRegistry = scriptRegistry cctx

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -14,7 +14,6 @@ import Test.Hydra.Prelude
 
 import qualified Cardano.Api.UTxO as UTxO
 import Cardano.Ledger.Babbage.PParams (PParams)
-import qualified Data.List as List
 import qualified Data.Map as Map
 import qualified Data.Text as T
 import GHC.Natural (wordToNatural)
@@ -123,21 +122,6 @@ spec =
                 & counterexample "Failed to ignore init tx with the wrong contestation period."
                 & counterexample (renderTx tx)
             Nothing -> property True
-
-    describe "initTx" $ do
-      prop "Ignore InitTx with wrong number of PT tokens distributed" $
-        withMaxSuccess 60 $ \txIn cperiod (party :| parties) cardanoKeys ->
-          let params = HeadParameters cperiod (party : parties)
-              -- Here we use a wrong number of cardano-keys to build the tx
-              -- as they are used to generate the PT tokens to be minted
-              wrongCardanoKeys = List.tail cardanoKeys
-              tx = initTx testNetworkId wrongCardanoKeys params txIn
-           in case observeInitTx testNetworkId cardanoKeys cperiod party tx of
-                Just InitObservation{} -> do
-                  property False
-                    & counterexample "Failed to ignore init tx with the wrong number of PT tokens distributed."
-                    & counterexample (renderTx tx)
-                Nothing -> property True
 
 ledgerPParams :: PParams LedgerEra
 ledgerPParams = toLedgerPParams (shelleyBasedEra @Era) pparams

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -14,6 +14,7 @@ import Test.Hydra.Prelude
 
 import qualified Cardano.Api.UTxO as UTxO
 import Cardano.Ledger.Babbage.PParams (PParams)
+import qualified Data.List as List
 import qualified Data.Map as Map
 import qualified Data.Text as T
 import GHC.Natural (wordToNatural)
@@ -122,6 +123,21 @@ spec =
                 & counterexample "Failed to ignore init tx with the wrong contestation period."
                 & counterexample (renderTx tx)
             Nothing -> property True
+
+    describe "initTx" $ do
+      prop "Ignore InitTx with wrong number of PT tokens distributed" $
+        withMaxSuccess 60 $ \txIn cperiod (party :| parties) cardanoKeys ->
+          let params = HeadParameters cperiod (party : parties)
+              -- Here we use a wrong number of cardano-keys to build the tx
+              -- as they are used to generate the PT tokens to be minted
+              wrongCardanoKeys = List.tail cardanoKeys
+              tx = initTx testNetworkId wrongCardanoKeys params txIn
+           in case observeInitTx testNetworkId cardanoKeys cperiod party tx of
+                Just InitObservation{} -> do
+                  property False
+                    & counterexample "Failed to ignore init tx with the wrong number of PT tokens distributed."
+                    & counterexample (renderTx tx)
+                Nothing -> property True
 
 ledgerPParams :: PParams LedgerEra
 ledgerPParams = toLedgerPParams (shelleyBasedEra @Era) pparams

--- a/hydra-plutus/src/Hydra/Contract/HeadTokens.hs
+++ b/hydra-plutus/src/Hydra/Contract/HeadTokens.hs
@@ -52,10 +52,11 @@ validate initialValidator headValidator seedInput action context =
 validateTokensMinting :: ValidatorHash -> ValidatorHash -> TxOutRef -> ScriptContext -> Bool
 validateTokensMinting initialValidator headValidator seedInput context =
   traceIfFalse "minted wrong" $
-    participationTokensAreDistributed currency initialValidator txInfo nParties
+    seedInputIsConsumed
+      -- TODO remove below checks and Init mutations
+      && participationTokensAreDistributed currency initialValidator txInfo nParties
       && checkQuantities
       && assetNamesInPolicy == nParties + 1
-      && seedInputIsConsumed
  where
   currency = ownCurrencySymbol context
 


### PR DESCRIPTION
Actors check off-chain whether an initTx is well-formed during observation
 - Determine minted quantities
 - PT tokens are well distributed
 - and whether PTs are paid to v_initial.


* [ ] CHANGELOG is up to date
* [ ] Documentation is up to date
