### PR TITLE
Parse mainnet network flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,7 @@ changes.
 
 - **BREAKING**
  - Changed `hydra-node` and `hydra-tui` arguments.
- - Instead of `--network-id` flag they now use `--testnet-magic`.
-
-- Hydra node can now parse `Mainnet` network command line argument.
+ - Instead of `--network-id` flag they now use `--testnet-magic` and we support also `--mainnet` flag.
 
 - Changed interface of `Hydra.Ledger.Cardano.Evaluate` functions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,83 +10,119 @@ changes.
 
 ## [0.10.0] - UNRELEASED
 
+- Hydra node can now parse `Mainnet` network command line argument.
+
 - Changed interface of `Hydra.Ledger.Cardano.Evaluate` functions.
+
 
 ## [0.9.0] - 2023-03-02
 
-- Reduced the number of supported parties to `3`. This was caused by increased
-  size of minting policy and head validator scripts.
+:dragon_face: Renamed the repository from `hydra-poc` to [`hydra`](https://github.com/input-output-hk/hydra)!
+
+:warning: Delete your persistence directory!
+
+This release contains several breaking changes and you'll need to apply the
+following procedure to upgrade all the nodes running a head:
+
+1. Close the head
+2. Stop `hydra-node`
+3. Remove persistent files stored in `--persistence-dir`, in particular `server-output` and `state`
+4. Upgrade `hydra-node` version
+5. Start new `hydra-node` version
+
+Only when this procedure has been applied to all Hydra nodes can you open a new head again.
+
+### Changes to `hydra-node`
+
+- **BREAKING** Changes in the persistence format
+  [#725](https://github.com/input-output-hk/hydra/pull/725),
+  [#745](https://github.com/input-output-hk/hydra/pull/745).
 
 - **BREAKING** Changes to the API:
-  + Remove `TxSeen` and `TxExpired` server outputs. Use the `TxValid` and `TxInvalid` responses instead.
+  + Removed `TxSeen` and `TxExpired` server outputs. Use the `TxValid` and
+    `TxInvalid` responses instead.
   + All participants now see `TxValid` for all valid transactions (it replaces `TxSeen`).
-  + Rename `ReadyToCommit -> HeadIsInitializing`
-  + Add the `HeadId` to most server outputs. [#678](https://github.com/input-output-hk/hydra/pull/678)
-  + Add a `timestamp` and a monotonic `seq`uence number. [#618](https://github.com/input-output-hk/hydra/pull/618)
+  + Renamed `ReadyToCommit -> HeadIsInitializing`
+  + Added a `headId` to most server outputs. [#678](https://github.com/input-output-hk/hydra/pull/678)
+  + Added a `timestamp` and a monotonic `seq`uence number. [#618](https://github.com/input-output-hk/hydra/pull/618)
 
-- **BREAKING** `hydra-cardano-api` changes:
-  + Remove `Hydra.Cardano.Api.SlotNo` module.
-  + Replace `fromConsensusPointHF` with `fromConsensusPointInMode` and
-    `toConsensusPointHF` with `toConsensusPointInMode`.
-  + Re-export new `AcquiringFailure` type from `cardano-api`.
-  + Add `fromPlutusCurrencySymbol` conversion function.
-  + Introduce new `Hydra.Cardano.Api.Pretty` module and move functions
-    `renderTx`, `renderTxWithUTxO` and `renderTxs` from `hydra-node` package to
-    this new module.
+- **BREAKING** Addressed short-comings in `hydra-plutus` scripts
+  [#452](https://github.com/input-output-hk/hydra/pull/452) and improved their
+  performance / reduced cost
+  [#652](https://github.com/input-output-hk/hydra/pull/652),
+  [#701](https://github.com/input-output-hk/hydra/pull/701),
+  [#709](https://github.com/input-output-hk/hydra/pull/709). Roughly the cost of
+  transactions according to our
+  [benchmarks](https://hydra.family/head-protocol/benchmarks/transaction-cost/)
+  changed:
+  
+  + Init increased by 10%.
+  + Commit reduced by 50%.
+  + Collect reduced by 30%.
+  + Close reduced by 0.2-0.3₳
+  + Contest reduced by 0.1-0.2₳.
+  + Abort reduced by 0.1-0.3₳.
+  + Fanout reduced by 0.2-0.3₳.
 
-- **BREAKING** Addressed short-comings in `hydra-plutus` scripts:
-  + Check presence of state token (ST) and that it's consistent against datum.
-  + Reduce cost of `commitTx` by using the initial script as input reference.
-  + Moved check to reimburse commits to head validator and ensure its completeness.
-  + Remove snapshot number and utxo hash from Close and Contest reedemer as they
-    were already present in Closed datum.
-  + Check no tokens are minted/burnt in v-head for close, contest, commit and collectCom tx.
-  + The v_head output must now be the first output of the transaction so that we can make the validator code simpler.
-  + Introduce check in head validator to allow contest only once per party.
-  + Check that value is preserved in v_head
-  + Introduce a function `(===)` for strict equality check between serialized `Value`.
-  + Push contestation deadline on contest.
-  + Improve on-chain checks when minting tokens and off-chain checks when
-    observing `initTx` so that we ensure we are part of the _proper_ head.
-
-- **BREAKING** Change the way tx validity and contestation deadline is constructed for close transactions:
+- **BREAKING** Change the way contestation period and deadline are handled:
   + There is a new hydra-node flag `--contestation-period` expressed in seconds
     to control the close tx validity bounds as well as determine the
-    contestation deadline. (e.g. with `--contestation-period` 30s, the node will
-    close the head 30s after submitting the close transaction and other parties
-    will have another 30s to contest.)
-  + The deadline is up to `2 * --contestation-period` for Close tx.
-  + If hydra-node receives a `Init` tx with _not matching_ `--contestation period` then this tx is ignored which implies
-    that all parties need to agree on the same value for contestation period.
-  + API request payload to create the Init transaction does not contain the field `contestationPeriod` any more.
+    contestation deadline. For example, with `--contestation-period` 60s, the
+    node will close the head 60s after submitting the close transaction and
+    other parties will have another 60s to contest. This means the deadline may
+    be up `2 * --contestation-period` after a close transaction.
+    [#615](https://github.com/input-output-hk/hydra/pull/615) and
+    [ADR21](https://hydra.family/head-protocol/adr/21/)
+  + If hydra-node receives a `init` transaction with _not matching_
+    `--contestation-period` then this tx is ignored which implies that all
+    parties need to agree on the same value for contestation period.
+  + Removed `contestationPeriod` from the `Init` API request payload.
+  + The deadline get's pushed by `--contestation-period` **on each** contest
+    transaction. [#716](https://github.com/input-output-hk/hydra/pull/716)
 
-- Change the way the internal wallet initializes its state. [#621](https://github.com/input-output-hk/hydra/pull/621)
-  + The internal wallet does now always query ledger state and parameters at the tip.
-  + This should fix the `AcquireFailure` issues.
-  + Changed logs of `BeginInitialize` and `EndInitialize`.
-  + Added `SkipUpdate` constructor to the wallet logs.
+- Change the way the internal wallet initializes its state.
+  [#621](https://github.com/input-output-hk/hydra/pull/621)
+  + The internal wallet does now always query ledger state and parameters at the
+    tip. This should fix the `AcquireFailure` issues.
 
-- Hydra node can start following the chain from _genesis_ by setting `--start-chain-from 0` at startup time
+- Added `NoFuelUTXOFound` error next to the already existing `NotEnoughFuel`.
+  Previously the node would fail with `NotEnoughFuel` when utxo was not found.
+  Now `NotEnoughFuel` is used when there is not enough fuel and
+  `NoFuelUTXOFound` when utxo was not to be found.
 
-- Hydra node can now parse `Mainnet` network command line argument.
+- Added support have `hydra-node` to start following the chain from _genesis_ by
+  setting `--start-chain-from 0`.
 
-- Introducing `NoFuelUTXOFound` error. Previously the node would fail with
-  `NotEnoughFuel` when utxo was not found. Now `NotEnoughFuel` is used when
-  there is not enough fuel and `NoFuelUTXOFound` when utxo was not to be found.
+- Added script sizes to `hydra-node --script-info` and published transaction
+  cost benchmarks.
 
 - Changes to the logs:
-  - HeadLogic Outcome is now being logged on every protocol step transition.
-  - Added intermediate `LastSeenSnapshot` and extended `RequestedSnapshot` seen snapshot states.
+  + HeadLogic `Outcome` is now being logged on every protocol step transition.
+  + Added intermediate `LastSeenSnapshot` and extended `RequestedSnapshot` seen snapshot states.
+  + Changed wallet-related logs of `BeginInitialize`, `EndInitialize` and added
+    `SkipUpdate`.
 
-- Switched to using [nix flakes](https://nixos.wiki/wiki/Flakes):
-  + Allows us to use some CI services (cicero).
+### Changes to `hydra-cardano-api`
+
+- **BREAKING** Remove `Hydra.Cardano.Api.SlotNo` module.
+- **BREAKING** Replace `fromConsensusPointHF` with `fromConsensusPointInMode` and
+  `toConsensusPointHF` with `toConsensusPointInMode`.
+- Re-export new `AcquiringFailure` type from `cardano-api`.
+- Add `fromPlutusCurrencySymbol` conversion function.
+- Introduce new `Hydra.Cardano.Api.Pretty` module and move functions
+  `renderTx`, `renderTxWithUTxO` and `renderTxs` from `hydra-node` package to
+  this new module.
+
+### Other changes
+
+- `hydra-cluster` executable can be used to provide a local cardano "network"
+  with `--devnet` argument
+
+- Switched to using [nix flakes](https://nixos.wiki/wiki/Flakes) and
+  [CHaP](https://input-output-hk.github.io/cardano-haskell-packages/all-packages/)
   + Makes configuration of binary-caches easier to discover (you get asked about adding them).
   + Will make bumping dependencies (e.g. cardano-node) easier.
   + Build commands for binaries and docker images change, see updated [Contribution Guidelines](https://github.com/input-output-hk/hydra/blob/master/CONTRIBUTING.md)
-
-- Add script sizes to `hydra-node --script-info` and published transaction cost benchmarks.
-
-- `hydra-cluster` executable can be used to provide a local cardano "network" with `--devnet` argument
 
 ## [0.8.1] - 2022-11-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ changes.
 
 ## [0.10.0] - UNRELEASED
 
+- **BREAKING**
+ - Changed `hydra-node` and `hydra-tui` arguments.
+ - Instead of `--network-id` flag they now use `--testnet-magic`.
+
 - Hydra node can now parse `Mainnet` network command line argument.
 
 - Changed interface of `Hydra.Ledger.Cardano.Evaluate` functions.

--- a/demo/docker-compose.yaml
+++ b/demo/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       , "--cardano-verification-key", "/devnet/credentials/carol.vk"
       , "--ledger-genesis", "/devnet/genesis-shelley.json"
       , "--ledger-protocol-parameters", "/devnet/protocol-parameters.json"
-      , "--network-id", "42"
+      , "--testnet-magic", "42"
       , "--node-socket", "/devnet/node.socket"
       ]
     networks:
@@ -85,7 +85,7 @@ services:
       , "--cardano-verification-key", "/devnet/credentials/carol.vk"
       , "--ledger-genesis", "/devnet/genesis-shelley.json"
       , "--ledger-protocol-parameters", "/devnet/protocol-parameters.json"
-      , "--network-id", "42"
+      , "--testnet-magic", "42"
       , "--node-socket", "/devnet/node.socket"
       ]
     networks:
@@ -121,7 +121,7 @@ services:
       , "--cardano-verification-key", "/devnet/credentials/bob.vk"
       , "--ledger-genesis", "/devnet/genesis-shelley.json"
       , "--ledger-protocol-parameters", "/devnet/protocol-parameters.json"
-      , "--network-id", "42"
+      , "--testnet-magic", "42"
       , "--node-socket", "/devnet/node.socket"
       ]
     networks:
@@ -139,7 +139,7 @@ services:
     command:
       [ "--connect", "172.16.238.10:4001"
       , "--node-socket", "/devnet/node.socket"
-      , "--network-id", "42"
+      , "--testnet-magic", "42"
       , "--cardano-signing-key", "/devnet/credentials/alice.sk"
       ]
     volumes:
@@ -158,7 +158,7 @@ services:
     command:
       [ "--connect", "172.16.238.20:4001"
       , "--node-socket", "/devnet/node.socket"
-      , "--network-id", "42"
+      , "--testnet-magic", "42"
       , "--cardano-signing-key", "/devnet/credentials/bob.sk"
       ]
     volumes:
@@ -177,7 +177,7 @@ services:
     command:
       [ "--connect", "172.16.238.30:4001"
       , "--node-socket", "/devnet/node.socket"
-      , "--network-id", "42"
+      , "--testnet-magic", "42"
       , "--cardano-signing-key", "/devnet/credentials/carol.sk"
       ]
     volumes:

--- a/demo/run-tmux.py
+++ b/demo/run-tmux.py
@@ -85,7 +85,7 @@ if not session:
             '--cardano-verification-key', 'devnet/credentials/carol.vk',
             '--ledger-genesis', 'devnet/genesis-shelley.json',
             '--ledger-protocol-parameters', 'devnet/protocol-parameters.json',
-            '--network-id', '42',
+            '--testnet-magic', '42',
             '--node-socket', 'devnet/node.socket',
             ]))
         hydra_node_pane_bob = hydra_nodes_window.split_window(vertical=True)
@@ -107,7 +107,7 @@ if not session:
             '--cardano-verification-key', 'devnet/credentials/carol.vk',
             '--ledger-genesis', 'devnet/genesis-shelley.json',
             '--ledger-protocol-parameters', 'devnet/protocol-parameters.json',
-            '--network-id', '42',
+            '--testnet-magic', '42',
             '--node-socket', 'devnet/node.socket',
             ]))
         hydra_node_pane_carol = hydra_nodes_window.split_window(vertical=True)
@@ -129,7 +129,7 @@ if not session:
             '--cardano-verification-key', 'devnet/credentials/bob.vk',
             '--ledger-genesis', 'devnet/genesis-shelley.json',
             '--ledger-protocol-parameters', 'devnet/protocol-parameters.json',
-            '--network-id', '42',
+            '--testnet-magic', '42',
             '--node-socket', 'devnet/node.socket',
             ]))
         time.sleep(2)
@@ -142,7 +142,7 @@ if not session:
              'hydra-tui',
              '--connect', '0.0.0.0:4001',
              '--cardano-signing-key', 'devnet/credentials/alice.sk',
-             '--network-id', '42',
+             '--testnet-magic', '42',
              '--node-socket', 'devnet/node.socket',
             ]))
 
@@ -151,7 +151,7 @@ if not session:
             'hydra-tui',
             '--connect', '0.0.0.0:4002',
             '--cardano-signing-key', 'devnet/credentials/bob.sk',
-            '--network-id', '42',
+            '--testnet-magic', '42',
             '--node-socket', 'devnet/node.socket',
             ]))
 
@@ -160,7 +160,7 @@ if not session:
             'hydra-tui',
             '--connect', '0.0.0.0:4003',
             '--cardano-signing-key', 'devnet/credentials/carol.sk',
-            '--network-id', '42',
+            '--testnet-magic', '42',
             '--node-socket', 'devnet/node.socket',
             ]))
         sys.exit(0)

--- a/demo/seed-devnet.sh
+++ b/demo/seed-devnet.sh
@@ -92,7 +92,7 @@ function seedFaucet() {
 function publishReferenceScripts() {
   echo >&2 "Publishing reference scripts ('νInitial' & 'νCommit')..."
   hnode publish-scripts \
-    --network-id ${NETWORK_ID} \
+    --testnet-magic ${NETWORK_ID} \
     --node-socket ${DEVNET_DIR}/node.socket \
     --cardano-signing-key devnet/credentials/faucet.sk
 }

--- a/docs/docs/getting-started/demo/without-docker.md
+++ b/docs/docs/getting-started/demo/without-docker.md
@@ -95,7 +95,7 @@ source .env && hydra-node \
   --cardano-verification-key devnet/credentials/carol.vk \
   --ledger-genesis devnet/genesis-shelley.json \
   --ledger-protocol-parameters devnet/protocol-parameters.json \
-  --network-id 42 \
+  --testnet-magic 42 \
   --node-socket devnet/node.socket \
   --persistence-dir persistence/alice
 ```
@@ -120,7 +120,7 @@ source .env && hydra-node \
   --cardano-verification-key devnet/credentials/carol.vk \
   --ledger-genesis devnet/genesis-shelley.json \
   --ledger-protocol-parameters devnet/protocol-parameters.json \
-  --network-id 42 \
+  --testnet-magic 42 \
   --node-socket devnet/node.socket \
   --persistence-dir persistence/bob
 ```
@@ -145,7 +145,7 @@ source .env && hydra-node \
   --cardano-verification-key devnet/credentials/bob.vk \
   --ledger-genesis devnet/genesis-shelley.json \
   --ledger-protocol-parameters devnet/protocol-parameters.json \
-  --network-id 42 \
+  --testnet-magic 42 \
   --node-socket devnet/node.socket \
   --persistence-dir persistence/carol
 ```
@@ -172,7 +172,7 @@ Connect to the nodes using hydra-tui.
 hydra-tui \
   --connect 0.0.0.0:4001 \
   --cardano-signing-key devnet/credentials/alice.sk \
-  --network-id 42 \
+  --testnet-magic 42 \
   --node-socket devnet/node.socket
 ```
 

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -23,17 +23,17 @@ This image contains both `cardano-node` and `cardano-cli`. The latter is handy t
 The entire configuration of the `hydra-node` is provided through command-line options. Options are used to configure various elements of the network, API, chain connection and used ledger. You can use the `--help` option to get a description of all options:
 
 ```
-hydra-node - A prototype of Hydra Head protocol
 
 Usage: hydra-node ([-q|--quiet] (-n|--node-id NODE-ID) [-h|--host IP]
                     [-p|--port PORT] [-P|--peer ARG] [--api-host IP]
                     [--api-port PORT] [--monitoring-port PORT]
                     [--hydra-signing-key FILE] [--hydra-verification-key FILE]
                     [--hydra-scripts-tx-id TXID] [--persistence-dir DIR]
-                    [--testnet-magic INTEGER] [--node-socket FILE]
+                    (--mainnet | --testnet-magic NATURAL) [--node-socket FILE]
                     [--cardano-signing-key FILE]
                     [--cardano-verification-key FILE]
                     [--start-chain-from SLOT.HEADER_HASH]
+                    [--contestation-period CONTESTATION-PERIOD]
                     [--ledger-genesis FILE]
                     [--ledger-protocol-parameters FILE] |
                     COMMAND) [--version] [--script-info]
@@ -65,7 +65,7 @@ Available options:
   --hydra-verification-key FILE
                            Hydra verification key of another party in the Head.
                            Can be provided multiple times, once for each
-                           participant (current maximum limit is 4).
+                           participant (current maximum limit is 4 ).
   --hydra-scripts-tx-id TXID
                            The transaction which is expected to have published
                            Hydra scripts as reference scripts in its outputs.
@@ -75,11 +75,8 @@ Available options:
                            yourself.
   --persistence-dir DIR    The directory where the Hydra Head state is stored.Do
                            not edit these files manually!
-  --testnet-magic INTEGER     Network identifier for a testnet to connect to. We
-                           only need to provide the magic number here. For
-                           example: '2' is the 'preview' network. See
-                           https://book.world.dev.cardano.org/environments.html
-                           for available networks. (default: 42)
+  --mainnet                Use the mainnet magic id.
+  --testnet-magic NATURAL  Specify a testnet magic id.
   --node-socket FILE       Filepath to local unix domain socket used to
                            communicate with the cardano node.
                            (default: "node.socket")
@@ -97,6 +94,12 @@ Available options:
                            startup. Composed by the slot number, a separator
                            ('.') and the hash of the block header. For example:
                            52970883.d36a9936ae7a07f5f4bdc9ad0b23761cb7b14f35007e54947e27a1510f897f04.
+  --contestation-period CONTESTATION-PERIOD
+                           Contestation period for close transaction in seconds.
+                           If this value is not in sync with other participants
+                           hydra-node will ignore the initial tx. Additionally,
+                           this value needs to make sense compared to the
+                           current network we are running. (default: 60s)
   --ledger-genesis FILE    Path to a Shelley-compatible genesis JSON file used
                            for the Hydra ledger. You can use the corresponding
                            Cardano network's shelley genesis file from:
@@ -120,6 +123,7 @@ Available commands:
                             ┃    This costs money. About 50 Ada.    ┃
                             ┃ Spent using the provided signing key. ┃
                             ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
 
 ```
 

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -30,7 +30,7 @@ Usage: hydra-node ([-q|--quiet] (-n|--node-id NODE-ID) [-h|--host IP]
                     [--api-port PORT] [--monitoring-port PORT]
                     [--hydra-signing-key FILE] [--hydra-verification-key FILE]
                     [--hydra-scripts-tx-id TXID] [--persistence-dir DIR]
-                    [--network-id INTEGER] [--node-socket FILE]
+                    [--testnet-magic INTEGER] [--node-socket FILE]
                     [--cardano-signing-key FILE]
                     [--cardano-verification-key FILE]
                     [--start-chain-from SLOT.HEADER_HASH]
@@ -75,7 +75,7 @@ Available options:
                            yourself.
   --persistence-dir DIR    The directory where the Hydra Head state is stored.Do
                            not edit these files manually!
-  --network-id INTEGER     Network identifier for a testnet to connect to. We
+  --testnet-magic INTEGER     Network identifier for a testnet to connect to. We
                            only need to provide the magic number here. For
                            example: '2' is the 'preview' network. See
                            https://book.world.dev.cardano.org/environments.html
@@ -183,7 +183,7 @@ Hydra makes use of reference scripts to reduce the size of transactions driving 
 
 ```mdx-code-block
 <TerminalWindow>
-hydra-node publish-scripts --network-id 42 --node-socket /path/to/node.socket --cardano-signing-key cardano.sk
+hydra-node publish-scripts --testnet-magic 42 --node-socket /path/to/node.socket --cardano-signing-key cardano.sk
 </TerminalWindow>
 ```
 

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -24,12 +24,13 @@ The entire configuration of the `hydra-node` is provided through command-line op
 
 ```
 
+
 Usage: hydra-node ([-q|--quiet] (-n|--node-id NODE-ID) [-h|--host IP]
                     [-p|--port PORT] [-P|--peer ARG] [--api-host IP]
                     [--api-port PORT] [--monitoring-port PORT]
                     [--hydra-signing-key FILE] [--hydra-verification-key FILE]
                     [--hydra-scripts-tx-id TXID] [--persistence-dir DIR]
-                    (--mainnet | --testnet-magic NATURAL) [--node-socket FILE]
+                    [--mainnet | --testnet-magic NATURAL] [--node-socket FILE]
                     [--cardano-signing-key FILE]
                     [--cardano-verification-key FILE]
                     [--start-chain-from SLOT.HEADER_HASH]
@@ -76,7 +77,11 @@ Available options:
   --persistence-dir DIR    The directory where the Hydra Head state is stored.Do
                            not edit these files manually!
   --mainnet                Use the mainnet magic id.
-  --testnet-magic NATURAL  Specify a testnet magic id.
+  --testnet-magic NATURAL  Network identifier for a testnet to connect to. We
+                           only need to provide the magic number here. For
+                           example: '2' is the 'preview' network. See
+                           https://book.world.dev.cardano.org/environments.html
+                           for available networks. (default: 42)
   --node-socket FILE       Filepath to local unix domain socket used to
                            communicate with the cardano node.
                            (default: "node.socket")

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/demo/without-docker.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/demo/without-docker.md
@@ -98,7 +98,7 @@ source .env && hydra-node \
   --cardano-verification-key devnet/credentials/carol.vk \
   --ledger-genesis devnet/genesis-shelley.json \
   --ledger-protocol-parameters devnet/protocol-parameters.json \
-  --network-id 42 \
+  --testnet-magic 42 \
   --node-socket devnet/node.socket
 ```
 
@@ -121,7 +121,7 @@ source .env && hydra-node \
   --cardano-verification-key devnet/credentials/carol.vk \
   --ledger-genesis devnet/genesis-shelley.json \
   --ledger-protocol-parameters devnet/protocol-parameters.json \
-  --network-id 42 \
+  --testnet-magic 42 \
   --node-socket devnet/node.socket
 ```
 
@@ -144,7 +144,7 @@ source .env && hydra-node \
   --cardano-verification-key devnet/credentials/bob.vk \
   --ledger-genesis devnet/genesis-shelley.json \
   --ledger-protocol-parameters devnet/protocol-parameters.json \
-  --network-id 42 \
+  --testnet-magic 42 \
   --node-socket devnet/node.socket
 ```
 
@@ -178,7 +178,7 @@ hydra-tuiを使ってノードに接続します。例えば、アリスのハ�
 cabal exec hydra-tui -- \
   --connect 0.0.0.0:4001 \
   --cardano-signing-key devnet/credentials/alice.sk \
-  --network-id 42 \
+  --testnet-magic 42 \
   --node-socket devnet/node.socket
 ```
 

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
@@ -30,7 +30,7 @@ Usage: hydra-node ([-q|--quiet] (-n|--node-id NODE-ID) [-h|--host IP]
                     [--api-port PORT] [--monitoring-port PORT] 
                     [--hydra-signing-key FILE] [--hydra-verification-key FILE]
                     --hydra-scripts-tx-id TXID [--persistence-dir DIR] 
-                    [--network-id INTEGER] [--node-socket FILE] 
+                    [--testnet-magic INTEGER] [--node-socket FILE] 
                     [--cardano-signing-key FILE] 
                     [--cardano-verification-key FILE] 
                     [--start-chain-from SLOT.HEADER_HASH] 
@@ -74,7 +74,7 @@ Available options:
                            yourself.
   --persistence-dir DIR    The directory where the Hydra Head state is stored.Do
                            not edit these files manually!
-  --network-id INTEGER     Network identifier for a testnet to connect to. We
+  --testnet-magic INTEGER     Network identifier for a testnet to connect to. We
                            only need to provide the magic number here. For
                            example: '2' is the 'preview' network. See
                            https://book.world.dev.cardano.org/environments.html

--- a/docs/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
+++ b/docs/i18n/ja/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
@@ -10,31 +10,31 @@ import TerminalWindow from '@site/src/components/TerminalWindow';
 
 > `hydra-node`を使用した最初のステップ。
 
-Hydra ヘッドを動かすということは、他の複数のHydraノードに接続され、Cardanoノードに接続されたHydraノードを動かすということです。したがって、 [cardano-node](https://github.com/input-output-hk/cardano-node/) の実行は Hydraヘッドを動かすための前提条件となります。このガイドでは、Cardanoノードの実行に関する詳細については説明しませんので、必要であれば、この件に関する既存のドキュメントを探してください。
+Hydra ヘッドを動かすということは、他の複数の Hydra ノードに接続され、Cardano ノードに接続された Hydra ノードを動かすということです。したがって、 [cardano-node](https://github.com/input-output-hk/cardano-node/) の実行は Hydra ヘッドを動かすための前提条件となります。このガイドでは、Cardano ノードの実行に関する詳細については説明しませんので、必要であれば、この件に関する既存のドキュメントを探してください。
 
 :::tip cardano-node & cardano-cli
-Cardanoノードの実行には、コンテナや[公式Dockerイメージ](https://hub.docker.com/r/inputoutput/cardano-node)の使用を推奨しています。  
+Cardano ノードの実行には、コンテナや[公式 Docker イメージ](https://hub.docker.com/r/inputoutput/cardano-node)の使用を推奨しています。
 
 このイメージには `cardano-node` と `cardano-cli` の両方が含まれています。`cardano-cli`は様々なコマンドを実行するのに便利で、例えばアドレスの作成や鍵の生成を行うことができます。
 :::
 
-## Hydra-nodeのオプション...
+## Hydra-node のオプション...
 
 `hydra-node` の構成全体は、コマンドライン オプションを使用して提供されます。 オプションは、ネットワーク、API、チェーン接続、および使用される台帳のさまざまな要素を構成するために使用されます。 `--help` オプションを使用して、すべてのオプションの説明を取得できます。
 
 ```
-hydra-node - A prototype of Hydra Head protocol
 
-Usage: hydra-node ([-q|--quiet] (-n|--node-id NODE-ID) [-h|--host IP] 
-                    [-p|--port PORT] [-P|--peer ARG] [--api-host IP] 
-                    [--api-port PORT] [--monitoring-port PORT] 
+Usage: hydra-node ([-q|--quiet] (-n|--node-id NODE-ID) [-h|--host IP]
+                    [-p|--port PORT] [-P|--peer ARG] [--api-host IP]
+                    [--api-port PORT] [--monitoring-port PORT]
                     [--hydra-signing-key FILE] [--hydra-verification-key FILE]
-                    --hydra-scripts-tx-id TXID [--persistence-dir DIR] 
-                    [--testnet-magic INTEGER] [--node-socket FILE] 
-                    [--cardano-signing-key FILE] 
-                    [--cardano-verification-key FILE] 
-                    [--start-chain-from SLOT.HEADER_HASH] 
-                    [--ledger-genesis FILE] 
+                    [--hydra-scripts-tx-id TXID] [--persistence-dir DIR]
+                    (--mainnet | --testnet-magic NATURAL) [--node-socket FILE]
+                    [--cardano-signing-key FILE]
+                    [--cardano-verification-key FILE]
+                    [--start-chain-from SLOT.HEADER_HASH]
+                    [--contestation-period CONTESTATION-PERIOD]
+                    [--ledger-genesis FILE]
                     [--ledger-protocol-parameters FILE] |
                     COMMAND) [--version] [--script-info]
 
@@ -46,12 +46,13 @@ Available options:
                            It is important to have a unique identifier in order
                            to be able distinguish between connected peers.
   -h,--host IP             Listen address for incoming Hydra network
-                           connections. (default: 0.0.0.0)
+                           connections. (default: 127.0.0.1)
   -p,--port PORT           Listen port for incoming Hydra network connections.
                            (default: 5001)
   -P,--peer ARG            A peer address in the form <host>:<port>, where
                            <host> can be an IP address, or a host name. Can be
-                           provided multiple times, once for each peer node.
+                           provided multiple times, once for each peer (current
+                           maximum limit is 4 peers).
   --api-host IP            Listen address for incoming client API connections.
                            (default: 127.0.0.1)
   --api-port PORT          Listen port for incoming client API connections.
@@ -64,7 +65,7 @@ Available options:
   --hydra-verification-key FILE
                            Hydra verification key of another party in the Head.
                            Can be provided multiple times, once for each
-                           participant.
+                           participant (current maximum limit is 4 ).
   --hydra-scripts-tx-id TXID
                            The transaction which is expected to have published
                            Hydra scripts as reference scripts in its outputs.
@@ -74,11 +75,8 @@ Available options:
                            yourself.
   --persistence-dir DIR    The directory where the Hydra Head state is stored.Do
                            not edit these files manually!
-  --testnet-magic INTEGER     Network identifier for a testnet to connect to. We
-                           only need to provide the magic number here. For
-                           example: '2' is the 'preview' network. See
-                           https://book.world.dev.cardano.org/environments.html
-                           for available networks. (default: 42)
+  --mainnet                Use the mainnet magic id.
+  --testnet-magic NATURAL  Specify a testnet magic id.
   --node-socket FILE       Filepath to local unix domain socket used to
                            communicate with the cardano node.
                            (default: "node.socket")
@@ -89,13 +87,19 @@ Available options:
   --cardano-verification-key FILE
                            Cardano verification key of another party in the
                            Head. Can be provided multiple times, once for each
-                           participant.
+                           participant (current maximum limit is 4).
   --start-chain-from SLOT.HEADER_HASH
                            The id of the block we want to start observing the
                            chain from. If not given, uses the chain tip at
                            startup. Composed by the slot number, a separator
                            ('.') and the hash of the block header. For example:
                            52970883.d36a9936ae7a07f5f4bdc9ad0b23761cb7b14f35007e54947e27a1510f897f04.
+  --contestation-period CONTESTATION-PERIOD
+                           Contestation period for close transaction in seconds.
+                           If this value is not in sync with other participants
+                           hydra-node will ignore the initial tx. Additionally,
+                           this value needs to make sense compared to the
+                           current network we are running. (default: 60s)
   --ledger-genesis FILE    Path to a Shelley-compatible genesis JSON file used
                            for the Hydra ledger. You can use the corresponding
                            Cardano network's shelley genesis file from:
@@ -112,16 +116,17 @@ Available options:
 Available commands:
   publish-scripts          Publish Hydra's Plutus scripts on chain to be used
                            by the hydra-node as --hydra-script-tx-id.
-                           
-                            ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓ 
-                            ┃              ⚠ WARNING ⚠              ┃ 
-                            ┣═══════════════════════════════════════┫ 
-                            ┃    This costs money. About 50 Ada.    ┃ 
-                            ┃ Spent using the provided signing key. ┃ 
-                            ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ 
+
+                            ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+                            ┃              ⚠ WARNING ⚠              ┃
+                            ┣═══════════════════════════════════════┫
+                            ┃    This costs money. About 50 Ada.    ┃
+                            ┃ Spent using the provided signing key. ┃
+                            ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
 ```
 
-:::info  Dynamic Configuration
+:::info Dynamic Configuration
 
 現在のコマンドラインは、ユーザーフレンドリーとは言い難く、大規模なクラスタのセットアップにはやや使いにくいということは認識しています。
 
@@ -132,9 +137,9 @@ Available commands:
 
 ### カルダノ鍵(キー)
 
-前の項目では、Hydraノードのセットアップに必要なさまざまなオプションと要素について説明しました。この項目では、取得方法についてその一部をご紹介します。まず、Cardanoキーファイル(`--cardano-signing-key` と `--cardano-verification-key`)からです。
+前の項目では、Hydra ノードのセットアップに必要なさまざまなオプションと要素について説明しました。この項目では、取得方法についてその一部をご紹介します。まず、Cardano キーファイル(`--cardano-signing-key` と `--cardano-verification-key`)からです。
 
-ヘッド内において、参加者は2組の鍵で認証されます。 1組の鍵ペアは、Cardanoですでに一般的なEd25519の公開鍵/秘密鍵ペアです。このような鍵ペアは `cardano-cli` を用いて以下のように生成することができます。
+ヘッド内において、参加者は 2 組の鍵で認証されます。 1 組の鍵ペアは、Cardano ですでに一般的な Ed25519 の公開鍵/秘密鍵ペアです。このような鍵ペアは `cardano-cli` を用いて以下のように生成することができます。
 
 ```mdx-code-block
 <TerminalWindow>
@@ -142,42 +147,42 @@ cardano-cli address key-gen --verification-key-file cardano.vk --signing-key-fil
 </TerminalWindow>
 ```
 
-各参加者は自分の検証キーを他の参加者と共有することになります。 ノードを起動するには、**自分の署名キー**と**他の参加者の検証キー**が必要です。これらの鍵は現在、Hydraプロトコルの実行を促すオンチェーン・トランザクションの認証に使用されています。これは、望まれないアクターがヘッドのライフサイクルをいじくり回すのを防ぐためです（たとえば、ヘッドの外部の誰かが、初期化されたヘッドを中止させることができるのです）。これはヘッド参加者の資金を危険にさらすものではありませんが、それでも防ぎたい厄介なものです。
+各参加者は自分の検証キーを他の参加者と共有することになります。 ノードを起動するには、**自分の署名キー**と**他の参加者の検証キー**が必要です。これらの鍵は現在、Hydra プロトコルの実行を促すオンチェーン・トランザクションの認証に使用されています。これは、望まれないアクターがヘッドのライフサイクルをいじくり回すのを防ぐためです（たとえば、ヘッドの外部の誰かが、初期化されたヘッドを中止させることができるのです）。これはヘッド参加者の資金を危険にさらすものではありませんが、それでも防ぎたい厄介なものです。
 
-### Hydra鍵(キー)
+### Hydra 鍵(キー)
 
-2つ目のキーセットは、いわゆるHydraキーで、Head内のスナップショットのマルチシグネチャに使用されるものです。長期的には、これらの鍵はMuSig2アグリゲーション・マルチシグネチャ方式で使用されるキーペアとなる予定です。しかし、現時点では、集約型マルチシグネチャ暗号は[未実装](https://github.com/input-output-hk/hydra/issues/193)で、HydraノードはEd25519鍵に基づく安全なマルチシグネチャ方式となります。
+2 つ目のキーセットは、いわゆる Hydra キーで、Head 内のスナップショットのマルチシグネチャに使用されるものです。長期的には、これらの鍵は MuSig2 アグリゲーション・マルチシグネチャ方式で使用されるキーペアとなる予定です。しかし、現時点では、集約型マルチシグネチャ暗号は[未実装](https://github.com/input-output-hk/hydra/issues/193)で、Hydra ノードは Ed25519 鍵に基づく安全なマルチシグネチャ方式となります。
 
-これらはカルダノキーに似ていますが、混同しないでください。したがって、基本的にキーマテリアルで直接構成される別の基本的なディスク上の表現を使用します（カルダノキーは通常、テキストエンベロープにCBORエンコードされて保存されます）。デモ用の鍵ペアは、 `alice.{vk,sk}`、 `bob.{vk,sk}` 、 `carol.{vk,sk}` を [demo folder](https://github.com/input-output-hk/hydra/tree/master/demo)に用意しています。 現在、参加者はその中から1つを選び、Cardanoの鍵と同様の方法で、検証鍵を仲間と共有し、署名鍵を彼らに使うことが期待されている。 (TODO: システムのエントロピーを利用して新しいものを生成する簡単な方法を提供すべきである)
+これらはカルダノキーに似ていますが、混同しないでください。したがって、基本的にキーマテリアルで直接構成される別の基本的なディスク上の表現を使用します（カルダノキーは通常、テキストエンベロープに CBOR エンコードされて保存されます）。デモ用の鍵ペアは、 `alice.{vk,sk}`、 `bob.{vk,sk}` 、 `carol.{vk,sk}` を [demo folder](https://github.com/input-output-hk/hydra/tree/master/demo)に用意しています。 現在、参加者はその中から 1 つを選び、Cardano の鍵と同様の方法で、検証鍵を仲間と共有し、署名鍵を彼らに使うことが期待されている。 (TODO: システムのエントロピーを利用して新しいものを生成する簡単な方法を提供すべきである)
 
 ### 元帳パラメーター
 
-Hydra-Headのコアには、台帳があります。現時点では、HydraはCardanoにのみ配線されており、レイヤー1で使われているものと同様の台帳構成を想定しています。 これは、2つのコマンドラインオプション `--ledger-genesis` と `--ledger-protocol-parameters` として翻訳されます。前者は（シェリー！）生成規則を定義し、より具体的には、台帳が必要とする**グローバル**で更新不可能なプロトコルパラメータを定義しています。後者は、手数料や取引サイズなど、更新可能なプロトコルパラメータを定義します。これらはcardano-cliで使用されるものと同じ形式を使用します（例：`cardano-cli query protocol-parameters`の出力）。
+Hydra-Head のコアには、台帳があります。現時点では、Hydra は Cardano にのみ配線されており、レイヤー 1 で使われているものと同様の台帳構成を想定しています。 これは、2 つのコマンドラインオプション `--ledger-genesis` と `--ledger-protocol-parameters` として翻訳されます。前者は（シェリー！）生成規則を定義し、より具体的には、台帳が必要とする**グローバル**で更新不可能なプロトコルパラメータを定義しています。後者は、手数料や取引サイズなど、更新可能なプロトコルパラメータを定義します。これらは cardano-cli で使用されるものと同じ形式を使用します（例：`cardano-cli query protocol-parameters`の出力）。
 
-[hydra-cluster/config](https://github.com/input-output-hk/hydra/blob/master/hydra-cluster/config)に既存のファイルを提供しており、これをベースに利用することができます。特に、ヘッド内のコストを無効化するためのプロトコルパラメータが定義されています。それとは別に、現在のメインネットのパラメータもそのままコピーしています。ヒドラの台帳の面白いところは、レイヤー1と同じルールやコードを再利用している（いわゆる同型）にもかかわらず、パラメーターがレイヤー1とは若干異なるように変更されている点です。これは料金の場合ですが、例えばスクリプトの最大実行予算などでも可能です。ただし、すべてのパラメータが安全に変更できるわけではありません。値の最大サイズ（ネイティブアセットを運ぶ）を制御するパラメータや、UTxOの最小Ada値を変更すると、ヘッドが「closable」になってしまう可能性があります。経験則から言うと、取引に厳密に適用されるもの（手数料、実行単位、最大TXサイズ...）は変更しても安全である。しかし、UTxOに反映される可能性があるものは、そうではありません。 
+[hydra-cluster/config](https://github.com/input-output-hk/hydra/blob/master/hydra-cluster/config)に既存のファイルを提供しており、これをベースに利用することができます。特に、ヘッド内のコストを無効化するためのプロトコルパラメータが定義されています。それとは別に、現在のメインネットのパラメータもそのままコピーしています。ヒドラの台帳の面白いところは、レイヤー 1 と同じルールやコードを再利用している（いわゆる同型）にもかかわらず、パラメーターがレイヤー 1 とは若干異なるように変更されている点です。これは料金の場合ですが、例えばスクリプトの最大実行予算などでも可能です。ただし、すべてのパラメータが安全に変更できるわけではありません。値の最大サイズ（ネイティブアセットを運ぶ）を制御するパラメータや、UTxO の最小 Ada 値を変更すると、ヘッドが「closable」になってしまう可能性があります。経験則から言うと、取引に厳密に適用されるもの（手数料、実行単位、最大 TX サイズ...）は変更しても安全である。しかし、UTxO に反映される可能性があるものは、そうではありません。
 
 :::info About Protocol Parameters
-ほとんどのプロトコルパラメータは、まず第一にGenesisパラメータであるため、2つのファイルの間に少し重複があることに注意してください。さらに、これらのパラメーターの多くは、Hydraのコンテキストでは実際には無関係です（たとえば、Headの中に金庫やステークプールがないため、報酬インセンティブまたは委任ルールを構成するパラメーターは使用できません）。
+ほとんどのプロトコルパラメータは、まず第一に Genesis パラメータであるため、2 つのファイルの間に少し重複があることに注意してください。さらに、これらのパラメーターの多くは、Hydra のコンテキストでは実際には無関係です（たとえば、Head の中に金庫やステークプールがないため、報酬インセンティブまたは委任ルールを構成するパラメーターは使用できません）。
 :::
 
 ### 燃料
 
-最後に、Hydraノードがすべて動作するために必要なもう1つのことは、内部ウォレットについてです。実際、Hydraノードには現在初歩的なウォレットが付属しており、Headライフサイクル（Init, Commit, Close, Fanout...）を駆動するトランザクションの燃料として利用されています。これらのトランザクションはレイヤー1で発生するので、お金がかかります。
+最後に、Hydra ノードがすべて動作するために必要なもう 1 つのことは、内部ウォレットについてです。実際、Hydra ノードには現在初歩的なウォレットが付属しており、Head ライフサイクル（Init, Commit, Close, Fanout...）を駆動するトランザクションの燃料として利用されています。これらのトランザクションはレイヤー 1 で発生するので、お金がかかります。
 
-今のところ、これはHydraのウォレットによって内部的に管理されていますが、いくつかの助けが必要です。ノードに提供されるCardanoキーは、資金を保持することが期待されています。具体的には、特定のデータムハッシュでマークされた、少なくとも1つのUTxOエントリーがあります。
+今のところ、これは Hydra のウォレットによって内部的に管理されていますが、いくつかの助けが必要です。ノードに提供される Cardano キーは、資金を保持することが期待されています。具体的には、特定のデータムハッシュでマークされた、少なくとも 1 つの UTxO エントリーがあります。
 
 ```bash title="Fuel datum hash"
 a654fb60d21c1fed48db2c320aa6df9737ec0204c0ba53b9b94a09fb40e757f3
 ```
 
-便利なことに（少なくとも、今できる限り）、cardano-cliを使用して通常のUTxOをマークされた燃料UTxOに変換する[create-marker-utxo.sh](https://github.com/input-output-hk/hydra/blob/master/sample-node-config/gcp/scripts/create-marker-utxo.sh)というスクリプトが用意されています。マーカーが必要な理由は、Cardanoの鍵はコミットに必要な資金も保持することが期待されるからです（ただし、マークされていません）
+便利なことに（少なくとも、今できる限り）、cardano-cli を使用して通常の UTxO をマークされた燃料 UTxO に変換する[create-marker-utxo.sh](https://github.com/input-output-hk/hydra/blob/master/sample-node-config/gcp/scripts/create-marker-utxo.sh)というスクリプトが用意されています。マーカーが必要な理由は、Cardano の鍵はコミットに必要な資金も保持することが期待されるからです（ただし、マークされていません）
 
 :::info About commits
-長期的には、私たちは[Hydraノード外のコミットを移動](https://github.com/input-output-hk/hydra/issues/215)して、外部のウォレット（おそらく[CIP-0030](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0030)標準に従うウォレットを通じて）で行われるようにします。
+長期的には、私たちは[Hydra ノード外のコミットを移動](https://github.com/input-output-hk/hydra/issues/215)して、外部のウォレット（おそらく[CIP-0030](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0030)標準に従うウォレットを通じて）で行われるようにします。
 :::
 
 ## セットアップ例
 
-### GoogleクラウドとTerraform
+### Google クラウドと Terraform
 
-クラウド上の仮想マシン上でHydraノードをホストするためのサンプルノード構成を[sample-node-config/](https://github.com/input-output-hk/hydra/tree/master/sample-node-config/gcp/)ディレクトリに提供しています。 特に、このセットアップには [docker-compose.yaml](https://github.com/input-output-hk/hydra/blob/master/sample-node-config/gcp/docker-compose.yaml) という仕様があり、cardano-node + hydra-node サービスを設定するための良いテンプレートが提供されています。また、クラスタをセットアップするための様々な便利なスクリプトも提供されています。
+クラウド上の仮想マシン上で Hydra ノードをホストするためのサンプルノード構成を[sample-node-config/](https://github.com/input-output-hk/hydra/tree/master/sample-node-config/gcp/)ディレクトリに提供しています。 特に、このセットアップには [docker-compose.yaml](https://github.com/input-output-hk/hydra/blob/master/sample-node-config/gcp/docker-compose.yaml) という仕様があり、cardano-node + hydra-node サービスを設定するための良いテンプレートが提供されています。また、クラスタをセットアップするための様々な便利なスクリプトも提供されています。

--- a/hydra-cardano-api/hydra-cardano-api.cabal
+++ b/hydra-cardano-api/hydra-cardano-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          hydra-cardano-api
-version:       0.9.0
+version:       0.10.0
 synopsis:      A Haskell API for Cardano, tailored to the Hydra project.
 author:        IOG
 copyright:     2022 IOG

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/AddressInEra.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/AddressInEra.hs
@@ -2,7 +2,6 @@
 
 module Hydra.Cardano.Api.AddressInEra where
 
-import qualified Hydra.Cardano.Api.Network as Network
 import Hydra.Cardano.Api.PlutusScriptVersion (HasPlutusScriptVersion (..))
 import Hydra.Cardano.Api.Prelude
 
@@ -12,6 +11,7 @@ import qualified Cardano.Ledger.BaseTypes as Ledger
 import qualified Cardano.Ledger.Credential as Ledger
 import qualified Cardano.Ledger.Hashes as Ledger
 import qualified Cardano.Ledger.Keys as Ledger
+import Hydra.Cardano.Api.Network (Network)
 import qualified Plutus.V1.Ledger.Address as Plutus
 import Plutus.V2.Ledger.Api (
   Address (..),
@@ -76,10 +76,10 @@ toLedgerAddr = \case
     Ledger.Addr ntwrk creds stake
 
 -- | Convert a plutus 'Address' to an api 'AddressInEra'.
--- NOTE: Requires the 'NetworkId' discriminator (Testnet or Mainnet) because
+-- NOTE: Requires the 'Network' discriminator (Testnet or Mainnet) because
 -- Plutus addresses are stripped off it.
-fromPlutusAddress :: IsShelleyBasedEra era => NetworkId -> Plutus.Address -> AddressInEra era
-fromPlutusAddress networkId plutusAddress =
+fromPlutusAddress :: IsShelleyBasedEra era => Network -> Plutus.Address -> AddressInEra era
+fromPlutusAddress network plutusAddress =
   fromLedgerAddr $
     case (addressCredential, addressStakingCredential) of
       (cred, Just (StakingHash stakeCred)) ->
@@ -98,10 +98,5 @@ fromPlutusAddress networkId plutusAddress =
       Ledger.KeyHashObj . Ledger.KeyHash . unsafeHashFromBytes $ fromBuiltin h
     ScriptCredential (ValidatorHash h) ->
       Ledger.ScriptHashObj . Ledger.ScriptHash . unsafeHashFromBytes $ fromBuiltin h
-
-  network = networkIdToNetwork networkId
-
-  networkIdToNetwork Mainnet = Network.Mainnet
-  networkIdToNetwork (Testnet _) = Network.Testnet
 
   Plutus.Address{addressCredential, addressStakingCredential} = plutusAddress

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Network.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Network.hs
@@ -1,5 +1,11 @@
 module Hydra.Cardano.Api.Network (
   Network (..),
+  networkIdToNetwork,
 ) where
 
+import qualified Cardano.Api as Api
 import Cardano.Ledger.BaseTypes (Network (..))
+
+networkIdToNetwork :: Api.NetworkId -> Network
+networkIdToNetwork Api.Mainnet = Mainnet
+networkIdToNetwork (Api.Testnet _) = Testnet

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/TxOut.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/TxOut.hs
@@ -3,6 +3,7 @@
 module Hydra.Cardano.Api.TxOut where
 
 import Hydra.Cardano.Api.MultiAssetSupportedInEra (HasMultiAsset (..))
+import qualified Hydra.Cardano.Api.Network as Network
 import Hydra.Cardano.Api.PlutusScriptVersion (HasPlutusScriptVersion (..))
 import Hydra.Cardano.Api.Prelude
 import Hydra.Cardano.Api.TxIn (mkTxIn)
@@ -120,7 +121,7 @@ fromPlutusTxOut ::
 fromPlutusTxOut network out =
   TxOut addressInEra value datum ReferenceScriptNone
  where
-  addressInEra = fromPlutusAddress network plutusAddress
+  addressInEra = fromPlutusAddress (networkIdToNetwork network) plutusAddress
 
   value = TxOutValue multiAssetSupportedInEra $ fromPlutusValue plutusValue
 
@@ -130,6 +131,9 @@ fromPlutusTxOut network out =
       TxOutDatumHash scriptDataSupportedInEra . unsafeScriptDataHashFromBytes $ fromBuiltin hashBytes
     OutputDatum (Plutus.Datum datumData) ->
       TxOutDatumInline inlineDatumsSupportedInEra $ toScriptData datumData
+
+  networkIdToNetwork Mainnet = Network.Mainnet
+  networkIdToNetwork (Testnet _) = Network.Testnet
 
   Plutus.TxOut plutusAddress plutusValue plutusDatum _ = out
 

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/TxOut.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/TxOut.hs
@@ -3,7 +3,6 @@
 module Hydra.Cardano.Api.TxOut where
 
 import Hydra.Cardano.Api.MultiAssetSupportedInEra (HasMultiAsset (..))
-import qualified Hydra.Cardano.Api.Network as Network
 import Hydra.Cardano.Api.PlutusScriptVersion (HasPlutusScriptVersion (..))
 import Hydra.Cardano.Api.Prelude
 import Hydra.Cardano.Api.TxIn (mkTxIn)
@@ -16,6 +15,7 @@ import qualified Cardano.Ledger.Credential as Ledger
 import qualified Data.List as List
 import Hydra.Cardano.Api.AddressInEra (fromPlutusAddress)
 import Hydra.Cardano.Api.Hash (unsafeScriptDataHashFromBytes)
+import Hydra.Cardano.Api.Network (Network)
 import Hydra.Cardano.Api.ReferenceTxInsScriptsInlineDatumsSupportedInEra (HasInlineDatums, inlineDatumsSupportedInEra)
 import Hydra.Cardano.Api.ScriptData (toScriptData)
 import Hydra.Cardano.Api.ScriptDataSupportedInEra (HasScriptData, scriptDataSupportedInEra)
@@ -115,13 +115,13 @@ toLedgerTxOut =
 -- Plutus addresses are stripped off it.
 fromPlutusTxOut ::
   (HasMultiAsset era, HasScriptData era, HasInlineDatums era, IsShelleyBasedEra era) =>
-  NetworkId ->
+  Network ->
   Plutus.TxOut ->
   TxOut CtxUTxO era
 fromPlutusTxOut network out =
   TxOut addressInEra value datum ReferenceScriptNone
  where
-  addressInEra = fromPlutusAddress (networkIdToNetwork network) plutusAddress
+  addressInEra = fromPlutusAddress network plutusAddress
 
   value = TxOutValue multiAssetSupportedInEra $ fromPlutusValue plutusValue
 
@@ -131,9 +131,6 @@ fromPlutusTxOut network out =
       TxOutDatumHash scriptDataSupportedInEra . unsafeScriptDataHashFromBytes $ fromBuiltin hashBytes
     OutputDatum (Plutus.Datum datumData) ->
       TxOutDatumInline inlineDatumsSupportedInEra $ toScriptData datumData
-
-  networkIdToNetwork Mainnet = Network.Mainnet
-  networkIdToNetwork (Testnet _) = Network.Testnet
 
   Plutus.TxOut plutusAddress plutusValue plutusDatum _ = out
 

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/TxOut.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/TxOut.hs
@@ -15,7 +15,6 @@ import qualified Cardano.Ledger.Credential as Ledger
 import qualified Data.List as List
 import Hydra.Cardano.Api.AddressInEra (fromPlutusAddress)
 import Hydra.Cardano.Api.Hash (unsafeScriptDataHashFromBytes)
-import Hydra.Cardano.Api.Network (Network)
 import Hydra.Cardano.Api.ReferenceTxInsScriptsInlineDatumsSupportedInEra (HasInlineDatums, inlineDatumsSupportedInEra)
 import Hydra.Cardano.Api.ScriptData (toScriptData)
 import Hydra.Cardano.Api.ScriptDataSupportedInEra (HasScriptData, scriptDataSupportedInEra)
@@ -115,7 +114,7 @@ toLedgerTxOut =
 -- Plutus addresses are stripped off it.
 fromPlutusTxOut ::
   (HasMultiAsset era, HasScriptData era, HasInlineDatums era, IsShelleyBasedEra era) =>
-  Network ->
+  NetworkId ->
   Plutus.TxOut ->
   TxOut CtxUTxO era
 fromPlutusTxOut network out =

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               hydra-cluster
-version:            0.9.0
+version:            0.10.0
 synopsis:
   Integration test suite using a local cluster of cardano and hydra nodes
 
@@ -10,6 +10,7 @@ license:            Apache-2.0
 license-files:
   LICENSE
   NOTICE
+
 extra-source-files: README.md
 data-files:
   config/cardano-configurations/network/preprod/cardano-node/config.json
@@ -169,7 +170,7 @@ executable hydra-cluster
     , hydra-test-utils
     , optparse-applicative
 
-  build-tool-depends: hydra-node:hydra-node -any
+  build-tool-depends: hydra-node:hydra-node
   ghc-options:        -threaded -rtsopts
 
 executable log-filter
@@ -242,9 +243,7 @@ test-suite integration
     , temporary
     , text
 
-  build-tool-depends:
-    hspec-discover:hspec-discover -any, hydra-node:hydra-node -any
-
+  build-tool-depends: hspec-discover:hspec-discover, hydra-node:hydra-node
   ghc-options:        -threaded -rtsopts
 
 benchmark bench-e2e
@@ -278,5 +277,5 @@ benchmark bench-e2e
     , strict-containers
     , time
 
-  build-tool-depends: hydra-node:hydra-node -any
+  build-tool-depends: hydra-node:hydra-node
   ghc-options:        -threaded -rtsopts

--- a/hydra-cluster/src/Hydra/Cluster/Fixture.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Fixture.hs
@@ -62,4 +62,5 @@ actorName = \case
 data KnownNetwork
   = Preview
   | Preproduction
+  | Mainnet
   deriving (Show)

--- a/hydra-cluster/src/Hydra/Cluster/Options.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Options.hs
@@ -28,6 +28,7 @@ parseOptions =
   parseKnownNetwork =
     flag' (Just Preview) (long "preview" <> help "The preview testnet")
       <|> flag' (Just Preproduction) (long "preprod" <> help "The pre-production testnet")
+      <|> flag' (Just Mainnet) (long "mainnet" <> help "The mainnet")
       <|> flag'
         Nothing
         ( long "devnet"

--- a/hydra-cluster/test/Test/DirectChainSpec.hs
+++ b/hydra-cluster/test/Test/DirectChainSpec.hs
@@ -332,7 +332,7 @@ spec = around showLogsOnFailure $ do
                 ( "publish-scripts" :
                   mconcat
                     [ ["--node-socket", nodeSocket]
-                    , ["--testnet-magic", toArgNetworkId networkId]
+                    , toArgNetworkId networkId
                     , ["--cardano-signing-key", cardanoSigningKey]
                     ]
                 )

--- a/hydra-cluster/test/Test/DirectChainSpec.hs
+++ b/hydra-cluster/test/Test/DirectChainSpec.hs
@@ -332,7 +332,7 @@ spec = around showLogsOnFailure $ do
                 ( "publish-scripts" :
                   mconcat
                     [ ["--node-socket", nodeSocket]
-                    , ["--network-id", toArgNetworkId networkId]
+                    , ["--testnet-magic", toArgNetworkId networkId]
                     , ["--cardano-signing-key", cardanoSigningKey]
                     ]
                 )

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -365,7 +365,7 @@ spec = around showLogsOnFailure $ do
           let hydraSK = dir </> "hydra.sk"
           hydraSKey :: SigningKey HydraKey <- generate arbitrary
           void $ writeFileTextEnvelope hydraSK Nothing hydraSKey
-          withCreateProcess (proc "hydra-node" ["-n", "hydra-node-1", "--hydra-signing-key", hydraSK]){std_out = CreatePipe} $
+          withCreateProcess (proc "hydra-node" ["-n", "hydra-node-1", "--testnet-magic", "42", "--hydra-signing-key", hydraSK]){std_out = CreatePipe} $
             \_ (Just nodeStdout) _ _ ->
               waitForLog 10 nodeStdout "JSON object with key NodeOptions" $ \line ->
                 line ^? key "message" . key "tag" == Just (Aeson.String "NodeOptions")

--- a/hydra-node/exe/tx-cost/TxCost.hs
+++ b/hydra-node/exe/tx-cost/TxCost.hs
@@ -9,8 +9,6 @@ import Data.Maybe (fromJust)
 import Hydra.Cardano.Api (
   ExecutionUnits (..),
   Lovelace,
-  NetworkId (Testnet),
-  NetworkMagic (NetworkMagic),
   Tx,
   UTxO,
  )
@@ -250,9 +248,6 @@ checkSizeAndEvaluate tx knownUTxO = do
     _ -> Nothing
  where
   txSize = fromIntegral $ LBS.length $ serialize tx
-
-networkId :: NetworkId
-networkId = Testnet $ NetworkMagic 42
 
 serializedSize :: UTxO -> Natural
 serializedSize =

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -784,7 +784,7 @@ observeCommitTx networkId initials tx = do
     -- TODO: We could simplify this by just using the datum. However, we would
     -- need to ensure the commit is belonging to a head / is rightful. By just
     -- looking for some known initials we achieve this (a bit complicated) now.
-    case (mCommittedTxIn, onChainCommit >>= Commit.deserializeCommit) of
+    case (mCommittedTxIn, onChainCommit >>= Commit.deserializeCommit networkId) of
       (Nothing, Nothing) -> Just mempty
       (Just i, Just (_i, o)) -> Just $ UTxO.singleton (i, o)
       (Nothing, Just{}) -> error "found commit with no redeemer out ref but with serialized output."

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -18,6 +18,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import Hydra.Cardano.Api.Network (networkIdToNetwork)
 import Hydra.Chain (HeadId (..), HeadParameters (..))
 import Hydra.Chain.Direct.ScriptRegistry (ScriptRegistry (..))
 import Hydra.Chain.Direct.TimeHandle (PointInTime)
@@ -784,7 +785,7 @@ observeCommitTx networkId initials tx = do
     -- TODO: We could simplify this by just using the datum. However, we would
     -- need to ensure the commit is belonging to a head / is rightful. By just
     -- looking for some known initials we achieve this (a bit complicated) now.
-    case (mCommittedTxIn, onChainCommit >>= Commit.deserializeCommit networkId) of
+    case (mCommittedTxIn, onChainCommit >>= Commit.deserializeCommit (networkIdToNetwork networkId)) of
       (Nothing, Nothing) -> Just mempty
       (Just i, Just (_i, o)) -> Just $ UTxO.singleton (i, o)
       (Nothing, Just{}) -> error "found commit with no redeemer out ref but with serialized output."

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -39,7 +39,6 @@ import Options.Applicative (
   Parser,
   ParserInfo,
   ParserResult (..),
-  ReadM,
   auto,
   command,
   completer,

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -685,7 +685,7 @@ toArgs
         []
 
     argsChainConfig =
-      ["--network-id", toArgNetworkId networkId]
+      ["--testnet-magic", toArgNetworkId networkId]
         <> ["--node-socket", nodeSocket]
         <> ["--cardano-signing-key", cardanoSigningKey]
         <> ["--contestation-period", show contestationPeriod]

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -311,28 +311,19 @@ chainConfigParser =
     <*> contestationPeriodParser
 
 networkIdParser :: Parser NetworkId
-networkIdParser = pTestnet <|> pMainnet
-  where
-    pMainnet :: Parser NetworkId
-    pMainnet =
-      option expectMainnetString
-      (long "network-id"
-      <> metavar "TEXT"
-      <> help "Use the mainnet network."
-      )
-
-    pTestnet :: Parser NetworkId
-    pTestnet = option expectTestnetMagic
+networkIdParser =
+  option
+  (expectTestnetMagic <|> expectMainnetString)
       (  long "network-id"
-      <> metavar "NATURAL"
       <> showDefault
-      <> completer (listCompleter ["1", "2", "42"])
+      <> value (Testnet (NetworkMagic 42))
+      <> completer (listCompleter ["1", "2", "42", "mainnet", "Mainnet","m"])
       <>  help
-              "Network identifier for a testnet to connect to. We only need to \
+              "Either Mainnet network or identifier for a testnet to connect to. We only need to \
               \provide the magic number here. For example: '2' is the 'preview' \
               \network. See https://book.world.dev.cardano.org/environments.html for available networks."
       )
-
+  where
     expectTestnetMagic :: ReadM NetworkId
     expectTestnetMagic = eitherReader go
       where go :: String -> Either String NetworkId
@@ -346,7 +337,8 @@ networkIdParser = pTestnet <|> pMainnet
       where go :: String -> Either String NetworkId
             go "Mainnet" = pure Mainnet
             go "mainnet" = pure Mainnet
-            go _         = Left "Expected TEXT value Mainnet or mainnet"
+            go "m"       = pure Mainnet
+            go _         = Left "Expected TEXT value (Mainnet, mainnet or just m)"
 
 
 nodeSocketParser :: Parser FilePath

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -328,7 +328,13 @@ networkIdParser = pMainnet <|> fmap Testnet pTestnetMagic
         auto
         ( long "testnet-magic"
             <> metavar "NATURAL"
-            <> help "Specify a testnet magic id."
+            <> value 42
+            <> showDefault
+            <> completer (listCompleter ["1", "2", "42"])
+            <> help
+              "Network identifier for a testnet to connect to. We only need to \
+              \provide the magic number here. For example: '2' is the 'preview' \
+              \network. See https://book.world.dev.cardano.org/environments.html for available networks."
         )
 
 nodeSocketParser :: Parser FilePath

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -313,33 +313,32 @@ chainConfigParser =
 networkIdParser :: Parser NetworkId
 networkIdParser =
   option
-  (expectTestnetMagic <|> expectMainnetString)
-      (  long "network-id"
-      <> showDefault
-      <> value (Testnet (NetworkMagic 42))
-      <> completer (listCompleter ["1", "2", "42", "mainnet", "Mainnet","m"])
-      <>  help
-              "Either Mainnet network or identifier for a testnet to connect to. We only need to \
-              \provide the magic number here. For example: '2' is the 'preview' \
-              \network. See https://book.world.dev.cardano.org/environments.html for available networks."
-      )
-  where
-    expectTestnetMagic :: ReadM NetworkId
-    expectTestnetMagic = eitherReader go
-      where go :: String -> Either String NetworkId
-            go s =
-              case readMaybe s :: Maybe Word32 of
-                Nothing -> Left "Could not parse Testnet network magic"
-                Just i -> pure $ Testnet (NetworkMagic i)
+    (parseTestnet <|> parseMainnet)
+    ( long "network-id"
+        <> showDefault
+        <> value (Testnet (NetworkMagic 42))
+        <> completer (listCompleter ["1", "2", "42", "mainnet", "Mainnet", "m"])
+        <> help
+          "Either Mainnet network or a magic number identifying the testnet to connect to. We only need to \
+          \provide the magic number here. For example: '2' is the 'preview' \
+          \network. See https://book.world.dev.cardano.org/environments.html for available networks."
+    )
+ where
+  parseTestnet = eitherReader go
+   where
+    go :: String -> Either String NetworkId
+    go s =
+      case readMaybe s :: Maybe Word32 of
+        Nothing -> Left "Could not parse Testnet network magic"
+        Just i -> pure $ Testnet (NetworkMagic i)
 
-    expectMainnetString :: ReadM NetworkId
-    expectMainnetString = eitherReader go
-      where go :: String -> Either String NetworkId
-            go "Mainnet" = pure Mainnet
-            go "mainnet" = pure Mainnet
-            go "m"       = pure Mainnet
-            go _         = Left "Expected TEXT value (Mainnet, mainnet or just m)"
-
+  parseMainnet = eitherReader go
+   where
+    go :: String -> Either String NetworkId
+    go "Mainnet" = pure Mainnet
+    go "mainnet" = pure Mainnet
+    go "m" = pure Mainnet
+    go _ = Left "Expected TEXT value (Mainnet, mainnet or just m)"
 
 nodeSocketParser :: Parser FilePath
 nodeSocketParser =

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -691,7 +691,7 @@ toArgs
         []
 
     argsChainConfig =
-      ["--testnet-magic", toArgNetworkId networkId]
+      toArgNetworkId networkId
         <> ["--node-socket", nodeSocket]
         <> ["--cardano-signing-key", cardanoSigningKey]
         <> ["--contestation-period", show contestationPeriod]
@@ -716,10 +716,10 @@ toArgs
       , contestationPeriod
       } = chainConfig
 
-toArgNetworkId :: NetworkId -> String
+toArgNetworkId :: NetworkId -> [String]
 toArgNetworkId = \case
-  Mainnet -> error "Mainnet not supported"
-  Testnet (NetworkMagic magic) -> show magic
+  Mainnet -> ["--mainnet"]
+  Testnet (NetworkMagic magic) -> ["--testnet-magic", show magic]
 
 genFilePath :: String -> Gen FilePath
 genFilePath extension = do

--- a/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
@@ -8,6 +8,7 @@ import Hydra.Prelude hiding (label)
 import Test.Hydra.Prelude
 
 import qualified Cardano.Api.UTxO as UTxO
+import Hydra.Chain.Direct.Fixture (testNetworkId)
 import Cardano.Crypto.Util (SignableRepresentation (getSignableRepresentation))
 import Cardano.Ledger.Alonzo.TxInfo (TxOutSource (TxOutFromOutput))
 import Cardano.Ledger.Babbage.TxInfo (txInfoOutV2)
@@ -140,7 +141,7 @@ prop_serializingCommitRoundtrip =
   -- Plutus.TxOut
   forAll ((,) <$> arbitrary <*> (arbitrary >>= genOutput)) $ \singleUTxO ->
     let serialized = Commit.serializeCommit singleUTxO
-        deserialized = serialized >>= Commit.deserializeCommit
+        deserialized = serialized >>= Commit.deserializeCommit testNetworkId
      in case deserialized of
           Just actual -> actual === singleUTxO
           Nothing ->

--- a/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
@@ -8,7 +8,6 @@ import Hydra.Prelude hiding (label)
 import Test.Hydra.Prelude
 
 import qualified Cardano.Api.UTxO as UTxO
-import Hydra.Chain.Direct.Fixture (testNetworkId)
 import Cardano.Crypto.Util (SignableRepresentation (getSignableRepresentation))
 import Cardano.Ledger.Alonzo.TxInfo (TxOutSource (TxOutFromOutput))
 import Cardano.Ledger.Babbage.TxInfo (txInfoOutV2)
@@ -20,6 +19,7 @@ import Hydra.Cardano.Api (
   toLedgerTxOut,
   toPlutusTxOut,
  )
+import Hydra.Cardano.Api.Network (networkIdToNetwork)
 import Hydra.Chain.Direct.Contract.Abort (genAbortMutation, healthyAbortTx, propHasCommit, propHasInitial)
 import Hydra.Chain.Direct.Contract.Close (genCloseInitialMutation, genCloseMutation, healthyCloseInitialTx, healthyCloseTx)
 import Hydra.Chain.Direct.Contract.CollectCom (genCollectComMutation, healthyCollectComTx)
@@ -28,6 +28,7 @@ import Hydra.Chain.Direct.Contract.Contest (genContestMutation, healthyContestTx
 import Hydra.Chain.Direct.Contract.FanOut (genFanoutMutation, healthyFanoutTx)
 import Hydra.Chain.Direct.Contract.Init (genInitMutation, healthyInitTx)
 import Hydra.Chain.Direct.Contract.Mutation (propMutation, propTransactionEvaluates)
+import Hydra.Chain.Direct.Fixture (testNetworkId)
 import qualified Hydra.Contract.Commit as Commit
 import Hydra.Contract.Head (
   verifyPartySignature,
@@ -141,7 +142,7 @@ prop_serializingCommitRoundtrip =
   -- Plutus.TxOut
   forAll ((,) <$> arbitrary <*> (arbitrary >>= genOutput)) $ \singleUTxO ->
     let serialized = Commit.serializeCommit singleUTxO
-        deserialized = serialized >>= Commit.deserializeCommit testNetworkId
+        deserialized = serialized >>= Commit.deserializeCommit (networkIdToNetwork testNetworkId)
      in case deserialized of
           Just actual -> actual === singleUTxO
           Nothing ->

--- a/hydra-node/test/Hydra/OptionsSpec.hs
+++ b/hydra-node/test/Hydra/OptionsSpec.hs
@@ -140,6 +140,15 @@ spec = parallel $
                   }
             }
 
+    it "parses --network-id option as string for mainnet" $ do
+      setFlags ["--network-id", "Mainnet"]
+        `shouldParse` Run
+          defaultRunOptions
+            { chainConfig =
+                defaultChainConfig
+                  { networkId = Mainnet
+                  }
+            }
     it "parses --contestation-period option as a number of seconds" $ do
       shouldNotParse ["--contestation-period", "abc"]
       shouldNotParse ["--contestation-period", "s"]

--- a/hydra-node/test/Hydra/OptionsSpec.hs
+++ b/hydra-node/test/Hydra/OptionsSpec.hs
@@ -140,8 +140,24 @@ spec = parallel $
                   }
             }
 
-    it "parses --network-id option as string for mainnet" $ do
+    it "parses --network-id string option mainnet" $ do
+      setFlags ["--network-id", "mainnet"]
+        `shouldParse` Run
+          defaultRunOptions
+            { chainConfig =
+                defaultChainConfig
+                  { networkId = Mainnet
+                  }
+            }
       setFlags ["--network-id", "Mainnet"]
+        `shouldParse` Run
+          defaultRunOptions
+            { chainConfig =
+                defaultChainConfig
+                  { networkId = Mainnet
+                  }
+            }
+      setFlags ["--network-id", "m"]
         `shouldParse` Run
           defaultRunOptions
             { chainConfig =

--- a/hydra-node/test/Hydra/OptionsSpec.hs
+++ b/hydra-node/test/Hydra/OptionsSpec.hs
@@ -113,9 +113,9 @@ spec = parallel $
       setFlags ["--hydra-signing-key", "./alice.sk"]
         `shouldParse` Run defaultRunOptions{hydraSigningKey = "./alice.sk"}
 
-    it "parses --network-id option as a number" $ do
-      shouldNotParse ["--network-id", "abc"]
-      setFlags ["--network-id", "0"]
+    it "parses --testnet-magic option as a number" $ do
+      shouldNotParse ["--testnet-magic", "abc"]
+      setFlags ["--testnet-magic", "0"]
         `shouldParse` Run
           defaultRunOptions
             { chainConfig =
@@ -123,7 +123,7 @@ spec = parallel $
                   { networkId = Testnet (NetworkMagic 0)
                   }
             }
-      setFlags ["--network-id", "-1"] -- Word32 overflow expected
+      setFlags ["--testnet-magic", "-1"] -- Word32 overflow expected
         `shouldParse` Run
           defaultRunOptions
             { chainConfig =
@@ -131,7 +131,7 @@ spec = parallel $
                   { networkId = Testnet (NetworkMagic 4294967295)
                   }
             }
-      setFlags ["--network-id", "123"]
+      setFlags ["--testnet-magic", "123"]
         `shouldParse` Run
           defaultRunOptions
             { chainConfig =
@@ -140,8 +140,8 @@ spec = parallel $
                   }
             }
 
-    it "parses --network-id string option mainnet" $ do
-      setFlags ["--network-id", "mainnet"]
+    it "parses --testnet-magic string option mainnet" $ do
+      setFlags ["--testnet-magic", "mainnet"]
         `shouldParse` Run
           defaultRunOptions
             { chainConfig =
@@ -149,7 +149,7 @@ spec = parallel $
                   { networkId = Mainnet
                   }
             }
-      setFlags ["--network-id", "Mainnet"]
+      setFlags ["--testnet-magic", "Mainnet"]
         `shouldParse` Run
           defaultRunOptions
             { chainConfig =
@@ -157,7 +157,7 @@ spec = parallel $
                   { networkId = Mainnet
                   }
             }
-      setFlags ["--network-id", "m"]
+      setFlags ["--testnet-magic", "m"]
         `shouldParse` Run
           defaultRunOptions
             { chainConfig =
@@ -286,14 +286,14 @@ spec = parallel $
           mconcat
             [ ["publish-scripts"]
             , ["--node-socket", "foo"]
-            , ["--network-id", "42"]
+            , ["--testnet-magic", "42"]
             ]
 
       xit "does not parse with some missing option (2)" $
         shouldNotParse $
           mconcat
             [ ["publish-scripts"]
-            , ["--network-id", "42"]
+            , ["--testnet-magic", "42"]
             , ["--cardano-signing-key", "foo"]
             ]
 
@@ -309,7 +309,7 @@ spec = parallel $
         mconcat
           [ ["publish-scripts"]
           , ["--node-socket", "foo"]
-          , ["--network-id", "42"]
+          , ["--testnet-magic", "42"]
           , ["--cardano-signing-key", "bar"]
           ]
           `shouldParse` Publish

--- a/hydra-node/test/Hydra/OptionsSpec.hs
+++ b/hydra-node/test/Hydra/OptionsSpec.hs
@@ -270,7 +270,7 @@ spec = parallel $
           mconcat
             [ ["publish-scripts"]
             , ["--node-socket", "foo"]
-            , ["--testnet-magic", "42"]
+            , ["--mainnet"]
             ]
 
       xit "does not parse with some missing option (2)" $
@@ -289,7 +289,7 @@ spec = parallel $
             , ["--cardano-signing-key", "foo"]
             ]
 
-      it "should parse with all options" $
+      it "should parse using testnet and all options" $
         mconcat
           [ ["publish-scripts"]
           , ["--node-socket", "foo"]
@@ -301,6 +301,19 @@ spec = parallel $
               { publishNodeSocket = "foo"
               , publishNetworkId = Testnet (NetworkMagic 42)
               , publishSigningKey = "bar"
+              }
+      it "should parse using mainnet and all options" $
+        mconcat
+          [ ["publish-scripts"]
+          , ["--node-socket", "baz"]
+          , ["--mainnet"]
+          , ["--cardano-signing-key", "crux"]
+          ]
+          `shouldParse` Publish
+            PublishOptions
+              { publishNodeSocket = "baz"
+              , publishNetworkId = Mainnet
+              , publishSigningKey = "crux"
               }
 
 canRoundtripRunOptionsAndPrettyPrinting :: RunOptions -> Property

--- a/hydra-plutus/src/Hydra/Contract/Commit.hs
+++ b/hydra-plutus/src/Hydra/Contract/Commit.hs
@@ -9,9 +9,8 @@ import PlutusTx.Prelude
 
 import Codec.Serialise (deserialiseOrFail, serialise)
 import Data.ByteString.Lazy (fromStrict, toStrict)
-import Hydra.Cardano.Api (CtxUTxO, NetworkId (..), fromPlutusTxOut, fromPlutusTxOutRef, toPlutusTxOut, toPlutusTxOutRef)
+import Hydra.Cardano.Api (CtxUTxO, fromPlutusTxOut, fromPlutusTxOutRef, toPlutusTxOut, toPlutusTxOutRef)
 import qualified Hydra.Cardano.Api as OffChain
-import qualified Hydra.Cardano.Api.Network as Network
 import Hydra.Contract.Util (hasST, mustBurnST)
 import Hydra.Data.Party (Party)
 import Hydra.Prelude (Show)
@@ -73,13 +72,9 @@ deserializeCommit networkId Commit{input, preSerializedOutput} =
   case deserialiseOrFail . fromStrict $ fromBuiltin preSerializedOutput of
     Left{} -> Nothing
     Right dat -> do
-      txOut <- fromPlutusTxOut network <$> fromData dat
+      txOut <- fromPlutusTxOut networkId <$> fromData dat
       pure (fromPlutusTxOutRef input, txOut)
  where
-  network = networkIdToNetwork networkId
-
-  networkIdToNetwork Mainnet = Network.Mainnet
-  networkIdToNetwork (Testnet _) = Network.Testnet
 
 -- TODO: Party is not used on-chain but is needed off-chain while it's still
 -- based on mock crypto. When we move to real crypto we could simply use

--- a/hydra-plutus/src/Hydra/Contract/Commit.hs
+++ b/hydra-plutus/src/Hydra/Contract/Commit.hs
@@ -11,6 +11,8 @@ import Codec.Serialise (deserialiseOrFail, serialise)
 import Data.ByteString.Lazy (fromStrict, toStrict)
 import Hydra.Cardano.Api (CtxUTxO, fromPlutusTxOut, fromPlutusTxOutRef, toPlutusTxOut, toPlutusTxOutRef)
 import qualified Hydra.Cardano.Api as OffChain
+import Hydra.Cardano.Api.Network (Network)
+import Hydra.Contract.Error (ToErrorCode (..))
 import Hydra.Contract.Util (hasST, mustBurnST)
 import Hydra.Data.Party (Party)
 import Hydra.Prelude (Show)
@@ -31,7 +33,6 @@ import Plutus.V2.Ledger.Api (
 import PlutusTx (CompiledCode, fromData, toBuiltinData, toData)
 import qualified PlutusTx
 import qualified Prelude as Haskell
-import Hydra.Contract.Error (ToErrorCode (..))
 
 data CommitRedeemer
   = ViaCollectCom
@@ -67,12 +68,12 @@ serializeCommit (i, o) = do
 
 -- | Decode an on-chain 'SerializedTxOut' back into an off-chain 'TxOut'.
 -- NOTE: Depends on the 'Serialise' instance for Plutus' 'Data'.
-deserializeCommit :: OffChain.NetworkId -> Commit -> Maybe (OffChain.TxIn, OffChain.TxOut CtxUTxO)
-deserializeCommit networkId Commit{input, preSerializedOutput} =
+deserializeCommit :: Network -> Commit -> Maybe (OffChain.TxIn, OffChain.TxOut CtxUTxO)
+deserializeCommit network Commit{input, preSerializedOutput} =
   case deserialiseOrFail . fromStrict $ fromBuiltin preSerializedOutput of
     Left{} -> Nothing
     Right dat -> do
-      txOut <- fromPlutusTxOut networkId <$> fromData dat
+      txOut <- fromPlutusTxOut network <$> fromData dat
       pure (fromPlutusTxOutRef input, txOut)
  where
 

--- a/hydra-plutus/src/Hydra/Contract/Commit.hs
+++ b/hydra-plutus/src/Hydra/Contract/Commit.hs
@@ -9,9 +9,10 @@ import PlutusTx.Prelude
 
 import Codec.Serialise (deserialiseOrFail, serialise)
 import Data.ByteString.Lazy (fromStrict, toStrict)
-import Hydra.Cardano.Api (CtxUTxO, fromPlutusTxOut, fromPlutusTxOutRef, toPlutusTxOut, toPlutusTxOutRef)
+import Hydra.Cardano.Api (CtxUTxO, NetworkId (..), fromPlutusTxOut, fromPlutusTxOutRef, toPlutusTxOut, toPlutusTxOutRef)
 import qualified Hydra.Cardano.Api as OffChain
-import Hydra.Contract.Util (hasST, mustBurnST, networkIdToNetwork)
+import qualified Hydra.Cardano.Api.Network as Network
+import Hydra.Contract.Util (hasST, mustBurnST)
 import Hydra.Data.Party (Party)
 import Hydra.Prelude (Show)
 import Plutus.Extras (ValidatorType, scriptValidatorHash, wrapValidator)
@@ -76,6 +77,9 @@ deserializeCommit networkId Commit{input, preSerializedOutput} =
       pure (fromPlutusTxOutRef input, txOut)
  where
   network = networkIdToNetwork networkId
+
+  networkIdToNetwork Mainnet = Network.Mainnet
+  networkIdToNetwork (Testnet _) = Network.Testnet
 
 -- TODO: Party is not used on-chain but is needed off-chain while it's still
 -- based on mock crypto. When we move to real crypto we could simply use

--- a/hydra-plutus/src/Hydra/Contract/Util.hs
+++ b/hydra-plutus/src/Hydra/Contract/Util.hs
@@ -3,8 +3,6 @@
 
 module Hydra.Contract.Util where
 
-import Hydra.Cardano.Api (NetworkId (Mainnet, Testnet))
-import qualified Hydra.Cardano.Api.Network as Network
 import Plutus.V1.Ledger.Value (isZero)
 import Plutus.V2.Ledger.Api (
   CurrencySymbol,

--- a/hydra-plutus/src/Hydra/Contract/Util.hs
+++ b/hydra-plutus/src/Hydra/Contract/Util.hs
@@ -3,6 +3,10 @@
 module Hydra.Contract.Util where
 
 import Hydra.Prelude (Show)
+
+import Hydra.Cardano.Api (NetworkId (Mainnet, Testnet))
+import qualified Hydra.Cardano.Api.Network as Network
+import Hydra.Contract.Error (ToErrorCode (..))
 import Plutus.V1.Ledger.Value (isZero)
 import Plutus.V2.Ledger.Api (
   CurrencySymbol,
@@ -14,7 +18,6 @@ import Plutus.V2.Ledger.Api (
 import qualified PlutusTx.AssocMap as Map
 import PlutusTx.Builtins (serialiseData)
 import PlutusTx.Prelude
-import Hydra.Contract.Error (ToErrorCode (..))
 
 hydraHeadV1 :: BuiltinByteString
 hydraHeadV1 = "HydraHeadV1"
@@ -67,3 +70,8 @@ data UtilError
 instance ToErrorCode UtilError where
   toErrorCode = \case
     MintingOrBurningIsForbidden -> "U01"
+
+-- | Convert Cardano.Api 'NetworkId' to ledger `Network`
+networkIdToNetwork :: NetworkId -> Network.Network
+networkIdToNetwork Mainnet = Network.Mainnet
+networkIdToNetwork (Testnet _) = Network.Testnet

--- a/hydra-tui/hydra-tui.cabal
+++ b/hydra-tui/hydra-tui.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          hydra-tui
-version:       0.9.0
+version:       0.10.0
 synopsis:      TUI for managing a Hydra node
 description:   TUI for managing a Hydra node
 author:        IOG
@@ -140,7 +140,5 @@ test-suite tests
     , unix
     , vty
 
-  build-tool-depends:
-    hspec-discover:hspec-discover -any, hydra-node:hydra-node -any
-
+  build-tool-depends: hspec-discover:hspec-discover, hydra-node:hydra-node
   ghc-options:        -threaded -rtsopts

--- a/hydra-tui/src/Hydra/TUI/Options.hs
+++ b/hydra-tui/src/Hydra/TUI/Options.hs
@@ -9,7 +9,6 @@ import Hydra.Cardano.Api (
 import Hydra.Network (Host (Host))
 import Options.Applicative (
   Parser,
-  ReadM,
   auto,
   completer,
   eitherReader,

--- a/hydra-tui/test/Hydra/TUI/OptionsSpec.hs
+++ b/hydra-tui/test/Hydra/TUI/OptionsSpec.hs
@@ -5,8 +5,8 @@ import Test.Hydra.Prelude
 
 import Hydra.Cardano.Api (NetworkId (..), NetworkMagic (..))
 import Hydra.Network (Host (Host))
+import Hydra.Options (networkIdParser)
 import Hydra.TUI.Options (
-  parseCardanoNetworkId,
   parseCardanoNodeSocket,
   parseCardanoSigningKey,
   parseNodeHost,
@@ -24,7 +24,7 @@ spec = parallel $ do
   it "parses --connect option" $ do
     shouldParseWith parseNodeHost ["--connect", "127.0.0.1:4002"] (Host "127.0.0.1" 4002)
   it "parses --network-id option" $ do
-    shouldParseWith parseCardanoNetworkId ["--network-id", "123"] (Testnet $ NetworkMagic 123)
+    shouldParseWith networkIdParser ["--network-id", "123"] (Testnet $ NetworkMagic 123)
   it "parses --cardano-signing-key option" $ do
     shouldParseWith parseCardanoSigningKey ["--cardano-signing-key", "foo.sk"] "foo.sk"
   it "parses --node-socket option" $ do

--- a/hydra-tui/test/Hydra/TUI/OptionsSpec.hs
+++ b/hydra-tui/test/Hydra/TUI/OptionsSpec.hs
@@ -23,8 +23,8 @@ spec :: Spec
 spec = parallel $ do
   it "parses --connect option" $ do
     shouldParseWith parseNodeHost ["--connect", "127.0.0.1:4002"] (Host "127.0.0.1" 4002)
-  it "parses --network-id option" $ do
-    shouldParseWith networkIdParser ["--network-id", "123"] (Testnet $ NetworkMagic 123)
+  it "parses --testnet-magic option" $ do
+    shouldParseWith networkIdParser ["--testnet-magic", "123"] (Testnet $ NetworkMagic 123)
   it "parses --cardano-signing-key option" $ do
     shouldParseWith parseCardanoSigningKey ["--cardano-signing-key", "foo.sk"] "foo.sk"
   it "parses --node-socket option" $ do

--- a/hydraw/README.md
+++ b/hydraw/README.md
@@ -28,8 +28,16 @@ The frontend is written in vanilla HTML/CSS/JS and is dynamically served from th
 
 All commands must be run from within `hydraw/` and assuming your Hydra API host+port is `hydra.example.io:4001` and your cardano signing key is `cardano.sk`:
 
+You can choose the network by specifying `HYDRAW_NETWORK`.
+
+This value contain either network magic number in case you want to run hydraw on one of the testnets or a string "mainnet".
+
+In case HYDRAW_NETWORK is not set we default to `Testnet (NetworkMagic 42)`.
+
+In case the magic number parsing fails we assume you want to run on Mainnet!
+
 To launch the `hydraw` bridge:
 
 ``` sh
-HYDRA_API_HOST=hydra.example.io:4001 HYDRAW_CARDANO_SIGNING_KEY=cardano.sk cabal exec hydraw
+HYDRA_API_HOST=hydra.example.io:4001 HYDRAW_CARDANO_SIGNING_KEY=cardano.sk HYDRAW_NETWORK=2 cabal exec hydraw
 ```

--- a/hydraw/README.md
+++ b/hydraw/README.md
@@ -30,7 +30,7 @@ All commands must be run from within `hydraw/` and assuming your Hydra API host+
 
 You can choose the network by specifying `HYDRAW_NETWORK`.
 
-This value contain either network magic number in case you want to run hydraw on one of the testnets or a string "mainnet".
+This value contains either network magic number in case you want to run hydraw on one of the testnets or a string "mainnet".
 
 In case HYDRAW_NETWORK is not set we default to `Testnet (NetworkMagic 42)`.
 

--- a/hydraw/app/Main.hs
+++ b/hydraw/app/Main.hs
@@ -19,13 +19,15 @@ import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.Wai.Handler.WebSockets as Wai
 import qualified Network.WebSockets as WS
 import Safe (readMay)
+import Hydra.Cardano.Api (NetworkId (..), NetworkMagic (..))
 
 main :: IO ()
 main = do
   key <- fromMaybe (error "set HYDRAW_CARDANO_SIGNING_KEY environment variable") <$> lookupEnv "HYDRAW_CARDANO_SIGNING_KEY"
   host <- readHost . fromMaybe (error "set HYDRA_API_HOST environment variable") =<< lookupEnv "HYDRA_API_HOST"
+  network <- parseNetwork <$> lookupEnv "HYDRAW_NETWORK"
   withClient host $ \cnx -> do
-    Wai.websocketsOr WS.defaultConnectionOptions (websocketApp host) (httpApp key cnx)
+    Wai.websocketsOr WS.defaultConnectionOptions (websocketApp host) (httpApp network key cnx)
       & Warp.runSettings settings
  where
   port = 1337
@@ -38,6 +40,15 @@ main = do
             putStrLn "Server started..."
             putStrLn $ "Listening on: tcp/" <> show port
         )
+  -- try to parse magic number and if unsuccessfull default to 'Mainnet'
+  -- NOTE: if not set default network is 'Testnet' with magic 42
+  parseNetwork mStr =
+    case mStr of
+      Nothing -> Testnet (NetworkMagic 42)
+      Just i ->
+        case readMaybe i :: Maybe Word32 of
+          Nothing -> Mainnet
+          Just m  -> Testnet (NetworkMagic m)
 
 websocketApp :: Host -> WS.PendingConnection -> IO ()
 websocketApp host pendingConnection = do
@@ -60,8 +71,8 @@ websocketApp host pendingConnection = do
       (forever $ await >>= WS.send cnx)
       (forever $ WS.receive cnx >>= yield)
 
-httpApp :: FilePath -> WS.Connection -> Application
-httpApp key cnx req send =
+httpApp :: NetworkId -> FilePath -> WS.Connection -> Application
+httpApp networkId key cnx req send =
   case (requestMethod req, pathInfo req) of
     ("HEAD", _) -> do
       send $
@@ -74,16 +85,16 @@ httpApp key cnx req send =
     ("GET", "paint" : args) -> do
       case traverse (readMay . toString) args of
         Just [x, y, r, g, b] ->
-          send =<< handleGetPaint key cnx (x, y) (r, g, b)
+          send =<< handleGetPaint networkId key cnx (x, y) (r, g, b)
         _ ->
           send handleError
     (_, _) ->
       send handleNotFound
 
-handleGetPaint :: FilePath -> WS.Connection -> (Word8, Word8) -> (Word8, Word8, Word8) -> IO Response
-handleGetPaint key cnx (x, y) (red, green, blue) = do
+handleGetPaint :: NetworkId -> FilePath -> WS.Connection -> (Word8, Word8) -> (Word8, Word8, Word8) -> IO Response
+handleGetPaint networkId key cnx (x, y) (red, green, blue) = do
   putStrLn $ show (x, y) <> " -> " <> show (red, green, blue)
-  paintPixel key cnx Pixel{x, y, red, green, blue}
+  paintPixel networkId key cnx Pixel{x, y, red, green, blue}
   pure $ responseLBS status200 corsHeaders "OK"
 
 handleError :: Response

--- a/hydraw/app/Main.hs
+++ b/hydraw/app/Main.hs
@@ -3,6 +3,7 @@ module Main where
 import Hydra.Prelude
 
 import Control.Monad.Class.MonadSTM (newTQueueIO, readTQueue, writeTQueue)
+import Hydra.Cardano.Api (NetworkId (..), NetworkMagic (..))
 import Hydra.Network (Host, readHost)
 import Hydra.Painter (Pixel (..), paintPixel, withClient)
 import Network.HTTP.Types.Header (HeaderName)
@@ -19,7 +20,6 @@ import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.Wai.Handler.WebSockets as Wai
 import qualified Network.WebSockets as WS
 import Safe (readMay)
-import Hydra.Cardano.Api (NetworkId (..), NetworkMagic (..))
 
 main :: IO ()
 main = do
@@ -41,14 +41,13 @@ main = do
             putStrLn $ "Listening on: tcp/" <> show port
         )
   -- try to parse magic number and if unsuccessfull default to 'Mainnet'
-  -- NOTE: if not set default network is 'Testnet' with magic 42
   parseNetwork mStr =
     case mStr of
-      Nothing -> Testnet (NetworkMagic 42)
+      Nothing -> Mainnet
       Just i ->
         case readMaybe i :: Maybe Word32 of
           Nothing -> Mainnet
-          Just m  -> Testnet (NetworkMagic m)
+          Just m -> Testnet (NetworkMagic m)
 
 websocketApp :: Host -> WS.PendingConnection -> IO ()
 websocketApp host pendingConnection = do

--- a/hydraw/app/Main.hs
+++ b/hydraw/app/Main.hs
@@ -40,11 +40,12 @@ main = do
             putStrLn "Server started..."
             putStrLn $ "Listening on: tcp/" <> show port
         )
-  -- try to parse magic number and if unsuccessfull default to 'Mainnet'
+  -- in case expected network string is not set default to `Testnet (NetworkMagic 42)`
   parseNetwork mStr =
     case mStr of
-      Nothing -> Mainnet
+      Nothing -> Testnet (NetworkMagic 42)
       Just i ->
+        -- try to parse magic number and if it fails just default to 'Mainnet'
         case readMaybe i :: Maybe Word32 of
           Nothing -> Mainnet
           Just m -> Testnet (NetworkMagic m)

--- a/hydraw/hydraw.cabal
+++ b/hydraw/hydraw.cabal
@@ -77,6 +77,7 @@ executable hydraw
     , http-types
     , hydra-node
     , hydra-prelude
+    , hydra-cardano-api
     , hydraw
     , io-classes
     , relude

--- a/hydraw/hydraw.cabal
+++ b/hydraw/hydraw.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          hydraw
-version:       0.0.1
+version:       0.10.0
 build-type:    Simple
 
 common project-config
@@ -73,11 +73,11 @@ executable hydraw
     -Wunused-packages -threaded -rtsopts
 
   build-depends:
-    , base            >=4.7 && <5
+    , base               >=4.7 && <5
     , http-types
+    , hydra-cardano-api
     , hydra-node
     , hydra-prelude
-    , hydra-cardano-api
     , hydraw
     , io-classes
     , relude

--- a/hydraw/hydraw.cabal
+++ b/hydraw/hydraw.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          hydraw
-version:       0.10.0
+version:       0.0.1
 build-type:    Simple
 
 common project-config

--- a/hydraw/src/Hydra/Painter.hs
+++ b/hydraw/src/Hydra/Painter.hs
@@ -24,8 +24,8 @@ data Pixel = Pixel
   { x, y, red, green, blue :: Word8
   }
 
-paintPixel :: FilePath -> Connection -> Pixel -> IO ()
-paintPixel signingKeyPath cnx pixel = do
+paintPixel :: NetworkId -> FilePath -> Connection -> Pixel -> IO ()
+paintPixel networkId signingKeyPath cnx pixel = do
   sk <- readFileTextEnvelopeThrow (AsSigningKey AsPaymentKey) signingKeyPath
   let vk = getVerificationKey sk
   flushQueue cnx
@@ -42,9 +42,6 @@ paintPixel signingKeyPath cnx pixel = do
         Right tx -> sendTextData cnx $ Aeson.encode $ NewTx tx
     Right other -> error $ "Unexpected server answer:  " <> decodeUtf8 msg
  where
-  networkId = Testnet unusedNetworkMagic
-  unusedNetworkMagic = NetworkMagic 42
-
   flushQueue cnx =
     race_ (threadDelay 0.25) (void (receive cnx) >> flushQueue cnx)
 

--- a/sample-node-config/aws/docker/docker-compose.yaml
+++ b/sample-node-config/aws/docker/docker-compose.yaml
@@ -52,7 +52,7 @@ services:
       , "--cardano-signing-key", "/data/cardano-key.sk"
       , "--ledger-genesis", "/data/genesis-shelley.json"
       , "--ledger-protocol-parameters", "/data/protocol-parameters.json"
-      , "--network-id", "${NETWORK_MAGIC}"
+      , "--testnet-magic", "${NETWORK_MAGIC}"
       , "--node-socket", "/devnet/node.socket"
       # hardcoded peers
       ## Arnaud
@@ -82,7 +82,7 @@ services:
         "--"
       , "--connect", "hydra-node:4001"
       , "--node-socket", "/devnet/node.socket"
-      , "--network-id", "${NETWORK_MAGIC}"
+      , "--testnet-magic", "${NETWORK_MAGIC}"
       , "--cardano-signing-key", "/data/cardano-key.sk"
       ]
     volumes:

--- a/sample-node-config/gcp/docker-compose.yaml
+++ b/sample-node-config/gcp/docker-compose.yaml
@@ -48,7 +48,7 @@ services:
       , "--cardano-signing-key", "/data/keys/arnaud.sk"
       , "--ledger-genesis", "/data/genesis-shelley.json"
       , "--ledger-protocol-parameters", "/data/protocol-parameters.json"
-      , "--network-id", "${NETWORK_MAGIC}"
+      , "--testnet-magic", "${NETWORK_MAGIC}"
       , "--node-socket", "/devnet/node.socket"
       ]
 
@@ -59,7 +59,7 @@ services:
     command:
       [ "--connect", "hydra-node:4001"
       , "--node-socket", "/devnet/node.socket"
-      , "--network-id", "${NETWORK_MAGIC}"
+      , "--testnet-magic", "${NETWORK_MAGIC}"
       , "--cardano-signing-key", "/data/arnaud.sk"
       ]
     volumes:

--- a/sample-node-config/nixos/README.md
+++ b/sample-node-config/nixos/README.md
@@ -62,7 +62,7 @@ ssh -t example docker run --rm -it \
   ghcr.io/input-output-hk/hydra-tui \
   --connect 0.0.0.0:4001 \
   --node-socket /data/cardano-node/node.socket \
-  --network-id 2 \
+  --testnet-magic 2 \
   --cardano-signing-key /data/hydra-node/credentials/sebastian.cardano.sk
 ```
 

--- a/sample-node-config/nixos/hydraw.nix
+++ b/sample-node-config/nixos/hydraw.nix
@@ -66,7 +66,7 @@ in
         [ "--cardano-signing-key" "/data/credentials/sebastian.cardano.sk" ]
         [ "--ledger-genesis" "/cardano-node/config/preview/shelley-genesis.json" ]
         [ "--ledger-protocol-parameters" "/data/protocol-parameters.json" ]
-        [ "--network-id" networkMagic ]
+        [ "--testnet-magic" networkMagic ]
         [ "--node-socket" "/cardano-node/node.socket" ]
       ];
     };

--- a/testnets/README.md
+++ b/testnets/README.md
@@ -36,7 +36,7 @@ command and keep:
 
 ```sh
 hydra-node publish-scripts \
-    --network-id $(cat preview/db/protocolMagicId) \
+    --testnet-magic $(cat preview/db/protocolMagicId) \
     --node-socket "preview/node.socket" \
     --cardano-signing-key credentials/sebastian.cardano.sk
 ```
@@ -61,7 +61,7 @@ launch the `hydra-node`:
 hydra-node \
   --node-id 314 \
   --node-socket "preview/node.socket" \
-  --network-id $(cat preview/db/protocolMagicId) \
+  --testnet-magic $(cat preview/db/protocolMagicId) \
   --hydra-scripts-tx-id ${HYDRA_SCRIPTS_TX_ID} \
   --ledger-genesis "preview/genesis/shelley.json" \
   --ledger-protocol-parameters "../hydra-cluster/config/protocol-parameters.json" \
@@ -75,7 +75,7 @@ To start the `hydra-tui`:
 hydra-tui \
   --connect "0.0.0.0:4001" \
   --cardano-signing-key "credentials/sebastian.cardano.sk" \
-  --network-id $(cat preview/db/protocolMagicId) \
+  --testnet-magic $(cat preview/db/protocolMagicId) \
   --node-socket "preview/node.socket"
 ```
 


### PR DESCRIPTION
## Why
In order to get _mainnet ready_ I am doing this as the kickoff task - be able to actually connect hydra-node to the mainnet.

This PR:
- Adds the option to parse command line argument for mainnet network in hydra-node and hydra-tui
- Adds new flag `HYDRAW-NETWORK` that is either parsed as a testnet magic number or defaults to mainnet
- Tackles a FIXME in the `v_commit` validator related to hardcoded network

To check before merging:
* [x] CHANGELOG is up to date
* [x] Up to date with master
