### PR TITLE
Deadline gets "pushed out" on each contest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ changes.
   + The v_head output must now be the first output of the transaction so that we can make the validator code simpler.
   + Introduce check in head validator to allow contest only once per party.
   + Check that value is preserved in v_head
-  + Introduce a function `(===!)` for strict equality check between serialized `Value`.
+  + Introduce a function `(===)` for strict equality check between serialized `Value`.
+  + Push contestation deadline on contest.
 
 - **BREAKING** Change the way tx validity and contestation deadline is constructed for close transactions:
   + There is a new hydra-node flag `--contestation-period` expressed in seconds

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -433,14 +433,14 @@ contest ::
   PointInTime ->
   Tx
 contest ctx st confirmedSnapshot pointInTime = do
-  contestTx ownVerificationKey sn sigs pointInTime closedThreadOutput headId (contestationPeriod ctx)
+  contestTx ownVerificationKey sn sigs pointInTime closedThreadOutput headId contestationPeriod
  where
   (sn, sigs) =
     case confirmedSnapshot of
       ConfirmedSnapshot{signatures} -> (getSnapshot confirmedSnapshot, signatures)
       _ -> (getSnapshot confirmedSnapshot, mempty)
 
-  ChainContext{ownVerificationKey} = ctx
+  ChainContext{contestationPeriod, ownVerificationKey} = ctx
 
   ClosedState
     { closedThreadOutput

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -433,7 +433,7 @@ contest ::
   PointInTime ->
   Tx
 contest ctx st confirmedSnapshot pointInTime = do
-  contestTx ownVerificationKey sn sigs pointInTime closedThreadOutput headId
+  contestTx ownVerificationKey sn sigs pointInTime closedThreadOutput headId (contestationPeriod ctx)
  where
   (sn, sigs) =
     case confirmedSnapshot of

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -418,7 +418,10 @@ contestTx vk Snapshot{number, utxo} sig (slotNo, _) ClosedThreadOutput{closedThr
 
   onChainConstestationPeriod = toChain contestationPeriod
 
-  pushedContestationDeadline = addContestationPeriod closedContestationDeadline onChainConstestationPeriod
+  newContestationDeadline =
+    if length (contester : closedContesters) == length closedParties
+      then closedContestationDeadline
+      else addContestationPeriod closedContestationDeadline onChainConstestationPeriod
 
   headDatumAfter =
     mkTxOutDatum
@@ -426,7 +429,7 @@ contestTx vk Snapshot{number, utxo} sig (slotNo, _) ClosedThreadOutput{closedThr
         { snapshotNumber = toInteger number
         , utxoHash
         , parties = closedParties
-        , contestationDeadline = pushedContestationDeadline
+        , contestationDeadline = newContestationDeadline
         , contestationPeriod = onChainConstestationPeriod
         , headId = headIdToCurrencySymbol headId
         , contesters = contester : closedContesters

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -355,6 +355,7 @@ closeTx vk closing startSlotNo (endSlotNo, utcTime) openThreadOutput headId =
         , utxoHash = toBuiltin utxoHashBytes
         , parties = openParties
         , contestationDeadline
+        , contestationPeriod = openContestationPeriod
         , headId = headIdToCurrencySymbol headId
         , contesters = []
         }
@@ -415,14 +416,18 @@ contestTx vk Snapshot{number, utxo} sig (slotNo, _) ClosedThreadOutput{closedThr
 
   contester = toPlutusKeyHash (verificationKeyHash vk)
 
+  onChainConstestationPeriod = toChain contestationPeriod
+
+  pushedContestationDeadline = addContestationPeriod closedContestationDeadline onChainConstestationPeriod
+
   headDatumAfter =
     mkTxOutDatum
       Head.Closed
         { snapshotNumber = toInteger number
         , utxoHash
         , parties = closedParties
-        , contestationDeadline = closedContestationDeadline
-        , contestationPeriod = toChain contestationPeriod
+        , contestationDeadline = pushedContestationDeadline
+        , contestationPeriod = onChainConstestationPeriod
         , headId = headIdToCurrencySymbol headId
         , contesters = contester : closedContesters
         }

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -391,8 +391,9 @@ contestTx ::
   -- | Everything needed to spend the Head state-machine output.
   ClosedThreadOutput ->
   HeadId ->
+  ContestationPeriod ->
   Tx
-contestTx vk Snapshot{number, utxo} sig (slotNo, _) ClosedThreadOutput{closedThreadUTxO = (headInput, headOutputBefore, ScriptDatumForTxIn -> headDatumBefore), closedParties, closedContestationDeadline, closedContesters} headId =
+contestTx vk Snapshot{number, utxo} sig (slotNo, _) ClosedThreadOutput{closedThreadUTxO = (headInput, headOutputBefore, ScriptDatumForTxIn -> headDatumBefore), closedParties, closedContestationDeadline, closedContesters} headId contestationPeriod =
   unsafeBuildTransaction $
     emptyTxBody
       & addInputs [(headInput, headWitness)]
@@ -421,6 +422,7 @@ contestTx vk Snapshot{number, utxo} sig (slotNo, _) ClosedThreadOutput{closedThr
         , utxoHash
         , parties = closedParties
         , contestationDeadline = closedContestationDeadline
+        , contestationPeriod = toChain contestationPeriod
         , headId = headIdToCurrencySymbol headId
         , contesters = contester : closedContesters
         }

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -42,7 +42,7 @@ import Plutus.Orphans ()
 import Plutus.V2.Ledger.Api (BuiltinByteString, toBuiltin, toData)
 import qualified Plutus.V2.Ledger.Api as Plutus
 import Test.Hydra.Fixture (aliceSk, bobSk, carolSk)
-import Test.QuickCheck (elements, listOf, oneof, suchThat)
+import Test.QuickCheck (elements, listOf, oneof, suchThat, vectorOf)
 import Test.QuickCheck.Gen (choose)
 import Test.QuickCheck.Instances ()
 
@@ -194,17 +194,9 @@ data ContestMutation
     MutateValueInOutput
   | -- | Change the 'ContestationDeadline' in the 'Closed' output datum such that deadline is pushed away
     MutatePushedContestationDeadlineOnOutputClosedState
-  -- TODO
-  -- | -- | Change the 'ContestationDeadline' in the 'Closed' output datum such that deadline is NOT pushed away
-  --   MutateNotPushedContestationDeadlineOnOutputClosedState
-  -- | -- | Change the 'ContestationDeadline' in the 'Closed' input datum such that deadline is pushed away
-  --   MutatePushedContestationDeadlineOnInputClosedState
-  -- | -- | Change the 'ContestationDeadline' in the 'Closed' input datum such that deadline is NOT pushed away
-  --   MutateNotPushedContestationDeadlineOnInputClosedState
-  -- | -- | Change the 'ContestationPeriod' in the 'Closed' input datum such that deadline is pushed away
-  --   MutatePushedContestationPeriodOnInputClosedState
-  -- | -- | Change the 'ContestationPeriod' in the 'Closed' input datum such that deadline is NOT pushed away
-  --   MutateNotPushedContestationPeriodOnInputClosedState
+  | -- | Change the 'ContestationDeadline' in the 'Closed' output datum such that deadline is NOT pushed away
+    -- and contesters must change on input and output so they are complete
+    MutateNotPushedContestationDeadlineOnOutputClosedState
   deriving (Generic, Show, Enum, Bounded)
 
 genContestMutation :: (Tx, UTxO) -> Gen SomeMutation
@@ -284,6 +276,21 @@ genContestMutation
           let deadline = posixFromUTCTime healthyContestationDeadline
           -- Here we are replacing the contestationDeadline using the previous without pushing it
           pure $ headTxOut & changeHeadOutputDatum (replaceContestationDeadline deadline)
+      , SomeMutation (Just "must not push deadline") MutateNotPushedContestationDeadlineOnOutputClosedState <$> do
+          randomContesters <- vectorOf (length healthyParties - 1) $ Plutus.PubKeyHash . toBuiltin <$> genHash
+          randomPosixTime <- arbitrary
+          let contester = toPlutusKeyHash (verificationKeyHash somePartyCardanoVerificationKey)
+              mutatedContesters = contester : randomContesters
+              deadline = posixFromUTCTime healthyContestationDeadline
+              mutatedDeadline = deadline + randomPosixTime
+          pure $
+            Changes
+              [ ChangeInputHeadDatum $
+                  healthyClosedState & replaceContesters randomContesters
+              , ChangeOutput 0 $
+                  headTxOut & changeHeadOutputDatum (replaceContesters mutatedContesters)
+                    & changeHeadOutputDatum (replaceContestationDeadline mutatedDeadline)
+              ]
       ]
    where
     headTxOut = fromJust $ txOuts' tx !!? 0

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -273,6 +273,7 @@ genContestMutation
       , SomeMutation (Just "must push deadline") MutateContestationDeadlineInTheClosedState . ChangeOutput 0 <$> do
           let deadline =
                 case healthyClosedState of
+                  -- We are replacing the contestationDeadline using the previous without pushing it
                   Head.Closed{contestationDeadline} -> contestationDeadline
                   _ -> error "not in a closed state"
           pure $ changeHeadOutputDatum (replaceContestationDeadline deadline) headTxOut

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -278,10 +278,13 @@ genContestMutation
           pure $ headTxOut & changeHeadOutputDatum (replaceContestationDeadline deadline)
       , SomeMutation (Just "must not push deadline") MutateNotPushedContestationDeadlineOnOutputClosedState <$> do
           randomContesters <- vectorOf (length healthyParties - 1) $ Plutus.PubKeyHash . toBuiltin <$> genHash
+          -- Here we are replacing the contesters so they are almost complete in output
           randomPosixTime <- arbitrary
           let contester = toPlutusKeyHash (verificationKeyHash somePartyCardanoVerificationKey)
+              -- Here we are replacing the contesters so they are complete in output
               mutatedContesters = contester : randomContesters
               deadline = posixFromUTCTime healthyContestationDeadline
+              -- Here we are replacing the contestationDeadline using the previous and pushing it
               mutatedDeadline = deadline + randomPosixTime
           pure $
             Changes

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -114,7 +114,7 @@ healthyClosedState =
     , utxoHash = healthyClosedUTxOHash
     , parties = healthyOnChainParties
     , contestationDeadline = posixFromUTCTime healthyContestationDeadline
-    , contestationPeriod = fromInteger healthyContestationPeriodSeconds
+    , contestationPeriod = healthyOnChainContestationPeriod
     , headId = toPlutusCurrencySymbol testPolicyId
     , contesters = []
     }
@@ -128,8 +128,11 @@ healthyContestationDeadline =
     (fromInteger healthyContestationPeriodSeconds)
     (slotNoToUTCTime healthySlotNo)
 
+healthyOnChainContestationPeriod :: OnChain.ContestationPeriod
+healthyOnChainContestationPeriod = OnChain.contestationPeriodFromDiffTime $ fromInteger healthyContestationPeriodSeconds
+
 healthyContestationPeriod :: ContestationPeriod
-healthyContestationPeriod = fromChain $ OnChain.contestationPeriodFromDiffTime $ fromInteger healthyContestationPeriodSeconds
+healthyContestationPeriod = fromChain healthyOnChainContestationPeriod
 
 healthyContestationPeriodSeconds :: Integer
 healthyContestationPeriodSeconds = 10

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -292,7 +292,7 @@ genContestMutation
               , ChangeInputHeadDatum (healthyClosedState & replaceContesters alreadyContested)
               ]
       , SomeMutation (Just "changed parameters") MutateOutputContestationPeriod <$> do
-          randomCP <- arbitrary
+          randomCP <- arbitrary `suchThat` (/= healthyOnChainContestationPeriod)
           pure $ ChangeOutput 0 (headTxOut & changeHeadOutputDatum (replaceContestationPeriod randomCP))
       ]
    where

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -18,6 +18,7 @@ import Hydra.Chain.Direct.Contract.Mutation (
   changeHeadOutputDatum,
   changeMintedTokens,
   replaceContestationDeadline,
+  replaceContestationPeriod,
   replaceContesters,
   replaceParties,
   replacePolicyIdWith,
@@ -201,6 +202,8 @@ data ContestMutation
     -- changes the starting situation so that everyone else already contested.
     -- Remember the 'healthyContestTx' is already pushing out the deadline.
     PushDeadlineAlthoughItShouldNot
+  | -- | Change the contestation period to test parameters not changed in output.
+    MutateOutputContestationPeriod
   deriving (Generic, Show, Enum, Bounded)
 
 genContestMutation :: (Tx, UTxO) -> Gen SomeMutation
@@ -288,6 +291,9 @@ genContestMutation
               [ ChangeOutput 0 (headTxOut & changeHeadOutputDatum (replaceContesters (contester : alreadyContested)))
               , ChangeInputHeadDatum (healthyClosedState & replaceContesters alreadyContested)
               ]
+      , SomeMutation (Just "changed parameters") MutateOutputContestationPeriod <$> do
+          randomCP <- arbitrary
+          pure $ ChangeOutput 0 (headTxOut & changeHeadOutputDatum (replaceContestationPeriod randomCP))
       ]
    where
     headTxOut = fromJust $ txOuts' tx !!? 0

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -11,7 +11,6 @@ import Data.Maybe (fromJust)
 
 import Cardano.Api.UTxO as UTxO
 import qualified Data.List as List
-import qualified Data.List.NonEmpty as NE
 import Hydra.Chain.Direct.Contract.Gen (genForParty, genHash, genMintedOrBurnedValue)
 import Hydra.Chain.Direct.Contract.Mutation (
   Mutation (..),
@@ -38,13 +37,13 @@ import qualified Hydra.Data.Party as OnChain
 import Hydra.Ledger (hashUTxO)
 import Hydra.Ledger.Cardano (genOneUTxOFor, genValue, genVerificationKey)
 import Hydra.Ledger.Cardano.Evaluate (slotNoToUTCTime)
-import Hydra.Party (Party, deriveParty, partyToChain, vkey)
+import Hydra.Party (Party, deriveParty, partyToChain)
 import Hydra.Snapshot (Snapshot (..), SnapshotNumber)
 import Plutus.Orphans ()
 import Plutus.V2.Ledger.Api (BuiltinByteString, toBuiltin, toData)
 import qualified Plutus.V2.Ledger.Api as Plutus
 import Test.Hydra.Fixture (aliceSk, bobSk, carolSk)
-import Test.QuickCheck (elements, listOf, oneof, suchThat, vectorOf)
+import Test.QuickCheck (elements, listOf, oneof, suchThat)
 import Test.QuickCheck.Gen (choose)
 import Test.QuickCheck.Instances ()
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/FanOut.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/FanOut.hs
@@ -75,12 +75,6 @@ healthyContestationDeadline :: UTCTime
 healthyContestationDeadline =
   slotNoToUTCTime $ healthySlotNo - 1
 
-healthyContestationPeriod :: OnChain.ContestationPeriod
-healthyContestationPeriod = OnChain.contestationPeriodFromDiffTime $ fromInteger healthyContestationPeriodSeconds
-
-healthyContestationPeriodSeconds :: Integer
-healthyContestationPeriodSeconds = 10
-
 healthyFanoutDatum :: Head.State
 healthyFanoutDatum =
   Head.Closed
@@ -92,6 +86,10 @@ healthyFanoutDatum =
     , headId = toPlutusCurrencySymbol testPolicyId
     , contesters = []
     }
+ where
+  healthyContestationPeriodSeconds = 10
+
+  healthyContestationPeriod = OnChain.contestationPeriodFromDiffTime $ fromInteger healthyContestationPeriodSeconds
 
 data FanoutMutation
   = MutateAddUnexpectedOutput

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/FanOut.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/FanOut.hs
@@ -15,6 +15,7 @@ import Hydra.Chain.Direct.Tx (fanoutTx, mkHeadOutput)
 import qualified Hydra.Contract.HeadState as Head
 import Hydra.Contract.HeadTokens (mkHeadTokenScript)
 import Hydra.Data.ContestationPeriod (posixFromUTCTime)
+import qualified Hydra.Data.ContestationPeriod as OnChain
 import Hydra.Ledger (IsTx (hashUTxO))
 import Hydra.Ledger.Cardano (
   adaOnly,
@@ -74,6 +75,12 @@ healthyContestationDeadline :: UTCTime
 healthyContestationDeadline =
   slotNoToUTCTime $ healthySlotNo - 1
 
+healthyContestationPeriod :: OnChain.ContestationPeriod
+healthyContestationPeriod = OnChain.contestationPeriodFromDiffTime $ fromInteger healthyContestationPeriodSeconds
+
+healthyContestationPeriodSeconds :: Integer
+healthyContestationPeriodSeconds = 10
+
 healthyFanoutDatum :: Head.State
 healthyFanoutDatum =
   Head.Closed
@@ -81,6 +88,7 @@ healthyFanoutDatum =
     , utxoHash = toBuiltin $ hashUTxO @Tx healthyFanoutUTxO
     , parties = partyToChain <$> arbitrary `generateWith` 42
     , contestationDeadline = posixFromUTCTime healthyContestationDeadline
+    , contestationPeriod = healthyContestationPeriod
     , headId = toPlutusCurrencySymbol testPolicyId
     , contesters = []
     }

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
@@ -146,6 +146,7 @@ import qualified Hydra.Chain.Direct.Fixture as Fixture
 import Hydra.Chain.Direct.Tx (assetNameFromVerificationKey)
 import qualified Hydra.Contract.Head as Head
 import qualified Hydra.Contract.HeadState as Head
+import Hydra.Data.ContestationPeriod
 import qualified Hydra.Data.Party as Data (Party)
 import Hydra.Ledger.Cardano (genKeyPair, genOutput, genVerificationKey, renderTxWithUTxO)
 import Hydra.Ledger.Cardano.Evaluate (evaluateTx)
@@ -707,6 +708,20 @@ replaceUtxoHash utxoHash = \case
 replaceContestationDeadline :: POSIXTime -> Head.State -> Head.State
 replaceContestationDeadline contestationDeadline = \case
   Head.Closed{snapshotNumber, utxoHash, parties, headId, contesters, contestationPeriod} ->
+    Head.Closed
+      { snapshotNumber
+      , utxoHash
+      , parties
+      , contestationDeadline
+      , contestationPeriod
+      , headId
+      , contesters
+      }
+  otherState -> otherState
+
+replaceContestationPeriod :: ContestationPeriod -> Head.State -> Head.State
+replaceContestationPeriod contestationPeriod = \case
+  Head.Closed{snapshotNumber, utxoHash, parties, headId, contesters, contestationDeadline} ->
     Head.Closed
       { snapshotNumber
       , utxoHash

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
@@ -644,12 +644,13 @@ replacePolicyIdWith originalPolicyId otherPolicyId output =
 
 replaceSnapshotNumber :: Head.SnapshotNumber -> Head.State -> Head.State
 replaceSnapshotNumber snapshotNumber = \case
-  Head.Closed{parties, utxoHash, contestationDeadline, headId, contesters} ->
+  Head.Closed{parties, utxoHash, contestationDeadline, headId, contesters, contestationPeriod} ->
     Head.Closed
       { Head.parties = parties
       , Head.snapshotNumber = snapshotNumber
       , Head.utxoHash = utxoHash
       , Head.contestationDeadline = contestationDeadline
+      , Head.contestationPeriod = contestationPeriod
       , Head.headId = headId
       , Head.contesters = contesters
       }
@@ -670,12 +671,13 @@ replaceParties parties = \case
       , Head.utxoHash = utxoHash
       , Head.headId = headId
       }
-  Head.Closed{snapshotNumber, utxoHash, contestationDeadline, headId, contesters} ->
+  Head.Closed{snapshotNumber, utxoHash, contestationDeadline, headId, contesters, contestationPeriod} ->
     Head.Closed
       { Head.parties = parties
       , Head.snapshotNumber = snapshotNumber
       , Head.utxoHash = utxoHash
       , Head.contestationDeadline = contestationDeadline
+      , Head.contestationPeriod = contestationPeriod
       , Head.headId = headId
       , Head.contesters = contesters
       }
@@ -690,12 +692,13 @@ replaceUtxoHash utxoHash = \case
       , Head.utxoHash = utxoHash
       , Head.headId = headId
       }
-  Head.Closed{parties, snapshotNumber, contestationDeadline, headId, contesters} ->
+  Head.Closed{parties, snapshotNumber, contestationDeadline, headId, contesters, contestationPeriod} ->
     Head.Closed
       { Head.parties = parties
       , Head.snapshotNumber = snapshotNumber
       , Head.utxoHash = utxoHash
       , Head.contestationDeadline = contestationDeadline
+      , Head.contestationPeriod = contestationPeriod
       , Head.headId = headId
       , Head.contesters = contesters
       }
@@ -703,12 +706,13 @@ replaceUtxoHash utxoHash = \case
 
 replaceContestationDeadline :: POSIXTime -> Head.State -> Head.State
 replaceContestationDeadline contestationDeadline = \case
-  Head.Closed{snapshotNumber, utxoHash, parties, headId, contesters} ->
+  Head.Closed{snapshotNumber, utxoHash, parties, headId, contesters, contestationPeriod} ->
     Head.Closed
       { snapshotNumber
       , utxoHash
       , parties
       , contestationDeadline
+      , contestationPeriod
       , headId
       , contesters
       }
@@ -729,12 +733,13 @@ replaceHeadId headId = \case
       , Head.utxoHash = utxoHash
       , Head.headId = headId
       }
-  Head.Closed{snapshotNumber, utxoHash, contestationDeadline, parties, contesters} ->
+  Head.Closed{snapshotNumber, utxoHash, contestationDeadline, parties, contesters, contestationPeriod} ->
     Head.Closed
       { Head.parties = parties
       , Head.snapshotNumber = snapshotNumber
       , Head.utxoHash = utxoHash
       , Head.contestationDeadline = contestationDeadline
+      , Head.contestationPeriod = contestationPeriod
       , Head.headId = headId
       , Head.contesters = contesters
       }
@@ -742,12 +747,13 @@ replaceHeadId headId = \case
 
 replaceContesters :: [Plutus.PubKeyHash] -> Head.State -> Head.State
 replaceContesters contesters = \case
-  Head.Closed{snapshotNumber, utxoHash, contestationDeadline, parties, headId} ->
+  Head.Closed{snapshotNumber, utxoHash, contestationDeadline, parties, headId, contestationPeriod} ->
     Head.Closed
       { Head.parties = parties
       , Head.snapshotNumber = snapshotNumber
       , Head.utxoHash = utxoHash
       , Head.contestationDeadline = contestationDeadline
+      , Head.contestationPeriod = contestationPeriod
       , Head.headId = headId
       , Head.contesters = contesters
       }

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -398,7 +398,7 @@ forAllFanout action =
        in action utxo tx
             & label ("Fanout size: " <> prettyLength (countAssets $ txOuts' tx))
  where
-  maxSupported = 45
+  maxSupported = 39
 
   countAssets = getSum . foldMap (Sum . valueSize . txOutValue)
 

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -398,7 +398,7 @@ forAllFanout action =
        in action utxo tx
             & label ("Fanout size: " <> prettyLength (countAssets $ txOuts' tx))
  where
-  maxSupported = 39
+  maxSupported = 38
 
   countAssets = getSum . foldMap (Sum . valueSize . txOutValue)
 

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -417,16 +417,16 @@ checkContest ctx contestationDeadline contestationPeriod parties closedSnapshotN
     if length contesters' == length parties'
       then
         traceIfFalse "must not push deadline" $
-          contestationDeadlineFromDatum == contestationDeadline
+          contestationDeadline' == contestationDeadline
       else
         traceIfFalse "must push deadline" $
-          contestationDeadlineFromDatum == addContestationPeriod contestationDeadline contestationPeriod
+          contestationDeadline' == addContestationPeriod contestationDeadline contestationPeriod
 
   mustUpdateContesters =
     traceIfFalse "contester not included" $
       contesters' == contester : contesters
 
-  (contestSnapshotNumber, contestUtxoHash, parties', contestationDeadlineFromDatum, headId', contesters') =
+  (contestSnapshotNumber, contestUtxoHash, parties', contestationDeadline', headId', contesters') =
     -- XXX: fromBuiltinData is super big (and also expensive?)
     case fromBuiltinData @DatumType $ getDatum (headOutputDatum ctx) of
       Just

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -414,7 +414,7 @@ checkContest ctx contestationDeadline contestationPeriod parties closedSnapshotN
         && headId' == headId
 
   mustPushDeadline =
-    if length allContesters == length parties'
+    if length contesters' == length parties'
       then
         traceIfFalse "must not push deadline" $
           contestationDeadlineFromDatum == contestationDeadline
@@ -424,7 +424,7 @@ checkContest ctx contestationDeadline contestationPeriod parties closedSnapshotN
 
   mustUpdateContesters =
     traceIfFalse "contester not included" $
-      contesters' == allContesters
+      contesters' == contester : contesters
 
   (contestSnapshotNumber, contestUtxoHash, parties', contestationDeadlineFromDatum, headId', contesters') =
     -- XXX: fromBuiltinData is super big (and also expensive?)
@@ -442,7 +442,6 @@ checkContest ctx contestationDeadline contestationPeriod parties closedSnapshotN
 
   ScriptContext{scriptContextTxInfo = txInfo} = ctx
 
-  allContesters = contester : contesters
   contester =
     case txInfoSignatories txInfo of
       [signer] -> signer

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -414,8 +414,9 @@ checkContest ctx contestationDeadline contestationPeriod parties closedSnapshotN
         && headId' == headId
 
   mustPushDeadline =
-    traceIfFalse "must push deadline" $
-      contestationDeadlineFromDatum == addContestationPeriod contestationDeadline contestationPeriod
+    if length contesters' == length parties'
+      then traceIfFalse "must not push deadline" $ contestationDeadlineFromDatum == contestationDeadline
+      else traceIfFalse "must push deadline" $ contestationDeadlineFromDatum == addContestationPeriod contestationDeadline contestationPeriod
 
   mustUpdateContesters =
     traceIfFalse "contester not included" $

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -414,13 +414,17 @@ checkContest ctx contestationDeadline contestationPeriod parties closedSnapshotN
         && headId' == headId
 
   mustPushDeadline =
-    if length contesters' == length parties'
-      then traceIfFalse "must not push deadline" $ contestationDeadlineFromDatum == contestationDeadline
-      else traceIfFalse "must push deadline" $ contestationDeadlineFromDatum == addContestationPeriod contestationDeadline contestationPeriod
+    if length allContesters == length parties'
+      then
+        traceIfFalse "must not push deadline" $
+          contestationDeadlineFromDatum == contestationDeadline
+      else
+        traceIfFalse "must push deadline" $
+          contestationDeadlineFromDatum == addContestationPeriod contestationDeadline contestationPeriod
 
   mustUpdateContesters =
     traceIfFalse "contester not included" $
-      contesters' == (contester : contesters)
+      contesters' == allContesters
 
   (contestSnapshotNumber, contestUtxoHash, parties', contestationDeadlineFromDatum, headId', contesters') =
     -- XXX: fromBuiltinData is super big (and also expensive?)
@@ -438,6 +442,7 @@ checkContest ctx contestationDeadline contestationPeriod parties closedSnapshotN
 
   ScriptContext{scriptContextTxInfo = txInfo} = ctx
 
+  allContesters = contester : contesters
   contester =
     case txInfoSignatories txInfo of
       [signer] -> signer

--- a/hydra-plutus/src/Hydra/Contract/HeadState.hs
+++ b/hydra-plutus/src/Hydra/Contract/HeadState.hs
@@ -37,6 +37,7 @@ data State
       , snapshotNumber :: SnapshotNumber
       , utxoHash :: Hash
       , contestationDeadline :: POSIXTime
+      , contestationPeriod :: ContestationPeriod
       , headId :: CurrencySymbol
       , contesters :: [PubKeyHash]
       }


### PR DESCRIPTION
🥧 To be aligned with the contest spec, we are now pushing the contestation deadline using the previously defined contestation period.

🥧 The contestation deadline will only be pushed if the signer of the contest transaction is not the last one to contest.

To check before merging:
* [x] CHANGELOG is up to date
* [ ] Documentation is up to date
