### PR TITLE
Useless mutation

### DIFF
--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -166,7 +166,6 @@ data CollectComMutation
   = MutateOpenUTxOHash
   | -- | Test that collectCom cannot collect from an initial UTxO.
     MutateCommitToInitial
-  | MutateHeadTransition
   | -- | Test that every party has a chance to commit.
     MutateNumberOfParties
   | MutateHeadId
@@ -179,18 +178,6 @@ genCollectComMutation :: (Tx, UTxO) -> Gen SomeMutation
 genCollectComMutation (tx, _utxo) =
   oneof
     [ SomeMutation Nothing MutateOpenUTxOHash . ChangeOutput 0 <$> mutateUTxOHash
-    , SomeMutation Nothing MutateHeadTransition <$> do
-        changeRedeemer <- ChangeHeadRedeemer <$> (Head.Close <$> arbitrary)
-        differencCurrencySymbol <- arbitrary `suchThat` (/= toPlutusCurrencySymbol testPolicyId)
-        changeDatum <-
-          ChangeInputHeadDatum
-            <$> ( Head.Open
-                    <$> arbitrary
-                    <*> arbitrary
-                    <*> (toBuiltin <$> genHash)
-                    <*> pure differencCurrencySymbol
-                )
-        pure $ Changes [changeRedeemer, changeDatum]
     , SomeMutation Nothing MutateNumberOfParties <$> do
         -- NOTE: This also mutates the contestation period becuase we could not
         -- be bothered to decode/lookup the current one.


### PR DESCRIPTION
The MutateHeadTransition mutation was exercising the case of a rogue
close transaction trying to steal some commits.

The attack could have been the following:
* the head is initialized
* some members commit
* a rogue member creates a close transaction consuming all the commits
  and stealing the corresponding funds.

To explore this scenario, we crafted a close transaction which passes
L2 phase validation and is balanced. So successful in a way.

But we realize that there's no way one could create an open state
(which is needed for a valid close) without first having spent the
commits.

Said differently, the pre-requisite for this mutation was to be in
an impossible state.

Our conclusion is that this mutation does not make sense anymore.
Hence, we remove it.

To check before merging:
* [x] CHANGELOG is up to date
* [x] Up to date with master
