### PR TITLE
Add  missing explicit error expectation for transaction mutations

### DIFF
--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -239,9 +239,9 @@ data CloseMutation
   | -- | Check that snapshot numbers <= 0 need to close the head with the
     -- initial UTxO hash.
     MutateSnapshotNumberToLessThanEqualZero
-  | -- | Ensures the tx is multisigned by all Head
-    -- participants by changing the parties in the input head datum. If they do
-    -- not align the multisignature will not be valid anymore.
+  | -- | Ensures the close snapshot is multisigned by all Head participants by
+    -- changing the parties in the input head datum. If they do not align the
+    -- multisignature will not be valid anymore.
     SnapshotNotSignedByAllParties
   | -- | Ensures close is authenticated by a Head party by changing the signer
     -- used on the transaction to be not one of PTs.
@@ -250,19 +250,25 @@ data CloseMutation
     --
     -- Ensures the output state is consistent with the redeemer.
     MutateCloseUTxOHash
-  | -- | Ensures parties do not change between head input datum and head output datum.
+  | -- | Ensures parties do not change between head input datum and head output
+    --  datum.
     MutatePartiesInOutput
-  | -- | Ensures headId do not change between head input datum and head output datum.
+  | -- | Ensures headId do not change between head input datum and head output
+    -- datum.
     MutateHeadIdInOutput
   | -- | Invalidates the tx by changing the lower bound to be non finite.
     MutateInfiniteLowerBound
   | -- | Invalidates the tx by changing the upper bound to be non finite.
     MutateInfiniteUpperBound
-  | -- | Invalidates the tx by changing the contestation deadline to not satisfy `contestationDeadline = upperBound + contestationPeriod`.
+  | -- | Invalidates the tx by changing the contestation deadline to not satisfy
+    -- `contestationDeadline = upperBound + contestationPeriod`.
     MutateContestationDeadline
-  | -- | Invalidates the tx by changing the lower and upper bound to be not bounded as per spec `upperBound - lowerBound <= contestationPeriod`.
+  | -- | Invalidates the tx by changing the lower and upper bound to be not
+    -- bounded as per spec `upperBound - lowerBound <= contestationPeriod`.
     --
-    -- This also changes the resulting `head output` contestation deadline to be valid, so it satisfy `contestationDeadline = upperBound + contestationPeriod`.
+    -- This also changes the resulting `head output` contestation deadline to be
+    -- valid, so it satisfy `contestationDeadline = upperBound +
+    -- contestationPeriod`.
     MutateValidityInterval
   | -- | Ensure the Head cannot be closed with correct authentication from a
     -- different Head. We simulate this by changing the head policy id of the ST
@@ -273,13 +279,12 @@ data CloseMutation
     -- because the signer's PT, although with a consistent name, is not from the
     -- right head (has a different policy id than in the datum).
     CloseFromDifferentHead
-  | -- | Invalidates the tx by changing the output minted values to include burning/minting of tokens.
-    --
-    -- Minting or burning of the tokens should not be possible in v_head apart from 'checkAbort' or 'checkFanout'.
+  | -- | Minting or burning of tokens should not be possible in close.
     MutateTokenMintingOrBurning
   | -- | Invalidates the tx by changing the contesters to be non empty.
     MutateContesters
-  | -- | Invalidates the tx by changing output values arbitrarly to be differnet (not preserved) from the head.
+  | -- | Invalidates the tx by changing output values arbitrarly to be different
+    -- (not preserved) from the head.
     MutateValueInOutput
   deriving (Generic, Show, Enum, Bounded)
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -271,7 +271,7 @@ genCloseMutation (tx, _utxo) =
         mutatedSnapshotNumber <- arbitrary `suchThat` (<= 0)
         pure $ ChangeOutput 0 $ changeHeadOutputDatum (replaceSnapshotNumber mutatedSnapshotNumber) headTxOut
     , SomeMutation (Just $ toErrorCode SignatureVerificationFailed) MutateSnapshotNumberButNotSignature <$> do
-        mutatedSnapshotNumber <- arbitrarySizedNatural `suchThat` (\n -> n /= healthySnapshotNumber && n > 0)
+        mutatedSnapshotNumber <- arbitrarySizedNatural `suchThat` (> healthySnapshotNumber)
         pure $ ChangeOutput 0 $ changeHeadOutputDatum (replaceSnapshotNumber $ toInteger mutatedSnapshotNumber) headTxOut
     , SomeMutation (Just $ toErrorCode SignatureVerificationFailed) MutateParties . ChangeInputHeadDatum <$> do
         mutatedParties <- arbitrary `suchThat` (/= healthyOnChainParties)

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -225,20 +225,23 @@ healthyClosedUTxO =
 
 data CloseMutation
   = -- | Makes the tx `snapshot signature` invalid by changing the redeemer signature but not the snapshot number in resulting head output.
+    -- This ensures the snapshot signature is multisigned by all valid Head participants.
     MutateSignatureButNotSnapshotNumber
   | -- | Makes the tx `snapshot signature` invalid by changing the snapshot number in resulting head output but not the redeemer signature.
     MutateSnapshotNumberButNotSignature
   | -- | Makes the tx `utxo hash` invalid by changing the snapshot number in resulting head output to be a non-initual utxo (when snapshot number <= 0).
     MutateSnapshotNumberToLessThanZero
-  | -- | Makes the tx `snapshot signature` invalid by changing the parties in head input.
+  | -- | Makes the tx `snapshot signature` invalid by changing the parties in the head input (stored state).
     MutateParties
   | -- | Makes the tx `signer` invalid by using a signer not present in the list of distributed PTs.
+    -- This ensures that it's performed by a Head party.
     MutateRequiredSigner
   | -- | Makes the tx `snapshot signature` invalid by changing the utxo hash in resulting head output.
+    -- This ensures the output state is consistent with the redeemer.
     MutateCloseUTxOHash
-  | -- | Makes the tx resulting `head output` invalid by changing its parties to be different from the head input.
+  | -- | Makes the tx resulting `head output` invalid by changing its parties to be different from the head input (stored state).
     MutatePartiesInOutput
-  | -- | Makes the tx resulting `head output` invalid by changing its head id to be different from the head input.
+  | -- | Makes the tx resulting `head output` invalid by changing its head id to be different from the head input (stored state).
     MutateHeadIdInOutput
   | -- | Makes the tx `validity range` invalid by changing its lower bound to be non finite.
     MutateInfiniteLowerBound

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -228,38 +228,40 @@ data CloseMutation
   = -- | Ensures the snapshot signature is multisigned by all valid Head
     -- participants.
     --
-    -- Invalidates tx `snapshot signature` by changing the redeemer signature
+    -- Invalidates the tx by changing the redeemer signature
     -- but not the snapshot number in output head datum.
     MutateSignatureButNotSnapshotNumber
   | -- | Ensures the snapshot number is consistent with the signature.
     --
-    -- Invalidates the tx `snapshot signature` by changing the snapshot number
+    -- Invalidates the tx by changing the snapshot number
     -- in resulting head output but not the redeemer signature.
     MutateSnapshotNumberButNotSignature
   | -- | Check that snapshot numbers <= 0 need to close the head with the
     -- initial UTxO hash.
     MutateSnapshotNumberToLessThanEqualZero
-  | -- | Ensures the tx `snapshot signature` is multisigned by all Head
+  | -- | Ensures the tx is multisigned by all Head
     -- participants by changing the parties in the input head datum. If they do
     -- not align the multisignature will not be valid anymore.
     SnapshotNotSignedByAllParties
   | -- | Ensures close is authenticated by a Head party by changing the signer
     -- used on the transaction to be not one of PTs.
     MutateRequiredSigner
-  | -- | Makes the tx `snapshot signature` invalid by changing the utxo hash in resulting head output.
-    -- This ensures the output state is consistent with the redeemer.
+  | -- | Invalidates the tx by changing the utxo hash in resulting head output.
+    --
+    -- Ensures the output state is consistent with the redeemer.
     MutateCloseUTxOHash
   | -- | Ensures parties do not change between head input datum and head output datum.
     MutatePartiesInOutput
   | -- | Ensures headId do not change between head input datum and head output datum.
     MutateHeadIdInOutput
-  | -- | Makes the tx `validity range` invalid by changing its lower bound to be non finite.
+  | -- | Invalidates the tx by changing the lower bound to be non finite.
     MutateInfiniteLowerBound
-  | -- | Makes the tx `validity range` invalid by changing its upper bound to be non finite.
+  | -- | Invalidates the tx by changing the upper bound to be non finite.
     MutateInfiniteUpperBound
-  | -- | Makes the tx resulting `head output` invalid by changing its contestation deadline to not satisfy `contestationDeadline = upperBound + contestationPeriod`.
+  | -- | Invalidates the tx by changing the contestation deadline to not satisfy `contestationDeadline = upperBound + contestationPeriod`.
     MutateContestationDeadline
-  | -- | Makes the tx `validity range` invalid by changing its lower and upper bound to be not bounded as per spec `upperBound - lowerBound <= contestationPeriod`.
+  | -- | Invalidates the tx by changing the lower and upper bound to be not bounded as per spec `upperBound - lowerBound <= contestationPeriod`.
+    --
     -- This also changes the resulting `head output` contestation deadline to be valid, so it satisfy `contestationDeadline = upperBound + contestationPeriod`.
     MutateValidityInterval
   | -- | Ensure the Head cannot be closed with correct authentication from a
@@ -271,12 +273,13 @@ data CloseMutation
     -- because the signer's PT, although with a consistent name, is not from the
     -- right head (has a different policy id than in the datum).
     CloseFromDifferentHead
-  | -- | Makes the tx `output minted values` invalid by changing them to include burning/minting of tokens.
+  | -- | Invalidates the tx by changing the output minted values to include burning/minting of tokens.
+    --
     -- Minting or burning of the tokens should not be possible in v_head apart from 'checkAbort' or 'checkFanout'.
     MutateTokenMintingOrBurning
-  | -- | Makes the tx resulting `head output` invalid by changing its contesters to be non empty.
+  | -- | Invalidates the tx by changing the contesters to be non empty.
     MutateContesters
-  | -- | Makes the tx `output values` invalid by changing them arbitrarly to be differnet (not preserved) from the head.
+  | -- | Invalidates the tx by changing output values arbitrarly to be differnet (not preserved) from the head.
     MutateValueInOutput
   deriving (Generic, Show, Enum, Bounded)
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -245,15 +245,15 @@ data CloseMutation
     -- changing the parties in the input head datum. If they do not align the
     -- multisignature will not be valid anymore.
     SnapshotNotSignedByAllParties
-  | -- | Ensures close is authenticated by a single Head party by changing the signer
-    -- used on the tx to be not one of PTs.
+  | -- | Ensures close is authenticated by a one of the Head members by changing
+    --  the signer used on the tx to not be one of PTs.
     MutateRequiredSigner
-  | -- | Ensures close is authenticated by a single Head party by changing the signer
-    -- used on the tx to be empty.
+  | -- | Ensures close is authenticated by a one of the Head members by changing
+    --  the signer used on the tx to be empty.
     MutateNoRequiredSigner
-  | -- | Ensures close is authenticated by a single Head party by changing the signer
-    -- used on the tx to have multiple signers (including the signer to not fail for
-    -- SignerIsNotAParticipant).
+  | -- | Ensures close is authenticated by a one of the Head members by changing
+    --  the signer used on the tx to have multiple signers (including the signer
+    -- to not fail for SignerIsNotAParticipant).
     MutateMultipleRequiredSigner
   | -- | Invalidates the tx by changing the utxo hash in resulting head output.
     --
@@ -292,7 +292,7 @@ data CloseMutation
     MutateTokenMintingOrBurning
   | -- | Invalidates the tx by changing the contesters to be non empty.
     MutateContesters
-  | -- | Invalidates the tx by changing output values arbitrarly to be different
+  | -- | Invalidates the tx by changing output values arbitrarily to be different
     -- (not preserved) from the head.
     --
     -- Ensures values are preserved between head input and output.
@@ -399,8 +399,8 @@ data CloseInitialMutation
 -- We should probably validate all the mutation to this initial state but at
 -- least we keep this regression test as we stumbled upon problems with the following case.
 -- The nice thing to do would probably to generate either "normal" healthyCloseTx or
--- or healthyCloseInitialTx and apply all the mutation to it but we did'nt manage to do that
--- rightaway.
+-- or healthyCloseInitialTx and apply all the mutations to it but we didn't manage to do that
+-- right away.
 genCloseInitialMutation :: (Tx, UTxO) -> Gen SomeMutation
 genCloseInitialMutation (tx, _utxo) =
   oneof

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -327,7 +327,7 @@ genCloseMutation (tx, _utxo) =
 
   mutateCloseUTxOHash :: Gen (TxOut CtxTx)
   mutateCloseUTxOHash = do
-    mutatedUTxOHash <- genHash
+    mutatedUTxOHash <- genHash `suchThat` ((/= healthyClosedUTxOHash) . toBuiltin)
     pure $ changeHeadOutputDatum (replaceUtxoHash $ toBuiltin mutatedUTxOHash) headTxOut
 
 data CloseInitialMutation

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -97,9 +97,9 @@ healthyCloseTx =
   closingSnapshot :: ClosingSnapshot
   closingSnapshot =
     CloseWithConfirmedSnapshot
-      { snapshotNumber = healthySnapshotNumber
+      { snapshotNumber = healthyCloseSnapshotNumber
       , closeUtxoHash = UTxOHash $ hashUTxO @Tx healthyCloseUTxO
-      , signatures = healthySignature healthySnapshotNumber
+      , signatures = healthySignature healthyCloseSnapshotNumber
       }
 
 -- | Healthy close transaction for the specific case were we close a head
@@ -160,7 +160,7 @@ healthyOpenHeadTxOut =
 healthySnapshot :: Snapshot Tx
 healthySnapshot =
   Snapshot
-    { number = healthySnapshotNumber
+    { number = healthyCloseSnapshotNumber
     , utxo = healthyCloseUTxO
     , confirmed = []
     }
@@ -170,8 +170,8 @@ healthyCloseUTxO =
   (genOneUTxOFor somePartyCardanoVerificationKey `suchThat` (/= healthyUTxO))
     `generateWith` 42
 
-healthySnapshotNumber :: SnapshotNumber
-healthySnapshotNumber = 1
+healthyCloseSnapshotNumber :: SnapshotNumber
+healthyCloseSnapshotNumber = 1
 
 healthyOpenHeadDatum :: Head.State
 healthyOpenHeadDatum =
@@ -271,7 +271,7 @@ genCloseMutation (tx, _utxo) =
         mutatedSnapshotNumber <- arbitrary `suchThat` (<= 0)
         pure $ ChangeOutput 0 $ changeHeadOutputDatum (replaceSnapshotNumber mutatedSnapshotNumber) headTxOut
     , SomeMutation (Just $ toErrorCode SignatureVerificationFailed) MutateSnapshotNumberButNotSignature <$> do
-        mutatedSnapshotNumber <- arbitrarySizedNatural `suchThat` (> healthySnapshotNumber)
+        mutatedSnapshotNumber <- arbitrarySizedNatural `suchThat` (> healthyCloseSnapshotNumber)
         pure $ ChangeOutput 0 $ changeHeadOutputDatum (replaceSnapshotNumber $ toInteger mutatedSnapshotNumber) headTxOut
     , SomeMutation (Just $ toErrorCode SignatureVerificationFailed) MutateParties . ChangeInputHeadDatum <$> do
         mutatedParties <- arbitrary `suchThat` (/= healthyOnChainParties)
@@ -323,7 +323,7 @@ genCloseMutation (tx, _utxo) =
                       ( Head.Close
                           { signature =
                               toPlutusSignatures $
-                                healthySignature healthySnapshotNumber
+                                healthySignature healthyCloseSnapshotNumber
                           }
                       )
                 )

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -337,8 +337,8 @@ data CloseInitialMutation
 -- | Mutations for the specific case of closing with the intial state.
 -- We should probably validate all the mutation to this initial state but at
 -- least we keep this regression test as we stumbled upon problems with the following case.
--- The nice thing to do would probably to generate either "normal" healthy close or
--- or initial healthy close and apply all the mutation to it but we did'nt manage to do that
+-- The nice thing to do would probably to generate either "normal" healthyCloseTx or
+-- or healthyCloseInitialTx and apply all the mutation to it but we did'nt manage to do that
 -- rightaway.
 genCloseInitialMutation :: (Tx, UTxO) -> Gen SomeMutation
 genCloseInitialMutation (tx, _utxo) =

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -279,7 +279,7 @@ genCloseMutation (tx, _utxo) =
     , SomeMutation (Just $ toErrorCode SignerIsNotAParticipant) MutateRequiredSigner <$> do
         newSigner <- verificationKeyHash <$> genVerificationKey
         pure $ ChangeRequiredSigners [newSigner]
-    , SomeMutation Nothing MutateCloseUTxOHash . ChangeOutput 0 <$> mutateCloseUTxOHash
+    , SomeMutation (Just $ toErrorCode InvalidSnapshotSignature) MutateCloseUTxOHash . ChangeOutput 0 <$> mutateCloseUTxOHash
     , SomeMutation (Just $ toErrorCode IncorrectClosedContestationDeadline) MutateContestationDeadline <$> do
         mutatedDeadline <- genMutatedDeadline
         pure $ ChangeOutput 0 $ changeHeadOutputDatum (replaceContestationDeadline mutatedDeadline) headTxOut

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -182,16 +182,18 @@ healthyCommitOutput party committed =
 
 data CollectComMutation
   = MutateOpenUTxOHash
-  | -- | Test that collectCom cannot collect from an initial UTxO.
+  | -- | Ensures collectCom cannot collect from an initial UTxO.
     MutateCommitToInitial
-  | -- | Every party should have commited and been taken into account for the collectCom transaction to be
-    --   valid. Here we increase the number of parties in input and output but keep the commits unchanged.
-    --   This simulates the situation where one participant would not have commited already or whose commit
-    --   would have been ignored by the collectCom transaction.
+  | -- | Every party should have commited and been taken into account for the
+    -- collectCom transaction to be valid. Here we increase the number of
+    -- parties in input and output but keep the commits unchanged. This
+    -- simulates the situation where one participant would not have commited
+    -- already or whose commit would have been ignored by the collectCom
+    -- transaction.
     MutateNumberOfParties
   | MutateHeadId
   | MutateRequiredSigner
-  | -- | Minting or burning of the tokens should not be possible in v_head apart from 'checkAbort' or 'checkFanout'
+  | -- | Minting or burning of tokens should not be possible in collectCom.
     MutateTokenMintingOrBurning
   deriving (Generic, Show, Enum, Bounded)
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
@@ -22,6 +22,7 @@ import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry, registryUTxO)
 import Hydra.Chain.Direct.Tx (commitTx, mkHeadId, mkInitialOutput)
 import Hydra.Contract.Error (toErrorCode)
 import Hydra.Contract.HeadTokens (headPolicyId)
+import Hydra.Contract.Initial
 import qualified Hydra.Contract.Initial as Initial
 import Hydra.Contract.Util (UtilError (MintingOrBurningIsForbidden))
 import Hydra.Ledger.Cardano (
@@ -78,34 +79,50 @@ healthyCommittedUTxO = flip generateWith 42 $ do
   pure (txIn, txOut)
 
 data CommitMutation
-  = MutateCommitOutputValue
+  = -- | Invalidates the tx by changing the commit output value.
+    --
+    -- Ensures the committed value is consistent with the locked value
+    -- by the commit validator.
+    MutateCommitOutputValue
   | MutateCommittedValue
-  | MutateCommittedAddress
-  | MutateRequiredSigner
-  | -- | Change the policy Id of the ST and PTs both in input and output
-    MutateHeadId
-  | -- | Minting or burning of the tokens should not be possible in v_initial when checking the commit
+  | -- | Invalidates the tx by changing the address of the input out-ref.
+    --
+    -- Ensures the output tx out-ref is consistent with the input tx out-ref.
+    MutateCommittedAddress
+  | -- | Invalidates the tx by using a signer not present in the list of distributed PTs.
+    --
+    -- Ensures that it's performed by a Head party.
+    MutateRequiredSigner
+  | -- | Change the head policy id to simulate contestation using a ST and signer from a different head.
+    -- The signer shows a correct signature but from a different head.
+    -- This will cause the signer to not be present in the participation tokens.
+    ContestFromDifferentHead
+  | -- | Makes the tx `output minted values` invalid by changing them to include burning/minting of tokens.
+    --
+    -- Minting or burning of the tokens should not be possible in v_head apart from 'checkAbort' or 'checkFanout'.
     MutateTokenMintingOrBurning
   deriving (Generic, Show, Enum, Bounded)
 
 genCommitMutation :: (Tx, UTxO) -> Gen SomeMutation
 genCommitMutation (tx, _utxo) =
   oneof
-    [ SomeMutation Nothing MutateCommitOutputValue . ChangeOutput 0 <$> do
+    [ SomeMutation (Just $ toErrorCode LockedValueDoesNotMatch) MutateCommitOutputValue . ChangeOutput 0 <$> do
         mutatedValue <- genValue `suchThat` (/= commitOutputValue)
         pure $ commitTxOut{txOutValue = mutatedValue}
     , SomeMutation Nothing MutateCommittedValue <$> do
         mutatedValue <- genValue `suchThat` (/= committedOutputValue)
         let mutatedOutput = modifyTxOutValue (const mutatedValue) committedTxOut
         pure $ ChangeInput committedTxIn mutatedOutput Nothing
-    , SomeMutation Nothing MutateCommittedAddress <$> do
+    , SomeMutation (Just $ toErrorCode MismatchCommittedTxOutInDatum) MutateCommittedAddress <$> do
         mutatedAddress <- genAddressInEra Fixture.testNetworkId `suchThat` (/= committedAddress)
         let mutatedOutput = modifyTxOutAddress (const mutatedAddress) committedTxOut
         pure $ ChangeInput committedTxIn mutatedOutput Nothing
-    , SomeMutation Nothing MutateRequiredSigner <$> do
+    , SomeMutation (Just $ toErrorCode MissingOrInvalidCommitAuthor) MutateRequiredSigner <$> do
         newSigner <- verificationKeyHash <$> genVerificationKey
         pure $ ChangeRequiredSigners [newSigner]
-    , SomeMutation Nothing MutateHeadId <$> do
+    , -- XXX: This is a bit confusing and not giving much value. Maybe we can remove this.
+      -- This also seems to be covered by MutateRequiredSigner
+      SomeMutation (Just $ toErrorCode CouldNotFindTheCorrectCurrencySymbolInTokens) ContestFromDifferentHead <$> do
         otherHeadId <- fmap headPolicyId (arbitrary `suchThat` (/= healthyIntialTxIn))
         pure $
           Changes

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
@@ -108,7 +108,7 @@ genCommitMutation :: (Tx, UTxO) -> Gen SomeMutation
 genCommitMutation (tx, _utxo) =
   oneof
     [ SomeMutation (Just $ toErrorCode LockedValueDoesNotMatch) MutateCommitOutputValue . ChangeOutput 0 <$> do
-        mutatedValue <- genValue `suchThat` (/= commitOutputValue)
+        mutatedValue <- scale (`div` 2) genValue `suchThat` (/= commitOutputValue)
         pure $ commitTxOut{txOutValue = mutatedValue}
     , SomeMutation (Just $ toErrorCode LockedValueDoesNotMatch) MutateCommittedValue <$> do
         mutatedValue <- scale (`div` 2) genValue `suchThat` (/= committedOutputValue)

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
@@ -32,7 +32,7 @@ import Hydra.Ledger.Cardano (
   genVerificationKey,
  )
 import Hydra.Party (Party)
-import Test.QuickCheck (oneof, suchThat)
+import Test.QuickCheck (oneof, scale, suchThat)
 
 --
 -- CommitTx
@@ -107,8 +107,8 @@ genCommitMutation (tx, _utxo) =
     [ SomeMutation (Just $ toErrorCode LockedValueDoesNotMatch) MutateCommitOutputValue . ChangeOutput 0 <$> do
         mutatedValue <- genValue `suchThat` (/= commitOutputValue)
         pure $ commitTxOut{txOutValue = mutatedValue}
-    , SomeMutation Nothing MutateCommittedValue <$> do
-        mutatedValue <- genValue `suchThat` (/= committedOutputValue)
+    , SomeMutation (Just $ toErrorCode LockedValueDoesNotMatch) MutateCommittedValue <$> do
+        mutatedValue <- scale (`div` 2) genValue `suchThat` (/= committedOutputValue)
         let mutatedOutput = modifyTxOutValue (const mutatedValue) committedTxOut
         pure $ ChangeInput committedTxIn mutatedOutput Nothing
     , SomeMutation (Just $ toErrorCode MismatchCommittedTxOutInDatum) MutateCommittedAddress <$> do

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
@@ -84,7 +84,10 @@ data CommitMutation
     -- Ensures the committed value is consistent with the locked value by the
     -- commit validator.
     MutateCommitOutputValue
-  | MutateCommittedValue
+  | -- | Invalidates the tx by changing the value of the input committed utxo.
+    --
+    -- Ensures the output committed utxo value is consistent with the input committed utxo value.
+    MutateCommittedValue
   | -- | Invalidates the tx by changing the address of the input out-ref.
     --
     -- Ensures the output tx out-ref is consistent with the input tx out-ref.

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -194,26 +194,35 @@ healthySignature number =
 
 -- FIXME: Should try to mutate the 'closedAt' recorded time to something else
 data ContestMutation
-  = -- | Ensure signatures are actually checked.
+  = -- | Makes the tx `snapshot signature` invalid by changing the redeemer signature but not the snapshot number in resulting head output.
+    -- This ensures the snapshot signature is multisigned by all valid Head participants.
     MutateSignatureButNotSnapshotNumber
-  | -- | Ensure too old snapshot are not valid.
+  | -- | Makes the tx `snapshot signature` invalid by changing the snapshot number in resulting head output but not the redeemer signature.
+    -- This ensures the snapshot signature is aligned with snapshot number.
+    MutateSnapshotNumberButNotSignature
+  | -- | Makes the tx `snapshot signature` invalid by changing the snapshot number in the head input (stored state) to be too old.
+    -- This ensures that too old snapshot are not valid.
+    -- This also changes the redeemer so the tx snapshot signature is valid against it.
     MutateToNonNewerSnapshot
-  | -- | Ensure that it's performed by a Head party
+  | -- | Makes the tx `signer` invalid by using a signer not present in the list of distributed PTs.
+    -- | This ensures that it's performed by a Head party.
     MutateRequiredSigner
-  | -- | Ensure output state is consistent with redeemer
+  | -- | Makes the tx `snapshot signature` invalid by changing the utxo hash in resulting head output.
+    -- This ensures the output state is consistent with the redeemer.
     MutateContestUTxOHash
-  | -- | Change parties stored in the state, causing multisig to fail
+  | -- | Makes the tx `snapshot signature` invalid by changing the parties in the head input (stored state).
     MutateParties
-  | -- | Change the validity interval of the transaction to a value greater
-    -- than the contestation deadline
+  | -- | Makes the tx `validity range` invalid by changing its upper bound to be beyond contestation deadline from head input (stored state).
     MutateValidityPastDeadline
   | -- | Change the head policy id to simulate contestation using a ST and signer from a different head.
     -- The signer shows a correct signature but from a different head.
     -- This will cause the signer to not be present in the participation tokens.
     ContestFromDifferentHead
-  | -- | Minting or burning of the tokens should not be possible in v_head apart from 'checkAbort' or 'checkFanout'
+  | -- | Makes the tx `output minted values` invalid by changing them to include burning/minting of tokens.
+    -- Minting or burning of the tokens should not be possible in v_head apart from 'checkAbort' or 'checkFanout'.
     MutateTokenMintingOrBurning
-  | -- | Change the contesters to check if already contested
+  | -- | Makes the tx `signer` invalid by changing the head input (stored head) list of already contesters to include the signer.
+    -- This ensures a signed participant can only contest once.
     MutateInputContesters
   | -- | Change the resulting contesters arbitrarily to see if they are checked
     MutateContesters

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -256,11 +256,11 @@ genContestMutation
       , SomeMutation (Just $ toErrorCode SignerIsNotAParticipant) MutateRequiredSigner <$> do
           newSigner <- verificationKeyHash <$> genVerificationKey
           pure $ ChangeRequiredSigners [newSigner]
-      , SomeMutation (Just $ toErrorCode TooOldSnapshot) MutateContestUTxOHash . ChangeOutput 0 <$> do
+      , SomeMutation (Just $ toErrorCode SignatureVerificationFailed) MutateContestUTxOHash . ChangeOutput 0 <$> do
           mutatedUTxOHash <- genHash `suchThat` ((/= healthyContestUTxOHash) . toBuiltin)
           pure $
             changeHeadOutputDatum
-              (const $ healthyClosedState & replaceUtxoHash (toBuiltin mutatedUTxOHash))
+              (replaceUtxoHash (toBuiltin mutatedUTxOHash))
               headTxOut
       , SomeMutation (Just $ toErrorCode SignatureVerificationFailed) MutateParties . ChangeInputHeadDatum <$> do
           mutatedParties <- arbitrary `suchThat` (/= healthyOnChainParties)

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -213,15 +213,15 @@ data ContestMutation
   | -- | Invalidates the tx by changing the contest snapshot number too old.
     --
     -- This is achieved by updating the head input datum to be older, so the
-    -- healthy snapshot number becomes to old.
+    -- healthy snapshot number becomes too old.
     MutateToNonNewerSnapshot
-  | -- | Ensures close is authenticated by a single Head party by changing the signer
+  | -- | Ensures close is authenticated by one of the Head members by changing the signer
     -- used on the tx to be not one of PTs.
     MutateRequiredSigner
-  | -- | Ensures close is authenticated by a single Head party by changing the signer
+  | -- | Ensures close is authenticated by one of the Head members by changing the signer
     -- used on the tx to be empty.
     MutateNoRequiredSigner
-  | -- | Ensures close is authenticated by a single Head party by changing the signer
+  | -- | Ensures close is authenticated by one of the Head members by changing the signer
     -- used on the tx to have multiple signers (including the signer to not fail for
     -- SignerIsNotAParticipant).
     MutateMultipleRequiredSigner
@@ -248,7 +248,7 @@ data ContestMutation
     MutateInputContesters
   | -- | Ensures a the signer needs to be added to the head output datum.
     MutateContesters
-  | -- | Invalidates the tx by changing the output values arbitrarly to be
+  | -- | Invalidates the tx by changing the output values arbitrarily to be
     -- different (not preserved) from the head.
     --
     -- Ensures values are preserved between head input and output.
@@ -382,8 +382,9 @@ genContestMutation
           pure $ ChangeOutput 0 (headTxOut & changeHeadOutputDatum (replaceContestationPeriod randomCP))
       , SomeMutation (Just $ toErrorCode ChangedParameters) MutatePartiesInOutput <$> do
           mutatedParties <-
-            -- XXX: we need to length of mutatedParties is the same as healthyOnChainParties
-            -- so to not fail because of `must not push contestation deadline`.
+            -- The length of mutatedParties must be the same as
+            -- healthyOnChainParties so to not fail because of
+            -- `must not push contestation deadline`.
             vectorOf
               (length healthyOnChainParties)
               ( partyFromVerificationKeyBytes <$> genHash

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -275,7 +275,7 @@ genContestMutation
       , -- XXX: This is a bit confusing and not giving much value. Maybe we can remove this.
         -- This also seems to be covered by MutateRequiredSigner
         SomeMutation (Just $ toErrorCode SignerIsNotAParticipant) ContestFromDifferentHead <$> do
-          otherHeadId <- fmap headPolicyId (arbitrary `suchThat` (/= healthyClosedHeadTxIn))
+          otherHeadId <- headPolicyId <$> arbitrary `suchThat` (/= healthyClosedHeadTxIn)
           pure $
             Changes
               [ ChangeOutput 0 (replacePolicyIdWith testPolicyId otherHeadId headTxOut)

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -240,8 +240,8 @@ genContestMutation
             Head.Contest
               { signature = toPlutusSignatures mutatedSignature
               }
-      , SomeMutation (Just $ toErrorCode SignatureVerificationFailed) MutateToNonNewerSnapshot <$> do
-          mutatedSnapshotNumber <- choose (0, toInteger healthyClosedSnapshotNumber)
+      , SomeMutation (Just $ toErrorCode TooOldSnapshot) MutateToNonNewerSnapshot <$> do
+          mutatedSnapshotNumber <- choose (toInteger healthyContestSnapshotNumber, toInteger healthyContestSnapshotNumber + 1)
           pure $
             Changes
               [ ChangeInputHeadDatum $

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -60,7 +60,7 @@ import Plutus.Orphans ()
 import Plutus.V2.Ledger.Api (BuiltinByteString, toBuiltin, toData)
 import qualified Plutus.V2.Ledger.Api as Plutus
 import Test.Hydra.Fixture (aliceSk, bobSk, carolSk)
-import Test.QuickCheck (elements, listOf, oneof, suchThat, vectorOf)
+import Test.QuickCheck (arbitrarySizedNatural, elements, listOf, oneof, suchThat, vectorOf)
 import Test.QuickCheck.Gen (choose)
 import Test.QuickCheck.Instances ()
 
@@ -251,6 +251,9 @@ genContestMutation
             Head.Contest
               { signature = toPlutusSignatures mutatedSignature
               }
+      , SomeMutation (Just $ toErrorCode SignatureVerificationFailed) MutateSnapshotNumberButNotSignature <$> do
+          mutatedSnapshotNumber <- arbitrarySizedNatural `suchThat` (> healthyContestSnapshotNumber)
+          pure $ ChangeOutput 0 $ changeHeadOutputDatum (replaceSnapshotNumber $ toInteger mutatedSnapshotNumber) headTxOut
       , SomeMutation (Just $ toErrorCode TooOldSnapshot) MutateToNonNewerSnapshot <$> do
           mutatedSnapshotNumber <- choose (toInteger healthyContestSnapshotNumber, toInteger healthyContestSnapshotNumber + 1)
           pure $

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -194,48 +194,56 @@ healthySignature number =
 
 -- FIXME: Should try to mutate the 'closedAt' recorded time to something else
 data ContestMutation
-  = -- | Makes the tx `snapshot signature` invalid by changing the redeemer signature but not the snapshot number in resulting head output.
-    -- This ensures the snapshot signature is multisigned by all valid Head participants.
+  = -- | Invalidates the tx by changing the redeemer signature but not the snapshot number in resulting head output.
+    --
+    -- Ensures the snapshot signature is multisigned by all valid Head participants.
     MutateSignatureButNotSnapshotNumber
-  | -- | Makes the tx `snapshot signature` invalid by changing the snapshot number in resulting head output but not the redeemer signature.
-    -- This ensures the snapshot signature is aligned with snapshot number.
+  | -- | Invalidates the tx by changing the snapshot number in resulting head output but not the redeemer signature.
+    --
+    -- Ensures the snapshot signature is aligned with snapshot number.
     MutateSnapshotNumberButNotSignature
-  | -- | Makes the tx `snapshot signature` invalid by changing the snapshot number in the head input (stored state) to be too old.
-    -- This ensures that too old snapshot are not valid.
+  | -- | Invalidates the tx by changing the snapshot number in the head input (stored state) to be too old.
+    --
+    -- Ensures that too old snapshot are not valid.
+    --
     -- This also changes the redeemer so the tx snapshot signature is valid against it.
     MutateToNonNewerSnapshot
-  | -- | Makes the tx `signer` invalid by using a signer not present in the list of distributed PTs.
-    -- | This ensures that it's performed by a Head party.
+  | -- | Invalidates the tx by using a signer not present in the list of distributed PTs.
+    --
+    -- Ensures that it's performed by a Head party.
     MutateRequiredSigner
-  | -- | Makes the tx `snapshot signature` invalid by changing the utxo hash in resulting head output.
-    -- This ensures the output state is consistent with the redeemer.
+  | -- | Invalidates the tx by changing the utxo hash in resulting head output.
+    --
+    -- Ensures the output state is consistent with the redeemer.
     MutateContestUTxOHash
-  | -- | Makes the tx `snapshot signature` invalid by changing the parties in the head input (stored state).
+  | -- | Invalidates the tx by changing the parties in the head input (stored state).
     MutateParties
-  | -- | Makes the tx `validity range` invalid by changing its upper bound to be beyond contestation deadline from head input (stored state).
+  | -- | Invalidates the tx by changing the upper bound to be beyond contestation deadline from head input (stored state).
     MutateValidityPastDeadline
   | -- | Change the head policy id to simulate contestation using a ST and signer from a different head.
     -- The signer shows a correct signature but from a different head.
     -- This will cause the signer to not be present in the participation tokens.
     ContestFromDifferentHead
-  | -- | Makes the tx `output minted values` invalid by changing them to include burning/minting of tokens.
+  | -- | Invalidates the tx by changing the output minted values to include burning/minting of tokens.
+    --
     -- Minting or burning of the tokens should not be possible in v_head apart from 'checkAbort' or 'checkFanout'.
     MutateTokenMintingOrBurning
-  | -- | Makes the tx `signer` invalid by changing the head input (stored head) list of already contesters to include the signer.
-    -- This ensures a signed participant can only contest once.
+  | -- | Invalidates the tx by changing the head input (stored head) list of already contesters to include the signer.
+    --
+    -- Ensures a signed participant can only contest once.
     MutateInputContesters
-  | -- Makes the tx `signer` invalid by changing the head output to not include it as already contested.
+  | -- | Invalidates the tx by changing the head output to not include it as already contested.
     MutateContesters
-  | -- | Makes the tx `output values` invalid by changing them arbitrarly to be differnet (not preserved) from the head.
+  | -- | Invalidates the tx by changing the output values arbitrarly to be differnet (not preserved) from the head.
     MutateValueInOutput
-  | -- | Makes the tx `head output` invalid by changing the contestation deadline in head output such that deadline is not pushed away.
+  | -- | Invalidates the tx by changing the contestation deadline in head output such that deadline is not pushed away.
     NotUpdateDeadlineAlthoughItShould
   | -- | Pushes the deadline although this is the last contest. Instead of
     -- creating another healthy case and mutate that one, this mutation just
     -- changes the starting situation so that everyone else already contested.
     -- Remember the 'healthyContestTx' is already pushing out the deadline.
     PushDeadlineAlthoughItShouldNot
-  | -- | Makes the tx resulting `head output` invalid by changing its contestation period to be different from the head input (stored state).
+  | -- | Invalidates the tx by changing the contestation period to be different from the head input (stored state).
     MutateOutputContestationPeriod
   deriving (Generic, Show, Enum, Bounded)
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -301,7 +301,7 @@ genContestMutation
                     }
               ]
       , SomeMutation (Just $ toErrorCode SignerIsNotAParticipant) MutateRequiredSigner <$> do
-          newSigner <- verificationKeyHash <$> genVerificationKey
+          newSigner <- verificationKeyHash <$> genVerificationKey `suchThat` (/= healthyContesterVerificationKey)
           pure $ ChangeRequiredSigners [newSigner]
       , SomeMutation (Just $ toErrorCode NoSigners) MutateNoRequiredSigner <$> do
           pure $ ChangeRequiredSigners []

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          hydra-plutus
-version:       0.9.0
+version:       0.10.0
 synopsis:      Hydra Plutus Contracts
 author:        IOG
 copyright:     2022 IOG

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          hydra-plutus
-version:       0.10.0
+version:       0.9.0
 synopsis:      Hydra Plutus Contracts
 author:        IOG
 copyright:     2022 IOG

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -21,6 +21,7 @@ import PlutusTx.Prelude
 
 import Hydra.Contract.Commit (Commit (..))
 import qualified Hydra.Contract.Commit as Commit
+import Hydra.Contract.Error (ToErrorCode (..))
 import Hydra.Contract.HeadState (Input (..), Signature, SnapshotNumber, State (..))
 import Hydra.Contract.Util (hasST, mustNotMintOrBurn, (===))
 import Hydra.Data.ContestationPeriod (ContestationPeriod, addContestationPeriod, milliseconds)
@@ -61,7 +62,6 @@ import PlutusTx (CompiledCode)
 import qualified PlutusTx
 import qualified PlutusTx.AssocMap as Map
 import qualified PlutusTx.Builtins as Builtins
-import Hydra.Contract.Error (ToErrorCode (..))
 
 type DatumType = State
 type RedeemerType = Input
@@ -313,8 +313,7 @@ checkClose ctx parties initialUtxoHash sig cperiod headPolicyId =
 
   checkSnapshot
     | closedSnapshotNumber > 0 =
-      traceIfFalse "H11" $
-        verifySnapshotSignature parties closedSnapshotNumber closedUtxoHash sig
+      verifySnapshotSignature parties closedSnapshotNumber closedUtxoHash sig
     | otherwise =
       traceIfFalse "H12" $
         closedUtxoHash == initialUtxoHash
@@ -631,7 +630,6 @@ data HeadError
   | MissingCommits
   | HeadValueIsNotPreserved
   | HasBoundedValidityCheckFailed
-  | InvalidSnapshotSignature
   | ClosedWithNonInitialHash
   | IncorrectClosedContestationDeadline
   | InfiniteUpperBound
@@ -671,7 +669,6 @@ instance ToErrorCode HeadError where
     MissingCommits -> "H08"
     HeadValueIsNotPreserved -> "H09"
     HasBoundedValidityCheckFailed -> "H10"
-    InvalidSnapshotSignature -> "H11"
     ClosedWithNonInitialHash -> "H12"
     IncorrectClosedContestationDeadline -> "H13"
     InfiniteUpperBound -> "H14"

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -281,6 +281,7 @@ checkClose ctx parties initialUtxoHash sig cperiod headPolicyId =
     && checkSnapshot
     && mustBeSignedByParticipant ctx headPolicyId
     && mustInitializeContesters
+    -- XXX: missing to trace for this error code
     && hasST headPolicyId val
     && mustPreserveValue
     && mustNotChangeParameters

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -517,6 +517,7 @@ mkHeadAddress ctx =
    in txOutAddress (txInInfoResolved headInput)
 {-# INLINEABLE mkHeadAddress #-}
 
+-- XXX: We might not need to distinguish between the three cases here.
 mustBeSignedByParticipant ::
   ScriptContext ->
   CurrencySymbol ->

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -403,10 +403,10 @@ checkContest ctx contestationDeadline contestationPeriod parties closedSnapshotN
 
   mustBeNewer =
     traceIfFalse "H17" $
-      contestSnapshotNumber > closedSnapshotNumber
+      closedSnapshotNumber' > closedSnapshotNumber
 
   mustBeMultiSigned =
-    verifySnapshotSignature parties contestSnapshotNumber contestUtxoHash sig
+    verifySnapshotSignature parties closedSnapshotNumber' closedUtxoHash' sig
 
   mustBeWithinContestationPeriod =
     case ivTo (txInfoValidRange txInfo) of
@@ -433,7 +433,7 @@ checkContest ctx contestationDeadline contestationPeriod parties closedSnapshotN
     traceIfFalse "H22" $
       contesters' == contester : contesters
 
-  (contestSnapshotNumber, contestUtxoHash, parties', contestationDeadline', contestationPeriod', headId', contesters') =
+  (closedSnapshotNumber', closedUtxoHash', parties', contestationDeadline', contestationPeriod', headId', contesters') =
     -- XXX: fromBuiltinData is super big (and also expensive?)
     case fromBuiltinData @DatumType $ getDatum (headOutputDatum ctx) of
       Just

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -388,7 +388,6 @@ checkContest ctx contestationDeadline contestationPeriod parties closedSnapshotN
     && checkSignedParticipantContestOnlyOnce
     && mustBeWithinContestationPeriod
     && mustUpdateContesters
-    && hasST headId val
     && mustPushDeadline
     && mustNotChangeParameters
     && mustPreserveValue


### PR DESCRIPTION
This contributes to moving #705 forward.

To check before merging:
* [x] CHANGELOG is up to date
* [x] Up to date with master