### PR TITLE
Estimate script complexity and formulate an "acceptance" property

### DIFF
--- a/hydra-node/exe/tx-cost/Main.hs
+++ b/hydra-node/exe/tx-cost/Main.hs
@@ -302,14 +302,16 @@ costOfFanOut = markdownFanOutCost <$> computeFanOutCost
       [ "## Cost of FanOut Transaction"
       , "Involves spending head output and burning head tokens. Uses ada-only UTxO for better comparability."
       , ""
-      , "| Parties | UTxO  | Tx size | % max Mem | % max CPU | Min fee ₳ |"
-      , "| :------ | :---- | ------: | --------: | --------: | --------: |"
+      , "| Parties | UTxO  | UTxO (bytes) | Tx size | % max Mem | % max CPU | Min fee ₳ |"
+      , "| :------ | :---- | :----------- | ------: | --------: | --------: | --------: |"
       ]
         <> fmap
-          ( \(parties, numElems, txSize, mem, cpu, Lovelace minFee) ->
+          ( \(parties, numElems, utxoSize, txSize, mem, cpu, Lovelace minFee) ->
               "| " <> show parties
                 <> " | "
                 <> show numElems
+                <> " | "
+                <> show utxoSize
                 <> " | "
                 <> show txSize
                 <> " | "

--- a/hydra-node/exe/tx-cost/Main.hs
+++ b/hydra-node/exe/tx-cost/Main.hs
@@ -302,13 +302,15 @@ costOfFanOut = markdownFanOutCost <$> computeFanOutCost
       [ "## Cost of FanOut Transaction"
       , "Involves spending head output and burning head tokens. Uses ada-only UTxO for better comparability."
       , ""
-      , "| UTxO  | Tx size | % max Mem | % max CPU | Min fee ₳ |"
-      , "| :---- | ------: | --------: | --------: | --------: |"
+      , "| Parties | UTxO  | Tx size | % max Mem | % max CPU | Min fee ₳ |"
+      , "| :------ | :---- | ------: | --------: | --------: | --------: |"
       ]
         <> fmap
-          ( \(numElems, txSize, mem, cpu, Lovelace minFee) ->
-              "| " <> show numElems
-                <> "| "
+          ( \(parties, numElems, txSize, mem, cpu, Lovelace minFee) ->
+              "| " <> show parties
+                <> " | "
+                <> show numElems
+                <> " | "
                 <> show txSize
                 <> " | "
                 <> show (mem `percentOf` maxMem)

--- a/hydra-node/exe/tx-cost/Main.hs
+++ b/hydra-node/exe/tx-cost/Main.hs
@@ -200,13 +200,15 @@ costOfCollectCom = markdownCollectComCost <$> computeCollectComCost
     unlines $
       [ "## Cost of CollectCom Transaction"
       , ""
-      , "| Parties | Tx size | % max Mem | % max CPU | Min fee ₳ |"
-      , "| :------ | ------: | --------: | --------: | --------: |"
+      , "| Parties | UTxO (bytes) |Tx size | % max Mem | % max CPU | Min fee ₳ |"
+      , "| :------ | :----------- |------: | --------: | --------: | --------: |"
       ]
         <> fmap
-          ( \(numParties, txSize, mem, cpu, Lovelace minFee) ->
+          ( \(numParties, utxoSize, txSize, mem, cpu, Lovelace minFee) ->
               "| " <> show numParties
-                <> "| "
+                <> " | "
+                <> show utxoSize
+                <> " | "
                 <> show txSize
                 <> " | "
                 <> show (mem `percentOf` maxMem)

--- a/hydra-node/exe/tx-cost/TxCost.hs
+++ b/hydra-node/exe/tx-cost/TxCost.hs
@@ -126,7 +126,7 @@ computeCollectComCost =
     ctx <- genHydraContextFor numParties
     cctx <- pickChainContext ctx
     initTx <- genInitTx ctx
-    commits <- genCommits ctx initTx
+    commits <- genCommits' (genUTxOSized 1) ctx initTx
     let (committedUTxOs, stInitialized) = unsafeObserveInitAndCommits cctx initTx commits
     pure (fold committedUTxOs, collect cctx stInitialized, getKnownUTxO stInitialized)
 
@@ -212,7 +212,7 @@ computeFanOutCost = do
 
   -- Generate a fanout with a defined number of outputs.
   genFanoutTx numParties numOutputs = do
-    let utxo = genUTxOAdaOnlyOfSize numOutputs `generateWith` 42
+    utxo <- genUTxOAdaOnlyOfSize numOutputs
     ctx <- genHydraContextFor numParties
     (_committed, stOpen) <- genStOpen ctx
     snapshot <- genConfirmedSnapshot 1 utxo [] -- We do not validate the signatures

--- a/hydra-node/exe/tx-cost/TxCost.hs
+++ b/hydra-node/exe/tx-cost/TxCost.hs
@@ -44,6 +44,9 @@ import Hydra.Ledger.Cardano (
   genOutput,
   genTxIn,
   genUTxOAdaOnlyOfSize,
+  genUTxOAlonzo,
+  genUTxOSized,
+  simplifyUTxO,
  )
 import Hydra.Ledger.Cardano.Evaluate (
   estimateMinFee,

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -830,11 +830,19 @@ genCommits ::
   HydraContext ->
   Tx ->
   Gen [Tx]
-genCommits ctx txInit = do
+genCommits =
+  genCommits' genCommit
+
+genCommits' ::
+  Gen UTxO ->
+  HydraContext ->
+  Tx ->
+  Gen [Tx]
+genCommits' genUTxOToCommit ctx txInit = do
   allChainContexts <- deriveChainContexts ctx
   forM allChainContexts $ \cctx -> do
     let (_, stInitial) = fromJust $ observeInit cctx txInit
-    unsafeCommit cctx stInitial <$> genCommit
+    unsafeCommit cctx stInitial <$> genUTxOToCommit
 
 genCommit :: Gen UTxO
 genCommit =

--- a/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
@@ -26,7 +26,7 @@ import Hydra.Chain.Direct.Contract.Commit (genCommitMutation, healthyCommitTx)
 import Hydra.Chain.Direct.Contract.Contest (genContestMutation, healthyContestTx)
 import Hydra.Chain.Direct.Contract.FanOut (genFanoutMutation, healthyFanoutTx)
 import Hydra.Chain.Direct.Contract.Init (genInitMutation, healthyInitTx)
-import Hydra.Chain.Direct.Contract.Mutation (propMutation, propTransactionValidates)
+import Hydra.Chain.Direct.Contract.Mutation (propMutation, propTransactionEvaluates)
 import qualified Hydra.Contract.Commit as Commit
 import Hydra.Contract.Head (
   verifyPartySignature,
@@ -86,14 +86,14 @@ spec = parallel $ do
 
   describe "Init" $ do
     prop "is healthy" $
-      propTransactionValidates healthyInitTx
+      propTransactionEvaluates healthyInitTx
     prop "does not survive random adversarial mutations" $
       propMutation healthyInitTx genInitMutation
 
   describe "Abort" $ do
     prop "is healthy" $
       conjoin
-        [ propTransactionValidates healthyAbortTx
+        [ propTransactionEvaluates healthyAbortTx
         , propHasCommit healthyAbortTx
         , propHasInitial healthyAbortTx
         ]
@@ -101,32 +101,32 @@ spec = parallel $ do
       propMutation healthyAbortTx genAbortMutation
   describe "Commit" $ do
     prop "is healthy" $
-      propTransactionValidates healthyCommitTx
+      propTransactionEvaluates healthyCommitTx
     prop "does not survive random adversarial mutations" $
       propMutation healthyCommitTx genCommitMutation
   describe "CollectCom" $ do
     prop "is healthy" $
-      propTransactionValidates healthyCollectComTx
+      propTransactionEvaluates healthyCollectComTx
     prop "does not survive random adversarial mutations" $
       propMutation healthyCollectComTx genCollectComMutation
   describe "Close" $ do
     prop "is healthy" $
-      propTransactionValidates healthyCloseTx
+      propTransactionEvaluates healthyCloseTx
     prop "does not survive random adversarial mutations" $
       propMutation healthyCloseTx genCloseMutation
   describe "CloseInitial" $ do
     prop "is healthy" $
-      propTransactionValidates healthyCloseInitialTx
+      propTransactionEvaluates healthyCloseInitialTx
     prop "does not survive random adversarial mutations" $
       propMutation healthyCloseInitialTx genCloseInitialMutation
   describe "Contest" $ do
     prop "is healthy" $
-      propTransactionValidates healthyContestTx
+      propTransactionEvaluates healthyContestTx
     prop "does not survive random adversarial mutations" $
       propMutation healthyContestTx genContestMutation
   describe "Fanout" $ do
     prop "is healthy" $
-      propTransactionValidates healthyFanoutTx
+      propTransactionEvaluates healthyFanoutTx
     prop "does not survive random adversarial mutations" $
       propMutation healthyFanoutTx genFanoutMutation
 

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -12,7 +12,6 @@ import qualified Cardano.Api.UTxO as UTxO
 import Cardano.Binary (serialize)
 import qualified Data.ByteString.Lazy as LBS
 import Data.List (intersect)
-import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Hydra.Cardano.Api (
   Tx,
@@ -27,7 +26,7 @@ import Hydra.Cardano.Api (
   pattern TxOut,
   pattern TxOutDatumNone,
  )
-import Hydra.Cardano.Api.Pretty (renderTx, renderTxWithUTxO)
+import Hydra.Cardano.Api.Pretty (renderTx)
 import Hydra.Chain (
   OnChainTx (..),
   PostTxError (..),
@@ -83,11 +82,8 @@ import Hydra.Ledger.Cardano (
   genValue,
  )
 import Hydra.Ledger.Cardano.Evaluate (
-  evaluateTx',
   genValidityBoundsFromContestationPeriod,
-  maxTxExecutionUnits,
   maxTxSize,
-  renderEvaluationReportFailures,
  )
 import qualified Hydra.Ledger.Cardano.Evaluate as Fixture
 import Hydra.Options (maximumNumberOfParties)
@@ -99,7 +95,6 @@ import Test.QuickCheck (
   Property,
   Testable (property),
   checkCoverage,
-  choose,
   classify,
   conjoin,
   counterexample,

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -220,8 +220,8 @@ spec = parallel $ do
 
 prop_canCloseFanoutEveryCollect :: Property
 prop_canCloseFanoutEveryCollect = monadicST $ do
-  numParties <- pick $ choose (1, 20)
-  ctx@HydraContext{ctxContestationPeriod} <- pick $ genHydraContext numParties
+  let maxParties = 20
+  ctx@HydraContext{ctxContestationPeriod} <- pick $ genHydraContext maxParties
   cctx <- pick $ pickChainContext ctx
   -- Init
   txInit <- pick $ genInitTx ctx

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -280,23 +280,12 @@ propBelowSizeLimit txSizeLimit forAllTx =
  where
   showKB nb = show (nb `div` 1024) <> "kB"
 
--- TODO: DRY with Hydra.Chain.Direct.Contract.Mutation.propTransactionEvaluates?
 propIsValid ::
   ((UTxO -> Tx -> Property) -> Property) ->
   SpecWith ()
 propIsValid forAllTx =
   prop "validates within maxTxExecutionUnits" $
-    forAllTx $ \utxo tx -> do
-      case evaluateTx' maxTxExecutionUnits tx utxo of
-        Left validityError ->
-          property False
-            & counterexample ("Tx: " <> renderTxWithUTxO utxo tx)
-            & counterexample ("Evaluation failed: " <> show validityError)
-        Right evaluationReport ->
-          all isRight (Map.elems evaluationReport)
-            & counterexample ("Tx: " <> renderTxWithUTxO utxo tx)
-            & counterexample (toString $ "Failures: " <> renderEvaluationReportFailures evaluationReport)
-            & counterexample "Phase-2 validation failed"
+    forAllTx $ \utxo tx -> propTransactionEvaluates (tx, utxo)
 
 --
 -- QuickCheck Extras

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -32,7 +32,7 @@ import Hydra.Chain (
   OnChainTx (..),
   PostTxError (..),
  )
-import Hydra.Chain.Direct.Contract.Mutation (propTransactionValidates)
+import Hydra.Chain.Direct.Contract.Mutation (propTransactionEvaluates, propTransactionFailsEvaluation, propTransactionFailsPhase2)
 import Hydra.Chain.Direct.State (
   ChainContext (..),
   ChainState,
@@ -267,7 +267,7 @@ propBelowSizeLimit txSizeLimit forAllTx =
  where
   showKB nb = show (nb `div` 1024) <> "kB"
 
--- TODO: DRY with Hydra.Chain.Direct.Contract.Mutation.propTransactionValidates?
+-- TODO: DRY with Hydra.Chain.Direct.Contract.Mutation.propTransactionEvaluates?
 propIsValid ::
   ((UTxO -> Tx -> Property) -> Property) ->
   SpecWith ()


### PR DESCRIPTION
:chart_with_upwards_trend: Contains all kinds of changes which I made while estimating complexity of the `collectCom` transaction in comparison to the `fanout` transaction. See [logbook for notes](https://github.com/input-output-hk/hydra/wiki/Logbook-2023-H1#sn-on-complexity-of-fanout).

As these changes are a bit diverse, I'm happy to remove or PR separately if requested.

:chart_with_upwards_trend: **Notable**: Added the `prop_canCloseFanoutEveryCollect` "acceptance" property test which would generate various situations where the `collectCom` either fails already, **or** `collectCom`, `close` and `fanout` need to pass.

--- 
* [x] CHANGELOG is up to date
* [x] Documentation updated
* [x] Added and/or updated haddocks
* [x] No new TODOs introduced or explained herafter

