### PR TITLE
Inline snapshot emission

### DIFF
--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -597,12 +597,14 @@ onOpenClientNewTx env ledger st tx =
 --
 -- __Transition__: 'OpenState' → 'OpenState'
 onOpenNetworkReqTx ::
+  Eq (SeenSnapshot tx) =>
+  Environment ->
   Ledger tx ->
   OpenState tx ->
   -- | The transaction to be submitted to the head.
   tx ->
   Outcome tx
-onOpenNetworkReqTx ledger st tx =
+onOpenNetworkReqTx env ledger st tx =
   case applyTransactions seenUTxO [tx] of
     Left (_, err) -> Wait $ WaitOnNotApplicableTx err
     Right utxo' ->
@@ -621,6 +623,7 @@ onOpenNetworkReqTx ledger st tx =
               }
         )
         [ClientEffect $ TxSeen headId tx]
+        & emitSnapshot env
  where
   Ledger{applyTransactions} = ledger
 
@@ -736,6 +739,7 @@ onOpenNetworkReqSn env ledger st otherParty sn txs ev
 -- __Transition__: 'OpenState' → 'OpenState'
 onOpenNetworkAckSn ::
   IsTx tx =>
+  Environment ->
   OpenState tx ->
   -- | Party which sent the AckSn.
   Party ->
@@ -744,7 +748,7 @@ onOpenNetworkAckSn ::
   -- | Snapshot number of this AckSn.
   SnapshotNumber ->
   Outcome tx
-onOpenNetworkAckSn openState otherParty snapshotSignature sn =
+onOpenNetworkAckSn env openState otherParty snapshotSignature sn =
   case seenSnapshot of
     NoSeenSnapshot -> Wait WaitOnSeenSnapshot
     RequestedSnapshot -> Wait WaitOnSeenSnapshot
@@ -772,6 +776,7 @@ onOpenNetworkAckSn openState otherParty snapshotSignature sn =
                         }
                   )
                   [ClientEffect $ SnapshotConfirmed headId snapshot multisig]
+                  & emitSnapshot env
               else
                 NewState
                   ( onlyUpdateCoordinatedHeadState $
@@ -984,11 +989,11 @@ update env ledger st ev = case (st, ev) of
     | ttl == 0 ->
       OnlyEffects [ClientEffect $ TxExpired headId tx]
     | otherwise ->
-      onOpenNetworkReqTx ledger openState tx
+      onOpenNetworkReqTx env ledger openState tx
   (Open openState, NetworkEvent _ (ReqSn otherParty sn txs)) ->
     onOpenNetworkReqSn env ledger openState otherParty sn txs ev
   (Open openState, NetworkEvent _ (AckSn otherParty snapshotSignature sn)) ->
-    onOpenNetworkAckSn openState otherParty snapshotSignature sn
+    onOpenNetworkAckSn env openState otherParty snapshotSignature sn
   ( Open openState
     , OnChainEvent Observation{observedTx = OnCloseTx{snapshotNumber = closedSnapshotNumber, contestationDeadline}, newChainState}
     ) ->
@@ -1023,6 +1028,8 @@ update env ledger st ev = case (st, ev) of
   _ ->
     Error $ InvalidEvent ev st
 
+-- * Snapshot helper functions
+
 data SnapshotOutcome tx
   = ShouldSnapshot SnapshotNumber [tx] -- TODO(AB) : should really be a Set (TxId tx)
   | ShouldNotSnapshot NoSnapshotReason
@@ -1041,39 +1048,43 @@ isLeader HeadParameters{parties} p (UnsafeSnapshotNumber sn) =
     _ -> False
 
 -- | Snapshot emission decider
-newSn :: IsTx tx => Environment -> HeadParameters -> CoordinatedHeadState tx -> SnapshotOutcome tx
+newSn :: Eq (SeenSnapshot tx) => Environment -> HeadParameters -> CoordinatedHeadState tx -> SnapshotOutcome tx
 newSn Environment{party} parameters CoordinatedHeadState{confirmedSnapshot, seenSnapshot, seenTxs} =
-  let Snapshot{number} = getSnapshot confirmedSnapshot
-      nextSnapshotNumber = succ number
-   in if
-          | not (isLeader parameters party nextSnapshotNumber) ->
-            ShouldNotSnapshot $ NotLeader nextSnapshotNumber
-          | seenSnapshot /= NoSeenSnapshot ->
-            ShouldNotSnapshot $ SnapshotInFlight nextSnapshotNumber
-          | null seenTxs ->
-            ShouldNotSnapshot NoTransactionsToSnapshot
-          | otherwise ->
-            ShouldSnapshot nextSnapshotNumber seenTxs
+  if
+      | not (isLeader parameters party nextSn) ->
+        ShouldNotSnapshot $ NotLeader nextSn
+      | -- REVIEW: This is slightly different than in the spec. Also, if we use
+        -- seenSn /= confirmedSn here, the model tests would not pass ->
+        -- incomplete spec?
+        seenSnapshot /= NoSeenSnapshot ->
+        ShouldNotSnapshot $ SnapshotInFlight nextSn
+      | null seenTxs ->
+        ShouldNotSnapshot NoTransactionsToSnapshot
+      | otherwise ->
+        ShouldSnapshot nextSn seenTxs
+ where
+  nextSn = confirmedSn + 1
 
--- TODO: This is the only logic NOT in 'update' and gets applied on top of it in
--- "Hydra.Node". We tried to do this decision inside 'update' in the past, but
--- ended up doing it here. Is it really not possible to just call this function
--- from the respective places in 'update'? i.e. as a last step on
--- 'onOpenNetworkReqTx' and 'onOpenNetworkAckSn'?
-emitSnapshot :: IsTx tx => Environment -> [Effect tx] -> HeadState tx -> (HeadState tx, [Effect tx])
-emitSnapshot env@Environment{party} effects = \case
-  st@(Open OpenState{parameters, coordinatedHeadState, previousRecoverableState, chainState, headId}) ->
-    case newSn env parameters coordinatedHeadState of
-      ShouldSnapshot sn txs ->
-        ( Open
-            OpenState
-              { parameters
-              , coordinatedHeadState = coordinatedHeadState{seenSnapshot = RequestedSnapshot}
-              , previousRecoverableState
-              , chainState
-              , headId
-              }
-        , NetworkEffect (ReqSn party sn txs) : effects
-        )
-      _ -> (st, effects)
-  st -> (st, effects)
+  Snapshot{number = confirmedSn} = getSnapshot confirmedSnapshot
+
+-- | Emit a snapshot if we are the next snapshot leader. 'Outcome' modifying
+-- signature so it can be chained with other 'update' functions.
+emitSnapshot :: Eq (SeenSnapshot tx) => Environment -> Outcome tx -> Outcome tx
+emitSnapshot env@Environment{party} outcome =
+  case outcome of
+    NewState (Open OpenState{parameters, coordinatedHeadState, previousRecoverableState, chainState, headId}) effects ->
+      case newSn env parameters coordinatedHeadState of
+        ShouldSnapshot sn txs ->
+          NewState
+            ( Open
+                OpenState
+                  { parameters
+                  , coordinatedHeadState = coordinatedHeadState{seenSnapshot = RequestedSnapshot}
+                  , previousRecoverableState
+                  , chainState
+                  , headId
+                  }
+            )
+            $ NetworkEffect (ReqSn party sn txs) : effects
+        _ -> outcome
+    _ -> outcome

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -48,7 +48,6 @@ import Hydra.HeadLogic (
   HeadState (..),
   Outcome (..),
   defaultTTL,
-  emitSnapshot,
   getChainState,
   setChainState,
  )
@@ -168,9 +167,7 @@ processNextEvent HydraNode{nodeState, ledger, env} e =
   modifyHeadState $ \s ->
     case Logic.update env ledger s e of
       OnlyEffects effects -> (OnlyEffects effects, s)
-      NewState s' effects ->
-        let (s'', effects') = emitSnapshot env effects s'
-         in (NewState s'' effects', s'')
+      NewState s' effects -> (NewState s' effects, s')
       Error err -> (Error err, s)
       Wait reason -> (Wait reason, s)
  where

--- a/hydra-node/test/Hydra/SnapshotStrategySpec.hs
+++ b/hydra-node/test/Hydra/SnapshotStrategySpec.hs
@@ -13,6 +13,7 @@ import Hydra.HeadLogic (
   Effect (..),
   Environment (..),
   NoSnapshotReason (..),
+  Outcome (..),
   SeenSnapshot (..),
   SnapshotOutcome (..),
   emitSnapshot,
@@ -111,8 +112,8 @@ spec = do
                 inOpenState' threeParties $
                   coordinatedState{seenSnapshot = RequestedSnapshot}
 
-          emitSnapshot (envFor aliceSk) [] st
-            `shouldBe` (st', [NetworkEffect $ ReqSn alice 1 [tx]])
+          emitSnapshot (envFor aliceSk) (NewState st [])
+            `shouldBe` NewState st' [NetworkEffect $ ReqSn alice 1 [tx]]
 
 prop_singleMemberHeadAlwaysSnapshot :: ConfirmedSnapshot SimpleTx -> Property
 prop_singleMemberHeadAlwaysSnapshot sn =


### PR DESCRIPTION
This is slightly more inline with the spec and was identified a (minor) gap in #452.

It seems the definition from the spec is in principle okay, as all tests pass if we do `emitSnapshot` only in the cases which are also outlined in the spec.

~~However, I was unable to use snapshot numbers (like in the spec) without a model test not passing. It lacks observability and I didn't feel like tackling this now. With `/= NoSeenSnapshot` was working so I kept it as a `REVIEW` item.~~ Currently working on this and it's looking good (#733)

---

<!-- Tick off or strike-through / remove if not applicable -->
* [ ] ~~CHANGELOG updated~~
* [ ] ~~Documentation updated~~
* [x] Added and/or updated haddocks
* [x] No new TODOs introduced or explained herafter

