### PR TITLE
Align HeadLogic: Transaction pruning

### DIFF
--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -238,7 +238,7 @@ data CoordinatedHeadState tx = CoordinatedHeadState
   { -- | The latest UTxO resulting from applying 'seenTxs' to
     -- 'confirmedSnapshot'. Spec: L̂
     seenUTxO :: UTxOType tx
-  , -- | List of seen transactions. Spec: T̂
+  , -- | List of seen transactions pending inclusion in a snapshot. Spec: T̂
     seenTxs :: [tx]
   , -- | The latest confirmed snapshot. Spec: U̅, s̅ and σ̅
     confirmedSnapshot :: ConfirmedSnapshot tx
@@ -696,6 +696,8 @@ onOpenNetworkReqSn env ledger st otherParty sn txs =
                 { coordinatedHeadState =
                     coordinatedHeadState
                       { seenSnapshot = SeenSnapshot nextSnapshot mempty
+                      , -- TODO: prune transactions by applicability
+                        seenTxs = seenTxs \\ txs
                       }
                 }
           )
@@ -729,7 +731,7 @@ onOpenNetworkReqSn env ledger st otherParty sn txs =
     InitialSnapshot{initialUTxO} -> initialUTxO
     ConfirmedSnapshot{snapshot = Snapshot{utxo}} -> utxo
 
-  CoordinatedHeadState{confirmedSnapshot, seenSnapshot} = coordinatedHeadState
+  CoordinatedHeadState{confirmedSnapshot, seenSnapshot, seenTxs} = coordinatedHeadState
 
   OpenState{parameters, coordinatedHeadState} = st
 
@@ -767,6 +769,7 @@ onOpenNetworkAckSn env openState otherParty snapshotSignature sn =
             | verify (vkey otherParty) snapshotSignature snapshot = Map.insert otherParty snapshotSignature sigs
             | otherwise = sigs
       ifAllMembersHaveSigned snapshot sigs' $ do
+        -- TODO: verify the aggregated multisig, only the individuals, or both?
         let multisig = aggregateInOrder sigs' parties
         NewState
           ( onlyUpdateCoordinatedHeadState $
@@ -777,8 +780,6 @@ onOpenNetworkAckSn env openState otherParty snapshotSignature sn =
                       , signatures = multisig
                       }
                 , seenSnapshot = LastSeenSnapshot (number snapshot)
-                , -- TODO: prune in ReqSn
-                  seenTxs = seenTxs \\ confirmed snapshot
                 }
           )
           [ClientEffect $ SnapshotConfirmed headId snapshot multisig]
@@ -813,7 +814,7 @@ onOpenNetworkAckSn env openState otherParty snapshotSignature sn =
   onlyUpdateCoordinatedHeadState chs' =
     Open openState{coordinatedHeadState = chs'}
 
-  CoordinatedHeadState{seenSnapshot, seenTxs} = coordinatedHeadState
+  CoordinatedHeadState{seenSnapshot} = coordinatedHeadState
 
   OpenState
     { parameters = HeadParameters{parties}


### PR DESCRIPTION
* Prune transactions from `seenTxs` by their applicability to the new requested snapshot instead by their `Eq`uality or id.

---

<!-- Tick off or strike-through / remove if not applicable -->
* ~~[ ] CHANGELOG updated~~
* ~~[ ] Documentation updated~~
* [x] Added and/or updated haddocks
* [x] No new TODOs introduced or explained herafter
  - will be addressed in the next PR of this series
