### PR TITLE
Align HeadLogic: verify aggregated multi-signature

### DIFF
--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -770,43 +770,50 @@ onOpenNetworkAckSn ::
   SnapshotNumber ->
   Outcome tx
 onOpenNetworkAckSn env openState otherParty snapshotSignature sn =
-  -- Spec: wait ŝ = s
-  waitOnSeenSnapshot $ \snapshot sigs -> do
-    -- Spec: require s ∈ {ŝ, ŝ + 1} ∧ (j,σⱼ) ∉ ̂Σ
-    requireAckSn sigs $ do
-      let sigs'
-            -- TODO: Must check whether we know the 'otherParty' signing the snapshot
-            | verify (vkey otherParty) snapshotSignature snapshot = Map.insert otherParty snapshotSignature sigs
-            | otherwise = sigs
-      ifAllMembersHaveSigned snapshot sigs' $ do
-        -- TODO: verify the aggregated multisig, only the individuals, or both?
-        let multisig = aggregateInOrder sigs' parties
-        NewState
-          ( onlyUpdateCoordinatedHeadState $
-              coordinatedHeadState
-                { confirmedSnapshot =
-                    ConfirmedSnapshot
-                      { snapshot
-                      , signatures = multisig
-                      }
-                , seenSnapshot = LastSeenSnapshot (number snapshot)
-                }
-          )
-          [ClientEffect $ SnapshotConfirmed headId snapshot multisig]
-          & emitSnapshot env
+  -- Spec: require s ∈ {ŝ, ŝ + 1}
+  requireValidAckSn $ do
+    -- Spec: wait ŝ = s
+    waitOnSeenSnapshot $ \snapshot sigs -> do
+      -- Spec: (j,.) ∉ ̂Σ
+      requireNotSignedYet sigs $ do
+        let sigs'
+              -- TODO: Must check whether we know the 'otherParty' signing the snapshot
+              | verify (vkey otherParty) snapshotSignature snapshot = Map.insert otherParty snapshotSignature sigs
+              | otherwise = sigs
+        ifAllMembersHaveSigned snapshot sigs' $ do
+          -- TODO: verify the aggregated multisig, only the individuals, or both?
+          let multisig = aggregateInOrder sigs' parties
+          NewState
+            ( onlyUpdateCoordinatedHeadState $
+                coordinatedHeadState
+                  { confirmedSnapshot =
+                      ConfirmedSnapshot
+                        { snapshot
+                        , signatures = multisig
+                        }
+                  , seenSnapshot = LastSeenSnapshot (number snapshot)
+                  }
+            )
+            [ClientEffect $ SnapshotConfirmed headId snapshot multisig]
+            & emitSnapshot env
  where
   seenSn = seenSnapshotNumber seenSnapshot
 
-  requireAckSn sigs continue =
-    if sn `elem` [seenSn, seenSn + 1] && not (Map.member otherParty sigs)
+  requireValidAckSn continue =
+    if sn `elem` [seenSn, seenSn + 1]
       then continue
-      else Error $ RequireFailed "requireReqSn"
+      else Error $ RequireFailed "requireValidAckSn"
 
   waitOnSeenSnapshot continue =
     case seenSnapshot of
       SeenSnapshot snapshot sigs
         | seenSn == sn -> continue snapshot sigs
       _ -> Wait WaitOnSeenSnapshot
+
+  requireNotSignedYet sigs continue =
+    if not (Map.member otherParty sigs)
+      then continue
+      else Error $ RequireFailed "requireNotSignedYet"
 
   ifAllMembersHaveSigned snapshot sigs' cont =
     if Map.keysSet sigs' == Set.fromList parties

--- a/hydra-node/test/Hydra/CryptoSpec.hs
+++ b/hydra-node/test/Hydra/CryptoSpec.hs
@@ -49,9 +49,11 @@ specSignature =
   describe "Signature" $ do
     it "show includes escaped hex" $
       show (HydraSignature (SigEd25519DSIGN "aaa")) `shouldEndWith` "616161\""
+
     prop "can sign arbitrary messages" $ \sk (msgA :: ByteString) (msgB :: ByteString) ->
       msgA /= msgB
         ==> sign sk msgA =/= sign sk msgB
+
     prop "sign/verify roundtrip" $ \sk (msg :: ByteString) ->
       let sig = sign sk msg
        in verify (getVerificationKey sk) sig msg
@@ -65,3 +67,9 @@ specMultiSignature =
        in forAll (shuffle sigs) $ \shuffled ->
             length sigs > 1 && sigs /= shuffled
               ==> aggregate sigs =/= aggregate shuffled
+
+    prop "aggregate/verifyMultiSignature roundtrip" $ \sks (msg :: ByteString) ->
+      let sigs = map (\sk -> sign sk msg) sks
+          msig = aggregate sigs
+          vks = getVerificationKey <$> sks
+       in verifyMultiSignature vks msig msg


### PR DESCRIPTION
* Split requires in AckSn to reject too far in the future snapshots early. If we would wait first and require after, that would be a tautology.

* Verify the overall multi-signature as this is also what we will require for closing or finalizing a Head.

---

<!-- Tick off or strike-through / remove if not applicable -->
* ~~[ ] CHANGELOG updated~~
* ~~[ ] Documentation updated~~
* [x] Added and/or updated haddocks
* [x] No new TODOs introduced or explained herafter
  - reworded a TODO which is about checking authenticity of AckSn messages, see #727 
