### PR TITLE
Revert this old work around

### DIFF
--- a/hydra-node/src/Hydra/Persistence.hs
+++ b/hydra-node/src/Hydra/Persistence.hs
@@ -9,7 +9,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as C8
 import System.Directory (createDirectoryIfMissing, doesFileExist)
 import System.FilePath (takeDirectory)
-import UnliftIO.IO.File (withBinaryFileDurable, writeBinaryFileDurableAtomic)
+import UnliftIO.IO.File (withBinaryFile, writeBinaryFileDurableAtomic)
 
 newtype PersistenceException
   = PersistenceException String
@@ -63,7 +63,7 @@ createPersistenceIncremental fp = do
     PersistenceIncremental
       { append = \a -> do
           let bytes = toStrict $ Aeson.encode a <> "\n"
-          liftIO $ withBinaryFileDurable fp AppendMode (`BS.hPut` bytes)
+          liftIO $ withBinaryFile fp AppendMode (`BS.hPut` bytes)
       , loadAll =
           liftIO (doesFileExist fp) >>= \case
             False -> pure []

--- a/hydra-test-utils/src/Test/Hydra/Prelude.hs
+++ b/hydra-test-utils/src/Test/Hydra/Prelude.hs
@@ -41,7 +41,6 @@ import System.Directory (createDirectoryIfMissing, removePathForcibly)
 import System.Exit (ExitCode (..))
 import System.FilePath (takeDirectory)
 import System.IO.Temp (createTempDirectory, getCanonicalTemporaryDirectory)
-import System.Info (os)
 import System.Process (ProcessHandle, waitForProcess)
 import Test.HUnit.Lang (FailureReason (Reason), HUnitFailure (HUnitFailure))
 import Test.Hspec.Core.Format (Format, FormatConfig (..))
@@ -53,9 +52,7 @@ import Test.QuickCheck (Property, Testable, coverTable, forAll, tabulate)
 -- | Create a unique temporary directory.
 createSystemTempDirectory :: String -> IO FilePath
 createSystemTempDirectory template = do
-  tmpDir <- case os of
-    "darwin" -> pure "/tmp" -- https://github.com/input-output-hk/hydra/issues/158.
-    _ -> getCanonicalTemporaryDirectory
+  tmpDir <- getCanonicalTemporaryDirectory
   createTempDirectory tmpDir template
 
 -- | Create a temporary directory for the given 'action' to use.


### PR DESCRIPTION
FIX PermissionDenied issues on os x

When running the tests on os x with the Durable version we see the following errors:

```
  test/Hydra/API/ServerSpec.hs:61:3:
  1) Hydra.API.Server sends all sendOutput history to all connected clients after a restart
       uncaught exception: IOException of type PermissionDenied
       openFileFromDir: permission denied (Permission denied)

  To rerun use: --match "/Hydra.API.Server/sends all sendOutput history to all connected clients after a restart/"

  test/Hydra/PersistenceSpec.hs:43:5:
  2) Hydra.Persistence.PersistenceIncremental is consistent after multiple append calls in presence of new-lines
       uncaught exception: IOException of type PermissionDenied
       openFileFromDir: permission denied (Permission denied)
       (after 4 tests)
```

Which is probably due to the fact that we write in the tmp directory, which is a bit special,
and that the _Durable_ version pretends to deal with special directories but, maybe, not so
much in this case.

According to the documentation, `withBinaryFileDurable` behaves the same way as `withBinary` on Windows. On other systems it provides the following guarantees:

> * It successfully closes the file in case of an asynchronous exception
> * It reliably saves the file in the correct directory; including edge case situations like a different device being mounted to the current directory, or the current directory being renamed to some other name while the file is being used.
> * It ensures durability by executing an fsync() call before closing the file handle

So on Windows system, this commit does not change a thing.

On other systems, in the context of appending history to the persistent storage of the node we are not impacted by removing the above _Durable_ features:

* We only append to the end of the file
* We open/close the file everytime we append an history item to it

In this regard, the worst that could happen is some crash while appending one history item to the file which would result in this history item not written at all or partially written, in which case only the last line of the file would be corrupted.

This is a situation we were already in with the previous version of the code. Hence this P.R..