### PR TITLE
Breaking change procedure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,24 @@ changes.
 
 ## [0.9.0] - UNRELEASED
 
+:warning: Delete your persistence directory!
+
+This release contains several breaking changes and you'll need to apply the following procedure to upgrade
+all the nodes running a head:
+1. close the head
+2. stop Hydra node
+3. remove persistent files stored in `--persistence-dir`, in particular `server-output` and `state`
+4. upgrade Hydra node version
+5. start Hydra node
+
+Only when this procedure has been applied to all Hydra nodes can you open a new head again.
+
 - Reduced the number of supported parties to `3`. This was caused by increased
   size of minting policy and head validator scripts.
+
+- **BREAKING** Changes in the persistence format:
+  + Refactor HeadLogic with types for each state [#725](https://github.com/input-output-hk/hydra/pull/725)
+  + changes in the API hisotry [#745](https://github.com/input-output-hk/hydra/pull/745)
 
 - **BREAKING** Changes to the API:
   + Remove `TxSeen` and `TxExpired` server outputs. Use the `TxValid` and `TxInvalid` responses instead.


### PR DESCRIPTION
The following P.R (at least) introduced breaking changes impacting persistency:
* https://github.com/input-output-hk/hydra/pull/725
* https://github.com/input-output-hk/hydra/pull/745

There are other breaking changes, like, for instance:
* Plutus smart-contact
* API

All in all users will have to close/open their heads to upgrade. I think it's ok we also _break_ storage format in this particular release. Although we have to give the user instructions about how to do that. Hence this P.R.