### PR TITLE
Run cabal update in all CI jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,9 +58,12 @@ jobs:
         restore-keys: |
           cabal-${{ runner.os }}-${{ hashFiles('cabal.project', 'default.nix', 'shell.nix') }}
 
-    - name: 🔨 Build
+    - name: 🧰 Prepare tools
       run: |
         nix develop .#ci --command bash -c 'cabal update'
+
+    - name: 🔨 Build
+      run: |
         nix develop .#ci --command bash -c 'cabal build ${{ matrix.package }}'
 
     - name: ❓ Test
@@ -195,13 +198,16 @@ jobs:
         key: |
           cabal-${{ runner.os }}-${{ hashFiles('cabal.project', 'default.nix', 'shell.nix') }}
 
+    - name: 🧰 Prepare tools
+      run: |
+        nix develop .#ci --command bash -c 'cabal update'
+
     - name: 📈 Benchmark
       run: |
         nix develop .#ci --command bash -c 'cabal bench ${{ matrix.bench }} --benchmark-options "${{ matrix.options }}"'
 
     - name: 📚 Documentation (Haddock)
       run: |
-        nix develop .#ci --command bash -c 'cabal update'
         nix develop .#ci --command bash -c '.github/workflows/ci-haddock.sh'
 
     - name: 💾 Upload build & test artifacts


### PR DESCRIPTION
We were missing it a benchmark job and so it would sometimes fail when the cabal index was not cached from a previous job. Instead, we do cabal update now on each of our jobs which use cabal in a separate step.

This happened here for example: https://github.com/input-output-hk/hydra/actions/runs/4202072684/jobs/7289779883

<!-- Describe your change here -->

---

<!-- Tick off or strike-through / remove if not applicable -->
* [ ] CHANGELOG updated
* [ ] Documentation updated
* [ ] Added and/or updated haddocks
* [x] No new TODOs introduced or explained herafter
