### PR TITLE
Check overal transaction budget in evaluateTx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 As a minor extension, we also keep a semantic version for the `UNRELEASED`
 changes.
 
+## [0.10.0] - UNRELEASED
+
+- Changed interface of `Hydra.Ledger.Cardano.Evaluate` functions.
+
 ## [0.9.0] - 2023-03-02
 
 :dragon_face: Renamed the repository from `hydra-poc` to [`hydra`](https://github.com/input-output-hk/hydra)!

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          hydra-node
-version:       0.9.0
+version:       0.10.0
 synopsis:      The Hydra node
 author:        IOG
 copyright:     2022 IOG
@@ -351,6 +351,7 @@ test-suite tests
     , ouroboros-network
     , ouroboros-network-framework
     , plutus-ledger-api
+    , plutus-tx
     , process
     , QuickCheck
     , quickcheck-dynamic                ==2.0.0
@@ -366,5 +367,5 @@ test-suite tests
     , websockets
     , yaml
 
-  build-tool-depends: hspec-discover:hspec-discover -any
+  build-tool-depends: hspec-discover:hspec-discover
   ghc-options:        -threaded -rtsopts


### PR DESCRIPTION
This also introduces a new EvaluationError which aggregates the case of an overspent budget with the other transaction validation errors.

Checking the overall transaction budget is more realistic than only having the scripts fail it their individual budget exceeds the maxTxExecutionUnits (previous behavior).

<!-- Describe your change here -->

---

<!-- Tick off or strike-through / remove if not applicable -->
* [x] CHANGELOG updated
* [x] Documentation update not needed
* [x] Added and/or updated haddocks
* [x] No new TODOs introduced or explained herafter
