### PR TITLE
Limit concurrency of CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,10 @@
 name: "CI"
+
+# Limit concurrent runs of this workflow within a single PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,6 +5,11 @@
 # versioned images is suggested.
 name: Docker
 
+# Limit concurrent runs of this workflow within a single PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
We only want to have one job per PR per workflow running at the same time. This will make all other jobs get cancelled (e.g. when restarting jobs after rebasing)

<!-- Describe your change here -->

---

<!-- Tick off or strike-through / remove if not applicable -->
* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Added and/or updated haddocks not needed
* [x] No new TODOs introduced or explained herafter
