### PR TITLE
Can override faucet key from github secrets

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -10,6 +10,8 @@ on:
         options:
         - preview
         - preprod
+        # Uncomment the following line when we feel ready to run smoke tests on mainnet
+        # - mainnet
 
       hydra-scripts-tx-id:
         description: "TxId of already published scripts (leave empty to publish)"
@@ -47,6 +49,12 @@ jobs:
     - name: 🚬 Cleanup hydra-node state
       run: |
         rm -rf state-${{inputs.network}}/state-*
+
+    - name: 🤐 Setup secret faucet key
+      if: ${{ inputs.network == 'mainnet' }}
+      run: |
+        echo "${{secrets.faucet_sk}}" | base64 -d >hydra-cluster/config/credentials/faucet.sk
+        echo "${{secrets.faucet_vk}}" | base64 -d >hydra-cluster/config/credentials/faucet.vk
 
     - name: 🚬 Run hydra-cluster smoke test
       run: |

--- a/hydra-cluster/README.md
+++ b/hydra-cluster/README.md
@@ -40,6 +40,12 @@ to the `config/credentials/faucet.sk` on that network. The Hydra nodes
 can reference pre-existing contracts living at some well-known
 transaction or can post a new transaction to use those contracts.
 
+:warning: do not provide actual funds to this faucet address as the
+signing key is publicly available. Shall you want to run the smoke
+test with actual funds, you shall override these file to use a secret
+signing key safely stored. See how the C.I overrides these files in
+.github/workflows/smoke-test.yaml
+
 To run the smoke test against the official cardano testnet using a
 local `state-testnet` directory (to re-use the synchronized chain db):
 

--- a/hydra-cluster/README.md
+++ b/hydra-cluster/README.md
@@ -53,6 +53,16 @@ local `state-testnet` directory (to re-use the synchronized chain db):
 hydra-cluster --preview --state-directory state-testnet
 ```
 
+:warning: the C.I. overrides these files for mainnet. On the C.I. the
+faucet secrets are base64 encoded. Shall you need to update them, you
+could do it with the following commands (if you're not sure, do not
+do this, you may loose access to faucet funds):
+
+```sh
+#> cat faucet.vk | base64 | gh secret set faucet_vk
+#> cat faucet.sk | base64 | gh secret set faucet_sk
+```
+
 ## Local devnet
 
 `hydra-cluster` can run a local cardano devnet in the form of a single


### PR DESCRIPTION
We plan to provide the faucet some actual funds on mainnet. Although we don't plan to put that much assets there, it seems reasonable to implement a bare minimal protection of its private key.

I wish we could get rid of the faucet credentials in git. But it happens that these files are used by all sorts of tests. So what we do, instead, is that we let the C.I. override these files with some GitHub secrets before running the actual smoke tests.

That way, we ensure that:
* the faucet private key on mainnet is different from the one stored and publicly accessible on GitHub;
* the faucet funds are protected by the GitHub secret mechanism (which should be enough given the (very) small amount of value we plan to store there);
* the tests keep running locally and on preview and preprod networks.

But we have to deal with the following risk:
* alice, Bob and Carol assets are not protected as their signing keys are still publicly available but I think it's ok given the small amount of assets there and the reduced time slot during which it is there... we'll figure out something if Charly starts stealing from us;
* the C.I. overriding files that are in the repo could be misleading to people... I've made that clear in the README but who read a README?

Also note that I decided to keep the mainnet option commented for now so that we just activate it (uncomment) when we feel we're ready but don't have to wait more before merging this.

---

<!-- Tick off or strike-through / remove if not applicable -->
* [x] Documentation updated