### PR TITLE
Restarting the node with different parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ changes.
 - The hydra scripts are persisted in `hydra-plutus/scripts` and golden tests
   ensure they are not changed accidentally.
 
+- `hydra-node` detects misconfiguration and exits with the log item and
+  exception if the provided arguments are not inline with persisted state.
+
 ## [0.9.0] - 2023-03-02
 
 :dragon_face: Renamed the repository from `hydra-poc` to [`hydra`](https://github.com/input-output-hk/hydra)!

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -131,14 +131,17 @@ main = do
   checkParamsAgainstExistingState hs env =
     case hs of
       Idle _ -> []
-      Initial InitialState{parameters} -> checkCPAndParties "InitialState" parameters
-      Open OpenState{parameters} -> checkCPAndParties "OpenState" parameters
-      Closed ClosedState{parameters} -> checkCPAndParties "ClosedState" parameters
+      Initial InitialState{parameters} -> "InitialState: " : validateParameters parameters
+      Open OpenState{parameters} -> "OpenState: " : validateParameters parameters
+      Closed ClosedState{parameters} -> "ClosedState: " : validateParameters parameters
    where
-    checkCPAndParties st params
-      | Hydra.Chain.contestationPeriod params /= cp = [st <> " : " <> "Contestation period does not match"]
-      | Hydra.Chain.parties params /= envParties = [st <> " : " <> "Parties mismatch"]
-      | otherwise = []
+    validateParameters params =
+      flip execState [] $ do
+        when (Hydra.Chain.contestationPeriod params /= cp) $
+          modify (\s -> s <> ["Contestation period does not match. "])
+        when (Hydra.Chain.parties params /= envParties) $
+          modify (\s -> s <> ["Parties mismatch. "])
+
     Environment{contestationPeriod = cp, otherParties, party} = env
     envParties = party : otherParties
 

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -127,6 +127,7 @@ main = do
     action (Ledger.cardanoLedger globals ledgerEnv)
 
   -- check if hydra-node parameters are matching with the hydra-node state.
+  -- REVIEW: Should we also check against items we receive on-chain here? e.g. 'OpenThreadOutput' if in Open state?
   checkParamsAgainstExistingState :: HeadState Ledger.Tx -> Environment -> [String]
   checkParamsAgainstExistingState hs env =
     case hs of
@@ -138,9 +139,9 @@ main = do
     validateParameters st params =
       let res = flip execState [] $ do
             when (Hydra.Chain.contestationPeriod params /= cp) $
-              modify (\s -> s <> ["Contestation period does not match. "])
+              modify (<> ["Contestation period does not match. "])
             when (sort (Hydra.Chain.parties params) /= sort envParties) $
-              modify (\s -> s <> ["Parties mismatch. "])
+              modify (<> ["Parties mismatch. "])
        in case res of
             [] -> []
             items -> st : items

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -84,11 +84,11 @@ main = do
               pure $ Idle IdleState{chainState = initialChainState}
             Just headState -> do
               traceWith tracer LoadedState
+              let paramsMismatch = checkParamsAgainstExistingState headState env
+              when (not $ null paramsMismatch) $ do
+                traceWith tracer (Misconfiguration paramsMismatch)
+                throwIO $ PersistenceException $ concat paramsMismatch
               pure headState
-        let paramsMismatch = checkParamsAgainstExistingState hs env
-        when (not $ null paramsMismatch) $ do
-          traceWith tracer (Misconfiguration paramsMismatch)
-          throwIO $ PersistenceException $ concat paramsMismatch
         nodeState <- createNodeState hs
         ctx <- loadChainContext chainConfig party otherParties hydraScriptsTxId
         wallet <- mkTinyWallet (contramap DirectChain tracer) chainConfig

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -139,7 +139,7 @@ main = do
       let res = flip execState [] $ do
             when (Hydra.Chain.contestationPeriod params /= cp) $
               modify (\s -> s <> ["Contestation period does not match. "])
-            when (Hydra.Chain.parties params /= envParties) $
+            when (sort (Hydra.Chain.parties params) /= sort envParties) $
               modify (\s -> s <> ["Parties mismatch. "])
        in case res of
             [] -> []

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -131,16 +131,19 @@ main = do
   checkParamsAgainstExistingState hs env =
     case hs of
       Idle _ -> []
-      Initial InitialState{parameters} -> "InitialState: " : validateParameters parameters
-      Open OpenState{parameters} -> "OpenState: " : validateParameters parameters
-      Closed ClosedState{parameters} -> "ClosedState: " : validateParameters parameters
+      Initial InitialState{parameters} -> validateParameters "InitialState: " parameters
+      Open OpenState{parameters} -> validateParameters "OpenState: " parameters
+      Closed ClosedState{parameters} -> validateParameters "ClosedState: " parameters
    where
-    validateParameters params =
-      flip execState [] $ do
-        when (Hydra.Chain.contestationPeriod params /= cp) $
-          modify (\s -> s <> ["Contestation period does not match. "])
-        when (Hydra.Chain.parties params /= envParties) $
-          modify (\s -> s <> ["Parties mismatch. "])
+    validateParameters st params =
+      let res = flip execState [] $ do
+            when (Hydra.Chain.contestationPeriod params /= cp) $
+              modify (\s -> s <> ["Contestation period does not match. "])
+            when (Hydra.Chain.parties params /= envParties) $
+              modify (\s -> s <> ["Parties mismatch. "])
+       in case res of
+            [] -> []
+            items -> st : items
 
     Environment{contestationPeriod = cp, otherParties, party} = env
     envParties = party : otherParties

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -154,13 +154,15 @@ properties:
               additionalProperties: false
               required:
                 - tag
-                - misconfiguredItems
+                - misconfigurationErrors
               properties:
                 tag:
                   type: string
                   enum: ["Misconfiguration"]
-                misconfiguredItems:
+                misconfigurationErrors:
                   type: array
+                  items:
+                    $ref: "#definitions/ParamMismatch"
 
 definitions:
   APIServer:
@@ -435,6 +437,53 @@ definitions:
   # are based on internal type 'TimeServerOutput', so basically just contain an
   # adtitional 'timestamp' and 'seq'.
   ServerOutput: {}
+
+  ParamMismatch:
+    oneOf:
+      - title: ContestationPeriodMismatch
+        description: >-
+          The configured contestation period does not match with the value from the loaded state.
+        type: object
+        additionalProperties: false
+        required:
+          - tag
+          - loadedCp
+          - configuredCp
+        properties:
+          tag:
+            type: string
+            enum: ["ContestationPeriodMismatch"]
+          loadedCp:
+            <<: { "$ref": "api.yaml#/components/schemas/ContestationPeriod" }
+            description: >-
+              Contestation period present in the node state.
+          configuredCp:
+            <<: { "$ref": "api.yaml#/components/schemas/ContestationPeriod" }
+            description: >-
+              Contestation period configured as the node argument.
+      - title: PartiesMismatch
+        description: >-
+          The configured parties do not match with the value from the loaded state.
+        type: object
+        additionalProperties: false
+        required:
+          - tag
+          - loadedParties
+          - configuredParties
+        properties:
+          tag:
+            type: string
+            enum: ["PartiesMismatch"]
+          loadedParties:
+            type: array
+            <<: { "$ref": "api.yaml#/components/schemas/Party" }
+            description: >-
+              Parties present in the node state.
+          configuredParties:
+            type: array
+            <<: { "$ref": "api.yaml#/components/schemas/Party" }
+            description: >-
+              Parties configured as the node argument.
 
   # TODO: Fill the gap!
   Network: {}

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -147,6 +147,21 @@ properties:
                   type: string
                   enum: ["LoadedState"]
 
+            - title: Misconfiguration
+              description: >-
+                Hydra node detected a difference between loaded state and the node arguments.
+              type: object
+              additionalProperties: false
+              required:
+                - tag
+                - misconfiguredItems
+              properties:
+                tag:
+                  type: string
+                  enum: ["Misconfiguration"]
+                misconfiguredItems:
+                  type: array
+
 definitions:
   APIServer:
     oneOf:

--- a/hydra-node/src/Hydra/Logging.hs
+++ b/hydra-node/src/Hydra/Logging.hs
@@ -104,7 +104,7 @@ withTracerOutputTo ::
   IO a
 withTracerOutputTo hdl namespace action = do
   msgQueue <- newTBQueueIO @_ @(Envelope msg) defaultQueueSize
-  withAsync (writeLogs msgQueue) $ \_ ->
+  withAsync (writeLogs msgQueue `finally` flushLogs msgQueue) $ \_ ->
     action (tracer msgQueue) `finally` flushLogs msgQueue
  where
   tracer queue =

--- a/hydra-node/src/Hydra/Logging.hs
+++ b/hydra-node/src/Hydra/Logging.hs
@@ -104,8 +104,8 @@ withTracerOutputTo ::
   IO a
 withTracerOutputTo hdl namespace action = do
   msgQueue <- newTBQueueIO @_ @(Envelope msg) defaultQueueSize
-  withAsync (writeLogs msgQueue `finally` flushLogs msgQueue) $ \_ ->
-    action (tracer msgQueue)
+  withAsync (writeLogs msgQueue) $ \_ ->
+    action (tracer msgQueue) `finally` flushLogs msgQueue
  where
   tracer queue =
     Tracer $

--- a/hydra-node/src/Hydra/Logging.hs
+++ b/hydra-node/src/Hydra/Logging.hs
@@ -105,7 +105,7 @@ withTracerOutputTo ::
 withTracerOutputTo hdl namespace action = do
   msgQueue <- newTBQueueIO @_ @(Envelope msg) defaultQueueSize
   withAsync (writeLogs msgQueue `finally` flushLogs msgQueue) $ \_ ->
-    action (tracer msgQueue) `finally` flushLogs msgQueue
+    action (tracer msgQueue)
  where
   tracer queue =
     Tracer $

--- a/hydra-node/src/Hydra/Logging/Messages.hs
+++ b/hydra-node/src/Hydra/Logging/Messages.hs
@@ -23,7 +23,7 @@ data HydraLog tx net
   | CreatedState
   | LoadedState
   | NodeOptions {runOptions :: RunOptions}
-  | Misconfiguration [String]
+  | Misconfiguration {misconfiguredItems :: [String]}
   deriving (Generic)
 
 deriving instance (Eq net, Eq (HydraNodeLog tx)) => Eq (HydraLog tx net)

--- a/hydra-node/src/Hydra/Logging/Messages.hs
+++ b/hydra-node/src/Hydra/Logging/Messages.hs
@@ -23,6 +23,7 @@ data HydraLog tx net
   | CreatedState
   | LoadedState
   | NodeOptions {runOptions :: RunOptions}
+  | Misconfiguration Text
   deriving (Generic)
 
 deriving instance (Eq net, Eq (HydraNodeLog tx)) => Eq (HydraLog tx net)

--- a/hydra-node/src/Hydra/Logging/Messages.hs
+++ b/hydra-node/src/Hydra/Logging/Messages.hs
@@ -13,7 +13,7 @@ import Hydra.Prelude
 import Hydra.API.Server (APIServerLog)
 import Hydra.Chain.Direct.Handlers (DirectChainLog)
 import Hydra.Node (HydraNodeLog)
-import Hydra.Options (RunOptions)
+import Hydra.Options (ParamMismatch, RunOptions)
 
 data HydraLog tx net
   = DirectChain {directChain :: DirectChainLog}
@@ -23,7 +23,7 @@ data HydraLog tx net
   | CreatedState
   | LoadedState
   | NodeOptions {runOptions :: RunOptions}
-  | Misconfiguration {misconfiguredItems :: [String]}
+  | Misconfiguration {misconfigurationErrors :: [ParamMismatch]}
   deriving (Generic)
 
 deriving instance (Eq net, Eq (HydraNodeLog tx)) => Eq (HydraLog tx net)

--- a/hydra-node/src/Hydra/Logging/Messages.hs
+++ b/hydra-node/src/Hydra/Logging/Messages.hs
@@ -23,7 +23,7 @@ data HydraLog tx net
   | CreatedState
   | LoadedState
   | NodeOptions {runOptions :: RunOptions}
-  | Misconfiguration Text
+  | Misconfiguration [String]
   deriving (Generic)
 
 deriving instance (Eq net, Eq (HydraNodeLog tx)) => Eq (HydraLog tx net)


### PR DESCRIPTION
Fix #764 

NOTE: This is initial work on this item as I wanted to gather reviews. This PR only checks the contestation period and the parties. If the approach is good I will add more checks to complete our objective.

### Why
We want our hydra-node to behave well with respect to the provided arguments. In the presence of existing state it can happen that the arguments are not in line with what we have already in our state. For these cases we want to prevent the hydra-node from operating further until either state is cleared or node arguments match the state.

### What

Check node state (if any)  against the provided arguments, log and fail if we discover misconfiguration.



<!-- Tick off or strike-through / remove if not applicable -->
* [x] CHANGELOG updated
* [ ] Documentation updated
* [x] Added and/or updated haddocks
* [x] No new TODOs introduced or explained herafter
