### PR TITLE
Use TemplateHaskell to inline error codes

### DIFF
--- a/hydra-node/exe/tx-cost/Main.hs
+++ b/hydra-node/exe/tx-cost/Main.hs
@@ -128,14 +128,17 @@ scriptSizes =
   , ""
   , "| Name   | Hash | Size (Bytes) "
   , "| :----- | :--- | -----------: "
-  , "| " <> "μHead" <> " | N/A | " <> show mintingScriptSize <> " | "
   , "| " <> "νInitial" <> " | " <> serialiseToRawBytesHexText initialScriptHash <> " | " <> show initialScriptSize <> " | "
   , "| " <> "νCommit" <> " | " <> serialiseToRawBytesHexText commitScriptHash <> " | " <> show commitScriptSize <> " | "
   , "| " <> "νHead" <> " | " <> serialiseToRawBytesHexText headScriptHash <> " | " <> show headScriptSize <> " | "
+  , "| " <> "μHead" <> " | " <> serialiseToRawBytesHexText mintingScriptHash <> "* | " <> show mintingScriptSize <> " | "
+  , ""
+  , "* The minting policy hash is only usable for comparison. As the script is parameterized, the actual script is unique per Head."
   ]
  where
   ScriptInfo
-    { mintingScriptSize
+    { mintingScriptHash
+    , mintingScriptSize
     , initialScriptHash
     , initialScriptSize
     , commitScriptHash
@@ -156,7 +159,8 @@ costOfInit = markdownInitCost <$> computeInitCost
       ]
         <> fmap
           ( \(numParties, txSize, mem, cpu, Lovelace minFee) ->
-              "| " <> show numParties
+              "| "
+                <> show numParties
                 <> "| "
                 <> show txSize
                 <> " | "
@@ -182,7 +186,8 @@ costOfCommit = markdownCommitCost <$> computeCommitCost
       ]
         <> map
           ( \(ulen, txSize, mem, cpu, Lovelace minFee) ->
-              "| " <> show ulen
+              "| "
+                <> show ulen
                 <> "| "
                 <> show txSize
                 <> " | "
@@ -207,7 +212,8 @@ costOfCollectCom = markdownCollectComCost <$> computeCollectComCost
       ]
         <> fmap
           ( \(numParties, utxoSize, txSize, mem, cpu, Lovelace minFee) ->
-              "| " <> show numParties
+              "| "
+                <> show numParties
                 <> " | "
                 <> show utxoSize
                 <> " | "
@@ -234,7 +240,8 @@ costOfClose = markdownClose <$> computeCloseCost
       ]
         <> fmap
           ( \(numParties, txSize, mem, cpu, Lovelace minFee) ->
-              "| " <> show numParties
+              "| "
+                <> show numParties
                 <> "| "
                 <> show txSize
                 <> " | "
@@ -259,7 +266,8 @@ costOfContest = markdownContest <$> computeContestCost
       ]
         <> fmap
           ( \(numParties, txSize, mem, cpu, Lovelace minFee) ->
-              "| " <> show numParties
+              "| "
+                <> show numParties
                 <> "| "
                 <> show txSize
                 <> " | "
@@ -285,7 +293,8 @@ costOfAbort = markdownAbortCost <$> computeAbortCost
       ]
         <> fmap
           ( \(numParties, txSize, mem, cpu, Lovelace minFee) ->
-              "| " <> show numParties
+              "| "
+                <> show numParties
                 <> "| "
                 <> show txSize
                 <> " | "
@@ -311,7 +320,8 @@ costOfFanOut = markdownFanOutCost <$> computeFanOutCost
       ]
         <> fmap
           ( \(parties, numElems, utxoSize, txSize, mem, cpu, Lovelace minFee) ->
-              "| " <> show parties
+              "| "
+                <> show parties
                 <> " | "
                 <> show numElems
                 <> " | "

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
@@ -32,6 +32,7 @@ import Hydra.Chain.Direct.Tx (
 import Hydra.Chain.Direct.TxSpec (drop3rd, genAbortableOutputs)
 import Hydra.ContestationPeriod (toChain)
 import qualified Hydra.Contract.Commit as Commit
+import Hydra.Contract.Error (toErrorCode)
 import Hydra.Contract.Head (
   HeadError (
     BurntTokenNumberMismatch,
@@ -40,13 +41,9 @@ import Hydra.Contract.Head (
   ),
  )
 import qualified Hydra.Contract.HeadState as Head
-import Hydra.Contract.HeadTokens (
-  HeadTokensError (MintingNotAllowed),
-  headPolicyId,
-  mkHeadTokenScript,
- )
+import Hydra.Contract.HeadTokens (headPolicyId, mkHeadTokenScript)
+import Hydra.Contract.HeadTokensError (HeadTokensError (..))
 import qualified Hydra.Contract.Initial as Initial
-import Hydra.Contract.Error (toErrorCode)
 import Hydra.Ledger.Cardano (genVerificationKey)
 import Hydra.Party (Party, partyToChain)
 import Test.Hydra.Fixture (cperiod)

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
@@ -33,13 +33,7 @@ import Hydra.Chain.Direct.TxSpec (drop3rd, genAbortableOutputs)
 import Hydra.ContestationPeriod (toChain)
 import qualified Hydra.Contract.Commit as Commit
 import Hydra.Contract.Error (toErrorCode)
-import Hydra.Contract.Head (
-  HeadError (
-    BurntTokenNumberMismatch,
-    ReimbursedOutputsDontMatch,
-    SignerIsNotAParticipant
-  ),
- )
+import Hydra.Contract.HeadError (HeadError (..))
 import qualified Hydra.Contract.HeadState as Head
 import Hydra.Contract.HeadTokens (headPolicyId, mkHeadTokenScript)
 import Hydra.Contract.HeadTokensError (HeadTokensError (..))

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -31,22 +31,7 @@ import Hydra.Chain.Direct.TimeHandle (PointInTime)
 import Hydra.Chain.Direct.Tx (ClosingSnapshot (..), OpenThreadOutput (..), UTxOHash (UTxOHash), closeTx, mkHeadId, mkHeadOutput)
 import Hydra.ContestationPeriod (fromChain)
 import Hydra.Contract.Error (toErrorCode)
-import Hydra.Contract.Head (
-  HeadError (
-    ChangedParameters,
-    ClosedWithNonInitialHash,
-    ContestersNonEmpty,
-    HasBoundedValidityCheckFailed,
-    HeadValueIsNotPreserved,
-    IncorrectClosedContestationDeadline,
-    InfiniteLowerBound,
-    InfiniteUpperBound,
-    InvalidSnapshotSignature,
-    NoSigners,
-    SignerIsNotAParticipant,
-    TooManySigners
-  ),
- )
+import Hydra.Contract.HeadError (HeadError (..))
 import qualified Hydra.Contract.HeadState as Head
 import Hydra.Contract.HeadTokens (headPolicyId)
 import Hydra.Contract.Util (UtilError (MintingOrBurningIsForbidden))

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -36,15 +36,7 @@ import Hydra.Chain.Direct.Tx (
  )
 import qualified Hydra.Contract.Commit as Commit
 import Hydra.Contract.Error (toErrorCode)
-import Hydra.Contract.Head (
-  HeadError (
-    DatumNotFound,
-    IncorrectUtxoHash,
-    MissingCommits,
-    STNotSpent,
-    SignerIsNotAParticipant
-  ),
- )
+import Hydra.Contract.HeadError (HeadError (..))
 import qualified Hydra.Contract.HeadState as Head
 import Hydra.Contract.HeadTokens (headPolicyId)
 import Hydra.Contract.Util (UtilError (MintingOrBurningIsForbidden))

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
@@ -22,8 +22,8 @@ import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry, registryUTxO)
 import Hydra.Chain.Direct.Tx (commitTx, mkHeadId, mkInitialOutput)
 import Hydra.Contract.Error (toErrorCode)
 import Hydra.Contract.HeadTokens (headPolicyId)
-import Hydra.Contract.Initial
 import qualified Hydra.Contract.Initial as Initial
+import Hydra.Contract.InitialError (InitialError (..))
 import Hydra.Contract.Util (UtilError (MintingOrBurningIsForbidden))
 import Hydra.Ledger.Cardano (
   genAddressInEra,

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -32,22 +32,7 @@ import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry, registryUTxO)
 import Hydra.Chain.Direct.Tx (ClosedThreadOutput (..), contestTx, mkHeadId, mkHeadOutput)
 import Hydra.ContestationPeriod (ContestationPeriod, fromChain)
 import Hydra.Contract.Error (toErrorCode)
-import Hydra.Contract.Head (
-  HeadError (
-    ChangedParameters,
-    ContesterNotIncluded,
-    HeadValueIsNotPreserved,
-    MustNotPushDeadline,
-    MustPushDeadline,
-    NoSigners,
-    SignatureVerificationFailed,
-    SignerAlreadyContested,
-    SignerIsNotAParticipant,
-    TooManySigners,
-    TooOldSnapshot,
-    UpperBoundBeyondContestationDeadline
-  ),
- )
+import Hydra.Contract.HeadError (HeadError (..))
 import qualified Hydra.Contract.HeadState as Head
 import Hydra.Contract.HeadTokens (headPolicyId)
 import Hydra.Contract.Util (UtilError (MintingOrBurningIsForbidden))

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/FanOut.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/FanOut.hs
@@ -14,12 +14,7 @@ import Hydra.Chain.Direct.Fixture (testNetworkId, testPolicyId, testSeedInput)
 import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry, registryUTxO)
 import Hydra.Chain.Direct.Tx (fanoutTx, mkHeadOutput)
 import Hydra.Contract.Error (toErrorCode)
-import Hydra.Contract.Head (
-  HeadError (
-    FannedOutUtxoHashNotEqualToClosedUtxoHash,
-    LowerBoundBeforeContestationDeadline
-  ),
- )
+import Hydra.Contract.HeadError (HeadError (..))
 import qualified Hydra.Contract.HeadState as Head
 import Hydra.Contract.HeadTokens (mkHeadTokenScript)
 import Hydra.Data.ContestationPeriod (posixFromUTCTime)

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Init.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Init.hs
@@ -21,17 +21,9 @@ import Hydra.Chain.Direct.Contract.Mutation (
  )
 import Hydra.Chain.Direct.Fixture (testNetworkId, testPolicyId, testSeedInput)
 import Hydra.Chain.Direct.Tx (initTx)
-import Hydra.Contract.HeadState (State (..))
-import Hydra.Contract.HeadTokens (
-  HeadTokensError (
-    NoPT,
-    SeedNotSpent,
-    WrongDatum,
-    WrongNumberOfInitialOutputs,
-    WrongNumberOfTokensMinted
-  ),
- )
 import Hydra.Contract.Error (toErrorCode)
+import Hydra.Contract.HeadState (State (..))
+import Hydra.Contract.HeadTokensError (HeadTokensError (..))
 import Hydra.Ledger.Cardano (genOneUTxOFor, genValue, genVerificationKey)
 import Hydra.Party (Party)
 import Test.QuickCheck (choose, elements, oneof, suchThat, vectorOf)

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
@@ -337,9 +337,9 @@ applyMutation mutation (tx@(Tx body wits), utxo) = case mutation of
         -- change the lookup UTXO
         fn o@(TxOut addr value _ refScript)
           | isHeadOutput o =
-              TxOut addr value datumHash refScript
+            TxOut addr value datumHash refScript
           | otherwise =
-              o
+            o
         -- change the datums in the tx
         ShelleyTxBody ledgerBody scripts scriptData mAuxData scriptValidity = body
         newDatums = addDatum datum scriptData
@@ -587,12 +587,12 @@ alterTxIns fn tx =
   -- NOTE: This needs to be ordered, such that we can calculate the redeemer
   -- pointers correctly.
   newSortedInputs =
-    sortOn fst
-      $ fn
+    sortOn fst $
+      fn
         . resolveRedeemers
         . fmap fromLedgerTxIn
         . toList
-      $ Ledger.inputs ledgerBody
+        $ Ledger.inputs ledgerBody
 
   resolveRedeemers :: [TxIn] -> [(TxIn, Maybe ScriptData)]
   resolveRedeemers txInputs =

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -74,6 +74,7 @@ library
   exposed-modules:
     Hydra.Contract
     Hydra.Contract.Commit
+    Hydra.Contract.CommitError
     Hydra.Contract.Error
     Hydra.Contract.Hash
     Hydra.Contract.Head

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -81,6 +81,7 @@ library
     Hydra.Contract.HeadTokens
     Hydra.Contract.HeadTokensError
     Hydra.Contract.Initial
+    Hydra.Contract.InitialError
     Hydra.Contract.MintAction
     Hydra.Contract.Util
     Hydra.Data.ContestationPeriod

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -79,6 +79,7 @@ library
     Hydra.Contract.Head
     Hydra.Contract.HeadState
     Hydra.Contract.HeadTokens
+    Hydra.Contract.HeadTokensError
     Hydra.Contract.Initial
     Hydra.Contract.MintAction
     Hydra.Contract.Util

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -78,6 +78,7 @@ library
     Hydra.Contract.Error
     Hydra.Contract.Hash
     Hydra.Contract.Head
+    Hydra.Contract.HeadError
     Hydra.Contract.HeadState
     Hydra.Contract.HeadTokens
     Hydra.Contract.HeadTokensError

--- a/hydra-plutus/src/Hydra/Contract.hs
+++ b/hydra-plutus/src/Hydra/Contract.hs
@@ -23,7 +23,9 @@ import Plutus.V2.Ledger.Api (TxId (..), TxOutRef (..), toBuiltin)
 
 -- | Information about relevant Hydra scripts.
 data ScriptInfo = ScriptInfo
-  { -- | Size of the μHead minting script given default paramters
+  { -- | Hash of the μHead minting script given some default parameters.
+    mintingScriptHash :: ScriptHash
+  , -- | Size of the μHead minting script given some default parameters.
     mintingScriptSize :: Int64
   , initialScriptHash :: ScriptHash
   , initialScriptSize :: Int64
@@ -39,7 +41,8 @@ data ScriptInfo = ScriptInfo
 scriptInfo :: ScriptInfo
 scriptInfo =
   ScriptInfo
-    { mintingScriptSize = scriptSize $ HeadTokens.mintingPolicyScript defaultOutRef
+    { mintingScriptHash = plutusScriptHash $ HeadTokens.mintingPolicyScript defaultOutRef
+    , mintingScriptSize = scriptSize $ HeadTokens.mintingPolicyScript defaultOutRef
     , initialScriptHash = plutusScriptHash Initial.validatorScript
     , initialScriptSize = scriptSize Initial.validatorScript
     , commitScriptHash = plutusScriptHash Commit.validatorScript

--- a/hydra-plutus/src/Hydra/Contract/CommitError.hs
+++ b/hydra-plutus/src/Hydra/Contract/CommitError.hs
@@ -1,0 +1,17 @@
+module Hydra.Contract.CommitError (
+  errorCode,
+  module Hydra.Contract.CommitError,
+) where
+
+import Hydra.Contract.Error (ToErrorCode (..), errorCode)
+import Text.Show (Show)
+
+data CommitError
+  = STNotBurnedError
+  | STIsMissingInTheOutput
+  deriving (Show)
+
+instance ToErrorCode CommitError where
+  toErrorCode = \case
+    STNotBurnedError -> "C01"
+    STIsMissingInTheOutput -> "C02"

--- a/hydra-plutus/src/Hydra/Contract/Error.hs
+++ b/hydra-plutus/src/Hydra/Contract/Error.hs
@@ -36,7 +36,7 @@ class ToErrorCode a where
   toErrorCode :: a -> Text
 
 -- | Get the string literal from given error 'e'. Use this with template haskell
--- splices, e.g. $(toErrorCode MyError)
+-- splices, e.g. $(errorCode MyError)
 errorCode :: ToErrorCode e => e -> Q Exp
 errorCode =
   pure . LitE . StringL . toString . toErrorCode

--- a/hydra-plutus/src/Hydra/Contract/Error.hs
+++ b/hydra-plutus/src/Hydra/Contract/Error.hs
@@ -1,8 +1,42 @@
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | Error codes to be used in plutus scripts.
+--
+-- Define a new type and instantaite 'ToErrorCode' for error cases you want to
+-- use in scripts.
+--
+-- @
+-- data MyError = CaseA | CaseB deriving Show
+--
+-- instance ToErrorCode MyError where
+--   toErrorCode = \case
+--     CaseA -> "CA"
+--     CaseB -> "CB"
+-- @
+--
+-- In plutus-tx, you can then use template haskell to inline the error codes
+-- using the '$(errorCode ..)' splice.
+--
+-- @
+-- validator = traceError $(errorCode CaseA)
+-- @
+--
+-- This example will have your validator fail with user error "CA", which you
+-- can match for using 'toErrorCode CaseA' in Haskell.
 module Hydra.Contract.Error where
 
-import Hydra.Prelude (Text)
+import Hydra.Prelude
+
+import Language.Haskell.TH (Exp (..), Lit (StringL), Q)
 
 -- | Types which are used to describe errors as short error codes in scripts.
 class ToErrorCode a where
   -- | Get the short error code used in a script for given type.
   toErrorCode :: a -> Text
+
+-- | Get the string literal from given error 'e'. Use this with template haskell
+-- splices, e.g. $(toErrorCode MyError)
+errorCode :: ToErrorCode e => e -> Q Exp
+errorCode =
+  pure . LitE . StringL . toString . toErrorCode

--- a/hydra-plutus/src/Hydra/Contract/Error.hs
+++ b/hydra-plutus/src/Hydra/Contract/Error.hs
@@ -3,7 +3,7 @@
 
 -- | Error codes to be used in plutus scripts.
 --
--- Define a new type and instantaite 'ToErrorCode' for error cases you want to
+-- Define a new type and instantiate 'ToErrorCode' for error cases you want to
 -- use in scripts.
 --
 -- @

--- a/hydra-plutus/src/Hydra/Contract/HeadError.hs
+++ b/hydra-plutus/src/Hydra/Contract/HeadError.hs
@@ -1,0 +1,87 @@
+module Hydra.Contract.HeadError (
+  errorCode,
+  module Hydra.Contract.HeadError,
+) where
+
+import Hydra.Contract.Error (ToErrorCode (..), errorCode)
+import Text.Show (Show)
+
+data HeadError
+  = InvalidHeadStateTransition
+  | BurntTokenNumberMismatch
+  | ReimbursedOutputsDontMatch
+  | STNotSpent
+  | IncorrectUtxoHash
+  | ChangedParameters
+  | WrongStateInOutputDatum
+  | MissingCommits
+  | HeadValueIsNotPreserved
+  | HasBoundedValidityCheckFailed
+  | InvalidSnapshotSignature
+  | ClosedWithNonInitialHash
+  | IncorrectClosedContestationDeadline
+  | InfiniteUpperBound
+  | InfiniteLowerBound
+  | ContestersNonEmpty
+  | TooOldSnapshot
+  | UpperBoundBeyondContestationDeadline
+  | ContestNoUpperBoundDefined
+  | MustNotPushDeadline
+  | MustPushDeadline
+  | ContesterNotIncluded
+  | WrongNumberOfSigners
+  | SignerAlreadyContested
+  | FannedOutUtxoHashNotEqualToClosedUtxoHash
+  | LowerBoundBeforeContestationDeadline
+  | FanoutNoLowerBoundDefined
+  | CloseNoUpperBoundDefined
+  | ScriptNotSpendingAHeadInput
+  | SignerIsNotAParticipant
+  | NoSigners
+  | TooManySigners
+  | NoOutputDatumError
+  | DatumNotFound
+  | SignatureVerificationFailed
+  | PartySignatureVerificationFailed
+  deriving (Show)
+
+instance ToErrorCode HeadError where
+  toErrorCode = \case
+    InvalidHeadStateTransition -> "H01"
+    BurntTokenNumberMismatch -> "H02"
+    ReimbursedOutputsDontMatch -> "H03"
+    STNotSpent -> "H04"
+    IncorrectUtxoHash -> "H05"
+    ChangedParameters -> "H06"
+    WrongStateInOutputDatum -> "H07"
+    MissingCommits -> "H08"
+    HeadValueIsNotPreserved -> "H09"
+    HasBoundedValidityCheckFailed -> "H10"
+    -- XXX: This error code is redundant and can be removed in favor of H35.
+    -- This will also make the close checks consistent with the contest's
+    InvalidSnapshotSignature -> "H11"
+    ClosedWithNonInitialHash -> "H12"
+    IncorrectClosedContestationDeadline -> "H13"
+    InfiniteUpperBound -> "H14"
+    InfiniteLowerBound -> "H15"
+    ContestersNonEmpty -> "H16"
+    TooOldSnapshot -> "H17"
+    UpperBoundBeyondContestationDeadline -> "H18"
+    ContestNoUpperBoundDefined -> "H19"
+    MustNotPushDeadline -> "H20"
+    MustPushDeadline -> "H21"
+    ContesterNotIncluded -> "H22"
+    WrongNumberOfSigners -> "H23"
+    SignerAlreadyContested -> "H24"
+    FannedOutUtxoHashNotEqualToClosedUtxoHash -> "H25"
+    LowerBoundBeforeContestationDeadline -> "H26"
+    FanoutNoLowerBoundDefined -> "H27"
+    CloseNoUpperBoundDefined -> "H28"
+    ScriptNotSpendingAHeadInput -> "H29"
+    SignerIsNotAParticipant -> "H30"
+    NoSigners -> "H31"
+    TooManySigners -> "H32"
+    NoOutputDatumError -> "H33"
+    DatumNotFound -> "H34"
+    SignatureVerificationFailed -> "H35"
+    PartySignatureVerificationFailed -> "H36"

--- a/hydra-plutus/src/Hydra/Contract/HeadTokensError.hs
+++ b/hydra-plutus/src/Hydra/Contract/HeadTokensError.hs
@@ -1,0 +1,35 @@
+module Hydra.Contract.HeadTokensError (
+  errorCode,
+  module Hydra.Contract.HeadTokensError,
+) where
+
+import Hydra.Contract.Error (ToErrorCode (..), errorCode)
+import Text.Show (Show)
+
+data HeadTokensError
+  = SeedNotSpent
+  | WrongNumberOfTokensMinted
+  | MissingST
+  | WrongNumberOfInitialOutputs
+  | WrongDatum
+  | MintingNotAllowed
+  | NoPT
+  | WrongQuantity
+  | HeadDatum
+  | NoDatum
+  | MultipleHeadOutput
+  deriving (Show)
+
+instance ToErrorCode HeadTokensError where
+  toErrorCode = \case
+    SeedNotSpent -> "M01"
+    WrongNumberOfTokensMinted -> "M02"
+    MissingST -> "M03"
+    WrongNumberOfInitialOutputs -> "M04"
+    WrongDatum -> "M05"
+    MintingNotAllowed -> "M06"
+    NoPT -> "M07"
+    WrongQuantity -> "M08"
+    HeadDatum -> "M09"
+    NoDatum -> "M10"
+    MultipleHeadOutput -> "M11"

--- a/hydra-plutus/src/Hydra/Contract/InitialError.hs
+++ b/hydra-plutus/src/Hydra/Contract/InitialError.hs
@@ -1,0 +1,39 @@
+module Hydra.Contract.InitialError (
+  errorCode,
+  module Hydra.Contract.InitialError,
+) where
+
+import Hydra.Contract.Error (ToErrorCode (..), errorCode)
+import Text.Show (Show)
+
+data InitialError
+  = STNotBurned
+  | MissingOrInvalidCommitAuthor
+  | LockedValueDoesNotMatch
+  | MismatchCommittedTxOutInDatum
+  | CouldNotFindTheCorrectCurrencySymbolInTokens
+  | MultipleHeadTokensOrMoreThan1PTsFound
+  | NothingCommittedButTxOutInOutputDatum
+  | CommittedTxOutButNothingInOutputDatum
+  | MissingDatum
+  | UnexpectedInlineDatum
+  | CouldNotFindDatum
+  | ExpectedCommitDatumTypeGotSomethingElse
+  | ExpectedSingleCommitOutput
+  deriving (Show)
+
+instance ToErrorCode InitialError where
+  toErrorCode = \case
+    STNotBurned -> "I01"
+    MissingOrInvalidCommitAuthor -> "I02"
+    LockedValueDoesNotMatch -> "I03"
+    MismatchCommittedTxOutInDatum -> "I04"
+    CouldNotFindTheCorrectCurrencySymbolInTokens -> "I05"
+    MultipleHeadTokensOrMoreThan1PTsFound -> "I06"
+    NothingCommittedButTxOutInOutputDatum -> "I07"
+    CommittedTxOutButNothingInOutputDatum -> "I08"
+    MissingDatum -> "I09"
+    UnexpectedInlineDatum -> "I10"
+    CouldNotFindDatum -> "I11"
+    ExpectedCommitDatumTypeGotSomethingElse -> "I12"
+    ExpectedSingleCommitOutput -> "I13"


### PR DESCRIPTION
* Adds a `$(errorCode ...)` splice to inline error codes into plutus-tx code.

---

<!-- Tick off or strike-through / remove if not applicable -->
* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Added and/or updated haddocks
* [x] No new TODOs introduced or explained herafter
