### PR TITLE
Play with runners

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,55 @@
+This explains how to install a cardano runner for the Hydra project.
+
+This runner is used by our smoke-tests and allows us to keep on disk
+an, as up to date as possible, cardano-node database.
+
+# prepare pre-requisites
+
+Install the following pre-requisites:
+* git
+
+For instance on Debian:
+```bash
+sudo apt install git
+```
+
+Prepare the common directory for cardano database:
+```bash
+sudo mkdir -p /srv/var/cardano
+sudo chown "$(whoami)" /srv/var/cardano
+```
+
+# Add the server as a github runner
+
+In the project settings, go to Actions/Runners and click on [New self-hosted runner](https://github.com/input-output-hk/hydra/settings/actions/runners/new) and follow the procedure.
+
+:warning: When asked, add the following label to this runner: `cardano`
+
+# Customize github runner for nix
+
+So that the jobs can find nix later, you should customize the runner settings by adding some
+variables to the `.env` file:
+
+```bash
+cat <<EOF >>$HOME/actions-runner/.env
+PATH=$HOME/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/bin
+NIX_PROFILES="/nix/var/nix/profiles/default $HOME/.nix-profile"
+NIX_SSL_CERT_FILE="/etc/ssl/certs/ca-certificates.crt"
+EOF
+```
+
+# Install github runner as a systemd unit
+
+
+So that github runner runs as a daemon on the machine, [install it](https://docs.github.com/en/actions/hosting-your-own-runners/configuring-the-self-hosted-runner-application-as-a-service):
+
+
+```bash
+sudo ./svc.sh install
+```
+
+You can now start the service:
+
+```bash
+sudo ./svc.sh start
+```

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -20,7 +20,10 @@ on:
 jobs:
   smoke-test:
     name: "Smoke test on ${{inputs.network}}"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, cardano]
+    concurrency: cardano-${{inputs.network}}
+    env:
+      state_dir: /srv/var/cardano/state-${{inputs.network}}
     steps:
     - uses: actions/checkout@v3
       with:
@@ -34,21 +37,9 @@ jobs:
         extra_nix_config: |
           accept-flake-config = true
 
-    - name: ❄ Cachix cache of nix derivations
-      uses: cachix/cachix-action@v12
-      with:
-        name: hydra-node
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-
-    - name: 🔁 Github cache of state-directory
-      uses: actions/cache@v3
-      with:
-        path: state-${{inputs.network}}
-        key: state-${{inputs.network}}
-
     - name: 🚬 Cleanup hydra-node state
       run: |
-        rm -rf state-${{inputs.network}}/state-*
+        rm -rf ${state_dir}/state-*
 
     - name: 🤐 Setup secret faucet key
       if: ${{ inputs.network == 'mainnet' }}
@@ -59,9 +50,9 @@ jobs:
     - name: 🚬 Run hydra-cluster smoke test
       run: |
         if [ -n "${{inputs.hydra-scripts-tx-id}}" ]; then
-          nix develop ".?submodules=1#exes" --command bash -c "hydra-cluster --${{inputs.network}} --hydra-scripts-tx-id ${{inputs.hydra-scripts-tx-id}} --state-directory state-${{inputs.network}}"
+          nix develop ".?submodules=1#exes" --command bash -c "hydra-cluster --${{inputs.network}} --hydra-scripts-tx-id ${{inputs.hydra-scripts-tx-id}} --state-directory ${state_dir}"
         else
-          nix develop ".?submodules=1#exes" --command bash -c "hydra-cluster --${{inputs.network}} --publish-hydra-scripts --state-directory state-${{inputs.network}}"
+          nix develop ".?submodules=1#exes" --command bash -c "hydra-cluster --${{inputs.network}} --publish-hydra-scripts --state-directory ${state_dir}"
         fi
 
     - name: 💾 Upload logs
@@ -69,4 +60,4 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: hydra-cluster-logs
-        path: state-${{inputs.network}}/logs/**/*
+        path: ${state_dir}/logs/**/*

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -10,12 +10,12 @@ on:
         options:
         - preview
         - preprod
-        # Uncomment the following line when we feel ready to run smoke tests on mainnet
-        # - mainnet
+        - mainnet
 
       hydra-scripts-tx-id:
         description: "TxId of already published scripts (leave empty to publish)"
         required: false
+
 
 jobs:
   smoke-test:

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -13,6 +13,11 @@ license-files:
 
 extra-source-files: README.md
 data-files:
+  config/cardano-configurations/network/mainnet/cardano-node/config.json
+  config/cardano-configurations/network/mainnet/cardano-node/topology.json
+  config/cardano-configurations/network/mainnet/genesis/alonzo.json
+  config/cardano-configurations/network/mainnet/genesis/byron.json
+  config/cardano-configurations/network/mainnet/genesis/shelley.json
   config/cardano-configurations/network/preprod/cardano-node/config.json
   config/cardano-configurations/network/preprod/cardano-node/topology.json
   config/cardano-configurations/network/preprod/genesis/alonzo.json


### PR DESCRIPTION
Contributes to #761 

We want to run the smoke tests on mainnet but that means that we need way more resources than we used to need when only running them on preview or preprod. Just caching the cardano database between two runs will not work anymore or take forever as it's way bigger.

To solve that, we invest in a self-hosted GitHub runner dedicated to running the smoke tests and that will persistently keep the cardano-node database on disk between several runs.

This P.R. updates the C.I. so that the smoke tests use the runner. It also describes the procedure to install a GitHub runner for this. A runner has already been setup and smoke test do work on it:
* [smoke test on preview](https://github.com/input-output-hk/hydra/actions/runs/4439099742)
* [smoke test on preprod](https://github.com/input-output-hk/hydra/actions/runs/4439365459)
* [smoke test on mainnet](https://github.com/input-output-hk/hydra/actions/runs/4439366874) (fails because no cash here but that's ok)

---

* [x] Documentation updated