### PR TITLE
Everyone collects after observing the last commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ changes.
 - `hydra-node` detects misconfiguration and exits with the log item and
   exception if the provided arguments are not inline with persisted state.
 
+- All participants' `hydra-node` try to collect once seeing the last `commitTx`.
+
 ## [0.9.0] - 2023-03-02
 
 :dragon_face: Renamed the repository from `hydra-poc` to [`hydra`](https://github.com/input-output-hk/hydra)!


### PR DESCRIPTION
We change this to make it more robust to open heads. Now, all head participants would try to open a head with a collect, not only the last to commit. This is also how it is written in the spec right now.

---

<!-- Tick off or strike-through / remove if not applicable -->
* [x] CHANGELOG updated
* [x] Documentation updated
* [x] Added and/or updated haddocks
* [x] No new TODOs introduced or explained herafter
