### PR TITLE
Publish versioned docs

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -32,7 +32,6 @@ jobs:
         path: docs/public/unstable
 
     - name: 🚢 Publish Documentation
-      if: github.event_name == 'push'
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN || github.token }}

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -31,18 +31,6 @@ jobs:
         name: docs-unstable
         path: docs/public/unstable
 
-    # TODO: remove debugging steps
-
-    - name: DEBUG contents
-      run: |
-        find docs/
-
-    - name: DEBUG contents
-      uses: actions/upload-artifact@v3
-      with:
-        name: head-protocol
-        path: docs/public
-        
     - name: 🚢 Publish Documentation
       if: github.event_name == 'push'
       uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
This PR actually publishes the versioned docs prepared by #783 and #803.

---

<!-- Tick off or strike-through / remove if not applicable -->
* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Added and/or updated haddocks
* [x] No new TODOs introduced or explained herafter
