### PR TITLE
Fix flaky websocket tests

### DIFF
--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -35,6 +35,9 @@ import Test.Network.Ports (withFreePort)
 import Test.QuickCheck (checkCoverage, cover, generate)
 import Test.QuickCheck.Monadic (monadicIO, monitor, pick, run)
 
+-- NOTE: It is important to not run these tests using 'parallel' since we will
+-- end up with _flaky_ tests because in the threaded environment we can't easily
+-- guess which port is opened.
 spec :: Spec
 spec = do
   it "greets" $ do

--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -36,7 +36,7 @@ import Test.QuickCheck (checkCoverage, cover, generate)
 import Test.QuickCheck.Monadic (monadicIO, monitor, pick, run)
 
 spec :: Spec
-spec = parallel $ do
+spec = do
   it "greets" $ do
     failAfter 5 $
       withFreePort $ \port -> do

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -23,7 +23,7 @@ import Test.QuickCheck (
 import Test.QuickCheck.Instances.ByteString ()
 
 spec :: Spec
-spec = do
+spec = parallel $ do
   let lo = "127.0.0.1"
 
   describe "Ouroboros Network" $ do

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -23,7 +23,7 @@ import Test.QuickCheck (
 import Test.QuickCheck.Instances.ByteString ()
 
 spec :: Spec
-spec = parallel $ do
+spec = do
   let lo = "127.0.0.1"
 
   describe "Ouroboros Network" $ do


### PR DESCRIPTION
## Why
Tests that need to open a websocket are flaky because in the threaded environment we end up in a situation where a port is being already used but reported to be free by our internal functions. This is the most simple way of making these tests pass (by removing the parallel execution). I have tried couple of things that didn't work and don't think it is important to loose time on this.

## What

Remove `parallel` function from `ServerSpec` tests

---

<!-- Tick off or strike-through / remove if not applicable -->
* [ ] CHANGELOG updated
* [ ] Documentation updated
* [x] Added and/or updated haddocks
* [x] No new TODOs introduced or explained herafter
