### PR TITLE
Fix forgotten transaction encoding

### DIFF
--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -151,6 +151,8 @@ library
     , io-classes
     , iohk-monitoring
     , iproute
+    , lens
+    , lens-aeson
     , memory
     , modern-uri
     , network

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -4,6 +4,8 @@ module Hydra.API.ServerOutput where
 
 import Cardano.Binary (serialize')
 import Data.Aeson (Value (..), encode, withObject, (.:))
+import Control.Lens ((?~))
+import Data.Aeson.Lens (atKey)
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Lazy as LBS
@@ -170,6 +172,4 @@ prepareServerOutput OutputCBOR response =
  where
   encodedResponse = encode response
   replacedResponse tx =
-    case toJSON response of
-      Object km -> encode $ Object $ KeyMap.insert "transaction" (String . decodeUtf8 . Base16.encode $ serialize' tx) km
-      _other -> encodedResponse
+    encodedResponse & atKey "transaction" ?~ (String . decodeUtf8 . Base16.encode $ serialize' tx)

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -3,10 +3,10 @@
 module Hydra.API.ServerOutput where
 
 import Cardano.Binary (serialize')
-import Control.Lens (at, (.~))
+import Control.Lens ( (.~))
 import Data.Aeson (Value (..), encode, withObject, (.:))
 import qualified Data.Aeson.KeyMap as KeyMap
-import Data.Aeson.Lens (atKey, key, _Object)
+import Data.Aeson.Lens (key)
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Lazy as LBS
 import Hydra.API.ClientInput (ClientInput (..))

--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -194,7 +194,8 @@ spec = describe "ServerSpec" $ do
               waitMatch 5 conn $ \v ->
                 let expected =
                       Aeson.Array $ fromList [Aeson.String . decodeUtf8 . Base16.encode $ serialize' tx]
-                    result = Aeson.encode v ^? key "snapshot" . key "confirmedTransactions" . nonNull
+                    result =
+                      Aeson.encode v ^? key "snapshot" . key "confirmedTransactions" . nonNull
                 in guard $ result == Just expected
 
               sendOutput postTxFailedMessage
@@ -202,8 +203,9 @@ spec = describe "ServerSpec" $ do
               waitMatch 5 conn $ \v ->
                 let expected =
                       Aeson.Array $ fromList [Aeson.String . decodeUtf8 . Base16.encode $ serialize' tx]
-                    result = traceShow (Aeson.encode v) $ Aeson.encode v ^? key "postChainTx" . key "confirmedSnapshot" . key "snapshot" . key "confirmedTransactions" . nonNull
-                in traceShow "result" $ traceShow result $ guard $ result == Just expected
+                    result =
+                      Aeson.encode v ^? key "postChainTx" . key "confirmedSnapshot" . key "snapshot" . key "confirmedTransactions" . nonNull
+                in guard $ result == Just expected
 
             -- spawn another client but this one wants to see txs in json format
             withClient port "/" $ \conn -> do

--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -25,7 +25,7 @@ import qualified Data.Text as T
 import Data.Text.Encoding (decodeUtf8)
 import Hydra.API.Server (Server (Server, sendOutput), withAPIServer)
 import Hydra.API.ServerOutput (ServerOutput (..), TimedServerOutput (..), input)
-import Hydra.Chain (HeadId (HeadId))
+import Hydra.Chain (HeadId (HeadId), PostChainTx (CloseTx), confirmedSnapshot, PostTxError (NoSeedInput))
 import Hydra.Ledger.Simple (SimpleTx)
 import Hydra.Logging (nullTracer, showLogsOnFailure)
 import Hydra.Persistence (PersistenceIncremental (..), createPersistenceIncremental)
@@ -35,7 +35,7 @@ import Test.Hydra.Fixture (alice)
 import Test.Network.Ports (withFreePort)
 import Test.QuickCheck (checkCoverage, cover, generate)
 import Test.QuickCheck.Monadic (monadicIO, monitor, pick, run)
-import Hydra.Snapshot (Snapshot, confirmed)
+import Hydra.Snapshot (Snapshot, confirmed, ConfirmedSnapshot (ConfirmedSnapshot, signatures, snapshot))
 import Control.Lens ((^?))
 
 -- NOTE: It is important to not run these tests using 'parallel' since we will
@@ -163,7 +163,19 @@ spec = describe "ServerSpec" $ do
           withAPIServer @SimpleTx "127.0.0.1" (fromIntegral port) alice mockPersistence nullTracer noop $ \Server{sendOutput} -> do
             let snapshot = generatedSnapshot { confirmed = [tx] }
             let txValidMessage = TxValid{headId = HeadId "some-head-id", transaction = tx}
-            let snapShotConfirmedMessage = SnapshotConfirmed {headId = HeadId "some-head-id", snapshot, signatures = mempty}
+            let snapShotConfirmedMessage = SnapshotConfirmed {headId = HeadId "some-head-id", Hydra.API.ServerOutput.snapshot, Hydra.API.ServerOutput.signatures = mempty}
+            let postTxFailedMessage =
+                  PostTxOnChainFailed
+                    {postChainTx =
+                      CloseTx
+                        { confirmedSnapshot =
+                            ConfirmedSnapshot
+                              { Hydra.Snapshot.snapshot = snapshot
+                              , Hydra.Snapshot.signatures = mempty
+                              }
+                        }
+                     , postTxError = NoSeedInput
+                     }
                 guardForValue v expected =
                   case v of
                     Aeson.Object km ->
@@ -183,7 +195,15 @@ spec = describe "ServerSpec" $ do
                 let expected =
                       Aeson.Array $ fromList [Aeson.String . decodeUtf8 . Base16.encode $ serialize' tx]
                     result = Aeson.encode v ^? key "snapshot" . key "confirmedTransactions" . nonNull
-                in traceShow "v" $ traceShow v $ guard $ result == Just expected
+                in guard $ result == Just expected
+
+              sendOutput postTxFailedMessage
+
+              waitMatch 5 conn $ \v ->
+                let expected =
+                      Aeson.Array $ fromList [Aeson.String . decodeUtf8 . Base16.encode $ serialize' tx]
+                    result = traceShow (Aeson.encode v) $ Aeson.encode v ^? key "postChainTx" . key "confirmedSnapshot" . key "snapshot" . key "confirmedTransactions" . nonNull
+                in traceShow "result" $ traceShow result $ guard $ result == Just expected
 
             -- spawn another client but this one wants to see txs in json format
             withClient port "/" $ \conn -> do


### PR DESCRIPTION
## Why

I forgot to update the encoding of transactions in some of the fields in the `ServerOutput` previously and this PR amends that.

## What

Use `lens-aeson` package to drill into and update tx encoding in the json output for all of the fields containing transaction.
We decided to use `lens-aeson` in the end since we will need to do more changes in the `ServerOutput` than we expected and the package is convenient for this job.

---

<!-- Tick off or strike-through / remove if not applicable -->
* [ ] CHANGELOG updated
* [ ] Documentation updated
* [ ] Added and/or updated haddocks
* [x] No new TODOs introduced or explained herafter
