### PR TITLE
Exclude greetings from history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ changes.
 
 - Replaced existing websocket server with production-grade one
 
+- Removed `Greetings` messages from hydra-node history
+
 ## [0.9.0] - 2023-03-02
 
 :dragon_face: Renamed the repository from `hydra-poc` to [`hydra`](https://github.com/input-output-hk/hydra)!


### PR DESCRIPTION
fix #813 

## Why

We got a request from one of our clients to somehow mark the last historical message.

## What

Send `Greetings` as the last message (if there is a history served) and do it for each server re-connect.

---

<!-- Tick off or strike-through / remove if not applicable -->
* [x] CHANGELOG updated
* [ ] Documentation updated
* [x] Added and/or updated haddocks
* [x] No new TODOs introduced or explained herafter
