### PR TITLE
Use 25 ada to run the smoke tests scenario

### DIFF
--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -97,7 +97,7 @@ singlePartyHeadFullLifeCycle ::
   IO ()
 singlePartyHeadFullLifeCycle tracer workDir node@RunningNode{networkId} hydraScriptsTxId =
   (`finally` returnFundsToFaucet tracer node Alice) $ do
-    refuelIfNeeded tracer node Alice 100_000_000
+    refuelIfNeeded tracer node Alice 25_000_000
     -- Start hydra-node on chain tip
     tip <- queryTip networkId nodeSocket
     let contestationPeriod = UnsafeContestationPeriod 100


### PR DESCRIPTION
## Why
In order to run smoke-tests on mainnet minimal amount of ADA required is close to 25. In order to not spend more ADA than needed we want to alter our running scenario to only use the minimum needed for the test to complete.

## What

Update the ADA amount for _seeding_ from faucet to 25.

---

<!-- Tick off or strike-through / remove if not applicable -->
* [ ] CHANGELOG updated
* [ ] Documentation updated
* [ ] Added and/or updated haddocks
* [x] No new TODOs introduced or explained herafter
