### PR TITLE
Fix arithmetic underflow

### DIFF
--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -116,7 +116,7 @@ bench timeoutSeconds workDir dataset@Dataset{clientDatasets} clusterSize =
 
                 -- Expect to see ReadyToFanout within 3 seconds after deadline
                 remainingTime <- diffUTCTime deadline <$> getCurrentTime
-                waitFor tracer (truncate $ remainingTime + 3) [leader] $
+                waitFor tracer (remainingTime + 3) [leader] $
                   output "ReadyToFanout" ["headId" .= headId]
 
                 putTextLn "Finalizing the Head"

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -121,7 +121,7 @@ singlePartyHeadFullLifeCycle tracer workDir node@RunningNode{networkId} hydraScr
       -- Expect to see ReadyToFanout within 600 seconds after deadline.
       -- XXX: We still would like to have a network-specific time here
       remainingTime <- diffUTCTime deadline <$> getCurrentTime
-      waitFor tracer (truncate $ remainingTime + 60) [n1] $
+      waitFor tracer (remainingTime + 60) [n1] $
         output "ReadyToFanout" ["headId" .= headId]
       send n1 $ input "Fanout" []
       waitFor tracer 600 [n1] $

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -181,7 +181,7 @@ spec = around showLogsOnFailure $ do
 
                 -- Expect to see ReadyToFanout within 3 seconds after deadline
                 remainingTime <- diffUTCTime deadline <$> getCurrentTime
-                waitFor tracer (truncate $ remainingTime + 3) [n1] $
+                waitFor tracer (remainingTime + 3) [n1] $
                   output "ReadyToFanout" ["headId" .= headId]
 
                 send n1 $ input "Fanout" []
@@ -593,7 +593,7 @@ initAndClose tmpDir tracer clusterIx hydraScriptsTxId node@RunningNode{nodeSocke
 
     -- Expect to see ReadyToFanout within 3 seconds after deadline
     remainingTime <- diffUTCTime deadline <$> getCurrentTime
-    waitFor tracer (truncate $ remainingTime + 3) [n1] $
+    waitFor tracer (remainingTime + 3) [n1] $
       output "ReadyToFanout" ["headId" .= headId]
 
     send n1 $ input "Fanout" []


### PR DESCRIPTION
fix #820

## Why
Our smoke-tests fail with _arithmetic underflow_ exception in the presence of hydra-node state. The existing state usually contains `contestationPeriod` expressed in `UTCTime` and since it is older than the current time we see this exception when using `truncate` in combination with `diffUTCTime` [here](https://github.com/input-output-hk/hydra/blob/master/hydra-cluster/src/Hydra/Cluster/Scenarios.hs#L123)

## What
We can just use constant time to wait in the test or check the `deadline` against current time and if it is bigger then use it for waiting.


---

<!-- Tick off or strike-through / remove if not applicable -->
* [ ] CHANGELOG updated
* [ ] Documentation updated
* [x] Added and/or updated haddocks
* [x] No new TODOs introduced or explained herafter
