### PR TITLE
Fix seed-devnet script

### DIFF
--- a/demo/docker-compose.yaml
+++ b/demo/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
       ]
 
   hydra-node-1:
-    image: ghcr.io/input-output-hk/hydra-node
+    image: ghcr.io/input-output-hk/hydra-node:unstable
     build:
       context: ../
       target: hydra-node
@@ -58,7 +58,7 @@ services:
     restart: always
 
   hydra-node-2:
-    image: ghcr.io/input-output-hk/hydra-node
+    image: ghcr.io/input-output-hk/hydra-node:unstable
     build:
       context: ../
       target: hydra-node
@@ -94,7 +94,7 @@ services:
     restart: always
 
   hydra-node-3:
-    image: ghcr.io/input-output-hk/hydra-node
+    image: ghcr.io/input-output-hk/hydra-node:unstable
     build:
       context: ../
       target: hydra-node
@@ -130,7 +130,7 @@ services:
     restart: always
 
   hydra-tui-1:
-    image: ghcr.io/input-output-hk/hydra-tui
+    image: ghcr.io/input-output-hk/hydra-tui:unstable
     build:
        context: ../
        target: hydra-tui
@@ -149,7 +149,7 @@ services:
         ipv4_address: 172.16.238.11
 
   hydra-tui-2:
-    image: ghcr.io/input-output-hk/hydra-tui
+    image: ghcr.io/input-output-hk/hydra-tui:unstable
     build:
        context: ../
        target: hydra-tui
@@ -168,7 +168,7 @@ services:
         ipv4_address: 172.16.238.21
 
   hydra-tui-3:
-    image: ghcr.io/input-output-hk/hydra-tui
+    image: ghcr.io/input-output-hk/hydra-tui:unstable
     build:
        context: ../
        target: hydra-tui

--- a/demo/seed-devnet.sh
+++ b/demo/seed-devnet.sh
@@ -43,7 +43,7 @@ function hnode() {
   else
       docker run --rm -it \
         -v ${SCRIPT_DIR}/devnet:/devnet \
-        ghcr.io/input-output-hk/hydra-node -- ${@}
+        ghcr.io/input-output-hk/hydra-node:unstable -- ${@}
   fi
 }
 


### PR DESCRIPTION
fix #792 

## Why

`seed-devnet` script in our demo is broken on current master

## What
Use the `unstable` tag for the docker image so the latest changes are always there. This would ensure demo using docker is working against the current master.

---

<!-- Tick off or strike-through / remove if not applicable -->
* [ ] CHANGELOG updated
* [ ] Documentation updated
* [ ] Added and/or updated haddocks
* [ ] No new TODOs introduced or explained herafter
