### PR TITLE
Commit vs Rollbacks - Canceled

### DIFF
--- a/hydra-cluster/test/Test/DirectChainSpec.hs
+++ b/hydra-cluster/test/Test/DirectChainSpec.hs
@@ -435,15 +435,19 @@ withDirectChainTest tracer config ctx action = do
   eventMVar <- newEmptyTMVarIO
   stateVar <- newTVarIO initialChainState
 
-  let callback = \ev -> putTMVar eventMVar ev
-      modifyChainState = \cont -> atomically $ do
-        cs <- readTVar stateVar
-        newChainState <- cont cs
-        writeTVar stateVar newChainState
+  let callback = \cont -> do
+        cs <- readTVarIO stateVar
+        case cont cs of
+          Nothing -> pure ()
+          Just ev -> atomically $ do
+            putTMVar eventMVar ev
+            case ev of
+              Observation{newChainState} -> writeTVar stateVar newChainState
+              _OtherEvent -> pure ()
 
   wallet <- mkTinyWallet tracer config
 
-  withDirectChain tracer config ctx Nothing wallet modifyChainState callback $ \Chain{postTx} -> do
+  withDirectChain tracer config ctx Nothing wallet callback $ \Chain{postTx} -> do
     action
       DirectChainTest
         { postTx = \tx -> do

--- a/hydra-cluster/test/Test/DirectChainSpec.hs
+++ b/hydra-cluster/test/Test/DirectChainSpec.hs
@@ -16,6 +16,7 @@ import CardanoClient (
  )
 import CardanoNode (NodeLog, RunningNode (..), withCardanoNodeDevnet)
 import Control.Concurrent.STM (newEmptyTMVarIO, newTVarIO, readTVarIO, takeTMVar)
+import Control.Concurrent.STM.TMVar (putTMVar)
 import Control.Concurrent.STM.TVar (writeTVar)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -434,8 +435,7 @@ withDirectChainTest tracer config ctx action = do
   eventMVar <- newEmptyTMVarIO
   stateVar <- newTVarIO initialChainState
 
-  let callback = \_ -> pure ()
-
+  let callback = \ev -> putTMVar eventMVar ev
       modifyChainState = \cont -> atomically $ do
         cs <- readTVar stateVar
         newChainState <- cont cs

--- a/hydra-cluster/test/Test/DirectChainSpec.hs
+++ b/hydra-cluster/test/Test/DirectChainSpec.hs
@@ -16,7 +16,6 @@ import CardanoClient (
  )
 import CardanoNode (NodeLog, RunningNode (..), withCardanoNodeDevnet)
 import Control.Concurrent.STM (newEmptyTMVarIO, newTVarIO, readTVarIO, takeTMVar)
-import Control.Concurrent.STM.TMVar (putTMVar)
 import Control.Concurrent.STM.TVar (writeTVar)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -435,19 +434,16 @@ withDirectChainTest tracer config ctx action = do
   eventMVar <- newEmptyTMVarIO
   stateVar <- newTVarIO initialChainState
 
-  let callback = \cont -> do
-        cs <- readTVarIO stateVar
-        case cont cs of
-          Nothing -> pure ()
-          Just ev -> atomically $ do
-            putTMVar eventMVar ev
-            case ev of
-              Observation{newChainState} -> writeTVar stateVar newChainState
-              _OtherEvent -> pure ()
+  let callback = \_ -> pure ()
+
+      modifyChainState = \cont -> atomically $ do
+        cs <- readTVar stateVar
+        newChainState <- cont cs
+        writeTVar stateVar newChainState
 
   wallet <- mkTinyWallet tracer config
 
-  withDirectChain tracer config ctx Nothing wallet callback $ \Chain{postTx} -> do
+  withDirectChain tracer config ctx Nothing wallet modifyChainState callback $ \Chain{postTx} -> do
     action
       DirectChainTest
         { postTx = \tx -> do

--- a/hydra-cluster/test/Test/DirectChainSpec.hs
+++ b/hydra-cluster/test/Test/DirectChainSpec.hs
@@ -15,7 +15,7 @@ import CardanoClient (
   waitForUTxO,
  )
 import CardanoNode (NodeLog, RunningNode (..), withCardanoNodeDevnet)
-import Control.Concurrent.STM (newEmptyTMVarIO, newTVarIO, readTVarIO, takeTMVar)
+import Control.Concurrent.STM (newEmptyTMVarIO, newTVar, newTVarIO, readTVarIO, takeTMVar)
 import Control.Concurrent.STM.TMVar (putTMVar)
 import Control.Concurrent.STM.TVar (writeTVar)
 import qualified Data.ByteString as BS
@@ -435,19 +435,12 @@ withDirectChainTest tracer config ctx action = do
   eventMVar <- newEmptyTMVarIO
   stateVar <- newTVarIO initialChainState
 
-  let callback = \cont -> do
-        cs <- readTVarIO stateVar
-        case cont cs of
-          Nothing -> pure ()
-          Just ev -> atomically $ do
-            putTMVar eventMVar ev
-            case ev of
-              Observation{newChainState} -> writeTVar stateVar newChainState
-              _OtherEvent -> pure ()
+  let callback = \event -> do
+        atomically $ putTMVar eventMVar event
 
   wallet <- mkTinyWallet tracer config
 
-  withDirectChain tracer config ctx Nothing wallet callback $ \Chain{postTx} -> do
+  withDirectChain tracer config ctx wallet initialChainState callback $ \Chain{postTx} -> do
     action
       DirectChainTest
         { postTx = \tx -> do

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -44,7 +44,6 @@ import Hydra.Node (
   createEventQueue,
   createNodeState,
   initEnvironment,
-  modifyChainState,
   runHydraNode,
  )
 import Hydra.Options (
@@ -104,7 +103,7 @@ main = do
         ctx <- loadChainContext chainConfig party otherParties hydraScriptsTxId
         wallet <- mkTinyWallet (contramap DirectChain tracer) chainConfig
         let ChainStateAt{recordedAt} = getChainState hs
-        withDirectChain (contramap DirectChain tracer) chainConfig ctx recordedAt wallet (modifyChainState nodeState) (chainCallback eq) $ \chain -> do
+        withDirectChain (contramap DirectChain tracer) chainConfig ctx recordedAt wallet (chainCallback nodeState eq) $ \chain -> do
           let RunOptions{host, port, peers, nodeId} = opts
           withNetwork (contramap Network tracer) host port peers nodeId (putEvent eq . NetworkEvent defaultTTL) $ \hn -> do
             let RunOptions{apiHost, apiPort} = opts

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -44,6 +44,7 @@ import Hydra.Node (
   createEventQueue,
   createNodeState,
   initEnvironment,
+  modifyChainState,
   runHydraNode,
  )
 import Hydra.Options (
@@ -103,7 +104,7 @@ main = do
         ctx <- loadChainContext chainConfig party otherParties hydraScriptsTxId
         wallet <- mkTinyWallet (contramap DirectChain tracer) chainConfig
         let ChainStateAt{recordedAt} = getChainState hs
-        withDirectChain (contramap DirectChain tracer) chainConfig ctx recordedAt wallet (chainCallback nodeState eq) $ \chain -> do
+        withDirectChain (contramap DirectChain tracer) chainConfig ctx recordedAt wallet (modifyChainState nodeState) (chainCallback eq) $ \chain -> do
           let RunOptions{host, port, peers, nodeId} = opts
           withNetwork (contramap Network tracer) host port peers nodeId (putEvent eq . NetworkEvent defaultTTL) $ \hn -> do
             let RunOptions{apiHost, apiPort} = opts

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -10,7 +10,6 @@ import Hydra.Cardano.Api (serialiseToRawBytesHex)
 import Hydra.Chain (HeadParameters (..))
 import Hydra.Chain.Direct (initialChainState, loadChainContext, mkTinyWallet, withDirectChain)
 import Hydra.Chain.Direct.ScriptRegistry (publishHydraScripts)
-import Hydra.Chain.Direct.State (ChainStateAt (..))
 import Hydra.Chain.Direct.Util (readKeyPair)
 import Hydra.HeadLogic (
   ClosedState (..),
@@ -102,8 +101,8 @@ main = do
         nodeState <- createNodeState hs
         ctx <- loadChainContext chainConfig party otherParties hydraScriptsTxId
         wallet <- mkTinyWallet (contramap DirectChain tracer) chainConfig
-        let ChainStateAt{recordedAt} = getChainState hs
-        withDirectChain (contramap DirectChain tracer) chainConfig ctx recordedAt wallet (chainCallback nodeState eq) $ \chain -> do
+        let chainStateAt = getChainState hs
+        withDirectChain (contramap DirectChain tracer) chainConfig ctx wallet chainStateAt (chainCallback eq) $ \chain -> do
           let RunOptions{host, port, peers, nodeId} = opts
           withNetwork (contramap Network tracer) host port peers nodeId (putEvent eq . NetworkEvent defaultTTL) $ \hn -> do
             let RunOptions{apiHost, apiPort} = opts

--- a/hydra-node/src/Hydra/Chain.hs
+++ b/hydra-node/src/Hydra/Chain.hs
@@ -225,7 +225,7 @@ instance
 
 -- | A callback indicating receival of a potential Hydra transaction which is Maybe
 -- observing a relevant 'ChainEvent tx'.
-type ChainCallback tx m = (ChainStateType tx -> Maybe (ChainEvent tx)) -> m ()
+type ChainCallback tx m = ChainEvent tx -> STM m ()
 
 -- | A type tying both posting and observing transactions into a single /Component/.
 type ChainComponent tx m a = ChainCallback tx m -> (Chain tx m -> m a) -> m a

--- a/hydra-node/src/Hydra/Chain.hs
+++ b/hydra-node/src/Hydra/Chain.hs
@@ -225,7 +225,7 @@ instance
 
 -- | A callback indicating receival of a potential Hydra transaction which is Maybe
 -- observing a relevant 'ChainEvent tx'.
-type ChainCallback tx m = ChainEvent tx -> STM m ()
+type ChainCallback tx m = (ChainStateType tx -> Maybe (ChainEvent tx)) -> m ()
 
 -- | A type tying both posting and observing transactions into a single /Component/.
 type ChainComponent tx m a = ChainCallback tx m -> (Chain tx m -> m a) -> m a

--- a/hydra-node/src/Hydra/Chain.hs
+++ b/hydra-node/src/Hydra/Chain.hs
@@ -225,7 +225,7 @@ instance
 
 -- | A callback indicating receival of a potential Hydra transaction which is Maybe
 -- observing a relevant 'ChainEvent tx'.
-type ChainCallback tx m = (ChainStateType tx -> Maybe (ChainEvent tx)) -> m ()
+type ChainCallback tx m = ChainEvent tx -> m ()
 
 -- | A type tying both posting and observing transactions into a single /Component/.
 type ChainComponent tx m a = ChainCallback tx m -> (Chain tx m -> m a) -> m a

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -213,9 +213,8 @@ withDirectChain ::
   -- | Last known point on chain as loaded from persistence.
   Maybe ChainPoint ->
   TinyWallet IO ->
-  ((ChainStateAt -> STM IO ChainStateAt) -> IO ()) ->
   ChainComponent Tx IO a
-withDirectChain tracer config ctx persistedPoint wallet modifyChainState callback action = do
+withDirectChain tracer config ctx persistedPoint wallet callback action = do
   queue <- newTQueueIO
   -- Select a chain point from which to start synchronizing
   chainPoint <- maybe (queryTip networkId nodeSocket) pure $ do
@@ -233,7 +232,7 @@ withDirectChain tracer config ctx persistedPoint wallet modifyChainState callbac
   res <-
     race
       ( handle onIOException $ do
-          let handler = chainSyncHandler tracer modifyChainState callback getTimeHandle ctx
+          let handler = chainSyncHandler tracer callback getTimeHandle ctx
           let intersection = toConsensusPointInMode CardanoMode chainPoint
           let client = ouroborosApplication tracer intersection queue handler wallet
           withIOManager $ \iocp ->

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -185,6 +185,7 @@ chainSyncHandler ::
   (MonadSTM m, MonadThrow m) =>
   -- | Tracer for logging
   Tracer m DirectChainLog ->
+  ((ChainStateAt -> STM m ChainStateAt) -> m ()) ->
   ChainCallback Tx m ->
   -- | Means to acquire a new 'TimeHandle'.
   GetTimeHandle m ->
@@ -192,7 +193,7 @@ chainSyncHandler ::
   ChainContext ->
   -- | A chain-sync handler to use in a local-chain-sync client.
   ChainSyncHandler m
-chainSyncHandler tracer callback getTimeHandle ctx =
+chainSyncHandler tracer modifyChainState callback getTimeHandle ctx =
   ChainSyncHandler
     { onRollBackward
     , onRollForward
@@ -202,7 +203,7 @@ chainSyncHandler tracer callback getTimeHandle ctx =
   onRollBackward rollbackPoint = do
     let point = fromConsensusPointInMode CardanoMode rollbackPoint
     traceWith tracer $ RolledBackward{point}
-    callback (const . Just $ Rollback $ chainSlotFromPoint point)
+    atomically $ callback (Rollback $ chainSlotFromPoint point)
 
   onRollForward :: Block -> m ()
   onRollForward blk = do
@@ -222,22 +223,20 @@ chainSyncHandler tracer callback getTimeHandle ctx =
           Left reason ->
             throwIO TimeConversionException{slotNo, reason}
           Right utcTime ->
-            callback (const . Just $ Tick utcTime)
+            atomically $ callback (Tick utcTime)
 
-    forM_ receivedTxs $ \tx ->
-      callback $ \ChainStateAt{chainState = cs} ->
-        case observeSomeTx ctx cs tx of
-          Nothing -> Nothing
-          Just (observedTx, cs') ->
-            Just $
-              Observation
-                { observedTx
-                , newChainState =
-                    ChainStateAt
-                      { chainState = cs'
-                      , recordedAt = Just point
-                      }
-                }
+    forM_ receivedTxs $ \tx -> do
+      modifyChainState $ \cs@ChainStateAt{chainState} ->
+        case observeSomeTx ctx chainState tx of
+          Nothing -> pure cs
+          Just (observedTx, cs') -> do
+            let newChainState =
+                  ChainStateAt
+                    { chainState = cs'
+                    , recordedAt = Just point
+                    }
+            callback Observation{observedTx, newChainState}
+            pure newChainState
 
 prepareTxToPost ::
   (MonadSTM m, MonadThrow (STM m)) =>

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -193,7 +193,7 @@ chainSyncHandler ::
   ChainContext ->
   -- | A chain-sync handler to use in a local-chain-sync client.
   ChainSyncHandler m
-chainSyncHandler tracer modifyChainState callback getTimeHandle ctx =
+chainSyncHandler tracer modifyChainState pushEvent getTimeHandle ctx =
   ChainSyncHandler
     { onRollBackward
     , onRollForward
@@ -203,7 +203,7 @@ chainSyncHandler tracer modifyChainState callback getTimeHandle ctx =
   onRollBackward rollbackPoint = do
     let point = fromConsensusPointInMode CardanoMode rollbackPoint
     traceWith tracer $ RolledBackward{point}
-    atomically $ callback (Rollback $ chainSlotFromPoint point)
+    atomically $ pushEvent (Rollback $ chainSlotFromPoint point)
 
   onRollForward :: Block -> m ()
   onRollForward blk = do
@@ -223,7 +223,7 @@ chainSyncHandler tracer modifyChainState callback getTimeHandle ctx =
           Left reason ->
             throwIO TimeConversionException{slotNo, reason}
           Right utcTime ->
-            atomically $ callback (Tick utcTime)
+            atomically $ pushEvent (Tick utcTime)
 
     forM_ receivedTxs $ \tx -> do
       modifyChainState $ \cs@ChainStateAt{chainState} ->
@@ -235,7 +235,7 @@ chainSyncHandler tracer modifyChainState callback getTimeHandle ctx =
                     { chainState = cs'
                     , recordedAt = Just point
                     }
-            callback Observation{observedTx, newChainState}
+            pushEvent Observation{observedTx, newChainState}
             pure newChainState
 
 prepareTxToPost ::

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -975,6 +975,7 @@ onCurrentChainRollback ::
 onCurrentChainRollback currentState slot =
   NewState (rollback slot currentState) [ClientEffect RolledBack]
  where
+  -- TODO use slot instead of local rollbackSlot argument
   rollback rollbackSlot hs
     | chainStateSlot (getChainState hs) <= rollbackSlot = hs
     | otherwise =

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -16,6 +16,7 @@ module Hydra.HeadLogic where
 import Hydra.Prelude
 
 import Data.List (elemIndex)
+import qualified Data.List as List
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import GHC.Records (getField)
@@ -1060,8 +1061,8 @@ update env ledger st ev = case (st, ev) of
     OnlyEffects [ClientEffect $ PeerDisconnected{peer = nodeId}]
   (_, PostTxError{postChainTx, postTxError}) ->
     OnlyEffects [ClientEffect $ PostTxOnChainFailed{postChainTx, postTxError}]
-  (_, ClientEvent{clientInput}) ->
-    OnlyEffects [ClientEffect $ CommandFailed clientInput]
+  (invalidState, ClientEvent{clientInput}) ->
+    OnlyEffects [ClientEffect $ InvalidCommand (List.head $ words $ show invalidState) clientInput]
   _ ->
     Error $ InvalidEvent ev st
 

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -38,7 +38,7 @@ import Control.Monad.Class.MonadSTM (
  )
 import Hydra.API.Server (Server, sendOutput)
 import Hydra.Cardano.Api (AsType (AsSigningKey, AsVerificationKey))
-import Hydra.Chain (Chain (..), ChainCallback, ChainEvent (..), ChainStateType, IsChainState, PostTxError)
+import Hydra.Chain (Chain (..), ChainCallback, ChainStateType, IsChainState, PostTxError)
 import Hydra.Chain.Direct.Util (readFileTextEnvelopeThrow)
 import Hydra.Crypto (AsType (AsHydraKey))
 import Hydra.HeadLogic (
@@ -205,6 +205,7 @@ processEffect HydraNode{hn, oc = Chain{postTx}, server, eq, env = Environment{pa
 -- alternative implementation
 data EventQueue m e = EventQueue
   { putEvent :: e -> m ()
+  , putEventSTM :: e -> STM m ()
   , putEventAfter :: NominalDiffTime -> e -> m ()
   , nextEvent :: m e
   , isEmpty :: m Bool
@@ -226,6 +227,8 @@ createEventQueue = do
     EventQueue
       { putEvent =
           atomically . writeTQueue q
+      , putEventSTM =
+          writeTQueue q
       , putEventAfter = \delay e -> do
           atomically $ modifyTVar' numThreads succ
           void . async $ do
@@ -262,23 +265,27 @@ createNodeState initialState = do
       }
 
 chainCallback ::
-  MonadSTM m =>
-  NodeState tx m ->
   EventQueue m (Event tx) ->
   ChainCallback tx m
-chainCallback NodeState{modifyHeadState} eq cont = do
+chainCallback eventQueue chainEvent = do
   -- Provide chain state to continuation and update it when we get a newState
   -- NOTE: Although we do handle the chain state explictly in the 'HeadLogic',
   -- this is required as multiple transactions may be observed and the chain
   -- state shall accumulate the state changes coming with those observations.
-  mEvent <- atomically . modifyHeadState $ \hs ->
-    case cont $ getChainState hs of
-      Nothing ->
-        (Nothing, hs)
-      Just ev@Observation{newChainState} ->
-        (Just ev, setChainState newChainState hs)
-      Just ev ->
-        (Just ev, hs)
-  case mEvent of
-    Nothing -> pure ()
-    Just chainEvent -> putEvent eq $ OnChainEvent{chainEvent}
+  putEventSTM eventQueue $ OnChainEvent{chainEvent}
+
+modifyChainState ::
+  MonadSTM m =>
+  NodeState tx m ->
+  (ChainStateType tx -> STM m (ChainStateType tx)) ->
+  m ()
+modifyChainState NodeState{queryHeadState, modifyHeadState} cont = do
+  -- Provide chain state to continuation and update it when we get a newState
+  -- NOTE: Although we do handle the chain state explictly in the 'HeadLogic',
+  -- this is required as multiple transactions may be observed and the chain
+  -- state shall accumulate the state changes coming with those observations.
+  atomically $ do
+    hs <- queryHeadState
+    cs' <- cont $ getChainState hs
+    modifyHeadState $ \hs' -> do
+      ((), setChainState cs' hs')

--- a/hydra-node/test/Hydra/Chain/Direct/HandlersSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/HandlersSpec.hs
@@ -16,6 +16,7 @@ import Hydra.Cardano.Api (
   toLedgerTx,
  )
 import Hydra.Chain (
+  ChainCallback,
   ChainEvent (..),
   ChainSlot (..),
   HeadParameters,
@@ -112,8 +113,7 @@ spec = do
 
       chainContext <- pickBlind arbitrary
       let chainSyncCallback = \_cont -> failure "Unexpected callback"
-          modifyChainState = \_cont -> failure "Unexpected callback"
-          handler = chainSyncHandler nullTracer modifyChainState chainSyncCallback (pure timeHandle) chainContext
+          handler = chainSyncHandler nullTracer chainSyncCallback (pure timeHandle) chainContext
 
       run $
         onRollForward handler blk
@@ -122,23 +122,30 @@ spec = do
   prop "yields observed transactions rolling forward" . monadicIO $ do
     -- Generate a state and related transaction and a block containing it
     (ctx, st, tx, transition) <- pick genChainStateWithTx
-    -- let chainState = ChainStateAt{chainState = st, recordedAt = Nothing}
+    let chainState = ChainStateAt{chainState = st, recordedAt = Nothing}
     blk <- pickBlind $ genBlockAt 1 [tx]
     monitor (label $ show transition)
 
     timeHandle <- pickBlind arbitrary
-    let callback = \case
-          Rollback{} ->
-            failure "rolled back but expected roll forward."
-          Tick{} -> pure ()
-          Observation{observedTx} ->
-            if (fst <$> observeSomeTx ctx st tx) /= Just observedTx
-              then failure $ show (fst <$> observeSomeTx ctx st tx) <> " /= " <> show (Just observedTx)
-              else pure ()
+    let callback cont =
+          -- Give chain state in which we expect the 'tx' to yield an 'Observation'.
+          case cont chainState of
+            Nothing ->
+              -- XXX: We need this to debug as 'failure' (via 'run') does not
+              -- yield counter examples.
+              failure . toString $
+                unlines
+                  [ "expected continuation to yield an event"
+                  , "transition: " <> show transition
+                  , "chainState: " <> show st
+                  ]
+            Just Rollback{} ->
+              failure "rolled back but expected roll forward."
+            Just Tick{} -> pure ()
+            Just Observation{observedTx} ->
+              fst <$> observeSomeTx ctx st tx `shouldBe` Just observedTx
 
-        modifyChainState _ = pure ()
-
-    let handler = chainSyncHandler nullTracer modifyChainState callback (pure timeHandle) ctx
+    let handler = chainSyncHandler nullTracer callback (pure timeHandle) ctx
     run $ onRollForward handler blk
 
   prop "yields rollback events onRollBackward" . monadicIO $ do
@@ -149,18 +156,18 @@ spec = do
     -- Mock callback which keeps the chain state in a tvar
     stateVar <- run $ newTVarIO chainState
     rolledBackTo <- run newEmptyTMVarIO
-    let callback = \case
-          (Rollback slot) -> putTMVar rolledBackTo slot
-          _ -> pure ()
-    let modifyChainState cont = atomically $ do
-          cs <- readTVar stateVar
-          newChainState <- cont cs
-          writeTVar stateVar newChainState
+    let callback cont = do
+          cs <- readTVarIO stateVar
+          case cont cs of
+            Nothing -> do
+              failure "expected continuation to yield observation"
+            Just Tick{} -> pure ()
+            Just (Rollback slot) -> atomically $ putTMVar rolledBackTo slot
+            Just Observation{newChainState} -> atomically $ writeTVar stateVar newChainState
 
     let handler =
           chainSyncHandler
             nullTracer
-            modifyChainState
             callback
             (pure timeHandle)
             chainContext
@@ -181,14 +188,16 @@ spec = do
 recordEventsHandler :: ChainContext -> ChainStateAt -> GetTimeHandle IO -> IO (ChainSyncHandler IO, IO [ChainEvent Tx])
 recordEventsHandler ctx _cs getTimeHandle = do
   eventsVar <- newTVarIO []
-  let modifyChainState _ = pure ()
-  let handler = chainSyncHandler nullTracer modifyChainState (recordEvents eventsVar) getTimeHandle ctx
+  let handler = chainSyncHandler nullTracer (recordEvents eventsVar) getTimeHandle ctx
   pure (handler, getEvents eventsVar)
  where
   getEvents = readTVarIO
 
-  recordEvents var event = do
-    modifyTVar var (event :)
+  recordEvents :: TVar IO [ChainEvent Tx] -> ChainCallback Tx IO
+  recordEvents var cont = do
+    case cont _cs of
+      Nothing -> pure ()
+      Just e -> atomically $ modifyTVar var (e :)
 
 withCounterExample :: [Block] -> TVar IO ChainStateAt -> IO a -> PropertyM IO a
 withCounterExample blks headState step = do

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -449,8 +449,8 @@ instance
       case (hydraState s, hydraState s') of
         (st, st') -> tabulate "Transitions" [unsafeConstructorName st <> " -> " <> unsafeConstructorName st']
 
-  perform st command _ = do
-    case command of
+  perform st action _ = do
+    case action of
       Seed{seedKeys, seedContestationPeriod} ->
         seedWorld seedKeys seedContestationPeriod
       Commit party utxo ->

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -54,7 +54,6 @@ import Hydra.Node (
   HydraNode (..),
   chainCallback,
   createNodeState,
-  modifyChainState,
   putEvent,
  )
 import Hydra.Party (Party (..), deriveParty)
@@ -120,8 +119,8 @@ mockChainAndNetwork tr seedKeys nodes cp = do
         let seedInput = genTxIn `generateWith` 42
         nodeState <- createNodeState $ Idle IdleState{chainState}
         let HydraNode{eq} = node
-        let callback = chainCallback eq
-        let chainHandler = chainSyncHandler tr (modifyChainState nodeState) callback getTimeHandle ctx
+        let callback = chainCallback nodeState eq
+        let chainHandler = chainSyncHandler tr callback getTimeHandle ctx
         let node' =
               node
                 { hn =

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -13,6 +13,7 @@ import Control.Monad.Class.MonadAsync (Async, async)
 import Control.Monad.Class.MonadFork (labelThisThread)
 import Control.Monad.Class.MonadSTM (
   MonadLabelledSTM,
+  MonadSTM (newTVarIO, writeTVar),
   labelTQueueIO,
   modifyTVar,
   newTQueueIO,
@@ -20,13 +21,15 @@ import Control.Monad.Class.MonadSTM (
   tryReadTQueue,
   writeTQueue,
  )
+import Data.Sequence (Seq (Empty, (:|>)))
+import qualified Data.Sequence as Seq
 import qualified Data.Sequence.Strict as StrictSeq
 import Hydra.BehaviorSpec (
   ConnectToChain (..),
  )
 import Hydra.Chain (Chain (..))
 import Hydra.Chain.Direct.Fixture (testNetworkId)
-import Hydra.Chain.Direct.Handlers (ChainSyncHandler, DirectChainLog, SubmitTx, chainSyncHandler, mkChain, onRollForward)
+import Hydra.Chain.Direct.Handlers (ChainSyncHandler, DirectChainLog, SubmitTx, chainSyncHandler, mkChain, onRollBackward, onRollForward)
 import Hydra.Chain.Direct.ScriptRegistry (ScriptRegistry (..))
 import Hydra.Chain.Direct.State (ChainContext (..), ChainStateAt (..))
 import qualified Hydra.Chain.Direct.State as S
@@ -55,7 +58,9 @@ import Hydra.Node (
   putEvent,
  )
 import Hydra.Party (Party (..), deriveParty)
+import Ouroboros.Consensus.Block (blockPoint)
 import Ouroboros.Consensus.Cardano.Block (HardForkBlock (..))
+import Ouroboros.Consensus.Protocol.Praos.Header (HeaderBody (..))
 import qualified Ouroboros.Consensus.Protocol.Praos.Header as Praos
 import Ouroboros.Consensus.Shelley.Ledger (mkShelleyBlock)
 import Test.Consensus.Cardano.Generators ()
@@ -78,7 +83,8 @@ mockChainAndNetwork ::
 mockChainAndNetwork tr seedKeys nodes cp = do
   queue <- newTQueueIO
   labelTQueueIO queue "chain-queue"
-  tickThread <- async (labelThisThread "chain" >> simulateTicks queue)
+  chain <- newTVarIO (0, 0, Empty)
+  tickThread <- async (labelThisThread "chain" >> simulateTicks queue chain)
   let chainComponent = \node -> do
         let Environment{party = ownParty, otherParties} = env node
         let (vkey, vkeys) = findOwnCardanoKey ownParty seedKeys
@@ -132,16 +138,61 @@ mockChainAndNetwork tr seedKeys nodes cp = do
       rollbackAndForward = error "Not implemented, should never be called"
   return (ConnectToChain{..}, tickThread)
  where
+  blockTime :: Integer
   blockTime = 20 -- seconds
-  simulateTicks queue = forever $ do
-    threadDelay blockTime
+  simulateTicks queue chain = forever $ do
+    threadDelay $ fromIntegral blockTime
+    transactions <- flushQueue queue []
+    addNewBlockToChain chain transactions
+    sendRollForward chain
+
+    threadDelay $ fromIntegral blockTime
+    transactions' <- flushQueue queue []
+    addNewBlockToChain chain transactions'
+    sendRollForward chain
+
+    threadDelay $ fromIntegral blockTime
+    transactions'' <- flushQueue queue []
+    addNewBlockToChain chain transactions''
+    sendRollForward chain
+
+    threadDelay $ fromIntegral blockTime
+    transactions''' <- flushQueue queue []
+    addNewBlockToChain chain transactions'''
+    sendRollForward chain
+
+    sendRollBackward chain 2
+
+  flushQueue queue transactions = do
     hasTx <- atomically $ tryReadTQueue queue
     case hasTx of
       Just tx -> do
-        let block = mkBlock tx
+        flushQueue queue (tx : transactions)
+      Nothing -> pure transactions
+  appendToChain block (slotNum, cursor, blocks) =
+    (slotNum, cursor, blocks :|> block)
+  sendRollForward chain = do
+    (slotNum, position, blocks) <- atomically $ readTVar chain
+    case Seq.lookup position blocks of
+      Just block -> do
         allHandlers <- fmap chainHandler <$> readTVarIO nodes
         forM_ allHandlers (`onRollForward` block)
-      Nothing -> pure ()
+        atomically $ writeTVar chain (slotNum, position + 1, blocks)
+      Nothing ->
+        pure ()
+  sendRollBackward chain nbBlocks = do
+    (slotNum, position, blocks) <- atomically $ readTVar chain
+    case Seq.lookup (position - nbBlocks) blocks of
+      Just block -> do
+        allHandlers <- fmap chainHandler <$> readTVarIO nodes
+        let point = blockPoint block
+        forM_ allHandlers (`onRollBackward` point)
+        atomically $ writeTVar chain (slotNum, position - nbBlocks + 1, blocks)
+      Nothing ->
+        pure ()
+
+  addNewBlockToChain chain transactions =
+    atomically $ modifyTVar chain $ \(slotNum, position, blocks) -> appendToChain (mkBlock transactions (fromIntegral $ slotNum + blockTime) (fromIntegral position)) (slotNum + blockTime, position, blocks)
 
 -- | Find Cardano vkey corresponding to our Hydra vkey using signing keys lookup.
 -- This is a bit cumbersome and a tribute to the fact the `HydraNode` itself has no
@@ -151,10 +202,11 @@ findOwnCardanoKey me seedKeys = fromMaybe (error $ "cannot find cardano key for 
   csk <- getVerificationKey . signingKey . snd <$> find ((== me) . deriveParty . fst) seedKeys
   pure (csk, filter (/= csk) $ map (getVerificationKey . signingKey . snd) seedKeys)
 
-mkBlock :: Ledger.ValidatedTx LedgerEra -> Util.Block
-mkBlock ledgerTx =
-  let header = (arbitrary :: Gen (Praos.Header StandardCrypto)) `generateWith` 42
-      body = TxSeq . StrictSeq.fromList $ [ledgerTx]
+mkBlock :: [Ledger.ValidatedTx LedgerEra] -> SlotNo -> BlockNo -> Util.Block
+mkBlock transactions slotNum blockNum =
+  let Praos.Header{headerBody, headerSig} = (arbitrary :: Gen (Praos.Header StandardCrypto)) `generateWith` fromIntegral (unSlotNo slotNum)
+      header = Praos.Header{headerBody = headerBody{hbBlockNo = blockNum, hbSlotNo = slotNum}, headerSig}
+      body = TxSeq . StrictSeq.fromList $ transactions
    in BlockBabbage $ mkShelleyBlock $ Ledger.Block header body
 
 -- TODO: unify with BehaviorSpec's ?

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -51,6 +51,7 @@ import Hydra.Node (
   HydraNode (..),
   chainCallback,
   createNodeState,
+  modifyChainState,
   putEvent,
  )
 import Hydra.Party (Party (..), deriveParty)
@@ -113,8 +114,8 @@ mockChainAndNetwork tr seedKeys nodes cp = do
         let seedInput = genTxIn `generateWith` 42
         nodeState <- createNodeState $ Idle IdleState{chainState}
         let HydraNode{eq} = node
-        let callback = chainCallback nodeState eq
-        let chainHandler = chainSyncHandler tr callback getTimeHandle ctx
+        let callback = chainCallback eq
+        let chainHandler = chainSyncHandler tr (modifyChainState nodeState) callback getTimeHandle ctx
         let node' =
               node
                 { hn =

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -141,28 +141,16 @@ mockChainAndNetwork tr seedKeys nodes cp = do
   blockTime :: Integer
   blockTime = 20 -- seconds
   simulateTicks queue chain = forever $ do
+    rollForward chain queue
+    rollForward chain queue
+    rollForward chain queue
+    rollForward chain queue
+    sendRollBackward chain 2
+  rollForward chain queue = do
     threadDelay $ fromIntegral blockTime
     transactions <- flushQueue queue []
     addNewBlockToChain chain transactions
     sendRollForward chain
-
-    threadDelay $ fromIntegral blockTime
-    transactions' <- flushQueue queue []
-    addNewBlockToChain chain transactions'
-    sendRollForward chain
-
-    threadDelay $ fromIntegral blockTime
-    transactions'' <- flushQueue queue []
-    addNewBlockToChain chain transactions''
-    sendRollForward chain
-
-    threadDelay $ fromIntegral blockTime
-    transactions''' <- flushQueue queue []
-    addNewBlockToChain chain transactions'''
-    sendRollForward chain
-
-    sendRollBackward chain 2
-
   flushQueue queue transactions = do
     hasTx <- atomically $ tryReadTQueue queue
     case hasTx of

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -153,7 +153,7 @@ mockChainAndNetwork tr seedKeys nodes cp = do
     rollForward chain queue
     rollForward chain queue
     rollForward chain queue
-  -- sendRollBackward chain 2
+    sendRollBackward chain 2
   rollForward chain queue = do
     threadDelay $ fromIntegral blockTime
     transactions <- flushQueue queue []

--- a/hydra-node/test/Hydra/ModelSpec.hs
+++ b/hydra-node/test/Hydra/ModelSpec.hs
@@ -317,15 +317,16 @@ runIOSimProp :: Testable a => (forall s. PropertyM (RunMonad (IOSim s)) a) -> Ge
 runIOSimProp p = do
   Capture eval <- capture
   let tr = runSimTrace $ newTVarIO (Nodes mempty traceInIOSim mempty) >>= (runReaderT (runMonad $ eval $ monadic' p) . RunState)
-      traceDump = printTrace (Proxy :: Proxy (HydraLog Tx ())) tr
-      logsOnError = counterexample ("trace:\n" <> toString traceDump)
+  -- TODO: these are useful, but not on stdout
+  -- traceDump = printTrace (Proxy :: Proxy (HydraLog Tx ())) tr
+  -- logsOnError = counterexample ("trace:\n" <> toString traceDump)
   case traceResult False tr of
-    Right x ->
-      pure $ logsOnError x
+    Right _ ->
+      pure $ property True
     Left (FailureException (SomeException ex)) -> do
-      pure $ counterexample (show ex) $ logsOnError $ property False
+      pure $ counterexample (show ex) $ property False
     Left ex ->
-      pure $ counterexample (show ex) $ logsOnError $ property False
+      pure $ counterexample (show ex) $ property False
 
 unwrapAddress :: AddressInEra -> Text
 unwrapAddress = \case


### PR DESCRIPTION
Fixes #784

☕ introduces rollbackward on mock chain to simulate rollbacks during model spec executions.

☕ now rollbacks occur deterministically on discrete intervals.

---

<!-- Tick off or strike-through / remove if not applicable -->
* [ ] CHANGELOG updated
* [ ] Documentation updated
* [ ] Added and/or updated haddocks
* [ ] No new TODOs introduced or explained herafter
