### PR TITLE
Fix meta description in docs header page

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -43,7 +43,10 @@ export default function Home() {
   return (
     <Layout
       title={""}
-      description={`${translate({ id: "homepage.tagline" })}`}>
+      description={`${translate({ 
+        id: "homepage.tagline", 
+        message: "User manual, core concepts, API reference"
+      })}`}>
       <HomepageHeader />
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
We found our [hydra.family](https://hydra.family/head-protocol/) docs site was resolving wrong a header translation for the default language (it is working for fr and ja).

So to fix this we have provided a default message to this translation.

<!-- Tick off or strike-through / remove if not applicable -->
* ~[ ] CHANGELOG updated~
* ~[ ] Documentation updated~
* ~[ ] Added and/or updated haddocks~
* ~[ ] No new TODOs introduced or explained herafter~
