### PR TITLE
TUI not reset connected peers on Greetings message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,8 @@ changes.
 
 - Replaced existing websocket server with production-grade one
 
-- Removed `Greetings` messages from hydra-node history
+- Removed `Greetings` messages from hydra-node history and changed `hydra-tui`
+  to not wipe connected peers based on this message.
 
 - Disabled `aarch64-darwin` support, until a `cardano-node` for this platform is
   also available.

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -301,7 +301,6 @@ handleAppEvent s = \case
       }
   Update Greetings{me} ->
     s & meL ?~ me
-      & peersL .~ []
   Update (PeerConnected p) ->
     s & peersL %~ \cp -> nub $ cp <> [p]
   Update (PeerDisconnected p) ->


### PR DESCRIPTION
The hydra-tui was relying on the fact that the first message of the connection was the Greetings message and for some reason reset the connected peers upon this message. It was never really needed as the list would have been empty anyways.

<!-- Describe your change here -->

---

<!-- Tick off or strike-through / remove if not applicable -->
* [x] CHANGELOG updated
* [x] Documentation updated
* [x] Added and/or updated haddocks
* [x] No new TODOs introduced or explained herafter
