### PR TITLE
Decode TimedServerOutput in hydra-tui and use that in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ changes.
 - Removed `Greetings` messages from hydra-node history and changed `hydra-tui`
   to not wipe connected peers based on this message.
 
+- Use the server-provided `timestamp` of messages in the `hydra-tui`.
+
 - Disabled `aarch64-darwin` support, until a `cardano-node` for this platform is
   also available.
 


### PR DESCRIPTION
This will use the server provided timestamp in the hydra-tui when available.

Before:

![image](https://user-images.githubusercontent.com/2621189/234784947-5703f9f4-84df-4c45-9b37-d433fb527994.png)


After:

![image](https://user-images.githubusercontent.com/2621189/234784979-aafdcf31-56c4-4302-a062-883043778552.png)

(This is the same Head on mainnet)

---

<!-- Tick off or strike-through / remove if not applicable -->
* [x] CHANGELOG updated
* [x] Documentation update not needed
* [x] Added and/or updated haddocks not needed
* [x] No new TODOs introduced or explained herafter
