### PR TITLE
Build transactions using the real ProtocolParameters

### DIFF
--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
@@ -38,7 +38,7 @@ import qualified Hydra.Contract.HeadState as Head
 import Hydra.Contract.HeadTokens (headPolicyId, mkHeadTokenScript)
 import Hydra.Contract.HeadTokensError (HeadTokensError (..))
 import qualified Hydra.Contract.Initial as Initial
-import Hydra.Ledger.Cardano (genVerificationKey)
+import Hydra.Ledger.Cardano (genVerificationKey, unsafeBuildWithDefaultPParams)
 import Hydra.Party (Party, partyToChain)
 import Test.Hydra.Fixture (cperiod)
 import Test.QuickCheck (Property, choose, counterexample, elements, oneof, shuffle, suchThat)
@@ -58,7 +58,7 @@ healthyAbortTx =
       <> registryUTxO scriptRegistry
 
   tx =
-    either (error . show) id $
+    either (error . show) unsafeBuildWithDefaultPParams $
       abortTx
         committedUTxO
         scriptRegistry

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -40,7 +40,13 @@ import Hydra.Data.ContestationPeriod (posixFromUTCTime)
 import qualified Hydra.Data.ContestationPeriod as OnChain
 import qualified Hydra.Data.Party as OnChain
 import Hydra.Ledger (hashUTxO)
-import Hydra.Ledger.Cardano (genAddressInEra, genOneUTxOFor, genValue, genVerificationKey)
+import Hydra.Ledger.Cardano (
+  genAddressInEra,
+  genOneUTxOFor,
+  genValue,
+  genVerificationKey,
+  unsafeBuildWithDefaultPParams,
+ )
 import Hydra.Ledger.Cardano.Evaluate (genValidityBoundsFromContestationPeriod)
 import Hydra.Party (Party, deriveParty, partyToChain)
 import Hydra.Snapshot (Snapshot (..), SnapshotNumber)
@@ -58,14 +64,15 @@ healthyCloseTx =
   (tx, lookupUTxO)
  where
   tx =
-    closeTx
-      scriptRegistry
-      somePartyCardanoVerificationKey
-      closingSnapshot
-      healthyCloseLowerBoundSlot
-      healthyCloseUpperBoundPointInTime
-      openThreadOutput
-      (mkHeadId Fixture.testPolicyId)
+    unsafeBuildWithDefaultPParams $
+      closeTx
+        scriptRegistry
+        somePartyCardanoVerificationKey
+        closingSnapshot
+        healthyCloseLowerBoundSlot
+        healthyCloseUpperBoundPointInTime
+        openThreadOutput
+        (mkHeadId Fixture.testPolicyId)
 
   lookupUTxO =
     UTxO.singleton (healthyOpenHeadTxIn, healthyOpenHeadTxOut)
@@ -98,14 +105,15 @@ healthyCloseInitialTx =
   (tx, lookupUTxO)
  where
   tx =
-    closeTx
-      scriptRegistry
-      somePartyCardanoVerificationKey
-      closingSnapshot
-      healthyCloseLowerBoundSlot
-      healthyCloseUpperBoundPointInTime
-      openThreadOutput
-      (mkHeadId Fixture.testPolicyId)
+    unsafeBuildWithDefaultPParams $
+      closeTx
+        scriptRegistry
+        somePartyCardanoVerificationKey
+        closingSnapshot
+        healthyCloseLowerBoundSlot
+        healthyCloseUpperBoundPointInTime
+        openThreadOutput
+        (mkHeadId Fixture.testPolicyId)
 
   lookupUTxO =
     UTxO.singleton (healthyOpenHeadTxIn, healthyOpenHeadTxOut)

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -42,7 +42,12 @@ import Hydra.Contract.HeadTokens (headPolicyId)
 import Hydra.Contract.Util (UtilError (MintingOrBurningIsForbidden))
 import qualified Hydra.Data.ContestationPeriod as OnChain
 import qualified Hydra.Data.Party as OnChain
-import Hydra.Ledger.Cardano (genAdaOnlyUTxO, genAddressInEra, genVerificationKey)
+import Hydra.Ledger.Cardano (
+  genAdaOnlyUTxO,
+  genAddressInEra,
+  genVerificationKey,
+  unsafeBuildWithDefaultPParams,
+ )
 import Hydra.Party (Party, partyToChain)
 import Plutus.Orphans ()
 import PlutusTx.Builtins (toBuiltin)
@@ -64,13 +69,14 @@ healthyCollectComTx =
       <> registryUTxO scriptRegistry
 
   tx =
-    collectComTx
-      testNetworkId
-      scriptRegistry
-      somePartyCardanoVerificationKey
-      initialThreadOutput
-      ((txOut &&& scriptData) <$> healthyCommits)
-      (mkHeadId testPolicyId)
+    unsafeBuildWithDefaultPParams $
+      collectComTx
+        testNetworkId
+        scriptRegistry
+        somePartyCardanoVerificationKey
+        initialThreadOutput
+        ((txOut &&& scriptData) <$> healthyCommits)
+        (mkHeadId testPolicyId)
 
   scriptRegistry = genScriptRegistry `generateWith` 42
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
@@ -30,6 +30,7 @@ import Hydra.Ledger.Cardano (
   genOutput,
   genValue,
   genVerificationKey,
+  unsafeBuildWithDefaultPParams,
  )
 import Hydra.Party (Party)
 import Test.QuickCheck (oneof, scale, suchThat)
@@ -47,13 +48,14 @@ healthyCommitTx =
       <> UTxO.singleton healthyCommittedUTxO
       <> registryUTxO scriptRegistry
   tx =
-    commitTx
-      Fixture.testNetworkId
-      scriptRegistry
-      (mkHeadId Fixture.testPolicyId)
-      commitParty
-      (Just healthyCommittedUTxO)
-      (healthyIntialTxIn, toUTxOContext healthyInitialTxOut, initialPubKeyHash)
+    unsafeBuildWithDefaultPParams $
+      commitTx
+        Fixture.testNetworkId
+        scriptRegistry
+        (mkHeadId Fixture.testPolicyId)
+        commitParty
+        (Just healthyCommittedUTxO)
+        (healthyIntialTxIn, toUTxOContext healthyInitialTxOut, initialPubKeyHash)
 
   scriptRegistry = genScriptRegistry `generateWith` 42
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -42,7 +42,13 @@ import qualified Hydra.Data.ContestationPeriod as OnChain
 import Hydra.Data.Party (partyFromVerificationKeyBytes)
 import qualified Hydra.Data.Party as OnChain
 import Hydra.Ledger (hashUTxO)
-import Hydra.Ledger.Cardano (genAddressInEra, genOneUTxOFor, genValue, genVerificationKey)
+import Hydra.Ledger.Cardano (
+  genAddressInEra,
+  genOneUTxOFor,
+  genValue,
+  genVerificationKey,
+  unsafeBuildWithDefaultPParams,
+ )
 import Hydra.Ledger.Cardano.Evaluate (slotNoToUTCTime)
 import Hydra.Party (Party, deriveParty, partyToChain)
 import Hydra.Snapshot (Snapshot (..), SnapshotNumber)
@@ -50,7 +56,15 @@ import Plutus.Orphans ()
 import PlutusLedgerApi.V2 (BuiltinByteString, toBuiltin)
 import qualified PlutusLedgerApi.V2 as Plutus
 import Test.Hydra.Fixture (aliceSk, bobSk, carolSk)
-import Test.QuickCheck (arbitrarySizedNatural, elements, listOf, listOf1, oneof, suchThat, vectorOf)
+import Test.QuickCheck (
+  arbitrarySizedNatural,
+  elements,
+  listOf,
+  listOf1,
+  oneof,
+  suchThat,
+  vectorOf,
+ )
 import Test.QuickCheck.Gen (choose)
 import Test.QuickCheck.Instances ()
 
@@ -69,15 +83,16 @@ healthyContestTx =
       <> registryUTxO scriptRegistry
 
   tx =
-    contestTx
-      scriptRegistry
-      healthyContesterVerificationKey
-      healthyContestSnapshot
-      (healthySignature healthyContestSnapshotNumber)
-      (healthySlotNo, slotNoToUTCTime healthySlotNo)
-      closedThreadOutput
-      (mkHeadId testPolicyId)
-      healthyContestationPeriod
+    unsafeBuildWithDefaultPParams $
+      contestTx
+        scriptRegistry
+        healthyContesterVerificationKey
+        healthyContestSnapshot
+        (healthySignature healthyContestSnapshotNumber)
+        (healthySlotNo, slotNoToUTCTime healthySlotNo)
+        closedThreadOutput
+        (mkHeadId testPolicyId)
+        healthyContestationPeriod
 
   scriptRegistry = genScriptRegistry `generateWith` 42
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/FanOut.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/FanOut.hs
@@ -25,6 +25,7 @@ import Hydra.Ledger.Cardano (
   genOutput,
   genUTxOWithSimplifiedAddresses,
   genValue,
+  unsafeBuildWithDefaultPParams,
  )
 import Hydra.Ledger.Cardano.Evaluate (slotNoToUTCTime)
 import Hydra.Party (partyToChain)
@@ -42,12 +43,13 @@ healthyFanoutTx =
       <> registryUTxO scriptRegistry
 
   tx =
-    fanoutTx
-      scriptRegistry
-      healthyFanoutUTxO
-      (headInput, headOutput, headDatum)
-      healthySlotNo
-      headTokenScript
+    unsafeBuildWithDefaultPParams $
+      fanoutTx
+        scriptRegistry
+        healthyFanoutUTxO
+        (headInput, headOutput, headDatum)
+        healthySlotNo
+        headTokenScript
 
   scriptRegistry = genScriptRegistry `generateWith` 42
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Init.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Init.hs
@@ -24,7 +24,12 @@ import Hydra.Chain.Direct.Tx (initTx)
 import Hydra.Contract.Error (toErrorCode)
 import Hydra.Contract.HeadState (State (..))
 import Hydra.Contract.HeadTokensError (HeadTokensError (..))
-import Hydra.Ledger.Cardano (genOneUTxOFor, genValue, genVerificationKey)
+import Hydra.Ledger.Cardano (
+  genOneUTxOFor,
+  genValue,
+  genVerificationKey,
+  unsafeBuildWithDefaultPParams,
+ )
 import Hydra.Party (Party)
 import Test.QuickCheck (choose, elements, oneof, suchThat, vectorOf)
 import qualified Prelude
@@ -38,11 +43,12 @@ healthyInitTx =
   (tx, healthyLookupUTxO)
  where
   tx =
-    initTx
-      testNetworkId
-      healthyCardanoKeys
-      healthyHeadParameters
-      healthySeedInput
+    unsafeBuildWithDefaultPParams $
+      initTx
+        testNetworkId
+        healthyCardanoKeys
+        healthyHeadParameters
+        healthySeedInput
 
 healthyHeadParameters :: HeadParameters
 healthyHeadParameters =

--- a/hydra-node/test/Hydra/Chain/Direct/HandlersSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/HandlersSpec.hs
@@ -48,6 +48,7 @@ import Hydra.Chain.Direct.State (
   unsafeObserveInit,
  )
 import Hydra.Chain.Direct.TimeHandle (TimeHandle (slotToUTCTime), TimeHandleParams (..), genTimeParams, mkTimeHandle)
+import Hydra.Ledger.Cardano (unsafeBuildWithDefaultPParams)
 import Hydra.Options (maximumNumberOfParties)
 import Test.Consensus.Cardano.Generators ()
 import Test.QuickCheck (
@@ -277,7 +278,7 @@ genSequenceOfObservableBlocks = do
     HeadParameters ->
     StateT [TestBlock] Gen Tx
   stepInit ctx params = do
-    initTx <- lift $ initialize ctx params <$> genTxIn
+    initTx <- lift $ unsafeBuildWithDefaultPParams . initialize ctx params <$> genTxIn
     initTx <$ putNextBlock initTx
 
   stepCommits ::

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -37,6 +37,7 @@ import Hydra.HeadLogic (
   IdleState (..),
   defaultTTL,
  )
+import Hydra.Ledger.Cardano (unsafeBuildWithDefaultPParams)
 import Hydra.Logging (Tracer)
 import Hydra.Model.Payment (CardanoSigningKey (..))
 import Hydra.Network (Network (..))
@@ -188,7 +189,7 @@ createMockChain tracer ctx submitTx timeHandle seedInput =
           { getUTxO = pure mempty
           , getSeedInput = pure (Just seedInput)
           , sign = id
-          , coverFee = \_ tx -> pure (Right tx)
+          , coverFee = \_ tx -> pure (Right $ unsafeBuildWithDefaultPParams tx)
           , reset = pure ()
           , update = \_ _ -> pure ()
           }


### PR DESCRIPTION
~~Note:~~
~~Not sure if this is the correct approach here. I tried updating the tx with the protocol parameters just before calculating fees in the `Wallet` but it is very hard to do that.~~ 

~~Adding this draft PR just to see if this is what we want.~~

## Why
There was a fixme in code I wanted to resolve. 

## What
Instead of (prematurely) building the transaction (using default protocol parameters) we can postpone and use the proper protocol parameters at the internal wallet level (when calculating fees).

NOTE:
This also provides a way forward for resolving the TODO in the `calculateNeedlesslyHighFee` - `Do a better fee estimation based on the transaction's content.` 

---

<!-- Tick off or strike-through / remove if not applicable -->
* [ ] CHANGELOG updated
* [ ] Documentation updated
* [x] Added and/or updated haddocks
* [x] No new TODOs introduced or explained herafter
