### PR TITLE
Make the demo work on the long run for releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,6 +163,8 @@ instructions.
 During development
 + Make sure `CHANGELOG.md` is kept up-to-date with high-level, technical, but user-focused list of changes according to [keepachangelog](https://keepachangelog.com/en/1.0.0/)
 + Bump `UNRELEASED` version in `CHANGELOG.md` according to [semver](https://semver.org/)
++ Ensure `unstable` version of docker images is used in demo
+  - `sed -i -e "s,\(ghcr.io/input-output-hk/hydra-[^:]*\):[^[:space:]]*,\1:unstable," demo/*`
 + All `hydra-` packages are versioned the same, at latest on release their versions are aligned.
 + Other packages are versioned independently of `hydra-` packages and keep a dedicated changelog.
 

--- a/release.sh
+++ b/release.sh
@@ -53,13 +53,14 @@ prepare_release() {
   update_api_version   "$version"
   update_preview_txid "$version" "$preview_txid"
   update_preprod_txid "$version" "$preprod_txid"
+  update_demo_version "$version"
 
   find . -name '*-e' -exec rm '{}' \; # cleanup BSD sed mess
   
   git add .
   
   git commit -m "Prepare release $version"
- 
+
   git tag -as "$version" -F <(changelog "$version")
 }
 
@@ -151,6 +152,14 @@ update_txid() {
   rm "testnets/${network}/hydra-scripts.txid"
   echo "$txid" > "testnets/${network}/hydra-scripts-${version}.txid"
   ln -s "hydra-scripts-${version}.txid" testnets/${network}/hydra-scripts.txid
+}
+
+update_demo_version() {
+  local version="$1"
+  (
+    cd demo
+    sed -i -e "s,\(ghcr.io/input-output-hk/hydra-[^:]*\):[^[:space:]]*,\1:$version," *
+  )
 }
 
 changelog() {


### PR DESCRIPTION
By fixing the version of the docker images used in the demo for a given release, we ensure that this demo can work for some time even if we push new incompatible versions of the docker images in the registries.

The `release.sh` script takes care of setting up the docker images versions in the demo.

Then, later, we have to manually set it back to _unstable_ the same way we prepare the CHANGELOG with _UNSTABLE_. The release process is updated to take this into account. We can easily make this process automatic in a next iteration if need be by introducing some sort of `post_release` script. But that should be enough for now.

Related to #792



---

* [x] Documentation updated
