### PR TITLE
Better fee calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ changes.
 
 - Use the server-provided `timestamp` of messages in the `hydra-tui`.
 
+- Remove the hardcoded ada amount when calculating fee in the internal wallet. 
+
 - Disabled `aarch64-darwin` support, until a `cardano-node` for this platform is
   also available.
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
@@ -38,7 +38,7 @@ import qualified Hydra.Contract.HeadState as Head
 import Hydra.Contract.HeadTokens (headPolicyId, mkHeadTokenScript)
 import Hydra.Contract.HeadTokensError (HeadTokensError (..))
 import qualified Hydra.Contract.Initial as Initial
-import Hydra.Ledger.Cardano (genVerificationKey)
+import Hydra.Ledger.Cardano (genVerificationKey, unsafeBuildWithDefaultPParams)
 import Hydra.Party (Party, partyToChain)
 import Test.Hydra.Fixture (cperiod)
 import Test.QuickCheck (Property, choose, counterexample, elements, oneof, shuffle, suchThat)
@@ -58,7 +58,7 @@ healthyAbortTx =
       <> registryUTxO scriptRegistry
 
   tx =
-    either (error . show) id $
+    either (error . show) unsafeBuildWithDefaultPParams $
       abortTx
         committedUTxO
         scriptRegistry

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -40,7 +40,13 @@ import Hydra.Data.ContestationPeriod (posixFromUTCTime)
 import qualified Hydra.Data.ContestationPeriod as OnChain
 import qualified Hydra.Data.Party as OnChain
 import Hydra.Ledger (hashUTxO)
-import Hydra.Ledger.Cardano (genAddressInEra, genOneUTxOFor, genValue, genVerificationKey)
+import Hydra.Ledger.Cardano (
+  genAddressInEra,
+  genOneUTxOFor,
+  genValue,
+  genVerificationKey,
+  unsafeBuildWithDefaultPParams,
+ )
 import Hydra.Ledger.Cardano.Evaluate (genValidityBoundsFromContestationPeriod)
 import Hydra.Party (Party, deriveParty, partyToChain)
 import Hydra.Snapshot (Snapshot (..), SnapshotNumber)
@@ -58,14 +64,15 @@ healthyCloseTx =
   (tx, lookupUTxO)
  where
   tx =
-    closeTx
-      scriptRegistry
-      somePartyCardanoVerificationKey
-      closingSnapshot
-      healthyCloseLowerBoundSlot
-      healthyCloseUpperBoundPointInTime
-      openThreadOutput
-      (mkHeadId Fixture.testPolicyId)
+    unsafeBuildWithDefaultPParams $
+      closeTx
+        scriptRegistry
+        somePartyCardanoVerificationKey
+        closingSnapshot
+        healthyCloseLowerBoundSlot
+        healthyCloseUpperBoundPointInTime
+        openThreadOutput
+        (mkHeadId Fixture.testPolicyId)
 
   lookupUTxO =
     UTxO.singleton (healthyOpenHeadTxIn, healthyOpenHeadTxOut)
@@ -98,14 +105,15 @@ healthyCloseInitialTx =
   (tx, lookupUTxO)
  where
   tx =
-    closeTx
-      scriptRegistry
-      somePartyCardanoVerificationKey
-      closingSnapshot
-      healthyCloseLowerBoundSlot
-      healthyCloseUpperBoundPointInTime
-      openThreadOutput
-      (mkHeadId Fixture.testPolicyId)
+    unsafeBuildWithDefaultPParams $
+      closeTx
+        scriptRegistry
+        somePartyCardanoVerificationKey
+        closingSnapshot
+        healthyCloseLowerBoundSlot
+        healthyCloseUpperBoundPointInTime
+        openThreadOutput
+        (mkHeadId Fixture.testPolicyId)
 
   lookupUTxO =
     UTxO.singleton (healthyOpenHeadTxIn, healthyOpenHeadTxOut)

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -42,7 +42,12 @@ import Hydra.Contract.HeadTokens (headPolicyId)
 import Hydra.Contract.Util (UtilError (MintingOrBurningIsForbidden))
 import qualified Hydra.Data.ContestationPeriod as OnChain
 import qualified Hydra.Data.Party as OnChain
-import Hydra.Ledger.Cardano (genAdaOnlyUTxO, genAddressInEra, genVerificationKey)
+import Hydra.Ledger.Cardano (
+  genAdaOnlyUTxO,
+  genAddressInEra,
+  genVerificationKey,
+  unsafeBuildWithDefaultPParams,
+ )
 import Hydra.Party (Party, partyToChain)
 import Plutus.Orphans ()
 import PlutusTx.Builtins (toBuiltin)
@@ -64,13 +69,14 @@ healthyCollectComTx =
       <> registryUTxO scriptRegistry
 
   tx =
-    collectComTx
-      testNetworkId
-      scriptRegistry
-      somePartyCardanoVerificationKey
-      initialThreadOutput
-      ((txOut &&& scriptData) <$> healthyCommits)
-      (mkHeadId testPolicyId)
+    unsafeBuildWithDefaultPParams $
+      collectComTx
+        testNetworkId
+        scriptRegistry
+        somePartyCardanoVerificationKey
+        initialThreadOutput
+        ((txOut &&& scriptData) <$> healthyCommits)
+        (mkHeadId testPolicyId)
 
   scriptRegistry = genScriptRegistry `generateWith` 42
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
@@ -30,6 +30,7 @@ import Hydra.Ledger.Cardano (
   genOutput,
   genValue,
   genVerificationKey,
+  unsafeBuildWithDefaultPParams,
  )
 import Hydra.Party (Party)
 import Test.QuickCheck (oneof, scale, suchThat)
@@ -47,13 +48,14 @@ healthyCommitTx =
       <> UTxO.singleton healthyCommittedUTxO
       <> registryUTxO scriptRegistry
   tx =
-    commitTx
-      Fixture.testNetworkId
-      scriptRegistry
-      (mkHeadId Fixture.testPolicyId)
-      commitParty
-      (Just healthyCommittedUTxO)
-      (healthyIntialTxIn, toUTxOContext healthyInitialTxOut, initialPubKeyHash)
+    unsafeBuildWithDefaultPParams $
+      commitTx
+        Fixture.testNetworkId
+        scriptRegistry
+        (mkHeadId Fixture.testPolicyId)
+        commitParty
+        (Just healthyCommittedUTxO)
+        (healthyIntialTxIn, toUTxOContext healthyInitialTxOut, initialPubKeyHash)
 
   scriptRegistry = genScriptRegistry `generateWith` 42
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -42,7 +42,13 @@ import qualified Hydra.Data.ContestationPeriod as OnChain
 import Hydra.Data.Party (partyFromVerificationKeyBytes)
 import qualified Hydra.Data.Party as OnChain
 import Hydra.Ledger (hashUTxO)
-import Hydra.Ledger.Cardano (genAddressInEra, genOneUTxOFor, genValue, genVerificationKey)
+import Hydra.Ledger.Cardano (
+  genAddressInEra,
+  genOneUTxOFor,
+  genValue,
+  genVerificationKey,
+  unsafeBuildWithDefaultPParams,
+ )
 import Hydra.Ledger.Cardano.Evaluate (slotNoToUTCTime)
 import Hydra.Party (Party, deriveParty, partyToChain)
 import Hydra.Snapshot (Snapshot (..), SnapshotNumber)
@@ -50,7 +56,15 @@ import Plutus.Orphans ()
 import PlutusLedgerApi.V2 (BuiltinByteString, toBuiltin)
 import qualified PlutusLedgerApi.V2 as Plutus
 import Test.Hydra.Fixture (aliceSk, bobSk, carolSk)
-import Test.QuickCheck (arbitrarySizedNatural, elements, listOf, listOf1, oneof, suchThat, vectorOf)
+import Test.QuickCheck (
+  arbitrarySizedNatural,
+  elements,
+  listOf,
+  listOf1,
+  oneof,
+  suchThat,
+  vectorOf,
+ )
 import Test.QuickCheck.Gen (choose)
 import Test.QuickCheck.Instances ()
 
@@ -69,15 +83,16 @@ healthyContestTx =
       <> registryUTxO scriptRegistry
 
   tx =
-    contestTx
-      scriptRegistry
-      healthyContesterVerificationKey
-      healthyContestSnapshot
-      (healthySignature healthyContestSnapshotNumber)
-      (healthySlotNo, slotNoToUTCTime healthySlotNo)
-      closedThreadOutput
-      (mkHeadId testPolicyId)
-      healthyContestationPeriod
+    unsafeBuildWithDefaultPParams $
+      contestTx
+        scriptRegistry
+        healthyContesterVerificationKey
+        healthyContestSnapshot
+        (healthySignature healthyContestSnapshotNumber)
+        (healthySlotNo, slotNoToUTCTime healthySlotNo)
+        closedThreadOutput
+        (mkHeadId testPolicyId)
+        healthyContestationPeriod
 
   scriptRegistry = genScriptRegistry `generateWith` 42
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/FanOut.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/FanOut.hs
@@ -25,6 +25,7 @@ import Hydra.Ledger.Cardano (
   genOutput,
   genUTxOWithSimplifiedAddresses,
   genValue,
+  unsafeBuildWithDefaultPParams,
  )
 import Hydra.Ledger.Cardano.Evaluate (slotNoToUTCTime)
 import Hydra.Party (partyToChain)
@@ -42,12 +43,13 @@ healthyFanoutTx =
       <> registryUTxO scriptRegistry
 
   tx =
-    fanoutTx
-      scriptRegistry
-      healthyFanoutUTxO
-      (headInput, headOutput, headDatum)
-      healthySlotNo
-      headTokenScript
+    unsafeBuildWithDefaultPParams $
+      fanoutTx
+        scriptRegistry
+        healthyFanoutUTxO
+        (headInput, headOutput, headDatum)
+        healthySlotNo
+        headTokenScript
 
   scriptRegistry = genScriptRegistry `generateWith` 42
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Init.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Init.hs
@@ -24,7 +24,12 @@ import Hydra.Chain.Direct.Tx (initTx)
 import Hydra.Contract.Error (toErrorCode)
 import Hydra.Contract.HeadState (State (..))
 import Hydra.Contract.HeadTokensError (HeadTokensError (..))
-import Hydra.Ledger.Cardano (genOneUTxOFor, genValue, genVerificationKey)
+import Hydra.Ledger.Cardano (
+  genOneUTxOFor,
+  genValue,
+  genVerificationKey,
+  unsafeBuildWithDefaultPParams,
+ )
 import Hydra.Party (Party)
 import Test.QuickCheck (choose, elements, oneof, suchThat, vectorOf)
 import qualified Prelude
@@ -38,11 +43,12 @@ healthyInitTx =
   (tx, healthyLookupUTxO)
  where
   tx =
-    initTx
-      testNetworkId
-      healthyCardanoKeys
-      healthyHeadParameters
-      healthySeedInput
+    unsafeBuildWithDefaultPParams $
+      initTx
+        testNetworkId
+        healthyCardanoKeys
+        healthyHeadParameters
+        healthySeedInput
 
 healthyHeadParameters :: HeadParameters
 healthyHeadParameters =

--- a/hydra-node/test/Hydra/Chain/Direct/HandlersSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/HandlersSpec.hs
@@ -48,6 +48,7 @@ import Hydra.Chain.Direct.State (
   unsafeObserveInit,
  )
 import Hydra.Chain.Direct.TimeHandle (TimeHandle (slotToUTCTime), TimeHandleParams (..), genTimeParams, mkTimeHandle)
+import Hydra.Ledger.Cardano (unsafeBuildWithDefaultPParams)
 import Hydra.Options (maximumNumberOfParties)
 import Test.Consensus.Cardano.Generators ()
 import Test.QuickCheck (
@@ -277,7 +278,7 @@ genSequenceOfObservableBlocks = do
     HeadParameters ->
     StateT [TestBlock] Gen Tx
   stepInit ctx params = do
-    initTx <- lift $ initialize ctx params <$> genTxIn
+    initTx <- lift $ unsafeBuildWithDefaultPParams . initialize ctx params <$> genTxIn
     initTx <$ putNextBlock initTx
 
   stepCommits ::

--- a/hydra-node/test/Hydra/Chain/Direct/WalletSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/WalletSpec.hs
@@ -201,15 +201,16 @@ prop_balanceTransaction =
   forAllBlind (reasonablySized genLedgerTx) $ \tx ->
     forAllBlind (reasonablySized $ genOutputsForInputs tx) $ \lookupUTxO ->
       forAllBlind genMarkedUTxO $ \walletUTxO ->
-        case coverFee_ ledgerPParams Fixture.systemStart Fixture.epochInfo lookupUTxO walletUTxO tx of
-          Left err ->
-            property False
-              & counterexample ("Error: " <> show err)
-              & counterexample ("Lookup UTXO: \n" <> decodeUtf8 (encodePretty lookupUTxO))
-              & counterexample ("Wallet UTXO: \n" <> decodeUtf8 (encodePretty walletUTxO))
-              & counterexample (renderTx $ fromLedgerTx tx)
-          Right tx' ->
-            isBalanced (lookupUTxO <> walletUTxO) tx tx'
+        let cardanoTx = fromLedgerTx tx
+         in case coverFee_ ledgerPParams Fixture.systemStart Fixture.epochInfo lookupUTxO walletUTxO cardanoTx 0 of
+              Left err ->
+                property False
+                  & counterexample ("Error: " <> show err)
+                  & counterexample ("Lookup UTXO: \n" <> decodeUtf8 (encodePretty lookupUTxO))
+                  & counterexample ("Wallet UTXO: \n" <> decodeUtf8 (encodePretty walletUTxO))
+                  & counterexample (renderTx $ fromLedgerTx tx)
+              Right tx' ->
+                isBalanced (lookupUTxO <> walletUTxO) tx tx'
 
 isBalanced :: Map TxIn TxOut -> Tx LedgerEra -> Tx LedgerEra -> Property
 isBalanced utxo originalTx balancedTx =

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -37,6 +37,7 @@ import Hydra.HeadLogic (
   IdleState (..),
   defaultTTL,
  )
+import Hydra.Ledger.Cardano (unsafeBuildWithDefaultPParams)
 import Hydra.Logging (Tracer)
 import Hydra.Model.Payment (CardanoSigningKey (..))
 import Hydra.Network (Network (..))
@@ -188,7 +189,7 @@ createMockChain tracer ctx submitTx timeHandle seedInput =
           { getUTxO = pure mempty
           , getSeedInput = pure (Just seedInput)
           , sign = id
-          , coverFee = \_ tx -> pure (Right tx)
+          , coverFee = \_ tx -> pure (Right $ unsafeBuildWithDefaultPParams tx)
           , reset = pure ()
           , update = \_ _ -> pure ()
           }


### PR DESCRIPTION
Note: depends on #840  to be merged first

## Why
There is a todo related to hardcoded fees in the internal wallet.

#What
Use the cardano-api function to calculate the tx fee (`evaluateTransactionFee`). Also use `estimateTransactionKeyWitnessCount` to get the number of  (non Byron) witnesses.

---

<!-- Tick off or strike-through / remove if not applicable -->
* [x] CHANGELOG updated
* [ ] Documentation updated
* [x] Added and/or updated haddocks
* [x] No new TODOs introduced or explained herafter
