### PR TITLE
Populate caches first

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,57 @@ on:
     - cron: "0 4 * * *"
 
 jobs:
+
+  populate-build-cache:
+    name: "Populate build cache"
+    runs-on: ubuntu-latest
+    steps:
+    - name: 📥 Checkout repository
+      uses: actions/checkout@v3
+      with:
+        repository: input-output-hk/hydra
+        token: ${{ secrets.MY_TOKEN || github.token }}
+        # On pull_request events, we want to check out the latest commit of the
+        # PR, which is different to github.ref (the default, which would point
+        # to a "fake merge" commit). On push events, the default is fine as it
+        # refers to the pushed commit.
+        ref: ${{ github.event.pull_request.head.sha || github.ref }}
+        # Also ensure we have all history with all tags
+        fetch-depth: 0
+
+    - name: ❄ Prepare nix
+      uses: cachix/install-nix-action@v20
+      with:
+        extra_nix_config: |
+          accept-flake-config = true
+
+    - name: ❄ Cachix cache of nix derivations
+      uses: cachix/cachix-action@v12
+      with:
+        name: hydra-node
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+    - name: 🔁 Github cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cabal/packages
+          ~/.cabal/store
+          dist-newstyle
+        key: |
+          cabal-${{ runner.os }}-${{ hashFiles('cabal.project', 'default.nix', 'shell.nix') }}
+
+    - name: 🧰 Prepare tools
+      run: |
+        nix develop .#ci --command bash -c 'cabal update'
+
+    - name: 🔨 Build
+      run: |
+        nix develop .#ci --command bash -c 'cabal build all'
+
   build-test:
     name: "Build & test using cabal"
+    needs: [populate-build-cache]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -176,6 +225,7 @@ jobs:
 
   haddock-benchmarks:
     name: "Haddock & benchmarks"
+    needs: [populate-build-cache]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,13 +115,9 @@ jobs:
         restore-keys: |
           cabal-${{ runner.os }}-${{ hashFiles('cabal.project', 'default.nix', 'shell.nix') }}
 
-    - name: 🧰 Prepare tools
-      run: |
-        nix develop .#ci --command bash -c 'cabal update'
-
     - name: 🔨 Build
       run: |
-        nix develop .#ci --command bash -c 'cabal build ${{ matrix.package }}'
+        nix develop .#ci --command bash -c 'cabal update && cabal build ${{ matrix.package }}'
 
     - name: ❓ Test
       if: ${{ matrix.package != 'hydra-tui' }}
@@ -265,13 +261,9 @@ jobs:
         key: |
           cabal-${{ runner.os }}-${{ hashFiles('cabal.project', 'default.nix', 'shell.nix') }}
 
-    - name: 🧰 Prepare tools
-      run: |
-        nix develop .#ci --command bash -c 'cabal update'
-
     - name: 📈 Benchmark
       run: |
-        nix develop .#ci --command bash -c 'cabal bench ${{ matrix.bench }} --benchmark-options "${{ matrix.options }}"'
+        nix develop .#ci --command bash -c 'cabal update && cabal bench ${{ matrix.bench }} --benchmark-options "${{ matrix.options }}"'
 
     - name: 📚 Documentation (Haddock)
       run: |


### PR DESCRIPTION
We restructure the C.I. to have one job that will build and populate all the caches for the next jobs to run.

It shall improve our resources usage in C.I. as we ensure that most of the stuff are built only once.

It might improve our total job execution although... well it depends on so many things that it is not clear. But it will bring us more determinism in job execution that can pave the way to improvement.

The next big thing eating time in the job is downloading all the nix artifacts. It gives us some leads for future improvements in C.I. runtime.