### PR TITLE
Add cardano-scaling.cachix.org and use it in workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,8 +51,8 @@ jobs:
     - name: ❄ Cachix cache of nix derivations
       uses: cachix/cachix-action@v12
       with:
-        name: hydra-node
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        name: cardano-scaling
+        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
     - name: 🔁 Github cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
       uses: actions/cache@v3

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -47,8 +47,8 @@ jobs:
     - name: ❄ Cachix cache of nix derivations
       uses: cachix/cachix-action@v12
       with:
-        name: hydra-node
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        name: cardano-scaling
+        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
     - name: 🔨 Build images using nix
       run: |

--- a/flake.nix
+++ b/flake.nix
@@ -72,11 +72,13 @@
     extra-substituters = [
       "https://cache.iog.io"
       "https://hydra-node.cachix.org"
+      "https://cardano-scaling.cachix.org"
       "https://cache.zw3rk.com"
     ];
     extra-trusted-public-keys = [
       "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
       "hydra-node.cachix.org-1:vK4mOEQDQKl9FTbq76NjOuNaRD4pZLxi1yri31HHmIw="
+      "cardano-scaling.cachix.org-1:RKvHKhGs/b6CBDqzKbDk0Rv6sod2kPSXLwPzcUQg9lY="
       "loony-tools:pr9m4BkM/5/eSTZlkQyRt57Jz7OMBxNSUiMC4FkcNfk="
     ];
     allow-import-from-derivation = true;


### PR DESCRIPTION
This cache should have a limit of ~10GB before getting garbage collected while the `hydra-node.cachix.org` seems to be capped at ~5GB. We want to see if we have fewer cache misses in CI.

NOTE: I have also added a secret for writing to the cache in github settings and shared it with other contributors already.

---

<!-- Tick off or strike-through / remove if not applicable -->
* [X] CHANGELOG update not needed
* [X] Documentation update not needed
* [X] Added and/or updated haddocks not needed
* [X] No new TODOs introduced or explained herafter
