### PR TITLE
Add a query to fetch GenesisParameters from cardano-node

### DIFF
--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -203,6 +203,7 @@ test-suite integration
   other-modules:
     Paths_hydra_cluster
     Spec
+    Test.CardanoClientSpec
     Test.CardanoNodeSpec
     Test.DirectChainSpec
     Test.EndToEndSpec
@@ -248,7 +249,10 @@ test-suite integration
     , temporary
     , text
 
-  build-tool-depends: hspec-discover:hspec-discover, hydra-node:hydra-node
+  build-tool-depends:
+    , hspec-discover:hspec-discover
+    , hydra-node:hydra-node
+
   ghc-options:        -threaded -rtsopts
 
 benchmark bench-e2e

--- a/hydra-cluster/test/Test/CardanoClientSpec.hs
+++ b/hydra-cluster/test/Test/CardanoClientSpec.hs
@@ -1,0 +1,33 @@
+module Test.CardanoClientSpec where
+
+import Hydra.Prelude
+import Test.Hydra.Prelude
+
+import CardanoClient (QueryPoint (..), queryGenesisParameters)
+import CardanoNode (RunningNode (..), withCardanoNodeDevnet)
+import Data.Aeson ((.:))
+import qualified Data.Aeson as Aeson
+import Hydra.Cardano.Api (GenesisParameters (..))
+import Hydra.Ledger.Cardano.Configuration (readJsonFileThrow)
+import Hydra.Logging (showLogsOnFailure)
+import System.FilePath ((</>))
+import Test.EndToEndSpec (withClusterTempDir)
+
+spec :: Spec
+spec =
+  around showLogsOnFailure $
+    it "queryGenesisParameters works as expected" $ \tracer ->
+      failAfter 60 $
+        withClusterTempDir "queryGenesisParameters" $ \tmpDir -> do
+          -- This uses the hydra-cluster/config/devnet and updates the
+          -- systemStart to some current time making it the perfect target to
+          -- test against.
+          withCardanoNodeDevnet tracer tmpDir $ \RunningNode{nodeSocket, networkId} -> do
+            GenesisParameters{protocolParamSystemStart = queriedSystemStart} <-
+              queryGenesisParameters networkId nodeSocket QueryTip
+
+            let parseSystemStart =
+                  Aeson.withObject "GenesisShelley" $ \o -> o .: "systemStart"
+            expectedSystemStart <- readJsonFileThrow parseSystemStart $ tmpDir </> "genesis-shelley.json"
+
+            queriedSystemStart `shouldBe` expectedSystemStart

--- a/hydra-node/src/Hydra/Chain/CardanoClient.hs
+++ b/hydra-node/src/Hydra/Chain/CardanoClient.hs
@@ -225,6 +225,20 @@ queryProtocolParameters networkId socket queryPoint =
           )
    in runQuery networkId socket queryPoint query >>= throwOnEraMismatch
 
+-- | Query 'GenesisParameters' at a given point.
+--
+-- Throws at least 'QueryException' if query fails.
+queryGenesisParameters :: NetworkId -> FilePath -> QueryPoint -> IO GenesisParameters
+queryGenesisParameters networkId socket queryPoint =
+  let query =
+        QueryInEra
+          BabbageEraInCardanoMode
+          ( QueryInShelleyBasedEra
+              ShelleyBasedEraBabbage
+              QueryGenesisParameters
+          )
+   in runQuery networkId socket queryPoint query >>= throwOnEraMismatch
+
 -- | Query UTxO for all given addresses at given point.
 --
 -- Throws at least 'QueryException' if query fails.


### PR DESCRIPTION
Adds a `queryGenesisParameter` and a test covering that we get the appropriate values from the cardano-node.

---

<!-- Tick off or strike-through / remove if not applicable -->
* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Added and/or updated haddocks
* [x] No new TODOs introduced or explained herafter
