### PR TITLE
Update release.sh script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -61,17 +61,20 @@ prepare_release() {
   
   git add .
   
-  git commit -m "Prepare release $version"
+  git commit -m "Release $version"
 
   git tag -as "$version" -F <(changelog "$version")
+
+  git merge release "${version}" --ff-only
 }
 
 publish_release() {
   local version="$1"
 
   >&2 echo Prepared the release commit and tag, review it now and if everything is okay, push using:
-  >&2 echo git push
-  >&2 echo git push ${version}
+  >&2 echo git push origin master
+  >&2 echo git push origin release
+  >&2 echo git push origin ${version}
   >&2 echo
   >&2 echo And then you shall manually create the release page, see CONTRIBUTING.md
 }


### PR DESCRIPTION
Make release branch point to latest tag as well as it is currently used for piking the latest "stable" documentation to be published by the CI.

<!-- Describe your change here -->

---

<!-- Tick off or strike-through / remove if not applicable -->
* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Added and/or updated haddocks
* [x] No new TODOs introduced or explained herafter
