### PR TITLE
Use nix to build test binaries and then run the C.I.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,8 @@ jobs:
     - name: ❓ Test
       if: ${{ matrix.package != 'hydra-tui' }}
       run: |
-        nix develop .?submodules=1#tests.${{ matrix.package}} --command tests
+        cd ${{ matrix.package }}
+        nix develop .?submodules=1#tests.${{ matrix.package }} --command tests
 
     - name: ❓ Test (TUI)
       id: test_tui
@@ -83,7 +84,8 @@ jobs:
       # There is an open issue to tackle this problem. https://github.com/input-output-hk/hydra/issues/590
       continue-on-error: true
       run: |
-        nix develop .?submodules=1#tests.${{ matrix.package}} --command tests
+        cd ${{ matrix.package  }}
+        nix develop .?submodules=1#tests.${{ matrix.package }} --command tests
 
     - name: 💾 Upload build & test artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,18 +66,10 @@ jobs:
         restore-keys: |
           cabal-${{ runner.os }}-${{ hashFiles('cabal.project', 'default.nix', 'shell.nix') }}
 
-    - name: 🧰 Prepare tools
-      run: |
-        nix develop .#ci --command bash -c 'cabal update'
-
-    - name: 🔨 Build
-      run: |
-        nix develop .#ci --command bash -c 'cabal build ${{ matrix.package }}'
-
     - name: ❓ Test
       if: ${{ matrix.package != 'hydra-tui' }}
       run: |
-        nix develop .#ci --command bash -c 'cabal test ${{ matrix.package }}'
+        nix develop .?submodules=1#tests.${{ matrix.package}} --command tests
 
     - name: ❓ Test (TUI)
       id: test_tui
@@ -91,7 +83,7 @@ jobs:
       # There is an open issue to tackle this problem. https://github.com/input-output-hk/hydra/issues/590
       continue-on-error: true
       run: |
-        nix develop .#ci --command bash -c 'cabal test ${{ matrix.package }}'
+        nix develop .?submodules=1#tests.${{ matrix.package}} --command tests
 
     - name: 💾 Upload build & test artifacts
       uses: actions/upload-artifact@v3

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
           inherit system nixpkgs;
         };
         hydraPackages = import ./nix/hydra/packages.nix {
-          inherit hydraProject system;
+          inherit hydraProject system pkgs cardano-node;
         };
         hydraImages = import ./nix/hydra/docker.nix {
           inherit hydraPackages system nixpkgs;

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -195,7 +195,7 @@ executable log-filter
     , optparse-applicative
     , temporary
 
-test-suite integration
+test-suite tests
   import:             project-config
   hs-source-dirs:     test
   main-is:            Main.hs

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -9,7 +9,9 @@ license-files:
   LICENSE
   NOTICE
 
-data-files:    json-schemas/logs.yaml
+data-files:
+  json-schemas/logs.yaml
+  json-schemas/api.yaml
 
 source-repository head
   type:     git

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -38,17 +38,22 @@ rec {
       buildInputs = [nativePkgs.hydra-node.components.tests.tests];
     };
     hydra-cluster = pkgs.mkShell {
-       name = "hydra-cluster-tests";
-       buildInputs =
-       [
-         nativePkgs.hydra-cluster.components.tests.tests
-	 hydra-node
-	 cardano-node.packages.${system}.cardano-node
-       ];
+      name = "hydra-cluster-tests";
+      buildInputs =
+      [
+        nativePkgs.hydra-cluster.components.tests.tests
+        hydra-node
+        cardano-node.packages.${system}.cardano-node
+      ];
      };
     hydra-tui = pkgs.mkShell {
       name = "hydra-tui-tests";
-      buildInputs = [nativePkgs.hydra-tui.components.tests.tests];
+      buildInputs =
+      [
+        nativePkgs.hydra-tui.components.tests.tests
+        hydra-node
+	cardano-node.packages.${system}.cardano-node
+      ];
     };
   };
 }

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -2,6 +2,8 @@
 
 { hydraProject # as defined in default.nix
 , system ? builtins.currentSystem
+, pkgs
+, cardano-node
 }:
 let
   nativePkgs = hydraProject.hsPkgs;
@@ -10,7 +12,7 @@ let
     ({ lib, ... }: { options.nonReinstallablePkgs = lib.mkOption { apply = lib.remove "terminfo"; }; });
   musl64Pkgs = patchedForCrossProject.projectCross.musl64.hsPkgs;
 in
-{
+rec {
   hydra-node = nativePkgs.hydra-node.components.exes.hydra-node;
   hydra-node-static = musl64Pkgs.hydra-node.components.exes.hydra-node;
   hydra-tools-static = musl64Pkgs.hydra-node.components.exes.hydra-tools;
@@ -18,4 +20,35 @@ in
   hydra-tui-static = musl64Pkgs.hydra-tui.components.exes.hydra-tui;
   hydraw = nativePkgs.hydraw.components.exes.hydraw;
   hydraw-static = musl64Pkgs.hydraw.components.exes.hydraw;
+  tests = {
+    plutus-cbor = pkgs.mkShell {
+      name = "plutus-cbor-tests";
+      buildInputs = [nativePkgs.plutus-cbor.components.tests.tests];
+    };
+    plutus-merkle-tree = pkgs.mkShell {
+      name = "plutus-merkle-tree-tests";
+      buildInputs = [nativePkgs.plutus-merkle-tree.components.tests.tests];
+    };
+    hydra-plutus = pkgs.mkShell {
+      name = "hydra-plutus-tests";
+      buildInputs = [nativePkgs.hydra-plutus.components.tests.tests];
+    };
+    hydra-node = pkgs.mkShell {
+      name = "hydra-node-tests";
+      buildInputs = [nativePkgs.hydra-node.components.tests.tests];
+    };
+    hydra-cluster = pkgs.mkShell {
+       name = "hydra-cluster-tests";
+       buildInputs =
+       [
+         nativePkgs.hydra-cluster.components.tests.tests
+	 hydra-node
+	 cardano-node.packages.${system}.cardano-node
+       ];
+     };
+    hydra-tui = pkgs.mkShell {
+      name = "hydra-tui-tests";
+      buildInputs = [nativePkgs.hydra-tui.components.tests.tests];
+    };
+  };
 }

--- a/plutus-cbor/plutus-cbor.cabal
+++ b/plutus-cbor/plutus-cbor.cabal
@@ -79,7 +79,7 @@ library
 
   exposed-modules: Plutus.Codec.CBOR.Encoding
 
-test-suite unit
+test-suite tests
   import:             project-config
   type:               exitcode-stdio-1.0
   hs-source-dirs:     test

--- a/plutus-merkle-tree/plutus-merkle-tree.cabal
+++ b/plutus-merkle-tree/plutus-merkle-tree.cabal
@@ -83,7 +83,7 @@ library
     -- NOTE(SN): should fix HLS choking on PlutusTx plugin
     ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
 
-test-suite unit
+test-suite tests
   import:             project-config
   type:               exitcode-stdio-1.0
   hs-source-dirs:     test


### PR DESCRIPTION
That way we get the minimal nix derivations dependencies and hope for a blazing fast execution.

We rename all the test-suites so that they are all names `tests`. That looks more cohesive and make the C.I. matrix management easier.

I must admit it's not obvious how faster we run with this compared to #857 see C.I. perfs in [sheet](https://docs.google.com/spreadsheets/d/17whVnqDQ-DOw04vMXNWzXFABke2VenT5WZGs8_RMv7w/edit?usp=sharing)