### PR TITLE
Simplify post tx interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ changes.
     - Added current chain slot in OpenState.
     - Added current chain slot and time in chain Tick.
 
+- Simply postTx interface, in chain handle, to not depend on chain state type.
+  + This removed the need to keep the chain state type as part of on-chain effects.
+  + Changes to the logs:
+    - Removed chain state from OnChainEffect.
+
 - **BREAKING** Change the hydra-node command line options:
 
    - Removed `--ledger-genesis` argument. Hydra-node queries this information

--- a/hydra-cluster/test/Test/DirectChainSpec.hs
+++ b/hydra-cluster/test/Test/DirectChainSpec.hs
@@ -15,7 +15,7 @@ import CardanoClient (
   waitForUTxO,
  )
 import CardanoNode (NodeLog, RunningNode (..), withCardanoNodeDevnet)
-import Control.Concurrent.STM (newEmptyTMVarIO, newTVarIO, readTVarIO, takeTMVar)
+import Control.Concurrent.STM (newEmptyTMVarIO, takeTMVar)
 import Control.Concurrent.STM.TMVar (putTMVar)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -433,7 +433,6 @@ withDirectChainTest ::
   IO a
 withDirectChainTest tracer config ctx action = do
   eventMVar <- newEmptyTMVarIO
-  stateVar <- newTVarIO initialChainState
 
   let callback = \event -> do
         atomically $ putTMVar eventMVar event
@@ -443,9 +442,7 @@ withDirectChainTest tracer config ctx action = do
   withDirectChain tracer config ctx wallet initialChainState callback $ \Chain{postTx} -> do
     action
       DirectChainTest
-        { postTx = \tx -> do
-            cs <- readTVarIO stateVar
-            postTx cs tx
+        { postTx
         , waitCallback = atomically $ takeTMVar eventMVar
         }
 

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -1262,7 +1262,6 @@ definitions:
         additionalProperties: false
         required:
           - tag
-          - chainState
           - postChainTx
         description: >-
           An effect representing some transaction must be posted on-chain. Note
@@ -1272,8 +1271,6 @@ definitions:
           tag:
             type: string
             enum: ["OnChainEffect"]
-          chainState:
-            $ref: "api.yaml#/components/schemas/ChainState"
           postChainTx:
             $ref: "api.yaml#/components/schemas/PostChainTx"
       - title: Delay

--- a/hydra-node/src/Hydra/Chain.hs
+++ b/hydra-node/src/Hydra/Chain.hs
@@ -176,10 +176,10 @@ class
 
 -- | Handle to interface with the main chain network
 newtype Chain tx m = Chain
-  { postTx :: (IsChainState tx, MonadThrow m) => ChainStateType tx -> PostChainTx tx -> m ()
+  { postTx :: MonadThrow m => PostChainTx tx -> m ()
   -- ^ Construct and send a transaction to the main chain corresponding to the
-  -- given 'PostChainTx' description and the current 'ChainState'. This
-  -- function is not expected to block, so it is only responsible for
+  -- given 'PostChainTx' description.
+  -- This function is not expected to block, so it is only responsible for
   -- submitting, but it should validate the created transaction against a
   -- reasonable local view of the chain and throw an exception when invalid.
   --

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -128,7 +128,7 @@ mkChain ::
   Chain Tx m
 mkChain tracer queryTimeHandle wallet ctx LocalChainState{getLatest} submitTx =
   Chain
-    { postTx = \_chainState tx -> do
+    { postTx = \tx -> do
         chainState <- atomically getLatest
         traceWith tracer $ ToPost{toPost = tx}
         timeHandle <- queryTimeHandle

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -173,8 +173,8 @@ processEffect HydraNode{hn, oc = Chain{postTx}, server, eq, env = Environment{pa
   case e of
     ClientEffect i -> sendOutput server i
     NetworkEffect msg -> broadcast hn msg >> putEvent eq (NetworkEvent defaultTTL msg)
-    OnChainEffect{chainState, postChainTx} ->
-      postTx chainState postChainTx
+    OnChainEffect{postChainTx} ->
+      postTx postChainTx
         `catch` \(postTxError :: PostTxError tx) ->
           putEvent eq $ PostTxError{postChainTx, postTxError}
   traceWith tracer $ EndEffect party e

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -594,7 +594,7 @@ simulatedChainAndNetwork initialChainState = do
           atomically $ modifyTVar nodes (node :)
           pure $
             node
-              { oc = Chain{postTx = \_cs -> postTx nodes history chainStateVar}
+              { oc = Chain{postTx = postTx nodes history chainStateVar}
               , hn = createMockNetwork node nodes
               }
       , tickThread
@@ -756,7 +756,7 @@ createHydraNode ledger nodeState signingKey otherParties outputs outputHistory c
       , hn = Network{broadcast = \_ -> pure ()}
       , nodeState
       , ledger
-      , oc = Chain{postTx = \_ _ -> pure ()}
+      , oc = Chain{postTx = \_ -> pure ()}
       , server =
           Server
             { sendOutput = \out -> atomically $ do

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -371,7 +371,6 @@ chainEffect :: PostChainTx SimpleTx -> Effect SimpleTx
 chainEffect postChainTx =
   OnChainEffect
     { postChainTx
-    , chainState = SimpleChainState{slot = ChainSlot 0}
     }
 
 observeEventAtSlot :: Natural -> OnChainTx SimpleTx -> Event SimpleTx

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -170,7 +170,7 @@ createHydraNode signingKey otherParties contestationPeriod events = do
       { eq
       , hn = Network{broadcast = \_ -> pure ()}
       , nodeState
-      , oc = Chain{postTx = \_ _ -> pure ()}
+      , oc = Chain{postTx = \_ -> pure ()}
       , server = Server{sendOutput = \_ -> pure ()}
       , ledger = simpleLedger
       , env =
@@ -212,4 +212,4 @@ throwExceptionOnPostTx ::
   HydraNode tx IO ->
   IO (HydraNode tx IO)
 throwExceptionOnPostTx exception node =
-  pure node{oc = Chain{postTx = \_ _ -> throwIO exception}}
+  pure node{oc = Chain{postTx = \_ -> throwIO exception}}


### PR DESCRIPTION
🌴 Remove unused dependency with current chain state during post-tx

🌴 The above makes unnecessary to have the chain state on every chain effect either


⚠️ this was [mentioned](https://github.com/input-output-hk/hydra/blob/master/docs/adr/2022-04-13_018-single-state.md?plain=1#L85) to be used for tracing purposes, but idk if worth to maintain, thus the reason for this change.

---

<!-- Tick off or strike-through / remove if not applicable -->
* [x] CHANGELOG updated
* [x] Documentation updated
* [x] Added and/or updated haddocks
* [x] No new TODOs introduced or explained herafter
