### PR TITLE
Always push docker images

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -76,8 +76,7 @@ jobs:
         docker inspect ${IMAGE_NAME}:unstable
 
     - name: 📤 Maybe push
-      if: ${{ github.ref == 'refs/heads/master' || (github.ref_type == 'tag' && matrix.target != 'hydraw') }}
+      if: ${{ github.ref == 'refs/heads/master' || github.ref_type == 'tag' }}
       run: |
-        # Only push images from master or release tags, unless it's about
-        # 'hydraw' (which is not yet versioned)
+        # Only push images from master or release tags
         docker push -a ${IMAGE_NAME}


### PR DESCRIPTION
when we build from master or a git tag, we always want to make sure the docker images are pushed to the registry. Even when it is the non-released hydraw image.

<!-- Describe your change here -->

---

<!-- Tick off or strike-through / remove if not applicable -->
* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Added and/or updated haddocks not needed
* [x] No new TODOs introduced or explained herafter
