### PR TITLE
Change checklist in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,8 @@
 
 ---
 
-<!-- Tick off or strike-through / remove if not applicable -->
-* [ ] CHANGELOG updated
-* [ ] Documentation updated
-* [ ] Added and/or updated haddocks
+<!-- Consider each and tick it off one way or the other -->
+* [ ] CHANGELOG updated or not needed
+* [ ] Documentation updated or not needed
+* [ ] Haddocks updated or not needed
 * [ ] No new TODOs introduced or explained herafter


### PR DESCRIPTION
Seemingly nobody was ticking off the checklist. We still want to keep a reminder of what might still be missing in a PR before a reviewer needs to point it out though. The new wording should make it more clear that ticking it off is what is expected.


:point_down: is the new template in use
<!-- Describe your change here -->

---

<!-- Tick off or strike-through / remove if not applicable -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
