### PR TITLE
Use cardano-scaling.cachix.org in more workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,8 +130,8 @@ jobs:
     - name: ❄ Cachix cache of nix derivations
       uses: cachix/cachix-action@v12
       with:
-        name: hydra-node
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        name: cardano-scaling
+        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
     - name: ❄ Build static executables
       run: |
@@ -196,8 +196,8 @@ jobs:
     - name: ❄ Cachix cache of nix derivations
       uses: cachix/cachix-action@v12
       with:
-        name: hydra-node
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        name: cardano-scaling
+        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
     - name: 🔁 Github cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
       uses: actions/cache@v3
@@ -291,8 +291,8 @@ jobs:
     - name: ❄ Cachix cache of nix derivations
       uses: cachix/cachix-action@v12
       with:
-        name: hydra-node
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        name: cardano-scaling
+        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
     - name: ❄ Build specification PDF
       run: |


### PR DESCRIPTION
We want to use this new cachix cache to see why and when the static binary build (or any nix build) takes long because of garbage collected caches.

---

<!-- Tick off or strike-through / remove if not applicable -->
* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Added and/or updated haddocks not needed
* [x] No new TODOs introduced or explained herafter
