### PR TITLE
Nix build patches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -174,12 +174,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - bench: tx-cost
-            options: '--output-directory $(pwd)/docs/benchmarks'
-          - bench: hydra-cluster
+          - package: hydra-node
+            bench: tx-cost
+            options: '--output-directory $(pwd)/../docs/benchmarks'
+          - package: hydra-cluster
+            bench: bench-e2e
             options: '--scaling-factor 1'
-          - bench: plutus-merkle-tree
-            options: '$(pwd)/docs/benchmarks'
+          - package: plutus-merkle-tree
+            bench: on-chain-cost
+            options: '$(pwd)/../docs/benchmarks'
     steps:
     - name: 📥 Checkout repository
       uses: actions/checkout@v3
@@ -209,13 +212,10 @@ jobs:
         key: |
           cabal-${{ runner.os }}-${{ hashFiles('cabal.project', 'default.nix', 'shell.nix') }}
 
-    - name: 🧰 Prepare tools
-      run: |
-        nix develop .#ci --command bash -c 'cabal update'
-
     - name: 📈 Benchmark
       run: |
-        nix develop .#ci --command bash -c 'cabal bench ${{ matrix.bench }} --benchmark-options "${{ matrix.options }}"'
+        cd ${{ matrix.package }}
+        nix develop .?submodules=1#benchs.${{ matrix.package }} --command ${{ matrix.bench }} ${{ matrix.options }}
 
     - name: 📚 Documentation (Haddock)
       run: |

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -21,23 +21,23 @@ rec {
   hydraw = nativePkgs.hydraw.components.exes.hydraw;
   hydraw-static = musl64Pkgs.hydraw.components.exes.hydraw;
   tests = {
-    plutus-cbor = pkgs.mkShell {
+    plutus-cbor = pkgs.mkShellNoCC {
       name = "plutus-cbor-tests";
       buildInputs = [ nativePkgs.plutus-cbor.components.tests.tests ];
     };
-    plutus-merkle-tree = pkgs.mkShell {
+    plutus-merkle-tree = pkgs.mkShellNoCC {
       name = "plutus-merkle-tree-tests";
       buildInputs = [ nativePkgs.plutus-merkle-tree.components.tests.tests ];
     };
-    hydra-plutus = pkgs.mkShell {
+    hydra-plutus = pkgs.mkShellNoCC {
       name = "hydra-plutus-tests";
       buildInputs = [ nativePkgs.hydra-plutus.components.tests.tests ];
     };
-    hydra-node = pkgs.mkShell {
+    hydra-node = pkgs.mkShellNoCC {
       name = "hydra-node-tests";
       buildInputs = [ nativePkgs.hydra-node.components.tests.tests ];
     };
-    hydra-cluster = pkgs.mkShell {
+    hydra-cluster = pkgs.mkShellNoCC {
       name = "hydra-cluster-tests";
       buildInputs =
         [
@@ -46,7 +46,7 @@ rec {
           cardano-node.packages.${system}.cardano-node
         ];
     };
-    hydra-tui = pkgs.mkShell {
+    hydra-tui = pkgs.mkShellNoCC {
       name = "hydra-tui-tests";
       buildInputs =
         [

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -56,4 +56,23 @@ rec {
         ];
     };
   };
+  benchs = {
+    hydra-node = pkgs.mkShellNoCC {
+      name = "bench-tx-cost";
+      buildInputs = [ nativePkgs.hydra-node.components.benchmarks.tx-cost ];
+    };
+    hydra-cluster = pkgs.mkShellNoCC {
+      name = "bench-hydra-cluster";
+      buildInputs =
+        [
+          nativePkgs.hydra-cluster.components.benchmarks.bench-e2e
+          hydra-node
+          cardano-node.packages.${system}.cardano-node
+        ];
+    };
+    plutus-merkle-tree = pkgs.mkShellNoCC {
+      name = "bench-plutus-merkle-tree";
+      buildInputs = [ nativePkgs.plutus-merkle-tree.components.benchmarks.on-chain-cost ];
+    };
+  };
 }

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -23,37 +23,37 @@ rec {
   tests = {
     plutus-cbor = pkgs.mkShell {
       name = "plutus-cbor-tests";
-      buildInputs = [nativePkgs.plutus-cbor.components.tests.tests];
+      buildInputs = [ nativePkgs.plutus-cbor.components.tests.tests ];
     };
     plutus-merkle-tree = pkgs.mkShell {
       name = "plutus-merkle-tree-tests";
-      buildInputs = [nativePkgs.plutus-merkle-tree.components.tests.tests];
+      buildInputs = [ nativePkgs.plutus-merkle-tree.components.tests.tests ];
     };
     hydra-plutus = pkgs.mkShell {
       name = "hydra-plutus-tests";
-      buildInputs = [nativePkgs.hydra-plutus.components.tests.tests];
+      buildInputs = [ nativePkgs.hydra-plutus.components.tests.tests ];
     };
     hydra-node = pkgs.mkShell {
       name = "hydra-node-tests";
-      buildInputs = [nativePkgs.hydra-node.components.tests.tests];
+      buildInputs = [ nativePkgs.hydra-node.components.tests.tests ];
     };
     hydra-cluster = pkgs.mkShell {
       name = "hydra-cluster-tests";
       buildInputs =
-      [
-        nativePkgs.hydra-cluster.components.tests.tests
-        hydra-node
-        cardano-node.packages.${system}.cardano-node
-      ];
-     };
+        [
+          nativePkgs.hydra-cluster.components.tests.tests
+          hydra-node
+          cardano-node.packages.${system}.cardano-node
+        ];
+    };
     hydra-tui = pkgs.mkShell {
       name = "hydra-tui-tests";
       buildInputs =
-      [
-        nativePkgs.hydra-tui.components.tests.tests
-        hydra-node
-	cardano-node.packages.${system}.cardano-node
-      ];
+        [
+          nativePkgs.hydra-tui.components.tests.tests
+          hydra-node
+          cardano-node.packages.${system}.cardano-node
+        ];
     };
   };
 }


### PR DESCRIPTION
Some improvements from #867 comments:
* fix nix format
* lighter nix shell
* apply nix strategy to benchmarks

Note: I did not apply the nix strategy to haddock because, for some reason, I encountered strange errors when running haddock with nix:

```
#> nom build .?submodules=1#hydraProject.x86_64-linux.hsPkgs.hydra-plutus.components.library.doc
error: builder for '/nix/store/infy608n06mnryvp8x9gdj9f2m0qynlk-hydra-plutus-lib-hydra-plutus-0.10.0-haddock.drv' failed with exit code 1;
       last 10 log lines:
       >                            PlutusLedgerApi.V2.Contexts.$fUnsafeFromDataScriptContext
       > Context: Compiling expr: Plutus.Extras.wrapValidator
       >                            @ Hydra.Contract.Hash.DatumType
       >                            @ Hydra.Contract.Hash.RedeemerType
       >                            @ PlutusLedgerApi.V2.Contexts.ScriptContext
       >                            PlutusTx.IsData.Class.$fUnsafeFromDataBuiltinByteString
       >                            Hydra.Contract.Hash.$fUnsafeFromDataHashAlgorithm
       >                            PlutusLedgerApi.V2.Contexts.$fUnsafeFromDataScriptContext
       >                            Hydra.Contract.Hash.validator
       > Context: Compiling expr at "hydra-plutus-0.10.0-BRPCpz9EklZ675zXWrGxIb:Hydra.Contract.Hash:(51,6)-(51,43)"
       For full logs, run 'nix log /nix/store/infy608n06mnryvp8x9gdj9f2m0qynlk-hydra-plutus-lib-hydra-plutus-0.10.0-haddock.drv'.
┏━ Dependency Graph:
┃ ⚠︎ hydra-plutus-lib-hydra-plutus-0.10.0-haddock failed with exit code 1 after ⏱︎ 8s in buildPhase
┣━━━                                                      
┗━ ∑︎ ⚠︎ Exited after 1 build failures at 14:20:54 after 15s
```