### PR TITLE
do not optimize docusaurus build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -385,31 +385,29 @@ jobs:
         name: hydra-spec
         path: docs/static/
 
-    - name: 📚 Documentation
+    - name: 📚 Documentation sanity check
+      if: github.ref_name != 'master' && github.ref_name != 'release'
       working-directory: docs
       run: |
-        yarn && yarn build
-        mkdir -p public/
-        mv build/* public/
+        yarn && yarn build-dev
 
-    - name: 💾 Upload docs artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: docs-stable
-        path: docs/public
-
-    - name: 📚 Documentation (unstable)
-      if: github.ref_name != 'release'
+    - name: 📚 Prepare Documentation (unstable)
+      if: github.ref_name == 'master'
       working-directory: docs
       run: |
         sed -i 's|head-protocol|head-protocol/unstable|' docusaurus.config.js
-        yarn && yarn build
-        mkdir -p public/unstable
-        mv build/* public/unstable
 
-    - name: 💾 Upload docs artifact (unstable) - only master branch
-      if: github.ref_name == 'master'
+    - name: 📚 Documentation
+      if: github.ref_name == 'master' || github.ref_name == 'release'
+      working-directory: docs
+      run: |
+        yarn && yarn build
+        mkdir public
+        mv build/* public
+
+    - name: 💾 Upload docs artifact
+      if: github.ref_name == 'master' || github.ref_name == 'release'
       uses: actions/upload-artifact@v3
       with:
-        name: docs-unstable
-        path: docs/public/unstable
+        name: docs
+        path: docs/public

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -3,7 +3,7 @@ name: "Publish Docs"
 on:
   workflow_run:
     workflows: ["CI"]
-    branches: [master, release]
+    branches: [master]
     types: 
       - completed
 
@@ -13,23 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
+
     - name: 📥 Download last released docs
       uses: dawidd6/action-download-artifact@v2
       with:
         workflow: ci.yaml
         workflow_conclusion: success
         branch: release
-        name: docs-stable
+        name: docs
         path: docs-release
-
-    - name: 📥 Download latest docs
-      uses: dawidd6/action-download-artifact@v2
-      with:
-        workflow: ci.yaml
-        workflow_conclusion: success
-        branch: master
-        name: docs-stable
-        path: docs-master
 
     - name: 📥 Download latest /unstable docs
       uses: dawidd6/action-download-artifact@v2
@@ -37,26 +29,26 @@ jobs:
         workflow: ci.yaml
         workflow_conclusion: success
         branch: master
-        name: docs-unstable
-        path: docs-master-unstable
+        name: docs
+        path: docs-unstable
 
     - name: 🪓 Piece together docs
       run: |
         mkdir public
         mv docs-release public/head-protocol
-        mv docs-master-unstable public/head-protocol/unstable
+        mv docs-unstable public/head-protocol/unstable
         # Always use monthly reports from master
         # XXX: This depends on languages and assets are annoying
         rm -r public/head-protocol/monthly
-        mv docs-master/monthly public/head-protocol/monthly
+        cp -r public/head-protocol/unstable/monthly public/head-protocol/monthly
         rm -r public/head-protocol/ja/monthly
-        mv docs-master/ja/monthly public/head-protocol/ja/monthly
+        cp -r public/head-protocol/unstable/ja/monthly public/head-protocol/monthly
         rm -r public/head-protocol/fr/monthly
-        mv docs-master/fr/monthly public/head-protocol/fr/monthly
+        cp -r public/head-protocol/unstable/fr/monthly public/head-protocol/monthly
         # XXX: Need to copy assets as well. This will also litter with unrelated assets (js)
-        cp -r docs-master/assets/* public/head-protocol/assets/
-        cp -r docs-master/ja/assets/* public/head-protocol/ja/assets/
-        cp -r docs-master/fr/assets/* public/head-protocol/fr/assets/
+        cp -r public/head-protocol/unstable/assets/* public/head-protocol/assets/
+        cp -r public/head-protocol/unstable/ja/assets/* public/head-protocol/ja/assets/
+        cp -r public/head-protocol/unstable/fr/assets/* public/head-protocol/fr/assets/
 
     - name: 👉 Create redirect
       run: |
@@ -70,4 +62,3 @@ jobs:
         publish_dir: public
         enable_jekyll: true
         force_orphan: true
-    

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -22,8 +22,28 @@ jobs:
         branch: release
         name: docs
         path: docs-release
+        # TODO: backward compatibility
+        # remove the following line to throw an error instead
+        # of a warning if artifact is not found when we have
+        # a release branch with artifact name docs instead of
+        # docs-stable
+        if_no_artifact_found: warn
 
-    - name: 📥 Download latest /unstable docs
+    # TODO: backward compatibility
+    # remove the following block when we have
+    # a release branch with artifact name docs instead of
+    # docs-stable
+    - name: 📥 Download last released docs
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        workflow: ci.yaml
+        workflow_conclusion: success
+        branch: release
+        name: docs-stable
+        path: docs-release
+        if_no_artifact_found: ignore
+
+    - name: 📥 Download latest unstable docs
       uses: dawidd6/action-download-artifact@v2
       with:
         workflow: ci.yaml

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,6 +6,7 @@
     "docusaurus": "docusaurus",
     "prepare": "yarn enrich-document-metadata && yarn regenerate-plantuml",
     "build": "yarn prepare && docusaurus build",
+    "build-dev": "yarn prepare && docusaurus build --no-minify",
     "start": "yarn dummy-spec && docusaurus start",
     "validate:inputs": "./validate-api.js publish '/' '../hydra-node/golden/ReasonablySized (ClientInput (Tx BabbageEra)).json'",
     "validate:outputs": "./validate-api.js subscribe '/' '../hydra-node/golden/ReasonablySized (TimedServerOutput (Tx BabbageEra)).json'",


### PR DESCRIPTION
The _Documentation_ step was taking several minutes to optimize a web-site we will, most of the time, never publish. And, also, it was doing it twice sometimes.

So we do not generate documentation twice anymore. Also, we only generate optimized documentation for branch master and release. For all the other branches, we keep building the docusaurus stuff but only for sanity check so we don't optimize and we don't upload the artifact either.

To check that this P.R. did not break with the _Publish Docs_ workflow, one can check this run which contains an artifact that you can download to check locally (spoiler alert: it still works): https://github.com/input-output-hk/hydra/actions/runs/5047620832

* saves around 5 minutes
* [x] Introduces a new TODO to remove backward compatibility C.I. code in the future
