### PR TITLE
Print up to 1000 lines of failing nix build log

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build-test:
-    name: "Build & test using cabal"
+    name: "Build & test"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -47,6 +47,7 @@ jobs:
       with:
         extra_nix_config: |
           accept-flake-config = true
+          log-lines = 1000
 
     - name: ❄ Cachix cache of nix derivations
       uses: cachix/cachix-action@v12
@@ -105,7 +106,7 @@ jobs:
         path: /tmp/nix-shell.*/hydra-cluster-e2e-*/logs/*
 
   build-executables:
-    name: "Build using nix"
+    name: "Build static executables"
     runs-on: ubuntu-latest
     steps:
     - name: 📥 Checkout repository
@@ -126,6 +127,7 @@ jobs:
       with:
         extra_nix_config: |
           accept-flake-config = true
+          log-lines = 1000
 
     - name: ❄ Cachix cache of nix derivations
       uses: cachix/cachix-action@v12
@@ -177,6 +179,7 @@ jobs:
       with:
         extra_nix_config: |
           accept-flake-config = true
+          log-lines = 1000
 
     - name: ❄ Cachix cache of nix derivations
       uses: cachix/cachix-action@v12
@@ -235,6 +238,7 @@ jobs:
       with:
         extra_nix_config: |
           accept-flake-config = true
+          log-lines = 1000
 
     - name: ❄ Cachix cache of nix derivations
       uses: cachix/cachix-action@v12
@@ -317,6 +321,7 @@ jobs:
       with:
         extra_nix_config: |
           accept-flake-config = true
+          log-lines = 1000
 
     - name: ❄ Cachix cache of nix derivations
       uses: cachix/cachix-action@v12

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -43,6 +43,7 @@ jobs:
       with:
         extra_nix_config: |
           accept-flake-config = true
+          log-lines = 1000
 
     - name: ❄ Cachix cache of nix derivations
       uses: cachix/cachix-action@v12
@@ -50,7 +51,7 @@ jobs:
         name: cardano-scaling
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
-    - name: 🔨 Build images using nix
+    - name: 🔨 Build image using nix
       run: |
         IMAGE_NAME=ghcr.io/${{github.repository_owner}}/${{matrix.target}}
         echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV


### PR DESCRIPTION
Without this, nix build errors would only show the last 10 lines. For example: https://github.com/input-output-hk/hydra/actions/runs/5069152381/jobs/9102361637?pr=774 

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
