### PR TITLE
Fix references in the hydra specification

### DIFF
--- a/spec/default.nix
+++ b/spec/default.nix
@@ -9,7 +9,7 @@ pkgs.stdenvNoCC.mkDerivation rec {
   ];
   phases = [ "unpackPhase" "buildPhase" ];
   buildPhase = ''
-    pdflatex -file-line-error --synctex=1 -interaction=nonstopmode ${./main.tex}
+    latexmk -pdf ${./main.tex}
     mkdir -p $out
     mv *-main.pdf $out/${name}.pdf
   '';


### PR DESCRIPTION
Multiple invocation of pdflatex is needed. Using latexmk we can automate all the needed steps for generating a properly linked PDF

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
