### PR TITLE
FIX check doc workflow

### DIFF
--- a/.github/workflows/check-docs.yaml
+++ b/.github/workflows/check-docs.yaml
@@ -3,6 +3,7 @@ on:
   schedule:
     # Everyday at 5:00 AM UTC
     - cron: "0 5 * * *"
+  workflow_dispatch
 
 jobs:
   check-documentation-links:
@@ -11,7 +12,7 @@ jobs:
     steps:
     - name: Check for broken links
       id: link-report
-      uses: celinekurpershoek/link-checker@v1
+      uses: celinekurpershoek/link-checker@v1.0.2
       with:
         # Required:
         url: 'https://hydra.family/head-protocol/'


### PR DESCRIPTION
I noticed there is this [Check documentation](https://github.com/input-output-hk/hydra/actions/runs/5184766037) workflow in CI that never worked.
