### PR TITLE
Fix cardano-node version in demo docker setup

### DIFF
--- a/demo/docker-compose.yaml
+++ b/demo/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   cardano-node:
-    image: inputoutput/cardano-node:latest
+    image: inputoutput/cardano-node:1.35.7
     volumes:
       - ./devnet:/devnet
     environment:


### PR DESCRIPTION
fix #914 

## Why

User reported our demo fails in running the cardano-node. This is related to outdated configuration files for devnet.

## What
Update cardano-node version in `demo/docker-compose.yaml` to `1.35.7`

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
