### PR TITLE
Derive `Ord HeadId`

### DIFF
--- a/hydra-node/src/Hydra/Chain.hs
+++ b/hydra-node/src/Hydra/Chain.hs
@@ -75,7 +75,7 @@ instance IsTx tx => Arbitrary (PostChainTx tx) where
 
 -- | Uniquely identifies a Hydra Head.
 newtype HeadId = HeadId ByteString
-  deriving (Show, Eq, Generic)
+  deriving (Show, Eq, Ord, Generic)
   deriving (ToJSON, FromJSON) via (UsingRawBytesHex HeadId)
 
 instance SerialiseAsRawBytes HeadId where


### PR DESCRIPTION
I see no reasons why `Ord` is worse than `Eq`.

This is not public API, I think, so no CHANGELOG, right?

---


* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
