### PR TITLE
Filter source of haskell.nix project

### DIFF
--- a/nix/hydra/project.nix
+++ b/nix/hydra/project.nix
@@ -23,10 +23,24 @@ let
   };
 
   hsPkgs = pkgs.haskell-nix.project {
-    # TODO: probably should use flake.nix inputs.self here
-    src = pkgs.haskell-nix.haskellLib.cleanGit {
+    src = pkgs.haskell-nix.haskellLib.cleanSourceWith {
       name = "hydra";
       src = ./../..;
+      filter = path: type:
+        # Blacklist of paths which do not affect the haskell build. The smaller
+        # the resulting list of files is, the less likely we have redundant
+        # rebuilds.
+        builtins.all (x: baseNameOf path != x) [
+          "flake.nix"
+          "flake.lock"
+          "nix"
+          ".github"
+          "demo"
+          "docs"
+          "sample-node-config"
+          "spec"
+          "testnets"
+        ];
     };
     projectFileName = "cabal.project";
     compiler-nix-name = compiler;


### PR DESCRIPTION
This should remove some of the redundant rebuilds and "cache misses" due to files being changed which do not result in a change to the haskell results.

Not sure if specifying things to exclude is easier than specifying directories (= packages) to include. However, as the resulting list can be bigger than strictly needed (at the cost of redundant rebuilds) I opted for a blacklist over a whitelist.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
