### PR TITLE
Make it clear that we don't want copy/paste items forever

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,7 +205,7 @@ To write such an update:
      (good: "Implemented..", bad: "Started working on.."); use the backlog and
      calendars to collect
 
-   * **What are the goals of next week**: a short look-out onto the backlog and/or
+   - **What are the goals of next week**: a short look-out onto the backlog and/or
      roadmap; ask each contributor what they would like to get done next week; always start from scratch and don't carry over things from last week.
 
 2. Enrich the content with useful links and write a high-level summary. This

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,8 +205,8 @@ To write such an update:
      (good: "Implemented..", bad: "Started working on.."); use the backlog and
      calendars to collect
 
-   - **What are the goals of next week**: a short look-out onto the backlog and/or
-     roadmap; ask each contributor what they would like to get done next week
+   * **What are the goals of next week**: a short look-out onto the backlog and/or
+     roadmap; ask each contributor what they would like to get done next week; always start from scratch and don't carry over things from last week.
 
 2. Enrich the content with useful links and write a high-level summary. This
    should use a passive or "they"-style of writing. Tip: check out older updates


### PR DESCRIPTION
Some more precision to our contributing guide about the weekly update.

We've carried on some undone items from one weekly to the other but, actually, we don't want to do that: what we put in the weekly for next week is just a plan and if we did not achieve that at the end of the week, it's perfectly ok to not try to do it the week after. Maybe things just changed in between.