### PR TITLE
Fix headStatus and snapshotUTxO in Greetings message

### DIFF
--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -115,7 +115,7 @@ withAPIServer ::
   ServerComponent tx IO ()
 withAPIServer host port party PersistenceIncremental{loadAll, append} tracer chain callback action = do
   responseChannel <- newBroadcastTChanIO
-  timedOutputEvents <- reverse <$> loadAll
+  timedOutputEvents <- loadAll
 
   -- Intialize our read model from stored events
   headStatusP <- mkProjection Idle (output <$> timedOutputEvents) projectHeadStatus
@@ -123,7 +123,7 @@ withAPIServer host port party PersistenceIncremental{loadAll, append} tracer cha
 
   -- NOTE: we need to reverse the list because we store history in a reversed
   -- list in memory but in order on disk
-  history <- newTVarIO timedOutputEvents
+  history <- newTVarIO (reverse timedOutputEvents)
   (notifyServerRunning, waitForServerRunning) <- setupServerNotification
   race_
     (runAPIServer host port party tracer history chain callback headStatusP snapshotUtxoP responseChannel notifyServerRunning)

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -29,6 +29,11 @@ data TimedServerOutput tx = TimedServerOutput
 instance Arbitrary (ServerOutput tx) => Arbitrary (TimedServerOutput tx) where
   arbitrary = genericArbitrary
 
+-- | Generate a random timed server output given a normal server output.
+genTimedServerOutput :: ServerOutput tx -> Gen (TimedServerOutput tx)
+genTimedServerOutput o =
+  TimedServerOutput o <$> arbitrary <*> arbitrary
+
 instance (ToJSON tx, IsChainState tx) => ToJSON (TimedServerOutput tx) where
   toJSON TimedServerOutput{output, seq, time} =
     case toJSON output of


### PR DESCRIPTION
These have not been correctly loaded from disk and the projected headStatus was wrong. Not perfect, but to at least test this a bit, the server spec is extended to test with some persisted events.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
