### PR TITLE
Version all the things

### DIFF
--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -241,7 +241,6 @@ test-suite tests
     , plutus-ledger-api
     , process
     , QuickCheck
-    , regex-tdfa
     , say
     , stm
     , strict-containers

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -97,11 +97,9 @@ import System.Directory (createDirectoryIfMissing, removeDirectoryRecursive)
 import System.FilePath ((</>))
 import System.IO (hGetLine)
 import System.IO.Error (isEOFError)
-import System.Process (CreateProcess (..), StdStream (..), proc, readCreateProcess, withCreateProcess)
+import System.Process (CreateProcess (..), StdStream (..), proc, withCreateProcess)
 import System.Timeout (timeout)
 import Test.QuickCheck (generate, suchThat)
-import Text.Regex.TDFA ((=~))
-import Text.Regex.TDFA.Text ()
 import qualified Prelude
 
 allNodeIds :: [Int]
@@ -129,7 +127,7 @@ spec = around showLogsOnFailure $ do
           withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
             publishHydraScriptsAs node Faucet
               >>= canCloseWithLongContestationPeriod tracer tmpDir node
-      it "can submmit a timed tx" $ \tracer -> do
+      it "can submit a timed tx" $ \tracer -> do
         withClusterTempDir "timed-tx" $ \tmpDir -> do
           withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
             publishHydraScriptsAs node Faucet
@@ -398,11 +396,6 @@ spec = around showLogsOnFailure $ do
                     metrics `shouldSatisfy` ("hydra_head_events" `BS.isInfixOf`)
 
     describe "hydra-node executable" $ do
-      it "display proper semantic version given it is passed --version argument" $ \_ ->
-        failAfter 5 $ do
-          version <- readCreateProcess (proc "hydra-node" ["--version"]) ""
-          version `shouldSatisfy` (=~ ("[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9]+)?" :: String))
-
       it "logs its command line arguments" $ \tracer -> do
         withClusterTempDir "logs-options" $ \dir -> do
           withCardanoNodeDevnet (contramap FromCardanoNode tracer) dir $ \RunningNode{nodeSocket} -> do

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -345,6 +345,7 @@ test-suite tests
     , lens
     , lens-aeson
     , network
+    , optparse-applicative
     , ouroboros-consensus-cardano-test
     , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}  >=1.1.1.0
     , plutus-tx

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -353,6 +353,7 @@ test-suite tests
     , QuickCheck
     , quickcheck-dynamic                                                >=3.0.3
     , quickcheck-instances
+    , regex-tdfa
     , req
     , silently
     , text

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -345,7 +345,6 @@ test-suite tests
     , lens
     , lens-aeson
     , network
-    , optparse-applicative
     , ouroboros-consensus-cardano-test
     , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}  >=1.1.1.0
     , plutus-tx

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -1,10 +1,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Hydra.Options (
-  module Hydra.Options,
-  ParserResult (..),
-) where
+module Hydra.Options
+where
 
 import Hydra.Prelude
 

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Hydra.Options
-where
+module Hydra.Options (
+  module Hydra.Options,
+  ParserResult (..),
+  renderFailure,
+) where
 
 import Hydra.Prelude
 
@@ -61,6 +64,7 @@ import Options.Applicative (
   option,
   progDesc,
   progDescDoc,
+  renderFailure,
   short,
   showDefault,
   strOption,

--- a/hydra-node/test/Hydra/OptionsSpec.hs
+++ b/hydra-node/test/Hydra/OptionsSpec.hs
@@ -15,18 +15,16 @@ import Hydra.Options (
   Command (..),
   InvalidOptions (..),
   LedgerConfig (..),
+  ParserResult (..),
   PublishOptions (..),
   RunOptions (..),
   defaultChainConfig,
   defaultLedgerConfig,
   maximumNumberOfParties,
   parseHydraCommandFromArgs,
+  renderFailure,
   toArgs,
   validateRunOptions,
- )
-import Options.Applicative (
-  ParserResult (..),
-  renderFailure,
  )
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
 import Test.QuickCheck (Property, chooseEnum, counterexample, forAll, property, vectorOf, (===))

--- a/hydra-node/test/Hydra/OptionsSpec.hs
+++ b/hydra-node/test/Hydra/OptionsSpec.hs
@@ -32,6 +32,7 @@ import Options.Applicative (
 import Paths_hydra_node (version)
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
 import Test.QuickCheck (Property, chooseEnum, counterexample, forAll, property, vectorOf, (===))
+import Text.Regex.TDFA ((=~))
 
 spec :: Spec
 spec = parallel $

--- a/hydra-node/test/Hydra/OptionsSpec.hs
+++ b/hydra-node/test/Hydra/OptionsSpec.hs
@@ -5,7 +5,6 @@ module Hydra.OptionsSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import Data.Version (showVersion)
 import Hydra.Cardano.Api (ChainPoint (..), NetworkId (..), serialiseToRawBytesHexText, unsafeDeserialiseFromRawBytesBase16)
 import Hydra.Chain.Direct (NetworkMagic (..))
 import Hydra.ContestationPeriod (ContestationPeriod (UnsafeContestationPeriod))
@@ -29,7 +28,6 @@ import Options.Applicative (
   ParserResult (..),
   renderFailure,
  )
-import Paths_hydra_node (version)
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
 import Test.QuickCheck (Property, chooseEnum, counterexample, forAll, property, vectorOf, (===))
 import Text.Regex.TDFA ((=~))

--- a/hydra-tui/hydra-tui.cabal
+++ b/hydra-tui/hydra-tui.cabal
@@ -97,6 +97,7 @@ library
     , optparse-applicative
     , QuickCheck
     , text
+    , th-env
     , time
     , vty
     , websockets
@@ -136,6 +137,7 @@ test-suite tests
     , hydra-tui
     , io-classes
     , optparse-applicative
+    , regex-tdfa
     , temporary
     , unix
     , vty

--- a/hydra-tui/src/Hydra/TUI/Options.hs
+++ b/hydra-tui/src/Hydra/TUI/Options.hs
@@ -1,11 +1,6 @@
 module Hydra.TUI.Options where
 
-import Hydra.Prelude (
-  Applicative ((<*>)),
-  FilePath,
-  Semigroup ((<>)),
-  (<$>),
- )
+import Hydra.Prelude
 
 import Hydra.Cardano.Api (NetworkId)
 import Hydra.Network (Host (Host))
@@ -29,6 +24,7 @@ data Options = Options
   , cardanoNetworkId :: NetworkId
   , cardanoSigningKey :: FilePath
   }
+  deriving stock (Eq, Show)
 
 parseOptions :: Parser Options
 parseOptions =
@@ -55,7 +51,7 @@ parseNodeHost =
     ( long "connect"
         <> short 'c'
         <> help "Hydra-node to connect to in the form of <host>:<port>"
-        <> value (Host "0.0.0.0" 4001)
+        <> value (Host "127.0.0.1" 4001)
         <> showDefault
     )
 

--- a/hydra-tui/src/Hydra/TUI/Options.hs
+++ b/hydra-tui/src/Hydra/TUI/Options.hs
@@ -1,14 +1,20 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 module Hydra.TUI.Options where
 
 import Hydra.Prelude
 
+import Data.Version (Version (Version), showVersion)
 import Hydra.Cardano.Api (NetworkId)
 import Hydra.Network (Host (Host))
 import Hydra.Options (networkIdParser)
+import Hydra.Version (gitRevision)
+import Language.Haskell.TH.Env (envQ)
 import Options.Applicative (
   Parser,
   auto,
   help,
+  infoOption,
   long,
   metavar,
   option,
@@ -17,6 +23,7 @@ import Options.Applicative (
   strOption,
   value,
  )
+import Paths_hydra_tui (version)
 
 data Options = Options
   { hydraNodeHost :: Host
@@ -28,11 +35,27 @@ data Options = Options
 
 parseOptions :: Parser Options
 parseOptions =
-  Options
-    <$> parseNodeHost
-    <*> parseCardanoNodeSocket
-    <*> networkIdParser
-    <*> parseCardanoSigningKey
+  ( Options
+      <$> parseNodeHost
+      <*> parseCardanoNodeSocket
+      <*> networkIdParser
+      <*> parseCardanoSigningKey
+  )
+    <**> versionInfo
+ where
+  versionInfo :: Parser (Options -> Options)
+  versionInfo =
+    infoOption
+      (showVersion ourVersion)
+      (long "version" <> help "Show version")
+
+  ourVersion =
+    version & \(Version semver _) -> Version semver revision
+
+  revision =
+    maybeToList $
+      ($$(envQ "GIT_REVISION") :: Maybe String)
+        <|> gitRevision
 
 parseCardanoNodeSocket :: Parser FilePath
 parseCardanoNodeSocket =

--- a/hydra-tui/test/Hydra/TUI/OptionsSpec.hs
+++ b/hydra-tui/test/Hydra/TUI/OptionsSpec.hs
@@ -5,11 +5,9 @@ import Test.Hydra.Prelude
 
 import Hydra.Cardano.Api (NetworkId (..), NetworkMagic (..))
 import Hydra.Network (Host (Host))
-import Hydra.Options (networkIdParser)
 import Hydra.TUI.Options (
-  parseCardanoNodeSocket,
-  parseCardanoSigningKey,
-  parseNodeHost,
+  Options (..),
+  parseOptions,
  )
 import Options.Applicative (
   Parser,
@@ -22,13 +20,24 @@ import Options.Applicative (
 spec :: Spec
 spec = parallel $ do
   it "parses --connect option" $ do
-    shouldParseWith parseNodeHost ["--connect", "127.0.0.1:4002"] (Host "127.0.0.1" 4002)
+    shouldParseWith parseOptions ["--connect", "127.0.0.2:4002"] defaultOptions{hydraNodeHost = Host "127.0.0.2" 4002}
+  it "no arguments yield default options" $ do
+    shouldParseWith parseOptions [] defaultOptions
   it "parses --testnet-magic option" $ do
-    shouldParseWith networkIdParser ["--testnet-magic", "123"] (Testnet $ NetworkMagic 123)
+    shouldParseWith parseOptions ["--testnet-magic", "123"] defaultOptions{cardanoNetworkId = Testnet $ NetworkMagic 123}
   it "parses --cardano-signing-key option" $ do
-    shouldParseWith parseCardanoSigningKey ["--cardano-signing-key", "foo.sk"] "foo.sk"
+    shouldParseWith parseOptions ["--cardano-signing-key", "foo.sk"] defaultOptions{cardanoSigningKey = "foo.sk"}
   it "parses --node-socket option" $ do
-    shouldParseWith parseCardanoNodeSocket ["--node-socket", "something.socket"] "something.socket"
+    shouldParseWith parseOptions ["--node-socket", "something.socket"] defaultOptions{cardanoNodeSocket = "something.socket"}
+
+defaultOptions :: Options
+defaultOptions =
+  Options
+    { hydraNodeHost = Host "127.0.0.1" 4001
+    , cardanoNetworkId = Testnet $ NetworkMagic 42
+    , cardanoNodeSocket = "node.socket"
+    , cardanoSigningKey = "me.sk"
+    }
 
 shouldParseWith :: (Show a, Eq a) => Parser a -> [String] -> a -> Expectation
 shouldParseWith parser args result =

--- a/hydra-tui/test/Hydra/TUI/OptionsSpec.hs
+++ b/hydra-tui/test/Hydra/TUI/OptionsSpec.hs
@@ -11,24 +11,33 @@ import Hydra.TUI.Options (
  )
 import Options.Applicative (
   Parser,
-  ParserResult (Success),
+  ParserResult (Failure, Success),
   defaultPrefs,
   execParserPure,
   info,
+  renderFailure,
  )
+import Text.Regex.TDFA ((=~))
 
 spec :: Spec
 spec = parallel $ do
-  it "parses --connect option" $ do
-    shouldParseWith parseOptions ["--connect", "127.0.0.2:4002"] defaultOptions{hydraNodeHost = Host "127.0.0.2" 4002}
   it "no arguments yield default options" $ do
     shouldParseWith parseOptions [] defaultOptions
+  it "parses --connect option" $ do
+    shouldParseWith parseOptions ["--connect", "127.0.0.2:4002"] defaultOptions{hydraNodeHost = Host "127.0.0.2" 4002}
   it "parses --testnet-magic option" $ do
     shouldParseWith parseOptions ["--testnet-magic", "123"] defaultOptions{cardanoNetworkId = Testnet $ NetworkMagic 123}
   it "parses --cardano-signing-key option" $ do
     shouldParseWith parseOptions ["--cardano-signing-key", "foo.sk"] defaultOptions{cardanoSigningKey = "foo.sk"}
   it "parses --node-socket option" $ do
     shouldParseWith parseOptions ["--node-socket", "something.socket"] defaultOptions{cardanoNodeSocket = "something.socket"}
+  it "parses --version option" $ do
+    case execParserPure defaultPrefs (info parseOptions mempty) ["--version"] of
+      Failure theFailure ->
+        let (version, _exitCode) = renderFailure theFailure "test"
+         in version
+              `shouldSatisfy` (=~ ("[0-9]+\\.[0-9]+\\.[0-9]+(:?-[a-zA-Z0-9]+)" :: String))
+      _ -> failure "expected a version but did get something else"
 
 defaultOptions :: Options
 defaultOptions =

--- a/nix/hydra/project.nix
+++ b/nix/hydra/project.nix
@@ -56,12 +56,18 @@ let
       }
       # Inject the git revision into hydra-node --version
       # (see hydra-node/src/Hydra/Options.hs)
-      {
-        packages.hydra-node.preBuild = ''
-          echo ======= PATCHING --version to ${gitRev} =======
-          export GIT_REVISION=${gitRev}
-        '';
-      }
+      (
+        let
+          patchGitRevision = ''
+            echo ======= PATCHING --version to ${gitRev} =======
+            export GIT_REVISION=${gitRev}
+          '';
+        in
+        {
+          packages.hydra-node.preBuild = patchGitRevision;
+          packages.hydra-tui.preBuild = patchGitRevision;
+        }
+      )
       # Avoid plutus-tx errors in haddock (see also cabal.project)
       {
         packages.hydra-plutus.setupHaddockFlags = [ "--ghc-options='-fplugin-opt PlutusTx.Plugin:defer-errors'" ];


### PR DESCRIPTION
The hydra-tui tool does not have a version option.

Before the PR:
```
$ ./hydra-tui --version
Invalid option `--version'

Usage: hydra-tui [-c|--connect ARG] [--node-socket FILE]
                 [--mainnet | --testnet-magic NATURAL]
                 [-k|--cardano-signing-key FILE]
```

After:
```
$ ./hydra-tui --version
0.10.0-c1baa8f03caeda60d5a432150b54921687783392
```

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
