### PR TITLE
Build haddocks using nix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,7 +165,7 @@ jobs:
         junit_files: ./**/test-results.xml
 
   haddock:
-    name: "Haddock"
+    name: "Build haddock using nix"
     runs-on: ubuntu-latest
     steps:
     - name: 📥 Checkout repository
@@ -203,9 +203,11 @@ jobs:
 
     - name: 📚 Documentation (Haddock)
       run: |
-        nix develop .#ci --command bash -c '.github/workflows/ci-haddock.sh'
+        nix build .?submodules=1#haddocks
+        mkdir -p docs/static/haddock
+        cp -aL result/* docs/static/haddock/
 
-    - name: 💾 Upload build & test artifacts
+    - name: 💾 Upload haddock artifact
       uses: actions/upload-artifact@v3
       with:
         name: haddocks

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,18 +55,6 @@ jobs:
         name: cardano-scaling
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
-    - name: 🔁 Github cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cabal/packages
-          ~/.cabal/store
-          dist-newstyle
-        key: |
-          cabal-${{ runner.os }}-${{ hashFiles('cabal.project', 'default.nix', 'shell.nix') }}-${{ matrix.package }}
-        restore-keys: |
-          cabal-${{ runner.os }}-${{ hashFiles('cabal.project', 'default.nix', 'shell.nix') }}
-
     - name: ❓ Test
       if: ${{ matrix.package != 'hydra-tui' }}
       run: |
@@ -187,20 +175,6 @@ jobs:
         name: cardano-scaling
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
-    - name: 🔁 Github cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cabal/packages
-          ~/.cabal/store
-          dist-newstyle
-        key: |
-          cabal-${{ runner.os }}-${{ hashFiles('cabal.project', 'default.nix', 'shell.nix') }}
-
-    - name: 🧰 Prepare tools
-      run: |
-        nix develop .#ci --command bash -c 'cabal update'
-
     - name: 📚 Documentation (Haddock)
       run: |
         nix build .?submodules=1#haddocks
@@ -250,16 +224,6 @@ jobs:
       with:
         name: cardano-scaling
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
-
-    - name: 🔁 Github cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cabal/packages
-          ~/.cabal/store
-          dist-newstyle
-        key: |
-          cabal-${{ runner.os }}-${{ hashFiles('cabal.project', 'default.nix', 'shell.nix') }}
 
     - name: 📈 Benchmark
       run: |

--- a/flake.lock
+++ b/flake.lock
@@ -207,21 +207,6 @@
         "type": "github"
       }
     },
-    "blank_5": {
-      "locked": {
-        "lastModified": 1625557891,
-        "narHash": "sha256-O8/MWsPBGhhyPoPLHZAuoZiiHo9q6FLlEeIDEXuj6T4=",
-        "owner": "divnix",
-        "repo": "blank",
-        "rev": "5a5d2684073d9f563072ed07c871d577a6c614a8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "blank",
-        "type": "github"
-      }
-    },
     "cabal-32": {
       "flake": false,
       "locked": {
@@ -992,35 +977,6 @@
         "type": "github"
       }
     },
-    "devshell_5": {
-      "inputs": {
-        "flake-utils": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1663445644,
-        "narHash": "sha256-+xVlcK60x7VY1vRJbNUEAHi17ZuoQxAIH4S4iUFUGBA=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "e3dc3e21594fe07bdb24bdf1c8657acaa4cb8f66",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
     "dmerge": {
       "inputs": {
         "nixlib": [
@@ -1145,35 +1101,6 @@
         "type": "github"
       }
     },
-    "dmerge_5": {
-      "inputs": {
-        "nixlib": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ],
-        "yants": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "yants"
-        ]
-      },
-      "locked": {
-        "lastModified": 1659548052,
-        "narHash": "sha256-fzI2gp1skGA8mQo/FBFrUAtY0GQkAIAaV/V127TJPyY=",
-        "owner": "divnix",
-        "repo": "data-merge",
-        "rev": "d160d18ce7b1a45b88344aa3f13ed1163954b497",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "data-merge",
-        "type": "github"
-      }
-    },
     "em": {
       "flake": false,
       "locked": {
@@ -1218,22 +1145,6 @@
       "original": {
         "owner": "input-output-hk",
         "ref": "fixes",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_10": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -1503,36 +1414,6 @@
       "original": {
         "owner": "hamishmack",
         "ref": "hkm/nested-hydraJobs",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_18": {
-      "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_19": {
-      "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
         "repo": "flake-utils",
         "type": "github"
       }
@@ -1836,25 +1717,6 @@
         "type": "github"
       }
     },
-    "gomod2nix_5": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_23",
-        "utils": "utils_10"
-      },
-      "locked": {
-        "lastModified": 1655245309,
-        "narHash": "sha256-d/YPoQ/vFn1+GTmSdvbSBSTOai61FONxB4+Lt6w/IVI=",
-        "owner": "tweag",
-        "repo": "gomod2nix",
-        "rev": "40d32f82fc60d66402eb0972e6e368aeab3faf58",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tweag",
-        "repo": "gomod2nix",
-        "type": "github"
-      }
-    },
     "hackage": {
       "flake": false,
       "locked": {
@@ -1938,11 +1800,11 @@
     "hackage_4": {
       "flake": false,
       "locked": {
-        "lastModified": 1682036591,
-        "narHash": "sha256-QPrmInnsudgOP+bpJKzosItR0H1C5F54SmPLV8AlFPg=",
+        "lastModified": 1686788838,
+        "narHash": "sha256-1a68kNzL3DD9DiBTFounFMzofxH9Rw58IqFvSRnkaFA=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "9d83fdf40d77bc15719c6e498da98dbd0714dfa4",
+        "rev": "d59ae0a635f1ca8a6c65180e2445d798c2df5e95",
         "type": "github"
       },
       "original": {
@@ -2172,6 +2034,7 @@
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_6",
         "hackage": "hackage_4",
         "hls-1.10": "hls-1.10_2",
+        "hls-2.0": "hls-2.0",
         "hpc-coveralls": "hpc-coveralls_6",
         "hydra": "hydra_3",
         "iserv-proxy": "iserv-proxy_3",
@@ -2184,21 +2047,22 @@
         "nixpkgs-2111": "nixpkgs-2111_6",
         "nixpkgs-2205": "nixpkgs-2205_3",
         "nixpkgs-2211": "nixpkgs-2211_3",
+        "nixpkgs-2305": "nixpkgs-2305",
         "nixpkgs-unstable": "nixpkgs-unstable_6",
         "old-ghc-nix": "old-ghc-nix_6",
-        "stackage": "stackage_6",
-        "tullia": "tullia_5"
+        "stackage": "stackage_6"
       },
       "locked": {
-        "lastModified": 1682038252,
-        "narHash": "sha256-daWxBXHeSZZXVE4Xs4viwWWKSY6hVdtv9OS3fLGkFcQ=",
-        "owner": "input-output-hk",
+        "lastModified": 1686865728,
+        "narHash": "sha256-Zy51LDsOhkp+1S7oI7ho6YO8kaLv7gl2vbz4VtHNAsg=",
+        "owner": "ch1bo",
         "repo": "haskell.nix",
-        "rev": "124cd96d9576f29a5cbf78e1db463d98f5bba749",
+        "rev": "37efe37f24520f2c29ed9d16c5ab41991a20be42",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
+        "owner": "ch1bo",
+        "ref": "enable-haddock-tests",
         "repo": "haskell.nix",
         "type": "github"
       }
@@ -2233,6 +2097,23 @@
       "original": {
         "owner": "haskell",
         "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.0": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1684398654,
+        "narHash": "sha256-RW44up2BIyBBYN6tZur5f9kDDR3kr0Rd+TgPbLTfwB4=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "20c6d1e731cd9c0beef7338e2fc7a8126ba9b6fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.0.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -2501,32 +2382,9 @@
         "type": "github"
       }
     },
-    "incl_5": {
-      "inputs": {
-        "nixlib": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1669263024,
-        "narHash": "sha256-E/+23NKtxAqYG/0ydYgxlgarKnxmDbg6rCMWnOBqn9Q=",
-        "owner": "divnix",
-        "repo": "incl",
-        "rev": "ce7bebaee048e4cd7ebdb4cee7885e00c4e2abca",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "incl",
-        "type": "github"
-      }
-    },
     "iohk-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_26"
+        "nixpkgs": "nixpkgs_23"
       },
       "locked": {
         "lastModified": 1667394105,
@@ -2954,35 +2812,6 @@
         "type": "github"
       }
     },
-    "n2c_5": {
-      "inputs": {
-        "flake-utils": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1665039323,
-        "narHash": "sha256-SAh3ZjFGsaCI8FRzXQyp56qcGdAqgKEfJWPCQ0Sr7tQ=",
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "rev": "b008fe329ffb59b67bf9e7b08ede6ee792f2741a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "type": "github"
-      }
-    },
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
@@ -3156,41 +2985,6 @@
         "type": "github"
       }
     },
-    "nix-nomad_5": {
-      "inputs": {
-        "flake-compat": "flake-compat_10",
-        "flake-utils": [
-          "haskellNix",
-          "tullia",
-          "nix2container",
-          "flake-utils"
-        ],
-        "gomod2nix": "gomod2nix_5",
-        "nixpkgs": [
-          "haskellNix",
-          "tullia",
-          "nixpkgs"
-        ],
-        "nixpkgs-lib": [
-          "haskellNix",
-          "tullia",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1658277770,
-        "narHash": "sha256-T/PgG3wUn8Z2rnzfxf2VqlR1CBjInPE0l1yVzXxPnt0=",
-        "owner": "tristanpemble",
-        "repo": "nix-nomad",
-        "rev": "054adcbdd0a836ae1c20951b67ed549131fd2d70",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tristanpemble",
-        "repo": "nix-nomad",
-        "type": "github"
-      }
-    },
     "nix-tools": {
       "flake": false,
       "locked": {
@@ -3319,25 +3113,6 @@
       "inputs": {
         "flake-utils": "flake-utils_14",
         "nixpkgs": "nixpkgs_19"
-      },
-      "locked": {
-        "lastModified": 1658567952,
-        "narHash": "sha256-XZ4ETYAMU7XcpEeAFP3NOl9yDXNuZAen/aIJ84G+VgA=",
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "rev": "60bb43d405991c1378baf15a40b5811a53e32ffa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "type": "github"
-      }
-    },
-    "nix2container_6": {
-      "inputs": {
-        "flake-utils": "flake-utils_18",
-        "nixpkgs": "nixpkgs_24"
       },
       "locked": {
         "lastModified": 1658567952,
@@ -3544,41 +3319,6 @@
         ],
         "nixpkgs": [
           "cardano-node",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1661824785,
-        "narHash": "sha256-/PnwdWoO/JugJZHtDUioQp3uRiWeXHUdgvoyNbXesz8=",
-        "owner": "nix-community",
-        "repo": "nixago",
-        "rev": "8c1f9e5f1578d4b2ea989f618588d62a335083c3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixago",
-        "type": "github"
-      }
-    },
-    "nixago_5": {
-      "inputs": {
-        "flake-utils": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "flake-utils"
-        ],
-        "nixago-exts": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "blank"
-        ],
-        "nixpkgs": [
-          "haskellNix",
           "tullia",
           "std",
           "nixpkgs"
@@ -3934,11 +3674,11 @@
     },
     "nixpkgs-2205_3": {
       "locked": {
-        "lastModified": 1672580127,
-        "narHash": "sha256-3lW3xZslREhJogoOkjeZtlBtvFMyxHku7I/9IVehhT8=",
+        "lastModified": 1682600000,
+        "narHash": "sha256-ha4BehR1dh8EnXSoE1m/wyyYVvHI9txjW4w5/oxsW5Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0874168639713f547c05947c76124f78441ea46c",
+        "rev": "50fc86b75d2744e1ab3837ef74b53f103a9b55a0",
         "type": "github"
       },
       "original": {
@@ -3982,16 +3722,32 @@
     },
     "nixpkgs-2211_3": {
       "locked": {
-        "lastModified": 1675730325,
-        "narHash": "sha256-uNvD7fzO5hNlltNQUAFBPlcEjNG5Gkbhl/ROiX+GZU4=",
+        "lastModified": 1685314633,
+        "narHash": "sha256-8LXBPqTQXl5ofkjpJ18JcbmLJ/lWDoMxtUwiDYv0wro=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b7ce17b1ebf600a72178f6302c77b6382d09323f",
+        "rev": "c8a17ce7abc03c50cd072e9e6c9b389c5f61836b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-22.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2305": {
+      "locked": {
+        "lastModified": 1685338297,
+        "narHash": "sha256-+Aq4O0Jn1W1q927ZHc3Zn6RO7bwQGmb6O8xYoGy0KrM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6287b47dbfabbb8bfbb9b1b53d198ad58a774de4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -4126,11 +3882,11 @@
     },
     "nixpkgs-unstable_6": {
       "locked": {
-        "lastModified": 1675758091,
-        "narHash": "sha256-7gFSQbSVAFUHtGCNHPF7mPc5CcqDk9M2+inlVPZSneg=",
+        "lastModified": 1685347552,
+        "narHash": "sha256-9woSppRyUFo26yUffORTzttJ+apOt8MmCv6RxpPNTU4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "747927516efcb5e31ba03b7ff32f61f6d47e7d87",
+        "rev": "f2f1ec390714d303cf84ba086e34e45b450dd8c4",
         "type": "github"
       },
       "original": {
@@ -4358,53 +4114,6 @@
       }
     },
     "nixpkgs_23": {
-      "locked": {
-        "lastModified": 1653581809,
-        "narHash": "sha256-Uvka0V5MTGbeOfWte25+tfRL3moECDh1VwokWSZUdoY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "83658b28fe638a170a19b8933aa008b30640fbd1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_24": {
-      "locked": {
-        "lastModified": 1654807842,
-        "narHash": "sha256-ADymZpr6LuTEBXcy6RtFHcUZdjKTBRTMYwu19WOx17E=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "fc909087cc3386955f21b4665731dbdaceefb1d8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_25": {
-      "locked": {
-        "lastModified": 1665087388,
-        "narHash": "sha256-FZFPuW9NWHJteATOf79rZfwfRn5fE0wi9kRzvGfDHPA=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "95fda953f6db2e9496d2682c4fc7b82f959878f7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_26": {
       "locked": {
         "lastModified": 1670148586,
         "narHash": "sha256-EcDfOiTHs0UBAtyGc0wxJJdhcMjrJEgWXjJutxZGA3E=",
@@ -4667,21 +4376,6 @@
       }
     },
     "nosys_4": {
-      "locked": {
-        "lastModified": 1667881534,
-        "narHash": "sha256-FhwJ15uPLRsvaxtt/bNuqE/ykMpNAPF0upozFKhTtXM=",
-        "owner": "divnix",
-        "repo": "nosys",
-        "rev": "2d0d5207f6a230e9d0f660903f8db9807b54814f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "nosys",
-        "type": "github"
-      }
-    },
-    "nosys_5": {
       "locked": {
         "lastModified": 1667881534,
         "narHash": "sha256-FhwJ15uPLRsvaxtt/bNuqE/ykMpNAPF0upozFKhTtXM=",
@@ -5003,11 +4697,11 @@
     "stackage_6": {
       "flake": false,
       "locked": {
-        "lastModified": 1682035745,
-        "narHash": "sha256-sQqPKXGi5vpLGEF1hAdvr2YJNXzqRVBpyqeVGJrNsV8=",
+        "lastModified": 1686787811,
+        "narHash": "sha256-/FaBD6F4PQghlESTogzDtKEtozmiPS+VLuYwKnm7iYU=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "2863ba40a0be8ba0229cf99b0f309ada740d54af",
+        "rev": "6e1b365f280f69f321d9f564c849e1912a16f7ea",
         "type": "github"
       },
       "original": {
@@ -5208,51 +4902,6 @@
         "type": "github"
       }
     },
-    "std_5": {
-      "inputs": {
-        "arion": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "blank"
-        ],
-        "blank": "blank_5",
-        "devshell": "devshell_5",
-        "dmerge": "dmerge_5",
-        "flake-utils": "flake-utils_19",
-        "incl": "incl_5",
-        "makes": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "blank"
-        ],
-        "microvm": [
-          "haskellNix",
-          "tullia",
-          "std",
-          "blank"
-        ],
-        "n2c": "n2c_5",
-        "nixago": "nixago_5",
-        "nixpkgs": "nixpkgs_25",
-        "nosys": "nosys_5",
-        "yants": "yants_5"
-      },
-      "locked": {
-        "lastModified": 1674526466,
-        "narHash": "sha256-tMTaS0bqLx6VJ+K+ZT6xqsXNpzvSXJTmogkraBGzymg=",
-        "owner": "divnix",
-        "repo": "std",
-        "rev": "516387e3d8d059b50e742a2ff1909ed3c8f82826",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "std",
-        "type": "github"
-      }
-    },
     "tullia": {
       "inputs": {
         "nix-nomad": "nix-nomad",
@@ -5346,46 +4995,7 @@
         "type": "github"
       }
     },
-    "tullia_5": {
-      "inputs": {
-        "nix-nomad": "nix-nomad_5",
-        "nix2container": "nix2container_6",
-        "nixpkgs": [
-          "haskellNix",
-          "nixpkgs"
-        ],
-        "std": "std_5"
-      },
-      "locked": {
-        "lastModified": 1675695930,
-        "narHash": "sha256-B7rEZ/DBUMlK1AcJ9ajnAPPxqXY6zW2SBX+51bZV0Ac=",
-        "owner": "input-output-hk",
-        "repo": "tullia",
-        "rev": "621365f2c725608f381b3ad5b57afef389fd4c31",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "tullia",
-        "type": "github"
-      }
-    },
     "utils": {
-      "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "utils_10": {
       "locked": {
         "lastModified": 1653893745,
         "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
@@ -5597,29 +5207,6 @@
       "inputs": {
         "nixpkgs": [
           "cardano-node",
-          "tullia",
-          "std",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1667096281,
-        "narHash": "sha256-wRRec6ze0gJHmGn6m57/zhz/Kdvp9HS4Nl5fkQ+uIuA=",
-        "owner": "divnix",
-        "repo": "yants",
-        "rev": "d18f356ec25cb94dc9c275870c3a7927a10f8c3c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "yants",
-        "type": "github"
-      }
-    },
-    "yants_5": {
-      "inputs": {
-        "nixpkgs": [
-          "haskellNix",
           "tullia",
           "std",
           "nixpkgs"

--- a/flake.lock
+++ b/flake.lock
@@ -1800,11 +1800,11 @@
     "hackage_4": {
       "flake": false,
       "locked": {
-        "lastModified": 1686788838,
-        "narHash": "sha256-1a68kNzL3DD9DiBTFounFMzofxH9Rw58IqFvSRnkaFA=",
+        "lastModified": 1686875209,
+        "narHash": "sha256-bl2kSUL+V4ysHP9X3MApmKv6c6zU/zAMzYHgQtemCOs=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "d59ae0a635f1ca8a6c65180e2445d798c2df5e95",
+        "rev": "025888c21479e2aa389fd17e252ba00a23a42679",
         "type": "github"
       },
       "original": {
@@ -2053,16 +2053,15 @@
         "stackage": "stackage_6"
       },
       "locked": {
-        "lastModified": 1686865728,
-        "narHash": "sha256-Zy51LDsOhkp+1S7oI7ho6YO8kaLv7gl2vbz4VtHNAsg=",
-        "owner": "ch1bo",
+        "lastModified": 1686902017,
+        "narHash": "sha256-AaQtG0b/jDiNazKJ11sLRPtO5bYtGMqPgx4EYnxUUOQ=",
+        "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "37efe37f24520f2c29ed9d16c5ab41991a20be42",
+        "rev": "2942f931e678e4cb2a6e9219a331530383ca620f",
         "type": "github"
       },
       "original": {
-        "owner": "ch1bo",
-        "ref": "enable-haddock-tests",
+        "owner": "input-output-hk",
         "repo": "haskell.nix",
         "type": "github"
       }
@@ -4697,11 +4696,11 @@
     "stackage_6": {
       "flake": false,
       "locked": {
-        "lastModified": 1686787811,
-        "narHash": "sha256-/FaBD6F4PQghlESTogzDtKEtozmiPS+VLuYwKnm7iYU=",
+        "lastModified": 1686874209,
+        "narHash": "sha256-Xet74XT3UxPTfcFYm//omKe8QXmSHskrUidMPgtwiwI=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "6e1b365f280f69f321d9f564c849e1912a16f7ea",
+        "rev": "29d09d9df6420159d9319a0d8e34b32285c5723b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -41,32 +41,6 @@
         prefixAttrs = s: attrs:
           with pkgs.lib.attrsets;
           mapAttrs' (name: value: nameValuePair (s + name) value) attrs;
-        haddocks = pkgs.runCommand "hydra-haddocks"
-          {
-            paths = [
-              hydraProject.hsPkgs.plutus-cbor.components.library.doc
-              hydraProject.hsPkgs.plutus-merkle-tree.components.library.doc
-              hydraProject.hsPkgs.hydra-prelude.components.library.doc
-              hydraProject.hsPkgs.hydra-cardano-api.components.library.doc
-              hydraProject.hsPkgs.hydra-plutus.components.library.doc
-              hydraProject.hsPkgs.hydra-node.components.library.doc
-              hydraProject.hsPkgs.hydra-node.components.tests.tests.doc
-              hydraProject.hsPkgs.hydra-cluster.components.library.doc
-              hydraProject.hsPkgs.hydra-tui.components.library.doc
-            ];
-          }
-          ''
-            set -ex
-            mkdir -p $out
-            for p in $paths; do
-              cd $p
-              for html in $(find $haddockRoot -name html -type d); do
-                package=$(basename $(dirname $html))
-                mkdir -p $out/$package
-                cp -a $html/* $out/$package/
-              done
-            done
-          '';
       in
       rec {
         inherit hydraProject;
@@ -75,8 +49,6 @@
           hydraPackages //
           prefixAttrs "docker-" hydraImages // {
             spec = import ./spec { inherit pkgs; };
-          } // {
-            inherit haddocks;
           };
 
         devShells = (import ./nix/hydra/shell.nix {

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,32 @@
         prefixAttrs = s: attrs:
           with pkgs.lib.attrsets;
           mapAttrs' (name: value: nameValuePair (s + name) value) attrs;
+        haddocks = pkgs.runCommand "hydra-haddocks"
+          {
+            paths = [
+              hydraProject.hsPkgs.plutus-cbor.components.library.doc
+              hydraProject.hsPkgs.plutus-merkle-tree.components.library.doc
+              hydraProject.hsPkgs.hydra-prelude.components.library.doc
+              hydraProject.hsPkgs.hydra-cardano-api.components.library.doc
+              # TODO: hydraProject.hsPkgs.hydra-plutus.components.library.doc
+              # TODO: haddocks for tests
+              hydraProject.hsPkgs.hydra-node.components.library.doc
+              hydraProject.hsPkgs.hydra-cluster.components.library.doc
+              hydraProject.hsPkgs.hydra-tui.components.library.doc
+            ];
+          }
+          ''
+            set -ex
+            mkdir -p $out
+            for p in $paths; do
+              cd $p
+              for html in $(find $haddockRoot -name html -type d); do
+                package=$(basename $(dirname $html))
+                mkdir -p $out/$package
+                cp -a $html/* $out/$package/
+              done
+            done
+          '';
       in
       rec {
         inherit hydraProject;
@@ -52,6 +78,8 @@
           hydraPackages //
           prefixAttrs "docker-" hydraImages // {
             spec = import ./spec { inherit pkgs; };
+          } // {
+            inherit haddocks;
           };
 
         devShells = (import ./nix/hydra/shell.nix {

--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
               hydraProject.hsPkgs.plutus-merkle-tree.components.library.doc
               hydraProject.hsPkgs.hydra-prelude.components.library.doc
               hydraProject.hsPkgs.hydra-cardano-api.components.library.doc
-              # TODO: hydraProject.hsPkgs.hydra-plutus.components.library.doc
+              hydraProject.hsPkgs.hydra-plutus.components.library.doc
               # TODO: haddocks for tests
               hydraProject.hsPkgs.hydra-node.components.library.doc
               hydraProject.hsPkgs.hydra-cluster.components.library.doc

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     nixpkgs.follows = "haskellNix/nixpkgs";
-    haskellNix.url = "github:input-output-hk/haskell.nix";
+    haskellNix.url = "github:ch1bo/haskell.nix?ref=enable-haddock-tests";
     iohk-nix.url = "github:input-output-hk/iohk-nix";
     flake-utils.url = "github:numtide/flake-utils";
     CHaP = {
@@ -30,10 +30,7 @@
         hydraProject = import ./nix/hydra/project.nix {
           inherit (inputs) haskellNix iohk-nix CHaP;
           inherit system nixpkgs;
-          gitRev =
-            if (builtins.hasAttr "rev" self)
-            then self.rev
-            else "dirty";
+          gitRev = self.rev or "dirty";
         };
         hydraPackages = import ./nix/hydra/packages.nix {
           inherit hydraProject system pkgs cardano-node;
@@ -52,8 +49,8 @@
               hydraProject.hsPkgs.hydra-prelude.components.library.doc
               hydraProject.hsPkgs.hydra-cardano-api.components.library.doc
               hydraProject.hsPkgs.hydra-plutus.components.library.doc
-              # TODO: haddocks for tests
               hydraProject.hsPkgs.hydra-node.components.library.doc
+              hydraProject.hsPkgs.hydra-node.components.tests.tests.doc
               hydraProject.hsPkgs.hydra-cluster.components.library.doc
               hydraProject.hsPkgs.hydra-tui.components.library.doc
             ];

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     nixpkgs.follows = "haskellNix/nixpkgs";
-    haskellNix.url = "github:ch1bo/haskell.nix?ref=enable-haddock-tests";
+    haskellNix.url = "github:input-output-hk/haskell.nix";
     iohk-nix.url = "github:input-output-hk/iohk-nix";
     flake-utils.url = "github:numtide/flake-utils";
     CHaP = {

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -20,6 +20,7 @@ rec {
   hydra-tui-static = musl64Pkgs.hydra-tui.components.exes.hydra-tui;
   hydraw = nativePkgs.hydraw.components.exes.hydraw;
   hydraw-static = musl64Pkgs.hydraw.components.exes.hydraw;
+
   tests = {
     plutus-cbor = pkgs.mkShellNoCC {
       name = "plutus-cbor-tests";
@@ -56,12 +57,14 @@ rec {
         ];
     };
   };
+
   benchs = {
     hydra-node = pkgs.mkShellNoCC {
       name = "bench-hydra-node";
-      buildInputs = [ nativePkgs.hydra-node.components.benchmarks.tx-cost
-                      nativePkgs.hydra-node.components.benchmarks.micro
-                    ];
+      buildInputs = [
+        nativePkgs.hydra-node.components.benchmarks.tx-cost
+        nativePkgs.hydra-node.components.benchmarks.micro
+      ];
     };
     hydra-cluster = pkgs.mkShellNoCC {
       name = "bench-hydra-cluster";
@@ -77,4 +80,31 @@ rec {
       buildInputs = [ nativePkgs.plutus-merkle-tree.components.benchmarks.on-chain-cost ];
     };
   };
+
+  haddocks = pkgs.runCommand "hydra-haddocks"
+    {
+      paths = [
+        hydraProject.hsPkgs.plutus-cbor.components.library.doc
+        hydraProject.hsPkgs.plutus-merkle-tree.components.library.doc
+        hydraProject.hsPkgs.hydra-prelude.components.library.doc
+        hydraProject.hsPkgs.hydra-cardano-api.components.library.doc
+        hydraProject.hsPkgs.hydra-plutus.components.library.doc
+        hydraProject.hsPkgs.hydra-node.components.library.doc
+        hydraProject.hsPkgs.hydra-node.components.tests.tests.doc
+        hydraProject.hsPkgs.hydra-cluster.components.library.doc
+        hydraProject.hsPkgs.hydra-tui.components.library.doc
+      ];
+    }
+    ''
+      set -ex
+      mkdir -p $out
+      for p in $paths; do
+        cd $p
+        for html in $(find $haddockRoot -name html -type d); do
+          package=$(basename $(dirname $html))
+          mkdir -p $out/$package
+          cp -a $html/* $out/$package/
+        done
+      done
+    '';
 }

--- a/nix/hydra/project.nix
+++ b/nix/hydra/project.nix
@@ -54,11 +54,19 @@ let
         packages.hydra-tui.dontStrip = false;
         packages.hydraw.dontStrip = false;
       }
+      # Inject the git revision into hydra-node --version
+      # (see hydra-node/src/Hydra/Options.hs)
       {
         packages.hydra-node.preBuild = ''
           echo ======= PATCHING --version to ${gitRev} =======
           export GIT_REVISION=${gitRev}
         '';
+      }
+      # Avoid plutus-tx errors in haddock (see also cabal.project)
+      {
+        packages.hydra-plutus.setupHaddockFlags = [ "--ghc-options='-fplugin-opt PlutusTx.Plugin:defer-errors'" ];
+        packages.plutus-merkle-tree.setupHaddockFlags = [ "--ghc-options='-fplugin-opt PlutusTx.Plugin:defer-errors'" ];
+        packages.plutus-cbor.setupHaddockFlags = [ "--ghc-options='-fplugin-opt PlutusTx.Plugin:defer-errors'" ];
       }
       # Set libsodium-vrf on cardano-crypto-{praos,class}. Otherwise they depend
       # on libsodium, which lacks the vrf functionality.


### PR DESCRIPTION
This removes the last bit of `cabal-install` from the CI workflow.

Unfortunately, I had to fix/improve `haskell.nix` to provide a `.doc` derivation to get the haddocks for a test suite (we do want to link to `hydra-node` tests). https://github.com/input-output-hk/haskell.nix/pull/1982

This results in rebuilds of a few packages!

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
