### PR TITLE
FIX end-to-end-benchmark not published for experimental CI

### DIFF
--- a/.github/workflows/ci-cabal.yaml
+++ b/.github/workflows/ci-cabal.yaml
@@ -141,7 +141,7 @@ jobs:
             options: '-o $(pwd)/docs/static/ledger-bench.html'
           - package: hydra-cluster
             bench: bench-e2e
-            options: '--scaling-factor 1'
+            options: '--scaling-factor 1 --output-directory $(pwd)/docs/benchmarks'
           - package: plutus-merkle-tree
             bench: on-chain-cost
             options: '--output-directory $(pwd)/docs/benchmarks'


### PR DESCRIPTION
end-to-end-benchmark were not published for experimental CI

See [this run](https://github.com/input-output-hk/hydra/actions/runs/5387207302/jobs/9778769831?pr=948)

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
