### PR TITLE
Make the tui commit externally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ following procedure to upgrade all the nodes running a head:
 Only when this procedure has been applied to all Hydra nodes can you open a new
 head again.
 
-- **BREAKING** Hydra TUI now uses `--cardanoSigningKey` flag to specify a user
+- **BREAKING** Hydra TUI now uses `--cardano-signing-key` flag to specify a user
   key used to select UTxO and submit a commit transaction.
 
 - Fuel removal:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,10 @@ following procedure to upgrade all the nodes running a head:
 Only when this procedure has been applied to all Hydra nodes can you open a new
 head again.
 
-- Fuel removal: 
+- **BREAKING** Hydra TUI now uses `--cardanoSigningKey` flag to specify a user
+  key used to select UTxO and submit a commit transaction.
+
+- Fuel removal:
   + We no longer require marking of some utxo as `Fuel`.
   + Internal hydra transactions are paid either by using the largest internal
   wallet utxo or existing fuel marked utxo (deprecated).

--- a/hydra-cluster/src/Hydra/Cluster/Util.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Util.hs
@@ -12,15 +12,16 @@ import Hydra.Cardano.Api (
   PaymentKey,
   SigningKey,
   TextEnvelopeError (TextEnvelopeAesonDecodeError),
-  deserialiseFromTextEnvelope, textEnvelopeToJSON,
+  deserialiseFromTextEnvelope,
+  textEnvelopeToJSON,
  )
 import Hydra.Cluster.Fixture (Actor, actorName)
 import Hydra.ContestationPeriod (ContestationPeriod)
+import Hydra.Ledger.Cardano (genSigningKey)
 import Hydra.Options (ChainConfig (..), defaultChainConfig)
 import qualified Paths_hydra_cluster as Pkg
 import System.FilePath ((<.>), (</>))
 import Test.Hydra.Prelude (failure)
-import Hydra.Ledger.Cardano (genKeyPair)
 import Test.QuickCheck (generate)
 
 -- | Lookup a config file similar reading a file from disk.
@@ -49,12 +50,12 @@ keysFor actor = do
   asSigningKey :: AsType (SigningKey PaymentKey)
   asSigningKey = AsSigningKey AsPaymentKey
 
--- | Create and save new secret key at provided path
--- NOTE: Uses 'TextEnvelope' format
-createAndSaveSecretKey :: FilePath -> IO (SigningKey PaymentKey)
-createAndSaveSecretKey path = do
-  (_vk, sk) <- generate genKeyPair
-  writeFileBS path $ toStrict (textEnvelopeToJSON (Just "Key used to commit funds into a Head") sk)
+-- | Create and save new signing key at the provided path.
+-- NOTE: Uses 'TextEnvelope' format.
+createAndSaveSigningKey :: FilePath -> IO (SigningKey PaymentKey)
+createAndSaveSigningKey path = do
+  sk <- generate genSigningKey
+  writeFileLBS path $ textEnvelopeToJSON (Just "Key used to commit funds into a Head") sk
   pure sk
 
 chainConfigFor :: HasCallStack => Actor -> FilePath -> FilePath -> [Actor] -> ContestationPeriod -> IO ChainConfig

--- a/hydra-cluster/src/Hydra/Cluster/Util.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Util.hs
@@ -12,7 +12,7 @@ import Hydra.Cardano.Api (
   PaymentKey,
   SigningKey,
   TextEnvelopeError (TextEnvelopeAesonDecodeError),
-  deserialiseFromTextEnvelope,
+  deserialiseFromTextEnvelope, textEnvelopeToJSON,
  )
 import Hydra.Cluster.Fixture (Actor, actorName)
 import Hydra.ContestationPeriod (ContestationPeriod)
@@ -20,6 +20,8 @@ import Hydra.Options (ChainConfig (..), defaultChainConfig)
 import qualified Paths_hydra_cluster as Pkg
 import System.FilePath ((<.>), (</>))
 import Test.Hydra.Prelude (failure)
+import Hydra.Ledger.Cardano (genKeyPair)
+import Test.QuickCheck (generate)
 
 -- | Lookup a config file similar reading a file from disk.
 -- If the env variable `HYDRA_CONFIG_DIR` is set, filenames will be
@@ -46,6 +48,14 @@ keysFor actor = do
  where
   asSigningKey :: AsType (SigningKey PaymentKey)
   asSigningKey = AsSigningKey AsPaymentKey
+
+-- | Create and save new secret key at provided path
+-- NOTE: Uses 'TextEnvelope' format
+createAndSaveSecretKey :: FilePath -> IO (SigningKey PaymentKey)
+createAndSaveSecretKey path = do
+  (_vk, sk) <- generate genKeyPair
+  writeFileBS path $ toStrict (textEnvelopeToJSON (Just "Key used to commit funds into a Head") sk)
+  pure sk
 
 chainConfigFor :: HasCallStack => Actor -> FilePath -> FilePath -> [Actor] -> ContestationPeriod -> IO ChainConfig
 chainConfigFor me targetDir nodeSocket them cp = do

--- a/hydra-tui/hydra-tui.cabal
+++ b/hydra-tui/hydra-tui.cabal
@@ -96,6 +96,7 @@ library
     , microlens-th
     , optparse-applicative
     , QuickCheck
+    , req
     , text
     , th-env
     , time
@@ -128,6 +129,7 @@ test-suite tests
     , base
     , blaze-builder
     , bytestring
+    , filepath
     , hspec
     , hydra-cardano-api
     , hydra-cluster

--- a/hydra-tui/src/Hydra/Client.hs
+++ b/hydra-tui/src/Hydra/Client.hs
@@ -4,20 +4,26 @@ module Hydra.Client where
 
 import Hydra.Prelude
 
+import qualified Cardano.Api.UTxO as UTxO
 import Control.Concurrent.Async (link)
 import Control.Concurrent.Class.MonadSTM (newTBQueueIO, readTBQueue, writeTBQueue)
 import Control.Exception (Handler (Handler), IOException, catches)
 import Data.Aeson (eitherDecodeStrict, encode)
 import Hydra.API.ClientInput (ClientInput)
+import Hydra.API.RestServer (DraftCommitTxRequest (DraftCommitTxRequest), DraftCommitTxResponse (..), TxOutWithWitness (TxOutWithWitness))
 import Hydra.API.ServerOutput (TimedServerOutput)
 import Hydra.Cardano.Api (
   AsType (AsPaymentKey, AsSigningKey),
   PaymentKey,
   SigningKey,
+  signTx,
  )
+import Hydra.Chain.CardanoClient (submitTransaction)
 import Hydra.Chain.Direct.Util (readFileTextEnvelopeThrow)
 import Hydra.Network (Host (Host, hostname, port))
 import Hydra.TUI.Options (Options (..))
+import Network.HTTP.Req (defaultHttpConfig, responseBody, runReq)
+import qualified Network.HTTP.Req as Req
 import Network.WebSockets (ConnectionException, receiveData, runClient, sendBinaryData)
 
 data HydraEvent tx
@@ -35,6 +41,7 @@ data Client tx m = Client
   { sendInput :: ClientInput tx -> m ()
   -- ^ Send some input to the server.
   , sk :: SigningKey PaymentKey
+  , externalCommit :: UTxO.UTxO -> m ()
   }
 
 -- | Callback for receiving server outputs.
@@ -48,8 +55,8 @@ withClient ::
   (ToJSON (ClientInput tx), FromJSON (TimedServerOutput tx)) =>
   Options ->
   ClientComponent tx IO a
-withClient Options{hydraNodeHost = Host{hostname, port}, cardanoSigningKey} callback action = do
-  sk <- readFileTextEnvelopeThrow (AsSigningKey AsPaymentKey) cardanoSigningKey
+withClient Options{hydraNodeHost = Host{hostname, port}, cardanoSigningKey, cardanoNetworkId, cardanoNodeSocket} callback action = do
+  sk <- readExternalSk
   q <- newTBQueueIO 10
   withAsync (reconnect $ client q) $ \thread -> do
     -- NOTE(SN): if message formats are not compatible, this will terminate the TUI
@@ -59,8 +66,10 @@ withClient Options{hydraNodeHost = Host{hostname, port}, cardanoSigningKey} call
       Client
         { sendInput = atomically . writeTBQueue q
         , sk
+        , externalCommit
         }
  where
+  readExternalSk = readFileTextEnvelopeThrow (AsSigningKey AsPaymentKey) cardanoSigningKey
   -- TODO(SN): ping thread?
   client q = runClient (toString hostname) (fromIntegral port) "/" $ \con -> do
     -- REVIEW(SN): is sharing the 'con' fine?
@@ -85,6 +94,21 @@ withClient Options{hydraNodeHost = Host{hostname, port}, cardanoSigningKey} call
 
   handleDisconnect f =
     callback ClientDisconnected >> threadDelay 1 >> reconnect f
+
+  externalCommit payload =
+    runReq defaultHttpConfig request
+      <&> responseBody
+      >>= \DraftCommitTxResponse{commitTx} -> do
+        sk <- readExternalSk
+        submitTransaction cardanoNetworkId cardanoNodeSocket $ signTx sk commitTx
+   where
+    request =
+      Req.req
+        Req.POST
+        (Req.http hostname Req./: "commit")
+        (Req.ReqBodyLbs . encode . DraftCommitTxRequest $ (`TxOutWithWitness` Nothing) <$> payload)
+        Req.jsonResponse
+        (Req.port $ fromIntegral port)
 
 data ClientError = ClientJSONDecodeError String ByteString
   deriving (Eq, Show, Generic)

--- a/hydra-tui/src/Hydra/TUI/Options.hs
+++ b/hydra-tui/src/Hydra/TUI/Options.hs
@@ -84,7 +84,7 @@ parseCardanoSigningKey =
     ( long "cardano-signing-key"
         <> short 'k'
         <> metavar "FILE"
-        <> help "The path to the signing key file used for selecting, committing  UTxO and signing off-chain transactions. This file used the same 'Envelope' format than cardano-cli."
+        <> help "The path to the user signing key file used for selecting UTxO and signing a commit transaction. This file uses the same 'TextEnvelope' format as cardano-cli."
         <> value "me.sk"
         <> showDefault
     )

--- a/hydra-tui/src/Hydra/TUI/Options.hs
+++ b/hydra-tui/src/Hydra/TUI/Options.hs
@@ -30,6 +30,7 @@ data Options = Options
   , cardanoNodeSocket :: FilePath
   , cardanoNetworkId :: NetworkId
   , cardanoSigningKey :: FilePath
+  -- ^ User key used by the tui client to commit
   }
   deriving stock (Eq, Show)
 


### PR DESCRIPTION
## Why

We want to be able to commit from the TUI client using _external_ key, one different to the internal wallet key.

## What

Re-use `--cardanoSigningKey` flag to introduce this external key but make sure to spin the hydra node using a different key so that there are two keys at play. This is because we can't commit to a head UTxO belonging to the internal wallet key but also want to use the TUI to choose a UTxO, sign and submit a commit transaction instead of doing it manually.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
