### PR TITLE
Refactor HeadlogicSpec state handling

### DIFF
--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -472,16 +472,6 @@ hasNoEffectSatisfying (NewState _ effects) predicate
   | any predicate effects = failure $ "Found unwanted effect in: " <> show effects
 hasNoEffectSatisfying _ _ = pure ()
 
-isReqSn :: Effect tx -> Bool
-isReqSn = \case
-  NetworkEffect ReqSn{} -> True
-  _ -> False
-
-isAckSn :: Effect tx -> Bool
-isAckSn = \case
-  NetworkEffect AckSn{} -> True
-  _ -> False
-
 inInitialState :: [Party] -> HeadState SimpleTx
 inInitialState parties =
   Initial
@@ -576,27 +566,6 @@ assertOnlyEffects = \case
   OnlyEffects _ -> pure ()
   Error e -> failure $ "Unexpected 'Error' outcome: " <> show e
   Wait r -> failure $ "Unexpected 'Wait' outcome with reason: " <> show r
-
-applyEvent ::
-  (IsChainState tx) =>
-  (HeadState tx -> Event tx -> Outcome tx) ->
-  Event tx ->
-  StateT (HeadState tx) IO ()
-applyEvent action e = do
-  s <- get
-  s' <- lift $ assertNewState (action s e)
-  put s'
-
-assertStateUnchangedFrom ::
-  (IsChainState tx) =>
-  HeadState tx ->
-  Outcome tx ->
-  Expectation
-assertStateUnchangedFrom st = \case
-  NewState st' eff -> do
-    st' `shouldBe` st
-    eff `shouldBe` []
-  anything -> failure $ "unexpected outcome: " <> show anything
 
 testHeadId :: HeadId
 testHeadId = HeadId "1234"

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -94,73 +94,82 @@ spec =
         update bobEnv ledger s0 reqTx `shouldBe` Wait (WaitOnNotApplicableTx (ValidationError "cannot apply transaction"))
 
       it "confirms snapshot given it receives AckSn from all parties" $ do
-        let s0 = inOpenState threeParties ledger
-            reqSn = NetworkEvent defaultTTL $ ReqSn alice 1 []
+        let reqSn = NetworkEvent defaultTTL $ ReqSn alice 1 []
             snapshot1 = Snapshot 1 mempty []
             ackFrom sk vk = NetworkEvent defaultTTL $ AckSn vk (sign sk snapshot1) 1
-        s1 <- assertNewState $ update bobEnv ledger s0 reqSn
-        s2 <- assertNewState $ update bobEnv ledger s1 (ackFrom carolSk carol)
-        s3 <- assertNewState $ update bobEnv ledger s2 (ackFrom aliceSk alice)
+        snapshotInProgress <-
+          pure (inOpenState threeParties ledger)
+            >>= assertUpdateState bobEnv ledger reqSn
+            >>= assertUpdateState bobEnv ledger (ackFrom carolSk carol)
+            >>= assertUpdateState bobEnv ledger (ackFrom aliceSk alice)
 
-        getConfirmedSnapshot s3 `shouldBe` Just (Snapshot 0 mempty [])
+        getConfirmedSnapshot snapshotInProgress `shouldBe` Just (Snapshot 0 mempty [])
 
-        s4 <- assertNewState $ update bobEnv ledger s3 (ackFrom bobSk bob)
-        getConfirmedSnapshot s4 `shouldBe` Just snapshot1
+        snapshotConfirmed <- pure snapshotInProgress >>= assertUpdateState bobEnv ledger (ackFrom bobSk bob)
+        getConfirmedSnapshot snapshotConfirmed `shouldBe` Just snapshot1
 
       it "rejects last AckSn if one signature was from a different snapshot" $ do
-        let s0 = inOpenState threeParties ledger
-            reqSn = NetworkEvent defaultTTL $ ReqSn alice 1 []
+        let reqSn = NetworkEvent defaultTTL $ ReqSn alice 1 []
             snapshot = Snapshot 1 mempty []
             snapshot' = Snapshot 2 mempty []
             ackFrom sk vk = NetworkEvent defaultTTL $ AckSn vk (sign sk snapshot) 1
             invalidAckFrom sk vk = NetworkEvent defaultTTL $ AckSn vk (sign sk snapshot') 1
-        s1 <- assertNewState $ update bobEnv ledger s0 reqSn
-        s2 <- assertNewState $ update bobEnv ledger s1 (ackFrom carolSk carol)
-        s3 <- assertNewState $ update bobEnv ledger s2 (ackFrom aliceSk alice)
-        update bobEnv ledger s3 (invalidAckFrom bobSk bob)
+        waitingForLastAck <-
+          pure (inOpenState threeParties ledger)
+            >>= assertUpdateState bobEnv ledger reqSn
+            >>= assertUpdateState bobEnv ledger (ackFrom carolSk carol)
+            >>= assertUpdateState bobEnv ledger (ackFrom aliceSk alice)
+
+        update bobEnv ledger waitingForLastAck (invalidAckFrom bobSk bob)
           `shouldSatisfy` \case
-            Error (RequireFailed (InvalidMultisignature{vkeys})) -> vkeys == allVKeys
+            Error (RequireFailed InvalidMultisignature{vkeys}) -> vkeys == allVKeys
             _ -> False
 
       it "rejects last AckSn if one signature was from a different key" $ do
-        let s0 = inOpenState threeParties ledger
-            reqSn = NetworkEvent defaultTTL $ ReqSn alice 1 []
+        let reqSn = NetworkEvent defaultTTL $ ReqSn alice 1 []
             snapshot = Snapshot 1 mempty []
             ackFrom sk vk = NetworkEvent defaultTTL $ AckSn vk (sign sk snapshot) 1
-        s1 <- assertNewState $ update bobEnv ledger s0 reqSn
-        s2 <- assertNewState $ update bobEnv ledger s1 (ackFrom carolSk carol)
-        s3 <- assertNewState $ update bobEnv ledger s2 (ackFrom aliceSk alice)
-        update bobEnv ledger s3 (ackFrom (generateSigningKey "foo") bob)
+        waitingForLastAck <-
+          pure (inOpenState threeParties ledger)
+            >>= assertUpdateState bobEnv ledger reqSn
+            >>= assertUpdateState bobEnv ledger (ackFrom carolSk carol)
+            >>= assertUpdateState bobEnv ledger (ackFrom aliceSk alice)
+
+        update bobEnv ledger waitingForLastAck (ackFrom (generateSigningKey "foo") bob)
           `shouldSatisfy` \case
-            Error (RequireFailed (InvalidMultisignature{vkeys})) -> vkeys == allVKeys
+            Error (RequireFailed InvalidMultisignature{vkeys}) -> vkeys == allVKeys
             _ -> False
 
       it "rejects last AckSn if one signature was from a completely different message" $ do
-        let s0 = inOpenState threeParties ledger
-            reqSn = NetworkEvent defaultTTL $ ReqSn alice 1 []
+        let reqSn = NetworkEvent defaultTTL $ ReqSn alice 1 []
             snapshot1 = Snapshot 1 mempty []
             ackFrom sk vk = NetworkEvent defaultTTL $ AckSn vk (sign sk snapshot1) 1
             invalidAckFrom sk vk =
               NetworkEvent defaultTTL $
                 AckSn vk (coerce $ sign sk ("foo" :: ByteString)) 1
-        s1 <- assertNewState $ update bobEnv ledger s0 reqSn
-        s2 <- assertNewState $ update bobEnv ledger s1 (ackFrom carolSk carol)
-        s3 <- assertNewState $ update bobEnv ledger s2 (invalidAckFrom bobSk bob)
-        update bobEnv ledger s3 (ackFrom aliceSk alice)
+        waitingForLastAck <-
+          pure (inOpenState threeParties ledger)
+            >>= assertUpdateState bobEnv ledger reqSn
+            >>= assertUpdateState bobEnv ledger (ackFrom carolSk carol)
+            >>= assertUpdateState bobEnv ledger (invalidAckFrom bobSk bob)
+
+        update bobEnv ledger waitingForLastAck (ackFrom aliceSk alice)
           `shouldSatisfy` \case
-            Error (RequireFailed (InvalidMultisignature{vkeys})) -> vkeys == allVKeys
+            Error (RequireFailed InvalidMultisignature{vkeys}) -> vkeys == allVKeys
             _ -> False
 
       it "rejects last AckSn if already received signature from this party" $ do
-        let s0 = inOpenState threeParties ledger
-            reqSn = NetworkEvent defaultTTL $ ReqSn alice 1 []
+        let reqSn = NetworkEvent defaultTTL $ ReqSn alice 1 []
             snapshot1 = Snapshot 1 mempty []
             ackFrom sk vk = NetworkEvent defaultTTL $ AckSn vk (sign sk snapshot1) 1
-        s1 <- assertNewState $ update bobEnv ledger s0 reqSn
-        s2 <- assertNewState $ update bobEnv ledger s1 (ackFrom carolSk carol)
-        update bobEnv ledger s2 (ackFrom carolSk carol)
+        waitingForAck <-
+          pure (inOpenState threeParties ledger)
+            >>= assertUpdateState bobEnv ledger reqSn
+            >>= assertUpdateState bobEnv ledger (ackFrom carolSk carol)
+
+        update bobEnv ledger waitingForAck (ackFrom carolSk carol)
           `shouldSatisfy` \case
-            Error (RequireFailed (SnapshotAlreadySigned{receivedSignature})) -> receivedSignature == carol
+            Error (RequireFailed SnapshotAlreadySigned{receivedSignature}) -> receivedSignature == carol
             _ -> False
 
       it "waits if we receive a snapshot with not-yet-seen transactions" $ do
@@ -183,11 +192,13 @@ spec =
         update bobEnv ledger st event `shouldBe` Error (RequireFailed $ ReqSnNumberInvalid 2 0)
 
       it "waits if we receive a future snapshot while collecting signatures" $ do
-        let s0 = inOpenState threeParties ledger
-            reqSn1 = NetworkEvent defaultTTL $ ReqSn alice 1 []
+        let reqSn1 = NetworkEvent defaultTTL $ ReqSn alice 1 []
             reqSn2 = NetworkEvent defaultTTL $ ReqSn bob 2 []
-        s1 <- assertNewState $ update bobEnv ledger s0 reqSn1
-        update bobEnv ledger s1 reqSn2 `shouldBe` Wait (WaitOnSnapshotNumber 1)
+        st <-
+          pure (inOpenState threeParties ledger)
+            >>= assertUpdateState bobEnv ledger reqSn1
+
+        update bobEnv ledger st reqSn2 `shouldBe` Wait (WaitOnSnapshotNumber 1)
 
       it "acks signed snapshot from the constant leader" $ do
         let leader = alice
@@ -203,7 +214,7 @@ spec =
             notTheLeader = bob
             st = inOpenState threeParties ledger
         update bobEnv ledger st event `shouldSatisfy` \case
-          Error (RequireFailed (ReqSnNotLeader{requestedSn = 1, leader})) -> leader == notTheLeader
+          Error (RequireFailed ReqSnNotLeader{requestedSn = 1, leader}) -> leader == notTheLeader
           _ -> False
 
       it "rejects too-old snapshots" $ do
@@ -241,14 +252,15 @@ spec =
         update bobEnv ledger st event `shouldBe` Error (RequireFailed $ ReqSnNumberInvalid 3 0)
 
       it "rejects overlapping snapshot requests from the leader" $ do
-        let s0 = inOpenState threeParties ledger
-            theLeader = alice
+        let theLeader = alice
             nextSN = 1
             firstReqSn = NetworkEvent defaultTTL $ ReqSn theLeader nextSN [aValidTx 42]
             secondReqSn = NetworkEvent defaultTTL $ ReqSn theLeader nextSN [aValidTx 51]
+        receivedReqSn <-
+          pure (inOpenState threeParties ledger)
+            >>= assertUpdateState bobEnv ledger firstReqSn
 
-        s1 <- assertNewState $ update bobEnv ledger s0 firstReqSn
-        update bobEnv ledger s1 secondReqSn `shouldSatisfy` \case
+        update bobEnv ledger receivedReqSn secondReqSn `shouldSatisfy` \case
           Error RequireFailed{} -> True
           _ -> False
 
@@ -263,32 +275,39 @@ spec =
           `hasEffect` ClientEffect (PeerConnected nodeId)
 
       it "everyone does collect on last commit after collect com" $ do
-        let s0 = inInitialState threeParties
-            aliceCommit = OnCommitTx alice (utxoRef 1)
+        let aliceCommit = OnCommitTx alice (utxoRef 1)
             bobCommit = OnCommitTx bob (utxoRef 2)
             carolCommit = OnCommitTx carol (utxoRef 3)
-        s1 <- assertNewState $ update bobEnv ledger s0 (observeEventAtSlot 1 aliceCommit)
-        s2 <- assertNewState $ update bobEnv ledger s1 (observeEventAtSlot 2 bobCommit)
+        waitingForLastCommit <-
+          pure (inInitialState threeParties)
+            >>= assertUpdateState bobEnv ledger (observeEventAtSlot 1 aliceCommit)
+            >>= assertUpdateState bobEnv ledger (observeEventAtSlot 2 bobCommit)
+
         -- Bob is not the last party, but still does post a collect
-        update bobEnv ledger s2 (observeEventAtSlot 3 carolCommit) `hasEffectSatisfying` \case
-          OnChainEffect{postChainTx = CollectComTx{}} -> True
-          _ -> False
+        update bobEnv ledger waitingForLastCommit (observeEventAtSlot 3 carolCommit)
+          `hasEffectSatisfying` \case
+            OnChainEffect{postChainTx = CollectComTx{}} -> True
+            _ -> False
 
       it "cannot observe abort after collect com" $ do
-        let s0 = inInitialState threeParties
-        s1 <- assertNewState $ update bobEnv ledger s0 (observationEvent OnCollectComTx)
+        afterCollectCom <-
+          pure (inInitialState threeParties)
+            >>= assertUpdateState bobEnv ledger (observationEvent OnCollectComTx)
+
         let invalidEvent = observationEvent OnAbortTx
-        let s2 = update bobEnv ledger s1 invalidEvent
-        s2 `shouldBe` Error (InvalidEvent invalidEvent s1)
+        update bobEnv ledger afterCollectCom invalidEvent
+          `shouldBe` Error (InvalidEvent invalidEvent afterCollectCom)
 
       it "cannot observe collect com after abort" $ do
-        let s0 = inInitialState threeParties
-        s1 <- assertNewState $ update bobEnv ledger s0 (observationEvent OnAbortTx)
-        let invalidEvent = observationEvent OnCollectComTx
-        let s2 = update bobEnv ledger s1 invalidEvent
-        s2 `shouldBe` Error (InvalidEvent invalidEvent s1)
+        afterAbort <-
+          pure (inInitialState threeParties)
+            >>= assertUpdateState bobEnv ledger (observationEvent OnAbortTx)
 
-      it "notify user on head closing and when passing the contestation deadline" $ do
+        let invalidEvent = observationEvent OnCollectComTx
+        update bobEnv ledger afterAbort invalidEvent
+          `shouldBe` Error (InvalidEvent invalidEvent afterAbort)
+
+      it "notifies user on head closing and when passing the contestation deadline" $ do
         let s0 = inOpenState threeParties ledger
             snapshotNumber = 0
             contestationDeadline = arbitrary `generateWith` 42
@@ -370,8 +389,10 @@ spec =
             & \case
               Left _ -> Prelude.error "cannot generate expired tx"
               Right tx -> pure (utxo, tx)
-        let s0 =
-              Open
+        let ledger = cardanoLedger Fixture.defaultGlobals Fixture.defaultLedgerEnv
+        st <-
+          pure
+            ( Open
                 OpenState
                   { parameters = HeadParameters cperiod threeParties
                   , coordinatedHeadState =
@@ -385,10 +406,10 @@ spec =
                   , headId = testHeadId
                   , currentSlot = ChainSlot . fromIntegral . unSlotNo $ slotNo + 1
                   }
-        let ledger = cardanoLedger Fixture.defaultGlobals Fixture.defaultLedgerEnv
-        let event = NetworkEvent defaultTTL $ ReqSn alice 1 []
-        s1 <- assertNewState $ update bobEnv ledger s0 event
-        s1 `shouldSatisfy` \case
+            )
+            >>= assertUpdateState bobEnv ledger (NetworkEvent defaultTTL $ ReqSn alice 1 [])
+
+        st `shouldSatisfy` \case
           Open
             OpenState
               { coordinatedHeadState =
@@ -530,6 +551,11 @@ getConfirmedSnapshot = \case
     Just (getSnapshot confirmedSnapshot)
   _ ->
     Nothing
+
+-- | Asserts that the update function will update the state (return a NewState) for this Event
+assertUpdateState :: IsChainState tx => Environment -> Ledger tx -> Event tx -> HeadState tx -> IO (HeadState tx)
+assertUpdateState env ledger event st =
+  assertNewState $ update env ledger st event
 
 assertNewState ::
   (IsChainState tx) =>

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -543,12 +543,12 @@ getConfirmedSnapshot = \case
     Nothing
 
 -- | Asserts that the update function will update the state (return a NewState) for this Event
-assertUpdateState :: IsChainState tx => Environment -> Ledger tx -> Event tx -> HeadState tx -> IO (HeadState tx)
+assertUpdateState :: (HasCallStack, IsChainState tx) => Environment -> Ledger tx -> Event tx -> HeadState tx -> IO (HeadState tx)
 assertUpdateState env ledger event st =
   assertNewState $ update env ledger st event
 
 assertNewState ::
-  (IsChainState tx) =>
+  (HasCallStack, IsChainState tx) =>
   Outcome tx ->
   IO (HeadState tx)
 assertNewState = \case
@@ -558,7 +558,7 @@ assertNewState = \case
   Wait r -> failure $ "Unexpected 'Wait' outcome with reason: " <> show r
 
 assertOnlyEffects ::
-  (IsChainState tx) =>
+  (HasCallStack, IsChainState tx) =>
   Outcome tx ->
   IO ()
 assertOnlyEffects = \case

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-unused-do-bind #-}
 
 -- | Unit tests of the the protocol logic in 'HeadLogic'. These are very fine
 -- grained and specific to individual steps in the protocol. More high-level of
@@ -54,7 +55,7 @@ import qualified Hydra.Prelude as Prelude
 import Hydra.Snapshot (ConfirmedSnapshot (..), Snapshot (..), getSnapshot)
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
 import Test.Hydra.Fixture (alice, aliceSk, allVKeys, bob, bobSk, carol, carolSk, cperiod)
-import Test.QuickCheck (generate)
+import Test.QuickCheck.Monadic (monadicIO, pick, assert, run)
 
 spec :: Spec
 spec =
@@ -97,15 +98,14 @@ spec =
         let reqSn = NetworkEvent defaultTTL $ ReqSn alice 1 []
             snapshot1 = Snapshot 1 mempty []
             ackFrom sk vk = NetworkEvent defaultTTL $ AckSn vk (sign sk snapshot1) 1
-        snapshotInProgress <-
-          pure (inOpenState threeParties ledger)
-            >>= assertUpdateState bobEnv ledger reqSn
-            >>= assertUpdateState bobEnv ledger (ackFrom carolSk carol)
-            >>= assertUpdateState bobEnv ledger (ackFrom aliceSk alice)
+        snapshotInProgress <- runEvents (inOpenState threeParties ledger) $ do
+          assertUpdateState bobEnv ledger reqSn
+          assertUpdateState bobEnv ledger (ackFrom carolSk carol)
+          assertUpdateState bobEnv ledger (ackFrom aliceSk alice)
 
         getConfirmedSnapshot snapshotInProgress `shouldBe` Just (Snapshot 0 mempty [])
 
-        snapshotConfirmed <- pure snapshotInProgress >>= assertUpdateState bobEnv ledger (ackFrom bobSk bob)
+        snapshotConfirmed <- runEvents snapshotInProgress $ assertUpdateState bobEnv ledger (ackFrom bobSk bob)
         getConfirmedSnapshot snapshotConfirmed `shouldBe` Just snapshot1
 
       it "rejects last AckSn if one signature was from a different snapshot" $ do
@@ -115,10 +115,10 @@ spec =
             ackFrom sk vk = NetworkEvent defaultTTL $ AckSn vk (sign sk snapshot) 1
             invalidAckFrom sk vk = NetworkEvent defaultTTL $ AckSn vk (sign sk snapshot') 1
         waitingForLastAck <-
-          pure (inOpenState threeParties ledger)
-            >>= assertUpdateState bobEnv ledger reqSn
-            >>= assertUpdateState bobEnv ledger (ackFrom carolSk carol)
-            >>= assertUpdateState bobEnv ledger (ackFrom aliceSk alice)
+          runEvents (inOpenState threeParties ledger) $ do
+            assertUpdateState bobEnv ledger reqSn
+            assertUpdateState bobEnv ledger (ackFrom carolSk carol)
+            assertUpdateState bobEnv ledger (ackFrom aliceSk alice)
 
         update bobEnv ledger waitingForLastAck (invalidAckFrom bobSk bob)
           `shouldSatisfy` \case
@@ -130,10 +130,10 @@ spec =
             snapshot = Snapshot 1 mempty []
             ackFrom sk vk = NetworkEvent defaultTTL $ AckSn vk (sign sk snapshot) 1
         waitingForLastAck <-
-          pure (inOpenState threeParties ledger)
-            >>= assertUpdateState bobEnv ledger reqSn
-            >>= assertUpdateState bobEnv ledger (ackFrom carolSk carol)
-            >>= assertUpdateState bobEnv ledger (ackFrom aliceSk alice)
+          runEvents (inOpenState threeParties ledger) $ do
+            assertUpdateState bobEnv ledger reqSn
+            assertUpdateState bobEnv ledger (ackFrom carolSk carol)
+            assertUpdateState bobEnv ledger (ackFrom aliceSk alice)
 
         update bobEnv ledger waitingForLastAck (ackFrom (generateSigningKey "foo") bob)
           `shouldSatisfy` \case
@@ -148,10 +148,10 @@ spec =
               NetworkEvent defaultTTL $
                 AckSn vk (coerce $ sign sk ("foo" :: ByteString)) 1
         waitingForLastAck <-
-          pure (inOpenState threeParties ledger)
-            >>= assertUpdateState bobEnv ledger reqSn
-            >>= assertUpdateState bobEnv ledger (ackFrom carolSk carol)
-            >>= assertUpdateState bobEnv ledger (invalidAckFrom bobSk bob)
+          runEvents (inOpenState threeParties ledger) $ do
+            assertUpdateState bobEnv ledger reqSn
+            assertUpdateState bobEnv ledger (ackFrom carolSk carol)
+            assertUpdateState bobEnv ledger (invalidAckFrom bobSk bob)
 
         update bobEnv ledger waitingForLastAck (ackFrom aliceSk alice)
           `shouldSatisfy` \case
@@ -163,9 +163,9 @@ spec =
             snapshot1 = Snapshot 1 mempty []
             ackFrom sk vk = NetworkEvent defaultTTL $ AckSn vk (sign sk snapshot1) 1
         waitingForAck <-
-          pure (inOpenState threeParties ledger)
-            >>= assertUpdateState bobEnv ledger reqSn
-            >>= assertUpdateState bobEnv ledger (ackFrom carolSk carol)
+          runEvents (inOpenState threeParties ledger) $ do
+            assertUpdateState bobEnv ledger reqSn
+            assertUpdateState bobEnv ledger (ackFrom carolSk carol)
 
         update bobEnv ledger waitingForAck (ackFrom carolSk carol)
           `shouldSatisfy` \case
@@ -195,8 +195,8 @@ spec =
         let reqSn1 = NetworkEvent defaultTTL $ ReqSn alice 1 []
             reqSn2 = NetworkEvent defaultTTL $ ReqSn bob 2 []
         st <-
-          pure (inOpenState threeParties ledger)
-            >>= assertUpdateState bobEnv ledger reqSn1
+          runEvents (inOpenState threeParties ledger) $
+            assertUpdateState bobEnv ledger reqSn1
 
         update bobEnv ledger st reqSn2 `shouldBe` Wait (WaitOnSnapshotNumber 1)
 
@@ -257,8 +257,8 @@ spec =
             firstReqSn = NetworkEvent defaultTTL $ ReqSn theLeader nextSN [aValidTx 42]
             secondReqSn = NetworkEvent defaultTTL $ ReqSn theLeader nextSN [aValidTx 51]
         receivedReqSn <-
-          pure (inOpenState threeParties ledger)
-            >>= assertUpdateState bobEnv ledger firstReqSn
+          assertUpdateState bobEnv ledger firstReqSn
+            `evalStateT` inOpenState threeParties ledger
 
         update bobEnv ledger receivedReqSn secondReqSn `shouldSatisfy` \case
           Error RequireFailed{} -> True
@@ -279,9 +279,9 @@ spec =
             bobCommit = OnCommitTx bob (utxoRef 2)
             carolCommit = OnCommitTx carol (utxoRef 3)
         waitingForLastCommit <-
-          pure (inInitialState threeParties)
-            >>= assertUpdateState bobEnv ledger (observeEventAtSlot 1 aliceCommit)
-            >>= assertUpdateState bobEnv ledger (observeEventAtSlot 2 bobCommit)
+          runEvents (inInitialState threeParties) $ do
+            assertUpdateState bobEnv ledger (observeEventAtSlot 1 aliceCommit)
+            assertUpdateState bobEnv ledger (observeEventAtSlot 2 bobCommit)
 
         -- Bob is not the last party, but still does post a collect
         update bobEnv ledger waitingForLastCommit (observeEventAtSlot 3 carolCommit)
@@ -291,8 +291,8 @@ spec =
 
       it "cannot observe abort after collect com" $ do
         afterCollectCom <-
-          pure (inInitialState threeParties)
-            >>= assertUpdateState bobEnv ledger (observationEvent OnCollectComTx)
+          runEvents (inInitialState threeParties) $
+            assertUpdateState bobEnv ledger (observationEvent OnCollectComTx)
 
         let invalidEvent = observationEvent OnAbortTx
         update bobEnv ledger afterCollectCom invalidEvent
@@ -300,8 +300,8 @@ spec =
 
       it "cannot observe collect com after abort" $ do
         afterAbort <-
-          pure (inInitialState threeParties)
-            >>= assertUpdateState bobEnv ledger (observationEvent OnAbortTx)
+          runEvents (inInitialState threeParties) $
+            assertUpdateState bobEnv ledger (observationEvent OnAbortTx)
 
         let invalidEvent = observationEvent OnCollectComTx
         update bobEnv ledger afterAbort invalidEvent
@@ -376,8 +376,8 @@ spec =
           `shouldBe` Error (NotOurHead{ourHeadId = testHeadId, otherHeadId})
 
     describe "Coordinated Head Protocol using real Tx" $
-      prop "any tx with expiring upper validity range gets pruned" $ \slotNo -> do
-        (utxo, expiringTransaction) <- generate $ do
+      prop "any tx with expiring upper validity range gets pruned" $ \slotNo -> monadicIO $ do
+        (utxo, expiringTransaction) <- pick $ do
           (vk, sk) <- genKeyPair
           txOut <- genOutput vk
           utxo <- (,txOut) <$> genTxIn
@@ -390,32 +390,36 @@ spec =
               Left _ -> Prelude.error "cannot generate expired tx"
               Right tx -> pure (utxo, tx)
         let ledger = cardanoLedger Fixture.defaultGlobals Fixture.defaultLedgerEnv
-        st <-
-          pure
-            ( Open
-                OpenState
-                  { parameters = HeadParameters cperiod threeParties
-                  , coordinatedHeadState =
-                      CoordinatedHeadState
-                        { seenUTxO = UTxO.singleton utxo
-                        , seenTxs = [expiringTransaction]
-                        , confirmedSnapshot = InitialSnapshot $ UTxO.singleton utxo
-                        , seenSnapshot = NoSeenSnapshot
-                        }
-                  , chainState = Prelude.error "should not be used"
-                  , headId = testHeadId
-                  , currentSlot = ChainSlot . fromIntegral . unSlotNo $ slotNo + 1
-                  }
-            )
-            >>= assertUpdateState bobEnv ledger (NetworkEvent defaultTTL $ ReqSn alice 1 [])
+            st0 =
+              Open
+                  OpenState
+                    { parameters = HeadParameters cperiod threeParties
+                    , coordinatedHeadState =
+                        CoordinatedHeadState
+                          { seenUTxO = UTxO.singleton utxo
+                          , seenTxs = [expiringTransaction]
+                          , confirmedSnapshot = InitialSnapshot $ UTxO.singleton utxo
+                          , seenSnapshot = NoSeenSnapshot
+                          }
+                    , chainState = Prelude.error "should not be used"
+                    , headId = testHeadId
+                    , currentSlot = ChainSlot . fromIntegral . unSlotNo $ slotNo + 1
+                    }
 
-        st `shouldSatisfy` \case
+        st <-
+          run $ runEvents st0 $
+            assertUpdateState bobEnv ledger (NetworkEvent defaultTTL $ ReqSn alice 1 [])
+
+        assert $ case st of
           Open
             OpenState
               { coordinatedHeadState =
                 CoordinatedHeadState{seenTxs}
               } -> null seenTxs
           _ -> False
+
+runEvents :: Monad m => HeadState tx -> StateT (HeadState tx) m a -> m a
+runEvents = flip evalStateT
 
 --
 -- Assertion utilities
@@ -543,19 +547,22 @@ getConfirmedSnapshot = \case
     Nothing
 
 -- | Asserts that the update function will update the state (return a NewState) for this Event
-assertUpdateState :: (HasCallStack, IsChainState tx) => Environment -> Ledger tx -> Event tx -> HeadState tx -> IO (HeadState tx)
-assertUpdateState env ledger event st =
-  assertNewState $ update env ledger st event
+assertUpdateState :: (MonadState (HeadState tx) m, HasCallStack, IsChainState tx) => Environment -> Ledger tx -> Event tx -> m (HeadState tx)
+assertUpdateState env ledger event = do
+  st <- get
+  st' <- assertNewState $ update env ledger st event
+  put st'
+  pure st'
 
 assertNewState ::
-  (HasCallStack, IsChainState tx) =>
+  (HasCallStack, IsChainState tx, Applicative m) =>
   Outcome tx ->
-  IO (HeadState tx)
+  m (HeadState tx)
 assertNewState = \case
   NewState st _ -> pure st
-  OnlyEffects effects -> failure $ "Unexpected 'OnlyEffects' outcome: " <> show effects
-  Error e -> failure $ "Unexpected 'Error' outcome: " <> show e
-  Wait r -> failure $ "Unexpected 'Wait' outcome with reason: " <> show r
+  OnlyEffects effects -> Hydra.Prelude.error $ "Unexpected 'OnlyEffects' outcome: " <> show effects
+  Error e -> Hydra.Prelude.error $ "Unexpected 'Error' outcome: " <> show e
+  Wait r -> Hydra.Prelude.error $ "Unexpected 'Wait' outcome with reason: " <> show r
 
 assertOnlyEffects ::
   (HasCallStack, IsChainState tx) =>

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -116,11 +116,6 @@ spec = parallel $ do
       outputs <- getServerOutputs
       outputs `shouldContain` [PostTxOnChainFailed (InitTx $ HeadParameters cperiod [alice, bob, carol]) NoSeedInput]
 
-isReqSn :: Message tx -> Bool
-isReqSn = \case
-  ReqSn{} -> True
-  _ -> False
-
 eventsToOpenHead :: [Event SimpleTx]
 eventsToOpenHead =
   [ NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = NodeId "NodeId1"}}


### PR DESCRIPTION
There is quite some room to miss one step for another in the way
some tests are written in the HeadLogicSpec. We stumbled upon this
issue working on another PR.

Here we are very humble and just pipe the result of one step
application to another. This is very limited and only deals
with updates which return newState but fits with the actual
use case in the tests and can prevent some stupid mistakes.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
