### PR TITLE
Move website build to publish docs workflow

### DIFF
--- a/.github/workflows/ci-cabal.yaml
+++ b/.github/workflows/ci-cabal.yaml
@@ -277,46 +277,7 @@ jobs:
         path: docs/static/
 
     - name: 📚 Documentation sanity check
-      if: github.ref_name != 'master' && github.ref_name != 'release'
       working-directory: docs
       run: |
-        yarn && yarn build-dev
-
-
-    - name: 📚 Documentation
-      if: github.ref_name == 'master' || github.ref_name == 'release'
-      working-directory: docs
-      run: |
-        yarn && yarn build
-        rm -rf public
-        mkdir public
-        mv build/* public
-
-    - name: 💾 Upload docs artifact
-      if: github.ref_name == 'master' || github.ref_name == 'release'
-      uses: actions/upload-artifact@v3
-      with:
-        name: docs
-        path: docs/public
-
-    - name: 📚 Prepare /unstable Documentation
-      if: github.ref_name == 'master'
-      working-directory: docs
-      run: |
-        sed -i 's|head-protocol|head-protocol/unstable|' docusaurus.config.js
-
-    - name: 📚 /unstable Documentation
-      if: github.ref_name == 'master'
-      working-directory: docs
-      run: |
-        yarn && yarn build
-        rm -rf public
-        mkdir public
-        mv build/* public
-
-    - name: 💾 Upload /unstable docs artifact
-      if: github.ref_name == 'master'
-      uses: actions/upload-artifact@v3
-      with:
-        name: docs-unstable
-        path: docs/public
+        yarn
+        yarn build-dev

--- a/.github/workflows/ci-cabal.yaml
+++ b/.github/workflows/ci-cabal.yaml
@@ -135,16 +135,16 @@ jobs:
         include:
           - package: hydra-node
             bench: tx-cost
-            options: '--output-directory $(pwd)/docs/benchmarks'
+            options: '--output-directory $(pwd)/benchmarks'
           - package: hydra-node
             bench: micro
-            options: '-o $(pwd)/docs/static/ledger-bench.html'
+            options: '-o $(pwd)/benchmarks/ledger-bench.html'
           - package: hydra-cluster
             bench: bench-e2e
-            options: 'datasets datasets/3-nodes.json datasets/1-node.json --output-directory $(pwd)/docs/benchmarks --timeout 1000s'
+            options: 'datasets datasets/3-nodes.json datasets/1-node.json --output-directory $(pwd)/benchmarks --timeout 1000s'
           - package: plutus-merkle-tree
             bench: on-chain-cost
-            options: '--output-directory $(pwd)/docs/benchmarks'
+            options: '--output-directory $(pwd)/benchmarks'
     steps:
     - uses: actions/checkout@v3
 
@@ -153,13 +153,14 @@ jobs:
 
     - name: 📈 Benchmark
       run: |
+        mkdir -p benchmarks
         cabal bench ${{ matrix.bench }} --benchmark-options="${{ matrix.options }}"
 
     - name: 💾 Upload build & test artifacts
       uses: actions/upload-artifact@v3
       with:
         name: benchmarks
-        path: ./docs/benchmarks
+        path: benchmarks
 
   publish-benchmark-results:
     name: Publish benchmark results

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -32,14 +32,12 @@ jobs:
     - name: 📥 Checkout repository
       uses: actions/checkout@v3
       with:
-        repository: input-output-hk/hydra
-        token: ${{ secrets.MY_TOKEN || github.token }}
         # On pull_request events, we want to check out the latest commit of the
         # PR, which is different to github.ref (the default, which would point
         # to a "fake merge" commit). On push events, the default is fine as it
         # refers to the pushed commit.
         ref: ${{ github.event.pull_request.head.sha || github.ref }}
-        # Also ensure we have all history with all tags
+        # Also ensure we have all history with all commits
         fetch-depth: 0
 
     - name: ❄ Prepare nix
@@ -114,9 +112,6 @@ jobs:
     steps:
     - name: 📥 Checkout repository
       uses: actions/checkout@v3
-      with:
-        repository: input-output-hk/hydra
-        token: ${{ secrets.MY_TOKEN || github.token }}
 
     - name: ❄ Prepare nix
       uses: cachix/install-nix-action@v22
@@ -164,9 +159,6 @@ jobs:
     steps:
     - name: 📥 Checkout repository
       uses: actions/checkout@v3
-      with:
-        repository: input-output-hk/hydra
-        token: ${{ secrets.MY_TOKEN || github.token }}
 
     - name: ❄ Prepare nix
       uses: cachix/install-nix-action@v22
@@ -238,8 +230,6 @@ jobs:
     steps:
     - name: 📥 Checkout repository
       uses: actions/checkout@v3
-      with:
-        repository: input-output-hk/hydra
 
     - name: ❄ Prepare nix
       uses: cachix/install-nix-action@v22
@@ -273,8 +263,6 @@ jobs:
     - name: 📥 Checkout repository
       uses: actions/checkout@v3
       with:
-        repository: input-output-hk/hydra
-        token: ${{ secrets.MY_TOKEN || github.token }}
         # Ensure we have all history with all commits
         fetch-depth: 0
 

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -319,8 +319,8 @@ jobs:
       if: github.ref_name != 'master' && github.ref_name != 'release'
       working-directory: docs
       run: |
-        yarn && yarn build-dev
-
+        yarn
+        yarn build-dev
 
     - name: 📚 Documentation
       if: github.ref_name == 'master' || github.ref_name == 'release'

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -304,46 +304,7 @@ jobs:
         path: docs/static/
 
     - name: 📚 Documentation sanity check
-      if: github.ref_name != 'master' && github.ref_name != 'release'
       working-directory: docs
       run: |
         yarn
         yarn build-dev
-
-    - name: 📚 Documentation
-      if: github.ref_name == 'master' || github.ref_name == 'release'
-      working-directory: docs
-      run: |
-        yarn && yarn build
-        rm -rf public
-        mkdir public
-        mv build/* public
-
-    - name: 💾 Upload docs artifact
-      if: github.ref_name == 'master' || github.ref_name == 'release'
-      uses: actions/upload-artifact@v3
-      with:
-        name: docs
-        path: docs/public
-
-    - name: 📚 Prepare /unstable Documentation
-      if: github.ref_name == 'master'
-      working-directory: docs
-      run: |
-        sed -i 's|head-protocol|head-protocol/unstable|' docusaurus.config.js
-
-    - name: 📚 /unstable Documentation
-      if: github.ref_name == 'master'
-      working-directory: docs
-      run: |
-        yarn && yarn build
-        rm -rf public
-        mkdir public
-        mv build/* public
-
-    - name: 💾 Upload /unstable docs artifact
-      if: github.ref_name == 'master'
-      uses: actions/upload-artifact@v3
-      with:
-        name: docs-unstable
-        path: docs/public

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -82,7 +82,6 @@ jobs:
           ./**/test-results.xml
           ./**/hspec-results.md
 
-
     # NOTE: This depends on the path used in hydra-cluster e2e tests
     - name: 💾 Upload logs
       if: always()
@@ -129,14 +128,14 @@ jobs:
     - name: 📚 Documentation (Haddock)
       run: |
         nix build .?submodules=1#haddocks
-        mkdir -p docs/static/haddock
-        cp -aL result/* docs/static/haddock/
+        mkdir -p haddocks
+        cp -aL result/* haddocks/
 
     - name: 💾 Upload haddock artifact
       uses: actions/upload-artifact@v3
       with:
         name: haddocks
-        path: ./docs/static/haddock
+        path: haddocks
 
   benchmarks:
     name: "Benchmarks"
@@ -146,16 +145,16 @@ jobs:
         include:
           - package: hydra-node
             bench: tx-cost
-            options: '--output-directory $(pwd)/../docs/benchmarks'
+            options: '--output-directory $(pwd)/../benchmarks'
           - package: hydra-node
             bench: micro
-            options: '-o $(pwd)/../docs/static/ledger-bench.html'
+            options: '-o $(pwd)/../benchmarks/ledger-bench.html'
           - package: hydra-cluster
             bench: bench-e2e
-            options: 'datasets datasets/3-nodes.json datasets/1-node.json --output-directory $(pwd)/../docs/benchmarks --timeout 1000s'
+            options: 'datasets datasets/3-nodes.json datasets/1-node.json --output-directory $(pwd)/../benchmarks --timeout 1000s'
           - package: plutus-merkle-tree
             bench: on-chain-cost
-            options: '--output-directory $(pwd)/../docs/benchmarks'
+            options: '--output-directory $(pwd)/../benchmarks'
     steps:
     - name: 📥 Checkout repository
       uses: actions/checkout@v3
@@ -175,6 +174,7 @@ jobs:
 
     - name: 📈 Benchmark
       run: |
+        mkdir -p benchmarks
         cd ${{ matrix.package }}
         nix develop .?submodules=1#benchs.${{ matrix.package }} --command ${{ matrix.bench }} ${{ matrix.options }}
 
@@ -182,7 +182,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: benchmarks
-        path: ./docs/benchmarks
+        path: benchmarks
 
   publish-benchmark-results:
     name: Publish benchmark results

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -22,62 +22,45 @@ jobs:
         # Also ensure we have all history with all tags
         fetch-depth: 0
 
-    # TODO: Use the downloads below instead of these two steps after we have
-    # released a version with new artifact names
-    - name: 📥 Download released benchmarks/haddocks
-      uses: dawidd6/action-download-artifact@v2
-      with:
-        repo: input-output-hk/hydra
-        workflow: ci.yaml
-        workflow_conclusion: success
-        branch: release
-        name: benchmarks-and-haddocks
-        path: benchmarks-and-haddocks
-
-    - name: Extract old released benchmarks/haddocks
-      run: |
-        mv benchmarks-and-haddocks/benchmarks/* docs/benchmarks/
-        mv benchmarks-and-haddocks/static/haddock docs/static/
-
-    # - name: 📥 Download released benchmarks
-    #   uses: dawidd6/action-download-artifact@v2
-    #   with:
-    #     repo: input-output-hk/hydra
-    #     workflow: ci-nix.yaml
-    #     workflow_conclusion: success
-    #     branch: release
-    #     name: benchmarks
-    #     path: docs/benchmarks
-
-    # - name: 📥 Download released haddock documentation
-    #   uses: dawidd6/action-download-artifact@v2
-    #   with:
-    #     repo: input-output-hk/hydra
-    #     workflow: ci-nix.yaml
-    #     workflow_conclusion: success
-    #     branch: release
-    #     name: haddocks
-    #     path: docs/static/haddock
-
     - name: 📥 Download released hydra-spec
       uses: dawidd6/action-download-artifact@v2
       with:
         repo: input-output-hk/hydra
-        workflow: ci.yaml
+        workflow: ci-nix.yaml
         workflow_conclusion: success
         branch: release
         name: hydra-spec
         path: docs/static
 
+    - name: 📥 Download released benchmarks
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        repo: input-output-hk/hydra
+        workflow: ci-nix.yaml
+        workflow_conclusion: success
+        branch: release
+        name: benchmarks
+        path: docs/benchmarks
+
     - name: 📥 Download released test-results
       uses: dawidd6/action-download-artifact@v2
       with:
         repo: input-output-hk/hydra
-        workflow: ci.yaml
+        workflow: ci-nix.yaml
         workflow_conclusion: success
         branch: release
         name: test-results
         path: docs/benchmarks/tests
+
+    - name: 📥 Download released haddock documentation
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        repo: input-output-hk/hydra
+        workflow: ci-nix.yaml
+        workflow_conclusion: success
+        branch: release
+        name: haddocks
+        path: docs/static/haddock
 
     - name: Build documentation + latest monthly
       working-directory: docs

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["CI"]
     branches: [master]
-    types: 
+    types:
       - completed
 
 jobs:
@@ -14,80 +14,151 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
 
-    - name: 📥 Download last released docs
-      uses: dawidd6/action-download-artifact@v2
+    - name: 📥 Checkout repository
+      uses: actions/checkout@v3
       with:
-        workflow: ci-nix.yaml
-        workflow_conclusion: success
-        branch: release
-        name: docs
-        path: docs-release
-        # TODO: backward compatibility
-        # remove the following line to throw an error instead
-        # of a warning if artifact is not found when we have
-        # a release branch with artifact name docs instead of
-        # docs-stable
-        if_no_artifact_found: warn
+        repository: input-output-hk/hydra
+        ref: release
+        # Also ensure we have all history with all tags
+        fetch-depth: 0
 
-    # TODO: backward compatibility
-    # remove the following block when we have
-    # a release branch with artifact name docs instead of
-    # docs-stable
-    - name: 📥 Download last released docs
+    # TODO: Use the downloads below instead of these two steps after we have
+    # released a version with new artifact names
+    - name: 📥 Download released benchmarks/haddocks
       uses: dawidd6/action-download-artifact@v2
       with:
+        repo: input-output-hk/hydra
         workflow: ci.yaml
         workflow_conclusion: success
         branch: release
-        name: docs-stable
-        path: docs-release
-        if_no_artifact_found: ignore
+        name: benchmarks-and-haddocks
+        path: benchmarks-and-haddocks
 
-    - name: 📥 Download latest /unstable docs
-      uses: dawidd6/action-download-artifact@v2
-      with:
-        workflow: ci-nix.yaml
-        workflow_conclusion: success
-        branch: master
-        name: docs-unstable
-        path: docs-unstable
-
-    - name: 📥 Download latest / docs
-      uses: dawidd6/action-download-artifact@v2
-      with:
-        workflow: ci-nix.yaml
-        workflow_conclusion: success
-        branch: master
-        name: docs
-        path: docs-master
-
-    - name: 🪓 Piece together docs
+    - name: Extract old released benchmarks/haddocks
       run: |
-        mkdir public
-        mv docs-release public/head-protocol
-        mv docs-unstable public/head-protocol/unstable
-        # Always use monthly reports from master
-        # XXX: This depends on languages and assets are annoying
-        rm -r public/head-protocol/monthly
-        cp -r docs-master/monthly public/head-protocol/monthly
-        rm -r public/head-protocol/ja/monthly
-        cp -r docs-master/ja/monthly public/head-protocol/ja/monthly
-        rm -r public/head-protocol/fr/monthly
-        cp -r docs-master/fr/monthly public/head-protocol/fr/monthly
-        # XXX: Need to copy assets as well. This will also litter with unrelated assets (js)
-        cp -r docs-master/assets/* public/head-protocol/assets/
-        cp -r docs-master/ja/assets/* public/head-protocol/ja/assets/
-        cp -r docs-master/fr/assets/* public/head-protocol/fr/assets/
+        mv benchmarks-and-haddocks/benchmarks/* docs/benchmarks/
+        mv benchmarks-and-haddocks/static/haddock docs/static/
+
+    # - name: 📥 Download released benchmarks
+    #   uses: dawidd6/action-download-artifact@v2
+    #   with:
+    #     repo: input-output-hk/hydra
+    #     workflow: ci-nix.yaml
+    #     workflow_conclusion: success
+    #     branch: release
+    #     name: benchmarks
+    #     path: docs/benchmarks
+
+    # - name: 📥 Download released haddock documentation
+    #   uses: dawidd6/action-download-artifact@v2
+    #   with:
+    #     repo: input-output-hk/hydra
+    #     workflow: ci-nix.yaml
+    #     workflow_conclusion: success
+    #     branch: release
+    #     name: haddocks
+    #     path: docs/static/haddock
+
+    - name: 📥 Download released hydra-spec
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        repo: input-output-hk/hydra
+        workflow: ci.yaml
+        workflow_conclusion: success
+        branch: release
+        name: hydra-spec
+        path: docs/static
+
+    - name: 📥 Download released test-results
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        repo: input-output-hk/hydra
+        workflow: ci.yaml
+        workflow_conclusion: success
+        branch: release
+        name: test-results
+        path: docs/benchmarks/tests
+
+    - name: Build documentation + latest monthly
+      working-directory: docs
+      run: |
+        # TODO: redirect to /unstable/monthly instead?
+        # Use monthly reports (blog) from master
+        git checkout origin/master -- monthly/
+
+        yarn
+        yarn build
+
+        mkdir -p /tmp/public
+        mv build /tmp/public/head-protocol
+        # Clean the working copy
+        git clean -dxf
+
+    - name: Checkout master
+      working-directory: docs
+      run: |
+        git reset origin/master --hard
+        sed -i 's|head-protocol|head-protocol/unstable|' docusaurus.config.js
+        # TODO: debug
+        find .
+
+    - name: 📥 Download latest hydra-spec
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        repo: input-output-hk/hydra
+        workflow: ci-nix.yaml
+        workflow_conclusion: success
+        branch: master
+        name: hydra-spec
+        path: docs/static
+
+    - name: 📥 Download latest benchmarks
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        repo: input-output-hk/hydra
+        workflow: ci-nix.yaml
+        workflow_conclusion: success
+        branch: master
+        name: benchmarks
+        path: docs/benchmarks
+
+    - name: 📥 Download latest test-results
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        repo: input-output-hk/hydra
+        workflow: ci-nix.yaml
+        workflow_conclusion: success
+        branch: master
+        name: test-results
+        path: docs/benchmarks/tests
+
+    - name: 📥 Download latest haddock documentation
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        repo: input-output-hk/hydra
+        workflow: ci-nix.yaml
+        workflow_conclusion: success
+        branch: master
+        name: haddocks
+        path: docs/static/haddock
+
+    - name: Build /unstable documentation
+      working-directory: docs
+      run: |
+        yarn
+        yarn build
+
+        mv build /tmp/public/head-protocol/unstable
 
     - name: 👉 Create redirect
       run: |
-        echo "hydra.family" > public/CNAME
-        echo '<!DOCTYPE html><html><head><meta http-equiv="Refresh" content="0; URL=https://hydra.family/head-protocol"></head></html>' > public/index.html
+        echo "hydra.family" > /tmp/public/CNAME
+        echo '<!DOCTYPE html><html><head><meta http-equiv="Refresh" content="0; URL=https://hydra.family/head-protocol"></head></html>' > /tmp/public/index.html
 
     - name: 🚢 Publish Documentation
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN || github.token }}
-        publish_dir: public
+        publish_dir: /tmp/public
         enable_jekyll: true
         force_orphan: true

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -82,9 +82,11 @@ jobs:
     - name: Build documentation + latest monthly
       working-directory: docs
       run: |
-        # TODO: redirect to /unstable/monthly instead?
         # Use monthly reports (blog) from master
         git checkout origin/master -- monthly/
+
+        # TODO: what to do about broken links from monthly -> ?
+        sed -i 's|onBrokenLinks: "throw"|onBrokenLinks: "warn"|' docusaurus.config.js
 
         yarn
         yarn build
@@ -99,8 +101,6 @@ jobs:
       run: |
         git reset origin/master --hard
         sed -i 's|head-protocol|head-protocol/unstable|' docusaurus.config.js
-        # TODO: debug
-        find .
 
     - name: 📥 Download latest hydra-spec
       uses: dawidd6/action-download-artifact@v2

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -26,8 +26,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        repository: input-output-hk/hydra
-        token: ${{ secrets.MY_TOKEN || github.token }}
         submodules: true
 
     - name: ❄ Prepare nix

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,18 @@ $ yarn build
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
 
+Note that this will have quite some broken links as we are referring to
+generated documentation, test data and benchmarks. To put these artifacts at the
+right place before, you can use these `nix` builds from the repository root:
+
+```console
+nix build .#spec && ln -s $(readlink result)/hydra-spec.pdf docs/static/hydra-spec.pdf
+nix build ".?submodules=1#haddocks" -o docs/static/haddock
+
+(cd hydra-node; nix develop ".?submodules=1#benchs.hydra-node" --command tx-cost --output-directory $(pwd)/../docs/benchmarks)
+(cd hydra-cluster; nix develop ".?submodules=1#benchs.hydra-cluster" --command bench-e2e --scaling-factor 1 --output-directory $(pwd)/../docs/benchmarks)
+```
+
 # Translating
 
 Translations of the documentation are provided in the `i18n/{lang}` folder (for example `i18n/fr` for French). Translations of both the content and the various website elements (such as buttons, headers etc...) are needed. To initialize a new language translation (e.g. `fr`), run the following command:

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,7 +18,7 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "enrich-document-metadata": "node ./scripts/enrich-document-metadata.js",
-    "dummy-spec": "echo 'Do a nix build .#spec and put this instead here' > static/hydra-spec.pdf",
+    "dummy-spec": "[ -e static/hydra-spec.pdf ] || echo 'Do a nix build .#spec and put this instead here' > static/hydra-spec.pdf",
     "regenerate-plantuml": "./scripts/regenerate-plantuml.sh"
   },
   "dependencies": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,7 +6,7 @@
     "docusaurus": "docusaurus",
     "prepare": "yarn enrich-document-metadata && yarn regenerate-plantuml",
     "build": "yarn prepare && docusaurus build",
-    "build-dev": "yarn prepare && docusaurus build --no-minify",
+    "build-dev": "yarn prepare && docusaurus build --no-minify -l en",
     "start": "yarn dummy-spec && docusaurus start",
     "validate:inputs": "./validate-api.js publish '/' '../hydra-node/golden/ReasonablySized (ClientInput (Tx BabbageEra)).json'",
     "validate:outputs": "./validate-api.js subscribe '/' '../hydra-node/golden/ReasonablySized (TimedServerOutput (Tx BabbageEra)).json'",


### PR DESCRIPTION
* Do not fully build website in CI workflow, but only produce artifacts needed for the documentation, but instead build the website in the publish-docs workflow.
  - Only build english documentation in CI -> should improve CI runtime
  - Also clean up some artifacts to only contain generated data
  
* Build the website slightly differently: Instead of building it separately and piece together the `monthly/` section within the final HTML + asset files (hard-coding language paths etc.), do copy the sources from latest (`master`) into the last released version (to be published at `/`) to have most recent `monthly/` entries.
  - This leads to broken links detected, but they are broken right now on (e.g. end-to-end benchmarks in https://hydra.family/head-protocol/monthly/2023-06/#benchmark-performance-of-hydra-head-186)
  - Links are only broken until we have tagged the documentation consistent with the monthly report (built & checked against `master` in CI)

* CI runtime of documentation step with this branch (after)
    ![image](https://github.com/input-output-hk/hydra/assets/2621189/373d71aa-7d77-4c8a-9605-3d89dc50ff24)
  
  and without it (before)

    ![image](https://github.com/input-output-hk/hydra/assets/2621189/73cc47af-66ae-4568-ac58-e5e4ccb9cde5)



* See https://github.com/ch1bo/hydra/actions/runs/5422992829/jobs/9860856681 for an example run of publish-docs workflow and https://github.com/ch1bo/hydra/tree/gh-pages for the resulting website root.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
  - The broken links are a TODO in the code. Not sure how to handle this. Could make it an `XXX` entry instead.
