### PR TITLE
Fix release branch update in release.sh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,7 +177,6 @@ To perform a release of next `<version>`:
 2. Update CHANGELOG.md by replacing `UNRELEASED` with a date in
    [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) and prepare contents.
 3. Run `./release.sh <version>`
-4. Make branch *release* point to your release tag (so that the website is published)
 5. Create a github release page containing
    * The released changes (formatted) and giving credit where credit is due
    * Attach static binaries to the release (or link the CI artifact)

--- a/release.sh
+++ b/release.sh
@@ -55,7 +55,9 @@ prepare_release() {
 
   git tag -as "$version" -F <(changelog "$version")
 
-  git merge release "${version}" --ff-only
+  # Make branch release point to tag so that the website is published
+  git checkout release
+  git merge "${version}" --ff-only
 }
 
 publish_release() {


### PR DESCRIPTION
The previous git command did not work for me, so I updated it to what I would do manually.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
