### PR TITLE
Pure nix builds with patched git revision

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,10 +30,10 @@
         hydraProject = import ./nix/hydra/project.nix {
           inherit (inputs) haskellNix iohk-nix CHaP;
           inherit system nixpkgs;
-          gitRev = self.rev or "dirty";
         };
         hydraPackages = import ./nix/hydra/packages.nix {
           inherit hydraProject system pkgs cardano-node;
+          gitRev = self.rev or "dirty";
         };
         hydraImages = import ./nix/hydra/docker.nix {
           inherit hydraPackages system nixpkgs;

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -10,8 +10,8 @@ license-files:
   NOTICE
 
 data-files:
-  json-schemas/logs.yaml
   json-schemas/api.yaml
+  json-schemas/logs.yaml
 
 source-repository head
   type:     git
@@ -174,7 +174,6 @@ library
     , serialise
     , stm
     , text
-    , th-env
     , time
     , transformers
     , typed-protocols                                                   >=0.1.0.0
@@ -248,13 +247,13 @@ benchmark micro
   main-is:        Main.hs
   type:           exitcode-stdio-1.0
   build-depends:
-                  QuickCheck
-                , aeson
-                , base
-                , criterion
-                , hydra-cardano-api
-                , hydra-node
-                , hydra-prelude
+    , aeson
+    , base
+    , criterion
+    , hydra-cardano-api
+    , hydra-node
+    , hydra-prelude
+    , QuickCheck
 
   ghc-options:    -threaded -rtsopts
 

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -568,7 +568,8 @@ hydraNodeCommand =
     version & \(Version semver _) -> Version semver revision
 
   revision =
-    maybeToList $
+    pure . fromMaybe "unknown" $
+      -- TODO: gitRevision <|> patched in revision
       ($$(envQ "GIT_REVISION") :: Maybe String)
         <|> gitRevision
 

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Hydra.Options (
@@ -35,8 +34,7 @@ import Hydra.Ledger.Cardano ()
 import Hydra.Logging (Verbosity (..))
 import Hydra.Network (Host, NodeId (NodeId), PortNumber, readHost, readPort)
 import Hydra.Party (Party)
-import Hydra.Version (gitRevision)
-import Language.Haskell.TH.Env (envQ)
+import Hydra.Version (embeddedRevision, gitRevision, unknownVersion)
 import Options.Applicative (
   Parser,
   ParserInfo,
@@ -568,10 +566,10 @@ hydraNodeCommand =
     version & \(Version semver _) -> Version semver revision
 
   revision =
-    pure . fromMaybe "unknown" $
-      -- TODO: gitRevision <|> patched in revision
-      ($$(envQ "GIT_REVISION") :: Maybe String)
+    maybeToList $
+      embeddedRevision
         <|> gitRevision
+        <|> Just unknownVersion
 
   scriptInfo =
     infoOption

--- a/hydra-prelude/cbits/revision.c
+++ b/hydra-prelude/cbits/revision.c
@@ -1,0 +1,10 @@
+// Place holder for a git revision (40 characters) intended to be replaced in
+// the final binary.
+//
+// NOTE: Keep consistent with what is searched for in 'src/Hydra/Version.hs'
+char _hydra_gitrev[40]
+  = "0000000000" // 10
+    "0000000000" // 20
+    "0000000000" // 30
+    "0000000000" // 40
+    ;

--- a/hydra-prelude/hydra-prelude.cabal
+++ b/hydra-prelude/hydra-prelude.cabal
@@ -15,6 +15,7 @@ source-repository head
 
 library
   hs-source-dirs:     src
+  c-sources:          cbits/revision.c
   exposed-modules:
     Hydra.Prelude
     Hydra.Version

--- a/hydra-prelude/src/Hydra/Version.hs
+++ b/hydra-prelude/src/Hydra/Version.hs
@@ -1,33 +1,59 @@
 {-# LANGUAGE TemplateHaskell #-}
 
--- | Provides version numbers from git identifiers. Based on 'gitrev' package
--- with a 'Maybe' interface around it.
+-- | Provides version numbers from calling git on build time or from an embedded
+-- string.
+--
+-- The former is based on the 'gitrev' package with a 'Maybe' interface around
+-- it, while the embedding is done using a special c-array placeholder in
+-- cbits/revision.c
 module Hydra.Version where
 
 import Hydra.Prelude
 
 import qualified Development.GitRev as GitRev
+import Foreign.C (CString)
+import GHC.Foreign (peekCStringLen)
+import GHC.IO (unsafeDupablePerformIO)
+import GHC.IO.Encoding (utf8)
 
--- | Determine the version during build time using `git describe`.
+-- | Identifier to be used when no revision can be found.
+--
+-- This is also the default used in 'gitrev'.
+unknownVersion :: String
+unknownVersion = "UNKNOWN"
+
+-- | Determine the version on build time using `git describe`.
+-- FIXME: This does not change when hydra-prelude is not re-compiled
 gitDescribe :: Maybe String
 gitDescribe
-  | fromGit == unknownFromGit = Nothing
+  | fromGit == unknownVersion = Nothing
   | otherwise = Just fromGit
  where
   -- Git describe version found during compilation by running git. If git could
   -- not be run, then this will be "UNKNOWN".
   fromGit = $(GitRev.gitDescribe)
 
--- | Determine the version during build time using `git rev-parse`.
+-- | Determine the version on build time using `git rev-parse`.
+-- FIXME: This does not change when hydra-prelude is not re-compiled
 gitRevision :: Maybe String
 gitRevision
-  | fromGit == unknownFromGit = Nothing
+  | fromGit == unknownVersion = Nothing
   | otherwise = Just fromGit
  where
   -- Git revision found during compilation by running git. If
   -- git could not be run, then this will be "UNKNOWN".
   fromGit = $(GitRev.gitHash)
 
--- According to 'gitrev' docs, this is the default value returned on errors.
-unknownFromGit :: String
-unknownFromGit = "UNKNOWN"
+-- Placeholder for the git revision. Must match name in 'cbits/revision.c'.
+foreign import ccall "&_hydra_gitrev" c_gitrev :: CString
+
+-- | The git revision embedded at a special place holder in the object/binary.
+-- NOTE: Keep this consistent with what is hard-coded in 'cbits/revision.c'
+embeddedRevision :: Maybe String
+embeddedRevision
+  | embedded == placeholder = Nothing
+  | otherwise = Just embedded
+ where
+  embedded = unsafeDupablePerformIO (peekCStringLen utf8 (c_gitrev, 40))
+
+  placeholder = replicate 40 '0'

--- a/hydra-tui/src/Hydra/TUI/Options.hs
+++ b/hydra-tui/src/Hydra/TUI/Options.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Hydra.TUI.Options where
 
 import Hydra.Prelude
@@ -8,8 +6,7 @@ import Data.Version (Version (Version), showVersion)
 import Hydra.Cardano.Api (NetworkId)
 import Hydra.Network (Host (Host))
 import Hydra.Options (networkIdParser)
-import Hydra.Version (gitRevision)
-import Language.Haskell.TH.Env (envQ)
+import Hydra.Version (embeddedRevision, gitRevision, unknownVersion)
 import Options.Applicative (
   Parser,
   auto,
@@ -55,8 +52,9 @@ parseOptions =
 
   revision =
     maybeToList $
-      ($$(envQ "GIT_REVISION") :: Maybe String)
+      embeddedRevision
         <|> gitRevision
+        <|> Just unknownVersion
 
 parseCardanoNodeSocket :: Parser FilePath
 parseCardanoNodeSocket =

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -4,6 +4,7 @@
 , system ? builtins.currentSystem
 , pkgs
 , cardano-node
+, gitRev ? "unknown"
 }:
 let
   nativePkgs = hydraProject.hsPkgs;
@@ -15,9 +16,12 @@ in
 rec {
   hydra-node = nativePkgs.hydra-node.components.exes.hydra-node;
   hydra-node-static = musl64Pkgs.hydra-node.components.exes.hydra-node;
+
   hydra-tools-static = musl64Pkgs.hydra-node.components.exes.hydra-tools;
+
   hydra-tui = nativePkgs.hydra-tui.components.exes.hydra-tui;
   hydra-tui-static = musl64Pkgs.hydra-tui.components.exes.hydra-tui;
+
   hydraw = nativePkgs.hydraw.components.exes.hydraw;
   hydraw-static = musl64Pkgs.hydraw.components.exes.hydraw;
 

--- a/nix/hydra/project.nix
+++ b/nix/hydra/project.nix
@@ -9,8 +9,6 @@
 , CHaP
 
 , nixpkgs ? iohk-nix.nixpkgs
-
-, gitRev ? ""
 }:
 let
   # nixpkgs enhanced with haskell.nix and crypto libs as used by iohk
@@ -54,20 +52,6 @@ let
         packages.hydra-tui.dontStrip = false;
         packages.hydraw.dontStrip = false;
       }
-      # Inject the git revision into hydra-node --version
-      # (see hydra-node/src/Hydra/Options.hs)
-      (
-        let
-          patchGitRevision = ''
-            echo ======= PATCHING --version to ${gitRev} =======
-            export GIT_REVISION=${gitRev}
-          '';
-        in
-        {
-          packages.hydra-node.preBuild = patchGitRevision;
-          packages.hydra-tui.preBuild = patchGitRevision;
-        }
-      )
       # Avoid plutus-tx errors in haddock (see also cabal.project)
       {
         packages.hydra-plutus.setupHaddockFlags = [ "--ghc-options='-fplugin-opt PlutusTx.Plugin:defer-errors'" ];


### PR DESCRIPTION
* :watermelon: Instead of compiling the revision directly into the haskell binary, we keep the actual binary derivation independent of the git index and only depend on the sources needed to build the `hydra-node`/`hydra-tui` binaries.

* :watermelon: Then, in a second step, patch the git revision into the binary built by haskell.nix. This allows to re-use the already built binaries when no source changed, but only something unrelated in the repository, e.g. the README.md

* :watermelon: Ultimately this should lead to less rebuilds of the actual binaries in our CI as we can share those derivations.

  A sneak peeks of a rebuild on this branch:

  ![image](https://github.com/input-output-hk/hydra/assets/2621189/46869293-7814-460f-abe7-4309b4bad285)


---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter

---

Original problem description:

Since we are depending on the git revision (via the nix flake), the hydra-node derivation needs to be rebuilt on ANY change to the git index.

This is also the reason why the cardano-node for example does not compile the git revision into the binary, but does patch the string in the final binary:
  * https://github.com/input-output-hk/cardano-node/pull/5231/files
  * https://github.com/input-output-hk/cardano-node/blob/09c5830b2ae196cbaa17f4774ec6fcf15a8b0769/nix/haskell.nix#L320

On a side note, this broke the cardano-node build at least once.
