### PR TITLE
Spike: Event sourced persistence

### DIFF
--- a/hydra-cluster/test/Test/DirectChainSpec.hs
+++ b/hydra-cluster/test/Test/DirectChainSpec.hs
@@ -61,7 +61,7 @@ import Hydra.Cluster.Fixture (
 import Hydra.Cluster.Util (chainConfigFor, keysFor)
 import Hydra.ContestationPeriod (ContestationPeriod)
 import Hydra.Crypto (aggregate, sign)
-import Hydra.HeadLogic (HeadStateEvent)
+import Hydra.HeadLogic (HeadStateEvent, toChainStateEvents)
 import Hydra.Ledger (IsTx (..))
 import Hydra.Ledger.Cardano (Tx, genOneUTxOFor)
 import Hydra.Logging (Tracer, nullTracer, showLogsOnFailure)
@@ -70,7 +70,7 @@ import Hydra.Options (
   toArgNetworkId,
  )
 import Hydra.Party (Party)
-import Hydra.Persistence (PersistenceIncremental (..))
+import Hydra.Persistence (PersistenceIncremental (..), createPersistenceIncrementalView)
 import Hydra.Snapshot (ConfirmedSnapshot (..), Snapshot (..))
 import System.Process (proc, readCreateProcess)
 import Test.QuickCheck (generate)
@@ -451,7 +451,8 @@ withDirectChainTest tracer config ctx action = do
               atomically $ modifyTVar events (event :)
           , loadAll = readTVarIO events
           }
-  withDirectChain tracer config ctx wallet persistence initialChainState callback $ \Chain{postTx} -> do
+  let persistenceView = createPersistenceIncrementalView persistence toChainStateEvents
+  withDirectChain tracer config ctx wallet persistenceView initialChainState callback $ \Chain{postTx} -> do
     action
       DirectChainTest
         { postTx

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -109,7 +109,7 @@ main = do
         nodeState <- createNodeState hs
         ctx <- loadChainContext chainConfig party otherParties hydraScriptsTxId
         wallet <- mkTinyWallet (contramap DirectChain tracer) chainConfig
-        withDirectChain (contramap DirectChain tracer) chainConfig ctx wallet (getChainState hs) (putEvent . OnChainEvent) $ \chain -> do
+        withDirectChain (contramap DirectChain tracer) chainConfig ctx wallet persistence (getChainState hs) (putEvent . OnChainEvent) $ \chain -> do
           let RunOptions{host, port, peers, nodeId} = opts
               putNetworkEvent (Authenticated msg otherParty) = putEvent $ NetworkEvent defaultTTL otherParty msg
               RunOptions{apiHost, apiPort} = opts

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -58,9 +58,7 @@ import Hydra.Options (
   validateRunOptions,
  )
 import Hydra.Persistence (
-  Persistence (load),
   PersistenceIncremental (loadAll),
-  createPersistence,
   createPersistenceIncremental,
  )
 

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -90,9 +90,11 @@ import Hydra.Chain.Direct.Wallet (
   WalletInfoOnChain (..),
   newTinyWallet,
  )
+import Hydra.HeadLogic (HeadStateEvent)
 import Hydra.Logging (Tracer, traceWith)
 import Hydra.Options (ChainConfig (..))
 import Hydra.Party (Party)
+import Hydra.Persistence (PersistenceIncremental)
 import qualified Ouroboros.Consensus.HardFork.History as Consensus
 import Ouroboros.Network.Magic (NetworkMagic (..))
 import Ouroboros.Network.NodeToClient (
@@ -117,7 +119,6 @@ initialChainState =
   ChainStateAt
     { chainState = Idle
     , recordedAt = Nothing
-    , previous = Nothing
     }
 
 -- | Build the 'ChainContext' from a 'ChainConfig' and additional information.
@@ -185,10 +186,11 @@ withDirectChain ::
   ChainConfig ->
   ChainContext ->
   TinyWallet IO ->
+  PersistenceIncremental (HeadStateEvent Tx) IO ->
   -- | Last known chain state as loaded from persistence.
   ChainStateAt ->
   ChainComponent Tx IO a
-withDirectChain tracer config ctx wallet chainStateAt callback action = do
+withDirectChain tracer config ctx wallet persistence chainStateAt callback action = do
   -- Last known point on chain as loaded from persistence.
   let persistedPoint = recordedAt chainStateAt
   queue <- newTQueueIO
@@ -210,7 +212,7 @@ withDirectChain tracer config ctx wallet chainStateAt callback action = do
           localChainState
           (submitTx queue)
 
-  let handler = chainSyncHandler tracer callback getTimeHandle ctx localChainState
+  let handler = chainSyncHandler tracer callback getTimeHandle ctx localChainState persistence
   res <-
     race
       ( handle onIOException $

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -134,7 +134,6 @@ class HasKnownUTxO a where
 data ChainStateAt = ChainStateAt
   { chainState :: ChainState
   , recordedAt :: Maybe ChainPoint
-  , previous :: Maybe ChainStateAt
   }
   deriving (Eq, Show, Generic, ToJSON, FromJSON)
 

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1252,13 +1252,8 @@ newSn Environment{party} parameters CoordinatedHeadState{confirmedSnapshot, seen
 emitSnapshot :: Environment -> HeadState tx -> Outcome tx -> Outcome tx
 emitSnapshot env@Environment{party} openState outcome =
   case (openState, outcome) of
-<<<<<<< HEAD
-    ( OpenState{parameters, coordinatedHeadState = csh@CoordinatedHeadState{seenSnapshot}}
-      , NewState events
-=======
     ( Open OpenState{parameters, coordinatedHeadState = csh@CoordinatedHeadState{seenSnapshot}}
-      , NewState events effects
->>>>>>> 2cb5a3434 (Add tmp fix for emitSnapshot)
+      , NewState events
       ) ->
         case newSn env parameters csh of
           ShouldSnapshot sn txs -> do

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -703,7 +703,6 @@ onInitialChainCommitTx ::
   UTxOType tx ->
   Outcome tx
 onInitialChainCommitTx st newChainState pt utxo =
-  -- HeadStateEvent: TxCommitted
   NewState events
     `Combined` Effects
       ( notifyClient
@@ -874,7 +873,6 @@ onOpenNetworkReqSn env ledger st otherParty sn requestedTxIds =
           let snapshotSignature = sign signingKey nextSnapshot
           -- Spec: T̂ ← {tx | ∀tx ∈ T̂ , Û ◦ tx ≠ ⊥} and L̂ ← Û ◦ T̂
           let (seenTxs', seenUTxO') = pruneTransactions u
-          -- HeadStateEvent: ReqSnReceived
           NewState [ReqSnReceived{nextSnapshot, seenTxs = seenTxs', seenUTxO = seenUTxO'}]
             `Combined` Effects [NetworkEffect $ AckSn snapshotSignature sn]
  where

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -471,6 +471,16 @@ deriving instance (IsTx tx, IsChainState tx) => FromJSON (HeadStateEvent tx)
 instance (IsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (HeadStateEvent tx) where
   arbitrary = genericArbitrary
 
+toChainStateEvents :: HeadStateEvent tx -> Maybe (ChainStateType tx)
+toChainStateEvents = \case
+    HeadInitialized{newChainState} -> Just newChainState
+    TxCommitted{newChainState} -> Just newChainState
+    HeadAborted{newChainState} -> Just newChainState
+    HeadOpened{newChainState} -> Just newChainState
+    HeadClosed{newChainState} -> Just newChainState
+    HeadFannedOut{newChainState} -> Just newChainState
+    _ -> Nothing
+
 updateHeadState ::
   IsChainState tx =>
   HeadState tx ->

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -28,6 +28,8 @@ import Hydra.HeadLogic (
   Event (..),
   HeadState (..),
   HeadStateEvent,
+  OffChainAction (..),
+  OffChainEvent (..),
   Outcome (..),
   collectEffects,
   defaultTTL,
@@ -193,6 +195,10 @@ processEffect HydraNode{hn, oc = Chain{postTx}, server, eq, env = Environment{pa
       postTx postChainTx
         `catch` \(postTxError :: PostTxError tx) ->
           putEvent eq $ PostTxError{postChainTx, postTxError}
+    OffChainEffect action ->
+      case action of
+        RqEmitSn -> putEvent eq (OffChainEvent EmitSn)
+
   traceWith tracer $ EndEffect party eventId effectId
 
 -- ** Manage state

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -197,7 +197,7 @@ processEffect HydraNode{hn, oc = Chain{postTx}, server, eq, env = Environment{pa
           putEvent eq $ PostTxError{postChainTx, postTxError}
     OffChainEffect action ->
       case action of
-        RqEmitSn -> putEvent eq (OffChainEvent EmitSn)
+        RqEmitSn -> prependEvent eq (OffChainEvent EmitSn)
 
   traceWith tracer $ EndEffect party eventId effectId
 

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -41,7 +41,7 @@ import Hydra.Network.Message (Message)
 import Hydra.Node.EventQueue (EventQueue (..), Queued (..))
 import Hydra.Options (ChainConfig (..), RunOptions (..))
 import Hydra.Party (Party (..), deriveParty)
-import Hydra.Persistence (Persistence (..))
+import Hydra.Persistence (PersistenceIncremental (..))
 
 -- * Environment Handling
 
@@ -70,7 +70,7 @@ data HydraNode tx m = HydraNode
   , server :: Server tx m
   , ledger :: Ledger tx
   , env :: Environment
-  , persistence :: Persistence (HeadStateEvent tx) m
+  , persistence :: PersistenceIncremental (HeadStateEvent tx) m
   }
 
 data HydraNodeLog tx
@@ -128,7 +128,7 @@ stepHydraNode tracer node = do
     NoOutcome -> pure ()
     Error _ -> pure ()
     Wait _reason -> putEventAfter eq waitDelay (decreaseTTL e)
-    NewState events -> mapM_ save events
+    NewState events -> mapM_ append events
     Effects _ -> pure ()
     Combined l r -> handleOutcome e l >> handleOutcome e r
 
@@ -141,7 +141,7 @@ stepHydraNode tracer node = do
 
   Environment{party} = env
 
-  Persistence{save} = persistence
+  PersistenceIncremental{append} = persistence
 
   HydraNode{persistence, eq, env} = node
 

--- a/hydra-node/src/Hydra/Persistence.hs
+++ b/hydra-node/src/Hydra/Persistence.hs
@@ -76,3 +76,21 @@ createPersistenceIncremental fp = do
                 Left e -> throwIO $ PersistenceException e
                 Right decoded -> pure decoded
       }
+
+newtype PersistenceIncrementalView a m =
+  PersistenceIncrementalView {
+      selectAll :: FromJSON a => m [a]
+    }
+
+createPersistenceIncrementalView :: 
+  (Monad m, FromJSON a) =>
+  PersistenceIncremental a m ->
+  (a -> Maybe b) ->
+  PersistenceIncrementalView b m
+createPersistenceIncrementalView PersistenceIncremental{loadAll} f =
+  PersistenceIncrementalView {
+    selectAll = do
+      as <- loadAll
+      let bs = f <$> as
+      return $ catMaybes bs
+  }

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -63,7 +63,7 @@ import Hydra.Node (
  )
 import Hydra.Node.EventQueue (EventQueue (putEvent), createEventQueue)
 import Hydra.Party (Party, deriveParty)
-import Hydra.Persistence (Persistence (Persistence, load, save))
+import Hydra.Persistence (PersistenceIncremental (..))
 import Hydra.Snapshot (Snapshot (..), SnapshotNumber, getSnapshot)
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
 import Test.Hydra.Fixture (alice, aliceSk, bob, bobSk)
@@ -752,7 +752,7 @@ createHydraNode ::
   m (HydraNode tx m)
 createHydraNode ledger nodeState signingKey otherParties outputs outputHistory chain cp = do
   eq <- createEventQueue
-  persistenceVar <- newTVarIO Nothing
+  persistenceVar <- newTVarIO []
   labelTVarIO persistenceVar ("persistence-" <> shortLabel signingKey)
   connectNode chain $
     HydraNode
@@ -779,9 +779,11 @@ createHydraNode ledger nodeState signingKey otherParties outputs outputHistory c
             , contestationPeriod = cp
             }
       , persistence =
-          Persistence
-            { save = atomically . writeTVar persistenceVar . Just
-            , load = readTVarIO persistenceVar
+          PersistenceIncremental
+            { append = \event -> do
+                events <- readTVarIO persistenceVar
+                atomically $ writeTVar persistenceVar (events <> [event])
+            , loadAll = readTVarIO persistenceVar
             }
       }
 

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -552,6 +552,9 @@ inOpenState parties Ledger{initUTxO} =
   u0 = initUTxO
   confirmedSnapshot = InitialSnapshot u0
 
+headParameters :: [Party] -> HeadParameters
+headParameters = HeadParameters cperiod
+
 inOpenState' ::
   [Party] ->
   CoordinatedHeadState SimpleTx ->
@@ -566,7 +569,7 @@ inOpenState' parties coordinatedHeadState =
       , currentSlot = chainSlot
       }
  where
-  parameters = HeadParameters cperiod parties
+  parameters = headParameters parties
 
   chainSlot = ChainSlot 0
 

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -108,7 +108,7 @@ mockChainAndNetwork tr seedKeys cp = do
             }
     let getTimeHandle = pure $ arbitrary `generateWith` 42
     let seedInput = genTxIn `generateWith` 42
-    let HydraNode{eq = EventQueue{putEvent}} = node
+    let HydraNode{eq = EventQueue{putEvent}, persistence} = node
     localChainState <- newLocalChainState initialChainState
     let chainHandle =
           createMockChain
@@ -125,6 +125,7 @@ mockChainAndNetwork tr seedKeys cp = do
             getTimeHandle
             ctx
             localChainState
+            persistence
     let node' =
           node
             { hn = createMockNetwork node nodes

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -49,7 +49,7 @@ import Hydra.Crypto (HydraKey)
 import Hydra.HeadLogic (
   Environment (Environment, otherParties, party),
   Event (..),
-  defaultTTL,
+  defaultTTL, toChainStateEvents,
  )
 import Hydra.Logging (Tracer)
 import Hydra.Model.Payment (CardanoSigningKey (..))
@@ -60,6 +60,7 @@ import Hydra.Node (
  )
 import Hydra.Node.EventQueue (EventQueue (..))
 import Hydra.Party (Party (..), deriveParty)
+import Hydra.Persistence (createPersistenceIncrementalView)
 
 -- | Create a mocked chain which connects nodes through 'ChainSyncHandler' and
 -- 'Chain' interfaces. It calls connected chain sync handlers 'onRollForward' on
@@ -118,6 +119,7 @@ mockChainAndNetwork tr seedKeys cp = do
             getTimeHandle
             seedInput
             localChainState
+    let persistenceView = createPersistenceIncrementalView persistence toChainStateEvents
     let chainHandler =
           chainSyncHandler
             tr
@@ -125,7 +127,7 @@ mockChainAndNetwork tr seedKeys cp = do
             getTimeHandle
             ctx
             localChainState
-            persistence
+            persistenceView
     let node' =
           node
             { hn = createMockNetwork node nodes

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -43,7 +43,7 @@ import Hydra.Node (
 import Hydra.Node.EventQueue (EventQueue (..), createEventQueue)
 import Hydra.Options (defaultContestationPeriod)
 import Hydra.Party (Party, deriveParty)
-import Hydra.Persistence (Persistence (Persistence, load, save))
+import Hydra.Persistence (PersistenceIncremental (..))
 import Hydra.Snapshot (Snapshot (..))
 import Test.Hydra.Fixture (alice, aliceSk, bob, bobSk, carol, carolSk, cperiod)
 
@@ -195,9 +195,9 @@ createHydraNode signingKey otherParties contestationPeriod events = do
             , contestationPeriod
             }
       , persistence =
-          Persistence
-            { save = const $ pure ()
-            , load = failure "unexpected load"
+          PersistenceIncremental
+            { append = const $ pure ()
+            , loadAll = failure "unexpected loadAll"
             }
       }
  where

--- a/hydra-node/test/Hydra/SnapshotStrategySpec.hs
+++ b/hydra-node/test/Hydra/SnapshotStrategySpec.hs
@@ -11,7 +11,6 @@ import Hydra.HeadLogic (
   CoordinatedHeadState (..),
   Effect (..),
   Environment (..),
-  HeadState (Open),
   HeadStateEvent (..),
   NoSnapshotReason (..),
   Outcome (..),
@@ -94,17 +93,15 @@ spec = do
                   , confirmedSnapshot = initialSnapshot
                   , seenSnapshot = NoSeenSnapshot
                   }
+              ost = inOpenState' threeParties coordinatedState
+          let expectedEvent = SnapshotEmited{requested = 1, lastSeenSnapshot = NoSeenSnapshot}
+          emitSnapshot (envFor aliceSk) ost (NewState [])
+            `shouldBe` NewState [expectedEvent]
+            `Combined` Effects [NetworkEffect $ ReqSn alice 1 [tx]]
 
-          case inOpenState' threeParties coordinatedState of
-            Open ost -> do
-              let expectedEvent = SnapshotEmited{requested = 1, lastSeenSnapshot = NoSeenSnapshot}
-              emitSnapshot (envFor aliceSk) ost (NewState [])
-                `shouldBe` (NewState [expectedEvent] `Combined` Effects [NetworkEffect $ ReqSn alice 1 [tx]])
-
-              let seenSnapshot = RequestedSnapshot{lastSeen = 0, requested = 1}
-                  st' = inOpenState' threeParties $ coordinatedState{seenSnapshot}
-              foldl' updateHeadState (Open ost) [expectedEvent] `shouldBe` st'
-            _ -> Hydra.Prelude.error "unexpected"
+          let seenSnapshot = RequestedSnapshot{lastSeen = 0, requested = 1}
+              st' = inOpenState' threeParties $ coordinatedState{seenSnapshot}
+          foldl' updateHeadState ost [expectedEvent] `shouldBe` st'
 
 prop_singleMemberHeadAlwaysSnapshot :: ConfirmedSnapshot SimpleTx -> Property
 prop_singleMemberHeadAlwaysSnapshot sn = monadicST $ do

--- a/hydra-node/test/Hydra/SnapshotStrategySpec.hs
+++ b/hydra-node/test/Hydra/SnapshotStrategySpec.hs
@@ -21,7 +21,7 @@ import Hydra.HeadLogic (
   newSn,
   updateHeadState,
  )
-import Hydra.HeadLogicSpec (inOpenState')
+import Hydra.HeadLogicSpec (headParameters, inOpenState')
 import Hydra.Ledger (
   Ledger (..),
   txId,
@@ -99,7 +99,7 @@ spec = do
                   }
               ost = inOpenState' threeParties coordinatedState
           let expectedEvent = SnapshotEmited{requested = 1, lastSeenSnapshot = NoSeenSnapshot}
-          emitSnapshot (envFor aliceSk) ost (NewState [])
+          emitSnapshot (envFor aliceSk) (headParameters threeParties) coordinatedState NoSeenSnapshot
             `shouldBe` NewState [expectedEvent]
             `Combined` Effects [NetworkEffect $ ReqSn 1 [txId tx]]
 


### PR DESCRIPTION
Fixes #913 

<!-- Describe your change here -->

🏖️ The head logic now produces a list of events as part of its outcome during `update`.

🏖️ The node now applies a transition function to update the current state (in memory) while processing events.

🏖️ After every processed event, the node will persist it incrementally on disk.

🏖️ The node, upon start, will recover the head state from the persisted events.

🏖️ The below image summarize the transition function `updateHeadState`

<img width="1379" alt="image" src="https://github.com/input-output-hk/hydra/assets/14299604/32abc873-4669-4a0c-b48a-e9355c2f0742">
---

🐻 Proposal: Removed the previous reference from `ChainStateAt`.
- This makes head state events very lightweight (and can be improved even more by only persisting the current slot if there are no other changes on-chain after an observation).
- By persisting head state events along with chain state events, we ensure atomicity.
- This makes the rollback have to load all persisted events to compute the current chain state.
- No changes to persisted events will take place after rollback takes place. ⚠️ 
   We are expecting to address this as part of [this](https://github.com/input-output-hk/hydra/issues/185) story.

🐯 Proposal: Re-model `emitSnapshot` as a new internal effect/event process.
- This splits the process in two parts: effect & event
- The effect is being produced by the HeadLogic, during `ReqTx` and `AckSn` handling, and it carries the action of `ReqEmitSn`.
- The event (`EmitSn`) is being produced by the Node during the new effect processing, and is expected to be handled by the HeadLogic only when in `OpenState`.
- Because EmitSn is prepended to the queue, it is expected to be processed by the node immediately.
- This model is consistent and cohesive with the rest of the code.


<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
