### PR TITLE
Make with heartbeat more general

### DIFF
--- a/hydra-node/golden/HydraNodeLog SimpleTx.json
+++ b/hydra-node/golden/HydraNodeLog SimpleTx.json
@@ -983,8 +983,51 @@
                     },
                     {
                         "message": {
-                            "nodeId": "xesrfhamfdiwmt",
-                            "tag": "Connected"
+                            "party": {
+                                "vkey": "8edb18d298d9f72af3f1c3a807b9a712f22f3538e6c4464f2480585f3bd245fe"
+                            },
+                            "tag": "ReqTx",
+                            "transaction": {
+                                "id": 14,
+                                "inputs": [
+                                    -30,
+                                    -23,
+                                    -13,
+                                    -9,
+                                    -7,
+                                    6,
+                                    10,
+                                    23,
+                                    27,
+                                    28,
+                                    30
+                                ],
+                                "outputs": [
+                                    -28,
+                                    -25,
+                                    -23,
+                                    -22,
+                                    -18,
+                                    -17,
+                                    -12,
+                                    -11,
+                                    -10,
+                                    -7,
+                                    -6,
+                                    6,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    17,
+                                    18,
+                                    24,
+                                    25,
+                                    26,
+                                    27
+                                ]
+                            }
                         },
                         "tag": "NetworkEffect"
                     },
@@ -999,8 +1042,22 @@
                     },
                     {
                         "message": {
-                            "nodeId": "iwqrxexqufhwuamtztftzpsviaigfu",
-                            "tag": "Disconnected"
+                            "party": {
+                                "vkey": "e0019eb95cfef3546d2a94316a1d00763118a57612531b83b2581ef4ff9c3571"
+                            },
+                            "tag": "ReqTx",
+                            "transaction": {
+                                "id": 26,
+                                "inputs": [
+                                    -30,
+                                    -21,
+                                    -5
+                                ],
+                                "outputs": [
+                                    -18,
+                                    23
+                                ]
+                            }
                         },
                         "tag": "NetworkEffect"
                     },

--- a/hydra-node/golden/Message SimpleTx.json
+++ b/hydra-node/golden/Message SimpleTx.json
@@ -2,111 +2,15 @@
     "samples": [
         {
             "party": {
-                "vkey": "be16e9244485db773c136410300b1a3fd2ee115845be4378de5dfe61ab69c967"
+                "vkey": "ce1b146c7461cad519b8308b0ce97a1105ce0c78e7e749d175e82fa037f77229"
             },
-            "snapshotNumber": 6,
-            "tag": "ReqSn",
-            "transactions": [
-                {
-                    "id": -23,
-                    "inputs": [
-                        -26,
-                        -20,
-                        -19,
-                        -14,
-                        -13,
-                        -7,
-                        -5,
-                        -2,
-                        1,
-                        4,
-                        8,
-                        10,
-                        12,
-                        16,
-                        18,
-                        19,
-                        20,
-                        24,
-                        27,
-                        28,
-                        30
-                    ],
-                    "outputs": [
-                        -7,
-                        14,
-                        23
-                    ]
-                },
-                {
-                    "id": -20,
-                    "inputs": [
-                        -27,
-                        -21,
-                        -14,
-                        -11,
-                        -10,
-                        -9,
-                        13,
-                        16,
-                        17,
-                        18,
-                        21,
-                        30
-                    ],
-                    "outputs": [
-                        -27,
-                        -23,
-                        -21,
-                        -19,
-                        -14,
-                        -12,
-                        11,
-                        13,
-                        15,
-                        18,
-                        20,
-                        21,
-                        23,
-                        24,
-                        28
-                    ]
-                },
-                {
-                    "id": 21,
-                    "inputs": [
-                        -30,
-                        -25,
-                        -20,
-                        -17,
-                        -16,
-                        -15,
-                        -13,
-                        -7,
-                        -2,
-                        0,
-                        2,
-                        5,
-                        6,
-                        7,
-                        9,
-                        11,
-                        12,
-                        15,
-                        22,
-                        28,
-                        30
-                    ],
-                    "outputs": [
-                        16,
-                        21
-                    ]
-                }
-            ]
+            "signed": "11c7c7edfcdf2fe63439d2c32f4bb9ca35c8063aab8ebaf85cc2e492b878d87b61c618ecc873994b3ad6256e8479181aab3bc051955381a72c2ceea5d554210e",
+            "snapshotNumber": 12,
+            "tag": "AckSn"
         },
         {
             "party": {
-                "vkey": "041a3b93c0a27de4d9a75ce616291db3e4fc5d3a4d0af4294a912e11ce8bff0b"
+                "vkey": "f11b24c8db59dfd768d6a0c71e44319662721c40ddebaaab55c4614ec4755dc9"
             },
             "snapshotNumber": 10,
             "tag": "ReqSn",
@@ -900,7 +804,7 @@
         },
         {
             "party": {
-                "vkey": "9663811e72361f9ec5ed78529c9263e91d8a59cbd6e899752f89d29211583c05"
+                "vkey": "d064917db1d03ca2cd885a7703a1352e9a55acd2d0d8d573f8e1831101eeb589"
             },
             "tag": "ReqTx",
             "transaction": {
@@ -924,14 +828,63 @@
             }
         },
         {
-            "nodeId": "aefcpxbckfphzuyukurpnvgqtu",
-            "tag": "Connected"
+            "party": {
+                "vkey": "f74c0b8b9619c9069d808e2a358ad497ecf5ebd03e369d5b2283dd2ba2246199"
+            },
+            "tag": "ReqTx",
+            "transaction": {
+                "id": -27,
+                "inputs": [
+                    -25,
+                    -22,
+                    -21,
+                    -19,
+                    -13,
+                    -9,
+                    -1,
+                    0,
+                    3,
+                    7,
+                    8,
+                    9,
+                    12,
+                    14,
+                    20,
+                    21,
+                    22,
+                    24,
+                    25,
+                    27,
+                    28,
+                    30
+                ],
+                "outputs": [
+                    -30,
+                    -25,
+                    -23,
+                    -19,
+                    -15,
+                    -14,
+                    -1,
+                    0,
+                    11,
+                    12,
+                    15,
+                    17,
+                    20,
+                    21,
+                    23,
+                    24,
+                    25,
+                    29
+                ]
+            }
         },
         {
             "party": {
-                "vkey": "c3e808e514e186f6d187e611f949bd33fcf172d59cf80c666ceaa97f1995c33d"
+                "vkey": "5409ed3708fd864186f0a487828abe38be2a486728687ccccd445b92f4e6988b"
             },
-            "signed": "0fab631ea716558b9c5a9417ea494d3739c62b5d14f0d47abb990be079a2232f4f24e09f3d3595c162adaafe7581bf1d5e385d12cf83625af765698cb032a305",
+            "signed": "c7200b59662f30be4446cf27059f15e2390673d5e51fc9e9c4dae4520189b689fd40b97bda72e3fde1412b13368150ba285c99019f2e645f95ae62b1a3f17e0f",
             "snapshotNumber": 15,
             "tag": "AckSn"
         }

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1022,10 +1022,6 @@ update env ledger st ev = case (st, ev) of
     NewState (Open ost{currentSlot = chainSlot}) []
   (_, OnChainEvent Tick{}) ->
     OnlyEffects []
-  (_, NetworkEvent _ (Connected nodeId)) ->
-    OnlyEffects [ClientEffect $ PeerConnected{peer = nodeId}]
-  (_, NetworkEvent _ (Disconnected nodeId)) ->
-    OnlyEffects [ClientEffect $ PeerDisconnected{peer = nodeId}]
   (_, PostTxError{postChainTx, postTxError}) ->
     OnlyEffects [ClientEffect $ PostTxOnChainFailed{postChainTx, postTxError}]
   (_, ClientEvent{clientInput}) ->

--- a/hydra-node/src/Hydra/Network/Message.hs
+++ b/hydra-node/src/Hydra/Network/Message.hs
@@ -10,14 +10,20 @@ import Hydra.Network (NodeId)
 import Hydra.Party (Party)
 import Hydra.Snapshot (Snapshot, SnapshotNumber)
 
+
+data Connectivity
+  = Connected {nodeId :: NodeId}
+  | Disconnected {nodeId :: NodeId}
+  deriving stock (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+
 -- NOTE(SN): Every message comes from a 'Party', we might want to move it out of
 -- here into the 'NetworkEvent'
 data Message tx
   = ReqTx {party :: Party, transaction :: tx}
   | ReqSn {party :: Party, snapshotNumber :: SnapshotNumber, transactions :: [tx]}
   | AckSn {party :: Party, signed :: Signature (Snapshot tx), snapshotNumber :: SnapshotNumber}
-  | Connected {nodeId :: NodeId}
-  | Disconnected {nodeId :: NodeId}
   deriving stock (Generic, Eq, Show)
   deriving anyclass (ToJSON, FromJSON)
 
@@ -29,8 +35,6 @@ instance (ToCBOR tx, ToCBOR (UTxOType tx)) => ToCBOR (Message tx) where
     ReqTx party tx -> toCBOR ("ReqTx" :: Text) <> toCBOR party <> toCBOR tx
     ReqSn party sn txs -> toCBOR ("ReqSn" :: Text) <> toCBOR party <> toCBOR sn <> toCBOR txs
     AckSn party sig sn -> toCBOR ("AckSn" :: Text) <> toCBOR party <> toCBOR sig <> toCBOR sn
-    Connected nodeId -> toCBOR ("Connected" :: Text) <> toCBOR nodeId
-    Disconnected nodeId -> toCBOR ("Disconnected" :: Text) <> toCBOR nodeId
 
 instance (FromCBOR tx, FromCBOR (UTxOType tx)) => FromCBOR (Message tx) where
   fromCBOR =
@@ -38,6 +42,4 @@ instance (FromCBOR tx, FromCBOR (UTxOType tx)) => FromCBOR (Message tx) where
       ("ReqTx" :: Text) -> ReqTx <$> fromCBOR <*> fromCBOR
       "ReqSn" -> ReqSn <$> fromCBOR <*> fromCBOR <*> fromCBOR
       "AckSn" -> AckSn <$> fromCBOR <*> fromCBOR <*> fromCBOR
-      "Connected" -> Connected <$> fromCBOR
-      "Disconnected" -> Disconnected <$> fromCBOR
       msg -> fail $ show msg <> " is not a proper CBOR-encoded Message"

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -47,8 +47,7 @@ import Hydra.HeadLogic (
 import Hydra.Ledger (ChainSlot (..), Ledger (..), ValidationError (..))
 import Hydra.Ledger.Cardano (cardanoLedger, genKeyPair, genOutput, mkRangedTx)
 import Hydra.Ledger.Simple (SimpleChainState (..), SimpleTx (..), aValidTx, simpleLedger, utxoRef)
-import Hydra.Network (NodeId (..))
-import Hydra.Network.Message (Message (AckSn, Connected, ReqSn, ReqTx))
+import Hydra.Network.Message (Message (AckSn, ReqSn, ReqTx))
 import Hydra.Options (defaultContestationPeriod)
 import Hydra.Party (Party (..))
 import qualified Hydra.Prelude as Prelude
@@ -268,11 +267,6 @@ spec =
         let s0 = inClosedState threeParties
             event = NetworkEvent defaultTTL $ ReqTx alice (aValidTx 42)
         update bobEnv ledger s0 event `shouldBe` Error (InvalidEvent event s0)
-
-      it "notifies client when it receives a ping" $ do
-        let nodeId = NodeId "My special node id"
-        update bobEnv ledger (inOpenState threeParties ledger) (NetworkEvent defaultTTL $ Connected nodeId)
-          `hasEffect` ClientEffect (PeerConnected nodeId)
 
       it "everyone does collect on last commit after collect com" $ do
         let aliceCommit = OnCommitTx alice (utxoRef 1)

--- a/hydra-node/test/Hydra/Network/HeartbeatSpec.hs
+++ b/hydra-node/test/Hydra/Network/HeartbeatSpec.hs
@@ -7,7 +7,7 @@ import Control.Concurrent.Class.MonadSTM (MonadSTM (readTVarIO), modifyTVar', ne
 import Control.Monad.IOSim (runSimOrThrow)
 import Hydra.Network (Network (..), NodeId (..))
 import Hydra.Network.Heartbeat (Heartbeat (..), withHeartbeat)
-import Hydra.Network.Message (Message (Connected, Disconnected))
+import Hydra.Network.Message (Connectivity (Connected, Disconnected))
 
 spec :: Spec
 spec = parallel $ do
@@ -34,7 +34,7 @@ spec = parallel $ do
 
   it "sends Connected when Ping received from other peer" $ do
     let receivedHeartbeats = runSimOrThrow $ do
-          receivedMessages <- newTVarIO ([] :: [Message ()])
+          receivedMessages <- newTVarIO ([] :: [Connectivity])
 
           withHeartbeat nodeId (captureIncoming receivedMessages) (\incoming _ -> incoming (Ping otherNodeId)) noop $ \_ ->
             threadDelay 1
@@ -45,7 +45,7 @@ spec = parallel $ do
 
   it "sends Connected when any message received from other party" $ do
     let receivedHeartbeats = runSimOrThrow $ do
-          receivedMessages <- newTVarIO ([] :: [Message ()])
+          receivedMessages <- newTVarIO ([] :: [Connectivity])
 
           withHeartbeat nodeId (captureIncoming receivedMessages) (\incoming _ -> incoming (Data otherNodeId ())) noop $ \_ ->
             threadDelay 1
@@ -56,7 +56,7 @@ spec = parallel $ do
 
   it "do not send Connected on subsequent messages from already Connected party" $ do
     let receivedHeartbeats = runSimOrThrow $ do
-          receivedMessages <- newTVarIO ([] :: [Message ()])
+          receivedMessages <- newTVarIO ([] :: [Connectivity])
 
           withHeartbeat nodeId (captureIncoming receivedMessages) (\incoming _ -> incoming (Data otherNodeId ()) >> incoming (Ping otherNodeId)) noop $ \_ ->
             threadDelay 1
@@ -67,7 +67,7 @@ spec = parallel $ do
 
   it "sends Disconnected given no messages has been received from known party within twice heartbeat delay" $ do
     let receivedHeartbeats = runSimOrThrow $ do
-          receivedMessages <- newTVarIO ([] :: [Message ()])
+          receivedMessages <- newTVarIO ([] :: [Connectivity])
 
           let component incoming action =
                 race_

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -32,7 +32,7 @@ import Hydra.HeadLogic (
 import Hydra.Ledger (ChainSlot (ChainSlot))
 import Hydra.Ledger.Simple (SimpleChainState (..), SimpleTx (..), simpleLedger, utxoRef, utxoRefs)
 import Hydra.Logging (Tracer, showLogsOnFailure)
-import Hydra.Network (Network (..), NodeId (..))
+import Hydra.Network (Network (..))
 import Hydra.Network.Message (Message (..))
 import Hydra.Node (
   HydraNode (..),
@@ -104,11 +104,7 @@ spec = parallel $ do
 
   it "notifies client when postTx throws PostTxError" $
     showLogsOnFailure $ \tracer -> do
-      let events =
-            [ NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = NodeId "NodeId1"}}
-            , NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = NodeId "NodeId2"}}
-            , ClientEvent Init
-            ]
+      let events = [ ClientEvent Init ]
       (node, getServerOutputs) <- createHydraNode aliceSk [bob, carol] cperiod events >>= throwExceptionOnPostTx NoSeedInput >>= recordServerOutputs
 
       runToCompletion tracer node
@@ -118,9 +114,7 @@ spec = parallel $ do
 
 eventsToOpenHead :: [Event SimpleTx]
 eventsToOpenHead =
-  [ NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = NodeId "NodeId1"}}
-  , NetworkEvent{ttl = defaultTTL, message = Connected{nodeId = NodeId "NodeId2"}}
-  , observationEvent $ OnInitTx (HeadId "1234") cperiod [alice, bob, carol]
+  [ observationEvent $ OnInitTx (HeadId "1234") cperiod [alice, bob, carol]
   , ClientEvent{clientInput = Commit (utxoRef 2)}
   , observationEvent $ OnCommitTx carol (utxoRef 3)
   , observationEvent $ OnCommitTx bob (utxoRef 2)

--- a/hydra-plutus/test/Hydra/Plutus/GoldenSpec.hs
+++ b/hydra-plutus/test/Hydra/Plutus/GoldenSpec.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE TypeApplications #-}
+
 
 -- | Golden tests of hydra-plutus scripts.
 --


### PR DESCRIPTION
The Message type includes both, hydra protocol messages and connectivity related messages. Mixing both of them poses several issues:
* The HeadLogic is polluted by these connectivity messages
* Introducing an authentication of the messages is more complicated since connectivity messages has no concept of a party who could sign them see #727 

This PR splits the Messages into the core Messages of a Hydra head and the Connectivity messages. Connectivity messages will not reach the HeadLogic and go straight from the network middleware managing connectivity to the clients connected to the Hydra node.

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
