### PR TITLE
Introduce new module for HeadLogic types

### DIFF
--- a/hydra-cluster/src/Hydra/LogFilter.hs
+++ b/hydra-cluster/src/Hydra/LogFilter.hs
@@ -9,7 +9,7 @@ import Hydra.Prelude hiding (id)
 import qualified Data.Map as Map
 import Hydra.API.ClientInput (ClientInput (NewTx))
 import Hydra.API.ServerOutput (ServerOutput (..))
-import Hydra.HeadLogic (Effect (..), Event (..))
+import Hydra.HeadLogicTypes (Effect (..), Event (..))
 import Hydra.Ledger (IsTx (..))
 import Hydra.Logging (Envelope (..))
 import Hydra.Logging.Messages (HydraLog (Node))

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -75,7 +75,7 @@ import Hydra.Cluster.Scenarios (
 import Hydra.Cluster.Util (chainConfigFor, keysFor)
 import Hydra.ContestationPeriod (ContestationPeriod (UnsafeContestationPeriod))
 import Hydra.Crypto (HydraKey, generateSigningKey)
-import Hydra.HeadLogic (HeadState (Open), OpenState (parameters))
+import Hydra.HeadLogicTypes (HeadState (Open), OpenState (parameters))
 import Hydra.Ledger (txId)
 import Hydra.Ledger.Cardano (genKeyPair, mkRangedTx, mkSimpleTx)
 import Hydra.Logging (Tracer, showLogsOnFailure)

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -5,13 +5,15 @@ module Main where
 import Hydra.Prelude
 
 import Hydra.API.Server (Server (Server, sendOutput), withAPIServer)
+import Hydra.API.ServerOutput (ServerOutput (PeerConnected, PeerDisconnected))
 import Hydra.Cardano.Api (serialiseToRawBytesHex)
 import Hydra.Chain (HeadParameters (..))
 import Hydra.Chain.CardanoClient (QueryPoint (..), queryGenesisParameters)
 import Hydra.Chain.Direct (initialChainState, loadChainContext, mkTinyWallet, withDirectChain)
 import Hydra.Chain.Direct.ScriptRegistry (publishHydraScripts)
 import Hydra.Chain.Direct.Util (readKeyPair)
-import Hydra.HeadLogic (
+import Hydra.HeadLogic (getChainState)
+import Hydra.HeadLogicTypes (
   ClosedState (..),
   Environment (..),
   Event (..),
@@ -20,7 +22,6 @@ import Hydra.HeadLogic (
   InitialState (..),
   OpenState (..),
   defaultTTL,
-  getChainState,
  )
 import qualified Hydra.Ledger.Cardano as Ledger
 import Hydra.Ledger.Cardano.Configuration (
@@ -55,7 +56,6 @@ import Hydra.Options (
   validateRunOptions,
  )
 import Hydra.Persistence (Persistence (load), createPersistence, createPersistenceIncremental)
-import Hydra.API.ServerOutput (ServerOutput(PeerConnected, PeerDisconnected))
 
 newtype ParamMismatchError = ParamMismatchError String deriving (Eq, Show)
 

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -94,6 +94,7 @@ library
     Hydra.ContestationPeriod
     Hydra.Crypto
     Hydra.HeadLogic
+    Hydra.HeadLogicTypes
     Hydra.Ledger
     Hydra.Ledger.Cardano
     Hydra.Ledger.Cardano.Builder

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -30,114 +30,25 @@ import Hydra.Chain (
   IsChainState (chainStateSlot),
   OnChainTx (..),
   PostChainTx (..),
-  PostTxError,
  )
 import Hydra.ContestationPeriod
 import Hydra.Crypto (
-  HydraKey,
   Signature,
-  SigningKey,
-  VerificationKey,
   aggregateInOrder,
   sign,
   verifyMultiSignature,
  )
+import Hydra.HeadLogicTypes
 import Hydra.Ledger (
-  ChainSlot,
   IsTx,
   Ledger (..),
   UTxOType,
-  ValidationError,
   applyTransactions,
   txId,
  )
 import Hydra.Network.Message (Message (..))
 import Hydra.Party (Party (vkey))
 import Hydra.Snapshot (ConfirmedSnapshot (..), Snapshot (..), SnapshotNumber, getSnapshot)
-
--- * Types
-
--- TODO: Move logic up and types down or re-organize using explicit exports
-
--- | The different events which are processed by the head logic (the "core").
--- Corresponding to each of the "shell" layers, we distinguish between events
--- from the client, the network and the chain.
-data Event tx
-  = -- | Event received from clients via the "Hydra.API".
-    ClientEvent {clientInput :: ClientInput tx}
-  | -- | Event received from peers via a "Hydra.Network".
-    --
-    --  * `ttl` is a simple counter that's decreased every time the event is
-    --    reenqueued due to a wait. It's default value is `defaultTTL`
-    NetworkEvent {ttl :: TTL, message :: Message tx}
-  | -- | Event received from the chain via a "Hydra.Chain".
-    OnChainEvent {chainEvent :: ChainEvent tx}
-  | -- | Event to re-ingest errors from 'postTx' for further processing.
-    PostTxError {postChainTx :: PostChainTx tx, postTxError :: PostTxError tx}
-  deriving stock (Generic)
-
-deriving instance (IsTx tx, IsChainState tx) => Eq (Event tx)
-deriving instance (IsTx tx, IsChainState tx) => Show (Event tx)
-deriving instance (IsTx tx, IsChainState tx) => ToJSON (Event tx)
-deriving instance (IsTx tx, IsChainState tx) => FromJSON (Event tx)
-
-instance
-  ( IsTx tx
-  , Arbitrary (ChainStateType tx)
-  ) =>
-  Arbitrary (Event tx)
-  where
-  arbitrary = genericArbitrary
-
--- | Analogous to events, the pure head logic "core" can have effects emited to
--- the "shell" layers and we distinguish the same: effects onto the client, the
--- network and the chain.
-data Effect tx
-  = -- | Effect to be handled by the "Hydra.API", results in sending this 'ServerOutput'.
-    ClientEffect {serverOutput :: ServerOutput tx}
-  | -- | Effect to be handled by a "Hydra.Network", results in a 'Hydra.Network.broadcast'.
-    NetworkEffect {message :: Message tx}
-  | -- | Effect to be handled by a "Hydra.Chain", results in a 'Hydra.Chain.postTx'.
-    OnChainEffect {postChainTx :: PostChainTx tx}
-  deriving stock (Generic)
-
-deriving instance (IsTx tx, IsChainState tx) => Eq (Effect tx)
-deriving instance (IsTx tx, IsChainState tx) => Show (Effect tx)
-deriving instance (IsTx tx, IsChainState tx) => ToJSON (Effect tx)
-deriving instance (IsTx tx, IsChainState tx) => FromJSON (Effect tx)
-
-instance
-  ( IsTx tx
-  , Arbitrary (ChainStateType tx)
-  ) =>
-  Arbitrary (Effect tx)
-  where
-  arbitrary = genericArbitrary
-
--- | The main state of the Hydra protocol state machine. It holds both, the
--- overall protocol state, but also the off-chain 'CoordinatedHeadState'.
---
--- Each of the sub-types (InitialState, OpenState, etc.) contain black-box
--- 'chainState' corresponding to 'OnChainEvent' that has been observed leading
--- to the state.
---
--- Note that rollbacks are currently not fully handled in the head logic and
--- only this internal chain state gets replaced with the "rolled back to"
--- version.
-data HeadState tx
-  = Idle (IdleState tx)
-  | Initial (InitialState tx)
-  | Open (OpenState tx)
-  | Closed (ClosedState tx)
-  deriving stock (Generic)
-
-instance (IsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (HeadState tx) where
-  arbitrary = genericArbitrary
-
-deriving instance (IsTx tx, Eq (ChainStateType tx)) => Eq (HeadState tx)
-deriving instance (IsTx tx, Show (ChainStateType tx)) => Show (HeadState tx)
-deriving instance (IsTx tx, ToJSON (ChainStateType tx)) => ToJSON (HeadState tx)
-deriving instance (IsTx tx, FromJSON (ChainStateType tx)) => FromJSON (HeadState tx)
 
 -- | Get the chain state in any 'HeadState'.
 getChainState :: HeadState tx -> ChainStateType tx
@@ -155,127 +66,6 @@ setChainState chainState = \case
   Open st -> Open st{chainState}
   Closed st -> Closed st{chainState}
 
--- ** Idle
-
--- | An 'Idle' head only having a chain state with things seen on chain so far.
-newtype IdleState tx = IdleState {chainState :: ChainStateType tx}
-  deriving (Generic)
-
-deriving instance Eq (ChainStateType tx) => Eq (IdleState tx)
-deriving instance Show (ChainStateType tx) => Show (IdleState tx)
-deriving anyclass instance ToJSON (ChainStateType tx) => ToJSON (IdleState tx)
-deriving anyclass instance FromJSON (ChainStateType tx) => FromJSON (IdleState tx)
-
-instance (Arbitrary (ChainStateType tx)) => Arbitrary (IdleState tx) where
-  arbitrary = genericArbitrary
-
--- ** Initial
-
--- | An 'Initial' head which already has an identity and is collecting commits.
-data InitialState tx = InitialState
-  { parameters :: HeadParameters
-  , pendingCommits :: PendingCommits
-  , committed :: Committed tx
-  , chainState :: ChainStateType tx
-  , headId :: HeadId
-  }
-  deriving (Generic)
-
-deriving instance (IsTx tx, Eq (ChainStateType tx)) => Eq (InitialState tx)
-deriving instance (IsTx tx, Show (ChainStateType tx)) => Show (InitialState tx)
-deriving instance (IsTx tx, ToJSON (ChainStateType tx)) => ToJSON (InitialState tx)
-deriving instance (IsTx tx, FromJSON (ChainStateType tx)) => FromJSON (InitialState tx)
-
-instance (IsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (InitialState tx) where
-  arbitrary = do
-    InitialState
-      <$> arbitrary
-      <*> arbitrary
-      <*> arbitrary
-      <*> arbitrary
-      <*> arbitrary
-
-type PendingCommits = Set Party
-
-type Committed tx = Map Party (UTxOType tx)
-
--- ** Open
-
--- | An 'Open' head with a 'CoordinatedHeadState' tracking off-chain
--- transactions.
-data OpenState tx = OpenState
-  { parameters :: HeadParameters
-  , coordinatedHeadState :: CoordinatedHeadState tx
-  , chainState :: ChainStateType tx
-  , headId :: HeadId
-  , currentSlot :: ChainSlot
-  }
-  deriving (Generic)
-
-deriving instance (IsTx tx, Eq (ChainStateType tx)) => Eq (OpenState tx)
-deriving instance (IsTx tx, Show (ChainStateType tx)) => Show (OpenState tx)
-deriving instance (IsTx tx, ToJSON (ChainStateType tx)) => ToJSON (OpenState tx)
-deriving instance (IsTx tx, FromJSON (ChainStateType tx)) => FromJSON (OpenState tx)
-
-instance (IsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (OpenState tx) where
-  arbitrary =
-    OpenState
-      <$> arbitrary
-      <*> arbitrary
-      <*> arbitrary
-      <*> arbitrary
-      <*> arbitrary
-
--- | Off-chain state of the Coordinated Head protocol.
-data CoordinatedHeadState tx = CoordinatedHeadState
-  { seenUTxO :: UTxOType tx
-  -- ^ The latest UTxO resulting from applying 'seenTxs' to
-  -- 'confirmedSnapshot'. Spec: L̂
-  , seenTxs :: [tx]
-  -- ^ List of seen transactions pending inclusion in a snapshot. Spec: T̂
-  , confirmedSnapshot :: ConfirmedSnapshot tx
-  -- ^ The latest confirmed snapshot. Spec: U̅, s̅ and σ̅
-  , seenSnapshot :: SeenSnapshot tx
-  -- ^ Last seen snapshot and signatures accumulator. Spec: Û, ŝ and Σ̂
-  }
-  deriving stock (Generic)
-
-deriving instance IsTx tx => Eq (CoordinatedHeadState tx)
-deriving instance IsTx tx => Show (CoordinatedHeadState tx)
-deriving instance IsTx tx => ToJSON (CoordinatedHeadState tx)
-deriving instance IsTx tx => FromJSON (CoordinatedHeadState tx)
-
-instance IsTx tx => Arbitrary (CoordinatedHeadState tx) where
-  arbitrary = genericArbitrary
-
--- | Data structure to help in tracking whether we have seen or requested a
--- ReqSn already and if seen, the signatures we collected already.
-data SeenSnapshot tx
-  = -- | Never saw a ReqSn.
-    NoSeenSnapshot
-  | -- | No snapshot in flight with last seen snapshot number as given.
-    LastSeenSnapshot {lastSeen :: SnapshotNumber}
-  | -- | ReqSn was sent out and it should be considered already in flight.
-    RequestedSnapshot
-      { lastSeen :: SnapshotNumber
-      , requested :: SnapshotNumber
-      }
-  | -- | ReqSn for given snapshot was received.
-    SeenSnapshot
-      { snapshot :: Snapshot tx
-      , signatories :: Map Party (Signature (Snapshot tx))
-      -- ^ Collected signatures and so far.
-      }
-  deriving stock (Generic)
-
-instance IsTx tx => Arbitrary (SeenSnapshot tx) where
-  arbitrary = genericArbitrary
-
-deriving instance IsTx tx => Eq (SeenSnapshot tx)
-deriving instance IsTx tx => Show (SeenSnapshot tx)
-deriving instance IsTx tx => ToJSON (SeenSnapshot tx)
-deriving instance IsTx tx => FromJSON (SeenSnapshot tx)
-
 -- | Get the last seen snapshot number given a 'SeenSnapshot'.
 seenSnapshotNumber :: SeenSnapshot tx -> SnapshotNumber
 seenSnapshotNumber = \case
@@ -283,113 +73,6 @@ seenSnapshotNumber = \case
   LastSeenSnapshot{lastSeen} -> lastSeen
   RequestedSnapshot{lastSeen} -> lastSeen
   SeenSnapshot{snapshot = Snapshot{number}} -> number
-
--- ** Closed
-
--- | An 'Closed' head with an current candidate 'ConfirmedSnapshot', which may
--- be contested before the 'contestationDeadline'.
-data ClosedState tx = ClosedState
-  { parameters :: HeadParameters
-  , confirmedSnapshot :: ConfirmedSnapshot tx
-  , contestationDeadline :: UTCTime
-  , readyToFanoutSent :: Bool
-  -- ^ Tracks whether we have informed clients already about being
-  -- 'ReadyToFanout'.
-  , chainState :: ChainStateType tx
-  , headId :: HeadId
-  }
-  deriving (Generic)
-
-deriving instance (IsTx tx, Eq (ChainStateType tx)) => Eq (ClosedState tx)
-deriving instance (IsTx tx, Show (ChainStateType tx)) => Show (ClosedState tx)
-deriving instance (IsTx tx, ToJSON (ChainStateType tx)) => ToJSON (ClosedState tx)
-deriving instance (IsTx tx, FromJSON (ChainStateType tx)) => FromJSON (ClosedState tx)
-
-instance (IsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (ClosedState tx) where
-  arbitrary =
-    ClosedState
-      <$> arbitrary
-      <*> arbitrary
-      <*> arbitrary
-      <*> arbitrary
-      <*> arbitrary
-      <*> arbitrary
-
--- ** Other types
-
-type TTL = Natural
-
-defaultTTL :: TTL
-defaultTTL = 5
-
--- | Preliminary type for collecting errors occurring during 'update'.
--- TODO: Try to merge this (back) into 'Outcome'.
-data LogicError tx
-  = InvalidEvent (Event tx) (HeadState tx)
-  | InvalidState (HeadState tx)
-  | InvalidSnapshot {expected :: SnapshotNumber, actual :: SnapshotNumber}
-  | LedgerError ValidationError
-  | RequireFailed RequirementFailure
-  | NotOurHead {ourHeadId :: HeadId, otherHeadId :: HeadId}
-  deriving stock (Generic)
-
-instance (Typeable tx, Show (Event tx), Show (HeadState tx)) => Exception (LogicError tx)
-
-instance (Arbitrary (Event tx), Arbitrary (HeadState tx)) => Arbitrary (LogicError tx) where
-  arbitrary = genericArbitrary
-
-deriving instance (Eq (HeadState tx), Eq (Event tx)) => Eq (LogicError tx)
-deriving instance (Show (HeadState tx), Show (Event tx)) => Show (LogicError tx)
-deriving instance (ToJSON (Event tx), ToJSON (HeadState tx)) => ToJSON (LogicError tx)
-deriving instance (FromJSON (Event tx), FromJSON (HeadState tx)) => FromJSON (LogicError tx)
-
-data RequirementFailure
-  = ReqSnNumberInvalid {requestedSn :: SnapshotNumber, lastSeenSn :: SnapshotNumber}
-  | ReqSnNotLeader {requestedSn :: SnapshotNumber, leader :: Party}
-  | InvalidMultisignature {multisig :: Text, vkeys :: [VerificationKey HydraKey]}
-  | SnapshotAlreadySigned {knownSignatures :: [Party], receivedSignature :: Party}
-  | AckSnNumberInvalid {requestedSn :: SnapshotNumber, lastSeenSn :: SnapshotNumber}
-  deriving stock (Eq, Show, Generic)
-  deriving anyclass (ToJSON, FromJSON)
-
-instance Arbitrary RequirementFailure where
-  arbitrary = genericArbitrary
-
-data Outcome tx
-  = OnlyEffects {effects :: [Effect tx]}
-  | NewState {headState :: HeadState tx, effects :: [Effect tx]}
-  | Wait {reason :: WaitReason}
-  | Error {error :: LogicError tx}
-  deriving stock (Generic)
-
-deriving instance (IsTx tx, IsChainState tx) => Eq (Outcome tx)
-deriving instance (IsTx tx, IsChainState tx) => Show (Outcome tx)
-deriving instance (IsTx tx, IsChainState tx) => ToJSON (Outcome tx)
-deriving instance (IsTx tx, IsChainState tx) => FromJSON (Outcome tx)
-
-instance (IsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (Outcome tx) where
-  arbitrary = genericArbitrary
-
-data WaitReason
-  = WaitOnNotApplicableTx {validationError :: ValidationError}
-  | WaitOnSnapshotNumber {waitingFor :: SnapshotNumber}
-  | WaitOnSeenSnapshot
-  | WaitOnContestationDeadline
-  deriving stock (Generic, Eq, Show)
-  deriving anyclass (ToJSON, FromJSON)
-
-instance Arbitrary WaitReason where
-  arbitrary = genericArbitrary
-
-data Environment = Environment
-  { party :: Party
-  -- ^ This is the p_i from the paper
-  , -- NOTE(MB): In the long run we would not want to keep the signing key in
-    -- memory, i.e. have an 'Effect' for signing or so.
-    signingKey :: SigningKey HydraKey
-  , otherParties :: [Party]
-  , contestationPeriod :: ContestationPeriod
-  }
 
 -- * The Coordinated Head protocol
 
@@ -995,10 +678,11 @@ update env ledger st ev = case (st, ev) of
     onOpenNetworkAckSn env openState otherParty snapshotSignature sn
   ( Open openState@OpenState{headId = ourHeadId}
     , OnChainEvent Observation{observedTx = OnCloseTx{headId, snapshotNumber = closedSnapshotNumber, contestationDeadline}, newChainState}
-    ) | ourHeadId == headId ->
-      onOpenChainCloseTx openState newChainState closedSnapshotNumber contestationDeadline
+    )
+      | ourHeadId == headId ->
+          onOpenChainCloseTx openState newChainState closedSnapshotNumber contestationDeadline
       | otherwise ->
-        Error NotOurHead{ourHeadId, otherHeadId = headId}
+          Error NotOurHead{ourHeadId, otherHeadId = headId}
   (Open OpenState{coordinatedHeadState = CoordinatedHeadState{confirmedSnapshot}, headId}, ClientEvent GetUTxO) ->
     -- TODO: Is it really intuitive that we respond from the confirmed ledger if
     -- transactions are validated against the seen ledger?
@@ -1028,19 +712,6 @@ update env ledger st ev = case (st, ev) of
     OnlyEffects [ClientEffect $ CommandFailed clientInput]
   _ ->
     Error $ InvalidEvent ev st
-
--- * Snapshot helper functions
-
-data SnapshotOutcome tx
-  = ShouldSnapshot SnapshotNumber [tx] -- TODO(AB) : should really be a Set (TxId tx)
-  | ShouldNotSnapshot NoSnapshotReason
-  deriving (Eq, Show, Generic)
-
-data NoSnapshotReason
-  = NotLeader SnapshotNumber
-  | SnapshotInFlight SnapshotNumber
-  | NoTransactionsToSnapshot
-  deriving (Eq, Show, Generic)
 
 isLeader :: HeadParameters -> Party -> SnapshotNumber -> Bool
 isLeader HeadParameters{parties} p sn =

--- a/hydra-node/src/Hydra/HeadLogicTypes.hs
+++ b/hydra-node/src/Hydra/HeadLogicTypes.hs
@@ -1,0 +1,359 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Hydra.HeadLogicTypes where
+
+import Hydra.Prelude
+
+import Hydra.API.ClientInput (ClientInput (..))
+import Hydra.API.ServerOutput (ServerOutput (..))
+import Hydra.Chain (
+  ChainEvent (..),
+  ChainStateType,
+  HeadId,
+  HeadParameters (..),
+  IsChainState,
+  PostChainTx (..),
+  PostTxError,
+ )
+import Hydra.ContestationPeriod
+import Hydra.Crypto (
+  HydraKey,
+  Signature,
+  SigningKey,
+  VerificationKey,
+ )
+import Hydra.Ledger (
+  ChainSlot,
+  IsTx,
+  UTxOType,
+  ValidationError,
+ )
+import Hydra.Network.Message (Message (..))
+import Hydra.Party (Party)
+import Hydra.Snapshot (ConfirmedSnapshot (..), Snapshot (..), SnapshotNumber)
+
+-- * Types
+
+-- TODO: Move logic up and types down or re-organize using explicit exports
+
+-- | The different events which are processed by the head logic (the "core").
+-- Corresponding to each of the "shell" layers, we distinguish between events
+-- from the client, the network and the chain.
+data Event tx
+  = -- | Event received from clients via the "Hydra.API".
+    ClientEvent {clientInput :: ClientInput tx}
+  | -- | Event received from peers via a "Hydra.Network".
+    --
+    --  * `ttl` is a simple counter that's decreased every time the event is
+    --    reenqueued due to a wait. It's default value is `defaultTTL`
+    NetworkEvent {ttl :: TTL, message :: Message tx}
+  | -- | Event received from the chain via a "Hydra.Chain".
+    OnChainEvent {chainEvent :: ChainEvent tx}
+  | -- | Event to re-ingest errors from 'postTx' for further processing.
+    PostTxError {postChainTx :: PostChainTx tx, postTxError :: PostTxError tx}
+  deriving stock (Generic)
+
+deriving instance (IsTx tx, IsChainState tx) => Eq (Event tx)
+deriving instance (IsTx tx, IsChainState tx) => Show (Event tx)
+deriving instance (IsTx tx, IsChainState tx) => ToJSON (Event tx)
+deriving instance (IsTx tx, IsChainState tx) => FromJSON (Event tx)
+
+instance
+  ( IsTx tx
+  , Arbitrary (ChainStateType tx)
+  ) =>
+  Arbitrary (Event tx)
+  where
+  arbitrary = genericArbitrary
+
+-- | Analogous to events, the pure head logic "core" can have effects emited to
+-- the "shell" layers and we distinguish the same: effects onto the client, the
+-- network and the chain.
+data Effect tx
+  = -- | Effect to be handled by the "Hydra.API", results in sending this 'ServerOutput'.
+    ClientEffect {serverOutput :: ServerOutput tx}
+  | -- | Effect to be handled by a "Hydra.Network", results in a 'Hydra.Network.broadcast'.
+    NetworkEffect {message :: Message tx}
+  | -- | Effect to be handled by a "Hydra.Chain", results in a 'Hydra.Chain.postTx'.
+    OnChainEffect {postChainTx :: PostChainTx tx}
+  deriving stock (Generic)
+
+deriving instance (IsTx tx, IsChainState tx) => Eq (Effect tx)
+deriving instance (IsTx tx, IsChainState tx) => Show (Effect tx)
+deriving instance (IsTx tx, IsChainState tx) => ToJSON (Effect tx)
+deriving instance (IsTx tx, IsChainState tx) => FromJSON (Effect tx)
+
+instance
+  ( IsTx tx
+  , Arbitrary (ChainStateType tx)
+  ) =>
+  Arbitrary (Effect tx)
+  where
+  arbitrary = genericArbitrary
+
+-- | The main state of the Hydra protocol state machine. It holds both, the
+-- overall protocol state, but also the off-chain 'CoordinatedHeadState'.
+--
+-- Each of the sub-types (InitialState, OpenState, etc.) contain black-box
+-- 'chainState' corresponding to 'OnChainEvent' that has been observed leading
+-- to the state.
+--
+-- Note that rollbacks are currently not fully handled in the head logic and
+-- only this internal chain state gets replaced with the "rolled back to"
+-- version.
+data HeadState tx
+  = Idle (IdleState tx)
+  | Initial (InitialState tx)
+  | Open (OpenState tx)
+  | Closed (ClosedState tx)
+  deriving stock (Generic)
+
+instance (IsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (HeadState tx) where
+  arbitrary = genericArbitrary
+
+deriving instance (IsTx tx, Eq (ChainStateType tx)) => Eq (HeadState tx)
+deriving instance (IsTx tx, Show (ChainStateType tx)) => Show (HeadState tx)
+deriving instance (IsTx tx, ToJSON (ChainStateType tx)) => ToJSON (HeadState tx)
+deriving instance (IsTx tx, FromJSON (ChainStateType tx)) => FromJSON (HeadState tx)
+
+-- ** Idle
+
+-- | An 'Idle' head only having a chain state with things seen on chain so far.
+newtype IdleState tx = IdleState {chainState :: ChainStateType tx}
+  deriving (Generic)
+
+deriving instance Eq (ChainStateType tx) => Eq (IdleState tx)
+deriving instance Show (ChainStateType tx) => Show (IdleState tx)
+deriving anyclass instance ToJSON (ChainStateType tx) => ToJSON (IdleState tx)
+deriving anyclass instance FromJSON (ChainStateType tx) => FromJSON (IdleState tx)
+
+instance (Arbitrary (ChainStateType tx)) => Arbitrary (IdleState tx) where
+  arbitrary = genericArbitrary
+
+-- ** Initial
+
+-- | An 'Initial' head which already has an identity and is collecting commits.
+data InitialState tx = InitialState
+  { parameters :: HeadParameters
+  , pendingCommits :: PendingCommits
+  , committed :: Committed tx
+  , chainState :: ChainStateType tx
+  , headId :: HeadId
+  }
+  deriving (Generic)
+
+deriving instance (IsTx tx, Eq (ChainStateType tx)) => Eq (InitialState tx)
+deriving instance (IsTx tx, Show (ChainStateType tx)) => Show (InitialState tx)
+deriving instance (IsTx tx, ToJSON (ChainStateType tx)) => ToJSON (InitialState tx)
+deriving instance (IsTx tx, FromJSON (ChainStateType tx)) => FromJSON (InitialState tx)
+
+instance (IsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (InitialState tx) where
+  arbitrary = do
+    InitialState
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+
+type PendingCommits = Set Party
+
+type Committed tx = Map Party (UTxOType tx)
+
+-- ** Open
+
+-- | An 'Open' head with a 'CoordinatedHeadState' tracking off-chain
+-- transactions.
+data OpenState tx = OpenState
+  { parameters :: HeadParameters
+  , coordinatedHeadState :: CoordinatedHeadState tx
+  , chainState :: ChainStateType tx
+  , headId :: HeadId
+  , currentSlot :: ChainSlot
+  }
+  deriving (Generic)
+
+deriving instance (IsTx tx, Eq (ChainStateType tx)) => Eq (OpenState tx)
+deriving instance (IsTx tx, Show (ChainStateType tx)) => Show (OpenState tx)
+deriving instance (IsTx tx, ToJSON (ChainStateType tx)) => ToJSON (OpenState tx)
+deriving instance (IsTx tx, FromJSON (ChainStateType tx)) => FromJSON (OpenState tx)
+
+instance (IsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (OpenState tx) where
+  arbitrary =
+    OpenState
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+
+-- | Off-chain state of the Coordinated Head protocol.
+data CoordinatedHeadState tx = CoordinatedHeadState
+  { seenUTxO :: UTxOType tx
+  -- ^ The latest UTxO resulting from applying 'seenTxs' to
+  -- 'confirmedSnapshot'. Spec: L̂
+  , seenTxs :: [tx]
+  -- ^ List of seen transactions pending inclusion in a snapshot. Spec: T̂
+  , confirmedSnapshot :: ConfirmedSnapshot tx
+  -- ^ The latest confirmed snapshot. Spec: U̅, s̅ and σ̅
+  , seenSnapshot :: SeenSnapshot tx
+  -- ^ Last seen snapshot and signatures accumulator. Spec: Û, ŝ and Σ̂
+  }
+  deriving stock (Generic)
+
+deriving instance IsTx tx => Eq (CoordinatedHeadState tx)
+deriving instance IsTx tx => Show (CoordinatedHeadState tx)
+deriving instance IsTx tx => ToJSON (CoordinatedHeadState tx)
+deriving instance IsTx tx => FromJSON (CoordinatedHeadState tx)
+
+instance IsTx tx => Arbitrary (CoordinatedHeadState tx) where
+  arbitrary = genericArbitrary
+
+-- | Data structure to help in tracking whether we have seen or requested a
+-- ReqSn already and if seen, the signatures we collected already.
+data SeenSnapshot tx
+  = -- | Never saw a ReqSn.
+    NoSeenSnapshot
+  | -- | No snapshot in flight with last seen snapshot number as given.
+    LastSeenSnapshot {lastSeen :: SnapshotNumber}
+  | -- | ReqSn was sent out and it should be considered already in flight.
+    RequestedSnapshot
+      { lastSeen :: SnapshotNumber
+      , requested :: SnapshotNumber
+      }
+  | -- | ReqSn for given snapshot was received.
+    SeenSnapshot
+      { snapshot :: Snapshot tx
+      , signatories :: Map Party (Signature (Snapshot tx))
+      -- ^ Collected signatures and so far.
+      }
+  deriving stock (Generic)
+
+instance IsTx tx => Arbitrary (SeenSnapshot tx) where
+  arbitrary = genericArbitrary
+
+deriving instance IsTx tx => Eq (SeenSnapshot tx)
+deriving instance IsTx tx => Show (SeenSnapshot tx)
+deriving instance IsTx tx => ToJSON (SeenSnapshot tx)
+deriving instance IsTx tx => FromJSON (SeenSnapshot tx)
+
+-- ** Closed
+
+-- | An 'Closed' head with an current candidate 'ConfirmedSnapshot', which may
+-- be contested before the 'contestationDeadline'.
+data ClosedState tx = ClosedState
+  { parameters :: HeadParameters
+  , confirmedSnapshot :: ConfirmedSnapshot tx
+  , contestationDeadline :: UTCTime
+  , readyToFanoutSent :: Bool
+  -- ^ Tracks whether we have informed clients already about being
+  -- 'ReadyToFanout'.
+  , chainState :: ChainStateType tx
+  , headId :: HeadId
+  }
+  deriving (Generic)
+
+deriving instance (IsTx tx, Eq (ChainStateType tx)) => Eq (ClosedState tx)
+deriving instance (IsTx tx, Show (ChainStateType tx)) => Show (ClosedState tx)
+deriving instance (IsTx tx, ToJSON (ChainStateType tx)) => ToJSON (ClosedState tx)
+deriving instance (IsTx tx, FromJSON (ChainStateType tx)) => FromJSON (ClosedState tx)
+
+instance (IsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (ClosedState tx) where
+  arbitrary =
+    ClosedState
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+
+-- ** Other types
+
+type TTL = Natural
+
+defaultTTL :: TTL
+defaultTTL = 5
+
+-- | Preliminary type for collecting errors occurring during 'update'.
+-- TODO: Try to merge this (back) into 'Outcome'.
+data LogicError tx
+  = InvalidEvent (Event tx) (HeadState tx)
+  | InvalidState (HeadState tx)
+  | InvalidSnapshot {expected :: SnapshotNumber, actual :: SnapshotNumber}
+  | LedgerError ValidationError
+  | RequireFailed RequirementFailure
+  | NotOurHead {ourHeadId :: HeadId, otherHeadId :: HeadId}
+  deriving stock (Generic)
+
+instance (Typeable tx, Show (Event tx), Show (HeadState tx)) => Exception (LogicError tx)
+
+instance (Arbitrary (Event tx), Arbitrary (HeadState tx)) => Arbitrary (LogicError tx) where
+  arbitrary = genericArbitrary
+
+deriving instance (Eq (HeadState tx), Eq (Event tx)) => Eq (LogicError tx)
+deriving instance (Show (HeadState tx), Show (Event tx)) => Show (LogicError tx)
+deriving instance (ToJSON (Event tx), ToJSON (HeadState tx)) => ToJSON (LogicError tx)
+deriving instance (FromJSON (Event tx), FromJSON (HeadState tx)) => FromJSON (LogicError tx)
+
+data RequirementFailure
+  = ReqSnNumberInvalid {requestedSn :: SnapshotNumber, lastSeenSn :: SnapshotNumber}
+  | ReqSnNotLeader {requestedSn :: SnapshotNumber, leader :: Party}
+  | InvalidMultisignature {multisig :: Text, vkeys :: [VerificationKey HydraKey]}
+  | SnapshotAlreadySigned {knownSignatures :: [Party], receivedSignature :: Party}
+  | AckSnNumberInvalid {requestedSn :: SnapshotNumber, lastSeenSn :: SnapshotNumber}
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance Arbitrary RequirementFailure where
+  arbitrary = genericArbitrary
+
+data Outcome tx
+  = OnlyEffects {effects :: [Effect tx]}
+  | NewState {headState :: HeadState tx, effects :: [Effect tx]}
+  | Wait {reason :: WaitReason}
+  | Error {error :: LogicError tx}
+  deriving stock (Generic)
+
+deriving instance (IsTx tx, IsChainState tx) => Eq (Outcome tx)
+deriving instance (IsTx tx, IsChainState tx) => Show (Outcome tx)
+deriving instance (IsTx tx, IsChainState tx) => ToJSON (Outcome tx)
+deriving instance (IsTx tx, IsChainState tx) => FromJSON (Outcome tx)
+
+instance (IsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (Outcome tx) where
+  arbitrary = genericArbitrary
+
+data WaitReason
+  = WaitOnNotApplicableTx {validationError :: ValidationError}
+  | WaitOnSnapshotNumber {waitingFor :: SnapshotNumber}
+  | WaitOnSeenSnapshot
+  | WaitOnContestationDeadline
+  deriving stock (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance Arbitrary WaitReason where
+  arbitrary = genericArbitrary
+
+data Environment = Environment
+  { party :: Party
+  -- ^ This is the p_i from the paper
+  , -- NOTE(MB): In the long run we would not want to keep the signing key in
+    -- memory, i.e. have an 'Effect' for signing or so.
+    signingKey :: SigningKey HydraKey
+  , otherParties :: [Party]
+  , contestationPeriod :: ContestationPeriod
+  }
+
+-- * Snapshot
+
+data SnapshotOutcome tx
+  = ShouldSnapshot SnapshotNumber [tx] -- TODO(AB) : should really be a Set (TxId tx)
+  | ShouldNotSnapshot NoSnapshotReason
+  deriving (Eq, Show, Generic)
+
+data NoSnapshotReason
+  = NotLeader SnapshotNumber
+  | SnapshotInFlight SnapshotNumber
+  | NoTransactionsToSnapshot
+  deriving (Eq, Show, Generic)

--- a/hydra-node/src/Hydra/Logging/Monitoring.hs
+++ b/hydra-node/src/Hydra/Logging/Monitoring.hs
@@ -18,7 +18,7 @@ import Control.Concurrent.Class.MonadSTM (modifyTVar', newTVarIO, readTVarIO)
 import Control.Tracer (Tracer (Tracer))
 import Data.Map.Strict as Map
 import Hydra.API.ServerOutput (ServerOutput (..))
-import Hydra.HeadLogic (
+import Hydra.HeadLogicTypes (
   Effect (ClientEffect),
   Event (NetworkEvent),
  )

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -22,7 +22,7 @@ import Hydra.Cardano.Api (AsType (AsSigningKey, AsVerificationKey))
 import Hydra.Chain (Chain (..), ChainStateType, IsChainState, PostTxError)
 import Hydra.Chain.Direct.Util (readFileTextEnvelopeThrow)
 import Hydra.Crypto (AsType (AsHydraKey))
-import Hydra.HeadLogic (
+import Hydra.HeadLogicTypes (
   Effect (..),
   Environment (..),
   Event (..),

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -42,7 +42,7 @@ import Hydra.Chain (
 import Hydra.Chain.Direct.State (ChainStateAt (..))
 import Hydra.ContestationPeriod (ContestationPeriod (UnsafeContestationPeriod), toNominalDiffTime)
 import Hydra.Crypto (HydraKey, aggregate, sign)
-import Hydra.HeadLogic (
+import Hydra.HeadLogicTypes (
   Effect (..),
   Environment (..),
   Event (..),

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -27,7 +27,8 @@ import Hydra.Chain (
 import qualified Hydra.Chain.Direct.Fixture as Fixture
 import Hydra.Chain.Direct.State ()
 import Hydra.Crypto (aggregate, generateSigningKey, sign)
-import Hydra.HeadLogic (
+import Hydra.HeadLogic (update)
+import Hydra.HeadLogicTypes (
   ClosedState (..),
   CoordinatedHeadState (..),
   Effect (..),
@@ -42,7 +43,6 @@ import Hydra.HeadLogic (
   SeenSnapshot (NoSeenSnapshot, SeenSnapshot),
   WaitReason (..),
   defaultTTL,
-  update,
  )
 import Hydra.Ledger (ChainSlot (..), Ledger (..), ValidationError (..))
 import Hydra.Ledger.Cardano (cardanoLedger, genKeyPair, genOutput, mkRangedTx)
@@ -294,7 +294,7 @@ spec =
 
       it "cannot observe collect com after abort" $ do
         afterAbort <-
-          runEvents  bobEnv ledger (inInitialState threeParties) $
+          runEvents bobEnv ledger (inInitialState threeParties) $
             step (observationEvent OnAbortTx)
 
         let invalidEvent = observationEvent OnCollectComTx
@@ -558,9 +558,9 @@ data StepState tx = StepState
 -- | Asserts that the update function will update the state (return a NewState) for this Event
 step :: (MonadState (StepState tx) m, HasCallStack, IsChainState tx) => Event tx -> m (HeadState tx)
 step event = do
-  StepState{ headState, env, ledger} <- get
+  StepState{headState, env, ledger} <- get
   headState' <- assertNewState $ update env ledger headState event
-  put StepState{ env, ledger, headState = headState' }
+  put StepState{env, ledger, headState = headState'}
   pure headState'
 
 assertNewState ::

--- a/hydra-node/test/Hydra/Logging/MonitoringSpec.hs
+++ b/hydra-node/test/Hydra/Logging/MonitoringSpec.hs
@@ -8,7 +8,7 @@ import Test.Hydra.Prelude
 import qualified Data.Text as Text
 import Hydra.API.ServerOutput (ServerOutput (SnapshotConfirmed))
 import Hydra.BehaviorSpec (testHeadId)
-import Hydra.HeadLogic (
+import Hydra.HeadLogicTypes (
   Effect (ClientEffect),
   Event (NetworkEvent),
   defaultTTL,

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -59,12 +59,12 @@ import Hydra.Chain.Direct (initialChainState)
 import Hydra.Chain.Direct.Fixture (defaultGlobals, defaultLedgerEnv, testNetworkId)
 import Hydra.ContestationPeriod (ContestationPeriod (UnsafeContestationPeriod))
 import Hydra.Crypto (HydraKey)
-import Hydra.HeadLogic (
+import Hydra.HeadLogicTypes (
   Committed (),
   IdleState (..),
   PendingCommits,
  )
-import qualified Hydra.HeadLogic as HeadState
+import qualified Hydra.HeadLogicTypes as HeadState
 import Hydra.Ledger (IsTx (..))
 import Hydra.Ledger.Cardano (cardanoLedger, genSigningKey, mkSimpleTx)
 import Hydra.Logging (Tracer)

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -46,7 +46,7 @@ import Hydra.Chain.Direct.TimeHandle (TimeHandle)
 import Hydra.Chain.Direct.Wallet (TinyWallet (..))
 import Hydra.ContestationPeriod (ContestationPeriod)
 import Hydra.Crypto (HydraKey)
-import Hydra.HeadLogic (
+import Hydra.HeadLogicTypes (
   Environment (Environment, otherParties, party),
   Event (..),
   defaultTTL,

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -22,7 +22,7 @@ import Hydra.Chain (
  )
 import Hydra.ContestationPeriod (ContestationPeriod)
 import Hydra.Crypto (HydraKey, sign)
-import Hydra.HeadLogic (
+import Hydra.HeadLogicTypes (
   Environment (..),
   Event (..),
   HeadState (..),

--- a/hydra-node/test/Hydra/SnapshotStrategySpec.hs
+++ b/hydra-node/test/Hydra/SnapshotStrategySpec.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Hydra.SnapshotStrategySpec where
 
@@ -9,6 +8,12 @@ import Test.Hydra.Prelude
 import qualified Data.List as List
 import Hydra.Chain (HeadParameters (..))
 import Hydra.HeadLogic (
+  emitSnapshot,
+  isLeader,
+  newSn,
+ )
+import Hydra.HeadLogicSpec (inOpenState')
+import Hydra.HeadLogicTypes (
   CoordinatedHeadState (..),
   Effect (..),
   Environment (..),
@@ -16,11 +21,7 @@ import Hydra.HeadLogic (
   Outcome (..),
   SeenSnapshot (..),
   SnapshotOutcome (..),
-  emitSnapshot,
-  isLeader,
-  newSn,
  )
-import Hydra.HeadLogicSpec (inOpenState')
 import Hydra.Ledger (Ledger (..))
 import Hydra.Ledger.Simple (SimpleTx (..), aValidTx, simpleLedger)
 import Hydra.Network.Message (Message (..))


### PR DESCRIPTION
## Why
`HeadLogic` is the central part of the app and we think compile times would be better if we separate the types into another module.

## What
Introduce a new module for `HeadLogic` types

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
