### PR TITLE
Use check-jsonschema instead of jsonschema

### DIFF
--- a/.github/workflows/actions/setup_dev_ubuntu/install_packages
+++ b/.github/workflows/actions/setup_dev_ubuntu/install_packages
@@ -41,6 +41,9 @@ sudo apt-get install -y --no-install-recommends \
   libtool \
   autoconf
 
+# Needed to validate Hydra json schemas
+pip install check-jsonschema
+
 # Install ghc and cabal
 version_ghc=${VERSION_GHC:-8.10.7}
 ghcup install ghc ${version_ghc}

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -97,7 +97,9 @@ rec {
     };
     hydra-node = pkgs.mkShellNoCC {
       name = "hydra-node-tests";
-      buildInputs = [ nativePkgs.hydra-node.components.tests.tests ];
+      buildInputs = [ nativePkgs.hydra-node.components.tests.tests
+                      pkgs.check-jsonschema
+                    ];
     };
     hydra-cluster = pkgs.mkShellNoCC {
       name = "hydra-cluster-tests";

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -40,7 +40,7 @@ let
     pkgs.haskellPackages.hspec-discover
     pkgs.haskellPackages.cabal-plan
     # For validating JSON instances against a pre-defined schema
-    pkgs.python3Packages.jsonschema
+    pkgs.check-jsonschema
     # For generating plantuml drawings
     pkgs.plantuml
     # For plotting results of hydra-cluster benchmarks


### PR DESCRIPTION
## Why

We want to update the depricated `jsonschema` tool in favor of `check-jsonschema`



---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
