### PR TITLE
Workaround bench timeout

### DIFF
--- a/hydra-cluster/bench/Main.hs
+++ b/hydra-cluster/bench/Main.hs
@@ -81,10 +81,10 @@ benchOptionsParser =
     <*> option
       auto
       ( long "timeout"
-          <> value 600.0
+          <> value 700.0
           <> metavar "SECONDS"
           <> help
-            "The timeout for the run, in seconds (default: '600s')"
+            "The timeout for the run, in seconds (default: '700s')"
       )
     <*> option
       auto


### PR DESCRIPTION
We observe some timeouts on CI when running the benchmarks.

Looking at [this exemple](https://github.com/input-output-hk/hydra/actions/runs/5400717236/jobs/9809622903) it seems that the bench takes around 600 seconds to finish and hits the 600 timeout for just a few seconds of writing bench output to files.

In [this exemple](https://github.com/input-output-hk/hydra/actions/runs/5400717236/jobs/9813272692) (exact same code as in the previous exemple) we can see the bench only takes less than a minute.

Not proud because I don't get why we have so much discrepancy but let's push the timeout to 700 seconds so that we have a more stable CI.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
