### PR TITLE
Add hydra node version to the greetings message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ changes.
 
 ## [0.12.0] - UNRELEASED
 
+- `Greetings` message now contains also the hydra-node version.
+
 - *Fixed bugs* in `hydra-node`:
   + Multisignature verification would silently ignore certain keys in case the
   list of verification keys is not of same length as the list of signatures.

--- a/hydra-node/golden/ReasonablySized (ServerOutput (Tx BabbageEra)).json
+++ b/hydra-node/golden/ReasonablySized (ServerOutput (Tx BabbageEra)).json
@@ -1130,60 +1130,10 @@
             }
         },
         {
-            "headStatus": "Initializing",
+            "headStatus": "FanoutPossible",
+            "hydraNodeVersion": "R\u0000W # ",
             "me": {
-                "vkey": "4d412a69d48ef34b312d324c1e10a87e1d19ab85a5512f3f7540653fe36fd520"
-            },
-            "snapshotUtxo": {
-                "0301020804060203040603060305050607050400010307050201040302030206#64": {
-                    "address": "addr_test12p9v7fmnj978k4ru2a48lugs62a9wv7p789fehr9nt4r545ya4rsxqc4aqdrc",
-                    "datum": null,
-                    "datumhash": "f63498b4ae65be466e4a71878971b9c524458996450b0ff8262cddf3f0d99229",
-                    "inlineDatum": null,
-                    "referenceScript": {
-                        "script": {
-                            "cborHex": "830300828200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b782051a00013a40",
-                            "description": "",
-                            "type": "SimpleScript"
-                        },
-                        "scriptLanguage": "SimpleScriptLanguage"
-                    },
-                    "value": {
-                        "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
-                            "040602080306": 13
-                        },
-                        "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54": {
-                            "0508": 3
-                        },
-                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
-                            "080004040300": 7
-                        },
-                        "lovelace": 10
-                    }
-                },
-                "0501000501010803080408070703030401000602040500040101020003070404#85": {
-                    "address": "addr_test1vrkvh76uvxt88ury3fpvctuz9jquhs62aeqjw33cazd84agz8fxfh",
-                    "datum": null,
-                    "datumhash": null,
-                    "inlineDatum": null,
-                    "referenceScript": null,
-                    "value": {
-                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
-                            "": 16,
-                            "02000800": 14
-                        },
-                        "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7": {
-                            "06": 4
-                        },
-                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
-                            "0108": 10
-                        },
-                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
-                            "05": 10
-                        },
-                        "lovelace": 4
-                    }
-                }
+                "vkey": "cabff3d3ccf7095dd5aab4707bb04f0ab455b12ec263e5077d48b8cc75e1fde5"
             },
             "tag": "Greetings"
         },
@@ -4173,9 +4123,10 @@
             "tag": "HeadIsContested"
         },
         {
-            "headStatus": "Closed",
+            "headStatus": "Idle",
+            "hydraNodeVersion": "e瞶󶚍'",
             "me": {
-                "vkey": "c3807431a85f057dba7b3e5c2ccd849db69a0442d6448b16b9b103bda436bb53"
+                "vkey": "da98194e6a01269d26ec8235ea8a576bacc95ed118466338544db6dcfd068052"
             },
             "tag": "Greetings"
         },
@@ -5852,9 +5803,10 @@
             "tag": "PostTxOnChainFailed"
         },
         {
-            "headStatus": "Initializing",
+            "headStatus": "Final",
+            "hydraNodeVersion": "",
             "me": {
-                "vkey": "6084746594ed21feef0cae3a7d62d644013932dad22e5ca8a17f6ef1af6982cf"
+                "vkey": "45d12c2873aa315cf7759e68369a66eb6f769c6348abb164db9241592041a1c5"
             },
             "tag": "Greetings"
         },
@@ -10343,11 +10295,128 @@
             }
         },
         {
-            "headStatus": "Closed",
+            "headStatus": "FanoutPossible",
+            "hydraNodeVersion": "|",
             "me": {
-                "vkey": "be67ce2d97e2fbedab7080d76912db378ebca5cc82564ee3fce0c8b90756f820"
+                "vkey": "dc6c3c800962e6d32c68fccaeb6db1daf610777b0dcd8b4612b740908a2f7ba8"
             },
-            "snapshotUtxo": {},
+            "snapshotUtxo": {
+                "0008080601010700010500060807050802020704080305060701020207040105#98": {
+                    "address": "2RhQhCGqYPDpg3t64feSGG865gHFRkB7e8XN3nxhV2UHzpVGf8QCMczw76YwALVTi5Bk2bx95tv6VUQMABeMNShxtbRbTsJ6vygwxwkPbT4zMo",
+                    "datum": null,
+                    "datumhash": "2208e439244a1d0ef238352e3693098aba9de9dd0154f9056551636c8ed15dc1",
+                    "inlineDatum": null,
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "83030082820519fbda8202818200581ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a",
+                            "description": "",
+                            "type": "SimpleScript"
+                        },
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
+                    "value": {
+                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
+                            "000807050801": 3
+                        },
+                        "lovelace": 1
+                    }
+                },
+                "0307000805030700070108080506040100070605030604050101060101030801#82": {
+                    "address": "addr_test1vz7s88u4da9nqte6km78cjavxdg22s85ftup4pyjr9xa9ssz7dp0j",
+                    "datum": null,
+                    "inlineDatum": {
+                        "map": [
+                            {
+                                "k": {
+                                    "int": 5
+                                },
+                                "v": {
+                                    "int": -4
+                                }
+                            },
+                            {
+                                "k": {
+                                    "int": -1
+                                },
+                                "v": {
+                                    "constructor": 106,
+                                    "fields": [
+                                        {
+                                            "constructor": 975,
+                                            "fields": [
+                                                {
+                                                    "int": 4
+                                                },
+                                                {
+                                                    "int": -2
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "constructor": 203,
+                                            "fields": [
+                                                {
+                                                    "bytes": ""
+                                                },
+                                                {
+                                                    "bytes": ""
+                                                },
+                                                {
+                                                    "int": -1
+                                                },
+                                                {
+                                                    "bytes": "185615b0"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "constructor": 517,
+                                            "fields": [
+                                                {
+                                                    "bytes": "eb4834a5"
+                                                },
+                                                {
+                                                    "bytes": "94f5f457"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "list": [
+                                                {
+                                                    "bytes": "35"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "constructor": 470,
+                                            "fields": [
+                                                {
+                                                    "int": -3
+                                                },
+                                                {
+                                                    "int": 1
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "inlineDatumhash": "8dad6d3dd4f86a0524cd50c76225be6dc55932e0d80e545d04bd69228819795d",
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "8201838200581c0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e48205197e9083030484820180830301818200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f548204194885830301848200581cbd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c28200581c58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e78200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f548200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541",
+                            "description": "",
+                            "type": "SimpleScript"
+                        },
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
+                    "value": {
+                        "lovelace": 2
+                    }
+                }
+            },
             "tag": "Greetings"
         },
         {
@@ -12301,11 +12370,11 @@
             "tag": "ReadyToFanout"
         },
         {
-            "headStatus": "Closed",
+            "headStatus": "Open",
+            "hydraNodeVersion": "S\u0001\u0007𩎺:",
             "me": {
-                "vkey": "d5fdfec307865ade321a5a1bd6cb3925f1cda1638473889dc36bf0e1af687c22"
+                "vkey": "03d2db34948bae3c00e350572264be2f6d2f32ec518d85f538e13964c94c45a6"
             },
-            "snapshotUtxo": {},
             "tag": "Greetings"
         },
         {
@@ -12677,82 +12746,357 @@
             }
         },
         {
-            "headStatus": "Open",
+            "headStatus": "Idle",
+            "hydraNodeVersion": "W",
             "me": {
-                "vkey": "f1fccb432aeea588d91c8a0379e8801877fad4669cb7d9383a40eab6bf02891c"
+                "vkey": "10d17285e8a3a30573927068d2dcdfbc9a4deacd479e74e362db0a9b0f7b3174"
             },
             "snapshotUtxo": {
-                "0107040801070104050704020704040601060604040403020206040806050102#65": {
-                    "address": "EqGAuA8vHnPGgP8pA9rDf7op3vQVjEzmyXcFSA4aJiauxZ4GcbSCUZkR19Nd1Zg7UnxHbCVzY1gMTEnvYerk7kwjRyyJjojVF2PJ18U49GydVHM9iwoaEvQ",
-                    "datum": null,
-                    "datumhash": null,
-                    "inlineDatum": null,
-                    "referenceScript": null,
-                    "value": {
-                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
-                            "05": 12
-                        },
-                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
-                            "080104050208": 12
-                        },
-                        "lovelace": 4
-                    }
-                },
-                "0303010404010405050805050300030706000606030002070603060303000200#84": {
-                    "address": "addr1gyvjpeuz7pywnm6j4nvfcs6p4zwrjzxxupr2mp7ywnllkjyzj54svpsvetkpr",
+                "0108030507040405020106000600070503020202070606010503080008030805#65": {
+                    "address": "addr1x8s2w9p3nqfv8amnhgzwchtt8l7dt2kc2qrgqkcy0vyz2sdaqw0e2m6txqhn4dhu0396cv6s54q0gjhcr2zfyx2d6tpq7hayjj",
                     "datum": null,
                     "inlineDatum": {
-                        "bytes": "3b5283ab"
+                        "map": [
+                            {
+                                "k": {
+                                    "list": [
+                                        {
+                                            "int": 0
+                                        }
+                                    ]
+                                },
+                                "v": {
+                                    "constructor": 912,
+                                    "fields": []
+                                }
+                            }
+                        ]
                     },
-                    "inlineDatumhash": "8a3618cd4f3ba534d0708645bc8c09b73d32f4f80852a387e26f748e6874c089",
+                    "inlineDatumhash": "5b70a52edce0686223d94bac2051e46c6024d781e1d35d3b8c89f626ab149d53",
+                    "referenceScript": null,
+                    "value": {
+                        "b16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5": {
+                            "0405010203": 2,
+                            "07": 4
+                        },
+                        "lovelace": 2
+                    }
+                },
+                "0205000107020307020507040506050303060201070707060803060705030706#79": {
+                    "address": "addr_test1wpvwrdjhrpf3ksjfgcgv2pkw7y8lqv06s9agla6up2ccpecfgpld0",
+                    "datum": null,
+                    "datumhash": "642206314f534b29ad297d82440a5f9f210e30ca5ced805a587ca402de927342",
+                    "inlineDatum": null,
                     "referenceScript": {
                         "script": {
-                            "cborHex": "46450100002601",
+                            "cborHex": "4746010000220011",
                             "description": "",
                             "type": "PlutusScriptV1"
                         },
                         "scriptLanguage": "PlutusScriptLanguage PlutusScriptV1"
                     },
                     "value": {
-                        "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
-                            "": 8
-                        },
-                        "lovelace": 10
+                        "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2": {
+                            "02": 16
+                        }
                     }
                 },
-                "0400010104010403030202010701070607040006080007020103010006020203#32": {
-                    "address": "2cWKMJemoBak49EKdrm4P6A67fDmVBKYVcfoY4XyoHzvEh43yFTo5WdAKWofWUXEthAj1",
+                "0206010804010202010204030300000604020505070207000806080705020504#61": {
+                    "address": "addr1yxnyv36t3a2rzfs4q6mvyu7nqlr4dxjwkmykkskafg54yzjcuxm9wxznrdpyj3ssc5rvaug07qcl4qt63lm4cz43srnse2dzmn",
                     "datum": null,
-                    "datumhash": "2208e439244a1d0ef238352e3693098aba9de9dd0154f9056551636c8ed15dc1",
+                    "datumhash": "03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314",
                     "inlineDatum": null,
-                    "referenceScript": null,
-                    "value": {
-                        "lovelace": 9
-                    }
-                },
-                "0508070706020300070604010706020205040703000600000201010205060700#16": {
-                    "address": "addr_test1yzckk4h4asryhe4v8j4kqd0046rtxekv8hz2p4t3vq7hped44enr4t4gu5qp277lfw406m6m5r89wk0he4qsrlqn9a2q60jrxa",
-                    "datum": null,
-                    "inlineDatum": {
-                        "int": 1
-                    },
-                    "inlineDatumhash": "ee155ace9c40292074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e25",
                     "referenceScript": {
                         "script": {
-                            "cborHex": "820280",
+                            "cborHex": "8201858303008383030080820519f61a830301858200581cb16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e58200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f548200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b78200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b78200581c3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e82018582051a000149d98200581c3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e82041a00011e858202838200581c4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a568200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b88200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825418202828200581c3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e8200581cb16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5820519ae1082051a000121d482041953c0",
                             "description": "",
                             "type": "SimpleScript"
                         },
                         "scriptLanguage": "SimpleScriptLanguage"
                     },
                     "value": {
-                        "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
-                            "00000306": 12
+                        "lovelace": 13
+                    }
+                },
+                "0402020808040306060203040802060104010605040002060304040304080007#39": {
+                    "address": "addr1y9vwrdjhrpf3ksjfgcgv2pkw7y8lqv06s9agla6up2ccpeaaqw0e2m6txqhn4dhu0396cv6s54q0gjhcr2zfyx2d6tpq08mms2",
+                    "datum": null,
+                    "datumhash": "ee155ace9c40292074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e25",
+                    "inlineDatum": null,
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "8201818201838202848200581cb16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e58200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f548200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f548200581ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a8201858200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b88200581c0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e48200581cbd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c28200581c4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a568200581ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a8201858200581c4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a568200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825418200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f548200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b78200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541",
+                            "description": "",
+                            "type": "SimpleScript"
                         },
-                        "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7": {
-                            "": 9
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
+                    "value": {
+                        "lovelace": 8
+                    }
+                },
+                "0404010506010501030108040102080704040003050105000600070505020305#19": {
+                    "address": "2RhQhCGqYPDpqY8Q5qbBAbBQx8FP2aMQGNmTbbnthFKSudxu2vEePWcr8gf3H1n6AYKXnGQopdDJitQHjvkgQdTBQvAJNeR71QTvPxh3HWMXt5",
+                    "datum": null,
+                    "inlineDatum": {
+                        "list": [
+                            {
+                                "constructor": 590,
+                                "fields": [
+                                    {
+                                        "map": [
+                                            {
+                                                "k": {
+                                                    "int": -1
+                                                },
+                                                "v": {
+                                                    "int": -3
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "bytes": "05b9"
+                                                },
+                                                "v": {
+                                                    "int": 3
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "bytes": "91ab8a"
+                                                },
+                                                "v": {
+                                                    "int": -4
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "bytes": "16ed"
+                                                },
+                                                "v": {
+                                                    "bytes": "d72dfe"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "constructor": 179,
+                                        "fields": [
+                                            {
+                                                "bytes": ""
+                                            },
+                                            {
+                                                "int": -2
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "list": [
+                                            {
+                                                "int": 4
+                                            },
+                                            {
+                                                "bytes": "c5"
+                                            },
+                                            {
+                                                "bytes": "4252bf"
+                                            },
+                                            {
+                                                "int": 2
+                                            },
+                                            {
+                                                "bytes": "2a59dd3d"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "int": 1
+                                    },
+                                    {
+                                        "constructor": 620,
+                                        "fields": []
+                                    }
+                                ]
+                            },
+                            {
+                                "list": [
+                                    {
+                                        "int": 5
+                                    },
+                                    {
+                                        "map": [
+                                            {
+                                                "k": {
+                                                    "int": -4
+                                                },
+                                                "v": {
+                                                    "bytes": ""
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "int": -2
+                                                },
+                                                "v": {
+                                                    "int": 1
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "list": [
+                                            {
+                                                "bytes": "13c5b22f"
+                                            },
+                                            {
+                                                "bytes": "97fd29"
+                                            },
+                                            {
+                                                "int": 3
+                                            },
+                                            {
+                                                "int": 1
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "constructor": 7,
+                                        "fields": [
+                                            {
+                                                "bytes": "c4bd3813"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "bytes": ""
+                            }
+                        ]
+                    },
+                    "inlineDatumhash": "03e54cdeaa8e6065e40626f7a87a167bc87ae9d68a9154a0c64b6cebcab0ee9e",
+                    "referenceScript": null,
+                    "value": {
+                        "b16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5": {
+                            "02000400": 9
                         },
-                        "lovelace": 4
+                        "lovelace": 9
+                    }
+                },
+                "0501000307000705050205020008060204010307020000020702080108000300#27": {
+                    "address": "addr129vwrdjhrpf3ksjfgcgv2pkw7y8lqv06s9agla6up2ccpeuzm4ts2pgaxsnlp",
+                    "datum": null,
+                    "inlineDatum": {
+                        "map": [
+                            {
+                                "k": {
+                                    "bytes": "6bad"
+                                },
+                                "v": {
+                                    "map": [
+                                        {
+                                            "k": {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "int": 5
+                                                        },
+                                                        "v": {
+                                                            "bytes": "f5"
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "int": -3
+                                                        },
+                                                        "v": {
+                                                            "int": -1
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "v": {
+                                                "list": [
+                                                    {
+                                                        "bytes": "71db000b"
+                                                    },
+                                                    {
+                                                        "bytes": ""
+                                                    },
+                                                    {
+                                                        "bytes": "fb33"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "list": []
+                                            },
+                                            "v": {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "int": -4
+                                                        },
+                                                        "v": {
+                                                            "bytes": ""
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "int": 5
+                                                        },
+                                                        "v": {
+                                                            "bytes": "cf66"
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "bytes": ""
+                                                        },
+                                                        "v": {
+                                                            "bytes": "97b6"
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "bytes": "41c4fb"
+                                                        },
+                                                        "v": {
+                                                            "bytes": "98"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "k": {
+                                    "bytes": "c0bb7545"
+                                },
+                                "v": {
+                                    "bytes": "2af69842"
+                                }
+                            }
+                        ]
+                    },
+                    "inlineDatumhash": "9fa0a4d8ffb4a9e55b12862bcb0d19d0e2bc32c404666edad5883b5792aa0b9e",
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "4746010000220011",
+                            "description": "",
+                            "type": "PlutusScriptV2"
+                        },
+                        "scriptLanguage": "PlutusScriptLanguage PlutusScriptV2"
+                    },
+                    "value": {
+                        "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a": {
+                            "0703070102": 5
+                        },
+                        "lovelace": 5
                     }
                 }
             },
@@ -14595,8 +14939,9 @@
         },
         {
             "headStatus": "Closed",
+            "hydraNodeVersion": "",
             "me": {
-                "vkey": "6014a871d51e3e68b1c76908e6d197970e2388313a108e327c3bbf0aab83b982"
+                "vkey": "a489a53c72ed661df2d581f796f49ebae5ffe815eb0c4b47498d6de071684fff"
             },
             "tag": "Greetings"
         },
@@ -14605,99 +14950,221 @@
             "tag": "PeerDisconnected"
         },
         {
-            "headStatus": "Idle",
+            "headStatus": "Final",
+            "hydraNodeVersion": "",
             "me": {
-                "vkey": "270a155df639ff732e5623dfe8cbfed4f5c9fc6acbcd78837d3f21d0eb5b67a3"
+                "vkey": "9557a30808c91452a8c65cc8cd1a7749de750ee701afaa482ec59fc371602eb8"
             },
             "snapshotUtxo": {
-                "0103010702010606030007010308080301010401070803080701060707050307#8": {
-                    "address": "addr_test1qpjlcuy6tcqehz46wmmfwlqusacwfvm05ah5xnhutzr50da44enr4t4gu5qp277lfw406m6m5r89wk0he4qsrlqn9a2qz6gmwj",
+                "0006020008020003010501010706050408020402060408030304010408010605#78": {
+                    "address": "2RhQhCGqYPDnZtmvQPgsn3drWMk6tCnETinZ9RLHQsuzDbQC29qVZz35jXnBjXTz7N3up69xfMtRDzwgtjpqTFMJBuJN5cAUnrUXLi7arppcew",
                     "datum": null,
-                    "datumhash": "ae85d245a3d00bfde01f59f3c4fe0b4bfae1cb37e9cf91929eadcea4985711de",
-                    "inlineDatum": null,
+                    "inlineDatum": {
+                        "constructor": 144,
+                        "fields": [
+                            {
+                                "list": [
+                                    {
+                                        "bytes": ""
+                                    },
+                                    {
+                                        "constructor": 682,
+                                        "fields": [
+                                            {
+                                                "bytes": "e4a62db0"
+                                            },
+                                            {
+                                                "int": -4
+                                            },
+                                            {
+                                                "int": 2
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "constructor": 531,
+                                "fields": [
+                                    {
+                                        "bytes": "6bdca3"
+                                    },
+                                    {
+                                        "list": [
+                                            {
+                                                "bytes": "1834e8"
+                                            },
+                                            {
+                                                "bytes": "10bcf71e"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "inlineDatumhash": "a252fe5aaf80072f7a50a2d5e6ba5f1ac62e292a234f53e60c5aa8240513e254",
+                    "referenceScript": null,
+                    "value": {
+                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
+                            "0206": 16
+                        },
+                        "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7": {
+                            "08040706": 4
+                        },
+                        "76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b8": {
+                            "0807": 8
+                        },
+                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
+                            "0801": 11
+                        },
+                        "lovelace": 15
+                    }
+                },
+                "0308030404020806060705030507000607060700060501030208020106020507#58": {
+                    "address": "addr_test12pjlcuy6tcqehz46wmmfwlqusacwfvm05ah5xnhutzr50durcyusyqch34tm8",
+                    "datum": null,
+                    "inlineDatum": {
+                        "list": [
+                            {
+                                "constructor": 190,
+                                "fields": []
+                            },
+                            {
+                                "constructor": 987,
+                                "fields": [
+                                    {
+                                        "map": [
+                                            {
+                                                "k": {
+                                                    "bytes": "3ace1780"
+                                                },
+                                                "v": {
+                                                    "bytes": "1318dee6"
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "bytes": "9352"
+                                                },
+                                                "v": {
+                                                    "int": -5
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "bytes": "994da0"
+                                                },
+                                                "v": {
+                                                    "int": 0
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "int": 3
+                                                },
+                                                "v": {
+                                                    "bytes": ""
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "int": 0
+                                                },
+                                                "v": {
+                                                    "bytes": "5c"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "inlineDatumhash": "78b4555945ec7e7f1d0a2e48b250f5668930eee191e007b12f6032d44767621a",
                     "referenceScript": {
                         "script": {
-                            "cborHex": "82041923c5",
+                            "cborHex": "820519910d",
                             "description": "",
                             "type": "SimpleScript"
                         },
                         "scriptLanguage": "SimpleScriptLanguage"
                     },
                     "value": {
-                        "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
-                            "": 1
+                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
+                            "0103060407": 4
                         },
-                        "lovelace": 8
+                        "lovelace": 15
                     }
                 },
-                "0105060802070401060701010408070606030803020504020306060106040206#64": {
-                    "address": "2RhQhCGqYPDmuzAmeNzbXBf3XetSPQdDBdoeid9Enxv8CgkA44zuvDRyWmtcuQ787bBJ4bcshGgvTkxz5NW9v3eDTqm14VeRjmEdaTo8qAY8Ue",
+                "0406000608020305040802080501050002040000020107030307020801010708#28": {
+                    "address": "addr_test1zpjlcuy6tcqehz46wmmfwlqusacwfvm05ah5xnhutzr50da3ddt0tmqxf0n2c09tvq67lt5xkdnvc0wy5r2hzcpawrjse2y790",
                     "datum": null,
                     "inlineDatum": {
-                        "int": -2
+                        "list": [
+                            {
+                                "list": [
+                                    {
+                                        "bytes": "7d7629"
+                                    }
+                                ]
+                            }
+                        ]
                     },
-                    "inlineDatumhash": "0268be9dbd0446eaa217e1dec8f399249305e551d7fc1437dd84521f74aa621c",
+                    "inlineDatumhash": "d00df59b42c3dbbdd5c058c51d53e53536e98cacac2f85e737313d7989e4e649",
                     "referenceScript": null,
                     "value": {
                         "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
-                            "080802070306": 13
+                            "0503": 9
+                        },
+                        "1920e782f048e9ef52acd89c4341a89c3908c6e046ad87c474fffb48": {
+                            "0006": 6
                         },
                         "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
-                            "08010707": 8
+                            "0401": 4
                         },
-                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
-                            "0104": 2
+                        "76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b8": {
+                            "080800030504": 15
                         },
-                        "lovelace": 4
+                        "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a": {
+                            "04060307": 10
+                        },
+                        "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2": {
+                            "0501040602": 3
+                        },
+                        "lovelace": 15
                     }
                 },
-                "0303040500040505020108030606030600050004020806040502070008010701#63": {
-                    "address": "addr_test1grs2w9p3nqfv8amnhgzwchtt8l7dt2kc2qrgqkcy0vyz2svzm3qsxzqd5ez72",
+                "0507040606040201070406030805040307070608070505010708050308080207#5": {
+                    "address": "addr_test1zp9v7fmnj978k4ru2a48lugs62a9wv7p789fehr9nt4r544xger5hr65xynp2p4kcfeaxp7826dyadkfddpd6j3f2g9qcjmu28",
                     "datum": null,
                     "inlineDatum": {
-                        "bytes": "8c12239f"
+                        "constructor": 667,
+                        "fields": [
+                            {
+                                "constructor": 913,
+                                "fields": []
+                            }
+                        ]
                     },
-                    "inlineDatumhash": "c43c405cec476df6a73786e79bf5776c501b8496a60326ab6260d75506b248c9",
-                    "referenceScript": null,
-                    "value": {
-                        "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
-                            "": 16
-                        },
-                        "lovelace": 16
-                    }
-                },
-                "0706010607000803040300020204080407070108030705000708010005040100#93": {
-                    "address": "EqGAuA8vHnPFPUrgEjmXfHbDFPEvAFRxYfo4Ba8VcrpZPX99MSRJqFqVmAZUewp2aUfsDr7RrHNuEDrQjnu6BE2NYCJpUChoJbjxFommcBQP9n3VUPLbciT",
-                    "datum": null,
-                    "datumhash": null,
-                    "inlineDatum": null,
+                    "inlineDatumhash": "7b9e01d75ec534dad7a072041702897affeb9b6bf0384be1b54b1d08900a1720",
                     "referenceScript": {
                         "script": {
-                            "cborHex": "4746010000220011",
+                            "cborHex": "820285820285830300818200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b88201818200581c58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e78200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b782041a0001187e82051a000109f182051a000174918202808201858201838200581cbd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c28200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b88200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825418201848200581c0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e48200581c0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e48200581c3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e8200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f548303008082051a00013d2a82051a0001211f8201848200581c0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e48200581c4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a568200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b783030080",
                             "description": "",
-                            "type": "PlutusScriptV1"
+                            "type": "SimpleScript"
                         },
-                        "scriptLanguage": "PlutusScriptLanguage PlutusScriptV1"
+                        "scriptLanguage": "SimpleScriptLanguage"
                     },
                     "value": {
-                        "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
-                            "06000502": 13
+                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
+                            "02": 6
                         },
-                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
-                            "010403": 3
+                        "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2": {
+                            "0603": 13
                         },
-                        "lovelace": 11
-                    }
-                },
-                "0805070601030200030801030504080700020206070305040705040800000507#76": {
-                    "address": "Ae2tdPwUPEZDqaCTkRAuy52cJ9JUCXpkYrvicPUYx6Po74TddbQYCpc55Df",
-                    "datum": null,
-                    "datumhash": null,
-                    "inlineDatum": null,
-                    "referenceScript": null,
-                    "value": {
-                        "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a": {
-                            "03070305": 6
+                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
+                            "0106": 14
                         },
                         "lovelace": 14
                     }
@@ -16110,10 +16577,120 @@
         },
         {
             "headStatus": "Closed",
+            "hydraNodeVersion": "\u0019𒋫",
             "me": {
-                "vkey": "f15bd0193a2ce781339bd2b027a22781aa6094412fddf24fc1e3b226715701a9"
+                "vkey": "c357a164d2a03e57a7078925973b83b1f050f4ed9b3f0eb64844e9d29418a11e"
             },
-            "snapshotUtxo": {},
+            "snapshotUtxo": {
+                "0100030507070002020301080107000003030100040108050401080108020307#55": {
+                    "address": "addr_test1qp9v7fmnj978k4ru2a48lugs62a9wv7p789fehr9nt4r544aqw0e2m6txqhn4dhu0396cv6s54q0gjhcr2zfyx2d6tpq032x6q",
+                    "datum": null,
+                    "inlineDatum": {
+                        "int": 0
+                    },
+                    "inlineDatumhash": "03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314",
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "820280",
+                            "description": "",
+                            "type": "SimpleScript"
+                        },
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
+                    "value": {
+                        "1920e782f048e9ef52acd89c4341a89c3908c6e046ad87c474fffb48": {
+                            "060201": 7
+                        },
+                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
+                            "02": 13
+                        },
+                        "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a": {
+                            "01010704": 12
+                        },
+                        "lovelace": 13
+                    }
+                },
+                "0306020200040200050001030708040500080008050407010505060108070708#15": {
+                    "address": "2RhQhCGqYPDocLnzeec95c1y9Jdg9KkSkCFbAXj6VtSQLenfjGnsu3ZDwZkoNgSASxuMVuRXTwqxxbNWVbVv8xNtahTNdzbC2iimWg4C9hymJw",
+                    "datum": null,
+                    "datumhash": null,
+                    "inlineDatum": null,
+                    "referenceScript": null,
+                    "value": {
+                        "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
+                            "": 1
+                        },
+                        "b16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5": {
+                            "0105": 1
+                        },
+                        "lovelace": 8
+                    }
+                },
+                "0308030103050604080500080000010406070307070304040705020301030802#37": {
+                    "address": "addr_test1gpvwrdjhrpf3ksjfgcgv2pkw7y8lqv06s9agla6up2ccpeljx5zsgsdluk0",
+                    "datum": null,
+                    "inlineDatum": {
+                        "list": [
+                            {
+                                "bytes": "d63f"
+                            }
+                        ]
+                    },
+                    "inlineDatumhash": "cc2c6b0321b11e44208480b30d8f83bd2c03f0af108956cfbdea0fe2175d2558",
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "8201858303008482051a000176c68202858200581ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a8200581c4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a568200581cb16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e58200581c58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e78200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b78201848200581cbd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c28200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825418200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825418200581ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a830303848200581cb16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e58200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b78200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b88200581cb16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e58204190a7983030285830304858200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b88200581c4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a568200581c4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a568200581c4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a568200581c58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e782041a0001583d8201858200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825418200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b78200581ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a8200581cbd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c28200581c4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a5682051a000118938201808201858202848200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f548200581ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a8200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825418200581c0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e48201828200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b78200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b88202858200581cb16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e58200581c0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e48200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f548200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f548200581c4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a568202818200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b8820519c1a8830301838200581c58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e78202858200581c58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e78200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b78200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b88200581cb16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e58200581ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a8201838200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825418200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f548200581c3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e",
+                            "description": "",
+                            "type": "SimpleScript"
+                        },
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
+                    "value": {
+                        "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
+                            "0508050000": 8
+                        },
+                        "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54": {
+                            "07": 9
+                        },
+                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
+                            "020102040707": 14
+                        },
+                        "lovelace": 6
+                    }
+                },
+                "0804000808060408040406080700030405030104070706010006010103080305#2": {
+                    "address": "EqGAuA8vHnNwPRurqFByKbbcYhWKRojaGu1Ao63dpgNTuohCgkWD1sNfkwbo7tvDgdJTe1F3ymUVLPCCxntQn92NDxgAhkjLaeoUXfESc45k4eZaavcJPGz",
+                    "datum": null,
+                    "datumhash": null,
+                    "inlineDatum": null,
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "820183830300808201848201828200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b78200581cb16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e58200581c3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e8200581cb16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e58200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b882018382051933948200581cb16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e58200581cb16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5",
+                            "description": "",
+                            "type": "SimpleScript"
+                        },
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
+                    "value": {
+                        "1920e782f048e9ef52acd89c4341a89c3908c6e046ad87c474fffb48": {
+                            "": 15
+                        },
+                        "76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b8": {
+                            "07": 3
+                        },
+                        "b16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5": {
+                            "0304": 13
+                        },
+                        "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54": {
+                            "020205": 4
+                        },
+                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
+                            "05080708": 6
+                        },
+                        "lovelace": 8
+                    }
+                }
+            },
             "tag": "Greetings"
         },
         {

--- a/hydra-node/golden/ReasonablySized (ServerOutput SimpleTx).json
+++ b/hydra-node/golden/ReasonablySized (ServerOutput SimpleTx).json
@@ -52,15 +52,12 @@
             "tag": "CommandFailed"
         },
         {
-            "headStatus": "Closed",
+            "headStatus": "Open",
+            "hydraNodeVersion": "𧺁mH7叇󽏨",
             "me": {
-                "vkey": "a370ea4b5ee0a358b6c9194ee4bc8565d8d8baddcdc4c3cfdc4ccc8a51fb094c"
+                "vkey": "87f730001ad30d8cca3cb866c793c8d8b88d4ebd980294658fcfd8a46257fe94"
             },
-            "snapshotUtxo": [
-                -5,
-                -2,
-                -1
-            ],
+            "snapshotUtxo": [],
             "tag": "Greetings"
         },
         {
@@ -488,14 +485,11 @@
             ]
         },
         {
-            "headStatus": "Final",
+            "headStatus": "Closed",
+            "hydraNodeVersion": "V",
             "me": {
-                "vkey": "2f5e1bcd9b49e081a0e1b08798a4798d7d4edf1499dc48a05e838ec6cb619d0f"
+                "vkey": "64d9bfac7aa1a6c8731da40cfd0f3ca102d48d5c81efb130850f961334120541"
             },
-            "snapshotUtxo": [
-                -6,
-                -4
-            ],
             "tag": "Greetings"
         },
         {
@@ -778,13 +772,15 @@
             "tag": "HeadIsClosed"
         },
         {
-            "headStatus": "Initializing",
+            "headStatus": "Idle",
+            "hydraNodeVersion": "󼐦",
             "me": {
-                "vkey": "8f2253084df751343d6c12ee5edf3eccf1fc4bfd99396f38b531514349688f00"
+                "vkey": "4d8e57a1a668f8e9617214a07e8ab381607a60d376b9f7658553f97b29379828"
             },
             "snapshotUtxo": [
-                -2,
-                -1
+                -1,
+                4,
+                6
             ],
             "tag": "Greetings"
         },
@@ -1042,14 +1038,11 @@
             ]
         },
         {
-            "headStatus": "FanoutPossible",
+            "headStatus": "Initializing",
+            "hydraNodeVersion": "[p\u0003󺚿󻤦",
             "me": {
-                "vkey": "c6aabf39b3d9c02c1d1b626787d4f69aa64b528a88fde044184bda137d9a1dc3"
+                "vkey": "383387d9bbfaf3570bffa2e61f3363abf5f08ed575cbf0357c69dc1c176e6c33"
             },
-            "snapshotUtxo": [
-                -2,
-                -1
-            ],
             "tag": "Greetings"
         },
         {
@@ -1287,13 +1280,13 @@
             ]
         },
         {
-            "headStatus": "Closed",
+            "headStatus": "FanoutPossible",
+            "hydraNodeVersion": "􈿅J\"p-\u0004",
             "me": {
-                "vkey": "4ad0396ea2180de4fd0b8ca36c39727350466b30951f5be68275627d7a985d46"
+                "vkey": "90c367fe4412017c74de7d22e9b8478297d26d6c7eaa4f2467fa301d16a8fb60"
             },
             "snapshotUtxo": [
-                -4,
-                -1
+                1
             ],
             "tag": "Greetings"
         },
@@ -1381,15 +1374,15 @@
             ]
         },
         {
-            "headStatus": "FanoutPossible",
+            "headStatus": "Final",
+            "hydraNodeVersion": "|\u001065󶆼",
             "me": {
-                "vkey": "7330a5a7f832629641ec76492c0451c0231dec5b091d792daee8a026e980e313"
+                "vkey": "4dec6db3851bda10b538ff5a079e5b6830bc1f8f0a3d7e9d8ce6025d337e5ac1"
             },
             "snapshotUtxo": [
-                -4,
-                -3,
-                1,
-                6
+                -1,
+                4,
+                5
             ],
             "tag": "Greetings"
         },
@@ -1467,14 +1460,11 @@
         },
         {
             "headStatus": "Initializing",
+            "hydraNodeVersion": "",
             "me": {
-                "vkey": "497e015d8cf8f1818d2b3e487856f38ec6ce415d6a9960b6ebd53730f69b327b"
+                "vkey": "7d80ab7b2734c7789aa42d1e7dfc6f0c0244f818d867ad9039a6bbcfa87b547b"
             },
-            "snapshotUtxo": [
-                -6,
-                5,
-                6
-            ],
+            "snapshotUtxo": [],
             "tag": "Greetings"
         },
         {
@@ -1513,13 +1503,10 @@
         },
         {
             "headStatus": "Closed",
+            "hydraNodeVersion": "&*󲟨G>",
             "me": {
-                "vkey": "57cca95cbf4314415f006775d68b8895075d0f419fe44ad7a9d157e703b1263c"
+                "vkey": "00cac85e0342093b1502aabdc0be0df7f44d8f5e3fd75e6be189a29c73d64585"
             },
-            "snapshotUtxo": [
-                0,
-                6
-            ],
             "tag": "Greetings"
         },
         {
@@ -1939,20 +1926,7 @@
                 "tag": "InitTx"
             },
             "postTxError": {
-                "headUTxO": [],
-                "reason": "2",
-                "tag": "InternalWalletError",
-                "tx": {
-                    "id": -4,
-                    "inputs": [
-                        -5,
-                        -2
-                    ],
-                    "outputs": [
-                        -3,
-                        -2
-                    ]
-                }
+                "tag": "SpendingNodeUtxoForbidden"
             },
             "tag": "PostTxOnChainFailed"
         },

--- a/hydra-node/golden/ReasonablySized (TimedServerOutput (Tx BabbageEra)).json
+++ b/hydra-node/golden/ReasonablySized (TimedServerOutput (Tx BabbageEra)).json
@@ -2062,129 +2062,13 @@
             "timestamp": "1864-05-13T21:09:01.675961855697Z"
         },
         {
-            "headStatus": "Initializing",
+            "headStatus": "Open",
+            "hydraNodeVersion": "𫙯",
             "me": {
-                "vkey": "430b2136586206eb3ef01a7df7e6772d846e12ee189a02459e0563ed25d3a711"
+                "vkey": "ecdb17edbaf8aeb0397075d77596539772f4b9e6901fbbdab3ed75c3a121a086"
             },
             "seq": 4,
-            "snapshotUtxo": {
-                "0103000203020003020406070605060504050606020508010304010003040500#51": {
-                    "address": "2RhQhCGqYPDngvEbEcVgwaTn2kLcBon8PUunR94nJP9TtHnBgmERdEVP1Bh9h4at5JMBnGcgqWzwqQwhb1v2SbKATtCPDGNqcAKGx3ZK1oinMB",
-                    "datum": null,
-                    "datumhash": "e88bd757ad5b9bedf372d8d3f0cf6c962a469db61a265f6418e1ffed86da29ec",
-                    "inlineDatum": null,
-                    "referenceScript": null,
-                    "value": {
-                        "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
-                            "": 13
-                        },
-                        "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7": {
-                            "0707010506": 5
-                        },
-                        "76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b8": {
-                            "": 3
-                        },
-                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
-                            "070705030703": 7
-                        },
-                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
-                            "": 16
-                        },
-                        "lovelace": 12
-                    }
-                },
-                "0304040006050805010700080208040302030306050805000001040202060808#30": {
-                    "address": "EqGAuA8vHnNz6smZmjmQqNA74gUW3tKDsmDUw6aGCDpvZcEgCgbagLweLqcZjYWpcPZZqByRYyGK92XJqdLyXffPmEtgDB8YZTVcFm1K43wQ49wMEU1Ldrp",
-                    "datum": null,
-                    "inlineDatum": {
-                        "int": -1
-                    },
-                    "inlineDatumhash": "ae85d245a3d00bfde01f59f3c4fe0b4bfae1cb37e9cf91929eadcea4985711de",
-                    "referenceScript": null,
-                    "value": {
-                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
-                            "05": 13
-                        },
-                        "lovelace": 10
-                    }
-                },
-                "0608040606030805010602060602070508030807000702050000080207080200#15": {
-                    "address": "EqGAuA8vHnPBkvpybaGjYmCJkn175nbXks9XzhV9qL6eeGPmv5oN7uscatKuSfYRDjWvcfXgqV3Vobd5siodbwKPYH3LMRqvTzFnYUhktbsZnYyLgVpNDU8",
-                    "datum": null,
-                    "inlineDatum": {
-                        "int": 3
-                    },
-                    "inlineDatumhash": "e88bd757ad5b9bedf372d8d3f0cf6c962a469db61a265f6418e1ffed86da29ec",
-                    "referenceScript": {
-                        "script": {
-                            "cborHex": "820519a7c5",
-                            "description": "",
-                            "type": "SimpleScript"
-                        },
-                        "scriptLanguage": "SimpleScriptLanguage"
-                    },
-                    "value": {
-                        "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
-                            "0102050007": 2
-                        },
-                        "lovelace": 14
-                    }
-                },
-                "0806080700040207050803030807010501000104060301020301080501080502#55": {
-                    "address": "addr_test1qqxefct5wvh0n2h88uu44dz9q7l6nq7k2q3uzx54ruxr9e9xger5hr65xynp2p4kcfeaxp7826dyadkfddpd6j3f2g9q23wpxc",
-                    "datum": null,
-                    "inlineDatum": {
-                        "map": [
-                            {
-                                "k": {
-                                    "constructor": 99,
-                                    "fields": [
-                                        {
-                                            "map": [
-                                                {
-                                                    "k": {
-                                                        "bytes": "95836e"
-                                                    },
-                                                    "v": {
-                                                        "int": -1
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "bytes": "959de6"
-                                                    },
-                                                    "v": {
-                                                        "bytes": "c3"
-                                                    }
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "constructor": 835,
-                                            "fields": [
-                                                {
-                                                    "int": -1
-                                                },
-                                                {
-                                                    "int": 4
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                "v": {
-                                    "int": -5
-                                }
-                            }
-                        ]
-                    },
-                    "inlineDatumhash": "1c9c0cecc7a397fd87a5d7496c03e2655c2216e48178bb1fba096f8c80d58062",
-                    "referenceScript": null,
-                    "value": {
-                        "lovelace": 15
-                    }
-                }
-            },
+            "snapshotUtxo": {},
             "tag": "Greetings",
             "timestamp": "1864-05-07T07:06:19.369125871111Z"
         },
@@ -2641,111 +2525,134 @@
         },
         {
             "headStatus": "Initializing",
+            "hydraNodeVersion": "bᓡ",
             "me": {
-                "vkey": "b9acd99e01c4d4bb8d9dfbd4d83e3d41b67478dccfe1f5b7ad171c0ca07baae8"
+                "vkey": "1670b66319f1ed545456e2ec70f211e3224fbf2ea498ccfb501214197e7befaa"
             },
             "seq": 2,
             "snapshotUtxo": {
-                "0002020204010204070706060407010605000808060303050408030701010306#62": {
-                    "address": "EqGAuA8vHnNxQTF4Jz7u199A1rcp1PjkabniqTTvVZtN9VbuNNyWMfDTTJfKk9aDgDhwGDEpJuwMjBb6jSZKRhXpYoGcyxMs5FPFTLPt8siTKwU5VFSU5JS",
+                "0607060204060505010104000602040606040407030708040407050802010200#83": {
+                    "address": "addr_test1vpvwrdjhrpf3ksjfgcgv2pkw7y8lqv06s9agla6up2ccpecqqal60",
                     "datum": null,
                     "inlineDatum": {
-                        "bytes": "40e5ca"
+                        "list": [
+                            {
+                                "int": -5
+                            },
+                            {
+                                "list": [
+                                    {
+                                        "bytes": "e03d6939"
+                                    },
+                                    {
+                                        "map": [
+                                            {
+                                                "k": {
+                                                    "int": -2
+                                                },
+                                                "v": {
+                                                    "int": -5
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "bytes": "9efa4f77"
+                                                },
+                                                "v": {
+                                                    "int": 5
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "int": 4
+                                                },
+                                                "v": {
+                                                    "int": -3
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "int": 0
+                                                },
+                                                "v": {
+                                                    "bytes": ""
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "int": -4
+                                                },
+                                                "v": {
+                                                    "bytes": "dd814e"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "bytes": "a18523f9"
+                                    },
+                                    {
+                                        "list": []
+                                    }
+                                ]
+                            }
+                        ]
                     },
-                    "inlineDatumhash": "f2f13886b9b8a9db7589b65ac80dac4d9b58312f7ced30e34dd33acd5b1d901e",
+                    "inlineDatumhash": "1439957388c84e5ee9c8cc8ce7242c1fee7cbb9b2dd94ec5c07e17f0e3403972",
                     "referenceScript": {
                         "script": {
-                            "cborHex": "820519c4c2",
+                            "cborHex": "8200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7",
                             "description": "",
                             "type": "SimpleScript"
                         },
                         "scriptLanguage": "SimpleScriptLanguage"
                     },
                     "value": {
-                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
-                            "07": 12
+                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
+                            "080808050505": 9
                         },
-                        "lovelace": 10
+                        "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7": {
+                            "01": 3
+                        },
+                        "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a": {
+                            "": 7
+                        },
+                        "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2": {
+                            "04050005": 8
+                        },
+                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
+                            "020101": 9
+                        },
+                        "lovelace": 2
                     }
                 },
-                "0007060702030803020603030106000206020202080608080806060404010804#67": {
-                    "address": "addr1zx7s88u4da9nqte6km78cjavxdg22s85ftup4pyjr9xa9sj2eunh8ytu0d28c4m20lc3p5462ueuruw2nnwxtxh28ftqgpazdj",
+                "0801060604030204020403070805010106070208050307080801000307050105#47": {
+                    "address": "addr_test12qvjpeuz7pywnm6j4nvfcs6p4zwrjzxxupr2mp7ywnllkj8x8vqss7ckar9",
                     "datum": null,
-                    "datumhash": "03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314",
+                    "datumhash": "bb30a42c1e62f0afda5f0a4e8a562f7a13a24cea00ee81917b86b89e801314aa",
                     "inlineDatum": null,
                     "referenceScript": {
                         "script": {
-                            "cborHex": "4746010000220011",
+                            "cborHex": "8202848201858200581c4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a568204199f6182041a000178ad8200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f548202808201808200581cbd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c282041a00017744",
                             "description": "",
-                            "type": "PlutusScriptV2"
+                            "type": "SimpleScript"
                         },
-                        "scriptLanguage": "PlutusScriptLanguage PlutusScriptV2"
+                        "scriptLanguage": "SimpleScriptLanguage"
                     },
                     "value": {
-                        "lovelace": 15
-                    }
-                },
-                "0405030703040308000101030503020803000403020407080707060002070302#3": {
-                    "address": "addr_test1xrs2w9p3nqfv8amnhgzwchtt8l7dt2kc2qrgqkcy0vyz2stkucrak233ex3vxfmp6fp35xr225xvxg0hnnvdd2pt9xuqdgrl30",
-                    "datum": null,
-                    "datumhash": null,
-                    "inlineDatum": null,
-                    "referenceScript": null,
-                    "value": {
-                        "1920e782f048e9ef52acd89c4341a89c3908c6e046ad87c474fffb48": {
-                            "04070707": 5
+                        "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
+                            "0600040107": 16
                         },
-                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
-                            "0006030107": 8
-                        },
-                        "lovelace": 13
-                    }
-                },
-                "0607030604050304040300070606070706080003080304050708000805070501#84": {
-                    "address": "EqGAuA8vHnP3r5qzj6VPKmZr3GYboaBrLd6u8SSpYS3wDi1m8qFERPjAHZrf5xjcZSx2sFdYpVHjNgc9W1FrsZHFBuU6UuHDXBd1MxDph4agEmt57axsKQe",
-                    "datum": null,
-                    "inlineDatum": {
-                        "bytes": "c7af28f1"
-                    },
-                    "inlineDatumhash": "b1abd4d4cc3938c93f1813d01d8424b42be854b79c4e6838cecdb7ca2b229fcc",
-                    "referenceScript": null,
-                    "value": {
                         "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
-                            "0608": 12,
-                            "08010701": 10
-                        },
-                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
-                            "0008": 5
-                        },
-                        "lovelace": 7
-                    }
-                },
-                "0701070702000100010002080603070003000707060508000205070202040306#23": {
-                    "address": "addr_test1gqvjpeuz7pywnm6j4nvfcs6p4zwrjzxxupr2mp7ywnllkjyz3avqsqs37jw06",
-                    "datum": null,
-                    "datumhash": null,
-                    "inlineDatum": null,
-                    "referenceScript": null,
-                    "value": {
-                        "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
-                            "07030002": 15
+                            "0207080405": 1
                         },
                         "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
-                            "06050702": 14
+                            "05": 8
                         },
-                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
-                            "0301020501": 13
-                        }
-                    }
-                },
-                "0705080702000205060104070108060207080304080803020703080207070500#79": {
-                    "address": "addr1y8kvh76uvxt88ury3fpvctuz9jquhs62aeqjw33cazd84adaqw0e2m6txqhn4dhu0396cv6s54q0gjhcr2zfyx2d6tpq7vt566",
-                    "datum": null,
-                    "datumhash": null,
-                    "inlineDatum": null,
-                    "referenceScript": null,
-                    "value": {
-                        "lovelace": 6
+                        "b16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5": {
+                            "0500070302": 2
+                        },
+                        "lovelace": 3
                     }
                 }
             },
@@ -4328,12 +4235,199 @@
             "timestamp": "1864-05-09T01:50:36.2394149577Z"
         },
         {
-            "headStatus": "Open",
+            "headStatus": "Idle",
+            "hydraNodeVersion": "(􃜽譕9'E",
             "me": {
-                "vkey": "c1914ce84a64dc6b009d17e8bc50bfa8fef32e2360757fed5cff5b15d5b1beb6"
+                "vkey": "8ade8e111ba937f42b6057c771408d8d27468ae32c95abc533d53efe3c39236e"
             },
             "seq": 0,
-            "snapshotUtxo": {},
+            "snapshotUtxo": {
+                "0106040603010006010401070005030001080404050403030307070506060600#55": {
+                    "address": "2RhQhCGqYPDpCRCLgV3ZN4VJEWMj76chZ457zwDBGmJdtxB1KYGbrA5t2NYjTShKoUp2LMNfzdfur4Fu1sPMtGR1e1EspjbQH5SwyoyZLyZAPh",
+                    "datum": null,
+                    "inlineDatum": {
+                        "int": -1
+                    },
+                    "inlineDatumhash": "ae85d245a3d00bfde01f59f3c4fe0b4bfae1cb37e9cf91929eadcea4985711de",
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "820285820419ab18820519b3fd8201818200581c3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e820285820419fd1a82051988488201848200581c3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e8200581cbd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c28200581c0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e48200581cb16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e58200581c58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e78200581c4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56830303858202838200581ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a8200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f548200581c4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a568201808204194bc482051a000162368201848200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825418200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825418200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b78200581cb16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5",
+                            "description": "",
+                            "type": "SimpleScript"
+                        },
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
+                    "value": {
+                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
+                            "0801": 1
+                        },
+                        "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7": {
+                            "04020308": 7
+                        },
+                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
+                            "0807": 1
+                        },
+                        "lovelace": 7
+                    }
+                },
+                "0302050503060708050607000408030800020604080307080406070700010408#66": {
+                    "address": "addr1w9jlcuy6tcqehz46wmmfwlqusacwfvm05ah5xnhutzr50dct6p9vg",
+                    "datum": null,
+                    "inlineDatum": {
+                        "list": [
+                            {
+                                "map": [
+                                    {
+                                        "k": {
+                                            "constructor": 561,
+                                            "fields": [
+                                                {
+                                                    "int": -5
+                                                },
+                                                {
+                                                    "bytes": "33"
+                                                },
+                                                {
+                                                    "bytes": ""
+                                                },
+                                                {
+                                                    "int": -4
+                                                },
+                                                {
+                                                    "int": 2
+                                                }
+                                            ]
+                                        },
+                                        "v": {
+                                            "bytes": ""
+                                        }
+                                    },
+                                    {
+                                        "k": {
+                                            "constructor": 695,
+                                            "fields": [
+                                                {
+                                                    "int": -1
+                                                },
+                                                {
+                                                    "int": -5
+                                                },
+                                                {
+                                                    "bytes": "31cb7be5"
+                                                },
+                                                {
+                                                    "bytes": "40a2d8"
+                                                }
+                                            ]
+                                        },
+                                        "v": {
+                                            "bytes": "f21b22dd"
+                                        }
+                                    },
+                                    {
+                                        "k": {
+                                            "constructor": 354,
+                                            "fields": [
+                                                {
+                                                    "bytes": "9ee4"
+                                                },
+                                                {
+                                                    "bytes": "a05bd427"
+                                                }
+                                            ]
+                                        },
+                                        "v": {
+                                            "constructor": 970,
+                                            "fields": []
+                                        }
+                                    },
+                                    {
+                                        "k": {
+                                            "bytes": ""
+                                        },
+                                        "v": {
+                                            "map": [
+                                                {
+                                                    "k": {
+                                                        "bytes": ""
+                                                    },
+                                                    "v": {
+                                                        "bytes": "54"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "k": {
+                                            "int": 3
+                                        },
+                                        "v": {
+                                            "int": -1
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "bytes": "88"
+                            },
+                            {
+                                "list": []
+                            },
+                            {
+                                "int": 0
+                            }
+                        ]
+                    },
+                    "inlineDatumhash": "8c327681b364aff3114675302b012423806df24adb8c971e4d0c0f6cd7ec5843",
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "82051a00012e6b",
+                            "description": "",
+                            "type": "SimpleScript"
+                        },
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
+                    "value": {
+                        "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
+                            "0507060508": 6
+                        },
+                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
+                            "000406": 4
+                        },
+                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
+                            "": 10
+                        },
+                        "lovelace": 1
+                    }
+                },
+                "0501030206050500070504070608030606070600050207080407030206010006#83": {
+                    "address": "addr1v8kvh76uvxt88ury3fpvctuz9jquhs62aeqjw33cazd84age0a6xj",
+                    "datum": null,
+                    "datumhash": "0268be9dbd0446eaa217e1dec8f399249305e551d7fc1437dd84521f74aa621c",
+                    "inlineDatum": null,
+                    "referenceScript": null,
+                    "value": {
+                        "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7": {
+                            "": 10
+                        },
+                        "76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b8": {
+                            "000304": 4
+                        },
+                        "b16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5": {
+                            "": 5
+                        },
+                        "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54": {
+                            "010305": 7,
+                            "020003": 12
+                        },
+                        "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2": {
+                            "0306080306": 12
+                        },
+                        "lovelace": 7
+                    }
+                }
+            },
             "tag": "Greetings",
             "timestamp": "1864-05-15T23:49:52.485376876502Z"
         },
@@ -4446,12 +4540,447 @@
             "timestamp": "1864-05-07T05:08:47.414346227524Z"
         },
         {
-            "headStatus": "Closed",
+            "headStatus": "Open",
+            "hydraNodeVersion": "",
             "me": {
-                "vkey": "f5c88db696c2ad33ae4c8c65965217a9452b4cf7c0576dbef60298f96ce924e6"
+                "vkey": "3335fc6317b8ebc2ce18dd76d0795a51dac7312ac5fe13aeeffb9b2921ca37b8"
             },
             "seq": 5,
-            "snapshotUtxo": {},
+            "snapshotUtxo": {
+                "0003010403000705000606000506080301000207070401080401030008060002#39": {
+                    "address": "addr_test1vpjlcuy6tcqehz46wmmfwlqusacwfvm05ah5xnhutzr50dce6fe5d",
+                    "datum": null,
+                    "inlineDatum": {
+                        "map": [
+                            {
+                                "k": {
+                                    "bytes": "71e27042"
+                                },
+                                "v": {
+                                    "bytes": "f3"
+                                }
+                            },
+                            {
+                                "k": {
+                                    "map": [
+                                        {
+                                            "k": {
+                                                "constructor": 398,
+                                                "fields": [
+                                                    {
+                                                        "bytes": "9bdda411"
+                                                    }
+                                                ]
+                                            },
+                                            "v": {
+                                                "constructor": 524,
+                                                "fields": [
+                                                    {
+                                                        "bytes": "7f4d"
+                                                    },
+                                                    {
+                                                        "int": 5
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "int": 4
+                                                        },
+                                                        "v": {
+                                                            "bytes": "e58be7"
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "int": -1
+                                                        },
+                                                        "v": {
+                                                            "int": -5
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "int": 1
+                                                        },
+                                                        "v": {
+                                                            "bytes": "9a55f4"
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "int": 2
+                                                        },
+                                                        "v": {
+                                                            "bytes": ""
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "int": 4
+                                                        },
+                                                        "v": {
+                                                            "bytes": "286914"
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "v": {
+                                                "constructor": 266,
+                                                "fields": [
+                                                    {
+                                                        "int": -4
+                                                    },
+                                                    {
+                                                        "int": -3
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "list": []
+                                            },
+                                            "v": {
+                                                "list": [
+                                                    {
+                                                        "int": 0
+                                                    },
+                                                    {
+                                                        "int": -3
+                                                    },
+                                                    {
+                                                        "int": -3
+                                                    },
+                                                    {
+                                                        "bytes": "a296"
+                                                    },
+                                                    {
+                                                        "bytes": "f5"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "constructor": 229,
+                                                "fields": []
+                                            },
+                                            "v": {
+                                                "int": -5
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "bytes": "30"
+                                            },
+                                            "v": {
+                                                "constructor": 802,
+                                                "fields": [
+                                                    {
+                                                        "int": -3
+                                                    },
+                                                    {
+                                                        "bytes": "c0"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                },
+                                "v": {
+                                    "int": -3
+                                }
+                            },
+                            {
+                                "k": {
+                                    "map": [
+                                        {
+                                            "k": {
+                                                "list": [
+                                                    {
+                                                        "int": -3
+                                                    },
+                                                    {
+                                                        "int": -4
+                                                    },
+                                                    {
+                                                        "bytes": "38171849"
+                                                    }
+                                                ]
+                                            },
+                                            "v": {
+                                                "constructor": 422,
+                                                "fields": []
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "constructor": 156,
+                                                "fields": [
+                                                    {
+                                                        "bytes": ""
+                                                    },
+                                                    {
+                                                        "int": 1
+                                                    }
+                                                ]
+                                            },
+                                            "v": {
+                                                "list": [
+                                                    {
+                                                        "bytes": ""
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "int": -5
+                                                        },
+                                                        "v": {
+                                                            "bytes": "25"
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "int": -4
+                                                        },
+                                                        "v": {
+                                                            "bytes": "ba7e1d9d"
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "v": {
+                                                "constructor": 916,
+                                                "fields": [
+                                                    {
+                                                        "bytes": ""
+                                                    },
+                                                    {
+                                                        "int": 4
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                },
+                                "v": {
+                                    "constructor": 334,
+                                    "fields": [
+                                        {
+                                            "int": 4
+                                        },
+                                        {
+                                            "constructor": 502,
+                                            "fields": [
+                                                {
+                                                    "int": 4
+                                                },
+                                                {
+                                                    "bytes": "99"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "int": -3
+                                        },
+                                        {
+                                            "map": [
+                                                {
+                                                    "k": {
+                                                        "bytes": ""
+                                                    },
+                                                    "v": {
+                                                        "int": -1
+                                                    }
+                                                },
+                                                {
+                                                    "k": {
+                                                        "int": -1
+                                                    },
+                                                    "v": {
+                                                        "int": 0
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "map": []
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "k": {
+                                    "bytes": "95"
+                                },
+                                "v": {
+                                    "list": [
+                                        {
+                                            "map": [
+                                                {
+                                                    "k": {
+                                                        "bytes": "10"
+                                                    },
+                                                    "v": {
+                                                        "bytes": "e0043105"
+                                                    }
+                                                },
+                                                {
+                                                    "k": {
+                                                        "bytes": "3cdeee"
+                                                    },
+                                                    "v": {
+                                                        "int": 2
+                                                    }
+                                                },
+                                                {
+                                                    "k": {
+                                                        "int": -2
+                                                    },
+                                                    "v": {
+                                                        "bytes": ""
+                                                    }
+                                                },
+                                                {
+                                                    "k": {
+                                                        "bytes": "ff03a3d6"
+                                                    },
+                                                    "v": {
+                                                        "bytes": "7fb8dc"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "bytes": "b47affce"
+                                        },
+                                        {
+                                            "bytes": ""
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "k": {
+                                    "int": -1
+                                },
+                                "v": {
+                                    "constructor": 502,
+                                    "fields": [
+                                        {
+                                            "list": [
+                                                {
+                                                    "bytes": "4456a833"
+                                                },
+                                                {
+                                                    "int": 1
+                                                },
+                                                {
+                                                    "int": -5
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "int": -1
+                                        },
+                                        {
+                                            "constructor": 703,
+                                            "fields": [
+                                                {
+                                                    "bytes": "4f"
+                                                },
+                                                {
+                                                    "int": -1
+                                                },
+                                                {
+                                                    "bytes": "387f"
+                                                },
+                                                {
+                                                    "int": 1
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "list": [
+                                                {
+                                                    "bytes": ""
+                                                },
+                                                {
+                                                    "bytes": "e4a0"
+                                                },
+                                                {
+                                                    "int": -4
+                                                },
+                                                {
+                                                    "bytes": "6c2622"
+                                                },
+                                                {
+                                                    "int": 4
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "int": 5
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "inlineDatumhash": "7dacbed4849c3014687b18901bdb8855d234765cc0688b10642a98ce5a182f64",
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "4746010000220011",
+                            "description": "",
+                            "type": "PlutusScriptV2"
+                        },
+                        "scriptLanguage": "PlutusScriptLanguage PlutusScriptV2"
+                    },
+                    "value": {
+                        "1920e782f048e9ef52acd89c4341a89c3908c6e046ad87c474fffb48": {
+                            "0504": 16
+                        },
+                        "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7": {
+                            "040303": 11
+                        },
+                        "b16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5": {
+                            "050808030201": 4
+                        },
+                        "lovelace": 4
+                    }
+                },
+                "0505000006000507070001010504080705070006080600000008000004010204#65": {
+                    "address": "EqGAuA8vHnNwPgNcSg7UHUSSksU6v1m3SBdPsnwSubqgSByDyWqoehHTgCpStM23wuFmgDGRvGxTZgFsSv8ALvBCMtLMhxPH9n7RHRHD7SYz1ZD9gyw2MUZ",
+                    "datum": null,
+                    "datumhash": "f63498b4ae65be466e4a71878971b9c524458996450b0ff8262cddf3f0d99229",
+                    "inlineDatum": null,
+                    "referenceScript": null,
+                    "value": {
+                        "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
+                            "02": 13
+                        },
+                        "b16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5": {
+                            "03080505": 2
+                        },
+                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
+                            "02070606": 12,
+                            "04040004": 12,
+                            "0703020401": 9
+                        },
+                        "lovelace": 8
+                    }
+                }
+            },
             "tag": "Greetings",
             "timestamp": "1864-05-05T17:32:41.004894460995Z"
         },
@@ -6315,52 +6844,119 @@
             }
         },
         {
-            "headStatus": "FanoutPossible",
+            "headStatus": "Open",
+            "hydraNodeVersion": "䮕k󻬵",
             "me": {
-                "vkey": "76150bfe10287ee8d2d5f994dfb51a8059a0c484ed0c074fa46b4917651440b1"
+                "vkey": "89df2a48f7509442280570cd5ae812d0bd679f437225860ccb3c02a4fceef9ac"
             },
             "seq": 1,
             "snapshotUtxo": {
-                "0207000703010307030404020103030803070402030702050108040507050403#70": {
-                    "address": "2RhQhCGqYPDoGPjQG6s328dkYp5eFYRQ2EZdT8KgjcB2Fc9eZXx8Vs1n313EBXc9tQLHReqTNWk4wx96voaewacNwmZRBKgj3LQBvoAsrMxaaY",
+                "0202060606060503000108020506060801080703030608070300010208080401#28": {
+                    "address": "EqGAuA8vHnNfHFuSGHH9u5Sp8gY5GaEw95SkdgC711Fe2ukFrfr1vqH1JVscEUfke2MKoHdeS4tFY5D2D4K3wdAtaywhvokp7x6WVzTK2SnGMCtPLh1m1F6",
                     "datum": null,
-                    "datumhash": null,
+                    "datumhash": "e88bd757ad5b9bedf372d8d3f0cf6c962a469db61a265f6418e1ffed86da29ec",
+                    "inlineDatum": null,
+                    "referenceScript": null,
+                    "value": {
+                        "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
+                            "0502": 13
+                        },
+                        "76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b8": {
+                            "030504070307": 16
+                        },
+                        "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2": {
+                            "0105010300": 13
+                        },
+                        "lovelace": 3
+                    }
+                },
+                "0203080700030405050804080301030606080506080106020208070101020806#14": {
+                    "address": "EqGAuA8vHnNmTLkU3DdRhi1k2YqGdQQdZUnrZ4JnS2ERGCZLXNbf9MjFEo4CR74PqqDUkwokYEqRMgzcTsmLbGMThQ5evZkJHemqQM9YNoQnvgEoe9Wx92V",
+                    "datum": null,
+                    "inlineDatum": {
+                        "int": 2
+                    },
+                    "inlineDatumhash": "bb30a42c1e62f0afda5f0a4e8a562f7a13a24cea00ee81917b86b89e801314aa",
+                    "referenceScript": null,
+                    "value": {
+                        "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
+                            "0602": 5
+                        },
+                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
+                            "02": 10
+                        },
+                        "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7": {
+                            "0806000600": 10
+                        },
+                        "lovelace": 16
+                    }
+                },
+                "0206040704070508080808000701080400040801080507010400050506030204#18": {
+                    "address": "EqGAuA8vHnP5aUXZrNWvxrZMLrmVQFJXCTvJSgTrbVtcTu2USXnATs4H9jGBBBueUZ2kHeWcUo75rsoNRPpEX7g1weKHkPbEPU9LigGBYHj5ZoGX2vTUkV4",
+                    "datum": null,
+                    "datumhash": "ee155ace9c40292074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e25",
                     "inlineDatum": null,
                     "referenceScript": {
                         "script": {
-                            "cborHex": "82051999b5",
+                            "cborHex": "46450100002601",
                             "description": "",
-                            "type": "SimpleScript"
+                            "type": "PlutusScriptV1"
                         },
-                        "scriptLanguage": "SimpleScriptLanguage"
+                        "scriptLanguage": "PlutusScriptLanguage PlutusScriptV1"
                     },
                     "value": {
-                        "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
-                            "0101": 4
+                        "1920e782f048e9ef52acd89c4341a89c3908c6e046ad87c474fffb48": {
+                            "05050601": 8
                         },
-                        "lovelace": 5
+                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
+                            "070602080608": 4
+                        },
+                        "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54": {
+                            "": 14,
+                            "0603050007": 13
+                        },
+                        "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2": {
+                            "070300040408": 8
+                        },
+                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
+                            "": 6
+                        },
+                        "lovelace": 11
                     }
                 },
-                "0401040202050305050500070607010600010200040803030300050601080106#43": {
-                    "address": "addr1y9jlcuy6tcqehz46wmmfwlqusacwfvm05ah5xnhutzr50d62eunh8ytu0d28c4m20lc3p5462ueuruw2nnwxtxh28ftqe0gqwz",
+                "0306010005030103060008020103070503000802020105030306030306050302#93": {
+                    "address": "addr_test1grs2w9p3nqfv8amnhgzwchtt8l7dt2kc2qrgqkcy0vyz2svznevs2qgvj4fl7",
+                    "datum": null,
+                    "datumhash": "bfa726c3c149165b108e6ff550cb1a1c4f0fdc2e9f26a9a16f48babe73b600ce",
+                    "inlineDatum": null,
+                    "referenceScript": null,
+                    "value": {}
+                },
+                "0402010601010208010805080301060507080706000202000505010305020001#35": {
+                    "address": "2RhQhCGqYPDpPTGnzq8wVxBysxift1ecZJvsbzCcTk1kgHgYMH2DXbtSR7vWVAHnUPLvj8ux8SeBgjU6VRuUTDmQfvYArcYD9FFGeFSeX4SYX5",
                     "datum": null,
                     "inlineDatum": {
-                        "bytes": "bee5ec"
+                        "bytes": "6dda8e"
                     },
-                    "inlineDatumhash": "359c1a36d1572d40ec7905b3a6f85de109517268c3aca1bdbc41da37d4293414",
+                    "inlineDatumhash": "c865333aacce5b60de08e3f2fd9053342876bd9351af065afee5bab5cbcedf87",
                     "referenceScript": null,
                     "value": {
-                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
-                            "010303": 7
+                        "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
+                            "0708050502": 1
                         },
-                        "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7": {
-                            "0100050304": 2
+                        "76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b8": {
+                            "060308": 8
                         },
                         "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a": {
-                            "07060302": 6,
-                            "0807030803": 2
+                            "04020108": 4
                         },
-                        "lovelace": 13
+                        "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54": {
+                            "03": 14
+                        },
+                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
+                            "07010506": 14
+                        },
+                        "lovelace": 4
                     }
                 }
             },
@@ -7197,11 +7793,81 @@
             }
         },
         {
-            "headStatus": "Initializing",
+            "headStatus": "Open",
+            "hydraNodeVersion": "",
             "me": {
-                "vkey": "9e6184aff43c13bcc46f4b156c4a2b1a0feb9a86bd62bc6a16534798ae7d818b"
+                "vkey": "316ca58a871eb3c805087d951e4a75ca056abff204df352f86e0bdf6533d3069"
             },
             "seq": 6,
+            "snapshotUtxo": {
+                "0000060804000205070801050602080803010404020105080604050202000108#76": {
+                    "address": "addr_test12z66ue36465w2qq40005h2hadad6pnjht8mu6sgplsfj74yznehssqcul7pe6",
+                    "datum": null,
+                    "datumhash": null,
+                    "inlineDatum": null,
+                    "referenceScript": null,
+                    "value": {
+                        "lovelace": 8
+                    }
+                },
+                "0107030008020808080801040007070806020300080008040303040801020004#16": {
+                    "address": "2RhQhCGqYPDpeojJVqvvAHyYpYkh6deNq5SUDd2tPPb2F7vE7C6jXNYQey7TwdfcZL14M4g1QpUdrg4tqd8eiyYry6psssG623tNqL7kodmn8x",
+                    "datum": null,
+                    "inlineDatum": {
+                        "int": 5
+                    },
+                    "inlineDatumhash": "fb3d635c7cb573d1b9e9bff4a64ab4f25190d29b6fd8db94c605a218a23fa9ad",
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "820280",
+                            "description": "",
+                            "type": "SimpleScript"
+                        },
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
+                    "value": {
+                        "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
+                            "060504": 12
+                        },
+                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
+                            "": 15
+                        },
+                        "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7": {
+                            "02040204": 8
+                        },
+                        "76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b8": {
+                            "020107": 5
+                        },
+                        "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54": {
+                            "000308070706": 13
+                        },
+                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
+                            "": 6
+                        },
+                        "lovelace": 16
+                    }
+                },
+                "0502020806020200060408000503030101010200060407040802050603030407#20": {
+                    "address": "addr1gxckk4h4asryhe4v8j4kqd0046rtxekv8hz2p4t3vq7hpevpuq0szqcqd3wcl",
+                    "datum": null,
+                    "datumhash": "95c3003a78585e0db8c9496f6deef4de0ff000994b8534cd66d4fe96bb21ddd3",
+                    "inlineDatum": null,
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "8204194e19",
+                            "description": "",
+                            "type": "SimpleScript"
+                        },
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
+                    "value": {
+                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
+                            "": 2
+                        },
+                        "lovelace": 5
+                    }
+                }
+            },
             "tag": "Greetings",
             "timestamp": "1864-05-12T07:40:27.689564141113Z"
         },
@@ -8388,11 +9054,380 @@
             }
         },
         {
-            "headStatus": "Final",
+            "headStatus": "FanoutPossible",
+            "hydraNodeVersion": "z􁍎?`",
             "me": {
-                "vkey": "9976fb6a25e734d454367f33429cb6c3f2a08791fcb2ed7326028ca7541ea07a"
+                "vkey": "d20089afce6695510afc2e4025e231e523a6bf1c85ff01f39cfa842d086e538b"
             },
             "seq": 0,
+            "snapshotUtxo": {
+                "0008070606010700000407070002070301000201060502080101040700050108#68": {
+                    "address": "addr1x8s2w9p3nqfv8amnhgzwchtt8l7dt2kc2qrgqkcy0vyz2sf4g2kt8fjdsrpfxq3xp43v8wr6ws4dzj4ls40tceenpq0q6ppxn9",
+                    "datum": null,
+                    "datumhash": null,
+                    "inlineDatum": null,
+                    "referenceScript": null,
+                    "value": {
+                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
+                            "04": 6,
+                            "080606060002": 6
+                        },
+                        "lovelace": 6
+                    }
+                },
+                "0207070005060708030204080501020008060803030002040200030206070207#67": {
+                    "address": "2cWKMJemoBahnEwjVhU3ofKj7dcrTdCcEgJJY1cCNxhmj3kH1hGZSeoFhehh3rj4AJVrg",
+                    "datum": null,
+                    "inlineDatum": {
+                        "map": [
+                            {
+                                "k": {
+                                    "map": [
+                                        {
+                                            "k": {
+                                                "bytes": "1e"
+                                            },
+                                            "v": {
+                                                "constructor": 452,
+                                                "fields": [
+                                                    {
+                                                        "int": -5
+                                                    },
+                                                    {
+                                                        "bytes": "ccf7"
+                                                    },
+                                                    {
+                                                        "bytes": "d77cbf"
+                                                    },
+                                                    {
+                                                        "bytes": "cb07"
+                                                    },
+                                                    {
+                                                        "bytes": "4c"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "int": -5
+                                            },
+                                            "v": {
+                                                "int": -4
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "bytes": ""
+                                                        },
+                                                        "v": {
+                                                            "bytes": "fe"
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "bytes": "2c116349"
+                                                        },
+                                                        "v": {
+                                                            "int": 0
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "bytes": "dcedd4"
+                                                        },
+                                                        "v": {
+                                                            "bytes": "a6"
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "v": {
+                                                "map": []
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "int": -4
+                                                        },
+                                                        "v": {
+                                                            "int": -5
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "v": {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "int": 5
+                                                        },
+                                                        "v": {
+                                                            "bytes": "f6"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                },
+                                "v": {
+                                    "map": [
+                                        {
+                                            "k": {
+                                                "list": [
+                                                    {
+                                                        "bytes": ""
+                                                    },
+                                                    {
+                                                        "int": 5
+                                                    },
+                                                    {
+                                                        "int": 1
+                                                    }
+                                                ]
+                                            },
+                                            "v": {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "int": 5
+                                                        },
+                                                        "v": {
+                                                            "int": -5
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "int": 1
+                                                        },
+                                                        "v": {
+                                                            "bytes": "9524133c"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "bytes": "67a86f7b"
+                                                        },
+                                                        "v": {
+                                                            "bytes": ""
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "int": -1
+                                                        },
+                                                        "v": {
+                                                            "int": 5
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "v": {
+                                                "list": []
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "bytes": "d2329c"
+                                            },
+                                            "v": {
+                                                "bytes": "e3099cd0"
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "k": {
+                                    "constructor": 926,
+                                    "fields": [
+                                        {
+                                            "bytes": "cdb822"
+                                        },
+                                        {
+                                            "list": [
+                                                {
+                                                    "bytes": "d8"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "constructor": 655,
+                                            "fields": [
+                                                {
+                                                    "bytes": "ce"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "map": [
+                                                {
+                                                    "k": {
+                                                        "bytes": "b3"
+                                                    },
+                                                    "v": {
+                                                        "int": -2
+                                                    }
+                                                },
+                                                {
+                                                    "k": {
+                                                        "int": 1
+                                                    },
+                                                    "v": {
+                                                        "bytes": "809b9e"
+                                                    }
+                                                },
+                                                {
+                                                    "k": {
+                                                        "int": 1
+                                                    },
+                                                    "v": {
+                                                        "int": 1
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "v": {
+                                    "constructor": 121,
+                                    "fields": [
+                                        {
+                                            "constructor": 50,
+                                            "fields": [
+                                                {
+                                                    "int": 4
+                                                },
+                                                {
+                                                    "int": -2
+                                                },
+                                                {
+                                                    "int": -3
+                                                },
+                                                {
+                                                    "int": 5
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "k": {
+                                    "bytes": "4b"
+                                },
+                                "v": {
+                                    "int": -3
+                                }
+                            }
+                        ]
+                    },
+                    "inlineDatumhash": "4ad7f85b286733221e44f9d8635abc85517c4fce7ffa72377c2aa672515cf039",
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "82041a00012705",
+                            "description": "",
+                            "type": "SimpleScript"
+                        },
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
+                    "value": {
+                        "1920e782f048e9ef52acd89c4341a89c3908c6e046ad87c474fffb48": {
+                            "": 9,
+                            "04": 2
+                        },
+                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
+                            "07000107": 9
+                        },
+                        "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54": {
+                            "020608040006": 4
+                        },
+                        "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2": {
+                            "0200": 10
+                        },
+                        "lovelace": 9
+                    }
+                },
+                "0304050601070303060403000107080405020002010500080101050303070802#27": {
+                    "address": "addr_test1gq659t9n5excps5nqgnq6ckrhpa8g2k3f2lc2h4uvuess8596pcsspc2m83ja",
+                    "datum": null,
+                    "inlineDatum": {
+                        "constructor": 992,
+                        "fields": [
+                            {
+                                "bytes": "fa332e"
+                            },
+                            {
+                                "list": [
+                                    {
+                                        "map": [
+                                            {
+                                                "k": {
+                                                    "bytes": "1302"
+                                                },
+                                                "v": {
+                                                    "bytes": "1b"
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "int": 1
+                                                },
+                                                "v": {
+                                                    "bytes": "d22c"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "bytes": "78277ee0"
+                            },
+                            {
+                                "list": [
+                                    {
+                                        "list": []
+                                    }
+                                ]
+                            },
+                            {
+                                "int": 0
+                            }
+                        ]
+                    },
+                    "inlineDatumhash": "f93fd333e97176599d6bfda42d7cc118f83b62117472d932bbb5c335723f3756",
+                    "referenceScript": null,
+                    "value": {
+                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
+                            "04": 4
+                        },
+                        "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2": {
+                            "080603": 4
+                        },
+                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
+                            "04030706": 8
+                        },
+                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
+                            "": 15
+                        },
+                        "lovelace": 14
+                    }
+                }
+            },
             "tag": "Greetings",
             "timestamp": "1864-05-15T08:36:18.268523909689Z"
         },
@@ -8804,12 +9839,65 @@
             "timestamp": "1864-05-04T11:22:50.069694829107Z"
         },
         {
-            "headStatus": "Final",
+            "headStatus": "Closed",
+            "hydraNodeVersion": "W\u00056\rP",
             "me": {
-                "vkey": "5187e4d4a972862b78e13522c6c28c317147a3e393a39a3e598bcd4eeed558f7"
+                "vkey": "340915094ae3daf0f22311ec18f30baee19d9fd3099d3436d1834e138f56fe91"
             },
             "seq": 6,
-            "snapshotUtxo": {},
+            "snapshotUtxo": {
+                "0502040601080408010606060604080203080101040202050602010807070405#88": {
+                    "address": "EqGAuA8vHnP8Urob7vkb1q6s84aBkfUEJ9jo1cMrWyY7e4sFoopbcZHunbKHXTsTyZbgu6H9tk55tX6irniD8mSXZh9KR9X3mnpT7zfJDJ8o6RXd6j4yccd",
+                    "datum": null,
+                    "datumhash": "2208e439244a1d0ef238352e3693098aba9de9dd0154f9056551636c8ed15dc1",
+                    "inlineDatum": null,
+                    "referenceScript": null,
+                    "value": {
+                        "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7": {
+                            "00080303": 10,
+                            "080604060105": 14
+                        },
+                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
+                            "": 5
+                        },
+                        "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a": {
+                            "070208020705": 1
+                        },
+                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
+                            "050505020205": 7
+                        },
+                        "lovelace": 12
+                    }
+                },
+                "0705030006060001050007050208020406010703080500020501070206020707#0": {
+                    "address": "EqGAuA8vHnP7coMPv7quzvbqpYTsygunNoDFTuZ2e5f6EseNzxSmb2DoDcZcq9hz5PdPy1SZJdM2Y8DV3apAexfrK9KhCN7kM8hCgKkPAhEGNPr23eBUX9y",
+                    "datum": null,
+                    "inlineDatum": {
+                        "int": 2
+                    },
+                    "inlineDatumhash": "bb30a42c1e62f0afda5f0a4e8a562f7a13a24cea00ee81917b86b89e801314aa",
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "8200581c1920e782f048e9ef52acd89c4341a89c3908c6e046ad87c474fffb48",
+                            "description": "",
+                            "type": "SimpleScript"
+                        },
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
+                    "value": {
+                        "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a": {
+                            "020705080804": 10
+                        },
+                        "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54": {
+                            "": 14
+                        },
+                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
+                            "08070007": 14
+                        },
+                        "lovelace": 8
+                    }
+                }
+            },
             "tag": "Greetings",
             "timestamp": "1864-05-11T07:47:05.374197396879Z"
         },
@@ -8822,90 +9910,12 @@
             "timestamp": "1864-05-05T18:21:45.372564929435Z"
         },
         {
-            "headStatus": "FanoutPossible",
+            "headStatus": "Final",
+            "hydraNodeVersion": "%\u0019嬳囗\u0005",
             "me": {
-                "vkey": "d3e4c11aeb9ad8de2b11a2415e6dce6d377de67c23cf45c5f0be96f54ded21fc"
+                "vkey": "168c5d3ed1d8212e39f13e27a9759901b284e730815ede2e53c8d6f2e7a2e77f"
             },
             "seq": 1,
-            "snapshotUtxo": {
-                "0006000602040702080401020103000102080504050702050004050801030803#45": {
-                    "address": "2RhQhCGqYPDpAAv56VDkN7Fco4HN5ZDLTeGMrZR4aJiq3eTQqFrF85A8PPyf4uf8o7eyZGyi5cXZALAjm7GZakWXkedDP4cfoKg5DgcZa6d7rN",
-                    "datum": null,
-                    "inlineDatum": {
-                        "constructor": 511,
-                        "fields": []
-                    },
-                    "inlineDatumhash": "4f089f6cc1331e5d0af80a5788bca91f88e516b65f53eb8d159ad63524ce84ba",
-                    "referenceScript": null,
-                    "value": {
-                        "76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b8": {
-                            "02000708": 8
-                        },
-                        "b16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5": {
-                            "040706000600": 14
-                        },
-                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
-                            "010508030101": 9,
-                            "070603": 6
-                        },
-                        "lovelace": 2
-                    }
-                },
-                "0007050808080006070802050508020206070400030106050803070506000103#43": {
-                    "address": "EqGAuA8vHnNgYrc5LNk5rT1W78wBstJktvsUpWhmjdRx3tMaxuoZpkfFVE8qUywRDbPCCf3PWkoKeyjTzo8Qo2g6MhiGyR4Qzu5ebCtVoTYFwvAyeuVhWbj",
-                    "datum": null,
-                    "datumhash": null,
-                    "inlineDatum": null,
-                    "referenceScript": null,
-                    "value": {
-                        "lovelace": 10
-                    }
-                },
-                "0307040607030206060308070503030007000407050307040300060707070003#78": {
-                    "address": "addr1wy659t9n5excps5nqgnq6ckrhpa8g2k3f2lc2h4uvuess8s3arvrj",
-                    "datum": null,
-                    "datumhash": "0268be9dbd0446eaa217e1dec8f399249305e551d7fc1437dd84521f74aa621c",
-                    "inlineDatum": null,
-                    "referenceScript": null,
-                    "value": {
-                        "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
-                            "": 5
-                        },
-                        "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7": {
-                            "0604": 3
-                        },
-                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
-                            "060402": 11
-                        },
-                        "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2": {
-                            "": 2
-                        },
-                        "lovelace": 13
-                    }
-                },
-                "0308030800030807070701000308050504050707020800000006040602010001#85": {
-                    "address": "EqGAuA8vHnP3f4dj5VXmtJ5V1N8u5akkvNLxEXRb3N3jPJdoQXb3LcEVcXLzEXked3aU8LE2GW5BtJ4pT7uWRcbcYJ8P8mGHYUJyFEQ6Y55R5PyiC6U47Pv",
-                    "datum": null,
-                    "datumhash": null,
-                    "inlineDatum": null,
-                    "referenceScript": null,
-                    "value": {
-                        "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7": {
-                            "06": 7
-                        },
-                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
-                            "01": 5,
-                            "02": 2,
-                            "02020505": 3,
-                            "0205": 7
-                        },
-                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
-                            "07": 6
-                        },
-                        "lovelace": 9
-                    }
-                }
-            },
             "tag": "Greetings",
             "timestamp": "1864-05-05T23:06:32.231550432901Z"
         },
@@ -11964,11 +12974,153 @@
             "utxo": {}
         },
         {
-            "headStatus": "Open",
+            "headStatus": "FanoutPossible",
+            "hydraNodeVersion": "fYj\u000c",
             "me": {
-                "vkey": "ac77e1d3fe8431fcc83886bf42931de0e7eaa0a4929de63baf7639d828a267eb"
+                "vkey": "346e35d5fa4341423fad242ba327315b0de7699e40b7ae0172af260f4e1ad991"
             },
             "seq": 2,
+            "snapshotUtxo": {
+                "0003050101070603060308080603050604020605000106030307050607040506#49": {
+                    "address": "2RhQhCGqYPDpobDJajFvRnUjfivkCq6qFxZf4jxMmyfYPVvaEFCPVK6CjhKxp6fzJMVpC7PMNYWfCmzwUyvopKQScR9F35i2i24PGw94kfQxHf",
+                    "datum": null,
+                    "datumhash": null,
+                    "inlineDatum": null,
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "830301828303038382051a000163f2830301828200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b78200581cbd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c28202818200581c58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e782028482018082051a0001617582041a000171c783030080",
+                            "description": "",
+                            "type": "SimpleScript"
+                        },
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
+                    "value": {
+                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
+                            "050007": 8
+                        },
+                        "lovelace": 5
+                    }
+                },
+                "0004080707010001020203000804030305050600080504070401000305070305#43": {
+                    "address": "addr1wx66ue36465w2qq40005h2hadad6pnjht8mu6sgplsfj74qhpnf3s",
+                    "datum": null,
+                    "datumhash": "bb30a42c1e62f0afda5f0a4e8a562f7a13a24cea00ee81917b86b89e801314aa",
+                    "inlineDatum": null,
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "820282820283820519a02d8202818200581cbd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c28200581ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a83030080",
+                            "description": "",
+                            "type": "SimpleScript"
+                        },
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
+                    "value": {
+                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
+                            "02020107": 3
+                        },
+                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
+                            "000807010805": 10
+                        },
+                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
+                            "0607010706": 16
+                        },
+                        "lovelace": 12
+                    }
+                },
+                "0103030501060607030604070701010305040404080402010105020200050700#21": {
+                    "address": "2RhQhCGqYPDnv4jpcQxKzWFi6FtJTAZ61StueuZrjUXJQVANZytAuWtwHroCSf2TdoW9kpPxxekDnZMpMu4ZKQSZDducVpA6f5UzDPYjhuqsgJ",
+                    "datum": null,
+                    "datumhash": "2208e439244a1d0ef238352e3693098aba9de9dd0154f9056551636c8ed15dc1",
+                    "inlineDatum": null,
+                    "referenceScript": null,
+                    "value": {
+                        "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
+                            "": 1
+                        },
+                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
+                            "080301": 6
+                        },
+                        "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54": {
+                            "0406": 12
+                        },
+                        "lovelace": 5
+                    }
+                },
+                "0105080408080508070103020601080608060304040608060508040008050107#90": {
+                    "address": "addr_test1grkvh76uvxt88ury3fpvctuz9jquhs62aeqjw33cazd84avrsc6qgzqck7jaj",
+                    "datum": null,
+                    "datumhash": "ee155ace9c40292074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e25",
+                    "inlineDatum": null,
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "820180",
+                            "description": "",
+                            "type": "SimpleScript"
+                        },
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
+                    "value": {
+                        "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
+                            "": 12
+                        },
+                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
+                            "0607": 8
+                        },
+                        "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2": {
+                            "010807070604": 6
+                        },
+                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
+                            "0702070301": 10
+                        },
+                        "lovelace": 12
+                    }
+                },
+                "0304040606060403000307010203010403040604040602080201080205010203#98": {
+                    "address": "addr1z8s2w9p3nqfv8amnhgzwchtt8l7dt2kc2qrgqkcy0vyz2sgeyrnc9uzga8h49txcn3p5r2yu8yyvdczx4kruga8lldyqvu4hkd",
+                    "datum": null,
+                    "datumhash": "0268be9dbd0446eaa217e1dec8f399249305e551d7fc1437dd84521f74aa621c",
+                    "inlineDatum": null,
+                    "referenceScript": null,
+                    "value": {
+                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
+                            "050601020603": 8
+                        },
+                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
+                            "0600040102": 12
+                        },
+                        "lovelace": 8
+                    }
+                },
+                "0605010401000400060105040606020501040404000406050107000207070402#5": {
+                    "address": "addr1wy659t9n5excps5nqgnq6ckrhpa8g2k3f2lc2h4uvuess8s3arvrj",
+                    "datum": null,
+                    "datumhash": "2208e439244a1d0ef238352e3693098aba9de9dd0154f9056551636c8ed15dc1",
+                    "inlineDatum": null,
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "8303008382051939f18201808200581c4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56",
+                            "description": "",
+                            "type": "SimpleScript"
+                        },
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
+                    "value": {
+                        "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
+                            "0102": 16
+                        },
+                        "1920e782f048e9ef52acd89c4341a89c3908c6e046ad87c474fffb48": {
+                            "": 11
+                        },
+                        "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54": {
+                            "08040407": 6
+                        },
+                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
+                            "06": 5
+                        },
+                        "lovelace": 6
+                    }
+                }
+            },
             "tag": "Greetings",
             "timestamp": "1864-05-11T21:01:52.302436328624Z"
         },
@@ -12295,65 +13447,94 @@
             }
         },
         {
-            "headStatus": "Final",
+            "headStatus": "Open",
+            "hydraNodeVersion": "\u0018VQ",
             "me": {
-                "vkey": "710f3475dd831c0197ee7240a0cebd80c73ebf16d5432e4702f5328ede0042c2"
+                "vkey": "21b7b4849297987ef080c803892e7baf51cb0641b7f70f690332bc4b0951d6f7"
             },
             "seq": 0,
             "snapshotUtxo": {
-                "0107070504060606080605080704030402020505010608050405060205080606#40": {
-                    "address": "EqGAuA8vHnNhjfGqbRKJqT1Jjq1CnNxyitQNSqPGupmmcn5va4rMBZPhRZ9KB7acXCGXXc9KhmCkS3md4oCQiNGtmjLyXwdQhm93GgBPAp7bzENnFQT3jQm",
+                "0304030302030206040805080308080406050704040401070005030803040804#2": {
+                    "address": "addr_test1vz66ue36465w2qq40005h2hadad6pnjht8mu6sgplsfj74q9pm4f4",
                     "datum": null,
-                    "datumhash": null,
+                    "datumhash": "95c3003a78585e0db8c9496f6deef4de0ff000994b8534cd66d4fe96bb21ddd3",
                     "inlineDatum": null,
                     "referenceScript": {
                         "script": {
-                            "cborHex": "820182820281820419fbea82018482018082051938ac8200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b08254182041a00017324",
+                            "cborHex": "8201838205188a82051a000138218303018582041a000123e482041a000135ed8202808200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b78201858200581ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a8200581c3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e8200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f548200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b78200581c0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4",
                             "description": "",
                             "type": "SimpleScript"
                         },
                         "scriptLanguage": "SimpleScriptLanguage"
                     },
                     "value": {
-                        "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
-                            "": 13
-                        },
                         "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
-                            "040206030106": 16
+                            "080306": 10
                         },
-                        "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a": {
-                            "": 12
+                        "b16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5": {
+                            "050704": 3
                         },
                         "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54": {
-                            "040400020104": 9
+                            "0007": 5
                         },
-                        "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2": {
-                            "0002": 7
-                        },
-                        "lovelace": 2
+                        "lovelace": 9
                     }
                 },
-                "0300060005060702020107070108070501060700020708030605050405040805#90": {
-                    "address": "2cWKMJemoBamBtyb99CVTXNE1Lp4iRjqBQFhLTAhocGPyoGum1H6HoTx4wkkv5DBuc1ow",
+                "0503040707010605060603000500080708040103070206040700040303010608#96": {
+                    "address": "Ae2tdPwUPEZ6q6JWF6F5gN6uDfU1LJj4ameKuRnVX3pKNR5feRyqpQvsCrf",
                     "datum": null,
-                    "datumhash": null,
-                    "inlineDatum": null,
-                    "referenceScript": null,
-                    "value": {
-                        "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7": {
-                            "0807070301": 9
-                        },
-                        "lovelace": 16
-                    }
-                },
-                "0303060404000101030100060404010807020400020800060606030100060303#41": {
-                    "address": "EqGAuA8vHnNy3W1xWEKyJio7Fiq997Pj6WW75Lc4Zuu4LaNGC8i1oj24G8qW1duahwX8XEALkPJuSsUP2Uk7PmFMV4jCyfy4z18q6sYXF1mM2spFGjBxGzC",
-                    "datum": null,
-                    "datumhash": "f63498b4ae65be466e4a71878971b9c524458996450b0ff8262cddf3f0d99229",
-                    "inlineDatum": null,
+                    "inlineDatum": {
+                        "list": [
+                            {
+                                "constructor": 11,
+                                "fields": [
+                                    {
+                                        "list": [
+                                            {
+                                                "int": 1
+                                            },
+                                            {
+                                                "bytes": "0fb1bb44"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "int": 0
+                                    },
+                                    {
+                                        "list": [
+                                            {
+                                                "bytes": "08"
+                                            },
+                                            {
+                                                "bytes": "cf07"
+                                            },
+                                            {
+                                                "int": -2
+                                            },
+                                            {
+                                                "int": -2
+                                            },
+                                            {
+                                                "bytes": "3b"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "constructor": 768,
+                                        "fields": []
+                                    }
+                                ]
+                            },
+                            {
+                                "bytes": "e8"
+                            }
+                        ]
+                    },
+                    "inlineDatumhash": "0f7e89a14349f3febb0b128bf9960755040560d695b8bf72c5f88d1020a740b3",
                     "referenceScript": {
                         "script": {
-                            "cborHex": "82051a000117fd",
+                            "cborHex": "8303038382041a0001217e83030385830300838200581cb16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e58200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b78200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54820419b8ce820519d2e082051946e182041a000104068201848202838200581ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a8200581ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a8200581ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a8202828200581c3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e8200581c4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56830300818200581ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a8200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54",
                             "description": "",
                             "type": "SimpleScript"
                         },
@@ -12361,100 +13542,49 @@
                     },
                     "value": {
                         "1920e782f048e9ef52acd89c4341a89c3908c6e046ad87c474fffb48": {
-                            "0701": 9
-                        },
-                        "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
-                            "040706020105": 16
-                        },
-                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
-                            "": 2
-                        },
-                        "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54": {
-                            "06": 5
-                        },
-                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
-                            "07050107": 7
-                        },
-                        "lovelace": 6
-                    }
-                },
-                "0405080202000103000400070601010804070801060708050407030001040802#34": {
-                    "address": "2RhQhCGqYPDnXHhe6cvvHyCze3UNmfwQywuj8xiniocS56sqaAAm1soS9c8WQgKpKCRmPH5a3gtPYUXcoZbi1A57KjkuPSjnyKyL2NomCLpJpG",
-                    "datum": null,
-                    "inlineDatum": {
-                        "constructor": 675,
-                        "fields": [
-                            {
-                                "constructor": 66,
-                                "fields": [
-                                    {
-                                        "int": -5
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    "inlineDatumhash": "8994e12ae105baf599bc473f0f71cc4ab21bee795a3ac6d8cbcaffed0b29d7ce",
-                    "referenceScript": {
-                        "script": {
-                            "cborHex": "8303028382051a0001817d8202838200581ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a8200581c4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a568202808201818202828200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b88200581cbd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2",
-                            "description": "",
-                            "type": "SimpleScript"
-                        },
-                        "scriptLanguage": "SimpleScriptLanguage"
-                    },
-                    "value": {
-                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
-                            "060300": 6
-                        },
-                        "lovelace": 14
-                    }
-                },
-                "0506030701060704080608070500050102040201010303070701000503000005#64": {
-                    "address": "addr_test1gqvjpeuz7pywnm6j4nvfcs6p4zwrjzxxupr2mp7ywnllkjyzadwqwqsqldjr0",
-                    "datum": null,
-                    "datumhash": "642206314f534b29ad297d82440a5f9f210e30ca5ced805a587ca402de927342",
-                    "inlineDatum": null,
-                    "referenceScript": null,
-                    "value": {
-                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
-                            "070601": 10
+                            "0602": 10
                         },
                         "76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b8": {
-                            "0400050606": 16
+                            "030306070004": 1
                         },
-                        "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2": {
-                            "00050400": 1,
-                            "0108": 10
-                        },
-                        "lovelace": 9
+                        "lovelace": 16
                     }
                 },
-                "0802070806080400070106000008060600070400080303080100050704010108#90": {
-                    "address": "2RhQhCGqYPDpAEgTE2cBjMC6UFRfb5ose2L2RMXLeG7pG4o4966fcmbVHRhyGzo3ETD2GtmvKeK3yGHQCD8F6N1981NBit6Pod6j6UH2gGyLoi",
+                "0601000104020507080801030702030705020400060805080801060505030604#29": {
+                    "address": "addr12xckk4h4asryhe4v8j4kqd0046rtxekv8hz2p4t3vq7hpev95u6svqsw5d6ex",
                     "datum": null,
                     "datumhash": null,
                     "inlineDatum": null,
                     "referenceScript": {
                         "script": {
-                            "cborHex": "8201838202838201858200581ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a8200581c0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e48200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f548200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b88200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f548200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825418202828200581c3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e8200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b78200581c4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a568303048582041a000163308200581c3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e82051a00011710820180820280",
+                            "cborHex": "83030080",
                             "description": "",
                             "type": "SimpleScript"
                         },
                         "scriptLanguage": "SimpleScriptLanguage"
                     },
                     "value": {
-                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
-                            "010304": 7
-                        },
-                        "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7": {
-                            "080208": 15
-                        },
-                        "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a": {
-                            "0600010708": 10
+                        "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
+                            "0508010700": 6
                         },
                         "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54": {
-                            "08070805": 1
+                            "000703030703": 9
+                        },
+                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
+                            "050105": 11
+                        },
+                        "lovelace": 11
+                    }
+                },
+                "0605030205060705070406060806020807060200000706000706070508050004#81": {
+                    "address": "Ae2tdPwUPEYwPpTcKeKeUR4h8NSR2sf5rrPtJAum8rVyVGjPPmG31W1NDZi",
+                    "datum": null,
+                    "datumhash": null,
+                    "inlineDatum": null,
+                    "referenceScript": null,
+                    "value": {
+                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
+                            "000400": 7
                         },
                         "lovelace": 13
                     }
@@ -15008,308 +16138,12 @@
             "timestamp": "1864-05-06T16:40:37.20551722763Z"
         },
         {
-            "headStatus": "Initializing",
+            "headStatus": "Final",
+            "hydraNodeVersion": "!",
             "me": {
-                "vkey": "2e31aaec57a58b9908f1f965ce193827995af8ef80bdd634b94d3801ab0d06e3"
+                "vkey": "1799584fbb6d7d79c66241df48eeca4eb0568a641385b49ebaa5605c581e0aa5"
             },
             "seq": 0,
-            "snapshotUtxo": {
-                "0202000408060608030007080407020300040603030307050001060805000606#18": {
-                    "address": "2RhQhCGqYPDn9DBnGFJp5iHYLgEogLkk7sGvcgj8RuhU1a6b1gzV63JHyRBvh2UmktrUnuGthzqgLxgFFbqReurbDj1sZ9qdxJDsjcD6SG6vJw",
-                    "datum": null,
-                    "inlineDatum": {
-                        "map": [
-                            {
-                                "k": {
-                                    "int": -5
-                                },
-                                "v": {
-                                    "constructor": 370,
-                                    "fields": [
-                                        {
-                                            "int": -5
-                                        },
-                                        {
-                                            "constructor": 108,
-                                            "fields": []
-                                        },
-                                        {
-                                            "map": [
-                                                {
-                                                    "k": {
-                                                        "bytes": "35"
-                                                    },
-                                                    "v": {
-                                                        "bytes": "48f4"
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "int": -5
-                                                    },
-                                                    "v": {
-                                                        "bytes": ""
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "k": {
-                                    "list": []
-                                },
-                                "v": {
-                                    "list": [
-                                        {
-                                            "bytes": "00ce242f"
-                                        },
-                                        {
-                                            "int": -2
-                                        },
-                                        {
-                                            "map": [
-                                                {
-                                                    "k": {
-                                                        "bytes": "4492daa7"
-                                                    },
-                                                    "v": {
-                                                        "bytes": ""
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "int": 1
-                                                    },
-                                                    "v": {
-                                                        "int": 5
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "k": {
-                                    "map": [
-                                        {
-                                            "k": {
-                                                "int": -5
-                                            },
-                                            "v": {
-                                                "map": [
-                                                    {
-                                                        "k": {
-                                                            "bytes": "ab"
-                                                        },
-                                                        "v": {
-                                                            "bytes": "bffe13a7"
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "int": -2
-                                                        },
-                                                        "v": {
-                                                            "int": 1
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "int": 2
-                                                        },
-                                                        "v": {
-                                                            "bytes": "458f77bb"
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "int": 3
-                                                        },
-                                                        "v": {
-                                                            "bytes": ""
-                                                        }
-                                                    }
-                                                ]
-                                            }
-                                        },
-                                        {
-                                            "k": {
-                                                "constructor": 913,
-                                                "fields": [
-                                                    {
-                                                        "bytes": ""
-                                                    }
-                                                ]
-                                            },
-                                            "v": {
-                                                "bytes": ""
-                                            }
-                                        },
-                                        {
-                                            "k": {
-                                                "bytes": "ac5c1d63"
-                                            },
-                                            "v": {
-                                                "bytes": ""
-                                            }
-                                        },
-                                        {
-                                            "k": {
-                                                "bytes": ""
-                                            },
-                                            "v": {
-                                                "int": -5
-                                            }
-                                        },
-                                        {
-                                            "k": {
-                                                "int": 2
-                                            },
-                                            "v": {
-                                                "constructor": 402,
-                                                "fields": [
-                                                    {
-                                                        "bytes": "60d353"
-                                                    },
-                                                    {
-                                                        "int": -3
-                                                    },
-                                                    {
-                                                        "bytes": "1313cc"
-                                                    },
-                                                    {
-                                                        "int": 3
-                                                    },
-                                                    {
-                                                        "int": 0
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    ]
-                                },
-                                "v": {
-                                    "map": []
-                                }
-                            },
-                            {
-                                "k": {
-                                    "list": [
-                                        {
-                                            "map": [
-                                                {
-                                                    "k": {
-                                                        "int": -3
-                                                    },
-                                                    "v": {
-                                                        "bytes": "ed9566"
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "bytes": ""
-                                                    },
-                                                    "v": {
-                                                        "int": 0
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "int": 2
-                                                    },
-                                                    "v": {
-                                                        "bytes": "7a3c"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                "v": {
-                                    "int": -2
-                                }
-                            }
-                        ]
-                    },
-                    "inlineDatumhash": "de30b60cafd3d4a37f22f9b099ec78c0f417718b1a121610257f7640b408723b",
-                    "referenceScript": {
-                        "script": {
-                            "cborHex": "8303038382051993cf8202848202808201848200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b78200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825418200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825418200581c3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e8202828200581cbd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c28200581cbd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2830304858200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b88200581c58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e78200581ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a8200581c3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e8200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b78201828202818200581ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a82041a0001187b",
-                            "description": "",
-                            "type": "SimpleScript"
-                        },
-                        "scriptLanguage": "SimpleScriptLanguage"
-                    },
-                    "value": {
-                        "lovelace": 12
-                    }
-                },
-                "0407060602040303030405040004040208000608000800010404070000040707#28": {
-                    "address": "addr1x9vwrdjhrpf3ksjfgcgv2pkw7y8lqv06s9agla6up2ccpeaaqw0e2m6txqhn4dhu0396cv6s54q0gjhcr2zfyx2d6tpqqgzqw7",
-                    "datum": null,
-                    "datumhash": null,
-                    "inlineDatum": null,
-                    "referenceScript": null,
-                    "value": {
-                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
-                            "0507030201": 5
-                        },
-                        "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2": {
-                            "": 6,
-                            "02030602": 10
-                        },
-                        "lovelace": 3
-                    }
-                },
-                "0507030005050401000403010403070301050702040604050606030502020400#59": {
-                    "address": "EqGAuA8vHnPEfaYRuUqgkdvFNTJBKCUZmX5KaP9gWp5P1sXUcRhnWrYSkMAxQqtEGmMFJQVjwKsux724y1ChkcEpnvQMivXT8GYarnwuF8ebYqTVPKJ8ik8",
-                    "datum": null,
-                    "datumhash": null,
-                    "inlineDatum": null,
-                    "referenceScript": {
-                        "script": {
-                            "cborHex": "82051a00012393",
-                            "description": "",
-                            "type": "SimpleScript"
-                        },
-                        "scriptLanguage": "SimpleScriptLanguage"
-                    },
-                    "value": {
-                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
-                            "000508080203": 1
-                        },
-                        "b16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5": {
-                            "060708": 13
-                        },
-                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
-                            "07": 12
-                        },
-                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
-                            "": 2
-                        },
-                        "lovelace": 6
-                    }
-                },
-                "0600020608020705030104060508070308010204030306080308080100070507#78": {
-                    "address": "2RhQhCGqYPDoewN6JmjgCKmx9NU6hc6to1muTFH1a2SPcigY5TX2SvSbMJ8SuRKkEqSWvKAFPTy3fw5xnQE6SxHC1VPCHQwtGXYRNP5JTC6NR5",
-                    "datum": null,
-                    "datumhash": null,
-                    "inlineDatum": null,
-                    "referenceScript": null,
-                    "value": {
-                        "76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b8": {
-                            "00": 10
-                        },
-                        "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a": {
-                            "": 4
-                        },
-                        "lovelace": 13
-                    }
-                }
-            },
             "tag": "Greetings",
             "timestamp": "1864-05-12T01:56:44.221189556953Z"
         },
@@ -15882,12 +16716,12 @@
             "utxo": {}
         },
         {
-            "headStatus": "Initializing",
+            "headStatus": "Closed",
+            "hydraNodeVersion": "􇘠,󵟶%HV",
             "me": {
-                "vkey": "54283fb39dcd4dfaf0843b93a274e9c8a3e79078af9af9eb8910bba82bd4cc0a"
+                "vkey": "1f53af3d4400caf5acc5ef7db4c4e46f20a07d2323cc60d218e838899fbb7599"
             },
             "seq": 5,
-            "snapshotUtxo": {},
             "tag": "Greetings",
             "timestamp": "1864-05-05T21:21:24.790920178624Z"
         },
@@ -16241,623 +17075,71 @@
             "timestamp": "1864-05-08T08:24:09.815088700514Z"
         },
         {
-            "headStatus": "FanoutPossible",
+            "headStatus": "Closed",
+            "hydraNodeVersion": "\u001b􉲀",
             "me": {
-                "vkey": "def52eb5523244a39cde2953d07bca18130a4ac3f2f8dd1485d17303bb484fec"
+                "vkey": "5345cd0abeb555a1e72a0474d4d2a69e6c6bfacf1feaba9173446ca63a61f3ed"
             },
             "seq": 6,
-            "snapshotUtxo": {
-                "0002010204060305070302020806070003010107080803000704020702000404#23": {
-                    "address": "2RhQhCGqYPDoUiEM1qoyh1fFQrCqn225D36dD3K14ewgroguzim1DhXhfyMWy9F1dLg8X1VDXrfKjvzza5cRspznCCcnC5pFZhJr9vw9ZHYgdA",
-                    "datum": null,
-                    "datumhash": "4f539156bfbefc070a3b61cad3d1cedab3050e2b2a62f0ffe16a43eb0edc1ce8",
-                    "inlineDatum": null,
-                    "referenceScript": {
-                        "script": {
-                            "cborHex": "83030080",
-                            "description": "",
-                            "type": "SimpleScript"
-                        },
-                        "scriptLanguage": "SimpleScriptLanguage"
-                    },
-                    "value": {
-                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
-                            "06": 16
-                        },
-                        "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a": {
-                            "0108": 9
-                        },
-                        "b16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5": {
-                            "050006080603": 9
-                        },
-                        "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2": {
-                            "050001": 6
-                        },
-                        "lovelace": 1
-                    }
-                },
-                "0003040005040708070105080606050506020403010204000702030101070208#28": {
-                    "address": "addr1v8s2w9p3nqfv8amnhgzwchtt8l7dt2kc2qrgqkcy0vyz2sgrpdp6d",
-                    "datum": null,
-                    "datumhash": null,
-                    "inlineDatum": null,
-                    "referenceScript": {
-                        "script": {
-                            "cborHex": "820519689c",
-                            "description": "",
-                            "type": "SimpleScript"
-                        },
-                        "scriptLanguage": "SimpleScriptLanguage"
-                    },
-                    "value": {
-                        "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
-                            "070103": 4
-                        },
-                        "1920e782f048e9ef52acd89c4341a89c3908c6e046ad87c474fffb48": {
-                            "0206": 14
-                        },
-                        "76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b8": {
-                            "050206070603": 9
-                        },
-                        "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2": {
-                            "060503020505": 12
-                        },
-                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
-                            "02": 14
-                        },
-                        "lovelace": 8
-                    }
-                },
-                "0005060606020505050307030606040101050600000102040101010800050206#20": {
-                    "address": "2RhQhCGqYPDmpq6te5zujo4KD1j4h4fXyxKAmv4TwT6ZDh8jMtEHjKxiMaq754qDw4K68h1mrnC3yHv96LQu5KwxbgSQeXvinjorvPpwgJPWte",
-                    "datum": null,
-                    "inlineDatum": {
-                        "int": 5
-                    },
-                    "inlineDatumhash": "fb3d635c7cb573d1b9e9bff4a64ab4f25190d29b6fd8db94c605a218a23fa9ad",
-                    "referenceScript": {
-                        "script": {
-                            "cborHex": "820280",
-                            "description": "",
-                            "type": "SimpleScript"
-                        },
-                        "scriptLanguage": "SimpleScriptLanguage"
-                    },
-                    "value": {
-                        "lovelace": 7
-                    }
-                },
-                "0203070502010201040707030401020508030405050400050805050107060706#43": {
-                    "address": "addr1v8kvh76uvxt88ury3fpvctuz9jquhs62aeqjw33cazd84age0a6xj",
-                    "datum": null,
-                    "datumhash": null,
-                    "inlineDatum": null,
-                    "referenceScript": {
-                        "script": {
-                            "cborHex": "830301828205196419820519cfb9",
-                            "description": "",
-                            "type": "SimpleScript"
-                        },
-                        "scriptLanguage": "SimpleScriptLanguage"
-                    },
-                    "value": {
-                        "1920e782f048e9ef52acd89c4341a89c3908c6e046ad87c474fffb48": {
-                            "06060507": 1
-                        },
-                        "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a": {
-                            "": 1,
-                            "0107": 4
-                        },
-                        "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54": {
-                            "": 14
-                        },
-                        "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2": {
-                            "0807020804": 7
-                        },
-                        "lovelace": 2
-                    }
-                },
-                "0300030707020106080704070705050506080404010703000804070008080803#61": {
-                    "address": "2RhQhCGqYPDmzfikD4dxEsAwK4vfMitt3keiDCUbDXSDyYD3zY9fS7SUUotZtK2qa2SEERFxJkC6QkTLpe1HZLWzPGgXnU9cMqUEcY8E8q6una",
-                    "datum": null,
-                    "datumhash": "03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314",
-                    "inlineDatum": null,
-                    "referenceScript": null,
-                    "value": {
-                        "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
-                            "": 3
-                        },
-                        "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
-                            "02": 16
-                        },
-                        "76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b8": {
-                            "06": 6
-                        },
-                        "lovelace": 14
-                    }
-                },
-                "0504040702040306010400020500060704070307050807060207050300010403#33": {
-                    "address": "addr_test12z7s88u4da9nqte6km78cjavxdg22s85ftup4pyjr9xa9s59k5gqqpqrs0n5c",
-                    "datum": null,
-                    "inlineDatum": {
-                        "list": [
-                            {
-                                "list": [
-                                    {
-                                        "int": -3
-                                    },
-                                    {
-                                        "map": [
-                                            {
-                                                "k": {
-                                                    "bytes": ""
-                                                },
-                                                "v": {
-                                                    "int": 1
-                                                }
-                                            },
-                                            {
-                                                "k": {
-                                                    "bytes": "15c367"
-                                                },
-                                                "v": {
-                                                    "bytes": "f24da2"
-                                                }
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "map": [
-                                            {
-                                                "k": {
-                                                    "bytes": ""
-                                                },
-                                                "v": {
-                                                    "int": 0
-                                                }
-                                            },
-                                            {
-                                                "k": {
-                                                    "bytes": "25fc"
-                                                },
-                                                "v": {
-                                                    "bytes": "83e7476a"
-                                                }
-                                            },
-                                            {
-                                                "k": {
-                                                    "int": -4
-                                                },
-                                                "v": {
-                                                    "int": 4
-                                                }
-                                            },
-                                            {
-                                                "k": {
-                                                    "bytes": "99aac0"
-                                                },
-                                                "v": {
-                                                    "int": 3
-                                                }
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "constructor": 249,
-                                        "fields": []
-                                    }
-                                ]
-                            },
-                            {
-                                "list": [
-                                    {
-                                        "constructor": 940,
-                                        "fields": [
-                                            {
-                                                "int": 5
-                                            },
-                                            {
-                                                "int": -3
-                                            },
-                                            {
-                                                "int": -4
-                                            },
-                                            {
-                                                "bytes": "8f92be"
-                                            },
-                                            {
-                                                "int": -2
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "bytes": "c8c6733c"
-                                    },
-                                    {
-                                        "bytes": ""
-                                    },
-                                    {
-                                        "list": [
-                                            {
-                                                "bytes": "05b0"
-                                            },
-                                            {
-                                                "bytes": "7c49"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "int": 4
-                            },
-                            {
-                                "list": []
-                            }
-                        ]
-                    },
-                    "inlineDatumhash": "b77300362ecd213ac963660c15f563d86d987387f90cc8537e1c75875a3159a6",
-                    "referenceScript": {
-                        "script": {
-                            "cborHex": "8201818200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54",
-                            "description": "",
-                            "type": "SimpleScript"
-                        },
-                        "scriptLanguage": "SimpleScriptLanguage"
-                    },
-                    "value": {
-                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
-                            "0607": 14
-                        },
-                        "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7": {
-                            "03": 9
-                        },
-                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
-                            "0002080507": 13
-                        },
-                        "b16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5": {
-                            "0602030307": 7
-                        },
-                        "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2": {
-                            "": 15
-                        },
-                        "lovelace": 4
-                    }
-                }
-            },
             "tag": "Greetings",
             "timestamp": "1864-05-09T06:28:07.40637680079Z"
         },
         {
             "headStatus": "Open",
+            "hydraNodeVersion": "",
             "me": {
-                "vkey": "174f754387c893358b29ef36f2f74b071c84dc8beb6fffa8518015a738706af1"
+                "vkey": "15d87fdcde5e6cd144c8fec7b06ba4b33d070d3547a64ecfcb50ed0bd88c810e"
             },
             "seq": 3,
             "snapshotUtxo": {
-                "0203010501000304030801040108060805040307070504020307040104080801#74": {
-                    "address": "addr12yxefct5wvh0n2h88uu44dz9q7l6nq7k2q3uzx54ruxr9eyphcuqwqs6l4srt",
+                "0304040700010005000408080304020505040108010502010606080101050507#43": {
+                    "address": "2RhQhCGqYPDn1cQoVnHuX21pMdA9xi9XWkoxuGPLhq1RG6KmFq1MJKyVMJH9A2ahvrJH9ga48i5Tn8KckJ6yBTpuKkFJSFZJvS8jzKha3CzgBe",
                     "datum": null,
-                    "datumhash": null,
+                    "datumhash": "2208e439244a1d0ef238352e3693098aba9de9dd0154f9056551636c8ed15dc1",
                     "inlineDatum": null,
                     "referenceScript": null,
                     "value": {
-                        "b16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5": {
-                            "0501040604": 11
-                        },
-                        "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54": {
-                            "0003": 6,
-                            "030003": 5,
-                            "06070807": 16
-                        },
-                        "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2": {
-                            "00": 24
-                        },
-                        "lovelace": 16
-                    }
-                },
-                "0308060608070706060701050606080605020007060307030107070206080202#70": {
-                    "address": "addr_test1vpvwrdjhrpf3ksjfgcgv2pkw7y8lqv06s9agla6up2ccpecqqal60",
-                    "datum": null,
-                    "inlineDatum": {
-                        "map": [
-                            {
-                                "k": {
-                                    "bytes": "a0"
-                                },
-                                "v": {
-                                    "list": [
-                                        {
-                                            "int": 5
-                                        },
-                                        {
-                                            "map": [
-                                                {
-                                                    "k": {
-                                                        "int": 4
-                                                    },
-                                                    "v": {
-                                                        "bytes": "ed"
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "bytes": "49a1"
-                                                    },
-                                                    "v": {
-                                                        "int": 2
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "bytes": "d09710fa"
-                                                    },
-                                                    "v": {
-                                                        "bytes": "26"
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "int": -2
-                                                    },
-                                                    "v": {
-                                                        "bytes": "771648"
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "int": 2
-                                                    },
-                                                    "v": {
-                                                        "bytes": "f45f1a"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    },
-                    "inlineDatumhash": "fac4202ccc9050fad62b0525894294a5f3519df5b77fff1e9fc39c862f2d43bb",
-                    "referenceScript": {
-                        "script": {
-                            "cborHex": "46450100002601",
-                            "description": "",
-                            "type": "PlutusScriptV2"
-                        },
-                        "scriptLanguage": "PlutusScriptLanguage PlutusScriptV2"
-                    },
-                    "value": {
-                        "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54": {
-                            "04020801": 16
-                        },
-                        "lovelace": 13
-                    }
-                },
-                "0703070308040206080004040108050105030005070201070806040003030202#41": {
-                    "address": "2cWKMJemoBahLeMLga1dweZZSVofa9ux6HHTxnhaUTx234ZRsD1S3tUNLQD1UwDQcvR93",
-                    "datum": null,
-                    "inlineDatum": {
-                        "constructor": 729,
-                        "fields": [
-                            {
-                                "list": [
-                                    {
-                                        "int": 2
-                                    },
-                                    {
-                                        "map": [
-                                            {
-                                                "k": {
-                                                    "bytes": "f4"
-                                                },
-                                                "v": {
-                                                    "bytes": ""
-                                                }
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "constructor": 298,
-                                        "fields": [
-                                            {
-                                                "int": -3
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    "inlineDatumhash": "bdbb0cb22ac5c524ff0cbf83c281d0d4807a15432c1d7ec788a3d9254d0fab18",
-                    "referenceScript": null,
-                    "value": {
-                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
-                            "": 11
-                        },
-                        "lovelace": 13
-                    }
-                },
-                "0704040508050805060803010807000005030408060502060802000007000608#29": {
-                    "address": "2RhQhCGqYPDnhJi3sryadBLT2vakwr7mejR5g61DgPZgsHcVUefNAGgeydTgGgRRgF7Cs2kQ5oUWf58oxtBevUrMvkYUC1J6c63BJBKyAf3fRV",
-                    "datum": null,
-                    "inlineDatum": {
-                        "constructor": 296,
-                        "fields": [
-                            {
-                                "map": [
-                                    {
-                                        "k": {
-                                            "int": -5
-                                        },
-                                        "v": {
-                                            "map": [
-                                                {
-                                                    "k": {
-                                                        "bytes": "1d1f"
-                                                    },
-                                                    "v": {
-                                                        "bytes": "0b1356"
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "bytes": "168d"
-                                                    },
-                                                    "v": {
-                                                        "int": 2
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "k": {
-                                            "bytes": ""
-                                        },
-                                        "v": {
-                                            "map": [
-                                                {
-                                                    "k": {
-                                                        "bytes": ""
-                                                    },
-                                                    "v": {
-                                                        "bytes": "7866"
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "bytes": "5205"
-                                                    },
-                                                    "v": {
-                                                        "bytes": "baf1a13d"
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "bytes": "5a52fd"
-                                                    },
-                                                    "v": {
-                                                        "bytes": "98ba0c"
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "bytes": "89"
-                                                    },
-                                                    "v": {
-                                                        "bytes": "46"
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "int": -5
-                                                    },
-                                                    "v": {
-                                                        "bytes": ""
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "k": {
-                                            "list": [
-                                                {
-                                                    "int": -4
-                                                },
-                                                {
-                                                    "int": -1
-                                                },
-                                                {
-                                                    "bytes": ""
-                                                }
-                                            ]
-                                        },
-                                        "v": {
-                                            "map": [
-                                                {
-                                                    "k": {
-                                                        "bytes": "edf9cb"
-                                                    },
-                                                    "v": {
-                                                        "int": -1
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "bytes": "3d9b2327"
-                                                    },
-                                                    "v": {
-                                                        "int": 2
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "int": 5
-                                                    },
-                                                    "v": {
-                                                        "int": 5
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "int": 1
-                                                    },
-                                                    "v": {
-                                                        "bytes": ""
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "bytes": "3954"
-                                                    },
-                                                    "v": {
-                                                        "int": -4
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "k": {
-                                            "bytes": "f4001c"
-                                        },
-                                        "v": {
-                                            "int": 3
-                                        }
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    "inlineDatumhash": "24283a09d53937b026b036a8cdf5d59b7c53ea2cf46653a1e45898ee96e21741",
-                    "referenceScript": {
-                        "script": {
-                            "cborHex": "82041a00011557",
-                            "description": "",
-                            "type": "SimpleScript"
-                        },
-                        "scriptLanguage": "SimpleScriptLanguage"
-                    },
-                    "value": {
-                        "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
-                            "05": 13
+                        "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
+                            "0504": 3
                         },
                         "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
-                            "020305": 15
+                            "030208": 5
+                        },
+                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
+                            "0706": 12
+                        },
+                        "76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b8": {
+                            "010206": 15
+                        },
+                        "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2": {
+                            "0305": 7
+                        },
+                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
+                            "0707060005": 10
+                        },
+                        "lovelace": 7
+                    }
+                },
+                "0808080103020401070805050403060004020104020205080404080205010104#39": {
+                    "address": "2RhQhCGqYPDouAP7hMjd3nhPrYdPqgyh8YhpAVYB8sbLAkmWXa9Nrk1UZ4GqeqQTKrDMfTooazwUuba6izVAMnf6HUpzHx5xka6hVNSbJkjroc",
+                    "datum": null,
+                    "inlineDatum": {
+                        "int": 5
+                    },
+                    "inlineDatumhash": "fb3d635c7cb573d1b9e9bff4a64ab4f25190d29b6fd8db94c605a218a23fa9ad",
+                    "referenceScript": null,
+                    "value": {
+                        "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7": {
+                            "0107": 10,
+                            "0602": 15
+                        },
+                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
+                            "": 16
                         },
                         "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a": {
-                            "050605": 16
+                            "070001060208": 11
                         },
-                        "b16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5": {
-                            "010102080307": 7
-                        },
-                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
-                            "0301": 10
-                        },
-                        "lovelace": 6
+                        "lovelace": 2
                     }
                 }
             },
@@ -18077,10 +18359,546 @@
         },
         {
             "headStatus": "Initializing",
+            "hydraNodeVersion": "",
             "me": {
-                "vkey": "d3c771fbc818d8f725feead3a6638e427c12fd7ad0e4adc6ff3e5222b0f8c8ee"
+                "vkey": "1339e4ea15f88e772ab1508137ffce958bde8f9c16f3b8bf0841619ab1d1d785"
             },
             "seq": 4,
+            "snapshotUtxo": {
+                "0105050203010100010101060807030501070407000804080506050000060508#60": {
+                    "address": "addr128s2w9p3nqfv8amnhgzwchtt8l7dt2kc2qrgqkcy0vyz2sw20uzqxzx3duy",
+                    "datum": null,
+                    "inlineDatum": {
+                        "list": []
+                    },
+                    "inlineDatumhash": "45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0",
+                    "referenceScript": null,
+                    "value": {
+                        "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
+                            "06050706": 12
+                        },
+                        "1920e782f048e9ef52acd89c4341a89c3908c6e046ad87c474fffb48": {
+                            "05030600": 7
+                        },
+                        "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
+                            "": 5
+                        },
+                        "lovelace": 11
+                    }
+                },
+                "0107010107030106020606080603040502000306030307000805030503030106#37": {
+                    "address": "addr1g9mwvp7m9gcungkryasaysc6rp492rxry8meekxk4q4jnwyy7ehsxqstqr9dm",
+                    "datum": null,
+                    "datumhash": "bb30a42c1e62f0afda5f0a4e8a562f7a13a24cea00ee81917b86b89e801314aa",
+                    "inlineDatum": null,
+                    "referenceScript": null,
+                    "value": {
+                        "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
+                            "0803": 6
+                        },
+                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
+                            "": 10
+                        },
+                        "lovelace": 10
+                    }
+                },
+                "0402040802080304060606060007040202050606040506060106010607060405#90": {
+                    "address": "addr1yx66ue36465w2qq40005h2hadad6pnjht8mu6sgplsfj749xger5hr65xynp2p4kcfeaxp7826dyadkfddpd6j3f2g9qdldzzx",
+                    "datum": null,
+                    "inlineDatum": {
+                        "list": [
+                            {
+                                "map": [
+                                    {
+                                        "k": {
+                                            "constructor": 694,
+                                            "fields": [
+                                                {
+                                                    "int": 5
+                                                }
+                                            ]
+                                        },
+                                        "v": {
+                                            "int": 5
+                                        }
+                                    },
+                                    {
+                                        "k": {
+                                            "map": []
+                                        },
+                                        "v": {
+                                            "int": -3
+                                        }
+                                    },
+                                    {
+                                        "k": {
+                                            "constructor": 489,
+                                            "fields": [
+                                                {
+                                                    "bytes": "3c6e0c"
+                                                }
+                                            ]
+                                        },
+                                        "v": {
+                                            "bytes": ""
+                                        }
+                                    },
+                                    {
+                                        "k": {
+                                            "map": [
+                                                {
+                                                    "k": {
+                                                        "bytes": "f0"
+                                                    },
+                                                    "v": {
+                                                        "bytes": ""
+                                                    }
+                                                },
+                                                {
+                                                    "k": {
+                                                        "bytes": "82b7"
+                                                    },
+                                                    "v": {
+                                                        "bytes": ""
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "v": {
+                                            "constructor": 908,
+                                            "fields": [
+                                                {
+                                                    "int": -2
+                                                },
+                                                {
+                                                    "bytes": ""
+                                                },
+                                                {
+                                                    "bytes": "adb6"
+                                                },
+                                                {
+                                                    "bytes": "6ddc"
+                                                },
+                                                {
+                                                    "int": 4
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "k": {
+                                            "constructor": 231,
+                                            "fields": [
+                                                {
+                                                    "int": -3
+                                                },
+                                                {
+                                                    "bytes": "a8c936"
+                                                },
+                                                {
+                                                    "bytes": "c900"
+                                                }
+                                            ]
+                                        },
+                                        "v": {
+                                            "bytes": "e4ca"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "list": [
+                                    {
+                                        "int": -2
+                                    },
+                                    {
+                                        "list": [
+                                            {
+                                                "int": 2
+                                            },
+                                            {
+                                                "int": 3
+                                            },
+                                            {
+                                                "bytes": "cbb1ae01"
+                                            },
+                                            {
+                                                "int": 3
+                                            },
+                                            {
+                                                "bytes": "24eb"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "map": [
+                                            {
+                                                "k": {
+                                                    "bytes": "dc50654a"
+                                                },
+                                                "v": {
+                                                    "int": 4
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "bytes": "ff"
+                                                },
+                                                "v": {
+                                                    "int": 0
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "int": -2
+                                    },
+                                    {
+                                        "list": [
+                                            {
+                                                "int": -3
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "bytes": ""
+                            },
+                            {
+                                "list": [
+                                    {
+                                        "int": 4
+                                    },
+                                    {
+                                        "int": -3
+                                    }
+                                ]
+                            },
+                            {
+                                "list": []
+                            }
+                        ]
+                    },
+                    "inlineDatumhash": "23a0fc8748af6626ecaf0ff9935dd234d3569a318b488e3874911b6092e75308",
+                    "referenceScript": null,
+                    "value": {
+                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
+                            "00000407": 14
+                        },
+                        "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2": {
+                            "00": 10,
+                            "0201": 9
+                        },
+                        "lovelace": 15
+                    }
+                },
+                "0408020503050801060501000104040804070807000007070207060706000703#87": {
+                    "address": "addr_test1wq659t9n5excps5nqgnq6ckrhpa8g2k3f2lc2h4uvuess8s24hsvh",
+                    "datum": null,
+                    "inlineDatum": {
+                        "map": [
+                            {
+                                "k": {
+                                    "list": [
+                                        {
+                                            "constructor": 990,
+                                            "fields": [
+                                                {
+                                                    "bytes": "fc"
+                                                },
+                                                {
+                                                    "int": 1
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "int": -1
+                                        }
+                                    ]
+                                },
+                                "v": {
+                                    "int": 4
+                                }
+                            },
+                            {
+                                "k": {
+                                    "list": [
+                                        {
+                                            "bytes": ""
+                                        },
+                                        {
+                                            "list": []
+                                        },
+                                        {
+                                            "int": -5
+                                        },
+                                        {
+                                            "map": [
+                                                {
+                                                    "k": {
+                                                        "int": -5
+                                                    },
+                                                    "v": {
+                                                        "bytes": "37"
+                                                    }
+                                                },
+                                                {
+                                                    "k": {
+                                                        "int": -1
+                                                    },
+                                                    "v": {
+                                                        "bytes": "fca9"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "v": {
+                                    "map": [
+                                        {
+                                            "k": {
+                                                "constructor": 296,
+                                                "fields": []
+                                            },
+                                            "v": {
+                                                "int": 2
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "bytes": "039d0524"
+                                                        },
+                                                        "v": {
+                                                            "bytes": ""
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "bytes": ""
+                                                        },
+                                                        "v": {
+                                                            "bytes": "c6"
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "bytes": "8f4265"
+                                                        },
+                                                        "v": {
+                                                            "bytes": "320b"
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "v": {
+                                                "int": 1
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "constructor": 91,
+                                                "fields": [
+                                                    {
+                                                        "int": -5
+                                                    }
+                                                ]
+                                            },
+                                            "v": {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "bytes": "ae48c1"
+                                                        },
+                                                        "v": {
+                                                            "int": -1
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "bytes": "09"
+                                            },
+                                            "v": {
+                                                "list": [
+                                                    {
+                                                        "bytes": "7c9a"
+                                                    },
+                                                    {
+                                                        "bytes": "70"
+                                                    },
+                                                    {
+                                                        "int": 0
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "list": []
+                                            },
+                                            "v": {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "int": 2
+                                                        },
+                                                        "v": {
+                                                            "bytes": "f18041"
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "bytes": ""
+                                                        },
+                                                        "v": {
+                                                            "bytes": "1504"
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "bytes": "767510b5"
+                                                        },
+                                                        "v": {
+                                                            "int": -3
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "bytes": "5a"
+                                                        },
+                                                        "v": {
+                                                            "int": -3
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "k": {
+                                    "list": [
+                                        {
+                                            "map": []
+                                        },
+                                        {
+                                            "constructor": 824,
+                                            "fields": [
+                                                {
+                                                    "int": 0
+                                                },
+                                                {
+                                                    "int": 5
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "v": {
+                                    "list": [
+                                        {
+                                            "map": [
+                                                {
+                                                    "k": {
+                                                        "int": 0
+                                                    },
+                                                    "v": {
+                                                        "int": 5
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "map": [
+                                                {
+                                                    "k": {
+                                                        "bytes": ""
+                                                    },
+                                                    "v": {
+                                                        "int": 0
+                                                    }
+                                                },
+                                                {
+                                                    "k": {
+                                                        "bytes": "4ef7b00a"
+                                                    },
+                                                    "v": {
+                                                        "int": 0
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "k": {
+                                    "int": 5
+                                },
+                                "v": {
+                                    "int": 0
+                                }
+                            },
+                            {
+                                "k": {
+                                    "int": 3
+                                },
+                                "v": {
+                                    "int": -2
+                                }
+                            }
+                        ]
+                    },
+                    "inlineDatumhash": "be2714a184140fd440ec34625cb6255a5bff60d09bd561dc4fe6cad2888a4b0e",
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "83030085820183830301828200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f548200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54820419fd8d820519e6918202818201848200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f548200581c58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e78200581c4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a568200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825418202808200581c0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e483030083830302838200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f548200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825418200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825418202838200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b88200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b88200581cbd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2820519f78b",
+                            "description": "",
+                            "type": "SimpleScript"
+                        },
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
+                    "value": {
+                        "1920e782f048e9ef52acd89c4341a89c3908c6e046ad87c474fffb48": {
+                            "03020701": 16
+                        },
+                        "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7": {
+                            "06": 1
+                        },
+                        "76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b8": {
+                            "0006": 10
+                        },
+                        "lovelace": 1
+                    }
+                },
+                "0501040201050203060705050801020400060803080301070604070000040708#83": {
+                    "address": "2RhQhCGqYPDnPU9Bwd2U4QFR3NiJ1H1V4HP4B5AYgx6TWFvcmNFe4CfJXEtXqdMDKuTofUF4h9fqvTnhoKD23WpX3x9cSsdKcL3J16dcniA1nr",
+                    "datum": null,
+                    "inlineDatum": {
+                        "bytes": "4f"
+                    },
+                    "inlineDatumhash": "300db3a227e350a637bd67e1b1bebd6008efe91c1bda66de48f841653055a56b",
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "820280",
+                            "description": "",
+                            "type": "SimpleScript"
+                        },
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
+                    "value": {
+                        "lovelace": 9
+                    }
+                }
+            },
             "tag": "Greetings",
             "timestamp": "1864-05-14T16:07:03.218608073155Z"
         },
@@ -18366,181 +19184,416 @@
             "timestamp": "1864-05-12T19:19:43.735436553863Z"
         },
         {
-            "headStatus": "Closed",
+            "headStatus": "Initializing",
+            "hydraNodeVersion": "䎟󹑷",
             "me": {
-                "vkey": "95455e56e2259e2d97cdcf7a22d44a3bf078acfcb308f13b41666e8b52f2b2f8"
+                "vkey": "413305fd6b227b39115be20709f2a5ce63df7fa543f8e097dc3587f69838e830"
             },
             "seq": 2,
             "snapshotUtxo": {
-                "0101010305040000050602030801080704020706020501000303050807060307#68": {
-                    "address": "2RhQhCGqYPDo3iuH77vnNUwGVrNstFyFyH7nzCM761LLdw4vCQosieWQtMQKSqA4iBe8icwsRtxcjP7vQnZG2Q7WvUYjrefH7CKbu6i3d1KWCB",
+                "0006010408070605080107020705000401030505040107030203070606030408#50": {
+                    "address": "2cWKMJemoBajkWxWuEk5PGZaAKdww5zK2R3Rr4cDjZMdymiSzAnUwkiU3RpsmL7zrXghr",
                     "datum": null,
                     "datumhash": null,
                     "inlineDatum": null,
                     "referenceScript": {
                         "script": {
-                            "cborHex": "82028182028582051a00012912830302838200581c3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e8200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b88200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54820419ae628200581c0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e48202838200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b88200581c3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e8200581c3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e",
+                            "cborHex": "83030080",
                             "description": "",
                             "type": "SimpleScript"
                         },
                         "scriptLanguage": "SimpleScriptLanguage"
                     },
                     "value": {
-                        "lovelace": 10
-                    }
-                },
-                "0105050508000701030708040307080301080006050302050808060708000505#28": {
-                    "address": "addr129vwrdjhrpf3ksjfgcgv2pkw7y8lqv06s9agla6up2ccpeujpuqq2rhhrer",
-                    "datum": null,
-                    "datumhash": "f63498b4ae65be466e4a71878971b9c524458996450b0ff8262cddf3f0d99229",
-                    "inlineDatum": null,
-                    "referenceScript": {
-                        "script": {
-                            "cborHex": "4746010000220011",
-                            "description": "",
-                            "type": "PlutusScriptV2"
-                        },
-                        "scriptLanguage": "PlutusScriptLanguage PlutusScriptV2"
-                    },
-                    "value": {
-                        "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
-                            "080103040707": 11
-                        },
-                        "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a": {
-                            "01030703": 7
-                        },
-                        "lovelace": 4
-                    }
-                },
-                "0600020306080504060707070507080100010501030505030807060404010503#57": {
-                    "address": "addr1vxckk4h4asryhe4v8j4kqd0046rtxekv8hz2p4t3vq7hpegzwawyn",
-                    "datum": null,
-                    "datumhash": null,
-                    "inlineDatum": null,
-                    "referenceScript": null,
-                    "value": {
-                        "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
-                            "040704060806": 14,
-                            "06010200": 6
-                        },
                         "1920e782f048e9ef52acd89c4341a89c3908c6e046ad87c474fffb48": {
-                            "0201030700": 3
+                            "0806": 8
                         },
                         "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
-                            "0600": 5
+                            "03030003": 7
                         },
-                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
-                            "030501": 7
+                        "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7": {
+                            "050401": 4
                         },
-                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
-                            "01": 15
+                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
+                            "010306020608": 1
                         },
-                        "lovelace": 2
+                        "lovelace": 6
                     }
                 },
-                "0800070103020801030100060005040802000000010106010705010108010605#83": {
-                    "address": "addr1qx66ue36465w2qq40005h2hadad6pnjht8mu6sgplsfj74944enr4t4gu5qp277lfw406m6m5r89wk0he4qsrlqn9a2qd7gaed",
+                "0303020400000804000601080304010307060201070001060102040001040006#37": {
+                    "address": "addr1xx66ue36465w2qq40005h2hadad6pnjht8mu6sgplsfj7493ddt0tmqxf0n2c09tvq67lt5xkdnvc0wy5r2hzcpawrjsgsl883",
                     "datum": null,
                     "inlineDatum": {
                         "map": [
                             {
                                 "k": {
-                                    "int": -4
-                                },
-                                "v": {
                                     "list": [
                                         {
-                                            "constructor": 792,
-                                            "fields": [
+                                            "int": 2
+                                        },
+                                        {
+                                            "map": [
                                                 {
-                                                    "int": -1
+                                                    "k": {
+                                                        "bytes": ""
+                                                    },
+                                                    "v": {
+                                                        "bytes": "660655fd"
+                                                    }
                                                 },
                                                 {
-                                                    "int": -2
+                                                    "k": {
+                                                        "int": -1
+                                                    },
+                                                    "v": {
+                                                        "bytes": "d79e18"
+                                                    }
                                                 },
                                                 {
-                                                    "bytes": ""
-                                                },
-                                                {
-                                                    "int": -4
-                                                },
-                                                {
-                                                    "int": 0
+                                                    "k": {
+                                                        "int": 1
+                                                    },
+                                                    "v": {
+                                                        "int": -2
+                                                    }
                                                 }
                                             ]
                                         },
                                         {
-                                            "list": [
+                                            "map": [
                                                 {
-                                                    "int": 2
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "list": [
-                                                {
-                                                    "bytes": "9ee2"
+                                                    "k": {
+                                                        "bytes": ""
+                                                    },
+                                                    "v": {
+                                                        "bytes": "50c531"
+                                                    }
                                                 },
                                                 {
-                                                    "bytes": "85de"
+                                                    "k": {
+                                                        "int": 5
+                                                    },
+                                                    "v": {
+                                                        "bytes": "2b8d85"
+                                                    }
+                                                },
+                                                {
+                                                    "k": {
+                                                        "bytes": "0223"
+                                                    },
+                                                    "v": {
+                                                        "int": -5
+                                                    }
+                                                },
+                                                {
+                                                    "k": {
+                                                        "bytes": "32"
+                                                    },
+                                                    "v": {
+                                                        "bytes": "99"
+                                                    }
+                                                },
+                                                {
+                                                    "k": {
+                                                        "bytes": ""
+                                                    },
+                                                    "v": {
+                                                        "int": 4
+                                                    }
                                                 }
                                             ]
                                         },
-                                        {
-                                            "int": -2
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "k": {
-                                    "constructor": 646,
-                                    "fields": [
                                         {
                                             "list": [
                                                 {
                                                     "int": -5
                                                 },
                                                 {
-                                                    "int": 5
+                                                    "int": 1
                                                 },
                                                 {
-                                                    "bytes": "708cd151"
-                                                },
-                                                {
-                                                    "int": 5
-                                                },
-                                                {
-                                                    "bytes": "fe8a"
+                                                    "int": 3
                                                 }
                                             ]
+                                        },
+                                        {
+                                            "int": -5
                                         }
                                     ]
                                 },
                                 "v": {
-                                    "bytes": "8a"
+                                    "constructor": 245,
+                                    "fields": [
+                                        {
+                                            "map": []
+                                        },
+                                        {
+                                            "int": 3
+                                        },
+                                        {
+                                            "list": [
+                                                {
+                                                    "bytes": "e8ce3298"
+                                                },
+                                                {
+                                                    "int": -5
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "constructor": 851,
+                                            "fields": [
+                                                {
+                                                    "int": 0
+                                                },
+                                                {
+                                                    "bytes": "2313"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "list": []
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "k": {
+                                    "bytes": "59"
+                                },
+                                "v": {
+                                    "map": []
+                                }
+                            },
+                            {
+                                "k": {
+                                    "bytes": ""
+                                },
+                                "v": {
+                                    "map": [
+                                        {
+                                            "k": {
+                                                "bytes": "302940aa"
+                                            },
+                                            "v": {
+                                                "list": [
+                                                    {
+                                                        "bytes": "85cc5f"
+                                                    },
+                                                    {
+                                                        "bytes": ""
+                                                    },
+                                                    {
+                                                        "int": -1
+                                                    },
+                                                    {
+                                                        "bytes": "3bea9151"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "bytes": "a852"
+                                            },
+                                            "v": {
+                                                "int": -1
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "list": [
+                                                    {
+                                                        "int": -1
+                                                    }
+                                                ]
+                                            },
+                                            "v": {
+                                                "int": 1
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "int": 2
+                                            },
+                                            "v": {
+                                                "constructor": 343,
+                                                "fields": [
+                                                    {
+                                                        "bytes": "64"
+                                                    },
+                                                    {
+                                                        "int": -3
+                                                    },
+                                                    {
+                                                        "bytes": "54"
+                                                    },
+                                                    {
+                                                        "bytes": "371f37"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "k": {
+                                    "bytes": "cd1f"
+                                },
+                                "v": {
+                                    "constructor": 677,
+                                    "fields": [
+                                        {
+                                            "constructor": 80,
+                                            "fields": [
+                                                {
+                                                    "bytes": "8fcea43f"
+                                                },
+                                                {
+                                                    "int": 5
+                                                },
+                                                {
+                                                    "bytes": "38c517d9"
+                                                },
+                                                {
+                                                    "bytes": "d31d"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "map": [
+                                                {
+                                                    "k": {
+                                                        "int": -2
+                                                    },
+                                                    "v": {
+                                                        "int": 3
+                                                    }
+                                                },
+                                                {
+                                                    "k": {
+                                                        "int": -2
+                                                    },
+                                                    "v": {
+                                                        "int": 2
+                                                    }
+                                                },
+                                                {
+                                                    "k": {
+                                                        "int": 0
+                                                    },
+                                                    "v": {
+                                                        "bytes": "5c856b"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
                                 }
                             }
                         ]
                     },
-                    "inlineDatumhash": "df16b469eb461646fb41229f13f1e900e1df2bae860f2917fb88546077577757",
+                    "inlineDatumhash": "f49202f9fce3c8772211c1e08b98160df9936ef1c1aecfcc039080fee2f4f3d9",
+                    "referenceScript": null,
+                    "value": {
+                        "b16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5": {
+                            "08060508": 16
+                        },
+                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
+                            "": 13
+                        },
+                        "lovelace": 15
+                    }
+                },
+                "0602070706070800060405060305050701000708070305050607060507080204#44": {
+                    "address": "2RhQhCGqYPDoe1MDyi1YYetTWCmiHAbR7MVxnrBcEhgCFMWmQp5buZaPBNAUH8xjosSyzRzFfrkQF8rZjoLxzKNb2fpdsDeoBTcL7YKiBN88jR",
+                    "datum": null,
+                    "datumhash": null,
+                    "inlineDatum": null,
+                    "referenceScript": null,
+                    "value": {
+                        "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a": {
+                            "01030505": 9
+                        },
+                        "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54": {
+                            "02": 14
+                        },
+                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
+                            "0502050103": 11
+                        },
+                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
+                            "08010306": 9
+                        },
+                        "lovelace": 4
+                    }
+                },
+                "0700030601020300030004000501030701040108000202070801030504010303#76": {
+                    "address": "addr_test12rs2w9p3nqfv8amnhgzwchtt8l7dt2kc2qrgqkcy0vyz2svpccssvqsm98d2m",
+                    "datum": null,
+                    "datumhash": "642206314f534b29ad297d82440a5f9f210e30ca5ced805a587ca402de927342",
+                    "inlineDatum": null,
+                    "referenceScript": null,
+                    "value": {
+                        "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
+                            "08040307": 13
+                        },
+                        "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
+                            "000301070604": 6
+                        },
+                        "b16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5": {
+                            "": 10
+                        },
+                        "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541": {
+                            "": 10
+                        },
+                        "lovelace": 15
+                    }
+                },
+                "0800010408060700000306010701050002050400070403000000030601080500#60": {
+                    "address": "EqGAuA8vHnNjLRhhyKTKaCbMcutZs54fCUNNdBrAoq69aPjCi7SUL1v77FrcHrUSGByaZAnkY7SEBTqzbzj3njP5zL3r8CNR1NBXLWCNmqtKJxYzP4d5BNb",
+                    "datum": null,
+                    "datumhash": "95c3003a78585e0db8c9496f6deef4de0ff000994b8534cd66d4fe96bb21ddd3",
+                    "inlineDatum": null,
+                    "referenceScript": null,
+                    "value": {
+                        "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
+                            "04": 6
+                        },
+                        "1920e782f048e9ef52acd89c4341a89c3908c6e046ad87c474fffb48": {
+                            "08050208": 2
+                        },
+                        "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
+                            "020405": 10
+                        },
+                        "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a": {
+                            "": 9,
+                            "07": 6
+                        },
+                        "lovelace": 10
+                    }
+                },
+                "0800060001030106010708070203020608000202060006020404050702080103#6": {
+                    "address": "EqGAuA8vHnNnpKzPQATXWCHL3UwooNUe8RZehHmQ1ADEj9CTdNiyRe2FmR3knpkFNXSZu8Nwc9PaLgbvhcZVrgeCnyv7mecxQwTfdqkkEZrxZPZE2oXynXB",
+                    "datum": null,
+                    "datumhash": null,
+                    "inlineDatum": null,
                     "referenceScript": {
                         "script": {
-                            "cborHex": "82051a000159c5",
+                            "cborHex": "820284830300858201818200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b78201818200581c0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4820519cf0e830302828200581cb16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e58200581c58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e78201848200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f548200581c0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e48200581c0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e48200581c3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e82041a000114b18201858201808200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7830301818200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b88201858200581cbd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c28200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b88200581cbd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c28200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825418200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b882041908f48200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541",
                             "description": "",
                             "type": "SimpleScript"
                         },
                         "scriptLanguage": "SimpleScriptLanguage"
                     },
                     "value": {
-                        "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a": {
-                            "": 3,
-                            "0303070003": 11
+                        "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4": {
+                            "0508": 4
                         },
-                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
-                            "": 10
+                        "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56": {
+                            "060007000705": 1
                         },
-                        "lovelace": 12
+                        "lovelace": 13
                     }
                 }
             },
@@ -19019,9 +20072,10 @@
             "timestamp": "1864-05-10T11:33:11.802015905515Z"
         },
         {
-            "headStatus": "Idle",
+            "headStatus": "Final",
+            "hydraNodeVersion": "L􅙌極",
             "me": {
-                "vkey": "51097aed224a28dddfa1f973f9bedc3d3da71658749948dd519bcf418829027f"
+                "vkey": "fd942984790ae6bbc520f160a10798e6df99870cc7edc634c05067a26c2c1743"
             },
             "seq": 6,
             "snapshotUtxo": {},
@@ -19234,11 +20288,87 @@
             }
         },
         {
-            "headStatus": "Final",
+            "headStatus": "Idle",
+            "hydraNodeVersion": "fy棆^",
             "me": {
-                "vkey": "c8a74f854c5b511fd4b3665303794070a9b33e300b85c531eed372f9ffd73d5c"
+                "vkey": "cb402466a5405d7ad90e97bd8bbedea3aa7b580e8419243635519a9ea77292be"
             },
             "seq": 6,
+            "snapshotUtxo": {
+                "0104000807050100020108050402040803080405000702030403060706070504#46": {
+                    "address": "addr_test1gzckk4h4asryhe4v8j4kqd0046rtxekv8hz2p4t3vq7hpevzuelqzpg7vtc83",
+                    "datum": null,
+                    "datumhash": null,
+                    "inlineDatum": null,
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "830300858202838200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541820419bc13830301818200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b88200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541820519cea2820519543882051946e1",
+                            "description": "",
+                            "type": "SimpleScript"
+                        },
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
+                    "value": {
+                        "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e": {
+                            "0207": 10
+                        },
+                        "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54": {
+                            "000505000201": 5
+                        },
+                        "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2": {
+                            "0605000506": 14,
+                            "070701050201": 14
+                        },
+                        "lovelace": 12
+                    }
+                },
+                "0406040302040200030204080307020402070601010207000108010300080202#78": {
+                    "address": "addr_test1yznyv36t3a2rzfs4q6mvyu7nqlr4dxjwkmykkskafg54yzjcuxm9wxznrdpyj3ssc5rvaug07qcl4qt63lm4cz43srns6uszhv",
+                    "datum": null,
+                    "datumhash": "f63498b4ae65be466e4a71878971b9c524458996450b0ff8262cddf3f0d99229",
+                    "inlineDatum": null,
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "8202828205190fdd820419a261",
+                            "description": "",
+                            "type": "SimpleScript"
+                        },
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
+                    "value": {
+                        "76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b8": {
+                            "030108010206": 1
+                        },
+                        "eccbfb5c619673f0648a42cc2f822c81cbc34aee41274638e89a7af5": {
+                            "0208020206": 2
+                        },
+                        "lovelace": 3
+                    }
+                },
+                "0703010000010801060008060405020003040308060408080602080500060100#96": {
+                    "address": "addr1q8s2w9p3nqfv8amnhgzwchtt8l7dt2kc2qrgqkcy0vyz2sgdjnshguewlx4ww0eet26y2pal4xpav5prcydf28cvxtjqpgx6j9",
+                    "datum": null,
+                    "datumhash": "bfa726c3c149165b108e6ff550cb1a1c4f0fdc2e9f26a9a16f48babe73b600ce",
+                    "inlineDatum": null,
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "820284820183830301848200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825418200581cb16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e58200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b78200581cbd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c28201828200581ca646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a8200581c0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e48201838200581c3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e8200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825418200581c0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4830301818202818200581cb16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e58201858202828200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b88200581c0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e48200581cb16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e58201848200581c76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b88200581cb16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e58200581c3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e8200581c65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7830303838200581c3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e8200581c0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e48200581cb16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e58200581ce0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b0825418201818200581cbd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2",
+                            "description": "",
+                            "type": "SimpleScript"
+                        },
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
+                    "value": {
+                        "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7": {
+                            "050002040508": 11
+                        },
+                        "76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b8": {
+                            "07060807": 10
+                        },
+                        "lovelace": 15
+                    }
+                }
+            },
             "tag": "Greetings",
             "timestamp": "1864-05-11T01:59:31.960646105043Z"
         },

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -281,6 +281,7 @@ components:
           - headStatus
           - seq
           - timestamp
+          - hydraNodeVersion
         properties:
           tag:
             type: string
@@ -293,6 +294,8 @@ components:
             $ref: "#/components/schemas/UTxO"
           timestamp:
             $ref: "#/components/schemas/UTCTime"
+          hydraNodeVersion:
+            $ref: "#/components/schemas/HydraNodeVersion"
 
     PeerConnected:
       title: PeerConnected
@@ -1648,6 +1651,10 @@ components:
           $ref: "#/components/schemas/PlutusV2Script"
         redeemer:
           type: string
+    HydraNodeVersion:
+      type: string
+      description: |
+        Current hydra-node version.
 
     SequenceNumber:
       type: integer

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -15,6 +15,7 @@ import Control.Exception (IOException)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.Text (pack)
+import Data.Version (showVersion)
 import Hydra.API.ClientInput (ClientInput)
 import Hydra.API.Projection (Projection (..), mkProjection)
 import Hydra.API.RestServer (
@@ -25,7 +26,7 @@ import Hydra.API.RestServer (
 import Hydra.API.ServerOutput (
   HeadStatus (Idle),
   OutputFormat (..),
-  ServerOutput (Greetings, InvalidInput),
+  ServerOutput (Greetings, InvalidInput, hydraNodeVersion),
   ServerOutputConfig (..),
   TimedServerOutput (..),
   WithUTxO (..),
@@ -50,6 +51,7 @@ import Hydra.Chain.Direct.State ()
 import Hydra.Ledger (UTxOType)
 import Hydra.Logging (Tracer, traceWith)
 import Hydra.Network (IP, PortNumber)
+import qualified Hydra.Options as Options
 import Hydra.Party (Party)
 import Hydra.Persistence (PersistenceIncremental (..))
 import Network.HTTP.Types (Method, status200, status400, status500)
@@ -269,6 +271,7 @@ runAPIServer host port party tracer history chain callback headStatusP snapshotU
     headStatus <- atomically getLatestHeadStatus
     snapshotUtxo <- atomically getLatestSnapshotUtxo
     time <- getCurrentTime
+
     sendTextData con $
       Aeson.encode
         TimedServerOutput
@@ -279,6 +282,7 @@ runAPIServer host port party tracer history chain callback headStatusP snapshotU
                 { me = party
                 , headStatus
                 , snapshotUtxo
+                , hydraNodeVersion = showVersion Options.hydraNodeVersion
                 } ::
                 ServerOutput tx
           }

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -92,6 +92,7 @@ data ServerOutput tx
   deriving (Generic)
 
 deriving instance (IsChainState tx) => Eq (ServerOutput tx)
+
 deriving instance (IsChainState tx) => Show (ServerOutput tx)
 
 instance (IsChainState tx) => ToJSON (ServerOutput tx) where

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -87,7 +87,7 @@ data ServerOutput tx
     -- node. Currently used for knowing what signing key the server uses (it
     -- only knows one), 'HeadStatus' and optionally (if 'HeadIsOpen' or
     -- 'SnapshotConfirmed' message is emitted) UTxO's present in the Hydra Head.
-    Greetings {me :: Party, headStatus :: HeadStatus, snapshotUtxo :: Maybe (UTxOType tx)}
+    Greetings {me :: Party, headStatus :: HeadStatus, snapshotUtxo :: Maybe (UTxOType tx), hydraNodeVersion :: String}
   | PostTxOnChainFailed {postChainTx :: PostChainTx tx, postTxError :: PostTxError tx}
   deriving (Generic)
 
@@ -134,7 +134,12 @@ instance
     SnapshotConfirmed headId s ms -> SnapshotConfirmed <$> shrink headId <*> shrink s <*> shrink ms
     GetUTxOResponse headId u -> GetUTxOResponse <$> shrink headId <*> shrink u
     InvalidInput r i -> InvalidInput <$> shrink r <*> shrink i
-    Greetings me headStatus snapshotUtxo -> Greetings <$> shrink me <*> shrink headStatus <*> shrink snapshotUtxo
+    Greetings me headStatus snapshotUtxo hydraNodeVersion ->
+      Greetings
+        <$> shrink me
+        <*> shrink headStatus
+        <*> shrink snapshotUtxo
+        <*> shrink hydraNodeVersion
     PostTxOnChainFailed p e -> PostTxOnChainFailed <$> shrink p <*> shrink e
 
 -- | Possible transaction formats in the api server output

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -559,22 +559,23 @@ hydraNodeCommand =
  where
   versionInfo =
     infoOption
-      (showVersion ourVersion)
+      (showVersion hydraNodeVersion)
       (long "version" <> help "Show version")
-
-  ourVersion =
-    version & \(Version semver _) -> Version semver revision
-
-  revision =
-    maybeToList $
-      embeddedRevision
-        <|> gitRevision
-        <|> Just unknownVersion
 
   scriptInfo =
     infoOption
       (decodeUtf8 $ encodePretty Contract.scriptInfo)
       (long "script-info" <> help "Dump script info as JSON")
+
+hydraNodeVersion :: Version
+hydraNodeVersion =
+  version & \(Version semver _) -> Version semver revision
+ where
+  revision =
+    maybeToList $
+      embeddedRevision
+        <|> gitRevision
+        <|> Just unknownVersion
 
 defaultContestationPeriod :: ContestationPeriod
 defaultContestationPeriod = UnsafeContestationPeriod 60

--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -24,6 +24,7 @@ import qualified Data.ByteString.Base16 as Base16
 import qualified Data.List as List
 import qualified Data.Text as T
 import Data.Text.Encoding (decodeUtf8)
+import Data.Version (showVersion)
 import Hydra.API.Server (APIServerLog, RunServerException (..), Server (Server, sendOutput), withAPIServer)
 import Hydra.API.ServerOutput (ServerOutput (..), TimedServerOutput (..), genTimedServerOutput, input)
 import Hydra.Chain (
@@ -39,10 +40,10 @@ import Hydra.Ledger (txId)
 import Hydra.Ledger.Simple (SimpleTx)
 import Hydra.Logging (Tracer, showLogsOnFailure)
 import Hydra.Network (PortNumber)
+import qualified Hydra.Options as Options
 import Hydra.Party (Party)
 import Hydra.Persistence (PersistenceIncremental (..), createPersistenceIncremental)
 import Hydra.Snapshot (ConfirmedSnapshot (..), Snapshot (Snapshot, utxo), confirmed)
-import Hydra.Version (unknownVersion)
 import Network.WebSockets (Connection, receiveData, runClient, sendBinaryData)
 import System.IO.Error (isAlreadyInUseError)
 import System.Timeout (timeout)
@@ -73,18 +74,16 @@ spec = describe "ServerSpec" $
               withClient port "/" $ \conn -> do
                 waitMatch 5 conn $ guard . matchGreetings
 
-
     it "Greetings should contain the hydra-node version" $ do
       failAfter 5 $
         showLogsOnFailure $ \tracer ->
           withFreePort $ \port ->
             withTestAPIServer port alice mockPersistence tracer $ \_ -> do
               withClient port "/" $ \conn -> do
-
-                waitMatch 5 conn $ \v -> do
+                version <- waitMatch 5 conn $ \v -> do
                   guard $ matchGreetings v
-                  version <- v ^? key "hydraNodeVersion"
-                  guard $ version /= Aeson.String (T.pack unknownVersion)
+                  v ^? key "hydraNodeVersion"
+                version `shouldBe` toJSON (showVersion Options.hydraNodeVersion)
 
     it "sends sendOutput to all connected clients" $ do
       queue <- atomically newTQueue


### PR DESCRIPTION
fix https://github.com/input-output-hk/hydra/issues/894

## Why
To address user's needs expressed in the [issue](https://github.com/input-output-hk/hydra/issues/894)

## What
Add new field to the `Greetings` message and populate it in the API server code.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
