### PR TITLE
Align specification and code

### DIFF
--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -1000,14 +1000,14 @@ definitions:
     type: object
     additionalProperties: false
     required:
-      - seenUTxO
-      - seenTxs
+      - localUTxO
+      - localTxs
       - confirmedSnapshot
       - seenSnapshot
     properties:
-      seenUTxO:
+      localUTxO:
         $ref: "api.yaml#/components/schemas/UTxO"
-      seenTxs:
+      localTxs:
         type: array
         items:
           $ref: "api.yaml#/components/schemas/Transaction"

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -871,6 +871,7 @@ onOpenNetworkAckSn Environment{party} openState otherParty snapshotSignature sn 
           let multisig = aggregateInOrder sigs' parties
           requireVerifiedMultisignature multisig snapshot $ do
             let nextSn = sn + 1
+            -- Spec: T̂all ← {tx | ∀tx ∈ T̂all : tx ∉ Treq }
             let allTxs' = foldr Map.delete allTxs confirmed
             Effects [ClientEffect $ SnapshotConfirmed headId snapshot multisig]
               `Combined` if isLeader parameters party nextSn && not (null seenTxs)

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -238,7 +238,7 @@ data CoordinatedHeadState tx = CoordinatedHeadState
   -- ^ List of transactions applied locally and pending inclusion in a snapshot. Spec: T̂
   , allTxs :: Map.Map (TxIdType tx) tx
   -- ^ Map containing all the transactions ever seen by this node and not yet
-  -- included in a snapshot. Spec: T̂all
+  -- included in a snapshot. Spec: Tall
   , confirmedSnapshot :: ConfirmedSnapshot tx
   -- ^ The latest confirmed snapshot. Spec: U̅, s̅ and σ̅
   , seenSnapshot :: SeenSnapshot tx
@@ -652,7 +652,7 @@ onOpenNetworkReqTx ::
   tx ->
   Outcome tx
 onOpenNetworkReqTx env ledger st ttl tx = do
-  -- Spec: T̂all ← ̂Tall ∪ { (hash(tx), tx) }
+  -- Spec: Tall ← ̂Tall ∪ { (hash(tx), tx) }
   let chs' = coordinatedHeadState{allTxs = allTxs <> fromList [(txId tx, tx)]}
   -- Spec: wait L̂ ◦ tx ≠ ⊥ combined with L̂ ← L̂ ◦ tx
   waitApplyTx chs' $ \utxo' -> do
@@ -673,9 +673,9 @@ onOpenNetworkReqTx env ledger st ttl tx = do
                   { coordinatedHeadState =
                       chs''
                         { seenSnapshot =
-                            -- FIXME: Open point: This state update has no
-                            -- equivalence in the spec. Do we really need to
-                            -- store that we have requested a snapshot?
+                            -- XXX: This state update has no equivalence in the
+                            -- spec. Do we really need to store that we have
+                            -- requested a snapshot? If yes, should update spec.
                             RequestedSnapshot
                               { lastSeen = seenSnapshotNumber seenSnapshot
                               , requested = nextSn
@@ -752,9 +752,9 @@ onOpenNetworkReqSn env ledger st otherParty sn requestedTxIds =
   requireReqSn $
     -- Spec: wait s̅ = ŝ
     waitNoSnapshotInFlight $
-      -- Spec: wait ∀h ∈ Treq : (h, ·) ∈ T̂all
+      -- Spec: wait ∀h ∈ Treq : (h, ·) ∈ Tall
       waitResolvableTxs $ do
-        -- Spec: Treq ← {T̂all [h] | h ∈ Treq#}
+        -- Spec: Treq ← {Tall [h] | h ∈ Treq#}
         let requestedTxs = mapMaybe (`Map.lookup` allTxs) requestedTxIds
         -- Spec: require U̅ ◦ Treq /= ⊥ combined with Û ← Ū̅ ◦ Treq
         requireApplyTxs requestedTxs $ \u -> do
@@ -765,7 +765,7 @@ onOpenNetworkReqSn env ledger st otherParty sn requestedTxIds =
           (Effects [NetworkEffect $ AckSn snapshotSignature sn] `Combined`) $ do
             -- Spec: for loop which updates T̂ and L̂
             let (localTxs', localUTxO') = pruneTransactions u
-            -- Spec: T̂all ← {tx | ∀tx ∈ T̂all : tx ∉ Treq }
+            -- Spec: Tall ← {tx | ∀tx ∈ Tall : tx ∉ Treq }
             let allTxs' = foldr Map.delete allTxs requestedTxIds
             NewState
               ( Open

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -696,12 +696,11 @@ onOpenNetworkReqTx env ledger st ttl tx = do
             NewState (Open st{coordinatedHeadState = s'})
               `Combined` Wait (WaitOnNotApplicableTx err)
         | otherwise ->
-            -- FIXME: Check whether we really want to remove invalid tx from
-            -- allTxs? Especially in case of conflicting transactions this is
+            -- FIXME: Check whether we maybe want to remove invalid tx from
+            -- allTxs? Maybe problematic in case of conflicting transactions this is
             -- problematic as another leader could validly request them to be
             -- snapshotted.
-            NewState (Open st{coordinatedHeadState = untrackTxInState})
-              `Combined` Effects [ClientEffect $ TxInvalid headId seenUTxO tx err]
+            Effects [ClientEffect $ TxInvalid headId seenUTxO tx err]
 
   Ledger{applyTransactions} = ledger
 
@@ -714,8 +713,6 @@ onOpenNetworkReqTx env ledger st ttl tx = do
   OpenState{coordinatedHeadState, headId, currentSlot, parameters} = st
 
   trackTxInState = coordinatedHeadState{allTxs = Map.insert (txId tx) tx allTxs}
-
-  untrackTxInState = coordinatedHeadState{allTxs = Map.delete (txId tx) allTxs}
 
   snapshotInFlight = case seenSnapshot of
     NoSeenSnapshot -> False

--- a/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
@@ -53,9 +53,9 @@ spec = do
 
     let coordinatedHeadState =
           CoordinatedHeadState
-            { seenUTxO = initUTxO
+            { localUTxO = initUTxO
             , allTxs = mempty
-            , seenTxs = mempty
+            , localTxs = mempty
             , confirmedSnapshot = InitialSnapshot initUTxO
             , seenSnapshot = NoSeenSnapshot
             }
@@ -85,7 +85,7 @@ spec = do
 
       it "does NOT send ReqSn when we are NOT the leader even if no snapshot in flight" $ do
         let tx = aValidTx 1
-            st = coordinatedHeadState{seenTxs = [tx]}
+            st = coordinatedHeadState{localTxs = [tx]}
             outcome = update (envFor bobSk) simpleLedger (inOpenState' [alice, bob] st) $ NetworkEvent defaultTTL bob $ ReqTx tx
 
         collectEffects outcome `shouldNotSatisfy` sendReqSn
@@ -106,9 +106,9 @@ spec = do
         let st' =
               inOpenState' threeParties $
                 coordinatedHeadState
-                  { seenTxs = [tx]
+                  { localTxs = [tx]
                   , allTxs = Map.singleton (txId tx) tx
-                  , seenUTxO = initUTxO <> utxoRef (txId tx)
+                  , localUTxO = initUTxO <> utxoRef (txId tx)
                   , seenSnapshot = RequestedSnapshot{lastSeen = 0, requested = 1}
                   }
 
@@ -221,9 +221,9 @@ prop_singleMemberHeadAlwaysSnapshotOnReqTx sn = monadicST $ do
             }
     st =
       CoordinatedHeadState
-        { seenUTxO = mempty
+        { localUTxO = mempty
         , allTxs = mempty
-        , seenTxs = []
+        , localTxs = []
         , confirmedSnapshot = sn
         , seenSnapshot
         }

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -134,7 +134,7 @@ spec =
             (Open OpenState{coordinatedHeadState = CoordinatedHeadState{allTxs}}) -> txId t1 `member` allTxs
             _ -> False
 
-        it "keeps transactions in allTxs given it receives a ReqSn" $ do
+        it "removes transactions in allTxs given it receives a ReqSn" $ do
           let s0 = inOpenState threeParties ledger
               t1 = SimpleTx 1 mempty (utxoRef 1)
               reqSn = NetworkEvent defaultTTL alice $ ReqSn 1 [1]
@@ -143,23 +143,6 @@ spec =
           s1 <- assertNewState $ update bobEnv ledger sa reqSn
 
           s1 `shouldSatisfy` \case
-            (Open OpenState{coordinatedHeadState = CoordinatedHeadState{allTxs}}) -> txId t1 `member` allTxs
-            _ -> False
-
-        it "removes transactions from allTxs when included in a acked snapshot" $ do
-          let t1 = SimpleTx 1 mempty (utxoRef 1)
-              reqSn = NetworkEvent defaultTTL alice $ ReqSn 1 [1]
-              snapshot1 = Snapshot 1 (utxoRefs [1]) [1]
-              ackFrom sk vk = NetworkEvent defaultTTL vk $ AckSn (sign sk snapshot1) 1
-
-          sa <- runEvents bobEnv ledger (inOpenState threeParties ledger) $ do
-            step $ NetworkEvent defaultTTL alice $ ReqTx t1
-            step reqSn
-            step (ackFrom carolSk carol)
-            step (ackFrom aliceSk alice)
-            step (ackFrom bobSk bob)
-
-          sa `shouldSatisfy` \case
             (Open OpenState{coordinatedHeadState = CoordinatedHeadState{allTxs}}) -> txId t1 `notMember` allTxs
             _ -> False
 

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -83,9 +83,9 @@ spec =
 
       let coordinatedHeadState =
             CoordinatedHeadState
-              { seenUTxO = mempty
+              { localUTxO = mempty
               , allTxs = mempty
-              , seenTxs = mempty
+              , localTxs = mempty
               , confirmedSnapshot = InitialSnapshot mempty
               , seenSnapshot = NoSeenSnapshot
               }
@@ -455,9 +455,9 @@ spec =
                   { parameters = HeadParameters cperiod threeParties
                   , coordinatedHeadState =
                       CoordinatedHeadState
-                        { seenUTxO = UTxO.singleton utxo
+                        { localUTxO = UTxO.singleton utxo
                         , allTxs = mempty
-                        , seenTxs = [expiringTransaction]
+                        , localTxs = [expiringTransaction]
                         , confirmedSnapshot = InitialSnapshot $ UTxO.singleton utxo
                         , seenSnapshot = NoSeenSnapshot
                         }
@@ -475,8 +475,8 @@ spec =
           Open
             OpenState
               { coordinatedHeadState =
-                CoordinatedHeadState{seenTxs}
-              } -> null seenTxs
+                CoordinatedHeadState{localTxs}
+              } -> null localTxs
           _ -> False
 
 runEvents :: Monad m => Environment -> Ledger tx -> HeadState tx -> StateT (StepState tx) m a -> m a
@@ -534,9 +534,9 @@ inOpenState ::
 inOpenState parties Ledger{initUTxO} =
   inOpenState' parties $
     CoordinatedHeadState
-      { seenUTxO = u0
+      { localUTxO = u0
       , allTxs = mempty
-      , seenTxs = mempty
+      , localTxs = mempty
       , confirmedSnapshot
       , seenSnapshot = NoSeenSnapshot
       }

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -146,17 +146,6 @@ spec =
             (Open OpenState{coordinatedHeadState = CoordinatedHeadState{allTxs}}) -> txId t1 `member` allTxs
             _ -> False
 
-        it "removes transactions from allTxs when ttl expires" $ do
-          let t1 = SimpleTx 1 (utxoRef 1) (utxoRef 2)
-
-          sa <- runEvents bobEnv ledger (inOpenState threeParties ledger) $ do
-            step $ NetworkEvent 1 alice $ ReqTx t1
-            step $ NetworkEvent 0 alice $ ReqTx t1
-
-          sa `shouldSatisfy` \case
-            (Open OpenState{coordinatedHeadState = CoordinatedHeadState{allTxs}}) -> txId t1 `notMember` allTxs
-            _ -> False
-
         it "removes transactions from allTxs when included in a acked snapshot" $ do
           let t1 = SimpleTx 1 mempty (utxoRef 1)
               reqSn = NetworkEvent defaultTTL alice $ ReqSn 1 [1]

--- a/spec/fig_offchain_prot.tex
+++ b/spec/fig_offchain_prot.tex
@@ -73,10 +73,14 @@
 
 						%%% REQ TX
 						\On{$(\hpRT,\tx)$ from $\party_j$}{%
+
+							$\textcolor{red}{\hatmT_{\mathsf{all}} \gets \hatmT_{\mathsf{all}} \cup \{ (\hash(\tx),\tx )\}}$ % track tx in state
+
 							\Wait{$\hatmL \applytx \tx \neq \bot$}{
-								$\hatmT \gets \hatmT \cup \{\tx\}$ % candidates for next snapshot
 
 								$\hatmL \gets \hatmL\applytx\tx$ %
+
+								$\hatmT \gets \hatmT \cup \{\tx\}$ % candidates for next snapshot
 
 								% issue snapshot if we are leader
 								\If{$\hats = \bars \land \hpLdr(\bars + 1) = i$}{%
@@ -88,9 +92,11 @@
 						\vspace{12pt} %
 
 						%%% REQ SN
-						\On{$(\hpRS,s,\mT_{res})$ from $\party_j$}{ %
+						\On{$(\hpRS,s,\mT^{\#}_{req})$ from $\party_j$}{ %
 
 							\Req{$s = \hats + 1 ~ \land ~ \hpLdr(s) = j$} \; %
+
+							\textcolor{red}{Missing: lookup tx id $\hatmT^{\#}_{req}$ in $\hatmT_{\mathsf{all}}$ to get $\mT_{res}$}
 
 							% Wait for snapshot no snapshot in flight anymore and all txs applicable
 							\Wait{$\bars = \hats ~ \land ~ \barmU \applytx \mT_{res} \not= \bot ~ \and ~ \mT_{res} \subseteq \hatmT$}{ %
@@ -113,17 +119,20 @@
 								% this we would need to do a more recursive algorithm. Right now
 								% we throw out everything which is not applicable after a single
 								% pass. Also: Should we inform users if we drop a transaction?
-								\textcolor{red}{
-									$X\gets\hatmT$;\ $\hatmT\gets\emptyset$ \; %
-									\ForA{$\tx\in X$}{
-										\If{$\hatmU\applytx(\hatmT\cup\{\tx\})\not=\bot$}{
-											$\hatmT\gets\hatmT\cup\{\tx\}$
-										}
-									}}
-								$\hatmL \gets \hatmU\applytx\hatmT$
-								% TODO: This was here ^^^ before:
-								% $\hatmT \gets \{ tx \in \hatmT ~  | ~ \hatmU \applytx tx \not = \bot \}$ \; %
+								% \textcolor{red}{
+								% 	$X\gets\hatmT$;\ $\hatmT\gets\emptyset$ \; %
+								% 	\ForA{$\tx\in X$}{
+								% 		\If{$\hatmU\applytx(\hatmT\cup\{\tx\})\not=\bot$}{
+								% 			$\hatmT\gets\hatmT\cup\{\tx\}$
+								% 		}
+								% 	}}
 								% $\hatmL \gets \hatmU\applytx\hatmT$
+
+								\textcolor{red}{Missing: untrack $\hatmT_{\mathsf{all}}$}
+
+								$\hatmT \gets \{ tx \in \hatmT ~  | ~ \hatmU \applytx tx \not = \bot \}$ \; %
+
+								$\hatmL \gets \hatmU\applytx\hatmT$
 							}
 						}
 					\end{walgo}

--- a/spec/fig_offchain_prot.tex
+++ b/spec/fig_offchain_prot.tex
@@ -128,6 +128,11 @@
 								$\hatmL\gets\hatmL\applytx \tx$ \;
 								$\hatmT\gets\hatmT\cup\{\tx\}$
 							}
+							% FIXME: Open point: should we remove by id instead?
+							% \textcolor{blue}{
+							% 	$\hatmT \gets \{ tx ~ | ~ \forall tx \in \hatmT : tx \notin \mT_{req} \}$
+							% 	$\hatmL \gets \hatmU\applytx\hatmT$
+							% }
 
 							\textcolor{red}{Do clean up $\hatmT_{\mathsf{all}}$ here?}
 						}

--- a/spec/fig_offchain_prot.tex
+++ b/spec/fig_offchain_prot.tex
@@ -112,31 +112,24 @@
 
 							% NOTE: WE could make included transactions auditable by adding
 							% a merkle tree root to the (signed) snapshot data \eta'
-							$\msSig_i \gets \msSign(\hydraSigningKey, (\cid || \eta_{0} || \eta'))$ \; %
+							$\msSig_i \gets \msSign(\hydraSigningKey, (\textcolor{red}{\cid || \eta_{0} ||} \eta'))$ \; %
 							$\hatSigma \gets \emptyset$
 
 							$\Multi{}~(\hpAS,\hats,\msSig_i)$ \; %
 
-							$\forall \tx \in \mT_{res}: \Out~(\hpSeen,\tx)$ \; %
+							$\forall \tx \in \mT_{req}: \Out~(\hpSeen,\tx)$ \; %
 
-							% TODO: We would not be keeping all applicable transactions. For
-							% this we would need to do a more recursive algorithm. Right now
-							% we throw out everything which is not applicable after a single
-							% pass. Also: Should we inform users if we drop a transaction?
-							% \textcolor{red}{
-							% 	$X\gets\hatmT$;\ $\hatmT\gets\emptyset$ \; %
-							% 	\ForA{$\tx\in X$}{
-							% 		\If{$\hatmU\applytx(\hatmT\cup\{\tx\})\not=\bot$}{
-							% 			$\hatmT\gets\hatmT\cup\{\tx\}$
-							% 		}
-							% 	}}
-							% $\hatmL \gets \hatmU\applytx\hatmT$
+							% TODO: Should we inform users if we drop a transaction?
+							% XXX: This is a bit verbose for the spec
+							$\hatmL \gets \hatmU$ \;
+							$X\gets\hatmT$ \;
+							$\hatmT\gets\emptyset$ \; %
+							\For{$\tx\in X : \hatmL\applytx \tx \not=\bot$}{
+								$\hatmL\gets\hatmL\applytx \tx$ \;
+								$\hatmT\gets\hatmT\cup\{\tx\}$
+							}
 
-							\textcolor{red}{Do untrack $\hatmT_{\mathsf{all}}$ here?}
-
-							$\hatmT \gets \{ tx \in \hatmT ~  | ~ \hatmU \applytx tx \not = \bot \}$ \; %
-
-							$\hatmL \gets \hatmU\applytx\hatmT$
+							\textcolor{red}{Do clean up $\hatmT_{\mathsf{all}}$ here?}
 						}
 					\end{walgo}
 				} &

--- a/spec/fig_offchain_prot.tex
+++ b/spec/fig_offchain_prot.tex
@@ -74,7 +74,8 @@
 						%%% REQ TX
 						\On{$(\hpRT,\tx)$ from $\party_j$}{%
 
-							$\textcolor{red}{\hatmT_{\mathsf{all}} \gets \hatmT_{\mathsf{all}} \cup \{ (\hash(\tx),\tx )\}}$ % track tx in state
+							% track tx in state
+							$\hatmT_{\mathsf{all}} \gets \hatmT_{\mathsf{all}} \cup \{ (\hash(\tx),\tx )\}$
 
 							\Wait{$\hatmL \applytx \tx \neq \bot$}{
 
@@ -94,46 +95,49 @@
 						%%% REQ SN
 						\On{$(\hpRS,s,\mT^{\#}_{req})$ from $\party_j$}{ %
 
-							\Req{$s = \hats + 1 ~ \land ~ \hpLdr(s) = j$} \; %
+						\Req{$s = \hats + 1 ~ \land ~ \hpLdr(s) = j$} \; %
 
-							\textcolor{red}{Missing: lookup tx id $\hatmT^{\#}_{req}$ in $\hatmT_{\mathsf{all}}$ to get $\mT_{res}$}
+						% Wait for snapshot no snapshot in flight anymore and all txs applicable
+						\Wait{$\bars = \hats ~ \land ~ \forall h \in  \mT^{\#}_{req} : (h, \cdot) \in \hatmT_{\mathsf{all}}$}{
 
-							% Wait for snapshot no snapshot in flight anymore and all txs applicable
-							\Wait{$\bars = \hats ~ \land ~ \barmU \applytx \mT_{res} \not= \bot ~ \and ~ \mT_{res} \subseteq \hatmT$}{ %
-								$\hats \gets \bars + 1$ \; %
+							$\mT_{res} \gets \{ \hatmT_{\mathsf{all}}[h] ~ | ~ h \in \mT^{\#}_{req} \}$
 
-								$\hatmU \gets \barmU \applytx \mT_{res}$ \; %
 
-								$\eta' \gets (\hats, \combine(\hatmU))$ \; %
+							\Req{$\barmU \applytx \mT_{res} \not= \bot$}
 
-								% NOTE: WE could make included transactions auditable by adding
-								% a merkle tree root to the (signed) snapshot data \eta'
-								$\msSig_i \gets \msSign(\hydraSigningKey, (\cid || \eta_{0} || \eta'))$ \; %
-								$\hatSigma \gets \emptyset$
+							$\hats \gets \bars + 1$ \; %
 
-								$\Multi{}~(\hpAS,\hats,\msSig_i)$ \; %
+							$\hatmU \gets \barmU \applytx \mT_{res}$ \; %
 
-								$\forall \tx \in \mT_{res}: \Out~(\hpSeen,\tx)$ \; %
+							$\eta' \gets (\hats, \combine(\hatmU))$ \; %
 
-								% TODO: We would not be keeping all applicable transactions. For
-								% this we would need to do a more recursive algorithm. Right now
-								% we throw out everything which is not applicable after a single
-								% pass. Also: Should we inform users if we drop a transaction?
-								% \textcolor{red}{
-								% 	$X\gets\hatmT$;\ $\hatmT\gets\emptyset$ \; %
-								% 	\ForA{$\tx\in X$}{
-								% 		\If{$\hatmU\applytx(\hatmT\cup\{\tx\})\not=\bot$}{
-								% 			$\hatmT\gets\hatmT\cup\{\tx\}$
-								% 		}
-								% 	}}
-								% $\hatmL \gets \hatmU\applytx\hatmT$
+							% NOTE: WE could make included transactions auditable by adding
+							% a merkle tree root to the (signed) snapshot data \eta'
+							$\msSig_i \gets \msSign(\hydraSigningKey, (\cid || \eta_{0} || \eta'))$ \; %
+							$\hatSigma \gets \emptyset$
 
-								\textcolor{red}{Missing: untrack $\hatmT_{\mathsf{all}}$}
+							$\Multi{}~(\hpAS,\hats,\msSig_i)$ \; %
 
-								$\hatmT \gets \{ tx \in \hatmT ~  | ~ \hatmU \applytx tx \not = \bot \}$ \; %
+							$\forall \tx \in \mT_{res}: \Out~(\hpSeen,\tx)$ \; %
 
-								$\hatmL \gets \hatmU\applytx\hatmT$
-							}
+							% TODO: We would not be keeping all applicable transactions. For
+							% this we would need to do a more recursive algorithm. Right now
+							% we throw out everything which is not applicable after a single
+							% pass. Also: Should we inform users if we drop a transaction?
+							% \textcolor{red}{
+							% 	$X\gets\hatmT$;\ $\hatmT\gets\emptyset$ \; %
+							% 	\ForA{$\tx\in X$}{
+							% 		\If{$\hatmU\applytx(\hatmT\cup\{\tx\})\not=\bot$}{
+							% 			$\hatmT\gets\hatmT\cup\{\tx\}$
+							% 		}
+							% 	}}
+							% $\hatmL \gets \hatmU\applytx\hatmT$
+
+							\textcolor{red}{Do untrack $\hatmT_{\mathsf{all}}$ here?}
+
+							$\hatmT \gets \{ tx \in \hatmT ~  | ~ \hatmU \applytx tx \not = \bot \}$ \; %
+
+							$\hatmL \gets \hatmU\applytx\hatmT$
 						}
 					\end{walgo}
 				} &
@@ -158,6 +162,9 @@
 
 									$\eta' \gets (\hats, \combine(\hatmU))$ \; %
 									\Req{} $\msVfy(\hydraKeysAgg, (\textcolor{red}{\cid || \eta_{0} ||} \eta'), \msCSig)$ \;
+
+									\textcolor{blue}{Untrack $\hatmT_{\mathsf{all}}$}
+
 									$\barmU \gets \hatmU$ \; %
 									$\bars \gets \hats$ \; %
 									$\barsigma \gets \msCSig$ \; %

--- a/spec/fig_offchain_prot.tex
+++ b/spec/fig_offchain_prot.tex
@@ -128,13 +128,8 @@
 								$\hatmT\gets\hatmT\cup\{\tx\}$
 								$\hatmL\gets\hatmL\applytx \tx$ \;
 							}
-							% FIXME: Open point: should we remove by id instead?
-							% \textcolor{blue}{
-							% 	$\hatmT \gets \{ tx ~ | ~ \forall tx \in \hatmT : tx \notin \mT_{req} \}$
-							% 	$\hatmL \gets \hatmU\applytx\hatmT$
-							% }
 
-							\textcolor{blue}{$\hatmT_{\mathsf{all}} \gets \{ tx ~ | ~ \forall tx \in \hatmT_{\mathsf{all}} : tx \notin \mT_{req} \}$}
+							$\hatmT_{\mathsf{all}} \gets \{ tx ~ | ~ \forall tx \in \hatmT_{\mathsf{all}} : tx \notin \mT_{req} \}$
 						}
 					\end{walgo}
 				} &

--- a/spec/fig_offchain_prot.tex
+++ b/spec/fig_offchain_prot.tex
@@ -125,8 +125,8 @@
 							$X\gets\hatmT$ \;
 							$\hatmT\gets\emptyset$ \; %
 							\For{$\tx\in X : \hatmL\applytx \tx \not=\bot$}{
-								$\hatmL\gets\hatmL\applytx \tx$ \;
 								$\hatmT\gets\hatmT\cup\{\tx\}$
+								$\hatmL\gets\hatmL\applytx \tx$ \;
 							}
 							% FIXME: Open point: should we remove by id instead?
 							% \textcolor{blue}{
@@ -134,7 +134,7 @@
 							% 	$\hatmL \gets \hatmU\applytx\hatmT$
 							% }
 
-							\textcolor{red}{Do clean up $\hatmT_{\mathsf{all}}$ here?}
+							\textcolor{blue}{$\hatmT_{\mathsf{all}} \gets \{ tx ~ | ~ \forall tx \in \hatmT_{\mathsf{all}} : tx \notin \mT_{req} \}$}
 						}
 					\end{walgo}
 				} &
@@ -159,8 +159,6 @@
 
 									$\eta' \gets (\hats, \combine(\hatmU))$ \; %
 									\Req{} $\msVfy(\hydraKeysAgg, (\textcolor{red}{\cid || \eta_{0} ||} \eta'), \msCSig)$ \;
-
-									\textcolor{blue}{$\hatmT_{\mathsf{all}} \gets \{ tx ~ | ~ \forall tx \in \hatmT_{\mathsf{all}} : tx \notin \mT_{req} \}$}
 
 									$\barmU \gets \hatmU$ \; %
 									$\bars \gets \hats$ \; %

--- a/spec/fig_offchain_prot.tex
+++ b/spec/fig_offchain_prot.tex
@@ -100,7 +100,7 @@
 						% Wait for snapshot no snapshot in flight anymore and all txs applicable
 						\Wait{$\bars = \hats ~ \land ~ \forall h \in  \mT^{\#}_{req} : (h, \cdot) \in \hatmT_{\mathsf{all}}$}{
 
-							$\mT_{req} \gets \{ \hatmT_{\mathsf{all}}[h] ~ | ~ h \in \mT^{\#}_{req} \}$
+							$\mT_{req} \gets \{ \hatmT_{\mathsf{all}}[h] ~ | ~ \forall h \in \mT^{\#}_{req} \}$
 
 							\Req{$\barmU \applytx \mT_{req} \not= \bot$}
 
@@ -155,14 +155,14 @@
 									$\eta' \gets (\hats, \combine(\hatmU))$ \; %
 									\Req{} $\msVfy(\hydraKeysAgg, (\textcolor{red}{\cid || \eta_{0} ||} \eta'), \msCSig)$ \;
 
-									\textcolor{blue}{Untrack $\hatmT_{\mathsf{all}}$}
+									\textcolor{blue}{$\hatmT_{\mathsf{all}} \gets \{ tx ~ | ~ \forall tx \in \hatmT_{\mathsf{all}} : tx \notin \mT_{req} \}$}
 
 									$\barmU \gets \hatmU$ \; %
 									$\bars \gets \hats$ \; %
 									$\barsigma \gets \msCSig$ \; %
 
 									%$\Out~(\hpSnap,(\bars,\barmU))$ \;  %
-									$\forall \tx \in \mT_{res} : \Out (\hpConf,\tx)$ \; %
+									$\forall \tx \in \mT_{req} : \Out (\hpConf,\tx)$ \; %
 
 									% issue snapshot if we are leader
 									\If{$\hpLdr(s+1) = i \land \hatmT \neq \emptyset$}{%

--- a/spec/fig_offchain_prot.tex
+++ b/spec/fig_offchain_prot.tex
@@ -10,20 +10,20 @@
 				\adjustbox{valign=t,scale=\sfact}{
 					\begin{walgo}{0.6}
 						%%% INIT
-						\On{$(\hpInit)$ from client}{ %
+						\On{$(\hpInit)$ from client}{
 							$n \gets |\hydraKeys^{setup}|$ \;
-							$\hydraKeysAgg \gets \msCombVK(\hydraKeys^{setup})$ \; %
-							$\cardanoKeys \gets \cardanoKeys^{setup}$\; %
-							$\cPer \gets \cPer^{setup}$ \; %
-							$\PostTx{}~(\mtxInit, \nop, \hydraKeysAgg,\cardanoKeys,\cPer)$ \; %
+							$\hydraKeysAgg \gets \msCombVK(\hydraKeys^{setup})$ \;
+							$\cardanoKeys \gets \cardanoKeys^{setup}$\;
+							$\cPer \gets \cPer^{setup}$ \;
+							$\PostTx{}~(\mtxInit, \nop, \hydraKeysAgg,\cardanoKeys,\cPer)$ \;
 						}
 						\vspace{12pt}
 
-						\On{$(\gcChainInitial, \cid, \seed, \nop, \hydraKeysAgg, \cardanoKeys^{\#}, \cPer)$ from chain}{ %
-						\Req{} $\hydraKeysAgg=\msCombVK(\hydraKeys^{setup})$\; %
-						\Req{} $\cardanoKeys^{\#}= [ \hash(k)~|~\forall k \in \cardanoKeys^{setup}]$\; %
-						\Req{} $\cPer=\cPer^{setup}$\; %
-						\Req{} $\cid = \hash(\muHead(\seed))$ \; %
+						\On{$(\gcChainInitial, \cid, \seed, \nop, \hydraKeysAgg, \cardanoKeys^{\#}, \cPer)$ from chain}{
+						\Req{} $\hydraKeysAgg=\msCombVK(\hydraKeys^{setup})$\;
+						\Req{} $\cardanoKeys^{\#}= [ \hash(k)~|~\forall k \in \cardanoKeys^{setup}]$\;
+						\Req{} $\cPer=\cPer^{setup}$\;
+						\Req{} $\cid = \hash(\muHead(\seed))$ \;
 						}
 					\end{walgo}
 				}
@@ -31,23 +31,23 @@
 
 				\adjustbox{valign=t,scale=\sfact}{
 					\begin{walgo}{0.6}
-						\On{$(\gcChainCommit, j, U)$ from chain}{ %
+						\On{$(\gcChainCommit, j, U)$ from chain}{
 							$C_j \gets U $
 
-							\If{$\forall k \in [1..n]: C_k \neq \undefined$}{ %
-								$\eta \gets (0, \combine([C_1 \dots C_n]))$ \; %
-								$\PostTx{}~(\mtxCCom, \eta)$ \; %
-							} %
+							\If{$\forall k \in [1..n]: C_k \neq \undefined$}{
+								$\eta \gets (0, \combine([C_1 \dots C_n]))$ \;
+								$\PostTx{}~(\mtxCCom, \eta)$ \;
+							}
 						}
 
 						\vspace{12pt}
 
-						\On{$(\gcChainCollectCom, \eta_{0})$ from chain}{ %
+						\On{$(\gcChainCollectCom, \eta_{0})$ from chain}{
 							% Implictly means that all commits will defined as we cannot miss a commit (by assumption)
-							$\Uinit \gets \bigcup_{j=1}^{n} U_j$ \; %
-							% $\Out~(\hpSnap,(0,U_0))$ \; %
-							$\hatmU, \barmU, \hatmL \gets \Uinit$ \; %
-							$\hats,\bars \gets 0$ \; %
+							$\Uinit \gets \bigcup_{j=1}^{n} U_j$ \;
+							% $\Out~(\hpSnap,(0,U_0))$ \;
+							$\hatmU, \barmU, \hatmL \gets \Uinit$ \;
+							$\hats,\bars \gets 0$ \;
 							$\mT, \hatmT, \barmT \gets \emptyset$ \;
 						}
 
@@ -56,7 +56,7 @@
 			\end{tabular}
 
 			\\
-			\multicolumn{1}{l}{\line(1,0){490}} %
+			\multicolumn{1}{l}{\line(1,0){490}}
 			\\
 
 			%%% Open head
@@ -65,71 +65,53 @@
 					\begin{walgo}{0.65}
 
 						%%% NEW TX
-						\On{$(\hpNew,\tx)$ from client}{%
+						\On{$(\hpNew,\tx)$ from client}{
 							\Multi{} $(\hpRT,\tx)$%
 						}
 
 						\vspace{12pt}
 
 						%%% REQ TX
-						\On{$(\hpRT,\tx)$ from $\party_j$}{%
-
-							% track tx in state
-							$\mT_{\mathsf{all}} \gets \mT_{\mathsf{all}} \cup \{ (\hash(\tx),\tx )\}$
-
+						\On{$(\hpRT,\tx)$ from $\party_j$}{
+							$\mT_{\mathsf{all}} \gets \mT_{\mathsf{all}} \cup \{ (\hash(\tx),\tx )\}$ \;
 							\Wait{$\hatmL \applytx \tx \neq \bot$}{
-
-								$\hatmL \gets \hatmL\applytx\tx$ %
-
-								$\hatmT \gets \hatmT \cup \{\tx\}$ % candidates for next snapshot
-
+								$\hatmL \gets \hatmL\applytx\tx$ \;
+								$\hatmT \gets \hatmT \cup \{\tx\}$ \;
 								% issue snapshot if we are leader
-								\If{$\hats = \bars \land \hpLdr(\bars + 1) = i$}{%
-									\Multi{} $(\hpRS,\bars+1,\hatmT)$ \;%
+								\If{$\hats = \bars \land \hpLdr(\bars + 1) = i$}{
+									\Multi{} $(\hpRS,\bars+1,\hatmT)$ \;
 								}
 							}
 						}
 
-						\vspace{12pt} %
+						\vspace{12pt}
 
 						%%% REQ SN
-						\On{$(\hpRS,s,\mT^{\#}_{req})$ from $\party_j$}{ %
-
-						\Req{$s = \hats + 1 ~ \land ~ \hpLdr(s) = j$} \; %
-
-						% Wait for snapshot no snapshot in flight anymore and all txs applicable
-						\Wait{$\bars = \hats ~ \land ~ \forall h \in  \mT^{\#}_{req} : (h, \cdot) \in \mT_{\mathsf{all}}$}{
-
-							$\mT_{\mathsf{req}} \gets \{ \mT_{\mathsf{all}}[h] ~ | ~ \forall h \in \mT^{\#}_{req} \}$
-
-							\Req{$\barmU \applytx \mT_{\mathsf{req}} \not= \bot$}
-
-							$\hatmU \gets \barmU \applytx \mT_{\mathsf{req}}$ \; %
-
-							$\hats \gets \bars + 1$ \; %
-
-							$\eta' \gets (\hats, \combine(\hatmU))$ \; %
-
-							% NOTE: WE could make included transactions auditable by adding
-							% a merkle tree root to the (signed) snapshot data \eta'
-							$\msSig_i \gets \msSign(\hydraSigningKey, (\textcolor{red}{\cid || \eta_{0} ||} \eta'))$ \; %
-							$\hatSigma \gets \emptyset$
-
-							$\Multi{}~(\hpAS,\hats,\msSig_i)$ \; %
-
-							$\forall \tx \in \mT_{\mathsf{req}}: \Out~(\hpSeen,\tx)$ \; %
-
-							% TODO: Should we inform users if we drop a transaction?
-							% XXX: This is a bit verbose for the spec
-							$\hatmL \gets \hatmU$ \;
-							$X\gets\hatmT$ \;
-							$\hatmT\gets\emptyset$ \; %
-							\For{$\tx\in X : \hatmL\applytx \tx \not=\bot$}{
-								$\hatmT\gets\hatmT\cup\{\tx\}$
-								$\hatmL\gets\hatmL\applytx \tx$ \;
+						\On{$(\hpRS,s,\mT^{\#}_{req})$ from $\party_j$}{
+							\Req{$s = \hats + 1 ~ \land ~ \hpLdr(s) = j$} \;
+							\Wait{$\bars = \hats ~ \land ~ \forall h \in  \mT^{\#}_{req} : (h, \cdot) \in \mT_{\mathsf{all}}$}{
+								$\mT_{\mathsf{req}} \gets \{ \mT_{\mathsf{all}}[h] ~ | ~ \forall h \in \mT^{\#}_{req} \}$ \;
+								\Req{$\barmU \applytx \mT_{\mathsf{req}} \not= \bot$} \;
+								$\hatmU \gets \barmU \applytx \mT_{\mathsf{req}}$ \;
+								$\hats \gets \bars + 1$ \;
+								$\eta' \gets (\hats, \combine(\hatmU))$ \;
+								% NOTE: WE could make included transactions auditable by adding
+								% a merkle tree root to the (signed) snapshot data \eta'
+								$\msSig_i \gets \msSign(\hydraSigningKey, (\textcolor{red}{\cid || \eta_{0} ||} \eta'))$ \;
+								$\hatSigma \gets \emptyset$ \;
+								$\Multi{}~(\hpAS,\hats,\msSig_i)$ \;
+								$\forall \tx \in \mT_{\mathsf{req}}: \Out~(\hpSeen,\tx)$ \;
+								% TODO: Should we inform users if we drop a transaction?
+								% XXX: This is a bit verbose for the spec
+								$\hatmL \gets \hatmU$ \;
+								$X\gets\hatmT$ \;
+								$\hatmT\gets\emptyset$ \;
+								\For{$\tx\in X : \hatmL\applytx \tx \not=\bot$}{
+									$\hatmT\gets\hatmT\cup\{\tx\}$
+									$\hatmL\gets\hatmL\applytx \tx$ \;
+								}
+								$\mT_{\mathsf{all}} \gets \{ tx ~ | ~ \forall tx \in \mT_{\mathsf{all}} : tx \notin \mT_{\mathsf{req}} \}$ \;
 							}
-
-							$\mT_{\mathsf{all}} \gets \{ tx ~ | ~ \forall tx \in \mT_{\mathsf{all}} : tx \notin \mT_{\mathsf{req}} \}$
 						}
 					\end{walgo}
 				} &
@@ -137,71 +119,59 @@
 				\adjustbox{valign=t,scale=\sfact}{
 					\begin{walgo}{0.6}
 						%%% ACK SN
-						\On{$(\hpAS,s,\msSig_j)$ from $\party_j$}{ %
-
-							\Req{} $s \in \{\hats,\hats+1\}$
-							\; %
-
-							\Wait{$\hats=s$
-							}{ %
-
-								\Req{} $(j, \cdot) \notin \hatSigma$ \; %
-
-
-								\If{$\forall k \in [1..n]: (k,\cdot) \in \hatSigma$}{ %
+						\On{$(\hpAS,s,\msSig_j)$ from $\party_j$}{
+							\Req{} $s \in \{\hats,\hats+1\}$ \;
+							\Wait{$\hats=s$}{
+								\Req{} $(j, \cdot) \notin \hatSigma$ \;
+								\If{$\forall k \in [1..n]: (k,\cdot) \in \hatSigma$}{
 									% TODO: MS-ASig used different than in the preliminaries
-									$\msCSig \gets \msComb(\hydraKeys^{setup}, \hatSigma)$ \; %
+									$\msCSig \gets \msComb(\hydraKeys^{setup}, \hatSigma)$ \;
 
-									$\eta' \gets (\hats, \combine(\hatmU))$ \; %
+									$\eta' \gets (\hats, \combine(\hatmU))$ \;
 									\Req{} $\msVfy(\hydraKeysAgg, (\textcolor{red}{\cid || \eta_{0} ||} \eta'), \msCSig)$ \;
-
-									$\barmU \gets \hatmU$ \; %
-									$\bars \gets \hats$ \; %
-									$\barsigma \gets \msCSig$ \; %
-
-									%$\Out~(\hpSnap,(\bars,\barmU))$ \;  %
-									$\forall \tx \in \mT_{\mathsf{req}} : \Out (\hpConf,\tx)$ \; %
-
+									$\barmU \gets \hatmU$ \;
+									$\bars \gets \hats$ \;
+									$\barsigma \gets \msCSig$ \;
+									%$\Out~(\hpSnap,(\bars,\barmU))$ \;
+									$\forall \tx \in \mT_{\mathsf{req}} : \Out (\hpConf,\tx)$ \;
 									% issue snapshot if we are leader
-									\If{$\hpLdr(s+1) = i \land \hatmT \neq \emptyset$}{%
-										\Multi{} $(\hpRS,s+1,\hatmT)$ \;%
+									\If{$\hpLdr(s+1) = i \land \hatmT \neq \emptyset$}{
+										\Multi{} $(\hpRS,s+1,\hatmT)$ \;
 									}
 								}
-							} }
+							}
+						}
 					\end{walgo}
-
 				}
 			\end{tabular}
 
 			\\
-			\multicolumn{1}{l}{\line(1,0){490}} %
+			\multicolumn{1}{l}{\line(1,0){490}}
 			\\
 
 			%%% Closing the head
 			\begin{tabular}{c c}
 				\adjustbox{valign=t,scale=\sfact}{
 					\begin{walgo}{0.6}
-
 						% CLOSE from client
-						\On{$(\hpClose)$ from client}{ %
-							$\eta' \gets (\bars, \combine(\barmU))$ \; %
-							$\xi \gets \barsigma$ \; %
-							$\PostTx{}~(\mtxClose, \eta', \xi)$ \; %
+						\On{$(\hpClose)$ from client}{
+							$\eta' \gets (\bars, \combine(\barmU))$ \;
+							$\xi \gets \barsigma$ \;
+							$\PostTx{}~(\mtxClose, \eta', \xi)$ \;
 						}
-
 					\end{walgo}
 				}
-				 & \adjustbox{valign=t,scale=\sfact}{
+				 &
+				\adjustbox{valign=t,scale=\sfact}{
 					\begin{walgo}{0.6}
-
-						\On{$(\gcChainClose, \eta) \lor (\gcChainContest, \eta)$ from chain}{ %
+						\On{$(\gcChainClose, \eta) \lor (\gcChainContest, \eta)$ from chain}{
 							$(s_{c}, \cdot) \gets \eta$ \;
-							\If{$\bars > s_{c}$}{%
-								$\eta' \gets (\bars, \combine(\barmU))$ \; %
-								$\xi \gets \barsigma$ \; %
-								$\PostTx{}~(\mtxContest, \eta', \xi)$ \; %
-							} }
-
+							\If{$\bars > s_{c}$}{
+								$\eta' \gets (\bars, \combine(\barmU))$ \;
+								$\xi \gets \barsigma$ \;
+								$\PostTx{}~(\mtxContest, \eta', \xi)$ \;
+							}
+						}
 					\end{walgo}
 				}
 			\end{tabular}

--- a/spec/fig_offchain_prot.tex
+++ b/spec/fig_offchain_prot.tex
@@ -100,14 +100,13 @@
 						% Wait for snapshot no snapshot in flight anymore and all txs applicable
 						\Wait{$\bars = \hats ~ \land ~ \forall h \in  \mT^{\#}_{req} : (h, \cdot) \in \hatmT_{\mathsf{all}}$}{
 
-							$\mT_{res} \gets \{ \hatmT_{\mathsf{all}}[h] ~ | ~ h \in \mT^{\#}_{req} \}$
+							$\mT_{req} \gets \{ \hatmT_{\mathsf{all}}[h] ~ | ~ h \in \mT^{\#}_{req} \}$
 
+							\Req{$\barmU \applytx \mT_{req} \not= \bot$}
 
-							\Req{$\barmU \applytx \mT_{res} \not= \bot$}
+							$\hatmU \gets \barmU \applytx \mT_{req}$ \; %
 
 							$\hats \gets \bars + 1$ \; %
-
-							$\hatmU \gets \barmU \applytx \mT_{res}$ \; %
 
 							$\eta' \gets (\hats, \combine(\hatmU))$ \; %
 

--- a/spec/fig_offchain_prot.tex
+++ b/spec/fig_offchain_prot.tex
@@ -75,7 +75,7 @@
 						\On{$(\hpRT,\tx)$ from $\party_j$}{%
 
 							% track tx in state
-							$\hatmT_{\mathsf{all}} \gets \hatmT_{\mathsf{all}} \cup \{ (\hash(\tx),\tx )\}$
+							$\mT_{\mathsf{all}} \gets \mT_{\mathsf{all}} \cup \{ (\hash(\tx),\tx )\}$
 
 							\Wait{$\hatmL \applytx \tx \neq \bot$}{
 
@@ -98,13 +98,13 @@
 						\Req{$s = \hats + 1 ~ \land ~ \hpLdr(s) = j$} \; %
 
 						% Wait for snapshot no snapshot in flight anymore and all txs applicable
-						\Wait{$\bars = \hats ~ \land ~ \forall h \in  \mT^{\#}_{req} : (h, \cdot) \in \hatmT_{\mathsf{all}}$}{
+						\Wait{$\bars = \hats ~ \land ~ \forall h \in  \mT^{\#}_{req} : (h, \cdot) \in \mT_{\mathsf{all}}$}{
 
-							$\mT_{req} \gets \{ \hatmT_{\mathsf{all}}[h] ~ | ~ \forall h \in \mT^{\#}_{req} \}$
+							$\mT_{\mathsf{req}} \gets \{ \mT_{\mathsf{all}}[h] ~ | ~ \forall h \in \mT^{\#}_{req} \}$
 
-							\Req{$\barmU \applytx \mT_{req} \not= \bot$}
+							\Req{$\barmU \applytx \mT_{\mathsf{req}} \not= \bot$}
 
-							$\hatmU \gets \barmU \applytx \mT_{req}$ \; %
+							$\hatmU \gets \barmU \applytx \mT_{\mathsf{req}}$ \; %
 
 							$\hats \gets \bars + 1$ \; %
 
@@ -117,7 +117,7 @@
 
 							$\Multi{}~(\hpAS,\hats,\msSig_i)$ \; %
 
-							$\forall \tx \in \mT_{req}: \Out~(\hpSeen,\tx)$ \; %
+							$\forall \tx \in \mT_{\mathsf{req}}: \Out~(\hpSeen,\tx)$ \; %
 
 							% TODO: Should we inform users if we drop a transaction?
 							% XXX: This is a bit verbose for the spec
@@ -129,7 +129,7 @@
 								$\hatmL\gets\hatmL\applytx \tx$ \;
 							}
 
-							$\hatmT_{\mathsf{all}} \gets \{ tx ~ | ~ \forall tx \in \hatmT_{\mathsf{all}} : tx \notin \mT_{req} \}$
+							$\mT_{\mathsf{all}} \gets \{ tx ~ | ~ \forall tx \in \mT_{\mathsf{all}} : tx \notin \mT_{\mathsf{req}} \}$
 						}
 					\end{walgo}
 				} &
@@ -160,7 +160,7 @@
 									$\barsigma \gets \msCSig$ \; %
 
 									%$\Out~(\hpSnap,(\bars,\barmU))$ \;  %
-									$\forall \tx \in \mT_{req} : \Out (\hpConf,\tx)$ \; %
+									$\forall \tx \in \mT_{\mathsf{req}} : \Out (\hpConf,\tx)$ \; %
 
 									% issue snapshot if we are leader
 									\If{$\hpLdr(s+1) = i \land \hatmT \neq \emptyset$}{%

--- a/spec/macros.tex
+++ b/spec/macros.tex
@@ -162,7 +162,6 @@
 \newcommand{\txOutputs}{\mathcal{O}} % list of outputs
 \newcommand{\tyOutputs}{\mathcal{O}^*} % type of output lists
 \newcommand{\txMint}{\mathsf{mint}} % minted value
-\newcommand{\txID}{\mathit{txID}}
 \newcommand{\ID}{\mathsf{ID}}
 \newcommand{\txIdx}{\mathit{txIdx}}
 \newcommand{\txValidityMin}{t_{\mathsf{min}}}

--- a/spec/offchain.tex
+++ b/spec/offchain.tex
@@ -108,7 +108,7 @@ party's local state consists of the following variables:
 	      applying $\hatmT$ to $\barmU$ to validate requested transactions.
 	\item $\hatmT \in \mT^{*}$: List of transactions applied locally and pending
 	      inclusion in a snapshot (if this party is the next leader).
-	\item $\hatmT_{\mathsf{all}} \in (\tyBytes \times \mT)^{*}$: Associative list of all
+	\item $\mT_{\mathsf{all}} \in (\tyBytes \times \mT)^{*}$: Associative list of all
 	      seen transactions not yet included in a snapshot.
 \end{itemize}
 
@@ -162,42 +162,50 @@ client of the protocol can submit a new transaction $\tx$ to the head, which
 results in it being sent out to all parties as a $(\hpRT,\tx)$ message.\\
 
 \dparagraph{$\hpRT$.}\quad Upon receiving request $(\hpRT,\tx)$, the transaction
-gets recorded in $\hatmT$ and $\mT$ and applied to the local \emph{seen} ledger state
-$\hatmL \applytx \tx$. If there is no current snapshot ``in flight''
-($\hats = \bars$) and the receiving party $\party_{i}$ is the next snapshot
+gets recorded in $\mT_{\mathsf{all}}$ and applied to the \emph{local} ledger
+state $\hatmL \applytx \tx$. If not applicable yet, the protocol does $\KwWait$
+to retry later or eventually marks this transaction as invalid (see assumption
+about events piling up). After applying and if there is no current snapshot ``in
+flight'' ($\hats = \bars$) and the receiving party $\party_{i}$ is the next
+snapshot
 leader, a message to request snapshot signatures $\hpRS$ is sent. \\
 
-\dparagraph{$\hpRS$.}\quad Upon receiving request $(\hpRS,s,\mT_{res})$ from
-party $\party_j$, the receiver $\party_i$ checks that $s$ is the next snapshot
-number and that party $\party_j$ is responsible for leading its
-creation.\todo{define $\hpLdr$} Party $\party_i$ then waits until the previous
-snapshot is confirmed ($\bars = \hats$), and all requested transactions have
-been seen ($\mT_{res} \subseteq \mT$). Then all requested transactions $\mT_{res}$
-must be applicable to $\barmU$, otherwise the snapshot is rejected as invalid.
-Only then, $\party_i$ increments their seen-snapshot counter $\hats$, resets the
-signature accumulator $\hatSigma$, and computes the UTxO set $\hatmU$ of the new
-(seen) snapshot as $\hatmU \gets \barmU \applytx \mT_{res}$. Then, $\party_i$
-creates a signature $\msSig_i$ using their signing key $\hydraSigningKey$ on a
-message comprised by \textcolor{red}{the $\cid$, the $\eta_{0}$ corresponding to
-	the initial UTxO set $\Uinit$, and} the new $\eta'$ given by the new snapshot
-number $\hats$ and canonically combining $\hatmU$ (see
-Section~\ref{sec:close-tx} for details). The signature is sent to all head
-members via message $(\hpAS,\hats,\msSig_i)$. Finally, the pending transaction
-set $\hatmT$ gets pruned by the just requested transactions $\mT_{res}$ and the
-local ledger state $\hatmL$ is updated accordingly.\\
+\dparagraph{$\hpRS$.}\quad Upon receiving request
+$(\hpRS,s,\mT_{\mathsf{req}}^{\#})$ from party $\party_j$, the receiver
+$\party_i$ checks that $s$ is the next snapshot number and that party $\party_j$
+is responsible for leading its creation.\todo{define $\hpLdr$} Party $\party_i$
+has to $\KwWait$ until the previous snapshot is confirmed ($\bars = \hats$) and
+all requested transaction hashes $\mT_{\mathsf{req}}^{\#}$ can be resolved in
+$\mT_{\mathsf{all}}$. Then, all those resolved transactions $\mT_{\mathsf{req}}$
+are $\Req$d to be applicable to $\barmU$, otherwise the snapshot is rejected
+as invalid. Only then, $\party_i$ increments their seen-snapshot counter
+$\hats$, resets the signature accumulator $\hatSigma$, and computes the UTxO set
+$\hatmU$ of the new (seen) snapshot as
+$\hatmU \gets \barmU \applytx \mT_{\mathsf{req}}$. Then, $\party_i$ creates a
+signature $\msSig_i$ using their signing key $\hydraSigningKey$ on a message
+comprised by \textcolor{red}{the $\cid$, the $\eta_{0}$ corresponding to the
+	initial UTxO set $\Uinit$, and} the new $\eta'$ given by the new snapshot number
+$\hats$ and canonically combining $\hatmU$ (see Section~\ref{sec:close-tx} for
+details). The signature is sent to all head members via message
+$(\hpAS,\hats,\msSig_i)$. Finally, the pending transaction set $\hatmT$ gets
+pruned by re-applying all locally pending transactions $\hatmT$ to the just
+requested snapshot's UTxO set $\hatmU$ iteratively and ultimately yielding a
+``pruned'' version of $\hatmT$ and $\hatmU$. Also, the set of all transactions
+$\mT_{\mathsf{all}}$ can be reduced by the requested
+transactions $\mT_{\mathsf{req}}$.\\
 
-\dparagraph{$\hpAS$.}\quad Upon receiving acknowledgment $(\hpAS,s,\msSig_j)$,
-all participants $\Req$ that it is from an expected snapshot (either the last
-seen $\hats$ or + 1), potentially $\KwWait$ for the corresponding $\hpRS$ such
-that $\hats = s$ and $\Req$ that the signature is not yet included in
-$\hatSigma$. They store the received signature in the signature accumulator
-$\hatSigma$, and if signature from each party has been collected, $\party_i$
-aggregates the multisignature $\msCSig$ and $\Req$ it to be valid. If everything
-is fine, the snapshot can be considered confirmed by updating $\bars=s$ and
-participants also store the UTxO set in $\barmU$, as well as the signature in
-$\barsigma$ for later reference. Similar to the $\hpRT$, if $\party_i$ is the
-next snapshot leader and there are already transactions to snapshot in $\hatmT$,
-a corresponding $\hpRS$ is distributed.
+\dparagraph{$\hpAS$.}\quad Upon receiving acknowledgment $(\hpAS,s,\msSig_j)$, all
+participants $\Req$ that it is from an expected snapshot (either the last seen
+$\hats$ or + 1), potentially $\KwWait$ for the corresponding $\hpRS$ such that
+$\hats = s$ and $\Req$ that the signature is not yet included in $\hatSigma$.
+They store the received signature in the signature accumulator $\hatSigma$, and
+if the signature from each party has been collected, $\party_i$ aggregates the
+multisignature $\msCSig$ and $\Req$ it to be valid. If everything is fine, the
+snapshot can be considered confirmed by updating $\bars=s$ and participants also
+store the UTxO set in $\barmU$, as well as the signature in $\barsigma$ for
+later reference. Similar to the $\hpRT$, if $\party_i$ is the next snapshot
+leader and there are already transactions to snapshot in $\hatmT$, a
+corresponding $\hpRS$ is distributed.
 
 \subsubsection{Closing the head}
 

--- a/spec/offchain.tex
+++ b/spec/offchain.tex
@@ -104,12 +104,10 @@ party's local state consists of the following variables:
 	\item $\barmU$: UTxO set associated with the latest confirmed snapshot.
 	\item $\hatSigma \in {(\tyNatural \times \tyBytes)}^{*}$: Accumulator of
 	      signatures of the latest seen snapshot, indexed by parties.
-	\item $\hatmL$: Local ledger state used to validate requested transactions
-	      against.
-	\item $\hatmT \in \mT^{*}$: List of seen transactions currently pending to be
-	      included in the next snapshot (if this party is the next leader).
-	      Applying all these transactions to the last confirmed snapshot $\barmU$
-	      will result in $\hatmL$.
+	\item $\hatmL$: UTxO set representing the local ledger state resulting from
+	      applying $\hatmT$ to $\barmU$ to validate requested transactions.
+	\item $\hatmT \in \mT^{*}$: List of transactions applied locally and pending
+	      inclusion in a snapshot (if this party is the next leader).
 	\item $\hatmT_{\mathsf{all}} \in (\tyBytes \times \mT)^{*}$: Associative list of all
 	      seen transactions not yet included in a snapshot.
 \end{itemize}

--- a/spec/offchain.tex
+++ b/spec/offchain.tex
@@ -41,11 +41,11 @@ off-chain protocol logic relies on these assumptions:
 	\item Every network message received from a specific party is checked for
 	      authentication. An implementation of the specification needs to find a
 	      suitable means of authentication, either on the communication channel
-        or for individual messages. Unauthenticated messages must be dropped.
+	      or for individual messages. Unauthenticated messages must be dropped.
 	\item The head protocol gets correctly (and with completeness) notified about
 	      observed transactions on-chain belonging to the respective head
 	      instance.
-        % TODO: Mention multiple heads?
+	      % TODO: Mention multiple heads?
 	      % \item The specification covers only a single instance of a Hydra head.
 	      %       However, some implementations may choose to track multiple instances. As
 	      %       multiple Hydra heads might exist on the same blockchain, it is vital
@@ -57,9 +57,9 @@ off-chain protocol logic relies on these assumptions:
 	      to multiple invocations of the handling semantics.
 	\item Given the specification, events may pile up forever and implementations
 	      need to consider these situations (i.e.\ potential for DoS). A valid reaction
-        to this would be to just drop these events. Note that, from a security standpoint,
-        these situations are identical to a non-collaborative peer and closing the head
-        is also a possible reaction.
+	      to this would be to just drop these events. Note that, from a security standpoint,
+	      these situations are identical to a non-collaborative peer and closing the head
+	      is also a possible reaction.
 	\item The lifecycle of a Hydra head on-chain does not cross (hard fork)
 	      protocol update boundaries. Note that these events are announced in
 	      advance hence it should be possible for implementations to react in such
@@ -106,10 +106,12 @@ party's local state consists of the following variables:
 	      signatures of the latest seen snapshot, indexed by parties.
 	\item $\hatmL$: Local ledger state used to validate requested transactions
 	      against.
-	\item $\hatmT \in \mT^{*}$: List of transactions that extend from the last
-	      confirmed snapshot $\barmU$ to form $\hatmL$. These are also the
-	      transactions that would go into the next snapshot (if this party is the
-	      next leader).
+	\item $\hatmT \in \mT^{*}$: List of seen transactions currently pending to be
+	      included in the next snapshot (if this party is the next leader).
+	      Applying all these transactions to the last confirmed snapshot $\barmU$
+	      will result in $\hatmL$.
+	\item $\hatmT_{\mathsf{all}} \in (\tyBytes \times \mT)^{*}$: Associative list of all
+	      seen transactions not yet included in a snapshot.
 \end{itemize}
 
 \subsection{Protocol flow}


### PR DESCRIPTION
Fixes #974 

As also described in the issue, this

* Reverts the removal of transactions from `allTxs` upon `TxInvalid`
  - Discussed in https://github.com/input-output-hk/hydra/pull/988/commits/d608de38710bf36740028155ca2bd37036d4aa7e

* Updates the off-chain protocol section in the spec to match what is currently implemented

* Moves the removal of transactions from allTxs when handling a ReqSn (code + spec)

* Rename terms: `seenTxs -> localTxs`, `seenUTxO -> localUTxO`, `allTxs` stays the same

* Kept note of discussion points in code or follow-up items:

  - [x] Coherence of `TxInvalid` messages, e.g. when receiving invalid txs it's unintuitive to get informed about them; on the other hand, we would like to be informed if transactions are not valid to our local view
    - Captured in #990 
    
  - [x] There is no equivalence for storing the fact that we requested a snapshot in the spec. Do we really need it? If yes, we should have a mention of it in the spec or update the formalism accordingly.
    - [x] Covered by #982

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
