### PR TITLE
Ability to read protocol parameters via REST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ changes.
 
 - `Greetings` message now contains also the hydra-node version.
 
+- New REST endpoint (`/protocol-parameters`) which provides protocol-parameters
+  used in the hydra-node.
+
 - *Fixed bugs* in `hydra-node`:
   + Multisignature verification would silently ignore certain keys in case the
   list of verification keys is not of same length as the list of signatures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ changes.
 
 - `Greetings` message now contains also the hydra-node version.
 
-- New REST endpoint (`/protocol-parameters`) which provides protocol-parameters
-  used in the hydra-node.
+- New HTTP endpoint (`GET /protocol-parameters`) which provides the current protocol parameters
+  used by the hydra-node when validating transactions.
 
 - *Fixed bugs* in `hydra-node`:
   + Multisignature verification would silently ignore certain keys in case the

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -336,6 +336,7 @@ test-suite tests
     , hspec
     , hspec-core
     , hspec-golden-aeson
+    , hspec-wai
     , HUnit
     , hydra-cardano-api
     , hydra-node

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -141,6 +141,22 @@ channels:
           type: request
           method: POST
           bindingVersion: '0.1.0'
+  /protocol-parameters:
+    description: Endpoint to obtain protocol parameters used in hydra-node.
+    servers:
+      - localhost-http
+    subscribe:
+      summary: Get cardano protocol parameters.
+      operationId: getProtocolParameters
+      description: |
+        Clients can request from hydra-node it's protocol parameters used on start.
+      message:
+        $ref: "api.yaml#/components/messages/ProtocolParameters"
+      bindings:
+        http:
+          type: response
+          method: GET
+          bindingVersion: '0.1.0'
 components:
   messages:
     ########
@@ -786,6 +802,58 @@ components:
           Emitted by the server after drafting a commit transaction with the user provided utxos. Transaction returned to the user is in it's cbor representation encoded as Base16.
       payload:
         $ref: "api.yaml#/components/schemas/TextEnvelopeTransaction"
+
+    ProtocolParameters:
+      title: ProtocolParameters
+      description: |
+         Cardano protocol parameters used in hydra-node.
+         Example used in hydra-cluster package: https://github.com/input-output-hk/hydra/blob/master/hydra-cluster/config/protocol-parameters.json .
+      payload:
+       type: object
+       example:
+         {
+             "collateralPercentage": 150,
+             "costModels": {
+                 "PlutusScriptV1": {},
+                 "PlutusScriptV2": {}
+             },
+             "decentralization": null,
+             "executionUnitPrices": {
+                 "priceMemory": 5.77e-2,
+                 "priceSteps": 7.21e-5
+             },
+             "extraPraosEntropy": null,
+             "maxBlockBodySize": 65536,
+             "maxBlockExecutionUnits": {
+                 "memory": 80000000,
+                 "steps": 40000000000
+             },
+             "maxBlockHeaderSize": 1100,
+             "maxCollateralInputs": 3,
+             "maxTxExecutionUnits": {
+                 "memory": 14000000,
+                 "steps": 10000000000
+             },
+             "maxTxSize": 16384,
+             "maxValueSize": 5000,
+             "minPoolCost": 0,
+             "minUTxOValue": null,
+             "monetaryExpansion": 1.78650067e-3,
+             "poolPledgeInfluence": 0.1,
+             "poolRetireMaxEpoch": 18,
+             "protocolVersion": {
+                 "major": 7,
+                 "minor": 0
+             },
+             "stakeAddressDeposit": 400000,
+             "stakePoolDeposit": 500000000,
+             "stakePoolTargetNum": 50,
+             "treasuryCut": 0.1,
+             "txFeeFixed": 0,
+             "txFeePerByte": 0,
+             "utxoCostPerWord": 34488,
+             "utxoCostPerByte": 4310
+         }
 
   ########
   #

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -149,7 +149,7 @@ channels:
       summary: Get cardano protocol parameters.
       operationId: getProtocolParameters
       message:
-        $ref: "https://raw.githubusercontent.com/CardanoSolutions/cardanonical/main/cardano.json#/definitions/ProtocolParameters<Babbage>"
+        $ref: "#/components/messages/ProtocolParameters"
       bindings:
         http:
           type: response
@@ -801,6 +801,12 @@ components:
       payload:
         $ref: "api.yaml#/components/schemas/TextEnvelopeTransaction"
 
+    ProtocolParameters:
+      title: ProtocolParameters
+      payload:
+        type: object
+        additionalProperties: false
+        $ref: "https://raw.githubusercontent.com/CardanoSolutions/cardanonical/main/cardano.json#/definitions/ProtocolParameters<Babbage>"
 
   ########
   #

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -151,7 +151,7 @@ channels:
       description: |
         Clients can request from hydra-node it's protocol parameters used on start.
       message:
-        $ref: "api.yaml#/components/messages/ProtocolParameters"
+        $ref: "https://raw.githubusercontent.com/CardanoSolutions/cardanonical/main/cardano.json#/definitions/ProtocolParameters<Babbage>"
       bindings:
         http:
           type: response

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -142,14 +142,12 @@ channels:
           method: POST
           bindingVersion: '0.1.0'
   /protocol-parameters:
-    description: Endpoint to obtain protocol parameters used in hydra-node.
+    description: Endpoint to obtain protocol parameters used by the internal ledger of a hydra-node.
     servers:
       - localhost-http
     subscribe:
       summary: Get cardano protocol parameters.
       operationId: getProtocolParameters
-      description: |
-        Clients can request from hydra-node it's protocol parameters used on start.
       message:
         $ref: "https://raw.githubusercontent.com/CardanoSolutions/cardanonical/main/cardano.json#/definitions/ProtocolParameters<Babbage>"
       bindings:
@@ -803,57 +801,6 @@ components:
       payload:
         $ref: "api.yaml#/components/schemas/TextEnvelopeTransaction"
 
-    ProtocolParameters:
-      title: ProtocolParameters
-      description: |
-         Cardano protocol parameters used in hydra-node.
-         Example used in hydra-cluster package: https://github.com/input-output-hk/hydra/blob/master/hydra-cluster/config/protocol-parameters.json .
-      payload:
-       type: object
-       example:
-         {
-             "collateralPercentage": 150,
-             "costModels": {
-                 "PlutusScriptV1": {},
-                 "PlutusScriptV2": {}
-             },
-             "decentralization": null,
-             "executionUnitPrices": {
-                 "priceMemory": 5.77e-2,
-                 "priceSteps": 7.21e-5
-             },
-             "extraPraosEntropy": null,
-             "maxBlockBodySize": 65536,
-             "maxBlockExecutionUnits": {
-                 "memory": 80000000,
-                 "steps": 40000000000
-             },
-             "maxBlockHeaderSize": 1100,
-             "maxCollateralInputs": 3,
-             "maxTxExecutionUnits": {
-                 "memory": 14000000,
-                 "steps": 10000000000
-             },
-             "maxTxSize": 16384,
-             "maxValueSize": 5000,
-             "minPoolCost": 0,
-             "minUTxOValue": null,
-             "monetaryExpansion": 1.78650067e-3,
-             "poolPledgeInfluence": 0.1,
-             "poolRetireMaxEpoch": 18,
-             "protocolVersion": {
-                 "major": 7,
-                 "minor": 0
-             },
-             "stakeAddressDeposit": 400000,
-             "stakePoolDeposit": 500000000,
-             "stakePoolTargetNum": 50,
-             "treasuryCut": 0.1,
-             "txFeeFixed": 0,
-             "txFeePerByte": 0,
-             "utxoCostPerWord": 34488,
-             "utxoCostPerByte": 4310
-         }
 
   ########
   #

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -254,6 +254,8 @@ runAPIServer host port party tracer history chain callback headStatusP snapshotU
       ("POST", ["commit"]) -> do
         body <- consumeRequestBodyStrict req
         handleDraftCommitUtxo directChain tracer body (requestMethod req) (pathInfo req) respond
+      ("GET", ["protocol-parameters"]) -> do
+        respond $ responseLBS status200 [] "OK"
       _ -> do
         traceWith tracer $
           APIRestInputReceived

--- a/hydra-node/test/Hydra/API/RestServerSpec.hs
+++ b/hydra-node/test/Hydra/API/RestServerSpec.hs
@@ -5,17 +5,18 @@ module Hydra.API.RestServerSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
+import Data.Aeson (encode)
 import Data.Aeson.Lens (key)
 import Hydra.API.RestServer (DraftCommitTxRequest, DraftCommitTxResponse)
 import Hydra.API.ServerSpec (mockPersistence, withTestAPIServer)
+import Hydra.Chain.Direct.Fixture (defaultPParams)
 import Hydra.Chain.Direct.State ()
 import Hydra.JSONSchema (prop_validateJSONSchema)
 import Hydra.Logging (showLogsOnFailure)
-import Network.HTTP.Req (GET (GET), NoReqBody (NoReqBody), defaultHttpConfig, http, lbsResponse, port, req, responseStatusCode, runReq, (/:))
+import Network.HTTP.Req (GET (GET), NoReqBody (NoReqBody), defaultHttpConfig, http, lbsResponse, port, req, responseBody, responseStatusCode, runReq, (/:))
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
 import Test.Hydra.Fixture (alice)
 import Test.Network.Ports (withFreePort)
-import Test.QuickCheck.Monadic (monadicIO, run)
 import Test.QuickCheck.Property (property, withMaxSuccess)
 
 spec :: Spec
@@ -38,17 +39,17 @@ spec = do
 
   describe "REST API endpoints" $
     it "GET /protocol-parameters returns 200" $
-      monadicIO $ do
-        run $
-          showLogsOnFailure $ \tracer -> failAfter 5 $
-            withFreePort $ \port' ->
-              withTestAPIServer port' alice mockPersistence tracer $ \_ -> do
-                r <-
-                  runReq defaultHttpConfig $
-                    req
-                      GET
-                      (http "127.0.0.1" /: "protocol-parameters")
-                      NoReqBody
-                      lbsResponse
-                      (port $ fromIntegral port')
-                responseStatusCode r `shouldBe` 200
+      showLogsOnFailure $ \tracer -> failAfter 5 $
+        withFreePort $ \port' ->
+          withTestAPIServer port' alice mockPersistence tracer $ \_ -> do
+            r <-
+              runReq defaultHttpConfig $
+                req
+                  GET
+                  (http "127.0.0.1" /: "protocol-parameters")
+                  NoReqBody
+                  lbsResponse
+                  (port $ fromIntegral port')
+
+            responseBody r `shouldBe` encode defaultPParams
+            responseStatusCode r `shouldBe` 200

--- a/hydra-node/test/Hydra/API/RestServerSpec.hs
+++ b/hydra-node/test/Hydra/API/RestServerSpec.hs
@@ -7,24 +7,48 @@ import Test.Hydra.Prelude
 
 import Data.Aeson.Lens (key)
 import Hydra.API.RestServer (DraftCommitTxRequest, DraftCommitTxResponse)
+import Hydra.API.ServerSpec (mockPersistence, withTestAPIServer)
 import Hydra.Chain.Direct.State ()
 import Hydra.JSONSchema (prop_validateJSONSchema)
+import Hydra.Logging (showLogsOnFailure)
+import Network.HTTP.Req (GET (GET), NoReqBody (NoReqBody), defaultHttpConfig, http, lbsResponse, port, req, responseStatusCode, runReq, (/:))
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
+import Test.Hydra.Fixture (alice)
+import Test.Network.Ports (withFreePort)
+import Test.QuickCheck.Monadic (monadicIO, run)
 import Test.QuickCheck.Property (property, withMaxSuccess)
 
 spec :: Spec
-spec = parallel $ do
-  roundtripAndGoldenSpecs (Proxy @(ReasonablySized DraftCommitTxResponse))
-  roundtripAndGoldenSpecs (Proxy @(ReasonablySized DraftCommitTxRequest))
+spec = do
+  parallel $ do
+    roundtripAndGoldenSpecs (Proxy @(ReasonablySized DraftCommitTxResponse))
+    roundtripAndGoldenSpecs (Proxy @(ReasonablySized DraftCommitTxRequest))
 
-  prop "Validate /commit publish api schema" $
-    property $
-      withMaxSuccess 1 $
-        prop_validateJSONSchema @DraftCommitTxRequest "api.json" $
-          key "components" . key "messages" . key "DraftCommitTxRequest" . key "payload"
+    prop "Validate /commit publish api schema" $
+      property $
+        withMaxSuccess 1 $
+          prop_validateJSONSchema @DraftCommitTxRequest "api.json" $
+            key "components" . key "messages" . key "DraftCommitTxRequest" . key "payload"
 
-  prop "Validate /commit subscribe api schema" $
-    property $
-      withMaxSuccess 1 $
-        prop_validateJSONSchema @DraftCommitTxResponse "api.json" $
-          key "components" . key "messages" . key "DraftCommitTxResponse" . key "payload"
+    prop "Validate /commit subscribe api schema" $
+      property $
+        withMaxSuccess 1 $
+          prop_validateJSONSchema @DraftCommitTxResponse "api.json" $
+            key "components" . key "messages" . key "DraftCommitTxResponse" . key "payload"
+
+  describe "REST API endpoints" $
+    it "GET /protocol-parameters returns 200" $
+      monadicIO $ do
+        run $
+          showLogsOnFailure $ \tracer -> failAfter 5 $
+            withFreePort $ \port' ->
+              withTestAPIServer port' alice mockPersistence tracer $ \_ -> do
+                r <-
+                  runReq defaultHttpConfig $
+                    req
+                      GET
+                      (http "127.0.0.1" /: "protocol-parameters")
+                      NoReqBody
+                      lbsResponse
+                      (port $ fromIntegral port')
+                responseStatusCode r `shouldBe` 200

--- a/hydra-node/test/Hydra/API/RestServerSpec.hs
+++ b/hydra-node/test/Hydra/API/RestServerSpec.hs
@@ -38,7 +38,7 @@ spec = do
 
     apiServerSpec
 
--- REVIEW: we should add more tests for other routes here (eg. /commit)
+-- TODO: we should add more tests for other routes here (eg. /commit)
 apiServerSpec :: Spec
 apiServerSpec = do
   let webServer = httpApp nullTracer dummyChainHandle defaultPParams

--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -36,6 +36,7 @@ import Hydra.Chain (
   draftCommitTx,
   postTx,
  )
+import Hydra.Chain.Direct.Fixture (defaultPParams)
 import Hydra.Ledger (txId)
 import Hydra.Ledger.Simple (SimpleTx)
 import Hydra.Logging (Tracer, showLogsOnFailure)
@@ -433,7 +434,7 @@ withTestAPIServer ::
   (Server SimpleTx IO -> IO ()) ->
   IO ()
 withTestAPIServer port actor persistence tracer =
-  withAPIServer @SimpleTx "127.0.0.1" port actor persistence tracer dummyChainHandle noop
+  withAPIServer @SimpleTx "127.0.0.1" port actor persistence tracer dummyChainHandle defaultPParams noop
 
 withClient :: PortNumber -> String -> (Connection -> IO ()) -> IO ()
 withClient port path action = do


### PR DESCRIPTION
fix #735 

## Why

Our users seem to have a need to obtain protocol parameters from the REST endpoint.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
