### PR TITLE
Publish end-to-end bench result in PR comment

### DIFF
--- a/.github/workflows/ci-cabal.yaml
+++ b/.github/workflows/ci-cabal.yaml
@@ -186,7 +186,7 @@ jobs:
       id: comment-body
       run: |
         # Drop first 5 header lines and demote headlines one level
-        body="$(cat artifact/transaction-cost.md | sed '1,5d;s/^#/##/')"
+        body="$(cat <(cat artifact/transaction-cost.md | sed '1,5d;s/^#/##/') <(cat artifact/end-to-end-benchmarks.md | sed '1,5d;s/^#/##/') | grep -v '^:::')"
         body="${body//'%'/'%25'}"
         body="${body//$'\n'/'%0A'}"
         body="${body//$'\r'/'%0D'}"


### PR DESCRIPTION
Add the end-to-end benchmarks results to the PR as a comment, together with the transaction cost benchmarks. That way, we can more easily compare one PR with master or another PR.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
