### PR TITLE
Always output summary of hydra-cluster benchmark

### DIFF
--- a/hydra-cluster/bench/Main.hs
+++ b/hydra-cluster/bench/Main.hs
@@ -103,14 +103,14 @@ benchmarkFailedWith benchDir = \case
 
 benchmarkSucceeded :: Maybe FilePath -> [Summary] -> IO ()
 benchmarkSucceeded outputDirectory summaries = do
-  now <- getCurrentTime
-  let report = markdownReport now summaries
-  maybe dumpToStdout (writeTo report) outputDirectory
+  dumpToStdout
+  whenJust outputDirectory writeReport
  where
   dumpToStdout = mapM_ putTextLn (concatMap textReport summaries)
 
-  writeTo report outputDir = do
-    existsDir <- doesDirectoryExist outputDir
-    unless existsDir $ createDirectory outputDir
+  writeReport outputDir = do
+    now <- getCurrentTime
+    let report = markdownReport now summaries
+    createDirectoryIfMissing True outputDir
     withFile (outputDir </> "end-to-end-benchmarks.md") WriteMode $ \hdl -> do
       hPut hdl $ encodeUtf8 $ unlines report


### PR DESCRIPTION
Our CI not always uses the markdown (as comment or in the website) and sometimes we just want to see the results of some CI run.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
