### PR TITLE
Bump GHC further to 9.2.8

### DIFF
--- a/.github/workflows/ci-cabal.yaml
+++ b/.github/workflows/ci-cabal.yaml
@@ -30,7 +30,7 @@ jobs:
       uses: ./.github/workflows/actions/setup_dev_ubuntu
       with:
         clean_caches: true
-        version_ghc: 9.2.7
+        version_ghc: 9.2.8
 
     - name: cabal build
       run: |
@@ -55,7 +55,7 @@ jobs:
     - name: setup dev environment
       uses: ./.github/workflows/actions/setup_dev_ubuntu
       with:
-        version_ghc: 9.2.7
+        version_ghc: 9.2.8
 
     - name: ❓ Test
       if: ${{ matrix.package != 'hydra-tui' }}
@@ -119,7 +119,7 @@ jobs:
     - name: setup dev environment
       uses: ./.github/workflows/actions/setup_dev_ubuntu
       with:
-        version_ghc: 9.2.7
+        version_ghc: 9.2.8
 
     - name: 📚 Documentation (Haddock)
       run: |
@@ -156,7 +156,7 @@ jobs:
     - name: setup dev environment
       uses: ./.github/workflows/actions/setup_dev_ubuntu
       with:
-        version_ghc: 9.2.7
+        version_ghc: 9.2.8
 
     - name: 📈 Benchmark
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,12 @@ changes.
     and verify signature of received messages is from a known party
     and of course valid.
 
-- **BREAKING**Protocol change: Wait for all transactions requested in
-  a snapshot to be seen before acknowledging it, and only send
-  transaction ids in snapshot requests
+- **BREAKING**Protocol change: Wait for all transactions requested in a snapshot
+  to be seen before acknowledging it, and only send transaction ids in snapshot
+  requests
 
 - **BREAKING** Change to the Hydra scripts due to upgrading our plutus compiler
-  and toolchain.
+  and toolchain to GHC 9.2.8.
 
 ## [0.11.0] - 2023-06-30
 

--- a/nix/hydra/project.nix
+++ b/nix/hydra/project.nix
@@ -1,4 +1,4 @@
-{ compiler ? "ghc927"
+{ compiler ? "ghc928"
 
 , system ? builtins.currentSystem
 


### PR DESCRIPTION
This is a patch release ahead of previously 9.2.7 and promises better support for newer linux kernels.

Note that this is producing the exact same scripts as plutus-tx with 9.2.7 and hence is no breaking change over current master.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed (GHC update already in there)
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
