### PR TITLE
Add cardanonical schema as a submodule

### DIFF
--- a/.github/workflows/ci-cabal.yaml
+++ b/.github/workflows/ci-cabal.yaml
@@ -244,7 +244,13 @@ jobs:
     needs: [haddock,benchmarks,test,build-specification]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - name: 📥 Checkout repository
+      uses: actions/checkout@v3
+      with:
+        # For the cardanonical json schemas
+        submodules: true
+        # Ensure we have all history with all commits
+        fetch-depth: 0
 
     - name: 🚧 Setup Node.js
       uses: actions/setup-node@v3

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -255,6 +255,8 @@ jobs:
     - name: 📥 Checkout repository
       uses: actions/checkout@v3
       with:
+        # For the cardanonical json schemas
+        submodules: true
         # Ensure we have all history with all commits
         fetch-depth: 0
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "testnet/cardano-configurations"]
 	path = hydra-cluster/config/cardano-configurations
 	url = https://github.com/input-output-hk/cardano-configurations.git
+[submodule "hydra-node/json-schemas/cardanonical"]
+	path = hydra-node/json-schemas/cardanonical
+	url = https://github.com/CardanoSolutions/cardanonical

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -840,7 +840,7 @@ components:
       payload:
         type: object
         additionalProperties: false
-        $ref: "https://raw.githubusercontent.com/CardanoSolutions/cardanonical/main/cardano.json#/definitions/ProtocolParameters<Babbage>"
+        $ref: "cardanonical/cardano.json#/definitions/ProtocolParameters"
 
   ########
   #


### PR DESCRIPTION
This will make our schema validation not fail without a commit.

Avoids https://github.com/input-output-hk/hydra/actions/runs/5788084058/job/15686670468#step:4:131 in the future.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
