### PR TITLE
Fix latest tags of our docker images

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -65,7 +65,7 @@ jobs:
         # Also tag with semver and 'latest' if we are building a tag
         [[ ${BUILDING_TAG} = true && ${{matrix.target}} != "hydraw" ]] && \
           docker tag ${IMAGE_NAME}:unstable ${IMAGE_NAME}:${{github.ref_name}}
-        [[ ${BUILDING_TAG} = true] ]] && \
+        [[ ${BUILDING_TAG} = true ]] && \
           docker tag ${IMAGE_NAME}:unstable ${IMAGE_NAME}:latest
         docker images
         docker inspect ${IMAGE_NAME}:unstable


### PR DESCRIPTION
<!-- Describe your change here -->

🍦 Fix minor typo that was preventing to create the `latest` tags.

**note:**
we have manually fixed the `latest` tags for [hydra-node](https://github.com/input-output-hk/hydra/pkgs/container/hydra-node), [hydra-tui](https://github.com/input-output-hk/hydra/pkgs/container/hydra-tui) and [hydra-tools](https://github.com/input-output-hk/hydra/pkgs/container/hydra-tools) packages, so that now tag `0.11.0` is also set as `latest`.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
