### PR TITLE
Fix logs schema

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -27,6 +27,9 @@ packages:
   hydra-tui
   hydraw
 
+package cardano-crypto-praos
+  flags: -external-libsodium-vrf
+
 -- Compile more things in parallel
 package *
   ghc-options: -j8

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -800,7 +800,6 @@ definitions:
             $ref: "api.yaml#/components/schemas/SnapshotNumber"
           lastSeenSn:
             $ref: "api.yaml#/components/schemas/SnapshotNumber"
-
   HeadState:
     oneOf:
       - title: "Idle"
@@ -847,7 +846,213 @@ definitions:
             enum: ["Closed"]
           contents:
             $ref: "logs.yaml#/definitions/ClosedState"
-
+  StateChanged:
+    oneOf:
+      - title: "HeadInitialized"
+        additionalProperties: false
+        required:
+          - tag
+          - parameters
+          - chainState
+          - headId
+        properties:
+          tag:
+            type: string
+            enum: ["HeadInitialized"]
+          parameters:
+            $ref: "api.yaml#/components/schemas/HeadParameters"
+          chainState:
+            $ref: "api.yaml#/components/schemas/ChainState"
+          headId:
+            $ref: "api.yaml#/components/schemas/HeadId"
+      - title: "CommittedUTxO"
+        additionalProperties: false
+        required:
+          - tag
+          - party
+          - committedUTxO
+          - chainState
+        properties:
+          tag:
+            type: string
+            enum: ["CommittedUTxO"]
+          party:
+            $ref: "api.yaml#/components/schemas/Party"
+          committedUTxO:
+            $ref: "api.yaml#/components/schemas/UTxO"
+          chainState:
+            $ref: "api.yaml#/components/schemas/ChainState"
+      - title: "HeadAborted"
+        additionalProperties: false
+        required:
+          - tag
+          - chainState
+        properties:
+          tag:
+            type: string
+            enum: ["HeadAborted"]
+          chainState:
+            $ref: "api.yaml#/components/schemas/ChainState"
+      - title: "HeadOpened"
+        additionalProperties: false
+        required:
+          - tag
+          - chainState
+          - initialUTxO
+        properties:
+          tag:
+            type: string
+            enum: ["HeadOpened"]
+          chainState:
+            $ref: "api.yaml#/components/schemas/ChainState"
+          initialUTxO:
+            $ref: "api.yaml#/components/schemas/UTxO"
+      - title: "TransactionAppliedToLocalUTxO"
+        additionalProperties: false
+        required:
+          - tag
+          - tx
+          - newLocalUTxO
+        properties:
+          tag:
+            type: string
+            enum: ["TransactionAppliedToLocalUTxO"]
+          tx:
+            $ref: "api.yaml#/components/schemas/Transaction"
+          newLocalUTxO:
+            $ref: "api.yaml#/components/schemas/UTxO"
+      - title: "SnapshotRequestDecided"
+        additionalProperties: false
+        required:
+          - tag
+          - snapshotNumber
+        properties:
+          tag:
+            type: string
+            enum: ["SnapshotRequestDecided"]
+          snapshotNumber:
+            $ref: "api.yaml#/components/schemas/SnapshotNumber"
+      - title: "SnapshotRequested"
+        additionalProperties: false
+        required:
+          - tag
+          - snapshot
+          - requestedTxIds
+          - newLocalUTxO
+          - newLocalTxs
+        properties:
+          tag:
+            type: string
+            enum: ["SnapshotRequested"]
+          snapshot:
+            $ref: "api.yaml#/components/schemas/Snapshot"
+          requestedTxIds:
+            type: array
+            items:
+              $ref: "api.yaml#/components/schemas/TxId"
+          newLocalUTxO:
+            $ref: "api.yaml#/components/schemas/UTxO"
+          newLocalTxs:
+            type: array
+            items:
+              $ref: "api.yaml#/components/schemas/Transaction"
+      - title: "TransactionReceived"
+        additionalProperties: false
+        required:
+          - tag
+          - tx
+        properties:
+          tag:
+            type: string
+            enum: ["TransactionReceived"]
+          tx:
+            $ref: "api.yaml#/components/schemas/Transaction"
+      - title: "PartySignedSnapshot"
+        additionalProperties: false
+        required:
+          - tag
+          - snapshot
+          - party
+          - signature
+        properties:
+          tag:
+            type: string
+            enum: ["PartySignedSnapshot"]
+          snapshot:
+            $ref: "api.yaml#/components/schemas/Snapshot"
+          party:
+            $ref: "api.yaml#/components/schemas/Party"
+          signature:
+            $ref: "api.yaml#/components/schemas/Signature"
+      - title: "SnapshotConfirmed"
+        additionalProperties: false
+        required:
+          - tag
+          - snapshot
+          - signatures
+        properties:
+          tag:
+            type: string
+            enum: ["SnapshotConfirmed"]
+          snapshot:
+            $ref: "api.yaml#/components/schemas/Snapshot"
+          signatures:
+            $ref: "api.yaml#/components/schemas/MultiSignature"
+      - title: "HeadClosed"
+        additionalProperties: false
+        required:
+          - tag
+          - chainState
+          - contestationDeadline
+        properties:
+          tag:
+            type: string
+            enum: ["HeadClosed"]
+          chainState:
+            $ref: "api.yaml#/components/schemas/ChainState"
+          contestationDeadline:
+            $ref: "api.yaml#/components/schemas/UTCTime"
+      - title: "HeadIsReadyToFanout"
+        additionalProperties: false
+        required:
+          - tag
+        properties:
+          tag:
+            type: string
+            enum: ["HeadIsReadyToFanout"]
+      - title: "HeadFannedOut"
+        additionalProperties: false
+        required:
+          - tag
+          - chainState
+        properties:
+          tag:
+            type: string
+            enum: ["HeadFannedOut"]
+          chainState:
+            $ref: "api.yaml#/components/schemas/ChainState"
+      - title: "ChainRolledBack"
+        additionalProperties: false
+        required:
+          - tag
+          - chainState
+        properties:
+          tag:
+            type: string
+            enum: ["ChainRolledBack"]
+          chainState:
+            $ref: "api.yaml#/components/schemas/ChainState"
+      - title: "TickObserved"
+        additionalProperties: false
+        required:
+          - tag
+          - chainSlot
+        properties:
+          tag:
+            type: string
+            enum: ["TickObserved"]
+          chainSlot:
+            $ref: "api.yaml#/components/schemas/ChainSlot"
   IdleState:
     type: object
     additionalProperties: false

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -666,42 +666,6 @@ definitions:
             prefixItems:
               - $ref: "logs.yaml#/definitions/Event"
               - $ref: "logs.yaml#/definitions/HeadState"
-      - title: InvalidState
-        additionalProperties: false
-        required:
-          - tag
-          - contents
-        properties:
-          tag:
-            type: string
-            enum: ["InvalidState"]
-          contents:
-            $ref: "logs.yaml#/definitions/HeadState"
-      - title: InvalidSnapshot
-        additionalProperties: false
-        required:
-          - tag
-          - expected
-          - actual
-        properties:
-          tag:
-            type: string
-            enum: ["InvalidSnapshot"]
-          expected:
-            $ref: "api.yaml#/components/schemas/SnapshotNumber"
-          actual:
-            $ref: "api.yaml#/components/schemas/SnapshotNumber"
-      - title: LedgerError
-        additionalProperties: false
-        required:
-          - tag
-          - contents
-        properties:
-          tag:
-            type: string
-            enum: ["LedgerError"]
-          contents:
-            $ref: "logs.yaml#/definitions/ValidationError"
       - title: RequireFailed
         description: >-
           A precondition for some state transition within the Hydra
@@ -1455,7 +1419,7 @@ definitions:
             items:
               type: object
               $ref: "logs.yaml#/definitions/Effect"
-      - title: NewState
+      - title: StateChanged
         type: object
         additionalProperties: false
         required:
@@ -1466,7 +1430,7 @@ definitions:
         properties:
           tag:
             type: string
-            enum: ["NewState"]
+            enum: ["StateChanged"]
           headState:
             type: object
             $ref: "logs.yaml#/definitions/HeadState"

--- a/hydra-node/src/Hydra/HeadLogic/Error.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Error.hs
@@ -16,9 +16,6 @@ import Hydra.Snapshot (SnapshotNumber)
 -- TODO: Try to merge this (back) into 'Outcome'.
 data LogicError tx
   = InvalidEvent (Event tx) (HeadState tx)
-  | InvalidState (HeadState tx)
-  | InvalidSnapshot {expected :: SnapshotNumber, actual :: SnapshotNumber}
-  | LedgerError ValidationError
   | RequireFailed (RequirementFailure tx)
   | NotOurHead {ourHeadId :: HeadId, otherHeadId :: HeadId}
   deriving stock (Generic)


### PR DESCRIPTION
We forgot to update our logs schema when working on event sourced persistence.
There is `NewState` that needs to be removed in favor of `StateChanged`.
I noticed also that some constructors in the `Error` module are not used anywhere so I removed them (they are mentioned in the logs schema so removing those is still in scope I'd say). 
Our testing related to logging is flaky so we didn't see this fail right away and fixing these tests is not in scope of this pr.



---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
