### PR TITLE
Re-enable use of external libsodium

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -27,9 +27,6 @@ packages:
   hydra-tui
   hydraw
 
-package cardano-crypto-praos
-  flags: -external-libsodium-vrf
-
 -- Compile more things in parallel
 package *
   ghc-options: -j8


### PR DESCRIPTION
Unsetting the default enable flag `external-libsodium-vrf` on `cardano-crypto-praos` [broke](https://github.com/input-output-hk/hydra/actions/runs/5841864289/job/15842413458) the static builds on master.

By undoing this change, the static builds don't fail with ambiguous versions of the library being available and it's much better under our control which version of libsodium is used.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
