### PR TITLE
Update experimental CI versions of libsodium and secp256k1

### DIFF
--- a/.github/workflows/actions/setup_dev_ubuntu/install_libraries
+++ b/.github/workflows/actions/setup_dev_ubuntu/install_libraries
@@ -5,11 +5,12 @@ set -euxo pipefail
 mkdir -p src
 mkdir -p srv/bin
 # Install libsodium
+# Using revision from https://github.com/input-output-hk/iohk-nix
 (
   cd src
   git clone https://github.com/input-output-hk/libsodium
   cd libsodium
-  git checkout 66f017f1
+  git checkout dbb48cce5429cb6585c9034f002568964f1ce567
   ./autogen.sh
   ./configure --prefix="$(realpath $PWD/../../srv)"
   make
@@ -17,11 +18,12 @@ mkdir -p srv/bin
 )
 
 # Install secp256k1
+# Using revision from https://github.com/input-output-hk/iohk-nix
 (
   cd src
   git clone https://github.com/bitcoin-core/secp256k1
   cd secp256k1
-  git checkout ac83be33
+  git checkout v0.3.2
   ./autogen.sh
   ./configure --enable-module-schnorrsig --enable-experimental --prefix="$(realpath $PWD/../../srv)"
   make


### PR DESCRIPTION
As this CI is installing system dependencies "outside" of the nix workflow, the versions of these libraries need to be bumped as well. This commit is using the versions as defined in the iohk-nix repository, which is used in the nix workflow.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
