### PR TITLE
Cleanup dependencies

### DIFF
--- a/hydra-cardano-api/hydra-cardano-api.cabal
+++ b/hydra-cardano-api/hydra-cardano-api.cabal
@@ -112,27 +112,26 @@ library
     Hydra.Cardano.Api.VerificationKey
     Hydra.Cardano.Api.Witness
 
-  -- NOTE: Constraints to make cardano-api 1.35.4 compile, most of these should
-  -- be further upstream
+  -- NOTE: We use very narrow bounds on cardano libraries as they tend to break
+  -- their interfaces often.
   build-depends:
-    , aeson
-    , base
+    , aeson                   >=2
+    , base                    >=4.16
     , base16-bytestring
     , bytestring
-    , cardano-api                  >=1.36.0
-    , cardano-binary               >=1.5.0
-    , cardano-crypto-class         >=2.0.0
-    , cardano-ledger-allegra
-    , cardano-ledger-alonzo
-    , cardano-ledger-babbage
-    , cardano-ledger-binary
-    , cardano-ledger-byron
-    , cardano-ledger-core
-    , cardano-ledger-mary
-    , cardano-ledger-shelley
-    , cardano-prelude
+    , cardano-api             >=8.11.0 && <8.12
+    , cardano-binary          >=1.7.0  && <1.8
+    , cardano-crypto-class    >=2.1.1  && <2.2
+    , cardano-ledger-allegra  >=1.2.1  && <1.3
+    , cardano-ledger-alonzo   >=1.3.3  && <1.4
+    , cardano-ledger-babbage  >=1.4.2  && <1.5
+    , cardano-ledger-binary   >=1.1.1  && <1.2
+    , cardano-ledger-byron    >=1.0.0  && <1.1
+    , cardano-ledger-core     >=1.4.1  && <1.5
+    , cardano-ledger-mary     >=1.3.1  && <1.4
+    , cardano-ledger-shelley  >=1.4.2  && <1.5
     , containers
-    , plutus-ledger-api            >=1.1.0.0 && <1.7.0.0.0
+    , plutus-ledger-api       >=1.7.0  && <1.8
     , QuickCheck
     , serialise
-    , text                         >=2.0
+    , text                    >=2

--- a/hydra-cardano-api/hydra-cardano-api.cabal
+++ b/hydra-cardano-api/hydra-cardano-api.cabal
@@ -61,7 +61,7 @@ common project-config
 
   ghc-options:
     -Wall -Wcompat -Widentities -Wincomplete-record-updates
-    -Wincomplete-uni-patterns -Wredundant-constraints
+    -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
     -fprint-potential-instances
 
   if !flag(hydra-development)
@@ -116,10 +116,8 @@ library
   -- be further upstream
   build-depends:
     , aeson
-    , array
     , base
     , base16-bytestring
-    , bech32
     , bytestring
     , cardano-api                  >=1.36.0
     , cardano-binary               >=1.5.0
@@ -132,15 +130,9 @@ library
     , cardano-ledger-core
     , cardano-ledger-mary
     , cardano-ledger-shelley
-    , cardano-ledger-shelley-test
     , cardano-prelude
-    , cborg
     , containers
-    , data-default
     , plutus-ledger-api            >=1.1.0.0 && <1.7.0.0.0
     , QuickCheck
     , serialise
-    , stm
-    , strict-containers            >=0.1.0.0
     , text                         >=2.0
-    , time

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -101,7 +101,8 @@ common project-config
 
   ghc-options:
     -Wall -Wcompat -Widentities -Wincomplete-record-updates
-    -Wincomplete-uni-patterns -Wredundant-constraints
+    -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+    -fprint-potential-instances
 
   if !flag(hydra-development)
     ghc-options: -Werror
@@ -125,10 +126,8 @@ library
   build-depends:
     , aeson
     , async
-    , base                                                              >=4.7     && <5
+    , base                                         >=4.7     && <5
     , bytestring
-    , cardano-crypto-class
-    , cardano-ledger-core
     , cardano-slotting
     , containers
     , contra-tracer
@@ -139,30 +138,21 @@ library
     , http-client
     , hydra-cardano-api
     , hydra-node
-    , hydra-plutus
     , hydra-prelude
     , hydra-test-utils
     , io-classes
     , iohk-monitoring
     , lens
     , lens-aeson
-    , network
     , optparse-applicative
-    , ouroboros-consensus
-    , ouroboros-network
-    , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}  >=1.1.1.0
+    , plutus-ledger-api:plutus-ledger-api-testlib  >=1.1.1.0
     , process
     , QuickCheck
-    , random-shuffle
     , req
-    , retry
-    , say
-    , streaming-commons
     , temporary
     , text
     , time
     , unix
-    , unordered-containers
     , websockets
 
   ghc-options:     -haddock
@@ -173,8 +163,6 @@ executable hydra-cluster
   main-is:            Main.hs
   ghc-options:        -threaded -rtsopts
   build-depends:
-    , base                  >=4.7 && <5
-    , hydra-cardano-api
     , hydra-cluster
     , hydra-node
     , hydra-prelude
@@ -193,7 +181,6 @@ executable log-filter
     , aeson
     , base                  >=4.7 && <5
     , bytestring
-    , contra-tracer
     , hydra-cluster
     , hydra-node
     , hydra-prelude
@@ -219,36 +206,23 @@ test-suite tests
   build-depends:
     , aeson
     , async
-    , base                                                              >=4.7     && <5
-    , base16-bytestring
+    , base                >=4.7 && <5
     , bytestring
-    , cardano-crypto-class
-    , cardano-ledger-alonzo
-    , cardano-ledger-core
-    , cardano-ledger-shelley
     , containers
     , directory
     , filepath
-    , hedgehog-quickcheck
     , hspec
-    , hspec-core
     , hspec-golden-aeson
     , hydra-cardano-api
     , hydra-cluster
     , hydra-node
-    , hydra-plutus
     , hydra-prelude
     , hydra-test-utils
     , lens
     , lens-aeson
-    , ouroboros-network
-    , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}  >=1.1.1.0
     , process
     , QuickCheck
-    , say
     , stm
-    , strict-containers
-    , temporary
     , text
     , time
 
@@ -272,11 +246,9 @@ benchmark bench-e2e
     , aeson
     , base                  >=4.7 && <5
     , bytestring
-    , cardano-crypto-class
     , containers
     , directory
     , filepath
-    , hspec
     , HUnit
     , hydra-cardano-api
     , hydra-cluster
@@ -292,7 +264,6 @@ benchmark bench-e2e
     , regex-tdfa
     , scientific
     , statistics
-    , strict-containers
     , time
     , vector
 

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -173,8 +173,8 @@ library
     , ouroboros-network-api                                     >=0.1.0.0
     , ouroboros-network-framework                               >=0.3.0.0
     , ouroboros-network-protocols                               >=0.3.0.0
-    , plutus-core
-    , plutus-ledger-api                                         >=1.1.1.0
+    , plutus-core                                               >=1.7     && <1.8
+    , plutus-ledger-api                                         >=1.7     && <1.8
     , prometheus
     , QuickCheck
     , quickcheck-instances

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -100,10 +100,10 @@ library
     , hydra-cardano-api
     , hydra-plutus-extras
     , hydra-prelude
-    , plutus-core
-    , plutus-ledger-api
-    , plutus-tx
-    , plutus-tx-plugin
+    , plutus-core           >=1.7 && <1.8
+    , plutus-ledger-api     >=1.7 && <1.8
+    , plutus-tx             >=1.7 && <1.8
+    , plutus-tx-plugin      >=1.7 && <1.8
     , QuickCheck
     , serialise
     , template-haskell

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -97,8 +97,6 @@ library
     , base
     , base16-bytestring
     , bytestring
-    , containers
-    , directory
     , hydra-cardano-api
     , hydra-plutus-extras
     , hydra-prelude
@@ -106,12 +104,9 @@ library
     , plutus-ledger-api
     , plutus-tx
     , plutus-tx-plugin
-    , prettyprinter
     , QuickCheck
-    , quickcheck-instances
     , serialise
     , template-haskell
-    , text
     , time
 
   if flag(hydra-development)
@@ -132,7 +127,6 @@ test-suite tests
   build-depends:
     , base
     , hspec
-    , hspec-core
     , hspec-golden
     , hydra-cardano-api
     , hydra-plutus
@@ -140,7 +134,6 @@ test-suite tests
     , hydra-test-utils
     , plutus-ledger-api
     , QuickCheck
-    , time
 
   build-tool-depends: hspec-discover:hspec-discover
 
@@ -150,16 +143,10 @@ executable inspect-script
   main-is:        Main.hs
   build-depends:
     , aeson
-    , base
     , bytestring
-    , cardano-api           >=1.35.4
-    , containers
-    , data-default
-    , directory
     , hydra-cardano-api
     , hydra-plutus
     , hydra-prelude
-    , optparse-applicative
     , plutus-ledger-api
     , plutus-tx
     , prettyprinter

--- a/hydra-prelude/hydra-prelude.cabal
+++ b/hydra-prelude/hydra-prelude.cabal
@@ -25,13 +25,13 @@ library
     , aeson-pretty
     , base
     , base16-bytestring
-    , cardano-binary
+    , cardano-binary     >=1.7.0   && <1.8
     , generic-random
     , gitrev
     , io-classes         >=1.0.0.0
     , QuickCheck
     , relude
-    , si-timers
+    , si-timers          >=1.0.0.0
     , transformers
 
   default-extensions:

--- a/hydra-tui/hydra-tui.cabal
+++ b/hydra-tui/hydra-tui.cabal
@@ -62,7 +62,7 @@ common project-config
 
   ghc-options:
     -Wall -Wcompat -Widentities -Wincomplete-record-updates
-    -Wincomplete-uni-patterns -Wredundant-constraints
+    -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
     -fprint-potential-instances
 
   if !flag(hydra-development)
@@ -81,11 +81,7 @@ library
     , aeson
     , async
     , base
-    , brick                   ==0.73
-    , cardano-crypto-class
-    , cardano-ledger-alonzo
-    , cardano-ledger-core
-    , cardano-ledger-shelley
+    , brick                 ==0.73
     , containers
     , hydra-cardano-api
     , hydra-node
@@ -94,10 +90,8 @@ library
     , microlens
     , microlens-th
     , optparse-applicative
-    , QuickCheck
     , req
     , text
-    , th-env
     , time
     , vty
     , websockets
@@ -107,7 +101,6 @@ executable hydra-tui
   hs-source-dirs: exe
   main-is:        Main.hs
   build-depends:
-    , base
     , hydra-prelude
     , hydra-tui
     , optparse-applicative
@@ -125,7 +118,6 @@ test-suite tests
   main-is:            Main.hs
   type:               exitcode-stdio-1.0
   build-depends:
-    , base
     , blaze-builder
     , bytestring
     , filepath
@@ -139,7 +131,6 @@ test-suite tests
     , io-classes
     , optparse-applicative
     , regex-tdfa
-    , temporary
     , unix
     , vty
 

--- a/hydraw/hydraw.cabal
+++ b/hydraw/hydraw.cabal
@@ -44,6 +44,11 @@ common project-config
     TypeSynonymInstances
     ViewPatterns
 
+  ghc-options:
+    -Wall -Wcompat -Widentities -Wincomplete-record-updates
+    -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+    -fprint-potential-instances
+
 library
   import:          project-config
   hs-source-dirs:  src
@@ -51,26 +56,17 @@ library
   build-depends:
     , aeson
     , base
-    , cardano-crypto-class
-    , cardano-ledger-alonzo
-    , cardano-ledger-core
-    , cardano-ledger-shelley
     , containers
     , hydra-cardano-api
     , hydra-node
     , hydra-prelude
-    , text
     , websockets
 
 executable hydraw
   import:         project-config
   hs-source-dirs: app
   main-is:        Main.hs
-  ghc-options:
-    -Wall -Wcompat -Widentities -Wincomplete-record-updates
-    -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
-    -Wunused-packages -threaded -rtsopts
-
+  ghc-options:    -threaded -rtsopts
   build-depends:
     , http-types
     , hydra-cardano-api

--- a/plutus-cbor/plutus-cbor.cabal
+++ b/plutus-cbor/plutus-cbor.cabal
@@ -73,7 +73,6 @@ library
   hs-source-dirs:  src
   ghc-options:     -haddock
   build-depends:
-    , plutus-core
     , plutus-tx
     , plutus-tx-plugin
 
@@ -89,17 +88,13 @@ test-suite tests
   build-depends:
     , base
     , base16-bytestring
-    , binary
     , bytestring
     , cborg
-    , containers
     , hspec
     , hydra-prelude
     , hydra-test-utils   >=0.10.0
     , plutus-cbor
-    , plutus-ledger-api  >=1.1.0.0
     , plutus-tx
-    , plutus-tx-plugin
     , QuickCheck
 
   other-modules:
@@ -114,13 +109,10 @@ benchmark bench
   ghc-options:        -threaded -rtsopts
   build-tool-depends: hspec-discover:hspec-discover
   build-depends:
-    , base
     , bytestring
-    , cborg
     , criterion
     , hydra-prelude
     , plutus-cbor
-    , plutus-core
     , plutus-ledger-api  >=1.1.0.0
     , plutus-tx
     , QuickCheck
@@ -133,17 +125,13 @@ executable encoding-cost
   other-modules:  Plutus.Codec.CBOR.Encoding.Validator
   build-depends:
     , base
-    , base16-bytestring
     , binary
     , bytestring
-    , cardano-ledger-alonzo
-    , containers
-    , hspec
-    , hydra-prelude
-    , hydra-test-utils       >=0.10.0
-    , plutus-cbor
     , hydra-plutus-extras
-    , plutus-ledger-api      >=1.1.0.0
+    , hydra-prelude
+    , hydra-test-utils     >=0.10.0
+    , plutus-cbor
+    , plutus-ledger-api    >=1.1.0.0
     , plutus-tx
     , plutus-tx-plugin
     , QuickCheck

--- a/plutus-merkle-tree/plutus-merkle-tree.cabal
+++ b/plutus-merkle-tree/plutus-merkle-tree.cabal
@@ -91,9 +91,7 @@ test-suite tests
   build-tool-depends: hspec-discover:hspec-discover
   build-depends:
     , base
-    , base16-bytestring
     , bytestring
-    , containers
     , hspec
     , hydra-prelude
     , hydra-test-utils
@@ -117,16 +115,12 @@ benchmark on-chain-cost
   build-depends:
     , base
     , bytestring
-    , cardano-binary
-    , cardano-ledger-alonzo
-    , containers
     , directory
     , filepath
     , hydra-plutus-extras
     , hydra-prelude
-    , hydra-test-utils       >=0.10.0
-    , plutus-core
-    , plutus-ledger-api      >=1.1.0.0
+    , hydra-test-utils    >=0.10.0
+    , plutus-ledger-api   >=1.1.0.0
     , plutus-merkle-tree
     , plutus-tx
     , plutus-tx-plugin


### PR DESCRIPTION
* We have not had enabled -Wunused-packages in all components and several
build-depends are actually not needed.

  - Note that we do not enable -Wunused-packages in components which use the
plutus-tx-plugin as this would always be detected as unused.

* Also narrows down bounds for `cardano-..` dependencies on `hydra-cardano-api` and `hydra-node` to make it easier to bump index-state in the future (constraints help the solver á la "constraints liberate")

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
