### PR TITLE
Build binaries for aarch64-darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,8 +21,7 @@
     flake-utils.lib.eachSystem [
       "x86_64-linux"
       "x86_64-darwin"
-      # XXX: Disabled until cardano-node releases a verison supporting this
-      # "aarch64-darwin"
+      "aarch64-darwin"
     ]
       (system:
       let

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -12,8 +12,6 @@
 let
   inherit (hydraProject) compiler pkgs hsPkgs;
 
-  cardano-node-pkgs = cardano-node.packages.${system};
-
   cabal = pkgs.haskell-nix.cabal-install.${compiler};
 
   haskell-language-server = pkgs.haskell-nix.tool compiler "haskell-language-server" rec {
@@ -45,8 +43,9 @@ let
     pkgs.plantuml
     # For plotting results of hydra-cluster benchmarks
     pkgs.gnuplot
+  ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [
     # For integration tests
-    cardano-node-pkgs.cardano-node
+    cardano-node.packages.${system}.cardano-node
   ];
 
   devInputs = if withoutDevTools then [ ] else [
@@ -66,8 +65,9 @@ let
     # For docs/ (i.e. Docusaurus, Node.js & React)
     pkgs.yarn
     pkgs.nodejs
+  ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [
     # To interact with cardano-node and testing out things
-    cardano-node-pkgs.cardano-cli
+    cardano-node.packages.${system}.cardano-cli
   ];
 
   haskellNixShell = hsPkgs.shellFor {
@@ -99,6 +99,15 @@ let
     LANG = "en_US.UTF-8";
 
     GIT_SSL_CAINFO = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+
+    shellHook = ''
+      if [ ! which cardano-node ]; then
+        echo "WARNING: 'cardano-node' not found"
+      fi
+      if [ ! which cardano-cli ]; then
+        echo "WARNING: 'cardano-cli' not found"
+      fi
+    '';
   };
 
   # A "cabal-only" shell which does not use haskell.nix
@@ -129,10 +138,11 @@ let
     name = "hydra-node-exe-shell";
 
     buildInputs = [
-      cardano-node-pkgs.cardano-node
-      cardano-node-pkgs.cardano-cli
       hsPkgs.hydra-node.components.exes.hydra-node
       hsPkgs.hydra-cluster.components.exes.hydra-cluster
+    ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [
+      cardano-node.packages.${system}.cardano-node
+      cardano-node.packages.${system}.cardano-cli
     ];
   };
 
@@ -140,11 +150,12 @@ let
   demoShell = pkgs.mkShell {
     name = "hydra-demo-shell";
     buildInputs = [
-      cardano-node-pkgs.cardano-node
-      cardano-node-pkgs.cardano-cli
       hsPkgs.hydra-node.components.exes.hydra-node
       hsPkgs.hydra-tui.components.exes.hydra-tui
       run-tmux
+    ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [
+      cardano-node.packages.${system}.cardano-node
+      cardano-node.packages.${system}.cardano-cli
     ];
   };
 


### PR DESCRIPTION
* Make the nix-based [Hydra CI](https://ci.iog.io/project/input-output-hk-hydra) build aarch64-darwin binaries.

* ~~Also build muslc binaries in that workflow to make them available to our users (not published in this PR).~~

For this PR, the aarch64-darwin jobs should show up here: https://ci.iog.io/jobset/input-output-hk-hydra/pullrequest-1024#tabs-evaluations

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
