### PR TITLE
Fix dialog lens in hydra-tui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ changes.
 - Created `hydra-plutus-extras` package to re-use some utilities better between
   packages.
 
+- Fixed a bug in the `hydra-tui` dialogs where recipient and UTxO to spend where
+  not correctly selected.
+
 ## [0.11.0] - 2023-06-30
 
 This release contains breaking changes of the persistence and on-chain scripts

--- a/hydra-tui/hydra-tui.cabal
+++ b/hydra-tui/hydra-tui.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          hydra-tui
-version:       0.11.0
+version:       0.12.0
 synopsis:      TUI for managing a Hydra node
 description:   TUI for managing a Hydra node
 author:        IOG

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -492,10 +492,7 @@ handleNewTxEvent Client{sendInput, sk} CardanoClient{networkId} s = case s ^? he
    where
     title = "Select a recipient"
     form =
-      let field =
-            radioField
-              (lens id const)
-              [(u, show u, decodeUtf8 $ encodePretty u) | u <- nub addresses]
+      let field = radioField id [(u, show u, decodeUtf8 $ encodePretty u) | u <- nub addresses]
           addresses = getRecipientAddress <$> Map.elems utxo
           getRecipientAddress TxOut{txOutAddress = addr} = addr
        in newForm [field] (Prelude.head addresses)
@@ -512,7 +509,7 @@ handleNewTxEvent Client{sendInput, sk} CardanoClient{networkId} s = case s ^? he
 
     form =
       -- NOTE(SN): use 'Integer' because we don't have a 'Read Lovelace'
-      let field = editShowableFieldWithValidate (lens id (\_ newValue -> newValue)) "amount" (\n -> n > 0 && n <= limit)
+      let field = editShowableFieldWithValidate id "amount" (\n -> n > 0 && n <= limit)
        in newForm [field] limit
 
     submit s' amount = do
@@ -841,7 +838,7 @@ utxoRadioField ::
   [s -> FormFieldState s e n]
 utxoRadioField u =
   [ radioField
-      (lens id const)
+      id
       [ (i, show i, UTxO.render i)
       | i <- Map.toList u
       ]


### PR DESCRIPTION
Selecting recipients and UTxO to spend was broken due to the use of 'const' which yielded always the same entry in the list.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
