### PR TITLE
Add hydra-scripts-tx-id flag to readme instructions on hydra-cluster

### DIFF
--- a/hydra-cluster/README.md
+++ b/hydra-cluster/README.md
@@ -49,13 +49,17 @@ signing key safely stored. See how the C.I overrides these files in
 To run the smoke test against the official cardano testnet using a
 local `state-testnet` directory (to re-use the synchronized chain db):
 
+Note: To get the transaction id for `--hydra-scripts-tx-id` parameter you can
+consult our [release page](https://github.com/input-output-hk/hydra/releases)
+where you can find pre-published Hydra scripts for different networks.
+
 ```sh
-hydra-cluster --preview --state-directory state-testnet --hydra-scripts-tx-id 4793d318ec98741c0eebff7c62af6389a860c6e51c4fa1961cc5b7eab5a46f58
+hydra-cluster --preview --state-directory state-testnet --hydra-scripts-tx-id <tx-id>
 ```
 
 > Note: If you want to do it on mainnet
 > ```sh
-> hydra-cluster --mainnet --state-directory state-mainnet --hydra-scripts-tx-id eb4c5f213ffb646046cf1d3543ae240ac922deccdc99826edd9af8ad52ddb877
+> hydra-cluster --mainnet --state-directory state-mainnet --hydra-scripts-tx-id <tx-id>
 > ```
 
 :warning: the C.I. overrides these files for mainnet. On the C.I. the

--- a/hydra-cluster/README.md
+++ b/hydra-cluster/README.md
@@ -55,7 +55,7 @@ hydra-cluster --preview --state-directory state-testnet --hydra-scripts-tx-id 47
 
 > Note: If you want to do it on mainnet
 > ```sh
-> hydra-cluster --mainnet --state-directory state-mainnet
+> hydra-cluster --mainnet --state-directory state-mainnet --hydra-scripts-tx-id eb4c5f213ffb646046cf1d3543ae240ac922deccdc99826edd9af8ad52ddb877
 > ```
 
 :warning: the C.I. overrides these files for mainnet. On the C.I. the

--- a/hydra-cluster/README.md
+++ b/hydra-cluster/README.md
@@ -50,7 +50,7 @@ To run the smoke test against the official cardano testnet using a
 local `state-testnet` directory (to re-use the synchronized chain db):
 
 ```sh
-hydra-cluster --preview --state-directory state-testnet
+hydra-cluster --preview --state-directory state-testnet --hydra-scripts-tx-id 4793d318ec98741c0eebff7c62af6389a860c6e51c4fa1961cc5b7eab5a46f58
 ```
 
 > Note: If you want to do it on mainnet


### PR DESCRIPTION
NOTE: We still need to take care of updating this on each release so maybe we need to add some more code to our release.sh script to handle this.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
