### PR TITLE
Simplify some things in hydraw

### DIFF
--- a/hydra-cardano-api/hydra-cardano-api.cabal
+++ b/hydra-cardano-api/hydra-cardano-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          hydra-cardano-api
-version:       0.12.0
+version:       0.13.0
 synopsis:      A Haskell API for Cardano, tailored to the Hydra project.
 author:        IOG
 copyright:     2022 IOG

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Pretty.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Pretty.hs
@@ -48,6 +48,8 @@ renderTxWithUTxO utxo (Tx body _wits) =
       <> redeemerLines
       <> [""]
       <> requiredSignersLines
+      <> [""]
+      <> metadataLines
  where
   Api.ShelleyTxBody _lbody scripts scriptsData _auxData _validity = body
   outs = txOuts content
@@ -182,3 +184,8 @@ renderTxWithUTxO utxo (Tx body _wits) =
     "== REQUIRED SIGNERS" : case txExtraKeyWits content of
       Api.TxExtraKeyWitnessesNone -> ["[]"]
       Api.TxExtraKeyWitnesses xs -> ("- " <>) . show <$> xs
+
+  metadataLines =
+    [ "== REQUIRED SIGNERS"
+    , show (txMetadata content)
+    ]

--- a/hydraw/app/Main.hs
+++ b/hydraw/app/Main.hs
@@ -31,6 +31,7 @@ main = do
       & Warp.runSettings settings
  where
   port = 1337
+
   settings =
     Warp.defaultSettings
       & Warp.setPort port

--- a/hydraw/hydraw.cabal
+++ b/hydraw/hydraw.cabal
@@ -56,7 +56,6 @@ library
   build-depends:
     , aeson
     , base
-    , containers
     , hydra-cardano-api
     , hydra-node
     , hydra-prelude
@@ -73,7 +72,6 @@ executable hydraw
     , hydra-node
     , hydra-prelude
     , hydraw
-    , io-classes
     , safe
     , wai
     , wai-websockets

--- a/hydraw/src/Hydra/Painter.hs
+++ b/hydraw/src/Hydra/Painter.hs
@@ -2,17 +2,18 @@
 
 module Hydra.Painter where
 
+import Hydra.Cardano.Api
+import Hydra.Prelude
+
 import Control.Exception (IOException)
 import qualified Data.Aeson as Aeson
 import qualified Data.Map as Map
 import Hydra.API.ClientInput (ClientInput (GetUTxO, NewTx))
 import Hydra.API.ServerOutput (ServerOutput (GetUTxOResponse))
-import Hydra.Cardano.Api
 import Hydra.Chain.Direct.State ()
 import Hydra.Chain.Direct.Util (readFileTextEnvelopeThrow)
 import Hydra.Ledger.Cardano (emptyTxBody)
 import Hydra.Network (Host (..))
-import Hydra.Prelude
 import Network.WebSockets (
   Connection,
   runClient,

--- a/hydraw/src/Hydra/Painter.hs
+++ b/hydraw/src/Hydra/Painter.hs
@@ -47,9 +47,13 @@ paintPixel networkId signingKeyPath cnx pixel = do
     race_ (threadDelay 0.25) (void (receive cnx) >> flushQueue cnx)
 
 withClient :: Host -> (Connection -> IO ()) -> IO ()
-withClient Host{hostname, port} action = retry
+withClient Host{hostname, port} action =
+  retry
  where
-  retry = runClient (toString hostname) (fromIntegral port) "/" action `catch` \(_ :: IOException) -> retry
+  retry = do
+    putTextLn $ "Connecting to Hydra API on " <> hostname <> ":" <> show port <> ".."
+    runClient (toString hostname) (fromIntegral port) "/" action
+      `catch` \(e :: IOException) -> print e >> threadDelay 1 >> retry
 
 -- | Create a zero-fee, payment cardano transaction.
 mkPaintTx ::

--- a/hydraw/static/index.html
+++ b/hydraw/static/index.html
@@ -29,7 +29,7 @@
       })();
     </script>
     <footer>
-      Powered by <img width=32 src="https://ucarecdn.com/9d697897-6aec-4664-801d-e432df594520/-/format/webp/-/resize/100/" /> + <img width=32 src="https://https://hydra.family/head-protocol/img/hydra.png" />
+      Powered by <img width=32 src="https://ucarecdn.com/9d697897-6aec-4664-801d-e432df594520/-/format/webp/-/resize/100/" /> + <img width=32 src="https://hydra.family/head-protocol/img/hydra.png" />
     </footer>
     <script src="bundle.js"></script>
   </body>


### PR DESCRIPTION
Various modifications I made when preparing hydraw for a live coding session. Mostly simplifications with the exception of requiring a `HYDRAW_NETWORK` to be set now, which is also now following the parsing semantics of `cardano-cli`

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
