### PR TITLE
Use QueryTip for local state queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ changes.
 
 ## [0.13.0] - UNRELEASED
 
+- Added retries for local cardano-node queries. We witnessed these queries to
+  fail in case of a rollback so we ignore errors and retry for 5 times before
+  letting the query fail.
+
+
 - **BREAKING** Changes to `hydra-plutus` scripts.
 
 - Add option to draft a commit tx using inline datums.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ changes.
 
 ## [0.13.0] - UNRELEASED
 
-- Added retries for local cardano-node queries. We witnessed these queries to
-  fail in case of a rollback so we ignore errors and retry for 5 times before
-  letting the query fail.
+- Query at the tip for local cardano-node queries. We witnessed these queries
+  failing in case of a rollback and always querying at the tip seems to fix
+  this.
 
 
 - **BREAKING** Changes to `hydra-plutus` scripts.

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -163,9 +163,9 @@ mkTinyWallet tracer config = do
     point <- case queryPoint of
       QueryAt point -> pure point
       QueryTip -> queryTip networkId nodeSocket
-    walletUTxO <- Ledger.unUTxO . toLedgerUTxO <$> queryUTxO networkId nodeSocket (QueryAt point) [address]
-    BundleAsShelleyBasedProtocolParameters _ pparams <- queryProtocolParameters networkId nodeSocket (QueryAt point)
-    systemStart <- querySystemStart networkId nodeSocket (QueryAt point)
+    walletUTxO <- Ledger.unUTxO . toLedgerUTxO <$> queryUTxO networkId nodeSocket QueryTip [address]
+    BundleAsShelleyBasedProtocolParameters _ pparams <- queryProtocolParameters networkId nodeSocket QueryTip
+    systemStart <- querySystemStart networkId nodeSocket QueryTip
     epochInfo <- queryEpochInfo
     pure $ WalletInfoOnChain{walletUTxO, pparams, systemStart, epochInfo, tip = point}
 


### PR DESCRIPTION
fix #560 


- Attempt to fix the issue of hydra-node crashing after doing a local query to cardano-node using retry strategy for 5 times.
Note: Retry attempts should probably come from a configuration value.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
