### PR TITLE
Add hydra-node configuration file parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ changes.
 
 ## [0.13.0] - UNRELEASED
 
+- Provide the option to specify arguments to hydra-node as a configuration file.
+
 - **BREAKING** Changes to `hydra-plutus` scripts.
 
 - Add option to draft a commit tx using inline datums.

--- a/hydra-node.example.yaml
+++ b/hydra-node.example.yaml
@@ -1,0 +1,28 @@
+apiHost:
+  ipv4: 127.0.0.1
+  tag: IPv4
+apiPort: 4001
+chainConfig:
+  cardanoSigningKey: cardano.sk
+  cardanoVerificationKeys: []
+  contestationPeriod: 60
+  networkId:
+    magic: 42
+    tag: Testnet
+  nodeSocket: node.socket
+  startChainFrom: null
+host:
+  ipv4: 127.0.0.1
+  tag: IPv4
+hydraScriptsTxId: "0101010101010101010101010101010101010101010101010101010101010101"
+hydraSigningKey: hydra.sk
+hydraVerificationKeys: []
+ledgerConfig:
+  cardanoLedgerProtocolParametersFile: protocol-parameters.json
+nodeId: 'node-id-1'
+peers: []
+persistenceDir: "./"
+port: 5001
+verbosity:
+  contents: HydraNode
+  tag: Verbose

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -51,12 +51,13 @@ import Hydra.Node (
 import Hydra.Node.EventQueue (EventQueue (..), createEventQueue)
 import Hydra.Options (
   ChainConfig (..),
-  Command (GenHydraKey, Publish, Run),
+  Command (GenHydraKey, Publish, RunWithArguments, RunWithConfig),
   GenerateKeyPair (GenerateKeyPair, outputFile),
   LedgerConfig (..),
   PublishOptions (..),
   RunOptions (..),
   explain,
+  parseConfigurationOrFail,
   parseHydraCommand,
   validateRunOptions,
  )
@@ -67,7 +68,11 @@ main :: IO ()
 main = do
   command <- parseHydraCommand
   case command of
-    Run options -> do
+    RunWithArguments options -> do
+      either (die . explain) pure $ validateRunOptions options
+      run (identifyNode options)
+    RunWithConfig configFilePath -> do
+      options <- parseConfigurationOrFail configFilePath
       either (die . explain) pure $ validateRunOptions options
       run (identifyNode options)
     Publish options ->

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -190,6 +190,7 @@ library
     , wai-websockets
     , warp
     , websockets
+    , yaml
 
   ghc-options:     -haddock
 


### PR DESCRIPTION
fix #1054 

- This PR adds option to specify hydra-node arguments as a configuration file. The _old_ way, using the arguments still works, so this is not a breaking change.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
