### PR TITLE
Restore benchmark publication in PR

### DIFF
--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -193,12 +193,11 @@ jobs:
       id: comment-body
       run: |
         # Drop first 5 header lines and demote headlines one level
-        body="$(cat artifact/transaction-cost.md | sed '1,5d;s/^#/##/')"
+        body="$(cat <(cat artifact/transaction-cost.md | sed '1,5d;s/^#/##/') <(cat artifact/end-to-end-benchmarks.md | sed '1,5d;s/^#/##/') | grep -v '^:::')"
         body="${body//'%'/'%25'}"
         body="${body//$'\n'/'%0A'}"
         body="${body//$'\r'/'%0D'}"
         echo "::set-output name=body::$body"
-
     - name: 🔎 Find Comment
       uses: peter-evans/find-comment@v2
       id: find-comment


### PR DESCRIPTION
Benchmark publication has been accidentally removed with #1070 as it was only included in the experimental CI.

For instance, it was:
* present in #1009  (see End-To-End Benchmark Results)
* absent from #1075

This PR is restoring it as it was.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
