### PR TITLE
Make hydra-cluster --devnet open a head

### DIFF
--- a/hydra-cluster/exe/hydra-cluster/Main.hs
+++ b/hydra-cluster/exe/hydra-cluster/Main.hs
@@ -7,9 +7,9 @@ import CardanoNode (withCardanoNodeDevnet, withCardanoNodeOnKnownNetwork)
 import Hydra.Cluster.Faucet (publishHydraScriptsAs)
 import Hydra.Cluster.Fixture (Actor (Faucet))
 import Hydra.Cluster.Options (Options (..), PublishOrReuse (Publish, Reuse), parseOptions)
-import Hydra.Cluster.Scenarios (singlePartyHeadFullLifeCycle)
+import Hydra.Cluster.Scenarios (singlePartyHeadFullLifeCycle, singlePartyOpenAHead)
 import Hydra.Logging (Verbosity (Verbose), traceWith, withTracer)
-import HydraNode (EndToEndLog (..))
+import HydraNode (EndToEndLog (..), HydraClient (..))
 import Options.Applicative (ParserInfo, execParser, fullDesc, header, helper, info, progDesc)
 import Test.Hydra.Prelude (withTempDir)
 
@@ -30,8 +30,9 @@ run options =
               >>= singlePartyHeadFullLifeCycle tracer workDir node
         Nothing ->
           withCardanoNodeDevnet fromCardanoNode workDir $ \node -> do
-            publishOrReuseHydraScripts tracer node
-              >> forever (threadDelay 60) -- do nothing
+            txId <- publishOrReuseHydraScripts tracer node
+            singlePartyOpenAHead tracer workDir node txId $ \HydraClient{} -> do
+              forever (threadDelay 60) -- do nothing
  where
   Options{knownNetwork, stateDirectory, publishHydraScripts} = options
 

--- a/hydra-cluster/src/Hydra/Cluster/Options.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Options.hs
@@ -35,9 +35,11 @@ parseOptions =
             <> help
               ( toString $
                   unlines
-                    [ "Run cardano-node over a devnet and stand-by. This is useful when one"
-                    , "wants to have a local devnet possibly primed with Hydra contracts and"
-                    , "use it for testing"
+                    [ "Create a local cardano devnet by running a cardano-node, "
+                    , "start a hydra-node and open a single-party head in it. "
+                    , "Generates a wallet key pair and commits some into the head using it. "
+                    , "The keys are available on the state-directory. This is useful as a "
+                    , "sandbox for development and testing."
                     ]
               )
         )

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -34,6 +34,7 @@ import Hydra.API.HTTPServer (
  )
 import Hydra.Cardano.Api (
   BabbageEra,
+  File (File),
   Lovelace (..),
   PlutusScriptV2,
   Tx,
@@ -49,6 +50,7 @@ import Hydra.Cardano.Api (
   selectLovelace,
   signTx,
   toScriptData,
+  writeFileTextEnvelope,
  )
 import Hydra.Cardano.Api.Prelude (ReferenceScript (..), TxOut (..), TxOutDatum (..))
 import Hydra.Chain (HeadId)
@@ -210,6 +212,10 @@ singlePartyOpenAHead tracer workDir node hydraScriptsTxId callback =
         <&> \config -> config{networkId, startChainFrom = Just tip}
 
     (walletVk, walletSk) <- generate genKeyPair
+    let keyPath = workDir <> "/wallet.sk"
+    _ <- writeFileTextEnvelope (File keyPath) Nothing walletSk
+    traceWith tracer CreatedKey{keyPath}
+
     utxoToCommit <- seedFromFaucet node walletVk 100_000_000 (contramap FromFaucet tracer)
 
     withHydraNode tracer aliceChainConfig workDir 1 aliceSk [] [1] hydraScriptsTxId $ \n1 -> do

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -208,6 +208,7 @@ data EndToEndLog
   | RemainingFunds {actor :: String, utxo :: UTxO}
   | PublishedHydraScriptsAt {hydraScriptsTxId :: TxId}
   | UsingHydraScriptsAt {hydraScriptsTxId :: TxId}
+  | CreatedKey { keyPath :: FilePath }
   deriving (Eq, Show, Generic, ToJSON, FromJSON, ToObject)
 
 -- XXX: The two lists need to be of same length. Also the verification keys can


### PR DESCRIPTION
:mouse: Expands the scope of `hydra-cluster --devnet` to also run a `hydra-node` and open a single party head with some funds in it.

:mouse: This can be used to run the [kupo](https://github.com/CardanoSolutions/kupo) integration tests by setting `export HYDRA_HOST=0.0.0.0; export HYDRA_PORT=4001`, launching `hydra-cluster --devnet --publish-hydra-scripts` and then `cabal test` on kupo.

Related to #1078 

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
