### PR TITLE
Ensemble/complete mutations for commit validatior

### DIFF
--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
@@ -45,6 +45,7 @@ import Hydra.Ledger.Cardano (genAddressInEra, genVerificationKey)
 import Hydra.Party (Party, partyToChain)
 import Test.Hydra.Fixture (cperiod)
 import Test.QuickCheck (Property, choose, counterexample, elements, oneof, shuffle, suchThat)
+import Hydra.Contract.InitialError (InitialError(STNotBurned))
 
 --
 -- AbortTx
@@ -164,6 +165,8 @@ data AbortMutation
     ExtractValue
   | -- | State token is not burned
     DoNotBurnST
+    -- Here we want to check that the initial validator also fails on abort.
+  | DoNotBurnSTInitial
   deriving (Generic, Show, Enum, Bounded)
 
 genAbortMutation :: (Tx, UTxO) -> Gen SomeMutation
@@ -253,6 +256,9 @@ genAbortMutation (tx, utxo) =
               ++ divertFunds
     , SomeMutation (Just $ toErrorCode STNotBurnedError) DoNotBurnST
         <$> changeMintedTokens tx (valueFromList [(AssetId (headPolicyId testSeedInput) hydraHeadV1AssetName, 1)])
+    , SomeMutation (Just $ toErrorCode STNotBurned) DoNotBurnSTInitial
+        <$> changeMintedTokens tx (valueFromList [(AssetId (headPolicyId testSeedInput) hydraHeadV1AssetName, 1)])
+
     ]
 
 removePTFromMintedValue :: TxOut CtxUTxO -> Tx -> Value

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
@@ -20,7 +20,7 @@ import Hydra.Chain.Direct.Contract.Mutation (
   addPTWithQuantity,
   changeMintedValueQuantityFrom,
   isHeadOutput,
-  replacePolicyIdWith,
+  replacePolicyIdWith, changeMintedTokens,
  )
 import Hydra.Chain.Direct.Fixture (testNetworkId, testPolicyId, testSeedInput)
 import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry, registryUTxO)
@@ -28,6 +28,7 @@ import Hydra.Chain.Direct.Tx (
   UTxOWithScript,
   abortTx,
   mkHeadOutputInitial,
+  hydraHeadV1AssetName
  )
 import Hydra.Chain.Direct.TxSpec (drop3rd, genAbortableOutputs)
 import Hydra.ContestationPeriod (toChain)
@@ -249,8 +250,8 @@ genAbortMutation (tx, utxo) =
             , RemoveInput healthyHeadInput
             ]
               ++ divertFunds
-    , SomeMutation (Just $ toErrorCode STNotBurnedError) STNotBurned <$> do
-        pure $ Changes []
+    , SomeMutation (Just $ toErrorCode STNotBurnedError) STNotBurned <$>
+       changeMintedTokens tx (valueFromList [(AssetId (headPolicyId testSeedInput) hydraHeadV1AssetName,1)])
     ]
 
 removePTFromMintedValue :: TxOut CtxUTxO -> Tx -> Value

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
@@ -32,6 +32,7 @@ import Hydra.Chain.Direct.Tx (
 import Hydra.Chain.Direct.TxSpec (drop3rd, genAbortableOutputs)
 import Hydra.ContestationPeriod (toChain)
 import qualified Hydra.Contract.Commit as Commit
+import Hydra.Contract.CommitError (CommitError (..))
 import Hydra.Contract.Error (toErrorCode)
 import Hydra.Contract.HeadError (HeadError (..))
 import qualified Hydra.Contract.HeadState as Head
@@ -159,6 +160,8 @@ data AbortMutation
     MintOnAbort
   | -- | Not spend from v_head and also not burn anything to extract value.
     ExtractValue
+  | -- | State token is not burned
+    STNotBurned
   deriving (Generic, Show, Enum, Bounded)
 
 genAbortMutation :: (Tx, UTxO) -> Gen SomeMutation
@@ -246,6 +249,8 @@ genAbortMutation (tx, utxo) =
             , RemoveInput healthyHeadInput
             ]
               ++ divertFunds
+    , SomeMutation (Just $ toErrorCode STNotBurnedError) STNotBurned <$> do
+        pure $ Changes []
     ]
 
 removePTFromMintedValue :: TxOut CtxUTxO -> Tx -> Value

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
@@ -18,17 +18,18 @@ import Hydra.Chain.Direct.Contract.Mutation (
   Mutation (..),
   SomeMutation (..),
   addPTWithQuantity,
+  changeMintedTokens,
   changeMintedValueQuantityFrom,
   isHeadOutput,
-  replacePolicyIdWith, changeMintedTokens,
+  replacePolicyIdWith,
  )
 import Hydra.Chain.Direct.Fixture (testNetworkId, testPolicyId, testSeedInput)
 import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry, registryUTxO)
 import Hydra.Chain.Direct.Tx (
   UTxOWithScript,
   abortTx,
+  hydraHeadV1AssetName,
   mkHeadOutputInitial,
-  hydraHeadV1AssetName
  )
 import Hydra.Chain.Direct.TxSpec (drop3rd, genAbortableOutputs)
 import Hydra.ContestationPeriod (toChain)
@@ -162,7 +163,7 @@ data AbortMutation
   | -- | Not spend from v_head and also not burn anything to extract value.
     ExtractValue
   | -- | State token is not burned
-    STNotBurned
+    DoNotBurnST
   deriving (Generic, Show, Enum, Bounded)
 
 genAbortMutation :: (Tx, UTxO) -> Gen SomeMutation
@@ -250,8 +251,8 @@ genAbortMutation (tx, utxo) =
             , RemoveInput healthyHeadInput
             ]
               ++ divertFunds
-    , SomeMutation (Just $ toErrorCode STNotBurnedError) STNotBurned <$>
-       changeMintedTokens tx (valueFromList [(AssetId (headPolicyId testSeedInput) hydraHeadV1AssetName,1)])
+    , SomeMutation (Just $ toErrorCode STNotBurnedError) DoNotBurnST
+        <$> changeMintedTokens tx (valueFromList [(AssetId (headPolicyId testSeedInput) hydraHeadV1AssetName, 1)])
     ]
 
 removePTFromMintedValue :: TxOut CtxUTxO -> Tx -> Value

--- a/hydra-plutus/src/Hydra/Contract/Util.hs
+++ b/hydra-plutus/src/Hydra/Contract/Util.hs
@@ -49,7 +49,7 @@ mustNotMintOrBurn TxInfo{txInfoMint} =
 
 infix 4 ===
 
--- | Checks for exact exuality between two serialized values
+-- | Checks for exact equality between two serialized values.
 -- Equality on value is very memory intensive as it's defined on associative
 -- lists and `AssocMap` equality is implemented. Instead we can be more strict and
 -- require EXACTLY the same value and compare using the serialised bytes.


### PR DESCRIPTION
We noticed we were missing some checks in our mutation framework. Initially we didn't check that the commit and initial validators were not checking ST burning on abort.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
