### PR TITLE
Hydra tui fixes

### DIFF
--- a/hydra-tui/src/Hydra/TUI/Drawing.hs
+++ b/hydra-tui/src/Hydra/TUI/Drawing.hs
@@ -87,10 +87,16 @@ drawFocusPanelInitializing me InitializingState{remainingParties, initializingSc
 
 drawFocusPanelOpen :: NetworkId -> VerificationKey PaymentKey -> UTxO -> OpenScreen -> Widget Name
 drawFocusPanelOpen networkId vk utxo = \case
-  OpenHome -> drawUTxO (\a -> withAttr (if a == mkVkAddress networkId vk then own else mempty) $ drawAddress a) utxo
+  OpenHome ->
+    drawUTxO
+      (\a -> withAttr (if a == ownAddress then own else mempty) $ drawAddress a)
+      ownAddress
+      utxo
   SelectingUTxO x -> renderForm x
   EnteringAmount _ x -> renderForm x
   SelectingRecipient _ _ x -> renderForm x
+ where
+  ownAddress = mkVkAddress networkId vk
 
 drawFocusPanelClosed :: UTCTime -> ClosedState -> Widget Name
 drawFocusPanelClosed now (ClosedState{contestationDeadline}) = drawRemainingContestationPeriod contestationDeadline now
@@ -99,7 +105,15 @@ drawFocusPanelFinal :: NetworkId -> VerificationKey PaymentKey -> UTxO -> Widget
 drawFocusPanelFinal networkId vk utxo =
   padLeftRight 1 $
     txt ("Distributed UTXO, total: " <> renderValue (balance @Tx utxo))
-      <=> padLeft (Pad 2) (drawUTxO (\a -> withAttr (if a == mkVkAddress networkId vk then own else mempty) $ drawAddress a) utxo)
+      <=> padLeft
+        (Pad 2)
+        ( drawUTxO
+            (\a -> withAttr (if a == mkVkAddress networkId vk then own else mempty) $ drawAddress a)
+            ownAddress
+            utxo
+        )
+ where
+  ownAddress = mkVkAddress networkId vk
 
 drawFocusPanel :: NetworkId -> VerificationKey PaymentKey -> UTCTime -> Connection -> Widget Name
 drawFocusPanel networkId vk now (Connection{me, headState}) = case headState of
@@ -222,11 +236,11 @@ showHeadState = \case
     Closed{} -> "Closed"
     Final{} -> "Final"
 
-drawUTxO :: (AddressInEra -> Widget n) -> UTxO -> Widget n
-drawUTxO f utxo =
+drawUTxO :: (AddressInEra -> Widget n) -> AddressInEra -> UTxO -> Widget n
+drawUTxO f ownAddress utxo =
   let byAddress =
         Map.foldrWithKey
-          (\k v@TxOut{txOutAddress = addr} -> Map.unionWith (++) (Map.singleton addr [(k, v)]))
+          (\k v@TxOut{txOutAddress = addr} -> Map.unionWith (++) (if addr == ownAddress then Map.singleton addr [(k, v)] else mempty))
           mempty
           $ UTxO.toMap utxo
    in vBox

--- a/hydra-tui/src/Hydra/TUI/Drawing.hs
+++ b/hydra-tui/src/Hydra/TUI/Drawing.hs
@@ -89,7 +89,7 @@ drawFocusPanelOpen :: NetworkId -> VerificationKey PaymentKey -> UTxO -> OpenScr
 drawFocusPanelOpen networkId vk utxo = \case
   OpenHome ->
     drawUTxO
-      (\a -> withAttr (if a == ownAddress then own else mempty) $ drawAddress a)
+      (highlightOwnAddress ownAddress)
       ownAddress
       utxo
   SelectingUTxO x -> renderForm x
@@ -108,12 +108,16 @@ drawFocusPanelFinal networkId vk utxo =
       <=> padLeft
         (Pad 2)
         ( drawUTxO
-            (\a -> withAttr (if a == mkVkAddress networkId vk then own else mempty) $ drawAddress a)
+            (highlightOwnAddress ownAddress)
             ownAddress
             utxo
         )
  where
   ownAddress = mkVkAddress networkId vk
+
+highlightOwnAddress :: AddressInEra -> AddressInEra -> Widget n
+highlightOwnAddress ownAddress a =
+  withAttr (if a == ownAddress then own else mempty) $ drawAddress a
 
 drawFocusPanel :: NetworkId -> VerificationKey PaymentKey -> UTCTime -> Connection -> Widget Name
 drawFocusPanel networkId vk now (Connection{me, headState}) = case headState of


### PR DESCRIPTION
This PR fixes two TUI client bugs: 
 - Client displays all utxos present in the head instead only own utxos
 - When selecting recipients for a new tx our own address is present in a list
 
 These fixes enable easier time when demoing new hydra-node features (such as network resilience to crashes). Now we can easily select non-conflicting utxos so that we can demonstrate there are new SnapshotConfirmed messages even if we do multiple new txs while one of the node was down.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
