### PR TITLE
Fix hydra demo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,7 +170,7 @@ During development
 + Make sure `CHANGELOG.md` is kept up-to-date with high-level, technical, but user-focused list of changes according to [keepachangelog](https://keepachangelog.com/en/1.0.0/)
 + Bump `UNRELEASED` version in `CHANGELOG.md` according to [semver](https://semver.org/)
 + Ensure `unstable` version of docker images is used in demo
-  - `sed -i -e "s,\(ghcr.io/input-output-hk/hydra-[^:]*\):[^[:space:]]*,\1:unstable," demo/*`
+  - `sed -i.bak -e "s,\(ghcr.io/input-output-hk/hydra-[^:]*\):[^[:space:]]*,\1:unstable," demo/*`
 + All `hydra-` packages are versioned the same, at latest on release their versions are aligned.
 + Other packages are versioned independently of `hydra-` packages and keep a dedicated changelog.
 

--- a/demo/docker-compose.yaml
+++ b/demo/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
 
   hydra-node-1:
    # NOTE: Make sure to use the same image in ./seed-devnet.sh
-    image: ghcr.io/input-output-hk/hydra-node:0.14.0
+    image: ghcr.io/input-output-hk/hydra-node:unstable
     build:
       context: ../
       target: hydra-node
@@ -60,7 +60,7 @@ services:
 
   hydra-node-2:
     # NOTE: Make sure to use the same image in ./seed-devnet.sh
-    image: ghcr.io/input-output-hk/hydra-node:0.14.0
+    image: ghcr.io/input-output-hk/hydra-node:unstable
     build:
       context: ../
       target: hydra-node
@@ -97,7 +97,7 @@ services:
 
   hydra-node-3:
     # NOTE: Make sure to use the same image in ./seed-devnet.sh
-    image: ghcr.io/input-output-hk/hydra-node:0.14.0
+    image: ghcr.io/input-output-hk/hydra-node:unstable
     build:
       context: ../
       target: hydra-node
@@ -133,7 +133,7 @@ services:
     restart: always
 
   hydra-tui-1:
-    image: ghcr.io/input-output-hk/hydra-tui:0.14.0
+    image: ghcr.io/input-output-hk/hydra-tui:unstable
     build:
        context: ../
        target: hydra-tui
@@ -152,7 +152,7 @@ services:
         ipv4_address: 172.16.238.11
 
   hydra-tui-2:
-    image: ghcr.io/input-output-hk/hydra-tui:0.14.0
+    image: ghcr.io/input-output-hk/hydra-tui:unstable
     build:
        context: ../
        target: hydra-tui
@@ -171,7 +171,7 @@ services:
         ipv4_address: 172.16.238.21
 
   hydra-tui-3:
-    image: ghcr.io/input-output-hk/hydra-tui:0.14.0
+    image: ghcr.io/input-output-hk/hydra-tui:unstable
     build:
        context: ../
        target: hydra-tui

--- a/demo/prepare-devnet.sh
+++ b/demo/prepare-devnet.sh
@@ -13,8 +13,8 @@ cp -af "$BASEDIR/hydra-cluster/config/devnet/" "$TARGETDIR"
 cp -af "$BASEDIR/hydra-cluster/config/credentials" "$TARGETDIR"
 cp -af "$BASEDIR/hydra-cluster/config/protocol-parameters.json" "$TARGETDIR"
 echo '{"Producers": []}' > "$TARGETDIR/topology.json"
-sed -i "s/\"startTime\": [0-9]*/\"startTime\": $(date +%s)/" "$TARGETDIR/genesis-byron.json" && \
-sed -i "s/\"systemStart\": \".*\"/\"systemStart\": \"$(date -u +%FT%TZ)\"/" "$TARGETDIR/genesis-shelley.json"
+sed -i.bak "s/\"startTime\": [0-9]*/\"startTime\": $(date +%s)/" "$TARGETDIR/genesis-byron.json" && \
+sed -i.bak "s/\"systemStart\": \".*\"/\"systemStart\": \"$(date -u +%FT%TZ)\"/" "$TARGETDIR/genesis-shelley.json"
 
 find $TARGETDIR -type f -exec chmod 0400 {} \;
 mkdir "$TARGETDIR/ipc"

--- a/demo/seed-devnet.sh
+++ b/demo/seed-devnet.sh
@@ -49,7 +49,7 @@ function hnode() {
       docker run --rm -it \
         --pull always \
         -v ${SCRIPT_DIR}/devnet:/devnet \
-        ghcr.io/input-output-hk/hydra-node:0.14.0 -- ${@}
+        ghcr.io/input-output-hk/hydra-node:unstable -- ${@}
   fi
 }
 

--- a/release.sh
+++ b/release.sh
@@ -117,7 +117,7 @@ update_cabal_version() {
   
   for file in $cabal_files
   do
-    sed -i -e "s,\(^version: *\)[^ ]*,\1$version," $file
+    sed -i.bak -e "s,\(^version: *\)[^ ]*,\1$version," $file
   done
 }
 
@@ -125,20 +125,20 @@ update_api_version() {
   local version="$1" ; shift
   local api_file=hydra-node/json-schemas/api.yaml
 
-  sed -i -e "s,\(version: *\)'.*',\1'$version'," $api_file
+  sed -i.bak -e "s,\(version: *\)'.*',\1'$version'," $api_file
 }
 
 update_tutorial_version() {
   local version="$1"
   local tutorial_file=docs/docs/tutorial/index.md
-  sed -i -e "s,\(hydra/releases/download/)[^/]*,\1$version," $tutorial_file
+  sed -i.bak -e "s,\(hydra/releases/download/)[^/]*,\1$version," $tutorial_file
 }
 
 update_demo_version() {
   local version="$1"
   (
     cd demo
-    sed -i -e "s,\(ghcr.io/input-output-hk/hydra-[^:]*\):[^[:space:]]*,\1:$version," docker-compose.yaml seed-devnet.sh
+    sed -i.bak -e "s,\(ghcr.io/input-output-hk/hydra-[^:]*\):[^[:space:]]*,\1:$version," docker-compose.yaml seed-devnet.sh
   )
 }
 


### PR DESCRIPTION
The hydra-node versions on demo were pointing to an unreleased version, thus the reason for this PR.

Also took changed sed expressions to be portable as they were failing on my MacOs.

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
