### PR TITLE
Move -Werror from packages into project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,10 @@ Besides these general build instructions, some components might document
 additional steps and useful tools in their `README.md` files, e.g. the
 [docs](./docs/README.md) or the [hydra-cluster](./hydra-cluster/README.md)
 
+Warnings are treated as errors for the whole project. To ease development, it
+might be handy to it off locally in a `cabal.project.local` with: `cabal
+configure --ghc-options -Wwarn`.
+
 ### Coding standards
 
 Make sure to follow our [Coding

--- a/autotest.sh
+++ b/autotest.sh
@@ -45,7 +45,6 @@ FLAGS=$(echo "
     -XViewPatterns
     -fno-ignore-interface-pragmas
     -fno-omit-interface-pragmas
-    -fplugin-opt PlutusTx.Plugin:defer-errors
     -fobject-code
     -Wall
     -Wcompat

--- a/cabal.project
+++ b/cabal.project
@@ -36,15 +36,6 @@ package *
 tests: True
 benchmarks: True
 
-package hydra-plutus
-  haddock-options: "--optghc=-fplugin-opt PlutusTx.Plugin:defer-errors"
-
-package plutus-cbor
-  haddock-options: "--optghc=-fplugin-opt PlutusTx.Plugin:defer-errors"
-
-package plutus-merkle-tree
-  haddock-options: "--optghc=-fplugin-opt PlutusTx.Plugin:defer-errors"
-
 -- Fix compilation of strict-containers (see also nix/hydra/project.nix)
 package strict-containers
   ghc-options: "-Wno-noncanonical-monad-instances"

--- a/cabal.project
+++ b/cabal.project
@@ -32,13 +32,17 @@ packages:
 package *
   ghc-options: -j8
 
--- Always build tests and benchmarks
+-- Warnings as errors for local packages
+program-options
+  ghc-options: -Werror
+
+-- Always build tests and benchmarks of local packages
 tests: True
 benchmarks: True
+
+-- Always show detailed output for tests
+test-show-details: direct
 
 -- Fix compilation of strict-containers (see also nix/hydra/project.nix)
 package strict-containers
   ghc-options: "-Wno-noncanonical-monad-instances"
-
--- Always show detailed output for tests
-test-show-details: direct

--- a/hydra-cardano-api/hydra-cardano-api.cabal
+++ b/hydra-cardano-api/hydra-cardano-api.cabal
@@ -13,11 +13,6 @@ source-repository head
   type:     git
   location: https://github.com/input-output-hk/hydra
 
-flag hydra-development
-  description: Disable -Werror for development
-  default:     False
-  manual:      True
-
 common project-config
   default-language:   GHC2021
   default-extensions:
@@ -39,9 +34,6 @@ common project-config
     -Wall -Wcompat -Widentities -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
     -fprint-potential-instances
-
-  if !flag(hydra-development)
-    ghc-options: -Werror
 
 library
   import:          project-config

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -55,11 +55,6 @@ source-repository head
   type:     git
   location: https://github.com/input-output-hk/hydra
 
-flag hydra-development
-  description: Disable -Werror for development
-  default:     False
-  manual:      True
-
 common project-config
   default-language:   GHC2021
   default-extensions:
@@ -82,9 +77,6 @@ common project-config
     -Wall -Wcompat -Widentities -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
     -fprint-potential-instances
-
-  if !flag(hydra-development)
-    ghc-options: -Werror
 
 library
   import:          project-config

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -17,11 +17,6 @@ source-repository head
   type:     git
   location: https://github.com/input-output-hk/hydra
 
-flag hydra-development
-  description: Disable -Werror for development
-  default:     False
-  manual:      True
-
 common project-config
   default-language:   GHC2021
   default-extensions:
@@ -45,9 +40,6 @@ common project-config
     -Wall -Wcompat -Widentities -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
     -fprint-potential-instances
-
-  if !flag(hydra-development)
-    ghc-options: -Werror
 
 library
   import:          project-config
@@ -229,9 +221,7 @@ benchmark tx-cost
 
   ghc-options:    -threaded -rtsopts
 
-  if flag(hydra-development)
-    -- NOTE(SN): should fix HLS choking on PlutusTx plugin
-    ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
+  ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
 
 benchmark micro
   import:         project-config

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -221,8 +221,6 @@ benchmark tx-cost
 
   ghc-options:    -threaded -rtsopts
 
-  ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
-
 benchmark micro
   import:         project-config
   hs-source-dirs: bench/micro-bench

--- a/hydra-plutus-extras/hydra-plutus-extras.cabal
+++ b/hydra-plutus-extras/hydra-plutus-extras.cabal
@@ -15,11 +15,6 @@ source-repository head
   type:     git
   location: https://github.com/input-output-hk/hydra
 
-flag hydra-development
-  description: Disable -Werror for development
-  default:     False
-  manual:      True
-
 common project-config
   default-language:   GHC2021
   default-extensions:
@@ -42,9 +37,6 @@ common project-config
     -Wall -Wcompat -Widentities -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
     -fprint-potential-instances
-
-  if !flag(hydra-development)
-    ghc-options: -Werror
 
 library
   import:          project-config

--- a/hydra-plutus-extras/src/Hydra/Plutus/Extras.hs
+++ b/hydra-plutus-extras/src/Hydra/Plutus/Extras.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-specialize #-}
+
 module Hydra.Plutus.Extras (
   module Hydra.Plutus.Extras,
   module Hydra.Plutus.Extras.Time,

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -13,11 +13,6 @@ source-repository head
   type:     git
   location: https://github.com/input-output-hk/hydra
 
-flag hydra-development
-  description: Disable -Werror for development
-  default:     False
-  manual:      True
-
 common project-config
   default-language:   GHC2021
   default-extensions:
@@ -42,9 +37,6 @@ common project-config
     -Wnoncanonical-monad-instances -fobject-code
     -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
     -fno-strictness
-
-  if !flag(hydra-development)
-    ghc-options: -Werror
 
 library
   import:          project-config
@@ -86,9 +78,7 @@ library
     , template-haskell
     , time
 
-  if flag(hydra-development)
-    -- NOTE(SN): should fix HLS choking on PlutusTx plugin
-    ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
+  ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
 
 test-suite tests
   import:             project-config

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -78,8 +78,6 @@ library
     , template-haskell
     , time
 
-  ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
-
 test-suite tests
   import:             project-config
   ghc-options:        -threaded -rtsopts -with-rtsopts=-N

--- a/hydra-plutus/src/Hydra/Contract/Commit.hs
+++ b/hydra-plutus/src/Hydra/Contract/Commit.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-specialize #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 -- Avoid trace calls to be optimized away when inlining functions.
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-simplifier-inline #-}
 -- Plutus core version to compile to. In babbage era, that is Cardano protocol

--- a/hydra-plutus/src/Hydra/Contract/Hash.hs
+++ b/hydra-plutus/src/Hydra/Contract/Hash.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-specialize #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 -- Plutus core version to compile to. In babbage era, that is Cardano protocol
 -- version 7 and 8, only plutus-core version 1.0.0 is available.
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:target-version=1.0.0 #-}

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-specialize #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 -- Avoid trace calls to be optimized away when inlining functions.
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-simplifier-inline #-}
 -- Plutus core version to compile to. In babbage era, that is Cardano protocol

--- a/hydra-plutus/src/Hydra/Contract/HeadTokens.hs
+++ b/hydra-plutus/src/Hydra/Contract/HeadTokens.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-specialize #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 -- Avoid trace calls to be optimized away when inlining functions.
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-simplifier-inline #-}
 -- Plutus core version to compile to. In babbage era, that is Cardano protocol

--- a/hydra-plutus/src/Hydra/Contract/Initial.hs
+++ b/hydra-plutus/src/Hydra/Contract/Initial.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-specialize #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 -- Avoid trace calls to be optimized away when inlining functions.
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:no-simplifier-inline #-}
 -- Plutus core version to compile to. In babbage era, that is Cardano protocol

--- a/hydra-prelude/hydra-prelude.cabal
+++ b/hydra-prelude/hydra-prelude.cabal
@@ -40,4 +40,4 @@ library
     DerivingStrategies
     LambdaCase
 
-  ghc-options:        -Wall -Werror -Wcompat -Wunused-packages
+  ghc-options:        -Wall -Wcompat -Wunused-packages

--- a/hydra-test-utils/hydra-test-utils.cabal
+++ b/hydra-test-utils/hydra-test-utils.cabal
@@ -13,11 +13,6 @@ source-repository head
   type:     git
   location: https://github.com/input-output-hk/hydra
 
-flag hydra-development
-  description: Disable -Werror for development
-  default:     False
-  manual:      True
-
 common package-config
   default-language:   GHC2021
   default-extensions:
@@ -31,9 +26,6 @@ common package-config
   ghc-options:
     -Wall -Wcompat -Widentities -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
-
-  if !flag(hydra-development)
-    ghc-options: -Werror
 
 library
   import:          package-config

--- a/hydra-tui/hydra-tui.cabal
+++ b/hydra-tui/hydra-tui.cabal
@@ -14,11 +14,6 @@ source-repository head
   type:     git
   location: https://github.com/input-output-hk/hydra
 
-flag hydra-development
-  description: Disable -Werror for development
-  default:     False
-  manual:      True
-
 common project-config
   default-language:   GHC2021
   default-extensions:
@@ -40,9 +35,6 @@ common project-config
     -Wall -Wcompat -Widentities -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
     -fprint-potential-instances
-
-  if !flag(hydra-development)
-    ghc-options: -Werror
 
 library
   import:          project-config

--- a/nix/hydra/project.nix
+++ b/nix/hydra/project.nix
@@ -53,40 +53,28 @@ let
 
     inputMap = { "https://input-output-hk.github.io/cardano-haskell-packages" = CHaP; };
 
-    modules = [{
-      packages = {
-        # Strip debugging symbols from exes (smaller closures)
-        hydra-node.dontStrip = false;
-        hydra-tui.dontStrip = false;
-        hydraw.dontStrip = false;
-
-        # Fix compliation of strict-containers (see also cabal.project)
-        strict-containers.ghcOptions = [ "-Wno-noncanonical-monad-instances" ];
+    modules = [
+      # Strip debugging symbols from exes (smaller closures)
+      {
+        packages.hydra-node.dontStrip = false;
+        packages.hydra-tui.dontStrip = false;
+        packages.hydraw.dontStrip = false;
+      }
+      # Fix compliation of strict-containers (see also cabal.project)
+      {
+        packages.strict-containers.ghcOptions = [ "-Wno-noncanonical-monad-instances" ];
         # XXX: Could not figure out where to make this flag ^^^ effective in the haddock build
-        strict-containers.doHaddock = false;
-
-        # -Werror for CI
-
-        hydra-cardano-api.ghcOptions = [ "-Werror" ];
-        hydra-cluster.ghcOptions = [ "-Werror" ];
-        hydra-node.ghcOptions = [ "-Werror" ];
-        hydra-plutus.ghcOptions = [ "-Werror" ];
-        hydra-plutus-extras.ghcOptions = [ "-Werror" ];
-        hydra-prelude.ghcOptions = [ "-Werror" ];
-        hydra-test-utils.ghcOptions = [ "-Werror" ];
-        hydra-tui.ghcOptions = [ "-Werror" ];
-        hydraw.ghcOptions = [ "-Werror" ];
-        plutus-cbor.ghcOptions = [ "-Werror" ];
-        plutus-merkle-tree.ghcOptions = [ "-Werror" ];
-      };
-    }
+        packages.strict-containers.doHaddock = false;
+      }
+      # Fix compilation with newer ghc versions
       ({ lib, config, ... }:
         lib.mkIf (lib.versionAtLeast config.compiler.version "9.4") {
           # lib:ghc is a bit annoying in that it comes with it's own build-type:Custom, and then tries
           # to call out to all kinds of silly tools that GHC doesn't really provide.
           # For this reason, we try to get away without re-installing lib:ghc for now.
           reinstallableLibGhc = false;
-        })];
+        })
+    ];
   };
 in
 {

--- a/nix/hydra/project.nix
+++ b/nix/hydra/project.nix
@@ -53,33 +53,49 @@ let
 
     inputMap = { "https://input-output-hk.github.io/cardano-haskell-packages" = CHaP; };
 
-    modules = [
-      # Strip debugging symbols from exes (smaller closures)
-      {
-        packages.hydra-node.dontStrip = false;
-        packages.hydra-tui.dontStrip = false;
-        packages.hydraw.dontStrip = false;
-      }
-      # Avoid plutus-tx errors in haddock (see also cabal.project)
-      {
-        packages.hydra-plutus.setupHaddockFlags = [ "--ghc-options='-fplugin-opt PlutusTx.Plugin:defer-errors'" ];
-        packages.plutus-merkle-tree.setupHaddockFlags = [ "--ghc-options='-fplugin-opt PlutusTx.Plugin:defer-errors'" ];
-        packages.plutus-cbor.setupHaddockFlags = [ "--ghc-options='-fplugin-opt PlutusTx.Plugin:defer-errors'" ];
-      }
-      # Fix compliation of strict-containers (see also cabal.project)
-      {
-        packages.strict-containers.ghcOptions = [ "-Wno-noncanonical-monad-instances" ];
+    modules = [{
+      packages = {
+
+        # Strip debugging symbols from exes (smaller closures)
+        hydra-node.dontStrip = false;
+        hydra-tui.dontStrip = false;
+        hydraw.dontStrip = false;
+
+        # Avoid plutus-tx errors in haddock (see also cabal.project)
+        hydra-plutus.setupHaddockFlags = [ "--ghc-options='-fplugin-opt PlutusTx.Plugin:defer-errors'" ];
+
+        plutus-merkle-tree.setupHaddockFlags = [ "--ghc-options='-fplugin-opt PlutusTx.Plugin:defer-errors'" ];
+        plutus-cbor.setupHaddockFlags = [ "--ghc-options='-fplugin-opt PlutusTx.Plugin:defer-errors'" ];
+
+        # Fix compliation of strict-containers (see also cabal.project)
+        strict-containers.ghcOptions = [ "-Wno-noncanonical-monad-instances" ];
+
         # XXX: Could not figure out where to make this flag ^^^ effective in the haddock build
-        packages.strict-containers.doHaddock = false;
-      }
+        strict-containers.doHaddock = false;
+
+        # -Werror for CI
+
+        hydra-cardano-api.ghcOptions = [ "-Werror" ];
+        hydra-cluster.ghcOptions = [ "-Werror" ];
+        hydra-node.ghcOptions = [ "-Werror" ];
+        hydra-plutus.ghcOptions = [ "-Werror" ];
+        hydra-plutus-extras.ghcOptions = [ "-Werror" ];
+        hydra-prelude.ghcOptions = [ "-Werror" ];
+        hydra-test-utils.ghcOptions = [ "-Werror" ];
+        hydra-tui.ghcOptions = [ "-Werror" ];
+        hydraw.ghcOptions = [ "-Werror" ];
+        plutus-cbor.ghcOptions = [ "-Werror" ];
+        plutus-merkle-tree.ghcOptions = [ "-Werror" ];
+
+      };
+    }
       ({ lib, config, ... }:
         lib.mkIf (lib.versionAtLeast config.compiler.version "9.4") {
           # lib:ghc is a bit annoying in that it comes with it's own build-type:Custom, and then tries
           # to call out to all kinds of silly tools that GHC doesn't really provide.
           # For this reason, we try to get away without re-installing lib:ghc for now.
           reinstallableLibGhc = false;
-        })
-    ];
+        })];
   };
 in
 {

--- a/nix/hydra/project.nix
+++ b/nix/hydra/project.nix
@@ -55,21 +55,13 @@ let
 
     modules = [{
       packages = {
-
         # Strip debugging symbols from exes (smaller closures)
         hydra-node.dontStrip = false;
         hydra-tui.dontStrip = false;
         hydraw.dontStrip = false;
 
-        # Avoid plutus-tx errors in haddock (see also cabal.project)
-        hydra-plutus.setupHaddockFlags = [ "--ghc-options='-fplugin-opt PlutusTx.Plugin:defer-errors'" ];
-
-        plutus-merkle-tree.setupHaddockFlags = [ "--ghc-options='-fplugin-opt PlutusTx.Plugin:defer-errors'" ];
-        plutus-cbor.setupHaddockFlags = [ "--ghc-options='-fplugin-opt PlutusTx.Plugin:defer-errors'" ];
-
         # Fix compliation of strict-containers (see also cabal.project)
         strict-containers.ghcOptions = [ "-Wno-noncanonical-monad-instances" ];
-
         # XXX: Could not figure out where to make this flag ^^^ effective in the haddock build
         strict-containers.doHaddock = false;
 
@@ -86,7 +78,6 @@ let
         hydraw.ghcOptions = [ "-Werror" ];
         plutus-cbor.ghcOptions = [ "-Werror" ];
         plutus-merkle-tree.ghcOptions = [ "-Werror" ];
-
       };
     }
       ({ lib, config, ... }:

--- a/plutus-cbor/exe/encoding-cost/Plutus/Codec/CBOR/Encoding/Validator.hs
+++ b/plutus-cbor/exe/encoding-cost/Plutus/Codec/CBOR/Encoding/Validator.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-specialize #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 -- Plutus core version to compile to. Cardano protocol version 8 is only
 -- supporting plutus-core version 1.0.0.
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:target-version=1.0.0 #-}

--- a/plutus-cbor/plutus-cbor.cabal
+++ b/plutus-cbor/plutus-cbor.cabal
@@ -105,6 +105,4 @@ executable encoding-cost
     , QuickCheck
     , scientific
 
-  ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
-
   ghc-options:    -threaded -rtsopts

--- a/plutus-cbor/plutus-cbor.cabal
+++ b/plutus-cbor/plutus-cbor.cabal
@@ -13,11 +13,6 @@ source-repository head
   type:     git
   location: https://github.com/input-output-hk/hydra
 
-flag hydra-development
-  description: Disable -Werror for development
-  default:     False
-  manual:      True
-
 common project-config
   default-language:   GHC2021
   default-extensions:
@@ -40,9 +35,6 @@ common project-config
     -Wincomplete-uni-patterns -Wredundant-constraints
     -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
     -fno-strictness -fprint-potential-instances
-
-  if !flag(hydra-development)
-    ghc-options: -Werror
 
 library
   import:          project-config
@@ -113,8 +105,6 @@ executable encoding-cost
     , QuickCheck
     , scientific
 
-  if flag(hydra-development)
-    -- NOTE(SN): should fix HLS choking on PlutusTx plugin
-    ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
+  ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
 
   ghc-options:    -threaded -rtsopts

--- a/plutus-merkle-tree/bench/Validators.hs
+++ b/plutus-merkle-tree/bench/Validators.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-specialize #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
 -- Plutus core version to compile to. Cardano protocol version 8 is only
 -- supporting plutus-core version 1.0.0.
 {-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:target-version=1.0.0 #-}

--- a/plutus-merkle-tree/plutus-merkle-tree.cabal
+++ b/plutus-merkle-tree/plutus-merkle-tree.cabal
@@ -48,8 +48,6 @@ library
     , plutus-tx
     , text
 
-  ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
-
 test-suite tests
   import:             project-config
   type:               exitcode-stdio-1.0
@@ -92,5 +90,3 @@ benchmark on-chain-cost
     , plutus-tx
     , plutus-tx-plugin
     , QuickCheck
-
-  ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors

--- a/plutus-merkle-tree/plutus-merkle-tree.cabal
+++ b/plutus-merkle-tree/plutus-merkle-tree.cabal
@@ -13,11 +13,6 @@ source-repository head
   type:     git
   location: https://github.com/input-output-hk/hydra
 
-flag hydra-development
-  description: Disable -Werror for development
-  default:     False
-  manual:      True
-
 common project-config
   default-language:   GHC2021
   default-extensions:
@@ -41,9 +36,6 @@ common project-config
     -Wnoncanonical-monad-instances -fno-ignore-interface-pragmas
     -fno-omit-interface-pragmas -fno-strictness
 
-  if !flag(hydra-development)
-    ghc-options: -Werror
-
 library
   import:          project-config
   ghc-options:     -haddock
@@ -56,9 +48,7 @@ library
     , plutus-tx
     , text
 
-  if flag(hydra-development)
-    -- NOTE(SN): should fix HLS choking on PlutusTx plugin
-    ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
+  ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
 
 test-suite tests
   import:             project-config
@@ -103,6 +93,4 @@ benchmark on-chain-cost
     , plutus-tx-plugin
     , QuickCheck
 
-  if flag(hydra-development)
-    -- NOTE(SN): should fix HLS choking on PlutusTx plugin
-    ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
+  ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors


### PR DESCRIPTION
We should not have Werror on by default as it creates friction for downstream users consuming published releases of our libraries. If somebody includes our library in a build plan which does not match our development exactly, then that can issue a warning that will throw an error if Werror is set in our cabal files. Things which are innocuous such as StarIsType deprecations or ~ requires TypeOperator deprecations.

Users would then have to override our package in their build plan to add the development flag, which is needless work for developers.