### PR TITLE
Add a code formatting PR workflow

### DIFF
--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -24,6 +24,6 @@ jobs:
         name: cardano-scaling
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
-    - name: λ Check Haskell formatting
+    - name: 📐 Check code formatting
       run: |
-        nix develop .#ci --command bash -c "fourmolu --color always --check-idempotence --mode check **/*.hs"
+        nix develop .#ci --command treefmt --fail-on-change

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -1,0 +1,29 @@
+name: Check code formatting
+
+on:
+  pull_request:
+
+jobs:
+  formatting:
+    name: Check code formatting
+    runs-on: ubuntu-latest
+    steps:
+    - name: 📥 Checkout repository
+      uses: actions/checkout@v4
+
+    - name: ❄ Prepare nix
+      uses: cachix/install-nix-action@v23
+      with:
+        extra_nix_config: |
+          accept-flake-config = true
+          log-lines = 1000
+
+    - name: ❄ Cachix cache of nix derivations
+      uses: cachix/cachix-action@v12
+      with:
+        name: cardano-scaling
+        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
+
+    - name: λ Check Haskell formatting
+      run: |
+        nix develop .#ci --command bash -c "fourmolu --color always --check-idempotence --mode check **/*.hs"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,7 @@ you can:
 - Build & run the `hydra-node`: `cabal build hydra-node && cabal exec hydra-node -- --version`
 - Build & run all tests: `cabal test all`
 - Build & run all benchmarks: `cabal bench all`
+- Format code as enforced by CI: `treefmt`
 - Run `haskell-language-server` for an IDE experience
 - Run `hoogle` for symbol & documentation lookup
 

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -7,3 +7,6 @@ respectful: true # don't be too opinionated about newlines etc.
 haddock-style: single-line # '--' vs. '{-'
 newlines-between-decls: 1 # number of newlines between top-level declarations
 single-constraint-parens: never # whether or not to put braces around single constraints: https://fourmolu.github.io/config/single-constraint-parens/
+fixities:
+  - infixr 0 $
+  - infixr 1 &

--- a/hydra-cardano-api/src/Cardano/Api/UTxO.hs
+++ b/hydra-cardano-api/src/Cardano/Api/UTxO.hs
@@ -9,14 +9,14 @@
 module Cardano.Api.UTxO where
 
 import Cardano.Api hiding (UTxO, toLedgerUTxO)
-import qualified Cardano.Api
+import Cardano.Api qualified
 import Data.Coerce (coerce)
-import qualified Data.List as List
+import Data.List qualified as List
 import Data.Map (Map)
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Data.Set (Set)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Prelude
 
 type Era = BabbageEra

--- a/hydra-cardano-api/src/Hydra/Cardano/Api.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api.hs
@@ -148,14 +148,14 @@ import Hydra.Cardano.Api.Value as Extras
 import Hydra.Cardano.Api.VerificationKey ()
 import Hydra.Cardano.Api.Witness as Extras
 
-import qualified Cardano.Api
-import qualified Cardano.Api.Shelley
-import qualified Cardano.Ledger.Alonzo.TxAuxData as Ledger
-import qualified Cardano.Ledger.Alonzo.TxWits as Ledger
-import qualified Cardano.Ledger.Core as Ledger
-import qualified Cardano.Ledger.Keys as Ledger
-import qualified Cardano.Ledger.Keys.Bootstrap as Ledger
-import qualified Cardano.Ledger.Keys.WitVKey as Ledger
+import Cardano.Api qualified
+import Cardano.Api.Shelley qualified
+import Cardano.Ledger.Alonzo.TxAuxData qualified as Ledger
+import Cardano.Ledger.Alonzo.TxWits qualified as Ledger
+import Cardano.Ledger.Core qualified as Ledger
+import Cardano.Ledger.Keys qualified as Ledger
+import Cardano.Ledger.Keys.Bootstrap qualified as Ledger
+import Cardano.Ledger.Keys.WitVKey qualified as Ledger
 import Data.ByteString.Short (ShortByteString)
 import Prelude
 

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Address.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Address.hs
@@ -6,8 +6,8 @@ import Hydra.Cardano.Api.Prelude
 
 import Cardano.Api.Byron (Address (..))
 import Cardano.Binary (unsafeDeserialize')
-import qualified Cardano.Chain.Common as Ledger
-import qualified Data.ByteString as BS
+import Cardano.Chain.Common qualified as Ledger
+import Data.ByteString qualified as BS
 import Test.QuickCheck (frequency, oneof, vector)
 
 -- * Orphans

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/AddressInEra.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/AddressInEra.hs
@@ -3,11 +3,11 @@ module Hydra.Cardano.Api.AddressInEra where
 import Hydra.Cardano.Api.Prelude
 
 import Cardano.Api.Byron (Address (..))
-import qualified Cardano.Ledger.Address as Ledger
-import qualified Cardano.Ledger.BaseTypes as Ledger
-import qualified Cardano.Ledger.Credential as Ledger
-import qualified Cardano.Ledger.Hashes as Ledger
-import qualified Cardano.Ledger.Keys as Ledger
+import Cardano.Ledger.Address qualified as Ledger
+import Cardano.Ledger.BaseTypes qualified as Ledger
+import Cardano.Ledger.Credential qualified as Ledger
+import Cardano.Ledger.Hashes qualified as Ledger
+import Cardano.Ledger.Keys qualified as Ledger
 import Hydra.Cardano.Api.Network (Network)
 import PlutusLedgerApi.V2 (
   Address (..),
@@ -15,7 +15,7 @@ import PlutusLedgerApi.V2 (
   StakingCredential (StakingHash, StakingPtr),
   fromBuiltin,
  )
-import qualified PlutusLedgerApi.V2 as Plutus
+import PlutusLedgerApi.V2 qualified as Plutus
 
 -- * Extras
 

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/BlockHeader.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/BlockHeader.hs
@@ -4,7 +4,7 @@ module Hydra.Cardano.Api.BlockHeader where
 
 import Hydra.Cardano.Api.Prelude
 
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Test.QuickCheck (vectorOf)
 
 unsafeBlockHeaderHashFromBytes :: HasCallStack => ByteString -> Hash BlockHeader

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/ExecutionUnits.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/ExecutionUnits.hs
@@ -2,7 +2,7 @@ module Hydra.Cardano.Api.ExecutionUnits where
 
 import Hydra.Cardano.Api.Prelude
 
-import qualified Cardano.Ledger.Alonzo.Scripts as Ledger
+import Cardano.Ledger.Alonzo.Scripts qualified as Ledger
 
 -- * Type Conversions
 

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Hash.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Hash.hs
@@ -2,12 +2,12 @@ module Hydra.Cardano.Api.Hash where
 
 import Hydra.Cardano.Api.Prelude
 
-import qualified Cardano.Ledger.Alonzo.TxInfo as Ledger
-import qualified Cardano.Ledger.Keys as Ledger
+import Cardano.Ledger.Alonzo.TxInfo qualified as Ledger
+import Cardano.Ledger.Keys qualified as Ledger
 import Cardano.Ledger.SafeHash (unsafeMakeSafeHash)
-import qualified Cardano.Ledger.Shelley.Scripts as Ledger
-import qualified Data.ByteString as BS
-import qualified PlutusLedgerApi.V2 as Plutus
+import Cardano.Ledger.Shelley.Scripts qualified as Ledger
+import Data.ByteString qualified as BS
+import PlutusLedgerApi.V2 qualified as Plutus
 
 -- | Convert a cardano-api 'Hash' into a plutus 'PubKeyHash'
 toPlutusKeyHash :: Hash PaymentKey -> Plutus.PubKeyHash

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/KeyWitness.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/KeyWitness.hs
@@ -2,18 +2,18 @@ module Hydra.Cardano.Api.KeyWitness where
 
 import Hydra.Cardano.Api.Prelude
 
-import qualified Cardano.Ledger.Alonzo.TxWits as Ledger
-import qualified Cardano.Ledger.Era as Ledger
-import qualified Cardano.Ledger.Keys as Ledger
-import qualified Cardano.Ledger.Shelley.API as Ledger
-import qualified Data.Set as Set
+import Cardano.Ledger.Alonzo.TxWits qualified as Ledger
+import Cardano.Ledger.Era qualified as Ledger
+import Cardano.Ledger.Keys qualified as Ledger
+import Cardano.Ledger.Shelley.API qualified as Ledger
+import Data.Set qualified as Set
 
 -- * Extras
 
 -- | Construct a 'KeyWitness' from a transaction id and credentials.
 signWith ::
   forall era.
-  (IsShelleyBasedEra era) =>
+  IsShelleyBasedEra era =>
   TxId ->
   SigningKey PaymentKey ->
   KeyWitness era

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Lovelace.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Lovelace.hs
@@ -2,7 +2,7 @@ module Hydra.Cardano.Api.Lovelace where
 
 import Hydra.Cardano.Api.Prelude
 
-import qualified Cardano.Ledger.Coin as Ledger
+import Cardano.Ledger.Coin qualified as Ledger
 
 -- * Extras
 

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Network.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Network.hs
@@ -3,7 +3,7 @@ module Hydra.Cardano.Api.Network (
   networkIdToNetwork,
 ) where
 
-import qualified Cardano.Api as Api
+import Cardano.Api qualified as Api
 import Cardano.Ledger.BaseTypes (Network (..))
 
 networkIdToNetwork :: Api.NetworkId -> Network

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/PlutusScript.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/PlutusScript.hs
@@ -4,10 +4,10 @@ module Hydra.Cardano.Api.PlutusScript where
 
 import Hydra.Cardano.Api.Prelude
 
-import qualified Cardano.Ledger.Alonzo.Language as Ledger
-import qualified Cardano.Ledger.Alonzo.Scripts as Ledger
-import qualified Data.ByteString.Short as SBS
-import qualified PlutusLedgerApi.Common as Plutus
+import Cardano.Ledger.Alonzo.Language qualified as Ledger
+import Cardano.Ledger.Alonzo.Scripts qualified as Ledger
+import Data.ByteString.Short qualified as SBS
+import PlutusLedgerApi.Common qualified as Plutus
 import Test.QuickCheck (listOf)
 
 -- * Type Conversions
@@ -26,7 +26,7 @@ fromLedgerScript = \case
 -- | Convert a cardano-api 'PlutusScript' into a cardano-ledger 'Script'.
 toLedgerScript ::
   forall lang.
-  (IsPlutusScriptLanguage lang) =>
+  IsPlutusScriptLanguage lang =>
   PlutusScript lang ->
   Ledger.AlonzoScript (ShelleyLedgerEra Era)
 toLedgerScript (PlutusScriptSerialised bytes) =

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/PolicyId.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/PolicyId.hs
@@ -2,7 +2,7 @@ module Hydra.Cardano.Api.PolicyId where
 
 import Hydra.Cardano.Api.Prelude
 
-import qualified Cardano.Ledger.Hashes as Ledger
+import Cardano.Ledger.Hashes qualified as Ledger
 
 toLedgerScriptHash :: PolicyId -> Ledger.ScriptHash StandardCrypto
 toLedgerScriptHash (PolicyId scriptHash) = toShelleyScriptHash scriptHash

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Prelude.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Prelude.hs
@@ -40,10 +40,10 @@ import Cardano.Api.Shelley hiding (
   toLedgerUTxO,
  )
 import Cardano.Api.UTxO (UTxO, UTxO' (..))
-import qualified Cardano.Crypto.Hash.Class as CC
-import qualified Cardano.Ledger.Babbage as Ledger
-import qualified Cardano.Ledger.Binary as Ledger
-import qualified Cardano.Ledger.Core as Ledger
+import Cardano.Crypto.Hash.Class qualified as CC
+import Cardano.Ledger.Babbage qualified as Ledger
+import Cardano.Ledger.Binary qualified as Ledger
+import Cardano.Ledger.Core qualified as Ledger
 import Cardano.Ledger.Crypto (StandardCrypto)
 import Cardano.Ledger.Era (EraCrypto)
 import Data.Aeson (FromJSON (..), ToJSON (..))

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Pretty.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Pretty.hs
@@ -1,21 +1,21 @@
 -- | Pretty printing transactions and utxo's
 module Hydra.Cardano.Api.Pretty where
 
-import qualified Hydra.Cardano.Api as Api
+import Hydra.Cardano.Api qualified as Api
 import Hydra.Cardano.Api.Prelude
 
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Binary (serialize)
-import qualified Cardano.Ledger.Alonzo.Scripts as Ledger
-import qualified Cardano.Ledger.Alonzo.TxWits as Ledger
-import qualified Cardano.Ledger.Core as Ledger
-import qualified Cardano.Ledger.SafeHash as Ledger
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString.Lazy as BL
+import Cardano.Ledger.Alonzo.Scripts qualified as Ledger
+import Cardano.Ledger.Alonzo.TxWits qualified as Ledger
+import Cardano.Ledger.Core qualified as Ledger
+import Cardano.Ledger.SafeHash qualified as Ledger
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy qualified as BL
 import Data.Function (on)
 import Data.List (intercalate, sort, sortBy)
-import qualified Data.Map.Strict as Map
-import qualified Data.Text as T
+import Data.Map.Strict qualified as Map
+import Data.Text qualified as T
 import Hydra.Cardano.Api.ScriptData (fromLedgerData)
 
 -- | Obtain a human-readable pretty text representation of a transaction.

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/ReferenceScript.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/ReferenceScript.hs
@@ -4,7 +4,7 @@ import Hydra.Cardano.Api.Prelude
 
 import Hydra.Cardano.Api.PlutusScript (fromPlutusScript)
 import Hydra.Cardano.Api.ReferenceTxInsScriptsInlineDatumsSupportedInEra (HasInlineDatums (..))
-import qualified PlutusLedgerApi.V2 as Plutus
+import PlutusLedgerApi.V2 qualified as Plutus
 
 -- | Construct a 'ReferenceScript' from any given Plutus script.
 --

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/ScriptData.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/ScriptData.hs
@@ -5,16 +5,16 @@ module Hydra.Cardano.Api.ScriptData where
 import Hydra.Cardano.Api.Prelude
 
 import Cardano.Api.Byron (TxBody (..))
-import qualified Cardano.Ledger.Alonzo.Scripts.Data as Ledger
-import qualified Cardano.Ledger.Alonzo.TxWits as Ledger
-import qualified Cardano.Ledger.Era as Ledger
+import Cardano.Ledger.Alonzo.Scripts.Data qualified as Ledger
+import Cardano.Ledger.Alonzo.TxWits qualified as Ledger
+import Cardano.Ledger.Era qualified as Ledger
 import Codec.Serialise (deserialiseOrFail, serialise)
 import Control.Arrow (left)
 import Data.Aeson (Value (String), withText)
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Base16 as Base16
-import qualified Data.Map as Map
-import qualified PlutusLedgerApi.V2 as Plutus
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as Base16
+import Data.Map qualified as Map
+import PlutusLedgerApi.V2 qualified as Plutus
 import Test.QuickCheck (arbitrarySizedNatural, choose, oneof, scale, sized, vector)
 
 -- * Extras

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/ScriptDatum.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/ScriptDatum.hs
@@ -7,6 +7,6 @@ import Hydra.Cardano.Api.ScriptData (ToScriptData, toScriptData)
 -- * Extras
 
 -- | Construct a 'ScriptDatum' for use as transaction witness.
-mkScriptDatum :: (ToScriptData a) => a -> ScriptDatum WitCtxTxIn
+mkScriptDatum :: ToScriptData a => a -> ScriptDatum WitCtxTxIn
 mkScriptDatum =
   ScriptDatumForTxIn . toScriptData

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/ScriptHash.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/ScriptHash.hs
@@ -2,7 +2,7 @@ module Hydra.Cardano.Api.ScriptHash where
 
 import Hydra.Cardano.Api.Prelude
 
-import qualified Cardano.Ledger.Credential as Ledger
+import Cardano.Ledger.Credential qualified as Ledger
 
 -- | Extract the payment part of an address, as a script hash.
 getPaymentScriptHash :: AddressInEra era -> Maybe ScriptHash

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Tx.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Tx.hs
@@ -9,14 +9,14 @@ import Hydra.Cardano.Api.KeyWitness (
  )
 import Hydra.Cardano.Api.TxScriptValidity (toLedgerScriptValidity)
 
-import qualified Cardano.Api.UTxO as UTxO
-import qualified Cardano.Ledger.Alonzo.TxWits as Ledger
-import qualified Cardano.Ledger.Babbage.Tx as Ledger
+import Cardano.Api.UTxO qualified as UTxO
+import Cardano.Ledger.Alonzo.TxWits qualified as Ledger
+import Cardano.Ledger.Babbage.Tx qualified as Ledger
 import Cardano.Ledger.BaseTypes (maybeToStrictMaybe, strictMaybeToMaybe)
-import qualified Cardano.Ledger.Core as Ledger (Tx, hashScript)
+import Cardano.Ledger.Core qualified as Ledger (Tx, hashScript)
 import Data.Bifunctor (bimap)
 import Data.Functor ((<&>))
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Hydra.Cardano.Api.TxIn (mkTxIn)
 
 -- * Extras

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/TxBody.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/TxBody.hs
@@ -8,20 +8,19 @@ import Hydra.Cardano.Api.ScriptData (FromScriptData)
 import Hydra.Cardano.Api.TxIn (toLedgerTxIn)
 import Hydra.Cardano.Api.Value (toLedgerPolicyID)
 
-import qualified Cardano.Ledger.Alonzo.Scripts.Data as Ledger
-import qualified Cardano.Ledger.Alonzo.TxWits as Ledger
-import qualified Cardano.Ledger.Babbage.Tx as Ledger
+import Cardano.Ledger.Alonzo.Scripts.Data qualified as Ledger
+import Cardano.Ledger.Alonzo.TxWits qualified as Ledger
+import Cardano.Ledger.Babbage.Tx qualified as Ledger
 import Cardano.Ledger.BaseTypes (strictMaybeToMaybe)
-import qualified Cardano.Ledger.Core as Ledger
+import Cardano.Ledger.Core qualified as Ledger
 import Data.List (find)
-import qualified Data.Map as Map
-import qualified PlutusLedgerApi.V2 as Plutus
+import Data.Map qualified as Map
+import PlutusLedgerApi.V2 qualified as Plutus
 
 -- | Find and deserialise from 'ScriptData', a redeemer from the transaction
 -- associated to the given input.
 findRedeemerSpending ::
-  ( FromScriptData a
-  ) =>
+  FromScriptData a =>
   Tx Era ->
   TxIn ->
   Maybe a
@@ -31,8 +30,7 @@ findRedeemerSpending (getTxBody -> ShelleyTxBody _ body _ scriptData _ _) txIn =
 
 findRedeemerMinting ::
   forall a.
-  ( FromScriptData a
-  ) =>
+  FromScriptData a =>
   Tx Era ->
   PolicyId ->
   Maybe a

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/TxId.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/TxId.hs
@@ -5,9 +5,9 @@ module Hydra.Cardano.Api.TxId where
 import Hydra.Cardano.Api.Prelude
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
-import qualified Cardano.Crypto.Hash.Class as CC
-import qualified Cardano.Ledger.SafeHash as Ledger
-import qualified Cardano.Ledger.TxIn as Ledger
+import Cardano.Crypto.Hash.Class qualified as CC
+import Cardano.Ledger.SafeHash qualified as Ledger
+import Cardano.Ledger.TxIn qualified as Ledger
 
 -- missing CBOR instances
 

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/TxIn.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/TxIn.hs
@@ -4,13 +4,13 @@ module Hydra.Cardano.Api.TxIn where
 
 import Hydra.Cardano.Api.Prelude
 
-import qualified Cardano.Ledger.Alonzo.TxInfo as Ledger
-import qualified Cardano.Ledger.BaseTypes as Ledger
-import qualified Cardano.Ledger.Binary as Ledger
-import qualified Cardano.Ledger.TxIn as Ledger
-import qualified Data.ByteString as BS
-import qualified Data.Set as Set
-import qualified PlutusLedgerApi.V2 as Plutus
+import Cardano.Ledger.Alonzo.TxInfo qualified as Ledger
+import Cardano.Ledger.BaseTypes qualified as Ledger
+import Cardano.Ledger.Binary qualified as Ledger
+import Cardano.Ledger.TxIn qualified as Ledger
+import Data.ByteString qualified as BS
+import Data.Set qualified as Set
+import PlutusLedgerApi.V2 qualified as Plutus
 import Test.QuickCheck (choose, vectorOf)
 
 -- * Extras

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/TxOut.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/TxOut.hs
@@ -5,11 +5,11 @@ import Hydra.Cardano.Api.Prelude
 import Hydra.Cardano.Api.TxIn (mkTxIn)
 import Hydra.Cardano.Api.TxOutValue (mkTxOutValue)
 
-import qualified Cardano.Api.UTxO as UTxO
-import qualified Cardano.Ledger.Babbage.TxInfo as Ledger
-import qualified Cardano.Ledger.Core as Ledger
-import qualified Cardano.Ledger.Credential as Ledger
-import qualified Data.List as List
+import Cardano.Api.UTxO qualified as UTxO
+import Cardano.Ledger.Babbage.TxInfo qualified as Ledger
+import Cardano.Ledger.Core qualified as Ledger
+import Cardano.Ledger.Credential qualified as Ledger
+import Data.List qualified as List
 import Hydra.Cardano.Api.AddressInEra (fromPlutusAddress)
 import Hydra.Cardano.Api.Hash (unsafeScriptDataHashFromBytes)
 import Hydra.Cardano.Api.Network (Network)
@@ -18,7 +18,7 @@ import Hydra.Cardano.Api.ScriptData (toScriptData)
 import Hydra.Cardano.Api.ScriptDataSupportedInEra (HasScriptData, scriptDataSupportedInEra)
 import Hydra.Cardano.Api.Value (fromPlutusValue, minUTxOValue)
 import PlutusLedgerApi.V2 (OutputDatum (..), fromBuiltin)
-import qualified PlutusLedgerApi.V2 as Plutus
+import PlutusLedgerApi.V2 qualified as Plutus
 
 -- * Extras
 
@@ -80,7 +80,7 @@ findTxOutByAddress address tx =
 
 findTxOutByScript ::
   forall lang.
-  (IsPlutusScriptLanguage lang) =>
+  IsPlutusScriptLanguage lang =>
   UTxO ->
   PlutusScript lang ->
   Maybe (TxIn, TxOut CtxUTxO Era)

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/TxOutValue.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/TxOutValue.hs
@@ -7,7 +7,7 @@ import Hydra.Cardano.Api.MultiAssetSupportedInEra (HasMultiAsset (..))
 -- | Inject some 'Value' into a 'TxOutValue'
 mkTxOutValue ::
   forall era.
-  (HasMultiAsset era) =>
+  HasMultiAsset era =>
   Value ->
   TxOutValue era
 mkTxOutValue =

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/TxScriptValidity.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/TxScriptValidity.hs
@@ -2,7 +2,7 @@ module Hydra.Cardano.Api.TxScriptValidity where
 
 import Hydra.Cardano.Api.Prelude
 
-import qualified Cardano.Ledger.Alonzo.Tx as Ledger
+import Cardano.Ledger.Alonzo.Tx qualified as Ledger
 
 -- | Convert a cardano-api 'TxScriptValidity' into a cardano-ledger 'IsValid'
 -- boolean wrapper.

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/UTxO.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/UTxO.hs
@@ -5,15 +5,15 @@ import Hydra.Cardano.Api.TxId (toLedgerTxId)
 import Hydra.Cardano.Api.TxIn (fromLedgerTxIn, toLedgerTxIn)
 import Hydra.Cardano.Api.TxOut (fromLedgerTxOut, toLedgerTxOut)
 
-import qualified Cardano.Api.UTxO as UTxO
-import qualified Cardano.Ledger.Babbage.TxBody as Ledger
-import qualified Cardano.Ledger.BaseTypes as Ledger
-import qualified Cardano.Ledger.Shelley.UTxO as Ledger
-import qualified Cardano.Ledger.TxIn as Ledger
+import Cardano.Api.UTxO qualified as UTxO
+import Cardano.Ledger.Babbage.TxBody qualified as Ledger
+import Cardano.Ledger.BaseTypes qualified as Ledger
+import Cardano.Ledger.Shelley.UTxO qualified as Ledger
+import Cardano.Ledger.TxIn qualified as Ledger
 import Data.Foldable (toList)
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Data.String (IsString (..))
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 
 -- | Get a human-readable pretty text representation of a UTxO.
 renderUTxO :: IsString str => UTxO -> str

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/ValidityInterval.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/ValidityInterval.hs
@@ -4,7 +4,7 @@ module Hydra.Cardano.Api.ValidityInterval where
 
 import Hydra.Cardano.Api.Prelude
 
-import qualified Cardano.Ledger.Allegra.Scripts as Ledger
+import Cardano.Ledger.Allegra.Scripts qualified as Ledger
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Test.QuickCheck (oneof)
 

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Value.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Value.hs
@@ -3,16 +3,16 @@ module Hydra.Cardano.Api.Value where
 import Hydra.Cardano.Api.Prelude
 
 import Cardano.Api.Ledger (PParams)
-import qualified Cardano.Ledger.Alonzo.TxInfo as Ledger
+import Cardano.Ledger.Alonzo.TxInfo qualified as Ledger
 import Cardano.Ledger.Core (getMinCoinTxOut)
-import qualified Cardano.Ledger.Mary.Value as Ledger
+import Cardano.Ledger.Mary.Value qualified as Ledger
 import Data.Word (Word64)
 import Hydra.Cardano.Api.CtxUTxO (ToUTxOContext (..))
 import Hydra.Cardano.Api.Hash (unsafeScriptHashFromBytes)
 import Hydra.Cardano.Api.MultiAssetSupportedInEra (multiAssetSupportedInEra)
 import PlutusLedgerApi.V1.Value (flattenValue)
 import PlutusLedgerApi.V2 (CurrencySymbol, adaSymbol, adaToken, fromBuiltin, unCurrencySymbol, unTokenName)
-import qualified PlutusLedgerApi.V2 as Plutus
+import PlutusLedgerApi.V2 qualified as Plutus
 
 -- * Extras
 

--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -22,11 +22,11 @@ import Control.Lens (to, (^?))
 import Control.Monad.Class.MonadAsync (mapConcurrently)
 import Data.Aeson (Result (Error, Success), Value, encode, fromJSON, (.=))
 import Data.Aeson.Lens (key, _Array, _JSON, _Number, _String)
-import qualified Data.List as List
-import qualified Data.Map as Map
+import Data.List qualified as List
+import Data.Map qualified as Map
 import Data.Scientific (Scientific)
 import Data.Set ((\\))
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import Data.Time (UTCTime (UTCTime), utctDayTime)
 import Hydra.Cardano.Api (Tx, TxId, UTxO, getVerificationKey, signTx)
 import Hydra.Cluster.Faucet (FaucetLog, publishHydraScriptsAs, seedFromFaucet)
@@ -388,28 +388,30 @@ waitForAllConfirmations n1 Registry{processedTxs} allIds = do
 
   maybeTxValid v = do
     guard (v ^? key "tag" == Just "TxValid")
-    v ^? key "transaction" . to fromJSON >>= \case
-      Error _ -> Nothing
-      Success tx -> pure $ TxValid tx
+    v
+      ^? key "transaction" . to fromJSON >>= \case
+        Error _ -> Nothing
+        Success tx -> pure $ TxValid tx
 
   maybeTxInvalid v = do
     guard (v ^? key "tag" == Just "TxInvalid")
-    v ^? key "transaction" . to fromJSON >>= \case
-      Error _ -> Nothing
-      Success tx ->
-        TxInvalid tx <$> v ^? key "validationError" . key "reason" . _String
+    v
+      ^? key "transaction" . to fromJSON >>= \case
+        Error _ -> Nothing
+        Success tx ->
+          TxInvalid tx <$> v ^? key "validationError" . key "reason" . _String
 
   maybeSnapshotConfirmed v = do
     guard (v ^? key "tag" == Just "SnapshotConfirmed")
     snapshot <- v ^? key "snapshot"
     SnapshotConfirmed
       <$> snapshot
-        ^? key "confirmedTransactions"
-          . _Array
-          . to toList
-      <*> snapshot
-        ^? key "snapshotNumber"
-          . _Number
+      ^? key "confirmedTransactions"
+        . _Array
+        . to toList
+        <*> snapshot
+      ^? key "snapshotNumber"
+        . _Number
 
 confirmTx ::
   TVar IO (Map.Map TxId Event) ->

--- a/hydra-cluster/bench/Bench/Summary.hs
+++ b/hydra-cluster/bench/Bench/Summary.hs
@@ -9,7 +9,7 @@ import Data.Fixed (Nano)
 import Data.Time (nominalDiffTimeToSeconds)
 import Data.Vector (Vector, (!))
 import Statistics.Quantile (def)
-import qualified Statistics.Quantile as Statistics
+import Statistics.Quantile qualified as Statistics
 
 type Percent = Double
 

--- a/hydra-cluster/exe/log-filter/Main.hs
+++ b/hydra-cluster/exe/log-filter/Main.hs
@@ -1,8 +1,7 @@
-
 module Main where
 
 import Data.Aeson (decode, encode)
-import qualified Data.ByteString.Char8 as LBS
+import Data.ByteString.Char8 qualified as LBS
 import Hydra.Ledger.Cardano (Tx)
 import Hydra.LogFilter (tracePerformance)
 import Hydra.Prelude

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -58,7 +58,6 @@ source-repository head
 common project-config
   default-language:   GHC2021
   default-extensions:
-    NoImplicitPrelude
     DataKinds
     DefaultSignatures
     DeriveAnyClass
@@ -67,6 +66,7 @@ common project-config
     GADTs
     LambdaCase
     MultiWayIf
+    NoImplicitPrelude
     OverloadedStrings
     PartialTypeSignatures
     PatternSynonyms

--- a/hydra-cluster/src/CardanoClient.hs
+++ b/hydra-cluster/src/CardanoClient.hs
@@ -14,11 +14,11 @@ import Hydra.Prelude
 import Hydra.Cardano.Api hiding (Block)
 import Hydra.Chain.CardanoClient
 
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Slotting.Time (RelativeTime (getRelativeTime), diffRelativeTime, toRelativeTime)
 import CardanoNode (NodeLog (..), RunningNode (..))
-import qualified Data.Map as Map
-import qualified Hydra.Chain.CardanoClient as CardanoClient
+import Data.Map qualified as Map
+import Hydra.Chain.CardanoClient qualified as CardanoClient
 import Hydra.Logging (Tracer, traceWith)
 
 -- TODO(SN): DRY with Hydra.Cardano.Api

--- a/hydra-cluster/src/CardanoNode.hs
+++ b/hydra-cluster/src/CardanoNode.hs
@@ -7,13 +7,13 @@ import Hydra.Prelude
 import Control.Lens ((^?!))
 import Control.Tracer (Tracer, traceWith)
 import Data.Aeson ((.=))
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.KeyMap as Aeson.KeyMap
+import Data.Aeson qualified as Aeson
+import Data.Aeson.KeyMap qualified as Aeson.KeyMap
 import Data.Aeson.Lens (key, _Number)
 import Data.Fixed (Centi)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime, utcTimeToPOSIXSeconds)
 import Hydra.Cardano.Api (AsType (AsPaymentKey), File (..), NetworkId, PaymentKey, SigningKey, SocketPath, VerificationKey, generateSigningKey, getVerificationKey)
-import qualified Hydra.Cardano.Api as Api
+import Hydra.Cardano.Api qualified as Api
 import Hydra.Cluster.Fixture (
   KnownNetwork (Mainnet, Preproduction, Preview),
   defaultNetworkId,

--- a/hydra-cluster/src/Hydra/Cluster/Faucet.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Faucet.hs
@@ -4,7 +4,7 @@ import Hydra.Cardano.Api
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Ledger.Core (PParams)
 import CardanoClient (
   QueryPoint (QueryTip),

--- a/hydra-cluster/src/Hydra/Cluster/Fixture.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Fixture.hs
@@ -6,7 +6,7 @@ module Hydra.Cluster.Fixture where
 import Hydra.Prelude
 
 import Hydra.Cardano.Api (NetworkId)
-import qualified Hydra.Cardano.Api as Api
+import Hydra.Cardano.Api qualified as Api
 import Hydra.ContestationPeriod (ContestationPeriod (..))
 import Hydra.Crypto (HydraKey, SigningKey, VerificationKey, generateSigningKey, getVerificationKey)
 import Hydra.Party (Party, deriveParty)

--- a/hydra-cluster/src/Hydra/Cluster/Options.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Options.hs
@@ -1,6 +1,6 @@
 module Hydra.Cluster.Options where
 
-import qualified Data.ByteString.Char8 as BSC
+import Data.ByteString.Char8 qualified as BSC
 import Hydra.Cardano.Api (AsType (AsTxId), TxId, deserialiseFromRawBytesHex)
 import Hydra.Cluster.Fixture (KnownNetwork (..))
 import Hydra.Prelude

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -6,7 +6,7 @@ module Hydra.Cluster.Scenarios where
 import Hydra.Prelude
 import Test.Hydra.Prelude (failure)
 
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import CardanoClient (
   QueryPoint (QueryTip),
   buildTransaction,
@@ -18,12 +18,12 @@ import CardanoClient (
 import CardanoNode (RunningNode (..))
 import Control.Lens ((^?))
 import Data.Aeson (Value, object, (.=))
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Data.Aeson.Lens (key, _JSON)
 import Data.Aeson.Types (parseMaybe)
 import Data.ByteString (isInfixOf)
-import qualified Data.ByteString as B
-import qualified Data.Set as Set
+import Data.ByteString qualified as B
+import Data.Set qualified as Set
 import Hydra.API.HTTPServer (
   DraftCommitTxRequest (..),
   DraftCommitTxResponse (..),
@@ -56,7 +56,7 @@ import Hydra.Cardano.Api.Prelude (ReferenceScript (..), TxOut (..), TxOutDatum (
 import Hydra.Chain (HeadId)
 import Hydra.Chain.Direct.Tx (assetNameFromVerificationKey)
 import Hydra.Cluster.Faucet (createOutputAtAddress, seedFromFaucet, seedFromFaucet_)
-import qualified Hydra.Cluster.Faucet as Faucet
+import Hydra.Cluster.Faucet qualified as Faucet
 import Hydra.Cluster.Fixture (Actor (..), actorName, alice, aliceSk, aliceVk, bob, bobSk, bobVk)
 import Hydra.Cluster.Util (chainConfigFor, keysFor)
 import Hydra.ContestationPeriod (ContestationPeriod (UnsafeContestationPeriod))
@@ -77,7 +77,7 @@ import HydraNode (
   waitMatch,
   withHydraNode,
  )
-import qualified Network.HTTP.Client as L
+import Network.HTTP.Client qualified as L
 import Network.HTTP.Req (
   HttpException (VanillaHttpException),
   JsonResponse,
@@ -91,7 +91,7 @@ import Network.HTTP.Req (
   runReq,
   (/:),
  )
-import qualified PlutusLedgerApi.Test.Examples as Plutus
+import PlutusLedgerApi.Test.Examples qualified as Plutus
 import Test.Hspec.Expectations (shouldBe, shouldReturn, shouldThrow)
 import Test.QuickCheck (generate)
 

--- a/hydra-cluster/src/Hydra/Cluster/Util.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Util.hs
@@ -3,8 +3,8 @@ module Hydra.Cluster.Util where
 
 import Hydra.Prelude
 
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as BS
+import Data.Aeson qualified as Aeson
+import Data.ByteString qualified as BS
 import Hydra.Cardano.Api (
   AsType (AsPaymentKey, AsSigningKey),
   HasTypeProxy (AsType),
@@ -20,7 +20,7 @@ import Hydra.Cluster.Fixture (Actor, actorName)
 import Hydra.ContestationPeriod (ContestationPeriod)
 import Hydra.Ledger.Cardano (genSigningKey)
 import Hydra.Options (ChainConfig (..), defaultChainConfig)
-import qualified Paths_hydra_cluster as Pkg
+import Paths_hydra_cluster qualified as Pkg
 import System.FilePath ((<.>), (</>))
 import Test.Hydra.Prelude (failure)
 import Test.QuickCheck (generate)

--- a/hydra-cluster/src/Hydra/Generator.hs
+++ b/hydra-cluster/src/Hydra/Generator.hs
@@ -3,7 +3,7 @@ module Hydra.Generator where
 import Hydra.Cardano.Api
 import Hydra.Prelude hiding (size)
 
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import CardanoClient (mkGenesisTx)
 import Control.Monad (foldM)
 import Data.Aeson (object, withObject, (.:), (.=))
@@ -124,7 +124,8 @@ genDatasetConstantUTxO faucetSk pparams nClients nTxs = do
           utxoProducedByTx fundingTransaction
             & UTxO.filter ((== mkVkAddress networkId vk) . txOutAddress)
     txSequence <-
-      reverse . thrd
+      reverse
+        . thrd
         <$> foldM (generateOneTransfer networkId) (initialUTxO, keyPair, []) [1 .. nTxs]
     pure ClientDataset{clientKeys, initialUTxO, txSequence}
 

--- a/hydra-cluster/src/Hydra/LogFilter.hs
+++ b/hydra-cluster/src/Hydra/LogFilter.hs
@@ -6,7 +6,7 @@ module Hydra.LogFilter where
 
 import Hydra.Prelude hiding (id)
 
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Hydra.API.ClientInput (ClientInput (NewTx))
 import Hydra.API.ServerOutput (ServerOutput (..))
 import Hydra.HeadLogic (Effect (..), Event (..))
@@ -43,9 +43,9 @@ data Trace tx
       }
   deriving stock (Generic)
 
-deriving stock instance (IsTx tx) => Eq (Trace tx)
-deriving stock instance (IsTx tx) => Show (Trace tx)
-deriving anyclass instance (IsTx tx) => ToJSON (Trace tx)
+deriving stock instance IsTx tx => Eq (Trace tx)
+deriving stock instance IsTx tx => Show (Trace tx)
+deriving anyclass instance IsTx tx => ToJSON (Trace tx)
 
 data TraceKey
   = EventKey Word64

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -12,12 +12,12 @@ import Control.Concurrent.Class.MonadSTM (modifyTVar', newTVarIO, readTVarIO)
 import Control.Exception (IOException)
 import Control.Monad.Class.MonadAsync (forConcurrently)
 import Data.Aeson (Value (..), object, (.=))
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Aeson qualified as Aeson
+import Data.Aeson.KeyMap qualified as KeyMap
 import Data.Aeson.Types (Pair)
-import qualified Data.List as List
+import Data.List qualified as List
 import Data.Text (pack)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Hydra.API.HTTPServer (DraftCommitTxRequest (..), DraftCommitTxResponse (..), TxOutWithWitness (..))
 import Hydra.Cluster.Faucet (FaucetLog)
 import Hydra.Cluster.Util (readConfigFile)
@@ -26,10 +26,10 @@ import Hydra.Crypto (HydraKey)
 import Hydra.Ledger.Cardano ()
 import Hydra.Logging (Tracer, Verbosity (..), traceWith)
 import Hydra.Network (Host (Host), NodeId (NodeId))
-import qualified Hydra.Network as Network
+import Hydra.Network qualified as Network
 import Hydra.Options (ChainConfig (..), LedgerConfig (..), RunOptions (..), defaultChainConfig, toArgs)
 import Network.HTTP.Req (GET (..), HttpException, JsonResponse, NoReqBody (..), POST (..), ReqBodyJson (..), defaultHttpConfig, responseBody, runReq, (/:))
-import qualified Network.HTTP.Req as Req
+import Network.HTTP.Req qualified as Req
 import Network.WebSockets (Connection, receiveData, runClient, sendClose, sendTextData)
 import System.FilePath ((<.>), (</>))
 import System.IO.Temp (withSystemTempDirectory)
@@ -41,7 +41,7 @@ import System.Process (
   withCreateProcess,
  )
 import Test.Hydra.Prelude (checkProcessHasNotDied, failAfter, failure, withLogFile)
-import qualified Prelude
+import Prelude qualified
 
 data HydraClient = HydraClient
   { hydraNodeId :: Int
@@ -58,7 +58,7 @@ send HydraClient{tracer, hydraNodeId, connection} v = do
   sendTextData connection (Aeson.encode v)
   traceWith tracer $ SentMessage hydraNodeId v
 
-waitNext :: (HasCallStack) => HydraClient -> IO Aeson.Value
+waitNext :: HasCallStack => HydraClient -> IO Aeson.Value
 waitNext HydraClient{connection} = do
   bytes <- receiveData connection
   case Aeson.eitherDecode' bytes of
@@ -72,11 +72,11 @@ output tag pairs = object $ ("tag" .= tag) : pairs
 -- | Wait some time for a single API server output from each of given nodes.
 -- This function waits for @delay@ seconds for message @expected@  to be seen by all
 -- given @nodes@.
-waitFor :: (HasCallStack) => Tracer IO EndToEndLog -> DiffTime -> [HydraClient] -> Aeson.Value -> IO ()
+waitFor :: HasCallStack => Tracer IO EndToEndLog -> DiffTime -> [HydraClient] -> Aeson.Value -> IO ()
 waitFor tracer delay nodes v = waitForAll tracer delay nodes [v]
 
 -- | Wait up to some time for an API server output to match the given predicate.
-waitMatch :: (HasCallStack) => DiffTime -> HydraClient -> (Aeson.Value -> Maybe a) -> IO a
+waitMatch :: HasCallStack => DiffTime -> HydraClient -> (Aeson.Value -> Maybe a) -> IO a
 waitMatch delay client@HydraClient{tracer, hydraNodeId} match = do
   seenMsgs <- newTVarIO []
   timeout delay (go seenMsgs) >>= \case
@@ -120,7 +120,7 @@ waitForAllMatch delay nodes match = do
 -- | Wait some time for a list of outputs from each of given nodes.
 -- This function is the generalised version of 'waitFor', allowing several messages
 -- to be waited for and received in /any order/.
-waitForAll :: (HasCallStack) => Tracer IO EndToEndLog -> DiffTime -> [HydraClient] -> [Aeson.Value] -> IO ()
+waitForAll :: HasCallStack => Tracer IO EndToEndLog -> DiffTime -> [HydraClient] -> [Aeson.Value] -> IO ()
 waitForAll tracer delay nodes expected = do
   traceWith tracer (StartWaiting (map hydraNodeId nodes) expected)
   forConcurrently_ nodes $ \client@HydraClient{hydraNodeId} -> do
@@ -178,7 +178,7 @@ requestCommitTx :: HydraClient -> UTxO -> IO Tx
 requestCommitTx client =
   requestCommitTx' client . fmap (`TxOutWithWitness` Nothing)
 
-getMetrics :: (HasCallStack) => HydraClient -> IO ByteString
+getMetrics :: HasCallStack => HydraClient -> IO ByteString
 getMetrics HydraClient{hydraNodeId} = do
   failAfter 3 $
     try (runReq defaultHttpConfig request) >>= \case
@@ -213,7 +213,7 @@ data EndToEndLog
 -- XXX: The two lists need to be of same length. Also the verification keys can
 -- be derived from the signing keys.
 withHydraCluster ::
-  (HasCallStack) =>
+  HasCallStack =>
   Tracer IO EndToEndLog ->
   FilePath ->
   SocketPath ->
@@ -232,7 +232,7 @@ withHydraCluster tracer workDir nodeSocket firstNodeId allKeys hydraKeys hydraSc
   withConfiguredHydraCluster tracer workDir nodeSocket firstNodeId allKeys hydraKeys hydraScriptsTxId (const $ id) contestationPeriod action
 
 withConfiguredHydraCluster ::
-  (HasCallStack) =>
+  HasCallStack =>
   Tracer IO EndToEndLog ->
   FilePath ->
   SocketPath ->
@@ -405,7 +405,7 @@ withConnectionToNode tracer hydraNodeId action = do
 hydraNodeProcess :: RunOptions -> CreateProcess
 hydraNodeProcess = proc "hydra-node" . toArgs
 
-waitForNodesConnected :: (HasCallStack) => Tracer IO EndToEndLog -> [HydraClient] -> IO ()
+waitForNodesConnected :: HasCallStack => Tracer IO EndToEndLog -> [HydraClient] -> IO ()
 waitForNodesConnected tracer clients =
   mapM_ waitForNodeConnected clients
  where

--- a/hydra-cluster/test/Main.hs
+++ b/hydra-cluster/test/Main.hs
@@ -1,7 +1,7 @@
 module Main where
 
 import Hydra.Prelude
-import qualified Spec
+import Spec qualified
 import Test.Hspec.Runner
 import Test.Hydra.Prelude (combinedHspecFormatter)
 

--- a/hydra-cluster/test/Test/CardanoClientSpec.hs
+++ b/hydra-cluster/test/Test/CardanoClientSpec.hs
@@ -6,7 +6,7 @@ import Test.Hydra.Prelude
 import CardanoClient (QueryPoint (..), queryGenesisParameters)
 import CardanoNode (RunningNode (..), withCardanoNodeDevnet)
 import Data.Aeson ((.:))
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Hydra.Cardano.Api (GenesisParameters (..))
 import Hydra.Ledger.Cardano.Configuration (readJsonFileThrow)
 import Hydra.Logging (showLogsOnFailure)

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -7,18 +7,18 @@ module Test.EndToEndSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import CardanoClient (QueryPoint (..), queryGenesisParameters, queryTip, queryTipSlotNo, submitTx, waitForUTxO)
 import CardanoNode (RunningNode (..), withCardanoNodeDevnet)
 import Control.Concurrent.STM (newTVarIO, readTVarIO)
 import Control.Concurrent.STM.TVar (modifyTVar')
 import Control.Lens ((^..), (^?))
 import Data.Aeson (Result (..), Value (Null, Object, String), fromJSON, object, (.=))
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Data.Aeson.Lens (key, values, _JSON)
-import qualified Data.ByteString as BS
-import qualified Data.Map as Map
-import qualified Data.Set as Set
+import Data.ByteString qualified as BS
+import Data.Map qualified as Map
+import Data.Set qualified as Set
 import Data.Time (secondsToDiffTime)
 import Hydra.Cardano.Api (
   AddressInEra,
@@ -84,7 +84,7 @@ import System.FilePath ((</>))
 import System.IO (hGetLine)
 import System.IO.Error (isEOFError)
 import Test.QuickCheck (generate)
-import qualified Prelude
+import Prelude qualified
 
 allNodeIds :: [Int]
 allNodeIds = [1 .. 3]

--- a/hydra-cluster/test/Test/Ledger/Cardano/ConfigurationSpec.hs
+++ b/hydra-cluster/test/Test/Ledger/Cardano/ConfigurationSpec.hs
@@ -3,8 +3,8 @@ module Test.Ledger.Cardano.ConfigurationSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import qualified Data.Aeson as Json
-import qualified Data.Aeson.Types as Json
+import Data.Aeson qualified as Json
+import Data.Aeson.Types qualified as Json
 import Hydra.Cluster.Util (readConfigFile)
 import Hydra.Ledger.Cardano.Configuration (protocolParametersFromJson)
 

--- a/hydra-cluster/test/Test/LogFilterSpec.hs
+++ b/hydra-cluster/test/Test/LogFilterSpec.hs
@@ -3,7 +3,7 @@
 module Test.LogFilterSpec where
 
 import Data.Aeson (decode, object, (.=))
-import qualified Data.ByteString.Lazy as LBS
+import Data.ByteString.Lazy qualified as LBS
 import Data.Maybe (fromJust)
 import Data.Time.Format.ISO8601 (iso8601ParseM)
 import Hydra.Ledger.Cardano (Tx)

--- a/hydra-node/bench/micro-bench/Main.hs
+++ b/hydra-node/bench/micro-bench/Main.hs
@@ -1,4 +1,3 @@
-
 module Main where
 
 import Hydra.Prelude
@@ -6,8 +5,8 @@ import Hydra.Prelude
 import Criterion (bench, bgroup, nf, whnf)
 import Criterion.Main (defaultMain)
 import Data.Aeson (Value (String), object, (.=))
-import qualified Data.Aeson as Aeson
-import qualified Data.List as List
+import Data.Aeson qualified as Aeson
+import Data.List qualified as List
 import Hydra.API.ClientInput (ClientInput (NewTx))
 import Hydra.Cardano.Api (
   UTxO,

--- a/hydra-node/bench/tx-cost/TxCost.hs
+++ b/hydra-node/bench/tx-cost/TxCost.hs
@@ -2,9 +2,9 @@ module TxCost where
 
 import Hydra.Prelude hiding (catch)
 
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Binary (serialize)
-import qualified Data.ByteString.Lazy as LBS
+import Data.ByteString.Lazy qualified as LBS
 import Data.Maybe (fromJust)
 import Hydra.Cardano.Api (
   ExecutionUnits (..),
@@ -189,7 +189,8 @@ computeFanOutCost :: IO [(NumParties, NumUTxO, Natural, TxSize, MemUnit, CpuUnit
 computeFanOutCost = do
   interesting <- catMaybes <$> mapM (uncurry compute) [(p, u) | p <- [5], u <- [0, 1, 5, 10, 20, 30, 40, 50]]
   limit <-
-    maybeToList . getFirst
+    maybeToList
+      . getFirst
       <$> foldMapM
         (\(p, u) -> First <$> compute p u)
         [(p, u) | p <- [5], u <- [100, 99 .. 0]]

--- a/hydra-node/exe/hydra-net/Main.hs
+++ b/hydra-node/exe/hydra-net/Main.hs
@@ -1,4 +1,3 @@
-
 module Main where
 
 import Hydra.Prelude

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -22,7 +22,7 @@ import Hydra.HeadLogic (
   Event (..),
   defaultTTL,
  )
-import qualified Hydra.Ledger.Cardano as Ledger
+import Hydra.Ledger.Cardano qualified as Ledger
 import Hydra.Ledger.Cardano.Configuration (
   newGlobals,
   newLedgerEnv,

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -20,7 +20,6 @@ source-repository head
 common project-config
   default-language:   GHC2021
   default-extensions:
-    NoImplicitPrelude
     DataKinds
     DefaultSignatures
     DeriveAnyClass
@@ -30,6 +29,7 @@ common project-config
     GADTs
     LambdaCase
     MultiWayIf
+    NoImplicitPrelude
     OverloadedStrings
     PartialTypeSignatures
     PatternSynonyms

--- a/hydra-node/src/Hydra/API/APIServerLog.hs
+++ b/hydra-node/src/Hydra/API/APIServerLog.hs
@@ -2,8 +2,8 @@ module Hydra.API.APIServerLog where
 
 import Hydra.Prelude
 
-import qualified Data.Aeson as Aeson
-import qualified Data.Text as Text
+import Data.Aeson qualified as Aeson
+import Data.Text qualified as Text
 import Hydra.Network (PortNumber)
 import Network.HTTP.Types (renderStdMethod)
 import Test.QuickCheck (chooseEnum, listOf, oneof)

--- a/hydra-node/src/Hydra/API/HTTPServer.hs
+++ b/hydra-node/src/Hydra/API/HTTPServer.hs
@@ -4,12 +4,12 @@ module Hydra.API.HTTPServer where
 
 import Hydra.Prelude
 
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Ledger.Core (PParams)
 import Data.Aeson (KeyValue ((.=)), Value (Object), object, withObject, (.:), (.:?))
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.KeyMap as KeyMap
-import qualified Data.ByteString.Lazy as LBS
+import Data.Aeson qualified as Aeson
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.ByteString.Lazy qualified as LBS
 import Data.ByteString.Short ()
 import Data.Text (pack)
 import Hydra.API.APIServerLog (APIServerLog (..), Method (..), PathInfo (..))

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -58,7 +58,7 @@ type ServerComponent tx m a = ServerCallback tx m -> (Server tx m -> m a) -> m a
 
 withAPIServer ::
   forall tx.
-  (IsChainState tx) =>
+  IsChainState tx =>
   IP ->
   PortNumber ->
   Party ->

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -5,10 +5,10 @@ module Hydra.API.ServerOutput where
 import Cardano.Binary (serialize')
 import Control.Lens ((.~))
 import Data.Aeson (Value (..), defaultOptions, encode, genericParseJSON, genericToJSON, omitNothingFields, withObject, (.:))
-import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Aeson.KeyMap qualified as KeyMap
 import Data.Aeson.Lens (atKey, key)
-import qualified Data.ByteString.Base16 as Base16
-import qualified Data.ByteString.Lazy as LBS
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Lazy qualified as LBS
 import Hydra.API.ClientInput (ClientInput (..))
 import Hydra.Chain (ChainStateType, HeadId, IsChainState, OnChainId, PostChainTx (..), PostTxError)
 import Hydra.Crypto (MultiSignature)
@@ -26,7 +26,7 @@ data TimedServerOutput tx = TimedServerOutput
   }
   deriving stock (Eq, Show, Generic)
 
-instance (Arbitrary (ServerOutput tx)) => Arbitrary (TimedServerOutput tx) where
+instance Arbitrary (ServerOutput tx) => Arbitrary (TimedServerOutput tx) where
   arbitrary = genericArbitrary
 
 -- | Generate a random timed server output given a normal server output.
@@ -34,14 +34,14 @@ genTimedServerOutput :: ServerOutput tx -> Gen (TimedServerOutput tx)
 genTimedServerOutput o =
   TimedServerOutput o <$> arbitrary <*> arbitrary
 
-instance (IsChainState tx) => ToJSON (TimedServerOutput tx) where
+instance IsChainState tx => ToJSON (TimedServerOutput tx) where
   toJSON TimedServerOutput{output, seq, time} =
     case toJSON output of
       Object o ->
         Object $ o <> KeyMap.fromList [("seq", toJSON seq), ("timestamp", toJSON time)]
       _NotAnObject -> error "expected ServerOutput to serialize to an Object"
 
-instance (IsChainState tx) => FromJSON (TimedServerOutput tx) where
+instance IsChainState tx => FromJSON (TimedServerOutput tx) where
   parseJSON v = flip (withObject "TimedServerOutput") v $ \o ->
     TimedServerOutput <$> parseJSON v <*> o .: "seq" <*> o .: "timestamp"
 
@@ -92,17 +92,17 @@ data ServerOutput tx
   | IgnoredHeadInitializing {headId :: HeadId, participants :: [OnChainId]}
   deriving stock (Generic)
 
-deriving stock instance (IsChainState tx) => Eq (ServerOutput tx)
-deriving stock instance (IsChainState tx) => Show (ServerOutput tx)
+deriving stock instance IsChainState tx => Eq (ServerOutput tx)
+deriving stock instance IsChainState tx => Show (ServerOutput tx)
 
-instance (IsChainState tx) => ToJSON (ServerOutput tx) where
+instance IsChainState tx => ToJSON (ServerOutput tx) where
   toJSON =
     genericToJSON
       defaultOptions
         { omitNothingFields = True
         }
 
-instance (IsChainState tx) => FromJSON (ServerOutput tx) where
+instance IsChainState tx => FromJSON (ServerOutput tx) where
   parseJSON =
     genericParseJSON
       defaultOptions
@@ -166,7 +166,7 @@ data ServerOutputConfig = ServerOutputConfig
 -- 'handleTxOutput' so that we don't forget to update this function if they
 -- change.
 prepareServerOutput ::
-  (IsChainState tx) =>
+  IsChainState tx =>
   -- | Decide on tx representation
   ServerOutputConfig ->
   -- | Server output

--- a/hydra-node/src/Hydra/API/WSServer.hs
+++ b/hydra-node/src/Hydra/API/WSServer.hs
@@ -6,9 +6,9 @@ module Hydra.API.WSServer where
 import Hydra.Prelude hiding (TVar, readTVar, seq)
 
 import Control.Concurrent.STM (TChan, dupTChan, readTChan)
-import qualified Control.Concurrent.STM as STM
+import Control.Concurrent.STM qualified as STM
 import Control.Concurrent.STM.TVar (TVar, readTVar)
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Data.Version (showVersion)
 import Hydra.API.APIServerLog (APIServerLog (..))
 import Hydra.API.ClientInput (ClientInput)
@@ -31,7 +31,7 @@ import Hydra.Chain (
 import Hydra.Chain.Direct.State ()
 import Hydra.Ledger (UTxOType)
 import Hydra.Logging (Tracer, traceWith)
-import qualified Hydra.Options as Options
+import Hydra.Options qualified as Options
 import Hydra.Party (Party)
 import Network.WebSockets (
   PendingConnection (pendingRequest),
@@ -47,7 +47,7 @@ import Text.URI.QQ (queryKey, queryValue)
 
 wsApp ::
   forall tx.
-  (IsChainState tx) =>
+  IsChainState tx =>
   Party ->
   Tracer IO APIServerLog ->
   TVar [TimedServerOutput tx] ->

--- a/hydra-node/src/Hydra/Chain.hs
+++ b/hydra-node/src/Hydra/Chain.hs
@@ -13,7 +13,7 @@ module Hydra.Chain where
 
 import Hydra.Prelude
 
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.List (nub)
 import Data.List.NonEmpty ((<|))
 import Hydra.Cardano.Api (

--- a/hydra-node/src/Hydra/Chain/CardanoClient.hs
+++ b/hydra-node/src/Hydra/Chain/CardanoClient.hs
@@ -8,9 +8,9 @@ import Hydra.Prelude
 
 import Hydra.Cardano.Api hiding (Block)
 
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Ledger.Core (PParams)
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (EraMismatch)
 import Test.QuickCheck (oneof)
 
@@ -332,7 +332,7 @@ runQuery networkId socket point query =
 
 -- * Helpers
 
-throwOnEraMismatch :: (MonadThrow m) => Either EraMismatch a -> m a
+throwOnEraMismatch :: MonadThrow m => Either EraMismatch a -> m a
 throwOnEraMismatch res =
   case res of
     Left eraMismatch -> throwIO $ QueryEraMismatchException eraMismatch

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -9,7 +9,7 @@ module Hydra.Chain.Direct (
 
 import Hydra.Prelude
 
-import qualified Cardano.Ledger.Shelley.API as Ledger
+import Cardano.Ledger.Shelley.API qualified as Ledger
 import Cardano.Ledger.Slot (EpochInfo)
 import Cardano.Slotting.EpochInfo (hoistEpochInfo)
 import Control.Concurrent.Class.MonadSTM (
@@ -88,7 +88,7 @@ import Hydra.Chain.Direct.Wallet (
 import Hydra.Logging (Tracer, traceWith)
 import Hydra.Options (ChainConfig (..))
 import Hydra.Party (Party)
-import qualified Ouroboros.Consensus.HardFork.History as Consensus
+import Ouroboros.Consensus.HardFork.History qualified as Consensus
 import Ouroboros.Network.Magic (NetworkMagic (..))
 import Ouroboros.Network.Protocol.ChainSync.Client (
   ChainSyncClient (..),
@@ -322,7 +322,7 @@ chainSyncClient handler wallet startingPoint =
 
 txSubmissionClient ::
   forall m.
-  (MonadSTM m) =>
+  MonadSTM m =>
   Tracer m DirectChainLog ->
   TQueue m (Tx, TMVar m (Maybe (PostTxError Tx))) ->
   LocalTxSubmissionClient (TxInMode CardanoMode) (TxValidationErrorInMode CardanoMode) m ()

--- a/hydra-node/src/Hydra/Chain/Direct/Fixture.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Fixture.hs
@@ -14,10 +14,10 @@ import Hydra.Prelude
 import Cardano.Ledger.Alonzo.Core (ppPricesL)
 import Cardano.Ledger.Alonzo.Scripts (Prices (..))
 import Cardano.Ledger.BaseTypes (BoundedRational (..))
-import qualified Cardano.Ledger.BaseTypes as Ledger
+import Cardano.Ledger.BaseTypes qualified as Ledger
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core (PParams, ppMinFeeAL, ppMinFeeBL)
-import qualified Cardano.Slotting.Time as Slotting
+import Cardano.Slotting.Time qualified as Slotting
 import Control.Lens ((.~))
 import Data.Maybe (fromJust)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -9,12 +9,12 @@ module Hydra.Chain.Direct.Handlers where
 
 import Hydra.Prelude
 
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Slotting.Slot (SlotNo (..))
 import Control.Concurrent.Class.MonadSTM (modifyTVar, newTVarIO, writeTVar)
 import Control.Monad.Class.MonadSTM (throwSTM)
-import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import Hydra.Cardano.Api (
   AssetName (..),
   BlockHeader,
@@ -186,7 +186,7 @@ mkChain tracer queryTimeHandle wallet@TinyWallet{getUTxO} ctx LocalChainState{ge
 
 -- | Balance and sign the given partial transaction.
 finalizeTx ::
-  (MonadThrow m) =>
+  MonadThrow m =>
   TinyWallet m ->
   ChainContext ->
   ChainStateType Tx ->

--- a/hydra-node/src/Hydra/Chain/Direct/ScriptRegistry.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/ScriptRegistry.hs
@@ -5,8 +5,8 @@ module Hydra.Chain.Direct.ScriptRegistry where
 import Hydra.Prelude
 
 import Cardano.Api.UTxO (UTxO)
-import qualified Cardano.Api.UTxO as UTxO
-import qualified Data.Map as Map
+import Cardano.Api.UTxO qualified as UTxO
+import Data.Map qualified as Map
 import Hydra.Cardano.Api (
   CtxUTxO,
   Key (..),
@@ -48,9 +48,9 @@ import Hydra.Chain.CardanoClient (
   submitTransaction,
  )
 import Hydra.Contract (ScriptInfo (..), scriptInfo)
-import qualified Hydra.Contract.Commit as Commit
-import qualified Hydra.Contract.Head as Head
-import qualified Hydra.Contract.Initial as Initial
+import Hydra.Contract.Commit qualified as Commit
+import Hydra.Contract.Head qualified as Head
+import Hydra.Contract.Initial qualified as Initial
 import Hydra.Ledger.Cardano (genTxOutAdaOnly)
 
 -- | Hydra scripts published as reference scripts at these UTxO.

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -9,9 +9,9 @@ module Hydra.Chain.Direct.State where
 
 import Hydra.Prelude hiding (init)
 
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import Data.List ((\\))
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Data.Maybe (fromJust)
 import Hydra.Cardano.Api (
   AssetName (AssetName),
@@ -395,7 +395,7 @@ rejectMoreThanMainnetLimit network u = do
 -- | Construct a collect transaction based on the 'InitialState'. This will
 -- reimburse all the already committed outputs.
 abort ::
-  (HasCallStack) =>
+  HasCallStack =>
   ChainContext ->
   InitialState ->
   -- | Committed UTxOs to reimburse.
@@ -544,16 +544,21 @@ observeSomeTx ctx cst tx = case cst of
     first NotAnInitTx $ second Initial <$> observeInit ctx tx
   Initial st ->
     noObservation $
-      second Initial <$> observeCommit ctx st tx
-        <|> (,Idle) <$> observeAbort st tx
-        <|> second Open <$> observeCollect st tx
+      second Initial
+        <$> observeCommit ctx st tx
+        <|> (,Idle)
+        <$> observeAbort st tx
+        <|> second Open
+        <$> observeCollect st tx
   Open st ->
     noObservation $
       second Closed <$> observeClose st tx
   Closed st ->
     noObservation $
-      second Closed <$> observeContest st tx
-        <|> (,Idle) <$> observeFanout st tx
+      second Closed
+        <$> observeContest st tx
+        <|> (,Idle)
+        <$> observeFanout st tx
  where
   noObservation :: Maybe (OnChainTx Tx, ChainState) -> Either NoObservation (OnChainTx Tx, ChainState)
   noObservation = maybe (Left NoObservation) Right

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -12,27 +12,27 @@ module Hydra.Chain.Direct.Tx where
 import Hydra.Cardano.Api
 import Hydra.Prelude
 
-import qualified Cardano.Api.UTxO as UTxO
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString.Base16 as Base16
-import qualified Data.Map as Map
-import qualified Data.Set as Set
+import Cardano.Api.UTxO qualified as UTxO
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Base16 qualified as Base16
+import Data.Map qualified as Map
+import Data.Set qualified as Set
 import Hydra.Cardano.Api.Network (networkIdToNetwork)
 import Hydra.Chain (HeadId (..), HeadParameters (..))
 import Hydra.Chain.Direct.ScriptRegistry (ScriptRegistry (..))
 import Hydra.Chain.Direct.TimeHandle (PointInTime)
 import Hydra.ContestationPeriod (ContestationPeriod, fromChain, toChain)
-import qualified Hydra.Contract.Commit as Commit
-import qualified Hydra.Contract.Head as Head
-import qualified Hydra.Contract.HeadState as Head
-import qualified Hydra.Contract.HeadTokens as HeadTokens
-import qualified Hydra.Contract.Initial as Initial
+import Hydra.Contract.Commit qualified as Commit
+import Hydra.Contract.Head qualified as Head
+import Hydra.Contract.HeadState qualified as Head
+import Hydra.Contract.HeadTokens qualified as HeadTokens
+import Hydra.Contract.Initial qualified as Initial
 import Hydra.Contract.MintAction (MintAction (Burn, Mint))
 import Hydra.Contract.Util (hydraHeadV1)
 import Hydra.Crypto (MultiSignature, toPlutusSignatures)
 import Hydra.Data.ContestationPeriod (addContestationPeriod)
-import qualified Hydra.Data.ContestationPeriod as OnChain
-import qualified Hydra.Data.Party as OnChain
+import Hydra.Data.ContestationPeriod qualified as OnChain
+import Hydra.Data.Party qualified as OnChain
 import Hydra.Ledger (IsTx (hashUTxO))
 import Hydra.Ledger.Cardano (addReferenceInputs)
 import Hydra.Ledger.Cardano.Builder (
@@ -52,7 +52,7 @@ import Hydra.Plutus.Extras (posixFromUTCTime)
 import Hydra.Plutus.Orphans ()
 import Hydra.Snapshot (Snapshot (..), SnapshotNumber, fromChainSnapshot)
 import PlutusLedgerApi.V2 (CurrencySymbol (CurrencySymbol), fromBuiltin, toBuiltin)
-import qualified PlutusLedgerApi.V2 as Plutus
+import PlutusLedgerApi.V2 qualified as Plutus
 
 -- | Needed on-chain data to create Head transactions.
 type UTxOWithScript = (TxIn, TxOut CtxUTxO, HashableScriptData)

--- a/hydra-node/src/Hydra/Chain/Direct/Util.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Util.hs
@@ -4,10 +4,10 @@ module Hydra.Chain.Direct.Util where
 
 import Hydra.Prelude
 
-import qualified Cardano.Crypto.DSIGN as Crypto
+import Cardano.Crypto.DSIGN qualified as Crypto
 import Cardano.Ledger.Crypto (DSIGN)
 import Hydra.Cardano.Api hiding (Block, SigningKey, VerificationKey)
-import qualified Hydra.Cardano.Api as Shelley
+import Hydra.Cardano.Api qualified as Shelley
 import Ouroboros.Consensus.Cardano (CardanoBlock)
 
 type Block = CardanoBlock StandardCrypto

--- a/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
@@ -7,42 +7,42 @@ module Hydra.Chain.Direct.Wallet where
 import Hydra.Prelude
 
 import Cardano.Api.UTxO (UTxO)
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Crypto.Hash.Class
-import qualified Cardano.Ledger.Address as Ledger
+import Cardano.Ledger.Address qualified as Ledger
 import Cardano.Ledger.Alonzo.PlutusScriptApi (language)
 import Cardano.Ledger.Alonzo.Scripts (ExUnits (ExUnits), Tag (Spend), txscriptfee)
 import Cardano.Ledger.Alonzo.TxInfo (TranslationError)
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), RdmrPtr (RdmrPtr), Redeemers (..), txdats, txscripts)
 import Cardano.Ledger.Api (TransactionScriptFailure, evalTxExUnits, ppMaxTxExUnitsL, ppPricesL)
 import Cardano.Ledger.Babbage.Tx (body, getLanguageView, hashScriptIntegrity, refScripts, wits)
-import qualified Cardano.Ledger.Babbage.Tx as Babbage
+import Cardano.Ledger.Babbage.Tx qualified as Babbage
 import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..), outputs', spendInputs')
-import qualified Cardano.Ledger.Babbage.TxBody as Babbage
-import qualified Cardano.Ledger.BaseTypes as Ledger
+import Cardano.Ledger.Babbage.TxBody qualified as Babbage
+import Cardano.Ledger.BaseTypes qualified as Ledger
 import Cardano.Ledger.Binary (mkSized)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core (isNativeScript)
-import qualified Cardano.Ledger.Core as Core
-import qualified Cardano.Ledger.Core as Ledger
+import Cardano.Ledger.Core qualified as Core
+import Cardano.Ledger.Core qualified as Ledger
 import Cardano.Ledger.Crypto (HASH, StandardCrypto)
 import Cardano.Ledger.Hashes (EraIndependentTxBody)
-import qualified Cardano.Ledger.SafeHash as SafeHash
+import Cardano.Ledger.SafeHash qualified as SafeHash
 import Cardano.Ledger.Shelley.API (unUTxO)
-import qualified Cardano.Ledger.Shelley.API as Ledger
+import Cardano.Ledger.Shelley.API qualified as Ledger
 import Cardano.Ledger.Val (Val (..), invert)
 import Cardano.Slotting.EpochInfo (EpochInfo)
 import Cardano.Slotting.Time (SystemStart (..))
 import Control.Arrow (left)
 import Control.Concurrent.Class.MonadSTM (check, newTVarIO, readTVarIO, writeTVar)
 import Control.Lens ((^.))
-import qualified Data.List as List
+import Data.List qualified as List
 import Data.Map.Strict ((!))
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.Maybe.Strict (StrictMaybe (..))
 import Data.Ratio ((%))
-import qualified Data.Sequence.Strict as StrictSeq
-import qualified Data.Set as Set
+import Data.Sequence.Strict qualified as StrictSeq
+import Data.Set qualified as Set
 import Hydra.Cardano.Api (
   BlockHeader,
   ChainPoint,
@@ -70,7 +70,7 @@ import Hydra.Cardano.Api (
   toLedgerUTxO,
   verificationKeyHash,
  )
-import qualified Hydra.Cardano.Api as Api
+import Hydra.Cardano.Api qualified as Api
 import Hydra.Chain.CardanoClient (QueryPoint (..))
 import Hydra.Ledger.Cardano ()
 import Hydra.Logging (Tracer, traceWith)

--- a/hydra-node/src/Hydra/ContestationPeriod.hs
+++ b/hydra-node/src/Hydra/ContestationPeriod.hs
@@ -4,7 +4,7 @@ import Hydra.Prelude hiding (Show, show)
 
 import Data.Ratio ((%))
 import Data.Time (secondsToNominalDiffTime)
-import qualified Hydra.Data.ContestationPeriod as OnChain
+import Hydra.Data.ContestationPeriod qualified as OnChain
 import Test.QuickCheck (choose, oneof)
 import Text.Show (Show (..))
 
@@ -18,7 +18,8 @@ instance Show ContestationPeriod where
 
 instance Arbitrary ContestationPeriod where
   arbitrary = do
-    UnsafeContestationPeriod . fromInteger
+    UnsafeContestationPeriod
+      . fromInteger
       <$> oneof
         [ choose (1, confirmedHorizon)
         , pure confirmedHorizon

--- a/hydra-node/src/Hydra/Crypto.hs
+++ b/hydra-node/src/Hydra/Crypto.hs
@@ -40,16 +40,16 @@ import Cardano.Crypto.DSIGN (
   signDSIGN,
   verifyDSIGN,
  )
-import qualified Cardano.Crypto.DSIGN as Crypto
+import Cardano.Crypto.DSIGN qualified as Crypto
 import Cardano.Crypto.Hash (Blake2b_256, SHA256, castHash, hashFromBytes, hashToBytes)
-import qualified Cardano.Crypto.Hash as Crypto
+import Cardano.Crypto.Hash qualified as Crypto
 import Cardano.Crypto.Hash.Class (HashAlgorithm (digest))
 import Cardano.Crypto.Seed (getSeedBytes, mkSeedFromBytes)
 import Cardano.Crypto.Util (SignableRepresentation)
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Base16 as Base16
-import qualified Data.Map as Map
+import Data.Aeson qualified as Aeson
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as Base16
+import Data.Map qualified as Map
 import Hydra.Cardano.Api (
   AsType (AsHash, AsSigningKey, AsVerificationKey),
   HasTextEnvelope (..),
@@ -60,8 +60,8 @@ import Hydra.Cardano.Api (
   SerialiseAsRawBytes (..),
   serialiseToRawBytesHexText,
  )
-import qualified Hydra.Contract.HeadState as OnChain
-import qualified PlutusLedgerApi.V2 as Plutus
+import Hydra.Contract.HeadState qualified as OnChain
+import PlutusLedgerApi.V2 qualified as Plutus
 import Test.QuickCheck (vectorOf)
 import Test.QuickCheck.Instances.ByteString ()
 import Text.Show (Show (..))

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -22,12 +22,12 @@ module Hydra.HeadLogic (
 
 import Hydra.Prelude
 
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.Set ((\\))
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import GHC.Records (getField)
 import Hydra.API.ClientInput (ClientInput (..))
-import qualified Hydra.API.ServerOutput as ServerOutput
+import Hydra.API.ServerOutput qualified as ServerOutput
 import Hydra.Chain (
   ChainEvent (..),
   ChainStateHistory,
@@ -209,7 +209,7 @@ onInitialChainAbortTx newChainState committed headId =
 --
 -- __Transition__: 'InitialState' → 'OpenState'
 onInitialChainCollectTx ::
-  (IsChainState tx) =>
+  IsChainState tx =>
   InitialState tx ->
   -- | New chain state
   ChainStateType tx ->
@@ -718,7 +718,7 @@ update env ledger st ev = case (st, ev) of
 -- * HeadState aggregate
 
 -- | Reflect 'StateChanged' events onto the 'HeadState' aggregate.
-aggregate :: (IsChainState tx) => HeadState tx -> StateChanged tx -> HeadState tx
+aggregate :: IsChainState tx => HeadState tx -> StateChanged tx -> HeadState tx
 aggregate st = \case
   HeadInitialized{parameters = parameters@HeadParameters{parties}, headId, chainState} ->
     Initial

--- a/hydra-node/src/Hydra/HeadLogic/Error.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Error.hs
@@ -39,10 +39,10 @@ data RequirementFailure tx
   | SnapshotDoesNotApply {requestedSn :: SnapshotNumber, txid :: TxIdType tx, error :: ValidationError}
   deriving stock (Generic)
 
-deriving stock instance (Eq (TxIdType tx)) => Eq (RequirementFailure tx)
-deriving stock instance (Show (TxIdType tx)) => Show (RequirementFailure tx)
-deriving anyclass instance (ToJSON (TxIdType tx)) => ToJSON (RequirementFailure tx)
-deriving anyclass instance (FromJSON (TxIdType tx)) => FromJSON (RequirementFailure tx)
+deriving stock instance Eq (TxIdType tx) => Eq (RequirementFailure tx)
+deriving stock instance Show (TxIdType tx) => Show (RequirementFailure tx)
+deriving anyclass instance ToJSON (TxIdType tx) => ToJSON (RequirementFailure tx)
+deriving anyclass instance FromJSON (TxIdType tx) => FromJSON (RequirementFailure tx)
 
 instance Arbitrary (TxIdType tx) => Arbitrary (RequirementFailure tx) where
   arbitrary = genericArbitrary

--- a/hydra-node/src/Hydra/HeadLogic/Event.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Event.hs
@@ -37,10 +37,10 @@ data Event tx
     PostTxError {postChainTx :: PostChainTx tx, postTxError :: PostTxError tx}
   deriving stock (Generic)
 
-deriving stock instance (IsChainState tx) => Eq (Event tx)
-deriving stock instance (IsChainState tx) => Show (Event tx)
-deriving anyclass instance (IsChainState tx) => ToJSON (Event tx)
-deriving anyclass instance (IsChainState tx) => FromJSON (Event tx)
+deriving stock instance IsChainState tx => Eq (Event tx)
+deriving stock instance IsChainState tx => Show (Event tx)
+deriving anyclass instance IsChainState tx => ToJSON (Event tx)
+deriving anyclass instance IsChainState tx => FromJSON (Event tx)
 
 instance
   ( IsTx tx

--- a/hydra-node/src/Hydra/HeadLogic/Outcome.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Outcome.hs
@@ -27,10 +27,10 @@ data Effect tx
     OnChainEffect {postChainTx :: PostChainTx tx}
   deriving stock (Generic)
 
-deriving stock instance (IsChainState tx) => Eq (Effect tx)
-deriving stock instance (IsChainState tx) => Show (Effect tx)
-deriving anyclass instance (IsChainState tx) => ToJSON (Effect tx)
-deriving anyclass instance (IsChainState tx) => FromJSON (Effect tx)
+deriving stock instance IsChainState tx => Eq (Effect tx)
+deriving stock instance IsChainState tx => Show (Effect tx)
+deriving anyclass instance IsChainState tx => ToJSON (Effect tx)
+deriving anyclass instance IsChainState tx => FromJSON (Effect tx)
 
 instance
   ( IsTx tx
@@ -98,10 +98,10 @@ data Outcome tx
 instance Semigroup (Outcome tx) where
   (<>) = Combined
 
-deriving stock instance (IsChainState tx) => Eq (Outcome tx)
-deriving stock instance (IsChainState tx) => Show (Outcome tx)
-deriving anyclass instance (IsChainState tx) => ToJSON (Outcome tx)
-deriving anyclass instance (IsChainState tx) => FromJSON (Outcome tx)
+deriving stock instance IsChainState tx => Eq (Outcome tx)
+deriving stock instance IsChainState tx => Show (Outcome tx)
+deriving anyclass instance IsChainState tx => ToJSON (Outcome tx)
+deriving anyclass instance IsChainState tx => FromJSON (Outcome tx)
 
 instance (IsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (Outcome tx) where
   arbitrary = genericArbitrary
@@ -130,10 +130,10 @@ data WaitReason tx
   | WaitOnContestationDeadline
   deriving stock (Generic)
 
-deriving stock instance (IsTx tx) => Eq (WaitReason tx)
-deriving stock instance (IsTx tx) => Show (WaitReason tx)
-deriving anyclass instance (IsTx tx) => ToJSON (WaitReason tx)
-deriving anyclass instance (IsTx tx) => FromJSON (WaitReason tx)
+deriving stock instance IsTx tx => Eq (WaitReason tx)
+deriving stock instance IsTx tx => Show (WaitReason tx)
+deriving anyclass instance IsTx tx => ToJSON (WaitReason tx)
+deriving anyclass instance IsTx tx => FromJSON (WaitReason tx)
 
 instance IsTx tx => Arbitrary (WaitReason tx) where
   arbitrary = genericArbitrary

--- a/hydra-node/src/Hydra/HeadLogic/State.hs
+++ b/hydra-node/src/Hydra/HeadLogic/State.hs
@@ -4,7 +4,7 @@
 
 module Hydra.HeadLogic.State where
 
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Hydra.Chain (ChainStateType, HeadId, HeadParameters)
 import Hydra.ContestationPeriod (ContestationPeriod)
 import Hydra.Crypto (HydraKey, Signature, SigningKey)
@@ -83,7 +83,7 @@ deriving stock instance Show (ChainStateType tx) => Show (IdleState tx)
 deriving anyclass instance ToJSON (ChainStateType tx) => ToJSON (IdleState tx)
 deriving anyclass instance FromJSON (ChainStateType tx) => FromJSON (IdleState tx)
 
-instance (Arbitrary (ChainStateType tx)) => Arbitrary (IdleState tx) where
+instance Arbitrary (ChainStateType tx) => Arbitrary (IdleState tx) where
   arbitrary = genericArbitrary
 
 -- ** Initial

--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -12,28 +12,28 @@ import Hydra.Prelude
 import Hydra.Cardano.Api hiding (initialLedgerState)
 import Hydra.Ledger.Cardano.Builder
 
-import qualified Cardano.Api.UTxO as UTxO
-import qualified Cardano.Crypto.DSIGN as CC
-import qualified Cardano.Ledger.Babbage.Tx as Ledger
+import Cardano.Api.UTxO qualified as UTxO
+import Cardano.Crypto.DSIGN qualified as CC
+import Cardano.Ledger.Babbage.Tx qualified as Ledger
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
-import qualified Cardano.Ledger.BaseTypes as Ledger
+import Cardano.Ledger.BaseTypes qualified as Ledger
 import Cardano.Ledger.Binary (decCBOR, decodeFullAnnotator, serialize')
-import qualified Cardano.Ledger.Credential as Ledger
-import qualified Cardano.Ledger.Shelley.API.Mempool as Ledger
-import qualified Cardano.Ledger.Shelley.Genesis as Ledger
-import qualified Cardano.Ledger.Shelley.LedgerState as Ledger
-import qualified Cardano.Ledger.Shelley.Rules as Ledger
-import qualified Cardano.Ledger.Shelley.UTxO as Ledger
-import qualified Codec.CBOR.Decoding as CBOR
-import qualified Codec.CBOR.Encoding as CBOR
+import Cardano.Ledger.Credential qualified as Ledger
+import Cardano.Ledger.Shelley.API.Mempool qualified as Ledger
+import Cardano.Ledger.Shelley.Genesis qualified as Ledger
+import Cardano.Ledger.Shelley.LedgerState qualified as Ledger
+import Cardano.Ledger.Shelley.Rules qualified as Ledger
+import Cardano.Ledger.Shelley.UTxO qualified as Ledger
+import Codec.CBOR.Decoding qualified as CBOR
+import Codec.CBOR.Encoding qualified as CBOR
 import Control.Monad (foldM)
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.Default (def)
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromJust)
 import Data.Text.Lazy.Builder (toLazyText)
 import Formatting.Buildable (build)
-import qualified Hydra.Contract.Head as Head
+import Hydra.Contract.Head qualified as Head
 import Hydra.Ledger (ChainSlot (..), IsTx (..), Ledger (..), ValidationError (..))
 import Hydra.Ledger.Cardano.Json ()
 import PlutusLedgerApi.V2 (fromBuiltin)
@@ -230,7 +230,8 @@ genFixedSizeSequenceOfSimplePaymentTransactions numTxs = do
   keyPair@(vk, _) <- genKeyPair
   utxo <- genOneUTxOFor vk
   txs <-
-    reverse . thrd
+    reverse
+      . thrd
       <$> foldM (generateOneTransfer testNetworkId) (utxo, keyPair, []) [1 .. numTxs]
   pure (utxo, txs)
  where

--- a/hydra-node/src/Hydra/Ledger/Cardano/Builder.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano/Builder.hs
@@ -5,7 +5,7 @@ import Hydra.Cardano.Api
 import Hydra.Prelude
 
 import Data.Default (def)
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 
 -- * Executing
 

--- a/hydra-node/src/Hydra/Ledger/Cardano/Configuration.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano/Configuration.hs
@@ -8,14 +8,14 @@ import Hydra.Cardano.Api
 import Hydra.Prelude
 
 import Cardano.Ledger.BaseTypes (Globals (..), boundRational, mkActiveSlotCoeff)
-import qualified Cardano.Ledger.BaseTypes as Ledger
+import Cardano.Ledger.BaseTypes qualified as Ledger
 import Cardano.Ledger.Core (PParams)
 import Cardano.Ledger.Shelley.API (computeRandomnessStabilisationWindow, computeStabilityWindow)
-import qualified Cardano.Ledger.Shelley.API.Types as Ledger
+import Cardano.Ledger.Shelley.API.Types qualified as Ledger
 import Cardano.Slotting.EpochInfo (fixedEpochInfo)
 import Cardano.Slotting.Time (mkSlotLength)
-import qualified Data.Aeson as Json
-import qualified Data.Aeson.Types as Json
+import Data.Aeson qualified as Json
+import Data.Aeson.Types qualified as Json
 
 -- * Helpers
 

--- a/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs
@@ -12,11 +12,11 @@ module Hydra.Ledger.Cardano.Evaluate where
 
 import Hydra.Prelude hiding (label)
 
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Ledger.Alonzo.Language (BinaryPlutus (..), Language (PlutusV2), Plutus (..))
-import qualified Cardano.Ledger.Alonzo.PlutusScriptApi as Ledger
+import Cardano.Ledger.Alonzo.PlutusScriptApi qualified as Ledger
 import Cardano.Ledger.Alonzo.Scripts (CostModel, Prices (..), costModelsValid, emptyCostModels, mkCostModel, txscriptfee)
-import qualified Cardano.Ledger.Alonzo.Scripts.Data as Ledger
+import Cardano.Ledger.Alonzo.Scripts.Data qualified as Ledger
 import Cardano.Ledger.Alonzo.TxInfo (PlutusWithContext (PlutusWithContext), slotToPOSIXTime)
 import Cardano.Ledger.Api (ppCostModelsL, ppMaxBlockExUnitsL, ppMaxTxExUnitsL, ppMaxValSizeL, ppMinFeeAL, ppMinFeeBL, ppPricesL, ppProtocolVersionL)
 import Cardano.Ledger.BaseTypes (BoundedRational (boundRational), ProtVer (..), natVersion)
@@ -30,9 +30,9 @@ import Cardano.Slotting.Time (RelativeTime (RelativeTime), SlotLength (getSlotLe
 import Control.Arrow (left)
 import Control.Lens ((.~))
 import Control.Lens.Getter
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.Default (def)
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Data.Maybe (fromJust)
 import Data.Ratio ((%))
 import Data.SOP.NonEmpty (NonEmpty (NonEmptyOne))
@@ -75,13 +75,13 @@ import Ouroboros.Consensus.HardFork.History (
   initBound,
   mkInterpreter,
  )
-import qualified PlutusCore as PLC
+import PlutusCore qualified as PLC
 import PlutusLedgerApi.Common (mkTermToEvaluate)
-import qualified PlutusLedgerApi.Common as Plutus
+import PlutusLedgerApi.Common qualified as Plutus
 import Test.QuickCheck (choose)
 import Test.QuickCheck.Gen (chooseWord64)
 import UntypedPlutusCore (UnrestrictedProgram (..))
-import qualified UntypedPlutusCore as UPLC
+import UntypedPlutusCore qualified as UPLC
 
 -- * Evaluate transactions
 

--- a/hydra-node/src/Hydra/Ledger/Cardano/Json.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano/Json.hs
@@ -11,14 +11,14 @@ module Hydra.Ledger.Cardano.Json where
 import Hydra.Cardano.Api
 import Hydra.Prelude
 
-import qualified Cardano.Crypto.Hash.Class as Crypto
-import qualified Cardano.Ledger.Address as Ledger
-import qualified Cardano.Ledger.Allegra.Scripts as Ledger
-import qualified Cardano.Ledger.Alonzo.Scripts as Ledger
-import qualified Cardano.Ledger.Alonzo.TxAuxData as Ledger
-import qualified Cardano.Ledger.Alonzo.TxWits as Ledger
-import qualified Cardano.Ledger.Babbage.Tx as Ledger
-import qualified Cardano.Ledger.Babbage.TxBody as Ledger
+import Cardano.Crypto.Hash.Class qualified as Crypto
+import Cardano.Ledger.Address qualified as Ledger
+import Cardano.Ledger.Allegra.Scripts qualified as Ledger
+import Cardano.Ledger.Alonzo.Scripts qualified as Ledger
+import Cardano.Ledger.Alonzo.TxAuxData qualified as Ledger
+import Cardano.Ledger.Alonzo.TxWits qualified as Ledger
+import Cardano.Ledger.Babbage.Tx qualified as Ledger
+import Cardano.Ledger.Babbage.TxBody qualified as Ledger
 import Cardano.Ledger.BaseTypes (StrictMaybe (..), isSJust)
 import Cardano.Ledger.Binary (
   DecCBOR,
@@ -33,14 +33,14 @@ import Cardano.Ledger.Binary (
 import Cardano.Ledger.Binary.Decoding (Annotator)
 import Cardano.Ledger.Block (txid)
 import Cardano.Ledger.Core (eraProtVerLow)
-import qualified Cardano.Ledger.Core as Ledger
-import qualified Cardano.Ledger.Crypto as Ledger
-import qualified Cardano.Ledger.Keys as Ledger
-import qualified Cardano.Ledger.Mary.Value as Ledger
-import qualified Cardano.Ledger.SafeHash as Ledger
-import qualified Cardano.Ledger.Shelley.API as Ledger
-import qualified Cardano.Ledger.Shelley.TxCert as Ledger
-import qualified Codec.Binary.Bech32 as Bech32
+import Cardano.Ledger.Core qualified as Ledger
+import Cardano.Ledger.Crypto qualified as Ledger
+import Cardano.Ledger.Keys qualified as Ledger
+import Cardano.Ledger.Mary.Value qualified as Ledger
+import Cardano.Ledger.SafeHash qualified as Ledger
+import Cardano.Ledger.Shelley.API qualified as Ledger
+import Cardano.Ledger.Shelley.TxCert qualified as Ledger
+import Codec.Binary.Bech32 qualified as Bech32
 import Data.Aeson (
   FromJSONKey (fromJSONKey),
   FromJSONKeyFunction (FromJSONKeyTextParser),
@@ -55,15 +55,15 @@ import Data.Aeson (
   (.:?),
   (.=),
  )
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Data.Aeson.Types (
   Pair,
   Parser,
   toJSONKeyText,
  )
-import qualified Data.ByteString.Base16 as Base16
-import qualified Data.Map as Map
-import qualified Data.Set as Set
+import Data.ByteString.Base16 qualified as Base16
+import Data.Map qualified as Map
+import Data.Set qualified as Set
 
 --
 -- Addr

--- a/hydra-node/src/Hydra/Ledger/Simple.hs
+++ b/hydra-node/src/Hydra/Ledger/Simple.hs
@@ -20,7 +20,7 @@ import Data.Aeson (
   (.=),
  )
 import Data.List (maximum)
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import Hydra.Chain (ChainStateType, IsChainState (..))
 import Hydra.Ledger (
   ChainSlot (..),
@@ -101,7 +101,7 @@ instance IsChainState SimpleTx where
 -- MockTxIn
 --
 
--- |An identifier for a single output of a 'SimpleTx'.
+-- | An identifier for a single output of a 'SimpleTx'.
 newtype SimpleTxIn = SimpleTxIn {unSimpleTxIn :: Integer}
   deriving stock (Generic)
   deriving newtype (Eq, Ord, Show, Num, ToJSON, FromJSON)

--- a/hydra-node/src/Hydra/Logging.hs
+++ b/hydra-node/src/Hydra/Logging.hs
@@ -44,9 +44,9 @@ import Control.Tracer (
   traceWith,
  )
 import Data.Aeson (pairs, (.=))
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString.Lazy as LBS
-import qualified Data.Text as Text
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy qualified as LBS
+import Data.Text qualified as Text
 import Test.QuickCheck.Instances.Text ()
 import Test.QuickCheck.Instances.Time ()
 

--- a/hydra-node/src/Hydra/Logging/Monitoring.hs
+++ b/hydra-node/src/Hydra/Logging/Monitoring.hs
@@ -72,7 +72,7 @@ prepareRegistry = do
 data MetricDefinition where
   MetricDefinition :: forall a. Name -> (a -> Metric) -> (Name -> Registry -> IO (a, Registry)) -> MetricDefinition
 
--- |All custom 'MetricDefinition's for Hydra
+-- | All custom 'MetricDefinition's for Hydra
 allMetrics :: [MetricDefinition]
 allMetrics =
   [ MetricDefinition (Name "hydra_head_events") CounterMetric $ flip registerCounter mempty

--- a/hydra-node/src/Hydra/Network/Authenticate.hs
+++ b/hydra-node/src/Hydra/Network/Authenticate.hs
@@ -9,7 +9,7 @@ module Hydra.Network.Authenticate where
 import Cardano.Crypto.Util (SignableRepresentation)
 import Control.Tracer (Tracer)
 import Data.Aeson (Options (tagSingleConstructors), defaultOptions, genericToJSON)
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Hydra.Crypto (HydraKey, Key (SigningKey), Signature, sign, verify)
 import Hydra.Logging (traceWith)
 import Hydra.Network (Network (Network, broadcast), NetworkComponent)

--- a/hydra-node/src/Hydra/Network/Heartbeat.hs
+++ b/hydra-node/src/Hydra/Network/Heartbeat.hs
@@ -22,8 +22,8 @@ import Hydra.Prelude
 import Cardano.Binary (serialize')
 import Cardano.Crypto.Util (SignableRepresentation (getSignableRepresentation))
 import Control.Concurrent.Class.MonadSTM (modifyTVar', newTVarIO, readTVarIO, writeTVar)
-import qualified Data.Map as Map
-import qualified Data.Set as Set
+import Data.Map qualified as Map
+import Data.Set qualified as Set
 import Hydra.Network (Network (..), NetworkCallback, NetworkComponent, NodeId)
 import Hydra.Network.Message (Connectivity (Connected, Disconnected))
 
@@ -46,12 +46,12 @@ data Heartbeat msg
   deriving stock (Eq, Show, Ord, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
-instance (ToCBOR msg) => ToCBOR (Heartbeat msg) where
+instance ToCBOR msg => ToCBOR (Heartbeat msg) where
   toCBOR = \case
     (Data host hmsg) -> toCBOR (0 :: Int) <> toCBOR host <> toCBOR hmsg
     (Ping host) -> toCBOR (1 :: Int) <> toCBOR host
 
-instance (FromCBOR msg) => FromCBOR (Heartbeat msg) where
+instance FromCBOR msg => FromCBOR (Heartbeat msg) where
   fromCBOR =
     fromCBOR >>= \case
       (0 :: Int) -> Data <$> fromCBOR <*> fromCBOR

--- a/hydra-node/src/Hydra/Network/Message.hs
+++ b/hydra-node/src/Hydra/Network/Message.hs
@@ -31,10 +31,10 @@ data Message tx
     AckSn {signed :: Signature (Snapshot tx), snapshotNumber :: SnapshotNumber}
   deriving stock (Generic)
 
-deriving stock instance (IsTx tx) => Eq (Message tx)
-deriving stock instance (IsTx tx) => Show (Message tx)
-deriving anyclass instance (IsTx tx) => ToJSON (Message tx)
-deriving anyclass instance (IsTx tx) => FromJSON (Message tx)
+deriving stock instance IsTx tx => Eq (Message tx)
+deriving stock instance IsTx tx => Show (Message tx)
+deriving anyclass instance IsTx tx => ToJSON (Message tx)
+deriving anyclass instance IsTx tx => FromJSON (Message tx)
 
 instance IsTx tx => Arbitrary (Message tx) where
   arbitrary = genericArbitrary

--- a/hydra-node/src/Hydra/Network/Ouroboros.hs
+++ b/hydra-node/src/Hydra/Network/Ouroboros.hs
@@ -14,7 +14,7 @@ import Control.Monad.Class.MonadAsync (wait)
 import Hydra.Prelude
 
 import Codec.CBOR.Term (Term)
-import qualified Codec.CBOR.Term as CBOR
+import Codec.CBOR.Term qualified as CBOR
 import Control.Concurrent.STM (
   TChan,
   dupTChan,
@@ -24,8 +24,8 @@ import Control.Concurrent.STM (
  )
 import Control.Exception (IOException)
 import Data.Aeson (object, withObject, (.:), (.=))
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Types as Aeson
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Types qualified as Aeson
 import Data.Map.Strict as Map
 import Hydra.Logging (Tracer, nullTracer)
 import Hydra.Network (
@@ -113,7 +113,7 @@ import Ouroboros.Network.Subscription (
   SubscriptionTrace,
   WithIPList,
  )
-import qualified Ouroboros.Network.Subscription as Subscription
+import Ouroboros.Network.Subscription qualified as Subscription
 import Ouroboros.Network.Subscription.Ip (SubscriptionParams (..), WithIPList (WithIPList))
 import Ouroboros.Network.Subscription.Worker (LocalAddresses (LocalAddresses))
 

--- a/hydra-node/src/Hydra/Network/Ouroboros/Type.hs
+++ b/hydra-node/src/Hydra/Network/Ouroboros/Type.hs
@@ -2,8 +2,8 @@ module Hydra.Network.Ouroboros.Type where
 
 import Hydra.Prelude
 
-import qualified Cardano.Binary as CBOR
-import qualified Codec.CBOR.Read as CBOR
+import Cardano.Binary qualified as CBOR
+import Codec.CBOR.Read qualified as CBOR
 import GHC.Show (Show (show))
 import Network.TypedProtocol (PeerHasAgency (ClientAgency), Protocol (..))
 import Network.TypedProtocol.Codec (Codec)
@@ -53,9 +53,9 @@ instance Protocol (FireForget msg) where
   exclusionLemma_NobodyAndClientHaveAgency TokDone tok = case tok of {}
   exclusionLemma_NobodyAndServerHaveAgency TokDone tok = case tok of {}
 
-deriving stock instance (Show msg) => Show (Message (FireForget msg) from to)
+deriving stock instance Show msg => Show (Message (FireForget msg) from to)
 
-deriving stock instance (Eq msg) => Eq (Message (FireForget msg) from to)
+deriving stock instance Eq msg => Eq (Message (FireForget msg) from to)
 
 instance Show (ClientHasAgency (st :: FireForget msg)) where
   show TokIdle = "TokIdle"

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -43,8 +43,8 @@ import Hydra.HeadLogic (
   recoverChainStateHistory,
   recoverState,
  )
-import qualified Hydra.HeadLogic as Logic
-import qualified Hydra.HeadLogic.Heads as Heads
+import Hydra.HeadLogic qualified as Logic
+import Hydra.HeadLogic.Heads qualified as Heads
 import Hydra.HeadLogic.Outcome (StateChanged (..))
 import Hydra.HeadLogic.State (getHeadParameters)
 import Hydra.Ledger (IsTx, Ledger)
@@ -144,10 +144,10 @@ data HydraNodeLog tx
   | Misconfiguration {misconfigurationErrors :: [ParamMismatch]}
   deriving stock (Generic)
 
-deriving stock instance (IsChainState tx) => Eq (HydraNodeLog tx)
-deriving stock instance (IsChainState tx) => Show (HydraNodeLog tx)
-deriving anyclass instance (IsChainState tx) => ToJSON (HydraNodeLog tx)
-deriving anyclass instance (IsChainState tx) => FromJSON (HydraNodeLog tx)
+deriving stock instance IsChainState tx => Eq (HydraNodeLog tx)
+deriving stock instance IsChainState tx => Show (HydraNodeLog tx)
+deriving anyclass instance IsChainState tx => ToJSON (HydraNodeLog tx)
+deriving anyclass instance IsChainState tx => FromJSON (HydraNodeLog tx)
 
 instance (IsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (HydraNodeLog tx) where
   arbitrary = genericArbitrary
@@ -208,7 +208,7 @@ waitDelay = 0.1
 
 -- | Monadic interface around 'Hydra.Logic.update'.
 processNextEvent ::
-  (IsChainState tx) =>
+  IsChainState tx =>
   HydraNode tx m ->
   Event tx ->
   STM m (Outcome tx)
@@ -254,7 +254,7 @@ data NodeState tx m = NodeState
   }
 
 -- | Initialize a new 'NodeState'.
-createNodeState :: (MonadLabelledSTM m) => HeadState tx -> m (NodeState tx m)
+createNodeState :: MonadLabelledSTM m => HeadState tx -> m (NodeState tx m)
 createNodeState initialState = do
   tv <- newTVarIO initialState
   labelTVarIO tv "node-state"

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -9,11 +9,11 @@ module Hydra.Options (
 import Hydra.Prelude
 
 import Control.Arrow (left)
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as BSC
+import Data.ByteString qualified as BS
+import Data.ByteString.Char8 qualified as BSC
 import Data.IP (IP (IPv4), toIPv4, toIPv4w)
 import Data.Text (unpack)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Time.Clock (nominalDiffTimeToSeconds)
 import Data.Version (Version (..), showVersion)
 import Hydra.Cardano.Api (
@@ -32,7 +32,7 @@ import Hydra.Cardano.Api (
  )
 import Hydra.Chain (maximumNumberOfParties)
 import Hydra.ContestationPeriod (ContestationPeriod (UnsafeContestationPeriod))
-import qualified Hydra.Contract as Contract
+import Hydra.Contract qualified as Contract
 import Hydra.Ledger.Cardano ()
 import Hydra.Logging (Verbosity (..))
 import Hydra.Network (Host, NodeId (NodeId), PortNumber, readHost, readPort)

--- a/hydra-node/src/Hydra/Party.hs
+++ b/hydra-node/src/Hydra/Party.hs
@@ -9,7 +9,7 @@ import Data.Aeson (ToJSONKey)
 import Data.Aeson.Types (FromJSONKey)
 import Hydra.Cardano.Api (AsType (AsVerificationKey), SerialiseAsRawBytes (deserialiseFromRawBytes, serialiseToRawBytes), SigningKey, VerificationKey, getVerificationKey, verificationKeyHash)
 import Hydra.Crypto (AsType (AsHydraKey), HydraKey)
-import qualified Hydra.Data.Party as OnChain
+import Hydra.Data.Party qualified as OnChain
 
 -- | Identifies a party in a Hydra head by it's 'VerificationKey'.
 newtype Party = Party {vkey :: VerificationKey HydraKey}

--- a/hydra-node/src/Hydra/Persistence.hs
+++ b/hydra-node/src/Hydra/Persistence.hs
@@ -4,9 +4,9 @@ module Hydra.Persistence where
 
 import Hydra.Prelude
 
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as C8
+import Data.Aeson qualified as Aeson
+import Data.ByteString qualified as BS
+import Data.ByteString.Char8 qualified as C8
 import System.Directory (createDirectoryIfMissing, doesFileExist)
 import System.FilePath (takeDirectory)
 import UnliftIO.IO.File (withBinaryFile, writeBinaryFileDurableAtomic)

--- a/hydra-node/src/Hydra/Snapshot.hs
+++ b/hydra-node/src/Hydra/Snapshot.hs
@@ -8,7 +8,7 @@ import Cardano.Crypto.Util (SignableRepresentation (..))
 import Codec.Serialise (serialise)
 import Data.Aeson (object, withObject, (.:), (.=))
 import Hydra.Cardano.Api (SigningKey)
-import qualified Hydra.Contract.HeadState as Onchain
+import Hydra.Contract.HeadState qualified as Onchain
 import Hydra.Crypto (HydraKey, MultiSignature, aggregate, sign)
 import Hydra.Ledger (IsTx (..))
 import PlutusLedgerApi.V2 (toBuiltin, toData)

--- a/hydra-node/test/Hydra/API/ClientInputSpec.hs
+++ b/hydra-node/test/Hydra/API/ClientInputSpec.hs
@@ -5,7 +5,7 @@ import Test.Hydra.Prelude
 
 import Cardano.Binary (serialize')
 import Data.Aeson (Result (..), Value (String), fromJSON)
-import qualified Data.ByteString.Base16 as Base16
+import Data.ByteString.Base16 qualified as Base16
 import Hydra.API.ClientInput (ClientInput)
 import Hydra.Cardano.Api (serialiseToTextEnvelope, toLedgerTx)
 import Hydra.Ledger.Cardano (Tx)

--- a/hydra-node/test/Hydra/API/HTTPServerSpec.hs
+++ b/hydra-node/test/Hydra/API/HTTPServerSpec.hs
@@ -6,7 +6,7 @@ import Test.Hydra.Prelude
 import Cardano.Binary (serialize')
 import Data.Aeson (Result (Error, Success), Value (String), encode, fromJSON)
 import Data.Aeson.Lens (key, nth)
-import qualified Data.ByteString.Base16 as Base16
+import Data.ByteString.Base16 qualified as Base16
 import Hydra.API.HTTPServer (DraftCommitTxRequest, DraftCommitTxResponse, SubmitTxRequest (..), TransactionSubmitted, httpApp)
 import Hydra.API.ServerSpec (dummyChainHandle)
 import Hydra.Cardano.Api (serialiseToTextEnvelope, toLedgerTx)

--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -17,11 +17,11 @@ import Control.Concurrent.Class.MonadSTM (
   writeTQueue,
  )
 import Control.Lens ((^?))
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Data.Aeson.Lens (key, nonNull)
-import qualified Data.ByteString.Base16 as Base16
-import qualified Data.List as List
-import qualified Data.Text as T
+import Data.ByteString.Base16 qualified as Base16
+import Data.List qualified as List
+import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8)
 import Data.Version (showVersion)
 import Hydra.API.APIServerLog (APIServerLog)
@@ -42,7 +42,7 @@ import Hydra.Ledger (txId)
 import Hydra.Ledger.Simple (SimpleTx)
 import Hydra.Logging (Tracer, showLogsOnFailure)
 import Hydra.Network (PortNumber)
-import qualified Hydra.Options as Options
+import Hydra.Options qualified as Options
 import Hydra.Party (Party)
 import Hydra.Persistence (PersistenceIncremental (..), createPersistenceIncremental)
 import Hydra.Snapshot (ConfirmedSnapshot (..), Snapshot (Snapshot, utxo), confirmed)

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -19,7 +19,7 @@ import Control.Concurrent.Class.MonadSTM (
 import Control.Monad.Class.MonadAsync (Async, MonadAsync (async), cancel, forConcurrently_)
 import Control.Monad.IOSim (IOSim, runSimTrace, selectTraceEventsDynamic)
 import Data.List ((!!))
-import qualified Data.List as List
+import Data.List qualified as List
 import Hydra.API.ClientInput
 import Hydra.API.Server (Server (..))
 import Hydra.API.ServerOutput (ServerOutput (..))
@@ -499,7 +499,7 @@ waitUntilMatch nodes predicate =
 -- | Wait for an output matching the predicate and extracting some value. This
 -- will loop forever until a match has been found.
 waitMatch ::
-  (MonadThrow m) =>
+  MonadThrow m =>
   TestHydraClient tx m ->
   (ServerOutput tx -> Maybe a) ->
   m a
@@ -731,7 +731,7 @@ withHydraNode signingKey otherParties chain action = do
     action (createTestHydraClient outputs outputHistory node)
 
 createTestHydraClient ::
-  (MonadSTM m) =>
+  MonadSTM m =>
   TQueue m (ServerOutput tx) ->
   TVar m [ServerOutput tx] ->
   HydraNode tx m ->

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
@@ -7,9 +7,9 @@ module Hydra.Chain.Direct.Contract.Abort where
 import Hydra.Cardano.Api
 import Hydra.Prelude
 
-import qualified Cardano.Api.UTxO as UTxO
-import qualified Data.List as List
-import qualified Data.Map as Map
+import Cardano.Api.UTxO qualified as UTxO
+import Data.List qualified as List
+import Data.Map qualified as Map
 import Data.Maybe (fromJust)
 import Hydra.Chain (HeadParameters (..))
 import Hydra.Chain.Direct.Contract.Gen (genForParty)
@@ -32,14 +32,14 @@ import Hydra.Chain.Direct.Tx (
  )
 import Hydra.Chain.Direct.TxSpec (drop3rd, genAbortableOutputs)
 import Hydra.ContestationPeriod (toChain)
-import qualified Hydra.Contract.Commit as Commit
+import Hydra.Contract.Commit qualified as Commit
 import Hydra.Contract.CommitError (CommitError (..))
 import Hydra.Contract.Error (toErrorCode)
 import Hydra.Contract.HeadError (HeadError (..))
-import qualified Hydra.Contract.HeadState as Head
+import Hydra.Contract.HeadState qualified as Head
 import Hydra.Contract.HeadTokens (headPolicyId, mkHeadTokenScript)
 import Hydra.Contract.HeadTokensError (HeadTokensError (..))
-import qualified Hydra.Contract.Initial as Initial
+import Hydra.Contract.Initial qualified as Initial
 import Hydra.Contract.InitialError (InitialError (STNotBurned))
 import Hydra.Ledger.Cardano (genAddressInEra, genVerificationKey)
 import Hydra.Party (Party, partyToChain)

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -25,19 +25,19 @@ import Hydra.Chain.Direct.Contract.Mutation (
   replaceUtxoHash,
  )
 import Hydra.Chain.Direct.Fixture (testNetworkId)
-import qualified Hydra.Chain.Direct.Fixture as Fixture
+import Hydra.Chain.Direct.Fixture qualified as Fixture
 import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry, registryUTxO)
 import Hydra.Chain.Direct.TimeHandle (PointInTime)
 import Hydra.Chain.Direct.Tx (ClosingSnapshot (..), OpenThreadOutput (..), UTxOHash (UTxOHash), closeTx, mkHeadId, mkHeadOutput)
 import Hydra.ContestationPeriod (fromChain)
 import Hydra.Contract.Error (toErrorCode)
 import Hydra.Contract.HeadError (HeadError (..))
-import qualified Hydra.Contract.HeadState as Head
+import Hydra.Contract.HeadState qualified as Head
 import Hydra.Contract.HeadTokens (headPolicyId)
 import Hydra.Contract.Util (UtilError (MintingOrBurningIsForbidden))
 import Hydra.Crypto (HydraKey, MultiSignature, aggregate, sign, toPlutusSignatures)
-import qualified Hydra.Data.ContestationPeriod as OnChain
-import qualified Hydra.Data.Party as OnChain
+import Hydra.Data.ContestationPeriod qualified as OnChain
+import Hydra.Data.Party qualified as OnChain
 import Hydra.Ledger (hashUTxO)
 import Hydra.Ledger.Cardano (genAddressInEra, genOneUTxOFor, genValue, genVerificationKey)
 import Hydra.Ledger.Cardano.Evaluate (genValidityBoundsFromContestationPeriod)

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -6,9 +6,9 @@ module Hydra.Chain.Direct.Contract.CollectCom where
 import Hydra.Cardano.Api
 import Hydra.Prelude hiding (label)
 
-import qualified Cardano.Api.UTxO as UTxO
-import qualified Data.List as List
-import qualified Data.Map as Map
+import Cardano.Api.UTxO qualified as UTxO
+import Data.List qualified as List
+import Data.Map qualified as Map
 import Data.Maybe (fromJust)
 import Hydra.Chain.Direct.Contract.Gen (genForParty, genHash, genMintedOrBurnedValue)
 import Hydra.Chain.Direct.Contract.Mutation (
@@ -35,15 +35,15 @@ import Hydra.Chain.Direct.Tx (
   mkHeadOutput,
   mkInitialOutput,
  )
-import qualified Hydra.Contract.Commit as Commit
+import Hydra.Contract.Commit qualified as Commit
 import Hydra.Contract.CommitError (CommitError (STIsMissingInTheOutput))
 import Hydra.Contract.Error (toErrorCode)
 import Hydra.Contract.HeadError (HeadError (..))
-import qualified Hydra.Contract.HeadState as Head
+import Hydra.Contract.HeadState qualified as Head
 import Hydra.Contract.HeadTokens (headPolicyId)
 import Hydra.Contract.Util (UtilError (MintingOrBurningIsForbidden))
-import qualified Hydra.Data.ContestationPeriod as OnChain
-import qualified Hydra.Data.Party as OnChain
+import Hydra.Data.ContestationPeriod qualified as OnChain
+import Hydra.Data.Party qualified as OnChain
 import Hydra.Ledger.Cardano (
   genAdaOnlyUTxO,
   genAddressInEra,
@@ -55,7 +55,7 @@ import Hydra.Plutus.Orphans ()
 import PlutusTx.Builtins (toBuiltin)
 import Test.QuickCheck (choose, elements, oneof, suchThat)
 import Test.QuickCheck.Instances ()
-import qualified Prelude
+import Prelude qualified
 
 --
 -- CollectComTx

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Commit.hs
@@ -8,8 +8,8 @@ import Hydra.Prelude
 -- Arbitrary VerificationKey instance
 import Hydra.Chain.Direct.TxSpec ()
 
-import qualified Cardano.Api.UTxO as UTxO
-import qualified Data.List as List
+import Cardano.Api.UTxO qualified as UTxO
+import Data.List qualified as List
 import Data.Maybe (fromJust)
 import Hydra.Chain.Direct.Contract.Gen (genMintedOrBurnedValue)
 import Hydra.Chain.Direct.Contract.Mutation (
@@ -18,13 +18,13 @@ import Hydra.Chain.Direct.Contract.Mutation (
   changeMintedTokens,
   replacePolicyIdWith,
  )
-import qualified Hydra.Chain.Direct.Fixture as Fixture
+import Hydra.Chain.Direct.Fixture qualified as Fixture
 import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry, registryUTxO)
 import Hydra.Chain.Direct.Tx (commitTx, mkHeadId, mkInitialOutput)
-import qualified Hydra.Contract.Commit as Commit
+import Hydra.Contract.Commit qualified as Commit
 import Hydra.Contract.Error (toErrorCode)
 import Hydra.Contract.HeadTokens (headPolicyId)
-import qualified Hydra.Contract.Initial as Initial
+import Hydra.Contract.Initial qualified as Initial
 import Hydra.Contract.InitialError (InitialError (..))
 import Hydra.Ledger.Cardano (
   genAddressInEra,

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -26,19 +26,19 @@ import Hydra.Chain.Direct.Contract.Mutation (
   replaceUtxoHash,
  )
 import Hydra.Chain.Direct.Fixture (testNetworkId, testPolicyId)
-import qualified Hydra.Chain.Direct.Fixture as Fixture
+import Hydra.Chain.Direct.Fixture qualified as Fixture
 import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry, registryUTxO)
 import Hydra.Chain.Direct.Tx (ClosedThreadOutput (..), contestTx, mkHeadId, mkHeadOutput)
 import Hydra.ContestationPeriod (ContestationPeriod, fromChain)
 import Hydra.Contract.Error (toErrorCode)
 import Hydra.Contract.HeadError (HeadError (..))
-import qualified Hydra.Contract.HeadState as Head
+import Hydra.Contract.HeadState qualified as Head
 import Hydra.Contract.HeadTokens (headPolicyId)
 import Hydra.Contract.Util (UtilError (MintingOrBurningIsForbidden))
 import Hydra.Crypto (HydraKey, MultiSignature, aggregate, sign, toPlutusSignatures)
-import qualified Hydra.Data.ContestationPeriod as OnChain
+import Hydra.Data.ContestationPeriod qualified as OnChain
 import Hydra.Data.Party (partyFromVerificationKeyBytes)
-import qualified Hydra.Data.Party as OnChain
+import Hydra.Data.Party qualified as OnChain
 import Hydra.Ledger (hashUTxO)
 import Hydra.Ledger.Cardano (genAddressInEra, genOneUTxOFor, genValue, genVerificationKey)
 import Hydra.Ledger.Cardano.Evaluate (slotNoToUTCTime)
@@ -47,7 +47,7 @@ import Hydra.Plutus.Extras (posixFromUTCTime)
 import Hydra.Plutus.Orphans ()
 import Hydra.Snapshot (Snapshot (..), SnapshotNumber)
 import PlutusLedgerApi.V2 (BuiltinByteString, toBuiltin)
-import qualified PlutusLedgerApi.V2 as Plutus
+import PlutusLedgerApi.V2 qualified as Plutus
 import Test.Hydra.Fixture (aliceSk, bobSk, carolSk)
 import Test.QuickCheck (arbitrarySizedNatural, elements, listOf, listOf1, oneof, suchThat, vectorOf)
 import Test.QuickCheck.Gen (choose)

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/FanOut.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/FanOut.hs
@@ -13,9 +13,9 @@ import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry, registryUTxO)
 import Hydra.Chain.Direct.Tx (fanoutTx, mkHeadOutput)
 import Hydra.Contract.Error (toErrorCode)
 import Hydra.Contract.HeadError (HeadError (..))
-import qualified Hydra.Contract.HeadState as Head
+import Hydra.Contract.HeadState qualified as Head
 import Hydra.Contract.HeadTokens (mkHeadTokenScript)
-import qualified Hydra.Data.ContestationPeriod as OnChain
+import Hydra.Data.ContestationPeriod qualified as OnChain
 import Hydra.Ledger (IsTx (hashUTxO))
 import Hydra.Ledger.Cardano (
   adaOnly,

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Gen.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Gen.hs
@@ -3,9 +3,9 @@ module Hydra.Chain.Direct.Contract.Gen where
 
 import Cardano.Crypto.Hash (hashToBytes)
 import Codec.CBOR.Magic (uintegerFromBytes)
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Hydra.Cardano.Api
-import qualified Hydra.Chain.Direct.Fixture as Fixtures
+import Hydra.Chain.Direct.Fixture qualified as Fixtures
 import Hydra.Contract.HeadTokens (headPolicyId)
 import Hydra.Contract.Util (hydraHeadV1)
 import Hydra.Crypto (Hash (HydraKeyHash))

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Init.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Init.hs
@@ -7,7 +7,7 @@ module Hydra.Chain.Direct.Contract.Init where
 import Hydra.Cardano.Api
 import Hydra.Prelude
 
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import Data.Maybe (fromJust)
 import Hydra.Chain (HeadParameters (..))
 import Hydra.Chain.Direct.Contract.Gen (genForParty)
@@ -26,9 +26,9 @@ import Hydra.Contract.HeadState (State (..))
 import Hydra.Contract.HeadTokensError (HeadTokensError (..))
 import Hydra.Ledger.Cardano (genOneUTxOFor, genValue, genVerificationKey)
 import Hydra.Party (Party)
-import qualified PlutusLedgerApi.Test.Examples as Plutus
+import PlutusLedgerApi.Test.Examples qualified as Plutus
 import Test.QuickCheck (choose, elements, oneof, suchThat, vectorOf)
-import qualified Prelude
+import Prelude qualified
 
 --
 -- InitTx

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
@@ -130,34 +130,34 @@ module Hydra.Chain.Direct.Contract.Mutation where
 
 import Hydra.Cardano.Api
 
-import qualified Cardano.Api.UTxO as UTxO
-import qualified Cardano.Ledger.Alonzo.Scripts as Ledger
-import qualified Cardano.Ledger.Alonzo.Scripts.Data as Ledger
-import qualified Cardano.Ledger.Alonzo.TxWits as Ledger
-import qualified Cardano.Ledger.Babbage.TxBody as Ledger
+import Cardano.Api.UTxO qualified as UTxO
+import Cardano.Ledger.Alonzo.Scripts qualified as Ledger
+import Cardano.Ledger.Alonzo.Scripts.Data qualified as Ledger
+import Cardano.Ledger.Alonzo.TxWits qualified as Ledger
+import Cardano.Ledger.Babbage.TxBody qualified as Ledger
 import Cardano.Ledger.Binary (mkSized)
-import qualified Cardano.Ledger.Core as Ledger
-import qualified Cardano.Ledger.Mary.Value as Ledger
-import qualified Data.Map as Map
-import qualified Data.Sequence.Strict as StrictSeq
-import qualified Data.Set as Set
+import Cardano.Ledger.Core qualified as Ledger
+import Cardano.Ledger.Mary.Value qualified as Ledger
+import Data.Map qualified as Map
+import Data.Sequence.Strict qualified as StrictSeq
+import Data.Set qualified as Set
 import Hydra.Cardano.Api.Pretty (renderTxWithUTxO)
 import Hydra.Chain.Direct.Contract.Gen (genForParty)
 import Hydra.Chain.Direct.Fixture (testPolicyId)
-import qualified Hydra.Chain.Direct.Fixture as Fixture
+import Hydra.Chain.Direct.Fixture qualified as Fixture
 import Hydra.Chain.Direct.Tx (assetNameFromVerificationKey, findFirst)
-import qualified Hydra.Contract.Head as Head
-import qualified Hydra.Contract.HeadState as Head
+import Hydra.Contract.Head qualified as Head
+import Hydra.Contract.HeadState qualified as Head
 import Hydra.Data.ContestationPeriod
-import qualified Hydra.Data.Party as Data (Party)
+import Hydra.Data.Party qualified as Data (Party)
 import Hydra.Ledger.Cardano (genKeyPair, genOutput, genVerificationKey)
 import Hydra.Ledger.Cardano.Evaluate (evaluateTx)
 import Hydra.Party (Party)
 import Hydra.Plutus.Orphans ()
 import Hydra.Prelude hiding (label)
 import PlutusLedgerApi.V2 (CurrencySymbol, POSIXTime, toData)
-import qualified PlutusLedgerApi.V2 as Plutus
-import qualified System.Directory.Internal.Prelude as Prelude
+import PlutusLedgerApi.V2 qualified as Plutus
+import System.Directory.Internal.Prelude qualified as Prelude
 import Test.Hydra.Prelude
 import Test.QuickCheck (
   Property,

--- a/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/ContractSpec.hs
@@ -6,13 +6,13 @@ module Hydra.Chain.Direct.ContractSpec where
 import Hydra.Prelude hiding (label)
 import Test.Hydra.Prelude
 
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Crypto.Util (SignableRepresentation (getSignableRepresentation))
 import Cardano.Ledger.Alonzo.TxInfo (TxOutSource (TxOutFromOutput))
 import Cardano.Ledger.Babbage.TxInfo (txInfoOutV2)
-import qualified Cardano.Ledger.BaseTypes as Ledger
-import qualified Data.ByteString.Base16 as Base16
-import qualified Data.List as List
+import Cardano.Ledger.BaseTypes qualified as Ledger
+import Data.ByteString.Base16 qualified as Base16
+import Data.List qualified as List
 import Hydra.Cardano.Api (
   UTxO,
   toLedgerTxOut,
@@ -28,15 +28,15 @@ import Hydra.Chain.Direct.Contract.FanOut (genFanoutMutation, healthyFanoutTx)
 import Hydra.Chain.Direct.Contract.Init (genInitMutation, healthyInitTx)
 import Hydra.Chain.Direct.Contract.Mutation (propMutation, propTransactionEvaluates)
 import Hydra.Chain.Direct.Fixture (testNetworkId)
-import qualified Hydra.Contract.Commit as Commit
+import Hydra.Contract.Commit qualified as Commit
 import Hydra.Contract.Head (
   verifyPartySignature,
   verifySnapshotSignature,
  )
-import qualified Hydra.Contract.Head as OnChain
+import Hydra.Contract.Head qualified as OnChain
 import Hydra.Crypto (aggregate, generateSigningKey, sign, toPlutusSignatures)
 import Hydra.Ledger (hashUTxO)
-import qualified Hydra.Ledger as OffChain
+import Hydra.Ledger qualified as OffChain
 import Hydra.Ledger.Cardano (
   Tx,
   genUTxOSized,

--- a/hydra-node/test/Hydra/Chain/Direct/HandlersSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/HandlersSpec.hs
@@ -327,7 +327,7 @@ genSequenceOfObservableBlocks = do
     void $ stepCommits ctx initTx allContexts
   pure (cctx, initialChainState, reverse blks)
  where
-  nextSlot :: (Monad m) => StateT [TestBlock] m SlotNo
+  nextSlot :: Monad m => StateT [TestBlock] m SlotNo
   nextSlot = do
     get <&> \case
       [] -> 1

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -6,11 +6,11 @@ module Hydra.Chain.Direct.StateSpec where
 import Hydra.Prelude hiding (label)
 import Test.Hydra.Prelude
 
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Binary (serialize)
-import qualified Data.ByteString.Lazy as LBS
+import Data.ByteString.Lazy qualified as LBS
 import Data.List (intersect)
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import Hydra.Cardano.Api (
   NetworkId (Mainnet),
   Tx,
@@ -81,7 +81,7 @@ import Hydra.Chain.Direct.State (
  )
 import Hydra.Chain.Direct.Tx (ClosedThreadOutput (closedContesters), NotAnInit (NotAnInit), NotAnInitReason (..))
 import Hydra.ContestationPeriod (toNominalDiffTime)
-import qualified Hydra.Contract.HeadTokens as HeadTokens
+import Hydra.Contract.HeadTokens qualified as HeadTokens
 import Hydra.Ledger.Cardano (
   genOutput,
   genTxOut,
@@ -96,10 +96,10 @@ import Hydra.Ledger.Cardano.Evaluate (
   genValidityBoundsFromContestationPeriod,
   maxTxSize,
  )
-import qualified Hydra.Ledger.Cardano.Evaluate as Fixture
+import Hydra.Ledger.Cardano.Evaluate qualified as Fixture
 import Hydra.Snapshot (ConfirmedSnapshot (InitialSnapshot, initialUTxO))
-import qualified PlutusLedgerApi.Test.Examples as Plutus
-import qualified PlutusLedgerApi.V2 as Plutus
+import PlutusLedgerApi.Test.Examples qualified as Plutus
+import PlutusLedgerApi.V2 qualified as Plutus
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
 import Test.QuickCheck (
   Property,
@@ -124,7 +124,7 @@ import Test.QuickCheck (
   (==>),
  )
 import Test.QuickCheck.Monadic (monadicIO, monadicST, pick)
-import qualified Prelude
+import Prelude qualified
 
 spec :: Spec
 spec = parallel $ do

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -11,10 +11,10 @@ import Hydra.Chain.Direct.Tx
 import Hydra.Prelude hiding (label)
 import Test.Hydra.Prelude
 
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Ledger.Core (EraTx (getMinFeeTx))
-import qualified Data.Map as Map
-import qualified Data.Text as T
+import Data.Map qualified as Map
+import Data.Text qualified as T
 import GHC.Natural (wordToNatural)
 import Hydra.Cardano.Api.Pretty (renderTx)
 import Hydra.Chain (HeadParameters (..))
@@ -30,9 +30,9 @@ import Hydra.Chain.Direct.Fixture (
 import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry, registryUTxO)
 import Hydra.Chain.Direct.Wallet (ErrCoverFee (..), coverFee_)
 import Hydra.ContestationPeriod (ContestationPeriod (UnsafeContestationPeriod))
-import qualified Hydra.Contract.Commit as Commit
+import Hydra.Contract.Commit qualified as Commit
 import Hydra.Contract.HeadTokens (mkHeadTokenScript)
-import qualified Hydra.Contract.Initial as Initial
+import Hydra.Contract.Initial qualified as Initial
 import Hydra.Ledger.Cardano (adaOnly, genOneUTxOFor, genVerificationKey)
 import Hydra.Ledger.Cardano.Evaluate (EvaluationReport, maxTxExecutionUnits)
 import Hydra.Party (Party)
@@ -139,8 +139,10 @@ spec =
 
 withinTxExecutionBudget :: EvaluationReport -> Property
 withinTxExecutionBudget report =
-  ( totalMem <= maxMem
-      && totalCpu <= maxCpu
+  ( totalMem
+      <= maxMem
+      && totalCpu
+      <= maxCpu
   )
     & counterexample
       ( "Ex. Cost Limits exceeded, mem: "

--- a/hydra-node/test/Hydra/Chain/Direct/WalletSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/WalletSpec.hs
@@ -7,18 +7,18 @@ import Test.Hydra.Prelude
 
 import Cardano.Ledger.Babbage.Tx (AlonzoTx (..))
 import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..), BabbageTxOut (..), outputs')
-import qualified Cardano.Ledger.BaseTypes as Ledger
+import Cardano.Ledger.BaseTypes qualified as Ledger
 import Cardano.Ledger.Binary (mkSized)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core (Tx, Value)
-import qualified Cardano.Ledger.SafeHash as SafeHash
-import qualified Cardano.Ledger.Shelley.API as Ledger
+import Cardano.Ledger.SafeHash qualified as SafeHash
+import Cardano.Ledger.Shelley.API qualified as Ledger
 import Cardano.Ledger.Val (Val (..), invert)
 import Control.Concurrent (newEmptyMVar, putMVar, takeMVar)
 import Control.Tracer (nullTracer)
-import qualified Data.Map.Strict as Map
-import qualified Data.Sequence.Strict as StrictSeq
-import qualified Data.Set as Set
+import Data.Map.Strict qualified as Map
+import Data.Sequence.Strict qualified as StrictSeq
+import Data.Set qualified as Set
 import Hydra.Cardano.Api (
   ChainPoint (ChainPoint),
   Hash (HeaderHash),
@@ -38,11 +38,11 @@ import Hydra.Cardano.Api (
   txOutValue,
   verificationKeyHash,
  )
-import qualified Hydra.Cardano.Api as Api
+import Hydra.Cardano.Api qualified as Api
 import Hydra.Cardano.Api.Prelude (fromShelleyPaymentCredential)
 import Hydra.Cardano.Api.Pretty (renderTx)
 import Hydra.Chain.CardanoClient (QueryPoint (..))
-import qualified Hydra.Chain.Direct.Fixture as Fixture
+import Hydra.Chain.Direct.Fixture qualified as Fixture
 import Hydra.Chain.Direct.Wallet (
   Address,
   ChainQuery,
@@ -72,7 +72,7 @@ import Test.QuickCheck (
   suchThat,
   vectorOf,
  )
-import qualified Prelude
+import Prelude qualified
 
 spec :: Spec
 spec = parallel $ do

--- a/hydra-node/test/Hydra/CryptoSpec.hs
+++ b/hydra-node/test/Hydra/CryptoSpec.hs
@@ -10,9 +10,9 @@ import Test.Hydra.Prelude
 
 import Cardano.Crypto.DSIGN (SigDSIGN (SigEd25519DSIGN))
 import Cardano.Crypto.PinnedSizedBytes (psbFromByteString)
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as Char8
-import qualified Data.Map as Map
+import Data.ByteString qualified as BS
+import Data.ByteString.Char8 qualified as Char8
+import Data.Map qualified as Map
 import Hydra.Party (Party (vkey), deriveParty)
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
 import Test.QuickCheck (

--- a/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
@@ -6,8 +6,8 @@ module Hydra.HeadLogicSnapshotSpec where
 import Hydra.Prelude hiding (label)
 import Test.Hydra.Prelude
 
-import qualified Data.List as List
-import qualified Data.Map.Strict as Map
+import Data.List qualified as List
+import Data.Map.Strict qualified as Map
 import Hydra.Chain (HeadParameters (..))
 import Hydra.Crypto (sign)
 import Hydra.HeadLogic (

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -11,9 +11,9 @@ module Hydra.HeadLogicSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import Data.Map (notMember)
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import Hydra.API.ServerOutput (ServerOutput (..))
 import Hydra.Cardano.Api (genTxIn, mkVkAddress, txOutValue, unSlotNo, pattern TxValidityUpperBound)
 import Hydra.Chain (
@@ -24,10 +24,10 @@ import Hydra.Chain (
   OnChainTx (..),
   PostChainTx (CollectComTx, ContestTx),
  )
-import qualified Hydra.Chain.Direct.Fixture as Fixture
+import Hydra.Chain.Direct.Fixture qualified as Fixture
 import Hydra.Chain.Direct.State ()
 import Hydra.Crypto (generateSigningKey, sign)
-import qualified Hydra.Crypto as Crypto
+import Hydra.Crypto qualified as Crypto
 import Hydra.HeadLogic (
   ClosedState (..),
   CoordinatedHeadState (..),
@@ -54,7 +54,7 @@ import Hydra.Ledger.Simple (SimpleChainState (..), SimpleTx (..), aValidTx, simp
 import Hydra.Network.Message (Message (AckSn, ReqSn, ReqTx))
 import Hydra.Options (defaultContestationPeriod)
 import Hydra.Party (Party (..))
-import qualified Hydra.Prelude as Prelude
+import Hydra.Prelude qualified as Prelude
 import Hydra.Snapshot (ConfirmedSnapshot (..), Snapshot (..), getSnapshot)
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
 import Test.Hydra.Fixture (alice, aliceSk, bob, bobSk, carol, carolSk, cperiod)
@@ -623,7 +623,7 @@ data StepState tx = StepState
   }
 
 -- | Retrieves the latest 'HeadState' from within 'runEvents'.
-getState :: (MonadState (StepState tx) m) => m (HeadState tx)
+getState :: MonadState (StepState tx) m => m (HeadState tx)
 getState = headState <$> get
 
 -- | Calls 'update' and 'aggregate' to drive the 'runEvents' monad forward.

--- a/hydra-node/test/Hydra/JSONSchema.hs
+++ b/hydra-node/test/Hydra/JSONSchema.hs
@@ -7,16 +7,16 @@ import Hydra.Prelude
 import Control.Arrow (left)
 import Control.Lens (Traversal', at, (?~), (^..), (^?))
 import Data.Aeson ((.=))
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Data.Aeson.Lens (key, _Array, _String)
-import qualified Data.List as List
-import qualified Data.Map.Strict as Map
+import Data.List qualified as List
+import Data.Map.Strict qualified as Map
 import Data.Text (pack)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import Data.Versions (SemVer (SemVer), prettySemVer, semver)
-import qualified Data.Yaml as Yaml
+import Data.Yaml qualified as Yaml
 import GHC.IO.Exception (IOErrorType (OtherError))
-import qualified Paths_hydra_node as Pkg
+import Paths_hydra_node qualified as Pkg
 import System.Directory (listDirectory)
 import System.Exit (ExitCode (..))
 import System.FilePath (normalise, takeBaseName, takeExtension, (<.>), (</>))
@@ -25,7 +25,7 @@ import System.Process (readProcessWithExitCode)
 import Test.Hydra.Prelude (failure, withTempDir)
 import Test.QuickCheck (Property, counterexample, forAllBlind, forAllShrink, resize, vectorOf)
 import Test.QuickCheck.Monadic (assert, monadicIO, monitor, run)
-import qualified Prelude
+import Prelude qualified
 
 -- | Validate an 'Arbitrary' value against a JSON schema.
 --

--- a/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
+++ b/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
@@ -9,9 +9,9 @@ import Test.Hydra.Prelude
 import Cardano.Binary (decodeFull, serialize')
 import Cardano.Ledger.Credential (Credential (..))
 import Data.Aeson (eitherDecode, encode)
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Data.Aeson.Lens (key)
-import qualified Data.ByteString.Base16 as Base16
+import Data.ByteString.Base16 qualified as Base16
 import Data.Text (unpack)
 import Hydra.Cardano.Api.Pretty (renderTx)
 import Hydra.Chain.Direct.Fixture (defaultGlobals, defaultLedgerEnv)

--- a/hydra-node/test/Hydra/Logging/MonitoringSpec.hs
+++ b/hydra-node/test/Hydra/Logging/MonitoringSpec.hs
@@ -3,7 +3,7 @@ module Hydra.Logging.MonitoringSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import Hydra.API.ServerOutput (ServerOutput (SnapshotConfirmed))
 import Hydra.BehaviorSpec (testHeadId)
 import Hydra.HeadLogic (
@@ -34,7 +34,9 @@ spec =
         traceWith tracer (Node $ BeginEffect alice 0 0 (ClientEffect (SnapshotConfirmed testHeadId (Snapshot 1 (utxoRefs [1]) [43, 42]) mempty)))
 
         metrics <-
-          Text.lines . decodeUtf8 . responseBody
+          Text.lines
+            . decodeUtf8
+            . responseBody
             <$> runReq @IO defaultHttpConfig (req GET (http "localhost" /: "metrics") NoReqBody bsResponse (port p))
 
         metrics `shouldContain` ["hydra_head_confirmed_tx  2"]

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -21,7 +21,7 @@ import Hydra.Cardano.Api
 import Hydra.Prelude hiding (Any, label)
 
 import Cardano.Api.UTxO (pairs)
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import Control.Concurrent.Class.MonadSTM (
   MonadLabelledSTM,
   labelTQueueIO,
@@ -34,13 +34,13 @@ import Control.Concurrent.Class.MonadSTM (
 import Control.Monad.Class.MonadAsync (Async, async, cancel, link)
 import Control.Monad.Class.MonadFork (labelThisThread)
 import Data.List (nub)
-import qualified Data.List as List
+import Data.List qualified as List
 import Data.Map ((!))
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Data.Maybe (fromJust)
 import GHC.Natural (wordToNatural)
 import Hydra.API.ClientInput (ClientInput)
-import qualified Hydra.API.ClientInput as Input
+import Hydra.API.ClientInput qualified as Input
 import Hydra.API.ServerOutput (ServerOutput (..))
 import Hydra.BehaviorSpec (
   SimulatedChainNetwork (..),
@@ -61,7 +61,7 @@ import Hydra.HeadLogic (
   Committed (),
   IdleState (..),
  )
-import qualified Hydra.HeadLogic as HeadState
+import Hydra.HeadLogic qualified as HeadState
 import Hydra.Ledger (IsTx (..))
 import Hydra.Ledger.Cardano (cardanoLedger, genSigningKey, mkSimpleTx)
 import Hydra.Logging (Tracer)
@@ -70,12 +70,12 @@ import Hydra.Model.MockChain (mkMockTxIn, mockChainAndNetwork)
 import Hydra.Model.Payment (CardanoSigningKey (..), Payment (..), applyTx, genAdaValue)
 import Hydra.Node (createNodeState, runHydraNode)
 import Hydra.Party (Party (..), deriveParty)
-import qualified Hydra.Snapshot as Snapshot
+import Hydra.Snapshot qualified as Snapshot
 import Test.QuickCheck (choose, counterexample, elements, frequency, resize, sized, tabulate, vectorOf)
 import Test.QuickCheck.DynamicLogic (DynLogicModel)
 import Test.QuickCheck.StateModel (Any (..), HasVariables, Realized, RunModel (..), StateModel (..), VarContext)
 import Test.QuickCheck.StateModel.Variables (HasVariables (..))
-import qualified Prelude
+import Prelude qualified
 
 -- * The Model
 
@@ -373,7 +373,7 @@ genPayment WorldState{hydraParties, hydraState} =
       pure (party, Payment{from, to, value})
     _ -> error $ "genPayment impossible in state: " <> show hydraState
 
-unsafeConstructorName :: (Show a) => a -> String
+unsafeConstructorName :: Show a => a -> String
 unsafeConstructorName = Prelude.head . Prelude.words . show
 
 -- | Generate a list of pairs of Hydra/Cardano signing keys.
@@ -420,7 +420,7 @@ newtype RunMonad m a = RunMonad {runMonad :: ReaderT (RunState m) m a}
 instance MonadTrans RunMonad where
   lift = RunMonad . lift
 
-instance (MonadSTM m) => MonadState (Nodes m) (RunMonad m) where
+instance MonadSTM m => MonadState (Nodes m) (RunMonad m) where
   get = ask >>= lift . readTVarIO . nodesState
 
   put n = ask >>= lift . atomically . flip modifyTVar (const n) . nodesState

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -23,7 +23,7 @@ import Control.Concurrent.Class.MonadSTM (
 import Control.Monad.Class.MonadAsync (async, link)
 import Control.Monad.Class.MonadFork (labelThisThread)
 import Data.Sequence (Seq (Empty, (:|>)))
-import qualified Data.Sequence as Seq
+import Data.Sequence qualified as Seq
 import Hydra.BehaviorSpec (
   SimulatedChainNetwork (..),
  )

--- a/hydra-node/test/Hydra/Model/Payment.hs
+++ b/hydra-node/test/Hydra/Model/Payment.hs
@@ -8,14 +8,14 @@ module Hydra.Model.Payment where
 import Hydra.Cardano.Api
 import Hydra.Prelude hiding (Any, label)
 
-import qualified Data.List as List
+import Data.List qualified as List
 import Hydra.Chain.Direct.Fixture (testNetworkId)
 import Hydra.Ledger (IsTx (..))
 import Hydra.Ledger.Cardano (genKeyPair)
 import Test.QuickCheck (choose)
 import Test.QuickCheck.StateModel (HasVariables)
 import Test.QuickCheck.StateModel.Variables (HasVariables (..))
-import qualified Prelude
+import Prelude qualified
 
 newtype CardanoSigningKey = CardanoSigningKey {signingKey :: SigningKey PaymentKey}
 

--- a/hydra-node/test/Hydra/ModelSpec.hs
+++ b/hydra-node/test/Hydra/ModelSpec.hs
@@ -112,13 +112,13 @@ import Hydra.Cardano.Api
 import Hydra.Prelude
 import Test.Hydra.Prelude hiding (after)
 
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import Control.Concurrent.Class.MonadSTM (newTVarIO)
 import Control.Monad.Class.MonadTimer ()
 import Control.Monad.IOSim (Failure (FailureException), IOSim, runSimTrace, traceResult)
 import Data.Map ((!))
-import qualified Data.Map as Map
-import qualified Data.Set as Set
+import Data.Map qualified as Map
+import Data.Set qualified as Set
 import Hydra.API.ClientInput (ClientInput (..))
 import Hydra.API.ServerOutput (ServerOutput (..))
 import Hydra.BehaviorSpec (TestHydraClient (..), dummySimulatedChainNetwork)
@@ -138,8 +138,8 @@ import Hydra.Model (
   genSeed,
   runMonad,
  )
-import qualified Hydra.Model as Model
-import qualified Hydra.Model.Payment as Payment
+import Hydra.Model qualified as Model
+import Hydra.Model.Payment qualified as Payment
 import Hydra.Party (Party (..), deriveParty)
 import Test.QuickCheck (Property, Testable, counterexample, forAll, property, withMaxSuccess, within)
 import Test.QuickCheck.DynamicLogic (

--- a/hydra-node/test/Hydra/Network/ReliabilitySpec.hs
+++ b/hydra-node/test/Hydra/Network/ReliabilitySpec.hs
@@ -15,7 +15,7 @@ import Control.Monad.IOSim (runSimOrThrow)
 import Control.Tracer (Tracer (..), nullTracer)
 import Data.Sequence.Strict ((|>))
 import Data.Vector (Vector, empty, fromList, head, replicate, snoc)
-import qualified Data.Vector as Vector
+import Data.Vector qualified as Vector
 import Hydra.Network (Network (..))
 import Hydra.Network.Authenticate (Authenticated (..))
 import Hydra.Network.Heartbeat (Heartbeat (..), withHeartbeat)
@@ -272,7 +272,7 @@ captureIncoming :: MonadSTM m => TVar m (Vector p) -> p -> m ()
 captureIncoming receivedMessages msg =
   atomically $ modifyTVar' receivedMessages (`snoc` msg)
 
-capturePayload :: (MonadSTM m) => TVar m (Vector msg) -> Authenticated (Heartbeat msg) -> m ()
+capturePayload :: MonadSTM m => TVar m (Vector msg) -> Authenticated (Heartbeat msg) -> m ()
 capturePayload receivedMessages message = case payload message of
   Data _ msg ->
     atomically $ modifyTVar' receivedMessages (`snoc` msg)

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -28,12 +28,12 @@ import Hydra.HeadLogic (
   StateChanged,
   defaultTTL,
  )
-import qualified Hydra.HeadLogic as HeadLogic
+import Hydra.HeadLogic qualified as HeadLogic
 import Hydra.HeadLogicSpec (inInitialState)
 import Hydra.Ledger (ChainSlot (ChainSlot))
 import Hydra.Ledger.Simple (SimpleChainState (..), SimpleTx (..), simpleLedger, utxoRef, utxoRefs)
 import Hydra.Logging (Tracer, nullTracer, showLogsOnFailure, traceInTVar)
-import qualified Hydra.Logging as Logging
+import Hydra.Logging qualified as Logging
 import Hydra.Network (Network (..))
 import Hydra.Network.Message (Message (..))
 import Hydra.Node (
@@ -226,7 +226,7 @@ eventsToOpenHead =
       }
 
 runToCompletion ::
-  (IsChainState tx) =>
+  IsChainState tx =>
   Tracer IO (HydraNodeLog tx) ->
   HydraNode tx IO ->
   IO ()
@@ -311,7 +311,7 @@ messageRecorder = do
   appendMsg ref x = atomicModifyIORef' ref $ \old -> (old <> [x], ())
 
 throwExceptionOnPostTx ::
-  (IsChainState tx) =>
+  IsChainState tx =>
   PostTxError tx ->
   HydraNode tx IO ->
   IO (HydraNode tx IO)

--- a/hydra-node/test/Hydra/PersistenceSpec.hs
+++ b/hydra-node/test/Hydra/PersistenceSpec.hs
@@ -4,8 +4,8 @@ import Hydra.Prelude hiding (label)
 import Test.Hydra.Prelude
 
 import Data.Aeson (Value (..))
-import qualified Data.Aeson as Aeson
-import qualified Data.Text as Text
+import Data.Aeson qualified as Aeson
+import Data.Text qualified as Text
 import Hydra.Persistence (Persistence (..), PersistenceIncremental (..), createPersistence, createPersistenceIncremental)
 import Test.QuickCheck (checkCoverage, cover, elements, oneof, (===))
 import Test.QuickCheck.Gen (listOf)

--- a/hydra-node/test/Main.hs
+++ b/hydra-node/test/Main.hs
@@ -1,7 +1,7 @@
 module Main where
 
 import Hydra.Prelude
-import qualified Spec
+import Spec qualified
 import Test.Hspec.Runner
 import Test.Hydra.Prelude (combinedHspecFormatter)
 

--- a/hydra-node/test/Test/Util.hs
+++ b/hydra-node/test/Test/Util.hs
@@ -17,7 +17,7 @@ import Control.Monad.IOSim (
  )
 import Control.Tracer (Tracer (Tracer))
 import Data.Aeson (encode)
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Data.List (isInfixOf)
 import Hydra.Ledger.Simple (SimpleTx)
 import Hydra.Node (HydraNodeLog)

--- a/hydra-plutus-extras/hydra-plutus-extras.cabal
+++ b/hydra-plutus-extras/hydra-plutus-extras.cabal
@@ -18,7 +18,6 @@ source-repository head
 common project-config
   default-language:   GHC2021
   default-extensions:
-    NoImplicitPrelude
     DataKinds
     DefaultSignatures
     DeriveAnyClass
@@ -27,6 +26,7 @@ common project-config
     GADTs
     LambdaCase
     MultiWayIf
+    NoImplicitPrelude
     OverloadedStrings
     PartialTypeSignatures
     PatternSynonyms

--- a/hydra-plutus-extras/src/Hydra/Plutus/Extras/Time.hs
+++ b/hydra-plutus-extras/src/Hydra/Plutus/Extras/Time.hs
@@ -9,7 +9,7 @@ import Data.Fixed (Pico)
 import Data.Ratio ((%))
 import Data.Time (nominalDiffTimeToSeconds)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime, utcTimeToPOSIXSeconds)
-import qualified PlutusLedgerApi.V1.Time as Plutus
+import PlutusLedgerApi.V1.Time qualified as Plutus
 
 -- | Convert given on-chain 'POSIXTime' to a 'UTCTime'.
 posixToUTCTime :: Plutus.POSIXTime -> UTCTime

--- a/hydra-plutus-extras/src/Hydra/Plutus/Orphans.hs
+++ b/hydra-plutus-extras/src/Hydra/Plutus/Orphans.hs
@@ -7,11 +7,11 @@ module Hydra.Plutus.Orphans where
 import Hydra.Prelude
 
 import Data.Aeson (object, withObject, (.:), (.=))
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Base16 as Base16
+import Data.Aeson qualified as Aeson
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as Base16
 import PlutusLedgerApi.V2 (CurrencySymbol, POSIXTime (..), PubKeyHash (..), TokenName, TxId (..), TxOutRef (..), UpperBound, Value, upperBound)
-import qualified PlutusTx.AssocMap as AssocMap
+import PlutusTx.AssocMap qualified as AssocMap
 import PlutusTx.Prelude (BuiltinByteString, fromBuiltin, toBuiltin)
 import Test.QuickCheck (choose, vectorOf)
 import Test.QuickCheck.Instances.ByteString ()

--- a/hydra-plutus-extras/test/Main.hs
+++ b/hydra-plutus-extras/test/Main.hs
@@ -2,7 +2,7 @@ module Main where
 
 import Prelude
 
-import qualified Spec
+import Spec qualified
 import Test.Hspec (hspec)
 
 main :: IO ()

--- a/hydra-plutus/exe/inspect-script/Main.hs
+++ b/hydra-plutus/exe/inspect-script/Main.hs
@@ -4,16 +4,16 @@ import Hydra.Cardano.Api
 import Hydra.Prelude
 
 import Codec.Serialise (serialise)
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString.Lazy as BL
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy qualified as BL
 import Data.Text (pack)
 import Hydra.Cardano.Api.Prelude (unsafeHashFromBytes)
 import Hydra.Contract (scriptInfo)
 import Hydra.Contract.Commit as Commit
-import qualified Hydra.Contract.Hash as Hash
+import Hydra.Contract.Hash qualified as Hash
 import Hydra.Contract.Head as Head
 import Hydra.Contract.HeadState as Head
-import qualified Hydra.Contract.HeadTokens as HeadTokens
+import Hydra.Contract.HeadTokens qualified as HeadTokens
 import Hydra.Contract.Initial as Initial
 import PlutusLedgerApi.V2 (Data, SerialisedScript, toData)
 import PlutusTx (getPlc)

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -16,7 +16,6 @@ source-repository head
 common project-config
   default-language:   GHC2021
   default-extensions:
-    NoImplicitPrelude
     DataKinds
     DefaultSignatures
     DeriveAnyClass
@@ -25,6 +24,7 @@ common project-config
     GADTs
     LambdaCase
     MultiWayIf
+    NoImplicitPrelude
     OverloadedStrings
     PartialTypeSignatures
     PatternSynonyms

--- a/hydra-plutus/src/Hydra/Contract.hs
+++ b/hydra-plutus/src/Hydra/Contract.hs
@@ -4,18 +4,18 @@ module Hydra.Contract where
 import Hydra.Prelude
 
 import Codec.Serialise (serialise)
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as BSL
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BSL
 import Hydra.Cardano.Api (
   ScriptHash,
   fromPlutusScript,
   hashScript,
   pattern PlutusScript,
  )
-import qualified Hydra.Contract.Commit as Commit
-import qualified Hydra.Contract.Head as Head
-import qualified Hydra.Contract.HeadTokens as HeadTokens
-import qualified Hydra.Contract.Initial as Initial
+import Hydra.Contract.Commit qualified as Commit
+import Hydra.Contract.Head qualified as Head
+import Hydra.Contract.HeadTokens qualified as HeadTokens
+import Hydra.Contract.Initial qualified as Initial
 import PlutusLedgerApi.V2 (TxId (..), TxOutRef (..), toBuiltin)
 
 -- | Information about relevant Hydra scripts.

--- a/hydra-plutus/src/Hydra/Contract/Commit.hs
+++ b/hydra-plutus/src/Hydra/Contract/Commit.hs
@@ -15,7 +15,7 @@ import PlutusTx.Prelude
 import Codec.Serialise (deserialiseOrFail, serialise)
 import Data.ByteString.Lazy (fromStrict, toStrict)
 import Hydra.Cardano.Api (CtxUTxO, PlutusScriptVersion (PlutusScriptV2), fromPlutusTxOut, fromPlutusTxOutRef, toPlutusTxOut, toPlutusTxOutRef)
-import qualified Hydra.Cardano.Api as OffChain
+import Hydra.Cardano.Api qualified as OffChain
 import Hydra.Cardano.Api.Network (Network)
 import Hydra.Contract.CommitError (CommitError (..), errorCode)
 import Hydra.Contract.Util (hasST, mustBurnST)
@@ -33,8 +33,8 @@ import PlutusLedgerApi.V2 (
   txOutValue,
  )
 import PlutusTx (CompiledCode, fromData, toBuiltinData, toData)
-import qualified PlutusTx
-import qualified Prelude as Haskell
+import PlutusTx qualified
+import Prelude qualified as Haskell
 
 data CommitRedeemer
   = ViaCollectCom

--- a/hydra-plutus/src/Hydra/Contract/Hash.hs
+++ b/hydra-plutus/src/Hydra/Contract/Hash.hs
@@ -11,7 +11,7 @@ module Hydra.Contract.Hash where
 
 import PlutusTx.Prelude
 
-import qualified Hydra.Prelude as Haskell
+import Hydra.Prelude qualified as Haskell
 
 import Hydra.Cardano.Api (PlutusScriptVersion (PlutusScriptV2))
 import Hydra.Plutus.Extras (ValidatorType, scriptValidatorHash, wrapValidator)
@@ -23,7 +23,7 @@ import PlutusLedgerApi.V2 (
   ScriptHash,
  )
 import PlutusTx (CompiledCode)
-import qualified PlutusTx
+import PlutusTx qualified
 import PlutusTx.Builtins (blake2b_256, equalsByteString)
 import PlutusTx.IsData.Class (ToData (..))
 

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -14,7 +14,7 @@ import PlutusTx.Prelude
 
 import Hydra.Cardano.Api (PlutusScriptVersion (PlutusScriptV2))
 import Hydra.Contract.Commit (Commit (..))
-import qualified Hydra.Contract.Commit as Commit
+import Hydra.Contract.Commit qualified as Commit
 import Hydra.Contract.HeadError (HeadError (..), errorCode)
 import Hydra.Contract.HeadState (Input (..), Signature, SnapshotNumber, State (..))
 import Hydra.Contract.Util (hasST, mustNotMintOrBurn, (===))
@@ -50,9 +50,9 @@ import PlutusLedgerApi.V2 (
  )
 import PlutusLedgerApi.V2.Contexts (findDatum, findOwnInput)
 import PlutusTx (CompiledCode)
-import qualified PlutusTx
-import qualified PlutusTx.AssocMap as AssocMap
-import qualified PlutusTx.Builtins as Builtins
+import PlutusTx qualified
+import PlutusTx.AssocMap qualified as AssocMap
+import PlutusTx.Builtins qualified as Builtins
 
 type DatumType = State
 type RedeemerType = Input
@@ -166,9 +166,12 @@ checkCollectCom ctx@ScriptContext{scriptContextTxInfo = txInfo} (contestationPer
 
   mustNotChangeParameters =
     traceIfFalse $(errorCode ChangedParameters) $
-      parties' == parties
-        && contestationPeriod' == contestationPeriod
-        && headId' == headId
+      parties'
+        == parties
+        && contestationPeriod'
+        == contestationPeriod
+        && headId'
+        == headId
 
   mustCollectAllValue =
     traceIfFalse $(errorCode NotAllValueCollected) $
@@ -320,9 +323,12 @@ checkClose ctx parties initialUtxoHash sig cperiod headPolicyId =
 
   mustNotChangeParameters =
     traceIfFalse $(errorCode ChangedParameters) $
-      headId' == headPolicyId
-        && parties' == parties
-        && cperiod' == cperiod
+      headId'
+        == headPolicyId
+        && parties'
+        == parties
+        && cperiod'
+        == cperiod
 
   mustInitializeContesters =
     traceIfFalse $(errorCode ContestersNonEmpty) $
@@ -403,9 +409,12 @@ checkContest ctx contestationDeadline contestationPeriod parties closedSnapshotN
 
   mustNotChangeParameters =
     traceIfFalse $(errorCode ChangedParameters) $
-      parties' == parties
-        && headId' == headId
-        && contestationPeriod' == contestationPeriod
+      parties'
+        == parties
+        && headId'
+        == headId
+        && contestationPeriod'
+        == contestationPeriod
 
   mustPushDeadline =
     if length contesters' == length parties'
@@ -583,7 +592,8 @@ hasPT headCurrencySymbol txOut =
 verifySnapshotSignature :: [Party] -> SnapshotNumber -> BuiltinByteString -> [Signature] -> Bool
 verifySnapshotSignature parties snapshotNumber utxoHash sigs =
   traceIfFalse $(errorCode SignatureVerificationFailed) $
-    length parties == length sigs
+    length parties
+      == length sigs
       && all (uncurry $ verifyPartySignature snapshotNumber utxoHash) (zip parties sigs)
 {-# INLINEABLE verifySnapshotSignature #-}
 

--- a/hydra-plutus/src/Hydra/Contract/HeadState.hs
+++ b/hydra-plutus/src/Hydra/Contract/HeadState.hs
@@ -10,7 +10,7 @@ import GHC.Generics (Generic)
 import Hydra.Data.ContestationPeriod (ContestationPeriod)
 import Hydra.Data.Party (Party)
 import PlutusLedgerApi.V2 (CurrencySymbol, POSIXTime, PubKeyHash, TxOutRef)
-import qualified PlutusTx
+import PlutusTx qualified
 import Text.Show (Show)
 
 type SnapshotNumber = Integer

--- a/hydra-plutus/src/Hydra/Contract/HeadTokens.hs
+++ b/hydra-plutus/src/Hydra/Contract/HeadTokens.hs
@@ -21,12 +21,12 @@ import Hydra.Cardano.Api (
   toPlutusTxOutRef,
   pattern PlutusScript,
  )
-import qualified Hydra.Cardano.Api as Api
-import qualified Hydra.Contract.Head as Head
+import Hydra.Cardano.Api qualified as Api
+import Hydra.Contract.Head qualified as Head
 import Hydra.Contract.HeadState (headId, seed)
-import qualified Hydra.Contract.HeadState as Head
+import Hydra.Contract.HeadState qualified as Head
 import Hydra.Contract.HeadTokensError (HeadTokensError (..), errorCode)
-import qualified Hydra.Contract.Initial as Initial
+import Hydra.Contract.Initial qualified as Initial
 import Hydra.Contract.MintAction (MintAction (Burn, Mint))
 import Hydra.Contract.Util (hasST)
 import Hydra.Plutus.Extras (MintingPolicyType, wrapMintingPolicy)
@@ -44,8 +44,8 @@ import PlutusLedgerApi.V2 (
   serialiseCompiledCode,
  )
 import PlutusTx (CompiledCode)
-import qualified PlutusTx
-import qualified PlutusTx.AssocMap as AssocMap
+import PlutusTx qualified
+import PlutusTx.AssocMap qualified as AssocMap
 
 validate ::
   ScriptHash ->

--- a/hydra-plutus/src/Hydra/Contract/Initial.hs
+++ b/hydra-plutus/src/Hydra/Contract/Initial.hs
@@ -14,7 +14,7 @@ import PlutusTx.Prelude
 
 import Hydra.Cardano.Api (PlutusScriptVersion (PlutusScriptV2))
 import Hydra.Contract.Commit (Commit (..))
-import qualified Hydra.Contract.Commit as Commit
+import Hydra.Contract.Commit qualified as Commit
 import Hydra.Contract.Error (errorCode)
 import Hydra.Contract.InitialError (InitialError (..))
 import Hydra.Contract.Util (mustBurnST)
@@ -47,9 +47,9 @@ import PlutusLedgerApi.V2 (
   Value (getValue),
  )
 import PlutusTx (CompiledCode)
-import qualified PlutusTx
-import qualified PlutusTx.AssocMap as AssocMap
-import qualified PlutusTx.Builtins as Builtins
+import PlutusTx qualified
+import PlutusTx.AssocMap qualified as AssocMap
+import PlutusTx.Builtins qualified as Builtins
 
 data InitialRedeemer
   = ViaAbort
@@ -121,8 +121,10 @@ checkCommit commitValidator headId committedRefs context =
       ((_ : _), []) ->
         traceError $(errorCode CommittedTxOutMissingInOutputDatum)
       (TxInInfo{txInInfoOutRef, txInInfoResolved} : restCommitted, Commit{input, preSerializedOutput} : restCommits) ->
-        Builtins.serialiseData (toBuiltinData txInInfoResolved) == preSerializedOutput
-          && txInInfoOutRef == input
+        Builtins.serialiseData (toBuiltinData txInInfoResolved)
+          == preSerializedOutput
+          && txInInfoOutRef
+          == input
           && go (restCommitted, restCommits)
 
   checkHeadId =

--- a/hydra-plutus/src/Hydra/Contract/MintAction.hs
+++ b/hydra-plutus/src/Hydra/Contract/MintAction.hs
@@ -4,7 +4,7 @@
 -- of TemplateHaskell stage restriction.
 module Hydra.Contract.MintAction where
 
-import qualified PlutusTx
+import PlutusTx qualified
 
 data MintAction = Mint | Burn
 

--- a/hydra-plutus/src/Hydra/Contract/Util.hs
+++ b/hydra-plutus/src/Hydra/Contract/Util.hs
@@ -12,7 +12,7 @@ import PlutusLedgerApi.V2 (
   Value (getValue),
   toBuiltinData,
  )
-import qualified PlutusTx.AssocMap as AssocMap
+import PlutusTx.AssocMap qualified as AssocMap
 import PlutusTx.Builtins (serialiseData)
 import PlutusTx.Prelude
 

--- a/hydra-plutus/src/Hydra/Data/ContestationPeriod.hs
+++ b/hydra-plutus/src/Hydra/Data/ContestationPeriod.hs
@@ -4,13 +4,13 @@ module Hydra.Data.ContestationPeriod where
 
 import Hydra.Prelude
 
-import qualified PlutusTx.Prelude as Plutus
+import PlutusTx.Prelude qualified as Plutus
 
 import Data.Ratio ((%))
 import Data.Time (nominalDiffTimeToSeconds, secondsToNominalDiffTime)
 import PlutusLedgerApi.V1.Time (DiffMilliSeconds, fromMilliSeconds)
 import PlutusLedgerApi.V2 (POSIXTime (..))
-import qualified PlutusTx
+import PlutusTx qualified
 
 newtype ContestationPeriod = UnsafeContestationPeriod {milliseconds :: DiffMilliSeconds}
   deriving stock (Generic, Eq, Ord, Show)

--- a/hydra-plutus/src/Hydra/Data/Party.hs
+++ b/hydra-plutus/src/Hydra/Data/Party.hs
@@ -3,12 +3,12 @@ module Hydra.Data.Party where
 import Hydra.Prelude hiding (init)
 
 import Data.Aeson (Value (String), object, withObject, (.:), (.=))
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Base16 as Base16
-import qualified PlutusTx
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as Base16
+import PlutusTx qualified
 import PlutusTx.Builtins (BuiltinByteString, fromBuiltin, toBuiltin)
 import PlutusTx.IsData
-import qualified PlutusTx.Prelude as PlutusTx
+import PlutusTx.Prelude qualified as PlutusTx
 import Test.QuickCheck (vector)
 
 -- | On-chain representation of a Hydra party.

--- a/hydra-plutus/test/Hydra/Plutus/GoldenSpec.hs
+++ b/hydra-plutus/test/Hydra/Plutus/GoldenSpec.hs
@@ -23,13 +23,13 @@ import Hydra.Cardano.Api (
   writeFileTextEnvelope,
   pattern PlutusScript,
  )
-import qualified Hydra.Contract.Commit as Commit
-import qualified Hydra.Contract.Head as Head
-import qualified Hydra.Contract.HeadTokens as HeadTokens
-import qualified Hydra.Contract.Initial as Initial
+import Hydra.Contract.Commit qualified as Commit
+import Hydra.Contract.Head qualified as Head
+import Hydra.Contract.HeadTokens qualified as HeadTokens
+import Hydra.Contract.Initial qualified as Initial
 import Hydra.Version (gitDescribe)
 import PlutusLedgerApi.V2 (serialiseCompiledCode)
-import qualified PlutusLedgerApi.V2 as Plutus
+import PlutusLedgerApi.V2 qualified as Plutus
 import Test.Hspec.Golden (Golden (..))
 
 spec :: Spec

--- a/hydra-plutus/test/Main.hs
+++ b/hydra-plutus/test/Main.hs
@@ -5,7 +5,7 @@ import Hydra.Prelude
 import Test.Hspec.Runner (configFormat, defaultConfig, hspecWith)
 import Test.Hydra.Prelude (combinedHspecFormatter)
 
-import qualified Spec
+import Spec qualified
 
 main :: IO ()
 main =

--- a/hydra-prelude/src/Hydra/Prelude.hs
+++ b/hydra-prelude/src/Hydra/Prelude.hs
@@ -91,11 +91,11 @@ import Data.Aeson (
 import Data.Aeson.Encode.Pretty (
   encodePretty,
  )
-import qualified Data.ByteString.Base16 as Base16
-import qualified Data.Text as T
+import Data.ByteString.Base16 qualified as Base16
+import Data.Text qualified as T
 import GHC.Generics (Rep)
-import qualified Generic.Random as Random
-import qualified Generic.Random.Internal.Generic as Random
+import Generic.Random qualified as Random
+import Generic.Random.Internal.Generic qualified as Random
 import Relude hiding (
   MVar,
   Nat,

--- a/hydra-prelude/src/Hydra/Version.hs
+++ b/hydra-prelude/src/Hydra/Version.hs
@@ -10,7 +10,7 @@ module Hydra.Version where
 
 import Hydra.Prelude
 
-import qualified Development.GitRev as GitRev
+import Development.GitRev qualified as GitRev
 import Foreign.C (CString)
 import GHC.Foreign (peekCStringLen)
 import GHC.IO (unsafeDupablePerformIO)

--- a/hydra-test-utils/hydra-test-utils.cabal
+++ b/hydra-test-utils/hydra-test-utils.cabal
@@ -16,9 +16,9 @@ source-repository head
 common package-config
   default-language:   GHC2021
   default-extensions:
-    NoImplicitPrelude
     DataKinds
     LambdaCase
+    NoImplicitPrelude
     OverloadedStrings
     PatternSynonyms
     ViewPatterns

--- a/hydra-test-utils/src/Test/Hspec/MarkdownFormatter.hs
+++ b/hydra-test-utils/src/Test/Hspec/MarkdownFormatter.hs
@@ -2,9 +2,9 @@ module Test.Hspec.MarkdownFormatter (markdownFormatter) where
 
 import Hydra.Prelude hiding (intercalate)
 
-import qualified Data.ByteString as BS
-import qualified Data.List as List
-import qualified Data.Text as Text
+import Data.ByteString qualified as BS
+import Data.List qualified as List
+import Data.Text qualified as Text
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath (splitFileName)
 import Test.Hspec.Core.Format (

--- a/hydra-test-utils/src/Test/Plutus/Validator.hs
+++ b/hydra-test-utils/src/Test/Plutus/Validator.hs
@@ -12,8 +12,8 @@ module Test.Plutus.Validator (
 
 import Hydra.Prelude
 
-import qualified Cardano.Api.UTxO as UTxO
-import qualified Cardano.Ledger.Alonzo.Core as Ledger
+import Cardano.Api.UTxO qualified as UTxO
+import Cardano.Ledger.Alonzo.Core qualified as Ledger
 import Cardano.Ledger.Alonzo.Language (Language (PlutusV2))
 import Cardano.Ledger.Alonzo.Scripts (CostModel, costModelsValid, emptyCostModels, mkCostModel)
 import Cardano.Ledger.BaseTypes (ProtVer (..), natVersion)
@@ -22,7 +22,7 @@ import Cardano.Slotting.Slot (EpochSize (EpochSize))
 import Cardano.Slotting.Time (mkSlotLength)
 import Control.Lens ((.~))
 import Data.Default (def)
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Hydra.Cardano.Api (
   BuildTxWith (BuildTxWith),
   ExecutionUnits (..),
@@ -56,8 +56,8 @@ import Hydra.Cardano.Api (
   pattern TxOut,
  )
 import PlutusLedgerApi.Common (SerialisedScript)
-import qualified PlutusTx as Plutus
-import qualified Prelude
+import PlutusTx qualified as Plutus
+import Prelude qualified
 
 -- TODO: DRY with Hydra.Ledger.Cardano.Evaluate
 

--- a/hydra-test-utils/test/Main.hs
+++ b/hydra-test-utils/test/Main.hs
@@ -1,7 +1,7 @@
 module Main where
 
 import Hydra.Prelude
-import qualified HydraTestUtilsSpec
+import HydraTestUtilsSpec qualified
 import Test.Hspec.Runner
 import Test.Hydra.Prelude (combinedHspecFormatter)
 

--- a/hydra-tui/exe/Main.hs
+++ b/hydra-tui/exe/Main.hs
@@ -2,7 +2,7 @@ module Main where
 
 import Hydra.Prelude
 
-import qualified Hydra.TUI as TUI
+import Hydra.TUI qualified as TUI
 import Hydra.TUI.Options (parseOptions)
 import Options.Applicative (execParser, info)
 

--- a/hydra-tui/hydra-tui.cabal
+++ b/hydra-tui/hydra-tui.cabal
@@ -17,7 +17,6 @@ source-repository head
 common project-config
   default-language:   GHC2021
   default-extensions:
-    NoImplicitPrelude
     DataKinds
     DefaultSignatures
     DeriveAnyClass
@@ -26,6 +25,7 @@ common project-config
     GADTs
     LambdaCase
     MultiWayIf
+    NoImplicitPrelude
     OverloadedStrings
     PartialTypeSignatures
     TypeFamilies

--- a/hydra-tui/src/Hydra/Client.hs
+++ b/hydra-tui/src/Hydra/Client.hs
@@ -4,7 +4,7 @@ module Hydra.Client where
 
 import Hydra.Prelude
 
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import Control.Concurrent.Async (link)
 import Control.Concurrent.Class.MonadSTM (newTBQueueIO, readTBQueue, writeTBQueue)
 import Control.Exception (Handler (Handler), IOException, catches)
@@ -23,7 +23,7 @@ import Hydra.Chain.Direct.Util (readFileTextEnvelopeThrow)
 import Hydra.Network (Host (Host, hostname, port))
 import Hydra.TUI.Options (Options (..))
 import Network.HTTP.Req (defaultHttpConfig, responseBody, runReq)
-import qualified Network.HTTP.Req as Req
+import Network.HTTP.Req qualified as Req
 import Network.WebSockets (ConnectionException, receiveData, runClient, sendBinaryData)
 
 data HydraEvent tx
@@ -33,8 +33,8 @@ data HydraEvent tx
   | Tick UTCTime
   deriving stock (Generic)
 
-deriving stock instance (Eq (TimedServerOutput tx)) => Eq (HydraEvent tx)
-deriving stock instance (Show (TimedServerOutput tx)) => Show (HydraEvent tx)
+deriving stock instance Eq (TimedServerOutput tx) => Eq (HydraEvent tx)
+deriving stock instance Show (TimedServerOutput tx) => Show (HydraEvent tx)
 
 -- | Handle to interact with Hydra node
 data Client tx m = Client

--- a/hydra-tui/src/Hydra/TUI/Drawing.hs
+++ b/hydra-tui/src/Hydra/TUI/Drawing.hs
@@ -15,8 +15,8 @@ import Brick.Forms (
  )
 import Brick.Widgets.Border (hBorder, vBorder)
 import Brick.Widgets.Border.Style (ascii)
-import qualified Cardano.Api.UTxO as UTxO
-import qualified Data.Map as Map
+import Cardano.Api.UTxO qualified as UTxO
+import Data.Map qualified as Map
 import Data.Text (chunksOf)
 import Data.Time (defaultTimeLocale, formatTime)
 import Data.Time.Format (FormatTime)
@@ -29,14 +29,13 @@ import Hydra.Ledger (IsTx (..))
 import Hydra.Network (NodeId)
 import Hydra.Party (Party (..))
 import Hydra.TUI.Drawing.Utils (drawHex, drawShow, ellipsize, maybeWidget)
-import Hydra.TUI.Logging.Types (LogMessage (..), logMessagesL, LogVerbosity (..), logVerbosityL)
+import Hydra.TUI.Logging.Types (LogMessage (..), LogVerbosity (..), logMessagesL, logVerbosityL)
 import Hydra.TUI.Model
 import Hydra.TUI.Style
 import Lens.Micro ((^.), (^?), _head)
 import Paths_hydra_tui (version)
 
 -- | Main draw function
-
 draw :: CardanoClient -> Client Tx IO -> RootState -> [Widget Name]
 draw cardanoClient hydraClient s =
   case s ^. logStateL . logVerbosityL of
@@ -77,24 +76,27 @@ drawScreenShortLog CardanoClient{networkId} Client{sk} s =
           ]
 
 drawCommandPanel :: RootState -> Widget n
-drawCommandPanel s = vBox [ drawCommandList s
-                       , hBorder
-                       , drawLogCommandList (s ^. logStateL . logVerbosityL)
-                       ]
+drawCommandPanel s =
+  vBox
+    [ drawCommandList s
+    , hBorder
+    , drawLogCommandList (s ^. logStateL . logVerbosityL)
+    ]
 
 drawScreenFullLog :: RootState -> [Widget Name]
-drawScreenFullLog s = pure $
-  withBorderStyle ascii $
-    joinBorders $ hBox [
-      vBox
-        [ drawHeadState (s ^. connectedStateL)
-        , hBorder
-        , viewport fullFeedbackViewportName Vertical $ drawUserFeedbackFull (s ^. logStateL . logMessagesL)
-        ],
-      vBorder,
-      hLimit 20 $ joinBorders $ drawCommandPanel s
-     ]
-
+drawScreenFullLog s =
+  pure $
+    withBorderStyle ascii $
+      joinBorders $
+        hBox
+          [ vBox
+              [ drawHeadState (s ^. connectedStateL)
+              , hBorder
+              , viewport fullFeedbackViewportName Vertical $ drawUserFeedbackFull (s ^. logStateL . logMessagesL)
+              ]
+          , vBorder
+          , hLimit 20 $ joinBorders $ drawCommandPanel s
+          ]
 
 drawCommandList :: RootState -> Widget n
 drawCommandList s = vBox . fmap txt $ case s ^. connectedStateL of
@@ -110,16 +112,16 @@ drawCommandList s = vBox . fmap txt $ case s ^. connectedStateL of
 
 drawLogCommandList :: LogVerbosity -> Widget n
 drawLogCommandList s = vBox . fmap txt $ case s of
-    Short ->
-      [ "[<] Scroll Left"
-      , "[>] Scroll Right"
-      , "Full [H]istory Mode"
-      ]
-    Full ->
-      [ "[<] Scroll Up"
-      , "[>] Scroll Down"
-      , "[S]hort History Mode"
-      ]
+  Short ->
+    [ "[<] Scroll Left"
+    , "[>] Scroll Right"
+    , "Full [H]istory Mode"
+    ]
+  Full ->
+    [ "[<] Scroll Up"
+    , "[>] Scroll Down"
+    , "[S]hort History Mode"
+    ]
 
 drawFocusPanelInitializing :: IdentifiedState -> InitializingState -> Widget Name
 drawFocusPanelInitializing me InitializingState{remainingParties, initializingScreen} = case initializingScreen of
@@ -144,7 +146,7 @@ drawFocusPanelFinal networkId vk utxo =
     txt ("Distributed UTXO, total: " <> renderValue (balance @Tx utxo))
       <=> padLeft
         (Pad 2)
-        ( drawUTxO (highlightOwnAddress ownAddress) utxo )
+        (drawUTxO (highlightOwnAddress ownAddress) utxo)
  where
   ownAddress = mkVkAddress networkId vk
 

--- a/hydra-tui/src/Hydra/TUI/Drawing/Utils.hs
+++ b/hydra-tui/src/Hydra/TUI/Drawing/Utils.hs
@@ -1,7 +1,7 @@
 module Hydra.TUI.Drawing.Utils where
 
 import Brick (Widget, emptyWidget, txt)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import Hydra.Cardano.Api (SerialiseAsRawBytes, serialiseToRawBytesHexText)
 import Hydra.Prelude
 

--- a/hydra-tui/src/Hydra/TUI/Forms.hs
+++ b/hydra-tui/src/Hydra/TUI/Forms.hs
@@ -15,11 +15,11 @@ import Brick.Forms (
   newForm,
   radioField,
  )
-import qualified Cardano.Api.UTxO as UTxO
-import qualified Data.Map.Strict as Map
+import Cardano.Api.UTxO qualified as UTxO
+import Data.Map.Strict qualified as Map
 import Hydra.Chain.Direct.State ()
 import Lens.Micro (Lens', lens)
-import qualified Prelude
+import Prelude qualified
 
 utxoCheckboxField ::
   forall s e n.

--- a/hydra-tui/src/Hydra/TUI/Handlers.hs
+++ b/hydra-tui/src/Hydra/TUI/Handlers.hs
@@ -9,17 +9,17 @@ import Hydra.Prelude hiding (Down, padLeft)
 
 import Brick
 import Hydra.Cardano.Api
-import Hydra.Chain (PostTxError(NotEnoughFuel, InternalWalletError), reason)
+import Hydra.Chain (PostTxError (InternalWalletError, NotEnoughFuel), reason)
 
 import Brick.Forms (Form (formState), editShowableFieldWithValidate, handleFormEvent, newForm, radioField)
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import Data.List (nub, (\\))
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Graphics.Vty (
   Event (EvKey),
   Key (..),
  )
-import qualified Graphics.Vty as Vty
+import Graphics.Vty qualified as Vty
 import Hydra.API.ClientInput (ClientInput (..))
 import Hydra.API.ServerOutput (ServerOutput (..), TimedServerOutput (..))
 import Hydra.Chain.CardanoClient (CardanoClient (..))
@@ -32,10 +32,10 @@ import Hydra.Snapshot (Snapshot (..))
 import Hydra.TUI.Forms
 import Hydra.TUI.Handlers.Global (handleVtyGlobalEvents)
 import Hydra.TUI.Logging.Handlers (info, report, warn)
-import Hydra.TUI.Logging.Types (LogMessage, LogVerbosity (..), Severity (..), logMessagesL, LogState, logVerbosityL)
+import Hydra.TUI.Logging.Types (LogMessage, LogState, LogVerbosity (..), Severity (..), logMessagesL, logVerbosityL)
 import Hydra.TUI.Model
 import Lens.Micro.Mtl (use, (%=), (.=))
-import qualified Prelude
+import Prelude qualified
 
 handleEvent ::
   CardanoClient ->
@@ -73,7 +73,6 @@ handleVtyEventVia :: (Vty.Event -> EventM n s a) -> a -> BrickEvent w e -> Event
 handleVtyEventVia f x = \case
   VtyEvent e -> f e
   _ -> pure x
-
 
 handleGlobalEvents :: BrickEvent Name (HydraEvent Tx) -> EventM Name RootState ()
 handleGlobalEvents = \case
@@ -168,8 +167,9 @@ handleVtyEventsOpen cardanoClient hydraClient utxo e = do
           let amountEntered = formState i
           let ownAddress = mkVkAddress (networkId cardanoClient) (getVerificationKey $ sk hydraClient)
           let field =
-                radioField id
-                  [(u, show u, decodeUtf8 $ encodePretty u)
+                radioField
+                  id
+                  [ (u, show u, decodeUtf8 $ encodePretty u)
                   | u <- filter (/= ownAddress) (nub addresses)
                   ]
               addresses = getRecipientAddress <$> Map.elems (UTxO.toMap utxo)

--- a/hydra-tui/src/Hydra/TUI/Handlers/Global.hs
+++ b/hydra-tui/src/Hydra/TUI/Handlers/Global.hs
@@ -3,7 +3,7 @@ module Hydra.TUI.Handlers.Global where
 import Brick (EventM)
 import Brick.Main (halt)
 import Graphics.Vty (Event (..), Key (..), Modifier (..))
-import qualified Graphics.Vty as Vty
+import Graphics.Vty qualified as Vty
 import Hydra.Prelude
 
 handleVtyQuitEvents :: Vty.Event -> EventM n s ()

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -9,7 +9,7 @@ import Test.Hydra.Prelude
 import Blaze.ByteString.Builder.Char8 (writeChar)
 import CardanoNode (NodeLog, RunningNode (..), withCardanoNodeDevnet)
 import Control.Concurrent.Class.MonadSTM (newTQueueIO, readTQueue, tryReadTQueue, writeTQueue)
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Graphics.Vty (
   DisplayContext (..),
   Event (EvKey),

--- a/hydra-tui/test/Main.hs
+++ b/hydra-tui/test/Main.hs
@@ -1,7 +1,7 @@
 module Main where
 
 import Hydra.Prelude
-import qualified Spec
+import Spec qualified
 import Test.Hspec.Runner
 import Test.Hydra.Prelude (combinedHspecFormatter)
 

--- a/hydraw/app/Main.hs
+++ b/hydraw/app/Main.hs
@@ -14,9 +14,9 @@ import Network.Wai (
   responseFile,
   responseLBS,
  )
-import qualified Network.Wai.Handler.Warp as Warp
-import qualified Network.Wai.Handler.WebSockets as Wai
-import qualified Network.WebSockets as WS
+import Network.Wai.Handler.Warp qualified as Warp
+import Network.Wai.Handler.WebSockets qualified as Wai
+import Network.WebSockets qualified as WS
 import Safe (readMay)
 
 main :: IO ()
@@ -77,7 +77,7 @@ httpApp networkId key host req send =
       case traverse (readMay . toString) args of
         Just [x, y, red, green, blue] -> do
           putStrLn $ show (x, y) <> " -> " <> show (red, green, blue)
-          -- | spawn a connection in a new thread
+          -- \| spawn a connection in a new thread
           void $ async $ withClientNoRetry host $ \cnx ->
             paintPixel networkId key cnx Pixel{x, y, red, green, blue}
           send $ responseLBS status200 corsHeaders "OK"

--- a/hydraw/hydraw.cabal
+++ b/hydraw/hydraw.cabal
@@ -4,9 +4,8 @@ version:       0.0.1
 build-type:    Simple
 
 common project-config
-  default-language: GHC2021
+  default-language:   GHC2021
   default-extensions:
-    NoImplicitPrelude
     DataKinds
     DefaultSignatures
     DeriveAnyClass
@@ -15,6 +14,7 @@ common project-config
     GADTs
     LambdaCase
     MultiWayIf
+    NoImplicitPrelude
     OverloadedStrings
     PartialTypeSignatures
     TypeFamilies

--- a/hydraw/src/Hydra/Painter.hs
+++ b/hydraw/src/Hydra/Painter.hs
@@ -3,9 +3,9 @@ module Hydra.Painter where
 import Hydra.Cardano.Api
 import Hydra.Prelude
 
-import qualified Cardano.Api.UTxO as UTxO
+import Cardano.Api.UTxO qualified as UTxO
 import Control.Exception (IOException)
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Hydra.API.ClientInput (ClientInput (GetUTxO, NewTx))
 import Hydra.API.ServerOutput (ServerOutput (GetUTxOResponse))
 import Hydra.Chain.Direct.State ()

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -95,9 +95,10 @@ rec {
     };
     hydra-node = pkgs.mkShellNoCC {
       name = "hydra-node-tests";
-      buildInputs = [ nativePkgs.hydra-node.components.tests.tests
-                      pkgs.check-jsonschema
-                    ];
+      buildInputs = [
+        nativePkgs.hydra-node.components.tests.tests
+        pkgs.check-jsonschema
+      ];
     };
     hydra-cluster = pkgs.mkShellNoCC {
       name = "hydra-cluster-tests";

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -20,10 +20,6 @@ let
     sha256map."https://github.com/pepeiborra/ekg-json"."7a0af7a8fd38045fd15fb13445bdcc7085325460" = "sha256-fVwKxGgM0S4Kv/4egVAAiAjV7QB5PBqMVMCfsv7otIQ=";
   };
 
-  cabal-plan = pkgs.haskell-nix.tool compiler "cabal-plan" "latest";
-
-  fourmolu = pkgs.haskell-nix.tool compiler "fourmolu" "latest";
-
   libs = [
     pkgs.glibcLocales
     pkgs.libsodium-vrf # from iohk-nix overlay
@@ -39,8 +35,13 @@ let
     pkgs.git
     pkgs.pkg-config
     cabal
-    cabal-plan
+    (pkgs.haskell-nix.tool compiler "cabal-plan" "latest")
     pkgs.haskellPackages.hspec-discover
+    # Formatting
+    pkgs.treefmt
+    (pkgs.haskell-nix.tool compiler "fourmolu" "0.14.0.0")
+    (pkgs.haskell-nix.tool compiler "cabal-fmt" "0.1.9")
+    pkgs.nixpkgs-fmt
     # For validating JSON instances against a pre-defined schema
     pkgs.check-jsonschema
     # For generating plantuml drawings
@@ -53,9 +54,6 @@ let
   ];
 
   devInputs = if withoutDevTools then [ ] else [
-    # Automagically format .hs and .cabal files
-    fourmolu
-    pkgs.haskellPackages.cabal-fmt
     # Essenetial for a good IDE
     haskell-language-server
     # The interactive Glasgow Haskell Compiler as a Daemon

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -20,7 +20,9 @@ let
     sha256map."https://github.com/pepeiborra/ekg-json"."7a0af7a8fd38045fd15fb13445bdcc7085325460" = "sha256-fVwKxGgM0S4Kv/4egVAAiAjV7QB5PBqMVMCfsv7otIQ=";
   };
 
-  cabal-plan = pkgs.haskell-nix.tool compiler "cabal-plan" { };
+  cabal-plan = pkgs.haskell-nix.tool compiler "cabal-plan" "latest";
+
+  fourmolu = pkgs.haskell-nix.tool compiler "fourmolu" "latest";
 
   libs = [
     pkgs.glibcLocales
@@ -52,7 +54,7 @@ let
 
   devInputs = if withoutDevTools then [ ] else [
     # Automagically format .hs and .cabal files
-    pkgs.haskellPackages.fourmolu
+    fourmolu
     pkgs.haskellPackages.cabal-fmt
     # Essenetial for a good IDE
     haskell-language-server

--- a/plutus-cbor/bench/Main.hs
+++ b/plutus-cbor/bench/Main.hs
@@ -6,7 +6,7 @@ import Hydra.Prelude hiding ((<>))
 
 import Codec.Serialise (serialise)
 import Criterion.Main (bench, bgroup, defaultMain, whnf)
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Plutus.Codec.CBOR.Encoding (Encoding, encodeByteString, encodeInteger, encodeListLen, encodeMap, encodeMaybe, encodingToBuiltinByteString)
 import PlutusLedgerApi.V1 (
   Address (..),
@@ -22,8 +22,8 @@ import PlutusLedgerApi.V1 (
   toBuiltin,
   toData,
  )
-import qualified PlutusLedgerApi.V1 as Plutus
-import qualified PlutusTx.AssocMap as Plutus.Map
+import PlutusLedgerApi.V1 qualified as Plutus
+import PlutusTx.AssocMap qualified as Plutus.Map
 import PlutusTx.Semigroup ((<>))
 import Test.QuickCheck (choose, oneof, vector, vectorOf)
 

--- a/plutus-cbor/exe/encoding-cost/Main.hs
+++ b/plutus-cbor/exe/encoding-cost/Main.hs
@@ -1,7 +1,7 @@
 import Hydra.Prelude hiding (label)
 
 import Data.Binary.Builder (toLazyByteString)
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.ByteString.Builder.Scientific (FPFormat (Fixed), formatScientificBuilder)
 import Data.Ratio ((%))
 import Data.Scientific (unsafeFromRational)
@@ -10,8 +10,8 @@ import Plutus.Codec.CBOR.Encoding.Validator (
   encodeTxOutValidator,
   encodeTxOutsValidator,
  )
-import qualified PlutusLedgerApi.V1 as Plutus
-import qualified PlutusTx.AssocMap as Plutus.Map
+import PlutusLedgerApi.V1 qualified as Plutus
+import PlutusTx.AssocMap qualified as Plutus.Map
 import Test.Plutus.Validator (
   ExecutionUnits (..),
   defaultMaxExecutionUnits,
@@ -50,7 +50,7 @@ main = do
         ]
 
 relativeCostOf ::
-  (Plutus.ToData a) =>
+  Plutus.ToData a =>
   a ->
   ExecutionUnits ->
   (ValidatorKind -> Plutus.SerialisedScript) ->

--- a/plutus-cbor/exe/encoding-cost/Plutus/Codec/CBOR/Encoding/Validator.hs
+++ b/plutus-cbor/exe/encoding-cost/Plutus/Codec/CBOR/Encoding/Validator.hs
@@ -34,7 +34,7 @@ import PlutusLedgerApi.V1 (
 
 import Hydra.Plutus.Extras (wrapValidator)
 import PlutusLedgerApi.Common (SerialisedScript, serialiseCompiledCode)
-import qualified PlutusTx as Plutus
+import PlutusTx qualified as Plutus
 
 -- | A validator for measuring cost of encoding values. The validator is
 -- parameterized by the type of value.

--- a/plutus-cbor/plutus-cbor.cabal
+++ b/plutus-cbor/plutus-cbor.cabal
@@ -16,7 +16,6 @@ source-repository head
 common project-config
   default-language:   GHC2021
   default-extensions:
-    NoImplicitPrelude
     DataKinds
     DefaultSignatures
     DeriveAnyClass
@@ -25,6 +24,7 @@ common project-config
     GADTs
     LambdaCase
     MultiWayIf
+    NoImplicitPrelude
     OverloadedStrings
     PartialTypeSignatures
     TypeFamilies

--- a/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
+++ b/plutus-cbor/src/Plutus/Codec/CBOR/Encoding.hs
@@ -77,7 +77,7 @@ module Plutus.Codec.CBOR.Encoding (
 import PlutusTx.Prelude
 
 import PlutusTx.AssocMap (Map)
-import qualified PlutusTx.AssocMap as Map
+import PlutusTx.AssocMap qualified as Map
 import PlutusTx.Builtins (subtractInteger)
 
 -- * Encoding

--- a/plutus-cbor/test/Main.hs
+++ b/plutus-cbor/test/Main.hs
@@ -5,7 +5,7 @@ import Hydra.Prelude
 import Test.Hspec.Runner (configFormat, defaultConfig, hspecWith)
 import Test.Hydra.Prelude (combinedHspecFormatter)
 
-import qualified Spec
+import Spec qualified
 
 main :: IO ()
 main =

--- a/plutus-cbor/test/Plutus/Codec/CBOR/EncodingSpec.hs
+++ b/plutus-cbor/test/Plutus/Codec/CBOR/EncodingSpec.hs
@@ -3,11 +3,11 @@ module Plutus.Codec.CBOR.EncodingSpec where
 import Hydra.Prelude hiding (label)
 import Test.Hydra.Prelude
 
-import qualified Codec.CBOR.Encoding as CBOR
-import qualified Codec.CBOR.Pretty as CBOR
-import qualified Codec.CBOR.Write as CBOR
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Base16 as Base16
+import Codec.CBOR.Encoding qualified as CBOR
+import Codec.CBOR.Pretty qualified as CBOR
+import Codec.CBOR.Write qualified as CBOR
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as Base16
 import Plutus.Codec.CBOR.Encoding (
   Encoding,
   encodeBool,
@@ -23,8 +23,8 @@ import Plutus.Codec.CBOR.Encoding (
   encodingToBuiltinByteString,
  )
 
-import qualified PlutusTx.AssocMap as Plutus.Map
-import qualified PlutusTx.Builtins as Plutus
+import PlutusTx.AssocMap qualified as Plutus.Map
+import PlutusTx.Builtins qualified as Plutus
 import Test.QuickCheck (
   Property,
   choose,
@@ -40,7 +40,7 @@ import Test.QuickCheck (
   withMaxSuccess,
   (===),
  )
-import qualified Prelude
+import Prelude qualified
 
 spec :: Spec
 spec =

--- a/plutus-merkle-tree/bench/Main.hs
+++ b/plutus-merkle-tree/bench/Main.hs
@@ -3,12 +3,12 @@ module Main where
 import Hydra.Prelude hiding (catch)
 
 import Data.ByteString (hPut)
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.Fixed (E2, Fixed)
 import Data.Maybe (fromJust)
 import Plutus.MerkleTree (rootHash)
-import qualified Plutus.MerkleTree as MT
-import qualified PlutusTx.Prelude as Plutus
+import Plutus.MerkleTree qualified as MT
+import PlutusTx.Prelude qualified as Plutus
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath ((</>))
 import Test.Plutus.Validator (ExecutionUnits (..), defaultMaxExecutionUnits, evaluateScriptExecutionUnits)

--- a/plutus-merkle-tree/bench/Validators.hs
+++ b/plutus-merkle-tree/bench/Validators.hs
@@ -10,10 +10,10 @@ module Validators where
 import PlutusTx.Prelude
 
 import Hydra.Plutus.Extras (wrapValidator)
-import qualified Plutus.MerkleTree as MT
+import Plutus.MerkleTree qualified as MT
 import PlutusLedgerApi.Common (SerialisedScript, serialiseCompiledCode)
 import PlutusLedgerApi.V2 (ScriptContext)
-import qualified PlutusTx as Plutus
+import PlutusTx qualified as Plutus
 
 -- | A validator for measuring cost of MT membership validation.
 merkleTreeMemberValidator :: SerialisedScript

--- a/plutus-merkle-tree/plutus-merkle-tree.cabal
+++ b/plutus-merkle-tree/plutus-merkle-tree.cabal
@@ -16,7 +16,6 @@ source-repository head
 common project-config
   default-language:   GHC2021
   default-extensions:
-    NoImplicitPrelude
     DataKinds
     DefaultSignatures
     DeriveAnyClass
@@ -25,6 +24,7 @@ common project-config
     GADTs
     LambdaCase
     MultiWayIf
+    NoImplicitPrelude
     OverloadedStrings
     PartialTypeSignatures
     TypeFamilies

--- a/plutus-merkle-tree/src/Plutus/MerkleTree.hs
+++ b/plutus-merkle-tree/src/Plutus/MerkleTree.hs
@@ -16,15 +16,15 @@ module Plutus.MerkleTree where
 
 import PlutusPrelude hiding (toList)
 
-import qualified PlutusTx
+import PlutusTx qualified
 import PlutusTx.Builtins (divideInteger)
-import qualified PlutusTx.List as List
+import PlutusTx.List qualified as List
 import PlutusTx.Prelude hiding (toList)
 
-import qualified Data.ByteString.Base16 as Haskell.Base16
-import qualified Data.Text as Haskell.Text
-import qualified Data.Text.Encoding as Haskell.Text.Encoding
-import qualified Prelude as Haskell
+import Data.ByteString.Base16 qualified as Haskell.Base16
+import Data.Text qualified as Haskell.Text
+import Data.Text.Encoding qualified as Haskell.Text.Encoding
+import Prelude qualified as Haskell
 
 -- * MerkleTree
 

--- a/plutus-merkle-tree/test/Main.hs
+++ b/plutus-merkle-tree/test/Main.hs
@@ -5,7 +5,7 @@ import Hydra.Prelude
 import Test.Hspec.Runner (configFormat, defaultConfig, hspecWith)
 import Test.Hydra.Prelude (combinedHspecFormatter)
 
-import qualified Spec
+import Spec qualified
 
 main :: IO ()
 main =

--- a/plutus-merkle-tree/test/Plutus/MerkleTreeSpec.hs
+++ b/plutus-merkle-tree/test/Plutus/MerkleTreeSpec.hs
@@ -3,11 +3,11 @@ module Plutus.MerkleTreeSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.Maybe (fromJust)
 import Plutus.MerkleTree (MerkleTree)
-import qualified Plutus.MerkleTree as MT
-import qualified PlutusTx.Builtins as Plutus
+import Plutus.MerkleTree qualified as MT
+import PlutusTx.Builtins qualified as Plutus
 import Test.QuickCheck (
   Property,
   Testable,

--- a/sample-node-config/nixos/hydraw.nix
+++ b/sample-node-config/nixos/hydraw.nix
@@ -78,10 +78,10 @@ in
     ];
     entrypoint = "hydraw";
     environment = {
-      HYDRAW_CARDANO_SIGNING_KEY="/credentials/sebastian.cardano.sk";
-      HYDRA_API_HOST="localhost:4001";
+      HYDRAW_CARDANO_SIGNING_KEY = "/credentials/sebastian.cardano.sk";
+      HYDRA_API_HOST = "localhost:4001";
     };
-    extraOptions = ["--network=host"];
+    extraOptions = [ "--network=host" ];
   };
 
   # Configure the reverse proxy to point at it

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -1,0 +1,16 @@
+# One CLI to format the code tree - https://github.com/numtide/treefmt
+
+[formatter.haskell]
+command = "fourmolu"
+options = ["--mode", "inplace", "--check-idempotence",]
+includes = [ "*.hs" ]
+
+[formatter.cabal]
+command = "cabal-fmt"
+options = ["--inplace"]
+includes = ["*.cabal"]
+
+[formatter.nix]
+command = "nixpkgs-fmt"
+options = []
+includes = ["*.nix"]


### PR DESCRIPTION
* :broom: Adds a code formatting workflow which runs `treefmt` to check all code formatting in the project.

* :broom: Updates to latest available `fourmolu` and `cabal-fmt` version

* :broom: Applies changes to comply. Notable differences with new version of `fourmolu`:
  - [x] Postfix `qualified` (not configurable from `ourmolu`), e.g.
  ```diff
  -import qualified Cardano.Api
  +import Cardano.Api qualified
  ```
  - [x] Removed parenthesis from single constraints:
  ```diff
  -  (IsShelleyBasedEra era) =>
  +  IsShelleyBasedEra era =>
  ```
  - [ ] ~~Multiple `$` and `>>=` seemingly get broken into new lines differently now:~~
    - Fixed with a fixity override of `$`
  ```diff
  -        withOSStats workDir $
  -          withCardanoNodeDevnet (contramap FromCardanoNode tracer) workDir $ \node@RunningNode{nodeSocket} -> do
  +        withOSStats workDir
  +          $ withCardanoNodeDevnet (contramap FromCardanoNode tracer) workDir
  +          $ \node@RunningNode{nodeSocket} -> do
  ```
  - [ ] ~~Lenses are a bit annoying now and sometimes require additional parens:~~
      - Fixed with a fixity override of `&`
  ```diff
  & ppPricesL
  -      .~ ( Prices
  -            { prMem = fromJust $ boundRational 0
  -            , prSteps = fromJust $ boundRational 0
  -            }
  -         )
  -    & ppMinFeeAL .~ Coin 0
  -    & ppMinFeeBL .~ Coin 0
  +    .~ ( Prices
  +          { prMem = fromJust $ boundRational 0
  +          , prSteps = fromJust $ boundRational 0
  +          }
  +       )
  +      & ppMinFeeAL
  +    .~ Coin 0
  +      & ppMinFeeBL
  +    .~ Coin 0
  ```
  
---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
