### PR TITLE
Do not expliticly list local packages in shell.nix

### DIFF
--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -20,7 +20,7 @@ let
     sha256map."https://github.com/pepeiborra/ekg-json"."7a0af7a8fd38045fd15fb13445bdcc7085325460" = "sha256-fVwKxGgM0S4Kv/4egVAAiAjV7QB5PBqMVMCfsv7otIQ=";
   };
 
-  cabal-plan = pkgs.haskell-nix.tool compiler "cabal-plan" {};
+  cabal-plan = pkgs.haskell-nix.tool compiler "cabal-plan" { };
 
   libs = [
     pkgs.glibcLocales
@@ -73,22 +73,6 @@ let
   ];
 
   haskellNixShell = hsPkgs.shellFor {
-    # NOTE: Explicit list of local packages as hoogle would not work otherwise.
-    # Make sure these are consistent with the packages in cabal.project.
-    packages = ps: with ps; [
-      hydra-prelude
-      hydra-cardano-api
-      hydra-test-utils
-      hydra-plutus-extras
-      plutus-cbor
-      plutus-merkle-tree
-      hydra-plutus
-      hydra-node
-      hydra-cluster
-      hydra-tui
-      hydraw
-    ];
-
     buildInputs = libs ++ buildInputs ++ devInputs;
 
     withHoogle = !withoutDevTools;


### PR DESCRIPTION
This seems not to be needed anymore and it bit us on another branch where we created a new package and we forgot to mention it here.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
