### PR TITLE
Misleading error collect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ changes.
 
 ## [0.14.0] - UNRELEASED
 
+- Removed false positive `PostTxOnChainFailed` error from API outputs when the
+  collect transaction of another `hydra-node` was "faster" than ours.
+
 - Add a `hydra-chain-observer` executable to subscribe to a chain and just
   observe Hydra Head transactions (with minimal information right now).
 

--- a/hydra-cluster/bench/Main.hs
+++ b/hydra-cluster/bench/Main.hs
@@ -22,7 +22,7 @@ import Options.Applicative (
 import System.Directory (createDirectory, createDirectoryIfMissing, doesDirectoryExist)
 import System.Environment (withArgs)
 import System.FilePath ((</>))
-import Test.HUnit.Lang (HUnitFailure (..), formatFailureReason)
+import Test.HUnit.Lang (formatFailureReason)
 import Test.QuickCheck (generate, getSize, scale)
 
 main :: IO ()

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -67,6 +67,7 @@ import Hydra.Cluster.Scenarios (
   singlePartyCommitsExternalScriptWithInlineDatum,
   singlePartyCommitsFromExternalScript,
   singlePartyHeadFullLifeCycle,
+  threeNodesNoErrorsOnOpen,
  )
 import Hydra.Cluster.Util (chainConfigFor, keysFor)
 import Hydra.ContestationPeriod (ContestationPeriod (UnsafeContestationPeriod))
@@ -150,6 +151,13 @@ spec = around showLogsOnFailure $
               >>= canSubmitTransactionThroughAPI tracer tmpDir node
 
     describe "three hydra nodes scenario" $ do
+      it "does not error when all nodes open the head concurrently" $ \tracer ->
+        failAfter 60 $
+          withClusterTempDir "three-no-errors" $ \tmpDir -> do
+            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node -> do
+              publishHydraScriptsAs node Faucet
+                >>= threeNodesNoErrorsOnOpen tracer tmpDir node
+
       it "inits a Head, processes a single Cardano transaction and closes it again" $ \tracer ->
         failAfter 60 $
           withClusterTempDir "three-full-life-cycle" $ \tmpDir -> do

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -691,6 +691,10 @@ update env ledger st ev = case (st, ev) of
     -- TODO: Is it really intuitive that we respond from the confirmed ledger if
     -- transactions are validated against the seen ledger?
     Effects [ClientEffect . ServerOutput.GetUTxOResponse headId $ getField @"utxo" $ getSnapshot confirmedSnapshot]
+  -- NOTE: If posting the collectCom transaction failed in the open state, then
+  -- another party likely opened the head before us and it's okay to ignore.
+  (Open{}, PostTxError{postChainTx = CollectComTx{}}) ->
+    Effects []
   -- Closed
   (Closed closedState, OnChainEvent Observation{observedTx = OnContestTx{snapshotNumber}}) ->
     onClosedChainContestTx closedState snapshotNumber

--- a/hydra-node/test/Test/Util.hs
+++ b/hydra-node/test/Test/Util.hs
@@ -21,7 +21,7 @@ import Data.Aeson qualified as Aeson
 import Data.List (isInfixOf)
 import Hydra.Ledger.Simple (SimpleTx)
 import Hydra.Node (HydraNodeLog)
-import Test.HUnit.Lang (FailureReason (ExpectedButGot), HUnitFailure (HUnitFailure))
+import Test.HUnit.Lang (FailureReason (ExpectedButGot))
 import Test.QuickCheck (forAll, withMaxSuccess)
 
 -- | Run given 'action' in 'IOSim' and rethrow any exceptions.

--- a/hydra-test-utils/src/Test/Hydra/Prelude.hs
+++ b/hydra-test-utils/src/Test/Hydra/Prelude.hs
@@ -1,6 +1,7 @@
 module Test.Hydra.Prelude (
   createSystemTempDirectory,
   failure,
+  HUnitFailure (..),
   location,
   failAfter,
   combinedHspecFormatter,


### PR DESCRIPTION
:bug: Fixes #839 by removing the misleading `PostTxOnChainFailed` client output when a collect com failed because some other node opened the head "before us".

:bug: By delaying the transaction submission error propagate by one second, the observation code should already have been able to enqueue the `OnCollectComTx` event, which in turn allows the business logic to ignore the error when already in the open state.

NOTE: Only tested in e2e tests using the devnet.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
