### PR TITLE
Bump hardcoded deposit of script outputs to 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ changes.
 
 ## [0.14.0] - UNRELEASED
 
-- Increase maximum number of parties to 5
+- Increase maximum number of parties to 5.
 
 - **BREAKING** Sign the head identifier as part of snapshot signature
   and verify it on-chain
@@ -40,7 +40,8 @@ changes.
 
 - **BREAKING** Changes to Hydra scripts:
   - Switch to using inline datums instead of (optionally) published datums in
-    transactions.
+    transactions. This also includes a bump in the hard-coded deposit of script
+    outputs to 2.2₳.
   - Upgrading our toolchain to GHC 9.6
 
 - **BREAKING** Changes to persisted state:

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -103,7 +103,7 @@ hydraHeadV1AssetName = AssetName (fromBuiltin hydraHeadV1)
 
 -- FIXME: sould not be hardcoded
 headValue :: Value
-headValue = lovelaceToValue (Lovelace 2_000_000)
+headValue = lovelaceToValue (Lovelace 2_200_000)
 
 -- * Create Hydra Head transactions
 


### PR DESCRIPTION
Since we use inline datums, the deposit we need to put in outputs is higher now. When trying to initialize a head on mainnet this was reported to be `2193790` lovelace for the initTxs head output.

TODO: why did the end-to-end tests not fail before?

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
