### PR TITLE
Check if cardano-cli works with DraftCommitTxResponse json output

### DIFF
--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -154,6 +154,7 @@ test-suite tests
     Test.DirectChainSpec
     Test.EndToEndSpec
     Test.GeneratorSpec
+    Test.Hydra.Cluster.CardanoCliSpec
     Test.Hydra.Cluster.FaucetSpec
     Test.Ledger.Cardano.ConfigurationSpec
     Test.LogFilterSpec

--- a/hydra-cluster/test/Test/Hydra/Cluster/CardanoCliSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/CardanoCliSpec.hs
@@ -1,0 +1,59 @@
+module Test.Hydra.Cluster.CardanoCliSpec where
+
+import Hydra.Prelude hiding (toString)
+import Test.Hydra.Prelude
+
+import Control.Lens ((^?))
+import Data.Aeson (encode)
+import Data.Aeson.Key (toString)
+import Data.Aeson.Lens (key, _String)
+import Data.ByteString.Lazy qualified as BS
+import Data.Text (pack, unpack)
+import Hydra.API.HTTPServer (DraftCommitTxResponse (DraftCommitTxResponse))
+import Hydra.Cardano.Api (Tx)
+import System.Exit (ExitCode (..))
+import System.FilePath ((</>))
+import System.Process (proc, readCreateProcessWithExitCode)
+import Test.QuickCheck (generate)
+
+spec :: Spec
+spec =
+  describe "cardano-cli" $
+    it "cardano-cli can accept a draft commit tx in text-envelope format" $
+      withTempDir "cardano-cli" $ \tmpDir -> do
+        let txFile = tmpDir </> "tx.raw"
+        draftCommitResponse <- DraftCommitTxResponse <$> generate (arbitrary :: Gen Tx)
+        let textEnvelope = encode $ toJSON draftCommitResponse
+        _ <- BS.writeFile txFile textEnvelope
+
+        (exitCode, output, _errors) <- readCreateProcessWithExitCode (cardanoCliSign txFile) ""
+        exitCode `shouldBe` ExitSuccess
+        findInOutput "type" "Witnessed Tx BabbageEra" output
+ where
+  cardanoCliSign txFile =
+    proc
+      "cardano-cli"
+      [ "transaction"
+      , "sign"
+      , "--tx-file"
+      , txFile
+      , "--signing-key-file"
+      , "config/credentials/alice.sk"
+      , "--testnet-magic"
+      , "42"
+      , "--out-file"
+      , "/dev/stdout"
+      ]
+
+  findInOutput lookFor expectedString output =
+    case output ^? key lookFor . _String of
+      Nothing ->
+        failure $
+          unpack $
+            unlines $
+              [ "Failed to find key " <> pack (toString lookFor) <> " in TextEnvelope."
+              , "cardano-cli output:"
+              , pack output
+              ]
+      Just foundString -> do
+        foundString `shouldBe` expectedString

--- a/hydra-cluster/test/Test/Hydra/Cluster/CardanoCliSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/CardanoCliSpec.hs
@@ -4,10 +4,9 @@ import Hydra.Prelude hiding (toString)
 import Test.Hydra.Prelude
 
 import Control.Lens ((^?))
-import Data.Aeson (encode)
+import Data.Aeson (encodeFile)
 import Data.Aeson.Key (toString)
 import Data.Aeson.Lens (key, _String)
-import Data.ByteString.Lazy qualified as BS
 import Data.Text (pack, unpack)
 import Hydra.API.HTTPServer (DraftCommitTxResponse (DraftCommitTxResponse))
 import Hydra.Cardano.Api (Tx)
@@ -23,8 +22,7 @@ spec =
       withTempDir "cardano-cli" $ \tmpDir -> do
         let txFile = tmpDir </> "tx.raw"
         draftCommitResponse <- DraftCommitTxResponse <$> generate (arbitrary :: Gen Tx)
-        let textEnvelope = encode $ toJSON draftCommitResponse
-        _ <- BS.writeFile txFile textEnvelope
+        encodeFile txFile draftCommitResponse
 
         (exitCode, output, _errors) <- readCreateProcessWithExitCode (cardanoCliSign txFile) ""
         exitCode `shouldBe` ExitSuccess

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -113,6 +113,7 @@ rec {
           nativePkgs.hydra-cluster.components.tests.tests
           hydra-node
           cardano-node.packages.${system}.cardano-node
+          cardano-node.packages.${system}.cardano-cli
           hydra-chain-observer
         ];
     };


### PR DESCRIPTION
### Why 

 To make sure that cardano-cli can be used on our draft commit transaction.

### What

Produce a `DraftCommitTxResponse` json output and assert it is usable from the cardano-cli.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
