### PR TITLE
Release script changes & changelog 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,52 +10,57 @@ changes.
 
 ## [0.14.0] - UNRELEASED
 
-- Remove hard-coded deposit of 2₳ from internal wallet. Now the wallet does only
-  use as much deposit for script outputs as minimally needed and reduces the Ada
-  locked throughout a head life-cycle.
+- **BREAKING** Multiple changes to the Hydra Head protocol on-chain:
 
-- Increase maximum number of parties to 5
+  - Sign the head identifier as part of snapshot signature and verify it
+    on-chain. This fully addresses security advisory
+    [CVE-2023-42806](https://github.com/input-output-hk/hydra/security/advisories/GHSA-gr36-mc6v-72qq).
 
-- **BREAKING** Sign the head identifier as part of snapshot signature
-  and verify it on-chain
+  - Switched to using inline datums instead of (optionally) published datums in
+    transactions. [#1162](https://github.com/input-output-hk/hydra/pull/1162)
 
-- Removed false positive `PostTxOnChainFailed` error from API outputs when the
-  collect transaction of another `hydra-node` was "faster" than ours.
+  - Upgraded toolchain to GHC 9.6 and a newer `plutus-tx` compiler.
 
-- Add a `hydra-chain-observer` executable to subscribe to a chain and just
-  observe Hydra Head transactions (with minimal information right now).
+- **BREAKING** Internal persisted chain state serialization changed when
+  switching to inline datums. Make sure to close heads before and wipe the
+  `--persistence-dir` before using this `hydra-node` version.
 
-- Improved `gen-hydra-keys` command to not overwrite keys if they are present
-  already.
+- **BREAKING** Introduced messages resending logic in the `Network` layer to
+  improve reliability in the face of connection issues.
+  [#188](https://github.com/input-output-hk/hydra/issues/188) This persists
+  network messages on disk in order to gracefully handle crashes and detects
+  inconsistencies between persisted state and configuration.
+
+- Increased maximum number of parties to 5. This is possible to small
+  optimizations on the Head protocol transactions.
+
+- Removed hard-coded deposit of 2₳ from internal wallet. Now the wallet does
+  only use as much deposit for script outputs as minimally needed and reduces
+  the Ada locked throughout a head life-cycle.
+  [#1176](https://github.com/input-output-hk/hydra/pull/1176)
 
 - Clients are notified when head initialization is ignored via a new
   `IgnoredHeadInitializing` API server output. This helps detecting
   misconfigurations of credentials and head parameters (which need to match).
   [#529](https://github.com/input-output-hk/hydra/issues/529)
 
+- Removed false positive `PostTxOnChainFailed` error from API outputs when the
+  collect transaction of another `hydra-node` was "faster" than ours.
+  [#839](https://github.com/input-output-hk/hydra/issues/839)
+
 - Hydra node API `submit-transaction` endpoint now accepts three types of
-  encoding: Base16 encoded CBOR string, TextEnvelope type and JSON.
+  encoding: Base16 encoded CBOR string, a TextEnvelope with CBOR and full JSON.
+  [#1111](https://github.com/input-output-hk/hydra/issues/1111)
 
-- **BREAKING** Introduce messages resending logic in the `Network`
-  layer to improve reliability in the face of transient connection
-  issues.
+- Improved `gen-hydra-keys` command to not overwrite keys if they are present
+  already. [#1136](https://github.com/input-output-hk/hydra/issues/1136)
 
-- Persist network messages on disk in order to gracefully handle crashes
+- Add a `hydra-chain-observer` executable to subscribe to a chain and just
+  observe Hydra Head transactions (with minimal information right now).
+  [#1158](https://github.com/input-output-hk/hydra/pull/1158)
 
-- **BREAKING** Changes to Hydra scripts:
-  - Switch to using inline datums instead of (optionally) published datums in
-    transactions.
-  - Upgrading our toolchain to GHC 9.6
-
-- **BREAKING** Changes to persisted state:
-  - The internal chain state serialization changed when switching to inline datums.
-
-- Fixed TUI key bindings for exiting in dialogs.
-
-- Prevent users from resuming a Hydra node after changing its configurations.
-Ensure that the node terminates when attempting to start a Hydra node with a
-number of configured peers that doesn't match the persisted state (i.e., the
-number of parties in the /acks vector).
+- Fixed `hydra-tui` key bindings for exiting in dialogs.
+  [#1159](https://github.com/input-output-hk/hydra/issues/1159)
 
 ## [0.13.0] - 2023-10-03
 
@@ -72,9 +77,9 @@ number of parties in the /acks vector).
 - Remove hydra-tools package. Move functionality to generate hydra keys to the
   hydra-node executable.
 
-Changes to `hydra-node` state persistency:
-  Remove the recursive definition of the chain state.
-  This makes the event store more lightweight and easier to read and work with.
+- Changes to `hydra-node` state persistency:
+  - Remove the recursive definition of the chain state.
+  - This makes the event store more lightweight and easier to read and work with.
 
 ## [0.12.0] - 2023-08-18
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,7 +198,8 @@ During development
 To perform a release of next `<version>`:
 
 1. Publish hydra scripts onto `preview`, `preprod`, and `mainnet` using the
-   [smoke test][smoke-test] and take note of the transaction ids.
+   [smoke test][smoke-test] and put the transaction ids as new `<version>`
+   entries into [networks.json](./networks.json).
 2. Update CHANGELOG.md by replacing `UNRELEASED` with a date in
    [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) and prepare contents.
 3. Run `./release.sh <version>`

--- a/docs/docs/tutorial/index.md
+++ b/docs/docs/tutorial/index.md
@@ -46,7 +46,7 @@ curl -L -O https://github.com/input-output-hk/hydra/releases/download/${version}
 unzip -d bin hydra-x86_64-linux-${version}.zip
 curl -L -o - https://github.com/input-output-hk/cardano-node/releases/download/8.1.2/cardano-node-8.1.2-linux.tar.gz \
   | tar xz -C bin ./cardano-node ./cardano-cli
-curl -L -o - https://github.com/input-output-hk/mithril/releases/download/2331.1/mithril-2331.1-linux-x64.tar.gz \
+curl -L -o - https://github.com/input-output-hk/mithril/releases/download/2347.0/mithril-2347.0-linux-x64.tar.gz \
   | tar xz -C bin mithril-client
 chmod +x bin/*
 ```

--- a/docs/docs/tutorial/index.md
+++ b/docs/docs/tutorial/index.md
@@ -41,8 +41,9 @@ components of the Cardano ecosystem, putting them in a `bin/` directory:
 
 ```shell
 mkdir -p bin
-curl -L -O https://github.com/input-output-hk/hydra/releases/download/0.14.0/hydra-x86_64-linux-0.14.0.zip
-unzip -d bin hydra-x86_64-linux-0.14.0.zip
+version=0.13.0
+curl -L -O https://github.com/input-output-hk/hydra/releases/download/${version}/hydra-x86_64-linux-${version}.zip
+unzip -d bin hydra-x86_64-linux-${version}.zip
 curl -L -o - https://github.com/input-output-hk/cardano-node/releases/download/8.1.2/cardano-node-8.1.2-linux.tar.gz \
   | tar xz -C bin ./cardano-node ./cardano-cli
 curl -L -o - https://github.com/input-output-hk/mithril/releases/download/2331.1/mithril-2331.1-linux-x64.tar.gz \
@@ -55,8 +56,9 @@ chmod +x bin/*
 
 ```shell
 mkdir -p bin
-curl -L -O https://github.com/input-output-hk/hydra/releases/download/0.14.0/hydra-aarch64-darwin-0.14.0.zip
-unzip -d bin hydra-aarch64-darwin-0.14.0.zip
+version=0.13.0
+curl -L -O https://github.com/input-output-hk/hydra/releases/download/${version}/hydra-aarch64-darwin-${version}.zip
+unzip -d bin hydra-aarch64-darwin-${version}.zip
 curl -L -o - https://github.com/input-output-hk/mithril/releases/download/2347.0/mithril-2347.0-macos-x64.tar.gz \
   | tar xz -C bin
 curl -L -o - https://github.com/input-output-hk/cardano-node/releases/download/8.1.2/cardano-node-8.1.2-macos.tar.gz \

--- a/docs/docs/tutorial/index.md
+++ b/docs/docs/tutorial/index.md
@@ -701,7 +701,7 @@ You can do this through the websocket API one last time:
 { "tag": "Fanout" }
 ```
 
-This will again submit a transactin to the layer one and once successful is
+This will again submit a transaction to the layer one and once successful is
 indicated by a `HeadIsFinalized` message which includes the distributed `utxo`.
 
 To confirm, you can query the funds of both, `alice` and `bob`, on the layer

--- a/docs/docs/tutorial/index.md
+++ b/docs/docs/tutorial/index.md
@@ -329,14 +329,14 @@ will be used on the layer two by the `hydra-node`. For this, we will use the
 <TabItem value="alice" label="Alice">
 
 ```shell
-hydra-tools gen-hydra-key --output-file credentials/alice-hydra
+hydra-node gen-hydra-key --output-file credentials/alice-hydra
 ```
 
 </TabItem>
 <TabItem value="bob" label="Bob">
 
 ```shell
-hydra-tools gen-hydra-key --output-file credentials/bob-hydra
+hydra-node gen-hydra-key --output-file credentials/bob-hydra
 ```
 
 </TabItem>

--- a/docs/docs/tutorial/index.md
+++ b/docs/docs/tutorial/index.md
@@ -58,7 +58,7 @@ chmod +x bin/*
 mkdir -p bin
 version=0.13.0
 curl -L -O https://github.com/input-output-hk/hydra/releases/download/${version}/hydra-aarch64-darwin-${version}.zip
-unzip -d bin hydra-aarch64-darwin-${version}.zip
+unzip -d bin hydra-aarch64-darwin-${HYDRA_VERSION}.zip
 curl -L -o - https://github.com/input-output-hk/mithril/releases/download/2347.0/mithril-2347.0-macos-x64.tar.gz \
   | tar xz -C bin
 curl -L -o - https://github.com/input-output-hk/cardano-node/releases/download/8.1.2/cardano-node-8.1.2-macos.tar.gz \
@@ -381,11 +381,11 @@ In summary, the Hydra head participants exchanged and agreed on:
 
 ## Step 3: Start the Hydra node
 
-With all these parameters defined, we now pick a version of the Head protocol we
-want to use. This is defined by the `hydra-node --version` itself and the
+With all these parameters defined, we now pick a HYDRA_VERSION of the Head protocol we
+want to use. This is defined by the `hydra-node --HYDRA_VERSION` itself and the
 `--hydra-scripts-tx-id` which point to scripts published on-chain.
 
-For all [released](https://github.com/input-output-hk/hydra/releases) versions
+For all [released](https://github.com/input-output-hk/hydra/releases) HYDRA_VERSIONs
 of the `hydra-node` and common Cardano networks, the scripts do get
 pre-published and we can just use them. See the [user
 manual](../getting-started/quickstart#reference-scripts) for more information
@@ -397,12 +397,13 @@ Let's start the `hydra-node` with all these parameters now:
 <TabItem value="alice" label="Alice">
 
 ```shell
+version=0.13.0
 hydra-node \
   --node-id "alice-node" \
   --persistence-dir persistence-alice \
   --cardano-signing-key credentials/alice-node.sk \
   --hydra-signing-key credentials/alice-hydra.sk \
-  --hydra-scripts-tx-id e5eb53b913e274e4003692d7302f22355af43f839f7aa73cb5eb53510f564496 \
+  --hydra-scripts-tx-id $(curl https://raw.githubusercontent.com/input-output-hk/hydra/master/networks.json | jq -r ".preprod.\"${version}\"") \
   --ledger-protocol-parameters protocol-parameters.json \
   --testnet-magic 1 \
   --node-socket node.socket \
@@ -419,12 +420,13 @@ hydra-node \
 <TabItem value="bob" label="Bob">
 
 ```shell
+version=0.13.0
 hydra-node \
   --node-id "bob-node" \
   --persistence-dir persistence-bob \
   --cardano-signing-key credentials/bob-node.sk \
   --hydra-signing-key credentials/bob-hydra.sk \
-  --hydra-scripts-tx-id e5eb53b913e274e4003692d7302f22355af43f839f7aa73cb5eb53510f564496 \
+  --hydra-scripts-tx-id $(curl https://raw.githubusercontent.com/input-output-hk/hydra/master/networks.json | jq -r ".preprod.\"${version}\"") \
   --ledger-protocol-parameters protocol-parameters.json \
   --testnet-magic 1 \
   --node-socket node.socket \

--- a/networks.json
+++ b/networks.json
@@ -1,0 +1,12 @@
+{
+    "mainnet": {
+        "0.13.0": "989e3ab136a2cdd3132a99975e76e02f62bcb03ba64ddbb5d2dfddffca8d390d"
+    },
+    "preprod": {
+        "0.13.0": "f917dcd1fa2653e33d6d0ca5a067468595b546120c3085fab60848c34f92c265",
+        "0.14.0": "d8ba8c488f52228b200df48fe28305bc311d0507da2c2420b10835bf00d21948"
+    },
+    "preview": {
+        "0.13.0": "1e00c627ec4b2ad0b4aa68068d3818ca0e41338c87e5504cda118c4050a98763"
+    }
+}

--- a/release.sh
+++ b/release.sh
@@ -161,7 +161,7 @@ update_api_version() {
 update_tutorial_version() {
   local version="$1"
   local tutorial_file=docs/docs/tutorial/index.md
-  sed -i"" -e "s,\(hydra/releases/download/\)[^/]*,\1$version," $tutorial_file
+  sed -i"" -e "s,\(version=\).*,\1$version," $tutorial_file
 }
 
 update_demo_version() {

--- a/release.sh
+++ b/release.sh
@@ -131,7 +131,7 @@ update_api_version() {
 update_tutorial_version() {
   local version="$1"
   local tutorial_file=docs/docs/tutorial/index.md
-  sed -i.bak -e "s,\(hydra/releases/download/)[^/]*,\1$version," $tutorial_file
+  sed -i.bak -e "s,\(hydra/releases/download/\)[^/]*,\1$version," $tutorial_file
 }
 
 update_demo_version() {

--- a/release.sh
+++ b/release.sh
@@ -49,6 +49,7 @@ check_can_release() {
   confirm_uncommitted_changes
   check_version_is_valid $version
   check_changelog_is_up_to_date $version
+  check_networks_is_up_to_date $version
 
   true #avoid error on last instruction of function (see bash -e)
 }
@@ -137,6 +138,24 @@ check_changelog_is_up_to_date() {
   && exit_err "$version is not released in CHANGELOG.md. Please replace UNRELEASED with the current date"
 
   true #avoid error on last instruction of function (see bash -e)
+}
+
+# Check whether a transaction id is present for all networks and given version.
+check_networks_is_up_to_date() {
+  local version="$1"
+
+  local networks=(
+    mainnet
+    preprod
+    preview
+  )
+
+  local networks_file=networks.json
+
+  for network in "${networks[@]}"; do
+    cat ${networks_file} | jq -e ".\"${network}\".\"${version}\"" > /dev/null \
+    || exit_err "Missing transaction id for ${version} on ${network} in ${networks_file}"
+  done
 }
 
 # Prepare helper functions

--- a/release.sh
+++ b/release.sh
@@ -16,6 +16,7 @@ main() {
   publish_release "$version" # fake for now
 }
 
+# Like 'echo' but on stderr
 err() {
   echo >&2 "$1"
 }
@@ -138,7 +139,7 @@ update_cabal_version() {
   
   for file in $cabal_files
   do
-    sed -i.bak -e "s,\(^version: *\)[^ ]*,\1$version," $file
+    sed -i"" -e "s,\(^version: *\)[^ ]*,\1$version," $file
   done
 }
 
@@ -146,20 +147,20 @@ update_api_version() {
   local version="$1" ; shift
   local api_file=hydra-node/json-schemas/api.yaml
 
-  sed -i.bak -e "s,\(version: *\)'.*',\1'$version'," $api_file
+  sed -i"" -e "s,\(version: *\)'.*',\1'$version'," $api_file
 }
 
 update_tutorial_version() {
   local version="$1"
   local tutorial_file=docs/docs/tutorial/index.md
-  sed -i.bak -e "s,\(hydra/releases/download/\)[^/]*,\1$version," $tutorial_file
+  sed -i"" -e "s,\(hydra/releases/download/\)[^/]*,\1$version," $tutorial_file
 }
 
 update_demo_version() {
   local version="$1"
   (
     cd demo
-    sed -i.bak -e "s,\(ghcr.io/input-output-hk/hydra-[^:]*\):[^[:space:]]*,\1:$version," docker-compose.yaml seed-devnet.sh
+    sed -i"" -e "s,\(ghcr.io/input-output-hk/hydra-[^:]*\):[^[:space:]]*,\1:$version," docker-compose.yaml seed-devnet.sh
   )
 }
 

--- a/release.sh
+++ b/release.sh
@@ -45,6 +45,7 @@ EOF
 check_can_release() {
   local version="$1"
 
+  check_on_master
   confirm_uncommitted_changes
   check_version_is_valid $version
   check_changelog_is_up_to_date $version
@@ -102,6 +103,12 @@ ask_continue() {
   if [[ ! $REPLY =~ ^[Yy]$ ]]
   then
     exit_err "Aborted release"
+  fi
+}
+
+check_on_master() {
+  if [ $(git rev-parse --abbrev-ref HEAD) != "master" ]; then
+    exit_err "Not on branch 'master'"
   fi
 }
 

--- a/release.sh
+++ b/release.sh
@@ -13,7 +13,7 @@ main() {
 
   prepare_release "$version"
 
-  publish_release "$version" # fake for now
+  publish_release_instructions "$version"
 }
 
 # Like 'echo' but on stderr
@@ -35,7 +35,7 @@ $message
 
   $0 <version>
 
-Publishes a new release of hydra.
+Prepares a new release of hydra.
 <version> must respect [Semantic Versioning](http://semver.org/)
 EOF
 
@@ -70,19 +70,20 @@ prepare_release() {
   git tag -as "$version" -F <(changelog "$version")
 
   # Make branch release point to tag so that the website is published
-  git checkout release
+  git checkout --track origin/release
   git merge "${version}" --ff-only
+
+  git checkout master
 }
 
-publish_release() {
+publish_release_instructions() {
   local version="$1"
 
   err "Prepared the release commit and tag, review it now and if everything is okay, push using:"
+  err ""
   err "git push origin master"
   err "git push origin release"
   err "git push origin ${version}"
-  err ""
-  err "And then you shall manually create the release page, see CONTRIBUTING.md"
 }
 
 # Checking helper functions


### PR DESCRIPTION
* Fixed and refined `release.sh` script to work for 0.14.0

* Also cleaned up the changelog and added links to issues

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
