### PR TITLE
Fix logs.yaml schema for missing definitions

### DIFF
--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -1051,6 +1051,26 @@ definitions:
             $ref: "api.yaml#/components/schemas/SnapshotNumber"
           lastSeenSn:
             $ref: "api.yaml#/components/schemas/SnapshotNumber"
+      - title: "SnapshotDoesNotApply"
+        description: >-
+          Received a ReqSn whose snapshot contains transactions that do not apply
+          cleanly on the currently confirmed UTxO set
+        additionalProperties: false
+        required:
+          - tag
+          - requestedSn
+          - txid
+          - error
+        properties:
+          tag:
+            type: string
+            enum: ["SnapshotDoesNotApply"]
+          requestedSn:
+            $ref: "api.yaml#/components/schemas/SnapshotNumber"
+          txid:
+            $ref: "api.yaml#/components/schemas/TxId"
+          error:
+            $ref: "logs.yaml#/definitions/ValidationError"
   HeadState:
     oneOf:
       - title: "Idle"

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -907,16 +907,17 @@ definitions:
         additionalProperties: false
         required:
           - tag
-          - contents
+          - invalidEvent
+          - currentHeadState
         properties:
           tag:
             type: string
             enum: ["InvalidEvent"]
-          contents:
-            type: array
-            prefixItems:
-              - $ref: "logs.yaml#/definitions/Event"
-              - $ref: "logs.yaml#/definitions/HeadState"
+          invalidEvent:
+            $ref: "logs.yaml#/definitions/Event"
+          currentHeadState:
+            $ref: "logs.yaml#/definitions/HeadState"
+
       - title: RequireFailed
         description: >-
           A precondition for some state transition within the Hydra
@@ -928,13 +929,14 @@ definitions:
         additionalProperties: false
         required:
           - tag
-          - contents
+          - requirementfailure
         properties:
           tag:
             type: string
             enum: ["RequireFailed"]
-          contents:
+          requirementFailure:
             $ref: "logs.yaml#/definitions/RequirementFailure"
+
       - title: NotOurHead
         description: >-
           We just observed an on-chain event that does not apply to
@@ -1350,9 +1352,9 @@ definitions:
         items:
           $ref: "api.yaml#/components/schemas/Party"
       committed:
-        type: array
-        items:
-          $ref: "api.yaml#/components/schemas/Party"
+        type: object
+        additionalProperties:
+          $ref: "api.yaml#/components/schemas/UTxO"
       chainState:
         $ref: "api.yaml#/components/schemas/ChainState"
       headId:

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -1634,6 +1634,24 @@ definitions:
           newChainState:
             $ref: "api.yaml#/components/schemas/ChainState"
 
+      - title: IgnoredInitTx
+        type: object
+        additionalProperties: false
+        required:
+          - tag
+          - headId
+          - participants
+        properties:
+          tag:
+            type: string
+            enum: ["IgnoredInitTx"]
+          headId:
+            $ref: "api.yaml#/components/schemas/HeadId"
+          participants:
+            items:
+              type: string
+              contentEncoding: base16
+
       - title: Rollback
         type: object
         additionalProperties: false
@@ -1646,6 +1664,7 @@ definitions:
             enum: ["Rollback"]
           rolledBackChainState:
             $ref: "api.yaml#/components/schemas/ChainState"
+
       - title: Tick
         description: |
           Time has progressed on the chain.

--- a/hydra-node/src/Hydra/API/APIServerLog.hs
+++ b/hydra-node/src/Hydra/API/APIServerLog.hs
@@ -34,6 +34,10 @@ instance Arbitrary APIServerLog where
       , APIHTTPRequestReceived <$> arbitrary <*> arbitrary
       ]
 
+  shrink = \case
+    APIInvalidInput r i -> [APIInvalidInput r' (Text.pack i') | r' <- shrink r, i' <- shrink (Text.unpack i)]
+    _other -> []
+
 -- | New type wrapper to define JSON instances.
 newtype PathInfo = PathInfo ByteString
   deriving stock (Eq, Show)

--- a/hydra-node/src/Hydra/Chain.hs
+++ b/hydra-node/src/Hydra/Chain.hs
@@ -82,6 +82,13 @@ deriving anyclass instance IsTx tx => FromJSON (PostChainTx tx)
 
 instance IsTx tx => Arbitrary (PostChainTx tx) where
   arbitrary = genericArbitrary
+  shrink = \case
+    InitTx{headParameters} -> InitTx <$> shrink headParameters
+    AbortTx{utxo} -> AbortTx <$> shrink utxo
+    CollectComTx{utxo} -> CollectComTx <$> shrink utxo
+    CloseTx{confirmedSnapshot} -> CloseTx <$> shrink confirmedSnapshot
+    ContestTx{confirmedSnapshot} -> ContestTx <$> shrink confirmedSnapshot
+    FanoutTx{utxo, contestationDeadline} -> FanoutTx <$> shrink utxo <*> shrink contestationDeadline
 
 -- | Describes transactions as seen on chain. Holds as minimal information as
 -- possible to simplify observing the chain.

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -392,3 +392,4 @@ data DirectChainLog
 
 instance Arbitrary DirectChainLog where
   arbitrary = genericArbitrary
+  shrink = genericShrink

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -137,6 +137,7 @@ data ChainStateAt = ChainStateAt
 
 instance Arbitrary ChainStateAt where
   arbitrary = genericArbitrary
+  shrink = genericShrink
 
 instance IsChainState Tx where
   type ChainStateType Tx = ChainStateAt
@@ -179,6 +180,7 @@ data ChainState
 
 instance Arbitrary ChainState where
   arbitrary = genChainState
+  shrink = genericShrink
 
 instance HasKnownUTxO ChainState where
   getKnownUTxO :: ChainState -> UTxO
@@ -248,6 +250,13 @@ data InitialState = InitialState
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
+instance Arbitrary InitialState where
+  arbitrary = do
+    ctx <- genHydraContext maxGenParties
+    snd <$> genStInitial ctx
+
+  shrink = genericShrink
+
 instance HasKnownUTxO InitialState where
   getKnownUTxO st =
     UTxO $
@@ -269,6 +278,13 @@ data OpenState = OpenState
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
+instance Arbitrary OpenState where
+  arbitrary = do
+    ctx <- genHydraContext maxGenParties
+    snd <$> genStOpen ctx
+
+  shrink = genericShrink
+
 instance HasKnownUTxO OpenState where
   getKnownUTxO st =
     UTxO.singleton openThreadUTxO
@@ -284,6 +300,14 @@ data ClosedState = ClosedState
   }
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
+
+instance Arbitrary ClosedState where
+  arbitrary = do
+    -- XXX: Untangle the whole generator mess here
+    (_, st, _) <- genFanoutTx maxGenParties maxGenAssets
+    pure st
+
+  shrink = genericShrink
 
 instance HasKnownUTxO ClosedState where
   getKnownUTxO st =
@@ -740,23 +764,11 @@ genChainState :: Gen ChainState
 genChainState =
   oneof
     [ pure Idle
-    , Initial <$> genInitialState
-    , Open <$> genOpenState
-    , Closed <$> genClosedState
+    , Initial <$> arbitrary
+    , Open <$> arbitrary
+    , Closed <$> arbitrary
     ]
- where
-  genInitialState = do
-    ctx <- genHydraContext maxGenParties
-    snd <$> genStInitial ctx
 
-  genOpenState = do
-    ctx <- genHydraContext maxGenParties
-    snd <$> genStOpen ctx
-
-  genClosedState = do
-    -- XXX: Untangle the whole generator mess here
-    (_, st, _) <- genFanoutTx maxGenParties maxGenAssets
-    pure st
 
 -- | Generate a 'ChainContext' and 'ChainState' within the known limits above, along with a
 -- transaction that results in a transition away from it.

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -769,7 +769,6 @@ genChainState =
     , Closed <$> arbitrary
     ]
 
-
 -- | Generate a 'ChainContext' and 'ChainState' within the known limits above, along with a
 -- transaction that results in a transition away from it.
 genChainStateWithTx :: Gen (ChainContext, ChainState, Tx, ChainTransition)

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -85,6 +85,10 @@ data InitialThreadOutput = InitialThreadOutput
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
+instance Arbitrary InitialThreadOutput where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
+
 -- | Representation of the Head output after a CollectCom transaction.
 data OpenThreadOutput = OpenThreadOutput
   { openThreadUTxO :: (TxIn, TxOut CtxUTxO)
@@ -94,6 +98,10 @@ data OpenThreadOutput = OpenThreadOutput
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
+instance Arbitrary OpenThreadOutput where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
+
 data ClosedThreadOutput = ClosedThreadOutput
   { closedThreadUTxO :: (TxIn, TxOut CtxUTxO)
   , closedParties :: [OnChain.Party]
@@ -102,6 +110,10 @@ data ClosedThreadOutput = ClosedThreadOutput
   }
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
+
+instance Arbitrary ClosedThreadOutput where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
 
 hydraHeadV1AssetName :: AssetName
 hydraHeadV1AssetName = AssetName (fromBuiltin hydraHeadV1)

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -14,6 +14,7 @@ import Hydra.Prelude
 
 import Cardano.Api.UTxO qualified as UTxO
 import Data.Aeson qualified as Aeson
+import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as Base16
 import Data.Map qualified as Map
 import Data.Set qualified as Set
@@ -54,6 +55,7 @@ import Hydra.Plutus.Orphans ()
 import Hydra.Snapshot (Snapshot (..), SnapshotNumber, fromChainSnapshot)
 import PlutusLedgerApi.V2 (CurrencySymbol (CurrencySymbol), fromBuiltin, toBuiltin)
 import PlutusLedgerApi.V2 qualified as Plutus
+import Test.QuickCheck (vectorOf)
 
 -- | Needed on-chain data to create Head transactions.
 type UTxOWithScript = (TxIn, TxOut CtxUTxO, HashableScriptData)
@@ -70,6 +72,9 @@ instance FromJSON UTxOHash where
     case Base16.decode $ encodeUtf8 cborText of
       Left e -> fail e
       Right bs -> pure $ UTxOHash bs
+
+instance Arbitrary UTxOHash where
+  arbitrary = UTxOHash . BS.pack <$> vectorOf 32 arbitrary
 
 -- | Representation of the Head output after an Init transaction.
 data InitialThreadOutput = InitialThreadOutput

--- a/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
@@ -419,3 +419,4 @@ deriving anyclass instance FromJSON TinyWalletLog
 
 instance Arbitrary TinyWalletLog where
   arbitrary = genericArbitrary
+  shrink = genericShrink

--- a/hydra-node/src/Hydra/HeadLogic/Error.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Error.hs
@@ -15,8 +15,8 @@ import Hydra.Snapshot (SnapshotNumber)
 -- | Preliminary type for collecting errors occurring during 'update'.
 -- TODO: Try to merge this (back) into 'Outcome'.
 data LogicError tx
-  = InvalidEvent (Event tx) (HeadState tx)
-  | RequireFailed (RequirementFailure tx)
+  = InvalidEvent { invalidEvent :: (Event tx), currentHeadState :: (HeadState tx) }
+  | RequireFailed { requirementFailure :: (RequirementFailure tx) }
   | NotOurHead {ourHeadId :: HeadId, otherHeadId :: HeadId}
   deriving stock (Generic)
 

--- a/hydra-node/src/Hydra/HeadLogic/Error.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Error.hs
@@ -15,8 +15,8 @@ import Hydra.Snapshot (SnapshotNumber)
 -- | Preliminary type for collecting errors occurring during 'update'.
 -- TODO: Try to merge this (back) into 'Outcome'.
 data LogicError tx
-  = InvalidEvent { invalidEvent :: (Event tx), currentHeadState :: (HeadState tx) }
-  | RequireFailed { requirementFailure :: (RequirementFailure tx) }
+  = InvalidEvent {invalidEvent :: (Event tx), currentHeadState :: (HeadState tx)}
+  | RequireFailed {requirementFailure :: (RequirementFailure tx)}
   | NotOurHead {ourHeadId :: HeadId, otherHeadId :: HeadId}
   deriving stock (Generic)
 

--- a/hydra-node/src/Hydra/HeadLogic/Error.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Error.hs
@@ -24,6 +24,7 @@ instance (Typeable tx, Show (Event tx), Show (HeadState tx), Show (RequirementFa
 
 instance (Arbitrary (Event tx), Arbitrary (HeadState tx), Arbitrary (RequirementFailure tx)) => Arbitrary (LogicError tx) where
   arbitrary = genericArbitrary
+  shrink = genericShrink
 
 deriving stock instance (Eq (HeadState tx), Eq (Event tx), Eq (RequirementFailure tx)) => Eq (LogicError tx)
 deriving stock instance (Show (HeadState tx), Show (Event tx), Show (RequirementFailure tx)) => Show (LogicError tx)

--- a/hydra-node/src/Hydra/HeadLogic/Event.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Event.hs
@@ -42,10 +42,6 @@ deriving stock instance IsChainState tx => Show (Event tx)
 deriving anyclass instance IsChainState tx => ToJSON (Event tx)
 deriving anyclass instance IsChainState tx => FromJSON (Event tx)
 
-instance
-  ( IsTx tx
-  , Arbitrary (ChainStateType tx)
-  ) =>
-  Arbitrary (Event tx)
-  where
+instance (IsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (Event tx) where
   arbitrary = genericArbitrary
+  shrink = genericShrink

--- a/hydra-node/src/Hydra/HeadLogic/Outcome.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Outcome.hs
@@ -106,6 +106,9 @@ deriving anyclass instance IsChainState tx => FromJSON (Outcome tx)
 
 instance (IsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (Outcome tx) where
   arbitrary = genericArbitrary
+  shrink = \case
+    Combined l r -> [l, r] <> [Combined l' r' | l' <- shrink l, r' <- shrink r]
+    other -> genericShrink other
 
 collectEffects :: Outcome tx -> [Effect tx]
 collectEffects = \case

--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -451,6 +451,7 @@ instance Arbitrary TxId where
 
 instance Arbitrary (TxOut CtxUTxO) where
   arbitrary = genTxOut
+  shrink txOut = fromLedgerTxOut <$> shrink (toLedgerTxOut txOut)
 
 instance Arbitrary (VerificationKey PaymentKey) where
   arbitrary = fst <$> genKeyPair

--- a/hydra-node/src/Hydra/Logging.hs
+++ b/hydra-node/src/Hydra/Logging.hs
@@ -54,6 +54,10 @@ data Verbosity = Quiet | Verbose Text
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
+instance Arbitrary Verbosity where
+  arbitrary = genericArbitrary
+  shrink = genericShrink
+
 -- | Provides logging metadata for entries.
 data Envelope a = Envelope
   { timestamp :: UTCTime
@@ -76,6 +80,7 @@ instance ToJSON a => ToJSON (Envelope a) where
 
 instance Arbitrary a => Arbitrary (Envelope a) where
   arbitrary = genericArbitrary
+  shrink = genericShrink
 
 defaultQueueSize :: Natural
 defaultQueueSize = 500

--- a/hydra-node/src/Hydra/Logging/Messages.hs
+++ b/hydra-node/src/Hydra/Logging/Messages.hs
@@ -34,3 +34,4 @@ deriving anyclass instance (FromJSON net, FromJSON (HydraNodeLog tx)) => FromJSO
 
 instance (Arbitrary net, Arbitrary (HydraNodeLog tx)) => Arbitrary (HydraLog tx net) where
   arbitrary = genericArbitrary
+  shrink = genericShrink

--- a/hydra-node/src/Hydra/Network/Authenticate.hs
+++ b/hydra-node/src/Hydra/Network/Authenticate.hs
@@ -101,3 +101,4 @@ instance ToJSON AuthLog where
 
 instance Arbitrary AuthLog where
   arbitrary = genericArbitrary
+  shrink = genericShrink

--- a/hydra-node/src/Hydra/Network/Reliability.hs
+++ b/hydra-node/src/Hydra/Network/Reliability.hs
@@ -157,9 +157,11 @@ data ReliabilityLog
 
 instance Arbitrary (Vector Int) where
   arbitrary = fromList <$> listOf (getPositive <$> arbitrary)
+  shrink v = fromList <$> shrink (toList v)
 
 instance Arbitrary ReliabilityLog where
   arbitrary = genericArbitrary
+  shrink = genericShrink
 
 -- | Handle for all persistence operations in the Reliability network layer.
 -- This handle takes care of storing and retreiving vector clock and all

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -136,6 +136,7 @@ deriving anyclass instance IsChainState tx => FromJSON (HydraNodeLog tx)
 
 instance (IsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (HydraNodeLog tx) where
   arbitrary = genericArbitrary
+  shrink = genericShrink
 
 runHydraNode ::
   ( MonadCatch m

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -165,14 +165,19 @@ data RunOptions = RunOptions
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
+-- Orphan instance
+instance Arbitrary IP where
+  arbitrary = IPv4 . toIPv4w <$> arbitrary
+  shrink = genericShrink
+
 instance Arbitrary RunOptions where
   arbitrary = do
     verbosity <- elements [Quiet, Verbose "HydraNode"]
     nodeId <- arbitrary
-    host <- IPv4 . toIPv4w <$> arbitrary
+    host <- arbitrary
     port <- arbitrary
     peers <- reasonablySized arbitrary
-    apiHost <- IPv4 . toIPv4w <$> arbitrary
+    apiHost <- arbitrary
     apiPort <- arbitrary
     monitoringPort <- arbitrary
     hydraSigningKey <- genFilePath "sk"
@@ -198,6 +203,8 @@ instance Arbitrary RunOptions where
         , chainConfig
         , ledgerConfig
         }
+
+  shrink = genericShrink
 
 runOptionsParser :: Parser RunOptions
 runOptionsParser =

--- a/hydra-node/src/Hydra/Party.hs
+++ b/hydra-node/src/Hydra/Party.hs
@@ -5,12 +5,12 @@ module Hydra.Party where
 
 import Hydra.Prelude
 
-import Data.Aeson (ToJSONKey (..), FromJSONKeyFunction (FromJSONKeyTextParser))
+import Data.Aeson (FromJSONKeyFunction (FromJSONKeyTextParser), ToJSONKey (..))
 import Data.Aeson.Types (FromJSONKey (..), toJSONKeyText)
+import Data.ByteString.Base16 qualified as Hex
 import Hydra.Cardano.Api (AsType (AsVerificationKey), SerialiseAsRawBytes (deserialiseFromRawBytes, serialiseToRawBytes), SigningKey, VerificationKey, getVerificationKey, verificationKeyHash)
 import Hydra.Crypto (AsType (AsHydraKey), HydraKey)
 import Hydra.Data.Party qualified as OnChain
-import qualified Data.ByteString.Base16 as Hex
 
 -- | Identifies a party in a Hydra head by it's 'VerificationKey'.
 newtype Party = Party {vkey :: VerificationKey HydraKey}
@@ -23,14 +23,16 @@ instance ToJSONKey Party where
 instance FromJSONKey Party where
   fromJSONKey = FromJSONKeyTextParser $ partyFromHexText
    where
-     partyFromHexText ::  MonadFail m =>
-      Text -> m Party
-     partyFromHexText t =
-       case Hex.decode (encodeUtf8 t) of
-         Left err -> fail $ "failed to decode from base16: " <> err
-         Right bytes -> case deserialiseFromRawBytes (AsVerificationKey AsHydraKey) bytes of
-           Left err -> fail $ "failed to decode verification key from bytes: " <> show err
-           Right vkey -> pure $ Party{vkey}
+    partyFromHexText ::
+      MonadFail m =>
+      Text ->
+      m Party
+    partyFromHexText t =
+      case Hex.decode (encodeUtf8 t) of
+        Left err -> fail $ "failed to decode from base16: " <> err
+        Right bytes -> case deserialiseFromRawBytes (AsVerificationKey AsHydraKey) bytes of
+          Left err -> fail $ "failed to decode verification key from bytes: " <> show err
+          Right vkey -> pure $ Party{vkey}
 
 -- REVIEW: Do we really want to define Ord or also use unordered-containers
 -- based on Hashable?

--- a/hydra-node/src/Hydra/Snapshot.hs
+++ b/hydra-node/src/Hydra/Snapshot.hs
@@ -127,6 +127,10 @@ instance IsTx tx => Arbitrary (ConfirmedSnapshot tx) where
     headId <- arbitrary
     genConfirmedSnapshot headId 0 utxo ks
 
+  shrink = \case
+    InitialSnapshot hid sn -> [InitialSnapshot hid sn' | sn' <- shrink sn]
+    ConfirmedSnapshot sn sigs -> ConfirmedSnapshot <$> shrink sn <*> shrink sigs
+
 genConfirmedSnapshot ::
   IsTx tx =>
   HeadId ->


### PR DESCRIPTION
A flaky test run was discovering this and we seemingly had forgotten to add this schema when introducing the `IgnoredInitTx` and the `SnapshotDoesNotApply` constructors. 

We also add a bunch of missing `shrink` definitions to help troubleshooting errors from failing property tests which otherwise can be huge and uninformative.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
