### PR TITLE
Fix asset quantity for CollectCom mutation

### DIFF
--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -213,7 +213,7 @@ genCollectComMutation (tx, _utxo) =
                 (AssetId pid _, _) -> pid /= testPolicyId
                 _ -> True
           (assetId, Quantity n) <- elements nonPTs
-          q <- Quantity <$> choose (0, n)
+          q <- Quantity <$> choose (1, n)
           pure $ valueFromList [(assetId, q)]
         -- Add another output which would extract the 'removedValue'. The ledger
         -- would check for this, and this is needed because the way we implement


### PR DESCRIPTION
Our mutation tests for `CollectCom` were failing because `valueFromList` excludes the element if the Quantity is zero. I didn't check but probably the api has changed since we didn't observe this before.

```
valueFromList :: [(AssetId, Quantity)] -> Value
valueFromList = Value
              . Map.filter (/= 0)
              . Map.fromListWith (<>)

```

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
