### PR TITLE
WebSocket Resource-Based API

### DIFF
--- a/docs/adr/2023-12-08_030.adr.md
+++ b/docs/adr/2023-12-08_030.adr.md
@@ -1,0 +1,58 @@
+---
+slug: 30
+title: |
+  29. Updates to the Websocket and HTTP APIs
+authors: [@cardenaso11, @quantumplation]
+tags: []
+---
+
+## Status
+Draft
+
+## Context
+
+Currently, working with the Hydra APIs can be awkward, for the following reasons:
+- The websocket API provides a mixture of "event stream" and "resource" semantics; Some state is maintained by observing a stream of events, while other state is requested as if it were a "resource"
+- When connecting, there is very limited ability to pick and choose what you subscribe to; Connections receive the whole firehose of events
+- When connecting, you must choose between either receiving the whole (potentially very long) history of events, or only receiving events going forward; If a connection is the result of an interrupted connection, there is no way to negotiate a point to restart from.
+
+We propose a few small changes to the API to address these usability concerns.
+
+# Decision
+
+First, we will maintain backwards compatibility with the existing API:
+- Connecting to the websocket server at `/` will subscribe to all events, and accept the currently supported messages
+- POSTing to `/commit`` will continue to draft a commit transaction
+- GETing `/protocol-parameters`` will return the current cardano protocol parameters
+- POSTing to `/cardano-transaction` will submit a new layer 1 transaction
+- The query parameter `history` can be set to no to subscribe to only events going forward
+- The query parameters tx-output and snapshot-utxo will still be supported.
+
+However, additionally, we will extend the APIs in the following way:
+- The history parameter can optionally also be set to a "message ID"; This will borrow semantics from the chainsync miniprotocol, and asserts "this message ID should be considered in both of our pasts, send me messages starting from the message after this one"
+- Connecting to the websocket will allow an `events` query parameter, which is a comma separated list of events which the client would like to receive
+- A new message type, `UpdateSubscription` will allow the client to change the events they are subscribed to
+- A new message type, `ReplayFrom` will allow the client to reset their point in the event stream, and receive all events from that point
+- A new HTTP GET route, `/head`, will return the current status of the head: what state its in, which peers are connected, committed, etc.
+- A new HTTP GET route, `/utxo`, will return the current UTxO
+- A new HTTP GET route, `/utxo/addresses/{address}`, will return the current UTxO, filtered to just those held at `{address}`
+- A new HTTP GET route, `/utxo/tx/{tx}/{index}`, will return a specific UTXO, if it exists
+- A new HTTP POST route, `/transaction`, will submit a layer 2 transaction, similar to the "NewTx" message on the websocket API
+
+<!--
+NOTE: we're very open to discussion on the above, we're just putting forward a suggestion
+
+In particular, perhaps maintaining backwards compatibility is less important to you; or perhaps you want to avoid providing HTTP routes for things that can be serviced by websocket messages; or perhaps you want to structure the routes differently.
+
+Similarly, perhaps the `/utxo/addresses/{address}` query isn't aligned with the current way the UTXO is stored, and we should instead defer that to the kupo integration.
+
+The exact details aren't important to us, mostly just the objectives outlined in the context.
+-->
+
+## Consequences
+
+As a consequence of these changes:
+- No existing client consumers will need to change their code
+- Clients will now have the ability to resume from specific points in time, enabling more robust and performant dApp integrations
+- Clients will now be able to fetch resources via a simple HTTP request, making debugging or light-weight integration much easier
+- Clients will now have the ability to subscribe to specific events, reducing network bandwidth and processing costs to integrate with Hydra


### PR DESCRIPTION
- plutus: 1.9 -> 1.15.0.1 cardano-api: 8.20 -> 8.29.1
- hydra-cardano-api: reexport createAndValidateTransactionBody
- hydra-cardano-api: reexport makeShelleyKeyWitness
- Regenerate plutus scripts
- Acknowledge different canonical serialization of some auxiliary metadata
- hydra-plutus: split getHeadAddress into getHeadInput and getHeadAddress
- getHeadInput: Use case split instead of fromMaybe
- Regenerate plutus scripts
- nix flake update
- LogFilterSpec: update txids
- Submit NewTx transactions as CBOR in an envelope in benchmark
- Only extract txId from JSON-serialised Tx in benchmarks
- Rename MultiAssetSupportedInEra -> MaryEraOnwards
- Rename HasInlineDatums -> BabbageEraOnwards
- Rename HasScriptData -> IsAlonzoEraOnwards
- Move (latest) Era-specific helpers to Hydra.Cardano.Api module
- Create an Era-specific wrapper for defaultTxBodyContent
- Create an Era-specific wrapper for signShelleyTransaction
- Do not mention Babbage outside of hydra-cardano-api
- Use recent cabal index-states
- initial draft of resource-based WebSocket API improvement ADR
