### PR TITLE
TUI - Enhance UX to request confirmation for terminating actions

### DIFF
--- a/hydra-tui/src/Hydra/TUI/Drawing.hs
+++ b/hydra-tui/src/Hydra/TUI/Drawing.hs
@@ -134,6 +134,7 @@ drawFocusPanelOpen networkId vk utxo = \case
   SelectingUTxO x -> renderForm x
   EnteringAmount _ x -> renderForm x
   SelectingRecipient _ _ x -> renderForm x
+  ConfirmingClose x -> vBox [txt "Confirm Close action:", renderForm x]
  where
   ownAddress = mkVkAddress networkId vk
 

--- a/hydra-tui/src/Hydra/TUI/Drawing.hs
+++ b/hydra-tui/src/Hydra/TUI/Drawing.hs
@@ -127,6 +127,7 @@ drawFocusPanelInitializing :: IdentifiedState -> InitializingState -> Widget Nam
 drawFocusPanelInitializing me InitializingState{remainingParties, initializingScreen} = case initializingScreen of
   InitializingHome -> drawRemainingParties me remainingParties
   CommitMenu x -> vBox [txt "Select UTxOs to commit:", renderForm x]
+  ConfirmingAbort x -> vBox [txt "Confirm Abort action:", renderForm x]
 
 drawFocusPanelOpen :: NetworkId -> VerificationKey PaymentKey -> UTxO -> OpenScreen -> Widget Name
 drawFocusPanelOpen networkId vk utxo = \case

--- a/hydra-tui/src/Hydra/TUI/Forms.hs
+++ b/hydra-tui/src/Hydra/TUI/Forms.hs
@@ -63,7 +63,7 @@ utxoRadioField u =
 
 confirmRadioField ::
   forall s e n.
-  ( s ~ (Text, Bool)
+  ( s ~ Bool
   , n ~ Text
   ) =>
   Form s e n
@@ -71,11 +71,11 @@ confirmRadioField =
   newForm
     [ radioField
         id
-        [ (opt, fst opt, fst opt)
+        [ (snd opt, fst opt, fst opt)
         | opt <- options
         ]
     ]
-    (Prelude.head options)
+    True
  where
   options = [("[y]es", True), ("[n]o", False)]
 

--- a/hydra-tui/src/Hydra/TUI/Forms.hs
+++ b/hydra-tui/src/Hydra/TUI/Forms.hs
@@ -60,3 +60,23 @@ utxoRadioField u =
         ]
     ]
     (Prelude.head $ Map.toList u)
+
+confirmRadioField ::
+  forall s e n.
+  ( s ~ (Text, Bool)
+  , n ~ Text
+  ) =>
+  Form s e n
+confirmRadioField =
+  newForm
+    [ radioField
+        id
+        [ (opt, fst opt, fst opt)
+        | opt <- options
+        ]
+    ]
+    (Prelude.head options)
+ where
+  options = [("[y]es", True), ("[n]o", False)]
+
+  radioFields = radioField id [(opt, fst opt, show $ fst opt) | opt <- options]

--- a/hydra-tui/src/Hydra/TUI/Forms.hs
+++ b/hydra-tui/src/Hydra/TUI/Forms.hs
@@ -77,6 +77,6 @@ confirmRadioField =
     ]
     True
  where
-  options = [("[y]es", True), ("[n]o", False)]
+  options = [("yes", True), ("no", False)]
 
   radioFields = radioField id [(opt, fst opt, show $ fst opt) | opt <- options]

--- a/hydra-tui/src/Hydra/TUI/Handlers.hs
+++ b/hydra-tui/src/Hydra/TUI/Handlers.hs
@@ -140,7 +140,7 @@ handleVtyEventsInitializingScreen cardanoClient hydraClient e = do
       case e of
         EvKey KEsc [] -> id .= InitializingHome
         EvKey KEnter [] -> do
-          let (_, selected) = formState i
+          let selected = formState i
           if selected
             then liftIO $ sendInput hydraClient Abort
             else id .= InitializingHome
@@ -159,7 +159,7 @@ handleVtyEventsOpen cardanoClient hydraClient utxo e = do
       case e of
         EvKey KEsc [] -> id .= OpenHome
         EvKey KEnter [] -> do
-          let (_, selected) = formState i
+          let selected = formState i
           if selected
             then liftIO $ sendInput hydraClient Close
             else id .= OpenHome

--- a/hydra-tui/src/Hydra/TUI/Handlers.hs
+++ b/hydra-tui/src/Hydra/TUI/Handlers.hs
@@ -140,10 +140,20 @@ handleVtyEventsOpen :: CardanoClient -> Client Tx IO -> UTxO -> Vty.Event -> Eve
 handleVtyEventsOpen cardanoClient hydraClient utxo e = do
   case e of
     EvKey (KChar 'c') [] ->
-      liftIO $ sendInput hydraClient Close
+      id .= ConfirmingClose confirmRadioField
     _ -> pure ()
   k <- use id
   case k of
+    ConfirmingClose i -> do
+      case e of
+        EvKey KEsc [] -> id .= OpenHome
+        EvKey KEnter [] -> do
+          let (_, selected) = formState i
+          if selected
+            then liftIO $ sendInput hydraClient Close
+            else id .= OpenHome
+        _ -> pure ()
+      zoom confirmingCloseFormL $ handleFormEvent (VtyEvent e)
     OpenHome -> do
       case e of
         EvKey (KChar 'n') [] -> do

--- a/hydra-tui/src/Hydra/TUI/Model.hs
+++ b/hydra-tui/src/Hydra/TUI/Model.hs
@@ -42,6 +42,8 @@ type UTxOCheckboxForm e n = Form (Map TxIn (TxOut CtxUTxO, Bool)) e n
 
 type UTxORadioFieldForm e n = Form (TxIn, TxOut CtxUTxO) e n
 
+type ConfirmingRadioFieldForm e n = Form (Text, Bool) e n
+
 data InitializingState = InitializingState
   { remainingParties :: [Party]
   , initializingScreen :: InitializingScreen
@@ -56,6 +58,7 @@ data OpenScreen
   | SelectingUTxO {selectingUTxOForm :: UTxORadioFieldForm (HydraEvent Tx) Name}
   | EnteringAmount {utxoSelected :: (TxIn, TxOut CtxUTxO), enteringAmountForm :: Form Integer (HydraEvent Tx) Name}
   | SelectingRecipient {utxoSelected :: (TxIn, TxOut CtxUTxO), amountEntered :: Integer, selectingRecipientForm :: Form AddressInEra (HydraEvent Tx) Name}
+  | ConfirmingClose {confirmingCloseForm :: ConfirmingRadioFieldForm (HydraEvent Tx) Name}
 
 newtype ClosedState = ClosedState {contestationDeadline :: UTCTime}
 
@@ -83,6 +86,7 @@ makeLensesFor
   [ ("selectingUTxOForm", "selectingUTxOFormL")
   , ("enteringAmountForm", "enteringAmountFormL")
   , ("selectingRecipientForm", "selectingRecipientFormL")
+  , ("confirmingCloseForm", "confirmingCloseFormL")
   ]
   ''OpenScreen
 

--- a/hydra-tui/src/Hydra/TUI/Model.hs
+++ b/hydra-tui/src/Hydra/TUI/Model.hs
@@ -42,7 +42,7 @@ type UTxOCheckboxForm e n = Form (Map TxIn (TxOut CtxUTxO, Bool)) e n
 
 type UTxORadioFieldForm e n = Form (TxIn, TxOut CtxUTxO) e n
 
-type ConfirmingRadioFieldForm e n = Form (Text, Bool) e n
+type ConfirmingRadioFieldForm e n = Form Bool e n
 
 data InitializingState = InitializingState
   { remainingParties :: [Party]

--- a/hydra-tui/src/Hydra/TUI/Model.hs
+++ b/hydra-tui/src/Hydra/TUI/Model.hs
@@ -52,6 +52,7 @@ data InitializingState = InitializingState
 data InitializingScreen
   = InitializingHome
   | CommitMenu {commitMenu :: UTxOCheckboxForm (HydraEvent Tx) Name}
+  | ConfirmingAbort {confirmingAbortForm :: ConfirmingRadioFieldForm (HydraEvent Tx) Name}
 
 data OpenScreen
   = OpenHome
@@ -111,6 +112,7 @@ makeLensesFor
 
 makeLensesFor
   [ ("commitMenu", "commitMenuL")
+  , ("confirmingAbortForm", "confirmingAbortFormL")
   ]
   ''InitializingScreen
 

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -74,6 +74,8 @@ spec = do
           shouldRender "Head id"
           sendInputEvent $ EvKey (KChar 'a') []
           threadDelay 1
+          sendInputEvent $ EvKey KEnter []
+          threadDelay 1
           shouldRender "Idle"
           sendInputEvent $ EvKey (KChar 'q') []
 

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -95,6 +95,8 @@ spec = do
           shouldRender "Open"
           sendInputEvent $ EvKey (KChar 'c') []
           threadDelay 1
+          sendInputEvent $ EvKey KEnter []
+          threadDelay 1
           shouldRender "Closed"
           shouldRender "Remaining time to contest"
           -- XXX: This is a hack to estimate the time it takes until we can


### PR DESCRIPTION
<!-- Describe your change here -->
When running the demo on devnet, we observed that due to the fast confirmation time, it is too easy to close a head immediately after collecting the last commit, as the TUI utilizes the same key-binding for both actions.

Moreover, it is a good practice to safeguard such actions in order to prevent accidents. 

---

🎁 Add a confirmation dialog prompt for Close/Abort actions to prevent accidental termination of the head.

<!-- Consider each and tick it off one way or the other -->
* [X] CHANGELOG updated or not needed
* [X] Documentation updated or not needed
* [X] Haddocks updated or not needed
* [X] No new TODOs introduced or explained herafter
