### PR TITLE
Re-enable e2e nix-shell support on darwin

### DIFF
--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -48,7 +48,6 @@ let
     pkgs.plantuml
     # For plotting results of hydra-cluster benchmarks
     pkgs.gnuplot
-  ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [
     # For integration tests
     cardano-node.packages.${system}.cardano-node
   ];
@@ -67,7 +66,6 @@ let
     # For docs/ (i.e. Docusaurus, Node.js & React)
     pkgs.yarn
     pkgs.nodejs
-  ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [
     # To interact with cardano-node and testing out things
     cardano-node.packages.${system}.cardano-cli
   ];
@@ -126,7 +124,6 @@ let
     buildInputs = [
       hsPkgs.hydra-node.components.exes.hydra-node
       hsPkgs.hydra-cluster.components.exes.hydra-cluster
-    ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [
       cardano-node.packages.${system}.cardano-node
       cardano-node.packages.${system}.cardano-cli
     ];
@@ -139,7 +136,6 @@ let
       hsPkgs.hydra-node.components.exes.hydra-node
       hsPkgs.hydra-tui.components.exes.hydra-tui
       run-tmux
-    ] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [
       cardano-node.packages.${system}.cardano-node
       cardano-node.packages.${system}.cardano-cli
     ];


### PR DESCRIPTION
<!-- Describe your change here -->

⛄ re-enable cardano-node and cardano-cli for the nix shell when running on darwin.

---

<!-- Consider each and tick it off one way or the other -->
* [X] CHANGELOG updated or not needed
* [X] Documentation updated or not needed
* [X] Haddocks updated or not needed
* [X] No new TODOs introduced or explained herafter
