### PR TITLE
Replace use of outputs' with view outputsTxBodyL

### DIFF
--- a/hydra-cardano-api/hydra-cardano-api.cabal
+++ b/hydra-cardano-api/hydra-cardano-api.cabal
@@ -100,6 +100,7 @@ library
     , cardano-ledger-mary     >=1.3.1    && <1.4
     , cardano-ledger-shelley  >=1.7      && <1.8
     , containers
+    , lens
     , plutus-ledger-api       >=1.15.0.1 && <1.16
     , QuickCheck
     , serialise

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/UTxO.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/UTxO.hs
@@ -6,10 +6,12 @@ import Hydra.Cardano.Api.TxIn (fromLedgerTxIn, toLedgerTxIn, txIns')
 import Hydra.Cardano.Api.TxOut (fromLedgerTxOut, toLedgerTxOut)
 
 import Cardano.Api.UTxO qualified as UTxO
+import Cardano.Ledger.Api (outputsTxBodyL)
 import Cardano.Ledger.Babbage.TxBody qualified as Ledger
 import Cardano.Ledger.BaseTypes qualified as Ledger
 import Cardano.Ledger.Shelley.UTxO qualified as Ledger
 import Cardano.Ledger.TxIn qualified as Ledger
+import Control.Lens ((^.))
 import Data.Foldable (toList)
 import Data.Map qualified as Map
 import Data.Maybe (mapMaybe)
@@ -26,7 +28,7 @@ renderUTxO =
 -- outputs they correspond to.
 utxoFromTx :: Tx Era -> UTxO
 utxoFromTx (Tx body@(ShelleyTxBody _ ledgerBody _ _ _ _) _) =
-  let txOuts = toList $ Ledger.outputs' ledgerBody
+  let txOuts = toList $ ledgerBody ^. outputsTxBodyL
       txIns =
         [ Ledger.TxIn (toLedgerTxId $ getTxId body) ix
         | ix <- [Ledger.TxIx 0 .. toEnum (length txOuts)]

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Value.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Value.hs
@@ -8,7 +8,6 @@ import Cardano.Ledger.Core (getMinCoinTxOut)
 import Cardano.Ledger.Mary.Value qualified as Ledger
 import Data.Word (Word64)
 import Hydra.Cardano.Api.CtxUTxO (ToUTxOContext (..))
-import Hydra.Cardano.Api.Hash (unsafeScriptHashFromBytes)
 import Hydra.Cardano.Api.MaryEraOnwards (maryEraOnwards)
 import Hydra.Cardano.Api.PolicyId (fromPlutusCurrencySymbol)
 import PlutusLedgerApi.V1.Value (flattenValue)

--- a/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
@@ -17,7 +17,7 @@ import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), RdmrPtr (RdmrPtr), Redee
 import Cardano.Ledger.Api (TransactionScriptFailure, ensureMinCoinTxOut, evalTxExUnits, outputsTxBodyL, ppMaxTxExUnitsL, ppPricesL)
 import Cardano.Ledger.Babbage.Tx (body, getLanguageView, hashScriptIntegrity, wits)
 import Cardano.Ledger.Babbage.Tx qualified as Babbage
-import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..), outputs', spendInputs')
+import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..), spendInputs')
 import Cardano.Ledger.Babbage.TxBody qualified as Babbage
 import Cardano.Ledger.Babbage.UTxO (getReferenceScripts)
 import Cardano.Ledger.BaseTypes qualified as Ledger
@@ -193,7 +193,7 @@ applyTxs txs isOurs utxo =
       let txId = getTxId tx
       modify (`Map.withoutKeys` spendInputs' (body tx))
       let indexedOutputs =
-            let outs = toList $ outputs' (body tx)
+            let outs = toList $ body tx ^. outputsTxBodyL
                 maxIx = fromIntegral $ length outs
              in zip [Ledger.TxIx ix | ix <- [0 .. maxIx]] outs
       forM_ indexedOutputs $ \(ix, out@(Babbage.BabbageTxOut addr _ _ _)) ->

--- a/hydra-node/src/Hydra/Ledger/Cardano/Json.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano/Json.hs
@@ -17,6 +17,7 @@ import Cardano.Ledger.Allegra.Scripts qualified as Ledger
 import Cardano.Ledger.Alonzo.Scripts qualified as Ledger
 import Cardano.Ledger.Alonzo.TxAuxData qualified as Ledger
 import Cardano.Ledger.Alonzo.TxWits qualified as Ledger
+import Cardano.Ledger.Api (outputsTxBodyL)
 import Cardano.Ledger.Babbage.Tx qualified as Ledger
 import Cardano.Ledger.Babbage.TxBody qualified as Ledger
 import Cardano.Ledger.BaseTypes (StrictMaybe (..), isSJust)
@@ -41,6 +42,7 @@ import Cardano.Ledger.SafeHash qualified as Ledger
 import Cardano.Ledger.Shelley.API qualified as Ledger
 import Cardano.Ledger.Shelley.TxCert qualified as Ledger
 import Codec.Binary.Bech32 qualified as Bech32
+import Control.Lens ((^.))
 import Data.Aeson (
   FromJSONKey (fromJSONKey),
   FromJSONKeyFunction (FromJSONKeyTextParser),
@@ -217,7 +219,7 @@ instance ToJSON (Ledger.BabbageTxBody LedgerEra) where
         [ onlyIf (const True) "inputs" (Set.map fromLedgerTxIn (Ledger.spendInputs' b))
         , onlyIf (not . null) "collateral" (Set.map fromLedgerTxIn (Ledger.collateralInputs' b))
         , onlyIf (not . null) "referenceInputs" (Set.map fromLedgerTxIn (Ledger.referenceInputs' b))
-        , onlyIf (const True) "outputs" (fromLedgerTxOut <$> Ledger.outputs' b)
+        , onlyIf (const True) "outputs" (fromLedgerTxOut <$> b ^. outputsTxBodyL)
         , onlyIf isSJust "collateralReturn" (fromLedgerTxOut <$> Ledger.collateralReturn' b)
         , onlyIf isSJust "totalCollateral" (Ledger.totalCollateral' b)
         , onlyIf (not . null) "certificates" (Ledger.certs' b)

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
@@ -134,12 +134,14 @@ import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Ledger.Alonzo.Scripts qualified as Ledger
 import Cardano.Ledger.Alonzo.Scripts.Data qualified as Ledger
 import Cardano.Ledger.Alonzo.TxWits qualified as Ledger
+import Cardano.Ledger.Api (outputsTxBodyL)
 import Cardano.Ledger.Babbage.TxBody qualified as Ledger
 import Cardano.Ledger.Binary (mkSized)
 import Cardano.Ledger.Core qualified as Ledger
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Mary.Value qualified as Ledger
 import Control.Exception (assert)
+import Control.Lens ((^.))
 import Data.Map qualified as Map
 import Data.Sequence.Strict qualified as StrictSeq
 import Data.Set qualified as Set
@@ -660,7 +662,7 @@ alterTxOuts fn tx =
 
   ledgerOutputs' = StrictSeq.fromList . map (mkSized ledgerEraVersion . toLedgerTxOut . toCtxUTxOTxOut) $ outputs'
 
-  outputs' = fn . fmap fromLedgerTxOut . toList $ Ledger.outputs' ledgerBody
+  outputs' = fn . fmap fromLedgerTxOut . toList $ ledgerBody ^. outputsTxBodyL
 
   scriptData' = ensureDatums outputs' scriptData
 


### PR DESCRIPTION
Lenses are the designated way to deal with ledger type families. ouputTxBodyL is a lens that will work for all eras. Needed for conway support.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
