### PR TITLE
Wait for cardano-node sync

### DIFF
--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -6,8 +6,8 @@ import Hydra.Prelude
 import Test.Hydra.Prelude
 
 import Bench.Summary (Summary (..), makeQuantiles)
-import CardanoClient (awaitTransaction, submitTransaction, submitTx)
-import CardanoNode (RunningNode (..), withCardanoNodeDevnet)
+import CardanoClient (RunningNode (..), awaitTransaction, submitTransaction, submitTx)
+import CardanoNode (withCardanoNodeDevnet)
 import Control.Concurrent.Class.MonadSTM (
   MonadSTM (readTVarIO),
   check,

--- a/hydra-cluster/exe/hydra-cluster/Main.hs
+++ b/hydra-cluster/exe/hydra-cluster/Main.hs
@@ -2,7 +2,6 @@ module Main where
 
 import Hydra.Prelude
 
-import CardanoClient (waitForFullySynchronized)
 import CardanoNode (withCardanoNodeDevnet, withCardanoNodeOnKnownNetwork)
 import Hydra.Cluster.Faucet (publishHydraScriptsAs)
 import Hydra.Cluster.Fixture (Actor (Faucet))
@@ -25,7 +24,6 @@ run options =
       case knownNetwork of
         Just network ->
           withCardanoNodeOnKnownNetwork fromCardanoNode workDir network $ \node -> do
-            waitForFullySynchronized fromCardanoNode node
             publishOrReuseHydraScripts tracer node
               >>= singlePartyHeadFullLifeCycle tracer workDir node
         Nothing ->

--- a/hydra-cluster/src/CardanoNode.hs
+++ b/hydra-cluster/src/CardanoNode.hs
@@ -300,6 +300,9 @@ withCardanoNode tr stateDirectory args@CardanoNodeArgs{nodeSocket} networkId act
   waitForNode = do
     let nodeSocketPath = File socketPath
     waitForSocket nodeSocketPath
+    -- we wait for synchronization since otherwise we will receive a query
+    -- exception when trying to obtain pparams and the era is not the one we
+    -- expect.
     _ <- waitForFullySynchronized tr networkId nodeSocketPath
     traceWith tr $ MsgSocketIsReady $ unFile nodeSocketPath
     action nodeSocketPath

--- a/hydra-cluster/src/Hydra/Cluster/Faucet.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Faucet.hs
@@ -8,6 +8,7 @@ import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Ledger.Core (PParams)
 import CardanoClient (
   QueryPoint (QueryTip),
+  RunningNode (..),
   SubmitTransactionException,
   awaitTransaction,
   buildAddress,
@@ -18,7 +19,6 @@ import CardanoClient (
   submitTransaction,
   waitForPayment,
  )
-import CardanoNode (RunningNode (..))
 import Control.Exception (IOException)
 import Control.Monad.Class.MonadThrow (Handler (Handler), catches)
 import Control.Tracer (Tracer, traceWith)

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -8,13 +8,14 @@ import Test.Hydra.Prelude
 
 import Cardano.Api.UTxO qualified as UTxO
 import CardanoClient (
+  NodeLog,
   QueryPoint (QueryTip),
+  RunningNode (..),
   buildTransaction,
   queryTip,
   queryUTxOFor,
   submitTx,
  )
-import CardanoNode (NodeLog, RunningNode (..))
 import Control.Concurrent.Async (mapConcurrently_)
 import Control.Lens ((^?))
 import Data.Aeson (Value, object, (.=))

--- a/hydra-cluster/test/Test/CardanoClientSpec.hs
+++ b/hydra-cluster/test/Test/CardanoClientSpec.hs
@@ -3,8 +3,8 @@ module Test.CardanoClientSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import CardanoClient (QueryPoint (..), queryGenesisParameters)
-import CardanoNode (RunningNode (..), withCardanoNodeDevnet)
+import CardanoClient (QueryPoint (..), RunningNode (..), queryGenesisParameters)
+import CardanoNode (withCardanoNodeDevnet)
 import Data.Aeson ((.:))
 import Data.Aeson qualified as Aeson
 import Hydra.Cardano.Api (GenesisParameters (..))

--- a/hydra-cluster/test/Test/CardanoNodeSpec.hs
+++ b/hydra-cluster/test/Test/CardanoNodeSpec.hs
@@ -4,12 +4,11 @@ import Hydra.Prelude
 import Test.Hydra.Prelude
 
 import CardanoNode (
-  RunningNode (..),
   getCardanoNodeVersion,
   withCardanoNodeDevnet,
  )
 
-import CardanoClient (queryTipSlotNo)
+import CardanoClient (RunningNode (..), queryTipSlotNo)
 import Hydra.Cardano.Api (NetworkId (Testnet), NetworkMagic (NetworkMagic), unFile)
 import Hydra.Logging (showLogsOnFailure)
 import System.Directory (doesFileExist)

--- a/hydra-cluster/test/Test/ChainObserverSpec.hs
+++ b/hydra-cluster/test/Test/ChainObserverSpec.hs
@@ -9,8 +9,8 @@ module Test.ChainObserverSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import CardanoClient (submitTx)
-import CardanoNode (NodeLog, RunningNode (..), withCardanoNodeDevnet)
+import CardanoClient (NodeLog, RunningNode (..), submitTx)
+import CardanoNode (withCardanoNodeDevnet)
 import Control.Concurrent.Class.MonadSTM (modifyTVar', newTVarIO, readTVarIO)
 import Control.Exception (IOException)
 import Control.Lens ((^?))

--- a/hydra-cluster/test/Test/DirectChainSpec.hs
+++ b/hydra-cluster/test/Test/DirectChainSpec.hs
@@ -7,14 +7,16 @@ import Test.Hydra.Prelude
 
 import Cardano.Api.UTxO (UTxO' (UTxO, toMap))
 import CardanoClient (
+  NodeLog,
   QueryPoint (QueryTip),
+  RunningNode (..),
   buildAddress,
   queryTip,
   queryUTxO,
   submitTx,
   waitForUTxO,
  )
-import CardanoNode (NodeLog, RunningNode (..), withCardanoNodeDevnet)
+import CardanoNode (withCardanoNodeDevnet)
 import Control.Concurrent.STM (newEmptyTMVarIO, takeTMVar)
 import Control.Concurrent.STM.TMVar (putTMVar)
 import Hydra.Cardano.Api (

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -7,10 +7,18 @@ import Hydra.Prelude
 import Test.Hydra.Prelude
 
 import Cardano.Api.UTxO qualified as UTxO
-import CardanoClient (QueryPoint (..), queryEpochNo, queryGenesisParameters, queryTip, queryTipSlotNo, submitTx, waitForUTxO)
+import CardanoClient (
+  QueryPoint (..),
+  RunningNode (..),
+  queryEpochNo,
+  queryGenesisParameters,
+  queryTip,
+  queryTipSlotNo,
+  submitTx,
+  waitForUTxO,
+ )
 import CardanoNode (
   CardanoNodeArgs (..),
-  RunningNode (..),
   forkIntoConwayInEpoch,
   setupCardanoDevnet,
   unsafeDecodeJsonFile,
@@ -522,7 +530,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
         withClusterTempDir "unsupported-era" $ \tmpDir -> do
           args <- setupCardanoDevnet tmpDir
           forkIntoConwayInEpoch tmpDir args 1
-          withCardanoNode (contramap FromCardanoNode tracer) tmpDir args $ \nodeSocket -> do
+          withCardanoNode (contramap FromCardanoNode tracer) tmpDir args defaultNetworkId $ \nodeSocket -> do
             let pparams = defaultPParams
             let node = RunningNode{nodeSocket, networkId = defaultNetworkId, pparams}
             hydraScriptsTxId <- publishHydraScriptsAs node Faucet
@@ -542,7 +550,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
         withClusterTempDir "unsupported-era-startup" $ \tmpDir -> do
           args <- setupCardanoDevnet tmpDir
           forkIntoConwayInEpoch tmpDir args 1
-          withCardanoNode (contramap FromCardanoNode tracer) tmpDir args $ \nodeSocket -> do
+          withCardanoNode (contramap FromCardanoNode tracer) tmpDir args defaultNetworkId $ \nodeSocket -> do
             let pparams = defaultPParams
             let node = RunningNode{nodeSocket, networkId = defaultNetworkId, pparams}
             hydraScriptsTxId <- publishHydraScriptsAs node Faucet

--- a/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
@@ -3,7 +3,8 @@ module Test.Hydra.Cluster.FaucetSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import CardanoNode (RunningNode (..), withCardanoNodeDevnet)
+import CardanoClient (RunningNode (..))
+import CardanoNode (withCardanoNodeDevnet)
 import Control.Concurrent.Async (replicateConcurrently_)
 import Hydra.Cardano.Api (AssetId (AdaAssetId), selectAsset, txOutValue)
 import Hydra.Chain.CardanoClient (QueryPoint (..), queryUTxOFor)

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -7,7 +7,8 @@ import Hydra.Prelude
 import Test.Hydra.Prelude
 
 import Blaze.ByteString.Builder.Char8 (writeChar)
-import CardanoNode (NodeLog, RunningNode (..), withCardanoNodeDevnet)
+import CardanoClient (NodeLog, RunningNode (..))
+import CardanoNode (withCardanoNodeDevnet)
 import Control.Concurrent.Class.MonadSTM (newTQueueIO, readTQueue, tryReadTQueue, writeTQueue)
 import Data.ByteString qualified as BS
 import Graphics.Vty (


### PR DESCRIPTION
Smoke tests were failing because we would query the protocol-parameters while the node is not yet in sync and that would throw era missmatch because of the latest changes to hydra-node. We solve this by waiting for the cardano-node to be in sync immediately since this workflow is used only when running smoke-tests. We should investigate if this error we get makes sense for the potential users trying to run their hydra-node using the cardano-node that is not fully synced.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
