### PR TITLE
Fix seed devnet script

### DIFF
--- a/demo/seed-devnet.sh
+++ b/demo/seed-devnet.sh
@@ -97,8 +97,14 @@ function publishReferenceScripts() {
 
 function queryPParams() {
   echo >&2 "Query Protocol parameters"
-  docker exec demo-cardano-node-1 cardano-cli query protocol-parameters --testnet-magic ${NETWORK_ID} --out-file /dev/stdout \
-  | jq ".txFeeFixed = 0 | .txFeePerByte = 0 | .executionUnitPrices.priceMemory = 0 | .executionUnitPrices.priceSteps = 0" > protocol-parameters.json
+  if [ "$( docker container inspect -f '{{.State.Running}}' demo-cardano-node-1 )" == "true" ];
+   then
+     docker exec demo-cardano-node-1 cardano-cli query protocol-parameters --testnet-magic ${NETWORK_ID} --socket-path ${DEVNET_DIR}/node.socket --out-file /dev/stdout \
+      | jq ".txFeeFixed = 0 | .txFeePerByte = 0 | .executionUnitPrices.priceMemory = 0 | .executionUnitPrices.priceSteps = 0" > devnet/protocol-parameters.json
+   else
+     cardano-cli query protocol-parameters --testnet-magic ${NETWORK_ID} --socket-path ${DEVNET_DIR}/node.socket  --out-file /dev/stdout \
+      | jq ".txFeeFixed = 0 | .txFeePerByte = 0 | .executionUnitPrices.priceMemory = 0 | .executionUnitPrices.priceSteps = 0" > devnet/protocol-parameters.json
+  fi
   echo >&2 "Saved in protocol-parameters.json"
 }
 


### PR DESCRIPTION
When fetching protocol parameters in the demo we should not use docker if the user chose to run the demo without it.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
