### PR TITLE
Change queryUTxO to queryCurrentEra in the same n2c connection

### DIFF
--- a/hydra-cluster/src/CardanoClient.hs
+++ b/hydra-cluster/src/CardanoClient.hs
@@ -91,16 +91,14 @@ waitForPayment ::
   Address ShelleyAddr ->
   IO UTxO
 waitForPayment networkId socket amount addr = do
-  AnyCardanoEra era <- queryCurrentEra networkId socket QueryTip
-  go era
+  go
  where
-  go :: CardanoEra era -> IO (UTxO' (TxOut CtxUTxO))
-  go era = do
-    utxo <- queryUTxO networkId socket QueryTip [addr] era
+  go = do
+    utxo <- queryUTxO networkId socket QueryTip [addr]
     let expectedPayment = selectPayment utxo
     if expectedPayment /= mempty
       then pure $ UTxO expectedPayment
-      else threadDelay 1 >> go era
+      else threadDelay 1 >> go
 
   selectPayment (UTxO utxo) =
     Map.filter ((== amount) . selectLovelace . txOutValue) utxo

--- a/hydra-cluster/test/Test/DirectChainSpec.hs
+++ b/hydra-cluster/test/Test/DirectChainSpec.hs
@@ -161,7 +161,7 @@ spec = around (showLogsOnFailure "DirectChainSpec") $ do
 
                 -- Expect that Alice got her committed value back to her
                 -- external address
-                utxo <- queryUTxO networkId nodeSocket QueryTip [aliceExternalAddress] era
+                utxo <- queryUTxO networkId nodeSocket QueryTip [aliceExternalAddress]
                 let aliceValues = txOutValue <$> toList utxo
                 aliceValues `shouldContain` [lovelaceToValue aliceCommitment]
 

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -150,7 +150,7 @@ mkTinyWallet tracer config era = do
     point <- case queryPoint of
       QueryAt point -> pure point
       QueryTip -> queryTip networkId nodeSocket
-    walletUTxO <- Ledger.unUTxO . toLedgerUTxO <$> queryUTxO networkId nodeSocket QueryTip [address] era
+    walletUTxO <- Ledger.unUTxO . toLedgerUTxO <$> queryUTxO networkId nodeSocket QueryTip [address]
     pparams <- queryProtocolParameters networkId nodeSocket QueryTip era
     systemStart <- querySystemStart networkId nodeSocket QueryTip
     epochInfo <- queryEpochInfo


### PR DESCRIPTION
This allows us to keep the same era agnostic interface, while we convert the arbitrary era UTxO into our canonical (Babbage) UTxO

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
