### PR TITLE
Display stderr output upon e2e spec failure

### DIFF
--- a/hydra-cluster/src/CardanoNode.hs
+++ b/hydra-cluster/src/CardanoNode.hs
@@ -281,8 +281,7 @@ withCardanoNode tr stateDirectory args@CardanoNodeArgs{nodeSocket} networkId act
     hSetBuffering out NoBuffering
     withCreateProcess process{std_out = UseHandle out, std_err = CreatePipe} $
       \_stdin _stdout mError processHandle -> do
-        let errorHandle = fromMaybe (error "Should not happen™") mError
-            runningNonde = checkProcessHasNotDied "cardano-node" processHandle errorHandle
+        let runningNonde = checkProcessHasNotDied "cardano-node" processHandle mError
         ( race runningNonde waitForNode >>= \case
             Left{} -> error "should never been reached"
             Right a -> pure a

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -301,7 +301,7 @@ withHydraNode' ::
   PParams LedgerEra ->
   -- | If given use this as std out.
   Maybe Handle ->
-  (Handle -> Handle -> ProcessHandle -> IO a) ->
+  (Handle -> Maybe Handle -> ProcessHandle -> IO a) ->
   IO a
 withHydraNode' chainConfig workDir hydraNodeId hydraSKey hydraVKeys allNodeIds pparams mGivenStdOut action = do
   withSystemTempDirectory "hydra-node" $ \dir -> do
@@ -339,10 +339,9 @@ withHydraNode' chainConfig workDir hydraNodeId hydraSKey hydraVKeys allNodeIds p
             }
 
     withCreateProcess p $ \_stdin mCreatedStdOut mCreatedStdErr processHandle ->
-      case (mCreatedStdOut <|> mGivenStdOut, mCreatedStdErr) of
-        (Just out, Just err) -> action out err processHandle
-        (Nothing, _) -> error "Should not happen™"
-        (_, Nothing) -> error "Should not happen™"
+      case mCreatedStdOut <|> mGivenStdOut of
+        Just out -> action out mCreatedStdErr processHandle
+        Nothing -> error "Should not happen™"
  where
   -- NOTE: We want to have zeroed fees in the Head.
   writeZeroedPParams (PParams BabbagePParams{bppProtocolVersion}) =

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -281,9 +281,9 @@ withHydraNode ::
 withHydraNode tracer chainConfig workDir hydraNodeId hydraSKey hydraVKeys allNodeIds pparams action = do
   withLogFile logFilePath $ \logFileHandle -> do
     withHydraNode' chainConfig workDir hydraNodeId hydraSKey hydraVKeys allNodeIds pparams (Just logFileHandle) $ do
-      \_ _ processHandle -> do
+      \_ err processHandle -> do
         race
-          (checkProcessHasNotDied ("hydra-node (" <> show hydraNodeId <> ")") processHandle)
+          (checkProcessHasNotDied ("hydra-node (" <> show hydraNodeId <> ")") processHandle err)
           (withConnectionToNode tracer hydraNodeId action)
           <&> either absurd id
  where

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -535,14 +535,14 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
             let node = RunningNode{nodeSocket, networkId = defaultNetworkId, pparams}
             hydraScriptsTxId <- publishHydraScriptsAs node Faucet
             chainConfig <- chainConfigFor Alice tmpDir nodeSocket hydraScriptsTxId [] cperiod
-            withHydraNode' chainConfig tmpDir 1 aliceSk [] [1] pparams Nothing $ \out err ph -> do
+            withHydraNode' chainConfig tmpDir 1 aliceSk [] [1] pparams Nothing $ \out mStdErr ph -> do
               -- Assert nominal startup
               waitForLog 5 out "missing NodeOptions" (Text.isInfixOf "NodeOptions")
 
               waitUntilEpoch tmpDir args node 1
 
               waitForProcess ph `shouldReturn` ExitFailure 1
-              errorOutputs <- hGetContents err
+              errorOutputs <- maybe (pure "Should not happen™") hGetContents mStdErr
               errorOutputs `shouldContain` "Received blocks in unsupported era"
               errorOutputs `shouldContain` "upgrade your hydra-node"
 
@@ -558,9 +558,9 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
 
             waitUntilEpoch tmpDir args node 2
 
-            withHydraNode' chainConfig tmpDir 1 aliceSk [] [1] pparams Nothing $ \_out err ph -> do
+            withHydraNode' chainConfig tmpDir 1 aliceSk [] [1] pparams Nothing $ \_out mStdErr ph -> do
               waitForProcess ph `shouldReturn` ExitFailure 1
-              errorOutputs <- hGetContents err
+              errorOutputs <- maybe (pure "Should not happen™") hGetContents mStdErr
               errorOutputs `shouldContain` "Connected to cardano-node in unsupported era"
               errorOutputs `shouldContain` "upgrade your hydra-node"
 

--- a/hydra-test-utils/src/Test/Hydra/Prelude.hs
+++ b/hydra-test-utils/src/Test/Hydra/Prelude.hs
@@ -145,13 +145,13 @@ checkProcessHasNotDied name processHandle mStdErr =
   waitForProcess processHandle >>= \case
     ExitSuccess -> failure "Process has stopped"
     ExitFailure exit -> do
-      let failureMsg = "Process " <> show name <> " exited with failure code: " <> show exit
-      errorMsg <- case mStdErr of
-        Nothing -> pure [failureMsg]
-        Just stdErr -> do
-          errorOutput <- hGetContents stdErr
-          pure [failureMsg, "Process stderr: " <> errorOutput]
-      failure . toString $ unlines errorMsg
+      mErrorOutput <- traverse hGetContents mStdErr
+      let mErrorMsg = ("Process stderr: " <>) <$> mErrorOutput
+      failure . toString $
+        unlines
+          ( "Process " <> show name <> " exited with failure code: " <> show exit
+              : maybeToList mErrorMsg
+          )
 
 -- | Like 'coverTable', but construct the weight requirements generically from
 -- the provided label.

--- a/hydra-test-utils/src/Test/Hydra/Prelude.hs
+++ b/hydra-test-utils/src/Test/Hydra/Prelude.hs
@@ -145,12 +145,13 @@ checkProcessHasNotDied name processHandle mStdErr =
   waitForProcess processHandle >>= \case
     ExitSuccess -> failure "Process has stopped"
     ExitFailure exit -> do
-      errorOutput <- maybe (pure "Should not happen™") hGetContents mStdErr
-      failure . toString $
-        unlines
-          [ "Process " <> show name <> " exited with failure code: " <> show exit
-          , "Process stderr: " <> errorOutput
-          ]
+      let failureMsg = "Process " <> show name <> " exited with failure code: " <> show exit
+      errorMsg <- case mStdErr of
+        Nothing -> pure [failureMsg]
+        Just stdErr -> do
+          errorOutput <- hGetContents stdErr
+          pure [failureMsg, "Process stderr: " <> errorOutput]
+      failure . toString $ unlines errorMsg
 
 -- | Like 'coverTable', but construct the weight requirements generically from
 -- the provided label.


### PR DESCRIPTION
<!-- Describe your change here -->

🛡️ Improved e2e debugging by displaying stderr output upon spec failure, as exceptions are being thrown to this channel.

---

<!-- Consider each and tick it off one way or the other -->
* [X] CHANGELOG updated or not needed
* [X] Documentation updated or not needed
* [X] Haddocks updated or not needed
* [X] No new TODOs introduced or explained herafter
