### PR TITLE
Create a github action to build cardano-node binaries

### DIFF
--- a/.github/workflows/cardano-node.yaml
+++ b/.github/workflows/cardano-node.yaml
@@ -1,0 +1,42 @@
+# XXX: Temporary workflow to produce static ELF binaries for cardan-node 8.7.2
+# Remove again when upstream releases them again.
+name: Cardano-node
+
+on:
+  workflow_dispatch:
+    version:
+      description: "Cardano node version to build (git ref)"
+      required: true
+      default: "8.7.2"
+
+jobs:
+  build-executables-linux:
+    name: "Build x86_64-linux static executables"
+    runs-on: ubuntu-latest
+    steps:
+    - name: 📥 Checkout cardano-node ${{inputs.version}}
+      uses: actions/checkout@v4
+      with:
+        repository: IntersectMBO/cardano-node
+        ref: ${{inputs.version}}
+
+    - name: ❄ Prepare nix
+      uses: cachix/install-nix-action@v23
+      with:
+        extra_nix_config: |
+          accept-flake-config = true
+          log-lines = 1000
+
+    - name: ❄ Build cardano-node static executables
+      run: |
+        mkdir -p out/
+        nix build .#hydraJobs.x86_64-linux.musl.cardano-node
+        cp result/bin/* out/
+        nix build .#hydraJobs.x86_64-linux.musl.cardano-cli
+        cp result/bin/* out/
+
+    - name: 💾 Upload matching cardano-node executables
+      uses: actions/upload-artifact@v4
+      with:
+        name: cardano-node-x86_64-linux # automatically zips
+        path: out/*

--- a/.github/workflows/cardano-node.yaml
+++ b/.github/workflows/cardano-node.yaml
@@ -4,21 +4,17 @@ name: Cardano-node
 
 on:
   workflow_dispatch:
-    version:
-      description: "Cardano node version to build (git ref)"
-      required: true
-      default: "8.7.2"
 
 jobs:
   build-executables-linux:
     name: "Build x86_64-linux static executables"
     runs-on: ubuntu-latest
     steps:
-    - name: 📥 Checkout cardano-node ${{inputs.version}}
+    - name: 📥 Checkout cardano-node 8.7.2
       uses: actions/checkout@v4
       with:
         repository: IntersectMBO/cardano-node
-        ref: ${{inputs.version}}
+        ref: 8.7.2
 
     - name: ❄ Prepare nix
       uses: cachix/install-nix-action@v23

--- a/.github/workflows/cardano-node.yaml
+++ b/.github/workflows/cardano-node.yaml
@@ -1,5 +1,6 @@
-# XXX: Temporary workflow to produce static ELF binaries for cardan-node 8.7.2
-# Remove again when upstream releases them again.
+# Produce distributable binaries for cardano-node 8.7.2
+#
+# XXX: Remove again when upstream releases them (again).
 name: Cardano-node
 
 on:
@@ -44,8 +45,9 @@ jobs:
     - name: 📥 Checkout cardano-node 8.7.2
       uses: actions/checkout@v4
       with:
-        repository: IntersectMBO/cardano-node
-        ref: 8.7.2
+        # 8.7.2-fork which provides a macos flake output
+        repository: ch1bo/cardano-node
+        ref: 170817f5ba3f7838ffd9bd181bc30504906a6506
 
     - name: ❄ Prepare nix
       uses: cachix/install-nix-action@v23
@@ -57,10 +59,9 @@ jobs:
     - name: ❄ Build executables
       run: |
         mkdir -p out
-        nix build .#cardano-node
-        cp result/bin/* out/
-        nix build .#cardano-cli
-        cp result/bin/* out/
+        nix build .#hydraJobs.aarch64-darwin.native.cardano-node-macos
+        tar -C out -xzvf result/cardano-node-*-macos.tar.gz cardano-node cardano-cli '*.dylib'
+        # NOTE: github strips permissions so setting chmod +x here does not help
 
     - name: 💾 Upload executables
       uses: actions/upload-artifact@v4

--- a/.github/workflows/cardano-node.yaml
+++ b/.github/workflows/cardano-node.yaml
@@ -36,3 +36,34 @@ jobs:
       with:
         name: cardano-node-x86_64-linux # automatically zips
         path: out/*
+
+  build-executables-macos:
+    name: "Build aarch64-darwin dynamic executables"
+    runs-on: [self-hosted, macOS, ARM64]
+    steps:
+    - name: 📥 Checkout cardano-node 8.7.2
+      uses: actions/checkout@v4
+      with:
+        repository: IntersectMBO/cardano-node
+        ref: 8.7.2
+
+    - name: ❄ Prepare nix
+      uses: cachix/install-nix-action@v23
+      with:
+        extra_nix_config: |
+          accept-flake-config = true
+          log-lines = 1000
+
+    - name: ❄ Build executables
+      run: |
+        mkdir -p out
+        nix build .#cardano-node
+        cp result/bin/* out/
+        nix build .#cardano-cli
+        cp result/bin/* out/
+
+    - name: 💾 Upload executables
+      uses: actions/upload-artifact@v4
+      with:
+        name: cardano-node-aarch64-darwin # automatically zips
+        path: out/*

--- a/.github/workflows/check-tutorial.yaml
+++ b/.github/workflows/check-tutorial.yaml
@@ -31,7 +31,7 @@ jobs:
         import re
         with open("docs/docs/tutorial/index.md", "r") as tutorial:
             body = tutorial.read()
-            usedCardanoNodeVersions = re.findall(r"cardano-node/releases/download/([0-9]+\.[0-9]+\.[0-9]+)", body)
+            usedCardanoNodeVersions = re.findall(r"cardano-node-.*-([0-9]+\.[0-9]+\.[0-9]+).zip", body)
 
         with open("hydra-cluster/test/Test/CardanoNodeSpec.hs", "r") as cardanoNodeSpecFile:
             body = cardanoNodeSpecFile.read()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,7 +208,9 @@ To perform a release of next `<version>`:
    push the branches `master`, `release` and the `<version>` tag.
 5. Create a github release page containing
    * The released changes (formatted) and giving credit where credit is due
-   * Attach static binaries to the release (or link the CI artifact)
+   * Built hydra (and cardano-node) binaries to the release using naming scheme:
+     `hydra-<platform>-<version>.zip` where `platform` is `x86_64-linux` or
+     `aarch64-darwin` (the same for `cardano-node` instead of `hydra`)
    * The just published `hydra-scripts-tx-id` from step 1
 
 [smoke-test]: https://github.com/input-output-hk/hydra/actions/workflows/smoke-test.yaml

--- a/docs/docs/tutorial/index.md
+++ b/docs/docs/tutorial/index.md
@@ -44,8 +44,8 @@ mkdir -p bin
 version=0.14.0
 curl -L -O https://github.com/input-output-hk/hydra/releases/download/${version}/hydra-x86_64-linux-${version}.zip
 unzip -d bin hydra-x86_64-linux-${version}.zip
-curl -L -o - https://github.com/input-output-hk/cardano-node/releases/download/8.7.2/cardano-node-8.7.2-linux.tar.gz \
-  | tar xz -C bin ./cardano-node ./cardano-cli
+curl -L -o - https://github.com/input-output-hk/hydra/releases/download/${version}/cardano-node-x86_64-linux-8.7.2.zip
+unzip -d bin cardano-node-8.7.2-linux.zip
 curl -L -o - https://github.com/input-output-hk/mithril/releases/download/2347.0/mithril-2347.0-linux-x64.tar.gz \
   | tar xz -C bin mithril-client
 chmod +x bin/*
@@ -58,12 +58,12 @@ chmod +x bin/*
 mkdir -p bin
 version=0.14.0
 curl -L -O https://github.com/input-output-hk/hydra/releases/download/${version}/hydra-aarch64-darwin-${version}.zip
-unzip -d bin hydra-aarch64-darwin-${HYDRA_VERSION}.zip
+unzip -d bin hydra-aarch64-darwin-${version}.zip
+curl -L -o - https://github.com/input-output-hk/hydra/releases/download/${version}/cardano-node-aarch-darwin-8.7.2.zip
+unzip -d bin cardano-node-8.7.2-linux.zip
 curl -L -o - https://github.com/input-output-hk/mithril/releases/download/2347.0/mithril-2347.0-macos-x64.tar.gz \
   | tar xz -C bin
-curl -L -o - https://github.com/input-output-hk/cardano-node/releases/download/8.7.2/cardano-node-8.7.2-macos.tar.gz \
-  | tar xz -C bin cardano-node cardano-cli '*.dylib'
-chmod +x bin/mithril-client
+chmod +x bin/*
 ```
 
 </TabItem>


### PR DESCRIPTION
This is neede as the upstream project did not publish their binaries for at least version 8.7.2.

* Add a workflow building static linux and dynamic macos binaries of `cardano-node` and `cardano-cli` on demand (manual dispatch). An example run for a successful build: https://github.com/input-output-hk/hydra/actions/runs/7447617327

* Update tutorial to point to the (to be) locations of where to download `cardano-node`

* Using `zip` archives (for now) to be consistent with Hydra, although they do not retain permissions.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
