### PR TITLE
Disable Hydra CI for darwin builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,7 @@
         };
 
         # Build selected derivations in CI for caching
-        hydraJobs = {
+        hydraJobs = pkgs.lib.optionalAttrs (!pkgs.stdenv.isDarwin) {
           packages = { inherit (packages) hydra-node hydra-tui hydraw spec; };
           devShells = { inherit (devShells) default ci; };
         };


### PR DESCRIPTION
The IOG Hydra CI is often failing on the darwin runners and we want to have less false negatives on our tests. Now that we have own github actions, this should only impact nix cache hits on cache.iog.io

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
