### PR TITLE
Fix logs schema

### DIFF
--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -1555,7 +1555,7 @@ components:
             tag:
               type: string
               enum: ["InvalidHeadId"]
-            headSeed:
+            headId:
               $ref: "api.yaml#/components/schemas/HeadId"
         - title: FailedToConstructAbortTx
           description: |

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -1732,10 +1732,10 @@ definitions:
         additionalProperties: false
         required:
           - tag
-          - contestationPeriod
-          - parties
           - headId
           - headSeed
+          - headParameters
+          - participants
         description: >-
           The initial transaction of the Head, announcing various parameters and
           the parties, has been posted on-chain.
@@ -1743,19 +1743,16 @@ definitions:
           tag:
             type: string
             enum: ["OnInitTx"]
-          contestationPeriod:
-            type: number
-            description: >-
-              The length of the contestaion period, in seconds, represented as a
-              decimal number.
-          parties:
-            type: array
-            items:
-              $ref: "api.yaml#/components/schemas/Party"
           headId:
             $ref: "api.yaml#/components/schemas/HeadId"
           headSeed:
             $ref: "api.yaml#/components/schemas/HeadSeed"
+          headParameters:
+            $ref: "api.yaml#/components/schemas/HeadParameters"
+          participants:
+            type: array
+            items:
+              $ref: "api.yaml#/components/schemas/OnChainId"
       - title: OnCommitTx
         type: object
         additionalProperties: false
@@ -1806,12 +1803,15 @@ definitions:
         additionalProperties: false
         required:
           - tag
+          - headId
           - snapshotNumber
           - contestationDeadline
         properties:
           tag:
             type: string
             enum: ["OnCloseTx"]
+          headId:
+            $ref: "api.yaml#/components/schemas/HeadId"
           snapshotNumber:
             type: integer
             minimum: 0
@@ -1822,11 +1822,14 @@ definitions:
         additionalProperties: false
         required:
           - tag
+          - headId
           - snapshotNumber
         properties:
           tag:
             type: string
             enum: ["OnContestTx"]
+          headId:
+            $ref: "api.yaml#/components/schemas/HeadId"
           snapshotNumber:
             type: integer
             minimum: 0
@@ -1835,10 +1838,13 @@ definitions:
         additionalProperties: false
         required:
           - tag
+          - headId
         properties:
           tag:
             type: string
             enum: ["OnFanoutTx"]
+          headId:
+            $ref: "api.yaml#/components/schemas/HeadId"
 
   Effect:
     description: >-

--- a/hydra-node/src/Hydra/Chain.hs
+++ b/hydra-node/src/Hydra/Chain.hs
@@ -95,7 +95,11 @@ data OnChainTx tx
       , headParameters :: HeadParameters
       , participants :: [OnChainId]
       }
-  | OnCommitTx {headId :: HeadId, party :: Party, committed :: UTxOType tx}
+  | OnCommitTx
+      { headId :: HeadId
+      , party :: Party
+      , committed :: UTxOType tx
+      }
   | OnAbortTx {headId :: HeadId}
   | OnCollectComTx {headId :: HeadId}
   | OnCloseTx
@@ -103,7 +107,10 @@ data OnChainTx tx
       , snapshotNumber :: SnapshotNumber
       , contestationDeadline :: UTCTime
       }
-  | OnContestTx {headId :: HeadId, snapshotNumber :: SnapshotNumber}
+  | OnContestTx
+      { headId :: HeadId
+      , snapshotNumber :: SnapshotNumber
+      }
   | OnFanoutTx {headId :: HeadId}
   deriving stock (Generic)
 

--- a/hydra-node/test/Hydra/API/HTTPServerSpec.hs
+++ b/hydra-node/test/Hydra/API/HTTPServerSpec.hs
@@ -18,7 +18,7 @@ import System.FilePath ((</>))
 import System.IO.Unsafe (unsafePerformIO)
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
 import Test.Hspec.Wai (MatchBody (..), ResponseMatcher (matchBody), get, shouldRespondWith, with)
-import Test.QuickCheck.Property (counterexample, forAll, property, withMaxSuccess)
+import Test.QuickCheck.Property (counterexample, forAll, property)
 
 spec :: Spec
 spec = do
@@ -29,38 +29,30 @@ spec = do
     roundtripAndGoldenSpecs (Proxy @(ReasonablySized TransactionSubmitted))
 
     prop "Validate /commit publish api schema" $
-      property $
-        withMaxSuccess 1 $
-          prop_validateJSONSchema @DraftCommitTxRequest "api.json" $
-            key "components" . key "messages" . key "DraftCommitTxRequest" . key "payload"
+      prop_validateJSONSchema @DraftCommitTxRequest "api.json" $
+        key "components" . key "messages" . key "DraftCommitTxRequest" . key "payload"
 
     prop "Validate /commit subscribe api schema" $
-      property $
-        withMaxSuccess 1 $
-          prop_validateJSONSchema @DraftCommitTxResponse "api.json" $
-            key "components" . key "messages" . key "DraftCommitTxResponse" . key "payload"
+      prop_validateJSONSchema @DraftCommitTxResponse "api.json" $
+        key "components" . key "messages" . key "DraftCommitTxResponse" . key "payload"
 
     prop "Validate /cardano-transaction publish api schema" $
-      property $
-        withMaxSuccess 1 $
-          prop_validateJSONSchema @(SubmitTxRequest Tx) "api.json" $
-            key "channels"
-              . key "/cardano-transaction"
-              . key "publish"
-              . key "message"
-              . key "payload"
+      prop_validateJSONSchema @(SubmitTxRequest Tx) "api.json" $
+        key "channels"
+          . key "/cardano-transaction"
+          . key "publish"
+          . key "message"
+          . key "payload"
 
     prop "Validate /cardano-transaction subscribe api schema" $
-      property $
-        withMaxSuccess 1 $
-          prop_validateJSONSchema @TransactionSubmitted "api.json" $
-            key "channels"
-              . key "/cardano-transaction"
-              . key "subscribe"
-              . key "message"
-              . key "oneOf"
-              . nth 0
-              . key "payload"
+      prop_validateJSONSchema @TransactionSubmitted "api.json" $
+        key "channels"
+          . key "/cardano-transaction"
+          . key "subscribe"
+          . key "message"
+          . key "oneOf"
+          . nth 0
+          . key "payload"
 
     apiServerSpec
     describe "SubmitTxRequest accepted tx formats" $ do

--- a/hydra-node/test/Hydra/LoggingSpec.hs
+++ b/hydra-node/test/Hydra/LoggingSpec.hs
@@ -20,12 +20,8 @@ spec = do
 
     captured `shouldContain` "{\"foo\":42}"
 
-  -- NOTE: We limit the number of successes because those tests are rather
-  -- slow and the underlying `Property` already generate large samples.
-  modifyMaxSuccess (const 5) $
-    prop "Validates logs.yaml schema" $
-      prop_validateJSONSchema @(Envelope (HydraLog Tx ())) "logs.json" id
+  prop "Validates logs.yaml schema" $
+    prop_validateJSONSchema @(Envelope (HydraLog Tx ())) "logs.json" id
 
-  modifyMaxSuccess (const 10) $
-    prop "Schema covers all defined log entries" $
-      prop_specIsComplete @(HydraLog Tx ()) "logs.json" (key "properties" . key "message")
+  prop "Schema covers all defined log entries" $
+    prop_specIsComplete @(HydraLog Tx ()) "logs.json" (key "properties" . key "message")


### PR DESCRIPTION
:lady_beetle: Fixes several broken JSON schemas from stateless observation changes (have not been released, hence no CHANGELOG update here)

:lady_beetle: Fixes and improves output of `prop_validateJSONSchema` such that it allowed me to find those schema mismatches each with 1-2 runs of `--match "/Hydra.Logging/Validates logs.yaml schema/"`. The 5 successes and 100 sized test vectors seem to be a good trade-off.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
