### PR TITLE
Fix the fix of ContestationPeriod fromDiffTime

### DIFF
--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -76,7 +76,7 @@ data Event = Event
   deriving stock (Generic, Eq, Show)
   deriving anyclass (ToJSON)
 
-bench :: Int -> DiffTime -> FilePath -> Dataset -> IO Summary
+bench :: Int -> NominalDiffTime -> FilePath -> Dataset -> IO Summary
 bench startingNodeId timeoutSeconds workDir dataset@Dataset{clientDatasets, title, description} = do
   putStrLn $ "Test logs available in: " <> (workDir </> "test.log")
   withFile (workDir </> "test.log") ReadWriteMode $ \hdl ->
@@ -122,7 +122,7 @@ bench startingNodeId timeoutSeconds workDir dataset@Dataset{clientDatasets, titl
                 v ^? key "contestationDeadline" . _JSON
 
               -- Expect to see ReadyToFanout within 3 seconds after deadline
-              remainingTime <- realToFrac . diffUTCTime deadline <$> getCurrentTime
+              remainingTime <- diffUTCTime deadline <$> getCurrentTime
               waitFor hydraTracer (remainingTime + 3) [leader] $
                 output "ReadyToFanout" ["headId" .= headId]
 

--- a/hydra-cluster/bench/Bench/Options.hs
+++ b/hydra-cluster/bench/Bench/Options.hs
@@ -31,14 +31,14 @@ data Options
       { workDirectory :: Maybe FilePath
       , outputDirectory :: Maybe FilePath
       , scalingFactor :: Int
-      , timeoutSeconds :: DiffTime
+      , timeoutSeconds :: NominalDiffTime
       , clusterSize :: Word64
       , startingNodeId :: Int
       }
   | DatasetOptions
       { datasetFiles :: [FilePath]
       , outputDirectory :: Maybe FilePath
-      , timeoutSeconds :: DiffTime
+      , timeoutSeconds :: NominalDiffTime
       , startingNodeId :: Int
       }
 
@@ -119,7 +119,7 @@ scalingFactorParser =
         <> help "The scaling factor to apply to transactions generator (default: 100)"
     )
 
-timeoutParser :: Parser DiffTime
+timeoutParser :: Parser NominalDiffTime
 timeoutParser =
   option
     auto

--- a/hydra-cluster/exe/hydra-cluster/Main.hs
+++ b/hydra-cluster/exe/hydra-cluster/Main.hs
@@ -2,7 +2,7 @@ module Main where
 
 import Hydra.Prelude
 
-import CardanoNode (withCardanoNodeDevnet, withCardanoNodeOnKnownNetwork)
+import CardanoNode (waitForFullySynchronized, withCardanoNodeDevnet, withCardanoNodeOnKnownNetwork)
 import Hydra.Cluster.Faucet (publishHydraScriptsAs)
 import Hydra.Cluster.Fixture (Actor (Faucet))
 import Hydra.Cluster.Options (Options (..), PublishOrReuse (Publish, Reuse), parseOptions)
@@ -24,6 +24,7 @@ run options =
       case knownNetwork of
         Just network ->
           withCardanoNodeOnKnownNetwork fromCardanoNode workDir network $ \node -> do
+            waitForFullySynchronized fromCardanoNode node
             publishOrReuseHydraScripts tracer node
               >>= singlePartyHeadFullLifeCycle tracer workDir node
         Nothing ->

--- a/hydra-cluster/src/CardanoClient.hs
+++ b/hydra-cluster/src/CardanoClient.hs
@@ -164,6 +164,6 @@ mkGenesisTx networkId pparams signingKey initialAmount recipients =
 data RunningNode = RunningNode
   { nodeSocket :: SocketPath
   , networkId :: NetworkId
-  , blockTime :: DiffTime
+  , blockTime :: NominalDiffTime
   -- ^ Expected time between blocks (varies a lot on testnets)
   }

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -8,7 +8,6 @@ import Test.Hydra.Prelude
 
 import Cardano.Api.UTxO qualified as UTxO
 import CardanoClient (
-  NodeLog,
   QueryPoint (QueryTip),
   RunningNode (..),
   buildTransaction,
@@ -16,6 +15,7 @@ import CardanoClient (
   queryUTxOFor,
   submitTx,
  )
+import CardanoNode (NodeLog)
 import Control.Concurrent.Async (mapConcurrently_)
 import Control.Lens ((^?))
 import Data.Aeson (Value, object, (.=))

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -60,7 +60,7 @@ import Hydra.Cluster.Faucet (FaucetLog, createOutputAtAddress, seedFromFaucet, s
 import Hydra.Cluster.Faucet qualified as Faucet
 import Hydra.Cluster.Fixture (Actor (..), actorName, alice, aliceSk, aliceVk, bob, bobSk, bobVk, carol, carolSk)
 import Hydra.Cluster.Util (chainConfigFor, keysFor, modifyConfig, setNetworkId)
-import Hydra.ContestationPeriod (ContestationPeriod (UnsafeContestationPeriod), fromDiffTime)
+import Hydra.ContestationPeriod (ContestationPeriod (UnsafeContestationPeriod), fromNominalDiffTime)
 import Hydra.HeadId (HeadId)
 import Hydra.Ledger (IsTx (balance))
 import Hydra.Ledger.Cardano (genKeyPair)
@@ -232,7 +232,7 @@ singlePartyHeadFullLifeCycle tracer workDir node hydraScriptsTxId =
     refuelIfNeeded tracer node Alice 25_000_000
     -- Start hydra-node on chain tip
     tip <- queryTip networkId nodeSocket
-    contestationPeriod <- fromDiffTime $ 10 * blockTime
+    contestationPeriod <- fromNominalDiffTime $ 10 * blockTime
     aliceChainConfig <-
       chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [] contestationPeriod
         <&> modifyConfig (\config -> config{networkId, startChainFrom = Just tip})
@@ -250,7 +250,7 @@ singlePartyHeadFullLifeCycle tracer workDir node hydraScriptsTxId =
         guard $ v ^? key "tag" == Just "HeadIsClosed"
         guard $ v ^? key "headId" == Just (toJSON headId)
         v ^? key "contestationDeadline" . _JSON
-      remainingTime <- realToFrac . diffUTCTime deadline <$> getCurrentTime
+      remainingTime <- diffUTCTime deadline <$> getCurrentTime
       waitFor hydraTracer (remainingTime + 3 * blockTime) [n1] $
         output "ReadyToFanout" ["headId" .= headId]
       send n1 $ input "Fanout" []

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -74,14 +74,14 @@ output tag pairs = object $ ("tag" .= tag) : pairs
 -- | Wait some time for a single API server output from each of given nodes.
 -- This function waits for @delay@ seconds for message @expected@  to be seen by all
 -- given @nodes@.
-waitFor :: HasCallStack => Tracer IO HydraNodeLog -> DiffTime -> [HydraClient] -> Aeson.Value -> IO ()
+waitFor :: HasCallStack => Tracer IO HydraNodeLog -> NominalDiffTime -> [HydraClient] -> Aeson.Value -> IO ()
 waitFor tracer delay nodes v = waitForAll tracer delay nodes [v]
 
 -- | Wait up to some time for an API server output to match the given predicate.
-waitMatch :: HasCallStack => DiffTime -> HydraClient -> (Aeson.Value -> Maybe a) -> IO a
+waitMatch :: HasCallStack => NominalDiffTime -> HydraClient -> (Aeson.Value -> Maybe a) -> IO a
 waitMatch delay client@HydraClient{tracer, hydraNodeId} match = do
   seenMsgs <- newTVarIO []
-  timeout delay (go seenMsgs) >>= \case
+  timeout (realToFrac delay) (go seenMsgs) >>= \case
     Just x -> pure x
     Nothing -> do
       msgs <- readTVarIO seenMsgs
@@ -106,7 +106,7 @@ waitMatch delay client@HydraClient{tracer, hydraNodeId} match = do
 -- | Wait up to some `delay` for some JSON `Value` to match given function.
 --
 -- This is a generalisation of `waitMatch` to multiple nodes.
-waitForAllMatch :: (Eq a, Show a, HasCallStack) => DiffTime -> [HydraClient] -> (Aeson.Value -> Maybe a) -> IO a
+waitForAllMatch :: (Eq a, Show a, HasCallStack) => NominalDiffTime -> [HydraClient] -> (Aeson.Value -> Maybe a) -> IO a
 waitForAllMatch delay nodes match = do
   when (null nodes) $
     failure "no clients to wait for"
@@ -122,13 +122,12 @@ waitForAllMatch delay nodes match = do
 -- | Wait some time for a list of outputs from each of given nodes.
 -- This function is the generalised version of 'waitFor', allowing several messages
 -- to be waited for and received in /any order/.
-waitForAll :: HasCallStack => Tracer IO HydraNodeLog -> DiffTime -> [HydraClient] -> [Aeson.Value] -> IO ()
+waitForAll :: HasCallStack => Tracer IO HydraNodeLog -> NominalDiffTime -> [HydraClient] -> [Aeson.Value] -> IO ()
 waitForAll tracer delay nodes expected = do
   traceWith tracer (StartWaiting (map hydraNodeId nodes) expected)
   forConcurrently_ nodes $ \client@HydraClient{hydraNodeId} -> do
     msgs <- newIORef []
-    -- The chain is slow...
-    result <- timeout delay $ tryNext client msgs expected
+    result <- timeout (realToFrac delay) $ tryNext client msgs expected
     case result of
       Just x -> pure x
       Nothing -> do
@@ -393,13 +392,13 @@ withConnectionToNode tracer hydraNodeId action = do
 hydraNodeProcess :: RunOptions -> CreateProcess
 hydraNodeProcess = proc "hydra-node" . toArgs
 
-waitForNodesConnected :: HasCallStack => Tracer IO HydraNodeLog -> DiffTime -> [HydraClient] -> IO ()
-waitForNodesConnected tracer timeOut clients =
+waitForNodesConnected :: HasCallStack => Tracer IO HydraNodeLog -> NominalDiffTime -> [HydraClient] -> IO ()
+waitForNodesConnected tracer delay clients =
   mapM_ waitForNodeConnected clients
  where
   allNodeIds = hydraNodeId <$> clients
   waitForNodeConnected n@HydraClient{hydraNodeId} =
-    waitForAll tracer timeOut [n] $
+    waitForAll tracer delay [n] $
       fmap
         ( \nodeId ->
             object

--- a/hydra-cluster/test/Test/CardanoNodeSpec.hs
+++ b/hydra-cluster/test/Test/CardanoNodeSpec.hs
@@ -6,10 +6,13 @@ import Test.Hydra.Prelude
 import CardanoNode (
   getCardanoNodeVersion,
   withCardanoNodeDevnet,
+  withCardanoNodeOnKnownNetwork,
  )
 
 import CardanoClient (RunningNode (..), queryTipSlotNo)
 import Hydra.Cardano.Api (NetworkId (Testnet), NetworkMagic (NetworkMagic), unFile)
+import Hydra.Cardano.Api qualified as NetworkId
+import Hydra.Cluster.Fixture (KnownNetwork (Mainnet))
 import Hydra.Logging (showLogsOnFailure)
 import System.Directory (doesFileExist)
 
@@ -21,17 +24,35 @@ spec = do
   it "has expected cardano-node version available" $
     getCardanoNodeVersion >>= (`shouldContain` "8.7.2")
 
-  -- NOTE: We hard-code the expected networkId here to detect any change to the
-  -- genesis-shelley.json
   it "withCardanoNodeDevnet does start a block-producing devnet within 5 seconds" $
     failAfter 5 $
-      showLogsOnFailure "CardanoNodeSpec" $ \tr -> do
-        withTempDir "hydra-cluster" $ \tmp -> do
-          withCardanoNodeDevnet tr tmp $ \RunningNode{nodeSocket, networkId} -> do
-            doesFileExist (unFile nodeSocket) `shouldReturn` True
-            networkId `shouldBe` Testnet (NetworkMagic 42)
-            -- Should produce blocks (tip advances)
-            slot1 <- queryTipSlotNo networkId nodeSocket
-            threadDelay 1
-            slot2 <- queryTipSlotNo networkId nodeSocket
-            slot2 `shouldSatisfy` (> slot1)
+      showLogsOnFailure "CardanoNodeSpec" $ \tr ->
+        withTempDir "hydra-cluster" $ \tmp ->
+          withCardanoNodeDevnet tr tmp $
+            \RunningNode{nodeSocket, networkId, blockTime} -> do
+              doesFileExist (unFile nodeSocket) `shouldReturn` True
+              -- NOTE: We hard-code the expected networkId and blockTime here to
+              -- detect any change to the genesis-shelley.json
+              networkId `shouldBe` Testnet (NetworkMagic 42)
+              blockTime `shouldBe` 0.1
+              -- Should produce blocks (tip advances)
+              slot1 <- queryTipSlotNo networkId nodeSocket
+              threadDelay 1
+              slot2 <- queryTipSlotNo networkId nodeSocket
+              slot2 `shouldSatisfy` (> slot1)
+
+  it "withCardanoNodeOnKnownNetwork on mainnet starts synchronizing within 5 seconds" $
+    -- NOTE: This implies that withCardanoNodeOnKnownNetwork does not
+    -- synchronize the whole chain before continuing.
+    failAfter 5 $
+      showLogsOnFailure "CardanoNodeSpec" $ \tr ->
+        withTempDir "hydra-cluster" $ \tmp ->
+          withCardanoNodeOnKnownNetwork tr tmp Mainnet $
+            \RunningNode{nodeSocket, networkId, blockTime} -> do
+              networkId `shouldBe` NetworkId.Mainnet
+              blockTime `shouldBe` 20
+              -- Should synchronize blocks (tip advances)
+              slot1 <- queryTipSlotNo networkId nodeSocket
+              threadDelay 1
+              slot2 <- queryTipSlotNo networkId nodeSocket
+              slot2 `shouldSatisfy` (> slot1)

--- a/hydra-cluster/test/Test/ChainObserverSpec.hs
+++ b/hydra-cluster/test/Test/ChainObserverSpec.hs
@@ -9,8 +9,8 @@ module Test.ChainObserverSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import CardanoClient (NodeLog, RunningNode (..), submitTx)
-import CardanoNode (withCardanoNodeDevnet)
+import CardanoClient (RunningNode (..), submitTx)
+import CardanoNode (NodeLog, withCardanoNodeDevnet)
 import Control.Concurrent.Class.MonadSTM (modifyTVar', newTVarIO, readTVarIO)
 import Control.Exception (IOException)
 import Control.Lens ((^?))

--- a/hydra-cluster/test/Test/DirectChainSpec.hs
+++ b/hydra-cluster/test/Test/DirectChainSpec.hs
@@ -7,7 +7,6 @@ import Test.Hydra.Prelude
 
 import Cardano.Api.UTxO (UTxO' (UTxO, toMap))
 import CardanoClient (
-  NodeLog,
   QueryPoint (QueryTip),
   RunningNode (..),
   buildAddress,
@@ -16,7 +15,7 @@ import CardanoClient (
   submitTx,
   waitForUTxO,
  )
-import CardanoNode (withCardanoNodeDevnet)
+import CardanoNode (NodeLog, withCardanoNodeDevnet)
 import Control.Concurrent.STM (newEmptyTMVarIO, takeTMVar)
 import Control.Concurrent.STM.TMVar (putTMVar)
 import Hydra.Cardano.Api (

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -269,7 +269,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
                   v ^? key "contestationDeadline" . _JSON
 
                 -- Expect to see ReadyToFanout within 3 seconds after deadline
-                remainingTime <- realToFrac . diffUTCTime deadline <$> getCurrentTime
+                remainingTime <- diffUTCTime deadline <$> getCurrentTime
                 waitFor hydraTracer (remainingTime + 3) [n1] $
                   output "ReadyToFanout" ["headId" .= headId]
 
@@ -831,7 +831,7 @@ initAndClose tmpDir tracer clusterIx hydraScriptsTxId node@RunningNode{nodeSocke
       v ^? key "contestationDeadline" . _JSON
 
     -- Expect to see ReadyToFanout within 3 seconds after deadline
-    remainingTime <- realToFrac . diffUTCTime deadline <$> getCurrentTime
+    remainingTime <- diffUTCTime deadline <$> getCurrentTime
     waitFor hydraTracer (remainingTime + 3) [n1] $
       output "ReadyToFanout" ["headId" .= headId]
 

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -57,7 +57,6 @@ import Hydra.Cluster.Fixture (
   carolSk,
   carolVk,
   cperiod,
-  defaultNetworkId,
  )
 import Hydra.Cluster.Scenarios (
   EndToEndLog (..),
@@ -511,7 +510,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
         withClusterTempDir "unsupported-era" $ \tmpDir -> do
           args <- setupCardanoDevnet tmpDir
           forkIntoConwayInEpoch tmpDir args 1
-          withCardanoNode (contramap FromCardanoNode tracer) tmpDir args defaultNetworkId $ \node@RunningNode{nodeSocket} -> do
+          withCardanoNode (contramap FromCardanoNode tracer) tmpDir args $ \node@RunningNode{nodeSocket} -> do
             let hydraTracer = contramap FromHydraNode tracer
             hydraScriptsTxId <- publishHydraScriptsAs node Faucet
             chainConfig <- chainConfigFor Alice tmpDir nodeSocket hydraScriptsTxId [] cperiod
@@ -531,7 +530,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
         withClusterTempDir "unsupported-era-startup" $ \tmpDir -> do
           args <- setupCardanoDevnet tmpDir
           forkIntoConwayInEpoch tmpDir args 1
-          withCardanoNode (contramap FromCardanoNode tracer) tmpDir args defaultNetworkId $ \node@RunningNode{nodeSocket} -> do
+          withCardanoNode (contramap FromCardanoNode tracer) tmpDir args $ \node@RunningNode{nodeSocket} -> do
             let hydraTracer = contramap FromHydraNode tracer
             hydraScriptsTxId <- publishHydraScriptsAs node Faucet
             chainConfig <- chainConfigFor Alice tmpDir nodeSocket hydraScriptsTxId [] cperiod
@@ -549,7 +548,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
           args <- setupCardanoDevnet tmpDir
 
           forkIntoConwayInEpoch tmpDir args 10
-          withCardanoNode (contramap FromCardanoNode tracer) tmpDir args defaultNetworkId $
+          withCardanoNode (contramap FromCardanoNode tracer) tmpDir args $
             \node@RunningNode{nodeSocket} -> do
               let lovelaceBalanceValue = 100_000_000
               -- Funds to be used as fuel by Hydra protocol transactions
@@ -585,7 +584,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
           args <- setupCardanoDevnet tmpDir
 
           forkIntoConwayInEpoch tmpDir args 10
-          withCardanoNode (contramap FromCardanoNode tracer) tmpDir args defaultNetworkId $
+          withCardanoNode (contramap FromCardanoNode tracer) tmpDir args $
             \node@RunningNode{nodeSocket} -> do
               let lovelaceBalanceValue = 100_000_000
               -- Funds to be used as fuel by Hydra protocol transactions

--- a/hydra-node/src/Hydra/ContestationPeriod.hs
+++ b/hydra-node/src/Hydra/ContestationPeriod.hs
@@ -42,7 +42,7 @@ instance Arbitrary ContestationPeriod where
 fromDiffTime :: MonadFail m => DiffTime -> m ContestationPeriod
 fromDiffTime dt =
   if seconds > 0
-    then pure . UnsafeContestationPeriod $ truncate seconds
+    then pure . UnsafeContestationPeriod . max 1 $ truncate seconds
     else fail $ "fromDiffTime: contestation period <= 0: " <> show dt
  where
   seconds :: Pico = realToFrac dt

--- a/hydra-node/src/Hydra/ContestationPeriod.hs
+++ b/hydra-node/src/Hydra/ContestationPeriod.hs
@@ -42,7 +42,7 @@ instance Arbitrary ContestationPeriod where
 fromDiffTime :: MonadFail m => DiffTime -> m ContestationPeriod
 fromDiffTime dt =
   if seconds > 0
-    then pure . UnsafeContestationPeriod . max 1 $ truncate seconds
+    then pure . UnsafeContestationPeriod $ ceiling seconds
     else fail $ "fromDiffTime: contestation period <= 0: " <> show dt
  where
   seconds :: Pico = realToFrac dt

--- a/hydra-node/src/Hydra/ContestationPeriod.hs
+++ b/hydra-node/src/Hydra/ContestationPeriod.hs
@@ -37,15 +37,19 @@ instance Arbitrary ContestationPeriod where
     oneMonth = oneDay * 30
     oneYear = oneDay * 365
 
--- | Create a 'ContestationPeriod' from a 'DiffTime'. This will fail if a
--- negative DiffTime is provided and truncates to 1s if values < 1s are given.
-fromDiffTime :: MonadFail m => DiffTime -> m ContestationPeriod
-fromDiffTime dt =
+-- | Create a 'ContestationPeriod' from a 'NominalDiffTime'. This will fail if a
+-- negative NominalDiffTime is provided and truncates to 1s if values < 1s are given.
+fromNominalDiffTime :: MonadFail m => NominalDiffTime -> m ContestationPeriod
+fromNominalDiffTime dt =
   if seconds > 0
     then pure . UnsafeContestationPeriod $ ceiling seconds
-    else fail $ "fromDiffTime: contestation period <= 0: " <> show dt
+    else fail $ "fromNominalDiffTime: contestation period <= 0: " <> show dt
  where
   seconds :: Pico = realToFrac dt
+
+toNominalDiffTime :: ContestationPeriod -> NominalDiffTime
+toNominalDiffTime (UnsafeContestationPeriod s) =
+  secondsToNominalDiffTime $ fromIntegral s
 
 -- | Convert an off-chain contestation period to its on-chain representation.
 toChain :: ContestationPeriod -> OnChain.ContestationPeriod
@@ -61,7 +65,3 @@ fromChain cp =
   UnsafeContestationPeriod
     . truncate
     $ toInteger (OnChain.milliseconds cp) % 1000
-
-toNominalDiffTime :: ContestationPeriod -> NominalDiffTime
-toNominalDiffTime (UnsafeContestationPeriod s) =
-  secondsToNominalDiffTime $ fromIntegral s

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -18,7 +18,6 @@ import Data.ByteString.Char8 qualified as BSC
 import Data.IP (IP (IPv4), toIPv4, toIPv4w)
 import Data.Text (unpack)
 import Data.Text qualified as T
-import Data.Time.Clock (nominalDiffTimeToSeconds)
 import Data.Version (Version (..), showVersion)
 import Hydra.Cardano.Api (
   AsType (AsTxId),

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -34,7 +34,7 @@ import Hydra.Cardano.Api (
   serialiseToRawBytesHexText,
  )
 import Hydra.Chain (maximumNumberOfParties)
-import Hydra.ContestationPeriod (ContestationPeriod (UnsafeContestationPeriod), fromDiffTime)
+import Hydra.ContestationPeriod (ContestationPeriod (UnsafeContestationPeriod), fromNominalDiffTime)
 import Hydra.Contract qualified as Contract
 import Hydra.Ledger.Cardano ()
 import Hydra.Logging (Verbosity (..))
@@ -745,7 +745,7 @@ contestationPeriodParser =
  where
   parseNatural = UnsafeContestationPeriod <$> auto
 
-  parseViaDiffTime = auto >>= fromDiffTime
+  parseViaDiffTime = auto >>= fromNominalDiffTime
 
 data InvalidOptions
   = MaximumNumberOfPartiesExceeded

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -721,10 +721,10 @@ testContestationPeriod = UnsafeContestationPeriod 3600
 nothingHappensFor ::
   (MonadTimer m, MonadThrow m, IsChainState tx) =>
   TestHydraClient tx m ->
-  DiffTime ->
+  NominalDiffTime ->
   m ()
 nothingHappensFor node secs =
-  timeout secs (waitForNext node) >>= (`shouldBe` Nothing)
+  timeout (realToFrac secs) (waitForNext node) >>= (`shouldBe` Nothing)
 
 withHydraNode ::
   forall s a.

--- a/hydra-node/test/Hydra/ContestationPeriodSpec.hs
+++ b/hydra-node/test/Hydra/ContestationPeriodSpec.hs
@@ -2,10 +2,11 @@ module Hydra.ContestationPeriodSpec where
 
 import Hydra.Prelude
 
-import Hydra.ContestationPeriod (fromDiffTime)
+import Data.Time (picosecondsToDiffTime)
+import Hydra.ContestationPeriod (ContestationPeriod, fromDiffTime)
 import Test.Hspec (Spec, describe)
 import Test.Hspec.QuickCheck (prop)
-import Test.QuickCheck (getNonPositive, getPositive)
+import Test.QuickCheck (getNonPositive, getPositive, (===))
 import Test.QuickCheck.Instances.Time ()
 
 spec :: Spec
@@ -16,3 +17,8 @@ spec = do
 
     prop "fails for diff times <= 0" $
       isNothing . fromDiffTime . getNonPositive
+
+    prop "rounds to 1 second" $ \n ->
+      let subSecondPicos = getPositive n `mod` 1_000_000_000_000
+       in fromDiffTime (picosecondsToDiffTime subSecondPicos)
+            === (fromDiffTime 1 :: Maybe ContestationPeriod)

--- a/hydra-node/test/Hydra/ContestationPeriodSpec.hs
+++ b/hydra-node/test/Hydra/ContestationPeriodSpec.hs
@@ -1,9 +1,9 @@
 module Hydra.ContestationPeriodSpec where
 
-import Hydra.Prelude
+import Hydra.Prelude hiding (label)
 
-import Data.Time (picosecondsToDiffTime)
-import Hydra.ContestationPeriod (ContestationPeriod, fromDiffTime)
+import Data.Time (secondsToNominalDiffTime)
+import Hydra.ContestationPeriod (ContestationPeriod, fromNominalDiffTime)
 import Test.Hspec (Spec, describe)
 import Test.Hspec.QuickCheck (prop)
 import Test.QuickCheck (getNonPositive, getPositive, (===))
@@ -11,14 +11,14 @@ import Test.QuickCheck.Instances.Time ()
 
 spec :: Spec
 spec = do
-  describe "fromDiffTime" $ do
+  describe "fromNominalDiffTime" $ do
     prop "works for diff times > 0" $
-      isJust . fromDiffTime . getPositive
+      isJust . fromNominalDiffTime . getPositive
 
     prop "fails for diff times <= 0" $
-      isNothing . fromDiffTime . getNonPositive
+      isNothing . fromNominalDiffTime . getNonPositive
 
     prop "rounds to 1 second" $ \n ->
-      let subSecondPicos = getPositive n `mod` 1_000_000_000_000
-       in fromDiffTime (picosecondsToDiffTime subSecondPicos)
-            === (fromDiffTime 1 :: Maybe ContestationPeriod)
+      let subSecond = getPositive n / 100 -- Definitely < 1 second
+       in fromNominalDiffTime (secondsToNominalDiffTime subSecond)
+            === (fromNominalDiffTime 1 :: Maybe ContestationPeriod)

--- a/hydra-test-utils/src/Test/Hydra/Prelude.hs
+++ b/hydra-test-utils/src/Test/Hydra/Prelude.hs
@@ -90,10 +90,10 @@ failure msg =
   throwIO (HUnitFailure location $ Reason msg)
 
 -- | Fail some monadic action if it does not complete within given timeout.
--- A 'DiffTime' can be represented as a decimal number of seconds.
-failAfter :: (HasCallStack, MonadTimer m, MonadThrow m) => DiffTime -> m a -> m a
+-- A 'NominalDiffTime' can be represented as a decimal number of seconds.
+failAfter :: (HasCallStack, MonadTimer m, MonadThrow m) => NominalDiffTime -> m a -> m a
 failAfter seconds action =
-  timeout seconds action >>= \case
+  timeout (realToFrac seconds) action >>= \case
     Nothing -> failure $ "Test timed out after " <> show seconds
     Just a -> pure a
 

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -7,8 +7,8 @@ import Hydra.Prelude
 import Test.Hydra.Prelude
 
 import Blaze.ByteString.Builder.Char8 (writeChar)
-import CardanoClient (NodeLog, RunningNode (..))
-import CardanoNode (withCardanoNodeDevnet)
+import CardanoClient (RunningNode (..))
+import CardanoNode (NodeLog, withCardanoNodeDevnet)
 import Control.Concurrent.Class.MonadSTM (newTQueueIO, readTQueue, tryReadTQueue, writeTQueue)
 import Data.ByteString qualified as BS
 import Graphics.Vty (


### PR DESCRIPTION
I think I need a break.. this time I added a test to make sure that we do not create `0` second contestation periods even with sub-second diff times.

This now also loads the parameters from the shelley genesis.json to not need to synchronize the network to get the `blockTime` and make this testable.

Also, this uses `NominalDiffTime` in more places (which is the better type for fixed durations).

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
