### PR TITLE
Smoke test with mithril

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -16,6 +16,11 @@ on:
         description: "TxId of already published scripts (leave empty to publish)"
         required: false
 
+      use-mithril:
+        description: "Bootstrap cardano-node using mithril (removes existing db/)"
+        required: false
+        type: boolean
+
 jobs:
   smoke-test:
     name: "Smoke test on ${{inputs.network}}"
@@ -34,7 +39,12 @@ jobs:
         extra_nix_config: |
           accept-flake-config = true
 
-    - name: 🚬 Cleanup hydra-node state
+    - name: 🧹 Delete cardano-node db (when using mithril)
+      if: ${{ inputs.use-mithril }}
+      run: |
+        rm -rf ${state_dir}/db
+
+    - name: 🧹 Cleanup hydra-node state
       run: |
         rm -rf ${state_dir}/state-*
 
@@ -47,10 +57,14 @@ jobs:
     - name: 🚬 Run hydra-cluster smoke test
       run: |
         if [ -n "${{inputs.hydra-scripts-tx-id}}" ]; then
-          nix develop .#exes --command bash -c "hydra-cluster --${{inputs.network}} --hydra-scripts-tx-id ${{inputs.hydra-scripts-tx-id}} --state-directory ${state_dir}"
+          HYDRA_SCRIPTS_ARG="--hydra-scripts-tx-id ${{inputs.hydra-scripts-tx-id}}"
         else
-          nix develop .#exes --command bash -c "hydra-cluster --${{inputs.network}} --publish-hydra-scripts --state-directory ${state_dir}"
+          HYDRA_SCRIPTS_ARG="--publish-hydra-scripts"
         fi
+        if ${{inputs.use-mithril}}; then
+          USE_MITHRIL_ARG="--use-mithril"
+        fi
+        nix develop .#exes --command bash -c "hydra-cluster --${{inputs.network}} --state-directory ${state_dir} ${HYDRA_SCRIPTS_ARG} ${USE_MITHRIL_ARG}"
 
     - name: 💾 Upload logs
       if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ changes.
 
 - Adapt cardano client and the chain-sync client to survive after the fork to Conway era.
 
+- The `hydra-cluster` binary can bootstrap `cardano-node`s running on public
+  networks using `mithril-client`.
+
 ## [0.14.0] - 2023-12-04
 
 - **BREAKING** Multiple changes to the Hydra Head protocol on-chain:

--- a/flake.lock
+++ b/flake.lock
@@ -377,6 +377,27 @@
         "type": "github"
       }
     },
+    "crane_2": {
+      "inputs": {
+        "nixpkgs": [
+          "mithril",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1700327093,
+        "narHash": "sha256-OgYvlBABxJYWhZ/HBd0bPVcIEkT+xDhDCpRYqtVhYWY=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "ae7cd510e508ee03d792005c2f1c0a3ff25ecb80",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "customConfig": {
       "locked": {
         "lastModified": 1630400035,
@@ -641,6 +662,24 @@
         "owner": "input-output-hk",
         "ref": "hkm/gitlab-fix",
         "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1698882062,
+        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
@@ -1436,6 +1475,28 @@
         "type": "github"
       }
     },
+    "mithril": {
+      "inputs": {
+        "crane": "crane_2",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs_12",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1700729885,
+        "narHash": "sha256-9eRpfYrIypumOHZev3CcD5okDIPIdG2y78AUNFqvN2k=",
+        "owner": "input-output-hk",
+        "repo": "mithril",
+        "rev": "0780dfa5153baacbb68770d24e719a435e85e1f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "2347.0",
+        "repo": "mithril",
+        "type": "github"
+      }
+    },
     "n2c": {
       "inputs": {
         "flake-utils": [
@@ -1890,6 +1951,24 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1698611440,
+        "narHash": "sha256-jPjHjrerhYDy3q9+s5EAsuhyhuknNfowY6yt6pjn9pc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0cbe9f69c234a7700596e943bfae7ef27a31b735",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-regression": {
       "locked": {
         "lastModified": 1643052045,
@@ -1982,6 +2061,22 @@
       "original": {
         "owner": "nixos",
         "ref": "release-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_12": {
+      "locked": {
+        "lastModified": 1700444282,
+        "narHash": "sha256-s/+tgT+Iz0LZO+nBvSms+xsMqvHt2LqYniG9r+CYyJc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3f21a22b5aafefa1845dec6f4a378a8f53d8681c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -2366,6 +2461,7 @@
         "flake-utils": "flake-utils_7",
         "haskellNix": "haskellNix_2",
         "iohk-nix": "iohk-nix",
+        "mithril": "mithril",
         "nixpkgs": [
           "haskellNix",
           "nixpkgs"
@@ -2641,6 +2737,27 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "mithril",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1699786194,
+        "narHash": "sha256-3h3EH1FXQkIeAuzaWB+nK0XK54uSD46pp+dMD3gAcB4=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "e82f32aa7f06bbbd56d7b12186d555223dc399d1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,7 @@
       flake = false;
     };
     cardano-node.url = "github:input-output-hk/cardano-node/8.7.2";
+    mithril.url = "github:input-output-hk/mithril/2347.0";
   };
 
   outputs =
@@ -31,7 +32,7 @@
           inherit system nixpkgs;
         };
         hydraPackages = import ./nix/hydra/packages.nix {
-          inherit hydraProject system pkgs cardano-node;
+          inherit hydraProject system pkgs inputs;
           gitRev = self.rev or "dirty";
         };
         hydraImages = import ./nix/hydra/docker.nix {
@@ -52,12 +53,10 @@
           };
 
         devShells = (import ./nix/hydra/shell.nix {
-          inherit (inputs) cardano-node;
-          inherit hydraProject system;
+          inherit inputs hydraProject system;
         }) // {
           ci = (import ./nix/hydra/shell.nix {
-            inherit (inputs) cardano-node;
-            inherit hydraProject system;
+            inherit inputs hydraProject system;
             withoutDevTools = true;
           }).default;
         };

--- a/hydra-cluster/exe/hydra-cluster/Main.hs
+++ b/hydra-cluster/exe/hydra-cluster/Main.hs
@@ -25,7 +25,7 @@ run options =
       case knownNetwork of
         Just network -> do
           when (useMithril == UseMithril) $
-            downloadLatestSnapshotTo network workDir
+            downloadLatestSnapshotTo (contramap FromMithril tracer) network workDir
           withCardanoNodeOnKnownNetwork fromCardanoNode workDir network $ \node -> do
             waitForFullySynchronized fromCardanoNode node
             publishOrReuseHydraScripts tracer node

--- a/hydra-cluster/exe/hydra-cluster/Main.hs
+++ b/hydra-cluster/exe/hydra-cluster/Main.hs
@@ -25,7 +25,6 @@ run options =
       case knownNetwork of
         Just network -> do
           when (useMithril == UseMithril) $
-            -- TODO: fails if workDir/db already exists
             downloadLatestSnapshotTo network workDir
           withCardanoNodeOnKnownNetwork fromCardanoNode workDir network $ \node -> do
             waitForFullySynchronized fromCardanoNode node

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -105,6 +105,7 @@ library
     , temporary
     , text
     , time
+    , typed-process
     , unix
     , websockets
 

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -68,6 +68,7 @@ library
     CardanoNode
     Hydra.Cluster.Faucet
     Hydra.Cluster.Fixture
+    Hydra.Cluster.Mithril
     Hydra.Cluster.Options
     Hydra.Cluster.Scenarios
     Hydra.Cluster.Util
@@ -154,6 +155,7 @@ test-suite tests
     Test.GeneratorSpec
     Test.Hydra.Cluster.CardanoCliSpec
     Test.Hydra.Cluster.FaucetSpec
+    Test.Hydra.Cluster.MithrilSpec
     Test.LogFilterSpec
     Test.OfflineChainSpec
 

--- a/hydra-cluster/src/Hydra/Cluster/Fixture.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Fixture.hs
@@ -63,4 +63,4 @@ data KnownNetwork
   = Preview
   | Preproduction
   | Mainnet
-  deriving stock (Show)
+  deriving stock (Show, Eq, Enum, Bounded)

--- a/hydra-cluster/src/Hydra/Cluster/Fixture.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Fixture.hs
@@ -63,4 +63,5 @@ data KnownNetwork
   = Preview
   | Preproduction
   | Mainnet
-  deriving stock (Show, Eq, Enum, Bounded)
+  deriving stock (Generic, Show, Eq, Enum, Bounded)
+  deriving anyclass (ToJSON, FromJSON)

--- a/hydra-cluster/src/Hydra/Cluster/Mithril.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Mithril.hs
@@ -14,7 +14,7 @@ downloadLatestSnapshotTo network dir = do
   -- TODO: Use a tracer?
   putTextLn $ "Downloading latest snapshot of " <> show network <> " to " <> show dir
   genesisKey <- parseRequest (genesisKeyURLForNetwork network) >>= httpBS <&> getResponseBody
-  -- TODO: not inherit handles
+  -- TODO: not inherit handles?
   callProcess "mithril-client" $
     concat
       [ ["--aggregator-endpoint", aggregatorEndpointForNetwork network]

--- a/hydra-cluster/src/Hydra/Cluster/Mithril.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Mithril.hs
@@ -1,0 +1,34 @@
+-- | Mithril client to bootstrap cardano nodes in the hydra-cluster.
+module Hydra.Cluster.Mithril where
+
+import Hydra.Prelude
+
+import Hydra.Cluster.Fixture (KnownNetwork (..))
+import Network.HTTP.Simple (getResponseBody, httpBS, parseRequest)
+import System.Process (callProcess)
+
+-- | Downloads and unpacks latest snapshot for given network in db/ of given
+-- directory.
+downloadLatestSnapshotTo :: KnownNetwork -> FilePath -> IO ()
+downloadLatestSnapshotTo network dir = do
+  -- TODO: Use a tracer?
+  putTextLn $ "Downloading latest snapshot of " <> show network <> " to " <> show dir
+  genesisKey <- parseRequest (genesisKeyURLForNetwork network) >>= httpBS <&> getResponseBody
+  -- TODO: not inherit handles
+  callProcess "mithril-client" $
+    concat
+      [ ["--aggregator-endpoint", aggregatorEndpointForNetwork network]
+      , ["snapshot", "download", "latest"]
+      , ["--genesis-verification-key", decodeUtf8 genesisKey]
+      , ["--download-dir", dir]
+      ]
+ where
+  genesisKeyURLForNetwork = \case
+    Mainnet -> "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-mainnet/genesis.vkey"
+    Preproduction -> "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/genesis.vkey"
+    Preview -> "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/pre-release-preview/genesis.vkey"
+
+  aggregatorEndpointForNetwork = \case
+    Mainnet -> "https://aggregator.release-mainnet.api.mithril.network/aggregator"
+    Preproduction -> "https://aggregator.release-preprod.api.mithril.network/aggregator"
+    Preview -> "https://aggregator.pre-release-preview.api.mithril.network/aggregator"

--- a/hydra-cluster/src/Hydra/Cluster/Mithril.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Mithril.hs
@@ -3,26 +3,46 @@ module Hydra.Cluster.Mithril where
 
 import Hydra.Prelude
 
+import Control.Tracer (Tracer, traceWith)
+import Data.Aeson (Value)
+import Data.Aeson qualified as Aeson
+import Data.ByteString qualified as BS
 import Hydra.Cluster.Fixture (KnownNetwork (..))
 import Network.HTTP.Simple (getResponseBody, httpBS, parseRequest)
-import System.Process (callProcess)
+import System.Process.Typed (createPipe, getStdout, proc, setStdout, withProcessWait_)
+
+data MithrilLog
+  = StartSnapshotDownload {network :: KnownNetwork, directory :: FilePath}
+  | -- | Output captured directly from mithril-client
+    StdOut {output :: Value}
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
 
 -- | Downloads and unpacks latest snapshot for given network in db/ of given
 -- directory.
-downloadLatestSnapshotTo :: KnownNetwork -> FilePath -> IO ()
-downloadLatestSnapshotTo network dir = do
-  -- TODO: Use a tracer?
-  putTextLn $ "Downloading latest snapshot of " <> show network <> " to " <> show dir
+downloadLatestSnapshotTo :: Tracer IO MithrilLog -> KnownNetwork -> FilePath -> IO ()
+downloadLatestSnapshotTo tracer network directory = do
+  traceWith tracer StartSnapshotDownload{network, directory}
   genesisKey <- parseRequest (genesisKeyURLForNetwork network) >>= httpBS <&> getResponseBody
-  -- TODO: not inherit handles?
-  callProcess "mithril-client" $
-    concat
-      [ ["--aggregator-endpoint", aggregatorEndpointForNetwork network]
-      , ["snapshot", "download", "latest"]
-      , ["--genesis-verification-key", decodeUtf8 genesisKey]
-      , ["--download-dir", dir]
-      ]
+  let cmd =
+        setStdout createPipe $
+          proc "mithril-client" $
+            concat
+              [ ["--aggregator-endpoint", aggregatorEndpointForNetwork network]
+              , ["snapshot", "download", "latest"]
+              , ["--genesis-verification-key", decodeUtf8 genesisKey]
+              , ["--download-dir", directory]
+              , ["--json"]
+              ]
+  withProcessWait_ cmd traceStdout
  where
+  traceStdout p =
+    forever $ do
+      bytes <- BS.hGetLine (getStdout p)
+      case Aeson.eitherDecodeStrict bytes of
+        Left err -> error $ "failed to decode: \n" <> show bytes <> "\nerror: " <> show err
+        Right output -> traceWith tracer StdOut{output}
+
   genesisKeyURLForNetwork = \case
     Mainnet -> "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-mainnet/genesis.vkey"
     Preproduction -> "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/genesis.vkey"

--- a/hydra-cluster/src/Hydra/Cluster/Options.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Options.hs
@@ -4,26 +4,30 @@ import Data.ByteString.Char8 qualified as BSC
 import Hydra.Cardano.Api (AsType (AsTxId), TxId, deserialiseFromRawBytesHex)
 import Hydra.Cluster.Fixture (KnownNetwork (..))
 import Hydra.Prelude
-import Options.Applicative (Parser, eitherReader, flag', help, long, metavar, strOption)
+import Options.Applicative (Parser, eitherReader, flag, flag', help, long, metavar, strOption)
 import Options.Applicative.Builder (option)
 
 data Options = Options
   { knownNetwork :: Maybe KnownNetwork
   , stateDirectory :: Maybe FilePath
   , publishHydraScripts :: PublishOrReuse
+  , useMithril :: UseMithril
   }
   deriving stock (Show)
 
 data PublishOrReuse = Publish | Reuse TxId
   deriving stock (Show)
 
--- TODO: Provide an option to use mithril aggregated snapshots to bootstrap the testnet
+data UseMithril = NotUseMithril | UseMithril
+  deriving stock (Show, Eq)
+
 parseOptions :: Parser Options
 parseOptions =
   Options
     <$> parseKnownNetwork
     <*> parseStateDirectory
     <*> parsePublishHydraScripts
+    <*> parseUseMithril
  where
   parseKnownNetwork =
     flag' (Just Preview) (long "preview" <> help "The preview testnet")
@@ -65,6 +69,17 @@ parseOptions =
         ( long "hydra-scripts-tx-id"
             <> metavar "TXID"
             <> help
-              "Use the hydra scripts already published in given transaction id.\
+              "Use the hydra scripts already published in given transaction id. \
               \See --publish-hydra-scripts or hydra-node publish-scripts"
         )
+
+  parseUseMithril =
+    flag
+      NotUseMithril
+      UseMithril
+      ( long "use-mithril"
+          <> help
+            "Use mithril-client to download and verify the latest network snapshot. \
+            \If not set, the cardano-node will synchronize the network given the current \
+            \cardano-node state in --state-directory."
+      )

--- a/hydra-cluster/src/Hydra/Cluster/Options.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Options.hs
@@ -80,6 +80,7 @@ parseOptions =
       ( long "use-mithril"
           <> help
             "Use mithril-client to download and verify the latest network snapshot. \
+            \When setting this, ensure that there is no db/ in --state-directory. \
             \If not set, the cardano-node will synchronize the network given the current \
             \cardano-node state in --state-directory."
       )

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -59,6 +59,7 @@ import Hydra.Chain.Direct.Tx (verificationKeyToOnChainId)
 import Hydra.Cluster.Faucet (FaucetLog, createOutputAtAddress, seedFromFaucet, seedFromFaucet_)
 import Hydra.Cluster.Faucet qualified as Faucet
 import Hydra.Cluster.Fixture (Actor (..), actorName, alice, aliceSk, aliceVk, bob, bobSk, bobVk, carol, carolSk)
+import Hydra.Cluster.Mithril (MithrilLog)
 import Hydra.Cluster.Util (chainConfigFor, keysFor, modifyConfig, setNetworkId)
 import Hydra.ContestationPeriod (ContestationPeriod (UnsafeContestationPeriod), fromNominalDiffTime)
 import Hydra.HeadId (HeadId)
@@ -104,6 +105,7 @@ data EndToEndLog
   = FromCardanoNode NodeLog
   | FromFaucet FaucetLog
   | FromHydraNode HydraNodeLog
+  | FromMithril MithrilLog
   | StartingFunds {actor :: String, utxo :: UTxO}
   | RefueledFunds {actor :: String, refuelingAmount :: Lovelace, utxo :: UTxO}
   | RemainingFunds {actor :: String, utxo :: UTxO}

--- a/hydra-cluster/test/Test/Hydra/Cluster/MithrilSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/MithrilSpec.hs
@@ -1,0 +1,36 @@
+module Test.Hydra.Cluster.MithrilSpec where
+
+import Hydra.Prelude
+import Test.Hydra.Prelude
+
+import Hydra.Cluster.Fixture (KnownNetwork)
+import Hydra.Cluster.Mithril (downloadLatestSnapshotTo)
+import System.Directory (doesDirectoryExist, listDirectory)
+import System.FilePath ((</>))
+
+spec :: Spec
+spec = do
+  describe "downloadLatestSnapshotTo" $
+    -- TODO: generate test tree instead of folding into one case (timings etc.)
+    it "starts downloading db" $ do
+      forAllNetworks $ \network ->
+        withTempDir ("mithril-download-" <> show network) $ \tmpDir -> do
+          let dbPath = tmpDir </> "db"
+          doesDirectoryExist dbPath `shouldReturn` False
+          race_
+            (downloadLatestSnapshotTo network tmpDir)
+            (failAfter 60 $ waitUntilDirContainsFiles dbPath)
+
+waitUntilDirContainsFiles :: FilePath -> IO ()
+waitUntilDirContainsFiles dir = do
+  exists <- doesDirectoryExist dir
+  if exists
+    then do
+      contents <- listDirectory dir
+      if null contents
+        then threadDelay 1 >> waitUntilDirContainsFiles dir
+        else pure ()
+    else threadDelay 1 >> waitUntilDirContainsFiles dir
+
+forAllNetworks :: (KnownNetwork -> IO ()) -> IO ()
+forAllNetworks f = foldMap f (enumFromTo minBound maxBound)

--- a/hydra-cluster/test/Test/Hydra/Cluster/MithrilSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/MithrilSpec.hs
@@ -19,7 +19,9 @@ spec = parallel $ do
           doesDirectoryExist dbPath `shouldReturn` False
           race_
             (downloadLatestSnapshotTo tracer network tmpDir)
-            (failAfter 80 $ waitUntilDirContainsFiles dbPath)
+            -- XXX: The timeout here depends on the network (certificate chain
+            -- length) and the machine it runs on.
+            (failAfter 100 $ waitUntilDirContainsFiles dbPath)
 
 waitUntilDirContainsFiles :: FilePath -> IO ()
 waitUntilDirContainsFiles dir = do

--- a/hydra-cluster/test/Test/Hydra/Cluster/MithrilSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/MithrilSpec.hs
@@ -3,38 +3,50 @@ module Test.Hydra.Cluster.MithrilSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
+import Control.Concurrent.Class.MonadSTM (newTVarIO, readTVarIO)
+import Control.Lens ((^?!))
+import Data.Aeson.Lens (key, _Number)
 import Hydra.Cluster.Fixture (KnownNetwork)
-import Hydra.Cluster.Mithril (downloadLatestSnapshotTo)
-import Hydra.Logging (showLogsOnFailure)
-import System.Directory (doesDirectoryExist, listDirectory)
+import Hydra.Cluster.Mithril (MithrilLog (..), downloadLatestSnapshotTo)
+import Hydra.Logging (Envelope (..), Tracer, traceInTVar)
+import System.Directory (doesDirectoryExist)
 import System.FilePath ((</>))
 
 spec :: Spec
 spec = parallel $ do
   describe "downloadLatestSnapshotTo" $
-    forAllNetworks "starts downloading db" $ \network ->
-      showLogsOnFailure "MithrilSpec" $ \tracer ->
-        withTempDir ("mithril-download-" <> show network) $ \tmpDir -> do
-          let dbPath = tmpDir </> "db"
-          doesDirectoryExist dbPath `shouldReturn` False
-          race_
-            (downloadLatestSnapshotTo tracer network tmpDir)
-            -- XXX: The timeout here depends on the network (certificate chain
-            -- length) and the machine it runs on.
-            (failAfter 100 $ waitUntilDirContainsFiles dbPath)
+    forEechKnownNetwork "invokes mithril-client correctly" $ \network -> do
+      (tracer, getTraces) <- captureTracer "MithrilSpec"
+      withTempDir ("mithril-download-" <> show network) $ \tmpDir -> do
+        let dbPath = tmpDir </> "db"
+        doesDirectoryExist dbPath `shouldReturn` False
+        race_
+          (downloadLatestSnapshotTo tracer network tmpDir)
+          (waitForStep 3 getTraces)
 
-waitUntilDirContainsFiles :: FilePath -> IO ()
-waitUntilDirContainsFiles dir = do
-  exists <- doesDirectoryExist dir
-  if exists
-    then do
-      contents <- listDirectory dir
-      if null contents
-        then threadDelay 1 >> waitUntilDirContainsFiles dir
-        else pure ()
-    else threadDelay 1 >> waitUntilDirContainsFiles dir
+-- | Wait for the 'StdOut' message that matches the given step number.
+waitForStep :: HasCallStack => Natural -> IO [Envelope MithrilLog] -> IO ()
+waitForStep step getTraces = do
+  traces <- getTraces
+  unless (any isRightStep traces) $ do
+    threadDelay 1
+    waitForStep step getTraces
+ where
+  isRightStep = \case
+    Envelope{message = StdOut{output}} ->
+      output ^?! key "step_num" . _Number == fromIntegral step
+    _ -> False
 
-forAllNetworks :: String -> (KnownNetwork -> IO ()) -> Spec
-forAllNetworks msg action =
+-- | Create a tracer that captures all messages and a function to retrieve all
+-- traces captured.
+captureTracer :: Text -> IO (Tracer IO a, IO [Envelope a])
+captureTracer namespace = do
+  traces <- newTVarIO []
+  let tracer = traceInTVar traces namespace
+  pure (tracer, readTVarIO traces)
+
+-- | Creates test cases for each 'KnownNetwork'.
+forEechKnownNetwork :: String -> (KnownNetwork -> IO ()) -> Spec
+forEechKnownNetwork msg action =
   forM_ (enumFromTo minBound maxBound) $ \network ->
     it (msg <> " (" <> show network <> ")") $ action network

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -3,7 +3,7 @@
 { hydraProject # as defined in default.nix
 , system ? builtins.currentSystem
 , pkgs
-, cardano-node
+, inputs
 , gitRev ? "unknown"
 }:
 let
@@ -132,9 +132,10 @@ rec {
         [
           nativePkgs.hydra-cluster.components.tests.tests
           hydra-node
-          cardano-node.packages.${system}.cardano-node
-          cardano-node.packages.${system}.cardano-cli
           hydra-chain-observer
+          inputs.cardano-node.packages.${system}.cardano-node
+          inputs.cardano-node.packages.${system}.cardano-cli
+          inputs.mithril.packages.${system}.mithril-client-cli
           pkgs.check-jsonschema
         ];
     };
@@ -144,7 +145,7 @@ rec {
         [
           nativePkgs.hydra-tui.components.tests.tests
           hydra-node
-          cardano-node.packages.${system}.cardano-node
+          inputs.cardano-node.packages.${system}.cardano-node
         ];
     };
   };
@@ -163,8 +164,8 @@ rec {
         [
           nativePkgs.hydra-cluster.components.benchmarks.bench-e2e
           hydra-node
-          cardano-node.packages.${system}.cardano-node
-          cardano-node.packages.${system}.cardano-cli
+          inputs.cardano-node.packages.${system}.cardano-node
+          inputs.cardano-node.packages.${system}.cardano-cli
         ];
     };
     plutus-merkle-tree = pkgs.mkShellNoCC {

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -6,7 +6,7 @@
   # Used in CI to have a smaller closure
   withoutDevTools ? false
 , hydraProject
-, cardano-node
+, inputs
 , system ? builtins.currentSystem
 }:
 let
@@ -49,7 +49,11 @@ let
     # For plotting results of hydra-cluster benchmarks
     pkgs.gnuplot
     # For integration tests
-    cardano-node.packages.${system}.cardano-node
+    inputs.cardano-node.packages.${system}.cardano-node
+    # To interact with cardano-node and integration tests
+    inputs.cardano-node.packages.${system}.cardano-cli
+    # To interact with mithril and integration tests
+    inputs.mithril.packages.${system}.mithril-client-cli
   ];
 
   devInputs = if withoutDevTools then [ ] else [
@@ -66,8 +70,6 @@ let
     # For docs/ (i.e. Docusaurus, Node.js & React)
     pkgs.yarn
     pkgs.nodejs
-    # To interact with cardano-node and testing out things
-    cardano-node.packages.${system}.cardano-cli
   ];
 
   haskellNixShell = hsPkgs.shellFor {
@@ -117,15 +119,17 @@ let
     STACK_IN_NIX_SHELL = "true";
   };
 
-  # A shell which does provide hydra-node and hydra-cluster executables.
+  # A shell which does provide hydra-node and hydra-cluster executables along
+  # with cardano-node, cardano-cli and mithril-client.
   exeShell = pkgs.mkShell {
     name = "hydra-node-exe-shell";
 
     buildInputs = [
       hsPkgs.hydra-node.components.exes.hydra-node
       hsPkgs.hydra-cluster.components.exes.hydra-cluster
-      cardano-node.packages.${system}.cardano-node
-      cardano-node.packages.${system}.cardano-cli
+      inputs.cardano-node.packages.${system}.cardano-node
+      inputs.cardano-node.packages.${system}.cardano-cli
+      inputs.mithril.packages.${system}.mithril-client-cli
     ];
   };
 
@@ -136,8 +140,8 @@ let
       hsPkgs.hydra-node.components.exes.hydra-node
       hsPkgs.hydra-tui.components.exes.hydra-tui
       run-tmux
-      cardano-node.packages.${system}.cardano-node
-      cardano-node.packages.${system}.cardano-cli
+      inputs.cardano-node.packages.${system}.cardano-node
+      inputs.cardano-node.packages.${system}.cardano-cli
     ];
   };
 


### PR DESCRIPTION
* Adds `--use-mithril` to `hydra-cluster` which makes it use `mithril-client` to download the cardano network state before starting `cardano-node`.

* Adds `mithril-client` to our development and CI shells.

* Adds integration tests to ensure that `mithril-client` is invoked correctly on all known networks.

A mithril-bootstrapped smoke test run on preview is here: https://github.com/input-output-hk/hydra/actions/runs/7540117340/job/20524247050

Not in scope / moved to red bin:

* Connection to cardano-node sometimes fails (too early?) https://github.com/input-output-hk/hydra/actions/runs/7541070906/job/20527001929

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
