### PR TITLE
Add IPC server to hydra-chain-observer

### DIFF
--- a/hydra-chain-observer/hydra-chain-observer.cabal
+++ b/hydra-chain-observer/hydra-chain-observer.cabal
@@ -64,12 +64,17 @@ library
   hs-source-dirs:  src
   ghc-options:     -haddock
   build-depends:
+    , aeson
+    , base
     , hydra-cardano-api
     , hydra-node
     , hydra-plutus
     , hydra-prelude
+    , io-classes
+    , network
     , optparse-applicative
     , ouroboros-network-protocols
+    , text
 
   exposed-modules:
     Hydra.ChainObserver

--- a/hydra-chain-observer/src/Hydra/ChainObserver.hs
+++ b/hydra-chain-observer/src/Hydra/ChainObserver.hs
@@ -4,6 +4,10 @@ module Hydra.ChainObserver where
 
 import Hydra.Prelude
 
+import Control.Concurrent (forkFinally)
+import Control.Exception ()
+import Data.Aeson qualified as Aeson
+import Data.Text qualified as Text
 import Hydra.Cardano.Api (
   Block (..),
   BlockInMode (..),
@@ -21,6 +25,7 @@ import Hydra.Cardano.Api (
   SocketPath,
   Tx,
   UTxO,
+  chainTipToChainPoint,
   connectToLocalNode,
   getTxBody,
   getTxId,
@@ -44,6 +49,22 @@ import Hydra.Contract qualified as Contract
 import Hydra.HeadId (HeadId (..))
 import Hydra.Ledger.Cardano (adjustUTxO)
 import Hydra.Logging (Tracer, Verbosity (..), traceWith, withTracer)
+import Hydra.Network (Host (..), PortNumber)
+import Hydra.Node.EventQueue (EventQueue (..), Queued (..), createEventQueue)
+import Network.Socket (
+  AddrInfo (..),
+  SocketType (..),
+  accept,
+  bind,
+  close,
+  defaultHints,
+  defaultProtocol,
+  getAddrInfo,
+  listen,
+  socket,
+  socketToHandle,
+  withSocketsDo,
+ )
 import Options.Applicative (execParser)
 import Ouroboros.Network.Protocol.ChainSync.Client (
   ChainSyncClient (..),
@@ -51,10 +72,53 @@ import Ouroboros.Network.Protocol.ChainSync.Client (
   ClientStIntersect (..),
   ClientStNext (..),
  )
+import System.IO (hClose, hPutStrLn)
+
+runIPCServer :: Tracer IO ChainObserverLog -> Host -> EventQueue IO HeadObservation -> IO ()
+runIPCServer tracer host@Host{hostname, port} eq = withSocketsDo $ do
+  bracket
+    openTCPListener
+    close
+    ( \sock -> do
+        traceWith tracer (ServerStarted port)
+        forever $ do
+          (conn, _) <- accept sock
+          -- XXX: Fork a new thread to handle the new accepted connection
+          forkFinally
+            (handleClient conn)
+            ( \_ -> do
+                close conn
+                close sock
+            )
+    )
+ where
+  openTCPListener = do
+    is <- getAddrInfo (Just defaultHints) (Just $ toString hostname) (Just $ show port)
+    sockAddr <- case is of
+      (inf : _) -> pure inf
+      _ -> die "getAdrrInfo failed"
+    sock <- socket (addrFamily sockAddr) Stream defaultProtocol
+    traceWith tracer $ ConnectingTo host
+    bind sock (addrAddress sockAddr)
+    traceWith tracer $ ConnectedTo host
+    listen sock 5
+    return sock
+
+  handleClient conn = do
+    hdl <- socketToHandle conn ReadWriteMode
+    hSetBuffering hdl LineBuffering
+    traceWith tracer NewClientConnection
+    pushObservation hdl `finally` hClose hdl
+
+  pushObservation hdl = forever $ do
+    Queued{queuedEvent} <- nextEvent eq
+    hPutStrLn hdl (prettyJSONString $ toJSON queuedEvent)
+
+  prettyJSONString = Text.unpack . Text.strip . decodeUtf8 . Aeson.encode
 
 main :: IO ()
 main = do
-  Options{networkId, nodeSocket, startChainFrom} <- execParser hydraChainObserverOptions
+  Options{networkId, nodeSocket, host, port, startChainFrom} <- execParser hydraChainObserverOptions
   withTracer (Verbose "hydra-chain-observer") $ \tracer -> do
     traceWith tracer KnownScripts{scriptInfo = Contract.scriptInfo}
     traceWith tracer ConnectingToNode{nodeSocket, networkId}
@@ -62,9 +126,18 @@ main = do
       Nothing -> queryTip networkId nodeSocket
       Just x -> pure x
     traceWith tracer StartObservingFrom{chainPoint}
-    connectToLocalNode
-      (connectInfo nodeSocket networkId)
-      (clientProtocols tracer networkId chainPoint)
+    eq@EventQueue{putEvent} <- createEventQueue
+    race
+      ( runIPCServer tracer Host{hostname = show host, port} eq
+          `catch` \(e :: SomeException) -> die $ displayException e
+      )
+      ( connectToLocalNode
+          (connectInfo nodeSocket networkId)
+          (clientProtocols tracer networkId chainPoint putEvent)
+      )
+      >>= \case
+        Left{} -> error "Something went wrong: "
+        Right a -> pure a
 
 type ChainObserverLog :: Type
 data ChainObserverLog
@@ -79,9 +152,14 @@ data ChainObserverLog
   | HeadAbortTx {headId :: HeadId}
   | HeadContestTx {headId :: HeadId}
   | Rollback {point :: ChainPoint}
-  | RollForward {receivedTxIds :: [TxId]}
+  | RollForward {point :: ChainPoint, receivedTxIds :: [TxId]}
+  | ServerStarted {listeningPort :: PortNumber}
+  | -- FIXME: export Log module from hydra-net and use AddrInfo instead of Host
+    ConnectingTo {address :: Host}
+  | ConnectedTo {address :: Host}
+  | NewClientConnection
   deriving stock (Eq, Show, Generic)
-  deriving anyclass (ToJSON)
+  deriving anyclass (ToJSON, FromJSON)
 
 type BlockType :: Type
 type BlockType = BlockInMode CardanoMode
@@ -101,10 +179,11 @@ clientProtocols ::
   Tracer IO ChainObserverLog ->
   NetworkId ->
   ChainPoint ->
+  (HeadObservation -> IO ()) ->
   LocalNodeClientProtocols BlockType ChainPoint ChainTip slot tx txid txerr query IO
-clientProtocols tracer networkId startingPoint =
+clientProtocols tracer networkId startingPoint observerHandle =
   LocalNodeClientProtocols
-    { localChainSyncClient = LocalChainSyncClient $ chainSyncClient tracer networkId startingPoint
+    { localChainSyncClient = LocalChainSyncClient $ chainSyncClient tracer networkId startingPoint observerHandle
     , localTxSubmissionClient = Nothing
     , localStateQueryClient = Nothing
     , localTxMonitoringClient = Nothing
@@ -128,8 +207,9 @@ chainSyncClient ::
   Tracer m ChainObserverLog ->
   NetworkId ->
   ChainPoint ->
+  (HeadObservation -> m ()) ->
   ChainSyncClient BlockType ChainPoint ChainTip m ()
-chainSyncClient tracer networkId startingPoint =
+chainSyncClient tracer networkId startingPoint observerHandle =
   ChainSyncClient $
     pure $
       SendMsgFindIntersect [startingPoint] clientStIntersect
@@ -143,18 +223,23 @@ chainSyncClient tracer networkId startingPoint =
           ChainSyncClient $ throwIO (IntersectionNotFound startingPoint)
       }
 
-  clientStIdle :: UTxO -> ClientStIdle BlockType ChainPoint tip m ()
+  clientStIdle :: UTxO -> ClientStIdle BlockType ChainPoint ChainTip m ()
   clientStIdle utxo = SendMsgRequestNext (clientStNext utxo) (pure $ clientStNext utxo)
 
-  clientStNext :: UTxO -> ClientStNext BlockType ChainPoint tip m ()
+  clientStNext :: UTxO -> ClientStNext BlockType ChainPoint ChainTip m ()
   clientStNext utxo =
     ClientStNext
-      { recvMsgRollForward = \blockInMode _tip -> ChainSyncClient $ do
+      { recvMsgRollForward = \blockInMode tip -> ChainSyncClient $ do
           case blockInMode of
             BlockInMode _ (Block _header txs) BabbageEraInCardanoMode -> do
-              traceWith tracer RollForward{receivedTxIds = getTxId . getTxBody <$> txs}
-              let (utxo', logs) = observeAll networkId utxo txs
-              forM_ logs (traceWith tracer)
+              let point = chainTipToChainPoint tip
+              let receivedTxIds = getTxId . getTxBody <$> txs
+              traceWith tracer RollForward{point, receivedTxIds}
+              let (utxo', observations) = observeAll networkId utxo txs
+              -- FIXME we should be exposing OnChainTx instead of working around NoHeadTx.
+              forM_ observations $ \observation -> do
+                maybe (pure ()) (traceWith tracer) . logObservation $ observation
+                observerHandle observation
               pure $ clientStIdle utxo'
             _ -> pure $ clientStIdle utxo
       , recvMsgRollBackward = \point _tip -> ChainSyncClient $ do
@@ -162,25 +247,32 @@ chainSyncClient tracer networkId startingPoint =
           pure $ clientStIdle utxo
       }
 
-observeTx :: NetworkId -> UTxO -> Tx -> (UTxO, Maybe ChainObserverLog)
+logObservation ::
+  HeadObservation ->
+  Maybe ChainObserverLog
+logObservation = \case
+  NoHeadTx -> Nothing
+  Init InitObservation{headId} -> pure $ HeadInitTx{headId}
+  Commit CommitObservation{headId} -> pure $ HeadCommitTx{headId}
+  CollectCom CollectComObservation{headId} -> pure $ HeadCollectComTx{headId}
+  Close CloseObservation{headId} -> pure $ HeadCloseTx{headId}
+  Fanout FanoutObservation{headId} -> pure $ HeadFanoutTx{headId}
+  Abort AbortObservation{headId} -> pure $ HeadAbortTx{headId}
+  Contest ContestObservation{headId} -> pure $ HeadContestTx{headId}
+
+observeTx :: NetworkId -> UTxO -> Tx -> (UTxO, Maybe HeadObservation)
 observeTx networkId utxo tx =
   let utxo' = adjustUTxO tx utxo
    in case observeHeadTx networkId utxo tx of
         NoHeadTx -> (utxo, Nothing)
-        Init InitObservation{headId} -> (utxo', pure $ HeadInitTx{headId})
-        Commit CommitObservation{headId} -> (utxo', pure $ HeadCommitTx{headId})
-        CollectCom CollectComObservation{headId} -> (utxo', pure $ HeadCollectComTx{headId})
-        Close CloseObservation{headId} -> (utxo', pure $ HeadCloseTx{headId})
-        Fanout FanoutObservation{headId} -> (utxo', pure $ HeadFanoutTx{headId})
-        Abort AbortObservation{headId} -> (utxo', pure $ HeadAbortTx{headId})
-        Contest ContestObservation{headId} -> (utxo', pure $ HeadContestTx{headId})
+        observation -> (utxo', pure observation)
 
-observeAll :: NetworkId -> UTxO -> [Tx] -> (UTxO, [ChainObserverLog])
+observeAll :: NetworkId -> UTxO -> [Tx] -> (UTxO, [HeadObservation])
 observeAll networkId utxo txs =
   second reverse $ foldr go (utxo, []) txs
  where
-  go :: Tx -> (UTxO, [ChainObserverLog]) -> (UTxO, [ChainObserverLog])
-  go tx (utxo'', logs) =
+  go :: Tx -> (UTxO, [HeadObservation]) -> (UTxO, [HeadObservation])
+  go tx (utxo'', observations) =
     case observeTx networkId utxo'' tx of
-      (utxo', Nothing) -> (utxo', logs)
-      (utxo', Just logEntry) -> (utxo', logEntry : logs)
+      (utxo', Nothing) -> (utxo', observations)
+      (utxo', Just observation) -> (utxo', observation : observations)

--- a/hydra-chain-observer/src/Hydra/ChainObserver/Options.hs
+++ b/hydra-chain-observer/src/Hydra/ChainObserver/Options.hs
@@ -2,10 +2,14 @@ module Hydra.ChainObserver.Options where
 
 import Hydra.Prelude
 
+import Hydra.Network (IP, PortNumber)
+
 import Hydra.Cardano.Api (ChainPoint, NetworkId, SocketPath)
 import Hydra.Options (
+  hostParser,
   networkIdParser,
   nodeSocketParser,
+  portParser,
   startChainFromParser,
  )
 import Options.Applicative (Parser, ParserInfo, fullDesc, header, helper, info, progDesc)
@@ -14,6 +18,8 @@ type Options :: Type
 data Options = Options
   { networkId :: NetworkId
   , nodeSocket :: SocketPath
+  , host :: IP
+  , port :: PortNumber
   , startChainFrom :: Maybe ChainPoint
   -- ^ Point at which to start following the chain.
   }
@@ -24,6 +30,8 @@ optionsParser =
   Options
     <$> networkIdParser
     <*> nodeSocketParser
+    <*> hostParser
+    <*> portParser
     <*> optional startChainFromParser
 
 hydraChainObserverOptions :: ParserInfo Options

--- a/hydra-chain-observer/test/Hydra/ChainObserverSpec.hs
+++ b/hydra-chain-observer/test/Hydra/ChainObserverSpec.hs
@@ -6,7 +6,8 @@ import Test.Hydra.Prelude
 import Hydra.Chain.Direct.Fixture (testNetworkId)
 import Hydra.Chain.Direct.State (HasKnownUTxO (getKnownUTxO), genChainStateWithTx)
 import Hydra.Chain.Direct.State qualified as Transition
-import Hydra.ChainObserver (ChainObserverLog (..), observeAll, observeTx)
+import Hydra.Chain.Direct.Tx (HeadObservation (..))
+import Hydra.ChainObserver (observeAll, observeTx)
 import Hydra.Ledger.Cardano (genSequenceOfSimplePaymentTransactions)
 import Test.QuickCheck (counterexample, forAll, forAllBlind, property, (=/=), (===))
 import Test.QuickCheck.Property (checkCoverage)
@@ -21,13 +22,13 @@ spec =
             counterexample (show transition) $
               let utxo = getKnownUTxO st
                in case snd $ observeTx testNetworkId utxo tx of
-                    Just (HeadInitTx{}) -> transition === Transition.Init
-                    Just (HeadCommitTx{}) -> transition === Transition.Commit
-                    Just (HeadCollectComTx{}) -> transition === Transition.Collect
-                    Just (HeadAbortTx{}) -> transition === Transition.Abort
-                    Just (HeadCloseTx{}) -> transition === Transition.Close
-                    Just (HeadContestTx{}) -> transition === Transition.Contest
-                    Just (HeadFanoutTx{}) -> transition === Transition.Fanout
+                    Just (Init{}) -> transition === Transition.Init
+                    Just (Abort{}) -> transition === Transition.Abort
+                    Just (Commit{}) -> transition === Transition.Commit
+                    Just (CollectCom{}) -> transition === Transition.Collect
+                    Just (Close{}) -> transition === Transition.Close
+                    Just (Contest{}) -> transition === Transition.Contest
+                    Just (Fanout{}) -> transition === Transition.Fanout
                     _ -> property False
 
     prop "Updates UTxO state given transaction part of Head lifecycle" $

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -174,6 +174,7 @@ test-suite tests
     , io-classes
     , lens
     , lens-aeson
+    , network
     , process
     , QuickCheck
     , stm

--- a/hydra-cluster/test/Test/ChainObserverSpec.hs
+++ b/hydra-cluster/test/Test/ChainObserverSpec.hs
@@ -23,9 +23,23 @@ import Hydra.Cluster.Faucet (FaucetLog, publishHydraScriptsAs, seedFromFaucet_)
 import Hydra.Cluster.Fixture (Actor (..), aliceSk, cperiod)
 import Hydra.Cluster.Util (chainConfigFor, keysFor)
 import Hydra.Logging (showLogsOnFailure)
+import Hydra.Network (Host (..))
 import HydraNode (HydraNodeLog, input, output, requestCommitTx, send, waitFor, waitMatch, withHydraNode)
+import Network.Socket (
+  AddrInfo (..),
+  SocketType (..),
+  close,
+  connect,
+  defaultHints,
+  defaultProtocol,
+  getAddrInfo,
+  socket,
+  socketToHandle,
+  withSocketsDo,
+ )
+import System.IO (hClose)
 import System.IO.Error (isEOFError, isIllegalOperation)
-import System.Process (CreateProcess (std_out), StdStream (..), proc, withCreateProcess)
+import System.Process (proc, withCreateProcess)
 
 spec :: Spec
 spec = do
@@ -41,7 +55,7 @@ spec = do
             (aliceCardanoVk, _aliceCardanoSk) <- keysFor Alice
             aliceChainConfig <- chainConfigFor Alice tmpDir nodeSocket hydraScriptsTxId [] cperiod
             withHydraNode hydraTracer aliceChainConfig tmpDir 1 aliceSk [] [1] $ \hydraNode -> do
-              withChainObserver cardanoNode $ \observer -> do
+              withChainObserver cardanoNode Host{hostname = "127.0.0.1", port = 8888} $ \observer -> do
                 seedFromFaucet_ cardanoNode aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
 
                 send hydraNode $ input "Init" []
@@ -50,35 +64,35 @@ spec = do
                   guard $ v ^? key "tag" == Just "HeadIsInitializing"
                   v ^? key "headId" . _String
 
-                chainObserverSees observer "HeadInitTx" headId
+                chainObserverSees observer "Init" headId
 
                 requestCommitTx hydraNode mempty >>= submitTx cardanoNode
                 waitFor hydraTracer 5 [hydraNode] $
                   output "HeadIsOpen" ["utxo" .= object mempty, "headId" .= headId]
 
-                chainObserverSees observer "HeadCommitTx" headId
-                chainObserverSees observer "HeadCollectComTx" headId
+                chainObserverSees observer "Commit" headId
+                chainObserverSees observer "CollectCom" headId
 
                 send hydraNode $ input "Close" []
 
-                chainObserverSees observer "HeadCloseTx" headId
+                chainObserverSees observer "Close" headId
 
                 waitFor hydraTracer 50 [hydraNode] $
                   output "ReadyToFanout" ["headId" .= headId]
 
                 send hydraNode $ input "Fanout" []
 
-                chainObserverSees observer "HeadFanoutTx" headId
+                chainObserverSees observer "Fanout" headId
 
 chainObserverSees :: HasCallStack => ChainObserverHandle -> Value -> Text -> IO ()
 chainObserverSees observer txType headId =
   awaitMatch observer 5 $ \v -> do
-    guard $ v ^? key "message" . key "tag" == Just txType
-    let actualId = v ^? key "message" . key "headId" . _String
+    guard $ v ^? key "tag" == Just txType
+    let actualId = v ^? key "contents" . key "headId" . _String
     guard $ actualId == Just headId
 
 awaitMatch :: HasCallStack => ChainObserverHandle -> DiffTime -> (Aeson.Value -> Maybe a) -> IO a
-awaitMatch chainObserverHandle delay f = do
+awaitMatch ChainObserverHandle{hdl} delay f = do
   seenMsgs <- newTVarIO []
   timeout delay (go seenMsgs) >>= \case
     Just x -> pure x
@@ -92,38 +106,6 @@ awaitMatch chainObserverHandle delay f = do
                 <> unlines (align 20 (decodeUtf8 . Aeson.encode <$> msgs))
             ]
  where
-  go seenMsgs = do
-    msg <- awaitNext chainObserverHandle
-    atomically (modifyTVar' seenMsgs (msg :))
-    maybe (go seenMsgs) pure (f msg)
-
-  align _ [] = []
-  align n (h : q) = h : fmap (T.replicate n " " <>) q
-
-newtype ChainObserverHandle = ChainObserverHandle {awaitNext :: IO Value}
-
-data ChainObserverLog
-  = FromCardanoNode NodeLog
-  | FromHydraNode HydraNodeLog
-  | FromFaucet FaucetLog
-  deriving (Eq, Show, Generic)
-  deriving anyclass (ToJSON)
-
--- | Starts a 'hydra-chain-observer' on some Cardano network.
-withChainObserver :: RunningNode -> (ChainObserverHandle -> IO ()) -> IO ()
-withChainObserver cardanoNode action =
-  -- XXX: If this throws an IOException, 'withFile' invocations around mislead
-  -- to the file path opened (e.g. the cardano-node log file) in the test
-  -- failure output. Print the exception here to have some debuggability at
-  -- least.
-  handle (\(e :: IOException) -> print e >> throwIO e) $
-    withCreateProcess process{std_out = CreatePipe} $ \_in (Just out) _err _ph ->
-      action
-        ChainObserverHandle
-          { awaitNext = awaitNext out
-          }
- where
-  awaitNext :: Handle -> IO Aeson.Value
   awaitNext out = do
     x <- try (hGetLine out)
     case x of
@@ -139,10 +121,73 @@ withChainObserver cardanoNode action =
             awaitNext out
           Right value -> pure value
 
+  go seenMsgs = do
+    msg <- awaitNext hdl
+    atomically (modifyTVar' seenMsgs (msg :))
+    maybe (go seenMsgs) pure (f msg)
+
+  align _ [] = []
+  align n (h : q) = h : fmap (T.replicate n " " <>) q
+
+newtype ChainObserverHandle = ChainObserverHandle {hdl :: Handle}
+
+data ChainObserverLog
+  = FromCardanoNode NodeLog
+  | FromHydraNode HydraNodeLog
+  | FromFaucet FaucetLog
+  | ConnectedToObserver
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON)
+
+-- | Starts a 'hydra-chain-observer' on some Cardano network.
+withChainObserver :: RunningNode -> Host -> (ChainObserverHandle -> IO ()) -> IO ()
+withChainObserver cardanoNode Host{hostname, port} action =
+  handle (\(e :: IOException) -> print e >> throwIO e) $
+    withCreateProcess process $ \_in _out err ph ->
+      race
+        (checkProcessHasNotDied "hydra-chain-observer" ph err)
+        withConnectionToObserver
+        <&> either absurd id
+ where
+  withConnectionToObserver = do
+    connectedOnce <- newIORef False
+    tryConnect connectedOnce (200 :: Int)
+
+  tryConnect connectedOnce n
+    | n == 0 = failure "Timed out waiting for connection to hydra-chain-observer"
+    | otherwise =
+        doConnect connectedOnce `catch` \(e :: IOException) -> do
+          putStrLn $ "Error while establishing connection to hydra-chain-observer: " <> displayException e
+          readIORef connectedOnce >>= \case
+            False -> threadDelay 0.1 >> tryConnect connectedOnce (n - 1)
+            True -> throwIO e
+
+  doConnect connectedOnce =
+    withSocketsDo $ bracket openConnection closeConnection $ \(_socket, hdl) -> do
+      atomicWriteIORef connectedOnce True
+      action ChainObserverHandle{hdl}
+
+  openConnection = do
+    is <- getAddrInfo (Just defaultHints) (Just $ toString hostname) (Just $ show port)
+    sockAddr <- case is of
+      (inf : _) -> pure inf
+      _ -> die "getAdrrInfo failed"
+    sock <- socket (addrFamily sockAddr) Stream defaultProtocol
+    connect sock (addrAddress sockAddr)
+    hdl <- socketToHandle sock ReadWriteMode
+    hSetBuffering hdl LineBuffering
+    return (sock, hdl)
+
+  closeConnection (sock, hdl) = do
+    hClose hdl
+    close sock
+
   process =
     proc
       "hydra-chain-observer"
       $ ["--node-socket", unFile nodeSocket]
+        <> ["--host", toString hostname]
+        <> ["--port", show port]
         <> case networkId of
           Mainnet -> ["--mainnet"]
           Testnet (NetworkMagic magic) -> ["--testnet-magic", show magic]

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -645,7 +645,8 @@ data HeadObservation
   | Close CloseObservation
   | Contest ContestObservation
   | Fanout FanoutObservation
-  deriving (Eq, Show)
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
 
 -- | Observe any Hydra head transaction.
 observeHeadTx :: NetworkId -> UTxO -> Tx -> HeadObservation
@@ -673,7 +674,8 @@ data InitObservation = InitObservation
   , -- XXX: Improve naming
     participants :: [OnChainId]
   }
-  deriving stock (Show, Eq)
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
 
 data NotAnInitReason
   = NoHeadOutput
@@ -762,7 +764,8 @@ data CommitObservation = CommitObservation
   , committed :: UTxO
   , headId :: HeadId
   }
-  deriving (Eq, Show)
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
 
 -- | Identify a commit tx by:
 --
@@ -833,7 +836,8 @@ data CollectComObservation = CollectComObservation
   , headId :: HeadId
   , utxoHash :: UTxOHash
   }
-  deriving stock (Show, Eq)
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
 
 -- | Identify a collectCom tx by lookup up the input spending the Head output
 -- and decoding its redeemer.
@@ -878,7 +882,8 @@ data CloseObservation = CloseObservation
   , headId :: HeadId
   , snapshotNumber :: SnapshotNumber
   }
-  deriving stock (Show, Eq)
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
 
 -- | Identify a close tx by lookup up the input spending the Head output and
 -- decoding its redeemer.
@@ -923,7 +928,8 @@ data ContestObservation = ContestObservation
   , snapshotNumber :: SnapshotNumber
   , contesters :: [Plutus.PubKeyHash]
   }
-  deriving stock (Show, Eq)
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
 
 -- | Identify a close tx by lookup up the input spending the Head output and
 -- decoding its redeemer.
@@ -960,7 +966,9 @@ observeContestTx utxo tx = do
       Just Head.Closed{snapshotNumber} -> snapshotNumber
       _ -> error "wrong state in output datum"
 
-newtype FanoutObservation = FanoutObservation {headId :: HeadId} deriving (Eq, Show)
+newtype FanoutObservation = FanoutObservation {headId :: HeadId}
+  deriving stock (Eq, Show, Generic)
+  deriving newtype (ToJSON, FromJSON)
 
 -- | Identify a fanout tx by lookup up the input spending the Head output and
 -- decoding its redeemer.
@@ -980,7 +988,9 @@ observeFanoutTx utxo tx = do
  where
   headScript = fromPlutusScript Head.validatorScript
 
-newtype AbortObservation = AbortObservation {headId :: HeadId} deriving (Eq, Show)
+newtype AbortObservation = AbortObservation {headId :: HeadId}
+  deriving stock (Eq, Show, Generic)
+  deriving newtype (ToJSON, FromJSON)
 
 -- | Identify an abort tx by looking up the input spending the Head output and
 -- decoding its redeemer.

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -968,7 +968,7 @@ observeContestTx utxo tx = do
 
 newtype FanoutObservation = FanoutObservation {headId :: HeadId}
   deriving stock (Eq, Show, Generic)
-  deriving newtype (ToJSON, FromJSON)
+  deriving anyclass (ToJSON, FromJSON)
 
 -- | Identify a fanout tx by lookup up the input spending the Head output and
 -- decoding its redeemer.
@@ -990,7 +990,7 @@ observeFanoutTx utxo tx = do
 
 newtype AbortObservation = AbortObservation {headId :: HeadId}
   deriving stock (Eq, Show, Generic)
-  deriving newtype (ToJSON, FromJSON)
+  deriving anyclass (ToJSON, FromJSON)
 
 -- | Identify an abort tx by looking up the input spending the Head output and
 -- decoding its redeemer.

--- a/hydra-plutus/src/Hydra/Contract.hs
+++ b/hydra-plutus/src/Hydra/Contract.hs
@@ -32,7 +32,7 @@ data ScriptInfo = ScriptInfo
   , headScriptSize :: Int64
   }
   deriving stock (Eq, Show, Generic)
-  deriving anyclass (ToJSON)
+  deriving anyclass (ToJSON, FromJSON)
 
 -- | Gather 'ScriptInfo' from the current Hydra scripts. This is useful to
 -- determine changes in between version of 'hydra-plutus'.


### PR DESCRIPTION
<!-- Describe your change here -->

🥥 Add ipc server to hydra-chain-observer for clients to connect and start receiving head observations.

🥥 Updated e2e tests to rely on client connection instead of stdout.

🥥 Add json instances to head observations.

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [X] Documentation updated or not needed
* [X] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
