### PR TITLE
Use cardano-node 8.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ changes.
 
 ## [0.15.0] - UNRELEASED
 
+- Tested against `cardano-node 8.7.3` and `cardano-cli 8.17.0.0`.
+
 - Hydra Direct Chain layer does not maintain state and does not make any logic
   decisions. This is now completely responsibility of the HydraLogic layer.
   Posting transactions from this layer is now free of any knowledge of L1 keys.

--- a/demo/docker-compose.yaml
+++ b/demo/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   cardano-node:
-    image: ghcr.io/input-output-hk/cardano-node:8.7.2
+    image: ghcr.io/input-output-hk/cardano-node:8.7.3
     volumes:
       - ./devnet:/devnet
     environment:

--- a/docs/docs/tutorial/index.md
+++ b/docs/docs/tutorial/index.md
@@ -44,8 +44,8 @@ mkdir -p bin
 version=0.14.0
 curl -L -O https://github.com/input-output-hk/hydra/releases/download/${version}/hydra-x86_64-linux-${version}.zip
 unzip -d bin hydra-x86_64-linux-${version}.zip
-curl -L -o - https://github.com/input-output-hk/hydra/releases/download/${version}/cardano-node-x86_64-linux-8.7.2.zip
-unzip -d bin cardano-node-8.7.2-linux.zip
+curl -L -o - https://github.com/input-output-hk/cardano-node/releases/download/8.7.3/cardano-node-8.7.3-linux.tar.gz \
+  | tar xz -C bin ./cardano-node ./cardano-cli
 curl -L -o - https://github.com/input-output-hk/mithril/releases/download/2347.0/mithril-2347.0-linux-x64.tar.gz \
   | tar xz -C bin mithril-client
 chmod +x bin/*
@@ -59,10 +59,10 @@ mkdir -p bin
 version=0.14.0
 curl -L -O https://github.com/input-output-hk/hydra/releases/download/${version}/hydra-aarch64-darwin-${version}.zip
 unzip -d bin hydra-aarch64-darwin-${version}.zip
-curl -L -o - https://github.com/input-output-hk/hydra/releases/download/${version}/cardano-node-aarch-darwin-8.7.2.zip
-unzip -d bin cardano-node-8.7.2-linux.zip
-curl -L -o - https://github.com/input-output-hk/mithril/releases/download/2347.0/mithril-2347.0-macos-x64.tar.gz \
-  | tar xz -C bin
+curl -L -o - https://github.com/input-output-hk/hydra/releases/download/${version}/cardano-node-aarch-darwin-8.7.3.zip
+unzip -d bin cardano-node-8.7.3-linux.zip
+curl -L -o - https://github.com/input-output-hk/cardano-node/releases/download/8.7.3/cardano-node-8.7.3-macos.tar.gz \
+  | tar xz -C bin --wildcards ./cardano-node ./cardano-cli '*.dylib'
 chmod +x bin/*
 ```
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     "CHaP_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1701964264,
-        "narHash": "sha256-sOs8bLbMvtIBQLywB3AM6wcpHr5JUmHJyDhtBmRkHBI=",
+        "lastModified": 1702593630,
+        "narHash": "sha256-IWu27+sfPtazjIZiWLUm8G4BKvjXmIL+/1XT/ETnfhg=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "b3ccccc588891d765bd68cd2fc1110844a3bef35",
+        "rev": "9783a177efcea5beb8808aab7513098bdab185ba",
         "type": "github"
       },
       "original": {
@@ -305,16 +305,16 @@
         "utils": "utils_2"
       },
       "locked": {
-        "lastModified": 1702024268,
-        "narHash": "sha256-DSvhXbm75rXMLgRCg/CLLeDFa6JbcCLTLJZoH/VY0MY=",
-        "owner": "input-output-hk",
+        "lastModified": 1702654749,
+        "narHash": "sha256-fIzSNSKWC7qMRjHUMHfrMnEzHiFu7ac/UUgfofXqaFY=",
+        "owner": "intersectmbo",
         "repo": "cardano-node",
-        "rev": "30b6e447c7e4586f43e30a68fe47c8481b0ba205",
+        "rev": "a4a8119b59b1fbb9a69c79e1e6900e91292161e7",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
-        "ref": "8.7.2",
+        "owner": "intersectmbo",
+        "ref": "8.7.3",
         "repo": "cardano-node",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
       url = "github:input-output-hk/cardano-haskell-packages?ref=repo";
       flake = false;
     };
-    cardano-node.url = "github:input-output-hk/cardano-node/8.7.2";
+    cardano-node.url = "github:intersectmbo/cardano-node/8.7.3";
     mithril.url = "github:input-output-hk/mithril/2347.0";
   };
 

--- a/hydra-cluster/test/Test/CardanoNodeSpec.hs
+++ b/hydra-cluster/test/Test/CardanoNodeSpec.hs
@@ -22,7 +22,7 @@ spec = do
   -- false positives test errors in case someone uses an "untested" /
   -- different than in shell.nix version of cardano-node and cardano-cli.
   it "has expected cardano-node version available" $
-    getCardanoNodeVersion >>= (`shouldContain` "8.7.2")
+    getCardanoNodeVersion >>= (`shouldContain` "8.7.3")
 
   it "withCardanoNodeDevnet does start a block-producing devnet within 5 seconds" $
     failAfter 5 $

--- a/sample-node-config/aws/docker/docker-compose.yaml
+++ b/sample-node-config/aws/docker/docker-compose.yaml
@@ -4,7 +4,7 @@ version: "3.9"
 
 services:
   cardano-node:
-    image: inputoutput/cardano-node:8.7.2
+    image: inputoutput/cardano-node:8.7.3
     restart: always
     logging:
       driver: "awslogs"


### PR DESCRIPTION
:sparkles: Update to using the latest (recommended) `cardano-node` version `8.7.3`

:sparkles: Update instructions for downloading binaries from upstream (again).

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
