### PR TITLE
Always download config files when running hydra-cluster on known networks

### DIFF
--- a/hydra-cluster/src/CardanoNode.hs
+++ b/hydra-cluster/src/CardanoNode.hs
@@ -171,11 +171,10 @@ withCardanoNodeOnKnownNetwork tracer workDir knownNetwork action = do
       , "alonzo-genesis.json"
       , "conway-genesis.json"
       ]
-      $ \fn ->
-        unlessM (doesFileExist $ workDir </> fn) $ do
-          createDirectoryIfMissing True $ workDir </> takeDirectory fn
-          fetchConfigFile (knownNetworkPath </> fn)
-            >>= writeFileBS (workDir </> fn)
+      $ \fn -> do
+        createDirectoryIfMissing True $ workDir </> takeDirectory fn
+        fetchConfigFile (knownNetworkPath </> fn)
+          >>= writeFileBS (workDir </> fn)
 
   knownNetworkPath =
     knownNetworkConfigBaseURL </> knownNetworkName


### PR DESCRIPTION
This ensures that we use the latest configuration for public testnets (and mainnet), which is especially important in the run-up to hard-fork events where genesis files or new cardano-node config options are introduced.

<!-- Describe your change here -->
Fixes #1259

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
