### PR TITLE
Run smoke tests on running node

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -40,11 +40,6 @@ jobs:
         extra_nix_config: |
           accept-flake-config = true
 
-    - name: 🧹 Delete cardano-node db (when using mithril)
-      if: ${{ inputs.use-mithril }}
-      run: |
-        rm -rf ${state_dir}/db
-
     - name: 🧹 Cleanup hydra-node state
       run: |
         rm -rf ${state_dir}/state-*

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -117,6 +117,8 @@ executable hydra-cluster
   main-is:            Main.hs
   ghc-options:        -threaded -rtsopts
   build-depends:
+    , directory
+    , filepath
     , hydra-cluster
     , hydra-node
     , hydra-prelude

--- a/hydra-cluster/src/CardanoClient.hs
+++ b/hydra-cluster/src/CardanoClient.hs
@@ -167,3 +167,4 @@ data RunningNode = RunningNode
   , blockTime :: NominalDiffTime
   -- ^ Expected time between blocks (varies a lot on testnets)
   }
+  deriving (Show, Eq)

--- a/hydra-cluster/src/Hydra/Cluster/Fixture.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Fixture.hs
@@ -66,3 +66,10 @@ data KnownNetwork
   | Sanchonet
   deriving stock (Generic, Show, Eq, Enum, Bounded)
   deriving anyclass (ToJSON, FromJSON)
+
+toNetworkId :: KnownNetwork -> NetworkId
+toNetworkId = \case
+  Mainnet -> Api.Mainnet
+  Preproduction -> Api.Testnet (Api.NetworkMagic 1)
+  Preview -> Api.Testnet (Api.NetworkMagic 2)
+  Sanchonet -> Api.Testnet (Api.NetworkMagic 4)


### PR DESCRIPTION
<!-- Describe your change here -->
## Why
We want to host a hydra-explorer on the same runner used to perform our smoke-tests.

Currently the smoke-tests clean-up the cardano-node/db dir when the mithril flag is being used.

For that reason we need to remove this logic from the CI so that running the smoke-tests does not affect the new hosted explorer.

## What
This PR attempts to adress these concerns by allowing the smoke-tests to:
+ run on an existing running cardano-node instance
+ or to spin-up a new cardano-node instance if there is none.

---

<!-- Consider each and tick it off one way or the other -->
* [X] CHANGELOG updated or not needed
* [X] Documentation updated or not needed
* [X] Haddocks updated or not needed
* [X] No new TODOs introduced or explained herafter
