### PR TITLE
smoke-test: add sanchonet

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -11,6 +11,7 @@ on:
         - preview
         - preprod
         - mainnet
+        - sanchonet
 
       hydra-scripts-tx-id:
         description: "TxId of already published scripts (leave empty to publish)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ changes.
 
 - Provide more details about why a command failed. Added the state of the head logic at the point of failure.
 
+- Add `--sanchonet` option to `hydra-cluster` binary.
+
 ## [0.15.0] - 2024-01-18
 
 - Tested with `cardano-node 8.7.3` and `cardano-cli 8.17.0.0`.

--- a/hydra-cluster/src/CardanoNode.hs
+++ b/hydra-cluster/src/CardanoNode.hs
@@ -187,6 +187,7 @@ withCardanoNodeOnKnownNetwork tracer workDir knownNetwork action = do
     Preview -> "preview"
     Preproduction -> "preprod"
     Mainnet -> "mainnet"
+    Sanchonet -> "sanchonet"
 
   fetchConfigFile path =
     parseRequestThrow path >>= httpBS <&> getResponseBody

--- a/hydra-cluster/src/Hydra/Cluster/Fixture.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Fixture.hs
@@ -63,5 +63,6 @@ data KnownNetwork
   = Preview
   | Preproduction
   | Mainnet
+  | Sanchonet
   deriving stock (Generic, Show, Eq, Enum, Bounded)
   deriving anyclass (ToJSON, FromJSON)

--- a/hydra-cluster/src/Hydra/Cluster/Options.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Options.hs
@@ -33,6 +33,7 @@ parseOptions =
     flag' (Just Preview) (long "preview" <> help "The preview testnet")
       <|> flag' (Just Preproduction) (long "preprod" <> help "The pre-production testnet")
       <|> flag' (Just Mainnet) (long "mainnet" <> help "The mainnet")
+      <|> flag' (Just Sanchonet) (long "sanchonet" <> help "The sanchonet preview testnet")
       <|> flag'
         Nothing
         ( long "devnet"


### PR DESCRIPTION
Add sanchonet to the list of smoke-test configurations
Add `--sanchonet` to hydra-cluster binary.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
