### PR TITLE
Retry websocket client connection in hydra-node

### DIFF
--- a/hydra-node/src/Hydra/API/WSServer.hs
+++ b/hydra-node/src/Hydra/API/WSServer.hs
@@ -59,10 +59,6 @@ wsApp ::
   PendingConnection ->
   IO ()
 wsApp party tracer history callback headStatusP snapshotUtxoP responseChannel pending = do
-  -- XXX: Moving this here improved on flakyness of tests (which would see a
-  -- 'HandshakeException'). This indicates that there might be a race
-  -- condition between notifyingServerRunning and clients starting and
-  -- handshaking on connections still?
   traceWith tracer NewAPIConnection
   let path = requestPath $ pendingRequest pending
   queryParams <- uriQuery <$> mkURIBs path


### PR DESCRIPTION
Some of the ServerSpec tests were flaky on our CI and failed with:

```
  test/Hydra/API/ServerSpec.hs:152:5:
  1) Hydra.API.Server.ServerSpec echoes history (past outputs) to client upon reconnection
       uncaught exception: ConnectionException
       ParseException "string"
       (after 89 tests)
```

However, it is not trivial to test websocket connections without real sockets and this commit tries to make the test harness more robust in connecting to the server (in case it's just a race condition).

The fact that upstream 'websockets' tests are even ["waiting some"](https://github.com/jaspervdj/websockets/blob/2474e53f920181d9f3c4c305bf2ab8237167b4b2/tests/haskell/Network/WebSockets/Server/Tests.hs#L147) in their tests, retrying for some time should be fine in our tests.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
