### PR TITLE
Prepare hydra-explorer docker image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -18,7 +18,7 @@ jobs:
   docker:
     strategy:
       matrix:
-        target: [ hydra-node, hydra-tui, hydraw ]
+        target: [ hydra-node, hydra-tui, hydraw, hydra-explorer ]
 
     runs-on: ubuntu-latest
     steps:

--- a/nix/hydra/docker.nix
+++ b/nix/hydra/docker.nix
@@ -27,6 +27,15 @@ in
     };
   };
 
+  hydra-explorer = pkgs.dockerTools.buildImage {
+    name = "hydra-explorer";
+    tag = "latest";
+    created = "now";
+    config = {
+      Entrypoint = [ "${hydraPackages.hydra-explorer-static}/bin/hydra-explorer" ];
+    };
+  };
+
   hydraw = pkgs.dockerTools.buildImage {
     name = "hydraw";
     tag = "latest";


### PR DESCRIPTION
## Why
We want to build a ci/cd pipeline for the hydra-explorer package.

For that we decided to use docker over systemd processes and other approaches.

So we need to be able to build and publish a docker image of the explorer on release.

## What
This PR attempts to adress this problem by adding the explorer as part of our released artifacts.

Disclaimer: this is a temp solution until we move the project into its separate repo. 

<!-- Consider each and tick it off one way or the other -->
* [X] CHANGELOG updated or not needed
* [X] Documentation updated or not needed
* [X] Haddocks updated or not needed
* [X] No new TODOs introduced or explained herafter
