### PR TITLE
Work around an issue in HLS 2.6

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1072,6 +1072,23 @@
         "type": "github"
       }
     },
+    "hls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1707224159,
+        "narHash": "sha256-1quJwNdQGL/pSk0tYZ/p8ye50HN4ClWlrFf2FWnt0wA=",
+        "owner": "cardano-scaling",
+        "repo": "haskell-language-server",
+        "rev": "1170a7c3134fe7591c3e890e23521fe838ac2abe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cardano-scaling",
+        "ref": "2.6-patched",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-1.10": {
       "flake": false,
       "locked": {
@@ -2531,6 +2548,7 @@
         "cardano-node": "cardano-node",
         "flake-utils": "flake-utils_7",
         "haskellNix": "haskellNix_2",
+        "hls": "hls",
         "iohk-nix": "iohk-nix",
         "mithril": "mithril",
         "nixpkgs": [

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,12 @@
       url = "github:input-output-hk/cardano-haskell-packages?ref=repo";
       flake = false;
     };
+    # Use a patched 2.6.0.0 as we are also affected by
+    # https://github.com/haskell/haskell-language-server/issues/4046
+    hls = {
+      url = "github:cardano-scaling/haskell-language-server?ref=2.6-patched";
+      flake = false;
+    };
     cardano-node.url = "github:intersectmbo/cardano-node/8.7.3";
     mithril.url = "github:input-output-hk/mithril/2347.0";
   };

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -14,10 +14,10 @@ let
 
   cabal = pkgs.haskell-nix.cabal-install.${compiler};
 
+  # Build HLS form our fork (see flake.nix)
   haskell-language-server = pkgs.haskell-nix.tool compiler "haskell-language-server" rec {
-    src = pkgs.haskell-nix.sources."hls-2.6";
+    src = inputs.hls;
     cabalProject = builtins.readFile (src + "/cabal.project");
-    sha256map."https://github.com/pepeiborra/ekg-json"."7a0af7a8fd38045fd15fb13445bdcc7085325460" = "sha256-fVwKxGgM0S4Kv/4egVAAiAjV7QB5PBqMVMCfsv7otIQ=";
   };
 
   libs = [
@@ -57,7 +57,7 @@ let
   ];
 
   devInputs = if withoutDevTools then [ ] else [
-    # Essenetial for a good IDE
+    # Essential for a good IDE
     haskell-language-server
     # The interactive Glasgow Haskell Compiler as a Daemon
     pkgs.haskellPackages.ghcid


### PR DESCRIPTION
We are affected by
https://github.com/haskell/haskell-language-server/issues/4046 and this makes hls 2.6.0.0 not block on our codebase.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
