### PR TITLE
Build the explorer with threaded ghc options

### DIFF
--- a/hydra-explorer/hydra-explorer.cabal
+++ b/hydra-explorer/hydra-explorer.cabal
@@ -40,6 +40,7 @@ common project-config
 
 library
   import:          project-config
+  ghc-options:     -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs:  src
   ghc-options:     -haddock
   build-depends:


### PR DESCRIPTION
<!-- Describe your change here -->

## Why
The explorer crashes when running aside a cardano-node with the following error message:
```
hydra-explorer: file descriptor 55523160 out of range for select (0--1024).
Recompile with -threaded to work around this.
```
We expect the explorer to remain alive and continue to follow the network.

## What
Build hydra-explorer with threaded ghc options.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
