### PR TITLE
Make hydra-explorer configurable

### DIFF
--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -49,6 +49,7 @@ jobs:
       if: ${{ matrix.package != 'hydra-tui' }}
       run: |
         cd ${{ matrix.package }}
+        nix build .#tests.${{ matrix.package }}
         nix develop .#tests.${{ matrix.package }} --command tests
 
     - name: ❓ Test (TUI)
@@ -61,6 +62,7 @@ jobs:
         TERM: "xterm"
       run: |
         cd ${{ matrix.package  }}
+        nix build .#tests.${{ matrix.package }}
         nix develop .#tests.${{ matrix.package }} --build
 
     - name: 💾 Upload build & test artifacts
@@ -168,6 +170,7 @@ jobs:
       run: |
         mkdir -p benchmarks
         cd ${{ matrix.package }}
+        nix build .#benchs.${{ matrix.package }}
         nix develop .#benchs.${{ matrix.package }} --command ${{ matrix.bench }} ${{ matrix.options }}
 
     - name: 💾 Upload build & test artifacts

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -173,6 +173,7 @@ test-suite tests
     , http-conduit
     , hydra-cardano-api
     , hydra-cluster
+    , hydra-explorer
     , hydra-node:{hydra-node, testlib}
     , hydra-prelude
     , hydra-test-utils

--- a/hydra-cluster/test/Test/HydraExplorerSpec.hs
+++ b/hydra-cluster/test/Test/HydraExplorerSpec.hs
@@ -17,7 +17,6 @@ import Hydra.Cluster.Faucet (FaucetLog, publishHydraScriptsAs, seedFromFaucet_)
 import Hydra.Cluster.Fixture (Actor (..), aliceSk, bobSk, cperiod)
 import Hydra.Cluster.Util (chainConfigFor, keysFor)
 import Hydra.Logging (showLogsOnFailure)
-import Hydra.Network (Host (..))
 import Hydra.Options qualified as Options
 import HydraNode (HydraNodeLog, input, send, waitMatch, withHydraNode)
 import Network.HTTP.Client (responseBody)
@@ -130,7 +129,7 @@ withHydraExplorer cardanoNode mStartChainFrom action =
       "hydra-explorer"
       $ Options.toArgNodeSocket nodeSocket
         <> Options.toArgNetworkId networkId
-        <> Options.toArgPeer Host{hostname = "0.0.0.0", port = 9090}
+        <> Options.toArgApiPort 9090
         <> Options.toArgStartChainFrom mStartChainFrom
 
   RunningNode{nodeSocket, networkId} = cardanoNode

--- a/hydra-cluster/test/Test/HydraExplorerSpec.hs
+++ b/hydra-cluster/test/Test/HydraExplorerSpec.hs
@@ -16,6 +16,7 @@ import Hydra.Cardano.Api (ChainPoint (..))
 import Hydra.Cluster.Faucet (FaucetLog, publishHydraScriptsAs, seedFromFaucet_)
 import Hydra.Cluster.Fixture (Actor (..), aliceSk, bobSk, cperiod)
 import Hydra.Cluster.Util (chainConfigFor, keysFor)
+import Hydra.Explorer.Options (toArgStartChainFrom)
 import Hydra.Logging (showLogsOnFailure)
 import Hydra.Options qualified as Options
 import HydraNode (HydraNodeLog, input, send, waitMatch, withHydraNode)
@@ -49,7 +50,7 @@ spec = do
             seedFromFaucet_ cardanoNode bobCardanoVk 25_000_000 (contramap FromFaucet tracer)
             bobHeadId <- withHydraNode hydraTracer bobChainConfig tmpDir 2 bobSk [] [2] initHead
 
-            withHydraExplorer cardanoNode Nothing $ \explorer -> do
+            withHydraExplorer cardanoNode (Just ChainPointAtGenesis) $ \explorer -> do
               allHeads <- getHeads explorer
               length (allHeads ^. _Array) `shouldBe` 2
               allHeads ^. nth 0 . key "headId" . _String `shouldBe` aliceHeadId
@@ -130,6 +131,6 @@ withHydraExplorer cardanoNode mStartChainFrom action =
       $ Options.toArgNodeSocket nodeSocket
         <> Options.toArgNetworkId networkId
         <> Options.toArgApiPort 9090
-        <> Options.toArgStartChainFrom mStartChainFrom
+        <> toArgStartChainFrom mStartChainFrom
 
   RunningNode{nodeSocket, networkId} = cardanoNode

--- a/hydra-cluster/test/Test/HydraExplorerSpec.hs
+++ b/hydra-cluster/test/Test/HydraExplorerSpec.hs
@@ -12,11 +12,13 @@ import CardanoNode (NodeLog, withCardanoNodeDevnet)
 import Control.Lens ((^.), (^?))
 import Data.Aeson as Aeson
 import Data.Aeson.Lens (key, nth, _Array, _String)
-import Hydra.Cardano.Api (NetworkId (..), NetworkMagic (..), unFile)
+import Hydra.Cardano.Api (ChainPoint (..))
 import Hydra.Cluster.Faucet (FaucetLog, publishHydraScriptsAs, seedFromFaucet_)
 import Hydra.Cluster.Fixture (Actor (..), aliceSk, bobSk, cperiod)
 import Hydra.Cluster.Util (chainConfigFor, keysFor)
 import Hydra.Logging (showLogsOnFailure)
+import Hydra.Network (Host (..))
+import Hydra.Options qualified as Options
 import HydraNode (HydraNodeLog, input, send, waitMatch, withHydraNode)
 import Network.HTTP.Client (responseBody)
 import Network.HTTP.Simple (httpJSON, parseRequestThrow)
@@ -48,7 +50,7 @@ spec = do
             seedFromFaucet_ cardanoNode bobCardanoVk 25_000_000 (contramap FromFaucet tracer)
             bobHeadId <- withHydraNode hydraTracer bobChainConfig tmpDir 2 bobSk [] [2] initHead
 
-            withHydraExplorer cardanoNode $ \explorer -> do
+            withHydraExplorer cardanoNode Nothing $ \explorer -> do
               allHeads <- getHeads explorer
               length (allHeads ^. _Array) `shouldBe` 2
               allHeads ^. nth 0 . key "headId" . _String `shouldBe` aliceHeadId
@@ -63,7 +65,7 @@ spec = do
           withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \cardanoNode@RunningNode{nodeSocket} -> do
             let hydraTracer = contramap FromHydraNode tracer
             hydraScriptsTxId <- publishHydraScriptsAs cardanoNode Faucet
-            withHydraExplorer cardanoNode $ \explorer -> do
+            withHydraExplorer cardanoNode Nothing $ \explorer -> do
               (aliceCardanoVk, _aliceCardanoSk) <- keysFor Alice
               aliceChainConfig <- chainConfigFor Alice tmpDir nodeSocket hydraScriptsTxId [] cperiod
               seedFromFaucet_ cardanoNode aliceCardanoVk 25_000_000 (contramap FromFaucet tracer)
@@ -109,8 +111,8 @@ data HydraExplorerLog
   deriving anyclass (ToJSON)
 
 -- | Starts a 'hydra-explorer' on some Cardano network.
-withHydraExplorer :: RunningNode -> (HydraExplorerHandle -> IO ()) -> IO ()
-withHydraExplorer cardanoNode action =
+withHydraExplorer :: RunningNode -> Maybe ChainPoint -> (HydraExplorerHandle -> IO ()) -> IO ()
+withHydraExplorer cardanoNode mStartChainFrom action =
   withCreateProcess process{std_out = CreatePipe, std_err = CreatePipe} $
     \_in _stdOut err processHandle ->
       race
@@ -126,9 +128,9 @@ withHydraExplorer cardanoNode action =
   process =
     proc
       "hydra-explorer"
-      $ ["--node-socket", unFile nodeSocket]
-        <> case networkId of
-          Mainnet -> ["--mainnet"]
-          Testnet (NetworkMagic magic) -> ["--testnet-magic", show magic]
+      $ Options.toArgNodeSocket nodeSocket
+        <> Options.toArgNetworkId networkId
+        <> Options.toArgPeer Host{hostname = "0.0.0.0", port = 9090}
+        <> Options.toArgStartChainFrom mStartChainFrom
 
   RunningNode{nodeSocket, networkId} = cardanoNode

--- a/hydra-explorer/hydra-explorer.cabal
+++ b/hydra-explorer/hydra-explorer.cabal
@@ -50,6 +50,7 @@ library
     , hydra-node
     , hydra-prelude
     , io-classes
+    , optparse-applicative
     , servant
     , servant-server
     , wai
@@ -58,6 +59,7 @@ library
   exposed-modules:
     Hydra.Explorer
     Hydra.Explorer.ExplorerState
+    Hydra.Explorer.Options
 
 executable hydra-explorer
   import:         project-config

--- a/hydra-explorer/src/Hydra/Explorer.hs
+++ b/hydra-explorer/src/Hydra/Explorer.hs
@@ -7,7 +7,7 @@ import Control.Concurrent.Class.MonadSTM (modifyTVar', newTVarIO, readTVarIO)
 import Hydra.API.APIServerLog (APIServerLog (..), Method (..), PathInfo (..))
 import Hydra.Chain.Direct.Tx (HeadObservation)
 import Hydra.Explorer.ExplorerState (ExplorerState, HeadState, aggregateHeadObservations)
-import Hydra.Explorer.Options (Options (..), hydraExplorerOptions)
+import Hydra.Explorer.Options (Options (..), hydraExplorerOptions, toArgStartChainFrom)
 import Hydra.Logging (Tracer, Verbosity (..), traceWith, withTracer)
 import Hydra.Options qualified as Options
 import Network.Wai (Middleware, Request (..))
@@ -96,7 +96,7 @@ main = do
         chainObserverArgs =
           Options.toArgNodeSocket nodeSocket
             <> Options.toArgNetworkId networkId
-            <> Options.toArgStartChainFrom startChainFrom
+            <> toArgStartChainFrom startChainFrom
     race
       ( withArgs chainObserverArgs $
           Hydra.ChainObserver.main (observerHandler explorerState)

--- a/hydra-explorer/src/Hydra/Explorer.hs
+++ b/hydra-explorer/src/Hydra/Explorer.hs
@@ -97,16 +97,13 @@ main = do
           Options.toArgNodeSocket nodeSocket
             <> Options.toArgNetworkId networkId
             <> toArgStartChainFrom startChainFrom
-    race
+    race_
       ( withArgs chainObserverArgs $
           Hydra.ChainObserver.main (observerHandler explorerState)
       )
       ( traceWith tracer (APIServerStarted port)
           *> Warp.runSettings (settings tracer port) (httpApp tracer getHeads)
       )
-      >>= \case
-        Left{} -> error "Something went wrong"
-        Right a -> pure a
  where
   settings tracer port =
     Warp.defaultSettings

--- a/hydra-explorer/src/Hydra/Explorer/Options.hs
+++ b/hydra-explorer/src/Hydra/Explorer/Options.hs
@@ -1,0 +1,41 @@
+module Hydra.Explorer.Options where
+
+import Hydra.Prelude
+
+import Hydra.Cardano.Api (ChainPoint (..), NetworkId, SocketPath)
+import Hydra.Network (Host)
+import Hydra.Options (
+  networkIdParser,
+  nodeSocketParser,
+  peerParser,
+  startChainFromParser,
+ )
+import Options.Applicative (Parser, ParserInfo, fullDesc, header, helper, info, progDesc)
+
+type Options :: Type
+data Options = Options
+  { networkId :: NetworkId
+  , host :: Host
+  , nodeSocket :: SocketPath
+  , startChainFrom :: Maybe ChainPoint
+  }
+  deriving stock (Show, Eq)
+
+optionsParser :: Parser Options
+optionsParser =
+  Options
+    <$> networkIdParser
+    <*> peerParser
+    <*> nodeSocketParser
+    <*> optional startChainFromParser
+
+hydraExplorerOptions :: ParserInfo Options
+hydraExplorerOptions =
+  info
+    ( optionsParser
+        <**> helper
+    )
+    ( fullDesc
+        <> progDesc "Explore hydra heads from chain."
+        <> header "hydra-explorer"
+    )

--- a/hydra-explorer/src/Hydra/Explorer/Options.hs
+++ b/hydra-explorer/src/Hydra/Explorer/Options.hs
@@ -3,11 +3,11 @@ module Hydra.Explorer.Options where
 import Hydra.Prelude
 
 import Hydra.Cardano.Api (ChainPoint (..), NetworkId, SocketPath)
-import Hydra.Network (Host)
+import Hydra.Network (PortNumber)
 import Hydra.Options (
+  apiPortParser,
   networkIdParser,
   nodeSocketParser,
-  peerParser,
   startChainFromParser,
  )
 import Options.Applicative (Parser, ParserInfo, fullDesc, header, helper, info, progDesc)
@@ -15,7 +15,7 @@ import Options.Applicative (Parser, ParserInfo, fullDesc, header, helper, info, 
 type Options :: Type
 data Options = Options
   { networkId :: NetworkId
-  , host :: Host
+  , port :: PortNumber
   , nodeSocket :: SocketPath
   , startChainFrom :: Maybe ChainPoint
   }
@@ -25,7 +25,7 @@ optionsParser :: Parser Options
 optionsParser =
   Options
     <$> networkIdParser
-    <*> peerParser
+    <*> apiPortParser
     <*> nodeSocketParser
     <*> optional startChainFromParser
 

--- a/hydra-explorer/src/Hydra/Explorer/Options.hs
+++ b/hydra-explorer/src/Hydra/Explorer/Options.hs
@@ -2,7 +2,7 @@ module Hydra.Explorer.Options where
 
 import Hydra.Prelude
 
-import Hydra.Cardano.Api (ChainPoint (..), NetworkId, SocketPath)
+import Hydra.Cardano.Api (ChainPoint (..), NetworkId, SlotNo (..), SocketPath, serialiseToRawBytesHexText)
 import Hydra.Network (PortNumber)
 import Hydra.Options (
   apiPortParser,
@@ -39,3 +39,13 @@ hydraExplorerOptions =
         <> progDesc "Explore hydra heads from chain."
         <> header "hydra-explorer"
     )
+
+toArgStartChainFrom :: Maybe ChainPoint -> [String]
+toArgStartChainFrom = \case
+  Just ChainPointAtGenesis ->
+    ["--start-chain-from", "0"]
+  Just (ChainPoint (SlotNo slotNo) headerHash) ->
+    let headerHashBase16 = toString (serialiseToRawBytesHexText headerHash)
+     in ["--start-chain-from", show slotNo <> "." <> headerHashBase16]
+  Nothing ->
+    []

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -820,6 +820,15 @@ toArgs
     toArgPeer p =
       ["--peer", show p]
 
+    toArgStartChainFrom = \case
+      Just ChainPointAtGenesis ->
+        error "ChainPointAtGenesis"
+      Just (ChainPoint (SlotNo slotNo) headerHash) ->
+        let headerHashBase16 = toString (serialiseToRawBytesHexText headerHash)
+         in ["--start-chain-from", show slotNo <> "." <> headerHashBase16]
+      Nothing ->
+        []
+
     argsChainConfig = \case
       Offline
         OfflineChainConfig
@@ -860,16 +869,6 @@ toArgNodeSocket nodeSocket = ["--node-socket", unFile nodeSocket]
 
 toArgApiPort :: PortNumber -> [String]
 toArgApiPort apiPort = ["--api-port", show apiPort]
-
-toArgStartChainFrom :: Maybe ChainPoint -> [String]
-toArgStartChainFrom = \case
-  Just ChainPointAtGenesis ->
-    error "ChainPointAtGenesis"
-  Just (ChainPoint (SlotNo slotNo) headerHash) ->
-    let headerHashBase16 = toString (serialiseToRawBytesHexText headerHash)
-     in ["--start-chain-from", show slotNo <> "." <> headerHashBase16]
-  Nothing ->
-    []
 
 toArgNetworkId :: NetworkId -> [String]
 toArgNetworkId = \case

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -817,18 +817,6 @@ toArgs
       Quiet -> ["--quiet"]
       _ -> []
 
-    toArgPeer p =
-      ["--peer", show p]
-
-    toArgStartChainFrom = \case
-      Just ChainPointAtGenesis ->
-        error "ChainPointAtGenesis"
-      Just (ChainPoint (SlotNo slotNo) headerHash) ->
-        let headerHashBase16 = toString (serialiseToRawBytesHexText headerHash)
-         in ["--start-chain-from", show slotNo <> "." <> headerHashBase16]
-      Nothing ->
-        []
-
     argsChainConfig = \case
       Offline
         OfflineChainConfig
@@ -850,7 +838,7 @@ toArgs
           , contestationPeriod
           } ->
           toArgNetworkId networkId
-            <> ["--node-socket", unFile nodeSocket]
+            <> toArgNodeSocket nodeSocket
             <> ["--hydra-scripts-tx-id", toString $ serialiseToRawBytesHexText hydraScriptsTxId]
             <> ["--cardano-signing-key", cardanoSigningKey]
             <> ["--contestation-period", show contestationPeriod]
@@ -863,6 +851,22 @@ toArgs
     CardanoLedgerConfig
       { cardanoLedgerProtocolParametersFile
       } = ledgerConfig
+
+toArgNodeSocket :: SocketPath -> [String]
+toArgNodeSocket nodeSocket = ["--node-socket", unFile nodeSocket]
+
+toArgPeer :: Host -> [String]
+toArgPeer p = ["--peer", show p]
+
+toArgStartChainFrom :: Maybe ChainPoint -> [String]
+toArgStartChainFrom = \case
+  Just ChainPointAtGenesis ->
+    error "ChainPointAtGenesis"
+  Just (ChainPoint (SlotNo slotNo) headerHash) ->
+    let headerHashBase16 = toString (serialiseToRawBytesHexText headerHash)
+     in ["--start-chain-from", show slotNo <> "." <> headerHashBase16]
+  Nothing ->
+    []
 
 toArgNetworkId :: NetworkId -> [String]
 toArgNetworkId = \case

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -803,7 +803,7 @@ toArgs
       <> ["--host", show host]
       <> ["--port", show port]
       <> ["--api-host", show apiHost]
-      <> ["--api-port", show apiPort]
+      <> toArgApiPort apiPort
       <> ["--hydra-signing-key", hydraSigningKey]
       <> concatMap (\vk -> ["--hydra-verification-key", vk]) hydraVerificationKeys
       <> concatMap toArgPeer peers
@@ -816,6 +816,9 @@ toArgs
     isVerbose = \case
       Quiet -> ["--quiet"]
       _ -> []
+
+    toArgPeer p =
+      ["--peer", show p]
 
     argsChainConfig = \case
       Offline
@@ -855,8 +858,8 @@ toArgs
 toArgNodeSocket :: SocketPath -> [String]
 toArgNodeSocket nodeSocket = ["--node-socket", unFile nodeSocket]
 
-toArgPeer :: Host -> [String]
-toArgPeer p = ["--peer", show p]
+toArgApiPort :: PortNumber -> [String]
+toArgApiPort apiPort = ["--api-port", show apiPort]
 
 toArgStartChainFrom :: Maybe ChainPoint -> [String]
 toArgStartChainFrom = \case


### PR DESCRIPTION
<!-- Describe your change here -->

## Why
Soon we are going to host the hydra-explorer and want it to be listening on port 80.
Because in other environments port 80 might not be available, we need to make the explorer configurable.

## What
This PR aims to address the above.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
