### PR TITLE
Add Close, Fanout and RollbackAndForward to our MBT

### DIFF
--- a/hydra-node/src/Hydra/Chain/Direct/TimeHandle.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/TimeHandle.hs
@@ -70,20 +70,6 @@ instance Arbitrary TimeHandle where
     TimeHandleParams{systemStart, eraHistory, currentSlot} <- genTimeParams
     pure $ mkTimeHandle currentSlot systemStart eraHistory
 
--- | Construct fixed 'TimeHandle' that starts from 0 and has the era horizon far in the future.
--- This is used in our 'Model' tests and we want to make sure the tests finish before
--- the horizon is reached to prevent the 'PastHorizon' exceptions.
-fixedTimeHandleWithinHorizon :: Gen TimeHandle
-fixedTimeHandleWithinHorizon = do
-  let startSeconds = 0
-  let startTime = posixSecondsToUTCTime $ secondsToNominalDiffTime startSeconds
-  uptimeSeconds <- getPositive <$> arbitrary
-  let currentSlotNo = SlotNo $ truncate $ uptimeSeconds + startSeconds
-      -- NOTE: we use the larger number for k here to have the era horizon far
-      -- in the future
-      safeZone = 3 * 216000 / 0.05
-      horizonSlot = SlotNo $ truncate $ uptimeSeconds + safeZone
-  pure $ mkTimeHandle currentSlotNo (SystemStart startTime) (eraHistoryWithHorizonAt horizonSlot)
 
 -- | Construct a time handle using current slot and given chain parameters. See
 -- 'queryTimeHandle' to create one by querying a cardano-node.

--- a/hydra-node/src/Hydra/Chain/Direct/TimeHandle.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/TimeHandle.hs
@@ -70,6 +70,21 @@ instance Arbitrary TimeHandle where
     TimeHandleParams{systemStart, eraHistory, currentSlot} <- genTimeParams
     pure $ mkTimeHandle currentSlot systemStart eraHistory
 
+-- | Construct fixed 'TimeHandle' that starts from 0 and has the era horizon far in the future.
+-- This is used in our 'Model' tests and we want to make sure the tests finish before
+-- the horizon is reached to prevent the 'PastHorizon' exceptions.
+fixedTimeHandleWithinHorizon :: Gen TimeHandle
+fixedTimeHandleWithinHorizon = do
+  let startSeconds = 0
+  let startTime = posixSecondsToUTCTime $ secondsToNominalDiffTime startSeconds
+  uptimeSeconds <- getPositive <$> arbitrary
+  let currentSlotNo = SlotNo $ truncate $ uptimeSeconds + startSeconds
+      -- NOTE: we use the larger number for k here to have the era horizon far
+      -- in the future
+      safeZone = 3 * 216000 / 0.05
+      horizonSlot = SlotNo $ truncate $ uptimeSeconds + safeZone
+  pure $ mkTimeHandle currentSlotNo (SystemStart startTime) (eraHistoryWithHorizonAt horizonSlot)
+
 -- | Construct a time handle using current slot and given chain parameters. See
 -- 'queryTimeHandle' to create one by querying a cardano-node.
 mkTimeHandle ::

--- a/hydra-node/src/Hydra/Chain/Direct/TimeHandle.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/TimeHandle.hs
@@ -70,7 +70,6 @@ instance Arbitrary TimeHandle where
     TimeHandleParams{systemStart, eraHistory, currentSlot} <- genTimeParams
     pure $ mkTimeHandle currentSlot systemStart eraHistory
 
-
 -- | Construct a time handle using current slot and given chain parameters. See
 -- 'queryTimeHandle' to create one by querying a cardano-node.
 mkTimeHandle ::

--- a/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs
@@ -66,7 +66,7 @@ import Hydra.Ledger.Cardano.Time (slotNoFromUTCTime, slotNoToUTCTime)
 import Ouroboros.Consensus.Cardano.Block (CardanoEras)
 import Ouroboros.Consensus.HardFork.History (
   Bound (Bound, boundEpoch, boundSlot, boundTime),
-  EraEnd (EraEnd),
+  EraEnd (..),
   EraParams (..),
   EraSummary (..),
   SafeZone (..),
@@ -312,6 +312,28 @@ eraHistoryWithHorizonAt slotNo@(SlotNo n) =
                 , boundSlot = slotNo
                 , boundEpoch = EpochNo n
                 }
+        , eraParams
+        }
+
+  eraParams =
+    EraParams
+      { eraEpochSize = EpochSize 1
+      , eraSlotLength = mkSlotLength 1
+      , -- NOTE: unused if the 'eraEnd' is already defined, but would be used to
+        -- extend the last era accordingly in the real cardano-node
+        eraSafeZone = UnsafeIndefiniteSafeZone
+      }
+
+eraHistoryWithoutHorizon :: EraHistory
+eraHistoryWithoutHorizon  =
+  EraHistory (mkInterpreter summary)
+ where
+  summary :: Summary (CardanoEras StandardCrypto)
+  summary =
+    Summary . NonEmptyOne $
+      EraSummary
+        { eraStart = initBound
+        , eraEnd = EraUnbounded
         , eraParams
         }
 

--- a/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs
@@ -325,7 +325,7 @@ eraHistoryWithHorizonAt slotNo@(SlotNo n) =
       }
 
 eraHistoryWithoutHorizon :: EraHistory
-eraHistoryWithoutHorizon  =
+eraHistoryWithoutHorizon =
   EraHistory (mkInterpreter summary)
  where
   summary :: Summary (CardanoEras StandardCrypto)

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -495,11 +495,10 @@ instance
       Fanout{} ->
         case hydraState st of
           Final{finalUTxO} -> do
+            let sortByLovelace = sort . fmap (selectLovelace . txOutValue)
             decorateFailure st action (toTxOuts finalUTxO) (toList result)
-            let getLovelace = selectLovelace . foldMap txOutValue
-            -- TODO: Is it enough to just compare the values? Should we make
-            -- sure there is equal number of outputs and that we can actually
-            pure (getLovelace (toTxOuts finalUTxO) == getLovelace (toList result))
+            pure $
+              sortByLovelace (toTxOuts finalUTxO) == sortByLovelace (toList result)
           _ -> pure False
       _ -> pure True
 

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -779,7 +779,7 @@ performFanout party = do
   party `sendsInput` Input.Fanout
 
   lift $
-    waitUntilMatch [thisNode] $ \case
+    waitUntilMatch (toList nodes) $ \case
       HeadIsFinalized{} -> True
       err@CommandFailed{} -> error $ show err
       _ -> False

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -146,7 +146,7 @@ isPendingCommitFrom _ _ = False
 
 type Uncommitted = Map.Map Party (UTxOType Payment)
 
-data OffChainState = OffChainState {confirmedUTxO :: UTxOType Payment}
+newtype OffChainState = OffChainState {confirmedUTxO :: UTxOType Payment}
   deriving stock (Eq, Show)
 
 -- This is needed to be able to use `WorldState` inside DL formulae
@@ -687,8 +687,7 @@ performNewTx party tx = do
 waitForOpen :: MonadDelay m => TestHydraClient tx m -> RunMonad m ()
 waitForOpen node = do
   outs <- lift $ serverOutputs node
-  unless (any headIsOpen outs) $
-    waitAndRetry
+  unless (any headIsOpen outs) waitAndRetry
  where
   waitAndRetry = lift (threadDelay 0.1) >> waitForOpen node
 
@@ -697,8 +696,7 @@ waitForOpen node = do
 waitForClosed :: MonadDelay m => TestHydraClient tx m -> RunMonad m ()
 waitForClosed node = do
   outs <- lift $ serverOutputs node
-  unless (any headIsClosed outs) $
-    waitAndRetry
+  unless (any headIsClosed outs) waitAndRetry
  where
   waitAndRetry = lift (threadDelay 0.1) >> waitForClosed node
 

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -379,7 +379,7 @@ genToCommit (hk, ck) = do
 
 genContestationPeriod :: Gen ContestationPeriod
 genContestationPeriod = do
-  n <- choose (1, 10)
+  n <- choose (1, 200)
   pure $ UnsafeContestationPeriod $ wordToNatural n
 
 genInit :: [(SigningKey HydraKey, b)] -> Gen (Action WorldState ())

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -217,10 +217,7 @@ instance StateModel WorldState where
       Some . Fanout . deriveParty . fst <$> elements hydraParties
 
     genRollbackAndForward = do
-      -- TODO: investigate why choosing higher number of blocks e.g. (1, 5)
-      -- causes arithmetic underflow. Maybe we need a pointer to the current
-      -- block so we don't rollback past that one?
-      numberOfBlocks <- choose (1, 2)
+      numberOfBlocks <- choose (1, 10)
       pure . Some $ RollbackAndForward (wordToNatural numberOfBlocks)
 
   precondition WorldState{hydraState = Start} Seed{} =

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -492,10 +492,13 @@ instance
       Fanout{} ->
         case hydraState st of
           Final{finalUTxO} -> do
-            let sortByLovelace = sort . fmap (selectLovelace . txOutValue)
+            -- NOTE: Sort `[TxOut]` by the address and values. We want to make
+            -- sure that the fannout outputs match what we had in the open Head
+            -- exactly.
+            let sortByAddressAndValue = sortOn (\o -> (txOutAddress o, selectLovelace (txOutValue o)))
             decorateFailure st action (toTxOuts finalUTxO) (toList result)
             pure $
-              sortByLovelace (toTxOuts finalUTxO) == sortByLovelace (toList result)
+              sortByAddressAndValue (toTxOuts finalUTxO) == sortByAddressAndValue (toList result)
           _ -> pure False
       _ -> pure True
 

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -182,6 +182,7 @@ instance StateModel WorldState where
         frequency
           [ (5, genCommit pendingCommits)
           , (1, genAbort)
+          , (1, genRollbackAndForward)
           ]
       Open{} ->
         frequency
@@ -240,14 +241,8 @@ instance StateModel WorldState where
     True
   precondition WorldState{hydraState = Closed{}} (Fanout _) =
     True
-  precondition WorldState{hydraState} (RollbackAndForward _) =
-    case hydraState of
-      Open{} -> True
-      Closed{} -> True
-      Initial{} -> False
-      Idle{} -> False
-      Start{} -> False
-      Final{} -> False
+  precondition WorldState{} (RollbackAndForward _) =
+    True
   precondition _ StopTheWorld =
     True
   precondition _ _ =

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -251,6 +251,8 @@ instance StateModel WorldState where
     True
   precondition WorldState{hydraState = Closed{}} (Fanout _) =
     True
+  precondition WorldState{hydraState = Final{}} (CheckFanoutUTxO _ _) =
+    True
   precondition _ StopTheWorld =
     True
   precondition _ _ =
@@ -777,7 +779,7 @@ performFanout party = do
   party `sendsInput` Input.Fanout
 
   lift $
-    waitUntilMatch (toList nodes) $ \case
+    waitUntilMatch [thisNode] $ \case
       HeadIsFinalized{} -> True
       err@CommandFailed{} -> error $ show err
       _ -> False

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -187,10 +187,7 @@ mockChainAndNetwork tr seedKeys commits = do
   blockTime = 20
 
   simulateChain nodes chain queue =
-    forever $ do
-      rollForward nodes chain queue
-      rollForward nodes chain queue
-      rollbackAndForward nodes chain 2
+    forever $ rollForward nodes chain queue
 
   rollForward nodes chain queue = do
     threadDelay blockTime

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -42,7 +42,7 @@ import Hydra.Chain.Direct.Handlers (
  )
 import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry, registryUTxO)
 import Hydra.Chain.Direct.State (ChainContext (..), initialChainState)
-import Hydra.Chain.Direct.TimeHandle (TimeHandle)
+import Hydra.Chain.Direct.TimeHandle (TimeHandle, fixedTimeHandleWithinHorizon)
 import Hydra.Chain.Direct.Tx (verificationKeyToOnChainId)
 import Hydra.Chain.Direct.Wallet (TinyWallet (..))
 import Hydra.Crypto (HydraKey)
@@ -126,7 +126,7 @@ mockChainAndNetwork tr seedKeys commits = do
             , ownParty
             , scriptRegistry
             }
-    let getTimeHandle = pure $ arbitrary `generateWith` 42
+    let getTimeHandle = pure $ fixedTimeHandleWithinHorizon `generateWith` 42
     let HydraNode{eq = EventQueue{putEvent}} = node
     let
       -- NOTE: this very simple function put the transaction in a queue for

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -210,11 +210,9 @@ mockChainAndNetwork tr seedKeys commits = do
         pure ()
 
   rollbackAndForward nodes chain numberOfBlocks = do
-    (_, _, blocks, _) <- readTVarIO chain
-    when (fromIntegral numberOfBlocks < length blocks) $ do
-      doRollBackward nodes chain numberOfBlocks
-      replicateM_ (fromIntegral numberOfBlocks) $
-        doRollForward nodes chain
+    doRollBackward nodes chain numberOfBlocks
+    replicateM_ (fromIntegral numberOfBlocks) $
+      doRollForward nodes chain
 
   doRollBackward nodes chain nbBlocks = do
     (slotNum, position, blocks, _) <- readTVarIO chain

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -210,9 +210,11 @@ mockChainAndNetwork tr seedKeys commits = do
         pure ()
 
   rollbackAndForward nodes chain numberOfBlocks = do
-    doRollBackward nodes chain numberOfBlocks
-    replicateM_ (fromIntegral numberOfBlocks) $
-      doRollForward nodes chain
+    (_, _, blocks, _) <- readTVarIO chain
+    when (fromIntegral numberOfBlocks < length blocks) $ do
+      doRollBackward nodes chain numberOfBlocks
+      replicateM_ (fromIntegral numberOfBlocks) $
+        doRollForward nodes chain
 
   doRollBackward nodes chain nbBlocks = do
     (slotNum, position, blocks, _) <- readTVarIO chain

--- a/hydra-node/test/Hydra/ModelSpec.hs
+++ b/hydra-node/test/Hydra/ModelSpec.hs
@@ -144,6 +144,7 @@ import Hydra.Party (Party (..), deriveParty)
 import Test.QuickCheck (Property, Testable, counterexample, forAll, property, withMaxSuccess, within)
 import Test.QuickCheck.DynamicLogic (
   DL,
+  Quantification,
   action,
   anyActions_,
   forAllDL,
@@ -151,7 +152,7 @@ import Test.QuickCheck.DynamicLogic (
   forAllQ,
   getModelStateDL,
   whereQ,
-  withGenQ, Quantification,
+  withGenQ,
  )
 import Test.QuickCheck.Gen.Unsafe (Capture (Capture), capture)
 import Test.QuickCheck.Monadic (PropertyM, assert, monadic', monitor, run)
@@ -245,7 +246,6 @@ conflictFreeLiveness = do
       eventually (ObserveConfirmedTx tx)
     _ -> pure ()
   action_ Model.StopTheWorld
-
 
 prop_generateTraces :: Actions WorldState -> Property
 prop_generateTraces actions =
@@ -366,8 +366,8 @@ runIOSimProp p = do
 
 nonConflictingTx :: WorldState -> Quantification (Party, Payment.Payment)
 nonConflictingTx st =
-    withGenQ (genPayment st) (const [])
-      `whereQ` \(party, tx) -> precondition st (Model.NewTx party tx)
+  withGenQ (genPayment st) (const [])
+    `whereQ` \(party, tx) -> precondition st (Model.NewTx party tx)
 
 eventually :: Action WorldState () -> DL WorldState ()
 eventually a = action_ (Wait 10) >> action_ a

--- a/hydra-node/test/Hydra/ModelSpec.hs
+++ b/hydra-node/test/Hydra/ModelSpec.hs
@@ -165,7 +165,7 @@ import Test.QuickCheck.StateModel (
   stateAfter,
   pattern Actions,
  )
-import Test.Util (printTrace, traceInIOSim, traceDebug)
+import Test.Util (printTrace, traceInIOSim)
 
 spec :: Spec
 spec = do
@@ -192,10 +192,8 @@ fanoutContainsWholeConfirmedUTxO = do
       (party, payment) <- forAllNonVariableQ (nonConflictingTx st)
       tx <- action $ Model.NewTx party payment
       eventually (ObserveConfirmedTx tx)
-      confirmedUTxO <- action $ Model.GetConfirmedUTxO party
-      _ <- action $ Model.Close party
-      finalUTxO <- action $ Model.Fanout party
-      action_ $ Model.CheckFanoutUTxO confirmedUTxO finalUTxO
+      action_ $ Model.Close party
+      void $ action $ Model.Fanout party
     _ -> pure ()
   action_ Model.StopTheWorld
  where
@@ -377,7 +375,7 @@ runIOSimProp p = do
   nodes =
     Nodes
       { nodes = mempty
-      , logger = traceInIOSim <> traceDebug
+      , logger = traceInIOSim
       , threads = mempty
       , chain = dummySimulatedChainNetwork
       }

--- a/hydra-node/test/Hydra/ModelSpec.hs
+++ b/hydra-node/test/Hydra/ModelSpec.hs
@@ -194,6 +194,7 @@ fanoutContainsWholeConfirmedUTxO = do
       tx <- action $ Model.NewTx party payment
       eventually (ObserveConfirmedTx tx)
       action_ $ Model.Close party
+      -- NOTE: The check is actually in the Model postcondition for 'Fanout'
       void $ action $ Model.Fanout party
     _ -> pure ()
   action_ Model.StopTheWorld


### PR DESCRIPTION
In order to improve our MBT `Close`, `Fanout` and `RollbackAndForward` are added as the actions. Now the `MockChain` is only rolling forward and only rolls back when appropriate action is produced.

There is also new test case _fanout contains whole confirmed UTxO_ that should further assure us that the `Fanout` `UTxO` matches with whatever we transacted in the open `Head`.

NOTE:
Currently we are not able to compare equality between `Model` representation of the `UTxO` (`[(CardanoSigningKey, Value)]`) with the real `UTxO` . Even if the value and the address matches between the two the input `Ix` we generate when converting starts always from zero and we can't just sort `TxOuts` and compare that since there is no `Ord` instance.

This is related to #1260 as it will help reproduce this bug and preparatory work for #1057 

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
