### PR TITLE
Make HeadId usable on-chain

### DIFF
--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -1031,6 +1031,11 @@ mkHeadId = UnsafeHeadId . serialiseToRawBytes
 headIdToCurrencySymbol :: HeadId -> CurrencySymbol
 headIdToCurrencySymbol (UnsafeHeadId headId) = CurrencySymbol (toBuiltin headId)
 
+currencySymbolToHeadId :: MonadFail m => CurrencySymbol -> m HeadId
+currencySymbolToHeadId cs = do
+  policyId <- fromPlutusCurrencySymbol cs
+  pure $ mkHeadId policyId
+
 headIdToPolicyId :: MonadFail m => HeadId -> m PolicyId
 headIdToPolicyId = fromPlutusCurrencySymbol . headIdToCurrencySymbol
 

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -1032,9 +1032,7 @@ headIdToCurrencySymbol :: HeadId -> CurrencySymbol
 headIdToCurrencySymbol (UnsafeHeadId headId) = CurrencySymbol (toBuiltin headId)
 
 currencySymbolToHeadId :: MonadFail m => CurrencySymbol -> m HeadId
-currencySymbolToHeadId cs = do
-  policyId <- fromPlutusCurrencySymbol cs
-  pure $ mkHeadId policyId
+currencySymbolToHeadId = fmap mkHeadId . fromPlutusCurrencySymbol
 
 headIdToPolicyId :: MonadFail m => HeadId -> m PolicyId
 headIdToPolicyId = fromPlutusCurrencySymbol . headIdToCurrencySymbol

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -50,7 +50,7 @@ import Test.QuickCheck (
   (===),
  )
 import Test.QuickCheck.Instances.Semigroup ()
-import Test.QuickCheck.Monadic (assert, monadicIO, monitor)
+import Test.QuickCheck.Monadic (monadicIO)
 import Test.QuickCheck.Property (checkCoverage)
 
 spec :: Spec
@@ -72,8 +72,7 @@ spec =
         let headId = mkHeadId $ headPolicyId txIn
         let cs = headIdToCurrencySymbol headId
         headId' <- currencySymbolToHeadId cs
-        monitor (counterexample (show headId' <> " should be equal to " <> show headId))
-        assert (headId' == headId)
+        pure $ headId' === headId
 
     describe "observeHeadTx" $ do
       prop "All valid transitions for all possible states can be observed." $


### PR DESCRIPTION
fix #919 

In order to address user issue related to HeadId this PR introduces `currencySymbolToHeadId` function so that the users can roundrip this type from/to `CurrencySymbol` since `headIdToCurrencySymbol` already exists.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
