### PR TITLE
Replace hlint shell job with check derivation

### DIFF
--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -30,4 +30,4 @@ jobs:
 
     - name: 📐 Check hlint
       run: |
-        nix develop .#fmt --command hlint .
+        nix build .#checks.x86_64-linux.hlint

--- a/flake.lock
+++ b/flake.lock
@@ -791,6 +791,21 @@
         "type": "github"
       }
     },
+    "flake-utils_8": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "ghc-8.6.5-iohk": {
       "flake": false,
       "locked": {
@@ -1534,6 +1549,28 @@
         "ref": "hkm/remote-iserv",
         "type": "git",
         "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+      }
+    },
+    "lint-utils": {
+      "inputs": {
+        "flake-utils": "flake-utils_8",
+        "nixpkgs": [
+          "haskellNix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1708093119,
+        "narHash": "sha256-GiFM4MMQzFDHHBJ3GLd8yBjGWBnSRuPXUkokqEsS+qQ=",
+        "owner": "homotopic",
+        "repo": "lint-utils",
+        "rev": "f2d9c9c985cc81fcf55be71270d250073102b228",
+        "type": "github"
+      },
+      "original": {
+        "owner": "homotopic",
+        "repo": "lint-utils",
+        "type": "github"
       }
     },
     "lowdown-src": {
@@ -2621,6 +2658,7 @@
         "haskellNix": "haskellNix_2",
         "hls": "hls",
         "iohk-nix": "iohk-nix",
+        "lint-utils": "lint-utils",
         "mithril": "mithril",
         "nixpkgs": [
           "haskellNix",

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -7,6 +7,7 @@
   withoutDevTools ? false
 , hydraProject
 , inputs
+, tools
 , system ? builtins.currentSystem
 }:
 let
@@ -16,7 +17,6 @@ let
 
   fourmolu = pkgs.haskell-nix.tool compiler "fourmolu" "0.14.0.0";
   cabal-fmt = pkgs.haskell-nix.tool compiler "cabal-fmt" "0.1.9";
-  hlint = pkgs.haskell-nix.tool compiler "hlint" "3.8";
   apply-refact = pkgs.haskell-nix.tool compiler "apply-refact" "0.14.0.0";
 
   # Build HLS form our fork (see flake.nix)
@@ -47,7 +47,7 @@ let
     fourmolu
     cabal-fmt
     pkgs.nixpkgs-fmt
-    hlint
+    tools.hlint
     apply-refact
     # For validating JSON instances against a pre-defined schema
     pkgs.check-jsonschema
@@ -159,7 +159,7 @@ let
       fourmolu
       cabal-fmt
       pkgs.nixpkgs-fmt
-      hlint
+      tools.hlint
       apply-refact
     ];
   };


### PR DESCRIPTION
This PR introduces [lint-utils](https://github.com/homotopic/lint-utils) to demonstrate two principles. 

1. to ensure consistency between local and remote builds
2. to not require no-op jobs to rerun

It does this by way of introducing a check derivation that produces no functional output, but will fail if the check is not met.

lint-utils is well supported by multiple people and in use commercially by third-parties

---

* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
