### PR TITLE
Validate txs in model

### DIFF
--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -368,6 +368,7 @@ test-suite tests
     , regex-tdfa
     , req
     , silently
+    , temporary
     , text
     , time
     , typed-protocols-examples                                          >=0.1.0.0

--- a/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
+++ b/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
@@ -2,6 +2,7 @@
 
 module Hydra.Ledger.CardanoSpec where
 
+import Cardano.Api.UTxO (fromApi, toApi)
 import Hydra.Cardano.Api
 import Hydra.Prelude
 import Test.Hydra.Prelude
@@ -56,6 +57,8 @@ spec =
               \   \"value\":{\"lovelace\":14}}}"
         shouldParseJSONAs @UTxO bs
 
+      prop "Roundtrip to and from Api" roundtripFromAndToApi
+
     describe "ProtocolParameters" $
       prop "Roundtrip JSON encoding" roundtripProtocolParameters
 
@@ -106,6 +109,10 @@ shouldParseJSONAs bs =
   case Aeson.eitherDecode bs of
     Left err -> failure err
     Right (_ :: a) -> pure ()
+
+roundtripFromAndToApi :: UTxO -> Property
+roundtripFromAndToApi utxo =
+  fromApi (toApi utxo) === utxo
 
 -- | Test that the 'ProtocolParameters' To/FromJSON instances to roundtrip. Note
 -- that we use the ledger 'PParams' type to generate values, but the cardano-api

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -616,7 +616,7 @@ performCommit parties party paymentUTxO = do
         lift $
           waitMatch actorNode $ \case
             Committed{party = cp, utxo = committedUTxO}
-              | cp == party -> Just committedUTxO
+              | cp == party, committedUTxO == realUTxO -> Just committedUTxO
             err@CommandFailed{} -> error $ show err
             _ -> Nothing
       pure $ fromUtxo observedUTxO

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -391,16 +391,6 @@ genInit hydraParties = do
   let party = deriveParty key
   pure $ Init party
 
-genCommit' ::
-  [(SigningKey HydraKey, CardanoSigningKey)] ->
-  (SigningKey HydraKey, CardanoSigningKey) ->
-  Gen (Action WorldState [(CardanoSigningKey, Value)])
-genCommit' hydraParties hydraParty = do
-  let (_, sk) = fromJust $ find (== hydraParty) hydraParties
-  value <- genAdaValue
-  let utxo = [(sk, value)]
-  pure $ Commit (deriveParty . fst $ hydraParty) utxo
-
 genPayment :: WorldState -> Gen (Party, Payment)
 genPayment WorldState{hydraParties, hydraState} =
   case hydraState of

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -31,7 +31,7 @@ import Hydra.BehaviorSpec (
   SimulatedChainNetwork (..),
  )
 import Hydra.Cardano.Api.Pretty (renderTxWithUTxO)
-import Hydra.Chain (Chain (..), PostTxError (..), initHistory)
+import Hydra.Chain (Chain (..), initHistory)
 import Hydra.Chain.Direct.Fixture (testNetworkId)
 import Hydra.Chain.Direct.Handlers (
   ChainSyncHandler (..),

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -127,6 +127,21 @@ mockChainAndNetwork tr seedKeys commits = do
     let vks = getVerificationKey . signingKey . snd <$> seedKeys
     env{participants = verificationKeyToOnChainId <$> vks}
 
+  -- In case of two consecutive rollback actions it can happen that the
+  -- tx can't be evaluated to be correct. Waiting for some time to
+  -- see the needed inputs helps resolve these errors
+  waitToEvaluateTx n chain tx = do
+    (_, _, _, utxo) <- readTVarIO chain
+    let result = evaluateTx tx utxo
+    if n == 0
+       then pure (result, utxo)
+       else
+        case result of
+          Left _ -> threadDelay 0.1 >> waitToEvaluateTx (n - 1) chain tx
+          Right report
+            | any isLeft report -> threadDelay 0.1 >> waitToEvaluateTx (n - 1) chain tx
+            | otherwise -> pure (result, utxo)
+
   connectNode nodes chain queue node = do
     localChainState <- newLocalChainState (initHistory initialChainState)
     let Environment{party = ownParty} = env node
@@ -140,29 +155,30 @@ mockChainAndNetwork tr seedKeys commits = do
             }
     let getTimeHandle = pure $ fixedTimeHandleIndefiniteHorizon `generateWith` 42
     let HydraNode{eq = EventQueue{putEvent}} = node
+
     -- Validate transactions on submission and queue them for inclusion if valid.
-    let submitTx tx =
-          atomically $ do
-            (_, _, _, utxo) <- readTVar chain
-            -- TODO: dry with block tx validation
-            case evaluateTx tx utxo of
-              Left err ->
-                throwSTM . userError . toString $
-                  unlines
-                    [ "MockChain: Invalid tx submitted"
-                    , "Tx: " <> toText (renderTxWithUTxO utxo tx)
-                    , "Error: " <> show err
-                    ]
-              Right report
-                | any isLeft report ->
-                    throwSTM . userError . toString $
-                      unlines
-                        [ "MockChain: Invalid tx submitted"
-                        , "Tx: " <> toText (renderTxWithUTxO utxo tx)
-                        , "Error: " <> show (lefts . toList $ report)
-                        ]
-                | otherwise ->
-                    writeTQueue queue tx
+    let submitTx tx = do
+          (result, utxo) <- waitToEvaluateTx (2 :: Int) chain tx
+          -- TODO: dry with block tx validation
+          case result of
+            Left err ->
+              atomically . throwSTM . userError . toString $
+                unlines
+                  [ "MockChain: Invalid tx submitted"
+                  , "Tx: " <> toText (renderTxWithUTxO utxo tx)
+                  , "Error: " <> show err
+                  ]
+            Right report
+              | any isLeft report ->
+                  atomically . throwSTM . userError . toString $
+                    unlines
+                      [ "MockChain: Invalid tx submitted"
+                      , "Tx: " <> toText (renderTxWithUTxO utxo tx)
+                      , "Error: " <> show (lefts . toList $ report)
+                      ]
+              | otherwise ->
+                  atomically $ writeTQueue queue tx
+
     let chainHandle =
           createMockChain
             tr

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -5,7 +5,7 @@ module Hydra.Model.MockChain where
 import Hydra.Cardano.Api
 import Hydra.Prelude hiding (Any, label)
 
-import Cardano.Api.UTxO (fromPairs, pairs)
+import Cardano.Api.UTxO (fromPairs)
 import Control.Concurrent.Class.MonadSTM (
   MonadLabelledSTM,
   MonadSTM (newTVarIO, writeTVar),
@@ -62,7 +62,7 @@ import Hydra.HeadLogic.State (
   InitialState (..),
   OpenState (..),
  )
-import Hydra.Ledger (ChainSlot (..), Ledger (..), txId)
+import Hydra.Ledger (ChainSlot (..), Ledger (..), ValidationError (..), collectTransactions)
 import Hydra.Ledger.Cardano (adjustUTxO, fromChainSlot, genTxOutAdaOnly)
 import Hydra.Ledger.Cardano.Evaluate (eraHistoryWithoutHorizon, evaluateTx)
 import Hydra.Logging (Tracer)
@@ -111,7 +111,6 @@ mockChainAndNetwork tr seedKeys commits = do
 
   seedInput = genTxIn `generateWith` 42
 
-  -- TODO: why not use the full 'cardanoLedger'?
   ledger = scriptLedger seedInput
 
   Ledger{applyTransactions, initUTxO} = ledger
@@ -145,29 +144,20 @@ mockChainAndNetwork tr seedKeys commits = do
           atomically $ do
             -- NOTE: Determine the current "view" on the chain (important while
             -- rolled back, before new roll forwards were issued)
-            (_, position, blocks, globalUTxO) <- readTVar chain
+            (slot, position, blocks, globalUTxO) <- readTVar chain
             let utxo = case Seq.lookup (fromIntegral position) blocks of
                   Nothing -> globalUTxO
                   Just (_, _, blockUTxO) -> blockUTxO
-            -- TODO: dry with block tx validation
-            case evaluateTx tx utxo of
-              Left err ->
+            case applyTransactions slot utxo [tx] of
+              Left (_tx, err) ->
                 throwSTM . userError . toString $
                   unlines
                     [ "MockChain: Invalid tx submitted"
                     , "Tx: " <> toText (renderTxWithUTxO utxo tx)
                     , "Error: " <> show err
                     ]
-              Right report
-                | any isLeft report ->
-                    throwSTM . userError . toString $
-                      unlines
-                        [ "MockChain: Invalid tx submitted"
-                        , "Tx: " <> toText (renderTxWithUTxO utxo tx)
-                        , "Error: " <> show (lefts . toList $ report)
-                        ]
-                | otherwise ->
-                    writeTQueue queue tx
+              Right _utxo' ->
+                writeTQueue queue tx
     let chainHandle =
           createMockChain
             tr
@@ -244,7 +234,7 @@ mockChainAndNetwork tr seedKeys commits = do
       Nothing ->
         pure ()
 
-  -- FIXME: This should actually work more like a chain fork / switch to longer
+  -- XXX: This should actually work more like a chain fork / switch to longer
   -- chain. That is, the ledger switches to the longer chain state right away
   -- and we issue rollback and forwards to synchronize clients. However,
   -- submission will already validate against the new ledger state.
@@ -266,24 +256,16 @@ mockChainAndNetwork tr seedKeys commits = do
         pure ()
 
   addNewBlockToChain chain transactions =
-    modifyTVar chain $ \(slotNum, position, blocks, utxo) ->
+    modifyTVar chain $ \(slotNum, position, blocks, utxo) -> do
       -- NOTE: Assumes 1 slot = 1 second
       let newSlot = slotNum + ChainSlot (truncate blockTime)
           header = genBlockHeaderAt (fromChainSlot newSlot) `generateWith` 42
-       in case applyTransactions newSlot utxo transactions of
-            Left err ->
-              error $
-                toText $
-                  "On-chain transactions are not supposed to fail: "
-                    <> show err
-                    <> "\nTx:\n"
-                    <> (show @String $ txId <$> transactions)
-                    <> "\nUTxO:\n"
-                    <> show (fst <$> pairs utxo)
-            Right utxo' ->
-              -- FIXME: this includes all transactions even if only one of them
-              -- would apply (e.g. concurrent collect transactions in Hydra)
-              (newSlot, position, blocks :|> (header, transactions, utxo'), utxo')
+          -- NOTE: Transactions that do not apply to the current state (eg.
+          -- UTxO) are silently dropped which emulates the chain behaviour that
+          -- only the client is potentially witnessing the failure, and no
+          -- invalid transaction will ever be included in the chain.
+          (txs', utxo') = collectTransactions ledger newSlot utxo transactions
+       in (newSlot, position, blocks :|> (header, txs', utxo'), utxo')
 
 -- | Construct fixed 'TimeHandle' that starts from 0 and has the era horizon far in the future.
 -- This is used in our 'Model' tests and we want to make sure the tests finish before
@@ -308,20 +290,20 @@ scriptLedger seedInput =
  where
   initUTxO = fromPairs [(seedInput, (arbitrary >>= genTxOutAdaOnly) `generateWith` 42)]
 
+  -- XXX: We could easily add 'slot' validation here and this would already
+  -- emulate the dropping of outdated transactions from the cardano-node
+  -- mempool.
   applyTransactions !slot utxo = \case
     [] -> Right utxo
     (tx : txs) ->
       case evaluateTx tx utxo of
+        Left err ->
+          Left (tx, ValidationError{reason = show err})
         Right report
-          | all isRight report ->
-              let utxo' = adjustUTxO tx utxo
-               in applyTransactions slot utxo' txs
-        _ ->
-          -- Transactions that do not apply to the current state (eg. UTxO) are
-          -- silently dropped which emulates the chain behaviour that only the
-          -- client is potentially witnessing the failure, and no invalid
-          -- transaction will ever be included in the chain
-          applyTransactions slot utxo txs
+          | any isLeft report ->
+              Left (tx, ValidationError{reason = show . lefts $ toList report})
+          | otherwise ->
+              applyTransactions slot (adjustUTxO tx utxo) txs
 
 -- | Find Cardano vkey corresponding to our Hydra vkey using signing keys lookup.
 -- This is a bit cumbersome and a tribute to the fact the `HydraNode` itself has no

--- a/hydra-node/test/Hydra/ModelSpec.hs
+++ b/hydra-node/test/Hydra/ModelSpec.hs
@@ -145,7 +145,7 @@ import Hydra.Model (
 import Hydra.Model qualified as Model
 import Hydra.Model.Payment qualified as Payment
 import Hydra.Party (Party (..), deriveParty)
-import Test.QuickCheck (Property, Testable, counterexample, forAll, forAllShrink, property, withMaxSuccess, within)
+import Test.QuickCheck (Property, Testable, counterexample, forAllShrink, property, withMaxSuccess, within)
 import Test.QuickCheck.DynamicLogic (
   DL,
   Quantification,

--- a/hydra-node/test/Hydra/ModelSpec.hs
+++ b/hydra-node/test/Hydra/ModelSpec.hs
@@ -219,16 +219,19 @@ prop_checkHeadOpensIfAllPartiesCommit =
 
 headOpensIfAllPartiesCommit :: DL WorldState ()
 headOpensIfAllPartiesCommit = do
-  _ <- seedTheWorld
-  _ <- initHead
+  seedTheWorld
+  initHead
   everybodyCommit
-  void $ eventually' ObserveHeadIsOpen
+  eventually' ObserveHeadIsOpen
  where
-  eventually' a = action (Wait 1000) >> action a
-  seedTheWorld = forAllQ (withGenQ genSeed (const [])) >>= action
+  eventually' a = action (Wait 1000) >> action_ a
+
+  seedTheWorld = forAllNonVariableQ (withGenQ genSeed (const [])) >>= action_
+
   initHead = do
     WorldState{hydraParties} <- getModelStateDL
-    forAllQ (withGenQ (genInit hydraParties) (const [])) >>= action
+    forAllQ (withGenQ (genInit hydraParties) (const [])) >>= action_
+
   everybodyCommit = do
     WorldState{hydraParties} <- getModelStateDL
     forM_ hydraParties $ \party ->


### PR DESCRIPTION
The 'evaluateTx' function used at the core of validating transactions in the MockChain can fail in two ways, once when translating the transaction and then each validator individually.

:microscope: The MockChain now evaluates transactions on submission and only includes valid transactions in blocks.

:microscope: This also fixes race conditions in MockChain when updating the `chain` variable versus invoking handlers.

:microscope: Fixes the model in various ways to pass now the transaction checking. Mostly it was requiring every party to observe consequences of an action before having them act.

  :bulb: One situation was very interesting: The tests were finding an issue when a `commit` transaction was actually observed by the sending node, but another node sending an `abort` was not yet valid, because they reimbursed value was not matching. i.e. the aborting node has not yet seen & processed the commit, but the chain included it already. This is actually something that can happen and a user would need to retry here. However we opted to just not model this and instead require every node to observe a commit before continuing.

:microscope: Improved shrinking on generated actions. This should already reduce error situation complexity, but more work can be done here.

:microscope: Some fixes on the test scenarios / dynamic logic properties.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter

  - One `XXX` about reworking the `MockChain` to be more like a real chain (would be too big to be in scope, but this is something we really should do)
  - One `XXX` of adding slot validation to the used `scriptLedger`.