### PR TITLE
Make toRealUTxO distributive

### DIFF
--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -6,7 +6,6 @@ import Hydra.Cardano.Api
 import Hydra.Prelude hiding (Any, label)
 
 import Cardano.Api.UTxO (fromPairs, pairs)
-import Cardano.Binary (serialize', unsafeDeserialize')
 import Control.Concurrent.Class.MonadSTM (
   MonadLabelledSTM,
   MonadSTM (newTVarIO, writeTVar),
@@ -333,12 +332,6 @@ createMockChain tracer ctx submitTx timeHandle seedInput chainState =
         ctx
         chainState
         submitTx
-
-mkMockTxIn :: VerificationKey PaymentKey -> Word -> TxIn
-mkMockTxIn vk ix = TxIn (TxId tid) (TxIx ix)
- where
-  -- NOTE: Ugly, works because both binary representations are 32-byte long.
-  tid = unsafeDeserialize' (serialize' vk)
 
 -- NOTE: This is a workaround until the upstream PR is merged:
 -- https://github.com/input-output-hk/io-sim/issues/133

--- a/hydra-node/test/Hydra/Model/Payment.hs
+++ b/hydra-node/test/Hydra/Model/Payment.hs
@@ -17,15 +17,20 @@ import Test.QuickCheck.StateModel (HasVariables)
 import Test.QuickCheck.StateModel.Variables (HasVariables (..))
 import Prelude qualified
 
+-- NOTE: New type wrapper to add Ord and Eq instances to signing keys
 newtype CardanoSigningKey = CardanoSigningKey {signingKey :: SigningKey PaymentKey}
 
 instance Show CardanoSigningKey where
   show CardanoSigningKey{signingKey} =
     show . mkVkAddress @Era testNetworkId . getVerificationKey $ signingKey
 
--- NOTE: We need this orphan instance in order to lookup keys in lists.
+instance Ord CardanoSigningKey where
+  CardanoSigningKey ska <= CardanoSigningKey skb =
+    verificationKeyHash (getVerificationKey ska) <= verificationKeyHash (getVerificationKey skb)
+
 instance Eq CardanoSigningKey where
-  CardanoSigningKey (PaymentSigningKey skd) == CardanoSigningKey (PaymentSigningKey skd') = skd == skd'
+  CardanoSigningKey ska == CardanoSigningKey skb =
+    verificationKeyHash (getVerificationKey ska) == verificationKeyHash (getVerificationKey skb)
 
 instance ToJSON CardanoSigningKey where
   toJSON = error "don't use"

--- a/hydra-node/test/Hydra/ModelSpec.hs
+++ b/hydra-node/test/Hydra/ModelSpec.hs
@@ -139,6 +139,8 @@ import Hydra.Model (
   genPayment,
   genSeed,
   runMonad,
+  toRealUTxO,
+  toTxOuts,
  )
 import Hydra.Model qualified as Model
 import Hydra.Model.Payment qualified as Payment
@@ -181,14 +183,14 @@ spec = do
   prop "check conflict-free liveness" prop_checkConflictFreeLiveness
   prop "check head opens if all participants commit" prop_checkHeadOpensIfAllPartiesCommit
   prop "fanout contains whole confirmed UTxO" prop_fanoutContainsWholeConfirmedUTxO
-  -- FIXME: implement toRealUTxO correctly so the distributive property holds
-  xprop "realUTxO is distributive" $ propIsDistributive Model.toRealUTxO
+  prop "toRealUTxO is distributive" $ propIsDistributive toRealUTxO
+  prop "toTxOuts is distributive" $ propIsDistributive toTxOuts
 
-propIsDistributive :: (Show b, Eq b, Semigroup b) => ([a] -> b) -> [a] -> [a] -> Property
-propIsDistributive fn as bs =
-  fn as <> fn bs === fn (as <> bs)
-    & counterexample ("fn (as <> bs)   " <> show (fn (as <> bs)))
-    & counterexample ("fn as <> fn bs: " <> show (fn as <> fn bs))
+propIsDistributive :: (Show b, Eq b, Semigroup a, Semigroup b) => (a -> b) -> a -> a -> Property
+propIsDistributive f x y =
+  f x <> f y === f (x <> y)
+    & counterexample ("f (x <> y)   " <> show (f (x <> y)))
+    & counterexample ("f x <> f y: " <> show (f x <> f y))
 
 prop_fanoutContainsWholeConfirmedUTxO :: Property
 prop_fanoutContainsWholeConfirmedUTxO =


### PR DESCRIPTION
This should spare us some headaches when we convert multiple UTxOType Payment to UTxOType Tx (actual utxos) in the future.

This also checks that `toTxOuts` is distributive (although that is quite obvious).

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
