### PR TITLE
Add tx metadata to label Hydra transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ changes.
 
 ## [0.16.0] - UNRELEASED
 
+- Add metadata to identify Hydra protocol transactions created by `hydra-node`.
+
 - **BREAKING** Transaction serialization on hydra-node api and persisted data changed.
 
 - Provide more details about why a command failed. Added the state of the head logic at the point of failure.

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Pretty.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Pretty.hs
@@ -187,6 +187,6 @@ renderTxWithUTxO utxo (Tx body _wits) =
       Api.TxExtraKeyWitnesses xs -> ("- " <>) . show <$> xs
 
   metadataLines =
-    [ "== REQUIRED SIGNERS"
+    [ "== METADATA"
     , show (txMetadata content)
     ]

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -118,17 +118,33 @@ instance Arbitrary ClosedThreadOutput where
 hydraHeadV1AssetName :: AssetName
 hydraHeadV1AssetName = AssetName (fromBuiltin hydraHeadV1)
 
--- | Create a transaction metadata entry to identify Hydra transactions (for informational purposes).
+-- | The metadata label used for identifying Hydra protocol transactions. As
+-- suggested by a friendly large language model: The number most commonly
+-- associated with "Hydra" is 5, as in the mythological creature Hydra, which
+-- had multiple heads, and the number 5 often symbolizes multiplicity or
+-- diversity. However, there is no specific numerical association for Hydra
+-- smaller than 10000 beyond this mythological reference.
+hydraMetadataLabel :: Word64
+hydraMetadataLabel = 55555
+
+-- | Create a transaction metadata entry to identify Hydra transactions (for
+-- informational purposes).
 mkHydraHeadV1TxName :: Text -> TxMetadata
 mkHydraHeadV1TxName name =
-  TxMetadata $ Map.fromList [(metadataLabel, TxMetaText $ "HydraV1/" <> name)]
+  TxMetadata $ Map.fromList [(hydraMetadataLabel, TxMetaText $ "HydraV1/" <> name)]
+
+-- | Get the metadata entry to identify Hydra transactions (for informational
+-- purposes).
+getHydraHeadV1TxName :: Tx -> Maybe Text
+getHydraHeadV1TxName =
+  lookupName . txMetadata . getTxBodyContent . getTxBody
  where
-  -- As suggested by a friendly large language model: The number most commonly
-  -- associated with "Hydra" is 5, as in the mythological creature Hydra, which
-  -- had multiple heads, and the number 5 often symbolizes multiplicity or
-  -- diversity. However, there is no specific numerical association for Hydra
-  -- smaller than 10000 beyond this mythological reference.
-  metadataLabel = 55555
+  lookupName = \case
+    TxMetadataNone -> Nothing
+    TxMetadataInEra (TxMetadata m) ->
+      case Map.lookup hydraMetadataLabel m of
+        Just (TxMetaText name) -> Just name
+        _ -> Nothing
 
 -- * Create Hydra Head transactions
 


### PR DESCRIPTION
This is only for informational purposes and helps with debugging by identifying Hydra protocol transactions more quickly.

For example with `renderTx`:
![image](https://github.com/input-output-hk/hydra/assets/2621189/65d9569d-2ef8-478b-9706-a10a32e66de0)


<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
