### PR TITLE
Remove initUTxO from Ledger handle

### DIFF
--- a/hydra-node/src/Hydra/Ledger.hs
+++ b/hydra-node/src/Hydra/Ledger.hs
@@ -68,7 +68,7 @@ nextChainSlot (ChainSlot n) = ChainSlot (n + 1)
 -- | An abstract interface for a 'Ledger'. Allows to define mock / simpler
 -- implementation for testing as well as limiting feature-envy from the business
 -- logic by forcing a closed interface.
-data Ledger tx = Ledger
+newtype Ledger tx = Ledger
   { applyTransactions ::
       ChainSlot ->
       UTxOType tx ->
@@ -78,12 +78,6 @@ data Ledger tx = Ledger
   -- validation failures returned from the ledger.
   -- TODO: 'ValidationError' should also include the UTxO, which is not
   -- necessarily the same as the given UTxO after some transactions
-  , initUTxO :: UTxOType tx
-  -- ^ Generates an initial UTxO set. This is only temporary as it does not
-  -- allow to initialize the UTxO.
-  --
-  -- TODO: This seems redundant with the `Monoid (UTxOType tx)` constraints
-  -- coming with `IsTx`. We probably want to dry this out.
   }
 
 canApply :: Ledger tx -> ChainSlot -> UTxOType tx -> tx -> ValidationResult

--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -60,10 +60,7 @@ import Test.QuickCheck (
 -- | Use the cardano-ledger as an in-hydra 'Ledger'.
 cardanoLedger :: Ledger.Globals -> Ledger.LedgerEnv LedgerEra -> Ledger Tx
 cardanoLedger globals ledgerEnv =
-  Ledger
-    { applyTransactions
-    , initUTxO = mempty
-    }
+  Ledger{applyTransactions}
  where
   -- NOTE(SN): See full note on 'applyTx' why we only have a single transaction
   -- application here.

--- a/hydra-node/src/Hydra/Ledger/Simple.hs
+++ b/hydra-node/src/Hydra/Ledger/Simple.hs
@@ -118,15 +118,14 @@ instance FromCBOR SimpleTxIn where
 
 simpleLedger :: Ledger SimpleTx
 simpleLedger =
-  Ledger
-    { -- NOTE: _slot is unused as SimpleTx transactions don't have a notion of time.
-      applyTransactions = \_slot ->
-        foldlM $ \utxo tx@(SimpleTx _ ins outs) ->
-          if ins `Set.isSubsetOf` utxo && utxo `Set.disjoint` outs
-            then Right $ (utxo Set.\\ ins) `Set.union` outs
-            else Left (tx, ValidationError "cannot apply transaction")
-    , initUTxO = mempty
-    }
+  Ledger{applyTransactions}
+ where
+  -- NOTE: _slot is unused as SimpleTx transactions don't have a notion of time.
+  applyTransactions _slot =
+    foldlM $ \utxo tx@(SimpleTx _ ins outs) ->
+      if ins `Set.isSubsetOf` utxo && utxo `Set.disjoint` outs
+        then Right $ (utxo Set.\\ ins) `Set.union` outs
+        else Left (tx, ValidationError "cannot apply transaction")
 
 --
 -- Builders

--- a/hydra-node/test/Hydra/Model/MockChainSpec.hs
+++ b/hydra-node/test/Hydra/Model/MockChainSpec.hs
@@ -9,7 +9,7 @@ import Hydra.Ledger.Cardano (genSequenceOfSimplePaymentTransactions)
 import Hydra.Model.MockChain (scriptLedger)
 import Hydra.Prelude
 import Test.Hydra.Prelude
-import Test.QuickCheck (Property, Testable (property), counterexample, forAll, forAllBlind, (===))
+import Test.QuickCheck (Property, Testable (property), counterexample, forAllBlind, (===))
 
 spec :: Spec
 spec =
@@ -17,18 +17,17 @@ spec =
 
 appliesValidTransaction :: Property
 appliesValidTransaction =
-  forAll arbitrary $ \txin ->
-    forAllBlind genSequenceOfSimplePaymentTransactions $ \(utxo, txs) ->
-      let result = applyTransactions (scriptLedger txin) (ChainSlot 0) utxo txs
-       in case result of
-            Right u ->
-              isOutputOfLastTransaction txs u
-            Left (tx, err) ->
-              property False
-                & counterexample ("Error: " <> show err)
-                & counterexample ("Failing tx: " <> renderTx tx)
-                & counterexample ("All txs: " <> unpack (decodeUtf8With lenientDecode $ prettyPrintJSON txs))
-                & counterexample ("Initial UTxO: " <> unpack (decodeUtf8With lenientDecode $ prettyPrintJSON utxo))
+  forAllBlind genSequenceOfSimplePaymentTransactions $ \(utxo, txs) ->
+    let result = applyTransactions scriptLedger (ChainSlot 0) utxo txs
+     in case result of
+          Right u ->
+            isOutputOfLastTransaction txs u
+          Left (tx, err) ->
+            property False
+              & counterexample ("Error: " <> show err)
+              & counterexample ("Failing tx: " <> renderTx tx)
+              & counterexample ("All txs: " <> unpack (decodeUtf8With lenientDecode $ prettyPrintJSON txs))
+              & counterexample ("Initial UTxO: " <> unpack (decodeUtf8With lenientDecode $ prettyPrintJSON utxo))
 
 isOutputOfLastTransaction :: [Tx] -> UTxO -> Property
 isOutputOfLastTransaction txs utxo =


### PR DESCRIPTION
Minor refactor.

This was not really used anywhere and is redundant to the `Monoid (UTxOType tx)` constraint.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
