### PR TITLE
Improve fee estimation in internal wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,15 @@ changes.
 
 - Add `--sanchonet` option to `hydra-cluster` binary.
 
+- Reduce cost of transactions submitted by `hydra-node` by better estimating
+  fees in internal wallet
+  [#1315](https://github.com/input-output-hk/hydra/pull/1315).
+
 ## [0.15.0] - 2024-01-18
 
 - Tested with `cardano-node 8.7.3` and `cardano-cli 8.17.0.0`.
 
-- **BREAKING** Remove head state from `hydra-node` chain layer [1196](https://github.com/input-output-hk/hydra/pull/1196):
+- **BREAKING** Remove head state from `hydra-node` chain layer [#1196](https://github.com/input-output-hk/hydra/pull/1196):
   - Not maintain head state in the chain layer anymore and all decision making (whether it's "our" head) is now fully contained in the logic layer.
   - This is a breaking change on the persisted `state` file, which now only stores so-called `spendableUTxO`. This raises a `PersistenceException` if an incompatible `state` file is loaded.
   - Heads need to be closed before upgrade to this version, as wiping `state` in the `--persistence-dir` is needed.

--- a/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
@@ -12,16 +12,29 @@ import Cardano.Crypto.Hash.Class
 import Cardano.Ledger.Address qualified as Ledger
 import Cardano.Ledger.Alonzo.Plutus.TxInfo (TranslationError)
 import Cardano.Ledger.Alonzo.PlutusScriptApi (language)
-import Cardano.Ledger.Alonzo.Scripts (ExUnits (ExUnits), Tag (Spend), txscriptfee)
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (ExUnits), Tag (Spend))
 import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), RdmrPtr (RdmrPtr), Redeemers (..), txdats, txscripts)
-import Cardano.Ledger.Api (TransactionScriptFailure, ensureMinCoinTxOut, evalTxExUnits, outputsTxBodyL, ppMaxTxExUnitsL, ppPricesL)
+import Cardano.Ledger.Api (
+  TransactionScriptFailure,
+  bodyTxL,
+  collateralInputsTxBodyL,
+  ensureMinCoinTxOut,
+  evalTxExUnits,
+  feeTxBodyL,
+  getMinFeeTx,
+  inputsTxBodyL,
+  mkBasicTx,
+  outputsTxBodyL,
+  ppMaxTxExUnitsL,
+  scriptIntegrityHashTxBodyL,
+  witsTxL,
+ )
 import Cardano.Ledger.Babbage.Tx (body, getLanguageView, hashScriptIntegrity, wits)
 import Cardano.Ledger.Babbage.Tx qualified as Babbage
-import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..), spendInputs')
+import Cardano.Ledger.Babbage.TxBody (spendInputs')
 import Cardano.Ledger.Babbage.TxBody qualified as Babbage
 import Cardano.Ledger.Babbage.UTxO (getReferenceScripts)
 import Cardano.Ledger.BaseTypes qualified as Ledger
-import Cardano.Ledger.Binary (mkSized)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core (isNativeScript)
 import Cardano.Ledger.Core qualified as Core
@@ -36,13 +49,13 @@ import Cardano.Slotting.EpochInfo (EpochInfo)
 import Cardano.Slotting.Time (SystemStart (..))
 import Control.Arrow (left)
 import Control.Concurrent.Class.MonadSTM (check, newTVarIO, readTVarIO, writeTVar)
-import Control.Lens ((^.))
+import Control.Lens ((%~), (.~), (^.))
 import Data.List qualified as List
 import Data.Map.Strict ((!))
 import Data.Map.Strict qualified as Map
 import Data.Maybe.Strict (StrictMaybe (..))
 import Data.Ratio ((%))
-import Data.Sequence.Strict qualified as StrictSeq
+import Data.Sequence.Strict ((|>))
 import Data.Set qualified as Set
 import Hydra.Cardano.Api (
   BlockHeader,
@@ -60,7 +73,6 @@ import Hydra.Cardano.Api (
   fromLedgerTxOut,
   fromLedgerUTxO,
   getChainPoint,
-  ledgerEraVersion,
   makeShelleyAddress,
   selectLovelace,
   shelleyAddressInEra,
@@ -226,7 +238,6 @@ data ChangeError = ChangeError {inputBalance :: Coin, outputBalance :: Coin}
 -- necessary fees and augments inputs / outputs / collateral accordingly to
 -- cover for the transaction cost and get the change back.
 --
--- TODO: The fee calculation is currently very dumb and static.
 -- XXX: All call sites of this function use cardano-api types
 coverFee_ ::
   Core.PParams LedgerEra ->
@@ -237,71 +248,77 @@ coverFee_ ::
   Babbage.AlonzoTx LedgerEra ->
   Either ErrCoverFee (Babbage.AlonzoTx LedgerEra)
 coverFee_ pparams systemStart epochInfo lookupUTxO walletUTxO partialTx@Babbage.AlonzoTx{body, wits} = do
-  (input, output) <- findUTxOToPayFees walletUTxO
+  (feeTxIn, feeTxOut) <- findUTxOToPayFees walletUTxO
 
-  let newInputs = spendInputs' body <> Set.singleton input
+  let newInputs = spendInputs' body <> Set.singleton feeTxIn
   resolvedInputs <- traverse resolveInput (toList newInputs)
 
+  -- Ensure we have at least the minimum amount of ada. NOTE: setMinCoinTxOut
+  -- would invalidate most Hydra protocol transactions.
+  let txOuts = body ^. outputsTxBodyL <&> ensureMinCoinTxOut pparams
+
+  -- Compute costs of redeemers
   let utxo = lookupUTxO <> walletUTxO
-  estimatedScriptCosts <-
-    estimateScriptsCost pparams systemStart epochInfo utxo partialTx
+  estimatedScriptCosts <- estimateScriptsCost pparams systemStart epochInfo utxo partialTx
   let adjustedRedeemers =
         adjustRedeemers
           (spendInputs' body)
           newInputs
           estimatedScriptCosts
           (txrdmrs wits)
-      needlesslyHighFee = calculateNeedlesslyHighFee adjustedRedeemers
 
-  -- Ensure we have at least the minimum amount of ada. NOTE: setMinCointTxOut
-  -- would invalidate most Hydra protocol transactions.
-  let txOuts = body ^. outputsTxBodyL <&> ensureMinCoinTxOut pparams
-
-  -- Add a change output
-  change <-
-    first ErrNotEnoughFunds $
-      mkChange
-        output
-        resolvedInputs
-        (toList txOuts)
-        needlesslyHighFee
-  let newOutputs = txOuts <> StrictSeq.singleton change
-
-      referenceScripts = getReferenceScripts @LedgerEra (Ledger.UTxO utxo) (Babbage.referenceInputs' body)
+  -- Compute script integrity hash from adjusted redeemers
+  let referenceScripts = getReferenceScripts @LedgerEra (Ledger.UTxO utxo) (Babbage.referenceInputs' body)
       langs =
         [ getLanguageView pparams l
         | (_hash, script) <- Map.toList $ Map.union (txscripts wits) referenceScripts
         , (not . isNativeScript @LedgerEra) script
         , l <- maybeToList (language script)
         ]
-      finalBody =
-        body
-          { btbInputs = newInputs
-          , btbOutputs = mkSized ledgerEraVersion <$> newOutputs
-          , btbCollateral = Set.singleton input
-          , btbTxFee = needlesslyHighFee
-          , btbScriptIntegrityHash =
-              hashScriptIntegrity
-                (Set.fromList langs)
-                adjustedRedeemers
-                (txdats wits)
-          }
-  pure $
-    partialTx
-      { body = finalBody
-      , wits = wits{txrdmrs = adjustedRedeemers}
-      }
+      scriptIntegrityHash =
+        hashScriptIntegrity
+          (Set.fromList langs)
+          adjustedRedeemers
+          (txdats wits)
+
+  let
+    unbalancedBody =
+      body
+        & inputsTxBodyL .~ newInputs
+        & outputsTxBodyL .~ txOuts
+        & collateralInputsTxBodyL .~ Set.singleton feeTxIn
+        & scriptIntegrityHashTxBodyL .~ scriptIntegrityHash
+    unbalancedTx =
+      mkBasicTx unbalancedBody
+        & witsTxL .~ wits{txrdmrs = adjustedRedeemers}
+
+  -- Compute fee using a body with selected txOut to pay fees (= full change)
+  -- FIXME: There will be more witnesses.. so we need to account for that as well.
+  let costingTx =
+        unbalancedTx
+          & bodyTxL . outputsTxBodyL %~ (|> feeTxOut)
+          & bodyTxL . feeTxBodyL .~ Coin 10_000_000
+      fee = getMinFeeTx pparams costingTx
+
+  -- Balance tx with a change output and computed fee
+  change <-
+    first ErrNotEnoughFunds $
+      mkChange
+        feeTxOut
+        resolvedInputs
+        (toList txOuts)
+        fee
+  let balancedTx =
+        unbalancedTx
+          & bodyTxL . outputsTxBodyL %~ (|> change)
+          & bodyTxL . feeTxBodyL .~ fee
+  pure balancedTx
  where
   findUTxOToPayFees utxo = case findLargestUTxO utxo of
     Nothing ->
       Left ErrNoFuelUTxOFound
     Just (i, o) ->
       Right (i, o)
-
-  -- TODO: Do a better fee estimation based on the transaction's content.
-  calculateNeedlesslyHighFee (Redeemers redeemers) =
-    let executionCost = txscriptfee (pparams ^. ppPricesL) $ foldMap snd redeemers
-     in Coin 2_000_000 <> executionCost
 
   getAdaValue :: TxOut -> Coin
   getAdaValue (Babbage.BabbageTxOut _ value _ _) =

--- a/hydra-node/test/Hydra/Chain/Direct/WalletSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/WalletSpec.hs
@@ -223,6 +223,7 @@ prop_balanceTransaction =
   forAllBlind (resize 0 genLedgerTx) $ \tx ->
     forAllBlind (reasonablySized $ genOutputsForInputs tx) $ \lookupUTxO ->
       forAllBlind (reasonablySized genUTxO) $ \walletUTxO ->
+        -- FIXME: this does not cover signing
         case coverFee_ Fixture.pparams Fixture.systemStart Fixture.epochInfo lookupUTxO walletUTxO tx of
           Left err ->
             property False


### PR DESCRIPTION
:coin: Using the cardano-ledger we improve the fee estimation to be within `0.1` ADA of the minimum fee.

:coin: Practically, this reduces cost of initializing and aborting a single party head from about `6.4` ADA to only `3.7` ADA.

:coin: There is still some overestimation in `coverFees`, however this is only due to the commit transaction requiring (usually) two witnesses, while all other txs would only be fine with one.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
  - An `XXX` note how to address the witness overestimation / make commit more flexible in the future.