### PR TITLE
Refactor flake, shells and hydraProject

### DIFF
--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -26,7 +26,7 @@ jobs:
 
     - name: 📐 Check code formatting
       run: |
-        nix develop .#fmt --command treefmt --fail-on-change
+        nix build .#checks.x86_64-linux.treefmt
 
     - name: 📐 Check hlint
       run: |

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,6 @@
 -- Custom repository for cardano haskell packages, see CONTRIBUTING.md
 repository cardano-haskell-packages
-  url: https://input-output-hk.github.io/cardano-haskell-packages
+  url: https://intersectmbo.github.io/cardano-haskell-packages
   secure: True
   root-keys:
     3e0cce471cf09815f930210f7827266fd09045445d65923e6d0238a6cd15126f

--- a/cabal.project
+++ b/cabal.project
@@ -44,7 +44,3 @@ benchmarks: True
 
 -- Always show detailed output for tests
 test-show-details: direct
-
--- Fix compilation of strict-containers (see also nix/hydra/project.nix)
-package strict-containers
-  ghc-options: "-Wno-noncanonical-monad-instances"

--- a/flake.lock
+++ b/flake.lock
@@ -3,15 +3,15 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1707261293,
-        "narHash": "sha256-icbnYI4cK6juBHsLKnvhmolVuAg+XcrBFR4xnawjZyE=",
-        "owner": "input-output-hk",
+        "lastModified": 1708528137,
+        "narHash": "sha256-/1+yfZ2Mq2wxZDUB9Xj4slWNI5almLL9fRFZVrhzX60=",
+        "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "2211393aee44275d2eed09f20e28ad252e248108",
+        "rev": "173254b7827969116d132334666f4fe52109d991",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
+        "owner": "intersectmbo",
         "ref": "repo",
         "repo": "cardano-haskell-packages",
         "type": "github"
@@ -116,17 +116,17 @@
     "blst_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1656163412,
-        "narHash": "sha256-xero1aTe2v4IhWIJaEDUsVDOfE77dOV5zKeHWntHogY=",
+        "lastModified": 1691598027,
+        "narHash": "sha256-oqljy+ZXJAXEB/fJtmB8rlAr4UXM+Z2OkDa20gpILNA=",
         "owner": "supranational",
         "repo": "blst",
-        "rev": "03b5124029979755c752eec45f3c29674b558446",
+        "rev": "3dd0f804b1819e5d03fb22ca2e6fac105932043a",
         "type": "github"
       },
       "original": {
         "owner": "supranational",
+        "ref": "v0.3.11",
         "repo": "blst",
-        "rev": "03b5124029979755c752eec45f3c29674b558446",
         "type": "github"
       }
     },
@@ -936,11 +936,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1706660549,
-        "narHash": "sha256-vSYdk5Z40Cr6AlOKZEsOto5gIsI/egsxoDRBpp6lmd8=",
+        "lastModified": 1708561382,
+        "narHash": "sha256-IDr2G3komoctjHALk8wGvDKOF39BaqrdEmjvAOsob5I=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "a2751becae6189be230fe9d2582ea9464d79442e",
+        "rev": "4b07be837c34475fdde3c9bb9903a850b5692bac",
         "type": "github"
       },
       "original": {
@@ -1059,11 +1059,11 @@
         "stackage": "stackage_2"
       },
       "locked": {
-        "lastModified": 1706662202,
-        "narHash": "sha256-gTGsgdlXXwcsSgQxQkxcv1iOS90m8Xr8ze5i5BnCbo0=",
+        "lastModified": 1708563005,
+        "narHash": "sha256-RgC6n1kuSDo90Jy1ETlCGL3tr125WeWiDl6z6amEXoQ=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "7ea60f43d7f104bd5764c11d566ce726b6a681ab",
+        "rev": "83acf6dc3fe8b3b9d218df2ee88ac875d1aeb801",
         "type": "github"
       },
       "original": {
@@ -1480,11 +1480,11 @@
         "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1702362799,
-        "narHash": "sha256-cU8cZXNuo5GRwrSvWqdaqoW5tJ2HWwDEOvWwIVPDPmo=",
+        "lastModified": 1708437078,
+        "narHash": "sha256-EUsAEG0LmnMmX7Z6JW2LX8/VhpAJ2dXVwVGXWn5LmxQ=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "b426fb9e0b109a9d1dd2e1476f9e0bd8bb715142",
+        "rev": "5ab7134bb21d7bd858dbe1c702761aa7e15eaf88",
         "type": "github"
       },
       "original": {
@@ -2801,11 +2801,11 @@
     "stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1706659779,
-        "narHash": "sha256-MfXSjpyFPUPpKuDAaRUNbeTPRQLxa88h7gVnitZ5YDk=",
+        "lastModified": 1708560571,
+        "narHash": "sha256-/ZxWtAaoskXxeE79aA/K5PirGFUsqdu2TLRLskDj1js=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "d3f2896c19425d021387668dc51d031921b0c0de",
+        "rev": "e0cb41371d5b1e76cddb4e25d748fdb87c176176",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1560,11 +1560,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708093119,
-        "narHash": "sha256-GiFM4MMQzFDHHBJ3GLd8yBjGWBnSRuPXUkokqEsS+qQ=",
+        "lastModified": 1708583908,
+        "narHash": "sha256-zuNxxkt/wS8Z5TbGarf4QZVDt1R65dDkEw/s2T/tCW4=",
         "owner": "homotopic",
         "repo": "lint-utils",
-        "rev": "f2d9c9c985cc81fcf55be71270d250073102b228",
+        "rev": "2d77caa3644065ee0f462cc5ea654280c59127b2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -92,13 +92,16 @@
           inherit pkgs inputMap;
           compiler-nix-name = compiler;
         };
+
         hydraPackages = import ./nix/hydra/packages.nix {
           inherit system pkgs inputs hsPkgs;
           gitRev = self.rev or "dirty";
         };
+
         hydraImages = import ./nix/hydra/docker.nix {
           inherit hydraPackages system nixpkgs;
         };
+
         prefixAttrs = s: attrs:
           with pkgs.lib.attrsets;
           mapAttrs' (name: value: nameValuePair (s + name) value) attrs;

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
       inputs.nixpkgs.follows = "haskellNix/nixpkgs";
     };
     CHaP = {
-      url = "github:input-output-hk/cardano-haskell-packages?ref=repo";
+      url = "github:intersectmbo/cardano-haskell-packages?ref=repo";
       flake = false;
     };
     # Use a patched 2.6.0.0 as we are also affected by

--- a/flake.nix
+++ b/flake.nix
@@ -60,13 +60,30 @@
 
         tools = {
           apply-refact = pkgs.haskell-nix.tool compiler "apply-refact" "0.14.0.0";
+          cabal = pkgs.haskell-nix.cabal-install.${compiler};
           cabal-fmt = pkgs.haskell-nix.tool compiler "cabal-fmt" "0.1.9";
+          cabal-plan = pkgs.haskell-nix.tool compiler "cabal-plan" "latest";
           fourmolu = pkgs.haskell-nix.tool compiler "fourmolu" "0.14.0.0";
           haskell-language-server = pkgs.haskell-nix.tool compiler "haskell-language-server" rec {
             src = inputs.hls;
             cabalProject = builtins.readFile (src + "/cabal.project");
           };
           hlint = pkgs.haskell-nix.tool compiler "hlint" "3.8";
+          inherit (pkgs)
+            check-jsonschema
+            git
+            gnuplot
+            nixpkgs-fmt
+            nodejs
+            pkg-config
+            plantuml
+            treefmt
+            websocat
+            yarn
+            yq;
+          inherit (pkgs.haskellPackages) hspec-discover ghcid graphmod;
+          inherit (inputs.cardano-node.packages.${system}) cardano-node cardano-cli;
+          mithril-client-cli = inputs.mithril.packages.${system}.mithril-client-cli;
         };
 
         inputMap = { "https://intersectmbo.github.io/cardano-haskell-packages" = inputs.CHaP; };

--- a/flake.nix
+++ b/flake.nix
@@ -117,6 +117,15 @@
 
         checks = let lu = inputs.lint-utils.linters.${system}; in {
           hlint = lu.hlint { src = self; hlint = tools.hlint; };
+          treefmt = lu.treefmt {
+            src = self;
+            buildInputs = [
+              tools.cabal-fmt
+              tools.nixpkgs-fmt
+              tools.fourmolu
+            ];
+            treefmt = tools.treefmt;
+          };
         };
 
         devShells = import ./nix/hydra/shell.nix {

--- a/flake.nix
+++ b/flake.nix
@@ -99,19 +99,14 @@
           hlint = lu.hlint { src = self; hlint = tools.hlint; };
         };
 
-        devShells = (import ./nix/hydra/shell.nix {
+        devShells = import ./nix/hydra/shell.nix {
           inherit inputs tools pkgs hsPkgs system compiler;
-        }) // {
-          ci = (import ./nix/hydra/shell.nix {
-            inherit inputs pkgs system tools;
-            withoutDevTools = true;
-          }).default;
         };
 
         # Build selected derivations in CI for caching
         hydraJobs = pkgs.lib.optionalAttrs (!pkgs.stdenv.isDarwin) {
           packages = { inherit (packages) hydra-node hydra-tui hydraw spec; };
-          devShells = { inherit (devShells) default ci; };
+          devShells = { inherit (devShells) default; };
         };
       });
 

--- a/nix/hydra/docker.nix
+++ b/nix/hydra/docker.nix
@@ -2,8 +2,8 @@
 # metadata, as this is only added by the Github workflow.
 
 { hydraPackages # as defined in packages.nix
-, system ? builtins.currentSystem
-, nixpkgs ? <nixpkgs>
+, system
+, nixpkgs
 }:
 let
   pkgs = import nixpkgs { inherit system; };

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -1,6 +1,6 @@
 # A set of buildables we typically build for releases
 
-{ hydraProject # as defined in default.nix
+{ hsPkgs # as defined in default.nix
 , system ? builtins.currentSystem
 , pkgs
 , inputs
@@ -55,9 +55,9 @@ let
       '';
     };
 
-  nativePkgs = hydraProject.hsPkgs;
+  nativePkgs = hsPkgs;
   # Allow reinstallation of terminfo as it's not installed with cross compilers.
-  patchedForCrossProject = hydraProject.hsPkgs.appendModule
+  patchedForCrossProject = hsPkgs.appendModule
     ({ lib, ... }: { options.nonReinstallablePkgs = lib.mkOption { apply = lib.remove "terminfo"; }; });
   musl64Pkgs = patchedForCrossProject.projectCross.musl64.hsPkgs;
 in
@@ -184,15 +184,15 @@ rec {
   haddocks = pkgs.runCommand "hydra-haddocks"
     {
       paths = [
-        hydraProject.hsPkgs.plutus-cbor.components.library.doc
-        hydraProject.hsPkgs.plutus-merkle-tree.components.library.doc
-        hydraProject.hsPkgs.hydra-prelude.components.library.doc
-        hydraProject.hsPkgs.hydra-cardano-api.components.library.doc
-        hydraProject.hsPkgs.hydra-plutus.components.library.doc
-        hydraProject.hsPkgs.hydra-node.components.library.doc
-        hydraProject.hsPkgs.hydra-node.components.tests.tests.doc
-        hydraProject.hsPkgs.hydra-cluster.components.library.doc
-        hydraProject.hsPkgs.hydra-tui.components.library.doc
+        hsPkgs.plutus-cbor.components.library.doc
+        hsPkgs.plutus-merkle-tree.components.library.doc
+        hsPkgs.hydra-prelude.components.library.doc
+        hsPkgs.hydra-cardano-api.components.library.doc
+        hsPkgs.hydra-plutus.components.library.doc
+        hsPkgs.hydra-node.components.library.doc
+        hsPkgs.hydra-node.components.tests.tests.doc
+        hsPkgs.hydra-cluster.components.library.doc
+        hsPkgs.hydra-tui.components.library.doc
       ];
     }
     ''

--- a/nix/hydra/project.nix
+++ b/nix/hydra/project.nix
@@ -62,12 +62,6 @@ let
         packages.hydra-tui.dontStrip = false;
         packages.hydraw.dontStrip = false;
       }
-      # Fix compliation of strict-containers (see also cabal.project)
-      {
-        packages.strict-containers.ghcOptions = [ "-Wno-noncanonical-monad-instances" ];
-        # XXX: Could not figure out where to make this flag ^^^ effective in the haddock build
-        packages.strict-containers.doHaddock = false;
-      }
       # Use different static libs on darwin
       # TODO: Always use these?
       (pkgs.lib.mkIf pkgs.hostPlatform.isDarwin {

--- a/nix/hydra/project.nix
+++ b/nix/hydra/project.nix
@@ -49,6 +49,9 @@ pkgs.haskell-nix.project {
       ];
     })
     {
+      # lib:ghc is a bit annoying in that it comes with it's own build-type:Custom, and then tries
+      # to call out to all kinds of silly tools that GHC doesn't really provide.
+      # For this reason, we try to get away without re-installing lib:ghc for now.
       reinstallableLibGhc = false;
     }
   ];

--- a/nix/hydra/project.nix
+++ b/nix/hydra/project.nix
@@ -1,84 +1,55 @@
-{ compiler ? "ghc964"
+{ compiler-nix-name
 
-, system ? builtins.currentSystem
+, inputMap
 
-, haskellNix
+, pkgs
 
-, iohk-nix
-
-, CHaP
-
-, nixpkgs ? iohk-nix.nixpkgs
 }:
-let
-  # nixpkgs enhanced with haskell.nix and crypto libs as used by iohk
-  pkgs = import nixpkgs {
-    inherit system;
-    overlays = [
-      # This overlay contains libsodium and libblst libraries
-      iohk-nix.overlays.crypto
-      # This overlay contains pkg-config mappings via haskell.nix to use the
-      # crypto libraries above
-      iohk-nix.overlays.haskell-nix-crypto
-      # Keep haskell.nix as the last overlay!
-      #
-      # Reason: haskell.nix modules/overlays neds to be last
-      # https://github.com/input-output-hk/haskell.nix/issues/1954
-      haskellNix.overlay
-      # Custom static libs used for darwin build
-      (import ../static-libs.nix)
-    ];
+
+pkgs.haskell-nix.project {
+  src = pkgs.haskell-nix.haskellLib.cleanSourceWith {
+    name = "hydra";
+    src = ./../..;
+    filter = path: type:
+      # Blacklist of paths which do not affect the haskell build. The smaller
+      # the resulting list of files is, the less likely we have redundant
+      # rebuilds.
+      builtins.all (x: baseNameOf path != x) [
+        "flake.nix"
+        "flake.lock"
+        "nix"
+        ".github"
+        "demo"
+        "docs"
+        "sample-node-config"
+        "spec"
+        "testnets"
+      ];
   };
+  projectFileName = "cabal.project";
 
-  hsPkgs = pkgs.haskell-nix.project {
-    src = pkgs.haskell-nix.haskellLib.cleanSourceWith {
-      name = "hydra";
-      src = ./../..;
-      filter = path: type:
-        # Blacklist of paths which do not affect the haskell build. The smaller
-        # the resulting list of files is, the less likely we have redundant
-        # rebuilds.
-        builtins.all (x: baseNameOf path != x) [
-          "flake.nix"
-          "flake.lock"
-          "nix"
-          ".github"
-          "demo"
-          "docs"
-          "sample-node-config"
-          "spec"
-          "testnets"
-        ];
-    };
-    projectFileName = "cabal.project";
-    compiler-nix-name = compiler;
+  inherit inputMap compiler-nix-name;
 
-    inputMap = { "https://input-output-hk.github.io/cardano-haskell-packages" = CHaP; };
-
-    modules = [
-      # Strip debugging symbols from exes (smaller closures)
-      {
-        packages.hydra-node.dontStrip = false;
-        packages.hydra-tui.dontStrip = false;
-        packages.hydraw.dontStrip = false;
-      }
-      # Use different static libs on darwin
-      # TODO: Always use these?
-      (pkgs.lib.mkIf pkgs.hostPlatform.isDarwin {
-        packages.hydra-node.ghcOptions = with pkgs; [
-          "-L${lib.getLib static-gmp}/lib"
-          "-L${lib.getLib static-libsodium-vrf}/lib"
-          "-L${lib.getLib static-secp256k1}/lib"
-          "-L${lib.getLib static-openssl}/lib"
-          "-L${lib.getLib static-libblst}/lib"
-        ];
-      })
-      {
-       reinstallableLibGhc = false;
-      }
-    ];
-  };
-in
-{
-  inherit compiler pkgs hsPkgs;
+  modules = [
+    # Strip debugging symbols from exes (smaller closures)
+    {
+      packages.hydra-node.dontStrip = false;
+      packages.hydra-tui.dontStrip = false;
+      packages.hydraw.dontStrip = false;
+    }
+    # Use different static libs on darwin
+    # TODO: Always use these?
+    (pkgs.lib.mkIf pkgs.hostPlatform.isDarwin {
+      packages.hydra-node.ghcOptions = with pkgs; [
+        "-L${lib.getLib static-gmp}/lib"
+        "-L${lib.getLib static-libsodium-vrf}/lib"
+        "-L${lib.getLib static-secp256k1}/lib"
+        "-L${lib.getLib static-openssl}/lib"
+        "-L${lib.getLib static-libblst}/lib"
+      ];
+    })
+    {
+      reinstallableLibGhc = false;
+    }
+  ];
 }

--- a/nix/hydra/project.nix
+++ b/nix/hydra/project.nix
@@ -73,14 +73,9 @@ let
           "-L${lib.getLib static-libblst}/lib"
         ];
       })
-      # Fix compilation with newer ghc versions
-      ({ lib, config, ... }:
-        lib.mkIf (lib.versionAtLeast config.compiler.version "9.4") {
-          # lib:ghc is a bit annoying in that it comes with it's own build-type:Custom, and then tries
-          # to call out to all kinds of silly tools that GHC doesn't really provide.
-          # For this reason, we try to get away without re-installing lib:ghc for now.
-          reinstallableLibGhc = false;
-        })
+      {
+       reinstallableLibGhc = false;
+      }
     ];
   };
 in

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -5,25 +5,16 @@
 {
   # Used in CI to have a smaller closure
   withoutDevTools ? false
-, hydraProject
+, hsPkgs
 , inputs
 , tools
-, system ? builtins.currentSystem
+, system
+, pkgs
+, compiler
 }:
 let
-  inherit (hydraProject) compiler pkgs hsPkgs;
 
   cabal = pkgs.haskell-nix.cabal-install.${compiler};
-
-  fourmolu = pkgs.haskell-nix.tool compiler "fourmolu" "0.14.0.0";
-  cabal-fmt = pkgs.haskell-nix.tool compiler "cabal-fmt" "0.1.9";
-  apply-refact = pkgs.haskell-nix.tool compiler "apply-refact" "0.14.0.0";
-
-  # Build HLS form our fork (see flake.nix)
-  haskell-language-server = pkgs.haskell-nix.tool compiler "haskell-language-server" rec {
-    src = inputs.hls;
-    cabalProject = builtins.readFile (src + "/cabal.project");
-  };
 
   libs = [
     pkgs.glibcLocales
@@ -44,11 +35,11 @@ let
     pkgs.haskellPackages.hspec-discover
     # Formatting
     pkgs.treefmt
-    fourmolu
-    cabal-fmt
+    tools.fourmolu
+    tools.cabal-fmt
     pkgs.nixpkgs-fmt
     tools.hlint
-    apply-refact
+    tools.apply-refact
     # For validating JSON instances against a pre-defined schema
     pkgs.check-jsonschema
     # For generating plantuml drawings
@@ -65,7 +56,7 @@ let
 
   devInputs = if withoutDevTools then [ ] else [
     # Essential for a good IDE
-    haskell-language-server
+    tools.haskell-language-server
     # The interactive Glasgow Haskell Compiler as a Daemon
     pkgs.haskellPackages.ghcid
     # Generate a graph of the module dependencies in the "dot" format
@@ -108,7 +99,7 @@ let
     name = "hydra-node-cabal-shell";
 
     buildInputs = libs ++ [
-      pkgs.haskell-nix.compiler.${compiler}
+      hsPkgs.compiler.${compiler}
       pkgs.cabal-install
       pkgs.pkg-config
     ] ++ buildInputs ++ devInputs;
@@ -156,11 +147,11 @@ let
     name = "hydra-format-shell";
     buildInputs = [
       pkgs.treefmt
-      fourmolu
-      cabal-fmt
+      tools.fourmolu
+      tools.cabal-fmt
       pkgs.nixpkgs-fmt
       tools.hlint
-      apply-refact
+      tools.apply-refact
     ];
   };
 

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -96,18 +96,6 @@ let
     ];
   };
 
-  fmtShell = pkgs.mkShell {
-    name = "hydra-format-shell";
-    buildInputs = [
-      tools.treefmt
-      tools.fourmolu
-      tools.cabal-fmt
-      tools.nixpkgs-fmt
-      tools.hlint
-      tools.apply-refact
-    ];
-  };
-
   # If you want to modify `Python` code add `libtmux` and pyyaml to the
   # `buildInputs` then enter it and then run `Python` module directly so you
   # have fast devel cycle.
@@ -122,5 +110,4 @@ in
   cabalOnly = cabalShell;
   exes = exeShell;
   demo = demoShell;
-  fmt = fmtShell;
 }

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -4,14 +4,49 @@
 
 { hsPkgs
 , inputs
-, tools
 , system
 , pkgs
 , compiler
 }:
 let
 
-  buildInputs = pkgs.lib.mapAttrsToList (_: v: v) tools;
+  buildInputs = [
+    # For running automatic refactoring with hlint
+    pkgs.apply-refact
+    pkgs.cabal-fmt
+    pkgs.cabal-install
+    # Handy tool to debug the cabal build plan
+    pkgs.cabal-plan
+    # To interact with cardano-node and integration tests
+    pkgs.cardano-cli
+    # For integration tests
+    pkgs.cardano-node
+    # For validating JSON instances against a pre-defined schema
+    pkgs.check-jsonschema
+    pkgs.fourmolu
+    pkgs.git
+    # For plotting results of hydra-cluster benchmarks
+    pkgs.gnuplot
+    pkgs.haskell-language-server
+    pkgs.hlint
+    pkgs.haskellPackages.hspec-discover
+    # The interactive Glasgow Haskell Compiler as a Daemon
+    pkgs.haskellPackages.ghcid
+    # Generate a graph of the module dependencies in the "dot" format
+    pkgs.haskellPackages.graphmod
+    # To interact with mithril and integration tests
+    pkgs.mithril-client-cli
+    pkgs.nixpkgs-fmt
+    pkgs.nodejs
+    pkgs.pkg-config
+    # For generating plantuml drawings
+    pkgs.plantuml
+    pkgs.treefmt
+    # Handy to interact with the hydra-node via websockets
+    pkgs.websocat
+    pkgs.yarn
+    pkgs.yq
+  ];
 
   libs = [
     pkgs.glibcLocales
@@ -53,8 +88,8 @@ let
 
     buildInputs = libs ++ [
       hsPkgs.compiler.${compiler}
-      tools.cabal-install
-      tools.pkg-config
+      pkgs.cabal-install
+      pkgs.pkg-config
     ] ++ buildInputs;
 
     # Ensure that libz.so and other libraries are available to TH splices.

--- a/spec/default.nix
+++ b/spec/default.nix
@@ -1,5 +1,4 @@
-{ pkgs ? import <nixpkgs> { }
-}:
+{ pkgs }:
 
 pkgs.stdenvNoCC.mkDerivation rec {
   name = "hydra-spec";


### PR DESCRIPTION
We no longer need .#ci. input-output-hk urls are stale. Moves pkgs and tools to the top level and simplified the haskell.nix project function. Removes` impure argument defaults like currentSystem and \<nixpkgs\>.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
