### PR TITLE
Re-enable tests and detail changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,15 @@ changes.
 
 ## [0.16.0] - UNRELEASED
 
-- Add metadata to identify Hydra protocol transactions created by `hydra-node`.
+- **DO NOT RELEASE** as only tested against Sanchonet.
+
+- **BREAKING** Update to and tested against `cardano-node 8.8.0-pre` and `cardano-cli 8.20`. This made smoke tests incompatible with public testnets and mainnet.
+
+- **BREAKING** Hydra scripts changed due to updates in the `plutus` toolchain.
 
 - **BREAKING** Transaction serialization on hydra-node api and persisted data changed.
+
+- Add metadata to identify Hydra protocol transactions created by `hydra-node`.
 
 - Provide more details about why a command failed. Added the state of the head logic at the point of failure.
 
@@ -23,15 +29,7 @@ changes.
 
 - Add `--sanchonet` option to `hydra-cluster` binary.
 
-- Reduce cost of transactions submitted by `hydra-node` by better estimating
-  fees in internal wallet
-  [#1315](https://github.com/input-output-hk/hydra/pull/1315).
-
-- **BREAKING** Regenerated hydra scripts.
-
-- **BREAKING** Update to cardano-node 8.8.0 and remove Mainnet compatibility. Application is now only tested against Sanchonet.
-
-- Tested with `cardano-node 8.8.0-pre` and `cardano-node 8.20`.
+- Reduce cost of transactions submitted by `hydra-node` by better estimating fees in internal wallet [#1315](https://github.com/input-output-hk/hydra/pull/1315).
 
 ## [0.15.0] - 2024-01-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ changes.
 
 - **BREAKING** Update to and tested against `cardano-node 8.8.0-pre` and `cardano-cli 8.20`. This made smoke tests incompatible with public testnets and mainnet.
 
-- **BREAKING** Hydra scripts changed due to updates in the `plutus` toolchain.
+- **BREAKING** Hydra scripts changed due to updates in the `plutus` toolchain:
+  - Overall slight increase in script size.
+  - 50% less memory usage in `close` and `contest` transactions.
+  - Slightly less memory usage in `abort` and may be possible with 6 parties now.
 
 - **BREAKING** Transaction serialization on hydra-node api and persisted data changed.
 

--- a/hydra-cluster/test/Test/CardanoNodeSpec.hs
+++ b/hydra-cluster/test/Test/CardanoNodeSpec.hs
@@ -38,7 +38,8 @@ spec = do
         slot2 <- queryTipSlotNo networkId nodeSocket
         slot2 `shouldSatisfy` (> slot1)
 
-    it "withCardanoNodeOnKnownNetwork on mainnet starts synchronizing within 5 seconds" $ \(_, _) -> pendingWith "not yet supported"
+    it "withCardanoNodeOnKnownNetwork on mainnet starts synchronizing within 5 seconds" $ \_ ->
+      pendingWith "cardano-node 8.8 is not supported on mainnet (config mismatch)"
 
     it "withCardanoNodeOnKnownNetwork on sanchonet starts synchronizing within 5 seconds" $ \(tr, tmp) ->
       -- NOTE: This implies that withCardanoNodeOnKnownNetwork does not
@@ -53,7 +54,9 @@ spec = do
         slot2 `shouldSatisfy` (> slot1)
 
     describe "findRunningCardanoNode" $ do
-      it "returns Nothing on non-matching network" $ const $ pendingWith "No other valid network to test against."
+      it "returns Nothing on non-matching network" $ \(tr, tmp) -> do
+        withCardanoNodeOnKnownNetwork tr tmp Sanchonet $ \_ -> do
+          findRunningCardanoNode tmp Preproduction `shouldReturn` Nothing
 
       it "returns Just running node on matching network" $ \(tr, tmp) -> do
         withCardanoNodeOnKnownNetwork tr tmp Sanchonet $ \runningNode -> do


### PR DESCRIPTION
Pushed my changes from within #1297 again as they have seemingly gotten lost.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
