### PR TITLE
LoggingSpec: add threadDelay

### DIFF
--- a/hydra-node/test/Hydra/LoggingSpec.hs
+++ b/hydra-node/test/Hydra/LoggingSpec.hs
@@ -18,6 +18,9 @@ spec = do
       withTracer (Verbose "test") $ \tracer -> do
         traceWith tracer (object ["foo" .= (42 :: Int)])
 
+    -- This test is flakey in CI. Suspected race condition.
+    liftIO $ threadDelay 2
+
     captured `shouldContain` "{\"foo\":42}"
 
   prop "Validates logs.yaml schema" $


### PR DESCRIPTION
Not sure if this fixes the flaky logging output test.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
