### PR TITLE
Better free port behavior

### DIFF
--- a/hydra-test-utils/src/Test/Network/Ports.hs
+++ b/hydra-test-utils/src/Test/Network/Ports.hs
@@ -5,9 +5,8 @@ import Hydra.Prelude
 
 import Network.Socket (
   PortNumber,
-  close',
  )
-import Network.Socket.Free (openFreePort)
+import Network.Socket.Free (getFreePort)
 
 -- | Find a TCPv4 port which is likely to be free for listening on
 -- @localhost@. This binds a socket, receives an OS-assigned port, then closes
@@ -19,9 +18,7 @@ import Network.Socket.Free (openFreePort)
 -- Do not use this unless you have no other option.
 getRandomPort :: IO PortNumber
 getRandomPort = do
-  (port, sock) <- openFreePort
-  liftIO $ close' sock
-  return $ fromIntegral port
+  fromIntegral <$> getFreePort
 
 -- | Find a free TCPv4 port and pass it to the given 'action'.
 --


### PR DESCRIPTION
In order to improve port handling in tests I found out that `getFreePort` behaves a bit better than the combination of `openFreePort` and `close'`. On my local I can run `cabal test hydra-node` and see it go through without any errors related to busy ports.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
