### PR TITLE
Fix Conway support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ changes.
 
 - Reduce cost of transactions submitted by `hydra-node` by better estimating fees in internal wallet [#1315](https://github.com/input-output-hk/hydra/pull/1315).
 
+- Fix conversion of `Conway` blocks and fully verify `hydra-node` working on Conway networks like `sanchonet`.
+
 ## [0.15.0] - 2024-01-18
 
 - Tested with `cardano-node 8.7.3` and `cardano-cli 8.17.0.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ changes.
 
 - Fix conversion of `Conway` blocks and fully verify `hydra-node` working on Conway networks like `sanchonet`.
 
+- Add support for `Conway` in `hydra-chain-observer`.
+
 ## [0.15.0] - 2024-01-18
 
 - Tested with `cardano-node 8.7.3` and `cardano-cli 8.17.0.0`.

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Tx.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Tx.hs
@@ -35,7 +35,7 @@ convertTx ::
   Maybe (Tx eraTo)
 convertTx tx =
   case deserialiseFromCBOR (proxyToAsType (Proxy @(Tx eraTo))) bytes of
-    Left err -> trace ("CONVERT TX: " <> show err) Nothing
+    Left err -> Nothing
     Right tx' -> Just tx'
  where
   bytes = serialiseToCBOR tx

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Tx.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Tx.hs
@@ -17,7 +17,6 @@ import Cardano.Ledger.Core qualified as Ledger (Tx, hashScript)
 import Data.Bifunctor (bimap)
 import Data.Functor ((<&>))
 import Data.Map qualified as Map
-import Debug.Trace (trace)
 import Hydra.Cardano.Api.AlonzoEraOnwards (IsAlonzoEraOnwards (..))
 import Hydra.Cardano.Api.TxIn (mkTxIn)
 
@@ -35,7 +34,7 @@ convertTx ::
   Maybe (Tx eraTo)
 convertTx tx =
   case deserialiseFromCBOR (proxyToAsType (Proxy @(Tx eraTo))) bytes of
-    Left err -> Nothing
+    Left _err -> Nothing
     Right tx' -> Just tx'
  where
   bytes = serialiseToCBOR tx

--- a/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
@@ -55,7 +55,6 @@ import Cardano.Ledger.Hashes (EraIndependentTxBody)
 import Cardano.Ledger.SafeHash qualified as SafeHash
 import Cardano.Ledger.Shelley.API (unUTxO)
 import Cardano.Ledger.Shelley.API qualified as Ledger
-import Cardano.Ledger.Shelley.API.Wallet (evaluateTransactionFee)
 import Cardano.Ledger.Val (Val (..), invert)
 import Cardano.Slotting.EpochInfo (EpochInfo)
 import Cardano.Slotting.Time (SystemStart (..))
@@ -307,7 +306,7 @@ coverFee_ pparams systemStart epochInfo lookupUTxO walletUTxO partialTx@Babbage.
 
   -- Compute fee using a body with selected txOut to pay fees (= full change)
   -- and an aditional witness (we will sign this tx later)
-  let fee = evaluateTransactionFee pparams costingTx additionalWitnesses
+  let fee = estimateMinFeeTx pparams costingTx additionalWitnesses 0
       costingTx =
         unbalancedTx
           & bodyTxL . outputsTxBodyL %~ (|> feeTxOut)

--- a/testnets/sanchonet/cardano-node
+++ b/testnets/sanchonet/cardano-node
@@ -1,0 +1,1 @@
+../cardano-configurations/network/sanchonet/cardano-node

--- a/testnets/sanchonet/genesis
+++ b/testnets/sanchonet/genesis
@@ -1,0 +1,1 @@
+../cardano-configurations/network/sanchonet/genesis


### PR DESCRIPTION
* Seems like we fail to decode conway blocks when running the smoke tests on sanchonet. Converting transactions by re-encoding is maybe a more robust way forward.

* A successful smoke test with this version: https://github.com/input-output-hk/hydra/actions/runs/8046987024/job/21975334384

* Also fix `hydra-chain-observer` to handle conway blocks.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
