### PR TITLE
Switch to flake-parts

### DIFF
--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -49,8 +49,8 @@ jobs:
       if: ${{ matrix.package != 'hydra-tui' }}
       run: |
         cd ${{ matrix.package }}
-        nix build .#tests.${{ matrix.package }}
-        nix develop .#tests.${{ matrix.package }} --command tests
+        nix build .#${{ matrix.package }}-tests
+        nix develop .#${{ matrix.package }}-tests --command tests
 
     - name: ❓ Test (TUI)
       id: test_tui
@@ -62,8 +62,8 @@ jobs:
         TERM: "xterm"
       run: |
         cd ${{ matrix.package  }}
-        nix build .#tests.${{ matrix.package }}
-        nix develop .#tests.${{ matrix.package }} --build
+        nix build .#${{ matrix.package }}-tests
+        nix develop .#${{ matrix.package }}-tests --build
 
     - name: 💾 Upload build & test artifacts
       uses: actions/upload-artifact@v4
@@ -170,8 +170,8 @@ jobs:
       run: |
         mkdir -p benchmarks
         cd ${{ matrix.package }}
-        nix build .#benchs.${{ matrix.package }}
-        nix develop .#benchs.${{ matrix.package }} --command ${{ matrix.bench }} ${{ matrix.options }}
+        nix build .#${{ matrix.package }}-bench
+        nix develop .#${{ matrix.package }}-bench --command ${{ matrix.bench }} ${{ matrix.options }}
 
     - name: 💾 Upload build & test artifacts
       uses: actions/upload-artifact@v4

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,8 +36,8 @@ right place before, you can use these `nix` builds from the repository root:
 nix build .#spec && ln -s $(readlink result)/hydra-spec.pdf docs/static/hydra-spec.pdf
 nix build .#haddocks -o docs/static/haddock
 
-(cd hydra-node; nix develop .#benchs.hydra-node --command tx-cost --output-directory $(pwd)/../docs/benchmarks)
-(cd hydra-cluster; nix develop .#benchs.hydra-cluster --command bench-e2e --scaling-factor 1 --output-directory $(pwd)/../docs/benchmarks)
+(cd hydra-node; nix develop .#hydra-node-bench --command tx-cost --output-directory $(pwd)/../docs/benchmarks)
+(cd hydra-cluster; nix develop .#hydra-cluster-bench --command bench-e2e --scaling-factor 1 --output-directory $(pwd)/../docs/benchmarks)
 ```
 
 # Translating

--- a/flake.lock
+++ b/flake.lock
@@ -670,6 +670,24 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
+        "lastModified": 1706830856,
+        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
         "lastModified": 1698882062,
         "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
         "owner": "hercules-ci",
@@ -774,24 +792,6 @@
       }
     },
     "flake-utils_7": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_8": {
       "locked": {
         "lastModified": 1644229661,
         "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
@@ -1553,7 +1553,7 @@
     },
     "lint-utils": {
       "inputs": {
-        "flake-utils": "flake-utils_8",
+        "flake-utils": "flake-utils_7",
         "nixpkgs": [
           "haskellNix",
           "nixpkgs"
@@ -1608,7 +1608,7 @@
     "mithril": {
       "inputs": {
         "crane": "crane_2",
-        "flake-parts": "flake-parts",
+        "flake-parts": "flake-parts_2",
         "nixpkgs": "nixpkgs_12",
         "treefmt-nix": "treefmt-nix"
       },
@@ -2168,6 +2168,24 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
+        "lastModified": 1706550542,
+        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "dir": "lib",
         "lastModified": 1698611440,
         "narHash": "sha256-jPjHjrerhYDy3q9+s5EAsuhyhuknNfowY6yt6pjn9pc=",
         "owner": "NixOS",
@@ -2686,7 +2704,7 @@
       "inputs": {
         "CHaP": "CHaP",
         "cardano-node": "cardano-node",
-        "flake-utils": "flake-utils_7",
+        "flake-parts": "flake-parts",
         "haskellNix": "haskellNix_2",
         "hls": "hls",
         "iohk-nix": "iohk-nix",
@@ -2942,21 +2960,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     nixpkgs.follows = "haskellNix/nixpkgs";
     haskellNix.url = "github:input-output-hk/haskell.nix";
     iohk-nix.url = "github:input-output-hk/iohk-nix";
-    flake-utils.url = "github:numtide/flake-utils";
+    flake-parts.url = "github:hercules-ci/flake-parts";
     lint-utils = {
       url = "github:homotopic/lint-utils";
       inputs.nixpkgs.follows = "haskellNix/nixpkgs";
@@ -25,110 +25,107 @@
 
   outputs =
     { self
-    , flake-utils
+    , flake-parts
     , nixpkgs
     , cardano-node
     , ...
     } @ inputs:
-    flake-utils.lib.eachSystem [
-      "x86_64-linux"
-      "x86_64-darwin"
-      "aarch64-darwin"
-    ]
-      (system:
-      let
-        compiler = "ghc964";
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      perSystem = { config, system, ... }:
+        let
+          compiler = "ghc964";
 
-        # nixpkgs enhanced with haskell.nix and crypto libs as used by iohk
+          # nixpkgs enhanced with haskell.nix and crypto libs as used by iohk
 
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [
-            # This overlay contains libsodium and libblst libraries
-            inputs.iohk-nix.overlays.crypto
-            # This overlay contains pkg-config mappings via haskell.nix to use the
-            # crypto libraries above
-            inputs.iohk-nix.overlays.haskell-nix-crypto
-            # Keep haskell.nix as the last overlay!
-            #
-            # Reason: haskell.nix modules/overlays neds to be last
-            # https://github.com/input-output-hk/haskell.nix/issues/1954
-            inputs.haskellNix.overlay
-            # Custom static libs used for darwin build
-            (import ./nix/static-libs.nix)
-            inputs.nix-npm-buildpackage.overlays.default
-            # Specific versions of tools we require
-            (final: prev: {
-              apply-refact = pkgs.haskell-nix.tool compiler "apply-refact" "0.14.0.0";
-              cabal-fmt = pkgs.haskell-nix.tool compiler "cabal-fmt" "0.1.9";
-              cabal-install = pkgs.haskell-nix.cabal-install.${compiler};
-              cabal-plan = pkgs.haskell-nix.tool compiler "cabal-plan" "0.7.3.0";
-              fourmolu = pkgs.haskell-nix.tool compiler "fourmolu" "0.14.0.0";
-              haskell-language-server = pkgs.haskell-nix.tool compiler "haskell-language-server" rec {
-                src = inputs.hls;
-                cabalProject = builtins.readFile (src + "/cabal.project");
-              };
-              hlint = pkgs.haskell-nix.tool compiler "hlint" "3.8";
-              cardano-cli = inputs.cardano-node.packages.${system}.cardano-cli;
-              cardano-node = inputs.cardano-node.packages.${system}.cardano-node;
-              mithril-client-cli = inputs.mithril.packages.${system}.mithril-client-cli;
-            })
-          ];
-        };
-
-        inputMap = { "https://intersectmbo.github.io/cardano-haskell-packages" = inputs.CHaP; };
-
-        hsPkgs = import ./nix/hydra/project.nix {
-          inherit pkgs inputMap;
-          compiler-nix-name = compiler;
-        };
-
-        hydraPackages = import ./nix/hydra/packages.nix {
-          inherit system pkgs inputs hsPkgs self;
-          gitRev = self.rev or "dirty";
-        };
-
-        hydraImages = import ./nix/hydra/docker.nix {
-          inherit hydraPackages system nixpkgs;
-        };
-
-        prefixAttrs = s: attrs:
-          with pkgs.lib.attrsets;
-          mapAttrs' (name: value: nameValuePair (s + name) value) attrs;
-
-      in
-      rec {
-        legacyPackages = pkgs;
-
-        packages =
-          hydraPackages //
-          prefixAttrs "docker-" hydraImages // {
-            spec = import ./spec { inherit pkgs; };
-          };
-
-        checks = let lu = inputs.lint-utils.linters.${system}; in {
-          hlint = lu.hlint { src = self; hlint = pkgs.hlint; };
-          treefmt = lu.treefmt {
-            src = self;
-            buildInputs = [
-              pkgs.cabal-fmt
-              pkgs.nixpkgs-fmt
-              pkgs.fourmolu
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [
+              # This overlay contains libsodium and libblst libraries
+              inputs.iohk-nix.overlays.crypto
+              # This overlay contains pkg-config mappings via haskell.nix to use the
+              # crypto libraries above
+              inputs.iohk-nix.overlays.haskell-nix-crypto
+              # Keep haskell.nix as the last overlay!
+              #
+              # Reason: haskell.nix modules/overlays neds to be last
+              # https://github.com/input-output-hk/haskell.nix/issues/1954
+              inputs.haskellNix.overlay
+              # Custom static libs used for darwin build
+              (import ./nix/static-libs.nix)
+              inputs.nix-npm-buildpackage.overlays.default
+              # Specific versions of tools we require
+              (final: prev: {
+                apply-refact = pkgs.haskell-nix.tool compiler "apply-refact" "0.14.0.0";
+                cabal-fmt = pkgs.haskell-nix.tool compiler "cabal-fmt" "0.1.9";
+                cabal-install = pkgs.haskell-nix.cabal-install.${compiler};
+                cabal-plan = pkgs.haskell-nix.tool compiler "cabal-plan" "0.7.3.0";
+                fourmolu = pkgs.haskell-nix.tool compiler "fourmolu" "0.14.0.0";
+                haskell-language-server = pkgs.haskell-nix.tool compiler "haskell-language-server" rec {
+                  src = inputs.hls;
+                  cabalProject = builtins.readFile (src + "/cabal.project");
+                };
+                hlint = pkgs.haskell-nix.tool compiler "hlint" "3.8";
+                cardano-cli = inputs.cardano-node.packages.${system}.cardano-cli;
+                cardano-node = inputs.cardano-node.packages.${system}.cardano-node;
+                mithril-client-cli = inputs.mithril.packages.${system}.mithril-client-cli;
+              })
             ];
-            treefmt = pkgs.treefmt;
           };
-        };
 
-        devShells = import ./nix/hydra/shell.nix {
-          inherit inputs pkgs hsPkgs system compiler;
-        };
+          inputMap = { "https://intersectmbo.github.io/cardano-haskell-packages" = inputs.CHaP; };
 
-        # Build selected derivations in CI for caching
-        hydraJobs = pkgs.lib.optionalAttrs (!pkgs.stdenv.isDarwin) {
-          packages = { inherit (packages) hydra-node hydra-tui hydraw spec; };
-          devShells = { inherit (devShells) default; };
+          hsPkgs = import ./nix/hydra/project.nix {
+            inherit pkgs inputMap;
+            compiler-nix-name = compiler;
+          };
+
+          hydraPackages = import ./nix/hydra/packages.nix {
+            inherit system pkgs inputs hsPkgs self;
+            gitRev = self.rev or "dirty";
+          };
+
+          hydraImages = import ./nix/hydra/docker.nix {
+            inherit hydraPackages system nixpkgs;
+          };
+
+          prefixAttrs = s: attrs:
+            with pkgs.lib.attrsets;
+            mapAttrs' (name: value: nameValuePair (s + name) value) attrs;
+
+        in
+        rec {
+          legacyPackages = pkgs;
+
+          packages =
+            hydraPackages //
+            prefixAttrs "docker-" hydraImages // {
+              spec = import ./spec { inherit pkgs; };
+            };
+
+          checks = let lu = inputs.lint-utils.linters.${system}; in {
+            hlint = lu.hlint { src = self; hlint = pkgs.hlint; };
+            treefmt = lu.treefmt {
+              src = self;
+              buildInputs = [
+                pkgs.cabal-fmt
+                pkgs.nixpkgs-fmt
+                pkgs.fourmolu
+              ];
+              treefmt = pkgs.treefmt;
+            };
+          };
+
+          devShells = import ./nix/hydra/shell.nix {
+            inherit inputs pkgs hsPkgs system compiler;
+          };
+
         };
-      });
+    };
 
   nixConfig = {
     extra-substituters = [

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -116,73 +116,69 @@ rec {
 
   hydraw-static = musl64Pkgs.hydraw.components.exes.hydraw;
 
-  tests = {
-    plutus-cbor = pkgs.mkShellNoCC {
-      name = "plutus-cbor-tests";
-      buildInputs = [ nativePkgs.plutus-cbor.components.tests.tests ];
-    };
-    plutus-merkle-tree = pkgs.mkShellNoCC {
-      name = "plutus-merkle-tree-tests";
-      buildInputs = [ nativePkgs.plutus-merkle-tree.components.tests.tests ];
-    };
-    hydra-plutus = pkgs.mkShellNoCC {
-      name = "hydra-plutus-tests";
-      buildInputs = [ nativePkgs.hydra-plutus.components.tests.tests ];
-    };
-    hydra-node = pkgs.mkShellNoCC {
-      name = "hydra-node-tests";
-      buildInputs = [
-        nativePkgs.hydra-node.components.tests.tests
+  plutus-cbor-tests = pkgs.mkShellNoCC {
+    name = "plutus-cbor-tests";
+    buildInputs = [ nativePkgs.plutus-cbor.components.tests.tests ];
+  };
+  plutus-merkle-tree-tests = pkgs.mkShellNoCC {
+    name = "plutus-merkle-tree-tests";
+    buildInputs = [ nativePkgs.plutus-merkle-tree.components.tests.tests ];
+  };
+  hydra-plutus-tests = pkgs.mkShellNoCC {
+    name = "hydra-plutus-tests";
+    buildInputs = [ nativePkgs.hydra-plutus.components.tests.tests ];
+  };
+  hydra-node-tests = pkgs.mkShellNoCC {
+    name = "hydra-node-tests";
+    buildInputs = [
+      nativePkgs.hydra-node.components.tests.tests
+      pkgs.check-jsonschema
+    ];
+  };
+  hydra-cluster-tests = pkgs.mkShellNoCC {
+    name = "hydra-cluster-tests";
+    buildInputs =
+      [
+        nativePkgs.hydra-cluster.components.tests.tests
+        hydra-node
+        hydra-chain-observer
+        inputs.cardano-node.packages.${system}.cardano-node
+        inputs.cardano-node.packages.${system}.cardano-cli
+        inputs.mithril.packages.${system}.mithril-client-cli
         pkgs.check-jsonschema
+        hydra-explorer
       ];
-    };
-    hydra-cluster = pkgs.mkShellNoCC {
-      name = "hydra-cluster-tests";
-      buildInputs =
-        [
-          nativePkgs.hydra-cluster.components.tests.tests
-          hydra-node
-          hydra-chain-observer
-          inputs.cardano-node.packages.${system}.cardano-node
-          inputs.cardano-node.packages.${system}.cardano-cli
-          inputs.mithril.packages.${system}.mithril-client-cli
-          pkgs.check-jsonschema
-          hydra-explorer
-        ];
-    };
-    hydra-tui = pkgs.mkShellNoCC {
-      name = "hydra-tui-tests";
-      buildInputs =
-        [
-          nativePkgs.hydra-tui.components.tests.tests
-          hydra-node
-          inputs.cardano-node.packages.${system}.cardano-node
-        ];
-    };
+  };
+  hydra-tui-tests = pkgs.mkShellNoCC {
+    name = "hydra-tui-tests";
+    buildInputs =
+      [
+        nativePkgs.hydra-tui.components.tests.tests
+        hydra-node
+        inputs.cardano-node.packages.${system}.cardano-node
+      ];
   };
 
-  benchs = {
-    hydra-node = pkgs.mkShellNoCC {
-      name = "bench-hydra-node";
-      buildInputs = [
-        nativePkgs.hydra-node.components.benchmarks.tx-cost
-        nativePkgs.hydra-node.components.benchmarks.micro
+  hydra-node-bench = pkgs.mkShellNoCC {
+    name = "hydra-node-bench";
+    buildInputs = [
+      nativePkgs.hydra-node.components.benchmarks.tx-cost
+      nativePkgs.hydra-node.components.benchmarks.micro
+    ];
+  };
+  hydra-cluster-bench = pkgs.mkShellNoCC {
+    name = "hydra-cluster-bench";
+    buildInputs =
+      [
+        nativePkgs.hydra-cluster.components.benchmarks.bench-e2e
+        hydra-node
+        inputs.cardano-node.packages.${system}.cardano-node
+        inputs.cardano-node.packages.${system}.cardano-cli
       ];
-    };
-    hydra-cluster = pkgs.mkShellNoCC {
-      name = "bench-hydra-cluster";
-      buildInputs =
-        [
-          nativePkgs.hydra-cluster.components.benchmarks.bench-e2e
-          hydra-node
-          inputs.cardano-node.packages.${system}.cardano-node
-          inputs.cardano-node.packages.${system}.cardano-cli
-        ];
-    };
-    plutus-merkle-tree = pkgs.mkShellNoCC {
-      name = "bench-plutus-merkle-tree";
-      buildInputs = [ nativePkgs.plutus-merkle-tree.components.benchmarks.on-chain-cost ];
-    };
+  };
+  plutus-merkle-tree-bench = pkgs.mkShellNoCC {
+    name = "plutus-merkle-tree-bench";
+    buildInputs = [ nativePkgs.plutus-merkle-tree.components.benchmarks.on-chain-cost ];
   };
 
   haddocks = pkgs.runCommand "hydra-haddocks"


### PR DESCRIPTION
This shows how it would look if we switched to flake parts. Not much difference as is, except that we can no longer have `hydraJobs` or nested attributes like `benches`. This give us this option to modularise the flake.

Now

```
nix flake show --allow-import-from-derivation --json | jq
```

looks great


<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
