### PR TITLE
Remove hardcoded Babbage references

### DIFF
--- a/hydra-cardano-api/src/Cardano/Api/UTxO.hs
+++ b/hydra-cardano-api/src/Cardano/Api/UTxO.hs
@@ -20,6 +20,8 @@ import Data.Map qualified as Map
 import Data.Set (Set)
 import Data.Text (Text)
 import Data.Text qualified as T
+import Hydra.Cardano.Api.AlonzoEraOnwards (IsAlonzoEraOnwards (..))
+import Hydra.Cardano.Api.BabbageEraOnwards (IsBabbageEraOnwards (..))
 import Prelude
 
 type Era = BabbageEra
@@ -106,7 +108,7 @@ fromApi (Cardano.Api.UTxO eraUTxO) =
       (convertRefScriptToEra eraRefScript)
 
   convertAddressToEra :: AddressInEra era -> AddressInEra Era
-  convertAddressToEra (AddressInEra _ eraAddress) = anyAddressInShelleyBasedEra ShelleyBasedEraBabbage (toAddressAny eraAddress)
+  convertAddressToEra (AddressInEra _ eraAddress) = anyAddressInShelleyBasedEra shelleyBasedEra (toAddressAny eraAddress)
 
   convertValueToEra :: TxOutValue era -> TxOutValue Era
   convertValueToEra (TxOutValueByron lovelace) = lovelaceToTxOutValue shelleyBasedEra lovelace
@@ -114,12 +116,12 @@ fromApi (Cardano.Api.UTxO eraUTxO) =
 
   convertDatumToEra :: TxOutDatum CtxUTxO era -> TxOutDatum CtxUTxO Era
   convertDatumToEra TxOutDatumNone = TxOutDatumNone
-  convertDatumToEra (TxOutDatumHash _ hashScriptData) = TxOutDatumHash AlonzoEraOnwardsBabbage hashScriptData
-  convertDatumToEra (TxOutDatumInline _ hashableScriptData) = TxOutDatumInline BabbageEraOnwardsBabbage hashableScriptData
+  convertDatumToEra (TxOutDatumHash _ hashScriptData) = TxOutDatumHash alonzoEraOnwards hashScriptData
+  convertDatumToEra (TxOutDatumInline _ hashableScriptData) = TxOutDatumInline babbageEraOnwards hashableScriptData
 
   convertRefScriptToEra :: ReferenceScript era -> ReferenceScript Era
   convertRefScriptToEra ReferenceScriptNone = ReferenceScriptNone
-  convertRefScriptToEra (ReferenceScript _ scriptInAnyLang) = ReferenceScript BabbageEraOnwardsBabbage scriptInAnyLang
+  convertRefScriptToEra (ReferenceScript _ scriptInAnyLang) = ReferenceScript babbageEraOnwards scriptInAnyLang
 
 toApi :: UTxO -> Cardano.Api.UTxO Era
 toApi = coerce

--- a/hydra-cardano-api/src/Hydra/Cardano/Api.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api.hs
@@ -193,7 +193,7 @@ pattern ShelleyAddressInAnyEra <-
   Cardano.Api.ShelleyAddressInEra _
   where
     ShelleyAddressInAnyEra =
-      Cardano.Api.ShelleyAddressInEra ShelleyBasedEraBabbage
+      Cardano.Api.ShelleyAddressInEra shelleyBasedEra
 
 -- ** BalancedTxBody
 
@@ -217,14 +217,14 @@ pattern ShelleyBootstrapWitness{shelleyBootstrapWitness} <-
   Cardano.Api.Shelley.ShelleyBootstrapWitness _ shelleyBootstrapWitness
   where
     ShelleyBootstrapWitness =
-      Cardano.Api.Shelley.ShelleyBootstrapWitness ShelleyBasedEraBabbage
+      Cardano.Api.Shelley.ShelleyBootstrapWitness shelleyBasedEra
 
 pattern ShelleyKeyWitness :: Ledger.WitVKey 'Ledger.Witness StandardCrypto -> KeyWitness
 pattern ShelleyKeyWitness{shelleyKeyWitness} <-
   Cardano.Api.Shelley.ShelleyKeyWitness _ shelleyKeyWitness
   where
     ShelleyKeyWitness =
-      Cardano.Api.Shelley.ShelleyKeyWitness ShelleyBasedEraBabbage
+      Cardano.Api.Shelley.ShelleyKeyWitness shelleyBasedEra
 
 -- ** PlutusScript
 

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/AlonzoEraOnwards.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/AlonzoEraOnwards.hs
@@ -1,6 +1,6 @@
 module Hydra.Cardano.Api.AlonzoEraOnwards where
 
-import Hydra.Cardano.Api.Prelude
+import Cardano.Api (AlonzoEra, AlonzoEraOnwards (..), BabbageEra, ConwayEra)
 
 -- | Type class to produce 'AlonzoEraOnwards' witness values while staying
 -- parameterized by era.

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/BabbageEraOnwards.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/BabbageEraOnwards.hs
@@ -1,6 +1,6 @@
 module Hydra.Cardano.Api.BabbageEraOnwards where
 
-import Hydra.Cardano.Api.Prelude
+import Cardano.Api (BabbageEra, BabbageEraOnwards (..), ConwayEra)
 
 -- | Type class to produce 'BabbageEraOnwards' witness values while staying
 -- parameterized by era.

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Tx.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Tx.hs
@@ -17,6 +17,7 @@ import Cardano.Ledger.Core qualified as Ledger (Tx, hashScript)
 import Data.Bifunctor (bimap)
 import Data.Functor ((<&>))
 import Data.Map qualified as Map
+import Hydra.Cardano.Api.AlonzoEraOnwards (IsAlonzoEraOnwards (..))
 import Hydra.Cardano.Api.TxIn (mkTxIn)
 
 -- * Extras
@@ -93,15 +94,12 @@ toLedgerTx = \case
 fromLedgerTx :: Ledger.Tx (ShelleyLedgerEra Era) -> Tx Era
 fromLedgerTx ledgerTx =
   Tx
-    (ShelleyTxBody era body scripts scriptsData (strictMaybeToMaybe auxData) validity)
+    (ShelleyTxBody shelleyBasedEra body scripts scriptsData (strictMaybeToMaybe auxData) validity)
     (fromLedgerTxWitness wits)
  where
   -- XXX: The suggested way (by the ledger team) forward is to use lenses to
   -- introspect ledger transactions.
   Ledger.AlonzoTx body wits isValid auxData = ledgerTx
-
-  era =
-    ShelleyBasedEraBabbage
 
   scripts =
     Map.elems $ Ledger.txscripts' wits
@@ -109,12 +107,12 @@ fromLedgerTx ledgerTx =
   scriptsData :: TxBodyScriptData Era
   scriptsData =
     TxBodyScriptData
-      AlonzoEraOnwardsBabbage
+      alonzoEraOnwards
       (Ledger.txdats' wits)
       (Ledger.txrdmrs' wits)
 
   validity = case isValid of
     Ledger.IsValid True ->
-      TxScriptValidity AlonzoEraOnwardsBabbage ScriptValid
+      TxScriptValidity alonzoEraOnwards ScriptValid
     Ledger.IsValid False ->
-      TxScriptValidity AlonzoEraOnwardsBabbage ScriptInvalid
+      TxScriptValidity alonzoEraOnwards ScriptInvalid

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/ValidityInterval.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/ValidityInterval.hs
@@ -30,8 +30,8 @@ fromLedgerValidityInterval validityInterval =
         SNothing -> TxValidityNoLowerBound
         SJust s -> TxValidityLowerBound AllegraEraOnwardsBabbage s
       upperBound = case invalidHereAfter of
-        SNothing -> TxValidityUpperBound ShelleyBasedEraBabbage Nothing
-        SJust s -> TxValidityUpperBound ShelleyBasedEraBabbage (Just s)
+        SNothing -> TxValidityUpperBound shelleyBasedEra Nothing
+        SJust s -> TxValidityUpperBound shelleyBasedEra (Just s)
    in (lowerBound, upperBound)
 
 instance Arbitrary (TxValidityLowerBound Era) where
@@ -42,4 +42,4 @@ instance Arbitrary (TxValidityLowerBound Era) where
       ]
 
 instance Arbitrary (TxValidityUpperBound Era) where
-  arbitrary = TxValidityUpperBound ShelleyBasedEraBabbage . fmap SlotNo <$> arbitrary
+  arbitrary = TxValidityUpperBound (shelleyBasedEra @Era) . fmap SlotNo <$> arbitrary

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Value.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Value.hs
@@ -24,7 +24,7 @@ minUTxOValue pparams (TxOut addr val dat ref) =
   fromLedgerLovelace $
     getMinCoinTxOut
       pparams
-      (toShelleyTxOut ShelleyBasedEraBabbage (toUTxOContext out'))
+      (toShelleyTxOut shelleyBasedEra (toUTxOContext out'))
  where
   out' =
     TxOut


### PR DESCRIPTION
Use more class based era terms Required depending on cardano-api directly because of import cycles. Would prefer to move the type classes to a layer that contained only those, named `cardano-api-classy`.

Edit: Also might want to consider removing the view patterns now before conway.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
