### PR TITLE
Remove more hardcoded Babbage references

### DIFF
--- a/hydra-cardano-api/hydra-cardano-api.cabal
+++ b/hydra-cardano-api/hydra-cardano-api.cabal
@@ -44,6 +44,7 @@ library
     Hydra.Cardano.Api
     Hydra.Cardano.Api.Address
     Hydra.Cardano.Api.AddressInEra
+    Hydra.Cardano.Api.AllegraEraOnwards
     Hydra.Cardano.Api.AlonzoEraOnwards
     Hydra.Cardano.Api.BabbageEraOnwards
     Hydra.Cardano.Api.BlockHeader

--- a/hydra-cardano-api/src/Cardano/Api/UTxO.hs
+++ b/hydra-cardano-api/src/Cardano/Api/UTxO.hs
@@ -22,6 +22,7 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Hydra.Cardano.Api.AlonzoEraOnwards (IsAlonzoEraOnwards (..))
 import Hydra.Cardano.Api.BabbageEraOnwards (IsBabbageEraOnwards (..))
+import Hydra.Cardano.Api.MaryEraOnwards (IsMaryEraOnwards (..))
 import Prelude
 
 type Era = BabbageEra
@@ -112,7 +113,7 @@ fromApi (Cardano.Api.UTxO eraUTxO) =
 
   convertValueToEra :: TxOutValue era -> TxOutValue Era
   convertValueToEra (TxOutValueByron lovelace) = lovelaceToTxOutValue shelleyBasedEra lovelace
-  convertValueToEra (TxOutValueShelleyBased sbe value) = TxOutValueShelleyBased shelleyBasedEra (toLedgerValue MaryEraOnwardsBabbage $ fromLedgerValue sbe value)
+  convertValueToEra (TxOutValueShelleyBased sbe value) = TxOutValueShelleyBased shelleyBasedEra (toLedgerValue (maryEraOnwards @Era) $ fromLedgerValue sbe value)
 
   convertDatumToEra :: TxOutDatum CtxUTxO era -> TxOutDatum CtxUTxO Era
   convertDatumToEra TxOutDatumNone = TxOutDatumNone

--- a/hydra-cardano-api/src/Hydra/Cardano/Api.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api.hs
@@ -155,8 +155,9 @@ import Cardano.Ledger.Alonzo.TxWits qualified as Ledger
 import Cardano.Ledger.Core qualified as Ledger
 import Cardano.Ledger.Keys qualified as Ledger
 import Data.ByteString.Short (ShortByteString)
+import Hydra.Cardano.Api.AllegraEraOnwards (IsAllegraEraOnwards (..))
+import Hydra.Cardano.Api.BabbageEraOnwards (IsBabbageEraOnwards (..))
 import Prelude
-import Hydra.Cardano.Api.BabbageEraOnwards (IsBabbageEraOnwards(..))
 
 -- ** AddressInEra
 
@@ -356,7 +357,7 @@ pattern TxAuxScripts{txAuxScripts'} <-
   Cardano.Api.TxAuxScripts _ txAuxScripts'
   where
     TxAuxScripts =
-      Cardano.Api.TxAuxScripts AllegraEraOnwardsBabbage
+      Cardano.Api.TxAuxScripts allegraEraOnwards
 
 -- ** TxBody
 
@@ -694,7 +695,7 @@ pattern TxValidityLowerBound{lowerBound} <-
   Cardano.Api.TxValidityLowerBound _ lowerBound
   where
     TxValidityLowerBound =
-      Cardano.Api.TxValidityLowerBound AllegraEraOnwardsBabbage
+      Cardano.Api.TxValidityLowerBound allegraEraOnwards
 
 -- ** TxValidityUpperBound
 

--- a/hydra-cardano-api/src/Hydra/Cardano/Api.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api.hs
@@ -156,6 +156,7 @@ import Cardano.Ledger.Core qualified as Ledger
 import Cardano.Ledger.Keys qualified as Ledger
 import Data.ByteString.Short (ShortByteString)
 import Prelude
+import Hydra.Cardano.Api.BabbageEraOnwards (IsBabbageEraOnwards(..))
 
 -- ** AddressInEra
 
@@ -466,7 +467,7 @@ pattern TxBodyScriptData{txBodyScriptDatums, txBodyScriptRedeemers} <-
   Cardano.Api.TxBodyScriptData _ txBodyScriptDatums txBodyScriptRedeemers
   where
     TxBodyScriptData =
-      Cardano.Api.TxBodyScriptData AlonzoEraOnwardsBabbage
+      Cardano.Api.TxBodyScriptData alonzoEraOnwards
 
 -- ** TxExtraKeyWitnesses
 
@@ -484,7 +485,7 @@ pattern TxExtraKeyWitnesses{txExtraKeyWitnesses} <-
   Cardano.Api.TxExtraKeyWitnesses _ txExtraKeyWitnesses
   where
     TxExtraKeyWitnesses =
-      Cardano.Api.TxExtraKeyWitnesses AlonzoEraOnwardsBabbage
+      Cardano.Api.TxExtraKeyWitnesses alonzoEraOnwards
 
 -- ** TxFee
 
@@ -496,7 +497,7 @@ pattern TxFeeExplicit{txFeeExplicit} <-
   Cardano.Api.TxFeeExplicit _ txFeeExplicit
   where
     TxFeeExplicit =
-      Cardano.Api.TxFeeExplicit ShelleyBasedEraBabbage
+      Cardano.Api.TxFeeExplicit shelleyBasedEra
 
 -- ** TxIns
 
@@ -519,7 +520,7 @@ pattern TxInsReference{txInsReference'} <-
   Cardano.Api.TxInsReference _ txInsReference'
   where
     TxInsReference =
-      Cardano.Api.TxInsReference Cardano.Api.Shelley.BabbageEraOnwardsBabbage
+      Cardano.Api.TxInsReference babbageEraOnwards
 
 -- ** TxInsCollateral
 
@@ -538,7 +539,7 @@ pattern TxInsCollateral{txInsCollateral'} <-
   Cardano.Api.TxInsCollateral _ txInsCollateral'
   where
     TxInsCollateral =
-      Cardano.Api.TxInsCollateral AlonzoEraOnwardsBabbage
+      Cardano.Api.TxInsCollateral alonzoEraOnwards
 
 -- ** TxMetadataInEra
 
@@ -557,7 +558,7 @@ pattern TxMetadataInEra{txMetadataInEra} <-
   Cardano.Api.TxMetadataInEra _ txMetadataInEra
   where
     TxMetadataInEra =
-      Cardano.Api.TxMetadataInEra ShelleyBasedEraBabbage
+      Cardano.Api.TxMetadataInEra shelleyBasedEra
 
 -- ** TxMintValue
 
@@ -579,7 +580,7 @@ pattern TxMintValue{txMintValueInEra, txMintValueScriptWitnesses} <-
   Cardano.Api.TxMintValue _ txMintValueInEra txMintValueScriptWitnesses
   where
     TxMintValue =
-      Cardano.Api.TxMintValue MaryEraOnwardsBabbage
+      Cardano.Api.TxMintValue maryEraOnwards
 
 -- ** TxOut
 
@@ -598,7 +599,7 @@ pattern TxOut{txOutAddress, txOutValue, txOutDatum, txOutReferenceScript} <-
     TxOut addr value datum ref =
       Cardano.Api.TxOut
         addr
-        (TxOutValueShelleyBased ShelleyBasedEraBabbage (Extras.toLedgerValue value))
+        (TxOutValueShelleyBased shelleyBasedEra (Extras.toLedgerValue value))
         datum
         ref
 
@@ -641,21 +642,21 @@ pattern TxOutDatumHash{txOutDatumHash} <-
   Cardano.Api.TxOutDatumHash _ txOutDatumHash
   where
     TxOutDatumHash =
-      Cardano.Api.TxOutDatumHash AlonzoEraOnwardsBabbage
+      Cardano.Api.TxOutDatumHash alonzoEraOnwards
 
 pattern TxOutDatumInTx :: HashableScriptData -> TxOutDatum CtxTx
 pattern TxOutDatumInTx{txOutDatumScriptData} <-
   Cardano.Api.TxOutDatumInTx _ txOutDatumScriptData
   where
     TxOutDatumInTx =
-      Cardano.Api.TxOutDatumInTx AlonzoEraOnwardsBabbage
+      Cardano.Api.TxOutDatumInTx alonzoEraOnwards
 
 pattern TxOutDatumInline :: HashableScriptData -> TxOutDatum ctx
 pattern TxOutDatumInline{txOutDatumInlineScriptData} <-
   Cardano.Api.TxOutDatumInline _ txOutDatumInlineScriptData
   where
     TxOutDatumInline =
-      Cardano.Api.TxOutDatumInline Cardano.Api.Shelley.BabbageEraOnwardsBabbage
+      Cardano.Api.TxOutDatumInline babbageEraOnwards
 
 -- ** TxScriptValidity
 
@@ -674,7 +675,7 @@ pattern TxScriptValidity{txScriptValidity'} <-
   Cardano.Api.TxScriptValidity _ txScriptValidity'
   where
     TxScriptValidity =
-      Cardano.Api.TxScriptValidity AlonzoEraOnwardsBabbage
+      Cardano.Api.TxScriptValidity alonzoEraOnwards
 
 -- ** TxValidityLowerBound
 

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/AllegraEraOnwards.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/AllegraEraOnwards.hs
@@ -1,0 +1,23 @@
+module Hydra.Cardano.Api.AllegraEraOnwards where
+
+import Cardano.Api (AllegraEra, AllegraEraOnwards (..), AlonzoEra, BabbageEra, ConwayEra, MaryEra)
+
+-- | Type class to produce 'AllegraEraOnwards' witness values while staying
+-- parameterized by era.
+class IsAllegraEraOnwards era where
+  allegraEraOnwards :: AllegraEraOnwards era
+
+instance IsAllegraEraOnwards AllegraEra where
+  allegraEraOnwards = AllegraEraOnwardsAllegra
+
+instance IsAllegraEraOnwards MaryEra where
+  allegraEraOnwards = AllegraEraOnwardsMary
+
+instance IsAllegraEraOnwards AlonzoEra where
+  allegraEraOnwards = AllegraEraOnwardsAlonzo
+
+instance IsAllegraEraOnwards BabbageEra where
+  allegraEraOnwards = AllegraEraOnwardsBabbage
+
+instance IsAllegraEraOnwards ConwayEra where
+  allegraEraOnwards = AllegraEraOnwardsConway

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/MaryEraOnwards.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/MaryEraOnwards.hs
@@ -1,6 +1,6 @@
 module Hydra.Cardano.Api.MaryEraOnwards where
 
-import Hydra.Cardano.Api.Prelude
+import Cardano.Api (AlonzoEra, BabbageEra, ConwayEra, MaryEra, MaryEraOnwards (..))
 
 -- | Type class to produce 'MaryEraOnwards' witness values while staying
 -- parameterized by era.

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/ValidityInterval.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/ValidityInterval.hs
@@ -6,6 +6,7 @@ import Hydra.Cardano.Api.Prelude
 
 import Cardano.Ledger.Allegra.Scripts qualified as Ledger
 import Cardano.Ledger.BaseTypes (StrictMaybe (..), maybeToStrictMaybe)
+import Hydra.Cardano.Api.AllegraEraOnwards (IsAllegraEraOnwards (..))
 import Test.QuickCheck (oneof)
 
 toLedgerValidityInterval ::
@@ -28,7 +29,7 @@ fromLedgerValidityInterval validityInterval =
   let Ledger.ValidityInterval{Ledger.invalidBefore = invalidBefore, Ledger.invalidHereafter = invalidHereAfter} = validityInterval
       lowerBound = case invalidBefore of
         SNothing -> TxValidityNoLowerBound
-        SJust s -> TxValidityLowerBound AllegraEraOnwardsBabbage s
+        SJust s -> TxValidityLowerBound allegraEraOnwards s
       upperBound = case invalidHereAfter of
         SNothing -> TxValidityUpperBound shelleyBasedEra Nothing
         SJust s -> TxValidityUpperBound shelleyBasedEra (Just s)
@@ -38,7 +39,7 @@ instance Arbitrary (TxValidityLowerBound Era) where
   arbitrary =
     oneof
       [ pure TxValidityNoLowerBound
-      , TxValidityLowerBound AllegraEraOnwardsBabbage . SlotNo <$> arbitrary
+      , TxValidityLowerBound allegraEraOnwards . SlotNo <$> arbitrary
       ]
 
 instance Arbitrary (TxValidityUpperBound Era) where


### PR DESCRIPTION
Use more classes 

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
