### PR TITLE
Move PostTxError input event into chain event type

### DIFF
--- a/hydra-node/golden/Event SimpleTx.json
+++ b/hydra-node/golden/Event SimpleTx.json
@@ -1,60 +1,10 @@
 {
     "samples": [
         {
-            "postChainTx": {
-                "confirmedSnapshot": {
-                    "signatures": {
-                        "multiSignature": [
-                            "7acc594b607e17c7d275b512d2feab0865849f7f2842593a7398f409914a0e91372b3dd8db3ca62c45d1a468330451af82b46873ca98930ff2863faed279da0c",
-                            "63c7f2e54353aacf0e90876be875f68def0c38bf8c3937e0c34560ba035ad9455f630f3a58574c3ab941b44c9ef031e2aeed4ba07f843e5e3d5290f2fd1f0906",
-                            "417c10ea2b723c01e7a0f04a487d8e6484e25d376a05386cff5fa461fe154a128daff256e468dc89e69d0581fd4c5af875eb3cbe0ada2c54ef1cabcc204bf407",
-                            "2756453295179e357d5a533bfd56cbf1bacda088715fea72d3af7566a2b4f24f0878f4d54798e7e15d3d4d94871a5d2fd64c6a0db5e2c6fce275a4401cedc606",
-                            "062e353f2db34f825925f034859a8ee51d1add6311944fef339de85a35fb27d866f4e5aefc4e87a248e0d14f0a5714f5991b97cb86c3886fe893f7e7f91cb00e"
-                        ]
-                    },
-                    "snapshot": {
-                        "confirmedTransactions": [],
-                        "headId": "d47ef17a7ccc05bf82f0625c1d931a0e",
-                        "snapshotNumber": 27,
-                        "utxo": [
-                            2,
-                            12
-                        ]
-                    },
-                    "tag": "ConfirmedSnapshot"
-                },
-                "headId": "c59608c612d55a0c882abaa18a1c250e",
-                "headParameters": {
-                    "contestationPeriod": 75488,
-                    "parties": [
-                        {
-                            "vkey": "ba2b316673c386efb932066ceafeb187b3c055d8092ed46cc296b56588fb480b"
-                        }
-                    ]
-                },
-                "tag": "CloseTx"
+            "clientInput": {
+                "tag": "Contest"
             },
-            "postTxError": {
-                "knownUTxO": [
-                    -27,
-                    -23,
-                    -17,
-                    -16,
-                    -13,
-                    -9,
-                    -3,
-                    2,
-                    5,
-                    10,
-                    11,
-                    16,
-                    17,
-                    21,
-                    27
-                ],
-                "tag": "CannotFindOwnInitial"
-            },
-            "tag": "PostTxError"
+            "tag": "ClientEvent"
         },
         {
             "message": {

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -1588,23 +1588,6 @@ definitions:
             enum: ["OnChainEvent"]
           chainEvent:
             $ref: "logs.yaml#/definitions/OnChainEvent"
-      - title: PostTxError
-        type: object
-        additionalProperties: false
-        required:
-          - tag
-          - postChainTx
-          - postTxError
-        description: >-
-          Event emitted when posting a transaction on the main chain failed.
-        properties:
-          tag:
-            type: string
-            enum: ["PostTxError"]
-          postChainTx:
-            $ref: "api.yaml#/components/schemas/PostChainTx"
-          postTxError:
-            $ref: "api.yaml#/components/schemas/PostTxError"
 
   Message:
     description: >-
@@ -1734,6 +1717,24 @@ definitions:
             $ref: "api.yaml#/components/schemas/UTCTime"
           chainSlot:
             $ref: "api.yaml#/components/schemas/ChainSlot"
+
+      - title: PostTxError
+        type: object
+        additionalProperties: false
+        required:
+          - tag
+          - postChainTx
+          - postTxError
+        description: >-
+          Event emitted when posting a transaction on the main chain failed.
+        properties:
+          tag:
+            type: string
+            enum: ["PostTxError"]
+          postChainTx:
+            $ref: "api.yaml#/components/schemas/PostChainTx"
+          postTxError:
+            $ref: "api.yaml#/components/schemas/PostTxError"
 
   OnChainTx:
     description: >-

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -1669,24 +1669,6 @@ definitions:
           newChainState:
             $ref: "api.yaml#/components/schemas/ChainState"
 
-      - title: IgnoredInitTx
-        type: object
-        additionalProperties: false
-        required:
-          - tag
-          - headId
-          - participants
-        properties:
-          tag:
-            type: string
-            enum: ["IgnoredInitTx"]
-          headId:
-            $ref: "api.yaml#/components/schemas/HeadId"
-          participants:
-            items:
-              type: string
-              contentEncoding: base16
-
       - title: Rollback
         type: object
         additionalProperties: false

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -740,7 +740,7 @@ update env ledger st ev = case (st, ev) of
     cause (ClientEffect . ServerOutput.GetUTxOResponse headId $ getField @"utxo" $ getSnapshot confirmedSnapshot)
   -- NOTE: If posting the collectCom transaction failed in the open state, then
   -- another party likely opened the head before us and it's okay to ignore.
-  (Open{}, PostTxError{postChainTx = CollectComTx{}}) ->
+  (Open{}, OnChainEvent PostTxError{postChainTx = CollectComTx{}}) ->
     noop
   -- Closed
   (Closed closedState@ClosedState{headId = ourHeadId}, OnChainEvent Observation{observedTx = OnContestTx{headId, snapshotNumber, contestationDeadline}, newChainState})
@@ -764,7 +764,7 @@ update env ledger st ev = case (st, ev) of
     newState ChainRolledBack{chainState = rolledBackChainState}
   (_, OnChainEvent Tick{chainSlot}) ->
     newState TickObserved{chainSlot}
-  (_, PostTxError{postChainTx, postTxError}) ->
+  (_, OnChainEvent PostTxError{postChainTx, postTxError}) ->
     cause . ClientEffect $ ServerOutput.PostTxOnChainFailed{postChainTx, postTxError}
   (_, ClientEvent{clientInput}) ->
     cause . ClientEffect $ ServerOutput.CommandFailed clientInput st

--- a/hydra-node/src/Hydra/HeadLogic/Event.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Event.hs
@@ -5,13 +5,7 @@ module Hydra.HeadLogic.Event where
 import Hydra.Prelude
 
 import Hydra.API.ClientInput (ClientInput)
-import Hydra.Chain (
-  ChainEvent,
-  ChainStateType,
-  IsChainState,
-  PostChainTx,
-  PostTxError,
- )
+import Hydra.Chain (ChainEvent, IsChainState)
 import Hydra.Ledger (IsTx)
 import Hydra.Network.Message (Message)
 import Hydra.Party (Party)
@@ -33,8 +27,6 @@ data Event tx
     NetworkEvent {ttl :: TTL, party :: Party, message :: Message tx}
   | -- | Event received from the chain via a "Hydra.Chain".
     OnChainEvent {chainEvent :: ChainEvent tx}
-  | -- | Event to re-ingest errors from 'postTx' for further processing.
-    PostTxError {postChainTx :: PostChainTx tx, postTxError :: PostTxError tx}
   deriving stock (Generic)
 
 deriving stock instance IsChainState tx => Eq (Event tx)
@@ -42,6 +34,6 @@ deriving stock instance IsChainState tx => Show (Event tx)
 deriving anyclass instance IsChainState tx => ToJSON (Event tx)
 deriving anyclass instance IsChainState tx => FromJSON (Event tx)
 
-instance (IsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (Event tx) where
+instance (IsTx tx, IsChainState tx) => Arbitrary (Event tx) where
   arbitrary = genericArbitrary
   shrink = genericShrink

--- a/hydra-node/src/Hydra/HeadLogic/Outcome.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Outcome.hs
@@ -33,12 +33,7 @@ deriving stock instance IsChainState tx => Show (Effect tx)
 deriving anyclass instance IsChainState tx => ToJSON (Effect tx)
 deriving anyclass instance IsChainState tx => FromJSON (Effect tx)
 
-instance
-  ( IsTx tx
-  , Arbitrary (ChainStateType tx)
-  ) =>
-  Arbitrary (Effect tx)
-  where
+instance IsChainState tx => Arbitrary (Effect tx) where
   arbitrary = genericArbitrary
 
 -- | Head state changed event. These events represent all the internal state
@@ -111,7 +106,7 @@ deriving stock instance IsChainState tx => Show (Outcome tx)
 deriving anyclass instance IsChainState tx => ToJSON (Outcome tx)
 deriving anyclass instance IsChainState tx => FromJSON (Outcome tx)
 
-instance (IsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (Outcome tx) where
+instance IsChainState tx => Arbitrary (Outcome tx) where
   arbitrary = genericArbitrary
   shrink = genericShrink
 

--- a/hydra-node/src/Hydra/Snapshot.hs
+++ b/hydra-node/src/Hydra/Snapshot.hs
@@ -56,7 +56,7 @@ instance IsTx tx => FromJSON (Snapshot tx) where
       <*> (obj .: "utxo")
       <*> (obj .: "confirmedTransactions")
 
-instance (Arbitrary (TxIdType tx), Arbitrary (UTxOType tx)) => Arbitrary (Snapshot tx) where
+instance IsTx tx => Arbitrary (Snapshot tx) where
   arbitrary = genericArbitrary
 
   -- NOTE: See note on 'Arbitrary (ClientInput tx)'

--- a/hydra-node/test/Hydra/Chain/Direct/HandlersSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/HandlersSpec.hs
@@ -138,8 +138,8 @@ spec = do
         run $ newLocalChainState (initHistory ChainStateAt{spendableUTxO = utxo, recordedAt = Nothing})
       timeHandle <- pickBlind arbitrary
       let callback = \case
-            Rollback{} ->
-              failure "rolled back but expected roll forward."
+            Rollback{} -> failure "rolled back but expected roll forward."
+            PostTxError{} -> failure "Unxpected PostTxError event"
             Tick{} -> pure ()
             Observation{observedTx} -> do
               let observedTransition =


### PR DESCRIPTION
This makes the input event interface more uniform and still allows the handling of a failed `postTx` in the head logic the same way.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
