### PR TITLE
Small smoke test fixes

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -60,6 +60,11 @@ jobs:
         if ${{inputs.use-mithril}}; then
           USE_MITHRIL_ARG="--use-mithril"
         fi
+        # In case we run against an already running node, fix the permissions of
+        # the host-mounted node.socket file (which would be owned by root)
+        if [ -e ${state_dir}/node.socket ]; then
+          sudo chmod a+w ${state_dir}/node.socket
+        fi
         nix develop .#exes --command bash -c "hydra-cluster --${{inputs.network}} --state-directory ${state_dir} ${HYDRA_SCRIPTS_ARG} ${USE_MITHRIL_ARG}"
 
     - name: 💾 Upload logs

--- a/hydra-cluster/exe/hydra-cluster/Main.hs
+++ b/hydra-cluster/exe/hydra-cluster/Main.hs
@@ -22,6 +22,7 @@ main =
 run :: Options -> IO ()
 run options =
   withTracer (Verbose "hydra-cluster") $ \tracer -> do
+    traceWith tracer ClusterOptions{options}
     let fromCardanoNode = contramap FromCardanoNode tracer
     withStateDirectory $ \workDir ->
       case knownNetwork of
@@ -39,7 +40,7 @@ run options =
   Options{knownNetwork, stateDirectory, publishHydraScripts, useMithril} = options
 
   withRunningCardanoNode tracer workDir network action =
-    findRunningCardanoNode workDir network >>= \case
+    findRunningCardanoNode (contramap FromCardanoNode tracer) workDir network >>= \case
       Just node ->
         action node
       Nothing -> do

--- a/hydra-cluster/src/Hydra/Cluster/Options.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Options.hs
@@ -13,13 +13,16 @@ data Options = Options
   , publishHydraScripts :: PublishOrReuse
   , useMithril :: UseMithril
   }
-  deriving stock (Show)
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (ToJSON, FromJSON)
 
 data PublishOrReuse = Publish | Reuse TxId
-  deriving stock (Show)
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (ToJSON, FromJSON)
 
 data UseMithril = NotUseMithril | UseMithril
-  deriving stock (Show, Eq)
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (ToJSON, FromJSON)
 
 parseOptions :: Parser Options
 parseOptions =

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -59,6 +59,7 @@ import Hydra.Cluster.Faucet (FaucetLog, createOutputAtAddress, seedFromFaucet, s
 import Hydra.Cluster.Faucet qualified as Faucet
 import Hydra.Cluster.Fixture (Actor (..), actorName, alice, aliceSk, aliceVk, bob, bobSk, bobVk, carol, carolSk)
 import Hydra.Cluster.Mithril (MithrilLog)
+import Hydra.Cluster.Options (Options)
 import Hydra.Cluster.Util (chainConfigFor, keysFor, modifyConfig, setNetworkId)
 import Hydra.ContestationPeriod (ContestationPeriod (UnsafeContestationPeriod), fromNominalDiffTime)
 import Hydra.HeadId (HeadId)
@@ -101,7 +102,8 @@ import System.FilePath ((</>))
 import Test.QuickCheck (generate)
 
 data EndToEndLog
-  = FromCardanoNode NodeLog
+  = ClusterOptions {options :: Options}
+  | FromCardanoNode NodeLog
   | FromFaucet FaucetLog
   | FromHydraNode HydraNodeLog
   | FromMithril MithrilLog

--- a/hydra-cluster/test/Test/CardanoNodeSpec.hs
+++ b/hydra-cluster/test/Test/CardanoNodeSpec.hs
@@ -56,11 +56,11 @@ spec = do
     describe "findRunningCardanoNode" $ do
       it "returns Nothing on non-matching network" $ \(tr, tmp) -> do
         withCardanoNodeOnKnownNetwork tr tmp Sanchonet $ \_ -> do
-          findRunningCardanoNode tmp Preproduction `shouldReturn` Nothing
+          findRunningCardanoNode tr tmp Preproduction `shouldReturn` Nothing
 
       it "returns Just running node on matching network" $ \(tr, tmp) -> do
         withCardanoNodeOnKnownNetwork tr tmp Sanchonet $ \runningNode -> do
-          findRunningCardanoNode tmp Sanchonet `shouldReturn` Just runningNode
+          findRunningCardanoNode tr tmp Sanchonet `shouldReturn` Just runningNode
 
 setupTracerAndTempDir :: ToJSON msg => ((Tracer IO msg, FilePath) -> IO a) -> IO a
 setupTracerAndTempDir action =


### PR DESCRIPTION
* Added traces to give us more insights into when the smoke test fails (e.g. due to permission errors on the node.socket file)

* Fix permission of node.socket if it exists in smoke test workflow.

Test run with these changes: https://github.com/input-output-hk/hydra/actions/runs/8230455844

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
