### PR TITLE
Fix seedFromFaucet on multiple requests with same lovelace amount 

### DIFF
--- a/hydra-cardano-api/src/Hydra/Cardano/Api/PlutusScript.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/PlutusScript.hs
@@ -5,7 +5,6 @@ module Hydra.Cardano.Api.PlutusScript where
 import Hydra.Cardano.Api.Prelude
 
 import Cardano.Ledger.Alonzo.Scripts qualified as Ledger
-import Cardano.Ledger.Conway.Scripts qualified as Ledger
 import Cardano.Ledger.Plutus.Language qualified as Ledger
 import Data.ByteString.Short qualified as SBS
 import PlutusLedgerApi.Common qualified as Plutus

--- a/hydra-cluster/src/CardanoClient.hs
+++ b/hydra-cluster/src/CardanoClient.hs
@@ -79,6 +79,12 @@ submitTx :: RunningNode -> Tx -> IO ()
 submitTx RunningNode{networkId, nodeSocket} =
   submitTransaction networkId nodeSocket
 
+-- | Wait until the specified Address has received payments, visible on-chain,
+-- for the specified Lovelace amount. Returns the UTxO set containing all payments
+-- with the same Lovelace amount at the given Address.
+--
+-- Note that this function loops indefinitely; therefore, it's recommended to use
+-- it with a surrounding timeout mechanism.
 waitForPayments ::
   NetworkId ->
   SocketPath ->

--- a/hydra-cluster/src/CardanoClient.hs
+++ b/hydra-cluster/src/CardanoClient.hs
@@ -79,13 +79,13 @@ submitTx :: RunningNode -> Tx -> IO ()
 submitTx RunningNode{networkId, nodeSocket} =
   submitTransaction networkId nodeSocket
 
-waitForPayment ::
+waitForPayments ::
   NetworkId ->
   SocketPath ->
   Lovelace ->
   Address ShelleyAddr ->
   IO UTxO
-waitForPayment networkId socket amount addr =
+waitForPayments networkId socket amount addr =
   go
  where
   go = do
@@ -110,7 +110,7 @@ waitForUTxO networkId nodeSocket utxo =
   forEachUTxO = \case
     TxOut (ShelleyAddressInEra addr@ShelleyAddress{}) value _ _ -> do
       void $
-        waitForPayment
+        waitForPayments
           networkId
           nodeSocket
           (selectLovelace value)

--- a/hydra-cluster/src/CardanoClient.hs
+++ b/hydra-cluster/src/CardanoClient.hs
@@ -90,12 +90,12 @@ waitForPayment networkId socket amount addr =
  where
   go = do
     utxo <- queryUTxO networkId socket QueryTip [addr]
-    let expectedPayment = selectPayment utxo
-    if expectedPayment /= mempty
-      then pure $ UTxO expectedPayment
+    let expectedPayments = selectPayments utxo
+    if expectedPayments /= mempty
+      then pure $ UTxO expectedPayments
       else threadDelay 1 >> go
 
-  selectPayment (UTxO utxo) =
+  selectPayments (UTxO utxo) =
     Map.filter ((== amount) . selectLovelace . txOutValue) utxo
 
 waitForUTxO ::

--- a/hydra-cluster/src/Hydra/Cluster/Faucet.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Faucet.hs
@@ -71,7 +71,7 @@ seedFromFaucet node@RunningNode{networkId, nodeSocket} receivingVerificationKey 
 
   receivingAddress = buildAddress receivingVerificationKey networkId
 
-  theOutput :: TxOut CtxTx =
+  theOutput =
     TxOut
       (shelleyAddressInEra shelleyBasedEra receivingAddress)
       (lovelaceToValue lovelace)

--- a/hydra-cluster/src/Hydra/Cluster/Faucet.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Faucet.hs
@@ -74,7 +74,7 @@ seedFromFaucet node@RunningNode{networkId, nodeSocket} receivingVerificationKey 
       waitForPayments networkId nodeSocket lovelace receivingAddress
  where
   findOldPaymentsWithSameLovelace =
-    failAfter 3 $
+    failAfter 1 $
       ( do
           oldPayment <- waitForPayments networkId nodeSocket lovelace receivingAddress
           pure $ Just oldPayment

--- a/hydra-cluster/src/Hydra/Cluster/Faucet.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Faucet.hs
@@ -16,7 +16,7 @@ import CardanoClient (
   queryUTxOFor,
   sign,
   submitTransaction,
-  waitForPayment,
+  waitForPayments,
  )
 import Control.Exception (IOException)
 import Control.Monad.Class.MonadThrow (Handler (Handler), catches)
@@ -61,7 +61,7 @@ seedFromFaucet node@RunningNode{networkId, nodeSocket} receivingVerificationKey 
     Just oldPayments -> do
       signedTx <- retryOnExceptions tracer $ submitSeedTx faucetVk faucetSk
       void $ awaitTransaction networkId nodeSocket signedTx
-      paymentsWithSameLovelace <- waitForPayment networkId nodeSocket lovelace receivingAddress
+      paymentsWithSameLovelace <- waitForPayments networkId nodeSocket lovelace receivingAddress
       pure
         $ UTxO.fromPairs
           . filter
@@ -71,12 +71,12 @@ seedFromFaucet node@RunningNode{networkId, nodeSocket} receivingVerificationKey 
         $ UTxO.pairs paymentsWithSameLovelace
     Nothing -> do
       void $ retryOnExceptions tracer $ submitSeedTx faucetVk faucetSk
-      waitForPayment networkId nodeSocket lovelace receivingAddress
+      waitForPayments networkId nodeSocket lovelace receivingAddress
  where
   findOldPaymentsWithSameLovelace =
     failAfter 3 $
       ( do
-          oldPayment <- waitForPayment networkId nodeSocket lovelace receivingAddress
+          oldPayment <- waitForPayments networkId nodeSocket lovelace receivingAddress
           pure $ Just oldPayment
       )
         `catch` \(_ :: SomeException) -> pure Nothing

--- a/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
@@ -3,6 +3,7 @@ module Test.Hydra.Cluster.FaucetSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
+import Cardano.Api.UTxO qualified as UTxO
 import CardanoClient (RunningNode (..))
 import CardanoNode (withCardanoNodeDevnet)
 import Control.Concurrent.Async (replicateConcurrently_)
@@ -34,7 +35,9 @@ spec = do
             withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node -> do
               walletVk <- fst <$> generate genKeyPair
               uTxO1 <- seedFromFaucet node walletVk 2_000_000 (contramap FromFaucet tracer)
+              uTxO1 `shouldSatisfy` (\utxo -> length (UTxO.pairs utxo) == 1)
               uTxO2 <- seedFromFaucet node walletVk 2_000_000 (contramap FromFaucet tracer)
+              uTxO2 `shouldSatisfy` (\utxo -> length (UTxO.pairs utxo) == 1)
               uTxO1 `shouldNotBe` uTxO2
   describe "returnFundsToFaucet" $
     it "seedFromFaucet and returnFundsToFaucet should work together" $ do

--- a/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
@@ -18,44 +18,46 @@ import Test.QuickCheck (elements, generate)
 
 spec :: Spec
 spec = do
-  it "seedFromFaucet should work concurrently" $
-    showLogsOnFailure "FaucetSpec" $ \tracer ->
-      failAfter 30 $
+  describe "seedFromFaucet" $ do
+    it "should work concurrently" $
+      showLogsOnFailure "FaucetSpec" $ \tracer ->
+        failAfter 30 $
+          withTempDir "hydra-cluster" $ \tmpDir ->
+            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
+              replicateConcurrently_ 10 $ do
+                vk <- generate genVerificationKey
+                seedFromFaucet_ node vk 1_000_000 (contramap FromFaucet tracer)
+    it "should work when called multiple times with the same amount of lovelace" $
+      showLogsOnFailure "FaucetSpec" $ \tracer ->
+        failAfter 30 $
+          withTempDir "hydra-cluster" $ \tmpDir ->
+            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node -> do
+              walletVk <- fst <$> generate genKeyPair
+              uTxO1 <- seedFromFaucet node walletVk 2_000_000 (contramap FromFaucet tracer)
+              uTxO2 <- seedFromFaucet node walletVk 2_000_000 (contramap FromFaucet tracer)
+              uTxO1 `shouldNotBe` uTxO2
+  describe "returnFundsToFaucet" $
+    it "seedFromFaucet and returnFundsToFaucet should work together" $ do
+      showLogsOnFailure "FaucetSpec" $ \tracer ->
         withTempDir "hydra-cluster" $ \tmpDir ->
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-            replicateConcurrently_ 10 $ do
-              vk <- generate genVerificationKey
-              seedFromFaucet_ node vk 1_000_000 (contramap FromFaucet tracer)
-  it "seedFromFaucet should work when called multiple times with the same amount of lovelace" $
-    showLogsOnFailure "FaucetSpec" $ \tracer ->
-      failAfter 30 $
-        withTempDir "hydra-cluster" $ \tmpDir ->
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node -> do
-            walletVk <- fst <$> generate genKeyPair
-            uTxO1 <- seedFromFaucet node walletVk 2_000_000 (contramap FromFaucet tracer)
-            uTxO2 <- seedFromFaucet node walletVk 2_000_000 (contramap FromFaucet tracer)
-            uTxO1 `shouldNotBe` uTxO2
-  it "seedFromFaucet and returnFundsToFaucet should work together" $ do
-    showLogsOnFailure "FaucetSpec" $ \tracer ->
-      withTempDir "hydra-cluster" $ \tmpDir ->
-        withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node@RunningNode{networkId, nodeSocket} -> do
-          let faucetTracer = contramap FromFaucet tracer
-          actor <- generate $ elements [Alice, Bob, Carol]
-          (vk, _) <- keysFor actor
-          (faucetVk, _) <- keysFor Faucet
-          initialFaucetFunds <- queryUTxOFor networkId nodeSocket QueryTip faucetVk
-          seeded <- seedFromFaucet node vk 100_000_000 faucetTracer
-          returnFundsToFaucet faucetTracer node actor
-          remaining <- queryUTxOFor networkId nodeSocket QueryTip vk
-          finalFaucetFunds <- queryUTxOFor networkId nodeSocket QueryTip faucetVk
-          foldMap txOutValue remaining `shouldBe` mempty
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node@RunningNode{networkId, nodeSocket} -> do
+            let faucetTracer = contramap FromFaucet tracer
+            actor <- generate $ elements [Alice, Bob, Carol]
+            (vk, _) <- keysFor actor
+            (faucetVk, _) <- keysFor Faucet
+            initialFaucetFunds <- queryUTxOFor networkId nodeSocket QueryTip faucetVk
+            seeded <- seedFromFaucet node vk 100_000_000 faucetTracer
+            returnFundsToFaucet faucetTracer node actor
+            remaining <- queryUTxOFor networkId nodeSocket QueryTip vk
+            finalFaucetFunds <- queryUTxOFor networkId nodeSocket QueryTip faucetVk
+            foldMap txOutValue remaining `shouldBe` mempty
 
-          -- check the faucet has one utxo extra in the end
-          length seeded `shouldBe` length remaining + 1
+            -- check the faucet has one utxo extra in the end
+            length seeded `shouldBe` length remaining + 1
 
-          let initialFaucetValue = selectAsset (foldMap txOutValue initialFaucetFunds) AdaAssetId
-          let finalFaucetValue = selectAsset (foldMap txOutValue finalFaucetFunds) AdaAssetId
-          let difference = initialFaucetValue - finalFaucetValue
-          -- difference between starting faucet amount and final one should
-          -- just be the amount of paid fees
-          difference `shouldSatisfy` (< 340_000)
+            let initialFaucetValue = selectAsset (foldMap txOutValue initialFaucetFunds) AdaAssetId
+            let finalFaucetValue = selectAsset (foldMap txOutValue finalFaucetFunds) AdaAssetId
+            let difference = initialFaucetValue - finalFaucetValue
+            -- difference between starting faucet amount and final one should
+            -- just be the amount of paid fees
+            difference `shouldSatisfy` (< 340_000)

--- a/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
@@ -12,44 +12,50 @@ import Hydra.Cluster.Faucet (returnFundsToFaucet, seedFromFaucet, seedFromFaucet
 import Hydra.Cluster.Fixture (Actor (..))
 import Hydra.Cluster.Scenarios (EndToEndLog (..))
 import Hydra.Cluster.Util (keysFor)
-import Hydra.Ledger.Cardano (genVerificationKey)
+import Hydra.Ledger.Cardano (genKeyPair, genVerificationKey)
 import Hydra.Logging (showLogsOnFailure)
 import Test.QuickCheck (elements, generate)
 
 spec :: Spec
 spec = do
-  describe "seedFromFaucet" $
-    it "should work concurrently" $
-      showLogsOnFailure "FaucetSpec" $ \tracer ->
-        failAfter 30 $
-          withTempDir "hydra-cluster" $ \tmpDir ->
-            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-              replicateConcurrently_ 10 $ do
-                vk <- generate genVerificationKey
-                seedFromFaucet_ node vk 1_000_000 (contramap FromFaucet tracer)
-
-  describe "returnFundsToFaucet" $
-    it "seedFromFaucet and returnFundsToFaucet work together" $ do
-      showLogsOnFailure "FaucetSpec" $ \tracer ->
+  it "seedFromFaucet should work concurrently" $
+    showLogsOnFailure "FaucetSpec" $ \tracer ->
+      failAfter 30 $
         withTempDir "hydra-cluster" $ \tmpDir ->
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node@RunningNode{networkId, nodeSocket} -> do
-            let faucetTracer = contramap FromFaucet tracer
-            actor <- generate $ elements [Alice, Bob, Carol]
-            (vk, _) <- keysFor actor
-            (faucetVk, _) <- keysFor Faucet
-            initialFaucetFunds <- queryUTxOFor networkId nodeSocket QueryTip faucetVk
-            seeded <- seedFromFaucet node vk 100_000_000 faucetTracer
-            returnFundsToFaucet faucetTracer node actor
-            remaining <- queryUTxOFor networkId nodeSocket QueryTip vk
-            finalFaucetFunds <- queryUTxOFor networkId nodeSocket QueryTip faucetVk
-            foldMap txOutValue remaining `shouldBe` mempty
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
+            replicateConcurrently_ 10 $ do
+              vk <- generate genVerificationKey
+              seedFromFaucet_ node vk 1_000_000 (contramap FromFaucet tracer)
+  it "seedFromFaucet should work when called multiple times with the same amount of lovelace" $
+    showLogsOnFailure "FaucetSpec" $ \tracer ->
+      failAfter 30 $
+        withTempDir "hydra-cluster" $ \tmpDir ->
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node -> do
+            walletVk <- fst <$> generate genKeyPair
+            uTxO1 <- seedFromFaucet node walletVk 2_000_000 (contramap FromFaucet tracer)
+            uTxO2 <- seedFromFaucet node walletVk 2_000_000 (contramap FromFaucet tracer)
+            uTxO1 `shouldNotBe` uTxO2
+  it "seedFromFaucet and returnFundsToFaucet should work together" $ do
+    showLogsOnFailure "FaucetSpec" $ \tracer ->
+      withTempDir "hydra-cluster" $ \tmpDir ->
+        withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node@RunningNode{networkId, nodeSocket} -> do
+          let faucetTracer = contramap FromFaucet tracer
+          actor <- generate $ elements [Alice, Bob, Carol]
+          (vk, _) <- keysFor actor
+          (faucetVk, _) <- keysFor Faucet
+          initialFaucetFunds <- queryUTxOFor networkId nodeSocket QueryTip faucetVk
+          seeded <- seedFromFaucet node vk 100_000_000 faucetTracer
+          returnFundsToFaucet faucetTracer node actor
+          remaining <- queryUTxOFor networkId nodeSocket QueryTip vk
+          finalFaucetFunds <- queryUTxOFor networkId nodeSocket QueryTip faucetVk
+          foldMap txOutValue remaining `shouldBe` mempty
 
-            -- check the faucet has one utxo extra in the end
-            length seeded `shouldBe` length remaining + 1
+          -- check the faucet has one utxo extra in the end
+          length seeded `shouldBe` length remaining + 1
 
-            let initialFaucetValue = selectAsset (foldMap txOutValue initialFaucetFunds) AdaAssetId
-            let finalFaucetValue = selectAsset (foldMap txOutValue finalFaucetFunds) AdaAssetId
-            let difference = initialFaucetValue - finalFaucetValue
-            -- difference between starting faucet amount and final one should
-            -- just be the amount of paid fees
-            difference `shouldSatisfy` (< 340_000)
+          let initialFaucetValue = selectAsset (foldMap txOutValue initialFaucetFunds) AdaAssetId
+          let finalFaucetValue = selectAsset (foldMap txOutValue finalFaucetFunds) AdaAssetId
+          let difference = initialFaucetValue - finalFaucetValue
+          -- difference between starting faucet amount and final one should
+          -- just be the amount of paid fees
+          difference `shouldSatisfy` (< 340_000)

--- a/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
@@ -18,7 +18,7 @@ import Test.QuickCheck (elements, generate)
 
 spec :: Spec
 spec = do
-  describe "seedFromFaucet" $ do
+  describe "seedFromFaucet" $
     it "should work concurrently when called multiple times with the same amount of lovelace" $
       showLogsOnFailure "FaucetSpec" $ \tracer ->
         failAfter 30 $


### PR DESCRIPTION
<!-- Describe your change here -->

## What

When `seedFromFaucet` is called multiple times using the same amount of Lovelace, all subsequent calls yield the same UTxO as the first one repeatedly.

This occurs because `seedFromFaucet` invokes `waitForPayment` on the `receivingAddress` immediately after submitting the transaction for the requested funds, and due to `waitForPayment` selects the UTxO based on the Lovelace amount of value, subsequent calls will repeatedly fetch the first successful submission.

## How

🥐 Now, we wait for the transaction to be submitted on-chain before checking the payment arrived on the receiving address.

🥐 This allows for requesting the faucet for the same amount of Lovelace multiple times.

🥐 Note that the fix only applies when there are previous payments with the same Lovelace amount at the time `seedFromFaucet` is called.

---

<!-- Consider each and tick it off one way or the other -->
* [X] CHANGELOG updated or not needed
* [X] Documentation updated or not needed
* [X] Haddocks updated or not needed
* [X] No new TODOs introduced or explained herafter
