### PR TITLE
Fix stray ghc warnings

### DIFF
--- a/hydra-explorer/hydra-explorer.cabal
+++ b/hydra-explorer/hydra-explorer.cabal
@@ -83,7 +83,6 @@ test-suite tests
     , filepath
     , hspec
     , hspec-wai
-    , http-types
     , hydra-chain-observer
     , hydra-explorer
     , hydra-node
@@ -92,7 +91,6 @@ test-suite tests
     , lens
     , openapi3
     , QuickCheck
-    , wai-extra
     , yaml
 
   other-modules:

--- a/hydra-explorer/test/Hydra/ExplorerSpec.hs
+++ b/hydra-explorer/test/Hydra/ExplorerSpec.hs
@@ -24,8 +24,6 @@ import Data.OpenApi (
 import Data.Yaml qualified as Yaml
 import Hydra.Explorer (httpApp)
 import Hydra.Logging (nullTracer)
-import Network.HTTP.Types (statusCode)
-import Network.Wai.Test (SResponse (..))
 import System.FilePath ((</>))
 import Test.Hspec.Wai (MatchBody (..), ResponseMatcher (ResponseMatcher), shouldRespondWith, (<:>))
 import Test.Hspec.Wai qualified as Wai

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -332,7 +332,6 @@ test-suite tests
     , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-babbage:{cardano-ledger-babbage, testlib}
-    , cardano-ledger-binary
     , cardano-ledger-core
     , cardano-ledger-mary
     , cardano-ledger-shelley


### PR DESCRIPTION
Warnings are slipping through our CI somehow. I will address this in a following PR with nix.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
