### PR TITLE
Fix tutorial download instructions

### DIFF
--- a/.github/workflows/check-tutorial.yaml
+++ b/.github/workflows/check-tutorial.yaml
@@ -31,7 +31,7 @@ jobs:
         import re
         with open("docs/docs/tutorial/index.md", "r") as tutorial:
             body = tutorial.read()
-            usedCardanoNodeVersions = re.findall(r"cardano-node-.*-([0-9]+\.[0-9]+\.[0-9]+).zip", body)
+            usedCardanoNodeVersions = re.findall(r"cardano-node-([0-9]+\.[0-9]+\.[0-9]+)-.*\.tar\.gz", body)
 
         with open("hydra-cluster/test/Test/CardanoNodeSpec.hs", "r") as cardanoNodeSpecFile:
             body = cardanoNodeSpecFile.read()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ changes.
 
 ## [0.16.0] - UNRELEASED
 
-- Update to and tested against `cardano-node 8.9.0` and `cardano-cli 8.20.3.0`.
+- Tested with `cardano-node 8.9.0`, `cardano-cli 8.20.3.0` and `mithril 2408.0`.
 
 - **BREAKING** Hydra scripts changed due to updates in the `plutus` toolchain:
   - Overall slight increase in script size.

--- a/docs/docs/tutorial/index.md
+++ b/docs/docs/tutorial/index.md
@@ -45,8 +45,8 @@ version=0.15.0
 curl -L -O https://github.com/input-output-hk/hydra/releases/download/${version}/hydra-x86_64-linux-${version}.zip
 unzip -d bin hydra-x86_64-linux-${version}.zip
 curl -L -o - https://github.com/input-output-hk/cardano-node/releases/download/8.9.0/cardano-node-8.9.0-linux.tar.gz \
-  | tar xz -C bin ./cardano-node ./cardano-cli
-curl -L -o - https://github.com/input-output-hk/mithril/releases/download/2347.0/mithril-2347.0-linux-x64.tar.gz \
+  | tar xz ./bin/cardano-node ./bin/cardano-cli
+curl -L -o - https://github.com/input-output-hk/mithril/releases/download/2408.0/mithril-2408.0-linux-x64.tar.gz \
   | tar xz -C bin mithril-client
 chmod +x bin/*
 ```
@@ -59,10 +59,10 @@ mkdir -p bin
 version=0.15.0
 curl -L -O https://github.com/input-output-hk/hydra/releases/download/${version}/hydra-aarch64-darwin-${version}.zip
 unzip -d bin hydra-aarch64-darwin-${version}.zip
-curl -L -o - https://github.com/input-output-hk/hydra/releases/download/${version}/cardano-node-aarch-darwin-8.9.0.zip
-unzip -d bin cardano-node-8.9.0-linux.zip
 curl -L -o - https://github.com/input-output-hk/cardano-node/releases/download/8.9.0/cardano-node-8.9.0-macos.tar.gz \
-  | tar xz -C bin --wildcards ./cardano-node ./cardano-cli '*.dylib'
+  | tar xz --wildcards ./bin/cardano-node ./bin/cardano-cli './bin/*.dylib'
+curl -L -o - https://github.com/input-output-hk/mithril/releases/download/2408.0/mithril-2408.0-macos-x64.tar.gz \
+  | tar xz -C bin
 chmod +x bin/*
 ```
 
@@ -122,8 +122,7 @@ We will be using the `mithril-client` configured to download from
 `preprod` network to download the latest blockchain snapshot:
 
 ```shell
-SNAPSHOT_DIGEST=$(mithril-client snapshot list --json | jq -r '.[0].digest')
-mithril-client snapshot download $SNAPSHOT_DIGEST
+mithril-client snapshot download latest
 ```
 
 <details>

--- a/flake.lock
+++ b/flake.lock
@@ -385,11 +385,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700327093,
-        "narHash": "sha256-OgYvlBABxJYWhZ/HBd0bPVcIEkT+xDhDCpRYqtVhYWY=",
+        "lastModified": 1707461758,
+        "narHash": "sha256-VaqINICYEtVKF0X+chdNtXcNp6poZr385v6AG7j0ybM=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "ae7cd510e508ee03d792005c2f1c0a3ff25ecb80",
+        "rev": "505976eaeac289fe41d074bee37006ac094636bb",
         "type": "github"
       },
       "original": {
@@ -688,11 +688,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1698882062,
-        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
+        "lastModified": 1706830856,
+        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
+        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
         "type": "github"
       },
       "original": {
@@ -1613,16 +1613,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1700729885,
-        "narHash": "sha256-9eRpfYrIypumOHZev3CcD5okDIPIdG2y78AUNFqvN2k=",
+        "lastModified": 1708680939,
+        "narHash": "sha256-nmS2zNBs3ORveI6F/gXfdXPRnbuFhccqNXicT/Pmhhc=",
         "owner": "input-output-hk",
         "repo": "mithril",
-        "rev": "0780dfa5153baacbb68770d24e719a435e85e1f2",
+        "rev": "5afc6fcd44869db7ca48bab9ba124a3606aeedeb",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "2347.0",
+        "ref": "2408.0",
         "repo": "mithril",
         "type": "github"
       }
@@ -2186,11 +2186,11 @@
     "nixpkgs-lib_2": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1698611440,
-        "narHash": "sha256-jPjHjrerhYDy3q9+s5EAsuhyhuknNfowY6yt6pjn9pc=",
+        "lastModified": 1706550542,
+        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0cbe9f69c234a7700596e943bfae7ef27a31b735",
+        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
         "type": "github"
       },
       "original": {
@@ -2299,11 +2299,11 @@
     },
     "nixpkgs_12": {
       "locked": {
-        "lastModified": 1700444282,
-        "narHash": "sha256-s/+tgT+Iz0LZO+nBvSms+xsMqvHt2LqYniG9r+CYyJc=",
+        "lastModified": 1707451808,
+        "narHash": "sha256-UwDBUNHNRsYKFJzyTMVMTF5qS4xeJlWoeyJf+6vvamU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3f21a22b5aafefa1845dec6f4a378a8f53d8681c",
+        "rev": "442d407992384ed9c0e6d352de75b69079904e4e",
         "type": "github"
       },
       "original": {
@@ -2982,11 +2982,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699786194,
-        "narHash": "sha256-3h3EH1FXQkIeAuzaWB+nK0XK54uSD46pp+dMD3gAcB4=",
+        "lastModified": 1707300477,
+        "narHash": "sha256-qQF0fEkHlnxHcrKIMRzOETnRBksUK048MXkX0SOmxvA=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e82f32aa7f06bbbd56d7b12186d555223dc399d1",
+        "rev": "ac599dab59a66304eb511af07b3883114f061b9d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
       flake = false;
     };
     cardano-node.url = "github:intersectmbo/cardano-node/8.9.0";
-    mithril.url = "github:input-output-hk/mithril/2347.0";
+    mithril.url = "github:input-output-hk/mithril/2408.0";
     nix-npm-buildpackage.url = "github:serokell/nix-npm-buildpackage";
   };
 


### PR DESCRIPTION
* Fixes the tutorial download instructions for linux and macos as the paths in the `cardano-node` tarball had changed in `8.9.0`.

* Also, the macos instructions were referring the `hydra`-local build of `mithril` and `cardano-node` which we had temporarily.

* Also update to latest version of mithril and use the `latest` snapshot as this is now available in `mithril-client`

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
