### PR TITLE
Refactor BehaviorSpec and MockChain to use hydrate

### DIFF
--- a/hydra-node/src/Hydra/Environment.hs
+++ b/hydra-node/src/Hydra/Environment.hs
@@ -5,7 +5,7 @@ import Hydra.Prelude
 import Hydra.ContestationPeriod (ContestationPeriod)
 import Hydra.Crypto (HydraKey, SigningKey)
 import Hydra.OnChainId (OnChainId)
-import Hydra.Party (Party, deriveParty)
+import Hydra.Party (HasParty (..), Party, deriveParty)
 
 data Environment = Environment
   { party :: Party
@@ -34,3 +34,6 @@ instance Arbitrary Environment where
         , contestationPeriod
         , participants
         }
+
+instance HasParty Environment where
+  getParty = party

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -57,7 +57,7 @@ import Hydra.Network.Message (Message)
 import Hydra.Node.InputQueue (InputQueue (..), Queued (..), createInputQueue)
 import Hydra.Node.ParameterMismatch (ParamMismatch (..), ParameterMismatch (..))
 import Hydra.Options (ChainConfig (..), DirectChainConfig (..), RunOptions (..), defaultContestationPeriod)
-import Hydra.Party (Party (..), deriveParty)
+import Hydra.Party (HasParty (..), Party (..), deriveParty)
 
 -- * Environment Handling
 
@@ -152,6 +152,9 @@ data DraftHydraNode tx m = DraftHydraNode
     chainStateHistory :: ChainStateHistory tx
   }
 
+instance HasParty (DraftHydraNode tx m) where
+  getParty DraftHydraNode{env} = getParty env
+
 -- | Hydrate a 'DraftHydraNode' by loading events from source, re-aggregate node
 -- state and sending events to sinks while doing so.
 hydrate ::
@@ -232,6 +235,9 @@ data HydraNode tx m = HydraNode
   , hn :: Network m (Message tx)
   , server :: Server tx m
   }
+
+instance HasParty (HydraNode tx m) where
+  getParty HydraNode{env} = getParty env
 
 runHydraNode ::
   ( MonadCatch m

--- a/hydra-node/src/Hydra/Party.hs
+++ b/hydra-node/src/Hydra/Party.hs
@@ -72,3 +72,7 @@ partyFromChain =
   either (\e -> fail $ "partyFromChain failed: " <> show e) (pure . Party)
     . deserialiseFromRawBytes (AsVerificationKey AsHydraKey)
     . OnChain.partyToVerficationKeyBytes
+
+-- | Type class to retrieve the 'Party' from some type.
+class HasParty a where
+  getParty :: a -> Party

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -59,18 +59,14 @@ import Hydra.Chain.Direct.Fixture (defaultGlobals, defaultLedgerEnv, testNetwork
 import Hydra.Chain.Direct.State (initialChainState)
 import Hydra.ContestationPeriod (ContestationPeriod (UnsafeContestationPeriod))
 import Hydra.Crypto (HydraKey)
-import Hydra.HeadLogic (
-  Committed (),
-  IdleState (..),
- )
-import Hydra.HeadLogic qualified as HeadState
+import Hydra.HeadLogic (Committed ())
 import Hydra.Ledger (IsTx (..))
 import Hydra.Ledger.Cardano (cardanoLedger, genSigningKey, mkSimpleTx)
 import Hydra.Logging (Tracer)
 import Hydra.Logging.Messages (HydraLog (DirectChain, Node))
 import Hydra.Model.MockChain (mockChainAndNetwork)
 import Hydra.Model.Payment (CardanoSigningKey (..), Payment (..), applyTx, genAdaValue)
-import Hydra.Node (createNodeState, runHydraNode)
+import Hydra.Node (runHydraNode)
 import Hydra.Party (Party (..), deriveParty)
 import Hydra.Snapshot qualified as Snapshot
 import Test.Hydra.Prelude (failure)
@@ -587,9 +583,8 @@ seedWorld seedKeys seedCP futureCommits = do
       labelTQueueIO outputs ("outputs-" <> shortLabel hsk)
       outputHistory <- newTVarIO []
       labelTVarIO outputHistory ("history-" <> shortLabel hsk)
-      nodeState <- createNodeState Nothing $ HeadState.Idle IdleState{chainState = initialChainState}
-      node <- createHydraNode (contramap Node tr) ledger nodeState hsk otherParties outputs outputHistory mockChain seedCP
-      let testClient = createTestHydraClient outputs outputHistory node nodeState
+      node <- createHydraNode (contramap Node tr) ledger initialChainState hsk otherParties outputs outputHistory mockChain seedCP
+      let testClient = createTestHydraClient outputs outputHistory node
       nodeThread <- async $ labelThisThread ("node-" <> shortLabel hsk) >> runHydraNode node
       link nodeThread
       pure (testClient, nodeThread)


### PR DESCRIPTION
Resolves a TODO that uses the new 'hydrate' function instead of manual record construction where possible. This does not feel much cleaner as the code around MockChain and BehaviorSpec is quite contrived still.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
