### PR TITLE
Enhance hydra-cluster --devnet to produce constantly snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ changes.
 
 - Add `--sanchonet` option to `hydra-cluster` binary.
 
+- Enhance `hydra-cluster --devnet` mode to produce a constant stream of snaphsots by re-spending the sandbox UTxO.
+
 - Reduce cost of transactions submitted by `hydra-node` by better estimating fees in internal wallet [#1315](https://github.com/input-output-hk/hydra/pull/1315).
 
 - Fix conversion of `Conway` blocks in `hydra-node` and `hydra-chain-observer`. This also includes tests that verify `hydra-node` working on Conway networks like `sanchonet` and the `hydra-explorer` observing heads on `sanchonet`.

--- a/hydra-cluster/exe/hydra-cluster/Main.hs
+++ b/hydra-cluster/exe/hydra-cluster/Main.hs
@@ -7,9 +7,8 @@ import Hydra.Cluster.Faucet (publishHydraScriptsAs)
 import Hydra.Cluster.Fixture (Actor (Faucet))
 import Hydra.Cluster.Mithril (downloadLatestSnapshotTo)
 import Hydra.Cluster.Options (Options (..), PublishOrReuse (Publish, Reuse), UseMithril (UseMithril), parseOptions)
-import Hydra.Cluster.Scenarios (EndToEndLog (..), singlePartyHeadFullLifeCycle, singlePartyOpenAHead)
+import Hydra.Cluster.Scenarios (EndToEndLog (..), respendUTxO, singlePartyHeadFullLifeCycle, singlePartyOpenAHead)
 import Hydra.Logging (Verbosity (Verbose), traceWith, withTracer)
-import HydraNode (HydraClient (..))
 import Options.Applicative (ParserInfo, execParser, fullDesc, header, helper, info, progDesc)
 import System.Directory (removeDirectoryRecursive)
 import System.FilePath ((</>))
@@ -34,8 +33,10 @@ run options =
         Nothing -> do
           withCardanoNodeDevnet fromCardanoNode workDir $ \node -> do
             txId <- publishOrReuseHydraScripts tracer node
-            singlePartyOpenAHead tracer workDir node txId $ \HydraClient{} -> do
-              forever (threadDelay 60) -- do nothing
+            singlePartyOpenAHead tracer workDir node txId $ \client walletSk -> do
+              -- Start respending the same UTxO with a 100ms delay.
+              -- XXX: Should make this configurable
+              respendUTxO client walletSk 0.1
  where
   Options{knownNetwork, stateDirectory, publishHydraScripts, useMithril} = options
 

--- a/hydra-cluster/src/Hydra/Cluster/Options.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Options.hs
@@ -41,15 +41,13 @@ parseOptions =
         Nothing
         ( long "devnet"
             <> help
-              ( toString $
-                  unlines
-                    [ "Create a local cardano devnet by running a cardano-node, "
-                    , "start a hydra-node and open a single-party head in it. "
-                    , "Generates a wallet key pair and commits some into the head using it. "
-                    , "The keys are available on the state-directory. This is useful as a "
-                    , "sandbox for development and testing."
-                    ]
-              )
+              "Create a local cardano devnet by running a cardano-node, start a\
+              \hydra-node and open a single-party head in it. Generates a wallet\
+              \key pair and commits some ADA into the head using it. The head is\
+              \also simulating some traffic on this UTxO by re-spending it to\
+              \the same key constantly. The keys are available on the\
+              \state-directory. This is useful as a sandbox for development and\
+              \testing."
         )
 
   parseStateDirectory =

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -848,9 +848,7 @@ initAndClose tmpDir tracer clusterIx hydraScriptsTxId node@RunningNode{nodeSocke
       Data.Aeson.Success u ->
         failAfter 5 $ waitForUTxO networkId nodeSocket u
 
---
--- Fixtures
---
+-- * Fixtures
 
 aliceCommittedToHead :: Num a => a
 aliceCommittedToHead = 20_000_000
@@ -870,9 +868,7 @@ inHeadAddress =
  where
   network = Testnet (NetworkMagic 14)
 
---
--- Helpers
---
+-- * Helpers
 
 int :: Int -> Int
 int = id


### PR DESCRIPTION
This makes testing `kupo` integration simpler and also seems to be a nice default for a sandbox environment.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
