### PR TITLE
Ouroboros: Switch to versioned protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ changes.
 
 ## [0.17.0] - UNRELEASED
 
+- **BREAKING** `hydra-node` `/commit` enpoint now also accepts a _blueprint/draft_
+  transaction together with the `UTxO` which is spent in this transaction. `hydra-node` can
+  still be used like before if the provided `UTxO` is at public key address. In order to spend
+  from a script `UTxO`, and also unlock more involved use-cases, users need to provide additional
+  unsigned transaction that correctly specifies required data (like redeemers, validity ranges etc.)
+
 - Add `GET /snapshot/utxo` API endpoint to query confirmed UTxO set on demand.
   - Always responds with the last confirmed UTxO
 
@@ -17,13 +23,10 @@ changes.
 
 - `hydra-node` logs will now report `NetworkEvents` to distinguish between `ConnectivityEvent`s and `ReceivedMessage`s on the network.
 
-## [0.17.0] - UNRELEASED
-
-- **BREAKING** `hydra-node` `/commit` enpoint now also accepts a _blueprint/draft_
-  transaction together with the `UTxO` which is spent in this transaction. `hydra-node` can
-  still be used like before if the provided `UTxO` is at public key address. In order to spend
-  from a script `UTxO`, and also unlock more involved use-cases, users need to provide additional
-  unsigned transaction that correctly specifies required data (like redeemers, validity ranges etc.)
+- Hydra now uses a versioned protocol for handshaking. In the event of a node
+  attempting to connect using a different version of the networking protocol, a
+  `HandshakeFailure` event will be recorded in the logs and sent as a server
+  output on the API.
 
 ## [0.16.0] - 2024-04-03
 

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -95,6 +95,7 @@ library
     Hydra.Network.Ouroboros.Client
     Hydra.Network.Ouroboros.Server
     Hydra.Network.Ouroboros.Type
+    Hydra.Network.Ouroboros.VersionedProtocol
     Hydra.Network.Reliability
     Hydra.Node
     Hydra.Node.InputQueue

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -74,6 +74,7 @@ channels:
           - $ref: "api.yaml#/components/messages/Greetings"
           - $ref: "api.yaml#/components/messages/PeerConnected"
           - $ref: "api.yaml#/components/messages/PeerDisconnected"
+          - $ref: "api.yaml#/components/messages/PeerHandshakeFailure"
           - $ref: "api.yaml#/components/messages/HeadIsInitializing"
           - $ref: "api.yaml#/components/messages/Committed"
           - $ref: "api.yaml#/components/messages/HeadIsOpen"
@@ -333,6 +334,13 @@ components:
       payload:
         $ref: "api.yaml#/components/schemas/PeerDisconnected"
 
+    PeerHandshakeFailure:
+      title: PeerHandshakeFailure
+      description: |
+        A peer has failed to negotiate a protocol.
+      payload:
+        $ref: "api.yaml#/components/schemas/PeerHandshakeFailure"
+
     HeadIsInitializing:
       title: HeadIsInitializing
       description: |
@@ -494,6 +502,7 @@ components:
         - $ref: "api.yaml#/components/schemas/Greetings"
         - $ref: "api.yaml#/components/schemas/PeerConnected"
         - $ref: "api.yaml#/components/schemas/PeerDisconnected"
+        - $ref: "api.yaml#/components/schemas/PeerHandshakeFailure"
         - $ref: "api.yaml#/components/schemas/HeadIsInitializing"
         - $ref: "api.yaml#/components/schemas/Committed"
         - $ref: "api.yaml#/components/schemas/HeadIsOpen"
@@ -566,6 +575,34 @@ components:
           enum: ["PeerDisconnected"]
         peer:
           $ref: "api.yaml#/components/schemas/NodeId"
+        seq:
+          $ref: "api.yaml#/components/schemas/SequenceNumber"
+        timestamp:
+          $ref: "api.yaml#/components/schemas/UTCTime"
+
+    PeerHandshakeFailure:
+      type: object
+      required:
+        - tag
+        - remoteHost
+        - ourVersion
+        - theirVersions
+        - seq
+        - timestamp
+      properties:
+        tag:
+          type: string
+          enum: ["PeerHandshakeFailure"]
+        remoteHost:
+          type: object
+          $ref: "api.yaml#/components/schemas/IP"
+        ourVersion:
+          type: integer
+          minimum: 0
+        theirVersions:
+          type: array
+          items:
+            type: integer
         seq:
           $ref: "api.yaml#/components/schemas/SequenceNumber"
         timestamp:
@@ -1976,3 +2013,55 @@ components:
 
     # NOTE: We don't want anyone to depend on this!
     ChainState: {}
+
+    IP:
+      type: object
+      oneOf:
+        - title: IPv4
+          type: object
+          properties:
+            tag:
+              type: string
+              enum: ["IPv4"]
+            ipv4:
+              type: string
+        - title: IPv6
+          type: string
+          properties:
+            tag:
+              type: string
+              enum: ["IPv6"]
+            ipv6:
+              type: string
+
+    MkHydraVersionedProtocolNumber:
+      type: object
+      required:
+      - hydraVersionedProtocolNumber
+      properties:
+        hydraVersionedProtocolNumber:
+          type: integer
+          minimum: 0
+        
+    KnownHydraVersions:
+      oneOf:
+        - title: NoKnownHydraVersions
+          required:
+            - tag
+          properties:
+            tag:
+              type: string
+              enum: ["NoKnownHydraVersions"]
+        - title: KnownHydraVersions
+          type: object
+          required:
+          - tag
+          - fromKnownHydraVersions
+          properties:
+            tag:
+              type: string
+              enum: ["KnownHydraVersions"]
+            fromKnownHydraVersions:
+              type: array
+              items:
+                $ref: "api.yaml#/components/schemas/MkHydraVersionedProtocolNumber"

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -1645,6 +1645,26 @@ definitions:
                   nodeId:
                     type: string
 
+              - title: HandshakeFailure
+                type: object
+                additionalProperties: false
+                required:
+                  - tag
+                  - remoteHost
+                  - ourVersion
+                  - theirVersions
+                properties:
+                  tag:
+                    type: string
+                    enum: ["HandshakeFailure"]
+                  remoteHost:
+                    type: object
+                    $ref: "api.yaml#/components/schemas/IP"
+                  ourVersion:
+                    $ref: "api.yaml#/components/schemas/MkHydraVersionedProtocolNumber"
+                  theirVersions:
+                    $ref: "api.yaml#/components/schemas/KnownHydraVersions"
+
       - title: ReceivedMessage
         type: object
         additionalProperties: false
@@ -2110,26 +2130,6 @@ definitions:
             items:
               $ref: "api.yaml#/components/schemas/TxId"
 
-  IP:
-    type: object
-    oneOf:
-      - title: IPv4
-        type: object
-        properties:
-          tag:
-            type: string
-            enum: ["IPv4"]
-          ipv4:
-            type: string
-      - title: IPv6
-        type: string
-        properties:
-          tag:
-            type: string
-            enum: ["IPv6"]
-          ipv6:
-            type: string
-
   RunOptions:
     type: object
     required:
@@ -2164,7 +2164,7 @@ definitions:
         type: string
       host:
         type: object
-        $ref: "logs.yaml#/definitions/IP"
+        $ref: "api.yaml#/components/schemas/IP"
       port:
         type: integer
       peers:
@@ -2172,7 +2172,7 @@ definitions:
         items:
           $ref: "api.yaml#/components/schemas/Peer"
       apiHost:
-        $ref: "logs.yaml#/definitions/IP"
+        $ref: "api.yaml#/components/schemas/IP"
       apiPort:
         type: integer
       monitoringPort:

--- a/hydra-node/src/Hydra/Network/Message.hs
+++ b/hydra-node/src/Hydra/Network/Message.hs
@@ -8,7 +8,7 @@ import Cardano.Binary (serialize')
 import Cardano.Crypto.Util (SignableRepresentation, getSignableRepresentation)
 import Hydra.Crypto (Signature)
 import Hydra.Ledger (IsTx (TxIdType), UTxOType)
-import Hydra.Network (NodeId)
+import Hydra.Network (Host, NodeId)
 import Hydra.Party (Party)
 import Hydra.Snapshot (Snapshot, SnapshotNumber)
 
@@ -21,9 +21,44 @@ data NetworkEvent msg
 instance Arbitrary msg => Arbitrary (NetworkEvent msg) where
   arbitrary = genericArbitrary
 
+type HydraVersionedProtocolNumber :: Type
+newtype HydraVersionedProtocolNumber = MkHydraVersionedProtocolNumber {hydraVersionedProtocolNumber :: Int}
+  deriving stock (Eq, Show, Generic, Ord)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance Arbitrary HydraVersionedProtocolNumber where
+  arbitrary = genericArbitrary
+
+type KnownHydraVersions :: Type
+data KnownHydraVersions
+  = KnownHydraVersions {fromKnownHydraVersions :: [HydraVersionedProtocolNumber]}
+  | NoKnownHydraVersions
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance Arbitrary KnownHydraVersions where
+  arbitrary = genericArbitrary
+
+type HydraHandshakeRefused :: Type
+data HydraHandshakeRefused = HydraHandshakeRefused
+  { remoteHost :: Host
+  , ourVersion :: HydraVersionedProtocolNumber
+  , theirVersions :: KnownHydraVersions
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance Arbitrary HydraHandshakeRefused where
+  arbitrary = genericArbitrary
+
 data Connectivity
   = Connected {nodeId :: NodeId}
   | Disconnected {nodeId :: NodeId}
+  | HandshakeFailure
+      { remoteHost :: Host
+      , ourVersion :: HydraVersionedProtocolNumber
+      , theirVersions :: KnownHydraVersions
+      }
   deriving stock (Generic, Eq, Show)
   deriving anyclass (ToJSON, FromJSON)
 

--- a/hydra-node/src/Hydra/Network/Ouroboros/VersionedProtocol.hs
+++ b/hydra-node/src/Hydra/Network/Ouroboros/VersionedProtocol.hs
@@ -1,0 +1,58 @@
+module Hydra.Network.Ouroboros.VersionedProtocol where
+
+import Hydra.Prelude
+
+import Codec.CBOR.Term qualified as CBOR
+import Data.Text qualified as T
+import Hydra.Network (Host (..))
+import Hydra.Network.Message (HydraVersionedProtocolNumber (..))
+import Network.TypedProtocol.Pipelined ()
+import Ouroboros.Network.CodecCBORTerm (CodecCBORTerm (..))
+import Ouroboros.Network.Protocol.Handshake.Codec (VersionDataCodec, cborTermVersionDataCodec)
+import Ouroboros.Network.Protocol.Handshake.Version (Accept (..), Acceptable, Queryable, acceptableVersion, queryVersion)
+
+hydraVersionedProtocolCodec :: CodecCBORTerm (String, Maybe Int) HydraVersionedProtocolNumber
+hydraVersionedProtocolCodec = CodecCBORTerm{encodeTerm, decodeTerm}
+ where
+  encodeTerm :: HydraVersionedProtocolNumber -> CBOR.Term
+  encodeTerm x = CBOR.TInt $ hydraVersionedProtocolNumber x
+
+  decodeTerm :: CBOR.Term -> Either (String, Maybe Int) HydraVersionedProtocolNumber
+  decodeTerm (CBOR.TInt x) = Right $ MkHydraVersionedProtocolNumber x
+  decodeTerm _ = Left ("unknown tag", Nothing)
+
+type HydraVersionedProtocolData :: Type
+data HydraVersionedProtocolData = MkHydraVersionedProtocolData
+  deriving stock (Eq, Show, Generic, Ord)
+
+instance Acceptable HydraVersionedProtocolData where
+  acceptableVersion
+    MkHydraVersionedProtocolData
+    MkHydraVersionedProtocolData = Accept MkHydraVersionedProtocolData
+
+instance Queryable HydraVersionedProtocolData where
+  queryVersion MkHydraVersionedProtocolData = False
+
+hydraVersionedProtocolDataCodec ::
+  VersionDataCodec
+    CBOR.Term
+    HydraVersionedProtocolNumber
+    HydraVersionedProtocolData
+hydraVersionedProtocolDataCodec =
+  cborTermVersionDataCodec
+    (const CodecCBORTerm{encodeTerm, decodeTerm})
+ where
+  encodeTerm :: HydraVersionedProtocolData -> CBOR.Term
+  encodeTerm MkHydraVersionedProtocolData = CBOR.TNull
+
+  decodeTerm :: CBOR.Term -> Either Text HydraVersionedProtocolData
+  decodeTerm CBOR.TNull = Right MkHydraVersionedProtocolData
+  decodeTerm t = Left $ T.pack $ "unexpected term: " ++ show t
+
+type HydraNetworkConfig :: Type
+data HydraNetworkConfig = HydraNetworkConfig
+  { protocolVersion :: HydraVersionedProtocolNumber
+  , localHost :: Host
+  , remoteHosts :: [Host]
+  }
+  deriving stock (Eq, Show, Generic)

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -448,6 +448,7 @@ spec =
           let input = connectivityChanged ttl connectivityMessage
           let outcome = update bobEnv ledger headState input
           stateChanges outcome `shouldBe` []
+          outcome `hasEffectSatisfying` \case ClientEffect{} -> True; _ -> False
 
       prop "ignores abortTx of another head" $ \otherHeadId -> do
         let abortOtherHead = observeTx $ OnAbortTx{headId = otherHeadId}


### PR DESCRIPTION
Hydra now uses a versioned protocol for handshaking. In the event of a node attempting to connect using a different version of the networking protocol, a `HandshakeFailure` event will be recorded in the logs.