### PR TITLE
Limit rollback frequency in MockChain

### DIFF
--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -269,6 +269,11 @@ mockChainAndNetwork tr seedKeys commits = do
     doRollBackward nodes chain numberOfBlocks
     replicateM_ (fromIntegral numberOfBlocks) $
       doRollForward nodes chain
+    -- NOTE: There seems to be a race condition on multiple consecutive
+    -- rollbackAndForward calls, which would require some minimal (1ms) delay
+    -- here. However, waiting here for one blockTime is not wrong and enforces
+    -- rollbacks / chain switches to be not more often than blocks being added.
+    threadDelay blockTime
 
   doRollBackward nodes chain nbBlocks = do
     (slotNum, position, blocks, _) <- readTVarIO chain


### PR DESCRIPTION
Multiple consecutive invocations of rollbackAndForward on the MockChain seem to be prone to a race condition. However, it is unrealistic that chain forks happen more often than seeing new blocks (only when we learn about a new block the node would consider switching).

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
  - Added a NOTE
