### PR TITLE
Disable mithril sanchonet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ changes.
 
 ## [0.16.0] - UNRELEASED
 
-- Tested with `cardano-node 8.9.0`, `cardano-cli 8.20.3.0` and `mithril 2408.0`.
+- Tested with `cardano-node 8.9.0`, `cardano-cli 8.20.3.0` and `mithril 2412.0`.
 
 - **BREAKING** Hydra scripts changed due to updates in the `plutus` toolchain:
   - Overall slight increase in script size.

--- a/docs/docs/tutorial/index.md
+++ b/docs/docs/tutorial/index.md
@@ -46,7 +46,7 @@ curl -L -O https://github.com/input-output-hk/hydra/releases/download/${version}
 unzip -d bin hydra-x86_64-linux-${version}.zip
 curl -L -o - https://github.com/input-output-hk/cardano-node/releases/download/8.9.0/cardano-node-8.9.0-linux.tar.gz \
   | tar xz ./bin/cardano-node ./bin/cardano-cli
-curl -L -o - https://github.com/input-output-hk/mithril/releases/download/2408.0/mithril-2408.0-linux-x64.tar.gz \
+curl -L -o - https://github.com/input-output-hk/mithril/releases/download/2412.0/mithril-2412.0-linux-x64.tar.gz \
   | tar xz -C bin mithril-client
 chmod +x bin/*
 ```
@@ -61,7 +61,7 @@ curl -L -O https://github.com/input-output-hk/hydra/releases/download/${version}
 unzip -d bin hydra-aarch64-darwin-${version}.zip
 curl -L -o - https://github.com/input-output-hk/cardano-node/releases/download/8.9.0/cardano-node-8.9.0-macos.tar.gz \
   | tar xz --wildcards ./bin/cardano-node ./bin/cardano-cli './bin/*.dylib'
-curl -L -o - https://github.com/input-output-hk/mithril/releases/download/2408.0/mithril-2408.0-macos-x64.tar.gz \
+curl -L -o - https://github.com/input-output-hk/mithril/releases/download/2412.0/mithril-2412.0-macos-x64.tar.gz \
   | tar xz -C bin
 chmod +x bin/*
 ```
@@ -122,7 +122,7 @@ We will be using the `mithril-client` configured to download from
 `preprod` network to download the latest blockchain snapshot:
 
 ```shell
-mithril-client snapshot download latest
+mithril-client cardano-db download latest
 ```
 
 <details>

--- a/flake.lock
+++ b/flake.lock
@@ -385,11 +385,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707461758,
-        "narHash": "sha256-VaqINICYEtVKF0X+chdNtXcNp6poZr385v6AG7j0ybM=",
+        "lastModified": 1708794349,
+        "narHash": "sha256-jX+B1VGHT0ruHHL5RwS8L21R6miBn4B6s9iVyUJsJJY=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "505976eaeac289fe41d074bee37006ac094636bb",
+        "rev": "2c94ff9a6fbeb9f3ea0107f28688edbe9c81deaa",
         "type": "github"
       },
       "original": {
@@ -1613,16 +1613,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1708680939,
-        "narHash": "sha256-nmS2zNBs3ORveI6F/gXfdXPRnbuFhccqNXicT/Pmhhc=",
+        "lastModified": 1711106908,
+        "narHash": "sha256-uaMHVdqo07q+D03/wgN0T21X6kRhxt/dxoApV5NjkIU=",
         "owner": "input-output-hk",
         "repo": "mithril",
-        "rev": "5afc6fcd44869db7ca48bab9ba124a3606aeedeb",
+        "rev": "2e462c013abff0504f5ee53452b4edf6c20acf33",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "2408.0",
+        "ref": "2412.0",
         "repo": "mithril",
         "type": "github"
       }
@@ -2299,11 +2299,11 @@
     },
     "nixpkgs_12": {
       "locked": {
-        "lastModified": 1707451808,
-        "narHash": "sha256-UwDBUNHNRsYKFJzyTMVMTF5qS4xeJlWoeyJf+6vvamU=",
+        "lastModified": 1708976803,
+        "narHash": "sha256-yvRygcySjjSvj5JTaCdo7lPqJ/2mBV2XQ94Oaq/14qw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "442d407992384ed9c0e6d352de75b69079904e4e",
+        "rev": "548a86b335d7ecd8b57ec617781f5e652ab0c38e",
         "type": "github"
       },
       "original": {
@@ -2982,11 +2982,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707300477,
-        "narHash": "sha256-qQF0fEkHlnxHcrKIMRzOETnRBksUK048MXkX0SOmxvA=",
+        "lastModified": 1708897213,
+        "narHash": "sha256-QECZB+Hgz/2F/8lWvHNk05N6NU/rD9bWzuNn6Cv8oUk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "ac599dab59a66304eb511af07b3883114f061b9d",
+        "rev": "e497a9ddecff769c2a7cbab51e1ed7a8501e7a3a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
       flake = false;
     };
     cardano-node.url = "github:intersectmbo/cardano-node/8.9.0";
-    mithril.url = "github:input-output-hk/mithril/2408.0";
+    mithril.url = "github:input-output-hk/mithril/2412.0";
     nix-npm-buildpackage.url = "github:serokell/nix-npm-buildpackage";
   };
 

--- a/hydra-cluster/src/Hydra/Cluster/Mithril.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Mithril.hs
@@ -34,7 +34,7 @@ downloadLatestSnapshotTo tracer network directory = do
           proc "mithril-client" $
             concat
               [ ["--aggregator-endpoint", aggregatorEndpoint]
-              , ["snapshot", "download", "latest"]
+              , ["cardano-db", "download", "latest"]
               , ["--genesis-verification-key", decodeUtf8 genesisKey]
               , ["--download-dir", directory]
               , ["--json"]


### PR DESCRIPTION
The `testing-sanchonet` deployment currently needs an unreleased `mithril-client` version (which is not compatible to the remaining networks), so let's not suggest or test it.

This means that the smoke test bootstrap on sanchonet also stopped working.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
