### PR TITLE
Fix FaucetFailedToBuildTx in smoke test

### DIFF
--- a/hydra-cluster/src/Hydra/Cluster/Faucet.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Faucet.hs
@@ -112,7 +112,6 @@ returnFundsToFaucet tracer node@RunningNode{networkId, nodeSocket} sender = do
 
   (senderVk, senderSk) <- keysFor sender
   utxo <- queryUTxOFor networkId nodeSocket QueryTip senderVk
-
   retryOnExceptions tracer $ do
     let utxoValue = balance @Tx utxo
     let allLovelace = selectLovelace utxoValue
@@ -120,7 +119,7 @@ returnFundsToFaucet tracer node@RunningNode{networkId, nodeSocket} sender = do
     let otherTokens = filterValue (/= AdaAssetId) utxoValue
     -- XXX: Using a hard-coded high-enough value to satisfy the min utxo value.
     -- NOTE: We use the faucet address as the change deliberately here.
-    fee <- calculateTxFee node senderSk utxo faucetAddress 1_000_000
+    fee <- calculateTxFee node senderSk utxo faucetAddress 1_500_000
     let returnBalance = allLovelace - fee
     tx <- sign senderSk <$> buildTxBody utxo faucetAddress returnBalance otherTokens
     submitTransaction networkId nodeSocket tx

--- a/hydra-cluster/src/Hydra/Cluster/Faucet.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Faucet.hs
@@ -121,6 +121,8 @@ returnFundsToFaucet tracer RunningNode{networkId, nodeSocket} sender = do
     traceWith tracer $ ReturnedFunds{actor = actorName sender, returnAmount = allLovelace}
  where
   buildTxBody utxo faucetAddress =
+    -- Here we specify no outputs in the transaction so that a change output with the
+    -- entire value is created and paid to the faucet address.
     buildTransaction networkId nodeSocket faucetAddress utxo [] [] >>= \case
       Left e -> throwIO $ FaucetFailedToBuildTx{reason = e}
       Right body -> pure body

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -249,6 +249,7 @@ singlePartyHeadFullLifeCycle tracer workDir node hydraScriptsTxId =
         waitFor hydraTracer (10 * blockTime) [n1] $
           output "HeadIsFinalized" ["utxo" .= toJSON utxoToCommit, "headId" .= headId]
       traceRemainingFunds Alice
+      traceRemainingFunds AliceFunds
  where
   hydraTracer = contramap FromHydraNode tracer
 

--- a/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
@@ -6,7 +6,7 @@ import Test.Hydra.Prelude
 import CardanoClient (RunningNode (..))
 import CardanoNode (withCardanoNodeDevnet)
 import Control.Concurrent.Async (replicateConcurrently)
-import Hydra.Cardano.Api (AssetId (AdaAssetId), Coin (..), selectAsset, txOutValue)
+import Hydra.Cardano.Api (Coin (..), selectLovelace, txOutValue)
 import Hydra.Chain.CardanoClient (QueryPoint (..), queryUTxOFor)
 import Hydra.Cluster.Faucet (returnFundsToFaucet, seedFromFaucet)
 import Hydra.Cluster.Fixture (Actor (..))
@@ -33,26 +33,26 @@ spec = do
     prop "seedFromFaucet and returnFundsToFaucet should work together" $
       withMaxSuccess 10 $
         forAll (Coin <$> choose (1000000, 10000000000)) $ \coin -> do
-          showLogsOnFailure "FaucetSpec" $ \tracer ->
-            withTempDir "hydra-cluster" $ \tmpDir ->
-              withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node@RunningNode{networkId, nodeSocket} -> do
-                let faucetTracer = contramap FromFaucet tracer
-                actor <- generate $ elements [Alice, Bob, Carol]
-                (vk, _) <- keysFor actor
-                (faucetVk, _) <- keysFor Faucet
-                initialFaucetFunds <- queryUTxOFor networkId nodeSocket QueryTip faucetVk
-                seeded <- seedFromFaucet node vk coin faucetTracer
-                returnFundsToFaucet faucetTracer node actor
-                remaining <- queryUTxOFor networkId nodeSocket QueryTip vk
-                finalFaucetFunds <- queryUTxOFor networkId nodeSocket QueryTip faucetVk
-                foldMap txOutValue remaining `shouldBe` mempty
+          forAll (elements [Alice, Bob, Carol]) $ \actor -> do
+            showLogsOnFailure "FaucetSpec" $ \tracer ->
+              withTempDir "hydra-cluster" $ \tmpDir ->
+                withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node@RunningNode{networkId, nodeSocket} -> do
+                  let faucetTracer = contramap FromFaucet tracer
+                  (vk, _) <- keysFor actor
+                  (faucetVk, _) <- keysFor Faucet
+                  initialFaucetFunds <- queryUTxOFor networkId nodeSocket QueryTip faucetVk
+                  void $ seedFromFaucet node vk coin faucetTracer
+                  returnFundsToFaucet faucetTracer node actor
+                  remaining <- queryUTxOFor networkId nodeSocket QueryTip vk
+                  finalFaucetFunds <- queryUTxOFor networkId nodeSocket QueryTip faucetVk
+                  foldMap txOutValue remaining `shouldBe` mempty
 
-                -- check the faucet has one utxo extra in the end
-                length seeded `shouldBe` length remaining + 1
+                  -- check the faucet has one utxo extra in the end
+                  length finalFaucetFunds `shouldBe` length initialFaucetFunds + 1
 
-                let initialFaucetValue = selectAsset (foldMap txOutValue initialFaucetFunds) AdaAssetId
-                let finalFaucetValue = selectAsset (foldMap txOutValue finalFaucetFunds) AdaAssetId
-                let difference = initialFaucetValue - finalFaucetValue
-                -- difference between starting faucet amount and final one should
-                -- just be the amount of paid fees
-                difference `shouldSatisfy` (< 340_000)
+                  let initialFaucetValue = selectLovelace (foldMap txOutValue initialFaucetFunds)
+                  let finalFaucetValue = selectLovelace (foldMap txOutValue finalFaucetFunds)
+                  let difference = initialFaucetValue - finalFaucetValue
+                  -- difference between starting faucet amount and final one should
+                  -- just be the amount of paid fees
+                  difference `shouldSatisfy` (< 340_000)


### PR DESCRIPTION
<!-- Describe your change here -->

Our smoke test requires funds from the faucet to run. Once completed, it constructs a transaction to return the provided funds back to the faucet. To determine the amount of value to be returned, it subtracts a fee calculation from the remaining balance.

However, there is an issue with our fee calculation, causing the smoke test to fail with [FaucetFailedToBuildTx {reason = TxBodyErrorAdaBalanceNegative (Coin (-176))}](https://github.com/input-output-hk/hydra/actions/runs/8455143214/job/23161909806).

This PR aims to resolve the issue by removing the incorrect fee calculation and allowing the transaction to automatically balance itself during construction.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
