### PR TITLE
Add a test suite for testing consecutive close/contest transactions

### DIFF
--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -290,6 +290,7 @@ test-suite tests
     Hydra.Chain.Direct.StateSpec
     Hydra.Chain.Direct.TimeHandleSpec
     Hydra.Chain.Direct.TxSpec
+    Hydra.Chain.Direct.TxTraceSpec
     Hydra.Chain.Direct.WalletSpec
     Hydra.ContestationPeriodSpec
     Hydra.CryptoSpec

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -364,6 +364,7 @@ test-suite tests
     , lens-aeson
     , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}  >=1.1.1.0
     , plutus-tx
+    , pretty-simple
     , QuickCheck
     , quickcheck-dynamic                                                >=3.3.1   && <3.4
     , quickcheck-instances

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -479,13 +479,9 @@ collect ctx headId headParameters utxoToCollect spendableUTxO = do
 
   ChainContext{networkId, ownVerificationKey, scriptRegistry} = ctx
 
--- | Construct a close transaction based on the 'OpenState' and a confirmed
--- snapshot.
---  - 'SlotNo' parameter will be used as the 'Tx' lower bound.
---  - 'PointInTime' parameter will be used as an upper validity bound and
---       will define the start of the contestation period.
--- NB: lower and upper bound slot difference should not exceed contestation period
--- FIXME: wrong haddocks
+-- | Construct a close transaction spending the head output in given 'UTxO',
+-- head parameters, and a confirmed snapshot. NOTE: Lower and upper bound slot
+-- difference should not exceed contestation period.
 close ::
   ChainContext ->
   -- | Spendable UTxO containing head, initial and commit outputs

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -485,6 +485,7 @@ collect ctx headId headParameters utxoToCollect spendableUTxO = do
 --  - 'PointInTime' parameter will be used as an upper validity bound and
 --       will define the start of the contestation period.
 -- NB: lower and upper bound slot difference should not exceed contestation period
+-- FIXME: wrong haddocks
 close ::
   ChainContext ->
   -- | Spendable UTxO containing head, initial and commit outputs

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -534,6 +534,7 @@ contest ::
   HeadId ->
   ContestationPeriod ->
   ConfirmedSnapshot Tx ->
+  -- | Current slot and posix time to be used as the contestation time.
   PointInTime ->
   Either ContestTxError Tx
 contest ctx spendableUTxO headId contestationPeriod confirmedSnapshot pointInTime = do

--- a/hydra-node/src/Hydra/Snapshot.hs
+++ b/hydra-node/src/Hydra/Snapshot.hs
@@ -82,10 +82,12 @@ instance (Typeable tx, ToCBOR (UTxOType tx), ToCBOR (TxIdType tx)) => ToCBOR (Sn
 instance (Typeable tx, FromCBOR (UTxOType tx), FromCBOR (TxIdType tx)) => FromCBOR (Snapshot tx) where
   fromCBOR = Snapshot <$> fromCBOR <*> fromCBOR <*> fromCBOR <*> fromCBOR
 
--- | A snapshot that can be used to close a head with. Either the initial one, or when it was signed by all parties, i.e. it is confirmed.
+-- | A snapshot that can be used to close a head with. Either the initial one,
+-- or when it was signed by all parties, i.e. it is confirmed.
 data ConfirmedSnapshot tx
   = InitialSnapshot
-      { headId :: HeadId
+      { -- XXX: 'headId' is actually unused. Only 'getSnapshot' forces this to exist.
+        headId :: HeadId
       , initialUTxO :: UTxOType tx
       }
   | ConfirmedSnapshot

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Abort.hs
@@ -11,7 +11,6 @@ import Cardano.Api.UTxO qualified as UTxO
 import Data.List qualified as List
 import Data.Map qualified as Map
 import Hydra.Chain (HeadParameters (..))
-import Hydra.Chain.Direct.Contract.Gen (genForParty)
 import Hydra.Chain.Direct.Contract.Mutation (
   Mutation (..),
   SomeMutation (..),
@@ -42,7 +41,7 @@ import Hydra.Contract.Initial qualified as Initial
 import Hydra.Contract.InitialError (InitialError (STNotBurned))
 import Hydra.Ledger.Cardano (genAddressInEra, genVerificationKey)
 import Hydra.Party (Party, partyToChain)
-import Test.Hydra.Fixture (cperiod)
+import Test.Hydra.Fixture (cperiod, genForParty)
 import Test.QuickCheck (Property, choose, counterexample, elements, oneof, shuffle, suchThat)
 
 --

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Close.hs
@@ -8,7 +8,7 @@ import Hydra.Prelude hiding (label)
 
 import Cardano.Api.UTxO as UTxO
 import Data.Maybe (fromJust)
-import Hydra.Chain.Direct.Contract.Gen (genForParty, genHash, genMintedOrBurnedValue)
+import Hydra.Chain.Direct.Contract.Gen (genHash, genMintedOrBurnedValue)
 import Hydra.Chain.Direct.Contract.Mutation (
   Mutation (..),
   SomeMutation (..),
@@ -24,7 +24,6 @@ import Hydra.Chain.Direct.Contract.Mutation (
   replaceSnapshotNumber,
   replaceUtxoHash,
  )
-import Hydra.Chain.Direct.Fixture (testNetworkId)
 import Hydra.Chain.Direct.Fixture qualified as Fixture
 import Hydra.Chain.Direct.ScriptRegistry (genScriptRegistry, registryUTxO)
 import Hydra.Chain.Direct.TimeHandle (PointInTime)
@@ -47,7 +46,7 @@ import Hydra.Plutus.Orphans ()
 import Hydra.Snapshot (Snapshot (..), SnapshotNumber)
 import PlutusLedgerApi.V1.Time (DiffMilliSeconds (..), fromMilliSeconds)
 import PlutusLedgerApi.V2 (BuiltinByteString, POSIXTime, PubKeyHash (PubKeyHash), toBuiltin)
-import Test.Hydra.Fixture (aliceSk, bobSk, carolSk)
+import Test.Hydra.Fixture (aliceSk, bobSk, carolSk, genForParty)
 import Test.QuickCheck (arbitrarySizedNatural, choose, elements, listOf1, oneof, suchThat)
 import Test.QuickCheck.Instances ()
 
@@ -136,7 +135,7 @@ healthyOpenHeadTxIn = generateWith arbitrary 42
 
 healthyOpenHeadTxOut :: TxOut CtxUTxO
 healthyOpenHeadTxOut =
-  mkHeadOutput testNetworkId Fixture.testPolicyId headTxOutDatum
+  mkHeadOutput Fixture.testNetworkId Fixture.testPolicyId headTxOutDatum
     & addParticipationTokens healthyParticipants
  where
   headTxOutDatum = toUTxOContext (mkTxOutDatumInline healthyOpenHeadDatum)
@@ -293,7 +292,7 @@ genCloseMutation :: (Tx, UTxO) -> Gen SomeMutation
 genCloseMutation (tx, _utxo) =
   oneof
     [ SomeMutation (Just $ toErrorCode NotPayingToHead) NotContinueContract <$> do
-        mutatedAddress <- genAddressInEra testNetworkId
+        mutatedAddress <- genAddressInEra Fixture.testNetworkId
         pure $ ChangeOutput 0 (modifyTxOutAddress (const mutatedAddress) headTxOut)
     , SomeMutation (Just $ toErrorCode SignatureVerificationFailed) MutateSignatureButNotSnapshotNumber . ChangeHeadRedeemer <$> do
         Head.Close . toPlutusSignatures <$> (arbitrary :: Gen (MultiSignature (Snapshot Tx)))

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/CollectCom.hs
@@ -11,7 +11,7 @@ import Data.List qualified as List
 import Data.Map qualified as Map
 import Data.Maybe (fromJust)
 import Hydra.Chain (HeadParameters (..))
-import Hydra.Chain.Direct.Contract.Gen (genForParty, genHash, genMintedOrBurnedValue)
+import Hydra.Chain.Direct.Contract.Gen (genHash, genMintedOrBurnedValue)
 import Hydra.Chain.Direct.Contract.Mutation (
   Mutation (..),
   SomeMutation (..),
@@ -52,6 +52,7 @@ import Hydra.OnChainId (OnChainId)
 import Hydra.Party (Party, partyToChain)
 import Hydra.Plutus.Orphans ()
 import PlutusTx.Builtins (toBuiltin)
+import Test.Hydra.Fixture (genForParty)
 import Test.QuickCheck (choose, elements, oneof, suchThat)
 import Test.QuickCheck.Instances ()
 

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Contest.hs
@@ -9,7 +9,7 @@ import Hydra.Prelude hiding (label)
 import Data.Maybe (fromJust)
 
 import Cardano.Api.UTxO as UTxO
-import Hydra.Chain.Direct.Contract.Gen (genForParty, genHash, genMintedOrBurnedValue)
+import Hydra.Chain.Direct.Contract.Gen (genHash, genMintedOrBurnedValue)
 import Hydra.Chain.Direct.Contract.Mutation (
   Mutation (..),
   SomeMutation (..),
@@ -48,7 +48,7 @@ import Hydra.Plutus.Orphans ()
 import Hydra.Snapshot (Snapshot (..), SnapshotNumber)
 import PlutusLedgerApi.V2 (BuiltinByteString, toBuiltin)
 import PlutusLedgerApi.V2 qualified as Plutus
-import Test.Hydra.Fixture (aliceSk, bobSk, carolSk)
+import Test.Hydra.Fixture (aliceSk, bobSk, carolSk, genForParty)
 import Test.QuickCheck (arbitrarySizedNatural, elements, listOf, listOf1, oneof, suchThat, vectorOf)
 import Test.QuickCheck.Gen (choose)
 import Test.QuickCheck.Instances ()

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Gen.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Gen.hs
@@ -1,36 +1,16 @@
 -- | Generators used in mutation testing framework
 module Hydra.Chain.Direct.Contract.Gen where
 
-import Cardano.Crypto.Hash (hashToBytes)
-import Codec.CBOR.Magic (uintegerFromBytes)
 import Data.ByteString qualified as BS
 import Hydra.Cardano.Api
 import Hydra.Chain.Direct.Fixture qualified as Fixtures
 import Hydra.Contract.HeadTokens (headPolicyId)
 import Hydra.Contract.Util (hydraHeadV1)
-import Hydra.Crypto (Hash (HydraKeyHash))
-import Hydra.Party (Party (..))
 import Hydra.Prelude
 import PlutusTx.Builtins (fromBuiltin)
 import Test.QuickCheck (oneof, suchThat, vector)
 
 -- * Party / key utilities
-
--- | Generate some 'a' given the Party as a seed. NOTE: While this is useful to
--- generate party-specific values, it DOES depend on the generator used. For
--- example, `genForParty genVerificationKey` and `genForParty (fst <$>
--- genKeyPair)` do not yield the same verification keys!
-genForParty :: Gen a -> Party -> a
-genForParty gen Party{vkey} =
-  generateWith gen seed
- where
-  seed =
-    fromIntegral
-      . uintegerFromBytes
-      . hydraKeyHashToBytes
-      $ verificationKeyHash vkey
-
-  hydraKeyHashToBytes (HydraKeyHash h) = hashToBytes h
 
 genBytes :: Gen ByteString
 genBytes = arbitrary

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Init.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Init.hs
@@ -10,7 +10,6 @@ import Hydra.Prelude
 import Cardano.Api.UTxO qualified as UTxO
 import Data.Maybe (fromJust)
 import Hydra.Chain (HeadParameters (..))
-import Hydra.Chain.Direct.Contract.Gen (genForParty)
 import Hydra.Chain.Direct.Contract.Mutation (
   Mutation (..),
   SomeMutation (..),
@@ -28,6 +27,7 @@ import Hydra.Ledger.Cardano (genOneUTxOFor, genValue)
 import Hydra.OnChainId (OnChainId, genOnChainId)
 import Hydra.Party (Party)
 import PlutusLedgerApi.Test.Examples qualified as Plutus
+import Test.Hydra.Fixture (genForParty)
 import Test.QuickCheck (choose, elements, oneof, suchThat, vectorOf)
 import Prelude qualified
 

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -17,7 +17,6 @@ import Data.Map qualified as Map
 import Data.Text qualified as T
 import Hydra.Cardano.Api.Pretty (renderTx)
 import Hydra.Chain (HeadParameters (..))
-import Hydra.Chain.Direct.Contract.Gen (genForParty)
 import Hydra.Chain.Direct.Fixture (
   epochInfo,
   pparams,
@@ -36,6 +35,7 @@ import Hydra.Contract.Initial qualified as Initial
 import Hydra.Ledger.Cardano (adaOnly, genOneUTxOFor, genVerificationKey)
 import Hydra.Ledger.Cardano.Evaluate (EvaluationReport, maxTxExecutionUnits)
 import Hydra.Party (Party)
+import Test.Hydra.Fixture (genForParty)
 import Test.QuickCheck (
   Property,
   choose,

--- a/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
@@ -151,7 +151,7 @@ instance StateModel Model where
     case t of
       ProduceSnapshots snapshots -> m{snapshots = snapshots}
       Close sn -> m{headState = Closed, utxoV = result, snapshots = filter (> sn) $ snapshots m}
-      Contest{} -> m{headState = Closed, utxoV = result}
+      Contest sn -> m{headState = Closed, utxoV = result, snapshots = filter (> sn) $ snapshots m}
       Fanout -> m{headState = Final}
 
   precondition :: Model -> Action Model a -> Bool

--- a/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
@@ -3,12 +3,15 @@ module Hydra.Chain.Direct.TxTraceSpec where
 import Hydra.Prelude hiding (Any, State, label)
 import Test.Hydra.Prelude
 
+import Debug.Trace (traceM)
 import Test.QuickCheck (Property, Smart (..), checkCoverage, cover, elements, forAll)
 import Test.QuickCheck.StateModel (
   ActionWithPolarity (..),
   Actions (..),
   Any (..),
   HasVariables (getAllVariables),
+  LookUp,
+  RunModel (..),
   StateModel (..),
   Step ((:=)),
   Var,
@@ -53,6 +56,16 @@ instance HasVariables (Action State a) where
 
 deriving instance Eq (Action State a)
 deriving instance Show (Action State a)
+
+instance RunModel State Identity where
+  perform :: State -> Action State a -> LookUp Identity -> Identity a
+  perform _s action _lookup = do
+    traceM $ "performing action: " <> show action
+    case action of
+      Close -> pure ()
+      Contest -> pure ()
+      Fanout -> pure ()
+      Stop -> pure ()
 
 spec :: Spec
 spec =

--- a/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
@@ -167,12 +167,12 @@ instance StateModel Model where
   nextState m t result =
     case t of
       ProduceSnapshots snapshots -> m{snapshots = snapshots}
-      Close{actor, snapshotNumber} ->
+      Close{snapshotNumber} ->
         m
           { headState = Closed
           , utxoV = result
           , snapshots = filter (> snapshotNumber) $ snapshots m
-          , alreadyContested = actor : alreadyContested m
+          , alreadyContested = []
           }
       Contest{actor, snapshotNumber} ->
         m

--- a/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
@@ -5,7 +5,9 @@ import Test.Hydra.Prelude
 
 import Data.Map.Strict qualified as Map
 import Hydra.Chain.Direct.Contract.Close (healthyCloseTx)
+import Hydra.Ledger.Cardano (Tx)
 import Hydra.Ledger.Cardano.Evaluate (evaluateTx)
+import Hydra.Snapshot (Snapshot)
 import Test.QuickCheck (Property, Smart (..), checkCoverage, cover, elements, forAll)
 import Test.QuickCheck.Monadic (monadicIO)
 import Test.QuickCheck.StateModel (
@@ -22,61 +24,69 @@ import Test.QuickCheck.StateModel (
   runActions,
  )
 
+data Model = Model {snapshots :: [Snapshot Tx], headState :: State} deriving (Show)
+
 data State
   = Open
   | Closed
   | Final
   deriving (Show)
 
-instance StateModel State where
-  data Action State a where
-    Close :: Action State ()
-    Contest :: Action State ()
-    Fanout :: Action State ()
+instance StateModel Model where
+  data Action Model a where
+    ProduceSnapshots :: [Snapshot Tx] -> Action Model ()
+    Close :: Action Model ()
+    Contest :: Action Model ()
+    Fanout :: Action Model ()
     -- \| Helper action to identify the terminal state 'Final' and shorten
     -- traces using the 'precondition'.
-    Stop :: Action State ()
+    Stop :: Action Model ()
 
-  arbitraryAction :: VarContext -> State -> Gen (Any (Action State))
-  arbitraryAction _lookup = \case
-    Open -> pure $ Some Close
-    Closed -> Some <$> elements [Contest, Fanout]
-    Final -> pure $ Some Stop
+  arbitraryAction :: VarContext -> Model -> Gen (Any (Action Model))
+  arbitraryAction _lookup Model{headState} =
+    case headState of
+      Open -> pure $ Some Close
+      Closed -> Some <$> elements [Contest, Fanout]
+      Final -> pure $ Some Stop
 
-  initialState = Open
+  initialState = Model{snapshots = [], headState = Open}
 
-  nextState :: State -> Action State a -> Var a -> State
-  nextState s t _ =
-    case (s, t) of
-      (_, Stop) -> s
-      (Open, Close) -> Closed
-      (Closed, Contest) -> Closed
-      (Closed, Fanout) -> Final
-      _ -> s
+  nextState :: Model -> Action Model a -> Var a -> Model
+  nextState m Stop _ = m
+  nextState m t _ =
+    m
+      { headState =
+          case (headState m, t) of
+            (Open, Close) -> Closed
+            (Closed, Contest) -> Closed
+            (Closed, Fanout) -> Final
+            _ -> headState m
+      }
 
-  precondition :: State -> Action State a -> Bool
-  precondition Final Stop = False
+  precondition :: Model -> Action Model a -> Bool
+  precondition Model{headState = Final} Stop = False
   precondition _ _ = True
 
-instance HasVariables State where
+instance HasVariables Model where
   getAllVariables = mempty
 
-instance HasVariables (Action State a) where
+instance HasVariables (Action Model a) where
   getAllVariables = mempty
 
-deriving instance Eq (Action State a)
-deriving instance Show (Action State a)
+deriving instance Eq (Action Model a)
+deriving instance Show (Action Model a)
 
-instance RunModel State IO where
-  perform :: State -> Action State a -> LookUp IO -> IO a
-  perform s action _lookup = do
-    case s of
+instance RunModel Model IO where
+  perform :: Model -> Action Model a -> LookUp IO -> IO a
+  perform m action _lookup = do
+    case headState m of
       Open -> putStrLn "=========OPEN======="
       _ -> pure ()
 
     putStrLn $ "performing action: " <> show action
 
     case action of
+      ProduceSnapshots _snapshots -> pure ()
       Close -> do
         let (tx, utxo) = healthyCloseTx
 
@@ -98,13 +108,20 @@ spec = do
 
 prop_traces :: Property
 prop_traces =
-  forAll (arbitrary :: Gen (Actions State)) $ \(Actions_ _ (Smart _ steps)) ->
+  forAll (arbitrary :: Gen (Actions Model)) $ \(Actions_ _ (Smart _ steps)) ->
     checkCoverage $
       True
         & cover 1 (null steps) "empty"
         & cover 10 (hasFanout steps) "reach fanout"
         & cover 5 (countContests steps >= 2) "has multiple contests"
+        & cover 5 (containSomeSnapshots steps) "has some snapshots"
  where
+  containSomeSnapshots =
+    any $
+      \(_ := ActionWithPolarity{polarAction}) -> case polarAction of
+        ProduceSnapshots snapshots -> not $ null snapshots
+        _ -> False
+
   hasFanout =
     any $
       \(_ := ActionWithPolarity{polarAction}) -> case polarAction of
@@ -119,7 +136,7 @@ prop_traces =
             _ -> False
         )
 
-prop_runActions :: Actions State -> Property
+prop_runActions :: Actions Model -> Property
 prop_runActions actions =
   monadicIO $
     void (runActions actions)

--- a/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
@@ -56,7 +56,7 @@ deriving instance Show (Action State a)
 
 spec :: Spec
 spec =
-  prop "generates trace of transitions" $ prop_traces
+  prop "generates trace of transitions" prop_traces
 
 prop_traces :: Property
 prop_traces =
@@ -65,9 +65,18 @@ prop_traces =
       True
         & cover 1 (null steps) "empty"
         & cover 10 (hasFanout steps) "reach fanout"
+        & cover 5 (countContests steps >= 2) "has multiple contests"
  where
   hasFanout =
     any $
       \(_ := ActionWithPolarity{polarAction}) -> case polarAction of
         Fanout{} -> True
         _ -> False
+  countContests s =
+    length $
+      filter
+        ( \(_ := ActionWithPolarity{polarAction}) -> case polarAction of
+            Contest{} -> True
+            _ -> False
+        )
+        s

--- a/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
@@ -1,0 +1,49 @@
+module Hydra.Chain.Direct.TxTraceSpec where
+
+import Hydra.Prelude hiding (State)
+import Test.Hydra.Prelude
+import Test.QuickCheck (elements, forAll)
+
+data State
+  = Open
+  | Closed
+  | Final
+
+data Transition
+  = Close
+  | Contest
+  | Fanout
+  deriving (Show)
+
+genTransition :: State -> Gen Transition
+genTransition = \case
+  Open -> pure Close
+  Closed -> elements [Contest, Fanout]
+  Final -> undefined
+
+startingState :: State
+startingState = Open
+
+nextState :: State -> Transition -> State
+nextState s t =
+  case (s, t) of
+    (Open, Close) -> Closed
+    (Closed, Contest) -> Closed
+    (Closed, Fanout) -> Final
+    _ -> s
+
+genTrace :: Gen [Transition]
+genTrace = go [] startingState
+ where
+  go ts s = do
+    t <- genTransition s
+    let s' = nextState s t
+    case s' of
+      Final -> pure $ t : ts
+      _ -> go (t : ts) s'
+
+spec :: Spec
+spec =
+  prop "generates trace of transitions" $ do
+    forAll genTrace $ \transitions ->
+      not $ null transitions

--- a/hydra-node/test/Test/Hydra/Fixture.hs
+++ b/hydra-node/test/Test/Hydra/Fixture.hs
@@ -3,31 +3,41 @@ module Test.Hydra.Fixture where
 
 import Hydra.Prelude
 
-import Hydra.Cardano.Api (Key (..), SerialiseAsRawBytes (..), SigningKey, VerificationKey, getVerificationKey)
+import Cardano.Crypto.Hash (hashToBytes)
+import Codec.CBOR.Magic (uintegerFromBytes)
+import Hydra.Cardano.Api (Key (..), PaymentKey, SerialiseAsRawBytes (..), SigningKey, VerificationKey, getVerificationKey)
 import Hydra.ContestationPeriod (ContestationPeriod (..))
-import Hydra.Crypto (HydraKey, generateSigningKey)
+import Hydra.Crypto (Hash (..), HydraKey, generateSigningKey)
 import Hydra.Environment (Environment (..))
 import Hydra.HeadId (HeadId (..), HeadSeed (..))
+import Hydra.Ledger.Cardano (genVerificationKey)
 import Hydra.OnChainId (AsType (AsOnChainId), OnChainId)
 import Hydra.Party (Party (..), deriveParty)
 
+-- | Our beloved alice, bob, and carol.
 alice, bob, carol :: Party
 alice = deriveParty aliceSk
 bob = deriveParty bobSk
 carol = deriveParty carolSk
 
+-- | Hydra signing keys for 'alice', 'bob', and 'carol'.
 aliceSk, bobSk, carolSk :: SigningKey HydraKey
 aliceSk = generateSigningKey "alice"
 bobSk = generateSigningKey "bob"
+-- NOTE: Using 'zcarol' as seed results in ordered 'deriveParty' values
 carolSk = generateSigningKey "zcarol"
 
+-- | Hydra verification keys for 'alice', 'bob', and 'carol'.
 aliceVk, bobVk, carolVk :: VerificationKey HydraKey
 aliceVk = getVerificationKey aliceSk
 bobVk = getVerificationKey bobSk
 carolVk = getVerificationKey carolSk
 
-allVKeys :: [VerificationKey HydraKey]
-allVKeys = vkey <$> [alice, bob, carol]
+-- | Cardano payment keys for 'alice', 'bob', and 'carol'.
+alicePVk, bobPVk, carolPVk :: VerificationKey PaymentKey
+alicePVk = genVerificationKey `genForParty` alice
+bobPVk = genVerificationKey `genForParty` bob
+carolPVk = genVerificationKey `genForParty` carol
 
 cperiod :: ContestationPeriod
 cperiod = UnsafeContestationPeriod 42
@@ -48,6 +58,22 @@ deriveOnChainId Party{vkey} =
     Right oid -> oid
  where
   bytes = serialiseToRawBytes $ verificationKeyHash vkey
+
+-- | Generate some 'a' given the Party as a seed. NOTE: While this is useful to
+-- generate party-specific values, it DOES depend on the generator used. For
+-- example, `genForParty genVerificationKey` and `genForParty (fst <$>
+-- genKeyPair)` do not yield the same verification keys!
+genForParty :: Gen a -> Party -> a
+genForParty gen Party{vkey} =
+  generateWith gen seed
+ where
+  seed =
+    fromIntegral
+      . uintegerFromBytes
+      . hydraKeyHashToBytes
+      $ verificationKeyHash vkey
+
+  hydraKeyHashToBytes (HydraKeyHash h) = hashToBytes h
 
 -- | An environment fixture for testing.
 testEnvironment :: Environment

--- a/hydra-node/test/Test/Hydra/Fixture.hs
+++ b/hydra-node/test/Test/Hydra/Fixture.hs
@@ -6,6 +6,7 @@ import Hydra.Prelude
 import Cardano.Crypto.Hash (hashToBytes)
 import Codec.CBOR.Magic (uintegerFromBytes)
 import Hydra.Cardano.Api (Key (..), PaymentKey, SerialiseAsRawBytes (..), SigningKey, VerificationKey, getVerificationKey)
+import Hydra.Chain (HeadParameters (..))
 import Hydra.ContestationPeriod (ContestationPeriod (..))
 import Hydra.Crypto (Hash (..), HydraKey, generateSigningKey)
 import Hydra.Environment (Environment (..))
@@ -84,4 +85,12 @@ testEnvironment =
     , otherParties = [bob, carol]
     , contestationPeriod = cperiod
     , participants = deriveOnChainId <$> [alice, bob, carol]
+    }
+
+-- | Head parameters fixture for testing.
+testHeadParameters :: HeadParameters
+testHeadParameters =
+  HeadParameters
+    { contestationPeriod = cperiod
+    , parties = [alice, bob, carol]
     }


### PR DESCRIPTION
* :green_heart: Resolves #1370 as it can reproduce the issue in #1266:

```
cabal test hydra-cluster --test-options '-m TxTrace' # passes
git revert 85a9b36eb3a6b2dbdb2bad8aa94f5ffe21a8bdc1
cabal test hydra-cluster --test-options '-m TxTrace' # fails
```

* :green_heart: Adds a new stateful property based test suite in `TxSpec`, which hooks into `Hydra.Chain.Direct.State` transaction creation (i.e. `close` and `contest`) functions and ensures created transactions are valid and can be observed (by `observeHeadTx`)
  - The model is currently geared toward `close` and `contest` transactions
  - Head id, parameters, parties (alice, bob and carol) and close / contest times are all constant
  - Only correctly signed snapshots of a constant `UTxO` are used
  - Hence, variables are only the `Actor` and `SnapshotNumber` of `Close` and `Contest` actions.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
