### PR TITLE
Cardano api 8.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 As a minor extension, we also keep a semantic version for the `UNRELEASED`
 changes.
 
+## [0.17.0] - UNRELEASED
+
+- **DO NOT RELEASE** Currently broken against `cardano-node 8.9.0` in `conway`!
+
+- **BREAKING** Hydra scripts changed due to updates in `cardano-api` and the `plutus` toolchain:
+  - No significant change in transaction size or budgets.
+  - Re-export `PParams` type alias on latest `Era` in `Hydra.Cardano.Api`
 
 ## [0.16.0] - 2024-04-03
 

--- a/cabal.project
+++ b/cabal.project
@@ -12,8 +12,8 @@ repository cardano-haskell-packages
 
 -- See CONTRIBUTING.md for information about when and how to update these.
 index-state:
-  , hackage.haskell.org 2024-03-21T15:07:04Z
-  , cardano-haskell-packages 2024-03-21T19:04:02Z
+  , hackage.haskell.org 2024-04-09T15:27:52Z
+  , cardano-haskell-packages 2024-04-08T15:27:49Z
 
 packages:
   cardano-api-classy

--- a/cardano-api-classy/cardano-api-classy.cabal
+++ b/cardano-api-classy/cardano-api-classy.cabal
@@ -50,9 +50,11 @@ library
     Cardano.Api.Class.ToAlonzoScript
     Cardano.Api.Classy
 
+  -- NOTE: We only use an upper bound on cardano-api and have the other
+  -- dependencies on cardano-ledger* follow.
   build-depends:
     , base                   >=4.16
-    , cardano-api            >=8.42.0 && <8.43
-    , cardano-ledger-alonzo  >=1.6    && <1.7
-    , cardano-ledger-conway  >=1.12   && <1.13
-    , cardano-ledger-core    >=1.10   && <1.11
+    , cardano-api            ^>=8.44
+    , cardano-ledger-alonzo
+    , cardano-ledger-conway
+    , cardano-ledger-core

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1710945682,
-        "narHash": "sha256-xp1txUjrtCuKHAy0nvz/lu0MlNdNnzvP8l2p9MFB73Y=",
+        "lastModified": 1712590917,
+        "narHash": "sha256-DgXSWHF5b/UtM+ACBWLPNtMNTSGQrmtl/ME7e7dheLo=",
         "owner": "IntersectMBO",
         "repo": "cardano-haskell-packages",
-        "rev": "8df2bf06e4525ec39c106cd2593e3c5fd7f2b081",
+        "rev": "251738d00d5799850c6eb610c4ab7b175b66224a",
         "type": "github"
       },
       "original": {
@@ -936,11 +936,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1708561382,
-        "narHash": "sha256-IDr2G3komoctjHALk8wGvDKOF39BaqrdEmjvAOsob5I=",
+        "lastModified": 1712622274,
+        "narHash": "sha256-LpQUA5rdy1lwxaH2FtGXp0eHg9fUJa2e00G4owuakJU=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "4b07be837c34475fdde3c9bb9903a850b5692bac",
+        "rev": "50976bfc1171f31a9d447516efc33702741cb356",
         "type": "github"
       },
       "original": {

--- a/hydra-cardano-api/hydra-cardano-api.cabal
+++ b/hydra-cardano-api/hydra-cardano-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          hydra-cardano-api
-version:       0.16.0
+version:       0.17.0
 synopsis:      A Haskell API for Cardano, tailored to the Hydra project.
 author:        IOG
 copyright:     2022 IOG

--- a/hydra-cardano-api/hydra-cardano-api.cabal
+++ b/hydra-cardano-api/hydra-cardano-api.cabal
@@ -75,30 +75,30 @@ library
     Hydra.Cardano.Api.VerificationKey
     Hydra.Cardano.Api.Witness
 
-  -- NOTE: We use very narrow bounds on cardano libraries as they tend to break
-  -- their interfaces often.
+  -- NOTE: We only use an upper bound on cardano-api and have the other
+  -- dependencies on cardano-ledger* and plutus-ledger-api follow.
   build-depends:
     , aeson                   >=2
     , base                    >=4.16
     , base16-bytestring
     , bytestring
-    , cardano-api             >=8.42.0 && <8.43
+    , cardano-api             ^>=8.44
     , cardano-api-classy
-    , cardano-binary          >=1.7.0  && <1.8
-    , cardano-crypto-class    >=2.1.1  && <2.2
-    , cardano-ledger-allegra  >=1.3    && <1.4
-    , cardano-ledger-alonzo   >=1.6    && <1.7
-    , cardano-ledger-api      >=1.8    && <1.9
-    , cardano-ledger-babbage  >=1.6    && <1.7
-    , cardano-ledger-binary   >=1.3    && <1.4
-    , cardano-ledger-byron    >=1.0.0  && <1.1
-    , cardano-ledger-conway   >=1.12   && <1.13
-    , cardano-ledger-core     >=1.10   && <1.11
-    , cardano-ledger-mary     >=1.5    && <1.6
-    , cardano-ledger-shelley  >=1.9    && <1.10
+    , cardano-binary
+    , cardano-crypto-class
+    , cardano-ledger-allegra
+    , cardano-ledger-alonzo
+    , cardano-ledger-api
+    , cardano-ledger-babbage
+    , cardano-ledger-binary
+    , cardano-ledger-byron
+    , cardano-ledger-conway
+    , cardano-ledger-core
+    , cardano-ledger-mary
+    , cardano-ledger-shelley
     , containers
     , lens
-    , plutus-ledger-api       >=1.21   && <1.22
+    , plutus-ledger-api
     , QuickCheck
     , serialise
     , text                    >=2

--- a/hydra-cardano-api/src/Hydra/Cardano/Api.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api.hs
@@ -19,7 +19,6 @@ module Hydra.Cardano.Api (
   Era,
   LedgerEra,
   ledgerEraVersion,
-  LedgerProtocolParameters (..),
 
   -- * Wrapped Types
   module Hydra.Cardano.Api,
@@ -31,7 +30,7 @@ module Hydra.Cardano.Api (
   -- * Extras
   module Extras,
 
-  -- * Re-exports from @cardano-api@
+  -- * Re-exports from @cardano-api@, @cardano-api-classy@ and @cardano-ledger@
   module X,
 ) where
 
@@ -92,6 +91,7 @@ import Cardano.Api.Shelley as X (
   Address (..),
   Hash (HeaderHash),
   Key (..),
+  LedgerProtocolParameters (..),
   PlutusScriptOrReferenceInput (PScript),
   PoolId,
   ProtocolParameters (..),
@@ -114,7 +114,6 @@ import Cardano.Ledger.Coin as X (Coin (..))
 import Hydra.Cardano.Api.Prelude (
   Era,
   LedgerEra,
-  LedgerProtocolParameters,
   Map,
   StandardCrypto,
   ledgerEraVersion,
@@ -239,6 +238,10 @@ pattern PlutusScriptSerialised{plutusScriptSerialised} <-
   where
     PlutusScriptSerialised =
       Cardano.Api.Shelley.PlutusScriptSerialised
+
+-- ** PParams
+
+type PParams = Ledger.PParams (ShelleyLedgerEra Era)
 
 -- ** Script
 

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Tx.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Tx.hs
@@ -17,7 +17,7 @@ import Cardano.Ledger.Alonzo.TxAuxData (translateAlonzoTxAuxData)
 import Cardano.Ledger.Alonzo.TxWits qualified as Ledger
 import Cardano.Ledger.Api (
   AlonzoPlutusPurpose (..),
-  AsIndex (..),
+  AsIx (..),
   ConwayPlutusPurpose (..),
   EraTx (mkBasicTx),
   addrTxOutL,
@@ -151,13 +151,13 @@ convertConwayTx =
       $ Map.toList redeemerMap
 
   translatePlutusPurpose ::
-    Conway.ConwayPlutusPurpose Ledger.AsIndex (Ledger.ConwayEra StandardCrypto) ->
-    Maybe (Ledger.AlonzoPlutusPurpose Ledger.AsIndex (Ledger.BabbageEra StandardCrypto))
+    Conway.ConwayPlutusPurpose Ledger.AsIx (Ledger.ConwayEra StandardCrypto) ->
+    Maybe (Ledger.AlonzoPlutusPurpose Ledger.AsIx (Ledger.BabbageEra StandardCrypto))
   translatePlutusPurpose = \case
-    ConwaySpending (AsIndex ix) -> Just $ AlonzoSpending (AsIndex ix)
-    ConwayMinting (AsIndex ix) -> Just $ AlonzoMinting (AsIndex ix)
-    ConwayCertifying (AsIndex ix) -> Just $ AlonzoCertifying (AsIndex ix)
-    ConwayRewarding (AsIndex ix) -> Just $ AlonzoRewarding (AsIndex ix)
+    ConwaySpending (AsIx ix) -> Just $ AlonzoSpending (AsIx ix)
+    ConwayMinting (AsIx ix) -> Just $ AlonzoMinting (AsIx ix)
+    ConwayCertifying (AsIx ix) -> Just $ AlonzoCertifying (AsIx ix)
+    ConwayRewarding (AsIx ix) -> Just $ AlonzoRewarding (AsIx ix)
     ConwayVoting{} -> Nothing
     ConwayProposing{} -> Nothing
 

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/TxBody.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/TxBody.hs
@@ -23,6 +23,7 @@ findRedeemerSpending ::
   TxIn ->
   Maybe a
 findRedeemerSpending (getTxBody -> ShelleyTxBody _ body _ scriptData _ _) txIn = do
+  -- TODO: address this deprecation
   ptr <- strictMaybeToMaybe $ redeemerPointer body (AlonzoSpending . AsItem $ toLedgerTxIn txIn)
   lookupRedeemer ptr scriptData
 
@@ -32,6 +33,7 @@ findRedeemerMinting ::
   PolicyId ->
   Maybe a
 findRedeemerMinting (getTxBody -> ShelleyTxBody _ body _ scriptData _ _) pid = do
+  -- TODO: address this deprecation
   ptr <- strictMaybeToMaybe $ redeemerPointer body (AlonzoMinting . AsItem $ toLedgerPolicyID pid)
   lookupRedeemer ptr scriptData
 

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/TxBody.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/TxBody.hs
@@ -3,7 +3,7 @@ module Hydra.Cardano.Api.TxBody where
 import Hydra.Cardano.Api.Prelude
 
 import Cardano.Ledger.Alonzo.TxWits qualified as Ledger
-import Cardano.Ledger.Api (AlonzoPlutusPurpose (..), AsIndex, AsItem (..), PlutusPurpose)
+import Cardano.Ledger.Api (AlonzoPlutusPurpose (..), AsItem (..), AsIx, PlutusPurpose)
 import Cardano.Ledger.Babbage.Core (redeemerPointer)
 import Cardano.Ledger.BaseTypes (strictMaybeToMaybe)
 import Cardano.Ledger.Core qualified as Ledger
@@ -53,7 +53,7 @@ findScriptMinting (getTxBody -> ShelleyTxBody _ _ scripts _ _ _) pid = do
 
 lookupRedeemer ::
   Plutus.FromData a =>
-  PlutusPurpose AsIndex LedgerEra ->
+  PlutusPurpose AsIx LedgerEra ->
   TxBodyScriptData Era ->
   Maybe a
 lookupRedeemer ptr scriptData = do

--- a/hydra-cluster/bench/Main.hs
+++ b/hydra-cluster/bench/Main.hs
@@ -9,18 +9,11 @@ import Bench.EndToEnd (bench)
 import Bench.Options (Options (..), benchOptionsParser)
 import Bench.Summary (Summary (..), markdownReport, textReport)
 import Cardano.Binary (decodeFull, serialize)
-import Data.Aeson (eitherDecodeFileStrict')
 import Data.ByteString.Base16 qualified as Base16
 import Data.ByteString.Lazy qualified as LBS
-import Hydra.Cardano.Api (
-  ShelleyBasedEra (..),
-  ShelleyGenesis (..),
-  fromLedgerPParams,
- )
+import Hydra.Chain.Direct.Fixture (defaultPParams)
 import Hydra.Generator (Dataset (..), generateConstantUTxODataset)
-import Options.Applicative (
-  execParser,
- )
+import Options.Applicative (execParser)
 import System.Directory (createDirectoryIfMissing, doesDirectoryExist)
 import System.Environment (withArgs)
 import System.FilePath (takeDirectory, takeFileName, (</>))
@@ -47,12 +40,7 @@ main =
   play outputDirectory timeoutSeconds scalingFactor clusterSize startingNodeId workDir = do
     putStrLn $ "Generating single dataset in work directory: " <> workDir
     numberOfTxs <- generate $ scale (* scalingFactor) getSize
-    pparams <-
-      eitherDecodeFileStrict' ("config" </> "devnet" </> "genesis-shelley.json") >>= \case
-        Left err -> fail $ show err
-        Right shelleyGenesis ->
-          pure $ fromLedgerPParams ShelleyBasedEraShelley (sgProtocolParams shelleyGenesis)
-    dataset <- generateConstantUTxODataset pparams (fromIntegral clusterSize) numberOfTxs
+    dataset <- generateConstantUTxODataset defaultPParams (fromIntegral clusterSize) numberOfTxs
     let datasetPath = workDir </> "dataset.cbor"
     saveDataset datasetPath dataset
     run outputDirectory timeoutSeconds startingNodeId [datasetPath]

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -90,7 +90,6 @@ library
     , cardano-slotting
     , containers
     , contra-tracer
-    , data-default
     , directory
     , filepath
     , http-conduit

--- a/hydra-cluster/src/CardanoClient.hs
+++ b/hydra-cluster/src/CardanoClient.hs
@@ -126,7 +126,7 @@ waitForUTxO networkId nodeSocket utxo =
 
 mkGenesisTx ::
   NetworkId ->
-  ProtocolParameters ->
+  PParams ->
   -- | Owner of the 'initialFund'.
   SigningKey PaymentKey ->
   -- | Amount of initialFunds

--- a/hydra-cluster/src/Hydra/Generator.hs
+++ b/hydra-cluster/src/Hydra/Generator.hs
@@ -6,7 +6,7 @@ import Hydra.Prelude hiding (size)
 import Cardano.Api.UTxO qualified as UTxO
 import CardanoClient (mkGenesisTx)
 import Control.Monad (foldM)
-import Data.Default (def)
+import Hydra.Chain.Direct.Fixture (defaultPParams)
 import Hydra.Cluster.Fixture (Actor (Faucet), availableInitialFunds)
 import Hydra.Cluster.Util (keysFor)
 import Hydra.Ledger.Cardano (genSigningKey, generateOneTransfer)
@@ -42,7 +42,7 @@ instance FromCBOR Dataset where
 instance Arbitrary Dataset where
   arbitrary = sized $ \n -> do
     sk <- genSigningKey
-    genDatasetConstantUTxO sk defaultProtocolParameters (n `div` 10) n
+    genDatasetConstantUTxO sk defaultPParams (n `div` 10) n
 
 data ClientKeys = ClientKeys
   { signingKey :: SigningKey PaymentKey
@@ -83,14 +83,11 @@ instance ToCBOR ClientDataset where
 instance FromCBOR ClientDataset where
   fromCBOR = ClientDataset <$> fromCBOR <*> fromCBOR <*> fromCBOR
 
-defaultProtocolParameters :: ProtocolParameters
-defaultProtocolParameters = fromLedgerPParams ShelleyBasedEraShelley def
-
 -- | Generate 'Dataset' which does not grow the per-client UTXO set over time.
 -- The sequence of transactions generated consist only of simple payments from
 -- and to arbitrary keys controlled by the individual clients.
 generateConstantUTxODataset ::
-  ProtocolParameters ->
+  PParams ->
   -- | Number of clients
   Int ->
   -- | Number of transactions
@@ -103,7 +100,7 @@ generateConstantUTxODataset pparams nClients nTxs = do
 genDatasetConstantUTxO ::
   -- | The faucet signing key
   SigningKey PaymentKey ->
-  ProtocolParameters ->
+  PParams ->
   -- | Number of clients
   Int ->
   -- | Number of transactions

--- a/hydra-cluster/test/Test/GeneratorSpec.hs
+++ b/hydra-cluster/test/Test/GeneratorSpec.hs
@@ -13,7 +13,6 @@ import Hydra.Cluster.Util (keysFor)
 import Hydra.Generator (
   ClientDataset (..),
   Dataset (..),
-  defaultProtocolParameters,
   genDatasetConstantUTxO,
  )
 import Hydra.Ledger (ChainSlot (ChainSlot), applyTransactions)
@@ -44,7 +43,7 @@ prop_keepsUTxOConstant =
       let ledgerEnv = newLedgerEnv defaultPParams
       -- XXX: non-exhaustive pattern match
       pure $
-        forAll (genDatasetConstantUTxO faucetSk defaultProtocolParameters 1 n) $
+        forAll (genDatasetConstantUTxO faucetSk defaultPParams 1 n) $
           \Dataset{fundingTransaction, clientDatasets = [ClientDataset{txSequence}]} ->
             let initialUTxO = utxoFromTx fundingTransaction
                 finalUTxO = foldl' (apply defaultGlobals ledgerEnv) initialUTxO txSequence

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -153,8 +153,8 @@ library
     , ouroboros-network-api                                     >=0.1.0.0
     , ouroboros-network-framework                               >=0.3.0.0
     , ouroboros-network-protocols                               >=0.3.0.0
-    , plutus-core                                               >=1.21    && <1.22
-    , plutus-ledger-api                                         >=1.21    && <1.22
+    , plutus-core                                               >=1.21
+    , plutus-ledger-api                                         >=1.21
     , prometheus
     , QuickCheck
     , quickcheck-instances

--- a/hydra-node/src/Hydra/API/HTTPServer.hs
+++ b/hydra-node/src/Hydra/API/HTTPServer.hs
@@ -5,7 +5,6 @@ module Hydra.API.HTTPServer where
 import Hydra.Prelude
 
 import Cardano.Api.UTxO qualified as UTxO
-import Cardano.Ledger.Core (PParams)
 import Data.Aeson (KeyValue ((.=)), Value (Object), object, withObject, (.:), (.:?))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.KeyMap qualified as KeyMap
@@ -17,7 +16,7 @@ import Hydra.Cardano.Api (
   CtxUTxO,
   HashableScriptData,
   KeyWitnessInCtx (..),
-  LedgerEra,
+  PParams,
   PlutusScript,
   ScriptDatum (InlineScriptDatum, ScriptDatumForTxIn),
   ScriptWitnessInCtx (ScriptWitnessForSpending),
@@ -152,7 +151,7 @@ instance Arbitrary TransactionSubmitted where
 httpApp ::
   Tracer IO APIServerLog ->
   Chain tx IO ->
-  PParams LedgerEra ->
+  PParams ->
   -- | A means to get the 'HeadId' if initializing the Head.
   (STM IO) (Maybe HeadId) ->
   Application

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -4,7 +4,6 @@ module Hydra.API.Server where
 
 import Hydra.Prelude hiding (TVar, readTVar, seq)
 
-import Cardano.Ledger.Core (PParams)
 import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
 import Control.Concurrent.STM.TChan (newBroadcastTChanIO, writeTChan)
 import Control.Concurrent.STM.TVar (modifyTVar', newTVarIO)
@@ -22,7 +21,7 @@ import Hydra.API.ServerOutput (
   projectSnapshotUtxo,
  )
 import Hydra.API.WSServer (nextSequenceNumber, wsApp)
-import Hydra.Cardano.Api (LedgerEra)
+import Hydra.Cardano.Api (PParams)
 import Hydra.Chain (
   Chain (..),
   IsChainState,
@@ -66,7 +65,7 @@ withAPIServer ::
   PersistenceIncremental (TimedServerOutput tx) IO ->
   Tracer IO APIServerLog ->
   Chain tx IO ->
-  PParams LedgerEra ->
+  PParams ->
   ServerComponent tx IO ()
 withAPIServer host port party PersistenceIncremental{loadAll, append} tracer chain pparams callback action =
   handle onIOException $ do

--- a/hydra-node/src/Hydra/Chain/Direct/Fixture.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Fixture.hs
@@ -17,7 +17,7 @@ import Cardano.Ledger.Alonzo.Scripts (Prices (..))
 import Cardano.Ledger.BaseTypes (BoundedRational (..))
 import Cardano.Ledger.BaseTypes qualified as Ledger
 import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Core (PParams, ppMinFeeAL, ppMinFeeBL)
+import Cardano.Ledger.Core (ppMinFeeAL, ppMinFeeBL)
 import Cardano.Slotting.Time qualified as Slotting
 import Control.Lens ((.~))
 import Data.Maybe (fromJust)
@@ -26,6 +26,7 @@ import Hydra.Cardano.Api (
   LedgerEra,
   NetworkId (Testnet),
   NetworkMagic (NetworkMagic),
+  PParams,
   PolicyId,
   TxIn,
   genTxIn,
@@ -51,7 +52,8 @@ testSeedInput = generateWith genTxIn 42
 defaultLedgerEnv :: LedgerEnv LedgerEra
 defaultLedgerEnv = newLedgerEnv defaultPParams
 
-defaultPParams :: PParams LedgerEra
+-- | Default protocol parameters with zeroed fees and prices.
+defaultPParams :: PParams
 defaultPParams =
   pparams
     & ppPricesL

--- a/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
@@ -14,10 +14,10 @@ import Cardano.Ledger.Alonzo.Plutus.Context (ContextError)
 import Cardano.Ledger.Alonzo.Scripts (
   AlonzoEraScript (..),
   AlonzoPlutusPurpose (AlonzoSpending),
-  AsIndex (..),
+  AsIx (..),
   ExUnits (ExUnits),
   plutusScriptLanguage,
-  unAsIndex,
+  unAsIx,
  )
 import Cardano.Ledger.Alonzo.TxWits (
   AlonzoTxWits (..),
@@ -238,7 +238,7 @@ data ErrCoverFee
   = ErrNotEnoughFunds ChangeError
   | ErrNoFuelUTxOFound
   | ErrUnknownInput {input :: TxIn}
-  | ErrScriptExecutionFailed {scriptFailure :: (PlutusPurpose AsIndex LedgerEra, TransactionScriptFailure LedgerEra)}
+  | ErrScriptExecutionFailed {scriptFailure :: (PlutusPurpose AsIx LedgerEra, TransactionScriptFailure LedgerEra)}
   | ErrTranslationError (ContextError LedgerEra)
   deriving stock (Show)
 
@@ -366,7 +366,7 @@ coverFee_ pparams systemStart epochInfo lookupUTxO walletUTxO partialTx@Babbage.
     changeOut = totalIn <> invert totalOut
     refScript = SNothing
 
-  adjustRedeemers :: Set TxIn -> Set TxIn -> Map (PlutusPurpose AsIndex LedgerEra) ExUnits -> Redeemers LedgerEra -> Redeemers LedgerEra
+  adjustRedeemers :: Set TxIn -> Set TxIn -> Map (PlutusPurpose AsIx LedgerEra) ExUnits -> Redeemers LedgerEra -> Redeemers LedgerEra
   adjustRedeemers initialInputs finalInputs estimatedCosts (Redeemers initialRedeemers) =
     Redeemers $ Map.fromList $ map adjustOne $ Map.toList initialRedeemers
    where
@@ -377,12 +377,12 @@ coverFee_ pparams systemStart epochInfo lookupUTxO walletUTxO partialTx@Babbage.
     adjustOne (ptr, (d, _exUnits)) =
       case ptr of
         AlonzoSpending idx
-          | fromIntegral (unAsIndex idx) `elem` differences ->
-              (AlonzoSpending (AsIndex (unAsIndex idx + 1)), (d, executionUnitsFor ptr))
+          | fromIntegral (unAsIx idx) `elem` differences ->
+              (AlonzoSpending (AsIx (unAsIx idx + 1)), (d, executionUnitsFor ptr))
         _ ->
           (ptr, (d, executionUnitsFor ptr))
 
-    executionUnitsFor :: PlutusPurpose AsIndex LedgerEra -> ExUnits
+    executionUnitsFor :: PlutusPurpose AsIx LedgerEra -> ExUnits
     executionUnitsFor ptr =
       let ExUnits maxMem maxCpu = pparams ^. ppMaxTxExUnitsL
           ExUnits totalMem totalCpu = foldMap identity estimatedCosts
@@ -418,7 +418,7 @@ estimateScriptsCost ::
   Map TxIn TxOut ->
   -- | The pre-constructed transaction
   Babbage.AlonzoTx LedgerEra ->
-  Either ErrCoverFee (Map (PlutusPurpose AsIndex LedgerEra) ExUnits)
+  Either ErrCoverFee (Map (PlutusPurpose AsIx LedgerEra) ExUnits)
 estimateScriptsCost pparams systemStart epochInfo utxo tx = do
   case result of
     Left translationError ->

--- a/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
@@ -28,9 +28,9 @@ import Cardano.Ledger.Alonzo.TxWits (
 import Cardano.Ledger.Api (
   TransactionScriptFailure,
   bodyTxL,
+  calcMinFeeTx,
   collateralInputsTxBodyL,
   ensureMinCoinTxOut,
-  estimateMinFeeTx,
   evalTxExUnits,
   feeTxBodyL,
   inputsTxBodyL,
@@ -306,7 +306,7 @@ coverFee_ pparams systemStart epochInfo lookupUTxO walletUTxO partialTx@Babbage.
 
   -- Compute fee using a body with selected txOut to pay fees (= full change)
   -- and an aditional witness (we will sign this tx later)
-  let fee = estimateMinFeeTx pparams costingTx additionalWitnesses 0
+  let fee = calcMinFeeTx (Ledger.UTxO utxo) pparams costingTx additionalWitnesses
       costingTx =
         unbalancedTx
           & bodyTxL . outputsTxBodyL %~ (|> feeTxOut)

--- a/hydra-node/src/Hydra/Ledger/Cardano/Configuration.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano/Configuration.hs
@@ -7,7 +7,6 @@ module Hydra.Ledger.Cardano.Configuration (
 import Hydra.Cardano.Api
 import Hydra.Prelude
 
-import Cardano.Ledger.Api (PParams)
 import Cardano.Ledger.BaseTypes (Globals (..), boundRational, mkActiveSlotCoeff)
 import Cardano.Ledger.BaseTypes qualified as Ledger
 import Cardano.Ledger.Shelley.API (computeRandomnessStabilisationWindow, computeStabilityWindow)
@@ -81,7 +80,7 @@ newGlobals genesisParameters = do
 
 -- | Decode protocol parameters using the 'ProtocolParameters' instance as this
 -- is used by cardano-cli and matches the schema. TODO: define the schema
-pparamsFromJson :: Json.Value -> Json.Parser (PParams LedgerEra)
+pparamsFromJson :: Json.Value -> Json.Parser PParams
 pparamsFromJson v = do
   x <- parseJSON v
   case toLedgerPParams (shelleyBasedEra @Era) x of
@@ -89,7 +88,7 @@ pparamsFromJson v = do
     Right z -> pure z
 
 -- | Create a new ledger env from given protocol parameters.
-newLedgerEnv :: PParams LedgerEra -> Ledger.LedgerEnv LedgerEra
+newLedgerEnv :: PParams -> Ledger.LedgerEnv LedgerEra
 newLedgerEnv protocolParams =
   Ledger.LedgerEnv
     { Ledger.ledgerSlotNo = SlotNo 0

--- a/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs
@@ -217,13 +217,13 @@ prepareTxScripts tx utxo = do
       Right x -> pure x
 
   -- Fully applied UPLC programs which we could run using the cekMachine
-  programs <- forM results $ \(PlutusWithContext protocolVersion script arguments _exUnits _costModel) -> do
+  programs <- forM results $ \PlutusWithContext{pwcProtocolVersion, pwcScript, pwcDatums} -> do
     (PlutusRunnable x) <-
-      case script of
+      case pwcScript of
         Right runnable -> pure runnable
-        Left serialised -> left show $ decodePlutusRunnable protocolVersion serialised
-    let majorProtocolVersion = Plutus.MajorProtocolVersion $ getVersion protocolVersion
-    appliedTerm <- left show $ mkTermToEvaluate Plutus.PlutusV2 majorProtocolVersion x (unPlutusDatums arguments)
+        Left serialised -> left show $ decodePlutusRunnable pwcProtocolVersion serialised
+    let majorProtocolVersion = Plutus.MajorProtocolVersion $ getVersion pwcProtocolVersion
+    appliedTerm <- left show $ mkTermToEvaluate Plutus.PlutusV2 majorProtocolVersion x (unPlutusDatums pwcDatums)
     pure $ UPLC.Program () PLC.latestVersion appliedTerm
 
   pure $ flat . UnrestrictedProgram <$> programs

--- a/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs
@@ -19,7 +19,7 @@ import Cardano.Ledger.Api (CoinPerByte (..), ppCoinsPerUTxOByteL, ppCostModelsL,
 import Cardano.Ledger.BaseTypes (BoundedRational (boundRational), ProtVer (..), natVersion)
 import Cardano.Ledger.Binary (getVersion)
 import Cardano.Ledger.Coin (Coin (Coin))
-import Cardano.Ledger.Core (PParams, ppMaxTxSizeL)
+import Cardano.Ledger.Core (ppMaxTxSizeL)
 import Cardano.Ledger.Plutus (PlutusDatums (unPlutusDatums), PlutusLanguage (decodePlutusRunnable), PlutusRunnable (..), PlutusWithContext (..))
 import Cardano.Ledger.Plutus.Language (Language (PlutusV2))
 import Cardano.Ledger.Val (Val ((<+>)), (<×>))
@@ -43,8 +43,8 @@ import Hydra.Cardano.Api (
   ExecutionUnits (..),
   IsCardanoEra (cardanoEra),
   LedgerEpochInfo (..),
-  LedgerEra,
   LedgerProtocolParameters (..),
+  PParams,
   ProtocolParametersConversionError,
   ScriptExecutionError (ScriptErrorMissingScript),
   ScriptWitnessIndex,
@@ -239,7 +239,7 @@ prepareTxScripts tx utxo = do
 -- should not matter).
 -- XXX: Load and use mainnet parameters from a file which we can easily review
 -- to be in sync with mainnet.
-pparams :: PParams LedgerEra
+pparams :: PParams
 pparams =
   def
     & ppMaxTxSizeL .~ fromIntegral maxTxSize

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
@@ -133,7 +133,7 @@ import Hydra.Cardano.Api
 import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Ledger.Alonzo.Scripts qualified as Ledger
 import Cardano.Ledger.Alonzo.TxWits qualified as Ledger
-import Cardano.Ledger.Api (AllegraEraTxBody (vldtTxBodyL), AlonzoPlutusPurpose (..), AsIndex (..), inputsTxBodyL, mintTxBodyL, outputsTxBodyL, reqSignerHashesTxBodyL)
+import Cardano.Ledger.Api (AllegraEraTxBody (vldtTxBodyL), AlonzoPlutusPurpose (..), AsIx (..), inputsTxBodyL, mintTxBodyL, outputsTxBodyL, reqSignerHashesTxBodyL)
 import Cardano.Ledger.Core qualified as Ledger
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Mary.Value qualified as Ledger
@@ -328,13 +328,13 @@ applyMutation mutation (tx@(Tx body wits), utxo) = case mutation of
       | isHeadOutput (resolveInput ix) = (Ledger.Data (toData newRedeemer), units)
       | otherwise = (dat, units)
 
-    resolveInput :: Ledger.AlonzoPlutusPurpose AsIndex w -> TxOut CtxUTxO
+    resolveInput :: Ledger.AlonzoPlutusPurpose AsIx w -> TxOut CtxUTxO
     resolveInput ix =
       let k = case ix of
-            AlonzoSpending i -> unAsIndex i
-            AlonzoCertifying i -> unAsIndex i
-            AlonzoRewarding i -> unAsIndex i
-            AlonzoMinting i -> unAsIndex i
+            AlonzoSpending i -> unAsIx i
+            AlonzoCertifying i -> unAsIx i
+            AlonzoRewarding i -> unAsIx i
+            AlonzoMinting i -> unAsIx i
           txIn = Set.elemAt (fromIntegral k) ledgerInputs -- NOTE: calls 'error' if out of bounds
        in case UTxO.resolve (fromLedgerTxIn txIn) utxo of
             Nothing -> error $ "txIn not resolvable: " <> show txIn
@@ -595,7 +595,7 @@ ensureDatums outs scriptData =
 
 -- | Alter a transaction's redeemers map given some mapping function.
 alterRedeemers ::
-  ( Ledger.PlutusPurpose Ledger.AsIndex LedgerEra ->
+  ( Ledger.PlutusPurpose Ledger.AsIx LedgerEra ->
     (Ledger.Data LedgerEra, Ledger.ExUnits) ->
     (Ledger.Data LedgerEra, Ledger.ExUnits)
   ) ->
@@ -638,7 +638,7 @@ alterTxIns fn tx =
   rebuiltSpendingRedeemers = Map.fromList $
     flip mapMaybe (zip [0 ..] newSortedInputs) $ \(i, (_, mRedeemer)) ->
       mRedeemer <&> \d ->
-        (Ledger.AlonzoSpending (AsIndex i), (toLedgerData d, Ledger.ExUnits 0 0))
+        (Ledger.AlonzoSpending (AsIx i), (toLedgerData d, Ledger.ExUnits 0 0))
 
   -- NOTE: This needs to be ordered, such that we can calculate the redeemer
   -- pointers correctly.
@@ -654,7 +654,7 @@ alterTxIns fn tx =
   resolveRedeemers :: [TxIn] -> [(TxIn, Maybe HashableScriptData)]
   resolveRedeemers txInputs =
     zip txInputs [0 ..] <&> \(txIn, i) ->
-      case Map.lookup (Ledger.AlonzoSpending (AsIndex i)) redeemersMap of
+      case Map.lookup (Ledger.AlonzoSpending (AsIx i)) redeemersMap of
         Nothing -> (txIn, Nothing)
         Just (redeemerData, _exUnits) -> (txIn, Just $ fromLedgerData redeemerData)
 

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -126,12 +126,12 @@ spec =
                                           ErrTranslationError{} -> "Transaction context translation error"
                                       )
                                 Right ledgerTx ->
-                                  let actualExecutionCost = getMinFeeTx pparams ledgerTx
+                                  let minFeeWithoutRefScripts = getMinFeeTx pparams ledgerTx 0
                                       fee = txFee' apiTx
                                       apiTx = fromLedgerTx ledgerTx
-                                   in actualExecutionCost > Coin 0 && fee > actualExecutionCost
+                                   in minFeeWithoutRefScripts > Coin 0 && fee > minFeeWithoutRefScripts
                                         & label "Ok"
-                                        & counterexample ("Execution cost: " <> show actualExecutionCost)
+                                        & counterexample ("Min fee: " <> show minFeeWithoutRefScripts)
                                         & counterexample ("Fee: " <> show fee)
                                         & counterexample ("Tx: " <> show apiTx)
                                         & counterexample ("Input utxo: " <> show (walletUTxO <> lookupUTxO))

--- a/hydra-node/test/Hydra/Chain/Direct/WalletSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/WalletSpec.hs
@@ -5,7 +5,14 @@ module Hydra.Chain.Direct.WalletSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import Cardano.Ledger.Api (EraTx (getMinFeeTx), EraTxBody (feeTxBodyL, inputsTxBodyL), PParams, bodyTxL, coinTxOutL, outputsTxBodyL)
+import Cardano.Ledger.Api (
+  EraTx (getMinFeeTx),
+  EraTxBody (feeTxBodyL, inputsTxBodyL),
+  PParams,
+  bodyTxL,
+  coinTxOutL,
+  outputsTxBodyL,
+ )
 import Cardano.Ledger.Babbage.Tx (AlonzoTx (..))
 import Cardano.Ledger.Babbage.TxBody (BabbageTxBody (..), BabbageTxOut (..))
 import Cardano.Ledger.BaseTypes qualified as Ledger
@@ -74,6 +81,7 @@ import Test.QuickCheck (
   suchThat,
   vectorOf,
   (.&&.),
+  (===),
  )
 import Prelude qualified
 
@@ -259,7 +267,7 @@ hasLowFees pparams tx =
 
   actualFee = tx ^. bodyTxL . feeTxBodyL
 
-  minFee = getMinFeeTx pparams tx
+  minFee = getMinFeeTx pparams tx 0
 
 isBalanced :: Map TxIn TxOut -> Tx LedgerEra -> Tx LedgerEra -> Property
 isBalanced utxo originalTx balancedTx =
@@ -267,7 +275,7 @@ isBalanced utxo originalTx balancedTx =
       out' = outputBalance balancedTx
       out = outputBalance originalTx
       fee = (view feeTxBodyL . body) balancedTx
-   in coin (deltaValue out' inp') == fee
+   in coin (deltaValue out' inp') === fee
         & counterexample ("Fee:             " <> show fee)
         & counterexample ("Delta value:     " <> show (coin $ deltaValue out' inp'))
         & counterexample ("Added value:     " <> show (coin inp'))

--- a/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
+++ b/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
@@ -9,7 +9,6 @@ import Test.Hydra.Prelude
 
 import Cardano.Binary (decodeFull, serialize')
 import Cardano.Ledger.Api (ensureMinCoinTxOut)
-import Cardano.Ledger.Core (PParams ())
 import Cardano.Ledger.Credential (Credential (..))
 import Data.Aeson (eitherDecode, encode)
 import Data.Aeson qualified as Aeson
@@ -117,7 +116,7 @@ roundtripFromAndToApi utxo =
 -- | Test that the 'ProtocolParameters' To/FromJSON instances to roundtrip. Note
 -- that we use the ledger 'PParams' type to generate values, but the cardano-api
 -- type 'ProtocolParameters' is used for the serialization.
-roundtripProtocolParameters :: PParams LedgerEra -> Property
+roundtripProtocolParameters :: PParams -> Property
 roundtripProtocolParameters pparams = do
   case Aeson.decode (Aeson.encode expected) of
     Nothing ->

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -69,10 +69,10 @@ library
     , hydra-cardano-api
     , hydra-plutus-extras
     , hydra-prelude
-    , plutus-core          >=1.21 && <1.22
-    , plutus-ledger-api    >=1.21 && <1.22
-    , plutus-tx            >=1.21 && <1.22
-    , plutus-tx-plugin     >=1.21 && <1.22
+    , plutus-core          >=1.21
+    , plutus-ledger-api    >=1.21
+    , plutus-tx            >=1.21
+    , plutus-tx-plugin     >=1.21
     , QuickCheck
     , serialise
     , template-haskell


### PR DESCRIPTION
:boomerang: Update the `cardano-api` to latest 8.44.0, this includes bumps on the `cardano-ledger` and `plutus` packages.

:boomerang: This results in a breaking change on `hydra-plutus`, but no significant improvements otherwise.

:boomerang: This is currently broken against cardano-node 8.9.0 in `conway` as seemingly some decoders changed (can be seen in the `End-to-end on Cardano devnet, forking eras, support new era on restart` test)! Likely we want to only merge this with cardano-node 8.10.0 released.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
  - Two uses of `redeemerPointer` are deprecated now, still waiting for an answer from ledger team.