### PR TITLE
Use latest stable cardano-node in demo

### DIFF
--- a/demo/docker-compose.yaml
+++ b/demo/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   cardano-node:
-    image: ghcr.io/input-output-hk/cardano-node:8.7.3
+    image: ghcr.io/intersectmbo/cardano-node:8.9.1
     volumes:
       - ./devnet:/devnet
     environment:


### PR DESCRIPTION
The docker variant was broken as the conway-genesis.json was not parseable using the old 8.7.3 node and we seemingly have forgotten to update this container when we started to test against cardano-node 8.9

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
