### PR TITLE
Disable sanchonet integration tests

### DIFF
--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -334,13 +334,16 @@ withHydraNode' tracer chainConfig workDir hydraNodeId hydraSKey hydraVKeys allNo
       filepath <$ writeFileTextEnvelope (File filepath) Nothing vKey
     let p =
           ( hydraNodeProcess $
+              -- NOTE: Using 0.0.0.0 over 127.0.0.1 will make the hydra-node
+              -- crash if it can't bind the interface and make tests fail more
+              -- obvious when e.g. a hydra-node instance is already running.
               RunOptions
                 { verbosity = Verbose "HydraNode"
                 , nodeId = NodeId $ show hydraNodeId
-                , host = "127.0.0.1"
+                , host = "0.0.0.0"
                 , port = fromIntegral $ 5_000 + hydraNodeId
                 , peers
-                , apiHost = "127.0.0.1"
+                , apiHost = "0.0.0.0"
                 , apiPort = fromIntegral $ 4_000 + hydraNodeId
                 , monitoringPort = Just $ fromIntegral $ 6_000 + hydraNodeId
                 , hydraSigningKey

--- a/hydra-cluster/test/Test/CardanoNodeSpec.hs
+++ b/hydra-cluster/test/Test/CardanoNodeSpec.hs
@@ -41,7 +41,7 @@ spec = do
 
     describe "findRunningCardanoNode" $ do
       it "returns Nothing on non-matching network" $ \(tr, tmp) -> do
-        withCardanoNodeOnKnownNetwork tr tmp Sanchonet $ \_ -> do
+        withCardanoNodeOnKnownNetwork tr tmp Preview $ \_ -> do
           findRunningCardanoNode tr tmp Preproduction `shouldReturn` Nothing
 
       it "returns Just running node on matching network" $ \(tr, tmp) -> do
@@ -49,6 +49,8 @@ spec = do
           findRunningCardanoNode tr tmp Preview `shouldReturn` Just runningNode
 
   forEachKnownNetwork "withCardanoNodeOnKnownNetwork starts synchronizing within 10 seconds" $ \network -> do
+    when (network == Sanchonet) $
+      pendingWith "cardano-node 8.9 not anymore supported on sanchonet"
     -- NOTE: This implies that withCardanoNodeOnKnownNetwork does not
     -- synchronize the whole chain before continuing.
     setupTracerAndTempDir $ \(tr, tmp) ->


### PR DESCRIPTION
We currently target and test against cardano-node 8.9.x, while sanchonet is already requiring 8.10.0-pre which uses different conway-genesis.json configuration files.

We have a branch which works against 8.10.0-pre (see #1388), but we want to hold off on testing and relying on that version until it is supported on all public networks.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
