### PR TITLE
Add a GET /snapshot/utxo endpoint to supersede GetUTxO client input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 As a minor extension, we also keep a semantic version for the `UNRELEASED`
 changes.
 
+## [0.17.0] - UNRELEASED
+
+- Add `GET /snapshot/utxo` API endpoint to query confirmed UTxO set on demand.
+  - Always responds with the last confirmed UTxO
+
+- _DEPRECATED_ the `GetUTxO` client input and `GetUTxOResponse` server output. Use `GET /snapshot/utxo` instead.
 
 ## [0.16.0] - 2024-04-03
 

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -273,18 +273,14 @@ echo "{ \"tag\": \"NewTx\", \"transaction\": $(cat signed-tx.json | jq ".cborHex
 { "tag": "NewTx", "transaction": "84a3008182582009d34606abdcd0b10ebc89307cbfa0b469f9144194137b45b7a04b273961add81902af0181a200581d618fd0ece638ffd53b4bb79a69b87f35b79e647da9aab7525a2d0d7364011a0074483d0200a10081825820c736d40ee64c031851af26007c00a3b6fcbebccfd333a8ee6f14983f9be5331c58404bae506f5235778ec65eca6fdfcf6ec61ab93420b91e0b71ca82d437904f860e999372cf00252246ca77012e19c344b3af60df9f853af53fc86835f95a119609f5f6" }
 ```
 
-The `--tx-in` value is a UTxO obtained from the reply to the `{ "tag": "GetUTxO" }` message.
-E.g.:
+The `--tx-in` value is a UTxO obtained from the `GET /snapshot/utxo` request. For example:
 
-```json title="GetUTxOResponse"
+```json title="Example response of GET /snapshot/utxo"
 {
-  "tag": "GetUTxOResponse",
-  "utxo": {
-    "09d34606abdcd0b10ebc89307cbfa0b469f9144194137b45b7a04b273961add8#687": {
-      "address": "addr1w9htvds89a78ex2uls5y969ttry9s3k9etww0staxzndwlgmzuul5",
-      "value": {
-        "lovelace": 7620669
-      }
+  "09d34606abdcd0b10ebc89307cbfa0b469f9144194137b45b7a04b273961add8#687": {
+    "address": "addr1w9htvds89a78ex2uls5y969ttry9s3k9etww0staxzndwlgmzuul5",
+    "value": {
+      "lovelace": 7620669
     }
   }
 }

--- a/docs/docs/tutorial/index.md
+++ b/docs/docs/tutorial/index.md
@@ -592,23 +592,20 @@ head.
 
 First, we need to select a UTxO to spend. We can do this either by looking at
 the `utxo` field of the last `HeadIsOpen` or `SnapshotConfirmed` message, or
-query the API for the current UTxO set through the websocket session:
+query the API for the current UTxO set:
 
-```json title="Websocket API"
-{ "tag": "GetUTxO" }
+```shell
+curl -s 127.0.0.1:4001/snapshot/utxo | jq
 ```
 
 From the response, we would need to select a UTxO that is owned by `alice` to
-spend. We can do that also via the `snapshotUtxo` field in the `Greetings`
-message and using this `websocat` and `jq` invocation:
+spend:
 
 <!-- TODO: make this for both parties -->
 
 ```shell
-websocat -U "ws://0.0.0.0:4001?history=no" \
-  | jq "select(.tag == \"Greetings\") \
-    | .snapshotUtxo \
-    | with_entries(select(.value.address == \"$(cat credentials/alice-funds.addr)\"))" \
+curl -s 127.0.0.1:4001/snapshot/utxo \
+  | jq "with_entries(select(.value.address == \"$(cat credentials/alice-funds.addr)\"))" \
   > utxo.json
 ```
 

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -50,6 +50,7 @@ import Hydra.Party (Party)
 import HydraNode (
   HydraClient (..),
   HydraNodeLog,
+  getSnapshotUTxO,
   input,
   output,
   requestCommitTx,
@@ -620,15 +621,9 @@ initWithWrongKeys workDir tracer node@RunningNode{nodeSocket} hydraScriptsTxId =
 -- NOTE: This relies on zero-fee protocol parameters.
 respendUTxO :: HydraClient -> SigningKey PaymentKey -> NominalDiffTime -> IO ()
 respendUTxO client sk delay = do
-  utxo <- getUTxO
+  utxo <- getSnapshotUTxO client
   forever $ respend utxo
  where
-  getUTxO = do
-    send client $ input "GetUTxO" []
-    waitMatch 10 client $ \v -> do
-      guard $ v ^? key "tag" == Just "GetUTxOResponse"
-      v ^? key "utxo" >>= parseMaybe parseJSON
-
   vk = getVerificationKey sk
 
   respend utxo =

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -186,6 +186,21 @@ requestCommitTx :: HydraClient -> UTxO -> IO Tx
 requestCommitTx client =
   requestCommitTx' client . fmap (`TxOutWithWitness` Nothing)
 
+-- | Get the latest snapshot UTxO from the hydra-node. NOTE: While we usually
+-- avoid parsing responses using the same data types as the system under test,
+-- this parses the response as a 'UTxO' type as we often need to pick it apart.
+getSnapshotUTxO :: HydraClient -> IO UTxO
+getSnapshotUTxO HydraClient{hydraNodeId} =
+  runReq defaultHttpConfig request <&> responseBody
+ where
+  request =
+    Req.req
+      GET
+      (Req.http "127.0.0.1" /: "snapshot" /: "utxo")
+      NoReqBody
+      (Proxy :: Proxy (JsonResponse UTxO))
+      (Req.port $ 4_000 + hydraNodeId)
+
 getMetrics :: HasCallStack => HydraClient -> IO ByteString
 getMetrics HydraClient{hydraNodeId} = do
   failAfter 3 $

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -83,6 +83,7 @@ import Hydra.Options
 import HydraNode (
   HydraClient (..),
   getMetrics,
+  getSnapshotUTxO,
   input,
   output,
   requestCommitTx,
@@ -822,8 +823,7 @@ initAndClose tmpDir tracer clusterIx hydraScriptsTxId node@RunningNode{nodeSocke
       snapshot <- v ^? key "snapshot"
       guard $ snapshot == expectedSnapshot
 
-    send n1 $ input "GetUTxO" []
-    waitFor hydraTracer 10 [n1] $ output "GetUTxOResponse" ["utxo" .= newUTxO, "headId" .= headId]
+    (toJSON <$> getSnapshotUTxO n1) `shouldReturn` toJSON newUTxO
 
     send n1 $ input "Close" []
     deadline <- waitMatch 3 n1 $ \v -> do

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          hydra-node
-version:       0.16.0
+version:       0.17.0
 synopsis:      The Hydra node
 author:        IOG
 copyright:     2022 IOG

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -133,6 +133,25 @@ channels:
           type: response
           method: POST
           bindingVersion: '0.1.0'
+  /snapshot/utxo:
+    servers:
+      - localhost-http
+    subscribe:
+      operationId: getConfirmedUTxO
+      description: |
+        Get latest confirmed UTxO.
+
+        Possible responses of this endpoint are:
+          * 200: UTxO of latest confirmed snapshot
+          * 404: when head was never open
+      message:
+        payload:
+          $ref: "api.yaml#/components/schemas/UTxO"
+      bindings:
+        http:
+          type: response
+          method: GET
+          bindingVersion: '0.1.0'
   /protocol-parameters:
     servers:
       - localhost-http

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -296,6 +296,7 @@ components:
     GetUTxO:
       title: GetUTxO
       description: |
+        DEPRECATED: Use the `GET /snapshot/utxo http endpoint` to query the confirmed UTxO set.
         Asynchronously access the current UTxO set of the Hydra node. This eventually triggers a UTxO event from the server.
       payload:
         type: object
@@ -424,6 +425,7 @@ components:
     GetUTxOResponse:
       title: GetUTxOResponse
       description: |
+        DEPRECATED: Use the `GET /snapshot/utxo http endpoint` to query the confirmed UTxO set.
         Emitted as a result of a `GetUTxO` to reflect the current UTxO of the underlying node.
       payload:
         $ref: "api.yaml#/components/schemas/GetUTxOResponse"

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -96,7 +96,7 @@ withAPIServer host port party PersistenceIncremental{loadAll, append} tracer cha
             websocketsOr
               defaultConnectionOptions
               (wsApp party tracer history callback headStatusP snapshotUtxoP responseChannel)
-              (httpApp tracer chain pparams (getLatest headIdP))
+              (httpApp tracer chain pparams (atomically $ getLatest headIdP) (atomically $ getLatest snapshotUtxoP))
       )
       ( do
           waitForServerRunning

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -240,7 +240,7 @@ projectHeadStatus headStatus = \case
   HeadIsFinalized{} -> Final
   _other -> headStatus
 
--- | Projection function related to 'snapshotUtxo' field in 'Greetings' message.
+-- | Projection of latest confirmed snapshot UTxO.
 projectSnapshotUtxo :: Maybe (UTxOType tx) -> ServerOutput tx -> Maybe (UTxOType tx)
 projectSnapshotUtxo snapshotUtxo = \case
   SnapshotConfirmed _ snapshot _ -> Just $ Hydra.Snapshot.utxo snapshot


### PR DESCRIPTION
The endpoint is a next step toward [ADR25](https://hydra.family/head-protocol/unstable/adr/25) and directly returns the confirmed UTxO of a head as it would be the case for a restful API and deliberately not embeds the headId in the response.

## Quickstart
* Build `hydra-cluster`
* Run `hydra_cluster_datadir=hydra-cluster cabal exec hydra-cluster -- --devnet --publish-hydra-scripts`
* Do `curl -s 127.0.0.1:4001/snapshot/utxo | jq` to get this output:

![image](https://github.com/input-output-hk/hydra/assets/2621189/db9112fd-9c39-4a9b-af87-6b9b883edc10)

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
