### PR TITLE
Fix returnFundsToFaucet to not fail when nothing to return

### DIFF
--- a/hydra-cluster/src/Hydra/Cluster/Faucet.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Faucet.hs
@@ -112,7 +112,7 @@ returnFundsToFaucet tracer RunningNode{networkId, nodeSocket} sender = do
 
   (senderVk, senderSk) <- keysFor sender
   utxo <- queryUTxOFor networkId nodeSocket QueryTip senderVk
-  retryOnExceptions tracer $ do
+  unless (null utxo) . retryOnExceptions tracer $ do
     let utxoValue = balance @Tx utxo
     let allLovelace = selectLovelace utxoValue
     tx <- sign senderSk <$> buildTxBody utxo faucetAddress

--- a/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
@@ -13,46 +13,52 @@ import Hydra.Cluster.Fixture (Actor (..))
 import Hydra.Cluster.Scenarios (EndToEndLog (..))
 import Hydra.Cluster.Util (keysFor)
 import Hydra.Ledger.Cardano (genVerificationKey)
-import Hydra.Logging (showLogsOnFailure)
+import Hydra.Logging (Tracer, showLogsOnFailure)
 import Test.QuickCheck (choose, elements, forAll, generate, withMaxSuccess)
 
+setupDevnet :: ((Tracer IO EndToEndLog, RunningNode) -> IO a) -> IO a
+setupDevnet action =
+  failAfter 30 $
+    showLogsOnFailure "FaucetSpec" $ \tracer ->
+      withTempDir "hydra-cluster" $ \tmpDir ->
+        withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
+          action (tracer, node)
+
 spec :: Spec
-spec = do
-  describe "seedFromFaucet" $
-    it "should work concurrently when called multiple times with the same amount of lovelace" $
-      showLogsOnFailure "FaucetSpec" $ \tracer ->
-        failAfter 30 $
-          withTempDir "hydra-cluster" $ \tmpDir ->
-            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node -> do
-              utxos <- replicateConcurrently 10 $ do
-                vk <- generate genVerificationKey
-                seedFromFaucet node vk 1_000_000 (contramap FromFaucet tracer)
-              -- 10 unique outputs
-              length (fold utxos) `shouldBe` 10
-  describe "returnFundsToFaucet" $
-    prop "seedFromFaucet and returnFundsToFaucet should work together" $
-      withMaxSuccess 10 $
-        forAll (Coin <$> choose (1000000, 10000000000)) $ \coin -> do
-          forAll (elements [Alice, Bob, Carol]) $ \actor -> do
-            showLogsOnFailure "FaucetSpec" $ \tracer ->
-              withTempDir "hydra-cluster" $ \tmpDir ->
-                withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node@RunningNode{networkId, nodeSocket} -> do
-                  let faucetTracer = contramap FromFaucet tracer
-                  (vk, _) <- keysFor actor
-                  (faucetVk, _) <- keysFor Faucet
-                  initialFaucetFunds <- queryUTxOFor networkId nodeSocket QueryTip faucetVk
-                  void $ seedFromFaucet node vk coin faucetTracer
-                  returnFundsToFaucet faucetTracer node actor
-                  remaining <- queryUTxOFor networkId nodeSocket QueryTip vk
-                  finalFaucetFunds <- queryUTxOFor networkId nodeSocket QueryTip faucetVk
-                  foldMap txOutValue remaining `shouldBe` mempty
+spec =
+  around setupDevnet $ do
+    describe "seedFromFaucet" $
+      it "should work concurrently when called multiple times with the same amount of lovelace" $ \(tracer, node) -> do
+        utxos <- replicateConcurrently 10 $ do
+          vk <- generate genVerificationKey
+          seedFromFaucet node vk 1_000_000 (contramap FromFaucet tracer)
+        -- 10 unique outputs
+        length (fold utxos) `shouldBe` 10
 
-                  -- check the faucet has one utxo extra in the end
-                  length finalFaucetFunds `shouldBe` length initialFaucetFunds + 1
+    describe "returnFundsToFaucet" $ do
+      it "does nothing if nothing to return" $ \(tracer, node) -> do
+        returnFundsToFaucet (contramap FromFaucet tracer) node Alice
 
-                  let initialFaucetValue = selectLovelace (foldMap txOutValue initialFaucetFunds)
-                  let finalFaucetValue = selectLovelace (foldMap txOutValue finalFaucetFunds)
-                  let difference = initialFaucetValue - finalFaucetValue
-                  -- difference between starting faucet amount and final one should
-                  -- just be the amount of paid fees
-                  difference `shouldSatisfy` (< 340_000)
+      it "seedFromFaucet and returnFundsToFaucet should work together" $ \(tracer, node@RunningNode{networkId, nodeSocket}) -> do
+        withMaxSuccess 10 $
+          forAll (Coin <$> choose (1000000, 10000000000)) $ \coin ->
+            forAll (elements [Alice, Bob, Carol]) $ \actor -> do
+              let faucetTracer = contramap FromFaucet tracer
+              (vk, _) <- keysFor actor
+              (faucetVk, _) <- keysFor Faucet
+              initialFaucetFunds <- queryUTxOFor networkId nodeSocket QueryTip faucetVk
+              void $ seedFromFaucet node vk coin faucetTracer
+              returnFundsToFaucet faucetTracer node actor
+              remaining <- queryUTxOFor networkId nodeSocket QueryTip vk
+              finalFaucetFunds <- queryUTxOFor networkId nodeSocket QueryTip faucetVk
+              foldMap txOutValue remaining `shouldBe` mempty
+
+              -- check the faucet has one utxo extra in the end
+              length finalFaucetFunds `shouldBe` length initialFaucetFunds + 1
+
+              let initialFaucetValue = selectLovelace (foldMap txOutValue initialFaucetFunds)
+              let finalFaucetValue = selectLovelace (foldMap txOutValue finalFaucetFunds)
+              let difference = initialFaucetValue - finalFaucetValue
+              -- difference between starting faucet amount and final one should
+              -- just be the amount of paid fees
+              difference `shouldSatisfy` (< 340_000)


### PR DESCRIPTION
This was the case in one of the e2e scenarios where we had a failure before sending anything to AliceFunds, but the cleanup was still trying to build a transaction with nothing to return.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
