### PR TITLE
Name exposed nix apps after the attribute name

### DIFF
--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -37,7 +37,7 @@ let
     # Using mkDerivation instead of runCommand to make sure to use the same
     # stdenv as the original drv (important to determine targetPlatform).
     drv.stdenv.mkDerivation {
-      name = "${exe}-with-revision";
+      name = "${exe}";
       phases = [ "buildPhase" ];
       buildPhase = ''
         set -e


### PR DESCRIPTION
This is surprising behaviour

```
> nix run .#hydra-node
error: unable to execute '/nix/store/bz8rw8kd1w8gl3wa67jqa2w4lj7l0fh0-hydra-node-with-revision/bin/hydra-node-with-revision': No such file or directory
```

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
