### PR TITLE
Use test executables instead of test-suites

### DIFF
--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -45,8 +45,16 @@ jobs:
         name: cardano-scaling
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
-    - name: ❓ Test
-      if: ${{ matrix.package != 'hydra-tui' }}
+    - name: ❓ Test (Pure)
+      if: ${{ matrix.package == 'hydra-plutus'
+           || matrix.package == 'plutus-cbor'
+           || matrix.package == 'plutus-merkle-tree' }}
+      run: |
+        nix build .#checks.x86_64-linux.${{ matrix.package }}
+
+    - name: ❓ Test (Impure)
+      if: ${{ matrix.package == 'hydra-cluster'
+           || matrix.package == 'hydra-node' }}
       run: |
         cd ${{ matrix.package }}
         nix build .#${{ matrix.package }}-tests

--- a/flake.nix
+++ b/flake.nix
@@ -119,6 +119,21 @@
               ];
               treefmt = pkgs.treefmt;
             };
+            hydra-plutus = lu.tee-check {
+              name = "hydra-plutus";
+              src = self;
+              exe = "${packages.hydra-plutus-tests}/bin/tests";
+            };
+            plutus-cbor = lu.tee-check {
+              name = "plutus-cbor";
+              src = self;
+              exe = "${packages.plutus-cbor-tests}/bin/tests";
+            };
+            plutus-merkle-tree = lu.tee-check {
+              name = "plutus-merkle-tree";
+              src = self;
+              exe = "${packages.plutus-merkle-tree-tests}/bin/tests";
+            };
           };
 
           devShells = import ./nix/hydra/shell.nix {

--- a/flake.nix
+++ b/flake.nix
@@ -100,7 +100,7 @@
 
         in
         rec {
-          legacyPackages = pkgs;
+          legacyPackages = hsPkgs;
 
           packages =
             hydraPackages //

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -78,7 +78,7 @@ library
     , template-haskell
     , time
 
-test-suite tests
+executable tests
   import:             project-config
   ghc-options:        -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs:     test

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -121,18 +121,10 @@ rec {
 
   hydraw-static = musl64Pkgs.hydraw.components.exes.hydraw;
 
-  plutus-cbor-tests = pkgs.mkShellNoCC {
-    name = "plutus-cbor-tests";
-    buildInputs = [ nativePkgs.plutus-cbor.components.tests.tests ];
-  };
-  plutus-merkle-tree-tests = pkgs.mkShellNoCC {
-    name = "plutus-merkle-tree-tests";
-    buildInputs = [ nativePkgs.plutus-merkle-tree.components.tests.tests ];
-  };
-  hydra-plutus-tests = pkgs.mkShellNoCC {
-    name = "hydra-plutus-tests";
-    buildInputs = [ nativePkgs.hydra-plutus.components.tests.tests ];
-  };
+  plutus-cbor-tests = nativePkgs.plutus-cbor.components.exes.tests;
+
+  plutus-merkle-tree-tests = nativePkgs.plutus-merkle-tree.components.exes.tests;
+  hydra-plutus-tests = nativePkgs.hydra-plutus.components.exes.tests;
   hydra-node-tests = pkgs.mkShellNoCC {
     name = "hydra-node-tests";
     buildInputs = [

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -87,7 +87,7 @@ let
     name = "hydra-node-cabal-shell";
 
     buildInputs = libs ++ [
-      hsPkgs.compiler.${compiler}
+      hsPkgs.ghc
       pkgs.cabal-install
       pkgs.pkg-config
     ] ++ buildInputs;

--- a/plutus-cbor/plutus-cbor.cabal
+++ b/plutus-cbor/plutus-cbor.cabal
@@ -46,7 +46,7 @@ library
 
   exposed-modules: Plutus.Codec.CBOR.Encoding
 
-test-suite tests
+executable tests
   import:             project-config
   type:               exitcode-stdio-1.0
   hs-source-dirs:     test

--- a/plutus-merkle-tree/plutus-merkle-tree.cabal
+++ b/plutus-merkle-tree/plutus-merkle-tree.cabal
@@ -48,7 +48,7 @@ library
     , plutus-tx
     , text
 
-test-suite tests
+executable tests
   import:             project-config
   type:               exitcode-stdio-1.0
   hs-source-dirs:     test


### PR DESCRIPTION
Uses test executables instead of test-suites for pure tests and exposes these through nix flake check, so commits that do not affect those tests suites will cause the check to return immediately.

This also will cause our dependencies to be picked up by the hydra ci cache again.

This also means that `cabal test hydra-plutus` will not work as before.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
