### PR TITLE
Combine blueprint and commit tx metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ changes.
   from a script `UTxO`, and also unlock more involved use-cases, users need to provide additional
   unsigned transaction that correctly specifies required data (like redeemers, validity ranges etc.)
 
+- **BREAKING** `hydra-node` `/commit` endpoint now also accepts a
+  _blueprint/draft_ transaction together with the `UTxO` which is spent in this
+  transaction. `hydra-node` can still be used like before if the provided
+  `UTxO` is at public key address. In order to spend from a script `UTxO`, and
+  also unlock more involved use-cases, users need to provide additional
+  unsigned transaction that correctly specifies required data (like redeemers,
+  validity ranges etc.)
+
 - Update navigation and re-organized documentation website https://hydra.family
   - Updated logos
   - Removed localization as it got outdated and on-demand site translation tools exist.
@@ -36,6 +44,7 @@ changes.
 
 - Make `hydra-cluster --devnet` more configurable
   - Now it is idle by default again and a `--busy` will make it busy respending the same UTxO.
+
 
 ## [0.16.0] - 2024-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,19 +10,10 @@ changes.
 
 ## [0.17.0] - UNRELEASED
 
-- **BREAKING** `hydra-node` `/commit` enpoint now also accepts a _blueprint/draft_
-  transaction together with the `UTxO` which is spent in this transaction. `hydra-node` can
-  still be used like before if the provided `UTxO` is at public key address. In order to spend
-  from a script `UTxO`, and also unlock more involved use-cases, users need to provide additional
-  unsigned transaction that correctly specifies required data (like redeemers, validity ranges etc.)
-
-- **BREAKING** `hydra-node` `/commit` endpoint now also accepts a
-  _blueprint/draft_ transaction together with the `UTxO` which is spent in this
-  transaction. `hydra-node` can still be used like before if the provided
-  `UTxO` is at public key address. In order to spend from a script `UTxO`, and
-  also unlock more involved use-cases, users need to provide additional
-  unsigned transaction that correctly specifies required data (like redeemers,
-  validity ranges etc.)
+- **BREAKING** Change `hydra-node` API `/commit` endpoint for committing from scripts:o
+  - Instead of the custom `witness` extension of `UTxO`, the endpoint now accepts a _blueprint_ transaction together with the `UTxO` which is spent in this transaction.
+  - Usage is still the same for commiting "normal" `UTxO` owned by public key addresses.
+  - Spending from a script `UTxO` now needs the `blueprintTx` request type, which also unlocks more involved use-cases, where the commit transaction should also satisfy script spending constraints (like additional signers, validity ranges etc.)
 
 - Update navigation and re-organized documentation website https://hydra.family
   - Updated logos
@@ -44,7 +35,6 @@ changes.
 
 - Make `hydra-cluster --devnet` more configurable
   - Now it is idle by default again and a `--busy` will make it busy respending the same UTxO.
-
 
 ## [0.16.0] - 2024-04-03
 

--- a/hydra-cardano-api/src/Hydra/Cardano/Api.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api.hs
@@ -102,8 +102,10 @@ import Cardano.Api.Shelley as X (
   fromAlonzoCostModels,
   fromAlonzoPrices,
   fromPlutusData,
+  fromShelleyMetadata,
   toAlonzoPrices,
   toPlutusData,
+  toShelleyMetadata,
   toShelleyNetwork,
  )
 import Cardano.Api.UTxO (

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Tx.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Tx.hs
@@ -32,6 +32,7 @@ import Cardano.Ledger.Api (
   datsTxWitsL,
   feeTxBodyL,
   hashScriptTxWitsL,
+  hashTxAuxData,
   inputsTxBodyL,
   isValidTxL,
   mintTxBodyL,
@@ -56,7 +57,7 @@ import Cardano.Ledger.Api qualified as Ledger
 import Cardano.Ledger.Babbage qualified as Ledger
 import Cardano.Ledger.Babbage.Tx qualified as Ledger
 import Cardano.Ledger.Babbage.TxWits (upgradeTxDats)
-import Cardano.Ledger.BaseTypes (maybeToStrictMaybe, strictMaybeToMaybe)
+import Cardano.Ledger.BaseTypes (StrictMaybe (..), maybeToStrictMaybe, strictMaybeToMaybe)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Scripts (PlutusScript (..))
 import Cardano.Ledger.Conway.Scripts qualified as Conway
@@ -225,7 +226,9 @@ toLedgerTx = \case
             & hashScriptTxWitsL .~ scripts
             & datsTxWitsL .~ datums
             & rdmrsTxWitsL .~ redeemers
-     in mkBasicTx body
+     in mkBasicTx
+          -- TODO: Test that aux data hash is correctly updated in conversions
+          (body & auxDataHashTxBodyL .~ maybe SNothing (SJust . hashTxAuxData) auxData)
           & isValidTxL .~ toLedgerScriptValidity validity
           & auxDataTxL .~ maybeToStrictMaybe auxData
           & witsTxL .~ wits

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Tx.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Tx.hs
@@ -2,13 +2,6 @@ module Hydra.Cardano.Api.Tx where
 
 import Hydra.Cardano.Api.Prelude
 
-import Hydra.Cardano.Api.KeyWitness (
-  fromLedgerTxWitness,
-  toLedgerBootstrapWitness,
-  toLedgerKeyWitness,
- )
-import Hydra.Cardano.Api.TxScriptValidity (toLedgerScriptValidity)
-
 import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Ledger.Allegra.Scripts (translateTimelock)
 import Cardano.Ledger.Alonzo qualified as Ledger
@@ -31,8 +24,6 @@ import Cardano.Ledger.Api (
   dataTxOutL,
   datsTxWitsL,
   feeTxBodyL,
-  hashScriptTxWitsL,
-  hashTxAuxData,
   inputsTxBodyL,
   isValidTxL,
   mintTxBodyL,
@@ -55,9 +46,8 @@ import Cardano.Ledger.Api (
  )
 import Cardano.Ledger.Api qualified as Ledger
 import Cardano.Ledger.Babbage qualified as Ledger
-import Cardano.Ledger.Babbage.Tx qualified as Ledger
 import Cardano.Ledger.Babbage.TxWits (upgradeTxDats)
-import Cardano.Ledger.BaseTypes (StrictMaybe (..), maybeToStrictMaybe, strictMaybeToMaybe)
+import Cardano.Ledger.BaseTypes (maybeToStrictMaybe)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Scripts (PlutusScript (..))
 import Cardano.Ledger.Conway.Scripts qualified as Conway
@@ -207,55 +197,14 @@ txFee' (getTxBody -> TxBody body) =
 
 -- | Convert a cardano-api 'Tx' into a matching cardano-ledger 'Tx'.
 toLedgerTx ::
-  forall era.
-  ( Ledger.EraCrypto (ShelleyLedgerEra era) ~ StandardCrypto
-  , Ledger.AlonzoEraTx (ShelleyLedgerEra era)
-  ) =>
   Tx era ->
   Ledger.Tx (ShelleyLedgerEra era)
-toLedgerTx = \case
-  Tx (ShelleyTxBody _era body scripts scriptsData auxData validity) vkWits ->
-    let (datums, redeemers) =
-          case scriptsData of
-            TxBodyScriptData _ ds rs -> (ds, rs)
-            TxBodyNoScriptData -> (mempty, Ledger.Redeemers mempty)
-        wits =
-          mkBasicTxWits
-            & addrTxWitsL .~ toLedgerKeyWitness vkWits
-            & bootAddrTxWitsL .~ toLedgerBootstrapWitness vkWits
-            & hashScriptTxWitsL .~ scripts
-            & datsTxWitsL .~ datums
-            & rdmrsTxWitsL .~ redeemers
-     in mkBasicTx
-          (body & auxDataHashTxBodyL .~ maybe SNothing (SJust . hashTxAuxData) auxData)
-          & isValidTxL .~ toLedgerScriptValidity validity
-          & auxDataTxL .~ maybeToStrictMaybe auxData
-          & witsTxL .~ wits
+toLedgerTx (ShelleyTx _era tx) = tx
 
 -- | Convert a cardano-ledger's 'Tx' in the Babbage era into a cardano-api 'Tx'.
-fromLedgerTx :: Ledger.Tx (ShelleyLedgerEra Era) -> Tx Era
-fromLedgerTx ledgerTx =
-  Tx
-    (ShelleyTxBody shelleyBasedEra body' scripts scriptsData (strictMaybeToMaybe auxData) validity)
-    (fromLedgerTxWitness wits)
- where
-  -- XXX: The suggested way (by the ledger team) forward is to use lenses to
-  -- introspect ledger transactions.
-  Ledger.AlonzoTx body wits isValid auxData = ledgerTx
-  body' = body & auxDataHashTxBodyL .~ (hashTxAuxData <$> auxData)
-
-  scripts =
-    Map.elems $ Ledger.txscripts' wits
-
-  scriptsData :: TxBodyScriptData Era
-  scriptsData =
-    TxBodyScriptData
-      alonzoEraOnwards
-      (Ledger.txdats' wits)
-      (Ledger.txrdmrs' wits)
-
-  validity = case isValid of
-    Ledger.IsValid True ->
-      TxScriptValidity alonzoEraOnwards ScriptValid
-    Ledger.IsValid False ->
-      TxScriptValidity alonzoEraOnwards ScriptInvalid
+fromLedgerTx ::
+  IsShelleyBasedEra era =>
+  Ledger.Tx (ShelleyLedgerEra era) ->
+  Tx era
+fromLedgerTx =
+  ShelleyTx shelleyBasedEra

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -341,7 +341,7 @@ test-suite tests
     , cardano-ledger-babbage:{cardano-ledger-babbage, testlib}
     , cardano-ledger-core
     , cardano-ledger-mary
-    , cardano-ledger-shelley
+    , cardano-ledger-shelley:{cardano-ledger-shelley, testlib}
     , cardano-slotting
     , cardano-strict-containers
     , cborg

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -18,6 +18,7 @@ import Cardano.Ledger.Alonzo.TxAuxData (AlonzoTxAuxData (..), hashAlonzoTxAuxDat
 import Cardano.Ledger.Api (
   AlonzoPlutusPurpose (..),
   AsIndex (..),
+  Metadatum,
   Redeemers (..),
   auxDataHashTxBodyL,
   auxDataTxL,
@@ -334,10 +335,16 @@ commitTx networkId scriptRegistry headId party commitBlueprintTx (initialInput, 
   commitDatum =
     mkTxOutDatumInline $ mkCommitDatum party utxoToCommit (headIdToCurrencySymbol headId)
 
-  TxMetadata metadataMap = mkHydraHeadV1TxName "CommitTx"
+  TxMetadata commitMetadataMap = commitMetadata
 
-  txAuxMetadata = mkAlonzoTxAuxData @[] @LedgerEra (toShelleyMetadata metadataMap) []
+  txAuxMetadata = mkAlonzoTxAuxData @[] @LedgerEra (toShelleyMetadata commitMetadataMap) []
   CommitBlueprintTx{lookupUTxO, blueprintTx} = commitBlueprintTx
+
+commitMetadata :: TxMetadata
+commitMetadata = mkHydraHeadV1TxName "CommitTx"
+
+getAuxMetadata :: AlonzoTxAuxData LedgerEra -> Map Word64 Metadatum
+getAuxMetadata (AlonzoTxAuxData metadata _ _) = metadata
 
 mkCommitDatum :: Party -> UTxO -> CurrencySymbol -> Plutus.Datum
 mkCommitDatum party utxo headId =

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -343,9 +343,6 @@ commitTx networkId scriptRegistry headId party commitBlueprintTx (initialInput, 
 commitMetadata :: TxMetadata
 commitMetadata = mkHydraHeadV1TxName "CommitTx"
 
-getAuxMetadata :: AlonzoTxAuxData LedgerEra -> Map Word64 Metadatum
-getAuxMetadata (AlonzoTxAuxData metadata _ _) = metadata
-
 mkCommitDatum :: Party -> UTxO -> CurrencySymbol -> Plutus.Datum
 mkCommitDatum party utxo headId =
   Commit.datum (partyToChain party, commits, headId)

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -28,6 +28,7 @@ import Cardano.Ledger.Api (
 import Cardano.Ledger.Core (EraTx (getMinFeeTx))
 import Cardano.Ledger.Credential (Credential (..))
 import Control.Lens ((^.))
+import Data.ByteString qualified as BS
 import Data.Map qualified as Map
 import Data.Maybe.Strict (fromSMaybe)
 import Data.Set qualified as Set
@@ -78,6 +79,7 @@ import Test.Hydra.Prelude
 import Test.QuickCheck (
   Positive (..),
   Property,
+  checkCoverage,
   choose,
   conjoin,
   counterexample,
@@ -88,6 +90,7 @@ import Test.QuickCheck (
   label,
   oneof,
   property,
+  vector,
   vectorOf,
   withMaxSuccess,
   (.&&.),
@@ -95,7 +98,6 @@ import Test.QuickCheck (
  )
 import Test.QuickCheck.Instances.Semigroup ()
 import Test.QuickCheck.Monadic (monadicIO)
-import Test.QuickCheck.Property (checkCoverage)
 
 spec :: Spec
 spec =
@@ -337,17 +339,18 @@ genBlueprintTxWithUTxO =
       pure $ mkMeta [(l, TxMetaList $ Map.elems bytes <> Map.elems numbers <> Map.elems text)]
 
     bytesMetadata = do
-      metadata <- arbitrary
+      n <- choose (1, 50)
+      metadata <- BS.pack <$> vector n
       l <- arbitrary
       pure $ mkMeta [(l, TxMetaBytes metadata)]
 
     numberMetadata = do
-      metadata <- arbitrary
+      metadata <- elements [0 .. 100]
       l <- arbitrary
       pure $ mkMeta [(l, TxMetaNumber metadata)]
 
     textMetadata = do
-      n <- choose (2, 50)
+      n <- choose (2, 22)
       metadata <- Text.take n <$> genSomeText
       l <- arbitrary
       pure $ mkMeta [(l, TxMetaText metadata)]

--- a/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
+++ b/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
@@ -8,9 +8,11 @@ import Hydra.Prelude
 import Test.Hydra.Prelude
 
 import Cardano.Binary (decodeFull, serialize')
-import Cardano.Ledger.Api (ensureMinCoinTxOut)
+import Cardano.Ledger.Api (auxDataHashTxBodyL, bodyTxL, ensureMinCoinTxOut)
+import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Core (PParams ())
 import Cardano.Ledger.Credential (Credential (..))
+import Control.Lens ((.~))
 import Data.Aeson (eitherDecode, encode)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Lens (key)
@@ -70,6 +72,8 @@ spec =
       prop "Same TxId as TxBody after JSON decoding" roundtripTxId'
 
       prop "Roundtrip to and from Ledger" roundtripLedger
+
+      prop "Roundtrip tx metadata" roundtripTxMetadata
 
       prop "Roundtrip CBOR encoding" $ roundtripCBOR @Tx
 
@@ -151,6 +155,10 @@ roundtripTxId' tx@(Tx body _) =
 roundtripLedger :: Tx -> Property
 roundtripLedger tx =
   fromLedgerTx (toLedgerTx tx) === tx
+
+roundtripTxMetadata :: Tx -> Property
+roundtripTxMetadata tx =
+  fromLedgerTx (toLedgerTx tx & bodyTxL . auxDataHashTxBodyL .~ SNothing) === tx
 
 roundtripCBOR :: (Eq a, Show a, ToCBOR a, FromCBOR a) => a -> Property
 roundtripCBOR a =

--- a/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
+++ b/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
@@ -8,11 +8,9 @@ import Hydra.Prelude
 import Test.Hydra.Prelude
 
 import Cardano.Binary (decodeFull, serialize')
-import Cardano.Ledger.Api (auxDataHashTxBodyL, bodyTxL, ensureMinCoinTxOut)
-import Cardano.Ledger.BaseTypes (StrictMaybe (..))
+import Cardano.Ledger.Api (ensureMinCoinTxOut)
 import Cardano.Ledger.Core (PParams ())
 import Cardano.Ledger.Credential (Credential (..))
-import Control.Lens ((.~))
 import Data.Aeson (eitherDecode, encode)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Lens (key)
@@ -72,8 +70,6 @@ spec =
       prop "Same TxId as TxBody after JSON decoding" roundtripTxId'
 
       prop "Roundtrip to and from Ledger" roundtripLedger
-
-      prop "Roundtrip tx metadata" roundtripTxMetadata
 
       prop "Roundtrip CBOR encoding" $ roundtripCBOR @Tx
 
@@ -155,10 +151,6 @@ roundtripTxId' tx@(Tx body _) =
 roundtripLedger :: Tx -> Property
 roundtripLedger tx =
   fromLedgerTx (toLedgerTx tx) === tx
-
-roundtripTxMetadata :: Tx -> Property
-roundtripTxMetadata tx =
-  fromLedgerTx (toLedgerTx tx & bodyTxL . auxDataHashTxBodyL .~ SNothing) === tx
 
 roundtripCBOR :: (Eq a, Show a, ToCBOR a, FromCBOR a) => a -> Property
 roundtripCBOR a =

--- a/hydra-node/test/Hydra/Model/Payment.hs
+++ b/hydra-node/test/Hydra/Model/Payment.hs
@@ -81,6 +81,7 @@ instance HasVariables Payment where
   getAllVariables _ = mempty
 
 -- | Making `Payment` an instance of `IsTx` allows us to use it with `HeadLogic'`s messages.
+-- FIXME: Missing method implementation
 instance IsTx Payment where
   type TxIdType Payment = Int
   type UTxOType Payment = [(CardanoSigningKey, Value)]

--- a/hydra-node/test/Hydra/Model/Payment.hs
+++ b/hydra-node/test/Hydra/Model/Payment.hs
@@ -81,7 +81,6 @@ instance HasVariables Payment where
   getAllVariables _ = mempty
 
 -- | Making `Payment` an instance of `IsTx` allows us to use it with `HeadLogic'`s messages.
--- FIXME: Missing method implementation
 instance IsTx Payment where
   type TxIdType Payment = Int
   type UTxOType Payment = [(CardanoSigningKey, Value)]
@@ -90,6 +89,10 @@ instance IsTx Payment where
   txSpendingUTxO = error "undefined"
   balance = foldMap snd
   hashUTxO = encodeUtf8 . show @Text
+  txSpendingUTxO = \case
+    [] -> error "nothing to spend spending"
+    [(from, value)] -> Payment{from, to = from, value}
+    _ -> error "cant spend from multiple utxo in one payment"
 
 applyTx :: UTxOType Payment -> Payment -> UTxOType Payment
 applyTx utxo Payment{from, to, value} =

--- a/hydra-node/test/Hydra/Model/Payment.hs
+++ b/hydra-node/test/Hydra/Model/Payment.hs
@@ -86,7 +86,6 @@ instance IsTx Payment where
   type UTxOType Payment = [(CardanoSigningKey, Value)]
   type ValueType Payment = Value
   txId = error "undefined"
-  txSpendingUTxO = error "undefined"
   balance = foldMap snd
   hashUTxO = encodeUtf8 . show @Text
   txSpendingUTxO = \case


### PR DESCRIPTION
### Why 

We have a user report that the commit auxiliary data hashes are invalid when submitting the commit transaction to blockfrost, responding `ConflictingMetadataHash`.

### What

* Extends the property tests on `commitTx` construction to also check the auxiliary data hash of the resulting blueprint transaction is correct.

* ~~Fixes the auxiliary data hash computation and~~ refactors commit tx construction

* Resolves a warning of missing `txSpendingUTxO` for the `Payment` tx type

* Simplifies definition of `toLedgerTx` and `fromLedgerTx` in `hydra-cardano-api`

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
