### PR TITLE
Make hydra-cluster --devnet configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ changes.
   `HandshakeFailure` event will be recorded in the logs and sent as a server
   output on the API.
 
+- Make `hydra-cluster --devnet` more configurable
+  - Now it is idle by default again and a `--busy` will make it busy respending the same UTxO.
+
 ## [0.16.0] - 2024-04-03
 
 - Tested with `cardano-node 8.9.0`, `cardano-cli 8.20.3.0` and `mithril 2412.0`.

--- a/hydra-cluster/src/Hydra/Cluster/Options.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Options.hs
@@ -12,6 +12,7 @@ data Options = Options
   , stateDirectory :: Maybe FilePath
   , publishHydraScripts :: PublishOrReuse
   , useMithril :: UseMithril
+  , scenario :: Scenario
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)
@@ -24,6 +25,10 @@ data UseMithril = NotUseMithril | UseMithril
   deriving stock (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
+data Scenario = Idle | RespendUTxO
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
 parseOptions :: Parser Options
 parseOptions =
   Options
@@ -31,6 +36,7 @@ parseOptions =
     <*> parseStateDirectory
     <*> parsePublishHydraScripts
     <*> parseUseMithril
+    <*> parseScenario
  where
   parseKnownNetwork =
     flag' (Just Preview) (long "preview" <> help "The preview testnet")
@@ -85,4 +91,12 @@ parseOptions =
             \When setting this, ensure that there is no db/ in --state-directory. \
             \If not set, the cardano-node will synchronize the network given the current \
             \cardano-node state in --state-directory."
+      )
+
+  parseScenario =
+    flag
+      Idle
+      RespendUTxO
+      ( long "busy"
+          <> help "Start respending the same UTxO with a 100ms delay (only for devnet)."
       )


### PR DESCRIPTION
By default it will now open a head and wait again and only when given `--busy`, the head is busy respending the same head.

This allows to verify interactions with a open head interactively quickly by just doing:

```
cabal build hydra-cluster
hydra_cluster_datadir=hydra-cluster cabal exec hydra-cluster -- --devnet --publish-hydra-scripts
```

This is particularly handy when writing the user manual.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
