### PR TITLE
Only check with -Werror in CI

### DIFF
--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -233,6 +233,31 @@ jobs:
         body-file: comment-body.md
         reactions: rocket
 
+  nix-flake-check:
+    name: "nix flake check"
+    runs-on: ubuntu-latest
+    steps:
+    - name: 📥 Checkout repository
+      uses: actions/checkout@v4
+
+    - name: ❄ Prepare nix
+      uses: cachix/install-nix-action@v26
+      with:
+        extra_nix_config: |
+          accept-flake-config = true
+          log-lines = 1000
+
+    - name: ❄ Cachix cache of nix derivations
+      uses: cachix/cachix-action@v14
+      with:
+        name: cardano-scaling
+        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
+
+    - name: ❄ Nix Flake Check
+      run: |
+        nix flake check -L
+
+
   build-specification:
     name: "Build specification using nix"
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,9 +112,8 @@ Besides these general build instructions, some components might document
 additional steps and useful tools in their `README.md` files, e.g. the
 [docs](./docs/README.md) or the [hydra-cluster](./hydra-cluster/README.md)
 
-Warnings are treated as errors for the whole project. To ease development, it
-might be handy to it off locally in a `cabal.project.local` with: `cabal
-configure --ghc-options -Wwarn`.
+While warnings are not treated as errors during builds, CI will check for it
+before we merge any contributions.
 
 ### Coding standards
 

--- a/cabal.project
+++ b/cabal.project
@@ -35,10 +35,6 @@ packages:
 package *
   ghc-options: -j8
 
--- Warnings as errors for local packages
-program-options
-  ghc-options: -Werror
-
 -- Always build tests and benchmarks of local packages
 tests: True
 benchmarks: True

--- a/hydra-node/test/Hydra/Model/Payment.hs
+++ b/hydra-node/test/Hydra/Model/Payment.hs
@@ -86,6 +86,7 @@ instance IsTx Payment where
   type UTxOType Payment = [(CardanoSigningKey, Value)]
   type ValueType Payment = Value
   txId = error "undefined"
+  txSpendingUTxO = error "undefined"
   balance = foldMap snd
   hashUTxO = encodeUtf8 . show @Text
 


### PR DESCRIPTION
* Adds a `nix flake check` CI job to run on each PR which now also builds all components with `-Werror` enabled.

* Removes `-Werror` from `cabal.project`, to have the same behavior as `nix build` when building with `cabal`.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
