### PR TITLE
Re-enable Mithril integration tests on all networks

### DIFF
--- a/hydra-cluster/src/Hydra/Cluster/Mithril.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Mithril.hs
@@ -11,7 +11,6 @@ import Hydra.Cluster.Fixture (KnownNetwork (..))
 import Network.HTTP.Simple (getResponseBody, httpBS, parseRequest)
 import System.IO.Error (isEOFError)
 import System.Process.Typed (createPipe, getStderr, proc, setStderr, withProcessWait_)
-import Test.Hydra.Prelude (pendingWith)
 
 data MithrilLog
   = StartSnapshotDownload {network :: KnownNetwork, directory :: FilePath}
@@ -24,9 +23,6 @@ data MithrilLog
 -- directory.
 downloadLatestSnapshotTo :: Tracer IO MithrilLog -> KnownNetwork -> FilePath -> IO ()
 downloadLatestSnapshotTo tracer network directory = do
-  when (network == Sanchonet || network == Preview) $
-    pendingWith "Mithril deployment of testing-sanchonet requires mithril-client 0.8.0, which is not yet released and does not work on other networks."
-
   traceWith tracer StartSnapshotDownload{network, directory}
   genesisKey <- parseRequest genesisKeyURL >>= httpBS <&> getResponseBody
   let cmd =


### PR DESCRIPTION
Now that all networks work with the currently selected mithril-client version, we can test against all networks again.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
