### PR TITLE
cardano-node: 8.9.0 -> 8.11.0-pre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 As a minor extension, we also keep a semantic version for the `UNRELEASED`
 changes.
 
+## [0.18.0] - Unreleased
+
+- **DO NOT RELEASE** as the tested `cardano-node` version is not intended to be used on `mainnet` yet.
+- Tested with `cardano-node 8.11.0` and `cardano-cli 8.23.1.0`.
+
 ## [0.17.0] - 2024-05-20
 
 - **BREAKING** Change `hydra-node` API `/commit` endpoint for committing from scripts [#1380](https://github.com/input-output-hk/hydra/pull/1380):

--- a/cardano-api-classy/cardano-api-classy.cabal
+++ b/cardano-api-classy/cardano-api-classy.cabal
@@ -50,9 +50,11 @@ library
     Cardano.Api.Class.ToAlonzoScript
     Cardano.Api.Classy
 
+  -- NOTE: We only use an upper bound on cardano-api and have the other
+  -- dependencies on cardano-ledger* follow.
   build-depends:
     , base                   >=4.16
-    , cardano-api            >=8.42.0 && <8.43
-    , cardano-ledger-alonzo  >=1.6    && <1.7
-    , cardano-ledger-conway  >=1.12   && <1.13
-    , cardano-ledger-core    >=1.10   && <1.11
+    , cardano-api            ^>=8.46
+    , cardano-ledger-alonzo
+    , cardano-ledger-conway
+    , cardano-ledger-core

--- a/docs/docs/tutorial/index.md
+++ b/docs/docs/tutorial/index.md
@@ -40,7 +40,7 @@ mkdir -p bin
 version=0.17.0
 curl -L -O https://github.com/input-output-hk/hydra/releases/download/${version}/hydra-x86_64-linux-${version}.zip
 unzip -d bin hydra-x86_64-linux-${version}.zip
-curl -L -o - https://github.com/input-output-hk/cardano-node/releases/download/8.9.0/cardano-node-8.9.0-linux.tar.gz \
+curl -L -o - https://github.com/IntersectMBO/cardano-node/releases/download/8.11.0/cardano-node-8.11.0-linux.tar.gz \
   | tar xz ./bin/cardano-node ./bin/cardano-cli
 curl -L -o - https://github.com/input-output-hk/mithril/releases/download/2412.0/mithril-2412.0-linux-x64.tar.gz \
   | tar xz -C bin mithril-client
@@ -55,7 +55,7 @@ mkdir -p bin
 version=0.17.0
 curl -L -O https://github.com/input-output-hk/hydra/releases/download/${version}/hydra-aarch64-darwin-${version}.zip
 unzip -d bin hydra-aarch64-darwin-${version}.zip
-curl -L -o - https://github.com/input-output-hk/cardano-node/releases/download/8.9.0/cardano-node-8.9.0-macos.tar.gz \
+curl -L -o - https://github.com/IntersectMBO/cardano-node/releases/download/8.11.0/cardano-node-8.11.0-macos.tar.gz \
   | tar xz --wildcards ./bin/cardano-node ./bin/cardano-cli './bin/*.dylib'
 curl -L -o - https://github.com/input-output-hk/mithril/releases/download/2412.0/mithril-2412.0-macos-x64.tar.gz \
   | tar xz -C bin

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     "CHaP_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1709731402,
-        "narHash": "sha256-7h4/ns3WRI3BtK1FbUEm6nMqW1ahNNehiHr7eQ03muk=",
+        "lastModified": 1715690409,
+        "narHash": "sha256-+PWaq7ngq5d601d+GBNggNuzT+jXSV7Dl2IrMNCY1KQ=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "8e4f211a8e537c8c939b65e887556bd7441c774c",
+        "rev": "0ce6797192cbbab051cd8fe5b7516b55273229f1",
         "type": "github"
       },
       "original": {
@@ -305,16 +305,16 @@
         "utils": "utils_2"
       },
       "locked": {
-        "lastModified": 1709733493,
-        "narHash": "sha256-chcwbks+HyImFk7FpbkC7FFmfpScMx5T7K0TzTkGAww=",
+        "lastModified": 1715793024,
+        "narHash": "sha256-BoTWJKRc7gWSzptEuk32A/uV6MRkRx7vKdz34k8IPY8=",
         "owner": "intersectmbo",
         "repo": "cardano-node",
-        "rev": "0d98405a60d57e1c8e13406d51cce0e34356bd64",
+        "rev": "38c7f1cf2db12dff9c814ad10049f411a4b30448",
         "type": "github"
       },
       "original": {
         "owner": "intersectmbo",
-        "ref": "8.9.0",
+        "ref": "8.11.0-pre",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -843,6 +843,25 @@
     "ghc910X": {
       "flake": false,
       "locked": {
+        "lastModified": 1711543129,
+        "narHash": "sha256-MUI07CxYOng7ZwHnMCw0ugY3HmWo2p/f4r07CGV7OAM=",
+        "ref": "ghc-9.10",
+        "rev": "6ecd5f2ff97af53c7334f2d8581651203a2c6b7d",
+        "revCount": 62607,
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.10",
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      }
+    },
+    "ghc910X_2": {
+      "flake": false,
+      "locked": {
         "lastModified": 1714520650,
         "narHash": "sha256-4uz6RA1hRr0RheGNDM49a/B3jszqNNU8iHIow4mSyso=",
         "ref": "ghc-9.10",
@@ -862,48 +881,29 @@
     "ghc911": {
       "flake": false,
       "locked": {
+        "lastModified": 1711538967,
+        "narHash": "sha256-KSdOJ8seP3g30FaC2du8QjU9vumMnmzPR5wfkVRXQMk=",
+        "ref": "refs/heads/master",
+        "rev": "0acfe391583d77a72051d505f05fab0ada056c49",
+        "revCount": 62632,
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      },
+      "original": {
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      }
+    },
+    "ghc911_2": {
+      "flake": false,
+      "locked": {
         "lastModified": 1714817013,
         "narHash": "sha256-m2je4UvWfkgepMeUIiXHMwE6W+iVfUY38VDGkMzjCcc=",
         "ref": "refs/heads/master",
         "rev": "fc24c5cf6c62ca9e3c8d236656e139676df65034",
         "revCount": 62816,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
-    "ghc98X": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696643148,
-        "narHash": "sha256-E02DfgISH7EvvNAu0BHiPvl1E5FGMDi0pWdNZtIBC9I=",
-        "ref": "ghc-9.8",
-        "rev": "443e870d977b1ab6fc05f47a9a17bc49296adbd6",
-        "revCount": 61642,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "ref": "ghc-9.8",
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
-    "ghc99": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1701580282,
-        "narHash": "sha256-drA01r3JrXnkKyzI+owMZGxX0JameMzjK0W5jJE/+V4=",
-        "ref": "refs/heads/master",
-        "rev": "f5eb0f2982e9cf27515e892c4bdf634bcfb28459",
-        "revCount": 62197,
         "submodules": true,
         "type": "git",
         "url": "https://gitlab.haskell.org/ghc/ghc"
@@ -952,11 +952,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1709684582,
-        "narHash": "sha256-+rC8Vpaxdd4Nw2fJIn9wzAnzW5arILly5AkTG6chRAw=",
+        "lastModified": 1711412520,
+        "narHash": "sha256-48Aw1X7IuXZR6Wi2WOlvj9HpoUHty/JW1MqAehgnoHo=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "c2ed9aa79252ed67a1fb694b3fffaf7dd7ead6d2",
+        "rev": "fc84d1170ccc83d50db7b71a6edd090b2cef7657",
         "type": "github"
       },
       "original": {
@@ -974,8 +974,8 @@
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat_3",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "ghc98X": "ghc98X",
-        "ghc99": "ghc99",
+        "ghc910X": "ghc910X",
+        "ghc911": "ghc911",
         "hackage": [
           "cardano-node",
           "hackageNix"
@@ -990,7 +990,6 @@
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
-        "nix-tools-static": "nix-tools-static",
         "nixpkgs": [
           "cardano-node",
           "nixpkgs"
@@ -1007,11 +1006,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1708911681,
-        "narHash": "sha256-QGkzPN1HUYxgMU2EwiwjMvR2gQF0ffUdxALq1+bOdcY=",
+        "lastModified": 1712278203,
+        "narHash": "sha256-L4eFUxnID2EYYtONE3fmZxPQdgPlB6XbAfIjlZi4c+U=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "5031fa0b8346fcc533c33073530ca87b8390add3",
+        "rev": "57938c23a4d40e5a746f05f2b71af11a7273a133",
         "type": "github"
       },
       "original": {
@@ -1029,8 +1028,8 @@
         "cardano-shell": "cardano-shell_2",
         "flake-compat": "flake-compat_5",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_2",
-        "ghc910X": "ghc910X",
-        "ghc911": "ghc911",
+        "ghc910X": "ghc910X_2",
+        "ghc911": "ghc911_2",
         "hackage": "hackage",
         "hls-1.10": "hls-1.10_2",
         "hls-2.0": "hls-2.0_2",
@@ -1539,15 +1538,16 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1709083850,
-        "narHash": "sha256-6DQ89ktt8rRVV1pXEyX2JwPjaqS0mQkelkmJmka04rg=",
+        "lastModified": 1715311504,
+        "narHash": "sha256-Jxma8/3WMb++2V1sp/iMF+6azv8cBR+ZbkLr61p2R24=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "1c793a53ac0bd99b795c2180eb23d37e8389a74b",
+        "rev": "47727032a26ed92438afef6bdd45c95cd7399694",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "node-8.11",
         "repo": "iohk-nix",
         "type": "github"
       }
@@ -1555,18 +1555,18 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1691634696,
-        "narHash": "sha256-MZH2NznKC/gbgBu8NgIibtSUZeJ00HTLJ0PlWKCBHb0=",
-        "ref": "hkm/remote-iserv",
-        "rev": "43a979272d9addc29fbffc2e8542c5d96e993d73",
-        "revCount": 14,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+        "lastModified": 1708894040,
+        "narHash": "sha256-Rv+PajrnuJ6AeyhtqzMN+bcR8z9+aEnrUass+N951CQ=",
+        "owner": "stable-haskell",
+        "repo": "iserv-proxy",
+        "rev": "2f2a318fd8837f8063a0d91f329aeae29055fba9",
+        "type": "github"
       },
       "original": {
-        "ref": "hkm/remote-iserv",
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
+        "owner": "stable-haskell",
+        "ref": "iserv-syms",
+        "repo": "iserv-proxy",
+        "type": "github"
       }
     },
     "iserv-proxy_2": {
@@ -1794,23 +1794,6 @@
       "original": {
         "owner": "serokell",
         "repo": "nix-npm-buildpackage",
-        "type": "github"
-      }
-    },
-    "nix-tools-static": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1706266250,
-        "narHash": "sha256-9t+GRk3eO9muCtKdNAwBtNBZ5dH1xHcnS17WaQyftwA=",
-        "owner": "input-output-hk",
-        "repo": "haskell-nix-example",
-        "rev": "580cb6db546a7777dad3b9c0fa487a366c045c4e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "nix",
-        "repo": "haskell-nix-example",
         "type": "github"
       }
     },
@@ -2848,11 +2831,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1708906175,
-        "narHash": "sha256-KJDF0CO077Jx4GjjPK6pNkx6NkY7p1x5RMPfaIe8nl4=",
+        "lastModified": 1712276009,
+        "narHash": "sha256-KlRJ+CGXRueyz2VRLDwra5JBNaI2GkltNJAjHa7fowE=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "bfa4778050cf69fe50f91d39dcefbb9005d6d0d0",
+        "rev": "758035379a5ac4390879e4cd5164abe0c96fcea7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
       url = "github:cardano-scaling/haskell-language-server?ref=2.6-patched";
       flake = false;
     };
-    cardano-node.url = "github:intersectmbo/cardano-node/8.9.0";
+    cardano-node.url = "github:intersectmbo/cardano-node/8.11.0-pre";
     mithril.url = "github:input-output-hk/mithril/2418.1";
     nix-npm-buildpackage.url = "github:serokell/nix-npm-buildpackage";
   };

--- a/hydra-cardano-api/hydra-cardano-api.cabal
+++ b/hydra-cardano-api/hydra-cardano-api.cabal
@@ -75,30 +75,30 @@ library
     Hydra.Cardano.Api.VerificationKey
     Hydra.Cardano.Api.Witness
 
-  -- NOTE: We use very narrow bounds on cardano libraries as they tend to break
-  -- their interfaces often.
+  -- NOTE: We only use an upper bound on cardano-api and have the other
+  -- dependencies on cardano-ledger* and plutus-ledger-api follow.
   build-depends:
     , aeson                   >=2
     , base                    >=4.16
     , base16-bytestring
     , bytestring
-    , cardano-api             >=8.42.0 && <8.43
+    , cardano-api             ^>=8.46
     , cardano-api-classy
-    , cardano-binary          >=1.7.0  && <1.8
-    , cardano-crypto-class    >=2.1.1  && <2.2
-    , cardano-ledger-allegra  >=1.3    && <1.4
-    , cardano-ledger-alonzo   >=1.6    && <1.7
-    , cardano-ledger-api      >=1.8    && <1.9
-    , cardano-ledger-babbage  >=1.6    && <1.7
-    , cardano-ledger-binary   >=1.3    && <1.4
-    , cardano-ledger-byron    >=1.0.0  && <1.1
-    , cardano-ledger-conway   >=1.12   && <1.13
-    , cardano-ledger-core     >=1.10   && <1.11
-    , cardano-ledger-mary     >=1.5    && <1.6
-    , cardano-ledger-shelley  >=1.9    && <1.10
+    , cardano-binary
+    , cardano-crypto-class
+    , cardano-ledger-allegra
+    , cardano-ledger-alonzo
+    , cardano-ledger-api
+    , cardano-ledger-babbage
+    , cardano-ledger-binary
+    , cardano-ledger-byron
+    , cardano-ledger-conway
+    , cardano-ledger-core
+    , cardano-ledger-mary
+    , cardano-ledger-shelley
     , containers
     , lens
-    , plutus-ledger-api       >=1.21   && <1.22
+    , plutus-ledger-api
     , QuickCheck
     , serialise
     , text                    >=2

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Tx.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Tx.hs
@@ -10,7 +10,7 @@ import Cardano.Ledger.Alonzo.TxAuxData (translateAlonzoTxAuxData)
 import Cardano.Ledger.Alonzo.TxWits qualified as Ledger
 import Cardano.Ledger.Api (
   AlonzoPlutusPurpose (..),
-  AsIndex (..),
+  AsIx (..),
   ConwayPlutusPurpose (..),
   EraTx (mkBasicTx),
   addrTxOutL,
@@ -143,13 +143,13 @@ convertConwayTx =
       $ Map.toList redeemerMap
 
   translatePlutusPurpose ::
-    Conway.ConwayPlutusPurpose Ledger.AsIndex (Ledger.ConwayEra StandardCrypto) ->
-    Maybe (Ledger.AlonzoPlutusPurpose Ledger.AsIndex (Ledger.BabbageEra StandardCrypto))
+    Conway.ConwayPlutusPurpose Ledger.AsIx (Ledger.ConwayEra StandardCrypto) ->
+    Maybe (Ledger.AlonzoPlutusPurpose Ledger.AsIx (Ledger.BabbageEra StandardCrypto))
   translatePlutusPurpose = \case
-    ConwaySpending (AsIndex ix) -> Just $ AlonzoSpending (AsIndex ix)
-    ConwayMinting (AsIndex ix) -> Just $ AlonzoMinting (AsIndex ix)
-    ConwayCertifying (AsIndex ix) -> Just $ AlonzoCertifying (AsIndex ix)
-    ConwayRewarding (AsIndex ix) -> Just $ AlonzoRewarding (AsIndex ix)
+    ConwaySpending (AsIx ix) -> Just $ AlonzoSpending (AsIx ix)
+    ConwayMinting (AsIx ix) -> Just $ AlonzoMinting (AsIx ix)
+    ConwayCertifying (AsIx ix) -> Just $ AlonzoCertifying (AsIx ix)
+    ConwayRewarding (AsIx ix) -> Just $ AlonzoRewarding (AsIx ix)
     ConwayVoting{} -> Nothing
     ConwayProposing{} -> Nothing
 

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/TxBody.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/TxBody.hs
@@ -3,7 +3,7 @@ module Hydra.Cardano.Api.TxBody where
 import Hydra.Cardano.Api.Prelude
 
 import Cardano.Ledger.Alonzo.TxWits qualified as Ledger
-import Cardano.Ledger.Api (AlonzoPlutusPurpose (..), AsIndex, AsItem (..), PlutusPurpose)
+import Cardano.Ledger.Api (AlonzoPlutusPurpose (..), AsItem (..), AsIx, PlutusPurpose)
 import Cardano.Ledger.Babbage.Core (redeemerPointer)
 import Cardano.Ledger.BaseTypes (strictMaybeToMaybe)
 import Cardano.Ledger.Core qualified as Ledger
@@ -53,7 +53,7 @@ findScriptMinting (getTxBody -> ShelleyTxBody _ _ scripts _ _ _) pid = do
 
 lookupRedeemer ::
   Plutus.FromData a =>
-  PlutusPurpose AsIndex LedgerEra ->
+  PlutusPurpose AsIx LedgerEra ->
   TxBodyScriptData Era ->
   Maybe a
 lookupRedeemer ptr scriptData = do

--- a/hydra-cluster/config/devnet/genesis-conway.json
+++ b/hydra-cluster/config/devnet/genesis-conway.json
@@ -34,6 +34,8 @@
   "committee": {
     "members": {
     },
-    "quorum": 0
-  }
+    "threshold": 0
+  },
+  "minFeeRefScriptCostPerByte": 0,
+  "plutusV3CostModel":[]
 }

--- a/hydra-cluster/test/Test/CardanoNodeSpec.hs
+++ b/hydra-cluster/test/Test/CardanoNodeSpec.hs
@@ -18,10 +18,10 @@ import System.Directory (doesFileExist)
 import Test.Hydra.Cluster.Utils (forEachKnownNetwork)
 
 supportedNetworks :: [KnownNetwork]
-supportedNetworks = [Preview, Preproduction, Mainnet]
+supportedNetworks = [Sanchonet]
 
 supportedCardanoNodeVersion :: String
-supportedCardanoNodeVersion = "8.9.0"
+supportedCardanoNodeVersion = "8.11.0"
 
 forSupportedKnownNetworks :: String -> (KnownNetwork -> IO ()) -> Spec
 forSupportedKnownNetworks msg action = forEachKnownNetwork msg $ \network -> do

--- a/hydra-cluster/test/Test/Hydra/Cluster/CardanoCliSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/CardanoCliSpec.hs
@@ -36,7 +36,7 @@ spec =
             Just something -> something == "Witnessed Tx BabbageEra"
 
     it "has expected cardano-cli version available" $
-      readProcess "cardano-cli" ["--version"] "" >>= (`shouldContain` "8.20.3.0")
+      readProcess "cardano-cli" ["--version"] "" >>= (`shouldContain` "8.23.1.0")
 
     around (showLogsOnFailure "CardanoCliSpec") $ do
       it "query protocol-parameters is compatible with our FromJSON instance" $ \tracer ->

--- a/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
@@ -61,4 +61,4 @@ spec =
               let difference = initialFaucetValue - finalFaucetValue
               -- difference between starting faucet amount and final one should
               -- just be the amount of paid fees
-              difference `shouldSatisfy` (< 340_000)
+              difference `shouldSatisfy` (< 400_000)

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -151,11 +151,11 @@ library
     , optparse-applicative
     , ouroboros-consensus
     , ouroboros-consensus-cardano
-    , ouroboros-network-api                                     >=0.1.0.0
-    , ouroboros-network-framework                               >=0.3.0.0
-    , ouroboros-network-protocols                               >=0.3.0.0
-    , plutus-core                                               >=1.21    && <1.22
-    , plutus-ledger-api                                         >=1.21    && <1.22
+    , ouroboros-network-api                                     ^>=0.7.1
+    , ouroboros-network-framework
+    , ouroboros-network-protocols                               ^>=0.8
+    , plutus-core                                               >=1.21
+    , plutus-ledger-api                                         >=1.21
     , prometheus
     , QuickCheck
     , quickcheck-instances

--- a/hydra-node/src/Hydra/Chain/Direct/Tx.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Tx.hs
@@ -13,12 +13,12 @@ import Hydra.Cardano.Api
 import Hydra.Prelude
 
 import Cardano.Api.UTxO qualified as UTxO
+import Cardano.Ledger.Alonzo.Core (AsIxItem (..))
 import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
 import Cardano.Ledger.Alonzo.TxAuxData (AlonzoTxAuxData (..))
 import Cardano.Ledger.Api (
   AlonzoPlutusPurpose (..),
-  AsIndex (..),
-  AsItem (..),
+  AsIx (..),
   EraTxAuxData (hashTxAuxData),
   Redeemers (..),
   auxDataHashTxBodyL,
@@ -291,7 +291,7 @@ commitTx networkId scriptRegistry headId party commitBlueprintTx (initialInput, 
              in case Map.lookup txin resolved of
                   Nothing -> newRedeemerData
                   Just d ->
-                    (AlonzoSpending (AsIndex ix), (d, ExUnits 0 0)) : newRedeemerData
+                    (AlonzoSpending (AsIx ix), (d, ExUnits 0 0)) : newRedeemerData
         )
         []
         inputs
@@ -302,7 +302,7 @@ commitTx networkId scriptRegistry headId party commitBlueprintTx (initialInput, 
       ( \p (d, _ex) ->
           -- XXX: Should soon be available through cardano-ledger-api again
           case redeemerPointerInverse (tx ^. bodyTxL) p of
-            SJust (AlonzoSpending (AsItem txIn)) -> Map.singleton txIn d
+            SJust (AlonzoSpending (AsIxItem _ txIn)) -> Map.singleton txIn d
             _ -> mempty
       )
       (unRedeemers $ tx ^. witsTxL . rdmrsTxWitsL)

--- a/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano/Evaluate.hs
@@ -62,6 +62,7 @@ import Hydra.Cardano.Api (
 import Hydra.Cardano.Api.Pretty (renderTxWithUTxO)
 import Hydra.ContestationPeriod (ContestationPeriod (UnsafeContestationPeriod))
 import Hydra.Ledger.Cardano.Time (slotNoFromUTCTime, slotNoToUTCTime)
+import Ouroboros.Consensus.Block (GenesisWindow (..))
 import Ouroboros.Consensus.Cardano.Block (CardanoEras)
 import Ouroboros.Consensus.HardFork.History (
   Bound (Bound, boundEpoch, boundSlot, boundTime),
@@ -218,7 +219,7 @@ prepareTxScripts tx utxo = do
       Right x -> pure x
 
   -- Fully applied UPLC programs which we could run using the cekMachine
-  programs <- forM results $ \(PlutusWithContext protocolVersion script arguments _exUnits _costModel) -> do
+  programs <- forM results $ \(PlutusWithContext protocolVersion script _ arguments _exUnits _costModel) -> do
     (PlutusRunnable x) <-
       case script of
         Right runnable -> pure runnable
@@ -319,6 +320,7 @@ eraHistoryWithHorizonAt slotNo@(SlotNo n) =
       , -- NOTE: unused if the 'eraEnd' is already defined, but would be used to
         -- extend the last era accordingly in the real cardano-node
         eraSafeZone = UnsafeIndefiniteSafeZone
+      , eraGenesisWin = GenesisWindow 1
       }
 
 eraHistoryWithoutHorizon :: EraHistory
@@ -341,6 +343,7 @@ eraHistoryWithoutHorizon =
       , -- NOTE: unused if the 'eraEnd' is already defined, but would be used to
         -- extend the last era accordingly in the real cardano-node
         eraSafeZone = UnsafeIndefiniteSafeZone
+      , eraGenesisWin = GenesisWindow 1
       }
 
 epochSize :: EpochSize

--- a/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/Contract/Mutation.hs
@@ -133,7 +133,7 @@ import Hydra.Cardano.Api
 import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Ledger.Alonzo.Scripts qualified as Ledger
 import Cardano.Ledger.Alonzo.TxWits qualified as Ledger
-import Cardano.Ledger.Api (AllegraEraTxBody (vldtTxBodyL), AlonzoPlutusPurpose (..), AsIndex (..), inputsTxBodyL, mintTxBodyL, outputsTxBodyL, reqSignerHashesTxBodyL)
+import Cardano.Ledger.Api (AllegraEraTxBody (vldtTxBodyL), AlonzoPlutusPurpose (..), AsIx (..), inputsTxBodyL, mintTxBodyL, outputsTxBodyL, reqSignerHashesTxBodyL)
 import Cardano.Ledger.Core qualified as Ledger
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Mary.Value qualified as Ledger
@@ -304,13 +304,13 @@ applyMutation mutation (tx@(Tx body wits), utxo) = case mutation of
       | isHeadOutput (resolveInput ix) = (Ledger.Data (toData newRedeemer), units)
       | otherwise = (dat, units)
 
-    resolveInput :: Ledger.AlonzoPlutusPurpose AsIndex w -> TxOut CtxUTxO
+    resolveInput :: Ledger.AlonzoPlutusPurpose AsIx w -> TxOut CtxUTxO
     resolveInput ix =
       let k = case ix of
-            AlonzoSpending i -> unAsIndex i
-            AlonzoCertifying i -> unAsIndex i
-            AlonzoRewarding i -> unAsIndex i
-            AlonzoMinting i -> unAsIndex i
+            AlonzoSpending i -> unAsIx i
+            AlonzoCertifying i -> unAsIx i
+            AlonzoRewarding i -> unAsIx i
+            AlonzoMinting i -> unAsIx i
           txIn = Set.elemAt (fromIntegral k) ledgerInputs -- NOTE: calls 'error' if out of bounds
        in case UTxO.resolve (fromLedgerTxIn txIn) utxo of
             Nothing -> error $ "txIn not resolvable: " <> show txIn
@@ -571,7 +571,7 @@ ensureDatums outs scriptData =
 
 -- | Alter a transaction's redeemers map given some mapping function.
 alterRedeemers ::
-  ( Ledger.PlutusPurpose Ledger.AsIndex LedgerEra ->
+  ( Ledger.PlutusPurpose Ledger.AsIx LedgerEra ->
     (Ledger.Data LedgerEra, Ledger.ExUnits) ->
     (Ledger.Data LedgerEra, Ledger.ExUnits)
   ) ->
@@ -614,7 +614,7 @@ alterTxIns fn tx =
   rebuiltSpendingRedeemers = Map.fromList $
     flip mapMaybe (zip [0 ..] newSortedInputs) $ \(i, (_, mRedeemer)) ->
       mRedeemer <&> \d ->
-        (Ledger.AlonzoSpending (AsIndex i), (toLedgerData d, Ledger.ExUnits 0 0))
+        (Ledger.AlonzoSpending (AsIx i), (toLedgerData d, Ledger.ExUnits 0 0))
 
   -- NOTE: This needs to be ordered, such that we can calculate the redeemer
   -- pointers correctly.
@@ -630,7 +630,7 @@ alterTxIns fn tx =
   resolveRedeemers :: [TxIn] -> [(TxIn, Maybe HashableScriptData)]
   resolveRedeemers txInputs =
     zip txInputs [0 ..] <&> \(txIn, i) ->
-      case Map.lookup (Ledger.AlonzoSpending (AsIndex i)) redeemersMap of
+      case Map.lookup (Ledger.AlonzoSpending (AsIx i)) redeemersMap of
         Nothing -> (txIn, Nothing)
         Just (redeemerData, _exUnits) -> (txIn, Just $ fromLedgerData redeemerData)
 

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -186,7 +186,7 @@ spec =
                                           ErrTranslationError{} -> "Transaction context translation error"
                                       )
                                 Right ledgerTx ->
-                                  let actualExecutionCost = getMinFeeTx pparams ledgerTx
+                                  let actualExecutionCost = getMinFeeTx pparams ledgerTx 0
                                       fee = txFee' apiTx
                                       apiTx = fromLedgerTx ledgerTx
                                    in actualExecutionCost > Coin 0 && fee > actualExecutionCost

--- a/hydra-node/test/Hydra/Chain/Direct/WalletSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/WalletSpec.hs
@@ -259,7 +259,8 @@ hasLowFees pparams tx =
 
   actualFee = tx ^. bodyTxL . feeTxBodyL
 
-  minFee = getMinFeeTx pparams tx
+  minFee :: Coin
+  minFee = getMinFeeTx pparams tx 0
 
 isBalanced :: Map TxIn TxOut -> Tx LedgerEra -> Tx LedgerEra -> Property
 isBalanced utxo originalTx balancedTx =

--- a/hydra-plutus-extras/src/Hydra/Plutus/Orphans.hs
+++ b/hydra-plutus-extras/src/Hydra/Plutus/Orphans.hs
@@ -12,7 +12,7 @@ import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as Base16
 import PlutusLedgerApi.V2 (CurrencySymbol, POSIXTime (..), PubKeyHash (..), TokenName, TxId (..), TxOutRef (..), UpperBound, Value, upperBound)
 import PlutusTx.AssocMap qualified as AssocMap
-import PlutusTx.Prelude (BuiltinByteString, fromBuiltin, toBuiltin)
+import PlutusTx.Prelude (BuiltinByteString, Eq, fromBuiltin, toBuiltin)
 import Test.QuickCheck (choose, vectorOf)
 import Test.QuickCheck.Instances.ByteString ()
 
@@ -31,8 +31,8 @@ instance Arbitrary Value where
   arbitrary = genericArbitrary
   shrink = genericShrink
 
-instance (Arbitrary k, Arbitrary v) => Arbitrary (AssocMap.Map k v) where
-  arbitrary = AssocMap.fromList <$> arbitrary
+instance (PlutusTx.Prelude.Eq k, Arbitrary k, Arbitrary v) => Arbitrary (AssocMap.Map k v) where
+  arbitrary = AssocMap.safeFromList <$> arbitrary
 
 instance Arbitrary POSIXTime where
   arbitrary = POSIXTime <$> arbitrary

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -69,10 +69,10 @@ library
     , hydra-cardano-api
     , hydra-plutus-extras
     , hydra-prelude
-    , plutus-core          >=1.21 && <1.22
-    , plutus-ledger-api    >=1.21 && <1.22
-    , plutus-tx            >=1.21 && <1.22
-    , plutus-tx-plugin     >=1.21 && <1.22
+    , plutus-core          >=1.21
+    , plutus-ledger-api    >=1.21
+    , plutus-tx            >=1.21
+    , plutus-tx-plugin     >=1.21
     , QuickCheck
     , serialise
     , template-haskell

--- a/plutus-cbor/bench/Main.hs
+++ b/plutus-cbor/bench/Main.hs
@@ -133,16 +133,16 @@ genValue = do
   assetName <- genTokenName
   pure $
     Plutus.Value $
-      Plutus.Map.fromList
-        [(policyId, Plutus.Map.fromList [(assetName, n)])]
+      Plutus.Map.safeFromList
+        [(policyId, Plutus.Map.safeFromList [(assetName, n)])]
 
 genAdaOnlyValue :: Gen Plutus.Value
 genAdaOnlyValue = do
   n <- genAssetQuantity
   pure $
     Plutus.Value $
-      Plutus.Map.fromList
-        [(Plutus.adaSymbol, Plutus.Map.fromList [(Plutus.adaToken, n)])]
+      Plutus.Map.safeFromList
+        [(Plutus.adaSymbol, Plutus.Map.safeFromList [(Plutus.adaToken, n)])]
 
 genAssetQuantity :: Gen Integer
 genAssetQuantity = choose (1, 4_294_967_296) -- NOTE: 2**32

--- a/plutus-cbor/exe/encoding-cost/Main.hs
+++ b/plutus-cbor/exe/encoding-cost/Main.hs
@@ -119,16 +119,16 @@ genValue = do
   assetName <- genTokenName
   pure $
     Plutus.Value $
-      Plutus.Map.fromList
-        [(policyId, Plutus.Map.fromList [(assetName, n)])]
+      Plutus.Map.safeFromList
+        [(policyId, Plutus.Map.safeFromList [(assetName, n)])]
 
 genAdaOnlyValue :: Gen Plutus.Value
 genAdaOnlyValue = do
   n <- genAssetQuantity
   pure $
     Plutus.Value $
-      Plutus.Map.fromList
-        [(Plutus.adaSymbol, Plutus.Map.fromList [(Plutus.adaToken, n)])]
+      Plutus.Map.safeFromList
+        [(Plutus.adaSymbol, Plutus.Map.safeFromList [(Plutus.adaToken, n)])]
 
 genAssetQuantity :: Gen Integer
 genAssetQuantity = choose (1, 4_294_967_296) -- NOTE: 2**32

--- a/plutus-cbor/test/Plutus/Codec/CBOR/EncodingSpec.hs
+++ b/plutus-cbor/test/Plutus/Codec/CBOR/EncodingSpec.hs
@@ -185,7 +185,7 @@ genSomeValue =
           encodeMap
             (\(SomeValue k _ _ encodeKey) -> encodeKey k)
             (\(SomeValue v _ _ encodeValue) -> encodeValue v)
-            . Plutus.Map.fromList
+            . Plutus.Map.unsafeFromList
     return $ SomeValue val shrinkMap encodeCborg encodeOurs
 
   genSomeMapIndef :: Int -> Gen SomeValue
@@ -206,7 +206,7 @@ genSomeValue =
           encodeMapIndef
             (\(SomeValue k _ _ encodeKey) -> encodeKey k)
             (\(SomeValue v _ _ encodeValue) -> encodeValue v)
-            . Plutus.Map.fromList
+            . Plutus.Map.unsafeFromList
     return $ SomeValue val shrinkMap encodeCborg encodeOurs
 
   genSomeTag :: Gen SomeValue


### PR DESCRIPTION
Updates cardano-node to 8.11 and cardano-api to 8.46.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
