### PR TITLE
Don't build dockers in nix flake check - it is too big for CI

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -148,15 +148,7 @@
             "hydra-tui"
             "plutus-cbor"
             "plutus-merkle-tree"
-          ]) //
-          (if pkgs.stdenv.isLinux then
-            {
-              inherit (packages)
-                docker-hydra-explorer
-                docker-hydra-node
-                docker-hydra-tui
-                docker-hydraw;
-            } else { });
+          ]);
 
           devShells = import ./nix/hydra/shell.nix {
             inherit inputs pkgs hsPkgs system compiler;


### PR DESCRIPTION
<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
