### PR TITLE
Use max of start-chain-from and last known point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ changes.
 - **BREAKING** Changes to the `hydra-node` API `/commit` endpoint [#1463](https://github.com/input-output-hk/hydra/pull/1463):
   - Removed the check that prevented committing UTxOs from an internal `hydra-node` wallet.
   - `SpendingNodeUtxoForbidden` error was removed.
+  
+- Change `--start-chain-from` to always use the newer point when also a head state is known.
 
 ## [0.17.0] - 2024-05-20
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -161,7 +161,26 @@ hydra-node \
   --node-socket devnet/node.socket \
 ```
 
+:::info
 The `hydra-node` is compatible with the Cardano `mainnet` network, and can consequently operate using **real funds**. Please be sure to read the [known issues](/docs/known-issues) to fully understand the limitations and consequences of running Hydra nodes on mainnet. To choose `mainnet`, use `--mainnet` instead of `--testnet-magic`. 
+:::
+
+Using the direct node connection, the `hydra-node` does synchronize the chain and observes Hydra protocol transactions. On first startup, it will start observing from the chain's tip. Once a Hydra head has been observed, the point of the last known state change is used automatically.
+
+You can manually set the intersection point using `--start-chain-from <slot>.<hash>` which specifies a `slot` and block header `hash`. For example:
+
+```shell
+hydra-node \
+  --testnet-magic 2 \
+  --node-socket preview/node.socket \
+  --start-chain-from 49533501.e364500a42220ea47314215679b7e42e9bbb81fa69d1366fe738d8aef900f7ee
+```
+
+To synchronize from the genesis block, use `--start-chain-from 0`.
+
+:::info
+If the `hydra-node` already tracks a head in its `state` and `--start-chain-from` is given, the **newer** point is used.
+:::
 
 ## Offline mode
 

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -168,7 +168,7 @@ withDirectChain tracer config ctx wallet chainStateHistory callback action = do
   queue <- newTQueueIO
   -- Select a chain point from which to start synchronizing
   chainPoint <- maybe (queryTip networkId nodeSocket) pure $ do
-    (min <$> startChainFrom <*> persistedPoint)
+    (max <$> startChainFrom <*> persistedPoint)
       <|> persistedPoint
       <|> startChainFrom
 

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -646,10 +646,12 @@ startChainFromParser =
     ( long "start-chain-from"
         <> metavar "SLOT.HEADER_HASH"
         <> help
-          "The id of the block we want to start observing the chain from. \
-          \If not given, uses the chain tip at startup. Composed by the slot \
-          \number, a separator ('.') and the hash of the block header. \
-          \For example: 52970883.d36a9936ae7a07f5f4bdc9ad0b23761cb7b14f35007e54947e27a1510f897f04."
+          "The id of the block we want to start observing the chain from. Only \
+          \used if the last known head state is older than given point. If not \
+          \given and no known head state, the chain tip is used. Composed by the \
+          \slot number, a separator ('.') and the hash of the block header. For \
+          \example: \
+          \52970883.d36a9936ae7a07f5f4bdc9ad0b23761cb7b14f35007e54947e27a1510f897f04."
     )
  where
   readChainPoint :: String -> Maybe ChainPoint


### PR DESCRIPTION
Instead of using the oldest, use the newest point when both, a last known head state and start-chain-from is present.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks not needed
* [x] No new TODOs introduced
