### PR TITLE
Add spy and spy' for quick, colorful tracing

### DIFF
--- a/hydra-prelude/hydra-prelude.cabal
+++ b/hydra-prelude/hydra-prelude.cabal
@@ -29,6 +29,7 @@ library
     , generic-random
     , gitrev
     , io-classes         >=1.0.0.0
+    , pretty-simple
     , QuickCheck
     , relude
     , si-timers          >=1.0.0.0

--- a/hydra-prelude/src/Hydra/Prelude.hs
+++ b/hydra-prelude/src/Hydra/Prelude.hs
@@ -1,3 +1,6 @@
+-- NOTE: Usage of 'trace' in 'spy'.
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
 module Hydra.Prelude (
   module Relude,
   module Control.Monad.Class.MonadSTM,
@@ -35,6 +38,8 @@ module Hydra.Prelude (
   decodeBase16,
   (?>),
   withFile,
+  spy,
+  spy',
 ) where
 
 import Cardano.Binary (
@@ -154,6 +159,7 @@ import Test.QuickCheck (
  )
 import Test.QuickCheck.Gen (Gen (..))
 import Test.QuickCheck.Random (mkQCGen)
+import Text.Pretty.Simple (pShow)
 
 -- | Provides a sensible way of automatically deriving generic 'Arbitrary'
 -- instances for data-types. In the case where more advanced or tailored
@@ -249,3 +255,11 @@ withFile fp mode action =
   System.IO.withFile fp mode (try . action) >>= \case
     Left (e :: IOException) -> throwIO e
     Right x -> pure x
+
+-- | Like 'traceShow', but with pretty printing of the value.
+spy :: Show a => a -> a
+spy a = trace (toString $ pShow a) a
+
+-- | Like 'spy' but prefixed with a label.
+spy' :: Show a => String -> a -> a
+spy' msg a = trace (msg <> ": " <> toString (pShow a)) a


### PR DESCRIPTION
Saw these functions in a purescript library lately and thought these could be useful for quick inspection of values during debugging.

---

* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Haddocks update not needed
* [x] No new TODOs introduced
