### PR TITLE
Remove line-length limit from editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,6 @@ insert_final_newline = true
 
 [*.hs]
 indent_size = 2
-max_line_length = 80
 
 [*.py]
 indent_size = 4


### PR DESCRIPTION
We don't enforce this via formatting anyway, so it doesn't help to have it specified here.

As an alternative, we could add the following to `fourmolu.yaml` ( thanks for the hint @ffakenz ):

```
column-limit: 80
```

which would make fourmolu do a best-effort to agree with the limit, but even then that doesn't work perfectly:

![image](https://github.com/user-attachments/assets/af1974d2-d25f-48f9-8986-6fc17d54b906)

i.e. the red line shows that it still breaks occasionally.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
