### PR TITLE
Remove multicast reqSn step on decrementTx

### DIFF
--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -241,14 +241,6 @@ spec =
           let reqSn = ReqSn{snapshotVersion = 0, snapshotNumber = 1, transactionIds = [], decommitTx = Just decommitTx'}
           s1 `hasEffect` NetworkEffect reqSn
 
-        it "emits snapshot onDecrementTx with cleared decommitTx" $ do
-          let decommitTx = SimpleTx 1 mempty (utxoRef 1)
-              s0 = inOpenState' threeParties coordinatedHeadState{decommitTx = Just decommitTx}
-              leaderEnv = aliceEnv
-          o <- runHeadLogic leaderEnv ledger s0 $ do
-            step (observeTx OnDecrementTx{headId = testHeadId, newVersion = 1, distributedOutputs = [1]})
-          o `hasEffect` NetworkEffect (ReqSn 1 1 [] Nothing)
-
       describe "Tracks Transaction Ids" $ do
         it "keeps transactions in allTxs given it receives a ReqTx" $ do
           let s0 = inOpenState threeParties

--- a/spec/fig_offchain_prot.tex
+++ b/spec/fig_offchain_prot.tex
@@ -134,9 +134,6 @@
 							\If{$\mathsf{outputs}(\tx_{\omega}) = U_{\omega}$}{
 								$\tx_{\omega} \gets \bot$ \;
 								$\hatv \gets v$ \;
-								\If{$\hats = \bar{\mc S}.s \land \hpLdr(\bar{\mc S}.s + 1) = i$}{
-									\Multi{} $(\hpRS,\hatv,\bar{\mc S}.s+1,\hatmT, \tx_{\omega})$ \;
-								}
 							}
 						}
 


### PR DESCRIPTION
<!-- Describe your change here -->

This PR reduces the number of network messages in the presence of decrementTx, by avoiding unnecessary snapshot signature round-trips between peers.
> Removed **multicast reqSn** step **on** *decrementTx from chain*.

Since it is triggered by a chain observation, we expect/assume everyone will eventually observe it and continue cooperating.
 
---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
