### PR TITLE
Fix demo by using latest docker image to publish scripts

### DIFF
--- a/demo/seed-devnet.sh
+++ b/demo/seed-devnet.sh
@@ -51,7 +51,7 @@ function hnode() {
       docker run --rm -it \
         --pull always \
         -v ${SCRIPT_DIR}/devnet:/devnet \
-        ghcr.io/cardano-scaling/hydra-node:0.17.0 -- ${@}
+        ghcr.io/cardano-scaling/hydra-node:unstable -- ${@}
   fi
 }
 


### PR DESCRIPTION
We recently updated `hydra` to use the latest `cardano-api` that works with `cardano-node 9.1` and consequently also updated the `cardano-node` binary used to version `9.1`. 

Previous version of the ledger/api seem to have problems communicating with this node version, which manifests itself in this error where we used `hydra-node:0.17.0` still to post the scripts transaction (maybe incompatible deserialization of protocol params or so):

```
[ch1bo][~/code/iog/hydra/demo][⌥ master][󰁫821ms] λ ./seed-devnet.sh 
[...]
Publishing reference scripts...
0.17.0: Pulling from cardano-scaling/hydra-node
Digest: sha256:9d3b1aef1e7c07c0b3db2845dbcfd0a500d9b53e566d326e8099bf795a0abd70
Status: Image is up to date for ghcr.io/cardano-scaling/hydra-node:0.17.0
Environment variable stored in '.env'

	HYDRA_SCRIPTS_TX_ID=hydra-node: DecoderFailure (LocalStateQuery HardForkBlock (': * ByronBlock (': * (ShelleyBlock (TPraos StandardCrypto) (ShelleyEra StandardCrypto)) (': * (ShelleyBlock (TPraos StandardCrypto) (AllegraEra StandardCrypto)) (': * (ShelleyBlock (TPraos StandardCrypto) (MaryEra StandardCrypto)) (': * (ShelleyBlock (TPraos StandardCrypto) (AlonzoEra StandardCrypto)) (': * (ShelleyBlock (Praos StandardCrypto) (BabbageEra StandardCrypto)) (': * (ShelleyBlock (Praos StandardCrypto) (ConwayEra StandardCrypto)) ('[] *)))))))) Query (BlockQuery (HardForkBlock (': * ByronBlock (': * (ShelleyBlock (TPraos StandardCrypto) (ShelleyEra StandardCrypto)) (': * (ShelleyBlock (TPraos StandardCrypto) (AllegraEra StandardCrypto)) (': * (ShelleyBlock (TPraos StandardCrypto) (MaryEra StandardCrypto)) (': * (ShelleyBlock (TPraos StandardCrypto) (AlonzoEra StandardCrypto)) (': * (ShelleyBlock (Praos StandardCrypto) (BabbageEra StandardCrypto)) (': * (ShelleyBlock (Praos StandardCrypto) (ConwayEra StandardCrypto)) ('[] *))))))))))) ServerAgency TokQuerying BlockQuery (QueryHardFork GetInterpreter)) (DeserialiseFailure 13 "Size mismatch when decoding EraParams.
Expected 3, but found 4.")
```

By using the latest `master` version via the `hydra-node:unstable` docker image, this is fixed. 

---

* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Haddocks update not needed
* [x] No new TODOs introduced
