### PR TITLE
No processing of transactions during a decommit

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1413,11 +1413,11 @@
         "nixpkgs": "nixpkgs_9"
       },
       "locked": {
-        "lastModified": 1722860219,
-        "narHash": "sha256-ZsEI1H+4tzFktuAPPw2E3LFsmrL/u9g7rOOe9/SFJEg=",
+        "lastModified": 1723044854,
+        "narHash": "sha256-drzeiMBle5pI1V4ZRwJqS5lU2Ngazeab2pvk10Ara8g=",
         "owner": "cardano-scaling",
         "repo": "hydra-formal-specification",
-        "rev": "607b3830f91d78feeafdbb3e35909c1963b4017c",
+        "rev": "56f025e99b93b9d2f988970337148b0e3fbdc6fd",
         "type": "github"
       },
       "original": {

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -2229,7 +2229,7 @@ definitions:
           tag:
             type: string
             enum: ["WaitOnSnapshotVersion"]
-          waitingForNumber:
+          waitingForVersion:
             "$ref": "api.yaml#/components/schemas/SnapshotVersion"
             description: >-
               The expected number.

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -1055,6 +1055,16 @@ definitions:
             $ref: "api.yaml#/components/schemas/SnapshotNumber"
           leader:
             $ref: "api.yaml#/components/schemas/Party"
+      - title: "ReqSnDecommitNotSettled"
+        description: >-
+          Received a ReqSn message with specified new decommit but the previous one was not settled.
+        additionalProperties: false
+        required:
+          - tag
+        properties:
+          tag:
+            type: string
+            enum: ["ReqSnDecommitNotSettled"]
       - title: "InvalidMultisignature"
         description: >-
           Multisignature computed for a snapshot from individual parties signature is invalid.
@@ -2215,8 +2225,6 @@ definitions:
             enum: ["WaitOnSnapshotNumber"]
           waitingForNumber:
             "$ref": "api.yaml#/components/schemas/SnapshotNumber"
-            description: >-
-              The expected number.
       - title: WaitOnSnapshotVersion
         description: >-
           Requested snapshot version is not up to date, waiting for the next version number.
@@ -2231,8 +2239,6 @@ definitions:
             enum: ["WaitOnSnapshotVersion"]
           waitingForVersion:
             "$ref": "api.yaml#/components/schemas/SnapshotVersion"
-            description: >-
-              The expected number.
       - title: WaitOnSeenSnapshot
         description: >-
           No current snapshot is available, waiting for some snapshot to start.

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -2202,19 +2202,35 @@ definitions:
               Description of the cause of the validation failure.
       - title: WaitOnSnapshotNumber
         description: >-
-          Current observed snapshot is not the right one, waiting for some other
+          Current observed snapshot number is not the right one, waiting for some other
           number.
         type: object
         additionalProperties: false
         required:
           - tag
-          - waitingFor
+          - waitingForNumber
         properties:
           tag:
             type: string
             enum: ["WaitOnSnapshotNumber"]
-          waitingFor:
+          waitingForNumber:
             "$ref": "api.yaml#/components/schemas/SnapshotNumber"
+            description: >-
+              The expected number.
+      - title: WaitOnSnapshotVersion
+        description: >-
+          Requested snapshot version is not up to date, waiting for the next version number.
+        type: object
+        additionalProperties: false
+        required:
+          - tag
+          - waitingForVersion
+        properties:
+          tag:
+            type: string
+            enum: ["WaitOnSnapshotVersion"]
+          waitingForNumber:
+            "$ref": "api.yaml#/components/schemas/SnapshotVersion"
             description: >-
               The expected number.
       - title: WaitOnSeenSnapshot

--- a/hydra-node/src/Hydra/HeadLogic/Error.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Error.hs
@@ -35,6 +35,7 @@ data RequirementFailure tx
   = ReqSnNumberInvalid {requestedSn :: SnapshotNumber, lastSeenSn :: SnapshotNumber}
   | ReqSvNumberInvalid {requestedSv :: SnapshotVersion, lastSeenSv :: SnapshotVersion}
   | ReqSnNotLeader {requestedSn :: SnapshotNumber, leader :: Party}
+  | ReqSnDecommitNotSettled
   | InvalidMultisignature {multisig :: Text, vkeys :: [VerificationKey HydraKey]}
   | SnapshotAlreadySigned {knownSignatures :: [Party], receivedSignature :: Party}
   | AckSnNumberInvalid {requestedSn :: SnapshotNumber, lastSeenSn :: SnapshotNumber}

--- a/hydra-node/src/Hydra/HeadLogic/Outcome.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Outcome.hs
@@ -156,7 +156,8 @@ causes = Continue []
 
 data WaitReason tx
   = WaitOnNotApplicableTx {validationError :: ValidationError}
-  | WaitOnSnapshotNumber {waitingFor :: SnapshotNumber}
+  | WaitOnSnapshotNumber {waitingForNumber :: SnapshotNumber}
+  | WaitOnSnapshotVersion {waitingForVersion :: SnapshotVersion}
   | WaitOnSeenSnapshot
   | WaitOnTxs {waitingForTxIds :: [TxIdType tx]}
   | WaitOnContestationDeadline

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -439,7 +439,6 @@ spec = parallel $ do
 
       it "can process transactions while decommit pending" $
         shouldRunInSim $ do
-          -- NOTE: The simulated network has a block time of 20 (simulated) seconds.
           withSimulatedChainAndNetwork $ \chain ->
             withHydraNode aliceSk [bob] chain $ \n1 ->
               withHydraNode bobSk [alice] chain $ \n2 -> do
@@ -690,6 +689,7 @@ dummySimulatedChainNetwork =
 -- | With-pattern wrapper around 'simulatedChainAndNetwork' which does 'cancel'
 -- the 'tickThread'. Also, this will fix tx to 'SimpleTx' so that it can pick an
 -- initial chain state to play back to our test nodes.
+-- NOTE: The simulated network has a block time of 20 (simulated) seconds.
 withSimulatedChainAndNetwork ::
   (MonadTime m, MonadDelay m, MonadAsync m) =>
   (SimulatedChainNetwork SimpleTx m -> m ()) ->


### PR DESCRIPTION
fix #1526 

Related specification PR https://github.com/cardano-scaling/hydra-formal-specification/pull/7

### Why?

- New L2 transactions fail when decommit is _in flight_ because we try to re-apply the local decommit tx

### What

- Make sure the new snapshots are created only if the version is matched
- Any pending decommit needs to match with the decommit in confirmed snapshot thus preserved in the next snapshot/s until it is observed.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
