### PR TITLE
Derive head id and seed from node id in offline mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ changes.
 
 - Moved several pages from "core concepts" into the user manual and developer docs to futher improve user journey.
 
+- Offline mode of `hydra-node` uses `--node-id` to derive an artificial offline `headId`.
+
 ## [0.17.0] - 2024-05-20
 
 - **BREAKING** Change `hydra-node` API `/commit` endpoint for committing from scripts [#1380](https://github.com/cardano-scaling/hydra/pull/1380):

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -2087,6 +2087,13 @@ components:
             - type: string
               contentEncoding: base16
             - type: "null"
+      example: |
+        {
+          "address": "addr1w9htvds89a78ex2uls5y969ttry9s3k9etww0staxzndwlgmzuul5",
+          "value": {
+              "lovelace": 7620669
+          }
+        }
 
     HydraNodeVersion:
       type: string
@@ -2116,9 +2123,11 @@ components:
       type: object
       propertyNames:
         pattern: "^[0-9a-f]{64}#[0-9]+$"
-      items: # REVIEW: does this work? use additionalProperties here?
+      additionalProperties:
         $ref: "api.yaml#/components/schemas/TxOut"
-      example:
+      description: |
+        A set of unspent transaction outputs. Object keys are 'TxIn' and values are 'TxOut'.
+      example: |
         {
             "09d34606abdcd0b10ebc89307cbfa0b469f9144194137b45b7a04b273961add8#687": {
                 "address": "addr1w9htvds89a78ex2uls5y969ttry9s3k9etww0staxzndwlgmzuul5",
@@ -2141,7 +2150,7 @@ components:
         - blueprintTx
         - utxo
       properties:
-        blueptintTx:
+        blueprintTx:
           $ref: "api.yaml#/components/schemas/Transaction"
         utxo:
           $ref: "api.yaml#/components/schemas/UTxO"

--- a/hydra-node/src/Hydra/Node/Run.hs
+++ b/hydra-node/src/Hydra/Node/Run.hs
@@ -102,7 +102,7 @@ run opts = do
 
   prepareChainComponent tracer Environment{party} = \case
     Offline cfg ->
-      pure $ withOfflineChain cfg party
+      pure $ withOfflineChain nodeId cfg party
     Direct cfg -> do
       ctx <- loadChainContext cfg party
       wallet <- mkTinyWallet (contramap DirectChain tracer) cfg


### PR DESCRIPTION
Something requested by @Quantumplation for `hydra-doom`, so would need to be backported to the version we use there.

---

* [x] CHANGELOG updated
* [x] Documentation update not needed
* [x] Haddocks update not needed
* [x] No new TODOs introduced or explained herafter
