### PR TITLE
Fix demo persistence paths to ./devnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,3 @@ hspec-results.md
 # demo
 /devnet
 .env
-logs
-acks
-server-output
-state

--- a/nix/hydra/demo.nix
+++ b/nix/hydra/demo.nix
@@ -13,7 +13,7 @@
   # httpServer.enable = true;
   package = process-compose;
   settings = {
-    log_location = "./logs/all.log";
+    log_location = "./devnet/logs/all.log";
     log_level = "debug";
     environment = {
       BASEDIR = "./";
@@ -63,7 +63,8 @@
           --cardano-verification-key devnet/credentials/carol.vk \
           --ledger-protocol-parameters devnet/protocol-parameters.json \
           --testnet-magic 42 \
-          --node-socket devnet/node.socket
+          --node-socket devnet/node.socket \
+          --persistence-dir devnet
         '';
         ready_log_line = "NodeIsLeader";
         depends_on."seed-devnet".condition = "process_completed";
@@ -87,7 +88,8 @@
           --cardano-verification-key devnet/credentials/carol.vk \
           --ledger-protocol-parameters devnet/protocol-parameters.json \
           --testnet-magic 42 \
-          --node-socket devnet/node.socket
+          --node-socket devnet/node.socket \
+          --persistence-dir devnet
         '';
         ready_log_line = "NodeIsLeader";
         depends_on."seed-devnet".condition = "process_completed";
@@ -111,7 +113,8 @@
           --cardano-verification-key devnet/credentials/bob.vk \
           --ledger-protocol-parameters devnet/protocol-parameters.json \
           --testnet-magic 42 \
-          --node-socket devnet/node.socket
+          --node-socket devnet/node.socket \
+          --persistence-dir devnet
         '';
         ready_log_line = "NodeIsLeader";
         depends_on."seed-devnet".condition = "process_completed";


### PR DESCRIPTION
Changes the `hydra-node` invocations in the demo ( `nix run .#demo`) to set the `--persistence-dir` to be the devnet folder, and updates the .gitignore accordingly.

The reason for this is now you can just `rm -rf devnet` and not have to remove a bunch of random files like `acks` and `states` and `server-state` ....

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
