### PR TITLE
Use github hosted ARM64 based MacOS runners in binaries workflow

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -51,7 +51,7 @@ jobs:
   # system dependencies, but all third-party libraries are statically linked.
   build-executables-macos:
     name: "Build aarch64-darwin dynamic executables"
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: macos-latest
     steps:
     - name: 📥 Checkout repository
       uses: actions/checkout@v4


### PR DESCRIPTION
Our self-hosted runner is stuck and I wondered why we just not use the new [macos arm64](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) runners of github?

Let's see if the `binaries` job works on this and produces an artifact. @ffakenz would be good if you could give them a try on your machine.

---

* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Haddocks update not needed
* [x] No new TODOs introduced
