### PR TITLE
Fix binaries artifact names when built on tags

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -38,8 +38,12 @@ jobs:
       run: |
         nix build .#release-static
         # XXX: Why unzip https://github.com/actions/upload-artifact/issues/39
-        echo "VERSION=$(git describe --always ${{ github.ref }})" >> "$GITHUB_ENV"
         unzip result/*.zip -d out
+        # FIXME: this does not correctly git describe
+        git describe --always ${{ github.ref }}
+        git fetch --tags --force
+        git describe --always ${{ github.ref }}
+        echo "VERSION=$(git describe --always ${{ github.ref }})" >> "$GITHUB_ENV"
 
     - name: 💾 Upload executables
       uses: actions/upload-artifact@v4
@@ -76,8 +80,9 @@ jobs:
       run: |
         nix build .#release
         # XXX: Why unzip https://github.com/actions/upload-artifact/issues/39
-        echo "VERSION=$(git describe --always ${{ github.ref }})" >> "$GITHUB_ENV"
         unzip result/*.zip -d out
+        # FIXME: this does not correctly git describe
+        echo "VERSION=$(git describe --always ${{ github.ref }})" >> "$GITHUB_ENV"
 
     - name: 💾 Upload executables
       uses: actions/upload-artifact@v4

--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -22,7 +22,6 @@ jobs:
       with:
         # Also ensure we have all history with all tags
         fetch-depth: 0
-        fetch-tags: true
 
     - name: ❄ Prepare nix
       uses: cachix/install-nix-action@V27
@@ -67,7 +66,6 @@ jobs:
       with:
         # Also ensure we have all history with all tags
         fetch-depth: 0
-        fetch-tags: true
 
     - name: ❄ Prepare nix
       uses: cachix/install-nix-action@V27

--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -37,16 +37,18 @@ jobs:
         name: cardano-scaling
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
+    - name: 🕵 Determine version
+      run: |
+        # NOTE: For some reason the fetched tags on checkout are not effective
+        # and we need to refetch with --force for git describe.
+        git fetch --tags --force
+        echo "VERSION=$(git describe --always ${{ github.ref }})" >> "$GITHUB_ENV"
+
     - name: ❄ Build static executables
       run: |
         nix build .#release-static
         # XXX: Why unzip https://github.com/actions/upload-artifact/issues/39
         unzip result/*.zip -d out
-        # FIXME: this does not correctly git describe
-        git describe --always ${{ github.ref }}
-        git fetch --tags --force
-        git describe --always ${{ github.ref }}
-        echo "VERSION=$(git describe --always ${{ github.ref }})" >> "$GITHUB_ENV"
 
     - name: 💾 Upload executables
       uses: actions/upload-artifact@v4
@@ -80,13 +82,18 @@ jobs:
         name: cardano-scaling
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
+    - name: 🕵 Determine version
+      run: |
+        # NOTE: For some reason the fetched tags on checkout are not effective
+        # and we need to refetch with --force for git describe.
+        git fetch --tags --force
+        echo "VERSION=$(git describe --always ${{ github.ref }})" >> "$GITHUB_ENV"
+
     - name: ❄ Build executables
       run: |
         nix build .#release
         # XXX: Why unzip https://github.com/actions/upload-artifact/issues/39
         unzip result/*.zip -d out
-        # FIXME: this does not correctly git describe
-        echo "VERSION=$(git describe --always ${{ github.ref }})" >> "$GITHUB_ENV"
 
     - name: 💾 Upload executables
       uses: actions/upload-artifact@v4

--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -4,9 +4,11 @@ name: Binaries
 on:
   push:
     branches:
-    - "**"
+    - main
+    - release
     tags:
     - "*.*.*"
+  pull_request:
 
 jobs:
   # Produces static ELF binary for using MuslC which includes all needed

--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -20,6 +20,7 @@ jobs:
       with:
         # Also ensure we have all history with all tags
         fetch-depth: 0
+        fetch-tags: true
 
     - name: ❄ Prepare nix
       uses: cachix/install-nix-action@V27
@@ -62,6 +63,7 @@ jobs:
       with:
         # Also ensure we have all history with all tags
         fetch-depth: 0
+        fetch-tags: true
 
     - name: ❄ Prepare nix
       uses: cachix/install-nix-action@V27


### PR DESCRIPTION
Our `binaries` workflow builds artifacts for linux and macos of our main executables. 

On tags, it should produce artifacts named `hydra-<arch>-<os>-<version>.zip` or otherwise the tutorial instructions do not work. Also, we would like to have clean artifacts to be included in release notes. 

### Problem

For some reason the `git describe` was reporting a version x commits ahead of the previous release, instead of just the name of the latest tag.

We faced this issue in the last couple of releases:

> During our 0.17.0 release we notice our pipelines where producing wrong artifacts:
> 🚫 master: https://github.com/input-output-hk/hydra/actions/runs/9157524020
> ✅ release: https://github.com/input-output-hk/hydra/actions/runs/9157528381
> 🚫 tag: https://github.com/input-output-hk/hydra/actions/runs/9157529422

> https://github.com/input-output-hk/hydra/actions/runs/8539230275
> While `github.ref` resolves to `refs/tags/0.16.0` here, the result seems to be `##[debug]VERSION='0.15.0-513-g4e1e1ed67'`: https://github.com/input-output-hk/hydra/actions/runs/8539230275/job/23399638368#step:5:81

### Solution

:detective: Fixes version determination by refetching tags before calling `git describe`.

:detective: Runs binaries workflow not on every push, but only on PRs, important branches and obviously tags.

Fixed workflow on a temporary `0.0.0-test` tag: https://github.com/cardano-scaling/hydra/actions/runs/10417337202

![image](https://github.com/user-attachments/assets/f3802b40-a02e-45ad-a046-1bb9087eb45e)

---

* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Haddocks update not needed
* [x] No new TODOs introduced
