### PR TITLE
Explore magic-nix

### DIFF
--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -27,12 +27,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - package: plutus-cbor
-          - package: plutus-merkle-tree
-          - package: hydra-plutus
-          - package: hydra-tui
+          # - package: plutus-cbor
+          # - package: plutus-merkle-tree
+          # - package: hydra-plutus
+          # - package: hydra-tui
           - package: hydra-node
-          - package: hydra-cluster
+          # - package: hydra-cluster
     steps:
     - name: 📥 Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -66,7 +66,7 @@ jobs:
       run: |
         cd ${{ matrix.package }}
         nix build .#${{ matrix.package }}-tests
-        nix develop .#${{ matrix.package }}-tests --command tests
+        # nix develop .#${{ matrix.package }}-tests --command tests
 
     - name: ❓ Test (TUI)
       id: test_tui

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -36,18 +36,26 @@ jobs:
     - name: 📥 Checkout repository
       uses: actions/checkout@v4
 
-    - name: ❄ Prepare nix
-      uses: cachix/install-nix-action@V27
-      with:
-        extra_nix_config: |
-          accept-flake-config = true
-          log-lines = 1000
+    # - name: ❄ Install nix
+    - uses: DeterminateSystems/nix-installer-action@main
+    #   uses: cachix/install-nix-action@V27
+    #   with:
+    #     extra_nix_config: |
+    #       accept-flake-config = true
+    #       log-lines = 1000
 
-    - name: ❄ Cachix cache of nix derivations
-      uses: cachix/cachix-action@v15
+    # - name: ❄ Setup nix cache
+    - uses: DeterminateSystems/magic-nix-cache-action@main
       with:
-        name: cardano-scaling
-        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
+        diagnostic-endpoint: ""
+        diff-store: true
+        # upstream-cache: "https://cardano-scaling.cachix.org"
+
+    # TODO: ensure results are pushed into cachix
+    #   uses: cachix/cachix-action@v15
+    #   with:
+    #     name: cardano-scaling
+    #     authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
     - name: ❓ Test
       if: ${{ matrix.package != 'hydra-tui' }}
@@ -87,258 +95,258 @@ jobs:
         path: /tmp/nix-shell.*/hydra-cluster-e2e-*/logs/*
         if-no-files-found: ignore
 
-  publish-test-results:
-    name: Publish test results
-    needs: [build-test]
-    runs-on: ubuntu-latest
-    steps:
-    - name: 📥 Download test results
-      uses: actions/download-artifact@v4
-      with:
-       pattern: test-results-*
-       merge-multiple: true
+  # publish-test-results:
+  #   name: Publish test results
+  #   needs: [build-test]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: 📥 Download test results
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #      pattern: test-results-*
+  #      merge-multiple: true
 
-    - name: ✏ Publish test results to PR
-      uses: EnricoMi/publish-unit-test-result-action@v2
-      with:
-        junit_files: ./**/test-results.xml
+  #   - name: ✏ Publish test results to PR
+  #     uses: EnricoMi/publish-unit-test-result-action@v2
+  #     with:
+  #       junit_files: ./**/test-results.xml
 
-  haddock:
-    name: "Build haddock using nix"
-    runs-on: ubuntu-latest
-    steps:
-    - name: 📥 Checkout repository
-      uses: actions/checkout@v4
+  # haddock:
+  #   name: "Build haddock using nix"
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: 📥 Checkout repository
+  #     uses: actions/checkout@v4
 
-    - name: ❄ Prepare nix
-      uses: cachix/install-nix-action@V27
-      with:
-        extra_nix_config: |
-          accept-flake-config = true
-          log-lines = 1000
+  #   - name: ❄ Prepare nix
+  #     uses: cachix/install-nix-action@V27
+  #     with:
+  #       extra_nix_config: |
+  #         accept-flake-config = true
+  #         log-lines = 1000
 
-    - name: ❄ Cachix cache of nix derivations
-      uses: cachix/cachix-action@v15
-      with:
-        name: cardano-scaling
-        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
+  #   - name: ❄ Cachix cache of nix derivations
+  #     uses: cachix/cachix-action@v15
+  #     with:
+  #       name: cardano-scaling
+  #       authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
-    - name: 📚 Documentation (Haddock)
-      run: |
-        nix build .#haddocks
-        mkdir -p haddocks
-        cp -aL result/* haddocks/
+  #   - name: 📚 Documentation (Haddock)
+  #     run: |
+  #       nix build .#haddocks
+  #       mkdir -p haddocks
+  #       cp -aL result/* haddocks/
 
-    - name: 💾 Upload haddock artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: haddocks
-        path: haddocks
+  #   - name: 💾 Upload haddock artifact
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: haddocks
+  #       path: haddocks
 
-  benchmarks:
-    name: "Benchmarks"
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - package: hydra-node
-            bench: tx-cost
-            options: '--output-directory $(pwd)/../benchmarks'
-          - package: hydra-node
-            bench: micro
-            options: '-o $(pwd)/../benchmarks/ledger-bench.html'
-          - package: hydra-cluster
-            bench: bench-e2e
-            options: 'datasets datasets/1-node.json datasets/3-nodes.json --output-directory $(pwd)/../benchmarks --timeout 1000s'
-          - package: plutus-merkle-tree
-            bench: on-chain-cost
-            options: '$(pwd)/../benchmarks'
-    steps:
-    - name: 📥 Checkout repository
-      uses: actions/checkout@v4
+  # benchmarks:
+  #   name: "Benchmarks"
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       include:
+  #         - package: hydra-node
+  #           bench: tx-cost
+  #           options: '--output-directory $(pwd)/../benchmarks'
+  #         - package: hydra-node
+  #           bench: micro
+  #           options: '-o $(pwd)/../benchmarks/ledger-bench.html'
+  #         - package: hydra-cluster
+  #           bench: bench-e2e
+  #           options: 'datasets datasets/1-node.json datasets/3-nodes.json --output-directory $(pwd)/../benchmarks --timeout 1000s'
+  #         - package: plutus-merkle-tree
+  #           bench: on-chain-cost
+  #           options: '$(pwd)/../benchmarks'
+  #   steps:
+  #   - name: 📥 Checkout repository
+  #     uses: actions/checkout@v4
 
-    - name: ❄ Prepare nix
-      uses: cachix/install-nix-action@V27
-      with:
-        extra_nix_config: |
-          accept-flake-config = true
-          log-lines = 1000
+  #   - name: ❄ Prepare nix
+  #     uses: cachix/install-nix-action@V27
+  #     with:
+  #       extra_nix_config: |
+  #         accept-flake-config = true
+  #         log-lines = 1000
 
-    - name: ❄ Cachix cache of nix derivations
-      uses: cachix/cachix-action@v15
-      with:
-        name: cardano-scaling
-        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
+  #   - name: ❄ Cachix cache of nix derivations
+  #     uses: cachix/cachix-action@v15
+  #     with:
+  #       name: cardano-scaling
+  #       authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
-    - name: 📈 Benchmark
-      run: |
-        mkdir -p benchmarks
-        cd ${{ matrix.package }}
-        nix build .#${{ matrix.package }}-bench
-        nix develop .#${{ matrix.package }}-bench --command ${{ matrix.bench }} ${{ matrix.options }}
+  #   - name: 📈 Benchmark
+  #     run: |
+  #       mkdir -p benchmarks
+  #       cd ${{ matrix.package }}
+  #       nix build .#${{ matrix.package }}-bench
+  #       nix develop .#${{ matrix.package }}-bench --command ${{ matrix.bench }} ${{ matrix.options }}
 
-    - name: 💾 Upload build & test artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: benchmarks-${{matrix.package}}-${{matrix.bench}}
-        path: benchmarks
+  #   - name: 💾 Upload build & test artifacts
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: benchmarks-${{matrix.package}}-${{matrix.bench}}
+  #       path: benchmarks
 
-    # NOTE: This depends on the path used in hydra-cluster bench
-    - name: 💾 Upload logs
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: hydra-cluster-bench-logs
-        path: /tmp/nix-shell.*/bench-*/**/*.log
-        if-no-files-found: ignore
+  #   # NOTE: This depends on the path used in hydra-cluster bench
+  #   - name: 💾 Upload logs
+  #     if: always()
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: hydra-cluster-bench-logs
+  #       path: /tmp/nix-shell.*/bench-*/**/*.log
+  #       if-no-files-found: ignore
 
-  publish-benchmark-results:
-    name: Publish benchmark results
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-    # TODO: this is actually only requires the tx-cost benchmark results
-    needs: [benchmarks]
-    runs-on: ubuntu-latest
-    steps:
-    - name: 📥 Download generated documentation
-      uses: actions/download-artifact@v4
-      with:
-        path: artifact
-        pattern: benchmarks-*
-        merge-multiple: true
+  # publish-benchmark-results:
+  #   name: Publish benchmark results
+  #   if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+  #   # TODO: this is actually only requires the tx-cost benchmark results
+  #   needs: [benchmarks]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: 📥 Download generated documentation
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       path: artifact
+  #       pattern: benchmarks-*
+  #       merge-multiple: true
 
-    - name: ⚙ Prepare comment body
-      id: comment-body
-      run: |
-        # Drop first 5 header lines and demote headlines one level
-        cat <(cat artifact/transaction-cost.md | sed '1,5d;s/^#/##/') <(cat artifact/end-to-end-benchmarks.md | sed '1,5d;s/^#/##/') | grep -v '^:::' > comment-body.md
+  #   - name: ⚙ Prepare comment body
+  #     id: comment-body
+  #     run: |
+  #       # Drop first 5 header lines and demote headlines one level
+  #       cat <(cat artifact/transaction-cost.md | sed '1,5d;s/^#/##/') <(cat artifact/end-to-end-benchmarks.md | sed '1,5d;s/^#/##/') | grep -v '^:::' > comment-body.md
 
-    - name: 🔎 Find Comment
-      uses: peter-evans/find-comment@v3
-      id: find-comment
-      with:
-        issue-number: ${{ github.event.pull_request.number }}
-        comment-author: 'github-actions[bot]'
-        body-includes: Transaction costs
+  #   - name: 🔎 Find Comment
+  #     uses: peter-evans/find-comment@v3
+  #     id: find-comment
+  #     with:
+  #       issue-number: ${{ github.event.pull_request.number }}
+  #       comment-author: 'github-actions[bot]'
+  #       body-includes: Transaction costs
 
-    - name: ✏ Create or update comment
-      uses: peter-evans/create-or-update-comment@v4
-      with:
-        comment-id: ${{ steps.find-comment.outputs.comment-id }}
-        edit-mode: replace
-        issue-number: ${{ github.event.pull_request.number }}
-        body-file: comment-body.md
-        reactions: rocket
+  #   - name: ✏ Create or update comment
+  #     uses: peter-evans/create-or-update-comment@v4
+  #     with:
+  #       comment-id: ${{ steps.find-comment.outputs.comment-id }}
+  #       edit-mode: replace
+  #       issue-number: ${{ github.event.pull_request.number }}
+  #       body-file: comment-body.md
+  #       reactions: rocket
 
-  nix-flake-check:
-    name: "nix flake check"
-    runs-on: ubuntu-latest
-    steps:
-    - name: 📥 Checkout repository
-      uses: actions/checkout@v4
+  # nix-flake-check:
+  #   name: "nix flake check"
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: 📥 Checkout repository
+  #     uses: actions/checkout@v4
 
-    - name: ❄ Prepare nix
-      uses: cachix/install-nix-action@V27
-      with:
-        extra_nix_config: |
-          accept-flake-config = true
-          log-lines = 1000
+  #   - name: ❄ Prepare nix
+  #     uses: cachix/install-nix-action@V27
+  #     with:
+  #       extra_nix_config: |
+  #         accept-flake-config = true
+  #         log-lines = 1000
 
-    - name: ❄ Cachix cache of nix derivations
-      uses: cachix/cachix-action@v15
-      with:
-        name: cardano-scaling
-        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
+  #   - name: ❄ Cachix cache of nix derivations
+  #     uses: cachix/cachix-action@v15
+  #     with:
+  #       name: cardano-scaling
+  #       authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
-    - name: ❄ Nix Flake Check
-      run: |
-        nix flake check -L
+  #   - name: ❄ Nix Flake Check
+  #     run: |
+  #       nix flake check -L
 
 
-  build-specification:
-    name: "Build specification using nix"
-    runs-on: ubuntu-latest
-    steps:
-    - name: 📥 Checkout repository
-      uses: actions/checkout@v4
+  # build-specification:
+  #   name: "Build specification using nix"
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: 📥 Checkout repository
+  #     uses: actions/checkout@v4
 
-    - name: ❄ Prepare nix
-      uses: cachix/install-nix-action@V27
-      with:
-        extra_nix_config: |
-          accept-flake-config = true
-          log-lines = 1000
+  #   - name: ❄ Prepare nix
+  #     uses: cachix/install-nix-action@V27
+  #     with:
+  #       extra_nix_config: |
+  #         accept-flake-config = true
+  #         log-lines = 1000
 
-    - name: ❄ Cachix cache of nix derivations
-      uses: cachix/cachix-action@v15
-      with:
-        name: cardano-scaling
-        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
+  #   - name: ❄ Cachix cache of nix derivations
+  #     uses: cachix/cachix-action@v15
+  #     with:
+  #       name: cardano-scaling
+  #       authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
-    - name: ❄ Build specification PDF
-      run: |
-        nix build .#spec && cp result/*.pdf .
+  #   - name: ❄ Build specification PDF
+  #     run: |
+  #       nix build .#spec && cp result/*.pdf .
 
-    - name: 💾 Upload specification
-      uses: actions/upload-artifact@v4
-      with:
-        name: hydra-spec
-        path: |
-          ./*.pdf
+  #   - name: 💾 Upload specification
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: hydra-spec
+  #       path: |
+  #         ./*.pdf
 
-  documentation:
-    name: Documentation
-    needs: [haddock,benchmarks,build-test,build-specification]
-    runs-on: ubuntu-latest
-    steps:
-    - name: 📥 Checkout repository
-      uses: actions/checkout@v4
-      with:
-        # For the cardanonical json schemas
-        submodules: true
-        # Ensure we have all history with all commits
-        fetch-depth: 0
+  # documentation:
+  #   name: Documentation
+  #   needs: [haddock,benchmarks,build-test,build-specification]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: 📥 Checkout repository
+  #     uses: actions/checkout@v4
+  #     with:
+  #       # For the cardanonical json schemas
+  #       submodules: true
+  #       # Ensure we have all history with all commits
+  #       fetch-depth: 0
 
-    - name: 🚧 Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: 16
-        cache: 'yarn'
-        cache-dependency-path: docs/yarn.lock
+  #   - name: 🚧 Setup Node.js
+  #     uses: actions/setup-node@v4
+  #     with:
+  #       node-version: 16
+  #       cache: 'yarn'
+  #       cache-dependency-path: docs/yarn.lock
 
-    - name: ❓ Test API reference
-      working-directory: docs
-      run: |
-        yarn
-        yarn validate
+  #   - name: ❓ Test API reference
+  #     working-directory: docs
+  #     run: |
+  #       yarn
+  #       yarn validate
 
-    - name: 📥 Download benchmark results
-      uses: actions/download-artifact@v4
-      with:
-        path: docs/benchmarks
-        pattern: benchmarks-*
-        merge-multiple: true
+  #   - name: 📥 Download benchmark results
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       path: docs/benchmarks
+  #       pattern: benchmarks-*
+  #       merge-multiple: true
 
-    - name: 📥 Download haddock documentation
-      uses: actions/download-artifact@v4
-      with:
-        name: haddocks
-        path: docs/static/haddock
+  #   - name: 📥 Download haddock documentation
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: haddocks
+  #       path: docs/static/haddock
 
-    - name: 📥 Download test results
-      uses: actions/download-artifact@v4
-      with:
-        pattern: test-results-*
-        merge-multiple: true
-        path: docs/benchmarks/tests
+  #   - name: 📥 Download test results
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       pattern: test-results-*
+  #       merge-multiple: true
+  #       path: docs/benchmarks/tests
 
-    - name: 📥 Download specification PDF
-      uses: actions/download-artifact@v4
-      with:
-        name: hydra-spec
-        path: docs/static/
+  #   - name: 📥 Download specification PDF
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: hydra-spec
+  #       path: docs/static/
 
-    - name: 📚 Documentation sanity check
-      working-directory: docs
-      run: |
-        yarn
-        yarn build-dev
+  #   - name: 📚 Documentation sanity check
+  #     working-directory: docs
+  #     run: |
+  #       yarn
+  #       yarn build-dev

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -52,6 +52,9 @@ jobs:
         diff-store: true
         # upstream-cache: "https://cardano-scaling.cachix.org"
 
+    - run: |
+        cat ~/.config/nix/nix.conf
+
     # TODO: ensure results are pushed into cachix
     #   uses: cachix/cachix-action@v15
     #   with:

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -10,6 +10,7 @@ on:
     branches:
     - master
     - release
+    - magic-nix
   pull_request:
   schedule:
     # Everyday at 4:00 AM

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -39,27 +39,26 @@ jobs:
 
     # - name: ❄ Install nix
     - uses: DeterminateSystems/nix-installer-action@main
-    #   uses: cachix/install-nix-action@V27
+    # - uses: cachix/install-nix-action@V27
       with:
         extra-conf: |
           accept-flake-config = true
           log-lines = 1000
 
     # - name: ❄ Setup nix cache
-    - uses: DeterminateSystems/magic-nix-cache-action@main
-      with:
-        diagnostic-endpoint: ""
-        diff-store: true
+    # - uses: DeterminateSystems/magic-nix-cache-action@main
+    #   with:
+    #     diagnostic-endpoint: ""
+    #     diff-store: true
         # upstream-cache: "https://cardano-scaling.cachix.org"
+
+    - uses: cachix/cachix-action@v15
+      with:
+        name: cardano-scaling
+        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
     - run: |
         cat ~/.config/nix/nix.conf
-
-    # TODO: ensure results are pushed into cachix
-    #   uses: cachix/cachix-action@v15
-    #   with:
-    #     name: cardano-scaling
-    #     authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
     - name: ❓ Test
       if: ${{ matrix.package != 'hydra-tui' }}

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -42,8 +42,7 @@ jobs:
     #   uses: cachix/install-nix-action@V27
       with:
         extra-conf: |
-          allow-import-from-derivation = true
-          # accept-flake-config = true
+          accept-flake-config = true
           log-lines = 1000
 
     # - name: ❄ Setup nix cache

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -40,10 +40,11 @@ jobs:
     # - name: ❄ Install nix
     - uses: DeterminateSystems/nix-installer-action@main
     #   uses: cachix/install-nix-action@V27
-    #   with:
-    #     extra_nix_config: |
-    #       accept-flake-config = true
-    #       log-lines = 1000
+      with:
+        extra-conf: |
+          allow-import-from-derivation = true
+          # accept-flake-config = true
+          log-lines = 1000
 
     # - name: ❄ Setup nix cache
     - uses: DeterminateSystems/magic-nix-cache-action@main

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          hydra-node
-version:       0.18.2
+version:       0.18.1
 synopsis:      The Hydra node
 author:        IOG
 copyright:     2022 IOG

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          hydra-node
-version:       0.18.1
+version:       0.18.2
 synopsis:      The Hydra node
 author:        IOG
 copyright:     2022 IOG

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          hydra-node
-version:       0.18.1
+version:       0.18.3
 synopsis:      The Hydra node
 author:        IOG
 copyright:     2022 IOG


### PR DESCRIPTION
Another trial of [magic-nix](https://github.com/DeterminateSystems/magic-nix-cache-action) which uses the github internal cache as a binary cache for `nix`.

Magic nix does not offer out-of-the-box any public cache interaction and we would need to make this work together with [cachix](https://app.cachix.org/). In another exploration, @locallycompact encountered problems by having both enabled: https://github.com/DeterminateSystems/magic-nix-cache/issues/78 

However, before tackling this I wondered what the build time improvement would be. This PR contains commits and links to the findings:

- Plan: Getting a first single package built and rebuilt with both `magic-nix` or `cachix`.
- Magic-nix:
  - Using `accept-flake-config` to seed magic cache from cachix.
  - Rerun of `hydra-node` build with primed cache: https://github.com/cardano-scaling/hydra/actions/runs/10418269282/job/28854308115 -> build step only: `1m04s`, overall `2m49s` (still uploading)
  - Most time is spent on evaluating the derivation (IFD)
  - Post action uploads are rate limited - does a typical rebuild result in enough uploads?
  - Seems like magix-nix post action is re-uploading similar store paths on each rerun -> overall build time counts: `3m14s`
    Are our builds non-deterministic due to IFD?
  - Rebuild hydra-node (changed version number) with magic nix: https://github.com/cardano-scaling/hydra/actions/runs/10418479282 -> `4m45s` and no pushed paths pushed?
  - Rerun of the same action also resulted in a rebuild (indeed no paths were pushed) -> `4:19s`, also no paths pushed again
- Cachix:
  - Switching over to using `cachix-action` https://github.com/cardano-scaling/hydra/actions/runs/10419403396 -> rebuild of hydra-node in `4m47s`
  - Rerun of cachix build https://github.com/cardano-scaling/hydra/actions/runs/10419403396/job/28857732485 -> `1m28s`, `1m50s`
  - Dedicated rebuild of hydra-node with cachix https://github.com/cardano-scaling/hydra/actions/runs/10419717683/job/28858340501 -> `1m25s` (accidental cache hit)
  - Now with a proper, new version for rebuild with cachix: https://github.com/cardano-scaling/hydra/actions/runs/10420234054/job/28859845924 -> `5m04s`
  - Rerun after this https://github.com/cardano-scaling/hydra/actions/runs/10420234054/job/28860297642 -> `1m39s`
- Conclusion:
  - Magic nix is slightly faster in fetching (from github cache than download from cachix), but also spends more time in pushing paths after builds
  - Also saw some paths pushed too often, or not at all (e.g. the deliberate rebuild of `hydra-node` was never cached)
  - It does not provide public access to the cached derivations
  - Not worth it

This write-up is also available on the logbook: https://github.com/cardano-scaling/hydra/wiki/Logbook-2024-H1#2024-08-16

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
