### PR TITLE
Use the github revision to name binaries from PRs

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -41,7 +41,7 @@ jobs:
         # NOTE: For some reason the fetched tags on checkout are not effective
         # and we need to refetch with --force for git describe.
         git fetch --tags --force
-        echo "VERSION=$(git describe --always ${{ github.ref }})" >> "$GITHUB_ENV"
+        echo "VERSION=$(git describe --always HEAD)" | tee "$GITHUB_ENV"
 
     - name: ❄ Build static executables
       run: |
@@ -85,7 +85,7 @@ jobs:
         # NOTE: For some reason the fetched tags on checkout are not effective
         # and we need to refetch with --force for git describe.
         git fetch --tags --force
-        echo "VERSION=$(git describe --always ${{ github.ref }})" >> "$GITHUB_ENV"
+        echo "VERSION=$(git describe --always HEAD)" | tee "$GITHUB_ENV"
 
     - name: ❄ Build executables
       run: |


### PR DESCRIPTION
The binaries action was yielding an empty `VERSION` when built on `pull_request` triggers because how Github checks out pull requests. For example: https://github.com/cardano-scaling/hydra/actions/runs/10510022466/job/29121321565#step:5:29

This now uses `git describe HEAD` which should just work (tm) on both, branches, tags and PRs.

Before:
![image](https://github.com/user-attachments/assets/2f04ff72-6f2f-4ff7-9637-649905227dec)


After:
![image](https://github.com/user-attachments/assets/d69405ce-c24d-45de-872f-86dfa48783e4)


---

* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Haddocks updated not needed
* [x] No new TODOs introduced
