### PR TITLE
Update Algolia Search index

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -15,7 +15,7 @@ const editUrl = "https://github.com/cardano-scaling/hydra/tree/master/docs";
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: "Hydra Head protocol documentation",
-  url: "https://input-output-hk.github.io",
+  url: "https://hydra.family",
   baseUrl: "/head-protocol/",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -274,8 +274,8 @@ const config = {
         additionalLanguages: ["haskell"],
       },
       algolia: {
-        appId: "YZTAF8IOVB",
-        apiKey: "ad133fe3b0b40974c26853abc9cad2ab",
+        appId: "OF3CR7K89X",
+        apiKey: "09b2fc0200d06fb433a5f4ced7c9d427",
         indexName: "hydra-family",
         searchPagePath: "search",
         contextualSearch: true,


### PR DESCRIPTION
This is now using a different account and is fed by the docsearch crawler.

Plan on fixing #1556:
- [x] Create an account at algolia and invite at least one other from the team
- [x] Apply for docsearch x algolia https://docsearch.algolia.com/apply/
- [x] Await response and configure crawler
- [ ] Merge this PR
- [ ] Release website (either as a 0.18.2 or within 0.19.0)

---

* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Haddocks update not needed
* [x] No new TODOs introduced
