### PR TITLE
Use CI devShell (ensure right version of jq)

### DIFF
--- a/.github/workflows/network-test.yaml
+++ b/.github/workflows/network-test.yaml
@@ -41,6 +41,11 @@ jobs:
         name: cardano-scaling
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
+    - name: Set up and use the "ci" devShell
+      uses: nicknovitski/nix-develop@v1
+      with:
+        arguments: ".#ci"
+
     - name: Build docker images for netem specifically
       run: |
         nix build .#docker-hydra-node-for-netem

--- a/.github/workflows/network-test.yaml
+++ b/.github/workflows/network-test.yaml
@@ -119,14 +119,9 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: "docker-logs-netem-loss=${{ matrix.netem_loss }},scaling_factor=${{ matrix.scaling_factor }},peers=${{ matrix.peers }}"
-        path: demo/docker-logs
-        if-no-files-found: ignore
-
-    - name: 💾 Upload build & test artifacts
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: "benchmarks-netem-loss=${{ matrix.netem_loss }},scaling_factor=${{ matrix.scaling_factor }},peers=${{ matrix.peers }}"
-        path: benchmarks
+        name: "artifacts-netem-loss=${{ matrix.netem_loss }},scaling_factor=${{ matrix.scaling_factor }},peers=${{ matrix.peers }}"
+        path: |
+          demo/docker-logs
+          benchmarks
+          demo/devnet/protocol-parameters.json
         if-no-files-found: ignore

--- a/flake.nix
+++ b/flake.nix
@@ -168,7 +168,7 @@
           ]);
 
           devShells = import ./nix/hydra/shell.nix {
-            inherit inputs pkgs hsPkgs system compiler;
+            inherit inputs pkgs hsPkgs system compiler pkgsLatest;
           };
         };
     };

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -47,6 +47,8 @@ let
     pkgs.websocat
     pkgs.yarn
     pkgs.yq
+    # Use latest jq in all shells, to avoid 1.6 bug with large integers.
+    pkgsLatest.jq
   ];
 
   libs = [

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -7,6 +7,7 @@
 , system
 , pkgs
 , compiler
+, pkgsLatest
 }:
 let
 
@@ -131,6 +132,16 @@ let
     ];
   };
 
+  # Shell for CI activities
+  ciShell = pkgs.mkShell {
+    name = "hydra-ci-shell";
+    buildInputs = [
+      # Note: jq 1.6 has a bug that means it fails to read large integers
+      # correctly, so we require 1.7+ at least.
+      pkgsLatest.jq
+    ];
+  };
+
   # If you want to modify `Python` code add `libtmux` and pyyaml to the
   # `buildInputs` then enter it and then run `Python` module directly so you
   # have fast devel cycle.
@@ -145,4 +156,5 @@ in
   cabalOnly = cabalShell;
   exes = exeShell;
   demo = demoShell;
+  ci = ciShell;
 }


### PR DESCRIPTION
This is fix for a subtle bug brought up in #1338 ; namely, that version 1.6 of `jq` has a bug around integer handling:

```
> nix-shell -p jq -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/976fa3369d722e76f37c77493d99829540d43845.tar.gz
> jq -n '9223372036854775807'
9223372036854776000
```

jq 1.7+ doesn't have this issue. Unfortunately, `ubuntu-latest` ships with jq 1.6. So we need to use a special devShell.

Happily, [there is this nice GitHub action](https://github.com/marketplace/actions/nix-develop-action), which makes it easy!

So, we introduce a devShell with the right version of jq, and run our CI steps there.

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
