### PR TITLE
Build the docs with the ci devShell

### DIFF
--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -299,6 +299,20 @@ jobs:
         # Ensure we have all history with all commits
         fetch-depth: 0
 
+    - name: ❄ Prepare nix
+      uses: cachix/install-nix-action@V27
+      with:
+        extra_nix_config: |
+          accept-flake-config = true
+          log-lines = 1000
+
+    - name: Set up and use the "ci" devShell
+      uses: nicknovitski/nix-develop@v1
+      with:
+        arguments: ".#ci"
+
+    # Technically, we don't need this, given we're in a Nix shell;
+    # but we will keep it for the caching.
     - name: 🚧 Setup Node.js
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -24,6 +24,11 @@ jobs:
         # Also ensure we have all history with all tags
         fetch-depth: 0
 
+    - name: Set up and use the "ci" devShell
+      uses: nicknovitski/nix-develop@v1
+      with:
+        arguments: ".#ci"
+
     - name: Get released workflow run id
       id: released-workflow
       uses: actions/github-script@v7

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -138,6 +138,8 @@ let
   ciShell = pkgs.mkShell {
     name = "hydra-ci-shell";
     buildInputs = [
+      # For building docs
+      pkgs.plantuml
       # Note: jq 1.6 has a bug that means it fails to read large integers
       # correctly, so we require 1.7+ at least.
       pkgsLatest.jq


### PR DESCRIPTION
I've noticed that we cannot find the plantuml executable when doc-building in CI; this fixes that.

Here's an example of that error - https://github.com/cardano-scaling/hydra/actions/runs/10720480533/job/29727305271#step:9:101

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
