### PR TITLE
Add PlutusScriptV3 as an allowed property to pass validation

### DIFF
--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -2021,6 +2021,7 @@ components:
                 - SimpleScript
                 - PlutusScriptV1
                 - PlutusScriptV2
+                - PlutusScriptV3
       example:
         {
           "script": {


### PR DESCRIPTION
Adds `PlutusScriptV3` as an allowed `Script` kind.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
