### PR TITLE
Have the network-tests run on master, and fix bug in inputs read incorrectly

### DIFF
--- a/.github/workflows/network-test.yaml
+++ b/.github/workflows/network-test.yaml
@@ -1,6 +1,10 @@
 name: "Network fault tolerance"
 
 on:
+  push:
+    branches:
+    - master
+    - release
   pull_request:
   workflow_dispatch:
     inputs:
@@ -77,7 +81,7 @@ jobs:
     #
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
-      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
       with:
         limit-access-to-actor: true
 


### PR DESCRIPTION
Github, apparently, presently treats `github.event.inputs` and `inputs` differently:
<https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#providing-inputs>

In particular, `inputs` respects the types that you declare; `github.event.inputs` does not, when it is a Boolean.
