### PR TITLE
Update networking page

### DIFF
--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -316,7 +316,7 @@ jobs:
     - name: 🚧 Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 16
+        node-version: 18
         cache: 'yarn'
         cache-dependency-path: docs/yarn.lock
 


### PR DESCRIPTION
This is a short writeup of the findings; added to the "networking" page as an investigation.

I think a broader re-write of the page is in order, but can come separately, as it's a bit more work to document all the existing knowledge and implementation details.

~~Note also that I took the liberty to update the version of Docusaurus.~~ Edit: Nope, not doing this now, as it requires too many changes.

~~Locally, it gives only some additional warnings; nothing errors and it seems to render the same. The main reason for this change is that the new Docusaurus version has a more up-to-date mermaidjs implementation that allows for nicer diagrams, such as this one, a `block-beta` style:~~

```mermaid
block-beta
    columns 3
    space alice space
    space:3
    bob space carol
    
    alice --> bob
    bob   --> alice

    carol --> alice
    alice --> carol
    
    bob --> carol
    carol --> bob
```

~~Compare that to the exact same diagram in a normal mermaid "graph":~~

```mermaid
graph
    alice --> bob
    bob   --> alice

    carol --> alice
    alice --> carol
    
    bob --> carol
    carol --> bob
```
