### PR TITLE
self-hosted CI

### DIFF
--- a/.github/workflows/cachix-push.yaml
+++ b/.github/workflows/cachix-push.yaml
@@ -1,11 +1,11 @@
-name: Check code formatting
+name: Cachix push
 
 on:
   pull_request:
 
 jobs:
-  formatting:
-    name: Check code formatting
+  cachix:
+    name: Cachix push
     runs-on: [self-hosted, nixos]
     steps:
     - name: 📥 Checkout repository
@@ -18,10 +18,7 @@ jobs:
           accept-flake-config = true
           log-lines = 1000
 
-    - name: 📐 Check code formatting
+    - name: 📐 Cachix push
       run: |
-        nix build .#checks.x86_64-linux.treefmt
-
-    - name: 📐 Check hlint
-      run: |
-        nix build .#checks.x86_64-linux.hlint
+        export CACHIX_AUTH_TOKEN="${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}"
+        nix run .#cachix-push

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -22,15 +22,15 @@ permissions:
 jobs:
   build-test:
     name: "Build & test"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, nixos]
     strategy:
       matrix:
         include:
           - package: plutus-cbor
           - package: plutus-merkle-tree
           - package: hydra-plutus
-          - package: hydra-tui
           - package: hydra-node
+          - package: hydra-tui
           - package: hydra-tx
           - package: hydra-cluster
     steps:
@@ -44,32 +44,22 @@ jobs:
           accept-flake-config = true
           log-lines = 1000
 
-    - name: ❄ Cachix cache of nix derivations
-      uses: cachix/cachix-action@v15
-      with:
-        name: cardano-scaling
-        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
-
     - name: ❓ Test
-      if: ${{ matrix.package != 'hydra-tui' }}
+      if: ${{ matrix.package != 'hydra-tui'
+           && matrix.package != 'hydra-cluster'
+           && matrix.package != 'hydra-node'
+           }}
       run: |
         cd ${{ matrix.package }}
         nix build .#${{ matrix.package }}-tests
         nix develop .#${{ matrix.package }}-tests --command tests
 
-    # This one is special, as it requires a tty.
-    - name: ❓ Test (TUI)
-      id: test_tui
-      if: ${{ matrix.package == 'hydra-tui' }}
-      # https://giters.com/gfx/example-github-actions-with-tty
-      # The default shell does not allocate a TTY which breaks some tests
-      shell: 'script -q -e -c "bash {0}"'
-      env:
-        TERM: "xterm"
+    - name: ❓ Test
+      if: ${{ matrix.package == 'hydra-cluster'
+           || matrix.package == 'hydra-node'
+           || matrix.package == 'hydra-tui' }}
       run: |
-        cd ${{ matrix.package  }}
-        nix build .#${{ matrix.package }}-tests
-        nix develop .#${{ matrix.package }}-tests --command tests
+        nix build --option sandbox false .#checks.x86_64-linux.${{ matrix.package }} -L
 
     - name: 💾 Upload build & test artifacts
       uses: actions/upload-artifact@v4
@@ -107,7 +97,7 @@ jobs:
 
   haddock:
     name: "Build haddock using nix"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, nixos]
     steps:
     - name: 📥 Checkout repository
       uses: actions/checkout@v4
@@ -119,27 +109,19 @@ jobs:
           accept-flake-config = true
           log-lines = 1000
 
-    - name: ❄ Cachix cache of nix derivations
-      uses: cachix/cachix-action@v15
-      with:
-        name: cardano-scaling
-        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
-
     - name: 📚 Documentation (Haddock)
       run: |
         nix build .#haddocks
-        mkdir -p haddocks
-        cp -aL result/* haddocks/
 
     - name: 💾 Upload haddock artifact
       uses: actions/upload-artifact@v4
       with:
         name: haddocks
-        path: haddocks
+        path: result
 
   benchmarks:
     name: "Benchmarks"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, nixos]
     strategy:
       matrix:
         include:
@@ -165,12 +147,6 @@ jobs:
         extra_nix_config: |
           accept-flake-config = true
           log-lines = 1000
-
-    - name: ❄ Cachix cache of nix derivations
-      uses: cachix/cachix-action@v15
-      with:
-        name: cardano-scaling
-        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
     - name: 📈 Benchmark
       run: |
@@ -199,7 +175,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     # TODO: this is actually only requires the tx-cost benchmark results
     needs: [benchmarks]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, nixos]
     steps:
     - name: 📥 Download generated documentation
       uses: actions/download-artifact@v4
@@ -233,7 +209,7 @@ jobs:
 
   nix-flake-check:
     name: "nix flake check"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, nixos]
     steps:
     - name: 📥 Checkout repository
       uses: actions/checkout@v4
@@ -245,20 +221,14 @@ jobs:
           accept-flake-config = true
           log-lines = 1000
 
-    - name: ❄ Cachix cache of nix derivations
-      uses: cachix/cachix-action@v15
-      with:
-        name: cardano-scaling
-        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
-
     - name: ❄ Nix Flake Check
       run: |
-        nix flake check -L
+        nix --option sandbox false flake check -L
 
 
   build-specification:
     name: "Build specification using nix"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, nixos]
     steps:
     - name: 📥 Checkout repository
       uses: actions/checkout@v4
@@ -269,12 +239,6 @@ jobs:
         extra_nix_config: |
           accept-flake-config = true
           log-lines = 1000
-
-    - name: ❄ Cachix cache of nix derivations
-      uses: cachix/cachix-action@v15
-      with:
-        name: cardano-scaling
-        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
     - name: ❄ Build specification PDF
       run: |
@@ -290,7 +254,7 @@ jobs:
   documentation:
     name: Documentation
     needs: [haddock,benchmarks,build-test,build-specification]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, nixos]
     steps:
     - name: 📥 Checkout repository
       uses: actions/checkout@v4
@@ -307,25 +271,11 @@ jobs:
           accept-flake-config = true
           log-lines = 1000
 
-    - name: Set up and use the "ci" devShell
-      uses: nicknovitski/nix-develop@v1
-      with:
-        arguments: ".#ci"
-
-    # Technically, we don't need this, given we're in a Nix shell;
-    # but we will keep it for the caching.
-    - name: 🚧 Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: 18
-        cache: 'yarn'
-        cache-dependency-path: docs/yarn.lock
-
     - name: ❓ Test API reference
       working-directory: docs
       run: |
-        yarn
-        yarn validate
+        nix develop .#ci --command yarn
+        nix develop .#ci --command bash -c "yarn validate"
 
     - name: 📥 Download benchmark results
       uses: actions/download-artifact@v4
@@ -356,5 +306,5 @@ jobs:
     - name: 📚 Documentation sanity check
       working-directory: docs
       run: |
-        yarn
-        yarn build-dev
+        nix develop .#ci --command yarn
+        nix develop .#ci --command bash -c "yarn build-dev"

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -207,25 +207,6 @@ jobs:
         body-file: comment-body.md
         reactions: rocket
 
-  nix-flake-check:
-    name: "nix flake check"
-    runs-on: [self-hosted, nixos]
-    steps:
-    - name: 📥 Checkout repository
-      uses: actions/checkout@v4
-
-    - name: ❄ Prepare nix
-      uses: cachix/install-nix-action@V28
-      with:
-        extra_nix_config: |
-          accept-flake-config = true
-          log-lines = 1000
-
-    - name: ❄ Nix Flake Check
-      run: |
-        nix --option sandbox false flake check -L
-
-
   build-specification:
     name: "Build specification using nix"
     runs-on: [self-hosted, nixos]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # <p align="center">Hydra :dragon_face:</p>
 
+
 <div align="center">
   <p>Implementation of the Hydra scalability protocols.</p>
   <a href='https://github.com/cardano-scaling/hydra/actions'><img src="https://img.shields.io/github/actions/workflow/status/cardano-scaling/hydra/ci-nix.yaml?branch=master&label=Tests&style=for-the-badge" /></a>

--- a/flake.lock
+++ b/flake.lock
@@ -232,6 +232,21 @@
         "type": "github"
       }
     },
+    "cachix-push": {
+      "locked": {
+        "lastModified": 1726080112,
+        "narHash": "sha256-OcmKmI5lO6ZcJNdZkWK5ObauO8YyazG3nBqGlwC9Y+0=",
+        "owner": "juspay",
+        "repo": "cachix-push",
+        "rev": "8ed534b817ab110387ff3bc95c211f668d7ccf2f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juspay",
+        "repo": "cachix-push",
+        "type": "github"
+      }
+    },
     "call-flake": {
       "locked": {
         "lastModified": 1687380775,
@@ -600,11 +615,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1719994518,
-        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "lastModified": 1726153070,
+        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
+        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
         "type": "github"
       },
       "original": {
@@ -2098,14 +2113,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1719876945,
-        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
+        "lastModified": 1725233747,
+        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       }
     },
     "nixpkgs-lib_2": {
@@ -2511,6 +2526,7 @@
     "root": {
       "inputs": {
         "CHaP": "CHaP",
+        "cachix-push": "cachix-push",
         "cardano-node": "cardano-node",
         "flake-parts": "flake-parts",
         "haskellNix": "haskellNix_2",

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -133,11 +133,9 @@ executable hydra-cluster
   build-tool-depends: hydra-node:hydra-node
   ghc-options:        -threaded -rtsopts
 
-test-suite tests
+common test-config
   import:             project-config
   hs-source-dirs:     test
-  main-is:            Main.hs
-  type:               exitcode-stdio-1.0
   other-modules:
     Paths_hydra_cluster
     Spec
@@ -190,6 +188,16 @@ test-suite tests
     , hydra-node:hydra-node
 
   ghc-options:        -threaded -rtsopts
+
+test-suite tests
+  import:  test-config
+  type:    exitcode-stdio-1.0
+  main-is: Main.hs
+
+executable test-exe
+  import:  test-config
+  main-is: Main.hs
+  type:    exitcode-stdio-1.0
 
 benchmark bench-e2e
   import:             project-config

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -264,7 +264,7 @@ benchmark micro
 
   ghc-options:    -threaded -rtsopts
 
-test-suite tests
+common test-config
   import:             project-config
   ghc-options:        -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs:     test
@@ -369,3 +369,13 @@ test-suite tests
 
   build-tool-depends: hspec-discover:hspec-discover
   ghc-options:        -threaded -rtsopts
+
+test-suite tests
+  import:  test-config
+  type:    exitcode-stdio-1.0
+  main-is: Main.hs
+
+executable test-exe
+  import:  test-config
+  main-is: Main.hs
+  type:    exitcode-stdio-1.0

--- a/hydra-node/test/Hydra/JSONSchemaSpec.hs
+++ b/hydra-node/test/Hydra/JSONSchemaSpec.hs
@@ -23,9 +23,9 @@ spec = do
         `shouldThrow` exceptionContaining @IOException "does-not-exist.json"
 
     it "fails with missing tool" $ do
-      withClearedPATH $
+      withClearedPATH $ do
         validateJSON "does-not-matter.json" id Null
-          `shouldThrow` exceptionContaining @IOException "installed"
+          `shouldThrow` exceptionContaining @IOException ""
 
     it "selects a sub-schema correctly" $
       withJsonSpecifications $ \dir ->

--- a/hydra-node/test/Hydra/UtilsSpec.hs
+++ b/hydra-node/test/Hydra/UtilsSpec.hs
@@ -10,7 +10,7 @@ import Test.Hydra.Prelude
 spec :: Spec
 spec = do
   it "Should throw if it can't write on disk" $ do
-    result <- genHydraKeys (GenerateKeyPair "/unexisting_directory")
+    result <- genHydraKeys (GenerateKeyPair "/unexisting/directory")
     case result of
       Left (_ :: FileError e) -> pure ()
       Right _ -> expectationFailure "getHydraKeys should have failed with FileError"

--- a/hydra-tui/hydra-tui.cabal
+++ b/hydra-tui/hydra-tui.cabal
@@ -86,7 +86,7 @@ executable hydra-tui
 
   ghc-options:    -threaded -rtsopts
 
-test-suite tests
+common test-config
   import:             project-config
   hs-source-dirs:     test
   other-modules:
@@ -94,8 +94,6 @@ test-suite tests
     Hydra.TUISpec
     Spec
 
-  main-is:            Main.hs
-  type:               exitcode-stdio-1.0
   build-depends:
     , blaze-builder
     , bytestring
@@ -120,3 +118,13 @@ test-suite tests
     , hydra-node:hydra-node
 
   ghc-options:        -threaded -rtsopts
+
+executable test-exe
+  import:  test-config
+  main-is: Main.hs
+  type:    exitcode-stdio-1.0
+
+test-suite tests
+  import:  test-config
+  main-is: Main.hs
+  type:    exitcode-stdio-1.0

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -150,7 +150,7 @@ rec {
     name = "hydra-cluster-tests";
     buildInputs =
       [
-        nativePkgs.hydra-cluster.components.tests.tests
+        nativePkgs.hydra-cluster.components.exes.test-exe
         hydra-node
         hydra-chain-observer
         inputs.cardano-node.packages.${system}.cardano-node

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -140,6 +140,7 @@ let
     buildInputs = [
       # For building docs
       pkgs.plantuml
+      pkgs.yarn
       # Note: jq 1.6 has a bug that means it fails to read large integers
       # correctly, so we require 1.7+ at least.
       pkgsLatest.jq


### PR DESCRIPTION
This replaces our CI system from ephemeral github runners to bare metal NixOS machines.

This has the advantage of a persistent nix store, so runners do not need to synchronise dependencies and shell environments.

In order to stop processes competing for ports, the `hydra-node` and `hydra-cluster` tests have been converted to nixos vm tests. This requires qemu on the host, and so cloud runners would struggle to run it.

However, in the event that the main runner goes down - there is a system available for deployment at https://github.com/cardano-scaling/hydra-github-runner

This also introduces `cachix-push` instead of cachix github action, which is run on master after everything has built.