### PR TITLE
Max parallel jobs = 2. Slower, but more runner freedom.

### DIFF
--- a/.github/workflows/network-test.yaml
+++ b/.github/workflows/network-test.yaml
@@ -18,6 +18,10 @@ jobs:
   network-test:
     runs-on: ubuntu-latest
     strategy:
+      # Hack: Minimise concurrency as this is blocking our GitHub runners.
+      # This can be removed when the matrix mode itself is removed and the
+      # network testing is done in pure Haskell.
+      max-parallel: 2
       matrix:
         # Note: At present we can only run for 3 peers; to configure this for
         # more we need to make the docker-compose spin-up dynamic across


### PR DESCRIPTION
Hack to avoid using all our runners on these tasks.