### PR TITLE
No binaries on PRs; to reduce PR CI times

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -8,7 +8,6 @@ on:
     - release
     tags:
     - "*.*.*"
-  pull_request:
 
 jobs:
   # Produces static ELF binary for using MuslC which includes all needed


### PR DESCRIPTION
It takes a while to build them, and I suspect no-one is really using them. After all, if you've been able to submit a PR, you can almost certainly build the binaries yourself!