### PR TITLE
Network interface: reliable broadcast semantics

### DIFF
--- a/hydra-node/src/Hydra/Network/Reliability.hs
+++ b/hydra-node/src/Hydra/Network/Reliability.hs
@@ -107,7 +107,7 @@ import Data.Vector (
   (!?),
  )
 import Hydra.Logging (traceWith)
-import Hydra.Network (Network (..), NetworkComponent)
+import Hydra.Network (Network (..), NetworkCallback (..), NetworkComponent)
 import Hydra.Network.Authenticate (Authenticated (..))
 import Hydra.Network.Heartbeat (Heartbeat (..), isPing)
 import Hydra.Persistence (Persistence (..), PersistenceIncremental (..))
@@ -231,7 +231,10 @@ withReliability tracer MessagePersistence{saveAcks, loadAcks, appendMessage, loa
     withAsync (forever $ atomically (readTQueue resendQ) >>= broadcast) $ \_ ->
       reliableBroadcast sentMessages ourIndex acksCache network
  where
+  NetworkCallback{deliver} = callback
+
   allParties = fromList $ sort $ me : otherParties
+
   reliableBroadcast sentMessages ourIndex acksCache Network{broadcast} =
     action $
       Network
@@ -259,46 +262,47 @@ withReliability tracer MessagePersistence{saveAcks, loadAcks, appendMessage, loa
     cacheMessage msg =
       modifyTVar' sentMessages (|> msg)
 
-  reliableCallback acksCache sentMessages resend ourIndex (Authenticated (ReliableMsg acknowledged payload) party) = do
-    if length acknowledged /= length allParties
-      then
-        traceWith
-          tracer
-          ReceivedMalformedAcks
-            { fromParty = party
-            , partyAcks = acknowledged
-            , numberOfParties = length allParties
-            }
-      else do
-        eShouldCallbackWithKnownAcks <- atomically $ runMaybeT $ do
-          loadedAcks <- lift $ readTVar acksCache
-          partyIndex <- hoistMaybe $ findPartyIndex party
-          messageAckForParty <- hoistMaybe (acknowledged !? partyIndex)
-          knownAckForParty <- hoistMaybe $ loadedAcks !? partyIndex
-          if
-            | isPing payload ->
-                -- we do not update indices on Pings but we do propagate them
-                return (True, partyIndex, loadedAcks)
-            | messageAckForParty == knownAckForParty + 1 -> do
-                -- we update indices for next in line messages and propagate them
-                let newAcks = constructAcks loadedAcks partyIndex
-                lift $ writeTVar acksCache newAcks
-                return (True, partyIndex, newAcks)
-            | otherwise ->
-                -- other messages are dropped
-                return (False, partyIndex, loadedAcks)
+  reliableCallback acksCache sentMessages resend ourIndex =
+    NetworkCallback $ \(Authenticated (ReliableMsg acknowledged payload) party) -> do
+      if length acknowledged /= length allParties
+        then
+          traceWith
+            tracer
+            ReceivedMalformedAcks
+              { fromParty = party
+              , partyAcks = acknowledged
+              , numberOfParties = length allParties
+              }
+        else do
+          eShouldCallbackWithKnownAcks <- atomically $ runMaybeT $ do
+            loadedAcks <- lift $ readTVar acksCache
+            partyIndex <- hoistMaybe $ findPartyIndex party
+            messageAckForParty <- hoistMaybe (acknowledged !? partyIndex)
+            knownAckForParty <- hoistMaybe $ loadedAcks !? partyIndex
+            if
+              | isPing payload ->
+                  -- we do not update indices on Pings but we do propagate them
+                  return (True, partyIndex, loadedAcks)
+              | messageAckForParty == knownAckForParty + 1 -> do
+                  -- we update indices for next in line messages and propagate them
+                  let newAcks = constructAcks loadedAcks partyIndex
+                  lift $ writeTVar acksCache newAcks
+                  return (True, partyIndex, newAcks)
+              | otherwise ->
+                  -- other messages are dropped
+                  return (False, partyIndex, loadedAcks)
 
-        case eShouldCallbackWithKnownAcks of
-          Just (shouldCallback, theirIndex, localCounter) -> do
-            if shouldCallback
-              then do
-                callback Authenticated{payload, party}
-                traceWith tracer Received{acknowledged, localCounter, theirIndex, ourIndex}
-              else traceWith tracer Ignored{acknowledged, localCounter, theirIndex, ourIndex}
+          case eShouldCallbackWithKnownAcks of
+            Just (shouldCallback, theirIndex, localCounter) -> do
+              if shouldCallback
+                then do
+                  deliver Authenticated{payload, party}
+                  traceWith tracer Received{acknowledged, localCounter, theirIndex, ourIndex}
+                else traceWith tracer Ignored{acknowledged, localCounter, theirIndex, ourIndex}
 
-            when (isPing payload) $
-              resendMessagesIfLagging sentMessages resend theirIndex localCounter acknowledged ourIndex
-          Nothing -> pure ()
+              when (isPing payload) $
+                resendMessagesIfLagging sentMessages resend theirIndex localCounter acknowledged ourIndex
+            Nothing -> pure ()
 
   constructAcks acks wantedIndex =
     zipWith (\ack i -> if i == wantedIndex then ack + 1 else ack) acks partyIndexes

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -46,7 +46,7 @@ import Hydra.HeadLogic.Outcome (StateChanged (..))
 import Hydra.HeadLogic.State (getHeadParameters)
 import Hydra.Ledger (Ledger)
 import Hydra.Logging (Tracer, traceWith)
-import Hydra.Network (Network (..))
+import Hydra.Network (Network (..), NetworkCallback (..))
 import Hydra.Network.Message (Message, NetworkEvent (..))
 import Hydra.Node.InputQueue (InputQueue (..), Queued (..), createInputQueue)
 import Hydra.Node.ParameterMismatch (ParamMismatch (..), ParameterMismatch (..))
@@ -200,8 +200,9 @@ wireClientInput node = enqueue . ClientInput
  where
   DraftHydraNode{inputQueue = InputQueue{enqueue}} = node
 
-wireNetworkInput :: DraftHydraNode tx m -> NetworkEvent (Message tx) -> m ()
-wireNetworkInput node = enqueue . NetworkInput defaultTTL
+wireNetworkInput :: DraftHydraNode tx m -> NetworkCallback (NetworkEvent (Message tx)) m
+wireNetworkInput node =
+  NetworkCallback{deliver = enqueue . NetworkInput defaultTTL}
  where
   DraftHydraNode{inputQueue = InputQueue{enqueue}} = node
 

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -329,10 +329,7 @@ processEffects node tracer inputId effects = do
     traceWith tracer $ BeginEffect party inputId effectId effect
     case effect of
       ClientEffect i -> sendOutput server i
-      NetworkEffect msg -> do
-        broadcast hn msg
-        -- FIXME: This must not be here, such that the network layer can ensure correct delivery (i.e. reliable broadcast)
-        enqueue (NetworkInput defaultTTL (ReceivedMessage{sender = party, msg}))
+      NetworkEffect msg -> broadcast hn msg
       OnChainEffect{postChainTx} ->
         postTx postChainTx
           `catch` \(postTxError :: PostTxError tx) ->

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -826,8 +826,7 @@ createMockNetwork node nodes =
  where
   broadcast msg = do
     allNodes <- readTVarIO nodes
-    let otherNodes = filter (\n -> getParty n /= getParty node) allNodes
-    mapM_ (`handleMessage` msg) otherNodes
+    mapM_ (`handleMessage` msg) allNodes
 
   handleMessage HydraNode{inputQueue} msg =
     enqueue inputQueue . NetworkInput defaultTTL $ ReceivedMessage{sender, msg}

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -361,8 +361,7 @@ createMockNetwork draftNode nodes =
  where
   broadcast msg = do
     allNodes <- fmap node <$> readTVarIO nodes
-    let otherNodes = filter (\n -> getParty n /= getParty draftNode) allNodes
-    mapM_ (`handleMessage` msg) otherNodes
+    mapM_ (`handleMessage` msg) allNodes
 
   handleMessage HydraNode{inputQueue} msg =
     enqueue inputQueue . NetworkInput defaultTTL $ ReceivedMessage{sender, msg}

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -11,7 +11,7 @@ import Codec.CBOR.Write (toLazyByteString)
 import Control.Concurrent.Class.MonadSTM (modifyTVar', newTQueue, newTVarIO, readTQueue, readTVarIO, writeTQueue)
 import Hydra.Ledger.Simple (SimpleTx (..))
 import Hydra.Logging (nullTracer, showLogsOnFailure)
-import Hydra.Network (Host (..), Network)
+import Hydra.Network (Host (..), Network, NetworkCallback (..))
 import Hydra.Network.Message (
   HydraHandshakeRefused (..),
   HydraVersionedProtocolNumber (..),
@@ -36,6 +36,7 @@ spec = do
   describe "Ouroboros Network" $ do
     it "broadcasts messages to single connected peer" $ do
       received <- atomically newTQueue
+      let recordReceived = NetworkCallback{deliver = atomically . writeTQueue received}
       showLogsOnFailure "NetworkSpec" $ \tracer -> failAfter 30 $ do
         [port1, port2] <- fmap fromIntegral <$> randomUnusedTCPPorts 2
         let node1Config =
@@ -50,13 +51,14 @@ spec = do
                 , localHost = Host lo port2
                 , remoteHosts = [Host lo port1]
                 }
-        withOuroborosNetwork tracer node1Config (const $ pure ()) (const @_ @Integer $ pure ()) $ \hn1 ->
-          withOuroborosNetwork @Integer tracer node2Config (const $ pure ()) (atomically . writeTQueue received) $ \_ -> do
+        withOuroborosNetwork @Integer tracer node1Config (const $ pure ()) mockCallback $ \hn1 ->
+          withOuroborosNetwork @Integer tracer node2Config (const $ pure ()) recordReceived $ \_ -> do
             withNodeBroadcastingForever hn1 1 $
               atomically (readTQueue received) `shouldReturn` 1
 
     it "handshake failures should call the handshakeCallback" $ do
       received <- atomically newTQueue
+      let recordReceived = NetworkCallback{deliver = atomically . writeTQueue received}
       showLogsOnFailure "NetworkSpec" $ \tracer -> failAfter 30 $ do
         [port1, port2] <- fmap fromIntegral <$> randomUnusedTCPPorts 2
         let node1Config =
@@ -81,8 +83,8 @@ spec = do
         (handshakeCallback1, getHandshakeFailures1) <- createHandshakeCallback
         (handshakeCallback2, getHandshakeFailures2) <- createHandshakeCallback
 
-        withOuroborosNetwork @Integer @() tracer node1Config handshakeCallback1 (const @_ @Integer $ pure ()) $ \_ ->
-          withOuroborosNetwork @Integer tracer node2Config handshakeCallback2 (atomically . writeTQueue received) $ \_ -> do
+        withOuroborosNetwork @Integer @() tracer node1Config handshakeCallback1 mockCallback $ \_ ->
+          withOuroborosNetwork @Integer tracer node2Config handshakeCallback2 recordReceived $ \_ -> do
             threadDelay 0.1
             getHandshakeFailures1 `shouldReturn` [Host lo port2]
             getHandshakeFailures2 `shouldReturn` [Host lo port1]
@@ -91,6 +93,7 @@ spec = do
       node1received <- atomically newTQueue
       node2received <- atomically newTQueue
       node3received <- atomically newTQueue
+      let recordReceivedIn tq = NetworkCallback{deliver = atomically . writeTQueue tq}
       showLogsOnFailure "NetworkSpec" $ \tracer -> failAfter 30 $ do
         [port1, port2, port3] <- fmap fromIntegral <$> randomUnusedTCPPorts 3
         let node1Config =
@@ -111,9 +114,9 @@ spec = do
                 , localHost = Host lo port3
                 , remoteHosts = [Host lo port2, Host lo port1]
                 }
-        withOuroborosNetwork @Integer tracer node1Config (const $ pure ()) (atomically . writeTQueue node1received) $ \hn1 ->
-          withOuroborosNetwork tracer node2Config (const $ pure ()) (atomically . writeTQueue node2received) $ \hn2 -> do
-            withOuroborosNetwork tracer node3Config (const $ pure ()) (atomically . writeTQueue node3received) $ \hn3 -> do
+        withOuroborosNetwork @Integer tracer node1Config (const $ pure ()) (recordReceivedIn node1received) $ \hn1 ->
+          withOuroborosNetwork tracer node2Config (const $ pure ()) (recordReceivedIn node2received) $ \hn2 -> do
+            withOuroborosNetwork tracer node3Config (const $ pure ()) (recordReceivedIn node3received) $ \hn3 -> do
               withNodesBroadcastingForever [(hn1, 1), (hn2, 2), (hn3, 3)] $
                 assertAllnodesReceivedMessagesFromAllOtherNodes [(node1received, 1), (node2received, 2), (node3received, 3)]
 
@@ -157,3 +160,6 @@ prop_canRoundtripCBOREncoding ::
 prop_canRoundtripCBOREncoding a =
   let encoded = toLazyByteString $ toCBOR a
    in (snd <$> deserialiseFromBytes fromCBOR encoded) === Right a
+
+mockCallback :: Applicative m => NetworkCallback msg m
+mockCallback = NetworkCallback{deliver = \_ -> pure ()}

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -57,8 +57,6 @@ spec = do
               atomically (readTQueue received) `shouldReturn` 1
 
     it "handshake failures should call the handshakeCallback" $ do
-      received <- atomically newTQueue
-      let recordReceived = NetworkCallback{deliver = atomically . writeTQueue received}
       showLogsOnFailure "NetworkSpec" $ \tracer -> failAfter 30 $ do
         [port1, port2] <- fmap fromIntegral <$> randomUnusedTCPPorts 2
         let node1Config =
@@ -83,8 +81,8 @@ spec = do
         (handshakeCallback1, getHandshakeFailures1) <- createHandshakeCallback
         (handshakeCallback2, getHandshakeFailures2) <- createHandshakeCallback
 
-        withOuroborosNetwork @Integer @() tracer node1Config handshakeCallback1 mockCallback $ \_ ->
-          withOuroborosNetwork @Integer tracer node2Config handshakeCallback2 recordReceived $ \_ -> do
+        withOuroborosNetwork @Int @Int tracer node1Config handshakeCallback1 mockCallback $ \_ ->
+          withOuroborosNetwork @Int tracer node2Config handshakeCallback2 mockCallback $ \_ -> do
             threadDelay 0.1
             getHandshakeFailures1 `shouldReturn` [Host lo port2]
             getHandshakeFailures2 `shouldReturn` [Host lo port1]


### PR DESCRIPTION
Changes the `broadcast` semantics to send a message to everyone on the Hydra network, *including* ourselves.

Makes `NetworkCallback` a `newtype` and names the function `deliver`. This makes it consistent with literature and we can reason about the properties of certain `NetworkComponent` implementations. For example: We could require each `NetworkComponent` to bet "valid":

> Validity: If a correct process broadcasts a message m, then every correct
process eventually delivers m

This PR however, just moves the delivery to ourselves from the `Node` to the aggregate `Hydra.Node.Network` stack.

From the outside, the node behaves exactly as before.

---

* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Haddocks updated
* [x] No new TODOs introduced
