### PR TITLE
Update cardano-node to 9.1.1

### DIFF
--- a/.github/workflows/explorer/docker-compose.yaml
+++ b/.github/workflows/explorer/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   cardano-node:
-    image: ghcr.io/intersectmbo/cardano-node:9.1.0
+    image: ghcr.io/intersectmbo/cardano-node:9.1.1
     volumes:
       - /srv/var/cardano/state-preview:/data
     environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ changes.
 
 ## [0.19.0] - UNRELEASED
 
+- Tested with `cardano-node 9.1.1` and `cardano-cli 9.2.1.0`
+
 - Switch L2 ledger to use the `Conway` era. [#1178](https://github.com/cardano-scaling/hydra/issues/1178)
   - Conway formatted transactions can be submitted to the `hydra-node`, while past eras are still supported (except deprecated features like protocol updates).
   - This includes support for `PlutusV3` scripts, but most of the governance-related features have no meaning in the Hydra L2.

--- a/demo/docker-compose.yaml
+++ b/demo/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   cardano-node:
-    image: ghcr.io/intersectmbo/cardano-node:9.1.0
+    image: ghcr.io/intersectmbo/cardano-node:9.1.1
     volumes:
       - ./devnet:/devnet
     environment:

--- a/docs/docs/tutorial/index.md
+++ b/docs/docs/tutorial/index.md
@@ -32,8 +32,8 @@ After ensuring the tools above are available, begin by downloading pre-built bin
 ```shell
 mkdir -p bin
 hydra_version=0.18.1
-mithril_version=2428.0
-cardano_node_version=9.1.0
+mithril_version=2430.0
+cardano_node_version=9.1.1
 curl -L -O https://github.com/cardano-scaling/hydra/releases/download/${hydra_version}/hydra-x86_64-linux-${hydra_version}.zip
 unzip -d bin hydra-x86_64-linux-${hydra_version}.zip
 curl -L -O https://github.com/IntersectMBO/cardano-node/releases/download/${cardano_node_version}/cardano-node-${cardano_node_version}-linux.tar.gz
@@ -50,8 +50,8 @@ chmod +x bin/*
 ```shell
 mkdir -p bin
 hydra_version=0.18.1
-mithril_version=2428.0
-cardano_node_version=9.1.0
+mithril_version=2430.0
+cardano_node_version=9.1.1
 curl -L -O https://github.com/cardano-scaling/hydra/releases/download/${hydra_version}/hydra-aarch64-darwin-${hydra_version}.zip
 unzip -d bin hydra-aarch64-darwin-${hydra_version}.zip
 curl -L -O https://github.com/IntersectMBO/cardano-node/releases/download/${cardano_node_version}/cardano-node-${cardano_node_version}-macos.tar.gz

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     "CHaP_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1721831314,
-        "narHash": "sha256-I1j5HPSbbh3l1D0C9oP/59YB4e+64K9NDRl7ueD1c/Y=",
+        "lastModified": 1725170790,
+        "narHash": "sha256-dByd5I847MxV5i9kps89yL1OAvi7iDyC95BU7EM2wtw=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "8815ee7598bc39a02db8896b788f69accf892790",
+        "rev": "3bed5fccc06ecc11d4a8427112f107876263e0f3",
         "type": "github"
       },
       "original": {
@@ -320,16 +320,16 @@
         "utils": "utils_2"
       },
       "locked": {
-        "lastModified": 1721843629,
-        "narHash": "sha256-F5wgRA820x16f+8c/LlEEBG0rMJIA1XWw6X0ZwX5UWs=",
+        "lastModified": 1725255033,
+        "narHash": "sha256-VIwEjpaGk09+dAcKELjLSR2OP3qBCWTGHpd0SBjgbVc=",
         "owner": "intersectmbo",
         "repo": "cardano-node",
-        "rev": "176f99e51155cb3eaa0711db1c3c969d67438958",
+        "rev": "efd560070aaf042d1eb4680ae37fc607c7742319",
         "type": "github"
       },
       "original": {
         "owner": "intersectmbo",
-        "ref": "9.1.0",
+        "ref": "9.1.1",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -374,11 +374,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720546058,
-        "narHash": "sha256-iU2yVaPIZm5vMGdlT0+57vdB/aPq/V5oZFBRwYw+HBM=",
+        "lastModified": 1721842668,
+        "narHash": "sha256-k3oiD2z2AAwBFLa4+xfU+7G5fisRXfkvrMTCJrjZzXo=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "2d83156f23c43598cf44e152c33a59d3892f8b29",
+        "rev": "529c1a0b1f29f0d78fa3086b8f6a134c71ef3aaf",
         "type": "github"
       },
       "original": {
@@ -1643,16 +1643,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1720620343,
-        "narHash": "sha256-DXIX9kww679WFpiuQ2skk/bRuY4Jtlx1FaXK36YJPQE=",
+        "lastModified": 1721986510,
+        "narHash": "sha256-Qk8aEY1nyo6f+cCY6M/4YRSXtn7u31oM1lnPm3Ys80U=",
         "owner": "input-output-hk",
         "repo": "mithril",
-        "rev": "6756b0f7d73d37229321ec6be74954f5c6d0486c",
+        "rev": "52a7beb77c537b54fcb1ca171bf1b1c0c059bad8",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "2428.0",
+        "ref": "2430.0",
         "repo": "mithril",
         "type": "github"
       }
@@ -2230,11 +2230,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1720571246,
-        "narHash": "sha256-nkUXwunTck+hNMt2wZuYRN+jf2ySRjKTzI0fo5TDH78=",
+        "lastModified": 1721933792,
+        "narHash": "sha256-zYVwABlQnxpbaHMfX6Wt9jhyQstFYwN2XjleOJV3VVg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "16e401f01842c5bb2499e78c1fe227f939c0c474",
+        "rev": "2122a9b35b35719ad9a395fe783eabb092df01b1",
         "type": "github"
       },
       "original": {
@@ -2767,11 +2767,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720507012,
-        "narHash": "sha256-QIeZ43t9IVB4dLsFaWh2f4C7JSRfK7p+Y1U9dULsLXU=",
+        "lastModified": 1721769617,
+        "narHash": "sha256-6Pqa0bi5nV74IZcENKYRToRNM5obo1EQ+3ihtunJ014=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "8b63fe8cf7892c59b3df27cbcab4d5644035d72f",
+        "rev": "8db8970be1fb8be9c845af7ebec53b699fe7e009",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,8 +19,8 @@
       url = "github:haskell/haskell-language-server";
       flake = false;
     };
-    cardano-node.url = "github:intersectmbo/cardano-node/9.1.0";
-    mithril.url = "github:input-output-hk/mithril/2428.0";
+    cardano-node.url = "github:intersectmbo/cardano-node/9.1.1";
+    mithril.url = "github:input-output-hk/mithril/2430.0";
     nix-npm-buildpackage.url = "github:serokell/nix-npm-buildpackage";
   };
 

--- a/hydra-cluster/test/Test/CardanoNodeSpec.hs
+++ b/hydra-cluster/test/Test/CardanoNodeSpec.hs
@@ -21,7 +21,7 @@ supportedNetworks :: [KnownNetwork]
 supportedNetworks = [Mainnet, Preproduction, Preview, Sanchonet]
 
 supportedCardanoNodeVersion :: String
-supportedCardanoNodeVersion = "9.1.0"
+supportedCardanoNodeVersion = "9.1.1"
 
 forSupportedKnownNetworks :: String -> (KnownNetwork -> IO ()) -> Spec
 forSupportedKnownNetworks msg action = forEachKnownNetwork msg $ \network -> do

--- a/sample-node-config/another-nixos/flake.nix
+++ b/sample-node-config/another-nixos/flake.nix
@@ -6,7 +6,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    cardano-node.url = "github:IntersectMBO/cardano-node/9.1.0";
+    cardano-node.url = "github:IntersectMBO/cardano-node/9.1.1";
     hydra.url = "github:cardano-scaling/hydra/209de1dd8c5ae484a45a4db3af043c4a9d271306";
     mithril.url = "github:input-output-hk/mithril/2423.0";
   };


### PR DESCRIPTION
This also updates mithril and will make it compatible with latest mithril snapshots again, greatly benefiting smoke tests runtimes.

---

* [x] CHANGELOG updated
* [x] Documentation update not needed
* [x] Haddocks update not needed
* [x] No new TODOs introduced
