### PR TITLE
Website: fix index name in search

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -276,7 +276,7 @@ const config = {
       algolia: {
         appId: "OF3CR7K89X",
         apiKey: "09b2fc0200d06fb433a5f4ced7c9d427",
-        indexName: "hydra-family",
+        indexName: "hydra",
         searchPagePath: "search",
         contextualSearch: true,
       },


### PR DESCRIPTION
While id and api key are fine now, the index name changed too and this should be fixed by this PR now.

If this works, after merging this we should also bump the `release` branch 
