### PR TITLE
Fix algolia search

### DIFF
--- a/docs/adr/2023-10-16_028_offline_adr.md
+++ b/docs/adr/2023-10-16_028_offline_adr.md
@@ -1,5 +1,5 @@
 ---
-slug: 28. Offline mode
+slug: 28
 title: |
   28. Offline mode
 authors: [cardenaso11]

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -278,7 +278,7 @@ const config = {
         apiKey: "09b2fc0200d06fb433a5f4ced7c9d427",
         indexName: "hydra",
         searchPagePath: "search",
-        contextualSearch: true,
+        contextualSearch: false,
       },
     }),
 


### PR DESCRIPTION
It seems that the default facets of docusaurus do not work against our index, so disabling the contextual search for now.

Captured a follow-up bug about listing results double: #1636 

