### PR TITLE
Reinstate TUI tests

### DIFF
--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -57,6 +57,7 @@ jobs:
         nix build .#${{ matrix.package }}-tests
         nix develop .#${{ matrix.package }}-tests --command tests
 
+    # This one is special, as it requires a tty.
     - name: ❓ Test (TUI)
       id: test_tui
       if: ${{ matrix.package == 'hydra-tui' }}
@@ -68,7 +69,7 @@ jobs:
       run: |
         cd ${{ matrix.package  }}
         nix build .#${{ matrix.package }}-tests
-        nix develop .#${{ matrix.package }}-tests --build
+        nix develop .#${{ matrix.package }}-tests --command tests
 
     - name: 💾 Upload build & test artifacts
       uses: actions/upload-artifact@v4

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -167,6 +167,7 @@ rec {
         nativePkgs.hydra-tui.components.tests.tests
         hydra-node
         inputs.cardano-node.packages.${system}.cardano-node
+        inputs.cardano-node.packages.${system}.cardano-cli
       ];
   };
 


### PR DESCRIPTION
In the end all that was required was adding `cardano-cli` to the test shell ( thanks @locallycompact !)

Fixes #1640 