### PR TITLE
Use new team cachix cache; always accept flake config.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-use flake
+use flake . --accept-flake-config

--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -32,7 +32,7 @@ jobs:
     - name: ❄ Cachix cache of nix derivations
       uses: cachix/cachix-action@v15
       with:
-        name: cardano-scaling
+        name: cardano-scaling-hydra
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_HYDRA_AUTH_TOKEN }}'
 
     - name: 🕵 Determine version
@@ -76,7 +76,7 @@ jobs:
     - name: ❄ Cachix cache of nix derivations
       uses: cachix/cachix-action@v15
       with:
-        name: cardano-scaling
+        name: cardano-scaling-hydra
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_HYDRA_AUTH_TOKEN }}'
 
     - name: 🕵 Determine version

--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -33,7 +33,7 @@ jobs:
       uses: cachix/cachix-action@v15
       with:
         name: cardano-scaling
-        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
+        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_HYDRA_AUTH_TOKEN }}'
 
     - name: 🕵 Determine version
       run: |
@@ -77,7 +77,7 @@ jobs:
       uses: cachix/cachix-action@v15
       with:
         name: cardano-scaling
-        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
+        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_HYDRA_AUTH_TOKEN }}'
 
     - name: 🕵 Determine version
       run: |

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -47,7 +47,7 @@ jobs:
     - name: ❄ Cachix cache of nix derivations
       uses: cachix/cachix-action@v15
       with:
-        name: cardano-scaling
+        name: cardano-scaling-hydra
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_HYDRA_AUTH_TOKEN }}'
 
     - name: ❓ Test
@@ -122,7 +122,7 @@ jobs:
     - name: ❄ Cachix cache of nix derivations
       uses: cachix/cachix-action@v15
       with:
-        name: cardano-scaling
+        name: cardano-scaling-hydra
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_HYDRA_AUTH_TOKEN }}'
 
     - name: 📚 Documentation (Haddock)
@@ -169,7 +169,7 @@ jobs:
     - name: ❄ Cachix cache of nix derivations
       uses: cachix/cachix-action@v15
       with:
-        name: cardano-scaling
+        name: cardano-scaling-hydra
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_HYDRA_AUTH_TOKEN }}'
 
     - name: 📈 Benchmark
@@ -248,7 +248,7 @@ jobs:
     - name: ❄ Cachix cache of nix derivations
       uses: cachix/cachix-action@v15
       with:
-        name: cardano-scaling
+        name: cardano-scaling-hydra
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_HYDRA_AUTH_TOKEN }}'
 
     - name: ❄ Nix Flake Check
@@ -273,7 +273,7 @@ jobs:
     - name: ❄ Cachix cache of nix derivations
       uses: cachix/cachix-action@v15
       with:
-        name: cardano-scaling
+        name: cardano-scaling-hydra
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_HYDRA_AUTH_TOKEN }}'
 
     - name: ❄ Build specification PDF

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -48,7 +48,7 @@ jobs:
       uses: cachix/cachix-action@v15
       with:
         name: cardano-scaling
-        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
+        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_HYDRA_AUTH_TOKEN }}'
 
     - name: ❓ Test
       if: ${{ matrix.package != 'hydra-tui' }}
@@ -123,7 +123,7 @@ jobs:
       uses: cachix/cachix-action@v15
       with:
         name: cardano-scaling
-        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
+        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_HYDRA_AUTH_TOKEN }}'
 
     - name: 📚 Documentation (Haddock)
       run: |
@@ -170,7 +170,7 @@ jobs:
       uses: cachix/cachix-action@v15
       with:
         name: cardano-scaling
-        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
+        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_HYDRA_AUTH_TOKEN }}'
 
     - name: 📈 Benchmark
       run: |
@@ -249,7 +249,7 @@ jobs:
       uses: cachix/cachix-action@v15
       with:
         name: cardano-scaling
-        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
+        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_HYDRA_AUTH_TOKEN }}'
 
     - name: ❄ Nix Flake Check
       run: |
@@ -274,7 +274,7 @@ jobs:
       uses: cachix/cachix-action@v15
       with:
         name: cardano-scaling
-        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
+        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_HYDRA_AUTH_TOKEN }}'
 
     - name: ❄ Build specification PDF
       run: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -46,7 +46,7 @@ jobs:
       uses: cachix/cachix-action@v15
       with:
         name: cardano-scaling
-        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
+        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_HYDRA_AUTH_TOKEN }}'
 
     - name: 🔨 Build image using nix
       run: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -45,7 +45,7 @@ jobs:
     - name: ❄ Cachix cache of nix derivations
       uses: cachix/cachix-action@v15
       with:
-        name: cardano-scaling
+        name: cardano-scaling-hydra
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_HYDRA_AUTH_TOKEN }}'
 
     - name: 🔨 Build image using nix

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -22,7 +22,7 @@ jobs:
       uses: cachix/cachix-action@v15
       with:
         name: cardano-scaling
-        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
+        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_HYDRA_AUTH_TOKEN }}'
 
     - name: 📐 Check code formatting
       run: |

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: ❄ Cachix cache of nix derivations
       uses: cachix/cachix-action@v15
       with:
-        name: cardano-scaling
+        name: cardano-scaling-hydra
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_HYDRA_AUTH_TOKEN }}'
 
     - name: 📐 Check code formatting

--- a/.github/workflows/network-test.yaml
+++ b/.github/workflows/network-test.yaml
@@ -47,7 +47,7 @@ jobs:
     - name: ❄ Cachix cache of nix derivations
       uses: cachix/cachix-action@v15
       with:
-        name: cardano-scaling
+        name: cardano-scaling-hydra
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_HYDRA_AUTH_TOKEN }}'
 
     - name: Set up and use the "ci" devShell

--- a/.github/workflows/network-test.yaml
+++ b/.github/workflows/network-test.yaml
@@ -48,7 +48,7 @@ jobs:
       uses: cachix/cachix-action@v15
       with:
         name: cardano-scaling
-        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
+        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_HYDRA_AUTH_TOKEN }}'
 
     - name: Set up and use the "ci" devShell
       uses: nicknovitski/nix-develop@v1

--- a/flake.nix
+++ b/flake.nix
@@ -176,13 +176,13 @@
   nixConfig = {
     extra-substituters = [
       "https://cache.iog.io"
-      "https://hydra-node.cachix.org"
       "https://cardano-scaling.cachix.org"
+      "https://cardano-scaling-hydra.cachix.org"
     ];
     extra-trusted-public-keys = [
       "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
-      "hydra-node.cachix.org-1:vK4mOEQDQKl9FTbq76NjOuNaRD4pZLxi1yri31HHmIw="
       "cardano-scaling.cachix.org-1:RKvHKhGs/b6CBDqzKbDk0Rv6sod2kPSXLwPzcUQg9lY="
+      "cardano-scaling-hydra.cachix.org-1:BeseaVepduHmIhTaZVLNi9N+V0frR4WNqgoepPdOL1s="
     ];
     allow-import-from-derivation = true;
   };


### PR DESCRIPTION
Updates our cachix-cache to use a new, larger one; and also accepts the flake config (I was getting a warning about `extra-substituters` being ignored.)

Note that I'm dropping the `hydra-node` cachix cache, as I don't think that's maintained by anyone here, at present.

If we want to put it back, that's fine.