### PR TITLE
Allow for manual run of explorer workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,10 +28,17 @@ done
 Install the following pre-requisites:
 * `git`
 * `docker`
+* `docker compose`
 
 For instance on Ubuntu:
 ```bash
-sudo apt install git docker.io
+sudo apt install git docker.io docker-compose-v2
+```
+
+Ensure we can run docker commands:
+
+``` bash
+sudo usermod -aG docker $(whoami)
 ```
 
 Prepare the common directory for cardano database:

--- a/.github/workflows/explorer.yaml
+++ b/.github/workflows/explorer.yaml
@@ -11,7 +11,6 @@ jobs:
   explorer:
     name: "Deploy"
     runs-on: explorer
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: 📥 Checkout repository
       uses: actions/checkout@v4


### PR DESCRIPTION
Now these instructions should be enough to have the `explorer` workflow also work on the self-hosted runner: https://github.com/cardano-scaling/hydra/actions/runs/10940621106/job/30373482416
