### PR TITLE
Fix docker-compose of explorer setup

### DIFF
--- a/.github/workflows/explorer/docker-compose.yaml
+++ b/.github/workflows/explorer/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   cardano-node:
-    image: ghcr.io/intersectmbo/cardano-node:9.2
+    image: ghcr.io/intersectmbo/cardano-node:9.2.0
     volumes:
       - /srv/var/cardano/state-preview:/data
     environment:


### PR DESCRIPTION
This got broken in the recent cardano-node update. Was not noticed in that PR because explorer is only deployed with commits from master.

---

* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Haddocks update not needed
* [x] No new TODOs introduced
