### PR TITLE
Fix build of devShells in binaries workflow

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -56,7 +56,7 @@ jobs:
 
     - name: ❄ Build devShells (for cache)
       run: |
-        nix build .#devShells.default
+        nix build .#devShells.x86_64-linux.default
 
   build-macos:
     name: "Build for aarch64-darwin"
@@ -104,4 +104,4 @@ jobs:
 
     - name: ❄ Build devShells (for cache)
       run: |
-        nix build .#devShells.default
+        nix build .#devShells.aarch64-darwin.default


### PR DESCRIPTION
The instruction before was broken and the workflow only runs after merging.
