### PR TITLE
Fix handling of reward redeemers on commit transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ changes.
       - Remove Commit client input since it is unused
       - Revisit types related to observations/posting transactions and make sure the fields are named appropriatelly
 
+- Fix the **BUG** where commit endpoint drops withdraw redeemers [#1643](https://github.com/cardano-scaling/hydra/issues/1643)
+
 - Tested with `cardano-node 9.2.0` and `cardano-cli 9.4.1.0`.
 
 - **BREAKING** Rewrite of the commit script in aiken:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ changes.
       - Remove Commit client input since it is unused
       - Revisit types related to observations/posting transactions and make sure the fields are named appropriatelly
 
-- Fix the **BUG** where commit endpoint drops withdraw redeemers [#1643](https://github.com/cardano-scaling/hydra/issues/1643)
 
 - Tested with `cardano-node 9.2.0` and `cardano-cli 9.4.1.0`.
 
@@ -29,6 +28,8 @@ changes.
   - This makes `abort` and `collectCom` transactions more efficient and results
     in a new maximum number of head participants being `8`.
   - Changes script hashes in `hydra-plutus`
+
+- Fix the bug where commit endpoint drops withdraw redeemers [#1643](https://github.com/cardano-scaling/hydra/issues/1643)
 
 ## [0.19.0] - 2024-09-13
 

--- a/hydra-cardano-api/hydra-cardano-api.cabal
+++ b/hydra-cardano-api/hydra-cardano-api.cabal
@@ -61,6 +61,7 @@ library
     Hydra.Cardano.Api.ScriptData
     Hydra.Cardano.Api.ScriptDatum
     Hydra.Cardano.Api.ScriptHash
+    Hydra.Cardano.Api.StakeAddress
     Hydra.Cardano.Api.Tx
     Hydra.Cardano.Api.TxBody
     Hydra.Cardano.Api.TxId

--- a/hydra-cardano-api/src/Hydra/Cardano/Api.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api.hs
@@ -141,6 +141,7 @@ import Hydra.Cardano.Api.ReferenceScript as Extras
 import Hydra.Cardano.Api.ScriptData as Extras
 import Hydra.Cardano.Api.ScriptDatum as Extras
 import Hydra.Cardano.Api.ScriptHash as Extras
+import Hydra.Cardano.Api.StakeAddress as Extras
 import Hydra.Cardano.Api.Tx as Extras hiding (Tx)
 import Hydra.Cardano.Api.TxBody as Extras
 import Hydra.Cardano.Api.TxId as Extras

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/AddressInEra.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/AddressInEra.hs
@@ -58,18 +58,6 @@ mkScriptAddress networkId script =
  where
   version = plutusScriptVersion @lang
 
--- | Construct a stake address from a Plutus script.
-mkStakeScriptAddress ::
-  forall lang.
-  IsPlutusScriptLanguage lang =>
-  NetworkId ->
-  PlutusScript lang ->
-  StakeAddress
-mkStakeScriptAddress networkId script =
-  makeStakeAddress networkId $ StakeCredentialByScript $ hashScript $ PlutusScript version script
- where
-  version = plutusScriptVersion @lang
-
 -- * Type Conversions
 
 -- | From a ledger 'Addr' to an api 'AddressInEra'

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/AddressInEra.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/AddressInEra.hs
@@ -58,6 +58,18 @@ mkScriptAddress networkId script =
  where
   version = plutusScriptVersion @lang
 
+-- | Construct a stake address from a Plutus script.
+mkStakeScriptAddress ::
+  forall lang.
+  IsPlutusScriptLanguage lang =>
+  NetworkId ->
+  PlutusScript lang ->
+  StakeAddress
+mkStakeScriptAddress networkId script =
+  makeStakeAddress networkId $ StakeCredentialByScript $ hashScript $ PlutusScript version script
+ where
+  version = plutusScriptVersion @lang
+
 -- * Type Conversions
 
 -- | From a ledger 'Addr' to an api 'AddressInEra'

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/StakeAddress.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/StakeAddress.hs
@@ -1,0 +1,15 @@
+module Hydra.Cardano.Api.StakeAddress where
+
+import Hydra.Cardano.Api.Prelude
+
+-- | Construct a stake address from a Plutus script.
+mkScriptStakeAddress ::
+  forall lang.
+  IsPlutusScriptLanguage lang =>
+  NetworkId ->
+  PlutusScript lang ->
+  StakeAddress
+mkScriptStakeAddress networkId script =
+  makeStakeAddress networkId $ StakeCredentialByScript $ hashScript $ PlutusScript version script
+ where
+  version = plutusScriptVersion @lang

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -31,7 +31,6 @@ import Control.Lens ((^.))
 import Data.Map qualified as Map
 import Data.Maybe.Strict (StrictMaybe (..))
 import Data.Set qualified as Set
-import Hydra.Cardano.Api.Prelude (StakeCredential (StakeCredentialByScript))
 import Hydra.Cardano.Api.Pretty (renderTxWithUTxO)
 import Hydra.Chain.Direct.State (ChainContext (..), HasKnownUTxO (getKnownUTxO), genChainStateWithTx)
 import Hydra.Chain.Direct.State qualified as Transition
@@ -301,9 +300,7 @@ genBlueprintTxWithUTxO =
           let scriptWitness = mkScriptWitness alwaysSucceedingScript NoScriptDatumForStake redeemer
               alwaysSucceedingScript = PlutusScriptSerialised $ Plutus.alwaysSucceedingNAryFunction 2
               redeemer = toScriptData (123 :: Integer)
-              -- XXX: Depends on hydra-cardano-api prelude (maybe extract a helper to hydra-cardano-api?)
-              stakeCredential = StakeCredentialByScript $ hashScript $ PlutusScript alwaysSucceedingScript
-              stakeAddress = makeStakeAddress testNetworkId stakeCredential
+              stakeAddress = mkStakeScriptAddress testNetworkId alwaysSucceedingScript
           pure
             ( utxo
             , txbody

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -300,7 +300,7 @@ genBlueprintTxWithUTxO =
           let scriptWitness = mkScriptWitness alwaysSucceedingScript NoScriptDatumForStake redeemer
               alwaysSucceedingScript = PlutusScriptSerialised $ Plutus.alwaysSucceedingNAryFunction 2
               redeemer = toScriptData (123 :: Integer)
-              stakeAddress = mkStakeScriptAddress testNetworkId alwaysSucceedingScript
+              stakeAddress = mkScriptStakeAddress testNetworkId alwaysSucceedingScript
           pure
             ( utxo
             , txbody

--- a/hydra-tx/src/Hydra/Tx/Commit.hs
+++ b/hydra-tx/src/Hydra/Tx/Commit.hs
@@ -77,7 +77,7 @@ commitTx networkId scriptRegistry headId party commitBlueprintTx (initialInput, 
           & bodyTxL . inputsTxBodyL .~ newInputs
           & bodyTxL . referenceInputsTxBodyL <>~ Set.singleton (toLedgerTxIn initialScriptRef)
           & witsTxL . rdmrsTxWitsL
-            .~ Redeemers (fromList $ resolveNonSpendingRedeemers tx)
+            .~ Redeemers (fromList $ nonSpendingRedeemers tx)
               <> Redeemers (fromList $ mkRedeemers newRedeemers newInputs)
 
   -- Make redeemers (with zeroed units) from a TxIn -> Data map and a set of transaction inputs
@@ -104,7 +104,7 @@ commitTx networkId scriptRegistry headId party commitBlueprintTx (initialInput, 
       )
       (unRedeemers $ tx ^. witsTxL . rdmrsTxWitsL)
 
-  resolveNonSpendingRedeemers tx =
+  nonSpendingRedeemers tx =
     Map.foldMapWithKey
       ( \p (d, ex) ->
           case redeemerPointerInverse (tx ^. bodyTxL) p of


### PR DESCRIPTION
## Why

fix #1643 

Our commit transaction was accounting only for the spending redeemers and discarded the minting, rewarding etc.


## What

Keep the existing redeemers intact and only adjust the spending redeemers accounting for the new initial input to spend.



---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
