### PR TITLE
Warn on usages of spy and spy'

### DIFF
--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1423,7 +1423,7 @@ aggregate st = \case
             { coordinatedHeadState =
                 coordinatedHeadState
                   { localUTxO = newLocalUTxO
-                  , pendingDeposits = Map.delete (spy recoveredTxId) existingDeposits
+                  , pendingDeposits = Map.delete recoveredTxId existingDeposits
                   }
             }
        where

--- a/hydra-prelude/src/Hydra/Prelude.hs
+++ b/hydra-prelude/src/Hydra/Prelude.hs
@@ -257,9 +257,11 @@ withFile fp mode action =
     Right x -> pure x
 
 -- | Like 'traceShow', but with pretty printing of the value.
+{-# WARNING spy "Use for debugging purposes only" #-}
 spy :: Show a => a -> a
 spy a = trace (toString $ pShow a) a
 
 -- | Like 'spy' but prefixed with a label.
+{-# WARNING spy' "Use for debugging purposes only" #-}
 spy' :: Show a => String -> a -> a
 spy' msg a = trace (msg <> ": " <> toString (pShow a)) a


### PR DESCRIPTION
These functions should not remain in production code and only be used for debugging purposes only.

This is how it is shown in my editor:
![image](https://github.com/user-attachments/assets/3e373c10-342f-40e3-ac4c-9f6375955626)

![image](https://github.com/user-attachments/assets/f7b500e9-3bf3-4bf1-b285-05c429a4986f)

---

* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Haddocks updated
* [x] No new TODOs introduced
