### PR TITLE
Move / deduplicate genAbortableOutputs

### DIFF
--- a/hydra-tx/test/Hydra/Tx/Contract/Abort.hs
+++ b/hydra-tx/test/Hydra/Tx/Contract/Abort.hs
@@ -26,9 +26,10 @@ import Hydra.Tx (
   registryUTxO,
  )
 import Hydra.Tx.Abort (abortTx)
+import Hydra.Tx.Commit (mkCommitDatum)
 import Hydra.Tx.ContestationPeriod (toChain)
 import Hydra.Tx.Init (mkHeadOutputInitial)
-import Hydra.Tx.Utils (hydraHeadV1AssetName)
+import Hydra.Tx.Utils (adaOnly, hydraHeadV1AssetName, onChainIdToAssetName, verificationKeyToOnChainId)
 import Test.Hydra.Tx.Fixture (
   cperiod,
   testNetworkId,
@@ -36,9 +37,9 @@ import Test.Hydra.Tx.Fixture (
   testSeedInput,
  )
 import Test.Hydra.Tx.Gen (
-  genAbortableOutputs,
   genAddressInEra,
   genForParty,
+  genOneUTxOFor,
   genScriptRegistry,
   genVerificationKey,
  )
@@ -52,7 +53,7 @@ import Test.Hydra.Tx.Mutation (
   removePTFromMintedValue,
   replacePolicyIdWith,
  )
-import Test.QuickCheck (Property, choose, counterexample, elements, oneof, shuffle, suchThat)
+import Test.QuickCheck (Property, choose, counterexample, elements, oneof, shuffle, suchThat, vectorOf)
 
 --
 -- AbortTx
@@ -257,3 +258,85 @@ genAbortMutation (tx, utxo) =
     , SomeMutation (pure $ toErrorCode STNotBurned) DoNotBurnSTInitial
         <$> changeMintedTokens tx (fromList [(AssetId (headPolicyId testSeedInput) hydraHeadV1AssetName, 1)])
     ]
+
+-- * Generators
+
+-- NOTE: Uses 'testPolicyId' for the datum.
+genAbortableOutputs :: [Party] -> Gen ([(TxIn, TxOut CtxUTxO)], [(TxIn, TxOut CtxUTxO, UTxO)])
+genAbortableOutputs parties =
+  go
+ where
+  go = do
+    (initParties, commitParties) <- (`splitAt` parties) <$> choose (0, length parties)
+    initials <- mapM genInitial initParties
+    commits <- fmap (\(a, (b, c)) -> (a, b, c)) . Map.toList <$> generateCommitUTxOs commitParties
+    pure (initials, commits)
+
+  genInitial p =
+    mkInitial (genVerificationKey `genForParty` p) <$> arbitrary
+
+  mkInitial ::
+    VerificationKey PaymentKey ->
+    TxIn ->
+    (TxIn, TxOut CtxUTxO)
+  mkInitial vk txin =
+    ( txin
+    , initialTxOut vk
+    )
+
+  initialTxOut :: VerificationKey PaymentKey -> TxOut CtxUTxO
+  initialTxOut vk =
+    toUTxOContext $
+      TxOut
+        (mkScriptAddress testNetworkId initialScript)
+        (fromList [(AssetId testPolicyId (assetNameFromVerificationKey vk), 1)])
+        (mkTxOutDatumInline initialDatum)
+        ReferenceScriptNone
+
+  initialScript = fromPlutusScript @PlutusScriptV2 Initial.validatorScript
+
+  initialDatum = Initial.datum (toPlutusCurrencySymbol testPolicyId)
+
+-- | Generate a UTXO representing /commit/ outputs for a given list of `Party`.
+-- NOTE: Uses 'testPolicyId' for the datum.
+-- NOTE: We don't generate empty commits and it is used only at one place so perhaps move it?
+-- FIXME: This function is very complicated and it's hard to understand it after a while
+generateCommitUTxOs :: [Party] -> Gen (Map.Map TxIn (TxOut CtxUTxO, UTxO))
+generateCommitUTxOs parties = do
+  txins <- vectorOf (length parties) (arbitrary @TxIn)
+  let vks = (\p -> (genVerificationKey `genForParty` p, p)) <$> parties
+  committedUTxO <-
+    vectorOf (length parties) $
+      fmap adaOnly <$> (genOneUTxOFor =<< arbitrary)
+  let commitUTxO =
+        zip txins $
+          uncurry mkCommitUTxO <$> zip vks committedUTxO
+  pure $ Map.fromList commitUTxO
+ where
+  mkCommitUTxO :: (VerificationKey PaymentKey, Party) -> UTxO -> (TxOut CtxUTxO, UTxO)
+  mkCommitUTxO (vk, party) utxo =
+    ( toUTxOContext $
+        TxOut
+          (mkScriptAddress testNetworkId commitScript)
+          commitValue
+          (mkTxOutDatumInline commitDatum)
+          ReferenceScriptNone
+    , utxo
+    )
+   where
+    commitValue =
+      mconcat
+        [ lovelaceToValue (Coin 2000000)
+        , foldMap txOutValue utxo
+        , fromList
+            [ (AssetId testPolicyId (assetNameFromVerificationKey vk), 1)
+            ]
+        ]
+
+    commitScript = fromPlutusScript @PlutusScriptV3 commitValidatorScript
+
+    commitDatum = mkCommitDatum party utxo (toPlutusCurrencySymbol testPolicyId)
+
+assetNameFromVerificationKey :: VerificationKey PaymentKey -> AssetName
+assetNameFromVerificationKey =
+  onChainIdToAssetName . verificationKeyToOnChainId


### PR DESCRIPTION
This function is not only hard to read, but was even twice in our codebase. Moved it to Abort mutation tests as its the only location where it is used.

---

* [x] CHANGELOG updated not needed
* [x] Documentation updated not needed
* [x] Haddocks update not needed
* [x] No new TODOs introduced
