### PR TITLE
Tune tx trace spec

### DIFF
--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -554,18 +554,9 @@ decrement ctx spendableUTxO headId headParameters decrementingSnapshot = do
   pid <- headIdToPolicyId headId ?> InvalidHeadIdInDecrement{headId}
   let utxoOfThisHead' = utxoOfThisHead pid spendableUTxO
   headUTxO <- UTxO.find (isScriptTxOut headScript) utxoOfThisHead' ?> CannotFindHeadOutputInDecrement
-  case utxoToDecommit of
-    Nothing ->
-      Left SnapshotMissingDecrementUTxO
-    Just decrementUTxO
-      | null decrementUTxO ->
-          Left SnapshotDecrementUTxOIsNull
-    _ ->
-      Right $ decrementTx scriptRegistry ownVerificationKey headId headParameters headUTxO sn sigs
+  Right $ decrementTx scriptRegistry ownVerificationKey headId headParameters headUTxO sn sigs
  where
   headScript = fromPlutusScript @PlutusScriptV2 Head.validatorScript
-
-  Snapshot{utxoToDecommit} = sn
 
   (sn, sigs) =
     case decrementingSnapshot of

--- a/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
@@ -509,6 +509,7 @@ instance StateModel Model where
           { headState = Open
           , currentVersion = m.currentVersion + 1
           , utxoInHead = balanceUTxOInHead (utxoInHead m) (decommitUTxO snapshot)
+          -- TODO: why is this not needed?, pendingDecommitUTxO = m.pendingDecommitUTxO \\ snapshot.snapshotUTxO
           }
       Close{snapshot} ->
         m
@@ -524,7 +525,7 @@ instance StateModel Model where
           , closedSnapshotNumber = snapshot.number
           , alreadyContested = actor : alreadyContested m
           , utxoInHead = snapshotUTxO snapshot
-          , pendingDecommitUTxO = decommitUTxO snapshot
+          , pendingDecommitUTxO = if currentVersion == snapshot.version then decommitUTxO snapshot else mempty
           }
       Fanout{} -> m{headState = Final}
 

--- a/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
@@ -355,39 +355,6 @@ instance StateModel Model where
               , inHead
               , toDecommit
               }
-      -- FIXME: check whether these cases are met
-      -- oneof
-      --   [ -- valid
-      --     pure validSnapshot
-      --   , -- unbalanced
-      --     pure validSnapshot{inHead = utxoInHead}
-      --   , do
-      --       -- old
-      --       let number' = if closedSnapshotNumber == 0 then 0 else closedSnapshotNumber - 1
-      --       pure (validSnapshot :: ModelSnapshot){number = number'}
-      --   , -- new
-      --     pure (validSnapshot :: ModelSnapshot){number = closedSnapshotNumber + 1}
-      --   , do
-      --       -- shuffled
-      --       someUTxOToDecrement' <- shuffleValues filteredSomeUTxOToDecrement
-      --       pure validSnapshot{toDecommit = someUTxOToDecrement'}
-      --   , do
-      --       -- more in head
-      --       utxoInHead' <- increaseValues utxoInHead
-      --       pure validSnapshot{inHead = utxoInHead'}
-      --   , do
-      --       -- more in decommit
-      --       someUTxOToDecrement' <- increaseValues =<< submapOf utxoInHead
-      --       let balancedUTxOInHead' = balanceUTxOInHead utxoInHead someUTxOToDecrement'
-      --       pure
-      --         validSnapshot
-      --           { inHead = balancedUTxOInHead'
-      --           , toDecommit = someUTxOToDecrement'
-      --           }
-      --   , -- decommit all
-      --     pure validSnapshot{inHead = mempty, toDecommit = utxoInHead}
-      --   , arbitrary
-      --   ]
       pure validSnapshot
 
   -- Determine actions we want to perform and expect to work. If this is False,

--- a/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
@@ -294,7 +294,9 @@ instance StateModel Model where
             , do
                 actor <- elements allActors
                 snapshot <- genSnapshot
-                pure $ Some $ Close{actor, snapshot}
+                -- XXX: Too much randomness in genSnapshot
+                version <- elements [currentVersion, currentVersion + 1]
+                pure $ Some $ Close{actor, snapshot = snapshot{version}}
             )
           ]
             <> [ ( 1

--- a/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
@@ -309,20 +309,26 @@ instance StateModel Model where
                not (null utxoInHead)
                ]
       Closed{} ->
-        oneof $
-          [ do
-              -- Fanout with the currently known model state.
-              pure $
-                Some $
-                  Fanout
-                    { utxo = utxoInHead
-                    , deltaUTxO = pendingDecommitUTxO
-                    }
+        frequency $
+          [
+            ( 1
+            , do
+                -- Fanout with the currently known model state.
+                pure $
+                  Some $
+                    Fanout
+                      { utxo = utxoInHead
+                      , deltaUTxO = pendingDecommitUTxO
+                      }
+            )
           ]
-            <> [ do
-                  actor <- elements allActors
-                  snapshot <- genSnapshot
-                  pure $ Some Contest{actor, snapshot}
+            <> [
+                 ( 10
+                 , do
+                    actor <- elements allActors
+                    snapshot <- genSnapshot
+                    pure $ Some Contest{actor, snapshot}
+                 )
                ]
       Final -> pure $ Some Stop
    where

--- a/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
@@ -428,7 +428,6 @@ instance StateModel Model where
         && all (`elem` Map.keys utxoInHead) (Map.keys (decommitUTxO snapshot) <> Map.keys (snapshotUTxO snapshot))
         -- your tx is balanced with the utxo in the head
         && sum (decommitUTxO snapshot) + sum (snapshotUTxO snapshot) == sum utxoInHead
-        && (not . null $ decommitUTxO snapshot)
     Close{snapshot} ->
       headState == Open
         && ( if snapshot.number == 0
@@ -473,8 +472,6 @@ instance StateModel Model where
         && sum (decommitUTxO snapshot) + sum (snapshotUTxO snapshot) == sum utxoInHead
         -- Ignore decrements that work with non existing utxo in the head
         && all (`elem` Map.keys utxoInHead) (Map.keys (decommitUTxO snapshot) <> Map.keys (snapshotUTxO snapshot))
-        -- Ignore decrement without something to decommit
-        && (not . null $ decommitUTxO snapshot)
     Close{snapshot} ->
       headState == Open
         && ( snapshot.number == 0

--- a/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
@@ -25,6 +25,7 @@ import Cardano.Api.UTxO (UTxO)
 import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Ledger.Coin (Coin (..))
 import Data.Map.Strict qualified as Map
+import Data.Sequence (Seq (..), (|>))
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import GHC.Natural (naturalFromInteger, naturalToInteger)
 import Hydra.Cardano.Api (
@@ -205,14 +206,20 @@ type ModelUTxO = Map SingleUTxO Natural
 
 data Model = Model
   { headState :: State
-  , knownSnapshots :: [ModelSnapshot]
-  , currentVersion :: SnapshotVersion
-  , latestSnapshot :: SnapshotNumber
+  , knownSnapshots :: Seq ModelSnapshot
   , alreadyContested :: [Actor]
   , utxoInHead :: ModelUTxO
   , pendingDecommitUTxO :: ModelUTxO
   }
   deriving (Show)
+
+latestVersion :: Model -> SnapshotVersion
+latestVersion Model{knownSnapshots = _ :|> r} = r.version
+latestVersion _ = 0
+
+latestSnapshotNumber :: Model -> SnapshotNumber
+latestSnapshotNumber Model{knownSnapshots = _ :|> r} = r.number
+latestSnapshotNumber _ = 0
 
 -- | Model of a real snapshot which contains a 'SnapshotNumber` but also our
 -- simplified form of 'UTxO'.
@@ -281,9 +288,7 @@ instance StateModel Model where
   initialState =
     Model
       { headState = Open
-      , knownSnapshots = []
-      , currentVersion = 0
-      , latestSnapshot = 0
+      , knownSnapshots = mempty
       , alreadyContested = []
       , utxoInHead = fromList $ map (,10) [A, B, C]
       , pendingDecommitUTxO = Map.empty
@@ -292,20 +297,20 @@ instance StateModel Model where
   -- FIXME: 1.5k discards on 100 runs
 
   arbitraryAction :: VarContext -> Model -> Gen (Any (Action Model))
-  arbitraryAction _lookup Model{headState, knownSnapshots, currentVersion, latestSnapshot, utxoInHead, pendingDecommitUTxO} =
+  arbitraryAction _lookup m@Model{headState, knownSnapshots, utxoInHead, pendingDecommitUTxO} =
     case headState of
       Open{} ->
         oneof $
           [Some . NewSnapshot <$> genSnapshot]
             <> [ do
                   actor <- elements allActors
-                  snapshot <- elements knownSnapshots
+                  snapshot <- elements $ toList knownSnapshots
                   pure $ Some Decrement{actor, snapshot}
                | not (null knownSnapshots) -- XXX: DRY this check
                ]
             <> [ do
                   actor <- elements allActors
-                  snapshot <- elements knownSnapshots
+                  snapshot <- elements $ toList knownSnapshots
                   pure $ Some $ Close{actor, snapshot = snapshot}
                | not (null knownSnapshots)
                ]
@@ -326,24 +331,26 @@ instance StateModel Model where
             <> [ ( 10
                  , do
                     actor <- elements allActors
-                    snapshot <- elements knownSnapshots
+                    snapshot <- elements $ toList knownSnapshots
                     pure $ Some Contest{actor, snapshot}
                  )
                | not (null knownSnapshots)
                ]
       Final -> pure $ Some Stop
    where
-    -- TODO: Generate a snapshot an honest node would sign given the current model state.
+    -- FIXME: Generate a snapshot an honest node would sign given the current model state.
     genSnapshot = do
       someUTxOToDecrement <- reduceValues =<< genSubModelOf utxoInHead
       let filteredSomeUTxOToDecrement = Map.filter (> 0) someUTxOToDecrement
       let balancedUTxOInHead = balanceUTxOInHead utxoInHead filteredSomeUTxOToDecrement
 
-      version <- elements $ currentVersion : [currentVersion - 1 | currentVersion > 0] <> [currentVersion + 1]
+      let v = latestVersion m
+      let sn = latestSnapshotNumber m
+      version <- elements $ v : [v - 1 | v > 0] <> [v + 1]
       let validSnapshot =
             ModelSnapshot
               { version
-              , number = latestSnapshot
+              , number = sn
               , snapshotUTxO = balancedUTxOInHead
               , decommitUTxO = filteredSomeUTxOToDecrement
               }
@@ -354,10 +361,10 @@ instance StateModel Model where
           pure validSnapshot{snapshotUTxO = utxoInHead}
         , do
             -- old
-            let number' = if latestSnapshot == 0 then 0 else latestSnapshot - 1
+            let number' = if sn == 0 then 0 else sn - 1
             pure (validSnapshot :: ModelSnapshot){number = number'}
         , -- new
-          pure (validSnapshot :: ModelSnapshot){number = latestSnapshot + 1}
+          pure (validSnapshot :: ModelSnapshot){number = sn + 1}
         , do
             -- shuffled
             someUTxOToDecrement' <- shuffleValues filteredSomeUTxOToDecrement
@@ -409,26 +416,28 @@ instance StateModel Model where
   -- Determine actions we want to perform and expect to work. If this is False,
   -- validFailingAction is checked too.
   precondition :: Model -> Action Model a -> Bool
-  precondition Model{headState, knownSnapshots, latestSnapshot, alreadyContested, utxoInHead, pendingDecommitUTxO, currentVersion} = \case
+  precondition m@Model{headState, knownSnapshots, alreadyContested, utxoInHead, pendingDecommitUTxO} = \case
     Stop -> headState /= Final
     NewSnapshot{newSnapshot} ->
-      -- None of the produced snapshots is already known
-      newSnapshot `notElem` knownSnapshots
+      trace ("precondition NewSnapshot: " <> show newSnapshot) $
+        -- None of the produced snapshots is already known
+        newSnapshot `notElem` knownSnapshots
     Decrement{snapshot} ->
-      headState == Open
-        && snapshot.version == currentVersion
-        -- you are decrementing from existing utxo in the head
-        && all (`elem` Map.keys utxoInHead) (Map.keys (decommitUTxO snapshot) <> Map.keys (snapshotUTxO snapshot))
-        -- your tx is balanced with the utxo in the head
-        && sum (decommitUTxO snapshot) + sum (snapshotUTxO snapshot) == sum utxoInHead
-        && (not . null $ decommitUTxO snapshot)
+      trace ("precondition Decrement: " <> show snapshot) $
+        headState == Open
+          && snapshot.version == latestVersion m
+          -- you are decrementing from existing utxo in the head
+          && all (`elem` Map.keys utxoInHead) (Map.keys (decommitUTxO snapshot) <> Map.keys (snapshotUTxO snapshot))
+          -- your tx is balanced with the utxo in the head
+          && sum (decommitUTxO snapshot) + sum (snapshotUTxO snapshot) == sum utxoInHead
+          && (not . null $ decommitUTxO snapshot)
     Close{snapshot} ->
       headState == Open
         && ( if snapshot.number == 0
               then snapshotUTxO snapshot == initialUTxOInHead
               else
-                snapshot.number >= latestSnapshot
-                  && snapshot.version `elem` (currentVersion : [currentVersion - 1 | currentVersion > 0])
+                snapshot.number >= latestSnapshotNumber m
+                  && snapshot.version `elem` (latestVersion m : [latestVersion m - 1 | latestVersion m > 0])
            )
         -- you are decrementing from existing utxo in the head
         && all (`elem` Map.keys utxoInHead) (Map.keys (decommitUTxO snapshot) <> Map.keys (snapshotUTxO snapshot))
@@ -439,8 +448,8 @@ instance StateModel Model where
     Contest{actor, snapshot} ->
       headState == Closed
         && actor `notElem` alreadyContested
-        && snapshot.version `elem` (currentVersion : [currentVersion - 1 | currentVersion > 0])
-        && snapshot.number > latestSnapshot
+        && snapshot.version `elem` (latestVersion m : [latestVersion m - 1 | latestVersion m > 0])
+        && snapshot.number > latestSnapshotNumber m
         -- you are decrementing from existing utxo in the head
         && all (`elem` Map.keys utxoInHead) (Map.keys (decommitUTxO snapshot) <> Map.keys (snapshotUTxO snapshot))
         -- your tx is balanced with the utxo in the head
@@ -454,14 +463,14 @@ instance StateModel Model where
   -- False, the action is discarded (e.g. it's invalid or we don't want to see
   -- it tried to perform).
   validFailingAction :: Model -> Action Model a -> Bool
-  validFailingAction Model{headState, utxoInHead, currentVersion} = \case
+  validFailingAction m@Model{headState, utxoInHead} = \case
     Stop -> False
     NewSnapshot{} -> False
     -- Only filter non-matching states as we are not interested in these kind of
     -- verification failures.
     Decrement{snapshot} ->
       headState == Open
-        && snapshot.version /= currentVersion
+        && snapshot.version /= latestVersion m
         -- Ignore unbalanced decrements.
         -- TODO: make them fail gracefully and test this?
         && sum (decommitUTxO snapshot) + sum (snapshotUTxO snapshot) == sum utxoInHead
@@ -472,7 +481,7 @@ instance StateModel Model where
     Close{snapshot} ->
       headState == Open
         && ( snapshot.number == 0
-              || snapshot.version `elem` (currentVersion : [currentVersion - 1 | currentVersion > 0])
+              || snapshot.version `elem` (latestVersion m : [latestVersion m - 1 | latestVersion m > 0])
            )
         -- Ignore unbalanced close.
         -- TODO: make them fail gracefully and test this?
@@ -490,30 +499,25 @@ instance StateModel Model where
       headState == Closed
 
   nextState :: Model -> Action Model a -> Var a -> Model
-  nextState m@Model{currentVersion} t _result =
+  nextState m t _result =
     case t of
       Stop -> m
       NewSnapshot{newSnapshot} ->
-        m{knownSnapshots = m.knownSnapshots <> [newSnapshot]}
+        m{knownSnapshots = m.knownSnapshots :|> newSnapshot}
       Decrement{snapshot} ->
         m
           { headState = Open
-          , currentVersion = m.currentVersion + 1
-          , latestSnapshot = snapshot.number
           , utxoInHead = balanceUTxOInHead (utxoInHead m) (decommitUTxO snapshot)
           }
       Close{snapshot} ->
         m
           { headState = Closed
-          , latestSnapshot = snapshot.number
-          , alreadyContested = []
           , utxoInHead = snapshotUTxO snapshot
-          , pendingDecommitUTxO = if currentVersion == snapshot.version then decommitUTxO snapshot else mempty
+          , pendingDecommitUTxO = if latestVersion m == snapshot.version then decommitUTxO snapshot else mempty
           }
       Contest{actor, snapshot} ->
         m
           { headState = Closed
-          , latestSnapshot = snapshot.number
           , alreadyContested = actor : alreadyContested m
           , utxoInHead = snapshotUTxO snapshot
           , pendingDecommitUTxO = decommitUTxO snapshot
@@ -555,17 +559,17 @@ type instance Realized AppM a = a
 -- define a corresponding RunModel using our tx construction / evaluation hooks
 -- only.
 instance RunModel Model AppM where
-  perform Model{currentVersion} action _lookupVar = do
+  perform m action _lookupVar = do
     case action of
       Decrement{actor, snapshot} -> do
         let (s, signatures) = signedSnapshot snapshot
         tx <- newDecrementTx actor ConfirmedSnapshot{snapshot = s, signatures}
         performTx tx
       Close{actor, snapshot} -> do
-        tx <- newCloseTx actor currentVersion (confirmedSnapshot snapshot)
+        tx <- newCloseTx actor (latestVersion m) (confirmedSnapshot snapshot)
         performTx tx
       Contest{actor, snapshot} -> do
-        tx <- newContestTx actor currentVersion (confirmedSnapshot snapshot)
+        tx <- newContestTx actor (latestVersion m) (confirmedSnapshot snapshot)
         performTx tx
       Fanout{utxo, deltaUTxO} -> do
         tx <- newFanoutTx Alice utxo deltaUTxO

--- a/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
@@ -350,6 +350,7 @@ instance StateModel Model where
     -- TODO: Generate a snapshot an honest node would sign given the current model state.
     genSnapshot = do
       -- Only decommit if not already pending
+      -- TODO: prevent 0 quantity decommit
       toDecommit <-
         if null pendingDecommit
           then submapOf utxoInHead >>= reduceValues
@@ -489,6 +490,7 @@ instance StateModel Model where
           { headState = Closed
           , closedSnapshotNumber = snapshot.number
           , alreadyContested = []
+          , utxoInHead = snapshot.inHead
           , pendingDecommit = if currentVersion == snapshot.version then toDecommit snapshot else mempty
           }
       Contest{actor, snapshot} ->
@@ -496,6 +498,7 @@ instance StateModel Model where
           { headState = Closed
           , closedSnapshotNumber = snapshot.number
           , alreadyContested = actor : alreadyContested m
+          , utxoInHead = snapshot.inHead
           , pendingDecommit = if currentVersion == snapshot.version then toDecommit snapshot else mempty
           }
       Fanout{} -> m{headState = Final}


### PR DESCRIPTION
Rewrite of the model part and tuning of the TxTrace stateful property-based test suite comprised of:

* Allow for empty decrements, but identify `DecrementValueNegative` errors when constructing transactions.

* Added coverage to model test `TxTrace/all valid transactions`

* Changed how snapshots are generated and modeled: Instead of generating snapshots ad-hoc, we create them in a dedicated `NewSnapshot` action and only pick from a list of `knownSnapshots` when generating `Close` and other actions. This resembles better what is actually happening in the real world, where the adversary could only pick from a list of plausible snapshots. It also makes the `arbitraryAction` simpler and requires less `precondition`s. Lastly, this also results in less discarded values as was the original motivation in #1524 

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Haddocks updated
* [x] No new TODOs introduced or explained herafter
  - Three very minor `XXX` comments how further refactoring could be done in `TxTrace`
