### PR TITLE
Remove unused Commit client input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ changes.
      Missing off-chain items to implement as a series of next PR's:
       - Add documentation to explain the feature
       - Implement tests scenarios outlined in the [incremental-commit] (https://github.com/cardano-scaling/hydra/issues/199) issue
-      - Remove Commit client input since it is unused
       - Revisit types related to observations/posting transactions and make sure the fields are named appropriatelly
 
 

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -106,7 +106,6 @@ channels:
           - $ref: "api.yaml#/components/messages/Abort"
           - $ref: "api.yaml#/components/messages/NewTx"
           - $ref: "api.yaml#/components/messages/GetUTxO"
-          - $ref: "api.yaml#/components/messages/Commit"
           - $ref: "api.yaml#/components/messages/Recover"
           - $ref: "api.yaml#/components/messages/Decommit"
           - $ref: "api.yaml#/components/messages/Close"
@@ -2402,7 +2401,7 @@ components:
             evaluate scripts and calculate script integrity hashes.
           oneOf:
             - $ref: "api.yaml#/components/schemas/Cbor"
-            - type: "null" 
+            - type: "null"
         datum:
           oneOf:
             - type: string

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -354,21 +354,6 @@ components:
             enum: ["NewTx"]
           transaction:
             $ref: "api.yaml#/components/schemas/Transaction"
-    Commit:
-      title: Commit
-      description: |
-        Request to commit a UTxO to initializing Head by providing a UTxO.
-      payload:
-        type: object
-        required:
-          - tag
-          - utxo
-        properties:
-          tag:
-            type: string
-            enum: ["Commit"]
-          utxo:
-            $ref: "api.yaml#/components/schemas/UTxO"
     Recover:
       title: Recover
       description: |
@@ -1157,7 +1142,6 @@ components:
             - $ref: "api.yaml#/components/messages/Abort/payload"
             - $ref: "api.yaml#/components/messages/NewTx/payload"
             - $ref: "api.yaml#/components/messages/GetUTxO/payload"
-            - $ref: "api.yaml#/components/messages/Commit/payload"
             - $ref: "api.yaml#/components/messages/Decommit/payload"
             - $ref: "api.yaml#/components/messages/Recover/payload"
             - $ref: "api.yaml#/components/messages/Close/payload"

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -1725,7 +1725,6 @@ definitions:
               - $ref: "api.yaml#/components/messages/Init/payload"
               - $ref: "api.yaml#/components/messages/Abort/payload"
               - $ref: "api.yaml#/components/messages/NewTx/payload"
-              - $ref: "api.yaml#/components/messages/Commit/payload"
               - $ref: "api.yaml#/components/messages/Recover/payload"
               - $ref: "api.yaml#/components/messages/Decommit/payload"
               - $ref: "api.yaml#/components/messages/GetUTxO/payload"

--- a/hydra-node/src/Hydra/API/ClientInput.hs
+++ b/hydra-node/src/Hydra/API/ClientInput.hs
@@ -11,7 +11,6 @@ data ClientInput tx
   | Abort
   | NewTx {transaction :: tx}
   | GetUTxO
-  | Commit {utxo :: UTxOType tx}
   | Recover {recoverTxId :: TxIdType tx}
   | Decommit {decommitTx :: tx}
   | Close
@@ -36,7 +35,6 @@ instance (Arbitrary tx, Arbitrary (UTxOType tx), Arbitrary (TxIdType tx)) => Arb
     NewTx tx -> NewTx <$> shrink tx
     GetUTxO -> []
     Recover tx -> Recover <$> shrink tx
-    Commit tx -> Commit <$> shrink tx
     Decommit tx -> Decommit <$> shrink tx
     Close -> []
     Contest -> []

--- a/hydra-node/src/Hydra/API/ClientInput.hs
+++ b/hydra-node/src/Hydra/API/ClientInput.hs
@@ -4,7 +4,7 @@ module Hydra.API.ClientInput where
 
 import Hydra.Prelude
 
-import Hydra.Tx (IsTx, TxIdType, UTxOType)
+import Hydra.Tx (IsTx, TxIdType)
 
 data ClientInput tx
   = Init
@@ -23,7 +23,7 @@ deriving stock instance IsTx tx => Show (ClientInput tx)
 deriving anyclass instance IsTx tx => ToJSON (ClientInput tx)
 deriving anyclass instance IsTx tx => FromJSON (ClientInput tx)
 
-instance (Arbitrary tx, Arbitrary (UTxOType tx), Arbitrary (TxIdType tx)) => Arbitrary (ClientInput tx) where
+instance (Arbitrary tx, Arbitrary (TxIdType tx)) => Arbitrary (ClientInput tx) where
   arbitrary = genericArbitrary
 
   -- NOTE: Somehow, can't use 'genericShrink' here as GHC is complaining about


### PR DESCRIPTION
### Why

`Commit` client input was never used and this is a leftover from the work on incremental commits off-chain


---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
