### PR TITLE
Don't update the explorer docker-compose invocation yet

### DIFF
--- a/.github/workflows/explorer/docker-compose.yaml
+++ b/.github/workflows/explorer/docker-compose.yaml
@@ -23,8 +23,7 @@ services:
     ports:
       - "80:8080"
     command:
-      [ "direct"
-      , "--node-socket", "/data/node.socket"
+      [ "--node-socket", "/data/node.socket"
       , "--testnet-magic", "2"
       , "--api-port", "8080"
       # NOTE: Block in which current master scripts were published


### PR DESCRIPTION
This must only be done on the next release of hydra, which will include the new option for the explorer.

See #1631 