### PR TITLE
Re-use contestation period as a deposit deadline

### DIFF
--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -751,7 +751,9 @@ canRecoverDeposit tracer workDir node hydraScriptsTxId =
     (`finally` returnFundsToFaucet tracer node Bob) $ do
       refuelIfNeeded tracer node Alice 30_000_000
       refuelIfNeeded tracer node Bob 30_000_000
-      let contestationPeriod = UnsafeContestationPeriod 1
+      -- NOTE: this value is also used to determine the deposit deadline
+      let deadline = 1
+      let contestationPeriod = UnsafeContestationPeriod deadline
       aliceChainConfig <-
         chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [Bob] contestationPeriod
           <&> setNetworkId networkId
@@ -800,6 +802,8 @@ canRecoverDeposit tracer workDir node hydraScriptsTxId =
 
         let path = BSC.unpack $ urlEncode False $ encodeUtf8 $ T.pack $ show (getTxId $ getTxBody tx)
 
+        threadDelay $ fromIntegral deadline
+
         recoverResp <-
           parseUrlThrow ("DELETE " <> hydraNodeBaseUrl n1 <> "/commits/" <> path)
             >>= httpJSON
@@ -825,7 +829,8 @@ canSeePendingDeposits tracer workDir node hydraScriptsTxId =
     (`finally` returnFundsToFaucet tracer node Bob) $ do
       refuelIfNeeded tracer node Alice 30_000_000
       refuelIfNeeded tracer node Bob 30_000_000
-      let contestationPeriod = UnsafeContestationPeriod 1
+      let deadline = 1
+      let contestationPeriod = UnsafeContestationPeriod deadline
       aliceChainConfig <-
         chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [Bob] contestationPeriod
           <&> setNetworkId networkId
@@ -880,6 +885,7 @@ canSeePendingDeposits tracer workDir node hydraScriptsTxId =
 
         forM_ deposited $ \deposit -> do
           let path = BSC.unpack $ urlEncode False $ encodeUtf8 $ T.pack $ show deposit
+          threadDelay $ fromIntegral deadline
           recoverResp <-
             parseUrlThrow ("DELETE " <> hydraNodeBaseUrl n1 <> "/commits/" <> path)
               >>= httpJSON

--- a/hydra-node/golden/ReasonablySized (TimedServerOutput (Tx ConwayEra)).json
+++ b/hydra-node/golden/ReasonablySized (TimedServerOutput (Tx ConwayEra)).json
@@ -10419,440 +10419,64 @@
             }
         },
         {
-            "headId": "02030001000204020505080604050303",
-            "pendingDeposit": "0402080401050405060600010005000505020007020105030201040708070105",
+            "deadline": "1864-05-06T19:26:30.796269625716Z",
+            "headId": "04050608050705030601080505020605",
+            "pendingDeposit": "0208070301020202030704010808070103000802000807070306050505020600",
             "seq": 4,
             "tag": "CommitRecorded",
             "timestamp": "1864-05-06T04:10:24.672046057032Z",
             "utxoToCommit": {
-                "0104080307070403000003060205060104000002010401020503020205010403#27": {
-                    "address": "addr1z9n044gplk4jylwrd6wp3v9kjrlkfmwf6zse8792tpals9h7crec7zz8f5jwntxf669gjp9jd6q29wt4y7k7u86llams3sqz8n",
+                "0105020004080404050802070702000105050506040206010807020606020504#13": {
+                    "address": "addr1zxga2ep47ftqvurednye8ql5mw02ahyftln9e4dht0wpmuaatwxtq909t27fxsrvyghn4txcr6qef3lqcd460mcquayq2eqqug",
                     "datum": null,
-                    "inlineDatum": {
-                        "map": [
-                            {
-                                "k": {
-                                    "list": []
-                                },
-                                "v": {
-                                    "list": [
-                                        {
-                                            "bytes": "60bcf406"
-                                        },
-                                        {
-                                            "int": 5
-                                        },
-                                        {
-                                            "int": 1
-                                        },
-                                        {
-                                            "int": -1
-                                        },
-                                        {
-                                            "int": 0
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "k": {
-                                    "list": []
-                                },
-                                "v": {
-                                    "map": [
-                                        {
-                                            "k": {
-                                                "map": [
-                                                    {
-                                                        "k": {
-                                                            "int": 4
-                                                        },
-                                                        "v": {
-                                                            "bytes": "db"
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "int": 2
-                                                        },
-                                                        "v": {
-                                                            "int": -1
-                                                        }
-                                                    }
-                                                ]
-                                            },
-                                            "v": {
-                                                "bytes": "cb"
-                                            }
-                                        },
-                                        {
-                                            "k": {
-                                                "map": [
-                                                    {
-                                                        "k": {
-                                                            "int": -3
-                                                        },
-                                                        "v": {
-                                                            "int": 4
-                                                        }
-                                                    }
-                                                ]
-                                            },
-                                            "v": {
-                                                "bytes": ""
-                                            }
-                                        },
-                                        {
-                                            "k": {
-                                                "list": [
-                                                    {
-                                                        "int": -5
-                                                    },
-                                                    {
-                                                        "int": 0
-                                                    },
-                                                    {
-                                                        "int": 4
-                                                    }
-                                                ]
-                                            },
-                                            "v": {
-                                                "list": [
-                                                    {
-                                                        "bytes": "c0d5fd"
-                                                    },
-                                                    {
-                                                        "bytes": ""
-                                                    },
-                                                    {
-                                                        "int": -1
-                                                    },
-                                                    {
-                                                        "bytes": "7e6fb43a"
-                                                    },
-                                                    {
-                                                        "int": 5
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "k": {
-                                    "int": -1
-                                },
-                                "v": {
-                                    "list": [
-                                        {
-                                            "int": 1
-                                        },
-                                        {
-                                            "list": [
-                                                {
-                                                    "bytes": "7f36e143"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "k": {
-                                    "bytes": ""
-                                },
-                                "v": {
-                                    "list": [
-                                        {
-                                            "list": [
-                                                {
-                                                    "int": 2
-                                                },
-                                                {
-                                                    "int": 5
-                                                },
-                                                {
-                                                    "bytes": "fa"
-                                                },
-                                                {
-                                                    "bytes": "4d3e"
-                                                },
-                                                {
-                                                    "int": 0
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "bytes": "53"
-                                        },
-                                        {
-                                            "map": [
-                                                {
-                                                    "k": {
-                                                        "bytes": "b6932f"
-                                                    },
-                                                    "v": {
-                                                        "bytes": "968eaf"
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "bytes": "92"
-                                                    },
-                                                    "v": {
-                                                        "int": -3
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "int": -2
-                                                    },
-                                                    "v": {
-                                                        "bytes": "17922b"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            {
-                                "k": {
-                                    "map": [
-                                        {
-                                            "k": {
-                                                "map": []
-                                            },
-                                            "v": {
-                                                "int": -3
-                                            }
-                                        },
-                                        {
-                                            "k": {
-                                                "map": [
-                                                    {
-                                                        "k": {
-                                                            "bytes": ""
-                                                        },
-                                                        "v": {
-                                                            "bytes": "37c1"
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "bytes": "7da7"
-                                                        },
-                                                        "v": {
-                                                            "int": 3
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "bytes": ""
-                                                        },
-                                                        "v": {
-                                                            "int": 1
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "bytes": "57"
-                                                        },
-                                                        "v": {
-                                                            "bytes": ""
-                                                        }
-                                                    }
-                                                ]
-                                            },
-                                            "v": {
-                                                "int": 4
-                                            }
-                                        },
-                                        {
-                                            "k": {
-                                                "map": [
-                                                    {
-                                                        "k": {
-                                                            "bytes": "5fec22"
-                                                        },
-                                                        "v": {
-                                                            "bytes": "fcf14a"
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "int": 3
-                                                        },
-                                                        "v": {
-                                                            "bytes": "6a22eb7b"
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "int": 5
-                                                        },
-                                                        "v": {
-                                                            "bytes": "b178b4"
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "int": 1
-                                                        },
-                                                        "v": {
-                                                            "int": -3
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "int": 2
-                                                        },
-                                                        "v": {
-                                                            "bytes": "f331"
-                                                        }
-                                                    }
-                                                ]
-                                            },
-                                            "v": {
-                                                "constructor": 5,
-                                                "fields": [
-                                                    {
-                                                        "bytes": "ee"
-                                                    }
-                                                ]
-                                            }
-                                        },
-                                        {
-                                            "k": {
-                                                "map": [
-                                                    {
-                                                        "k": {
-                                                            "bytes": ""
-                                                        },
-                                                        "v": {
-                                                            "int": -1
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "int": -3
-                                                        },
-                                                        "v": {
-                                                            "int": 4
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "int": -1
-                                                        },
-                                                        "v": {
-                                                            "int": -4
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "bytes": "9186"
-                                                        },
-                                                        "v": {
-                                                            "bytes": "cffb6b14"
-                                                        }
-                                                    }
-                                                ]
-                                            },
-                                            "v": {
-                                                "bytes": "eb"
-                                            }
-                                        },
-                                        {
-                                            "k": {
-                                                "bytes": "7748b8"
-                                            },
-                                            "v": {
-                                                "map": [
-                                                    {
-                                                        "k": {
-                                                            "int": 1
-                                                        },
-                                                        "v": {
-                                                            "bytes": "c8"
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "int": 4
-                                                        },
-                                                        "v": {
-                                                            "bytes": "ec1d29cb"
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "bytes": "a6a6228a"
-                                                        },
-                                                        "v": {
-                                                            "bytes": "127cd7"
-                                                        }
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    ]
-                                },
-                                "v": {
-                                    "map": [
-                                        {
-                                            "k": {
-                                                "bytes": "c22c"
-                                            },
-                                            "v": {
-                                                "constructor": 4,
-                                                "fields": [
-                                                    {
-                                                        "int": 0
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    },
-                    "inlineDatumRaw": "a5809f4460bcf40605012000ff80a3a20441db022041cba12204409f240004ff9f43c0d5fd4020447e6fb43a05ff209f019f447f36e143ffff409f9f020541fa424d3e00ff4153a343b6932f43968eaf419222214317922bffa5a022a4404237c1427da703400141574004a5435fec2243fcf14a03446a22eb7b0543b178b401220242f331d87e9f41eeffa440202204202342918644cffb6b1441eb437748b8a30141c80444ec1d29cb44a6a6228a43127cd7a142c22cd87d9f00ff",
-                    "inlineDatumhash": "bfb206c20b8e6244430a3ab2d454550a64dd466ed732ab4f0723557acfacbcf4",
-                    "referenceScript": {
-                        "script": {
-                            "cborHex": "4746010000222601",
-                            "description": "",
-                            "type": "PlutusScriptV3"
-                        },
-                        "scriptLanguage": "PlutusScriptLanguage PlutusScriptV3"
-                    },
+                    "datumhash": null,
+                    "inlineDatum": null,
+                    "inlineDatumRaw": null,
+                    "referenceScript": null,
                     "value": {
-                        "2968e29e478d665a8cac25e08923e8243b9e471c620c381964983846": {
-                            "2c1825a3fab80f4e6cd60279345cc9fde2ef722f701a18d5c2699f948c42a57d": 1
+                        "6d7d3cfabbde27561b15a6c4a06a2944b0681debb4827b250ea650fa": {
+                            "4e3c57668fa34a927e71c6ef87879ad9067c": 1
                         },
-                        "lovelace": 8126982943083141873
+                        "lovelace": 1604533978959726338
                     }
                 },
-                "0202060607050000040707000504080603010703060002000104070306050000#53": {
-                    "address": "addr_test1zzhq20tv8zzc99r5hdrmrjyjqehqvdqz340pkld08fnmww0j8xdma8y6f3wjcr6fhesm9qetdgehu08h7kss9yfxgzesrp658v",
+                "0204030506060006080402060003070301070000040308080806040401050707#41": {
+                    "address": "EqGAuA8vHnP5d1i8F5CZvsVRK9EE88fr1vYESndCB3DFCuUnaqDwbapPGYXPGN5ZueMQfndh253zhYiosE3jxPXveALhRteX6ECghr6RwFavg3JmzTwc2x6",
                     "datum": null,
-                    "datumhash": "d16e38a22b20810e8ad53ccd02ce0e4c5896b7aebcb252211d9d4432d1df648a",
+                    "datumhash": null,
                     "inlineDatum": null,
                     "inlineDatumRaw": null,
                     "referenceScript": {
                         "script": {
-                            "cborHex": "830301838202808200581c538048d6be1c82b0e9057fdc316da009e1c76a9a6940ac84437aa281830301818200581cdfae413d2f5de14510ead4fdd2fcd702f697ae5795f7dd368a589e8d",
+                            "cborHex": "820408",
                             "description": "",
                             "type": "SimpleScript"
                         },
                         "scriptLanguage": "SimpleScriptLanguage"
                     },
                     "value": {
-                        "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
-                            "4d0251": 1
+                        "4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebe": {
+                            "705a048c9452b71ed63d78946342": 6659701736374965537
+                        }
+                    }
+                },
+                "0605020704060008010404030604080306080601080201050802070505060508#47": {
+                    "address": "addr1wxj6fxkmrzw642ujjdm2rpw345l3x603nwp9srn0w743slqlfptg2",
+                    "datum": null,
+                    "datumhash": null,
+                    "inlineDatum": null,
+                    "inlineDatumRaw": null,
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "46450100002601",
+                            "description": "",
+                            "type": "PlutusScriptV1"
+                        },
+                        "scriptLanguage": "PlutusScriptLanguage PlutusScriptV1"
+                    },
+                    "value": {
+                        "245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abae": {
+                            "ee6acf63569b62e35e9dfdd1df5a2d7866763522b1414adf3303e84fb536ef42": 1
                         }
                     }
                 }
@@ -20949,112 +20573,65 @@
             "timestamp": "1864-05-10T06:25:14.303653139792Z"
         },
         {
-            "headId": "01080200000505070104040605030706",
-            "pendingDeposit": "0706070001000708060005080306030801030203040105050501000508030706",
+            "deadline": "1864-05-10T15:42:01.212549671676Z",
+            "headId": "06070604080500040206010203060108",
+            "pendingDeposit": "0006010008020401030500070204050207000202070702080404060104040006",
             "seq": 0,
             "tag": "CommitRecorded",
             "timestamp": "1864-05-15T11:00:08.040641775434Z",
             "utxoToCommit": {
-                "0507070505000202080300030301040607070703080500000703040507000503#56": {
-                    "address": "EqGAuA8vHnP1TMdxoXr7Dg1sNb6HCi8MBfiNvkH8UMdsiCSmscawESaYCTwR4FC6WcQk4HKkKgxyi8DCPgv5DuP4NVkZQWkDd7W7ZNzivz7kjNJpedg2PAN",
+                "0003080006010603060302020403000605030606040305050004000203010304#78": {
+                    "address": "addr1xy7u20adgxe3f2z6emcqau835l7c4jxyyjsa9nz0t6zn5gs48p6xachh435tg6ur5czj26u6tzt0gcfeja5453x7yprqn6x3t5",
                     "datum": null,
-                    "datumhash": null,
+                    "datumhash": "c516f536223e85c314d61dcfcf2ebe24afd0edf7dfb9d7b6a8cd415213e365bd",
                     "inlineDatum": null,
                     "inlineDatumRaw": null,
-                    "referenceScript": null,
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "820406",
+                            "description": "",
+                            "type": "SimpleScript"
+                        },
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
                     "value": {
-                        "245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abae": {
-                            "6610a785494ce3e09221ec57e5de75c5fd3cdd": 1
-                        }
+                        "a50803178374aeed226cd07b42f704a1635dce943efb5405506094ed": {
+                            "32": 1
+                        },
+                        "lovelace": 2700663027340182653
+                    }
+                },
+                "0102040101010102080804080202010804000005050101020405030008030001#82": {
+                    "address": "EqGAuA8vHnP1qn2oMRhgS3Zvj3QAy5Z4VutjSrqVUyvTYydcM3RBPURFwW5Rrtdh9QWfCgXZUNQsG16tgziEZuKs347QQuqbnfQhcNQPiKuuE2QWnvqUNdr",
+                    "datum": null,
+                    "datumhash": "c21cd4ee9ec1f14e18483076d27f11768b87df0b7db8f66f6dee7cafed378543",
+                    "inlineDatum": null,
+                    "inlineDatumRaw": null,
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "8200581c8c8f80c2a1219ef468b74a64d2432d78264ee576afdb6e27809727c8",
+                            "description": "",
+                            "type": "SimpleScript"
+                        },
+                        "scriptLanguage": "SimpleScriptLanguage"
+                    },
+                    "value": {
+                        "66a50645cf4ba1b5150a90e7493ee44368c36855cc2e3d5851b7077e": {
+                            "0c4b7b8e842798188f78bac119b5343fda3f57dd2636a826a2600f6183cc81": 1
+                        },
+                        "lovelace": 7169045645035370142
                     }
                 }
             }
         },
         {
-            "headId": "04040407040002020100060308080403",
-            "pendingDeposit": "0102070706050506020402070803010003070505060400050600050407080000",
+            "deadline": "1864-05-06T04:22:40.958444889964Z",
+            "headId": "00030703080402010407060500020408",
+            "pendingDeposit": "0404030601050702060006050702000401060000030301020600030304000202",
             "seq": 0,
             "tag": "CommitRecorded",
             "timestamp": "1864-05-12T12:46:02.819279241506Z",
-            "utxoToCommit": {
-                "0104010804010403000702050000000208050406060404070405000105020706#78": {
-                    "address": "addr1zxfv2t5gm3mdlt8p7xgfjqs74420rqw2cj7v08zud4suj6vd8l5jfun0yqex2plhj7q32d7cf2h8ungp3my3qgycn09qszx5uk",
-                    "datum": null,
-                    "datumhash": "4affc7e37e677946c02152f8390a8b743d3cbae1e7506db104d73032ec4480fe",
-                    "inlineDatum": null,
-                    "inlineDatumRaw": null,
-                    "referenceScript": {
-                        "script": {
-                            "cborHex": "8201828200581cfa6a8391940c8ea742290927626419ec18f30ffdca10c07a5ddcc43a8200581ce541864dba30bc0bc3a1a72af4959721cc6644f0eb92a2d224bfcd77",
-                            "description": "",
-                            "type": "SimpleScript"
-                        },
-                        "scriptLanguage": "SimpleScriptLanguage"
-                    },
-                    "value": {
-                        "eb2885d1c891fdb0cdf314ad01fef64874b0f38a464f077adab9e691": {
-                            "31": 2627773735141366945
-                        },
-                        "lovelace": 1849131519602874895
-                    }
-                },
-                "0300000800050102030402060400000506000208060802060705060704070301#10": {
-                    "address": "addr_test1zqpemd3ya28gz2fcwpu4sr9fq34td7ykrgdt7edgdf9p3n5cl0ufqdv5l5dq2wt6krupendgmxgh54vz27x4pu28u9fqra9m4p",
-                    "datum": null,
-                    "datumhash": null,
-                    "inlineDatum": null,
-                    "inlineDatumRaw": null,
-                    "referenceScript": null,
-                    "value": {
-                        "21481b2dc0ffa5b1d5d49492d932de917b286e2321f6905da8b409a8": {
-                            "615b1f2ec2ce8b0f8eaf875db0c1": 1
-                        }
-                    }
-                },
-                "0302000501020304040607000403040505050204070703000404050205040206#10": {
-                    "address": "addr_test1xr8n92l77hjkn46kmckcduyn3j4yug6gj2xy2kzks5a599x20zfz6t52xcuqv6hxu8mr8lz3dxgsz70w6mh6wwgakmnskytfr5",
-                    "datum": null,
-                    "inlineDatum": {
-                        "int": 1
-                    },
-                    "inlineDatumRaw": "01",
-                    "inlineDatumhash": "ee155ace9c40292074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e25",
-                    "referenceScript": {
-                        "script": {
-                            "cborHex": "82050a",
-                            "description": "",
-                            "type": "SimpleScript"
-                        },
-                        "scriptLanguage": "SimpleScriptLanguage"
-                    },
-                    "value": {
-                        "442fe3819215f680f5004bbf511d410a0e3a4161d0ee8ac3f2aa9f47": {
-                            "35": 2377461906806794516
-                        }
-                    }
-                },
-                "0507060804050801070804020401070004010802060702040204030005040504#45": {
-                    "address": "addr_test1yq4l6fcxdkwy5mhgdyhwrvtqqcg3wpgt9y56kryhdu72a8m8y76n9lylcgmvczk3m2twl5slsxgwkpm0n8gfk4esm6eq8zhazw",
-                    "datum": null,
-                    "datumhash": null,
-                    "inlineDatum": null,
-                    "inlineDatumRaw": null,
-                    "referenceScript": {
-                        "script": {
-                            "cborHex": "8202848201828201818200581cbf84ef2a3e39a24fc64348141464467fc9a28768652983c08b13303d8202848200581c3cdbad27d543010c4a0738274327b68a731793e12751bc8c184faed48200581c99dcbb57d0cf8156e9f4215e64b325561256922f7309dfb51d05e4d48200581c1985ba76b461c0f10294c5040caefe8387492235f0f71a52638397c88200581ccdacd100f6d7841103a574e199b6524a9b40b17d56192310f23ba38a830302848201828200581c7d2b21fb237b848a22f361b007045df68d4774728c4fe0265ef2d3e28200581c20946d802595cd9f95f3d2645bcbf6a75dec454c7564ffa90b0fe4a78201818200581c737ad514c47b9a7b795d151b9309dc4176a47b43174bbec33b3cef058201838200581cd3684564ccfb29210ba8a67806e5f2310a838ea7981ed45f9fdb7b6a8200581cb73dbf6abb69f9da4097a2dcee5bf14f8ce56d6fda892a11a188abcc8200581c77a015fec94b1b99a0b408580dc3b601eca813f79205ae3ae91b1363830300848200581c3767a1a1fac06d477d0221ddbdd79211a7698684c432f352ed6556b68200581c6f65d13b6b6b5a4a4f586792be816b1da1404625db9ca237195bf04c8200581c63ef2f460c41fa9ca8e34122ec21f3300a3ea054d7701a74e19636368200581ce34fe207c71d0e4b5b47766ae45c7ac06704b3ec37c119d53ae97517830300828201828200581cdd1fbb9c0e7651e3f6005ed7b52b5c2e5263011bc796dbc5251e57d98200581c504f989619bf8ac145d84fd1ece1ed2e38b283c905a467137900fb468200581cb2a607bfc9cce4d5ee4c9b004600cf8de5133622aaaa5cb982b172ad8200581c88765a6bf7e4af503d6adfa32b0195d7ce1c765173ab83dcb72fef2d",
-                            "description": "",
-                            "type": "SimpleScript"
-                        },
-                        "scriptLanguage": "SimpleScriptLanguage"
-                    },
-                    "value": {
-                        "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
-                            "b77b85efcf113d09069cde28ff24164789d51a5a": 8255996737927913239
-                        },
-                        "lovelace": 8997811303481647775
-                    }
-                }
-            }
+            "utxoToCommit": {}
         },
         {
             "headId": "08020803010001060001060600010805",

--- a/hydra-node/golden/ServerOutput/CommitRecorded.json
+++ b/hydra-node/golden/ServerOutput/CommitRecorded.json
@@ -1,19 +1,85 @@
 {
     "samples": [
         {
-            "headId": "a310bc2d25324513509751f4bb3fc64c",
-            "pendingDeposit": "4f64b4e501caa23c9868dfa77e9c6ee13f36969ecce3c0e5b018f10c6175146e",
+            "deadline": "1864-05-09T12:43:39.421430191425Z",
+            "headId": "68595f07802a421aa17be13e73dbdd9d",
+            "pendingDeposit": "a558c7a694517116ce06e5375bc253b7557e7acef6248082932fda63ef0bd77b",
             "tag": "CommitRecorded",
             "utxoToCommit": {
-                "1da0dda3c32c4188cf2df93fe03d79bcfbcb23dfd3bb2d9fef70e2cc1920623c#95": {
-                    "address": "addr_test1vzehkwgdc93pf4tjdql86vctp5ddnhgnettcjnwrf22pumq8ru47t",
+                "2f49e79a9a8b7450962948ff0ffdb9c9420897651c471913786c4e1f92d0a72a#87": {
+                    "address": "EqGAuA8vHnPDeqbWGxyPcLX9YD8ut1pUibNcwwbKZQAoUExgLTRqPpefb44LFFW4agxCag4X4h18cPxjSQ987JER9gunoFUiZ2zKjnPqhLEfRtBJMR4qY9B",
                     "datum": null,
-                    "datumhash": "cb10ea9ced49987dc85a81309d778fb2796a9364cf611835e7f02b975fc25512",
+                    "inlineDatum": {
+                        "bytes": ""
+                    },
+                    "inlineDatumRaw": "40",
+                    "inlineDatumhash": "39df024ac52722fe8ae4c1a8740e4c5624a38c3820e504a059aae8728421f8bd",
+                    "referenceScript": null,
+                    "value": {
+                        "3e90ca095d09c8bb04e8624109d8f8fbbdd27c0ea33bf66bfd3e3bdd": {
+                            "ad28596723f573b811731b64832247512ff2d4dee2fb188638cea5dbcffc3c": 4166921036024893347
+                        },
+                        "lovelace": 1
+                    }
+                },
+                "35ef95a478e2d352118109ce8d4a7b45ab7f460590d6ec2420638e4e7a0b43c1#86": {
+                    "address": "addr_test1yq4tdvz9y9pfnz62eh4d5ysvf64xrhsnxgesgld67z075skdhgqqnewsmlm4jzmg8tyrrdqp0uw7zfkxzrz8plpd56fs8fef4a",
+                    "datum": null,
+                    "inlineDatum": {
+                        "int": -3
+                    },
+                    "inlineDatumRaw": "22",
+                    "inlineDatumhash": "95c3003a78585e0db8c9496f6deef4de0ff000994b8534cd66d4fe96bb21ddd3",
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "484701000022200101",
+                            "description": "",
+                            "type": "PlutusScriptV1"
+                        },
+                        "scriptLanguage": "PlutusScriptLanguage PlutusScriptV1"
+                    },
+                    "value": {
+                        "8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3": {
+                            "cb61fe9ce2458e7d4e8ece6719a9eee0cd1a6dee": 5529673388420696061,
+                            "f96e0464324b3f08595b": 2
+                        },
+                        "cdc4b664504b61069f85b3aa795aa687b09423a8f2f925ec3d559a20": {
+                            "847b69": 2
+                        },
+                        "lovelace": 4926645793686556066
+                    }
+                },
+                "3e928f973bb42c4460e61f9312deb353f5da31392c04676f700a85f1482866b9#98": {
+                    "address": "addr_test1qzkvpzjdjhpcl6kdxsj39s0jg2ackqew5ssjtqqfvc8725v6cdmcnumz38q78cqr6gstty0hrpqlp363wd8tqpeaqumqypdyr8",
+                    "datum": null,
+                    "datumhash": null,
                     "inlineDatum": null,
                     "inlineDatumRaw": null,
                     "referenceScript": {
                         "script": {
-                            "cborHex": "8200581c0e7348ec87874ba5575511441ecf51682824821fff97427d1c5c146f",
+                            "cborHex": "46450100002261",
+                            "description": "",
+                            "type": "PlutusScriptV2"
+                        },
+                        "scriptLanguage": "PlutusScriptLanguage PlutusScriptV2"
+                    },
+                    "value": {
+                        "2d725128406dc832eb74c4709aca0512499b3c7b17e00d7cb2e6d1b1": {
+                            "27033b77c6": 7088478949785575952,
+                            "7340b60da6f0ff93cdc9d37c4e87c7": 314982647972728306
+                        },
+                        "lovelace": 1
+                    }
+                },
+                "9574a8926e32d8ac24540f74b48859a9e9345a096d21802d93d3b417d68944cf#42": {
+                    "address": "addr1qx8m4xr7edxa23wc7ag6hjcrylha3ulsu3lznpame5y6c7q07n5yecpdwwe9gr26a34r77lgpwlpyqswpp3gttwr4uhsc8620y",
+                    "datum": null,
+                    "datumhash": null,
+                    "inlineDatum": null,
+                    "inlineDatumRaw": null,
+                    "referenceScript": {
+                        "script": {
+                            "cborHex": "8202818201848201818200581c26ea8a0d6509e3d7f471123a1b0dc3a6a843079c3cb121da165f4da98200581c8e698aec477571d81f19f7281bb6c4766dc48512e5e3ed6bb726f4478202838200581cec216502686d9a47b084d83d54f897137ed0d1f220a9e1af1b7621ff8200581cea423c09d4b9de047c0a27abe6cd05a40d75ce604de0f9d86c9ce80d8200581c6e757d239d4f088bd6e8e83fa8f307ea64a1e22fa64df46c07a9cc648202828200581c176b40c47c7df9f0e452055f8258f2837e8fe973153deb2f6b7468508200581ccfd715fe660733c5be0d3fc95c86785fff8c0899453530745697f134",
                             "description": "",
                             "type": "SimpleScript"
                         },
@@ -21,101 +87,156 @@
                     },
                     "value": {
                         "105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5": {
-                            "e2617282dec669eeb94cd323ebc20643a7e3b0dde5a3b5f8a9cb0e1e": 2
+                            "da2722d8b49c98874b9eafdb59786667b2a0a4743993": 6805035914308588488
                         },
-                        "66a2c11d762fe8e6e84a92878fd61a1fc944d600f2b4e1ee7c86cfa0": {
-                            "f5b2d8bafb5e9fbd": 5474725707454191587
+                        "724c2e0e0ac7f8c4afa4fa18038fb76e8573f7af644d7bbc88f9e393": {
+                            "32": 1,
+                            "ee991184f582811b6ae5530395b117879ad15414b3963d9cf91e6c": 8934491785691888450
                         },
-                        "lovelace": 1
+                        "lovelace": 5245046578922861563
                     }
                 },
-                "3dec6e0f8ab16b95b7773d9f4b1e8ae59f40073552ffb989dc11b440f323d832#69": {
-                    "address": "addr_test1qqyfep92ncd0002qt3gnxpcycd4kcunrk3r0kzmshl0r67ae335p9qhv86m7sgjz3fpcnvf5rnt2cllra87mcmsu0ejq73cpcq",
-                    "datum": null,
-                    "datumhash": "dd390e6fb883784d7cbffc39169956ad88baa269be5b925410d30603229d7185",
-                    "inlineDatum": null,
-                    "inlineDatumRaw": null,
-                    "referenceScript": {
-                        "script": {
-                            "cborHex": "8200581c21f442aebd65b497718e97c1cf64adcefb14f4a8c3530b152a9c3982",
-                            "description": "",
-                            "type": "SimpleScript"
-                        },
-                        "scriptLanguage": "SimpleScriptLanguage"
-                    },
-                    "value": {
-                        "8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3": {
-                            "fb3abff7b436c54b7bcb7c9353fe931900518149e7c7941b38ed": 1
-                        },
-                        "lovelace": 1
-                    }
-                },
-                "8f1b3d6858bbc533dc34ecb72cb22d433325f4a43cbe18a6e8530d3ac1d91fd1#97": {
-                    "address": "addr1vxg2kk38zscl853v7x39cwyezk8lqtew6e8htwexh9xkqfs2wpqha",
+                "ba877f246f3fc6b43faf49494562e255c3b9bd37ba54d31e499f2250ebbb1b22#79": {
+                    "address": "addr_test1xqhvxw5x2x3fzzflld0d6wxh0ep92xvh3qjx6e045kd2r206j48rsckpcf5d8t78az6gfv0lc8p4hk7ge07fwlnw2d6qz2evg5",
                     "datum": null,
                     "datumhash": null,
                     "inlineDatum": null,
                     "inlineDatumRaw": null,
                     "referenceScript": {
                         "script": {
-                            "cborHex": "820180",
+                            "cborHex": "484701000022200101",
                             "description": "",
-                            "type": "SimpleScript"
+                            "type": "PlutusScriptV2"
                         },
-                        "scriptLanguage": "SimpleScriptLanguage"
+                        "scriptLanguage": "PlutusScriptLanguage PlutusScriptV2"
                     },
                     "value": {
-                        "abfbdeaa53ab44dfb357a6ce3e22e6d5a6a3b057c838138ad9d1e06a": {
-                            "0a6c2e7ce96e0f504b04a415061b9ea3": 1
+                        "cae0629479deea101b11c2fc2556327dd705b1b5d9a80b8c30673fe1": {
+                            "096d2a6f13c765ffc51832e20d": 2
                         },
-                        "lovelace": 227856113935439342
+                        "lovelace": 468764666243078712
                     }
                 },
-                "9db584394f7811fc9604dd13b688e864be207fe9d2335334a1abd522916500cb#65": {
-                    "address": "addr1z87fzxxyhv89h3udpnn63auvsmknfgw8h2sa2nj7pccyjzwje7h2m7dzcwjh8f3dx64lwt9haqsdxa7s32naasjdhj3sqz9aw7",
+                "bad5ae8bf9b1d6adc5be11ae170cc7001aaad70d242f41bcdfdce0e21afe753d#44": {
+                    "address": "addr1z9lf2lp6lwhdzs5uzy6cctxgv7m2ns49fkhrwfuq4ek7t709gkpxw6kk9yxnsdndpt3r3pcs6v0jz3yhvp0kh6erxngsmsfcej",
                     "datum": null,
                     "inlineDatum": {
-                        "bytes": "e543"
+                        "list": [
+                            {
+                                "map": []
+                            },
+                            {
+                                "map": [
+                                    {
+                                        "k": {
+                                            "int": 2
+                                        },
+                                        "v": {
+                                            "int": -4
+                                        }
+                                    },
+                                    {
+                                        "k": {
+                                            "map": [
+                                                {
+                                                    "k": {
+                                                        "bytes": "6363ba"
+                                                    },
+                                                    "v": {
+                                                        "int": -2
+                                                    }
+                                                },
+                                                {
+                                                    "k": {
+                                                        "bytes": "135f30"
+                                                    },
+                                                    "v": {
+                                                        "bytes": "070913"
+                                                    }
+                                                },
+                                                {
+                                                    "k": {
+                                                        "bytes": "ecf0"
+                                                    },
+                                                    "v": {
+                                                        "bytes": "7c"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "v": {
+                                            "map": [
+                                                {
+                                                    "k": {
+                                                        "int": 4
+                                                    },
+                                                    "v": {
+                                                        "bytes": "fb"
+                                                    }
+                                                },
+                                                {
+                                                    "k": {
+                                                        "int": 0
+                                                    },
+                                                    "v": {
+                                                        "bytes": "aa5f"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "int": -3
+                            },
+                            {
+                                "list": [
+                                    {
+                                        "constructor": 1,
+                                        "fields": [
+                                            {
+                                                "int": 4
+                                            },
+                                            {
+                                                "bytes": "6f8796"
+                                            },
+                                            {
+                                                "bytes": "d76c"
+                                            },
+                                            {
+                                                "bytes": ""
+                                            },
+                                            {
+                                                "int": 5
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "bytes": "cb"
+                            }
+                        ]
                     },
-                    "inlineDatumRaw": "42e543",
-                    "inlineDatumhash": "6042a3d658c0c75e356db89fb69b9e565062e83ac6de36f6cee2f6cc61ce5586",
+                    "inlineDatumRaw": "9fa0a20223a3436363ba2143135f304307091342ecf0417ca20441fb0042aa5f229fd87a9f04436f879642d76c4005ffff41cbff",
+                    "inlineDatumhash": "f6f122d4dbeb95e127118acadfcfa82ebbe8d5b6b51a6556915a074cc4f35cdd",
                     "referenceScript": {
                         "script": {
-                            "cborHex": "8200581cc5dcc6e2c90dab246c5127d1d520ccefc2f9a48f1f213c14ea79e2bb",
+                            "cborHex": "82041a004b9d8f",
                             "description": "",
                             "type": "SimpleScript"
                         },
                         "scriptLanguage": "SimpleScriptLanguage"
                     },
                     "value": {
-                        "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
-                            "43be3dde54050eb926cafdf2f35be9a9bf8e0d": 4796155671044796811,
-                            "6ffb821096fb40b39dff5c3da0c0ebdcb646c7e6e73bef0117aa": 2
+                        "3bb3488685ba2f7c6bbf441c470f4aa2207d7ebe6da370c9a3a3ae93": {
+                            "b0fb19cef89a441c47f8f6820b406bfcb1a5283774f982f2ad8609b2a9564bc8": 2
                         },
-                        "b0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165": {
-                            "84227d5b262ea367a37a5bb8cf5c1df317082ad1af47a0b5f9d1071b968217": 2
+                        "8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3": {
+                            "f744ee": 1
                         },
-                        "lovelace": 8258311493319174747
-                    }
-                },
-                "fdbbd3610eb109f74c9f353c86d4aeafdc9f836091580b73f4cef12f366dffbb#96": {
-                    "address": "addr1qyhfs7a6mvqg928ujduydtj26mrh6g9tm78da35q03w6ch6p6nx3grpkwzqdu5z0a2jh69n3e2adqqa76u5lkm33ssaquklpmr",
-                    "datum": null,
-                    "inlineDatum": {
-                        "int": 3
-                    },
-                    "inlineDatumRaw": "03",
-                    "inlineDatumhash": "e88bd757ad5b9bedf372d8d3f0cf6c962a469db61a265f6418e1ffed86da29ec",
-                    "referenceScript": null,
-                    "value": {
-                        "245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abae": {
-                            "34": 1,
-                            "3eb620367fee3857be367297e059a9509770": 3
-                        },
-                        "aba763f6ea5f4ed49795829c4773dd4dc7ec9dcc3ee376f0d80dbeed": {
-                            "30": 1
-                        },
-                        "lovelace": 1
+                        "lovelace": 8050092423291003290
                     }
                 }
             }

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -1352,6 +1352,7 @@ components:
         - headId
         - utxoToCommit
         - pendingDeposit
+        - deadline
         - seq
         - timestamp
       properties:
@@ -1364,6 +1365,8 @@ components:
           $ref: "api.yaml#/components/schemas/UTxO"
         pendingDeposit:
           type: string
+        deadline:
+          $ref: "api.yaml#/components/schemas/UTCTime"
         seq:
           $ref: "api.yaml#/components/schemas/SequenceNumber"
         timestamp:

--- a/hydra-node/src/Hydra/API/HTTPServer.hs
+++ b/hydra-node/src/Hydra/API/HTTPServer.hs
@@ -28,6 +28,8 @@ import Hydra.Tx (
   IsTx (..),
   UTxOType,
  )
+import Hydra.Tx.ContestationPeriod (toNominalDiffTime)
+import Hydra.Tx.Environment (Environment (..))
 import Network.HTTP.Types (status200, status400, status404, status500)
 import Network.Wai (
   Application,
@@ -129,6 +131,7 @@ httpApp ::
   IsChainState tx =>
   Tracer IO APIServerLog ->
   Chain tx IO ->
+  Environment ->
   PParams LedgerEra ->
   -- | A means to get commit info.
   IO CommitInfo ->
@@ -139,7 +142,7 @@ httpApp ::
   -- | Callback to yield a 'ClientInput' to the main event loop.
   (ClientInput tx -> IO ()) ->
   Application
-httpApp tracer directChain pparams getCommitInfo getConfirmedUTxO getPendingDeposits putClientInput request respond = do
+httpApp tracer directChain env pparams getCommitInfo getConfirmedUTxO getPendingDeposits putClientInput request respond = do
   traceWith tracer $
     APIHTTPRequestReceived
       { method = Method $ requestMethod request
@@ -155,7 +158,7 @@ httpApp tracer directChain pparams getCommitInfo getConfirmedUTxO getPendingDepo
         Just utxo -> respond $ okJSON utxo
     ("POST", ["commit"]) ->
       consumeRequestBodyStrict request
-        >>= handleDraftCommitUtxo directChain getCommitInfo
+        >>= handleDraftCommitUtxo env directChain getCommitInfo
         >>= respond
     ("DELETE", ["commits", _]) ->
       consumeRequestBodyStrict request
@@ -184,13 +187,14 @@ httpApp tracer directChain pparams getCommitInfo getConfirmedUTxO getPendingDepo
 handleDraftCommitUtxo ::
   forall tx.
   IsChainState tx =>
+  Environment ->
   Chain tx IO ->
   -- | A means to get commit info.
   IO CommitInfo ->
   -- | Request body.
   LBS.ByteString ->
   IO Response
-handleDraftCommitUtxo directChain getCommitInfo body = do
+handleDraftCommitUtxo env directChain getCommitInfo body = do
   case Aeson.eitherDecode' body :: Either String (DraftCommitTxRequest tx) of
     Left err ->
       pure $ responseLBS status400 [] (Aeson.encode $ Aeson.String $ pack err)
@@ -212,10 +216,7 @@ handleDraftCommitUtxo directChain getCommitInfo body = do
         CannotCommit -> pure $ responseLBS status500 [] (Aeson.encode (FailedToDraftTxNotInitializing :: PostTxError tx))
  where
   deposit headId commitBlueprint = do
-    -- TODO: How to make this configurable for testing? Right now this is just
-    -- set to current time in order to have easier time testing the recover.
-    -- Perhaps use contestation deadline to come up with a meaningful value?
-    deadline <- getCurrentTime
+    deadline <- addUTCTime (toNominalDiffTime contestationPeriod) <$> getCurrentTime
     draftDepositTx headId commitBlueprint deadline <&> \case
       Left e -> responseLBS status400 [] (Aeson.encode $ toJSON e)
       Right depositTx -> okJSON $ DraftCommitTxResponse depositTx
@@ -233,6 +234,7 @@ handleDraftCommitUtxo directChain getCommitInfo body = do
       Right commitTx ->
         okJSON $ DraftCommitTxResponse commitTx
   Chain{draftCommitTx, draftDepositTx} = directChain
+  Environment{contestationPeriod} = env
 
 -- | Handle request to recover a pending deposit.
 handleRecoverCommitUtxo ::

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -138,7 +138,7 @@ data ServerOutput tx
   | DecommitRequested {headId :: HeadId, decommitTx :: tx, utxoToDecommit :: UTxOType tx}
   | DecommitInvalid {headId :: HeadId, decommitTx :: tx, decommitInvalidReason :: DecommitInvalidReason tx}
   | DecommitApproved {headId :: HeadId, decommitTxId :: TxIdType tx, utxoToDecommit :: UTxOType tx}
-  | CommitRecorded {headId :: HeadId, utxoToCommit :: UTxOType tx, pendingDeposit :: TxIdType tx}
+  | CommitRecorded {headId :: HeadId, utxoToCommit :: UTxOType tx, pendingDeposit :: TxIdType tx, deadline :: UTCTime}
   | CommitApproved {headId :: HeadId, utxoToCommit :: UTxOType tx}
   | DecommitFinalized {headId :: HeadId, decommitTxId :: TxIdType tx}
   | CommitFinalized {headId :: HeadId, theDeposit :: TxIdType tx}
@@ -197,7 +197,7 @@ instance (ArbitraryIsTx tx, IsChainState tx) => Arbitrary (ServerOutput tx) wher
     IgnoredHeadInitializing{} -> []
     DecommitRequested headId txid u -> DecommitRequested headId txid <$> shrink u
     DecommitInvalid{} -> []
-    CommitRecorded headId u txId -> CommitRecorded headId <$> shrink u <*> shrink txId
+    CommitRecorded headId u txId d -> CommitRecorded headId <$> shrink u <*> shrink txId <*> shrink d
     CommitApproved headId u -> CommitApproved headId <$> shrink u
     DecommitApproved headId txid u -> DecommitApproved headId txid <$> shrink u
     CommitRecovered headId u rid -> CommitRecovered headId <$> shrink u <*> shrink rid

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -941,12 +941,12 @@ onOpenChainDepositTx ::
   -- | Deposit deadline
   UTCTime ->
   Outcome tx
-onOpenChainDepositTx headId env st deposited depositTxId _deadline =
+onOpenChainDepositTx headId env st deposited depositTxId deadline =
   -- TODO: We should check for deadline and only request snapshots that have deadline further in the future so
   -- we don't end up with a snapshot that is already outdated.
   waitOnUnresolvedDecommit $
     newState CommitRecorded{pendingDeposits = Map.singleton depositTxId deposited, newLocalUTxO = localUTxO <> deposited}
-      <> cause (ClientEffect $ ServerOutput.CommitRecorded{headId, utxoToCommit = deposited, pendingDeposit = depositTxId})
+      <> cause (ClientEffect $ ServerOutput.CommitRecorded{headId, utxoToCommit = deposited, pendingDeposit = depositTxId, deadline})
       <> if not snapshotInFlight && isLeader parameters party nextSn
         then
           cause (NetworkEffect $ ReqSn version nextSn (txId <$> localTxs) Nothing (Just deposited))

--- a/hydra-node/src/Hydra/Node/Run.hs
+++ b/hydra-node/src/Hydra/Node/Run.hs
@@ -92,7 +92,7 @@ run opts = do
           -- API
           apiPersistence <- createPersistenceIncremental $ persistenceDir <> "/server-output"
           let apiServerConfig = APIServerConfig{host = apiHost, port = apiPort, tlsCertPath, tlsKeyPath}
-          withAPIServer apiServerConfig party apiPersistence (contramap APIServer tracer) chain pparams (wireClientInput wetHydraNode) $ \server -> do
+          withAPIServer apiServerConfig env party apiPersistence (contramap APIServer tracer) chain pparams (wireClientInput wetHydraNode) $ \server -> do
             -- Network
             let networkConfiguration = NetworkConfiguration{persistenceDir, signingKey, otherParties, host, port, peers, nodeId}
             withNetwork tracer networkConfiguration (wireNetworkInput wetHydraNode) $ \network -> do

--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -44,7 +44,7 @@ import Network.Simple.WSS qualified as WSS
 import Network.TLS (ClientHooks (onServerCertificate), ClientParams (clientHooks), defaultParamsClient)
 import Network.WebSockets (Connection, ConnectionException, receiveData, runClient, sendBinaryData)
 import System.IO.Error (isAlreadyInUseError)
-import Test.Hydra.Tx.Fixture (alice, defaultPParams, testHeadId)
+import Test.Hydra.Tx.Fixture (alice, defaultPParams, testEnvironment, testHeadId)
 import Test.Hydra.Tx.Gen ()
 import Test.Network.Ports (withFreePort)
 import Test.QuickCheck (checkCoverage, cover, generate)
@@ -320,7 +320,7 @@ spec =
                     , tlsCertPath = Just "test/tls/certificate.pem"
                     , tlsKeyPath = Just "test/tls/key.pem"
                     }
-            withAPIServer @SimpleTx config alice mockPersistence tracer dummyChainHandle defaultPParams noop $ \_ -> do
+            withAPIServer @SimpleTx config testEnvironment alice mockPersistence tracer dummyChainHandle defaultPParams noop $ \_ -> do
               let clientParams = defaultParamsClient "127.0.0.1" ""
                   allowAnyParams =
                     clientParams{clientHooks = (clientHooks clientParams){onServerCertificate = \_ _ _ _ -> pure []}}
@@ -388,7 +388,7 @@ withTestAPIServer ::
   (Server SimpleTx IO -> IO ()) ->
   IO ()
 withTestAPIServer port actor persistence tracer action = do
-  withAPIServer @SimpleTx config actor persistence tracer dummyChainHandle defaultPParams noop action
+  withAPIServer @SimpleTx config testEnvironment actor persistence tracer dummyChainHandle defaultPParams noop action
  where
   config = APIServerConfig{host = "127.0.0.1", port, tlsCertPath = Nothing, tlsKeyPath = Nothing}
 

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -391,7 +391,7 @@ spec = parallel $ do
                   let depositUTxO = utxoRefs [11]
                   let deadline = arbitrary `generateWith` 42
                   injectChainEvent n1 Observation{observedTx = OnDepositTx testHeadId depositUTxO 1 deadline, newChainState = SimpleChainState{slot = ChainSlot 0}}
-                  waitUntil [n1] $ CommitRecorded{headId = testHeadId, utxoToCommit = depositUTxO, pendingDeposit = 1}
+                  waitUntil [n1] $ CommitRecorded{headId = testHeadId, utxoToCommit = depositUTxO, pendingDeposit = 1, deadline}
 
                   waitUntilMatch [n1, n2] $
                     \case
@@ -422,8 +422,8 @@ spec = parallel $ do
                   injectChainEvent
                     n2
                     Observation{observedTx = OnDepositTx testHeadId depositUTxO2 2 deadline, newChainState = SimpleChainState{slot = ChainSlot 0}}
-                  waitUntil [n1] $ CommitRecorded{headId = testHeadId, utxoToCommit = depositUTxO, pendingDeposit = 1}
-                  waitUntil [n2] $ CommitRecorded{headId = testHeadId, utxoToCommit = depositUTxO2, pendingDeposit = 2}
+                  waitUntil [n1] $ CommitRecorded{headId = testHeadId, utxoToCommit = depositUTxO, pendingDeposit = 1, deadline}
+                  waitUntil [n2] $ CommitRecorded{headId = testHeadId, utxoToCommit = depositUTxO2, pendingDeposit = 2, deadline}
                   waitUntilMatch [n1, n2] $
                     \case
                       SnapshotConfirmed{snapshot = Snapshot{utxoToCommit}} ->
@@ -455,7 +455,7 @@ spec = parallel $ do
                     n1
                     Observation{observedTx = OnDepositTx testHeadId depositUTxO 1 deadline, newChainState = SimpleChainState{slot = ChainSlot 0}}
 
-                  waitUntil [n1] $ CommitRecorded{headId = testHeadId, utxoToCommit = depositUTxO, pendingDeposit = 1}
+                  waitUntil [n1] $ CommitRecorded{headId = testHeadId, utxoToCommit = depositUTxO, pendingDeposit = 1, deadline}
                   let normalTx = SimpleTx 2 (utxoRef 2) (utxoRef 3)
                   send n2 (NewTx normalTx)
                   waitUntil [n1] $ CommitApproved{headId = testHeadId, utxoToCommit = depositUTxO}
@@ -476,7 +476,7 @@ spec = parallel $ do
                     n1
                     Observation{observedTx = OnDepositTx testHeadId depositUTxO 1 deadline, newChainState = SimpleChainState{slot = ChainSlot 0}}
 
-                  waitUntil [n1] $ CommitRecorded{headId = testHeadId, utxoToCommit = depositUTxO, pendingDeposit = 1}
+                  waitUntil [n1] $ CommitRecorded{headId = testHeadId, utxoToCommit = depositUTxO, pendingDeposit = 1, deadline}
                   waitUntilMatch [n1] $
                     \case
                       SnapshotConfirmed{snapshot = Snapshot{utxoToCommit}} ->
@@ -506,7 +506,7 @@ spec = parallel $ do
                   injectChainEvent
                     n2
                     Observation{observedTx = OnDepositTx testHeadId depositUTxO 1 deadline, newChainState = SimpleChainState{slot = ChainSlot 0}}
-                  waitUntil [n2] $ CommitRecorded{headId = testHeadId, utxoToCommit = depositUTxO, pendingDeposit = 1}
+                  waitUntil [n2] $ CommitRecorded{headId = testHeadId, utxoToCommit = depositUTxO, pendingDeposit = 1, deadline}
                   send n1 Close
                   waitUntil [n1, n2] $ ReadyToFanout{headId = testHeadId}
                   send n2 Fanout
@@ -523,7 +523,7 @@ spec = parallel $ do
                   injectChainEvent
                     n1
                     Observation{observedTx = OnDepositTx testHeadId depositUTxO 1 deadline, newChainState = SimpleChainState{slot = ChainSlot 0}}
-                  waitUntil [n1] $ CommitRecorded{headId = testHeadId, utxoToCommit = depositUTxO, pendingDeposit = 1}
+                  waitUntil [n1] $ CommitRecorded{headId = testHeadId, utxoToCommit = depositUTxO, pendingDeposit = 1, deadline}
                   waitUntilMatch [n1, n2] $
                     \case
                       SnapshotConfirmed{snapshot = Snapshot{utxoToCommit}} ->
@@ -555,7 +555,7 @@ spec = parallel $ do
                   injectChainEvent
                     n1
                     Observation{observedTx = OnDepositTx testHeadId depositUTxO 1 deadline, newChainState = SimpleChainState{slot = ChainSlot 0}}
-                  waitUntil [n1] $ CommitRecorded{headId = testHeadId, utxoToCommit = depositUTxO, pendingDeposit = 1}
+                  waitUntil [n1] $ CommitRecorded{headId = testHeadId, utxoToCommit = depositUTxO, pendingDeposit = 1, deadline}
                   waitUntilMatch [n1, n2] $
                     \case
                       SnapshotConfirmed{snapshot = Snapshot{utxoToCommit}} ->


### PR DESCRIPTION
Depends on #1700 

Reuse contestation deadline as a deposit deadline. This is a follow-up from offchain incremental commits where we just used the current time as the deposit deadline. Now the contestation period is re-used as a deposit deadline and on top of that we provide information about it in the `CommitRecorded` server output.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
