### PR TITLE
Save space on the GitHub runners by not building the devShells

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -54,10 +54,6 @@ jobs:
         name: hydra-x86_64-linux-${{ env.VERSION }} # automatically zips
         path: out/*
 
-    - name: ❄ Build devShells (for cache)
-      run: |
-        nix build .#devShells.x86_64-linux.default
-
   build-macos:
     name: "Build for aarch64-darwin"
     runs-on: macos-latest
@@ -101,7 +97,3 @@ jobs:
       with:
         name: hydra-aarch64-darwin-${{ env.VERSION }} # automatically zips
         path: out/*
-
-    - name: ❄ Build devShells (for cache)
-      run: |
-        nix build .#devShells.aarch64-darwin.default


### PR DESCRIPTION
Reverts part of https://github.com/cardano-scaling/hydra/commit/1a74b59469776bb8ec0eb1b2d5dcd69719191d41#diff-fb5c295cef0d8c42d829f58e5ec19920f741526206f7601876d6412d394acc35R107 because there isn't enough space on the GitHub self-hosted runners :(