### PR TITLE
Remove cardano-configurations submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "testnets/cardano-configurations"]
-	path = testnets/cardano-configurations
-	url = git@github.com:input-output-hk/cardano-configurations.git


### PR DESCRIPTION
As far as I can tell this isn't used. It's interfering with using it as a source-repository-package for hydra-explorer.