### PR TITLE
Implement Claim redeemer branch for the deposit validator + relevant mutations

### DIFF
--- a/hydra-node/src/Hydra/API/HTTPServer.hs
+++ b/hydra-node/src/Hydra/API/HTTPServer.hs
@@ -216,7 +216,10 @@ handleDraftCommitUtxo env directChain getCommitInfo body = do
         CannotCommit -> pure $ responseLBS status500 [] (Aeson.encode (FailedToDraftTxNotInitializing :: PostTxError tx))
  where
   deposit headId commitBlueprint = do
-    deadline <- addUTCTime (toNominalDiffTime contestationPeriod) <$> getCurrentTime
+    -- NOTE: We double the contestation period and use it for the deadline
+    -- value in order to give enough time for the increment to be valid in
+    -- terms of deadline.
+    deadline <- addUTCTime (toNominalDiffTime contestationPeriod * 2) <$> getCurrentTime
     draftDepositTx headId commitBlueprint deadline <&> \case
       Left e -> responseLBS status400 [] (Aeson.encode $ toJSON e)
       Right depositTx -> okJSON $ DraftCommitTxResponse depositTx

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -390,8 +390,11 @@ prepareTxToPost timeHandle wallet ctx spendableUTxO tx =
       case collect ctx headId headParameters utxo spendableUTxO of
         Left _ -> throwIO (FailedToConstructCollectTx @Tx)
         Right collectTx -> pure collectTx
-    IncrementTx{headId, headParameters, incrementingSnapshot, depositTxId} ->
-      case increment ctx spendableUTxO headId headParameters incrementingSnapshot depositTxId of
+    IncrementTx{headId, headParameters, incrementingSnapshot, depositTxId} -> do
+      (_, currentTime) <- throwLeft currentPointInTime
+      let HeadParameters{contestationPeriod} = headParameters
+      (upperBound, _) <- calculateTxUpperBoundFromContestationPeriod currentTime contestationPeriod
+      case increment ctx spendableUTxO headId headParameters incrementingSnapshot depositTxId upperBound of
         Left _ -> throwIO (FailedToConstructIncrementTx @Tx)
         Right incrementTx' -> pure incrementTx'
     RecoverTx{headId, recoverTxId, deadline} -> do

--- a/hydra-plutus/src/Hydra/Contract/DepositError.hs
+++ b/hydra-plutus/src/Hydra/Contract/DepositError.hs
@@ -12,7 +12,7 @@ data DepositError
   | DepositNoLowerBoundDefined
   | DepositDeadlineNotReached
   | IncorrectDepositHash
-  | DTNotMinted
+  | WrongHeadIdInDepositDatum
   deriving stock (Show)
 
 instance ToErrorCode DepositError where
@@ -22,4 +22,4 @@ instance ToErrorCode DepositError where
     DepositNoLowerBoundDefined -> "D03"
     DepositDeadlineNotReached -> "D04"
     IncorrectDepositHash -> "D05"
-    DTNotMinted -> "D06"
+    WrongHeadIdInDepositDatum -> "D06"

--- a/hydra-tx/src/Hydra/Tx/Increment.hs
+++ b/hydra-tx/src/Hydra/Tx/Increment.hs
@@ -95,7 +95,7 @@ incrementTx scriptRegistry vk headId headParameters (headInput, headOutput) snap
   -- NOTE: we expect always a single output from a deposit tx
   (depositIn, depositOut) = List.head $ UTxO.pairs depositScriptUTxO
 
-  depositRedeemer = toScriptData Deposit.Claim
+  depositRedeemer = toScriptData $ Deposit.Claim $ headIdToCurrencySymbol headId
 
   depositWitness =
     BuildTxWith $

--- a/hydra-tx/src/Hydra/Tx/Increment.hs
+++ b/hydra-tx/src/Hydra/Tx/Increment.hs
@@ -14,6 +14,7 @@ import Hydra.Ledger.Cardano.Builder (
   addOutputs,
   addReferenceInputs,
   emptyTxBody,
+  setValidityUpperBound,
   unsafeBuildTransaction,
  )
 import Hydra.Tx.ContestationPeriod (toChain)
@@ -43,14 +44,16 @@ incrementTx ::
   Snapshot Tx ->
   -- | Deposit output UTxO to be spent in increment transaction
   UTxO ->
+  SlotNo ->
   Tx
-incrementTx scriptRegistry vk headId headParameters (headInput, headOutput) snapshot depositScriptUTxO =
+incrementTx scriptRegistry vk headId headParameters (headInput, headOutput) snapshot depositScriptUTxO upperValiditySlot =
   unsafeBuildTransaction $
     emptyTxBody
       & addInputs [(headInput, headWitness), (depositIn, depositWitness)]
       & addReferenceInputs [headScriptRef]
       & addOutputs [headOutput']
       & addExtraRequiredSigners [verificationKeyHash vk]
+      & setValidityUpperBound upperValiditySlot
       & setTxMetadata (TxMetadataInEra $ mkHydraHeadV1TxName "IncrementTx")
  where
   headRedeemer =

--- a/hydra-tx/test/Hydra/Tx/Contract/ContractSpec.hs
+++ b/hydra-tx/test/Hydra/Tx/Contract/ContractSpec.hs
@@ -43,7 +43,7 @@ import Hydra.Tx.Contract.Contest.ContestCurrent (genContestMutation, healthyCont
 import Hydra.Tx.Contract.Decrement (genDecrementMutation, healthyDecrementTx)
 import Hydra.Tx.Contract.Deposit (healthyDepositTx)
 import Hydra.Tx.Contract.FanOut (genFanoutMutation, healthyFanoutTx)
-import Hydra.Tx.Contract.Increment (healthyIncrementTx)
+import Hydra.Tx.Contract.Increment (genIncrementMutation, healthyIncrementTx)
 import Hydra.Tx.Contract.Init (genInitMutation, healthyInitTx)
 import Hydra.Tx.Contract.Recover (genRecoverMutation, healthyRecoverTx)
 import Hydra.Tx.Crypto (aggregate, sign, toPlutusSignatures)
@@ -112,6 +112,8 @@ spec = parallel $ do
   describe "Increment" $ do
     prop "is healthy" $
       propTransactionEvaluates healthyIncrementTx
+    prop "does not survive random adversarial mutations" $
+      propMutation healthyIncrementTx genIncrementMutation
   describe "Decrement" $ do
     prop "is healthy" $
       propTransactionEvaluates healthyDecrementTx

--- a/hydra-tx/test/Hydra/Tx/Contract/Deposit.hs
+++ b/hydra-tx/test/Hydra/Tx/Contract/Deposit.hs
@@ -3,6 +3,8 @@ module Hydra.Tx.Contract.Deposit where
 import Hydra.Cardano.Api
 import Hydra.Prelude
 
+import Data.Time (UTCTime (..), secondsToDiffTime)
+import Data.Time.Calendar (fromGregorian)
 import Hydra.Tx (mkHeadId)
 import Hydra.Tx.BlueprintTx (CommitBlueprintTx (..))
 import Hydra.Tx.Deposit (depositTx)
@@ -18,9 +20,10 @@ healthyDepositTx =
       testNetworkId
       (mkHeadId testPolicyId)
       CommitBlueprintTx{blueprintTx = txSpendingUTxO healthyDepositUTxO, lookupUTxO = healthyDepositUTxO}
-      deadline
+      depositDeadline
 
-  deadline = arbitrary `generateWith` 42
+depositDeadline :: UTCTime
+depositDeadline = UTCTime (fromGregorian 2024 15 0) (secondsToDiffTime 0)
 
 healthyDepositUTxO :: UTxO
 healthyDepositUTxO = genUTxOAdaOnlyOfSize 5 `generateWith` 42

--- a/hydra-tx/test/Hydra/Tx/Contract/Increment.hs
+++ b/hydra-tx/test/Hydra/Tx/Contract/Increment.hs
@@ -23,7 +23,7 @@ import Hydra.Plutus.Orphans ()
 import Hydra.Tx.ContestationPeriod (ContestationPeriod, toChain)
 import Hydra.Tx.Contract.Deposit (depositDeadline, healthyDepositTx)
 import Hydra.Tx.Crypto (HydraKey, MultiSignature (..), aggregate, sign)
-import Hydra.Tx.HeadId (mkHeadId)
+import Hydra.Tx.HeadId (headIdToCurrencySymbol, mkHeadId)
 import Hydra.Tx.HeadParameters (HeadParameters (..))
 import Hydra.Tx.Increment (
   incrementTx,
@@ -36,9 +36,9 @@ import Hydra.Tx.Snapshot (Snapshot (..), SnapshotNumber, SnapshotVersion)
 import Hydra.Tx.Utils (adaOnly, splitUTxO)
 import PlutusLedgerApi.V2 qualified as Plutus
 import PlutusTx.Builtins (toBuiltin)
-import Test.Hydra.Tx.Fixture (aliceSk, bobSk, carolSk, slotLength, systemStart, testNetworkId, testPolicyId)
+import Test.Hydra.Tx.Fixture (aliceSk, bobSk, carolSk, slotLength, systemStart, testHeadId, testNetworkId, testPolicyId)
 import Test.Hydra.Tx.Gen (genForParty, genScriptRegistry, genUTxOSized, genVerificationKey)
-import Test.QuickCheck (elements)
+import Test.QuickCheck (elements, oneof)
 import Test.QuickCheck.Instances ()
 
 healthyIncrementTx :: (Tx, UTxO)
@@ -147,17 +147,31 @@ healthyDatum =
 data IncrementMutation
   = -- | Move the deadline from the deposit datum back in time
     -- so that the increment upper bound is after the deadline
-    MutateDepositDeadline
+    DepositMutateDepositDeadline
+  | -- | Alter the head id
+    DepositMutateHeadId
   deriving stock (Generic, Show, Enum, Bounded)
 
 genIncrementMutation :: (Tx, UTxO) -> Gen SomeMutation
 genIncrementMutation (tx, utxo) =
-  SomeMutation (pure $ toErrorCode DepositDeadlineSurpassed) MutateDepositDeadline <$> do
-    let (depositIn, depositOut@(TxOut addr val _ rscript)) = UTxO.pairs (resolveInputsUTxO utxo tx) List.!! 1
-    let datum =
-          txOutDatum $
-            flip modifyInlineDatum (toTxContext depositOut) $ \case
-              DepositDatum (headCS', depositDatumDeadline, commits) ->
-                DepositDatum (headCS', Plutus.POSIXTime $ Plutus.getPOSIXTime depositDatumDeadline - 1, commits)
-    let newOutput = toCtxUTxOTxOut $ TxOut addr val datum rscript
-    pure $ ChangeInput depositIn newOutput (Just $ toScriptData Claim)
+  oneof
+    [ SomeMutation (pure $ toErrorCode DepositDeadlineSurpassed) DepositMutateDepositDeadline <$> do
+        let (depositIn, depositOut@(TxOut addr val _ rscript)) = UTxO.pairs (resolveInputsUTxO utxo tx) List.!! 1
+        let datum =
+              txOutDatum $
+                flip modifyInlineDatum (toTxContext depositOut) $ \case
+                  DepositDatum (headCS', depositDatumDeadline, commits) ->
+                    DepositDatum (headCS', Plutus.POSIXTime $ Plutus.getPOSIXTime depositDatumDeadline - 1, commits)
+        let newOutput = toCtxUTxOTxOut $ TxOut addr val datum rscript
+        pure $ ChangeInput depositIn newOutput (Just $ toScriptData $ Claim (headIdToCurrencySymbol testHeadId))
+    , SomeMutation (pure $ toErrorCode WrongHeadIdInDepositDatum) DepositMutateHeadId <$> do
+        otherHeadId <- arbitrary
+        let (depositIn, depositOut@(TxOut addr val _ rscript)) = UTxO.pairs (resolveInputsUTxO utxo tx) List.!! 1
+        let datum =
+              txOutDatum $
+                flip modifyInlineDatum (toTxContext depositOut) $ \case
+                  DepositDatum (_headCS, depositDatumDeadline, commits) ->
+                    DepositDatum (otherHeadId, depositDatumDeadline, commits)
+        let newOutput = toCtxUTxOTxOut $ TxOut addr val datum rscript
+        pure $ ChangeInput depositIn newOutput (Just $ toScriptData $ Claim (headIdToCurrencySymbol testHeadId))
+    ]


### PR DESCRIPTION
Subtask of #199  

- Implement the `Claim` redeemer branch of the deposit validator.

- Add head currency symbol to the `Claim` redeemer in order to check it against the datum value.

- Add upper validity bound for increment in order to be able to check if the deposit deadline has not been reached.

- Double the amount of contestation period value when setting the deposit deadline in order to give enough room for increment 
to be valid (before the deadline).

- Add appropriate deposit mutations.


---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
