### PR TITLE
Small semantic cleanup so modifications to the blueprintTx are all self-contained

### DIFF
--- a/hydra-tx/src/Hydra/Tx/Commit.hs
+++ b/hydra-tx/src/Hydra/Tx/Commit.hs
@@ -64,7 +64,6 @@ commitTx networkId scriptRegistry headId party commitBlueprintTx (initialInput, 
     toLedgerTx blueprintTx
       & spendFromInitial
       & bodyTxL . outputsTxBodyL .~ StrictSeq.singleton (toLedgerTxOut commitOutput)
-      & bodyTxL . reqSignerHashesTxBodyL <>~ Set.singleton (toLedgerKeyHash vkh)
       & bodyTxL . mintTxBodyL .~ mempty
       & addMetadata (mkHydraHeadV1TxName "CommitTx") blueprintTx
  where
@@ -76,6 +75,7 @@ commitTx networkId scriptRegistry headId party commitBlueprintTx (initialInput, 
      in tx
           & bodyTxL . inputsTxBodyL .~ newInputs
           & bodyTxL . referenceInputsTxBodyL <>~ Set.singleton (toLedgerTxIn initialScriptRef)
+          & bodyTxL . reqSignerHashesTxBodyL <>~ Set.singleton (toLedgerKeyHash vkh)
           & witsTxL . rdmrsTxWitsL
             .~ Redeemers (fromList $ nonSpendingRedeemers tx)
               <> Redeemers (fromList $ mkRedeemers newRedeemers newInputs)


### PR DESCRIPTION
As discussed during the hack-and-learn session, moving this down into the `spendFromInitial` itself is a bit more semantically clear and contained; it's necessary to sign it to spend it!
