### PR TITLE
Fix prepare-devnet script on MacOS

### DIFF
--- a/demo/prepare-devnet.sh
+++ b/demo/prepare-devnet.sh
@@ -10,9 +10,9 @@ TARGETDIR=${TARGETDIR:-devnet}
 [ -d "$TARGETDIR" ] && { echo "Cleaning up directory $TARGETDIR" ; rm -rf $TARGETDIR ; }
 
 cp -af "$BASEDIR/hydra-cluster/config/devnet" "$TARGETDIR"
-chmod u+w -R "$TARGETDIR"
+chmod -R u+w  "$TARGETDIR"
 cp -af "$BASEDIR/hydra-cluster/config/credentials" "$TARGETDIR"
-chmod u+w -R "$TARGETDIR"
+chmod -R u+w "$TARGETDIR"
 
 echo '{"Producers": []}' > "$TARGETDIR/topology.json"
 sed -i.bak "s/\"startTime\": [0-9]*/\"startTime\": $(date +%s)/" "$TARGETDIR/genesis-byron.json" && \


### PR DESCRIPTION
Since commit 2a36ef766a603e303490047865646fd1cd5bb580, the `prepare-devnet` script has been broken on MacOS. It seems that while the Linux implementation of `chmod` does not care about the order of flags and the mode(s), MacOS requires that flags come before the mode. Now, the `prepare-devnet` script should work on both macOS and Linux.

 
---

<!-- Consider each and tick it off one way or the other -->
- [x] CHANGELOG updated or not needed
- [x] Documentation updated or not needed
- [x] Haddocks updated or not needed
- [x] No new TODOs introduced or explained herafter
