### PR TITLE
Small changes to run benchmarks for lots of transactions

### DIFF
--- a/hydra-node/bench/micro-bench/Main.hs
+++ b/hydra-node/bench/micro-bench/Main.hs
@@ -37,7 +37,7 @@ main = do
 
 prepareTx :: IO (UTxO, Tx)
 prepareTx =
-  second List.head <$> generate (genFixedSizeSequenceOfSimplePaymentTransactions 1)
+  second List.head <$> generate (genFixedSizeSequenceOfSimplePaymentTransactions 4_000_000)
 
 benchApplyTxs :: (UTxO, Tx) -> Either (Tx, ValidationError) UTxO
 benchApplyTxs (utxo, tx) = applyTransactions defaultLedger (ChainSlot 1) utxo [tx]

--- a/hydra-node/bench/micro-bench/Main.hs
+++ b/hydra-node/bench/micro-bench/Main.hs
@@ -22,7 +22,11 @@ main :: IO ()
 main = do
   -- Use this env var to run benchmarks for more transations:
   --
-  -- > N_TXNS=100000 cabal bench micro --benchmark-options '+RTS -T'
+  -- > N_TXNS=1 cabal bench micro --benchmark-options '--json output.json +RTS -T'
+  --
+  -- You can then find the `peakMbAllocated` field in the resulting json file.
+  -- (Sorry, criterion makes it very hard to find this with a simple jq
+  -- command.)
   --
   nTxns <- fromMaybe 1 . (>>= readMaybe) <$> lookupEnv "N_TXNS"
   (utxo, tx) <- prepareTx nTxns

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -259,15 +259,18 @@ benchmark micro
   build-depends:
     , aeson
     , base
-    , criterion
     , hydra-cardano-api
     , hydra-node
     , hydra-node:testlib
     , hydra-prelude
     , hydra-tx
     , QuickCheck
+    , tasty-bench
 
-  ghc-options:    -threaded -rtsopts
+  mixins:
+    tasty-bench (Test.Tasty.Bench as Criterion, Test.Tasty.Bench as Criterion.Main)
+
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N4
 
 test-suite tests
   import:             project-config

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -259,16 +259,13 @@ benchmark micro
   build-depends:
     , aeson
     , base
+    , criterion
     , hydra-cardano-api
     , hydra-node
     , hydra-node:testlib
     , hydra-prelude
     , hydra-tx
     , QuickCheck
-    , tasty-bench
-
-  mixins:
-    tasty-bench (Test.Tasty.Bench as Criterion, Test.Tasty.Bench as Criterion.Main)
 
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N4
 


### PR DESCRIPTION
Fixes #1724 

This slightly modifies the micro benchmark to hake a configurable number of transactions to run for, and shows how to use it to get memory usage output.