### PR TITLE
Bump Mithril version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ changes.
 
 - Add `inlineDatumRaw` to transaction outputs on the `hydra-node` API.
 
-- Update mithril to `2445.0`
+- Update mithril to `unstable`
 
 - New websocket URL parameter `?address=...` to filter `SnapshotConfirmed`, `TxValid` and `TxInvalid` server outputs by address.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ changes.
 
 - Add `inlineDatumRaw` to transaction outputs on the `hydra-node` API.
 
-- Update mithril to `unstable`
+- Use different versions of mithril depending on the network (Sanchonet/Preview: Unstable, Mainnet/Preproduction: 2445.0)
 
 - New websocket URL parameter `?address=...` to filter `SnapshotConfirmed`, `TxValid` and `TxInvalid` server outputs by address.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ changes.
 
 - Add `inlineDatumRaw` to transaction outputs on the `hydra-node` API.
 
-- Update mithril to `2442.0`
+- Update mithril to `2445.0`
 
 - New websocket URL parameter `?address=...` to filter `SnapshotConfirmed`, `TxValid` and `TxInvalid` server outputs by address.
 

--- a/flake.lock
+++ b/flake.lock
@@ -387,11 +387,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1730060262,
-        "narHash": "sha256-RMgSVkZ9H03sxC+Vh4jxtLTCzSjPq18UWpiM0gq6shQ=",
+        "lastModified": 1730652660,
+        "narHash": "sha256-+XVYfmVXAiYA0FZT7ijHf555dxCe+AoAT5A6RU+6vSo=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "498d9f122c413ee1154e8131ace5a35a80d8fa76",
+        "rev": "a4ca93905455c07cb7e3aca95d4faf7601cba458",
         "type": "github"
       },
       "original": {
@@ -649,11 +649,11 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1725234343,
-        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
         "type": "github"
       },
       "original": {
@@ -1658,16 +1658,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1728992615,
-        "narHash": "sha256-L6zMN2A1e05ZK+5NLeXXIfdl1ZxWxqVw0AU50U84y5s=",
+        "lastModified": 1730818352,
+        "narHash": "sha256-+c7ClYK0QNtdzQLNYsvr4qZ76lwUXTdfVylZZwvZoNo=",
         "owner": "input-output-hk",
         "repo": "mithril",
-        "rev": "0d4d6bc2ac1b2f5e7fe6e57d905bd8542e6b87b1",
+        "rev": "67dc6e467778ceeeb0604a58bd9e76b1d9eea236",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "2442.0",
+        "ref": "2445.0",
         "repo": "mithril",
         "type": "github"
       }
@@ -2134,14 +2134,14 @@
     },
     "nixpkgs-lib_3": {
       "locked": {
-        "lastModified": 1725233747,
-        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
+        "lastModified": 1730504152,
+        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       }
     },
     "nixpkgs-regression": {
@@ -2257,11 +2257,11 @@
     },
     "nixpkgs_12": {
       "locked": {
-        "lastModified": 1725816686,
-        "narHash": "sha256-0Kq2MkQ/sQX1rhWJ/ySBBQlBJBUK8mPMDcuDhhdBkSU=",
+        "lastModified": 1730272153,
+        "narHash": "sha256-B5WRZYsRlJgwVHIV6DvidFN7VX7Fg9uuwkRW9Ha8z+w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "add0443ee587a0c44f22793b8c8649a0dbc3bb00",
+        "rev": "2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53",
         "type": "github"
       },
       "original": {
@@ -2815,11 +2815,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725271838,
-        "narHash": "sha256-VcqxWT0O/gMaeWTTjf1r4MOyG49NaNxW4GHTO3xuThE=",
+        "lastModified": 1730321837,
+        "narHash": "sha256-vK+a09qq19QNu2MlLcvN4qcRctJbqWkX7ahgPZ/+maI=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "9fb342d14b69aefdf46187f6bb80a4a0d97007cd",
+        "rev": "746901bb8dba96d154b66492a29f5db0693dbfcc",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -400,6 +400,21 @@
         "type": "github"
       }
     },
+    "crane_2": {
+      "locked": {
+        "lastModified": 1733688869,
+        "narHash": "sha256-KrhxxFj1CjESDrL5+u/zsVH0K+Ik9tvoac/oFPoxSB8=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "604637106e420ad99907cae401e13ab6b452e7d9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "customConfig": {
       "locked": {
         "lastModified": 1630400035,
@@ -654,6 +669,24 @@
         "owner": "hercules-ci",
         "repo": "flake-parts",
         "rev": "506278e768c2a08bec68eb62932193e341f55c90",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_4": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_4"
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
         "type": "github"
       },
       "original": {
@@ -1658,6 +1691,28 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
+        "lastModified": 1730818352,
+        "narHash": "sha256-+c7ClYK0QNtdzQLNYsvr4qZ76lwUXTdfVylZZwvZoNo=",
+        "owner": "input-output-hk",
+        "repo": "mithril",
+        "rev": "67dc6e467778ceeeb0604a58bd9e76b1d9eea236",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "2445.0",
+        "repo": "mithril",
+        "type": "github"
+      }
+    },
+    "mithril-unstable": {
+      "inputs": {
+        "crane": "crane_2",
+        "flake-parts": "flake-parts_4",
+        "nixpkgs": "nixpkgs_13",
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
         "lastModified": 1734004356,
         "narHash": "sha256-VkjGMXv4o5djKgwVZ3alut1+2w3inR77yo5BvB3DHQU=",
         "owner": "input-output-hk",
@@ -1758,7 +1813,7 @@
     },
     "nix-npm-buildpackage": {
       "inputs": {
-        "nixpkgs": "nixpkgs_13"
+        "nixpkgs": "nixpkgs_14"
       },
       "locked": {
         "lastModified": 1686315622,
@@ -2144,6 +2199,18 @@
         "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       }
     },
+    "nixpkgs-lib_4": {
+      "locked": {
+        "lastModified": 1733096140,
+        "narHash": "sha256-1qRH7uAUsyQI7R1Uwl4T+XvdNv778H0Nb5njNrqvylY=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+      }
+    },
     "nixpkgs-regression": {
       "locked": {
         "lastModified": 1643052045,
@@ -2272,6 +2339,22 @@
       }
     },
     "nixpkgs_13": {
+      "locked": {
+        "lastModified": 1733686850,
+        "narHash": "sha256-NQEO/nZWWGTGlkBWtCs/1iF1yl2lmQ1oY/8YZrumn3I=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "dd51f52372a20a93c219e8216fe528a648ffcbf4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_14": {
       "locked": {
         "lastModified": 1653917367,
         "narHash": "sha256-04MsJC0g9kE01nBuXThMppZK+yvCZECQnUaZKSU+HJo=",
@@ -2549,6 +2632,7 @@
         "iohk-nix": "iohk-nix",
         "lint-utils": "lint-utils",
         "mithril": "mithril",
+        "mithril-unstable": "mithril-unstable",
         "nix-npm-buildpackage": "nix-npm-buildpackage",
         "nixpkgs": [
           "haskellNix",
@@ -2820,6 +2904,27 @@
         "owner": "numtide",
         "repo": "treefmt-nix",
         "rev": "746901bb8dba96d154b66492a29f5db0693dbfcc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "mithril-unstable",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733761991,
+        "narHash": "sha256-s4DalCDepD22jtKL5Nw6f4LP5UwoMcPzPZgHWjAfqbQ=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "0ce9d149d99bc383d1f2d85f31f6ebd146e46085",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1658,16 +1658,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1730818352,
-        "narHash": "sha256-+c7ClYK0QNtdzQLNYsvr4qZ76lwUXTdfVylZZwvZoNo=",
+        "lastModified": 1734004356,
+        "narHash": "sha256-VkjGMXv4o5djKgwVZ3alut1+2w3inR77yo5BvB3DHQU=",
         "owner": "input-output-hk",
         "repo": "mithril",
-        "rev": "67dc6e467778ceeeb0604a58bd9e76b1d9eea236",
+        "rev": "12c09d851f69b178a16ed52048fcd617d2a4e997",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "2445.0",
+        "ref": "unstable",
         "repo": "mithril",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
       flake = false;
     };
     cardano-node.url = "github:intersectmbo/cardano-node/10.1.2";
-    mithril.url = "github:input-output-hk/mithril/2445.0";
+    mithril.url = "github:input-output-hk/mithril/unstable";
     nix-npm-buildpackage.url = "github:serokell/nix-npm-buildpackage";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
       flake = false;
     };
     cardano-node.url = "github:intersectmbo/cardano-node/10.1.2";
-    mithril.url = "github:input-output-hk/mithril/2442.0";
+    mithril.url = "github:input-output-hk/mithril/2445.0";
     nix-npm-buildpackage.url = "github:serokell/nix-npm-buildpackage";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -21,8 +21,11 @@
       flake = false;
     };
     cardano-node.url = "github:intersectmbo/cardano-node/10.1.2";
-    mithril.url = "github:input-output-hk/mithril/unstable";
     nix-npm-buildpackage.url = "github:serokell/nix-npm-buildpackage";
+
+
+    mithril.url = "github:input-output-hk/mithril/2445.0";
+    mithril-unstable.url = "github:input-output-hk/mithril/unstable";
   };
 
   outputs =
@@ -86,6 +89,10 @@
                 cardano-cli = inputs.cardano-node.packages.${system}.cardano-cli;
                 cardano-node = inputs.cardano-node.packages.${system}.cardano-node;
                 mithril-client-cli = inputs.mithril.packages.${system}.mithril-client-cli;
+                mithril-client-cli-unstable =
+                  pkgs.writeShellScriptBin "mithril-client-unstable" ''
+                    exec ${inputs.mithril-unstable.packages.${system}.mithril-client-cli}/bin/mithril-client "$@"
+                  '';
               })
             ];
           };

--- a/hydra-cluster/src/Hydra/Cluster/Mithril.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Mithril.hs
@@ -27,7 +27,7 @@ downloadLatestSnapshotTo tracer network directory = do
   genesisKey <- parseRequest genesisKeyURL >>= httpBS <&> getResponseBody
   let cmd =
         setStderr createPipe $
-          proc "mithril-client" $
+          proc mithrilExe $
             concat
               [ ["--aggregator-endpoint", aggregatorEndpoint]
               , ["cardano-db", "download", "latest"]
@@ -37,6 +37,14 @@ downloadLatestSnapshotTo tracer network directory = do
               ]
   withProcessWait_ cmd traceStderr
  where
+  -- Note: Minor hack; we use a different version of the mithril-client for
+  -- these networks. Hopefully this can be removed, one day.
+  mithrilExe =
+    case network of
+      Preview -> "mithril-client-unstable"
+      Sanchonet -> "mithril-client-unstable"
+      _ -> "mithril-client"
+
   traceStderr p =
     ignoreEOFErrors . forever $ do
       bytes <- BS.hGetLine (getStderr p)

--- a/hydra-cluster/test/Test/Hydra/Cluster/MithrilSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/MithrilSpec.hs
@@ -6,7 +6,6 @@ import Test.Hydra.Prelude
 import Control.Concurrent.Class.MonadSTM (newTVarIO, readTVarIO)
 import Control.Lens ((^?))
 import Data.Aeson.Lens (key)
-import Hydra.Cluster.Fixture (KnownNetwork (Sanchonet))
 import Hydra.Cluster.Mithril (MithrilLog (..), downloadLatestSnapshotTo)
 import Hydra.Logging (Envelope (..), Tracer, traceInTVar)
 import System.Directory (doesDirectoryExist)
@@ -17,7 +16,6 @@ spec :: Spec
 spec = parallel $ do
   describe "downloadLatestSnapshotTo" $
     forEachKnownNetwork "invokes mithril-client correctly" $ \network -> do
-      when (network == Sanchonet) $ pendingWith "Sanchonet broken on stable presently."
       (tracer, getTraces) <- captureTracer "MithrilSpec"
       withTempDir ("mithril-download-" <> show network) $ \tmpDir -> do
         let dbPath = tmpDir </> "db"

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -144,7 +144,8 @@ rec {
         hydra-chain-observer
         inputs.cardano-node.packages.${system}.cardano-node
         inputs.cardano-node.packages.${system}.cardano-cli
-        inputs.mithril.packages.${system}.mithril-client-cli
+        pkgs.mithril-client-cli
+        pkgs.mithril-client-cli-unstable
         pkgs.check-jsonschema
       ];
   };

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -40,6 +40,7 @@ let
     pkgs.haskellPackages.graphmod
     # To interact with mithril and integration tests
     pkgs.mithril-client-cli
+    pkgs.mithril-client-cli-unstable
     pkgs.nixpkgs-fmt
     pkgs.nodejs
     pkgs.pkg-config
@@ -122,7 +123,8 @@ let
       hsPkgs.hydra-cluster.components.exes.hydra-cluster
       inputs.cardano-node.packages.${system}.cardano-node
       inputs.cardano-node.packages.${system}.cardano-cli
-      inputs.mithril.packages.${system}.mithril-client-cli
+      pkgs.mithril-client-cli
+      pkgs.mithril-client-cli-unstable
     ];
   };
 


### PR DESCRIPTION
Update Mithril so we no-longer get breaking tests.

You can verify this locally with the following:

```
cabal test hydra-cluster --test-options '--match "downloadLatestSnapshot"' 
```

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
