### PR TITLE
Use hydraPackages to get the right version

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -189,7 +189,7 @@
 
           devShells = import ./nix/hydra/shell.nix {
             inherit (inputs) aiken;
-            inherit inputs pkgs hsPkgs system pkgsLatest;
+            inherit inputs pkgs hsPkgs system pkgsLatest hydraPackages;
             ghc = pkgs.buildPackages.haskell-nix.compiler.${compiler};
           };
         };

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -9,6 +9,7 @@
 , ghc
 , pkgsLatest
 , aiken
+, hydraPackages
 }:
 let
 
@@ -119,8 +120,8 @@ let
     name = "hydra-node-exe-shell";
 
     buildInputs = [
-      hsPkgs.hydra-node.components.exes.hydra-node
-      hsPkgs.hydra-cluster.components.exes.hydra-cluster
+      hydraPackages.hydra-node
+      hydraPackages.hydra-cluster
       inputs.cardano-node.packages.${system}.cardano-node
       inputs.cardano-node.packages.${system}.cardano-cli
       pkgs.mithril-client-cli
@@ -132,8 +133,8 @@ let
   demoShell = pkgs.mkShell {
     name = "hydra-demo-shell";
     buildInputs = [
-      hsPkgs.hydra-node.components.exes.hydra-node
-      hsPkgs.hydra-tui.components.exes.hydra-tui
+      hydraPackages.hydra-node
+      hydraPackages.hydra-tui
       run-tmux
       inputs.cardano-node.packages.${system}.cardano-node
       inputs.cardano-node.packages.${system}.cardano-cli


### PR DESCRIPTION
Some nice hacking with @ffakenz to tidy up which binaries we get in the `exes` shell :)

We did this so that the versions that come through in the `nix develop .#exes` shell have the revision (or `dirty`) correctly embedded.