### PR TITLE
Fix the tx-cost-diff scripts for new scripts, and some small bugs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,5 +12,4 @@ insert_final_newline = true
 indent_size = 2
 
 [*.py]
-indent_size = 4
-max_line_length = 80
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@ hspec-results.md
 /demo/.env
 /demo/devnet/
 /docs/static/haddock/
+
+# tx-cost-difference files
+diff.md
+old.md
+new.md
+new-headers.txt

--- a/hydra-node/bench/tx-cost/Main.hs
+++ b/hydra-node/bench/tx-cost/Main.hs
@@ -157,6 +157,7 @@ scriptSizes =
   , "| " <> "νDeposit" <> " | " <> serialiseToRawBytesHexText depositScriptHash <> " | " <> show depositScriptSize <> " | "
   , ""
   , "* The minting policy hash is only usable for comparison. As the script is parameterized, the actual script is unique per head."
+  , ""
   ]
  where
   ScriptInfo

--- a/scripts/diff.py
+++ b/scripts/diff.py
@@ -24,6 +24,14 @@ def parties(df):
 def utxo(df):
   return df.set_index("UTxO")
 
+def utxo_and_parties(df):
+  df = df.set_index(["UTxO", "Parties"])
+
+  df.index = df.index.to_flat_index()
+  df.index.name = "UTxO, Parties"
+
+  return df
+
 def compare(f, old, new):
   # New should be better, so we compare to that.
   df = f(new) - f(old)
@@ -67,11 +75,14 @@ diffs = [
   , (headers[2], compare( utxo,        base[3], branch[3]))
   ]
 
-# Then the remaining are all the same.
-for i in range(4, 9 + 1):
+# Then (almost all) the remaining are all the same,
+for i in range(4, 8 + 1):
   diffs.append(( headers[i - 1]
                , compare( parties, base[i], branch[i] )
                ))
+
+# Except fanout is different; it has parties _and_ UTxO
+diffs.append((headers[9], compare(utxo_and_parties, base[10], branch[10])))
 
 # Check that ther was _some_ difference, at least.
 some_change = any( df.to_numpy().sum() != 0 for _, df in diffs )


### PR DESCRIPTION
This fixes the `tx-cost-diff` PR comment in a few ways:

- Correct comparision for `Fanout` so it compares with the right Parties/UTxO
- Fix of markdown (adding a space) so that the `Init` table is picked up

As always, this won't work well on _this_ PR; but once merged it should be fine.