### PR TITLE
Refactor: Use PlutusScript instead of SerialisedScript where possible

### DIFF
--- a/hydra-cardano-api/src/Hydra/Cardano/Api/ReferenceScript.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/ReferenceScript.hs
@@ -2,22 +2,9 @@ module Hydra.Cardano.Api.ReferenceScript where
 
 import Hydra.Cardano.Api.Prelude
 
-import PlutusLedgerApi.V3 qualified as Plutus
-
 -- | Construct a 'ReferenceScript' from any given Plutus script.
---
--- NOTE: The script is treated as a 'PlutusScriptV3'
-mkScriptRef :: Plutus.SerialisedScript -> ReferenceScript Era
+mkScriptRef :: IsPlutusScriptLanguage lang => PlutusScript lang -> ReferenceScript Era
 mkScriptRef =
   ReferenceScript babbageBasedEra
     . toScriptInAnyLang
-    . PlutusScript PlutusScriptV3
-    . PlutusScriptSerialised
-
--- | Construct a PlutusV3 'ReferenceScript' from any given Plutus script.
-mkScriptRefV3 :: Plutus.SerialisedScript -> ReferenceScript Era
-mkScriptRefV3 =
-  ReferenceScript babbageBasedEra
-    . toScriptInAnyLang
-    . PlutusScript PlutusScriptV3
-    . PlutusScriptSerialised
+    . PlutusScript plutusScriptVersion

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -61,7 +61,6 @@ import Hydra.Cardano.Api (
   utxoFromTx,
   writeFileTextEnvelope,
   pattern BuildTxWith,
-  pattern PlutusScriptSerialised,
   pattern ReferenceScriptNone,
   pattern ScriptWitness,
   pattern TxOut,
@@ -446,9 +445,7 @@ singlePartyCommitsScriptBlueprint tracer workDir node hydraScriptsTxId =
         output "GetUTxOResponse" ["headId" .= headId, "utxo" .= (scriptUTxO <> scriptUTxO')]
  where
   prepareScriptPayload lovelaceAmt = do
-    let script = dummyValidatorScript
-    let serializedScript = PlutusScriptSerialised script
-    let scriptAddress = mkScriptAddress networkId serializedScript
+    let scriptAddress = mkScriptAddress networkId dummyValidatorScript
     let datumHash = mkTxOutDatumHash ()
     (scriptIn, scriptOut) <- createOutputAtAddress node scriptAddress datumHash (lovelaceToValue lovelaceAmt)
     let scriptUTxO = UTxO.singleton (scriptIn, scriptOut)
@@ -456,7 +453,7 @@ singlePartyCommitsScriptBlueprint tracer workDir node hydraScriptsTxId =
     let scriptWitness =
           BuildTxWith $
             ScriptWitness scriptWitnessInCtx $
-              mkScriptWitness serializedScript (mkScriptDatum ()) (toScriptData ())
+              mkScriptWitness dummyValidatorScript (mkScriptDatum ()) (toScriptData ())
     let spendingTx =
           unsafeBuildTransaction $
             defaultTxBodyContent

--- a/hydra-node/src/Hydra/Chain/ScriptRegistry.hs
+++ b/hydra-node/src/Hydra/Chain/ScriptRegistry.hs
@@ -22,7 +22,7 @@ import Hydra.Cardano.Api (
   makeShelleyKeyWitness,
   makeSignedTransaction,
   mkScriptAddress,
-  mkScriptRefV3,
+  mkScriptRef,
   mkTxOutAutoBalance,
   mkVkAddress,
   selectLovelace,
@@ -82,9 +82,9 @@ publishHydraScripts ::
   IO [TxId]
 publishHydraScripts networkId socketPath sk = do
   pparams <- queryProtocolParameters networkId socketPath QueryTip
-  forM scriptRefs $ \scriptRef -> do
+  forM scripts $ \script -> do
     utxo <- queryUTxOFor networkId socketPath QueryTip vk
-    let output = mkScriptTxOut pparams <$> [mkScriptRefV3 scriptRef]
+    let output = mkScriptTxOut pparams <$> [mkScriptRef script]
         totalDeposit = sum (selectLovelace . txOutValue <$> output)
         someUTxO =
           maybe mempty UTxO.singleton $
@@ -106,7 +106,7 @@ publishHydraScripts networkId socketPath sk = do
           void $ awaitTransaction networkId socketPath tx
           return $ getTxId body
  where
-  scriptRefs = [initialValidatorScript, commitValidatorScript, Head.validatorScript]
+  scripts = [initialValidatorScript, commitValidatorScript, Head.validatorScript]
   vk = getVerificationKey sk
 
   changeAddress = mkVkAddress networkId vk

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -13,7 +13,6 @@ import Data.Set qualified as Set
 import Hydra.Cardano.Api (
   CtxUTxO,
   NetworkId (Mainnet),
-  PlutusScriptV3,
   Tx,
   TxIn,
   TxOut,
@@ -36,7 +35,6 @@ import Hydra.Cardano.Api (
   utxoFromTx,
   valueSize,
   pattern PlutusScript,
-  pattern PlutusScriptSerialised,
  )
 import Hydra.Cardano.Api.Pretty (renderTx, renderTxWithUTxO)
 import Hydra.Chain (OnChainTx (..), PostTxError (..), maxMainnetLovelace, maximumNumberOfParties)
@@ -394,7 +392,7 @@ genInitTxMutation seedInput tx =
 
   -- We do replace the minting policy of all tokens and datum of a head output to
   -- simulate a faked init transaction.
-  alwaysSucceedsV3 = PlutusScriptSerialised dummyValidatorScript
+  alwaysSucceedsV3 = dummyValidatorScript
   originalPolicyId = HeadTokens.headPolicyId seedInput
   fakePolicyId = scriptPolicyId $ PlutusScript alwaysSucceedsV3
   changeMintingPolicy (out, idx)
@@ -416,7 +414,7 @@ genCommitTxMutation utxo tx =
 
   (initialTxIn, initialTxOut) =
     fromMaybe (error "not found initial script") $
-      UTxO.find (isScriptTxOut @PlutusScriptV3 initialScript) resolvedInputs
+      UTxO.find (isScriptTxOut initialValidatorScript) resolvedInputs
 
   resolvedInputs =
     UTxO.fromPairs $
@@ -426,11 +424,9 @@ genCommitTxMutation utxo tx =
     fromMaybe (error "not found redeemer") $
       findRedeemerSpending @Initial.RedeemerType tx initialTxIn
 
-  initialScript = PlutusScriptSerialised initialValidatorScript
+  fakeScriptAddress = mkScriptAddress testNetworkId fakeScript
 
-  fakeScriptAddress = mkScriptAddress @PlutusScriptV3 testNetworkId fakeScript
-
-  fakeScript = PlutusScriptSerialised dummyValidatorScript
+  fakeScript = dummyValidatorScript
 
 genAdaOnlyUTxOOnMainnetWithAmountBiggerThanOutLimit :: Gen UTxO
 genAdaOnlyUTxOOnMainnetWithAmountBiggerThanOutLimit = do

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -240,7 +240,7 @@ genBlueprintTxWithUTxO =
       )
 
   spendSomeScriptInputs (utxo, txbody) = do
-    let alwaysSucceedingScript = PlutusScriptSerialised dummyValidatorScript
+    let alwaysSucceedingScript = dummyValidatorScript
     datum <- unsafeHashableScriptData . fromPlutusData <$> arbitrary
     redeemer <- unsafeHashableScriptData . fromPlutusData <$> arbitrary
     let genTxOut = do
@@ -291,7 +291,7 @@ genBlueprintTxWithUTxO =
       , do
           lovelace <- arbitrary
           let redeemer = hedgehog genHashableScriptData `generateWith` 42
-              alwaysSucceedingScript = PlutusScriptSerialised dummyValidatorScript
+              alwaysSucceedingScript = dummyValidatorScript
               scriptWitness = mkScriptWitness alwaysSucceedingScript NoScriptDatumForStake redeemer
               stakeAddress = mkScriptStakeAddress testNetworkId alwaysSucceedingScript
           pure

--- a/hydra-plutus-extras/src/Hydra/Plutus/Extras.hs
+++ b/hydra-plutus-extras/src/Hydra/Plutus/Extras.hs
@@ -10,14 +10,12 @@ import Hydra.Prelude
 import Hydra.Plutus.Extras.Time
 
 import Cardano.Api (
-  IsPlutusScriptLanguage,
-  PlutusScriptVersion,
+  IsPlutusScriptLanguage (plutusScriptVersion),
+  PlutusScript,
+  Script (PlutusScript),
   SerialiseAsRawBytes (serialiseToRawBytes),
   hashScript,
-  pattern PlutusScript,
  )
-import Cardano.Api.Shelley (PlutusScript (PlutusScriptSerialised))
-import PlutusLedgerApi.Common (SerialisedScript)
 import PlutusLedgerApi.V3 (
   Datum (..),
   ScriptContext (..),
@@ -76,13 +74,12 @@ wrapMintingPolicy f c =
 
 -- * Similar utilities as plutus-ledger
 
--- | Compute the on-chain 'ScriptHash' for a given serialised plutus script. Use
--- this to refer to another validator script.
-scriptValidatorHash :: IsPlutusScriptLanguage lang => PlutusScriptVersion lang -> SerialisedScript -> ScriptHash
-scriptValidatorHash version =
+-- | Compute the on-chain 'ScriptHash' for a given plutus script. Use this to
+-- refer to another validator script.
+scriptValidatorHash :: IsPlutusScriptLanguage lang => PlutusScript lang -> ScriptHash
+scriptValidatorHash =
   ScriptHash
     . toBuiltin
     . serialiseToRawBytes
     . hashScript
-    . PlutusScript version
-    . PlutusScriptSerialised
+    . PlutusScript plutusScriptVersion

--- a/hydra-plutus/src/Hydra/Contract/Commit.hs
+++ b/hydra-plutus/src/Hydra/Contract/Commit.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 
--- | The validator used to collect & open or abort a Head.
+-- | Datum and redeemer types, as well as helper functions for the commit
+-- validator implemented in aiken.
 module Hydra.Contract.Commit where
 
 import PlutusTx.Prelude

--- a/hydra-plutus/src/Hydra/Contract/Dummy.hs
+++ b/hydra-plutus/src/Hydra/Contract/Dummy.hs
@@ -5,11 +5,11 @@
 
 module Hydra.Contract.Dummy where
 
-import Hydra.Cardano.Api (PlutusScriptVersion (PlutusScriptV3))
-import Hydra.Plutus.Extras (ValidatorType, scriptValidatorHash, wrapValidator)
 import Hydra.Prelude
 
-import PlutusLedgerApi.V3 (BuiltinData, ScriptContext, ScriptHash, SerialisedScript, serialiseCompiledCode, toOpaque)
+import Hydra.Cardano.Api (PlutusScript, pattern PlutusScriptSerialised)
+import Hydra.Plutus.Extras (ValidatorType, wrapValidator)
+import PlutusLedgerApi.V3 (BuiltinData, ScriptContext, serialiseCompiledCode, toOpaque)
 import PlutusTx (CompiledCode, compile)
 
 dummyValidator :: BuiltinData -> BuiltinData -> ScriptContext -> Bool
@@ -26,8 +26,5 @@ fakeWrap ::
   ValidatorType
 fakeWrap _ _ = toOpaque ()
 
-dummyValidatorScript :: SerialisedScript
-dummyValidatorScript = serialiseCompiledCode compiledDummyValidator
-
-validatorHash :: ScriptHash
-validatorHash = scriptValidatorHash PlutusScriptV3 dummyValidatorScript
+dummyValidatorScript :: PlutusScript
+dummyValidatorScript = PlutusScriptSerialised $ serialiseCompiledCode compiledDummyValidator

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -12,7 +12,10 @@ module Hydra.Contract.Head where
 
 import PlutusTx.Prelude
 
-import Hydra.Cardano.Api (PlutusScriptVersion (PlutusScriptV3))
+import Hydra.Cardano.Api (
+  PlutusScript,
+  pattern PlutusScriptSerialised,
+ )
 import Hydra.Contract.Commit (Commit (..))
 import Hydra.Contract.Commit qualified as Commit
 import Hydra.Contract.Deposit qualified as Deposit
@@ -34,8 +37,8 @@ import Hydra.Contract.HeadState (
 import Hydra.Contract.Util (hasST, hashPreSerializedCommits, hashTxOuts, mustBurnAllHeadTokens, mustNotMintOrBurn, (===))
 import Hydra.Data.ContestationPeriod (ContestationPeriod, addContestationPeriod, milliseconds)
 import Hydra.Data.Party (Party (vkey))
-import Hydra.Plutus.Extras (ValidatorType, scriptValidatorHash, wrapValidator)
-import PlutusLedgerApi.Common (SerialisedScript, serialiseCompiledCode)
+import Hydra.Plutus.Extras (ValidatorType, wrapValidator)
+import PlutusLedgerApi.Common (serialiseCompiledCode)
 import PlutusLedgerApi.V1.Time (fromMilliSeconds)
 import PlutusLedgerApi.V1.Value (lovelaceValue)
 import PlutusLedgerApi.V3 (
@@ -50,7 +53,6 @@ import PlutusLedgerApi.V3 (
   POSIXTime,
   PubKeyHash (getPubKeyHash),
   ScriptContext (..),
-  ScriptHash,
   ToData (toBuiltinData),
   TokenName (..),
   TxInInfo (..),
@@ -806,11 +808,8 @@ compiledValidator =
  where
   wrap = wrapValidator @DatumType @RedeemerType
 
-validatorScript :: SerialisedScript
-validatorScript = serialiseCompiledCode compiledValidator
-
-validatorHash :: ScriptHash
-validatorHash = scriptValidatorHash PlutusScriptV3 validatorScript
+validatorScript :: PlutusScript
+validatorScript = PlutusScriptSerialised $ serialiseCompiledCode compiledValidator
 
 decodeHeadOutputClosedDatum :: ScriptContext -> ClosedDatum
 decodeHeadOutputClosedDatum ctx =

--- a/hydra-plutus/src/Hydra/Contract/HeadTokens.hs
+++ b/hydra-plutus/src/Hydra/Contract/HeadTokens.hs
@@ -41,7 +41,6 @@ import PlutusLedgerApi.V3 (
   OutputDatum (..),
   ScriptContext (..),
   ScriptHash,
-  SerialisedScript,
   TxInInfo (..),
   TxInfo (..),
   TxOutRef,
@@ -185,13 +184,13 @@ validateTokensBurning context =
 unappliedMintingPolicy :: CompiledCode (TxOutRef -> MintingPolicyType)
 unappliedMintingPolicy =
   $$(PlutusTx.compile [||\vInitial vHead ref -> wrapMintingPolicy (validate vInitial vHead ref)||])
-    `PlutusTx.unsafeApplyCode` PlutusTx.liftCode plcVersion110 (scriptValidatorHash Api.PlutusScriptV3 initialValidatorScript)
-    `PlutusTx.unsafeApplyCode` PlutusTx.liftCode plcVersion110 Head.validatorHash
+    `PlutusTx.unsafeApplyCode` PlutusTx.liftCode plcVersion110 (scriptValidatorHash initialValidatorScript)
+    `PlutusTx.unsafeApplyCode` PlutusTx.liftCode plcVersion110 (scriptValidatorHash Head.validatorScript)
 
 -- | Get the applied head minting policy script given a seed 'TxOutRef'.
-mintingPolicyScript :: TxOutRef -> SerialisedScript
+mintingPolicyScript :: TxOutRef -> Api.PlutusScript
 mintingPolicyScript txOutRef =
-  serialiseCompiledCode $
+  PlutusScriptSerialised . serialiseCompiledCode $
     unappliedMintingPolicy
       `PlutusTx.unsafeApplyCode` PlutusTx.liftCode plcVersion110 txOutRef
 
@@ -205,4 +204,4 @@ headPolicyId =
 -- | Get the applied head minting policy script given a seed 'TxIn'.
 mkHeadTokenScript :: TxIn -> Api.PlutusScript
 mkHeadTokenScript =
-  PlutusScriptSerialised . mintingPolicyScript . toPlutusTxOutRef
+  mintingPolicyScript . toPlutusTxOutRef

--- a/hydra-plutus/src/Hydra/Contract/Initial.hs
+++ b/hydra-plutus/src/Hydra/Contract/Initial.hs
@@ -1,49 +1,21 @@
 {-# LANGUAGE TemplateHaskell #-}
-{-# OPTIONS_GHC -fno-specialize #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:conservative-optimisation #-}
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
--- Plutus core version to compile to. In babbage era, that is Cardano protocol
--- version 7 and 8, only plutus-core version 1.0.0 is available.
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:target-version=1.1.0 #-}
 
--- | The initial validator which allows participants to commit or abort.
+-- | Datum and redeemer types, as well as helper functions for the commit
+-- validator implemented in aiken.
 module Hydra.Contract.Initial where
 
-import PlutusTx.Prelude
-
-import Hydra.Cardano.Api (PlutusScriptVersion (..))
-import Hydra.Contract.Commit (Commit (..))
-import Hydra.Contract.Commit qualified as Commit
-import Hydra.Contract.Error (errorCode)
-import Hydra.Contract.InitialError (InitialError (..))
-import Hydra.Contract.Util (findTxInByTxOutRef, mustBurnST, scriptOutputsAt, valueLockedBy)
-import Hydra.Plutus (commitValidatorScript)
-import Hydra.Plutus.Extras (ValidatorType, scriptValidatorHash, wrapValidator)
-import PlutusCore.Core (plcVersion110)
-import PlutusLedgerApi.Common (SerialisedScript, serialiseCompiledCode)
-import PlutusLedgerApi.V1.Value (geq, isZero)
 import PlutusLedgerApi.V3 (
   CurrencySymbol,
   Datum (..),
-  FromData (fromBuiltinData),
-  OutputDatum (..),
-  PubKeyHash (getPubKeyHash),
   Redeemer (Redeemer),
-  ScriptContext (..),
-  ScriptHash,
   ToData (toBuiltinData),
-  TokenName (unTokenName),
-  TxInInfo (..),
-  TxInfo (..),
-  TxOut (txOutValue),
   TxOutRef,
-  Value (getValue),
  )
-import PlutusLedgerApi.V3.Contexts (findOwnInput)
-import PlutusTx (CompiledCode)
 import PlutusTx qualified
-import PlutusTx.AssocMap qualified as AssocMap
-import PlutusTx.Builtins qualified as Builtins
+
+type DatumType = CurrencySymbol
+
+type RedeemerType = InitialRedeemer
 
 data InitialRedeemer
   = ViaAbort
@@ -53,137 +25,6 @@ data InitialRedeemer
       }
 
 PlutusTx.unstableMakeIsData ''InitialRedeemer
-
-type DatumType = CurrencySymbol
-type RedeemerType = InitialRedeemer
-
--- | The v_initial validator verifies that:
---
---   * spent in a transaction also consuming a v_head output
---
---   * ensures the committed value is recorded correctly in the output datum
---
---   * ensures that the transaction was signed by the key corresponding to the
---     PubKeyHash encoded in the participation token name
---
--- NOTE: It does not need to ensure that the participation token is of some
--- specific Head currency.
-validator ::
-  -- | Hash of the commit validator
-  ScriptHash ->
-  DatumType ->
-  RedeemerType ->
-  ScriptContext ->
-  Bool
-validator commitValidator headId red context =
-  case red of
-    ViaAbort ->
-      traceIfFalse
-        $(errorCode STNotBurned)
-        (mustBurnST (txInfoMint $ scriptContextTxInfo context) headId)
-    ViaCommit{committedRefs} ->
-      checkCommit commitValidator headId committedRefs context
-
-checkCommit ::
-  -- | Hash of the commit validator
-  ScriptHash ->
-  -- | Head id
-  CurrencySymbol ->
-  [TxOutRef] ->
-  ScriptContext ->
-  Bool
-checkCommit commitValidator headId committedRefs context =
-  checkCommittedValue
-    && checkLockedCommit
-    && checkHeadId
-    && mustBeSignedByParticipant
-    && mustNotMintOrBurn
- where
-  checkCommittedValue =
-    traceIfFalse $(errorCode LockedValueDoesNotMatch) $
-      -- NOTE: Ada in initialValue is usually lower than in the locked ADA due
-      -- to higher deposit needed for commit output than for initial output
-      lockedValue `geq` (initialValue + committedValue)
-
-  checkLockedCommit =
-    traceIfFalse $(errorCode MismatchCommittedTxOutInDatum) $
-      go (committedUTxO, lockedCommits)
-   where
-    go = \case
-      ([], []) ->
-        True
-      ([], _ : _) ->
-        traceError $(errorCode MissingCommittedTxOutInOutputDatum)
-      (_ : _, []) ->
-        traceError $(errorCode CommittedTxOutMissingInOutputDatum)
-      (TxInInfo{txInInfoOutRef, txInInfoResolved} : restCommitted, Commit{input, preSerializedOutput} : restCommits) ->
-        Builtins.serialiseData (toBuiltinData txInInfoResolved) == preSerializedOutput
-          && txInInfoOutRef == input
-          && go (restCommitted, restCommits)
-
-  checkHeadId =
-    traceIfFalse $(errorCode WrongHeadIdInCommitDatum) $
-      headId' == headId
-
-  mustBeSignedByParticipant =
-    traceIfFalse $(errorCode MissingOrInvalidCommitAuthor) $
-      unTokenName ourParticipationTokenName `elem` (getPubKeyHash <$> txInfoSignatories txInfo)
-
-  mustNotMintOrBurn =
-    traceIfFalse $(errorCode MintingOrBurningIsForbidden) $
-      isZero $
-        txInfoMint txInfo
-
-  ourParticipationTokenName =
-    case AssocMap.lookup headId (getValue initialValue) of
-      Nothing -> traceError $(errorCode CouldNotFindTheCorrectCurrencySymbolInTokens)
-      Just tokenMap ->
-        case AssocMap.toList tokenMap of
-          [(tk, q)] | q == 1 -> tk
-          _moreThanOneToken -> traceError $(errorCode MultipleHeadTokensOrMoreThan1PTsFound)
-
-  initialValue =
-    maybe mempty (txOutValue . txInInfoResolved) $ findOwnInput context
-
-  committedValue =
-    foldMap (txOutValue . txInInfoResolved) committedUTxO
-
-  committedUTxO = do
-    flip fmap committedRefs $ \ref ->
-      case findTxInByTxOutRef ref txInfo of
-        Nothing -> traceError $(errorCode OutRefNotFound)
-        Just txInInfo -> txInInfo
-
-  lockedValue = valueLockedBy txInfo commitValidator
-
-  (lockedCommits, headId') =
-    case scriptOutputsAt commitValidator txInfo of
-      [(dat, _)] ->
-        case dat of
-          NoOutputDatum -> traceError $(errorCode MissingDatum)
-          OutputDatumHash _dh ->
-            traceError $(errorCode UnexpectedNonInlineDatum)
-          OutputDatum da ->
-            case fromBuiltinData @Commit.DatumType $ getDatum da of
-              Nothing -> traceError $(errorCode ExpectedCommitDatumTypeGotSomethingElse)
-              Just (_party, commits, hid) ->
-                (commits, hid)
-      _ -> traceError $(errorCode ExpectedSingleCommitOutput)
-
-  ScriptContext{scriptContextTxInfo = txInfo} = context
-
-compiledValidator :: CompiledCode ValidatorType
-compiledValidator =
-  $$(PlutusTx.compile [||wrap . validator||])
-    `PlutusTx.unsafeApplyCode` PlutusTx.liftCode plcVersion110 (scriptValidatorHash PlutusScriptV3 commitValidatorScript)
- where
-  wrap = wrapValidator @DatumType @RedeemerType
-
-validatorScript :: SerialisedScript
-validatorScript = serialiseCompiledCode compiledValidator
-
-validatorHash :: ScriptHash
-validatorHash = scriptValidatorHash PlutusScriptV3 validatorScript
 
 datum :: DatumType -> Datum
 datum a = Datum (toBuiltinData a)

--- a/hydra-plutus/src/Hydra/Contract/Util.hs
+++ b/hydra-plutus/src/Hydra/Contract/Util.hs
@@ -55,18 +55,6 @@ mustBurnAllHeadTokens minted headCurrencySymbol parties =
       Just tokenMap -> negate $ sum tokenMap
 {-# INLINEABLE mustBurnAllHeadTokens #-}
 
--- | Checks if the state token (ST) for list of parties containing specific
--- 'CurrencySymbol' are burnt.
-mustBurnST :: Value -> CurrencySymbol -> Bool
-mustBurnST val headCurrencySymbol =
-  case AssocMap.lookup headCurrencySymbol (getValue val) of
-    Nothing -> False
-    Just tokenMap ->
-      case AssocMap.lookup (TokenName hydraHeadV1) tokenMap of
-        Nothing -> False
-        Just v -> v == negate 1
-{-# INLINEABLE mustBurnST #-}
-
 mustNotMintOrBurn :: TxInfo -> Bool
 mustNotMintOrBurn TxInfo{txInfoMint} =
   traceIfFalse "U01" $
@@ -134,16 +122,3 @@ scriptOutputsAt h p =
       flt _ = Nothing
    in mapMaybe flt (txInfoOutputs p)
 {-# INLINEABLE scriptOutputsAt #-}
-
--- | Get the total value locked by the given validator in this transaction.
-valueLockedBy :: TxInfo -> ScriptHash -> Value
-valueLockedBy ptx h =
-  let outputs = map snd (scriptOutputsAt h ptx)
-   in mconcat outputs
-{-# INLINEABLE valueLockedBy #-}
-
--- | Given a UTXO reference and a transaction (`TxInfo`), resolve it to one of the transaction's inputs (`TxInInfo`).
-findTxInByTxOutRef :: TxOutRef -> TxInfo -> Maybe TxInInfo
-findTxInByTxOutRef outRef TxInfo{txInfoInputs} =
-  find (\TxInInfo{txInInfoOutRef} -> txInInfoOutRef == outRef) txInfoInputs
-{-# INLINEABLE findTxInByTxOutRef #-}

--- a/hydra-plutus/test/Hydra/Plutus/GoldenSpec.hs
+++ b/hydra-plutus/test/Hydra/Plutus/GoldenSpec.hs
@@ -16,6 +16,7 @@ import Test.Hydra.Prelude
 import Hydra.Cardano.Api (
   AsType (AsPlutusScriptV3, AsScript),
   File (..),
+  PlutusScript,
   Script,
   hashScript,
   readFileTextEnvelope,
@@ -27,7 +28,6 @@ import Hydra.Contract.Head qualified as Head
 import Hydra.Contract.HeadTokens qualified as HeadTokens
 import Hydra.Version (gitDescribe)
 import PlutusLedgerApi.V3 (serialiseCompiledCode)
-import PlutusLedgerApi.V3 qualified as Plutus
 import System.Process.Typed (runProcess_, shell)
 import Test.Hspec.Golden (Golden (..))
 
@@ -50,14 +50,14 @@ spec = do
   it "Head validator script" $
     goldenScript "vHead" Head.validatorScript
   it "Head minting policy script" $
-    goldenScript "mHead" (serialiseCompiledCode HeadTokens.unappliedMintingPolicy)
+    goldenScript "mHead" (PlutusScriptSerialised $ serialiseCompiledCode HeadTokens.unappliedMintingPolicy)
 
 -- | Write a golden script on first run and ensure it stays the same on
 -- subsequent runs.
-goldenScript :: String -> Plutus.SerialisedScript -> Golden Script
+goldenScript :: String -> PlutusScript -> Golden Script
 goldenScript name plutusScript =
   Golden
-    { output = PlutusScript $ PlutusScriptSerialised plutusScript
+    { output = PlutusScript plutusScript
     , encodePretty = show . hashScript
     , writeToFile
     , readFromFile

--- a/hydra-tx/src/Hydra/Tx/Abort.hs
+++ b/hydra-tx/src/Hydra/Tx/Abort.hs
@@ -10,10 +10,7 @@ import Hydra.Contract.Head qualified as Head
 import Hydra.Contract.HeadState qualified as Head
 import Hydra.Contract.Initial qualified as Initial
 import Hydra.Contract.MintAction (MintAction (Burn))
-import Hydra.Ledger.Cardano.Builder (
-  burnTokens,
-  unsafeBuildTransaction,
- )
+import Hydra.Ledger.Cardano.Builder (burnTokens, unsafeBuildTransaction)
 import Hydra.Plutus (commitValidatorScript, initialValidatorScript)
 import Hydra.Tx (ScriptRegistry (..))
 import Hydra.Tx.Utils (headTokensFromValue)
@@ -59,11 +56,11 @@ abortTx committedUTxO scriptRegistry vk (headInput, initialHeadOutput) headToken
   headWitness =
     BuildTxWith $
       ScriptWitness scriptWitnessInCtx $
-        mkScriptReference headScriptRef headScript InlineScriptDatum headRedeemer
+        mkScriptReference headScriptRef Head.validatorScript InlineScriptDatum headRedeemer
+
   headScriptRef =
     fst (headReference scriptRegistry)
-  headScript =
-    PlutusScriptSerialised Head.validatorScript
+
   headRedeemer =
     toScriptData Head.Abort
 
@@ -83,11 +80,9 @@ abortTx committedUTxO scriptRegistry vk (headInput, initialHeadOutput) headToken
   abortInitialWitness =
     BuildTxWith $
       ScriptWitness scriptWitnessInCtx $
-        mkScriptReference initialScriptRef initialScript InlineScriptDatum initialRedeemer
+        mkScriptReference initialScriptRef initialValidatorScript InlineScriptDatum initialRedeemer
   initialScriptRef =
     fst (initialReference scriptRegistry)
-  initialScript =
-    PlutusScriptSerialised initialValidatorScript
   initialRedeemer =
     toScriptData $ Initial.redeemer Initial.ViaAbort
 
@@ -95,11 +90,9 @@ abortTx committedUTxO scriptRegistry vk (headInput, initialHeadOutput) headToken
   abortCommitWitness =
     BuildTxWith $
       ScriptWitness scriptWitnessInCtx $
-        mkScriptReference commitScriptRef commitScript InlineScriptDatum commitRedeemer
+        mkScriptReference commitScriptRef commitValidatorScript InlineScriptDatum commitRedeemer
   commitScriptRef =
     fst (commitReference scriptRegistry)
-  commitScript =
-    PlutusScriptSerialised commitValidatorScript
   commitRedeemer =
     toScriptData (Commit.redeemer Commit.ViaAbort)
 

--- a/hydra-tx/src/Hydra/Tx/Close.hs
+++ b/hydra-tx/src/Hydra/Tx/Close.hs
@@ -79,13 +79,10 @@ closeTx scriptRegistry vk headId openVersion confirmedSnapshot startSlotNo (endS
   headWitness =
     BuildTxWith $
       ScriptWitness scriptWitnessInCtx $
-        mkScriptReference headScriptRef headScript InlineScriptDatum headRedeemer
+        mkScriptReference headScriptRef Head.validatorScript InlineScriptDatum headRedeemer
 
   headScriptRef =
     fst (headReference scriptRegistry)
-
-  headScript =
-    PlutusScriptSerialised Head.validatorScript
 
   headRedeemer = toScriptData $ Head.Close closeRedeemer
 

--- a/hydra-tx/src/Hydra/Tx/CollectCom.hs
+++ b/hydra-tx/src/Hydra/Tx/CollectCom.hs
@@ -58,13 +58,12 @@ collectComTx networkId scriptRegistry vk headId headParameters (headInput, initi
   headWitness =
     BuildTxWith $
       ScriptWitness scriptWitnessInCtx $
-        mkScriptReference headScriptRef headScript InlineScriptDatum headRedeemer
-  headScript = PlutusScriptSerialised Head.validatorScript
+        mkScriptReference headScriptRef Head.validatorScript InlineScriptDatum headRedeemer
   headScriptRef = fst (headReference scriptRegistry)
   headRedeemer = toScriptData Head.CollectCom
   headOutput =
     TxOut
-      (mkScriptAddress @PlutusScriptV3 networkId headScript)
+      (mkScriptAddress networkId Head.validatorScript)
       (txOutValue initialHeadOutput <> commitValue)
       headDatumAfter
       ReferenceScriptNone
@@ -85,12 +84,10 @@ collectComTx networkId scriptRegistry vk headId headParameters (headInput, initi
   commitWitness =
     BuildTxWith $
       ScriptWitness scriptWitnessInCtx $
-        mkScriptReference commitScriptRef commitScript InlineScriptDatum commitRedeemer
+        mkScriptReference commitScriptRef commitValidatorScript InlineScriptDatum commitRedeemer
   commitScriptRef =
     fst (commitReference scriptRegistry)
   commitValue =
     mconcat $ txOutValue <$> Map.elems commits
-  commitScript =
-    PlutusScriptSerialised commitValidatorScript
   commitRedeemer =
     toScriptData $ Commit.redeemer Commit.ViaCollectCom

--- a/hydra-tx/src/Hydra/Tx/Commit.hs
+++ b/hydra-tx/src/Hydra/Tx/Commit.hs
@@ -129,11 +129,8 @@ commitTx networkId scriptRegistry headId party commitBlueprintTx (initialInput, 
   commitOutput =
     TxOut commitAddress commitValue commitDatum ReferenceScriptNone
 
-  commitScript =
-    PlutusScriptSerialised commitValidatorScript
-
   commitAddress =
-    mkScriptAddress networkId commitScript
+    mkScriptAddress networkId commitValidatorScript
 
   utxoToCommit =
     UTxO.fromPairs $ mapMaybe (\txin -> (txin,) <$> UTxO.resolve txin lookupUTxO) committedTxIns

--- a/hydra-tx/src/Hydra/Tx/Contest.hs
+++ b/hydra-tx/src/Hydra/Tx/Contest.hs
@@ -77,13 +77,10 @@ contestTx scriptRegistry vk headId contestationPeriod openVersion snapshot sig (
   headWitness =
     BuildTxWith $
       ScriptWitness scriptWitnessInCtx $
-        mkScriptReference headScriptRef headScript InlineScriptDatum headRedeemer
+        mkScriptReference headScriptRef Head.validatorScript InlineScriptDatum headRedeemer
 
   headScriptRef =
     fst (headReference scriptRegistry)
-
-  headScript =
-    PlutusScriptSerialised Head.validatorScript
 
   contestRedeemer =
     case incrementalAction of

--- a/hydra-tx/src/Hydra/Tx/Decrement.hs
+++ b/hydra-tx/src/Hydra/Tx/Decrement.hs
@@ -68,14 +68,12 @@ decrementTx scriptRegistry vk headId headParameters (headInput, headOutput) snap
 
   decommitOutputs = maybe [] toList utxoToDecommit
 
-  headScript = PlutusScriptSerialised Head.validatorScript
-
   headScriptRef = fst (headReference scriptRegistry)
 
   headWitness =
     BuildTxWith $
       ScriptWitness scriptWitnessInCtx $
-        mkScriptReference headScriptRef headScript InlineScriptDatum headRedeemer
+        mkScriptReference headScriptRef Head.validatorScript InlineScriptDatum headRedeemer
 
   headDatumAfter =
     mkTxOutDatumInline $

--- a/hydra-tx/src/Hydra/Tx/Deposit.hs
+++ b/hydra-tx/src/Hydra/Tx/Deposit.hs
@@ -46,8 +46,6 @@ depositTx networkId headId commitBlueprintTx deadline =
 
   depositValue = foldMap txOutValue depositUTxO
 
-  depositScript = PlutusScriptSerialised depositValidatorScript
-
   deposits = mapMaybe Commit.serializeCommit $ UTxO.pairs depositUTxO
 
   depositPlutusDatum = Deposit.datum (headIdToCurrencySymbol headId, posixFromUTCTime deadline, deposits)
@@ -56,13 +54,13 @@ depositTx networkId headId commitBlueprintTx deadline =
 
   depositOutput =
     TxOut
-      (mkScriptAddress @PlutusScriptV3 networkId depositScript)
+      (depositAddress networkId)
       depositValue
       depositDatum
       ReferenceScriptNone
 
 depositAddress :: NetworkId -> AddressInEra
-depositAddress networkId = mkScriptAddress @PlutusScriptV3 networkId (PlutusScriptSerialised depositValidatorScript)
+depositAddress networkId = mkScriptAddress networkId depositValidatorScript
 
 -- * Observation
 

--- a/hydra-tx/src/Hydra/Tx/Fanout.hs
+++ b/hydra-tx/src/Hydra/Tx/Fanout.hs
@@ -45,11 +45,9 @@ fanoutTx scriptRegistry utxo utxoToCommit utxoToDecommit (headInput, headOutput)
   headWitness =
     BuildTxWith $
       ScriptWitness scriptWitnessInCtx $
-        mkScriptReference headScriptRef headScript InlineScriptDatum headRedeemer
+        mkScriptReference headScriptRef Head.validatorScript InlineScriptDatum headRedeemer
   headScriptRef =
     fst (headReference scriptRegistry)
-  headScript =
-    PlutusScriptSerialised Head.validatorScript
   headRedeemer =
     toScriptData $
       Head.Fanout

--- a/hydra-tx/src/Hydra/Tx/Increment.hs
+++ b/hydra-tx/src/Hydra/Tx/Increment.hs
@@ -69,14 +69,12 @@ incrementTx scriptRegistry vk headId headParameters (headInput, headOutput) snap
       & modifyTxOutDatum (const headDatumAfter)
       & modifyTxOutValue (<> depositedValue)
 
-  headScript = PlutusScriptSerialised Head.validatorScript
-
   headScriptRef = fst (headReference scriptRegistry)
 
   headWitness =
     BuildTxWith $
       ScriptWitness scriptWitnessInCtx $
-        mkScriptReference headScriptRef headScript InlineScriptDatum headRedeemer
+        mkScriptReference headScriptRef Head.validatorScript InlineScriptDatum headRedeemer
 
   utxoHash = toBuiltin $ hashUTxO @Tx utxo
 
@@ -93,8 +91,6 @@ incrementTx scriptRegistry vk headId headParameters (headInput, headOutput) snap
 
   depositedValue = foldMap (txOutValue . snd) $ UTxO.pairs (fromMaybe mempty utxoToCommit)
 
-  depositScript = PlutusScriptSerialised depositValidatorScript
-
   -- NOTE: we expect always a single output from a deposit tx
   (depositIn, _) = List.head $ UTxO.pairs depositScriptUTxO
 
@@ -103,6 +99,6 @@ incrementTx scriptRegistry vk headId headParameters (headInput, headOutput) snap
   depositWitness =
     BuildTxWith $
       ScriptWitness scriptWitnessInCtx $
-        mkScriptWitness depositScript InlineScriptDatum depositRedeemer
+        mkScriptWitness depositValidatorScript InlineScriptDatum depositRedeemer
 
   Snapshot{utxo, utxoToCommit, version, number} = snapshot

--- a/hydra-tx/src/Hydra/Tx/Init.hs
+++ b/hydra-tx/src/Hydra/Tx/Init.hs
@@ -43,12 +43,10 @@ initTx networkId seedTxIn participants parameters =
 mkHeadOutput :: NetworkId -> PolicyId -> TxOutDatum ctx -> TxOut ctx
 mkHeadOutput networkId tokenPolicyId datum =
   TxOut
-    (mkScriptAddress @PlutusScriptV3 networkId headScript)
+    (mkScriptAddress networkId Head.validatorScript)
     (fromList [(AssetId tokenPolicyId hydraHeadV1AssetName, 1)])
     datum
     ReferenceScriptNone
- where
-  headScript = PlutusScriptSerialised Head.validatorScript
 
 mkHeadOutputInitial :: NetworkId -> TxIn -> HeadParameters -> TxOut CtxTx
 mkHeadOutputInitial networkId seedTxIn HeadParameters{contestationPeriod, parties} =
@@ -72,8 +70,6 @@ mkInitialOutput networkId seedTxIn participant =
   initialValue =
     fromList [(AssetId tokenPolicyId (onChainIdToAssetName participant), 1)]
   initialAddress =
-    mkScriptAddress @PlutusScriptV3 networkId initialScript
-  initialScript =
-    PlutusScriptSerialised initialValidatorScript
+    mkScriptAddress @PlutusScriptV3 networkId initialValidatorScript
   initialDatum =
     mkTxOutDatumInline $ Initial.datum (toPlutusCurrencySymbol tokenPolicyId)

--- a/hydra-tx/src/Hydra/Tx/Recover.hs
+++ b/hydra-tx/src/Hydra/Tx/Recover.hs
@@ -37,12 +37,10 @@ recoverTx depositTxId deposited lowerBoundSlot =
   depositWitness =
     BuildTxWith $
       ScriptWitness scriptWitnessInCtx $
-        mkScriptWitness depositScript InlineScriptDatum redeemer
+        mkScriptWitness depositValidatorScript InlineScriptDatum redeemer
 
   depositOutputs =
     toTxContext <$> toList deposited
-
-  depositScript = PlutusScriptSerialised depositValidatorScript
 
 data RecoverObservation = RecoverObservation
   { headId :: HeadId
@@ -57,7 +55,7 @@ observeRecoverTx ::
   Maybe RecoverObservation
 observeRecoverTx networkId utxo tx = do
   let inputUTxO = resolveInputsUTxO utxo tx
-  (TxIn depositTxId _, depositOut) <- findTxOutByScript @PlutusScriptV3 inputUTxO depositScript
+  (TxIn depositTxId _, depositOut) <- findTxOutByScript inputUTxO depositValidatorScript
   dat <- txOutScriptData $ toTxContext depositOut
   (headCurrencySymbol, _, onChainDeposits) <- fromScriptData dat :: Maybe Deposit.DepositDatum
   deposits <- do
@@ -76,5 +74,3 @@ observeRecoverTx networkId utxo tx = do
             }
         )
     else Nothing
- where
-  depositScript = PlutusScriptSerialised depositValidatorScript

--- a/hydra-tx/test/Hydra/Tx/Contract/Abort.hs
+++ b/hydra-tx/test/Hydra/Tx/Contract/Abort.hs
@@ -122,7 +122,7 @@ propHasInitial (_, utxo) =
     & counterexample ("UTxO: " <> decodeUtf8 (encodePretty utxo))
     & counterexample ("Looking for Initial Script: " <> show addr)
  where
-  addr = mkScriptAddress testNetworkId (PlutusScriptSerialised initialValidatorScript)
+  addr = mkScriptAddress testNetworkId initialValidatorScript
   paysToInitialScript txOut =
     txOutAddress txOut == addr
 
@@ -132,7 +132,7 @@ propHasCommit (_, utxo) =
     & counterexample ("UTxO: " <> decodeUtf8 (encodePretty utxo))
     & counterexample ("Looking for Commit Script: " <> show addr)
  where
-  addr = mkScriptAddress testNetworkId (PlutusScriptSerialised commitValidatorScript)
+  addr = mkScriptAddress testNetworkId commitValidatorScript
   paysToCommitScript txOut =
     txOutAddress txOut == addr
 
@@ -287,12 +287,10 @@ genAbortableOutputs parties =
   initialTxOut :: VerificationKey PaymentKey -> TxOut CtxUTxO
   initialTxOut vk =
     TxOut
-      (mkScriptAddress testNetworkId initialScript)
+      (mkScriptAddress testNetworkId initialValidatorScript)
       (fromList [(AssetId testPolicyId (assetNameFromVerificationKey vk), 1)])
       (mkTxOutDatumInline initialDatum)
       ReferenceScriptNone
-
-  initialScript = PlutusScriptSerialised initialValidatorScript
 
   initialDatum = Initial.datum (toPlutusCurrencySymbol testPolicyId)
 
@@ -316,7 +314,7 @@ generateCommitUTxOs parties = do
   mkCommitUTxO (vk, party) utxo =
     ( toCtxUTxOTxOut $
         TxOut
-          (mkScriptAddress testNetworkId commitScript)
+          (mkScriptAddress testNetworkId commitValidatorScript)
           commitValue
           (mkTxOutDatumInline commitDatum)
           ReferenceScriptNone
@@ -331,8 +329,6 @@ generateCommitUTxOs parties = do
             [ (AssetId testPolicyId (assetNameFromVerificationKey vk), 1)
             ]
         ]
-
-    commitScript = PlutusScriptSerialised commitValidatorScript
 
     commitDatum = mkCommitDatum party utxo (toPlutusCurrencySymbol testPolicyId)
 

--- a/hydra-tx/test/Hydra/Tx/Contract/CollectCom.hs
+++ b/hydra-tx/test/Hydra/Tx/Contract/CollectCom.hs
@@ -172,10 +172,8 @@ healthyCommitOutput participant party committed =
  where
   txIn = genTxIn `genForParty` party
 
-  commitScript =
-    PlutusScriptSerialised commitValidatorScript
   commitAddress =
-    mkScriptAddress testNetworkId commitScript
+    mkScriptAddress testNetworkId commitValidatorScript
   commitValue =
     foldMap txOutValue committed
       <> fromList
@@ -253,7 +251,7 @@ genCollectComMutation (tx, _utxo) =
                 txIn
                 (toCtxUTxOTxOut $ mkInitialOutput testNetworkId testSeedInput participant)
                 (Just . toScriptData . Initial.redeemer $ Initial.ViaCommit [toPlutusTxOutRef txIn])
-            , AddScript $ PlutusScriptSerialised initialValidatorScript
+            , AddScript initialValidatorScript
             ]
     , SomeMutation (pure $ toErrorCode MintingOrBurningIsForbidden) MutateTokenMintingOrBurning
         <$> (changeMintedTokens tx =<< genMintedOrBurnedValue)

--- a/hydra-tx/testlib/Test/Hydra/Tx/Gen.hs
+++ b/hydra-tx/testlib/Test/Hydra/Tx/Gen.hs
@@ -245,11 +245,11 @@ genScriptRegistry = do
     ScriptRegistry
       { initialReference =
           ( TxIn txId' (TxIx 0)
-          , txOut{txOutReferenceScript = mkScriptRefV3 initialValidatorScript}
+          , txOut{txOutReferenceScript = mkScriptRef initialValidatorScript}
           )
       , commitReference =
           ( TxIn txId' (TxIx 1)
-          , txOut{txOutReferenceScript = mkScriptRefV3 commitValidatorScript}
+          , txOut{txOutReferenceScript = mkScriptRef commitValidatorScript}
           )
       , headReference =
           ( TxIn txId' (TxIx 2)

--- a/hydra-tx/testlib/Test/Hydra/Tx/Mutation.hs
+++ b/hydra-tx/testlib/Test/Hydra/Tx/Mutation.hs
@@ -514,8 +514,7 @@ deriving stock instance Eq Head.ContestRedeemer
 isHeadOutput :: TxOut CtxUTxO -> Bool
 isHeadOutput TxOut{txOutAddress = addr} = addr == headAddress
  where
-  headAddress = mkScriptAddress @PlutusScriptV3 Fixture.testNetworkId headScript
-  headScript = PlutusScriptSerialised Head.validatorScript
+  headAddress = mkScriptAddress Fixture.testNetworkId Head.validatorScript
 
 -- | Adds given 'Datum' and corresponding hash to the transaction's scripts.
 -- TODO: As we are creating the `TxOutDatum` from a known datum, passing a `TxOutDatum` is


### PR DESCRIPTION
The PlutusScript type is more specific as it carries the plutus version (fixed to V3 in hydra-cardano-api).

This also drops the unused Initial plutus-tx validator. 

---

* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Haddocks update not needed
* [x] No new TODOs introduced
