### PR TITLE
Repro for node-offline issue

### DIFF
--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -95,6 +95,14 @@ waitNoMatch delay client match = do
     Left _ -> pure () -- Success: waitMatch failed to find a match
     Right _ -> failure "waitNoMatch: A match was found when none was expected"
 
+-- | Wait up to some time and succeed if no API server output matches the given predicate.
+waitForAllNoMatch :: (Eq a, Show a, HasCallStack) => NominalDiffTime -> [HydraClient] -> (Aeson.Value -> Maybe a) -> IO ()
+waitForAllNoMatch delay clients match = do
+  result <- try (void $ waitForAllMatch delay clients match) :: IO (Either SomeException ())
+  case result of
+    Left _ -> pure () -- Success: waitMatch failed to find a match
+    Right _ -> failure "waitForAllNoMatch: A match was found when none was expected"
+
 -- | Wait up to some time for an API server output to match the given predicate.
 waitMatch :: HasCallStack => NominalDiffTime -> HydraClient -> (Aeson.Value -> Maybe a) -> IO a
 waitMatch delay client@HydraClient{tracer, hydraNodeId} match = do

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -59,6 +59,7 @@ import Hydra.Cluster.Scenarios (
   canSubmitTransactionThroughAPI,
   headIsInitializingWith,
   initWithWrongKeys,
+  oneOfNNodesCanDropForAWhile,
   persistenceCanLoadWithEmptyCommit,
   refuelIfNeeded,
   restartedNodeCanAbort,
@@ -298,6 +299,12 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
                   output "HeadIsFinalized" ["utxo" .= u0, "headId" .= headId]
 
     describe "restarting nodes" $ do
+      it "can survive a bit of downtime of 1 in 3 nodes" $ \tracer -> do
+        withClusterTempDir $ \tmpDir -> do
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
+            publishHydraScriptsAs node Faucet
+              >>= oneOfNNodesCanDropForAWhile tracer tmpDir node
+
       it "can abort head after restart" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
           withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->


### PR DESCRIPTION
Investigating a scenario where a node drops off and a Tx is submitted.

### Running

If you want to run this test:

```
cabal test hydra-cluster --test-options '--match "survive a bit of"'
```

The main observation at present is that `n3` (Carol) doesn't emit `SnapshotConfirmed`; despite the other two participants actually seeing it (you can confirm yourself by removing `n3` in the final `mapConcurrently`

```
  flip mapConcurrently_ [n1, n2] $ \n -> ...
```

and observe that it succeeds.


### Trivia

`waitMatch` is a bit dangerous because you can't see one one wait a message you _also_ want to see in a subsequent match; i.e. it's somehow "live" and you'll miss things if you do that.

As a result, I've removed some code like following, even though it's useful (from the final block where Carol is back):

```haskell

        -- They see Carol return
        waitForAllMatch (50 * blockTime) [n1, n2] $ \v -> do
          guard $ v ^? key "tag" == Just "PeerConnected"

        -- Carol sees them return
        flip mapConcurrently_ ["1", "2"] $ \i -> do
          waitMatch (100 * blockTime) n3 $ \v -> do
            guard $ v ^? key "tag" == Just "PeerConnected"
            guard $ v ^? key "peer" == Just i

```


---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
