### PR TITLE
Fix: Remove logic that trimmed the last byte from transaction ID in publishReferenceScripts function (Demo Setup)

### DIFF
--- a/demo/seed-devnet.sh
+++ b/demo/seed-devnet.sh
@@ -98,8 +98,7 @@ function publishReferenceScripts() {
   hnode publish-scripts \
     --testnet-magic ${NETWORK_ID} \
     --node-socket ${DEVNET_DIR}/node.socket \
-    --cardano-signing-key devnet/credentials/faucet.sk \
-    | tr '\n' ','
+    --cardano-signing-key devnet/credentials/faucet.sk
 }
 
 function queryPParams() {

--- a/demo/seed-devnet.sh
+++ b/demo/seed-devnet.sh
@@ -99,8 +99,7 @@ function publishReferenceScripts() {
     --testnet-magic ${NETWORK_ID} \
     --node-socket ${DEVNET_DIR}/node.socket \
     --cardano-signing-key devnet/credentials/faucet.sk \
-    | tr '\n' ',' \
-    | head -c -1
+    | tr '\n' ','
 }
 
 function queryPParams() {


### PR DESCRIPTION
I reported this in Discord, but this is a fix for the Hydra Head "Getting started" demo located here https://hydra.family/head-protocol/docs/getting-started

Running the `./seed-devnet.sh` command would invoke a function called `publishReferenceScripts` that saves a transaction id to the `.env` file named `HYDRA_SCRIPTS_TX_ID`. This function included a piped command: `head -c -1` which removed the last byte from the outputted transaction id.

This must have been utilized in a previous version, however now it incorrectly trims the last byte from the transaction id, causing it to be invalid (incorrect length). Running the `docker compose up -d hydra-node-{1,2,3}` would cause an error like so, and cause the containers to crash and keep restarting:
```
option --hydra-scripts-tx-id: RawBytesHexErrorBase16DecodeFail "0e2114c7a09c171ce8a8a5ba282fa2a47056a1c6415d4aaecbbb44093cdf2e7" "invalid bytestring size"
```

I have confirmed that removing this specific command fixes the issue and the Hydra nodes successfully start up.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
