### PR TITLE
Quickfix for the network tests to use the correct format for the published script addresses

### DIFF
--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -178,6 +178,7 @@ test-suite tests
     , lens-aeson
     , process
     , QuickCheck
+    , split
     , stm
     , text
     , time

--- a/hydra-cluster/test/Test/DirectChainSpec.hs
+++ b/hydra-cluster/test/Test/DirectChainSpec.hs
@@ -19,7 +19,7 @@ import CardanoNode (NodeLog, withCardanoNodeDevnet)
 import Control.Concurrent.STM (newEmptyTMVarIO, takeTMVar)
 import Control.Concurrent.STM.TMVar (putTMVar)
 import Control.Lens ((<>~))
-import Data.List qualified as List
+import Data.List.Split (splitWhen)
 import Data.Set qualified as Set
 import Hydra.Cardano.Api (
   ChainPoint (..),
@@ -427,7 +427,7 @@ spec = around (showLogsOnFailure "DirectChainSpec") $ do
                 )
             )
             ""
-        let hydraScriptsTxId = fromString <$> List.lines hydraScriptsTxIdStr
+        let hydraScriptsTxId = fromString <$> splitWhen (== ',') (filter (/= '\n') hydraScriptsTxIdStr)
         failAfter 5 $ void $ queryScriptRegistry networkId nodeSocket hydraScriptsTxId
 
   it "can only contest once" $ \tracer -> do

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -2,8 +2,9 @@
 
 module Main where
 
-import Hydra.Prelude hiding (fromList)
+import Hydra.Prelude hiding (fromList, intercalate)
 
+import Data.ByteString (intercalate)
 import Hydra.Cardano.Api (
   serialiseToRawBytesHex,
  )
@@ -34,7 +35,7 @@ main = do
     (_, sk) <- readKeyPair (publishSigningKey opts)
     let PublishOptions{publishNetworkId = networkId, publishNodeSocket} = opts
     txIds <- publishHydraScripts networkId publishNodeSocket sk
-    mapM_ putBSLn (serialiseToRawBytesHex <$> txIds)
+    putBSLn $ intercalate "," (serialiseToRawBytesHex <$> txIds)
 
 identifyNode :: RunOptions -> RunOptions
 identifyNode opt@RunOptions{verbosity = Verbose "HydraNode", nodeId} = opt{verbosity = Verbose $ "HydraNode-" <> show nodeId}

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -201,6 +201,7 @@ executable hydra-node
   hs-source-dirs: exe/hydra-node
   main-is:        Main.hs
   build-depends:
+    , bytestring
     , hydra-cardano-api
     , hydra-node
     , hydra-prelude


### PR DESCRIPTION
The recent PR #1782 removed behaviour that the _network tests_ relied on (as they use the latest code from this repo) but _broke_ the demo.

I think the essential lesson is at least a few things:

1. We need to test the demo in CI
2. One script doing two things is confusing
