### PR TITLE
Map and debug PlutusFailure cases of ApplyTx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ changes.
   - Overall this results in transactions still to be submitted once per client,
     but requires signifanctly less book-keeping on the client-side.
 
+- Auto-debug and provide more information on `PlutusFailure` when validating transactions on L2 ledger.
+
 - Bump docusaurus version
 
 - Add blockfrost support to `hydra-chain-observer`, to follow the chain via Blockfrost API.

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -109,6 +109,7 @@ library
     , cardano-ledger-api
     , cardano-ledger-babbage
     , cardano-ledger-babbage:testlib
+    , cardano-ledger-conway
     , cardano-ledger-conway:testlib
     , cardano-ledger-core
     , cardano-ledger-core:testlib

--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -38,6 +38,7 @@ import Data.Default (def)
 import Hydra.Chain.ChainState (ChainSlot (..))
 import Hydra.Ledger (Ledger (..), ValidationError (..))
 import Hydra.Tx (IsTx (..))
+import System.IO.Unsafe (unsafeDupablePerformIO)
 import Test.Cardano.Ledger.Babbage.Arbitrary ()
 import Test.Cardano.Ledger.Conway.Arbitrary ()
 import Test.Hydra.Tx.Gen (genKeyPair, genOneUTxOFor)
@@ -87,7 +88,10 @@ cardanoLedger globals ledgerEnv =
           "Plutus validation failed: "
             <> msg
             <> "Debug info: "
-            <> show (debugPlutus @StandardCrypto (decodeUtf8 ctx))
+            -- NOTE: There is not a clear reason why 'debugPlutus' is an IO
+            -- action. It only re-evaluates the script and does not have any
+            -- side-effects.
+            <> show (unsafeDupablePerformIO $ debugPlutus @StandardCrypto (decodeUtf8 ctx))
       _ -> ValidationError $ show e
 
     env' = ledgerEnv{Ledger.ledgerSlotNo = fromIntegral slot}


### PR DESCRIPTION
When submitting transactions which spend from scripts to the L2 cardano ledger, we can use debugPlutus to re-evaluate the script and dump debug information.

This does not fix the formatting though (newlines in Text).

TODO: a test would be good. @noonio you had a e2e scenario where we spend a script on the L2 recently?

This commit is also back-ported onto `doom` to benefit the hydra-doom project.

---

* [x] CHANGELOG updated
* [ ] Documentation updated or not needed
* [x] Haddocks update not needed
* [x] No new TODOs introduced
