### PR TITLE
Bring in example that just spends from a script in L2 and closes

### DIFF
--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -85,8 +85,11 @@ library
   build-depends:
     , aeson
     , async
-    , base                  >=4.7 && <5
+    , base                   >=4.7 && <5
     , bytestring
+    , cardano-ledger-alonzo
+    , cardano-ledger-api
+    , cardano-ledger-core
     , cardano-slotting
     , containers
     , contra-tracer

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -350,6 +350,9 @@ withHydraNode' tracer chainConfig workDir hydraNodeId hydraSKey hydraVKeys allNo
             & atKey "txFeePerByte" ?~ toJSON (Number 0)
             & key "executionUnitPrices" . atKey "priceMemory" ?~ toJSON (Number 0)
             & key "executionUnitPrices" . atKey "priceSteps" ?~ toJSON (Number 0)
+            & atKey "utxoCostPerByte" ?~ toJSON (Number 0)
+            & atKey "treasuryCut" ?~ toJSON (Number 0)
+            & atKey "minFeeRefScriptCostPerByte" ?~ toJSON (Number 0)
 
     let hydraSigningKey = dir </> (show hydraNodeId <> ".sk")
     void $ writeFileTextEnvelope (File hydraSigningKey) Nothing hydraSKey

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -67,6 +67,7 @@ import Hydra.Cluster.Scenarios (
   singlePartyCommitsFromExternalTxBlueprint,
   singlePartyCommitsScriptBlueprint,
   singlePartyHeadFullLifeCycle,
+  singlePartyUsesScriptOnL2,
   testPreventResumeReconfiguredPeer,
   threeNodesNoErrorsOnOpen,
  )
@@ -178,6 +179,11 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
           withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
             publishHydraScriptsAs node Faucet
               >>= singlePartyCommitsFromExternal tracer tmpDir node
+      it "can spend from a script on L2" $ \tracer -> do
+        withClusterTempDir $ \tmpDir -> do
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
+            publishHydraScriptsAs node Faucet
+              >>= singlePartyUsesScriptOnL2 tracer tmpDir node
       it "can submit a signed user transaction" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
           withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->


### PR DESCRIPTION
This brings in the bulk of the work from #1742 ; it demonstrates that one can spend from a script on L2. This is useful infrastructure to, say, test a custom ledger operation and check that the Hydra can deal with that on it's own ledger, but still close and go back to L1 successfully.

This is a useful test in any case.

Note that it contains a `TODO` around a bug we saw with autobalancing, that will hopefully be fixed in subsequent versions of `cardano-api`.

We make two further additions:

- We attempt to zero-out a few more fee fields in the protocol params
- We provide `buildTransactionWithPParams` to explicitly set the pparams instead of using the **L1 pparams**. This is an important observation!