### PR TITLE
Update spec flake input and tackle comments and TODOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ changes.
 
 - **BETA** hydra-node now supports incremental commits in beta mode. We would like to test out this feature
   with the community members building on Hydra. This feature means you can commit funds to a Head while it is running.
-  TODO: Implement missing spec changes.
 
 - There is a new `--deposit-deadline` argument to hydra-node that determines the maximum time for the hydra-node to detect a deposit.
   After this time has passed users can recover a deposit in case it wasn't observed previously.

--- a/flake.lock
+++ b/flake.lock
@@ -647,11 +647,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1717285511,
-        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
+        "lastModified": 1736143030,
+        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
+        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
         "type": "github"
       },
       "original": {
@@ -792,11 +792,11 @@
     "formal-ledger": {
       "flake": false,
       "locked": {
-        "lastModified": 1718812337,
-        "narHash": "sha256-3zAxfOEs/Ff5g13493iZGGhcvYaSOJNkQLN/G3/AhiY=",
+        "lastModified": 1736958942,
+        "narHash": "sha256-KAyojB3uClt72fhOzw9iDSCGzlL8EUhEtK/Xizj5pyU=",
         "owner": "IntersectMBO",
         "repo": "formal-ledger-specifications",
-        "rev": "6129d97a0419f8d920e3ed63e192f34cbaf65cc6",
+        "rev": "cef3505f275900c51737071b5671e5dad47dc576",
         "type": "github"
       },
       "original": {
@@ -1462,11 +1462,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1725260503,
-        "narHash": "sha256-PV3JrSImQCK048+lE474BJMGP24jMh/9F6uEV+UP0qg=",
+        "lastModified": 1738003268,
+        "narHash": "sha256-VdCO1qCzJBOiO+c6mdtGcJnRfbCRH7xYo9mt+fr63Vo=",
         "owner": "cardano-scaling",
         "repo": "hydra-formal-specification",
-        "rev": "34ea7455d151c239eb12ec5b0b0cb28ab2cc1df7",
+        "rev": "27d17772d37c202bbb11d979d0e3f549838cb6f4",
         "type": "github"
       },
       "original": {
@@ -2178,14 +2178,14 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1717284937,
-        "narHash": "sha256-lIbdfCsf8LMFloheeE6N31+BMIeixqyQWbSr2vk79EQ=",
+        "lastModified": 1735774519,
+        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
       }
     },
     "nixpkgs-lib_3": {
@@ -2278,11 +2278,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1718717814,
-        "narHash": "sha256-xB7AzKY4BP7yypo6g+sk1tnVK54sBIJMeEBB5CdbhT4=",
+        "lastModified": 1737223978,
+        "narHash": "sha256-5r5py5/ckGE7EzQk0uwOyeDus4xowRPmFrAhSNrb51g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "88af533d8ae8d1e7e4648decf7817ebff91abf56",
+        "rev": "d37c24666dc05cdf1e9b76ea4437e3f222c7f944",
         "type": "github"
       },
       "original": {

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -441,6 +441,7 @@ onOpenNetworkReqSn env ledger st otherParty sv sn requestedTxIds mDecommitTx mIn
                         , utxoToCommit = mUtxoToCommit
                         , utxoToDecommit = mUtxoToDecommit
                         }
+                -- TODO: Update spec comments to include eta-alpha/omega
                 -- Spec: η ← combine(𝑈)
                 --       σᵢ ← MS-Sign(kₕˢⁱᵍ, (cid‖v‖ŝ‖η‖ηω))
                 let snapshotSignature = sign signingKey nextSnapshot

--- a/hydra-plutus/src/Hydra/Contract/Deposit.hs
+++ b/hydra-plutus/src/Hydra/Contract/Deposit.hs
@@ -24,7 +24,6 @@ import PlutusTx qualified
 
 data DepositRedeemer
   = -- | Claims already deposited funds.
-    -- FIXME: Make sure to change the spec and add head CS to the Claim redeemer.
     Claim CurrencySymbol
   | -- | Recovers m number of deposited outputs.
     Recover Integer

--- a/hydra-plutus/src/Hydra/Contract/Head.hs
+++ b/hydra-plutus/src/Hydra/Contract/Head.hs
@@ -256,8 +256,6 @@ checkIncrement ::
   IncrementRedeemer ->
   Bool
 checkIncrement ctx@ScriptContext{scriptContextTxInfo = txInfo} openBefore redeemer =
-  -- FIXME: spec is mentioning the n also needs to be unchanged - what is n here? utxo hash?
-  -- "parameters cid, 𝑘̃ H , 𝑛, 𝑇 stay unchanged"
   mustNotChangeParameters (prevParties, nextParties) (prevCperiod, nextCperiod) (prevHeadId, nextHeadId)
     && mustIncreaseVersion
     && mustIncreaseValue
@@ -438,7 +436,6 @@ checkClose ctx openBefore redeemer =
           version == 0
             && snapshotNumber' == 0
             && utxoHash' == initialUtxoHash
-      -- FIXME: reflect the new CloseAny redeemer in the spec as well
       CloseAny{signature} ->
         traceIfFalse $(errorCode FailedCloseAny) $
           snapshotNumber' > 0

--- a/hydra-plutus/src/Hydra/Contract/HeadState.hs
+++ b/hydra-plutus/src/Hydra/Contract/HeadState.hs
@@ -52,7 +52,6 @@ data ClosedDatum = ClosedDatum
   -- ^ Spec: s
   , utxoHash :: Hash
   -- ^ Spec: η. Digest of snapshotted UTxO
-  -- | TODO: add alphaUTxOHash to the spec
   , alphaUTxOHash :: Hash
   , omegaUTxOHash :: Hash
   -- ^ Spec: ηΔ. Digest of UTxO still to be distributed
@@ -182,10 +181,8 @@ data Input
   | Abort
   | Fanout
       { numberOfFanoutOutputs :: Integer
-      , -- TODO: add this to the spec
-        numberOfCommitOutputs :: Integer
+      , numberOfCommitOutputs :: Integer
       , numberOfDecommitOutputs :: Integer
-      -- ^ Spec: n
       }
   deriving stock (Generic, Show)
 

--- a/hydra-tx/src/Hydra/Tx/Fanout.hs
+++ b/hydra-tx/src/Hydra/Tx/Fanout.hs
@@ -52,8 +52,7 @@ fanoutTx scriptRegistry utxo utxoToCommit utxoToDecommit (headInput, headOutput)
     toScriptData $
       Head.Fanout
         { numberOfFanoutOutputs = fromIntegral $ length $ toList utxo
-        , -- TODO: Update the spec with this new field 'numberOfCommitOutputs'
-          numberOfCommitOutputs = fromIntegral $ length orderedTxOutsToCommit
+        , numberOfCommitOutputs = fromIntegral $ length orderedTxOutsToCommit
         , numberOfDecommitOutputs = fromIntegral $ length orderedTxOutsToDecommit
         }
 


### PR DESCRIPTION
This PR updates the specification flake input and removes all relevant TODOs related to spec changes. It also updates spec related comments in code.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
