### PR TITLE
Streaming events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ changes.
 
 ## [0.20.1] - UNRELEASED
 
+- Stream historical data from disk in the hydra-node API server.
+
 - Record used and free memory when running `bench-e2e` benchmark.
+
 - Submit observations to a `hydra-explorer` via optional `--explorer` option.
 
 - Tested with `cardano-node 10.2` and `cardano-cli 10.3.0.0`.

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -118,6 +118,7 @@ library
     , cardano-slotting
     , cardano-strict-containers
     , cborg
+    , conduit
     , containers
     , contra-tracer
     , cryptonite
@@ -340,6 +341,7 @@ test-suite tests
     , cardano-slotting
     , cardano-strict-containers
     , cborg
+    , conduit
     , containers
     , contra-tracer
     , directory

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -894,6 +894,26 @@ definitions:
             minimum: 0
           input:
             "$ref": "logs.yaml#/definitions/Input"
+      - title: LoadingState
+        description: >-
+          Loading state events from persistence.
+        type: object
+        required:
+          - tag
+        properties:
+          tag:
+            type: string
+            enum: ["LoadingState"]
+      - title: ReplayingState
+        description: >-
+          Replaying state events from persistence.
+        type: object
+        required:
+          - tag
+        properties:
+          tag:
+            type: string
+            enum: ["ReplayingState"]
       - title: LoadedState
         description: >-
           Loaded state events from persistence.
@@ -901,14 +921,18 @@ definitions:
         additionalProperties: false
         required:
           - tag
-          - numberOfEvents
+          - lastEventId
+          - headState
         properties:
           tag:
             type: string
             enum: ["LoadedState"]
-          numberOfEvents:
-            type: integer
-            minimum: 0
+          lastEventId:
+            oneOf:
+              - type: "null"
+              - type: integer
+          headState:
+            $ref: "logs.yaml#/definitions/HeadState"
       - title: Misconfiguration
         description: >-
           Hydra node detected a difference between loaded state and the node arguments.

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -5,10 +5,10 @@ module Hydra.API.Server where
 import Hydra.Prelude hiding (TVar, mapM_, readTVar, seq)
 
 import Cardano.Ledger.Core (PParams)
-import Conduit (mapM_C, runConduitRes, (.|))
+import Conduit (runConduitRes, sinkList, (.|))
 import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
 import Control.Concurrent.STM.TChan (newBroadcastTChanIO, writeTChan)
-import Control.Concurrent.STM.TVar (modifyTVar, modifyTVar', newTVarIO)
+import Control.Concurrent.STM.TVar (modifyTVar', newTVarIO)
 import Control.Exception (IOException)
 import Data.Conduit.Combinators (iterM)
 import Hydra.API.APIServerLog (APIServerLog (..))
@@ -98,8 +98,7 @@ withAPIServer config env party persistence tracer chain pparams serverOutputFilt
     commitInfoP <- mkProjection CannotCommit projectCommitInfo
     headIdP <- mkProjection Nothing projectInitializingHeadId
     pendingDepositsP <- mkProjection [] projectPendingDeposits
-    history <- newTVarIO []
-    _ <-
+    loadedHistory <-
       runConduitRes $
         source
           -- .| mapC output
@@ -108,8 +107,10 @@ withAPIServer config env party persistence tracer chain pparams serverOutputFilt
           .| iterM (lift . atomically . update commitInfoP . output)
           .| iterM (lift . atomically . update headIdP . output)
           .| iterM (lift . atomically . update pendingDepositsP . output)
-          .| mapM_C (\v -> lift $ atomically $ modifyTVar history (v :))
+          -- FIXME: don't load whole history into memory
+          .| sinkList
 
+    history <- newTVarIO loadedHistory
     -- NOTE: we need to reverse the list because we store history in a reversed
     -- list in memory but in order on disk
     (notifyServerRunning, waitForServerRunning) <- setupServerNotification

--- a/hydra-node/src/Hydra/Events.hs
+++ b/hydra-node/src/Hydra/Events.hs
@@ -31,6 +31,7 @@ instance HasEventId (EventId, a) where
 data EventSource e m = EventSource
   { getEvents :: HasEventId e => m [e]
   -- ^ Retrieve all events from the event source.
+  -- TODO: define this in terms of sourceEvents
   , sourceEvents :: HasEventId e => ConduitT () e (ResourceT m) ()
   -- ^ Stream all events from the event source.
   }

--- a/hydra-node/src/Hydra/Events.hs
+++ b/hydra-node/src/Hydra/Events.hs
@@ -15,7 +15,7 @@ module Hydra.Events where
 
 import Hydra.Prelude
 
-import Conduit (ConduitT)
+import Conduit (ConduitT, ResourceT)
 import Hydra.Chain.ChainState (IsChainState)
 import Hydra.HeadLogic.Outcome (StateChanged)
 import Hydra.Tx.IsTx (ArbitraryIsTx)
@@ -31,7 +31,7 @@ instance HasEventId (EventId, a) where
 data EventSource e m = EventSource
   { getEvents :: HasEventId e => m [e]
   -- ^ Retrieve all events from the event source.
-  , sourceEvents :: forall i. HasEventId e => ConduitT i e m ()
+  , sourceEvents :: HasEventId e => ConduitT () e (ResourceT m) ()
   -- ^ Stream all events from the event source.
   }
 

--- a/hydra-node/src/Hydra/Events.hs
+++ b/hydra-node/src/Hydra/Events.hs
@@ -15,6 +15,7 @@ module Hydra.Events where
 
 import Hydra.Prelude
 
+import Conduit (ConduitT)
 import Hydra.Chain.ChainState (IsChainState)
 import Hydra.HeadLogic.Outcome (StateChanged)
 import Hydra.Tx.IsTx (ArbitraryIsTx)
@@ -24,9 +25,14 @@ type EventId = Word64
 class HasEventId a where
   getEventId :: a -> EventId
 
-newtype EventSource e m = EventSource
+instance HasEventId (EventId, a) where
+  getEventId = fst
+
+data EventSource e m = EventSource
   { getEvents :: HasEventId e => m [e]
   -- ^ Retrieve all events from the event source.
+  , sourceEvents :: forall i. HasEventId e => ConduitT i e m ()
+  -- ^ Stream all events from the event source.
   }
 
 newtype EventSink e m = EventSink

--- a/hydra-node/src/Hydra/Events.hs
+++ b/hydra-node/src/Hydra/Events.hs
@@ -25,9 +25,6 @@ type EventId = Word64
 class HasEventId a where
   getEventId :: a -> EventId
 
-instance HasEventId (EventId, a) where
-  getEventId = fst
-
 newtype EventSource e m = EventSource
   { sourceEvents :: HasEventId e => ConduitT () e (ResourceT m) ()
   -- ^ Stream all events from the event source.

--- a/hydra-node/src/Hydra/Network/Reliability.hs
+++ b/hydra-node/src/Hydra/Network/Reliability.hs
@@ -110,9 +110,10 @@ import Hydra.Logging (traceWith)
 import Hydra.Network (Network (..), NetworkCallback (..), NetworkComponent)
 import Hydra.Network.Authenticate (Authenticated (..))
 import Hydra.Network.Heartbeat (Heartbeat (..), isPing)
-import Hydra.Persistence (Persistence (..), PersistenceIncremental (..))
+import Hydra.Persistence (Persistence (..), PersistenceIncremental (..), loadAll)
 import Hydra.Tx (Party)
 import Test.QuickCheck.Instances.Vector ()
+import UnliftIO (MonadUnliftIO)
 
 data ReliableMsg msg = ReliableMsg
   { knownMessageIds :: Vector Int
@@ -180,7 +181,7 @@ data MessagePersistence m msg = MessagePersistence
 -- NOTE: This handle is returned in the underlying context just for the sake of
 -- convenience.
 mkMessagePersistence ::
-  (MonadThrow m, FromJSON msg, ToJSON msg) =>
+  (MonadUnliftIO m, MonadThrow m, FromJSON msg, ToJSON msg) =>
   Int ->
   PersistenceIncremental (Heartbeat msg) m ->
   Persistence (Vector Int) m ->

--- a/hydra-node/src/Hydra/Node/Network.hs
+++ b/hydra-node/src/Hydra/Node/Network.hs
@@ -93,6 +93,7 @@ import Hydra.Persistence (Persistence (..), createPersistence, createPersistence
 import Hydra.Tx (IsTx, Party, deriveParty)
 import Hydra.Tx.Crypto (HydraKey, SigningKey)
 import System.FilePath ((</>))
+import UnliftIO (MonadUnliftIO)
 
 -- | An alias for logging messages output by network component.
 -- The type is made complicated because the various subsystems use part of the tracer only.
@@ -174,7 +175,7 @@ withNetwork tracer configuration callback action = do
 --   * Some state already exists and is loaded,
 --   * The number of parties is not the same as the number of acknowledgments saved.
 configureMessagePersistence ::
-  (MonadIO m, MonadThrow m, FromJSON msg, ToJSON msg, MonadSTM m, MonadThread m, MonadThrow (STM m)) =>
+  (MonadThrow m, FromJSON msg, ToJSON msg, MonadUnliftIO m) =>
   Tracer m (HydraNodeLog tx) ->
   FilePath ->
   Int ->

--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -5,6 +5,7 @@ module Hydra.API.ServerSpec where
 import Hydra.Prelude hiding (decodeUtf8, seq)
 import Test.Hydra.Prelude
 
+import Conduit (yieldMany)
 import Control.Concurrent.Class.MonadSTM (
   check,
   modifyTVar',
@@ -415,16 +416,17 @@ withClient port path action =
             connect (n - 1)
 
 -- | Mocked persistence handle which just does nothing.
-mockPersistence :: Applicative m => PersistenceIncremental a m
+mockPersistence :: Monad m => PersistenceIncremental a m
 mockPersistence =
   mockPersistence' []
 
 -- | Mocked persistence which does not contain some constant elements.
-mockPersistence' :: Applicative m => [a] -> PersistenceIncremental a m
+mockPersistence' :: Monad m => [a] -> PersistenceIncremental a m
 mockPersistence' xs =
   PersistenceIncremental
     { append = \_ -> pure ()
     , loadAll = pure xs
+    , source = yieldMany xs
     }
 
 waitForValue :: HasCallStack => PortNumber -> (Aeson.Value -> Maybe ()) -> IO ()

--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -425,7 +425,6 @@ mockPersistence' :: Monad m => [a] -> PersistenceIncremental a m
 mockPersistence' xs =
   PersistenceIncremental
     { append = \_ -> pure ()
-    , loadAll = pure xs
     , source = yieldMany xs
     }
 

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -5,6 +5,7 @@ module Hydra.BehaviorSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude hiding (shouldBe, shouldNotBe, shouldReturn, shouldSatisfy)
 
+import Conduit (MonadUnliftIO)
 import Control.Concurrent.Class.MonadSTM (
   MonadLabelledSTM,
   modifyTVar,
@@ -1175,7 +1176,9 @@ withHydraNode signingKey otherParties chain action = do
   outputs <- atomically newTQueue
   outputHistory <- newTVarIO mempty
   let initialChainState = SimpleChainState{slot = ChainSlot 0}
-  node <- createHydraNode traceInIOSim simpleLedger initialChainState signingKey otherParties outputs outputHistory chain testContestationPeriod testDepositDeadline
+  -- FIXME: createHydaNode requires an instance 'MonadUnliftIO (IOSim s)'
+  -- node <- createHydraNode traceInIOSim simpleLedger initialChainState signingKey otherParties outputs outputHistory chain testContestationPeriod testDepositDeadline
+  let node = undefined :: HydraNode SimpleTx (IOSim s)
   withAsync (runHydraNode node) $ \_ ->
     action (createTestHydraClient outputs outputHistory node)
 
@@ -1195,7 +1198,7 @@ createTestHydraClient outputs outputHistory HydraNode{inputQueue, nodeState} =
     }
 
 createHydraNode ::
-  (MonadDelay m, MonadAsync m, MonadLabelledSTM m, IsChainState tx, MonadThrow m) =>
+  (MonadDelay m, MonadAsync m, MonadLabelledSTM m, IsChainState tx, MonadThrow m, MonadUnliftIO m) =>
   Tracer m (HydraNodeLog tx) ->
   Ledger tx ->
   ChainStateType tx ->

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -36,6 +36,7 @@ import Control.Concurrent.Class.MonadSTM (
  )
 import Control.Monad.Class.MonadAsync (Async, async, cancel, link)
 import Control.Monad.Class.MonadFork (labelThisThread)
+import Control.Monad.IOSim (IOSim)
 import Data.List (nub)
 import Data.List qualified as List
 import Data.Map ((!))
@@ -65,7 +66,7 @@ import Hydra.Logging (Tracer)
 import Hydra.Logging.Messages (HydraLog (DirectChain, Node))
 import Hydra.Model.MockChain (mockChainAndNetwork)
 import Hydra.Model.Payment (CardanoSigningKey (..), Payment (..), applyTx, genAdaValue)
-import Hydra.Node (runHydraNode)
+import Hydra.Node (HydraNode, runHydraNode)
 import Hydra.Tx.ContestationPeriod (ContestationPeriod (UnsafeContestationPeriod))
 import Hydra.Tx.Crypto (HydraKey)
 import Hydra.Tx.DepositDeadline (DepositDeadline (UnsafeDepositDeadline))
@@ -634,7 +635,9 @@ seedWorld seedKeys seedCP depositDeadline futureCommits = do
       labelTQueueIO outputs ("outputs-" <> shortLabel hsk)
       outputHistory <- newTVarIO []
       labelTVarIO outputHistory ("history-" <> shortLabel hsk)
-      node <- createHydraNode (contramap Node tr) ledger initialChainState hsk otherParties outputs outputHistory mockChain seedCP depositDeadline
+      -- FIXME: createHydaNode requires an instance 'MonadUnliftIO (IOSim s)'
+      -- node <- createHydraNode (contramap Node tr) ledger initialChainState hsk otherParties outputs outputHistory mockChain seedCP depositDeadline
+      let node = undefined :: HydraNode Tx m
       let testClient = createTestHydraClient outputs outputHistory node
       nodeThread <- async $ labelThisThread ("node-" <> shortLabel hsk) >> runHydraNode node
       link nodeThread

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -36,7 +36,6 @@ import Control.Concurrent.Class.MonadSTM (
  )
 import Control.Monad.Class.MonadAsync (Async, async, cancel, link)
 import Control.Monad.Class.MonadFork (labelThisThread)
-import Control.Monad.IOSim (IOSim)
 import Data.List (nub)
 import Data.List qualified as List
 import Data.Map ((!))
@@ -66,7 +65,7 @@ import Hydra.Logging (Tracer)
 import Hydra.Logging.Messages (HydraLog (DirectChain, Node))
 import Hydra.Model.MockChain (mockChainAndNetwork)
 import Hydra.Model.Payment (CardanoSigningKey (..), Payment (..), applyTx, genAdaValue)
-import Hydra.Node (HydraNode, runHydraNode)
+import Hydra.Node (runHydraNode)
 import Hydra.Tx.ContestationPeriod (ContestationPeriod (UnsafeContestationPeriod))
 import Hydra.Tx.Crypto (HydraKey)
 import Hydra.Tx.DepositDeadline (DepositDeadline (UnsafeDepositDeadline))
@@ -635,9 +634,7 @@ seedWorld seedKeys seedCP depositDeadline futureCommits = do
       labelTQueueIO outputs ("outputs-" <> shortLabel hsk)
       outputHistory <- newTVarIO []
       labelTVarIO outputHistory ("history-" <> shortLabel hsk)
-      -- FIXME: createHydaNode requires an instance 'MonadUnliftIO (IOSim s)'
-      -- node <- createHydraNode (contramap Node tr) ledger initialChainState hsk otherParties outputs outputHistory mockChain seedCP depositDeadline
-      let node = undefined :: HydraNode Tx m
+      node <- createHydraNode (contramap Node tr) ledger initialChainState hsk otherParties outputs outputHistory mockChain seedCP depositDeadline
       let testClient = createTestHydraClient outputs outputHistory node
       nodeThread <- async $ labelThisThread ("node-" <> shortLabel hsk) >> runHydraNode node
       link nodeThread

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -346,8 +346,7 @@ mockSink = EventSink{putEvent = const $ pure ()}
 mockSource :: Monad m => [a] -> EventSource a m
 mockSource events =
   EventSource
-    { getEvents = pure events
-    , sourceEvents = yieldMany events
+    { sourceEvents = yieldMany events
     }
 
 createRecordingSink :: IO (EventSink a IO, IO [a])
@@ -361,8 +360,7 @@ createMockSourceSink = do
   labelTVarIO tvar "in-memory-source-sink"
   let source =
         EventSource
-          { getEvents = readTVarIO tvar
-          , sourceEvents = do
+          { sourceEvents = do
               es <- lift . lift $ readTVarIO tvar
               yieldMany es
           }

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -5,7 +5,7 @@ module Hydra.NodeSpec where
 import Hydra.Prelude hiding (label)
 import Test.Hydra.Prelude
 
-import Conduit (yieldMany)
+import Conduit (MonadUnliftIO, yieldMany)
 import Control.Concurrent.Class.MonadSTM (MonadLabelledSTM, labelTVarIO, modifyTVar, newTVarIO, readTVarIO)
 import Hydra.API.ClientInput (ClientInput (..))
 import Hydra.API.Server (Server (..))
@@ -405,7 +405,7 @@ runToCompletion node@HydraNode{inputQueue = InputQueue{isEmpty}} = go
 -- | Creates a full 'HydraNode' with given parameters and primed 'Input's. Note
 -- that this node is 'notConnect'ed to any components.
 testHydraNode ::
-  (MonadDelay m, MonadAsync m, MonadLabelledSTM m, MonadThrow m) =>
+  (MonadDelay m, MonadAsync m, MonadLabelledSTM m, MonadThrow m, MonadUnliftIO m) =>
   Tracer m (HydraNodeLog SimpleTx) ->
   SigningKey HydraKey ->
   [Party] ->


### PR DESCRIPTION
Changes I made originally for the `hydra-doom` project to load all events in `state` (12GB+ in that use case) with constant memory using `conduit` streams.

~~There is a big TODO on this: `IOSim s` does not have a `MonadUnliftIO` instance and its not impossible to have one. We need to change the interface further such that we can compose `createHydraNode` and `hydrate` functions with in-memory `EventSource` variants.~~

~~A bit of a wart: The `mkProjection` does run the conduit for each projection, instead we should run the conduit once and build the projected in-memory read/query model once.~~

Also, the change here is not constant-memory as the `ServerOutput` history is still kept fully in memory. But this is a different story and should be covered by #1618

---

* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
