### PR TITLE
Revert smoke-test.yaml file to use install-nix-action directly

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -35,9 +35,10 @@ jobs:
         submodules: true
 
     - name: ❄ Setup Nix/Cachix
-      uses: ./.github/actions/nix-cachix-setup
+      uses: cachix/install-nix-action@v30
       with:
-        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
+        extra_nix_config: |
+          accept-flake-config = true
 
     - name: 🧹 Cleanup hydra-node state
       run: |


### PR DESCRIPTION
Seems like `install-nix-action` fails in smoke-tests if nix is already installed on the self-hosted machine.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
