### PR TITLE
chore: update terms link on docs footer

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -257,7 +257,7 @@ const config = {
             items: [
               {
                 label: "Terms and conditions",
-                to: "https://static.iohk.io/terms/iohktermsandconditions.pdf",
+                to: "https://static.iohk.io/terms/iog-terms-and-conditions.pdf",
               },
               {
                 label: "Privacy policy",


### PR DESCRIPTION
Update the terms and conditions link on the docs footer to make terms filenames consistent across all the websites. The file's content is the same on both.

---

* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
