### PR TITLE
HTTP chain observer fixes

### DIFF
--- a/hydra-chain-observer/src/Hydra/ChainObserver.hs
+++ b/hydra-chain-observer/src/Hydra/ChainObserver.hs
@@ -6,7 +6,7 @@ import Hydra.Prelude
 
 import Data.Version (showVersion)
 import Hydra.Blockfrost.ChainObserver (blockfrostClient)
-import Hydra.Cardano.Api (NetworkId (..))
+import Hydra.Cardano.Api (NetworkId (..), NetworkMagic (..))
 import Hydra.ChainObserver.NodeClient (ChainObservation, ChainObserverLog (..), NodeClient (..))
 import Hydra.ChainObserver.Options (Backend (..), Options (..), hydraChainObserverOptions)
 import Hydra.Contract qualified as Contract
@@ -43,7 +43,7 @@ reportObservation networkId baseURI observation = do
  where
   networkParam = case networkId of
     Mainnet -> "mainnet"
-    (Testnet magic) -> show magic
+    (Testnet (NetworkMagic magic)) -> show magic
 
   version = showVersion hydraNodeVersion
 

--- a/hydra-cluster/exe/hydra-cluster/Main.hs
+++ b/hydra-cluster/exe/hydra-cluster/Main.hs
@@ -33,7 +33,7 @@ run options =
         Nothing -> do
           withCardanoNodeDevnet fromCardanoNode workDir $ \node -> do
             txId <- publishOrReuseHydraScripts tracer node
-            singlePartyOpenAHead tracer workDir node txId $ \client walletSk -> do
+            singlePartyOpenAHead tracer workDir node txId $ \client walletSk _headId -> do
               case scenario of
                 Idle -> forever $ pure ()
                 RespendUTxO -> do

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -332,8 +332,8 @@ singlePartyOpenAHead ::
   RunningNode ->
   [TxId] ->
   -- | Continuation called when the head is open
-  (HydraClient -> SigningKey PaymentKey -> IO ()) ->
-  IO ()
+  (HydraClient -> SigningKey PaymentKey -> HeadId -> IO a) ->
+  IO a
 singlePartyOpenAHead tracer workDir node hydraScriptsTxId callback =
   (`finally` returnFundsToFaucet tracer node Alice) $ do
     refuelIfNeeded tracer node Alice 25_000_000
@@ -361,7 +361,7 @@ singlePartyOpenAHead tracer workDir node hydraScriptsTxId callback =
       waitFor hydraTracer (10 * blockTime) [n1] $
         output "HeadIsOpen" ["utxo" .= toJSON utxoToCommit, "headId" .= headId]
 
-      callback n1 walletSk
+      callback n1 walletSk headId
  where
   RunningNode{networkId, nodeSocket, blockTime} = node
 


### PR DESCRIPTION
The URL path parameter of `--explorer` posting in `hydra-chain-observer` was wrong and this also extends the `singlePartyOpenAHead` function in `hydra-cluster` to simplify the integration tests in `hydra-explorer`. 

---

* [x] CHANGELOG not needed
* [x] Documentation update not needed
* [x] Haddocks update not needed
* [x] No new TODOs
