### PR TITLE
Add docker image for hydra-chain-observer

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -28,7 +28,7 @@ jobs:
   docker:
     strategy:
       matrix:
-        target: [ hydra-node, hydra-tui, hydraw ]
+        target: [ hydra-node, hydra-tui, hydraw, hydra-chain-observer ]
 
     runs-on: ubuntu-latest
     steps:

--- a/nix/hydra/docker.nix
+++ b/nix/hydra/docker.nix
@@ -51,4 +51,13 @@
       '')
     ];
   };
+
+  hydra-chain-observer = pkgs.dockerTools.streamLayeredImage {
+    name = "hydra-chain-observer";
+    tag = "latest";
+    created = "now";
+    config = {
+      Entrypoint = [ "${hydraPackages.hydra-chain-observer-static}/bin/hydra-chain-observer" ];
+    };
+  };
 }


### PR DESCRIPTION
This will be available as a flake output and built by CI into https://github.com/orgs/cardano-scaling/packages

---

* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Haddocks update not needed
* [x] No new TODOs introduced
