### PR TITLE
Skip dstat on darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -191,7 +191,7 @@
           } // lib.attrsets.mergeAttrsList (map (x: componentsToWerrors x hsPkgs.${x}) hydraPackageNames);
 
           devShells = import ./nix/hydra/shell.nix {
-            inherit pkgs hsPkgs hydraPackages;
+            inherit pkgs hsPkgs hydraPackages system;
             ghc = pkgs.buildPackages.haskell-nix.compiler.${compiler};
           };
         };

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -6,6 +6,7 @@
 , pkgs
 , ghc
 , hydraPackages
+, system
 }:
 let
 
@@ -50,8 +51,10 @@ let
     pkgs.weeder
     pkgs.yarn
     pkgs.yq
-    pkgs.dstat
-  ];
+  ] ++
+  # `dstat` is required by the benchmark tests; but it's not supported on
+  # darwin; so we just don't include it.
+  (pkgs.lib.optionals pkgs.hostPlatform.isLinux [ pkgs.dstat ]);
 
   libs = [
     pkgs.glibcLocales


### PR DESCRIPTION
dstat doesn't seem supported on apple, yet it is used by our tests.

Let's just not include it in the shell, and pray that the apple people don't try and run these tests locally!

![image](https://github.com/user-attachments/assets/114e350f-4bbe-4c88-b6a6-65608e2d8314)

