### PR TITLE
Clear pending txs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ changes.
 
 - Submit observations to a `hydra-explorer` via optional `--explorer` option.
 
+- Add API query (GET /txs/pending) which responds with the set of local pending transactions.
+  * add new `PendingTxsRemoved` server output.
+
+- Add API command (DELETE /txs/pending) which prune local pending transactions and reset local state to previous confirmed snapshot.
+  * add new `PendingTxsPruned` state changed event.
+  * add new `PendingTxsRemoved` server output.
+
 ## [0.20.0] - 2025-02-04
 
 - **BETA** hydra-node now supports incremental commits in beta mode. We would like to test out this feature

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -89,7 +89,7 @@ import Hydra.Cardano.Api (
  )
 import Hydra.Cluster.Faucet (FaucetLog, createOutputAtAddress, seedFromFaucet, seedFromFaucet_)
 import Hydra.Cluster.Faucet qualified as Faucet
-import Hydra.Cluster.Fixture (Actor (..), actorName, alice, aliceSk, aliceVk, bob, bobSk, bobVk, carol, carolSk)
+import Hydra.Cluster.Fixture (Actor (..), actorName, alice, aliceSk, aliceVk, bob, bobSk, bobVk, carol, carolSk, carolVk, ddeadline)
 import Hydra.Cluster.Mithril (MithrilLog)
 import Hydra.Cluster.Options (Options)
 import Hydra.Cluster.Util (chainConfigFor, keysFor, modifyConfig, setNetworkId)
@@ -154,6 +154,80 @@ data EndToEndLog
   | CreatedKey {keyPath :: FilePath}
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON)
+
+oneOfNNodesCanDropForAWhile :: Tracer IO EndToEndLog -> FilePath -> RunningNode -> [TxId] -> IO ()
+oneOfNNodesCanDropForAWhile tracer workDir cardanoNode hydraScriptsTxId = do
+  let clients = [Alice, Bob, Carol]
+  [(aliceCardanoVk, aliceCardanoSk), (bobCardanoVk, _), (carolCardanoVk, _)] <- forM clients keysFor
+  seedFromFaucet_ cardanoNode aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
+  seedFromFaucet_ cardanoNode bobCardanoVk 100_000_000 (contramap FromFaucet tracer)
+  seedFromFaucet_ cardanoNode carolCardanoVk 100_000_000 (contramap FromFaucet tracer)
+
+  let contestationPeriod = UnsafeContestationPeriod 1
+  aliceChainConfig <-
+    chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [Bob, Carol] contestationPeriod ddeadline
+      <&> setNetworkId networkId
+
+  bobChainConfig <-
+    chainConfigFor Bob workDir nodeSocket hydraScriptsTxId [Alice, Carol] contestationPeriod ddeadline
+      <&> setNetworkId networkId
+
+  carolChainConfig <-
+    chainConfigFor Carol workDir nodeSocket hydraScriptsTxId [Alice, Bob] contestationPeriod ddeadline
+      <&> setNetworkId networkId
+
+  withHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [bobVk, carolVk] [1, 2, 3] $ \n1 -> do
+    aliceUTxO <- seedFromFaucet cardanoNode aliceCardanoVk 1_000_000 (contramap FromFaucet tracer)
+    withHydraNode hydraTracer bobChainConfig workDir 2 bobSk [aliceVk, carolVk] [1, 2, 3] $ \n2 -> do
+      withHydraNode hydraTracer carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] $ \n3 -> do
+        -- Init
+        send n1 $ input "Init" []
+        headId <- waitForAllMatch (10 * blockTime) [n1, n2, n3] $ headIsInitializingWith (Set.fromList [alice, bob, carol])
+
+        -- Alice commits something
+        requestCommitTx n1 aliceUTxO >>= submitTx cardanoNode
+
+        -- Everyone else commits nothing
+        mapConcurrently_ (\n -> requestCommitTx n mempty >>= submitTx cardanoNode) [n2, n3]
+
+        -- Observe open with the relevant UTxOs
+        waitFor hydraTracer (20 * blockTime) [n1, n2, n3] $
+          output "HeadIsOpen" ["utxo" .= toJSON aliceUTxO, "headId" .= headId]
+
+        -- Perform a simple transaction from alice to herself
+        utxo <- getSnapshotUTxO n1
+        tx <- mkTransferTx testNetworkId utxo aliceCardanoSk aliceCardanoVk
+        send n1 $ input "NewTx" ["transaction" .= tx]
+
+        -- Everyone confirms it
+        waitForAllMatch (200 * blockTime) [n1, n2, n3] $ \v -> do
+          guard $ v ^? key "tag" == Just "SnapshotConfirmed"
+          guard $ v ^? key "snapshot" . key "number" == Just (toJSON (1 :: Integer))
+
+      -- Carol disconnects and the others observe it
+      waitForAllMatch (100 * blockTime) [n1, n2] $ \v -> do
+        guard $ v ^? key "tag" == Just "PeerDisconnected"
+
+      -- Alice never-the-less submits a transaction
+      utxo <- getSnapshotUTxO n1
+      tx <- mkTransferTx testNetworkId utxo aliceCardanoSk aliceCardanoVk
+      send n1 $ input "NewTx" ["transaction" .= tx]
+
+      -- Carol reconnects, and then the snapshot can be confirmed
+      withHydraNode hydraTracer carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] $ \n3 -> do
+        -- Note: We can't use `waitForAlMatch` here as it expects them to
+        -- emit the exact same datatype; but Carol will be behind in sequence
+        -- numbers as she was offline.
+        flip mapConcurrently_ [n1, n2, n3] $ \n ->
+          waitMatch (200 * blockTime) n $ \v -> do
+            guard $ v ^? key "tag" == Just "SnapshotConfirmed"
+            guard $ v ^? key "snapshot" . key "number" == Just (toJSON (2 :: Integer))
+            -- Just check that everyone signed it.
+            let sigs = v ^.. key "signatures" . key "multiSignature" . values
+            guard $ length sigs == 3
+ where
+  RunningNode{nodeSocket, networkId, blockTime} = cardanoNode
+  hydraTracer = contramap FromHydraNode tracer
 
 restartedNodeCanObserveCommitTx :: Tracer IO EndToEndLog -> FilePath -> RunningNode -> [TxId] -> IO ()
 restartedNodeCanObserveCommitTx tracer workDir cardanoNode hydraScriptsTxId = do

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -96,6 +96,14 @@ waitNoMatch delay client match = do
     Left _ -> pure () -- Success: waitMatch failed to find a match
     Right _ -> failure "waitNoMatch: A match was found when none was expected"
 
+-- | Wait up to some time and succeed if no API server output matches the given predicate.
+waitForAllNoMatch :: (Eq a, Show a, HasCallStack) => NominalDiffTime -> [HydraClient] -> (Aeson.Value -> Maybe a) -> IO ()
+waitForAllNoMatch delay clients match = do
+  result <- try (void $ waitForAllMatch delay clients match) :: IO (Either SomeException ())
+  case result of
+    Left _ -> pure () -- Success: waitMatch failed to find a match
+    Right _ -> failure "waitForAllNoMatch: A match was found when none was expected"
+
 -- | Wait up to some time for an API server output to match the given predicate.
 waitMatch :: HasCallStack => NominalDiffTime -> HydraClient -> (Aeson.Value -> Maybe a) -> IO a
 waitMatch delay client@HydraClient{tracer, hydraNodeId} match = do

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -59,6 +59,7 @@ import Hydra.Cluster.Scenarios (
   canSubmitTransactionThroughAPI,
   headIsInitializingWith,
   initWithWrongKeys,
+  oneOfNNodesCanDropForAWhile,
   persistenceCanLoadWithEmptyCommit,
   refuelIfNeeded,
   restartedNodeCanAbort,
@@ -339,6 +340,12 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
                   output "HeadIsFinalized" ["utxo" .= u0, "headId" .= headId]
 
     describe "restarting nodes" $ do
+      it "can survive a bit of downtime of 1 in 3 nodes" $ \tracer -> do
+        withClusterTempDir $ \tmpDir -> do
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
+            publishHydraScriptsAs node Faucet
+              >>= oneOfNNodesCanDropForAWhile tracer tmpDir node
+
       it "can abort head after restart" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
           withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->

--- a/hydra-node/golden/ServerOutput/PendingTxsRemoved.json
+++ b/hydra-node/golden/ServerOutput/PendingTxsRemoved.json
@@ -1,0 +1,12 @@
+{
+    "samples": [
+        {
+            "headId": "7b77df24b27238e0d4fa20b4e56ba6b5",
+            "localTxIds": [
+                "96436ea84dab6d3f609671201b6654e95333d4879b68164ebecb0469471344c8"
+            ],
+            "tag": "PendingTxsRemoved"
+        }
+    ],
+    "seed": 625814324
+}

--- a/hydra-node/golden/ServerOutput/PendingTxsUpdated.json
+++ b/hydra-node/golden/ServerOutput/PendingTxsUpdated.json
@@ -1,0 +1,23 @@
+{
+    "samples": [
+        {
+            "headId": "c8dd1121a2b94d9fc1f4920e744b4130",
+            "newLocalTxIds": [
+                "372a84e1d7219e06d33ecd0caf50b6e5acc955273426bfb01e6bae9d2ea529e7",
+                "c6f3b9003b2545a9f9103293fa480e90b756014ff722666a4d2049fb60541a2b",
+                "cef88506274cf79ee18a69033f3405310bdcae7697ef6988af5bc63d4dbfcdd5",
+                "2b5741aeda5f58d8e6cc30dce0d993b3d3877abb02e1aa0e0878f0ecd5f2172f",
+                "d61c48a519371cd27edf22982643a2503fbaf6d3079129396a36667837bf3573",
+                "91b069b543e24757d9997a73917db784287ff4807ef7f474e59a94833d5dd763",
+                "20dd8cc4e28abfccdccaec6825fa369d3a5dab925cc2c5f97d70293e1d0ced5e",
+                "657696efe2aed1b249e20447cfbc6729d94b7d124f89cc9bf386040393e17950",
+                "0b3c8e6c1bc5940cae1f367c79a1a4d4044ccbce2d50af70be17c8a90e9eb869",
+                "c832843fcd115936998fa00f6d80b4ab4b4b1eb8b2cd8bdfcf5268b9a08e8163",
+                "49890a35edf12c2137178a0c57b8b20140a9fbf68c2e7186b0851cf5b60c21f6",
+                "0be3516504cbfa700fe1c6800aeeab365d2359730f1a1ab99a867b98a79b5ad0"
+            ],
+            "tag": "PendingTxsUpdated"
+        }
+    ],
+    "seed": 905378476
+}

--- a/hydra-node/golden/StateChanged/PendingTxsPruned.json
+++ b/hydra-node/golden/StateChanged/PendingTxsPruned.json
@@ -1,0 +1,8 @@
+{
+    "samples": [
+        {
+            "tag": "PendingTxsPruned"
+        }
+    ],
+    "seed": -70314332
+}

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -227,6 +227,26 @@ channels:
           method: GET
           bindingVersion: '0.1.0'
 
+  /snapshot:
+    servers:
+      - localhost-http
+    subscribe:
+      operationId: getConfirmed
+      description: |
+        Get latest confirmed snapshot.
+
+        Possible responses of this endpoint are:
+          * 200: Latest confirmed snapshot
+          * 404: when head was never open
+      message:
+        payload:
+          $ref: "api.yaml#/components/schemas/Snapshot"
+      bindings:
+        http:
+          type: response
+          method: GET
+          bindingVersion: '0.1.0'
+
   /decommit:
     servers:
       - localhost-http
@@ -292,7 +312,6 @@ channels:
           type: response
           method: GET
           bindingVersion: '0.1.0'
-
 
   /protocol-parameters:
     servers:

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -263,7 +263,7 @@ channels:
     servers:
       - localhost-http
     publish:
-      description: Clear pending tx in local state and resume UTxO to latest confirmed snapshot.
+      description: Clear pending txs in local state and reset local UTxO to latest confirmed snapshot.
       operationId: clearPendingTxs
       message:
         payload:
@@ -484,7 +484,7 @@ components:
     ClearPendingTxs:
       title: ClearPendingTxs
       description: |
-        Prune local pending txs. This restore the head to the previous confirmed snapshot.
+        Prune local pending txs. This reset the local head state to latest confirmed snapshot.
       payload:
         type: object
         required:

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -101,6 +101,8 @@ channels:
           - $ref: "api.yaml#/components/messages/CommitFinalized"
           - $ref: "api.yaml#/components/messages/CommitRecovered"
           - $ref: "api.yaml#/components/messages/CommitIgnored"
+          - $ref: "api.yaml#/components/messages/PendingTxsRemoved"
+          - $ref: "api.yaml#/components/messages/PendingTxsUpdated"
 
     publish:
       summary: Commands sent to the Hydra node.
@@ -256,6 +258,41 @@ channels:
           type: response
           method: POST
           bindingVersion: '0.1.0'
+
+  /txs/pending:
+    servers:
+      - localhost-http
+    publish:
+      description: Clear pending tx in local state and resume UTxO to latest confirmed snapshot.
+      operationId: clearPendingTxs
+      message:
+        payload:
+          type: string
+          enum: ["OK"]
+      bindings:
+        http:
+          type: request
+          method: DELETE
+          bindingVersion: '0.1.0'
+    subscribe:
+      operationId: getPendingTxs
+      description: |
+        Get latest pending txs.
+
+        Possible responses of this endpoint are:
+          * 200: Array of latest pending txs
+          * 404: when head was never open
+      message:
+        payload:
+          type: array
+          items:
+            $ref: "api.yaml#/components/schemas/TxId"
+      bindings:
+        http:
+          type: response
+          method: GET
+          bindingVersion: '0.1.0'
+
 
   /protocol-parameters:
     servers:
@@ -443,6 +480,19 @@ components:
           tag:
             type: string
             enum: ["GetUTxO"]
+
+    ClearPendingTxs:
+      title: ClearPendingTxs
+      description: |
+        Prune local pending txs. This restore the head to the previous confirmed snapshot.
+      payload:
+        type: object
+        required:
+          - tag
+        properties:
+          tag:
+            type: string
+            enum: ["ClearPendingTxs"]
 
     ########
     #
@@ -668,6 +718,19 @@ components:
       payload:
         $ref: "api.yaml#/components/schemas/CommitIgnored"
 
+    PendingTxsRemoved:
+      title: PendingTxsRemoved
+      description: |
+        Pending txs where removed and the head state is back to latest confirmed snapshot.
+      payload:
+        $ref: "api.yaml#/components/schemas/PendingTxsRemoved"
+
+    PendingTxsUpdated:
+      title: PendingTxsUpdated
+      description: |
+        Pending txs where updated during ReqSn.
+      payload:
+        $ref: "api.yaml#/components/schemas/PendingTxsUpdated"
 
     # END OF SERVER OUTPUT MESSAGES
 
@@ -736,6 +799,8 @@ components:
         - $ref: "api.yaml#/components/schemas/CommitFinalized"
         - $ref: "api.yaml#/components/schemas/CommitRecovered"
         - $ref: "api.yaml#/components/schemas/CommitIgnored"
+        - $ref: "api.yaml#/components/schemas/PendingTxsRemoved"
+        - $ref: "api.yaml#/components/schemas/PendingTxsUpdated"
 
     Greetings:
       type: object
@@ -1161,6 +1226,7 @@ components:
             - $ref: "api.yaml#/components/messages/Close/payload"
             - $ref: "api.yaml#/components/messages/Contest/payload"
             - $ref: "api.yaml#/components/messages/Fanout/payload"
+            - $ref: "api.yaml#/components/messages/ClearPendingTxs/payload"
         seq:
           $ref: "api.yaml#/components/schemas/SequenceNumber"
         timestamp:
@@ -1463,6 +1529,58 @@ components:
           oneOf:
            - $ref: "api.yaml#/components/schemas/UTxO"
            - type: "null"
+        seq:
+          $ref: "api.yaml#/components/schemas/SequenceNumber"
+        timestamp:
+          $ref: "api.yaml#/components/schemas/UTCTime"
+
+    PendingTxsRemoved:
+      title: PendingTxsRemoved
+      description: |
+        Prune local pending txs.
+      additionalProperties: false
+      type: object
+      required:
+        - tag
+        - headId
+        - seq
+        - timestamp
+      properties:
+        tag:
+          type: string
+          enum: ["PendingTxsRemoved"]
+        headId:
+          $ref: "api.yaml#/components/schemas/HeadId"
+        localTxIds:
+          type: array
+          items:
+            $ref: "api.yaml#/components/schemas/TxId"
+        seq:
+          $ref: "api.yaml#/components/schemas/SequenceNumber"
+        timestamp:
+          $ref: "api.yaml#/components/schemas/UTCTime"
+    
+    PendingTxsUpdated:
+      title: PendingTxsUpdated
+      description: |
+        Local pending txs updated during ReqSn.
+      additionalProperties: false
+      type: object
+      required:
+        - tag
+        - headId
+        - seq
+        - timestamp
+      properties:
+        tag:
+          type: string
+          enum: ["PendingTxsUpdated"]
+        headId:
+          $ref: "api.yaml#/components/schemas/HeadId"
+        newLocalTxIds:
+          type: array
+          items:
+            $ref: "api.yaml#/components/schemas/TxId"
         seq:
           $ref: "api.yaml#/components/schemas/SequenceNumber"
         timestamp:

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -1774,6 +1774,7 @@ definitions:
               - $ref: "api.yaml#/components/messages/Close/payload"
               - $ref: "api.yaml#/components/messages/Contest/payload"
               - $ref: "api.yaml#/components/messages/Fanout/payload"
+              - $ref: "api.yaml#/components/messages/ClearPendingTxs/payload"
 
       - title: NetworkInput
         type: object

--- a/hydra-node/src/Hydra/API/ClientInput.hs
+++ b/hydra-node/src/Hydra/API/ClientInput.hs
@@ -16,6 +16,7 @@ data ClientInput tx
   | Close
   | Contest
   | Fanout
+  | ClearPendingTxs
   deriving stock (Generic)
 
 deriving stock instance IsTx tx => Eq (ClientInput tx)
@@ -39,3 +40,4 @@ instance (Arbitrary tx, Arbitrary (TxIdType tx)) => Arbitrary (ClientInput tx) w
     Close -> []
     Contest -> []
     Fanout -> []
+    ClearPendingTxs -> []

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -354,3 +354,8 @@ projectSnapshotUtxo snapshotUtxo = \case
   SnapshotConfirmed _ snapshot _ -> Just $ Tx.utxo snapshot
   HeadIsOpen _ utxos -> Just utxos
   _other -> snapshotUtxo
+
+projectSnapshot :: Maybe (Snapshot tx) -> ServerOutput tx -> Maybe (Snapshot tx)
+projectSnapshot currSnapshot = \case
+  SnapshotConfirmed _ snapshot _ -> Just snapshot
+  _other -> currSnapshot

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1672,15 +1672,19 @@ aggregate st = \case
             coordinatedHeadState@CoordinatedHeadState{confirmedSnapshot}
           } ->
           case confirmedSnapshot of
-            InitialSnapshot{initialUTxO} ->
+            InitialSnapshot{headId, initialUTxO} ->
               Open
                 os
                   { coordinatedHeadState =
-                      coordinatedHeadState
+                      CoordinatedHeadState
                         { localUTxO = initialUTxO
-                        , localTxs = mempty
                         , allTxs = mempty
-                        , seenSnapshot = LastSeenSnapshot 1
+                        , localTxs = mempty
+                        , confirmedSnapshot = InitialSnapshot{headId, initialUTxO}
+                        , seenSnapshot = NoSeenSnapshot
+                        , pendingDeposits = mempty
+                        , decommitTx = Nothing
+                        , version = 0
                         }
                   }
             ConfirmedSnapshot

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1680,6 +1680,7 @@ aggregate st = \case
                         { localUTxO = initialUTxO
                         , localTxs = mempty
                         , allTxs = mempty
+                        , seenSnapshot = LastSeenSnapshot 1
                         }
                   }
             ConfirmedSnapshot
@@ -1687,6 +1688,7 @@ aggregate st = \case
                 Snapshot
                   { confirmed
                   , utxo
+                  , number
                   }
               } ->
                 Open
@@ -1696,6 +1698,7 @@ aggregate st = \case
                           { localUTxO = utxo
                           , localTxs = mempty
                           , allTxs = fromList $ fmap (\tx -> (txId tx, tx)) confirmed
+                          , seenSnapshot = LastSeenSnapshot number
                           }
                     }
       _otherState -> st

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1693,6 +1693,7 @@ aggregate st = \case
                   { confirmed
                   , utxo
                   , number
+                  , version
                   }
               } ->
                 Open
@@ -1703,6 +1704,7 @@ aggregate st = \case
                           , localTxs = mempty
                           , allTxs = fromList $ fmap (\tx -> (txId tx, tx)) confirmed
                           , seenSnapshot = LastSeenSnapshot number
+                          , version
                           }
                     }
       _otherState -> st

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -965,8 +965,7 @@ onOpenChainDepositTx headId env st deposited depositTxId deadline =
     newState CommitRecorded{pendingDeposits = Map.singleton depositTxId deposited, newLocalUTxO = localUTxO <> deposited}
       <> cause (ClientEffect $ ServerOutput.CommitRecorded{headId, utxoToCommit = deposited, pendingDeposit = depositTxId, deadline})
       <> if not snapshotInFlight && isLeader parameters party nextSn
-        then
-          cause (NetworkEffect $ ReqSn version nextSn (txId <$> localTxs) Nothing (Just deposited))
+        then cause (NetworkEffect $ ReqSn version nextSn (txId <$> localTxs) Nothing (Just deposited))
         else noop
  where
   waitOnUnresolvedDecommit cont =

--- a/hydra-node/src/Hydra/HeadLogic/Outcome.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Outcome.hs
@@ -92,6 +92,7 @@ data StateChanged tx
   | HeadContested {chainState :: ChainStateType tx, contestationDeadline :: UTCTime}
   | HeadIsReadyToFanout
   | HeadFannedOut {chainState :: ChainStateType tx}
+  | PendingTxsPruned
   | ChainRolledBack {chainState :: ChainStateType tx}
   | TickObserved {chainSlot :: ChainSlot}
   deriving stock (Generic)


### PR DESCRIPTION
<!-- Describe your change here -->

Closes https://github.com/cardano-scaling/hydra/issues/1284

## Summary
🐧  introduce new ClearPendingTxs ClientInput

🐧  introduce new endpoint DELETE txs/pending
  - calls new ClientInput

🐧  introduce new endpoint GET txs/pending
  - return pending txs in local state

🐧  introduce new ServerOutput PendingTxsRemoved
  - to signal when ClearPendingTxs has been performed
  - this is require to support the new endpoint projection

🐧  introduce new ServerOutput PendingTxsUpdated
  - to signal when localTxs get pruned on ReqSn
  - this is require to support the new endpoint projection

🐧  HeadLogic now handles ClearPendingTxs
  - persists PendingTxsPruned event
  - produce PendingTxsRemoved server output

🐧  HeadLogic handles event PendingTxsPruned
  - localTxs are pruned
  - localUTxO gets assigned to latest confirmed snapshot utxo
  - allTxs get assigned to latest confirmed snapshot txs

### TBD
- [ ] broadcast ClearPendingTxs (fire-forget)
- [ ] store pruned txs for later retry

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [X] No new TODOs introduced or explained herafter
