### PR TITLE
Drop back to 10.1.4 of cardano-node until 10.2.1 is ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@ changes.
 
 - Submit observations to a `hydra-explorer` via optional `--explorer` option.
 
-- Tested with `cardano-node 10.2` and `cardano-cli 10.3.0.0`.
-
 ## [0.20.0] - 2025-02-04
 
 - **BETA** hydra-node now supports incremental commits in beta mode. We would like to test out this feature

--- a/docs/docs/tutorial/index.md
+++ b/docs/docs/tutorial/index.md
@@ -46,7 +46,7 @@ that you have a good version of jq with this command:
 ```shell
 mkdir -p bin
 hydra_version=0.20.0
-cardano_node_version=10.2
+cardano_node_version=10.1.4
 curl -L -O https://github.com/cardano-scaling/hydra/releases/download/${hydra_version}/hydra-x86_64-linux-${hydra_version}.zip
 unzip -d bin hydra-x86_64-linux-${hydra_version}.zip
 curl -L -O https://github.com/IntersectMBO/cardano-node/releases/download/${cardano_node_version}/cardano-node-${cardano_node_version}-linux.tar.gz
@@ -62,7 +62,7 @@ chmod +x bin/*
 ```shell
 mkdir -p bin
 hydra_version=0.20.0
-cardano_node_version=10.2
+cardano_node_version=10.1.4
 curl -L -O https://github.com/cardano-scaling/hydra/releases/download/${hydra_version}/hydra-aarch64-darwin-${hydra_version}.zip
 unzip -d bin hydra-aarch64-darwin-${hydra_version}.zip
 curl -L -O https://github.com/IntersectMBO/cardano-node/releases/download/${cardano_node_version}/cardano-node-${cardano_node_version}-macos.tar.gz

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     "CHaP_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1737566866,
-        "narHash": "sha256-TQbNlisnUz3RoMb/kc+d6FYET7Qbim+mMMJg76TpLC8=",
+        "lastModified": 1735857786,
+        "narHash": "sha256-X6Fp2uU++62rgaH4J1pIN5AalfV7f9rM5dmFaByMWqU=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "1206c99a450da9681fbe5c3a403cff58569a2ca8",
+        "rev": "b9eaf0bbe60ccf64b7afc969b79f9820a4534bcf",
         "type": "github"
       },
       "original": {
@@ -340,16 +340,16 @@
         "utils": "utils_2"
       },
       "locked": {
-        "lastModified": 1738098813,
-        "narHash": "sha256-tdcqwA1OqgoiSZpYm6Yqaizou9I36Utmg2oy6s5OQ3A=",
+        "lastModified": 1736202991,
+        "narHash": "sha256-Oys38YkpSpB48/H2NseP9kTWXm92a7kjAZtdnorcIEY=",
         "owner": "intersectmbo",
         "repo": "cardano-node",
-        "rev": "c4d675beb9ae5bc86499dfa4287e550cd759f2c1",
+        "rev": "1f63dbf2ab39e0b32bf6901dc203866d3e37de08",
         "type": "github"
       },
       "original": {
         "owner": "intersectmbo",
-        "ref": "10.2.0",
+        "ref": "10.1.4",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -914,11 +914,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1736987292,
-        "narHash": "sha256-ZK4gWwsTWIP6j+SIHy7f2BLPcs8Q1yO8bP18thkIHLQ=",
+        "lastModified": 1729039425,
+        "narHash": "sha256-sIglYcw8Dacj4n0bRlUWo+NLkDMcVi6vtmKvUyG+ZrQ=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "28b6ddfbfad7274f33ad99939e19afb29ee5adf6",
+        "rev": "6dc43e5e01f113ce151056a8f94bce7bb2f13eb9",
         "type": "github"
       },
       "original": {
@@ -1533,11 +1533,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1734618971,
-        "narHash": "sha256-5StB/VhWHOj3zlBxshqVFa6cwAE0Mk/wxRo3eEfcy74=",
+        "lastModified": 1728687575,
+        "narHash": "sha256-38uD8SqT557eh5yyRYuthKm1yTtiWzAN0FH7L/01QKM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "dc900a3448e805243b0ed196017e8eb631e32240",
+        "rev": "86c2bd46e8a08f62ea38ffe77cb4e9c337b42217",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
       flake = false;
     };
     aiken.url = "github:aiken-lang/aiken/v1.1.9";
-    cardano-node.url = "github:intersectmbo/cardano-node/10.2.0";
+    cardano-node.url = "github:intersectmbo/cardano-node/10.1.4";
     flake-parts.url = "github:hercules-ci/flake-parts";
     haskellNix.url = "github:input-output-hk/haskell.nix/2025.02.02";
     hydra-spec.url = "github:cardano-scaling/hydra-formal-specification";

--- a/hydra-cluster/test/Test/CardanoNodeSpec.hs
+++ b/hydra-cluster/test/Test/CardanoNodeSpec.hs
@@ -21,7 +21,7 @@ supportedNetworks :: [KnownNetwork]
 supportedNetworks = [Mainnet, Preproduction, Preview, Sanchonet]
 
 supportedCardanoNodeVersion :: String
-supportedCardanoNodeVersion = "10.2"
+supportedCardanoNodeVersion = "10.1.4"
 
 forSupportedKnownNetworks :: String -> (KnownNetwork -> IO ()) -> Spec
 forSupportedKnownNetworks msg action = forEachKnownNetwork msg $ \network -> do

--- a/hydra-cluster/test/Test/Hydra/Cluster/CardanoCliSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/CardanoCliSpec.hs
@@ -35,7 +35,7 @@ spec =
             Just something -> something == "Witnessed Tx ConwayEra"
 
     it "has expected cardano-cli version available" $
-      readProcess "cardano-cli" ["--version"] "" >>= (`shouldContain` "10.3.0.0")
+      readProcess "cardano-cli" ["--version"] "" >>= (`shouldContain` "10.1.1.0")
 
     around (showLogsOnFailure "CardanoCliSpec") $ do
       it "query protocol-parameters is compatible with our FromJSON instance" $ \tracer ->


### PR DESCRIPTION
Apparently, 10.2 (.0?!) is not recommended for usage; so we go back to 10.1.4 for now; and when 10.2.1 (or later) comes out, we can update.