### PR TITLE
Fix version of nix-built, static hydra-chain-observer

### DIFF
--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -91,7 +91,10 @@ rec {
       paddedRevision;
 
   hydra-chain-observer-static =
-    musl64Pkgs.hydra-chain-observer.components.exes.hydra-chain-observer;
+    embedRevision
+      musl64Pkgs.hydra-chain-observer.components.exes.hydra-chain-observer
+      "hydra-chain-observer"
+      paddedRevision;
 
   hydra-cluster = pkgs.writers.writeBashBin "hydra-cluster" ''
     export PATH=$PATH:${hydra-node}/bin


### PR DESCRIPTION
See title

---

* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Haddocks update not needed
* [x] No new TODOs introduced
