### PR TITLE
Fix decoding of Hydra keys and ignore problematic head init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ changes.
 
 ## [0.20.1] - UNRELEASED
 
+- Fix a bug where decoding `Party` information from chain would crash the node
+  or chain observer. A problematic transaction will now be ignored and not
+  deemed a valid head protocol transaction. An example was if the datum would
+  contain CBOR instead of just hex encoded bytes.
+
 - Stream historical data from disk in the hydra-node API server.
 
 - Record used and free memory when running `bench-e2e` benchmark.

--- a/hydra-tx/src/Hydra/Tx/Crypto.hs
+++ b/hydra-tx/src/Hydra/Tx/Crypto.hs
@@ -56,6 +56,7 @@ import Hydra.Cardano.Api (
   Key (..),
   SerialiseAsCBOR,
   SerialiseAsRawBytes (..),
+  SerialiseAsRawBytesError (..),
   serialiseToRawBytesHexText,
  )
 import Hydra.Contract.HeadState qualified as OnChain
@@ -83,7 +84,10 @@ instance SerialiseAsRawBytes (Hash HydraKey) where
   serialiseToRawBytes (HydraKeyHash vkh) = hashToBytes vkh
 
   deserialiseFromRawBytes (AsHash AsHydraKey) bs =
-    maybe (error "TODO: SerialiseAsRawBytesError, but constructor not exported") (Right . HydraKeyHash) (hashFromBytes bs)
+    maybe
+      (Left $ SerialiseAsRawBytesError "invalid length when deserializing Hash HydraKey")
+      (Right . HydraKeyHash)
+      (hashFromBytes bs)
 
 instance Key HydraKey where
   -- Hydra verification key, which can be used to 'verify' signed messages.
@@ -140,7 +144,10 @@ instance SerialiseAsRawBytes (VerificationKey HydraKey) where
     rawSerialiseVerKeyDSIGN vk
 
   deserialiseFromRawBytes (AsVerificationKey AsHydraKey) bs =
-    maybe (error "TODO: SerialiseAsRawBytesError, but constructor not exported") (Right . HydraVerificationKey) (rawDeserialiseVerKeyDSIGN bs)
+    maybe
+      (Left $ SerialiseAsRawBytesError "invalid length when deserializing VerificationKey HydraKey")
+      (Right . HydraVerificationKey)
+      (rawDeserialiseVerKeyDSIGN bs)
 
 instance ToJSON (VerificationKey HydraKey) where
   toJSON = toJSON . serialiseToRawBytesHexText

--- a/hydra-tx/src/Hydra/Tx/Init.hs
+++ b/hydra-tx/src/Hydra/Tx/Init.hs
@@ -99,6 +99,7 @@ data InitObservation = InitObservation
 data NotAnInitReason
   = NoHeadOutput
   | NotAHeadDatum
+  | InvalidPartyInDatum
   | NoSTFound
   | NotAHeadPolicy
   deriving stock (Show, Eq, Generic)
@@ -131,6 +132,10 @@ observeInitTx tx = do
   unless (pid == HeadTokens.headPolicyId seedTxIn) $
     Left NotAHeadPolicy
 
+  parties <-
+    maybe (Left InvalidPartyInDatum) Right $
+      traverse partyFromChain onChainParties
+
   pure $
     InitObservation
       { headId = mkHeadId pid
@@ -138,7 +143,7 @@ observeInitTx tx = do
       , initialThreadUTxO = (mkTxIn tx ix, toCtxUTxOTxOut headOut)
       , initials
       , contestationPeriod
-      , parties = mapMaybe partyFromChain onChainParties
+      , parties
       , participants = assetNameToOnChainId <$> mintedTokenNames pid
       }
  where

--- a/hydra-tx/src/Hydra/Tx/Observe.hs
+++ b/hydra-tx/src/Hydra/Tx/Observe.hs
@@ -53,6 +53,10 @@ data HeadObservation
 -- | Observe any Hydra head transaction.
 observeHeadTx :: NetworkId -> UTxO -> Tx -> HeadObservation
 observeHeadTx networkId utxo tx =
+  -- XXX: This is throwing away valuable information! We should be collecting
+  -- all "not an XX" reasons here in case we fall through and want that
+  -- diagnostic information in the call site of this function. Collecting errors
+  -- could be done with 'validation' or a similar package.
   fromMaybe NoHeadTx $
     either (const Nothing) (Just . Init) (observeInitTx tx)
       <|> Abort <$> observeAbortTx utxo tx


### PR DESCRIPTION
We were not correctly decoding Hydra verification keys (but crashing via error) because of a missing data constructor.

This also makes the observeInitTx sort out heads that would have such problematic party datums.

An example transaction with problematic data is:
b860a236a7e77577628bf705286d449188831cf90d714934f1cc06369c6e3953 on preprod

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
