### PR TITLE
Fix server output history

### DIFF
--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -110,9 +110,9 @@ withAPIServer config env party persistence tracer chain pparams serverOutputFilt
           -- FIXME: don't load whole history into memory
           .| sinkList
 
-    history <- newTVarIO loadedHistory
     -- NOTE: we need to reverse the list because we store history in a reversed
     -- list in memory but in order on disk
+    history <- newTVarIO $ reverse loadedHistory
     (notifyServerRunning, waitForServerRunning) <- setupServerNotification
 
     let serverSettings =


### PR DESCRIPTION
This was not reversed anymore (although the comment explained it)

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
