### PR TITLE
Allow to run release.sh on non-master branches

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -55,23 +55,15 @@ jobs:
         echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
         nix build .#docker-${{ matrix.target }}
         docker load < result
-        
-        IMAGE_LABEL=unstable
-        BUILDING_WORKFLOW_DISPATCH=${{github.event_name == 'workflow_dispatch'}}
-        [[ ${BUILDING_WORKFLOW_DISPATCH} = true ]] && \
-          IMAGE_LABEL=workflow_dispatch-${{github.event.inputs.ref_name}}
 
-        IS_TAG=${{github.ref_type == 'tag'}}
-
-        # Only build say we are building a tag if it's a tag _and_ not part of a
-        # workflow-dispatch task
-        [[ ${IS_TAG} = true && ${BUILDING_WORKFLOW_DISPATCH} = false ]] && \
-          BUILDING_TAG=true ||
-          BUILDING_TAG=false
-        
         # Determine whether we are building a tag and if yes, set a VERSION_NAME
+        BUILDING_TAG=${{github.ref_type == 'tag'}}
         [[ ${BUILDING_TAG} = true ]] && \
           VERSION_NAME=${{github.ref_name}}
+
+        BUILDING_ON_MASTER=false
+        [[ git merge-base --is-ancestor HEAD origin/master ]] && \
+          BUILDING_ON_MASTER=true
 
         # Use 'FROM' instruction to use docker build with --label
         echo "FROM ${{matrix.target}}" | docker build \
@@ -79,17 +71,21 @@ jobs:
           --label org.opencontainers.image.licenses=Apache-2.0 \
           --label org.opencontainers.image.created=$(date -Is) \
           --label org.opencontainers.image.revision=${{github.sha}} \
-          --label org.opencontainers.image.version=${VERSION_NAME:-${IMAGE_LABEL}} \
-          --tag ${IMAGE_NAME}:${IMAGE_LABEL} -
-        
-        # Also tag with semver and 'latest' if we are building a tag
+          --label org.opencontainers.image.version=${VERSION_NAME:-unstable} \
+          --tag ${IMAGE_NAME}:unstable -
+
+        # Also tag with 'latest' if we are building on master
+        [[ ${BUIDING_TAG} && ${BUILDING_ON_MASTER} = true ]] && \
+          docker tag ${IMAGE_NAME}:unstable ${IMAGE_NAME}:latest
+        # Also tag with version if we are building a tag
         [[ ${BUILDING_TAG} = true && ${{matrix.target}} != "hydraw" ]] && \
-          docker tag ${IMAGE_NAME}:${IMAGE_LABEL} ${IMAGE_NAME}:${{github.ref_name}}
-        [[ ${BUILDING_TAG} = true ]] && \
-          docker tag ${IMAGE_NAME}:${IMAGE_LABEL} ${IMAGE_NAME}:latest
-        
+          docker tag ${IMAGE_NAME}:unstable ${IMAGE_NAME}:${VERSION_NAME}
+        # Also tag with ref name when manually dispatched
+        [[ ${{github.event_name == 'workflow_dispatch'}} = true ]] && \
+          docker tag ${IMAGE_NAME}:unstable ${IMAGE_NAME}:workflow_dispatch-${{github.event.inputs.ref_name}}
+
+        docker inspect ${IMAGE_NAME}:unstable
         docker images
-        docker inspect ${IMAGE_NAME}:${IMAGE_LABEL}
 
     - name: 📤 Push to registry
       run: |

--- a/release.sh
+++ b/release.sh
@@ -45,7 +45,6 @@ EOF
 check_can_release() {
   local version="$1"
 
-  check_on_master
   confirm_uncommitted_changes
   check_version_is_valid $version
   check_changelog_is_up_to_date $version
@@ -70,28 +69,31 @@ prepare_release() {
 
   git tag -as "$version" -F <(changelog "$version")
 
-  # Make branch release point to tag so that the website is published
-  git checkout release
-  git merge "${version}" --ff-only
-
-  git checkout master
+  if [ $(git rev-parse --abbrev-ref HEAD) = "master" ]; then
+    # Make branch release point to tag so that the website is published
+    git checkout release
+    git merge "${version}" --ff-only
+    git checkout master
+  fi
 }
 
 publish_release_instructions() {
   local version="$1"
+  local branch_name=$(git rev-parse --abbrev-ref HEAD)
 
   err "Prepared the release commit and tag, review it now and if everything is okay, push using:"
   err ""
-  err "git push origin master"
-  err "git push origin release"
+  err "git push origin ${branch_name}"
+  if [ ${branch_name} = "master" ]; then
+    err "git push origin release"
+  fi
   err "git push origin ${version}"
 }
 
 # Checking helper functions
 
 confirm_uncommitted_changes() {
-  if [ ! -z "$(git status --porcelain)" ]
-  then
+  if [ ! -z "$(git status --porcelain)" ]; then
     git status >&2
     echo >&2 "WARNING: You have unstaged changes. The release will stage everything and commit it."
     ask_continue
@@ -102,26 +104,19 @@ confirm_uncommitted_changes() {
 ask_continue() {
   read -p "Do you want to continue? [y/n] " -n 1 -r
   echo >&2 ""
-  if [[ ! $REPLY =~ ^[Yy]$ ]]
-  then
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     exit_err "Aborted release"
-  fi
-}
-
-check_on_master() {
-  if [ $(git rev-parse --abbrev-ref HEAD) != "master" ]; then
-    exit_err "Not on branch 'master'"
   fi
 }
 
 check_version_is_valid() {
   local version="$1"
 
-  echo $version | grep -E '^[0-9]*\.[0-9]*\.[0-9]*$' >/dev/null \
-  || exit_err "Invalid format for version: $version"
+  echo $version | grep -E '^[0-9]*\.[0-9]*\.[0-9]*$' >/dev/null ||
+    exit_err "Invalid format for version: $version"
 
-  git tag | grep "^$version$" >/dev/null \
-  && exit_err "A tag for this version already exists"
+  git tag | grep "^$version$" >/dev/null &&
+    exit_err "A tag for this version already exists"
 
   true #avoid error on last instruction of function (see bash -e)
 }
@@ -131,11 +126,11 @@ check_changelog_is_up_to_date() {
 
   local next_release="$(sed '/## *\[.*\]/ !d' CHANGELOG.md | head -n1)"
 
-  echo "$next_release" | grep "\[$version\]" >/dev/null \
-  || exit_err "$version is not the next release in CHANGELOG.md"
+  echo "$next_release" | grep "\[$version\]" >/dev/null ||
+    exit_err "$version is not the next release in CHANGELOG.md"
 
-  echo "$next_release" | grep UNRELEASED >/dev/null \
-  && exit_err "$version is not released in CHANGELOG.md. Please replace UNRELEASED with the current date"
+  echo "$next_release" | grep UNRELEASED >/dev/null &&
+    exit_err "$version is not released in CHANGELOG.md. Please replace UNRELEASED with the current date"
 
   true #avoid error on last instruction of function (see bash -e)
 }
@@ -153,25 +148,26 @@ check_networks_is_up_to_date() {
   local networks_file=networks.json
 
   for network in "${networks[@]}"; do
-    cat ${networks_file} | jq -e ".\"${network}\".\"${version}\"" > /dev/null \
-    || exit_err "Missing transaction id for ${version} on ${network} in ${networks_file}"
+    cat ${networks_file} | jq -e ".\"${network}\".\"${version}\"" >/dev/null ||
+      exit_err "Missing transaction id for ${version} on ${network} in ${networks_file}"
   done
 }
 
 # Prepare helper functions
 
 update_cabal_version() {
-  local version="$1" ; shift
+  local version="$1"
+  shift
   local cabal_files=hydra-*/*.cabal
 
-  for file in $cabal_files
-  do
+  for file in $cabal_files; do
     sed -i"" -e "s,\(^version: *\)[^ ]*,\1$version," $file
   done
 }
 
 update_api_version() {
-  local version="$1" ; shift
+  local version="$1"
+  shift
   local api_file=hydra-node/json-schemas/api.yaml
 
   sed -i"" -e "s,\(version: *\)'.*',\1'$version'," $api_file


### PR DESCRIPTION
This make the release.sh script slightly more flexible and also only prepares the 'release' branch wen releasing from 'master'.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Haddocks update not needed
* [x] No new TODOs introduced
