### PR TITLE
Fix binaries build

### DIFF
--- a/nix/hydra/project.nix
+++ b/nix/hydra/project.nix
@@ -62,7 +62,14 @@ pkgs.haskell-nix.project {
     })
     # Always use static snappy (from overlay, see nix/static-libs.nix)
     {
+      # XXX: Instead of patching to the static-snappy here for all binaries, we
+      # could try have both static and dynamic libs in the pkgs.snappy
+      # derivation? Using only the static libs in pkgs.snappy results in
+      # libHSsnappy relocation / symbol not found errors.
       packages.hydra-node.ghcOptions = [ "-L${pkgs.lib.getLib pkgs.static-snappy}/lib" ];
+      packages.hydra-tui.ghcOptions = [ "-L${pkgs.lib.getLib pkgs.static-snappy}/lib" ];
+      packages.hydra-chain-observer.ghcOptions = [ "-L${pkgs.lib.getLib pkgs.static-snappy}/lib" ];
+      packages.hydraw.ghcOptions = [ "-L${pkgs.lib.getLib pkgs.static-snappy}/lib" ];
     }
     {
       # lib:ghc is a bit annoying in that it comes with it's own build-type:Custom, and then tries


### PR DESCRIPTION
We need to patch up all the executables that are built using our cross-toolchain this way. See also comment in nix code.

Failing build on `master`: https://github.com/cardano-scaling/hydra/actions/runs/13654333887

Succeeded build with these changes (temporarily enabled the workflow for this branch): https://github.com/cardano-scaling/hydra/actions/runs/13656779952

---

* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Haddocks update not needed
* [x] No new TODOs introduced
