### PR TITLE
Use MVar for thread safety in Persistence

### DIFF
--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -143,6 +143,7 @@ library
     , QuickCheck
     , quickcheck-arbitrary-adt
     , quickcheck-instances
+    , resourcet
     , serialise
     , stm
     , text

--- a/hydra-node/test/Hydra/PersistenceSpec.hs
+++ b/hydra-node/test/Hydra/PersistenceSpec.hs
@@ -8,7 +8,7 @@ import Test.Hydra.Prelude
 import Data.Aeson (Value (..))
 import Data.Aeson qualified as Aeson
 import Data.Text qualified as Text
-import Hydra.Persistence (Persistence (..), PersistenceException (..), PersistenceIncremental (..), createPersistence, createPersistenceIncremental, loadAll)
+import Hydra.Persistence (Persistence (..), PersistenceIncremental (..), createPersistence, createPersistenceIncremental, loadAll)
 import Test.QuickCheck (checkCoverage, cover, elements, oneof, suchThat, (===))
 import Test.QuickCheck.Gen (listOf)
 import Test.QuickCheck.Monadic (monadicIO, monitor, pick, run)
@@ -68,9 +68,6 @@ spec = do
             race_
               (forever $ threadDelay 0.01 >> loadAll p)
               (forM_ moreItems $ \item -> append p item >> threadDelay 0.01)
-              `shouldThrow` \case
-                IncorrectAccessException{} -> True
-                _ -> False
 
 genPersistenceItem :: Gen Aeson.Value
 genPersistenceItem =


### PR DESCRIPTION
- Our persistence layer was checking the thread id of a _valid_ thread to source/append. This solution uses `MVar` primitive instead and relies on `ResourceT` to do the locking/unlocking on `source`. This improves our way of reading/appending to persistence since now, all of the sudden, we don't need to care about from which thread we use the persistence handle.
---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
