### PR TITLE
Fix docker workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -62,8 +62,9 @@ jobs:
           VERSION_NAME=${{github.ref_name}}
 
         BUILDING_ON_MASTER=false
-        [[ git merge-base --is-ancestor HEAD origin/master ]] && \
+        if (git merge-base --is-ancestor HEAD origin/master); then
           BUILDING_ON_MASTER=true
+        fi
 
         # Use 'FROM' instruction to use docker build with --label
         echo "FROM ${{matrix.target}}" | docker build \


### PR DESCRIPTION
The main flow which does not incorporate tagging with `latest` or the `tag` work with this, see for example: https://github.com/cardano-scaling/hydra/actions/runs/13680418837/job/38251079319

Whether building on `origin/master` and tagging with `latest` works we only know after merging this to `master`.

Whether building on a tag and also tagging the image with the tag name works, we only know after creating and pushing a tag.
