### PR TITLE
Add list of clients to documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ ETCD_AUTO_COMPACTION_RETENTION=168h
 > Only variables prefixed with `ETCD_` are passed on to the `etcd` process.
 
 
+- Add a list of [clients](https://hydra.family/head-protocol/unstable/docs/clients) to the docs
+
 ## [0.20.0] - 2025-02-04
 
 - **BETA** hydra-node now supports incremental commits in beta mode. We would like to test out this feature

--- a/docs/docs/clients.md
+++ b/docs/docs/clients.md
@@ -1,0 +1,22 @@
+---
+title: Clients
+---
+
+# Clients
+
+While the `hydra-node` tracks the main chain for opening/closing heads and connects to other nodes to form an overlay network, it also offers a [client API](/api-reference) to _use_ and _administrate_ the Hydra head. This API can be used directly by applications integrating with Hydra through SDKs, or via third-party components.
+
+## Client applications
+
+- [hydra-tui](https://hydra.family/head-protocol/docs/getting-started#use-the-head): Example client offering a terminal user interface (TUI) that can be used to adminstrate heads and submit simple payment transactions
+- [kupo](https://cardanosolutions.github.io/kupo/#section/Getting-started/-hydra-host-hostname-hydra-port-port-number): Lightweight indexer that directly supports connecting to a `hydra-node`
+
+## Client libraries
+
+- [meshjs](https://meshjs.dev/providers/hydra): Provider for the [meshjs SDK](https://meshjs.dev/) which supports the full Head life-cycle
+- [blaze](https://github.com/butaneprotocol/blaze-cardano/blob/main/packages/blaze-query/src/hydra.ts): Experimental provider for the [blaze SDK](https://blaze.butane.dev/)
+
+
+:::info
+Contributions to complete and keep this list up-to-date are more than welcome!
+:::

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -36,6 +36,7 @@ module.exports = {
         },
       ],
     },
+    "clients",
     "faqs",
     "get-involved",
     {


### PR DESCRIPTION
As MeshJS has now official support for a Hydra provider, keeping a list of clients that are using the API is long overdue.

This will help users to discover tools, but also be useful to notify / update clients in case we need to break the client API.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated
* [x] Documentation updated
* [x] Haddocks update not needed
* [x] No new TODOs introduced
