### PR TITLE
add GET /snapshot/latest-seen endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ changes.
 
 - Submit observations to a `hydra-explorer` via optional `--explorer` option.
 
+- Add API query (GET /snapshot/latest-seen) to fetch the latest seen snapshot by a node and help identify non-cooperating peers.
+
 - **BREAKING**
   - API Server does **NOT** serve the event history by default any more. Clients need to add a query parameter `?history=yes` in order to obtain the history.
   - Remove `GetUTxO` client input and corresponding `GetUTxOResponse`. There is already a way to query the `UTxO` in the Head with `GET /snapshot/utxo` query.

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -212,6 +212,9 @@ channels:
       operationId: getSeenSnapshot
       description: |
         Get latest seen snapshot.
+
+        This endpoint can help in situations where the head is not reaching consensus
+        by identifying the peers who are missing signing the current snapshot in flight and preventing its confirmation.
       message:
         payload:
           $ref: "api.yaml#/components/schemas/SeenSnapshot"

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -205,6 +205,22 @@ channels:
           method: DELETE
           bindingVersion: '0.1.0'
 
+  /snapshot/seen:
+    servers:
+      - localhost-http
+    subscribe:
+      operationId: getSeenSnapshot
+      description: |
+        Get latest seen snapshot.
+      message:
+        payload:
+          $ref: "api.yaml#/components/schemas/SeenSnapshot"
+      bindings:
+        http:
+          type: response
+          method: GET
+          bindingVersion: '0.1.0'
+
   /snapshot/utxo:
     servers:
       - localhost-http
@@ -1445,6 +1461,65 @@ components:
       contentEncoding: base16
       example:
         "820082582089ff4f3ff4a6052ec9d073b3be68b5e7596bd74a04e7b74504a8302fb2278cd95840f66eb3cd160372d617411408792c0ebd9791968e9948112894e2706697a55c10296b04019ed2f146f4d81e8ab17b9d14cf99569a2f85cbfa32320127831db202"
+
+    SeenSnapshot:
+      oneOf:
+        - title: NoSeenSnapshot
+          type: object
+          additionalProperties: false
+          required:
+            - tag
+          properties:
+            tag:
+              type: string
+              enum: ["NoSeenSnapshot"]
+        - title: LastSeenSnapshot
+          type: object
+          additionalProperties: false
+          required:
+            - tag
+            - lastSeen
+          properties:
+            tag:
+              type: string
+              enum: ["LastSeenSnapshot"]
+            lastSeen:
+              $ref: "api.yaml#/components/schemas/SnapshotNumber"
+        - title: RequestedSnapshot
+          type: object
+          additionalProperties: false
+          required:
+            - tag
+            - lastSeen
+            - requested
+          properties:
+            tag:
+              type: string
+              enum: ["RequestedSnapshot"]
+            lastSeen:
+              $ref: "api.yaml#/components/schemas/SnapshotNumber"
+            requested:
+              $ref: "api.yaml#/components/schemas/SnapshotNumber"
+        - title: SeenSnapshot
+          type: object
+          additionalProperties: false
+          required:
+            - tag
+            - snapshot
+            - signatories
+          properties:
+            tag:
+              type: string
+              enum: ["SeenSnapshot"]
+            snapshot:
+              $ref: "api.yaml#/components/schemas/Snapshot"
+            signatories:
+              type: object
+              propertyNames:
+                type: string
+                contentEncoding: base16
+              items:
+                $ref: "api.yaml#/components/schemas/Signature"
 
     ConfirmedSnapshot:
       oneOf:

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -205,7 +205,7 @@ channels:
           method: DELETE
           bindingVersion: '0.1.0'
 
-  /snapshot/seen:
+  /snapshot/last-seen:
     servers:
       - localhost-http
     subscribe:

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -1647,7 +1647,7 @@ definitions:
       confirmedSnapshot:
         $ref: "api.yaml#/components/schemas/ConfirmedSnapshot"
       seenSnapshot:
-        $ref: "logs.yaml#/definitions/SeenSnapshot"
+        $ref: "api.yaml#/components/schemas/SeenSnapshot"
       pendingDeposits:
         type: object
       decommitTx:
@@ -1658,65 +1658,6 @@ definitions:
       version:
         type: integer
         minimum: 0
-
-  SeenSnapshot:
-    oneOf:
-      - title: NoSeenSnapshot
-        type: object
-        additionalProperties: false
-        required:
-          - tag
-        properties:
-          tag:
-            type: string
-            enum: ["NoSeenSnapshot"]
-      - title: LastSeenSnapshot
-        type: object
-        additionalProperties: false
-        required:
-          - tag
-          - lastSeen
-        properties:
-          tag:
-            type: string
-            enum: ["LastSeenSnapshot"]
-          lastSeen:
-            $ref: "api.yaml#/components/schemas/SnapshotNumber"
-      - title: RequestedSnapshot
-        type: object
-        additionalProperties: false
-        required:
-          - tag
-          - lastSeen
-          - requested
-        properties:
-          tag:
-            type: string
-            enum: ["RequestedSnapshot"]
-          lastSeen:
-            $ref: "api.yaml#/components/schemas/SnapshotNumber"
-          requested:
-            $ref: "api.yaml#/components/schemas/SnapshotNumber"
-      - title: SeenSnapshot
-        type: object
-        additionalProperties: false
-        required:
-          - tag
-          - snapshot
-          - signatories
-        properties:
-          tag:
-            type: string
-            enum: ["SeenSnapshot"]
-          snapshot:
-            $ref: "api.yaml#/components/schemas/Snapshot"
-          signatories:
-            type: object
-            propertyNames:
-              type: string
-              contentEncoding: base16
-            items:
-              $ref: "api.yaml#/components/schemas/Signature"
 
   Input:
     description: >-

--- a/hydra-node/src/Hydra/API/HTTPServer.hs
+++ b/hydra-node/src/Hydra/API/HTTPServer.hs
@@ -152,7 +152,7 @@ httpApp tracer directChain env pparams getCommitInfo getConfirmedUTxO getSeenSna
       , path = PathInfo $ rawPathInfo request
       }
   case (requestMethod request, pathInfo request) of
-    ("GET", ["snapshot", "seen"]) ->
+    ("GET", ["snapshot", "last-seen"]) ->
       getSeenSnapshot >>= respond . okJSON
     ("GET", ["snapshot", "utxo"]) ->
       -- XXX: Should ensure the UTxO is of the right head and the head is still

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -128,7 +128,17 @@ withAPIServer config env party eventSource tracer chain pparams serverOutputFilt
             $ websocketsOr
               defaultConnectionOptions
               (wsApp party tracer historyTimedOutputs callback headStatusP headIdP snapshotUtxoP responseChannel serverOutputFilter)
-              (httpApp tracer chain env pparams (atomically $ getLatest commitInfoP) (atomically $ getLatest snapshotUtxoP) (atomically $ getLatest seenSnapshotP) (atomically $ getLatest pendingDepositsP) callback)
+              ( httpApp
+                  tracer
+                  chain
+                  env
+                  pparams
+                  (atomically $ getLatest commitInfoP)
+                  (atomically $ getLatest snapshotUtxoP)
+                  (atomically $ getLatest seenSnapshotP)
+                  (atomically $ getLatest pendingDepositsP)
+                  callback
+              )
       )
       ( do
           waitForServerRunning
@@ -142,6 +152,7 @@ withAPIServer config env party eventSource tracer chain pparams serverOutputFilt
                           update headStatusP stateChanged
                           update commitInfoP stateChanged
                           update snapshotUtxoP stateChanged
+                          update seenSnapshotP stateChanged
                           update headIdP stateChanged
                           update pendingDepositsP stateChanged
                         atomically $ writeTChan responseChannel (Left timedOutput)

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -315,6 +315,6 @@ projectSeenSnapshot seenSnapshot = \case
   StateChanged.PartySignedSnapshot{party, signature} ->
     case seenSnapshot of
       ss@SeenSnapshot{signatories} ->
-        ss{signatories = (Map.insert party signature signatories)}
+        ss{signatories = Map.insert party signature signatories}
       _ -> seenSnapshot
   _other -> seenSnapshot

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -12,6 +12,7 @@ import Control.Concurrent.STM.TChan (newBroadcastTChanIO, writeTChan)
 import Control.Exception (IOException)
 import Data.Conduit.Combinators (map)
 import Data.Conduit.List (catMaybes)
+import Data.Map.Strict qualified as Map
 import Hydra.API.APIServerLog (APIServerLog (..))
 import Hydra.API.ClientInput (ClientInput)
 import Hydra.API.HTTPServer (httpApp)
@@ -33,11 +34,13 @@ import Hydra.Chain.ChainState (IsChainState)
 import Hydra.Chain.Direct.State ()
 import Hydra.Events (EventSink (..), EventSource (..), StateEvent (..))
 import Hydra.HeadLogic.Outcome qualified as StateChanged
+import Hydra.HeadLogic.State (SeenSnapshot (..), seenSnapshotNumber)
 import Hydra.Logging (Tracer, traceWith)
 import Hydra.Network (IP, PortNumber)
 import Hydra.Tx (HeadId, IsTx (..), Party, txId)
 import Hydra.Tx qualified as Tx
 import Hydra.Tx.Environment (Environment)
+import Hydra.Tx.Snapshot (Snapshot (..))
 import Network.HTTP.Types (status500)
 import Network.Wai (responseLBS)
 import Network.Wai.Handler.Warp (
@@ -90,6 +93,7 @@ withAPIServer config env party eventSource tracer chain pparams serverOutputFilt
     -- NOTE: we do not keep the stored events around in memory
     headStatusP <- mkProjection Idle projectHeadStatus
     snapshotUtxoP <- mkProjection Nothing projectSnapshotUtxo
+    seenSnapshotP <- mkProjection NoSeenSnapshot projectSeenSnapshot
     commitInfoP <- mkProjection CannotCommit projectCommitInfo
     headIdP <- mkProjection Nothing projectInitializingHeadId
     pendingDepositsP <- mkProjection [] projectPendingDeposits
@@ -102,6 +106,7 @@ withAPIServer config env party eventSource tracer chain pparams serverOutputFilt
                 lift $ atomically $ do
                   update headStatusP stateChanged
                   update snapshotUtxoP stateChanged
+                  update seenSnapshotP stateChanged
                   update commitInfoP stateChanged
                   update headIdP stateChanged
                   update pendingDepositsP stateChanged
@@ -123,7 +128,7 @@ withAPIServer config env party eventSource tracer chain pparams serverOutputFilt
             $ websocketsOr
               defaultConnectionOptions
               (wsApp party tracer historyTimedOutputs callback headStatusP headIdP snapshotUtxoP responseChannel serverOutputFilter)
-              (httpApp tracer chain env pparams (atomically $ getLatest commitInfoP) (atomically $ getLatest snapshotUtxoP) (atomically $ getLatest pendingDepositsP) callback)
+              (httpApp tracer chain env pparams (atomically $ getLatest commitInfoP) (atomically $ getLatest snapshotUtxoP) (atomically $ getLatest seenSnapshotP) (atomically $ getLatest pendingDepositsP) callback)
       )
       ( do
           waitForServerRunning
@@ -281,3 +286,24 @@ projectSnapshotUtxo snapshotUtxo = \case
   StateChanged.SnapshotConfirmed _ snapshot _ -> Just $ Tx.utxo snapshot <> fromMaybe mempty (Tx.utxoToCommit snapshot)
   StateChanged.HeadOpened _ _ utxos -> Just utxos
   _other -> snapshotUtxo
+
+-- | Projection of latest seen snapshot.
+projectSeenSnapshot :: SeenSnapshot tx -> StateChanged.StateChanged tx -> SeenSnapshot tx
+projectSeenSnapshot seenSnapshot = \case
+  StateChanged.SnapshotRequestDecided{snapshotNumber} ->
+    RequestedSnapshot
+      { lastSeen = seenSnapshotNumber seenSnapshot
+      , requested = snapshotNumber
+      }
+  StateChanged.SnapshotRequested{snapshot} ->
+    SeenSnapshot snapshot mempty
+  StateChanged.HeadOpened{} ->
+    NoSeenSnapshot
+  StateChanged.SnapshotConfirmed{snapshot = Snapshot{number}} ->
+    LastSeenSnapshot number
+  StateChanged.PartySignedSnapshot{party, signature} ->
+    case seenSnapshot of
+      ss@SeenSnapshot{signatories} ->
+        ss{signatories = (Map.insert party signature signatories)}
+      _ -> seenSnapshot
+  _other -> seenSnapshot

--- a/hydra-node/test/Hydra/API/HTTPServerSpec.hs
+++ b/hydra-node/test/Hydra/API/HTTPServerSpec.hs
@@ -187,7 +187,7 @@ apiServerSpec = do
                 { matchBody = matchJSON defaultPParams
                 }
 
-    describe "GET /snapshot/seen" $ do
+    describe "GET /snapshot/last-seen" $ do
       prop "responds correctly" $ \seenSnapshot -> do
         let getSeenSnapshot = pure seenSnapshot
         withApplication
@@ -203,7 +203,7 @@ apiServerSpec = do
               putClientInput
           )
           $ do
-            get "/snapshot/seen"
+            get "/snapshot/last-seen"
               `shouldRespondWith` 200{matchBody = matchJSON seenSnapshot}
 
     describe "GET /snapshot/utxo" $ do

--- a/hydra-node/test/Hydra/API/HTTPServerSpec.hs
+++ b/hydra-node/test/Hydra/API/HTTPServerSpec.hs
@@ -19,6 +19,7 @@ import Hydra.Cardano.Api (
   serialiseToTextEnvelope,
  )
 import Hydra.Chain (Chain (draftCommitTx), PostTxError (..), draftDepositTx)
+import Hydra.HeadLogic.State (SeenSnapshot (..))
 import Hydra.JSONSchema (SchemaSelector, prop_validateJSONSchema, validateJSON, withJsonSpecifications)
 import Hydra.Ledger.Cardano (Tx)
 import Hydra.Ledger.Simple (SimpleTx)
@@ -154,32 +155,77 @@ apiServerSpec = do
         cantCommit = pure CannotCommit
         getPendingDeposits = pure []
         putClientInput = const (pure ())
+        getNoSeenSnapshot = pure NoSeenSnapshot
 
     describe "GET /protocol-parameters" $ do
-      with (return $ httpApp @SimpleTx nullTracer dummyChainHandle testEnvironment defaultPParams cantCommit getNothing getPendingDeposits putClientInput) $ do
-        it "matches schema" $
-          withJsonSpecifications $ \schemaDir -> do
+      with
+        ( return $
+            httpApp @SimpleTx
+              nullTracer
+              dummyChainHandle
+              testEnvironment
+              defaultPParams
+              cantCommit
+              getNothing
+              getNoSeenSnapshot
+              getPendingDeposits
+              putClientInput
+        )
+        $ do
+          it "matches schema" $
+            withJsonSpecifications $ \schemaDir -> do
+              get "/protocol-parameters"
+                `shouldRespondWith` 200
+                  { matchBody =
+                      matchValidJSON
+                        (schemaDir </> "api.json")
+                        (key "components" . key "messages" . key "ProtocolParameters" . key "payload")
+                  }
+          it "responds given parameters" $
             get "/protocol-parameters"
               `shouldRespondWith` 200
-                { matchBody =
-                    matchValidJSON
-                      (schemaDir </> "api.json")
-                      (key "components" . key "messages" . key "ProtocolParameters" . key "payload")
+                { matchBody = matchJSON defaultPParams
                 }
-        it "responds given parameters" $
-          get "/protocol-parameters"
-            `shouldRespondWith` 200
-              { matchBody = matchJSON defaultPParams
-              }
+
+    describe "GET /snapshot/seen" $ do
+      prop "responds correctly" $ \seenSnapshot -> do
+        let getSeenSnapshot = pure seenSnapshot
+        withApplication
+          ( httpApp @SimpleTx
+              nullTracer
+              dummyChainHandle
+              testEnvironment
+              defaultPParams
+              cantCommit
+              getNothing
+              getSeenSnapshot
+              getPendingDeposits
+              putClientInput
+          )
+          $ do
+            get "/snapshot/seen"
+              `shouldRespondWith` 200{matchBody = matchJSON seenSnapshot}
 
     describe "GET /snapshot/utxo" $ do
       prop "responds correctly" $ \utxo -> do
         let getUTxO = pure utxo
-        withApplication (httpApp @SimpleTx nullTracer dummyChainHandle testEnvironment defaultPParams cantCommit getUTxO getPendingDeposits putClientInput) $ do
-          get "/snapshot/utxo"
-            `shouldRespondWith` case utxo of
-              Nothing -> 404
-              Just u -> 200{matchBody = matchJSON u}
+        withApplication
+          ( httpApp @SimpleTx
+              nullTracer
+              dummyChainHandle
+              testEnvironment
+              defaultPParams
+              cantCommit
+              getUTxO
+              getNoSeenSnapshot
+              getPendingDeposits
+              putClientInput
+          )
+          $ do
+            get "/snapshot/utxo"
+              `shouldRespondWith` case utxo of
+                Nothing -> 404
+                Just u -> 200{matchBody = matchJSON u}
 
       prop "ok response matches schema" $ \(utxo :: UTxOType Tx) ->
         withMaxSuccess 4
@@ -188,27 +234,51 @@ apiServerSpec = do
           . withJsonSpecifications
           $ \schemaDir -> do
             let getUTxO = pure $ Just utxo
-            withApplication (httpApp @Tx nullTracer dummyChainHandle testEnvironment defaultPParams cantCommit getUTxO getPendingDeposits putClientInput) $ do
-              get "/snapshot/utxo"
-                `shouldRespondWith` 200
-                  { matchBody =
-                      matchValidJSON
-                        (schemaDir </> "api.json")
-                        (key "channels" . key "/snapshot/utxo" . key "subscribe" . key "message" . key "payload")
-                  }
+            withApplication
+              ( httpApp @Tx
+                  nullTracer
+                  dummyChainHandle
+                  testEnvironment
+                  defaultPParams
+                  cantCommit
+                  getUTxO
+                  getNoSeenSnapshot
+                  getPendingDeposits
+                  putClientInput
+              )
+              $ do
+                get "/snapshot/utxo"
+                  `shouldRespondWith` 200
+                    { matchBody =
+                        matchValidJSON
+                          (schemaDir </> "api.json")
+                          (key "channels" . key "/snapshot/utxo" . key "subscribe" . key "message" . key "payload")
+                    }
 
       prop "has inlineDatumRaw" $ \i ->
         forAll genTxOut $ \o -> do
           let o' = modifyTxOutDatum (const $ mkTxOutDatumInline (123 :: Integer)) o
           let getUTxO = pure $ Just $ UTxO.fromPairs [(i, o')]
-          withApplication (httpApp @Tx nullTracer dummyChainHandle testEnvironment defaultPParams cantCommit getUTxO getPendingDeposits putClientInput) $ do
-            get "/snapshot/utxo"
-              `shouldRespondWith` 200
-                { matchBody = MatchBody $ \_ body ->
-                    if isNothing (body ^? key (fromString $ Text.unpack $ renderTxIn i) . key "inlineDatumRaw")
-                      then Just $ "\ninlineDatumRaw not found in body:\n" <> show body
-                      else Nothing
-                }
+          withApplication
+            ( httpApp @Tx
+                nullTracer
+                dummyChainHandle
+                testEnvironment
+                defaultPParams
+                cantCommit
+                getUTxO
+                getNoSeenSnapshot
+                getPendingDeposits
+                putClientInput
+            )
+            $ do
+              get "/snapshot/utxo"
+                `shouldRespondWith` 200
+                  { matchBody = MatchBody $ \_ body ->
+                      if isNothing (body ^? key (fromString $ Text.unpack $ renderTxIn i) . key "inlineDatumRaw")
+                        then Just $ "\ninlineDatumRaw not found in body:\n" <> show body
+                        else Nothing
+                  }
 
     describe "POST /commit" $ do
       let getHeadId = pure $ NormalCommit (generateWith arbitrary 42)
@@ -219,9 +289,21 @@ apiServerSpec = do
                   pure $ Right tx
               }
       prop "responds on valid requests" $ \(request :: DraftCommitTxRequest Tx) ->
-        withApplication (httpApp nullTracer workingChainHandle testEnvironment defaultPParams getHeadId getNothing getPendingDeposits putClientInput) $ do
-          post "/commit" (Aeson.encode request)
-            `shouldRespondWith` 200
+        withApplication
+          ( httpApp
+              nullTracer
+              workingChainHandle
+              testEnvironment
+              defaultPParams
+              getHeadId
+              getNothing
+              getNoSeenSnapshot
+              getPendingDeposits
+              putClientInput
+          )
+          $ do
+            post "/commit" (Aeson.encode request)
+              `shouldRespondWith` 200
 
       let failingChainHandle postTxError =
             dummyChainHandle
@@ -241,11 +323,23 @@ apiServerSpec = do
               InvalidHeadId{} -> cover 1 True "InvalidHeadId"
               CannotFindOwnInitial{} -> cover 1 True "CannotFindOwnInitial"
               _ -> property
-        checkCoverage $
-          coverage $
-            withApplication (httpApp @Tx nullTracer (failingChainHandle postTxError) testEnvironment defaultPParams getHeadId getNothing getPendingDeposits putClientInput) $ do
-              post "/commit" (Aeson.encode (request :: DraftCommitTxRequest Tx))
-                `shouldRespondWith` expectedResponse
+        checkCoverage
+          $ coverage
+          $ withApplication
+            ( httpApp @Tx
+                nullTracer
+                (failingChainHandle postTxError)
+                testEnvironment
+                defaultPParams
+                getHeadId
+                getNothing
+                getNoSeenSnapshot
+                getPendingDeposits
+                putClientInput
+            )
+          $ do
+            post "/commit" (Aeson.encode (request :: DraftCommitTxRequest Tx))
+              `shouldRespondWith` expectedResponse
 
 -- * Helpers
 


### PR DESCRIPTION
<!-- Describe your change here -->

In a situation where the head is not reaching consensus, this endpoint helps identify the peer not cooperating: missing to sign the current snapshot in flight (emit AckSn) and preventing its confirmation.

This can happen in multiple situations, such as the one described in [issue #1773](https://github.com/cardano-scaling/hydra/issues/1773), often due to a peer going offline or falling out of sync because of differences in its local ledger state, configuration, or node version. This leads to conflicting views on UTxO availability, blocking further snapshot confirmation, and effectively stalling the Hydra head.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
