### PR TITLE
Bug report uses `Bug` type instead of `bug` label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: You might have found a bug and decide to report it
 title: ''
-labels: 'bug :bug:'
+type: Bug
 assignees: ''
 ---
 


### PR DESCRIPTION
Type is more useful; the label is a bit noisy.