### PR TITLE
Allow for additional etcd arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,21 @@ changes.
   - We now store the `time` in `StateEvent` which is a breaking change to our
   persistence loading
 
+- New environment variable, `HYDRA_ETCD_ADDITIONAL_ARGUMENTS`, when can be
+set before running the hydra node, to control additional etcd features.
+
+You may like to use this to control auto-compaction; for example switching to
+periodic retention for 7 days:
+
+```
+HYDRA_ETCD_ADDITIONAL_ARGUMENTS="--auto-compaction-mode=periodic --auto-compaction-retention=168h" hydra-node
+```
+
+> [!NOTE]
+> Note that spaces in the list of additional arguments is not supported; we
+> split on spaces to get the argument list correct.
+
+
 ## [0.20.0] - 2025-02-04
 
 - **BETA** hydra-node now supports incremental commits in beta mode. We would like to test out this feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,19 +40,19 @@ changes.
   - We now store the `time` in `StateEvent` which is a breaking change to our
   persistence loading
 
-- New environment variable, `HYDRA_ETCD_ADDITIONAL_ARGUMENTS`, when can be
-set before running the hydra node, to control additional etcd features.
+- New environment variable handling for the `etcd` service allows for control
+of (most) etcd parameters.
 
-You may like to use this to control auto-compaction; for example switching to
-periodic retention for 7 days:
+For example, you may like to use this to control auto-compaction by switching
+to periodic retention for 7 days:
 
 ```
-HYDRA_ETCD_ADDITIONAL_ARGUMENTS="--auto-compaction-mode=periodic --auto-compaction-retention=168h" hydra-node
+ETCD_AUTO_COMPACTION_MODE=periodic
+ETCD_AUTO_COMPACTION_RETENTION=168h
 ```
 
 > [!NOTE]
-> Note that spaces in the list of additional arguments is not supported; we
-> split on spaces to get the argument list correct.
+> Only variables prefixed with `ETCD_` are passed on to the `etcd` process.
 
 
 ## [0.20.0] - 2025-02-04

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -6,7 +6,7 @@ Running a Hydra head involves operating a Hydra node connected to other Hydra no
 hydra-node --help
 ```
 
-Below, we document selected aspects of the configuration. For a comprehensive guide, refer to the [tutorial](./tutorial) or specific _how to_ articles. 
+Below, we document selected aspects of the configuration. For a comprehensive guide, refer to the [tutorial](./tutorial) or specific _how to_ articles.
 
 ### Cardano keys
 
@@ -20,7 +20,7 @@ cardano-cli address key-gen \
   --signing-key-file cardano.sk
 ```
 
-These keys authenticate on-chain transactions and ensure that only authorized participants can control the head's lifecycle, preventing unauthorized actors from interfering (eg, aborting an initialized head). While this issue does not put participants' funds at risk, it is still inconvenient and can be avoided. 
+These keys authenticate on-chain transactions and ensure that only authorized participants can control the head's lifecycle, preventing unauthorized actors from interfering (eg, aborting an initialized head). While this issue does not put participants' funds at risk, it is still inconvenient and can be avoided.
 
 ### Hydra keys
 
@@ -72,6 +72,29 @@ submitted. This can happen, for example, if:
 Currently, the `hydra-node` does not handle this situation. Each client application should implement a retry mechanism based on the expected time for transaction inclusion.
 
 :::
+
+### Networking: Configuring the limits of etcd networking recovery
+
+Since switching to the [`etcd`-backed network
+configuration](https://github.com/cardano-scaling/hydra/pull/1854), the system
+is more resiliant to nodes going offline.
+
+However, because we don't want the etcd cluster to use up unlimited disk
+space, we set a limit to how long it will retain messages for. By default this
+is 1000 revisions across all keys. You can override this by setting the
+relevant `etcd` [environment
+variables](https://etcd.io/docs/v3.4/op-guide/configuration/).
+
+For example, to configure etcd to retain 7 days worth of revisions, in the
+call to running hydra-node, you can define:
+
+```
+ETCD_AUTO_COMPACTION_MODE=periodic
+ETCD_AUTO_COMPACTION_RETENTION=168h
+```
+
+which will be passed on to the `etcd` executable.
+
 
 ### Reference scripts
 
@@ -127,7 +150,7 @@ While the `hydra-node` needs to pay fees for protocol transactions, any wallet c
 
 This endpoint returns a commit transaction, which is balanced, and all fees are paid by the `hydra-node`. The integrated wallet must sign and submit this transaction to the Cardano network. See the [API documentation](pathname:///api-reference/#operation-publish-/commit) for details.
 
-If using your own UTXO to commit to a head, send the appropriate JSON representation of the said UTXO to the `/commit` API endpoint. 
+If using your own UTXO to commit to a head, send the appropriate JSON representation of the said UTXO to the `/commit` API endpoint.
 Using a _blueprint_ transaction with `/commit` offers flexibility, as `hydra-node` adds necessary commit transaction data without removing additional information specified in the blueprint transaction (eg, reference inputs, redeemers, validity ranges).
 
 > Note: Outputs of a blueprint transaction are not considered — only inputs are used to commit funds to the head. The `hydra-node` will also **ignore** any minting or burning specified in the blueprint transaction.
@@ -149,7 +172,7 @@ hydra-node \
 ```
 
 :::info
-The `hydra-node` is compatible with the Cardano `mainnet` network, and can consequently operate using **real funds**. Please be sure to read the [known issues](/docs/known-issues) to fully understand the limitations and consequences of running Hydra nodes on mainnet. To choose `mainnet`, use `--mainnet` instead of `--testnet-magic`. 
+The `hydra-node` is compatible with the Cardano `mainnet` network, and can consequently operate using **real funds**. Please be sure to read the [known issues](/docs/known-issues) to fully understand the limitations and consequences of running Hydra nodes on mainnet. To choose `mainnet`, use `--mainnet` instead of `--testnet-magic`.
 :::
 
 Using the direct node connection, the `hydra-node` synchronizes the chain and observes Hydra protocol transactions. On startup, it starts observing from the chain's tip. Once a Hydra head has been observed, the point of the last known state change is used automatically.

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -116,7 +116,6 @@ library
     , cryptonite
     , data-default
     , directory
-    , extra
     , filepath
     , grapesy
     , grapesy-etcd                    >=0.3

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -116,6 +116,7 @@ library
     , cryptonite
     , data-default
     , directory
+    , extra
     , filepath
     , grapesy
     , grapesy-etcd                    >=0.3

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -187,7 +187,8 @@ withEtcdNetwork tracer protocolVersion config callback action = do
   -- XXX: Could use discovery to simplify configuration
   -- NOTE: Configured using guides: https://etcd.io/docs/v3.5/op-guide
   etcdCmd envVars =
-    setEnv (Map.toList $ envVars <> defaultEnv)
+    -- NOTE: We append the inherited environment on top of the defaultEnv to allow overrides.
+    setEnv (Map.toList $ defaultEnv <> envVars)
       . setCreateGroup True -- Prevents interrupt of main process when we send SIGINT to etcd
       . setStderr createPipe
       . proc "etcd"

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -187,8 +187,8 @@ withEtcdNetwork tracer protocolVersion config callback action = do
   -- XXX: Could use discovery to simplify configuration
   -- NOTE: Configured using guides: https://etcd.io/docs/v3.5/op-guide
   etcdCmd envVars =
-    -- NOTE: We append the inherited environment on top of the defaultEnv to allow overrides.
-    setEnv (Map.toList $ defaultEnv <> envVars)
+    -- NOTE: We map prefers the left; so we need to mappend default at the end.
+    setEnv (Map.toList $ envVars <> defaultEnv)
       . setCreateGroup True -- Prevents interrupt of main process when we send SIGINT to etcd
       . setStderr createPipe
       . proc "etcd"

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -187,7 +187,7 @@ withEtcdNetwork tracer protocolVersion config callback action = do
   -- XXX: Could use discovery to simplify configuration
   -- NOTE: Configured using guides: https://etcd.io/docs/v3.5/op-guide
   etcdCmd envVars =
-    setEnv (Map.toList $ onlyEtcdVars envVars <> defaultEnv)
+    setEnv (Map.toList $ envVars <> defaultEnv)
       . setCreateGroup True -- Prevents interrupt of main process when we send SIGINT to etcd
       . setStderr createPipe
       . proc "etcd"
@@ -206,8 +206,6 @@ withEtcdNetwork tracer protocolVersion config callback action = do
           ["--initial-cluster-token", "hydra-network-1"]
         , ["--initial-cluster", clusterPeers]
         ]
-
-  onlyEtcdVars = Map.filterWithKey (\k _ -> "ETCD_" `isPrefixOf` k)
 
   defaultEnv :: Map.Map String String
   defaultEnv =


### PR DESCRIPTION
Fixes #1883 

This allows additional arguments to be specified.

Note that it's slightly hacky, as old arguments will still be listed but overwritten when etcd comes to read them; so it's functionally clean, but perhaps less than ideal when reading `ps aux | grep etcd`.

Open to other ideas here.