### PR TITLE
Hotfix for model spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ changes.
   - API Server does **NOT** serve the event history by default any more. Clients need to add a query parameter `?history=yes` in order to obtain the history.
   - Remove `GetUTxO` client input and corresponding `GetUTxOResponse`. There is already a way to query the `UTxO` in the Head with `GET /snapshot/utxo` query.
   - Renamed 'CommitFinalized' field 'theDeposit' to 'depositTxId'.
+  - We now store the `time` in `StateEvent` which is a breaking change to our
+  persistence loading
 
 ## [0.20.0] - 2025-02-04
 

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -345,7 +345,6 @@ test-suite tests
     , regex-tdfa
     , req
     , silently
-    , temporary
     , text
     , time
     , tls

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -711,7 +711,7 @@ performDecommit party tx = do
   party `sendsInput` Input.Decommit realTx
 
   lift $ do
-    waitUntilMatch [thisNode] $ \case
+    waitUntilMatch (Map.elems nodes) $ \case
       DecommitFinalized{} -> True
       _ -> False
 
@@ -928,9 +928,7 @@ waitForUTxOToSpend utxo key value node = go 100
     0 ->
       pure $ Left utxo
     n -> do
-      threadDelay 5
       u <- headUTxO node
-      threadDelay 5
       if u /= mempty
         then case find matchPayment (UTxO.pairs u) of
           Nothing -> go (n - 1)
@@ -945,7 +943,6 @@ headUTxO ::
   TestHydraClient tx m ->
   m (UTxOType tx)
 headUTxO node = do
-  threadDelay 1
   fromMaybe mempty . getHeadUTxO <$> queryState node
 
 isOwned :: CardanoSigningKey -> (TxIn, TxOut ctx) -> Bool


### PR DESCRIPTION
- Fixed ModelSpec to wait for _all_ nodes to see the msg
- Updated changelog to have note about `time` field breaking change on persistence
