### PR TITLE
Fix incremental commit/decommit state events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ changes.
   - Change `PeerConnected` and `PeerDisconnected` to indicate connectivity to `--peer` items and not the remote `node-id`.
   - Log outputs related to the network components changed significantly.
   - Persisted state (write ahead logs) of the network components changed significantly. The `<persistence-dir>/etcd` directory must not be lost or manual action to recover the L2 network (etcd cluster) with counter-parties needs to be taken.
+  - To configure the `etcd` instance used internally, you may use `ETCD_` environment variables. For example, to switch auto-compaction to periodic retention of 7 days:
+    ```
+    ETCD_AUTO_COMPACTION_MODE=periodic
+    ETCD_AUTO_COMPACTION_RETENTION=168h
+    ```
+
+- Fix a bug where incremental commits / decommits were not correctly observed after restart of `hydra-node`. This was due to incorrect handling of internal chain state [#1894](https://github.com/cardano-scaling/hydra/pull/1894)
 
 - Fix a bug where decoding `Party` information from chain would crash the node or chain observer.
   - A problematic transaction will now be ignored and not deemed a valid head protocol transaction.
@@ -39,21 +46,6 @@ changes.
   - Renamed 'CommitFinalized' field 'theDeposit' to 'depositTxId'.
   - We now store the `time` in `StateEvent` which is a breaking change to our
   persistence loading
-
-- New environment variable handling for the `etcd` service allows for control
-of (most) etcd parameters.
-
-For example, you may like to use this to control auto-compaction by switching
-to periodic retention for 7 days:
-
-```
-ETCD_AUTO_COMPACTION_MODE=periodic
-ETCD_AUTO_COMPACTION_RETENTION=168h
-```
-
-> [!NOTE]
-> Only variables prefixed with `ETCD_` are passed on to the `etcd` process.
-
 
 - Add a list of [clients](https://hydra.family/head-protocol/unstable/docs/clients) to the docs
 

--- a/hydra-node/golden/StateChanged/CommitFinalized.json
+++ b/hydra-node/golden/StateChanged/CommitFinalized.json
@@ -1,11 +1,41 @@
 {
     "samples": [
         {
-            "depositTxId": "0001010000010101000000000001000101000100000101010000010101010000",
-            "headId": "01010100010001010101000101000001",
-            "newVersion": 1,
+            "chainState": {
+                "recordedAt": {
+                    "blockHash": "0100000000010001010100010000000100000101010101000100010101000100",
+                    "slot": 1,
+                    "tag": "ChainPoint"
+                },
+                "spendableUTxO": {
+                    "0000010001000000000001000101010100000000010000000100000001000001#33": {
+                        "address": "2RhQhCGqYPDn9TWRPDVY9kcHEZpLDwnJka72YWCwDfxGA35wPizRdA9GyvhuD9qcqxKMaGPJZSjD2tBdXHee8wGiTFMAcxgxVLjs6fjkLan6mu",
+                        "datum": null,
+                        "datumhash": null,
+                        "inlineDatum": null,
+                        "inlineDatumRaw": null,
+                        "referenceScript": {
+                            "script": {
+                                "cborHex": "820501",
+                                "description": "",
+                                "type": "SimpleScript"
+                            },
+                            "scriptLanguage": "SimpleScriptLanguage"
+                        },
+                        "value": {
+                            "b0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165": {
+                                "1927e29b34ffa554fc50ccc8bf9b41e5ea17cbdfe6ae6e5a879765": 1094243968039730176
+                            },
+                            "lovelace": 1904754014670228328
+                        }
+                    }
+                }
+            },
+            "depositTxId": "0001010000000000010001000000010001000000000000010100010101000001",
+            "headId": "01010001000101000101010100010100",
+            "newVersion": 0,
             "tag": "CommitFinalized"
         }
     ],
-    "seed": -763406104
+    "seed": -1458698575
 }

--- a/hydra-node/golden/StateChanged/CommitRecorded.json
+++ b/hydra-node/golden/StateChanged/CommitRecorded.json
@@ -1,60 +1,36 @@
 {
     "samples": [
         {
-            "deadline": "1864-05-09T06:20:33.933700399873Z",
-            "headId": "00000000010100010101000001010100",
-            "newLocalUTxO": {},
-            "pendingDeposit": "0001000100010101000101000001010100000000000001010101000000000101",
-            "pendingDeposits": {
-                "0001000101000100010101010000010101000101000101010101010100010000": {
-                    "0100000100010001000100000001010000000101010100000001000000010100#20": {
-                        "address": "addr_test1zpqj8j637n2usgayxmdvx3x7qgvhv0yftnntnk9hj0n72w45j8q427df3l45d2k08auxhlel9c7x244t5xv3uuv9ledq64uz4u",
-                        "datum": null,
-                        "inlineDatum": {
-                            "int": 4
-                        },
-                        "inlineDatumRaw": "04",
-                        "inlineDatumhash": "642206314f534b29ad297d82440a5f9f210e30ca5ced805a587ca402de927342",
-                        "referenceScript": {
-                            "script": {
-                                "cborHex": "4746010000220011",
-                                "description": "",
-                                "type": "PlutusScriptV2"
-                            },
-                            "scriptLanguage": "PlutusScriptLanguage PlutusScriptV2"
-                        },
-                        "value": {
-                            "245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abae": {
-                                "a20c3107ed64ce5b715f": 1
-                            }
+            "chainState": {
+                "recordedAt": {
+                    "tag": "ChainPointAtGenesis"
+                },
+                "spendableUTxO": {}
+            },
+            "deadline": "1864-05-09T00:56:38.983698539086Z",
+            "headId": "01000100010101010100000100000001",
+            "newLocalUTxO": {
+                "0001000001010101000100000100010100010101010001010101000100010001#94": {
+                    "address": "addr1x9qn667sq6qap3j0yvp6khlzgzw57yc04dc6ha5rs8g0nrjpd2em6zxaucfcfht5gdmejvn24fke69qhu6u7kwh4r85qwa9902",
+                    "datum": null,
+                    "datumhash": "6825d60ec81f041ebf7dcdf1076312142d0a36432936e598dbe0694acc984692",
+                    "inlineDatum": null,
+                    "inlineDatumRaw": null,
+                    "referenceScript": null,
+                    "value": {
+                        "8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3": {
+                            "30": 2
                         }
                     }
                 }
             },
+            "pendingDeposit": "0100000101010100010001000000000100010001000100010001000101010100",
+            "pendingDeposits": {
+                "0000010101010000000001000100000100010101010001000100010100000000": {}
+            },
             "tag": "CommitRecorded",
-            "utxoToCommit": {
-                "0101010101010000010101000101000000000100010000010101000001000100#71": {
-                    "address": "addr1zyjya69cls6mv9gh0h7y7g7svjgfthyacuvv4ezlgyvc0s03fjs34slfuuls5xl7sm5e8yrkvvqn834pn99ermvfvscs0xkwy5",
-                    "datum": null,
-                    "datumhash": null,
-                    "inlineDatum": null,
-                    "inlineDatumRaw": null,
-                    "referenceScript": {
-                        "script": {
-                            "cborHex": "8202818201818200581cb1075ce9c25485e1f9547f8c9c9177e47239599a4cb96eea6e1ef1c5",
-                            "description": "",
-                            "type": "SimpleScript"
-                        },
-                        "scriptLanguage": "SimpleScriptLanguage"
-                    },
-                    "value": {
-                        "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
-                            "1709a19f55300ab14c212db363c5": 1
-                        }
-                    }
-                }
-            }
+            "utxoToCommit": {}
         }
     ],
-    "seed": 284889560
+    "seed": 735071337
 }

--- a/hydra-node/golden/StateChanged/CommitRecovered.json
+++ b/hydra-node/golden/StateChanged/CommitRecovered.json
@@ -1,12 +1,30 @@
 {
     "samples": [
         {
-            "headId": "01010001010101000101010101010001",
-            "newLocalUTxO": {},
-            "recoveredTxId": "0100000001000001000000000101010001000000000000000001010100010101",
+            "chainState": {
+                "recordedAt": null,
+                "spendableUTxO": {}
+            },
+            "headId": "00010000010101000000000000000001",
+            "newLocalUTxO": {
+                "0001000101010100010101010001000100010100010000010101010000000100#69": {
+                    "address": "addr_test1xru4r822mv0hsqjks0pg57r679eshp4wq55rkuqgkvjkuntqe42x85cw82wz3d86h423py4a8saq8kqhghws85hln5nqv39fdf",
+                    "datum": null,
+                    "datumhash": "325018121e9cac56dc21e64b14ed0a8bc3e3b62ba83b048f44c9ce0366345e06",
+                    "inlineDatum": null,
+                    "inlineDatumRaw": null,
+                    "referenceScript": null,
+                    "value": {
+                        "b0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165": {
+                            "03b18655f635784d096d": 1
+                        }
+                    }
+                }
+            },
+            "recoveredTxId": "0001010001000001010100010100010100010000000101000000010101000001",
             "recoveredUTxO": {},
             "tag": "CommitRecovered"
         }
     ],
-    "seed": -1010695085
+    "seed": 1182547604
 }

--- a/hydra-node/golden/StateChanged/DecommitFinalized.json
+++ b/hydra-node/golden/StateChanged/DecommitFinalized.json
@@ -1,11 +1,40 @@
 {
     "samples": [
         {
-            "decommitTxId": "0001000000000000000000000001000000000000010001010000010000010100",
-            "headId": "00000001010101000001000101000000",
+            "chainState": {
+                "recordedAt": {
+                    "blockHash": "0100010101010101010100000100010001000100000000010000010000010001",
+                    "slot": 1,
+                    "tag": "ChainPoint"
+                },
+                "spendableUTxO": {
+                    "0000000000010100010101000001010100010100010100010100000001010100#19": {
+                        "address": "addr_test1zpscm90puxtm785w02th7qws0w0v0vphzyh88g2w90e50387lg66ceyc8n04addy7qhqfwgpem2qkkhe3gafa47ltdls8pjj0t",
+                        "datum": null,
+                        "datumhash": null,
+                        "inlineDatum": null,
+                        "inlineDatumRaw": null,
+                        "referenceScript": {
+                            "script": {
+                                "cborHex": "83030081820180",
+                                "description": "",
+                                "type": "SimpleScript"
+                            },
+                            "scriptLanguage": "SimpleScriptLanguage"
+                        },
+                        "value": {
+                            "b0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165": {
+                                "eb0211177e54": 1
+                            }
+                        }
+                    }
+                }
+            },
+            "decommitTxId": "0101000101010000000101000001000000000101010001000100010100000101",
+            "headId": "00000101010100010001000000000100",
             "newVersion": 0,
             "tag": "DecommitFinalized"
         }
     ],
-    "seed": -2022187077
+    "seed": -277076702
 }

--- a/hydra-node/json-schemas/logs.yaml
+++ b/hydra-node/json-schemas/logs.yaml
@@ -1347,90 +1347,6 @@ definitions:
             enum: ["TransactionReceived"]
           tx:
             $ref: "api.yaml#/components/schemas/Transaction"
-      - title: "CommitRecorded"
-        additionalProperties: false
-        required:
-          - tag
-          - pendingDeposits
-          - newLocalUTxO
-        properties:
-          tag:
-            type: string
-            enum: ["CommitRecorded"]
-          pendingDeposits:
-            type: object
-          newLocalUTxO:
-            $ref: "api.yaml#/components/schemas/UTxO"
-      - title: "CommitFinalized"
-        additionalProperties: false
-        required:
-          - tag
-          - newVersion
-          - depositTxId
-        properties:
-          tag:
-            type: string
-            enum: ["CommitFinalized"]
-          newVersion:
-            $ref: "api.yaml#/components/schemas/SnapshotVersion"
-          depositTxId:
-            type: string
-      - title: "CommitRecovered"
-        additionalProperties: false
-        required:
-          - tag
-          - recoveredUTxO
-          - newLocalUTxO
-          - recoveredTxId
-        properties:
-          tag:
-            type: string
-            enum: ["CommitRecovered"]
-          recoveredUTxO:
-            $ref: "api.yaml#/components/schemas/UTxO"
-          newLocalUTxO:
-            $ref: "api.yaml#/components/schemas/UTxO"
-          recoveredTxId:
-            type: string
-      - title: "CommitIgnored"
-        additionalProperties: false
-        required:
-          - tag
-          - headId
-        properties:
-          tag:
-            type: string
-            enum: ["CommitIgnored"]
-          headId:
-            $ref: "api.yaml#/components/schemas/HeadId"
-          depositUTxO:
-            type: array
-            items:
-              $ref: "api.yaml#/components/schemas/UTxO"
-          snapshotUTxO:
-            oneOf:
-              - $ref: "api.yaml#/components/schemas/UTxO"
-              - type: "null"
-      - title: "DecommitRecorded"
-        additionalProperties: false
-        required:
-          - tag
-          - decommitTx
-        properties:
-          tag:
-            type: string
-            enum: ["DecommitRecorded"]
-          decommitTx:
-            type: object
-            $ref: "api.yaml#/components/schemas/Transaction"
-      - title: "DecommitFinalized"
-        additionalProperties: false
-        required:
-          - tag
-        properties:
-          tag:
-            type: string
-            enum: ["DecommitFinalized"]
       - title: "PartySignedSnapshot"
         additionalProperties: false
         required:
@@ -1462,6 +1378,86 @@ definitions:
             $ref: "api.yaml#/components/schemas/Snapshot"
           signatures:
             $ref: "api.yaml#/components/schemas/MultiSignature"
+      - title: "CommitRecorded"
+        additionalProperties: false
+        required:
+          - tag
+          - chainState
+          - pendingDeposits
+          - newLocalUTxO
+        properties:
+          tag:
+            type: string
+            enum: ["CommitRecorded"]
+          chainState:
+            $ref: "api.yaml#/components/schemas/ChainState"
+          pendingDeposits:
+            type: object
+          newLocalUTxO:
+            $ref: "api.yaml#/components/schemas/UTxO"
+      - title: "CommitFinalized"
+        additionalProperties: false
+        required:
+          - tag
+          - chainState
+          - newVersion
+          - depositTxId
+        properties:
+          tag:
+            type: string
+            enum: ["CommitFinalized"]
+          chainState:
+            $ref: "api.yaml#/components/schemas/ChainState"
+          newVersion:
+            $ref: "api.yaml#/components/schemas/SnapshotVersion"
+          depositTxId:
+            type: string
+      - title: "CommitRecovered"
+        additionalProperties: false
+        required:
+          - tag
+          - chainState
+          - recoveredUTxO
+          - newLocalUTxO
+          - recoveredTxId
+        properties:
+          tag:
+            type: string
+            enum: ["CommitRecovered"]
+          chainState:
+            $ref: "api.yaml#/components/schemas/ChainState"
+          recoveredUTxO:
+            $ref: "api.yaml#/components/schemas/UTxO"
+          newLocalUTxO:
+            $ref: "api.yaml#/components/schemas/UTxO"
+          recoveredTxId:
+            type: string
+      - title: "DecommitRecorded"
+        additionalProperties: false
+        required:
+          - tag
+          - decommitTx
+        properties:
+          tag:
+            type: string
+            enum: ["DecommitRecorded"]
+          decommitTx:
+            type: object
+            $ref: "api.yaml#/components/schemas/Transaction"
+      - title: "DecommitFinalized"
+        additionalProperties: false
+        required:
+          - tag
+          - chainState
+          - newVersion
+        properties:
+          tag:
+            type: string
+            enum: ["DecommitFinalized"]
+          chainState:
+            $ref: "api.yaml#/components/schemas/ChainState"
+          newVersion:
+            $ref: "api.yaml#/components/schemas/SnapshotVersion"
       - title: "HeadClosed"
         additionalProperties: false
         required:


### PR DESCRIPTION
These have not been carrying and updating the 'chainState' in our 'HeadState' aggregate. This would result in the chain layer not restarting from these last known chain points and we saw the hydra-node re-observing deposits, incrementas and (likely) decrements.

---

* [x] CHANGELOG updated
* [x] Documentation update not needed
* [x] Haddocks update not needed
* [x] No new TODOs introduced
