### PR TITLE
Add test for peer disconnected events

### DIFF
--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -156,14 +156,14 @@ spec = do
               waitFor $ PeerDisconnected carolConfig.advertise
               -- Bob stops
               pure ()
-            -- Question: When should we see Bob disconnect?
             -- We are now in minority
             waitFor NetworkDisconnected
             -- Carol starts again and we reach a majority
             withEtcdNetwork @Int tracer v1 carolConfig noopCallback $ \_ -> do
               waitFor NetworkConnected
-              waitFor $ PeerDisconnected bobConfig.advertise
               waitFor $ PeerConnected carolConfig.advertise
+              -- Once Carol is back, we see Bob disconnected.
+              waitFor $ PeerDisconnected bobConfig.advertise
 
       it "checks protocol version" $ \tracer -> do
         withTempDir "test-etcd" $ \tmp -> do

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -146,11 +146,11 @@ spec = do
           (carolRecordReceived, _, carolWaitConnectivity) <- newRecordingCallback
           let
             aliceWaitFor :: HasCallStack => Connectivity -> IO ()
-            aliceWaitFor = waitEq aliceWaitConnectivity 20
+            aliceWaitFor = waitEq aliceWaitConnectivity 100
             bobWaitFor :: HasCallStack => Connectivity -> IO ()
-            bobWaitFor = waitEq bobWaitConnectivity 20
+            bobWaitFor = waitEq bobWaitConnectivity 100
             carolWaitFor :: HasCallStack => Connectivity -> IO ()
-            carolWaitFor = waitEq carolWaitConnectivity 20
+            carolWaitFor = waitEq carolWaitConnectivity 100
           withEtcdNetwork @Int tracer v1 aliceConfig aliceRecordReceived $ \_ -> do
             withEtcdNetwork @Int tracer v1 bobConfig bobRecordReceived $ \_ -> do
               aliceWaitFor NetworkConnected

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -114,42 +114,13 @@ spec = do
         withTempDir "test-etcd" $ \tmp -> do
           PeerConfig3{aliceConfig, bobConfig, carolConfig} <- setup3Peers tmp
           -- Record and assert connectivity events from alice's perspective
-          (recordReceived, _, waitConnectivity) <- newRecordingCallback
-          let
-            waitFor :: HasCallStack => Connectivity -> IO ()
-            waitFor = waitEq waitConnectivity 10
-          withEtcdNetwork @Int tracer v1 aliceConfig recordReceived $ \_ -> do
-            withEtcdNetwork @Int tracer v1 bobConfig noopCallback $ \_ -> do
-              -- Alice now on majority cluster
-              waitFor NetworkConnected
-              waitFor $ PeerConnected bobConfig.advertise
-              withEtcdNetwork @Int tracer v1 carolConfig noopCallback $ \_ -> do
-                waitFor $ PeerConnected carolConfig.advertise
-                -- Carol stops
-                pure ()
-              waitFor $ PeerDisconnected carolConfig.advertise
-              -- Bob stops
-              pure ()
-            -- We are now in minority
-            waitFor NetworkDisconnected
-            -- Carol starts again and we reach a majority
-            withEtcdNetwork @Int tracer v1 carolConfig noopCallback $ \_ -> do
-              waitFor NetworkConnected
-              waitFor $ PeerConnected carolConfig.advertise
-
-      it "tracks peer disconnects/connections correctly" $ \tracer -> do
-        withTempDir "test-etcd" $ \tmp -> do
-          PeerConfig3{aliceConfig, bobConfig, carolConfig} <- setup3Peers tmp
-          -- Record and assert connectivity events from alice's perspective
           (aliceRecordReceived, _, aliceWaitConnectivity) <- newRecordingCallback
           (bobRecordReceived, _, bobWaitConnectivity) <- newRecordingCallback
           (carolRecordReceived, _, carolWaitConnectivity) <- newRecordingCallback
           let
-            aliceWaitFor :: HasCallStack => Connectivity -> IO ()
+            aliceWaitFor, bobWaitFor, carolWaitFor :: HasCallStack => Connectivity -> IO ()
             aliceWaitFor = waitEq aliceWaitConnectivity 100
-            bobWaitFor :: HasCallStack => Connectivity -> IO ()
             bobWaitFor = waitEq bobWaitConnectivity 100
-            carolWaitFor :: HasCallStack => Connectivity -> IO ()
             carolWaitFor = waitEq carolWaitConnectivity 100
           withEtcdNetwork @Int tracer v1 aliceConfig aliceRecordReceived $ \_ -> do
             withEtcdNetwork @Int tracer v1 bobConfig bobRecordReceived $ \_ -> do


### PR DESCRIPTION
This is a test to see if we can work out whether-or-not the peer liveness events were reported incorrectly.

It seems that there is, in fact, no problem with it. But maybe I've missed some interesting test case?

Fixes https://github.com/cardano-scaling/hydra/issues/1885 ( in theory, but actually just means we'll close it as non-reproducible. )

The most interesting observation is that you only see `PeerDisconnected` events _when in the majority again_! That's a bit unfortunate; but at least if you see `NetworkDisconnected` you know not to trust the `Alive Peers` list.

### Todo

- [ ] Note, in fact, that this _doesn't_ test the same thing in the bug report; i.e. that the `alive` key is actually written correctly. I might add a in a check for that explicitly.

