### PR TITLE
Always need history in TUI

### DIFF
--- a/hydra-tui/src/Hydra/Client.hs
+++ b/hydra-tui/src/Hydra/Client.hs
@@ -92,7 +92,7 @@ withClient Options{hydraNodeHost = Host{hostname, port}, cardanoSigningKey, card
  where
   readExternalSk = readFileTextEnvelopeThrow (AsSigningKey AsPaymentKey) cardanoSigningKey
   -- TODO(SN): ping thread?
-  client q = runClient (toString hostname) (fromIntegral port) "/" $ \con -> do
+  client q = runClient (toString hostname) (fromIntegral port) "/?history=yes" $ \con -> do
     -- REVIEW(SN): is sharing the 'con' fine?
     callback ClientConnected
     race_ (receiveOutputs con) (sendInputs q con)


### PR DESCRIPTION
Given the new state model, history wasn't provided when loading the TUI.

This affected the TUI's ability to know the present state of the node correctly. The easiest fix is just to have the TUI request the full history, and then it can be up to date!