### PR TITLE
Drop CurrentlyAlive

### DIFF
--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -407,7 +407,6 @@ pollConnectivity tracer conn advertise NetworkCallback{onConnectivity} = do
             traceWith tracer LowLeaseTTL{ttlRemaining}
           -- Determine alive peers
           alive <- getAlive
-          traceWith tracer CurrentlyAlive{alive}
           let othersAlive = alive \\ [advertise]
           seenAlive <- atomically $ swapTVar seenAliveVar othersAlive
           forM_ (othersAlive \\ seenAlive) $ onConnectivity . PeerConnected
@@ -572,7 +571,6 @@ data EtcdLog
   | FailedToDecodeValue {key :: Text, value :: Text, reason :: Text}
   | CreatedLease {leaseId :: Int64}
   | LowLeaseTTL {ttlRemaining :: DiffTime}
-  | CurrentlyAlive {alive :: [Host]}
   | NoKeepAliveResponse
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON)


### PR DESCRIPTION
The information provided through PeerConnected/PeerDisconnected is sufficient.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
