### PR TITLE
Fix memory leak when loading state from disk

### DIFF
--- a/hydra-node/src/Hydra/HeadLogic/State.hs
+++ b/hydra-node/src/Hydra/HeadLogic/State.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE StrictData #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-ambiguous-fields #-}
 

--- a/hydra-node/src/Hydra/HeadLogic/State.hs
+++ b/hydra-node/src/Hydra/HeadLogic/State.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE StrictData #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-ambiguous-fields #-}
 
@@ -153,7 +152,7 @@ data CoordinatedHeadState tx = CoordinatedHeadState
   -- ^ List of transactions applied locally and pending inclusion in a snapshot.
   -- Ordering in this list is important as transactions are added in order of
   -- application. Spec: T̂
-  , allTxs :: Map.Map (TxIdType tx) tx
+  , allTxs :: !(Map.Map (TxIdType tx) tx)
   -- ^ Map containing all the transactions ever seen by this node and not yet
   -- included in a snapshot. Spec: Tall
   , confirmedSnapshot :: ConfirmedSnapshot tx


### PR DESCRIPTION
We have a memory (space leak) when loading `state` files with many transactions.

This is due to a thunk being built up by repeatedly calling `aggregate` and not forcing `allTxs` throughout the initial load from disk.

For example, loading 2GB of `state` on master with a `hydra-node` invocation that exists after loading state due to mismatched parties -> **~1GB** max memory usage:
```
 151,712,666,608 bytes allocated in the heap
  14,411,335,656 bytes copied during GC
     973,747,296 bytes maximum residency (53 sample(s))
      24,460,192 bytes maximum slop
            2033 MiB total memory in use (0 MiB lost due to fragmentation)
```
![master-heap](https://github.com/user-attachments/assets/fb0db1e5-0bdc-4a33-84e7-ae207a8abd57)


With changes from this PR -> **12MB** max memory usage:
```
 152,039,750,336 bytes allocated in the heap
  17,318,725,168 bytes copied during GC
      12,855,112 bytes maximum residency (2268 sample(s))
         246,256 bytes maximum slop
              47 MiB total memory in use (0 MiB lost due to fragmentation)
```
![strictdata-heap](https://github.com/user-attachments/assets/d62c203f-3a16-4fbf-87a4-9126cf2a7766)


---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
