### PR TITLE
Observe correct deposit UTxO in Increment observation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ changes.
     ETCD_AUTO_COMPACTION_RETENTION=168h
     ```
 
+- Fix a bug in increment observation where wrong deposited UTxO was picked up.
+
 - Fix a bug where incremental commits / decommits were not correctly observed after restart of `hydra-node`. This was due to incorrect handling of internal chain state [#1894](https://github.com/cardano-scaling/hydra/pull/1894)
 
 - Fix a bug where decoding `Party` information from chain would crash the node or chain observer.

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -328,6 +328,7 @@ test-suite tests
     , hydra-node
     , hydra-node:testlib
     , hydra-plutus
+    , hydra-plutus-extras
     , hydra-prelude
     , hydra-test-utils
     , hydra-tx

--- a/hydra-tx/src/Hydra/Tx/Increment.hs
+++ b/hydra-tx/src/Hydra/Tx/Increment.hs
@@ -121,7 +121,7 @@ observeIncrementTx ::
 observeIncrementTx utxo tx = do
   let inputUTxO = resolveInputsUTxO utxo tx
   (headInput, headOutput) <- findTxOutByScript inputUTxO Head.validatorScript
-  (TxIn depositTxId _, depositOutput) <- findTxOutByScript utxo depositValidatorScript
+  (TxIn depositTxId _, depositOutput) <- findTxOutByScript inputUTxO depositValidatorScript
   dat <- txOutScriptData $ toTxContext depositOutput
   -- we need to be able to decode the datum, no need to use it tho
   _ :: Deposit.DepositDatum <- fromScriptData dat


### PR DESCRIPTION
- This PR should fix the bug we found where increment observation would pick the wrong deposit UTxO.

Fixes https://github.com/cardano-scaling/hydra/issues/1915

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
