### PR TITLE
hydra-chain-observer: Use bulk Blockfrost.getBlockTxsCBOR

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -15,16 +15,6 @@ index-state:
   , hackage.haskell.org 2025-04-12T10:35:52Z
   , cardano-haskell-packages  2025-04-11T16:42:25Z
 
-source-repository-package
-  type: git
-  location: https://github.com/cardano-scaling/blockfrost-haskell.git
-  tag: 042179583f439d09c271b11bac9e9289133c0a66
-  --sha256: j2kRxDxtehHB0mQ4lHE6PqjOVca2dHgQgJaxtCPDeM8=
-  subdir:
-    blockfrost-client-core
-    blockfrost-api
-    blockfrost-client
-
 packages:
   hydra-prelude
   hydra-cardano-api

--- a/hydra-chain-observer/hydra-chain-observer.cabal
+++ b/hydra-chain-observer/hydra-chain-observer.cabal
@@ -67,7 +67,7 @@ library
   build-depends:
     , base                         >=4.8.0
     , base16-bytestring
-    , blockfrost-client            >=0.9.1.0
+    , blockfrost-client            >=0.9.2.0
     , http-conduit
     , hydra-cardano-api
     , hydra-node

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -96,7 +96,7 @@ library
   build-depends:
     , aeson
     , base
-    , blockfrost-client               >=0.9.1.0
+    , blockfrost-client               >=0.9.2.0
     , bytestring
     , cardano-api
     , cardano-binary


### PR DESCRIPTION
instead of fetching each CBOR separately.

* Updates Hackage `index-state` and `hackage.nix` to pull `blockfrost-client 0.9.2`
* Drops `source-repository-package` for `blockfrost-api/client` as the overalapping instances [fix](https://github.com/blockfrost/blockfrost-haskell/pull/72) was merged and released as well

Related to #1880.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
