### PR TITLE
Add a metric to count the number of active peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ changes.
 
 ## [0.21.0] - UNRELEASED
 
+- New metric for counting the number of active peers: `hydra_head_peers_connected`
 - **BREAKING** Switch to using `etcd` internally to establish a reliable L2 network
   - New run-time dependency onto `etcd` binary
   - The peer network options to `hydra-node` (`--peer`) need to match across the Hydra network.

--- a/docs/docs/how-to/operating-hydra.md
+++ b/docs/docs/how-to/operating-hydra.md
@@ -43,6 +43,8 @@ will output:
 hydra_head_confirmed_tx  0
 # TYPE hydra_head_inputs counter
 hydra_head_inputs  50467
+# TYPE hydra_head_peers_connected gauge
+hydra_head_peers_connected  0.0
 # TYPE hydra_head_requested_tx counter
 hydra_head_requested_tx  0
 # TYPE hydra_head_tx_confirmation_time_ms histogram

--- a/hydra-node/src/Hydra/Logging/Monitoring.hs
+++ b/hydra-node/src/Hydra/Logging/Monitoring.hs
@@ -98,8 +98,8 @@ monitor transactionsMap metricsMap = \case
     tick "hydra_head_requested_tx"
   (Node LogicOutcome{outcome = Continue{stateChanges}}) -> do
     forM_ stateChanges $ \case
-      PeerConnected{} -> gauge Gauge.inc $ "hydra_head_peers_connected"
-      PeerDisconnected{} -> gauge Gauge.dec $ "hydra_head_peers_connected"
+      PeerConnected{} -> gauge Gauge.inc "hydra_head_peers_connected"
+      PeerDisconnected{} -> gauge Gauge.dec "hydra_head_peers_connected"
       SnapshotConfirmed{snapshot = Snapshot{confirmed}} -> do
         tickN "hydra_head_confirmed_tx" (length confirmed)
         forM_ confirmed $ \tx -> do

--- a/hydra-node/test/Hydra/Logging/MonitoringSpec.hs
+++ b/hydra-node/test/Hydra/Logging/MonitoringSpec.hs
@@ -11,8 +11,11 @@ import Hydra.Ledger.Simple (aValidTx, utxoRefs)
 import Hydra.Logging (nullTracer, traceWith)
 import Hydra.Logging.Messages (HydraLog (Node))
 import Hydra.Logging.Monitoring
+import Hydra.Network (Host (Host))
 import Hydra.Network.Message (Message (ReqTx))
 import Hydra.Node (HydraNodeLog (..))
+
+-- import Network.Socket (PortNumber(PortNumber))
 import Network.HTTP.Req (GET (..), NoReqBody (..), bsResponse, defaultHttpConfig, http, port, req, responseBody, runReq, (/:))
 import Test.Hydra.Tx.Fixture (alice, testHeadId)
 import Test.Network.Ports (randomUnusedTCPPorts)
@@ -29,6 +32,9 @@ spec =
         traceWith tracer (Node $ BeginInput alice 1 (receiveMessage (ReqTx tx2)))
         threadDelay 0.1
         traceWith tracer (Node $ LogicOutcome alice (Continue [SnapshotConfirmed testHeadId (testSnapshot 1 1 [tx2, tx1] (utxoRefs [1])) mempty] mempty))
+        traceWith tracer (Node $ LogicOutcome alice (Continue [PeerConnected (Host "a" 1)] mempty))
+        traceWith tracer (Node $ LogicOutcome alice (Continue [PeerConnected (Host "b" 2)] mempty))
+        traceWith tracer (Node $ LogicOutcome alice (Continue [PeerDisconnected (Host "b" 2)] mempty))
 
         metrics <-
           Text.lines
@@ -37,4 +43,5 @@ spec =
             <$> runReq @IO defaultHttpConfig (req GET (http "localhost" /: "metrics") NoReqBody bsResponse (port p))
 
         metrics `shouldContain` ["hydra_head_confirmed_tx  2"]
+        metrics `shouldContain` ["hydra_head_peers_connected  1.0"]
         metrics `shouldContain` ["hydra_head_tx_confirmation_time_ms_bucket{le=\"1000.0\"} 2.0"]


### PR DESCRIPTION
This adds a new metric to show the number of active peers:
```
hydra_head_peers_connected
```

It is a [prometheus "Gauge" metric](https://prometheus.io/docs/concepts/metric_types/#gauge), so it can go up and down, and does so on each `PeerConnected` and `PeerDisconnected` event.

> [!NOTE]
> This will only report counts as long as the # of peers is > (peers / 2). This is because that is what is required for etcd consensus, and this message is only emitted when etcd consensus is reached.
