### PR TITLE
hydra/sha512

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -11,7 +11,7 @@ concurrency:
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "hydra/sha512"]
     tags: [ "*.*.*" ]
   workflow_dispatch:
     inputs:

--- a/cabal.project
+++ b/cabal.project
@@ -12,8 +12,8 @@ repository cardano-haskell-packages
 
 -- See CONTRIBUTING.md for information about when and how to update these.
 index-state:
-  , hackage.haskell.org 2025-04-12T10:35:52Z
-  , cardano-haskell-packages  2025-04-11T16:42:25Z
+  , hackage.haskell.org 2025-04-22T10:01:33Z
+  , cardano-haskell-packages 2025-04-22T10:01:33Z
 
 packages:
   hydra-prelude

--- a/cabal.project
+++ b/cabal.project
@@ -50,3 +50,13 @@ allow-newer:
   , ouroboros-network-api:network
   , ouroboros-network-framework:network
   , ouroboros-network-protocols:network
+
+source-repository-package
+  type: git
+  location: https://github.com/cardano-scaling/plutus
+  tag: bdc9b541023906674fe54015638fc9cb2aa4a83b
+  --sha256: sha256-ibg4jC+YpsYz/753+89VkU3dc3adrjTHrqaBtl2301M=
+  subdir:
+    plutus-core
+    plutus-tx
+    plutus-tx-plugin

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1744391509,
-        "narHash": "sha256-eUpBbF1XDzpkFWLjGSHqtBzny0zAWe1euTJFj/ZEMLo=",
+        "lastModified": 1745317107,
+        "narHash": "sha256-mnctX3WY7zqy9QS4bSdpluCpq4MdSEe8XEOD+opYRhk=",
         "owner": "IntersectMBO",
         "repo": "cardano-haskell-packages",
-        "rev": "bddc33bdbbdcb9035a9ccd87e10a8c88d7c4c992",
+        "rev": "39c2a07ca686c111f11c81eca826c3f7b78d9ed7",
         "type": "github"
       },
       "original": {
@@ -898,11 +898,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1744417476,
-        "narHash": "sha256-qpZnGvtHSTNqBIj0VgnAfxt6PueNpaBP/kSjLcyPyTY=",
+        "lastModified": 1745367943,
+        "narHash": "sha256-uNeFIEnFGqmbLZk5UXLdWRKsyBvwLb4At3QrnH2HN4Y=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "b0bca298e2679df328930a34cafe87c02f71efbf",
+        "rev": "f12db0c941e509f8a9334418f0ccb38bfa0efe8c",
         "type": "github"
       },
       "original": {
@@ -914,11 +914,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1744417466,
-        "narHash": "sha256-0u+al6wxDAoMgai7hnbSTWDRbMCNyXMUrcMZGhQWlnU=",
+        "lastModified": 1745367932,
+        "narHash": "sha256-3wuje6j3cwmfvqkau5Qvg/ffV8c1OeOTDrCpOJWvbe0=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "61ed6b7a2250796fa67acab39354eacfec2aa886",
+        "rev": "b808c8edf5031fcc26a22306eafb2e037d2ec094",
         "type": "github"
       },
       "original": {
@@ -1039,11 +1039,11 @@
         "stackage": "stackage_2"
       },
       "locked": {
-        "lastModified": 1744419112,
-        "narHash": "sha256-c3GgMPwUojakoTDwDImwLm5A1KRU9rvJ0pfFBPCG0u0=",
+        "lastModified": 1745371029,
+        "narHash": "sha256-tBO1idwmBNceWutYrGCmD1cqdVWlH+Ys9DLZs1QH9dA=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "abc9bfa73f6346f0457e43b807bba85fe99fd0d1",
+        "rev": "ac4d74385d1e2848ca011a4fc905fec1e4600346",
         "type": "github"
       },
       "original": {
@@ -2606,11 +2606,11 @@
     "stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1744416721,
-        "narHash": "sha256-mTSilWUuHOThJvLiOVKS/CEwwgZ48RN6mUfJQs05iVQ=",
+        "lastModified": 1745367162,
+        "narHash": "sha256-Kt75CsTcck1d38A33LxgY8/n8kiqfs9LINLASXfdHH8=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "e01525c7b01d5ae76333ee4e311230f29731c094",
+        "rev": "b50895aadf07291c8cd806fc246489a492c1f76f",
         "type": "github"
       },
       "original": {

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -73,6 +73,7 @@ import Hydra.Cluster.Scenarios (
   singlePartyUsesScriptOnL2,
   singlePartyUsesSha512ScriptOnL2,
   singlePartyUsesWithdrawZeroTrick,
+  singlePartyUsesWithdrawZeroTrickUsingSha512Script,
   threeNodesNoErrorsOnOpen,
   threeNodesWithMirrorParty,
  )
@@ -228,6 +229,11 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
           withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
             publishHydraScriptsAs node Faucet
               >>= singlePartyUsesSha512ScriptOnL2 tracer tmpDir node
+      it "can use withdraw zero on L2 using sha512 script" $ \tracer -> do
+        withClusterTempDir $ \tmpDir -> do
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
+            publishHydraScriptsAs node Faucet
+              >>= singlePartyUsesWithdrawZeroTrickUsingSha512Script tracer tmpDir node
       it "can submit a signed user transaction" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
           withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -71,6 +71,7 @@ import Hydra.Cluster.Scenarios (
   singlePartyCommitsScriptBlueprint,
   singlePartyHeadFullLifeCycle,
   singlePartyUsesScriptOnL2,
+  singlePartyUsesSha512ScriptOnL2,
   singlePartyUsesWithdrawZeroTrick,
   threeNodesNoErrorsOnOpen,
   threeNodesWithMirrorParty,
@@ -222,6 +223,11 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
           withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
             publishHydraScriptsAs node Faucet
               >>= singlePartyUsesWithdrawZeroTrick tracer tmpDir node
+      it "can spend from a script using sha512 on L2" $ \tracer -> do
+        withClusterTempDir $ \tmpDir -> do
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
+            publishHydraScriptsAs node Faucet
+              >>= singlePartyUsesSha512ScriptOnL2 tracer tmpDir node
       it "can submit a signed user transaction" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
           withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -58,6 +58,7 @@ library
     Hydra.Contract.Initial
     Hydra.Contract.InitialError
     Hydra.Contract.MintAction
+    Hydra.Contract.Sha512Example
     Hydra.Contract.Util
     Hydra.Data.ContestationPeriod
     Hydra.Data.Party

--- a/hydra-plutus/src/Hydra/Contract/Sha512Example.hs
+++ b/hydra-plutus/src/Hydra/Contract/Sha512Example.hs
@@ -14,6 +14,11 @@ import PlutusTx (compile)
 import PlutusTx.Builtins (sha3_512)
 import PlutusTx.Prelude (Eq (..), check)
 
+trivialCheck :: Bool
+trivialCheck =
+  let x = sha3_512 "aaaaaaaa"
+   in x PlutusTx.Prelude.== x
+
 dummyValidatorScript :: PlutusScript
 dummyValidatorScript =
   PlutusScriptSerialised $
@@ -22,9 +27,21 @@ dummyValidatorScript =
             [||
             \ctx ->
               check $ case unsafeFromBuiltinData ctx of
-                ScriptContext{scriptContextScriptInfo = SpendingScript{}} ->
-                  let x = sha3_512 "aaaaaaaa"
-                   in x PlutusTx.Prelude.== x
+                ScriptContext{scriptContextScriptInfo = SpendingScript{}} -> trivialCheck
+                _ -> False
+            ||]
+        )
+
+dummyRewardingScript :: PlutusScript
+dummyRewardingScript =
+  PlutusScriptSerialised $
+    serialiseCompiledCode
+      $$( PlutusTx.compile
+            [||
+            \ctx ->
+              check $ case unsafeFromBuiltinData ctx of
+                ScriptContext{scriptContextScriptInfo = CertifyingScript{}} -> trivialCheck
+                ScriptContext{scriptContextScriptInfo = RewardingScript{}} -> trivialCheck
                 _ -> False
             ||]
         )

--- a/hydra-plutus/src/Hydra/Contract/Sha512Example.hs
+++ b/hydra-plutus/src/Hydra/Contract/Sha512Example.hs
@@ -22,34 +22,9 @@ dummyValidatorScript =
             [||
             \ctx ->
               check $ case unsafeFromBuiltinData ctx of
-                ScriptContext{scriptContextScriptInfo = SpendingScript{}} -> "" PlutusTx.Prelude.== sha3_512 ""
-                _ -> False
-            ||]
-        )
-
-dummyMintingScript :: PlutusScript
-dummyMintingScript =
-  PlutusScriptSerialised $
-    serialiseCompiledCode
-      $$( PlutusTx.compile
-            [||
-            \ctx ->
-              check $ case unsafeFromBuiltinData ctx of
-                ScriptContext{scriptContextScriptInfo = MintingScript{}} -> True
-                _ -> False
-            ||]
-        )
-
-dummyRewardingScript :: PlutusScript
-dummyRewardingScript =
-  PlutusScriptSerialised $
-    serialiseCompiledCode
-      $$( PlutusTx.compile
-            [||
-            \ctx ->
-              check $ case unsafeFromBuiltinData ctx of
-                ScriptContext{scriptContextScriptInfo = CertifyingScript{}} -> True
-                ScriptContext{scriptContextScriptInfo = RewardingScript{}} -> True
+                ScriptContext{scriptContextScriptInfo = SpendingScript{}} ->
+                  let x = sha3_512 "aaaaaaaa"
+                   in x PlutusTx.Prelude.== x
                 _ -> False
             ||]
         )

--- a/hydra-plutus/src/Hydra/Contract/Sha512Example.hs
+++ b/hydra-plutus/src/Hydra/Contract/Sha512Example.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fplugin PlutusTx.Plugin #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:defer-errors #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:target-version=1.1.0 #-}
+
+-- | Simple asserting validators that are primarily useful for testing.
+module Hydra.Contract.Sha512Example where
+
+import Hydra.Prelude
+
+import Hydra.Cardano.Api (PlutusScript, pattern PlutusScriptSerialised)
+import PlutusLedgerApi.V3 (ScriptContext (..), ScriptInfo (..), serialiseCompiledCode, unsafeFromBuiltinData)
+import PlutusTx (compile)
+import PlutusTx.Builtins (sha3_512)
+import PlutusTx.Prelude (Eq (..), check)
+
+dummyValidatorScript :: PlutusScript
+dummyValidatorScript =
+  PlutusScriptSerialised $
+    serialiseCompiledCode
+      $$( PlutusTx.compile
+            [||
+            \ctx ->
+              check $ case unsafeFromBuiltinData ctx of
+                ScriptContext{scriptContextScriptInfo = SpendingScript{}} -> "" PlutusTx.Prelude.== sha3_512 ""
+                _ -> False
+            ||]
+        )
+
+dummyMintingScript :: PlutusScript
+dummyMintingScript =
+  PlutusScriptSerialised $
+    serialiseCompiledCode
+      $$( PlutusTx.compile
+            [||
+            \ctx ->
+              check $ case unsafeFromBuiltinData ctx of
+                ScriptContext{scriptContextScriptInfo = MintingScript{}} -> True
+                _ -> False
+            ||]
+        )
+
+dummyRewardingScript :: PlutusScript
+dummyRewardingScript =
+  PlutusScriptSerialised $
+    serialiseCompiledCode
+      $$( PlutusTx.compile
+            [||
+            \ctx ->
+              check $ case unsafeFromBuiltinData ctx of
+                ScriptContext{scriptContextScriptInfo = CertifyingScript{}} -> True
+                ScriptContext{scriptContextScriptInfo = RewardingScript{}} -> True
+                _ -> False
+            ||]
+        )


### PR DESCRIPTION
The added test `canSpendFromASha512ScriptOnL2` is evaluating the `sha3_512` builtin added to plutus using the `Sha512Example` plutus script.

See the cabal.project file for the version of modified plutus that we use.