### PR TITLE
fix smoke-tests by squashing the UTxO to get a suitable output

### DIFF
--- a/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
@@ -63,24 +63,11 @@ spec =
               difference `shouldSatisfy` (< 400_000)
 
     describe "publishHydraScriptsAs" $ do
-      it "selects a suitable output" $ \(tracer, node@RunningNode{networkId, nodeSocket}) -> do
+      it "squash the UTxO to get a suitable output" $ \(tracer, node@RunningNode{networkId, nodeSocket}) -> do
         -- NOTE: Note use 'Faucet' as this has a very big initial amount
         (vk, _) <- keysFor Alice
         -- NOTE: 83 ADA is just enough to pay for reference scripts deposits.
         forM_ [1_000_000, 2_000_000, 83_000_000] $ \c -> seedFromFaucet node vk c tracer
-        utxoBefore <- queryUTxOFor networkId nodeSocket QueryTip vk
-
-        void $ publishHydraScriptsAs node Alice
-
-        -- Also, does not squash UTxO
-        utxoAfter <- queryUTxOFor networkId nodeSocket QueryTip vk
-        length utxoAfter `shouldBe` length utxoBefore
-
-      it "squash UTxO if no single suitable output is found" $ \(tracer, node@RunningNode{networkId, nodeSocket}) -> do
-        -- NOTE: Note use 'Faucet' as this has a very big initial amount
-        (vk, _) <- keysFor Alice
-        -- NOTE: 83 ADA is just enough to pay for reference scripts deposits.
-        forM_ [20_000_000, 22_000_000, 20_000_000, 23_000_000, 20_000_000] $ \c -> seedFromFaucet node vk c tracer
         utxoBefore <- queryUTxOFor networkId nodeSocket QueryTip vk
 
         void $ publishHydraScriptsAs node Alice

--- a/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
@@ -75,3 +75,21 @@ spec =
         -- Also, does not squash UTxO
         utxoAfter <- queryUTxOFor networkId nodeSocket QueryTip vk
         length utxoAfter `shouldBe` length utxoBefore
+
+      it "squash UTxO if no single suitable output is found" $ \(tracer, node@RunningNode{networkId, nodeSocket}) -> do
+        -- NOTE: Note use 'Faucet' as this has a very big initial amount
+        (vk, _) <- keysFor Alice
+        -- NOTE: 83 ADA is just enough to pay for reference scripts deposits.
+        forM_ [20_000_000, 25_000_000, 20_000_000, 30_000_000, 20_000_000] $ \c -> seedFromFaucet node vk c tracer
+        utxoBefore <- queryUTxOFor networkId nodeSocket QueryTip vk
+
+        void $ publishHydraScriptsAs node Alice
+
+        -- it squashed the UTxO
+        utxoAfter <- queryUTxOFor networkId nodeSocket QueryTip vk
+
+        length utxoAfter `shouldSatisfy` (< length utxoBefore)
+
+        let lovelaceAmtBefore = selectLovelace $ foldMap txOutValue utxoBefore
+        let lovelaceAmtAfter = selectLovelace $ foldMap txOutValue utxoAfter
+        lovelaceAmtAfter `shouldSatisfy` (< lovelaceAmtBefore)

--- a/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
@@ -80,7 +80,7 @@ spec =
         -- NOTE: Note use 'Faucet' as this has a very big initial amount
         (vk, _) <- keysFor Alice
         -- NOTE: 83 ADA is just enough to pay for reference scripts deposits.
-        forM_ [20_000_000, 25_000_000, 20_000_000, 30_000_000, 20_000_000] $ \c -> seedFromFaucet node vk c tracer
+        forM_ [20_000_000, 22_000_000, 20_000_000, 23_000_000, 20_000_000] $ \c -> seedFromFaucet node vk c tracer
         utxoBefore <- queryUTxOFor networkId nodeSocket QueryTip vk
 
         void $ publishHydraScriptsAs node Alice

--- a/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
@@ -68,15 +68,10 @@ spec =
         (vk, _) <- keysFor Alice
         -- NOTE: 83 ADA is just enough to pay for reference scripts deposits.
         forM_ [1_000_000, 2_000_000, 83_000_000] $ \c -> seedFromFaucet node vk c tracer
-        utxoBefore <- queryUTxOFor networkId nodeSocket QueryTip vk
 
         void $ publishHydraScriptsAs node Alice
 
         -- it squashed the UTxO
         utxoAfter <- queryUTxOFor networkId nodeSocket QueryTip vk
 
-        length utxoAfter `shouldSatisfy` (< length utxoBefore)
-
-        let lovelaceAmtBefore = selectLovelace $ foldMap txOutValue utxoBefore
-        let lovelaceAmtAfter = selectLovelace $ foldMap txOutValue utxoAfter
-        lovelaceAmtAfter `shouldSatisfy` (< lovelaceAmtBefore)
+        length utxoAfter `shouldBe` 1

--- a/hydra-node/src/Hydra/Chain/ScriptRegistry.hs
+++ b/hydra-node/src/Hydra/Chain/ScriptRegistry.hs
@@ -4,7 +4,7 @@ module Hydra.Chain.ScriptRegistry where
 
 import Hydra.Prelude
 
-import Cardano.Api (TxOut (..))
+import Cardano.Api (TxOut (..), lovelaceToValue)
 import Cardano.Api.UTxO qualified as UTxO
 import Data.List ((!!))
 import Hydra.Cardano.Api (
@@ -13,7 +13,6 @@ import Hydra.Cardano.Api (
   EraHistory,
   Key (..),
   LedgerEra,
-  Lovelace,
   NetworkId,
   PParams,
   PaymentKey,
@@ -35,14 +34,15 @@ import Hydra.Cardano.Api (
   mkTxOutAutoBalance,
   mkTxOutValue,
   mkVkAddress,
+  renderUTxO,
   selectLovelace,
   toCtxUTxOTxOut,
-  txOutDatum,
   txOutValue,
   txOuts',
   pattern ReferenceScriptNone,
   pattern TxOutDatumNone,
  )
+import Hydra.Cardano.Api.Pretty (renderTx)
 import Hydra.Cardano.Api.Tx (signTx)
 import Hydra.Chain.CardanoClient (
   QueryPoint (..),
@@ -98,70 +98,68 @@ publishHydraScripts networkId socketPath sk = do
   systemStart <- querySystemStart networkId socketPath QueryTip
   eraHistory <- queryEraHistory networkId socketPath QueryTip
   stakePools <- queryStakePools networkId socketPath QueryTip
-  txs <- buildHydraScriptTxs pparams systemStart eraHistory stakePools
+  txs <- buildHydraScriptTxs networkId socketPath sk pparams systemStart eraHistory stakePools
   forM txs $ \tx -> do
     submitTransaction networkId socketPath tx
     void $ awaitTransaction networkId socketPath tx
     pure $ txId tx
- where
-  vk = getVerificationKey sk
-  buildHydraScriptTxs pparams systemStart eraHistory stakePools = do
-    utxo <- queryUTxOFor networkId socketPath QueryTip vk
-    buildScriptPublishingTxs pparams systemStart networkId eraHistory stakePools utxo sk
-      `catch` \(ex :: PublishScriptException) ->
-        case ex of
-          FailedToBuildPublishingTx _ -> throwIO ex
-          FailedToSquashUTxOToCoverDeposit _ -> throwIO ex
-          FailedToFindUTxOToCoverDeposit totalDeposit -> do
-            let totalUTxOValue = selectLovelace $ foldMap (txOutValue . snd) (UTxO.pairs utxo)
-            if totalUTxOValue < totalDeposit
-              then throwIO ex
-              else do
-                -- XXX: squash the utxo and retry
-                rawSquashUTxOTx <- buildSquashUTxOTx pparams systemStart networkId eraHistory stakePools vk utxo totalDeposit
-                let squashUTxOTx = signTx sk rawSquashUTxOTx
-                submitTransaction networkId socketPath squashUTxOTx
-                void $ awaitTransaction networkId socketPath squashUTxOTx
-                buildHydraScriptTxs pparams systemStart eraHistory stakePools
 
-buildSquashUTxOTx ::
-  (MonadIO m, MonadThrow m) =>
+-- | Query for a suitable UTxO at the Tip to build the hydra scripts publishing transactions.
+--
+-- This is implemented by doing a first attempt with the Tip UTxO.
+-- If it fails because the required deposit amount couldn't be covered by any single output,
+-- we squash the UTxO outputs to create one large enough and retry once.
+--
+-- Can throw at least 'PublishScriptException' on failure.
+buildHydraScriptTxs ::
+  NetworkId ->
+  SocketPath ->
+  SigningKey PaymentKey ->
   PParams LedgerEra ->
   SystemStart ->
-  NetworkId ->
   EraHistory ->
   Set PoolId ->
-  VerificationKey PaymentKey ->
-  UTxO ->
-  Lovelace ->
-  m Tx
-buildSquashUTxOTx pparams systemStart networkId eraHistory stakePools vk utxo targetValue = do
-  let allOutputs = UTxO.pairs utxo
-      nonDatumOutputs = filter (not . hasDatum) allOutputs
-      sortedOutputs = sortedByValue nonDatumOutputs
-      selectedOutputs = selectOutputs [] mempty sortedOutputs
-      squashValue = foldMap (txOutValue . snd) selectedOutputs
-      squashOutput =
-        TxOut
-          changeAddress
-          (mkTxOutValue squashValue)
-          TxOutDatumNone
-          ReferenceScriptNone
-  case buildTransactionWithPParams' pparams systemStart eraHistory stakePools changeAddress utxo [] [squashOutput] of
-    Left err -> throwIO $ FailedToSquashUTxOToCoverDeposit err
-    Right tx -> pure tx
+  IO [Tx]
+buildHydraScriptTxs networkId socketPath sk pparams systemStart eraHistory stakePools = do
+  utxo <- queryUTxOFor networkId socketPath QueryTip vk
+  buildScriptPublishingTxs pparams systemStart networkId eraHistory stakePools utxo sk
+    `catch` \(ex :: PublishScriptException) ->
+      case ex of
+        FailedToFindUTxOToCoverDeposit totalDeposit -> do
+          putStrLn ("utxo: " <> renderUTxO utxo)
+          -- XXX: check if there is enough balance to cover the deposit.
+          -- If so, then squash the utxo and retry.
+          let allOutputs = UTxO.pairs utxo
+              -- XXX: leave the smallest output as change
+              squashOutputs = drop 1 $ sortOn (\(_, o) -> selectLovelace (txOutValue o)) allOutputs
+          let totalSquashUTxOValue = selectLovelace $ foldMap (txOutValue . snd) squashOutputs
+          if totalSquashUTxOValue < totalDeposit
+            then throwIO ex
+            else do
+              let
+                squashUTxO = UTxO.fromPairs squashOutputs
+                changeAddress = mkVkAddress networkId vk
+                squashedOutput =
+                  TxOut
+                    changeAddress
+                    (mkTxOutValue $ lovelaceToValue totalDeposit)
+                    TxOutDatumNone
+                    ReferenceScriptNone
+              putStrLn ("squashUTxO: " <> renderUTxO squashUTxO)
+              rawSquashUTxOTx <-
+                case buildTransactionWithPParams' pparams systemStart eraHistory stakePools changeAddress squashUTxO [] [squashedOutput] of
+                  Left err -> throwIO $ FailedToSquashUTxOToCoverDeposit err
+                  Right tx -> pure tx
+              let squashUTxOTx = signTx sk rawSquashUTxOTx
+              putStrLn ("squashUTxOTx: " <> renderTx squashUTxOTx)
+              submitTransaction networkId socketPath squashUTxOTx
+              void $ awaitTransaction networkId socketPath squashUTxOTx
+              utxo' <- queryUTxOFor networkId socketPath QueryTip vk
+              putStrLn ("utxo': " <> renderUTxO utxo')
+              buildScriptPublishingTxs pparams systemStart networkId eraHistory stakePools utxo' sk
+        _ -> throwIO ex
  where
-  changeAddress = mkVkAddress networkId vk
-  hasDatum (_, o) = txOutDatum o /= TxOutDatumNone
-  sortedByValue = sortOn (\(_, o) -> selectLovelace (txOutValue o))
-  selectOutputs acc total = \case
-    [] -> acc
-    _out | total >= targetValue -> acc
-    (txIn, txOut) : rest
-      | otherwise ->
-          let acc' = (txIn, txOut) : acc
-              total' = total + selectLovelace (txOutValue txOut)
-           in selectOutputs acc' total' rest
+  vk = getVerificationKey sk
 
 -- | Exception raised when building the script publishing transactions.
 data PublishScriptException


### PR DESCRIPTION
Mainnet smoke tests [failed](https://github.com/cardano-scaling/hydra/actions/runs/14647088689/job/41103915845) to publish the hydra script txs, despite the faucet UTxO having sufficient total value.

> hydra-cluster: FailedToFindUTxOToCoverDeposit {totalDeposit = Coin 80747850}

We suspect the reason is because the required deposit amount couldn't be covered by any single output.

Here we propose to squash the UTxO outputs to create one large enough.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
