### PR TITLE
Use a directory name that is the hash of the clusterPeers for etcd state

### DIFF
--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -60,6 +60,7 @@ import Hydra.Cluster.Scenarios (
   checkFanout,
   headIsInitializingWith,
   initWithWrongKeys,
+  nodeCanSupportMultipleEtcdClusters,
   nodeReObservesOnChainTxs,
   oneOfThreeNodesStopsForAWhile,
   persistenceCanLoadWithEmptyCommit,
@@ -281,6 +282,13 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
             withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node -> do
               publishHydraScriptsAs node Faucet
                 >>= threeNodesNoErrorsOnOpen tracer tmpDir node
+
+      it "node can support multiple etcd clusters" $ \tracer ->
+        failAfter 60 $
+          withClusterTempDir $ \tmpDir -> do
+            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node -> do
+              publishHydraScriptsAs node Faucet
+                >>= nodeCanSupportMultipleEtcdClusters tracer tmpDir node
 
       it "inits a Head, processes a single Cardano transaction and closes it again" $ \tracer ->
         failAfter 60 $

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -44,6 +44,7 @@ module Hydra.Network.Etcd where
 import Hydra.Prelude
 
 import Cardano.Binary (decodeFull', serialize')
+import Cardano.Crypto.Hash (SHA256, hashToStringAsHex, hashWithSerialiser)
 import Control.Concurrent.Class.MonadSTM (
   modifyTVar',
   newTBQueueIO,
@@ -61,6 +62,7 @@ import Data.Aeson qualified as Aeson
 import Data.Aeson.Types (Value)
 import Data.Bits ((.|.))
 import Data.ByteString qualified as BS
+import Data.ByteString.Char8 qualified as BS8
 import Data.List ((\\))
 import Data.List qualified as List
 import Data.Map qualified as Map
@@ -205,7 +207,7 @@ withEtcdNetwork tracer protocolVersion config callback action = do
       $ concat
         [ -- NOTE: Must be used in clusterPeers
           ["--name", show advertise]
-        , ["--data-dir", persistenceDir </> "etcd"]
+        , ["--data-dir", persistenceDir </> "etcd" </> hashToStringAsHex (hashWithSerialiser @SHA256 toCBOR $ BS8.pack clusterPeers)]
         , ["--listen-peer-urls", httpUrl listen]
         , ["--initial-advertise-peer-urls", httpUrl advertise]
         , ["--listen-client-urls", httpUrl clientHost]

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -113,7 +113,7 @@ spec = do
 
       it "emits connectivity events" $ \tracer -> do
         withTempDir "test-etcd" $ \tmp -> do
-          failAfter 20 $ do
+          failAfter 30 $ do
             PeerConfig3{aliceConfig, bobConfig, carolConfig} <- setup3Peers tmp
             -- Record and assert connectivity events from alice's perspective
             (recordReceived, _, waitConnectivity) <- newRecordingCallback


### PR DESCRIPTION
This should function as an "auto-clear" when connecting to a new cluster configuration.