### PR TITLE
Sized arbitrary

### DIFF
--- a/hydra-chain-observer/test/Hydra/ChainObserverSpec.hs
+++ b/hydra-chain-observer/test/Hydra/ChainObserverSpec.hs
@@ -3,6 +3,7 @@ module Hydra.ChainObserverSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
+import Hydra.Arbitrary (MinimumSized)
 import Hydra.Cardano.Api (Tx, utxoFromTx)
 import Hydra.Chain (OnChainTx)
 import Hydra.Chain.Direct.State (HasKnownUTxO (getKnownUTxO), genChainStateWithTx)

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -20,6 +20,7 @@ import Data.IP (IP (IPv4), toIPv4, toIPv4w)
 import Data.Text (unpack)
 import Data.Text qualified as T
 import Data.Version (Version (..), showVersion)
+import Hydra.Arbitrary (reasonablySized)
 import Hydra.Cardano.Api (
   AsType (AsTxId),
   ChainPoint (..),

--- a/hydra-node/test/Hydra/API/ClientInputSpec.hs
+++ b/hydra-node/test/Hydra/API/ClientInputSpec.hs
@@ -6,6 +6,7 @@ import Test.Hydra.Prelude
 import Data.Aeson (Result (..), fromJSON)
 import Data.Aeson.Lens (key)
 import Hydra.API.ClientInput (ClientInput)
+import Hydra.Arbitrary (MinimumSized)
 import Hydra.Cardano.Api (serialiseToTextEnvelope)
 import Hydra.JSONSchema (prop_specIsComplete, prop_validateJSONSchema)
 import Hydra.Ledger.Cardano (Tx)

--- a/hydra-node/test/Hydra/API/HTTPServerSpec.hs
+++ b/hydra-node/test/Hydra/API/HTTPServerSpec.hs
@@ -19,6 +19,7 @@ import Hydra.API.HTTPServer (
  )
 import Hydra.API.ServerOutput (CommitInfo (CannotCommit, NormalCommit))
 import Hydra.API.ServerSpec (dummyChainHandle)
+import Hydra.Arbitrary (ReasonablySized)
 import Hydra.Cardano.Api (
   mkTxOutDatumInline,
   modifyTxOutDatum,

--- a/hydra-node/test/Hydra/API/ServerOutputSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerOutputSpec.hs
@@ -5,6 +5,7 @@ import Test.Hydra.Prelude
 
 import Data.Aeson.Lens (key)
 import Hydra.API.ServerOutput (ClientMessage, Greetings (..), ServerOutput, TimedServerOutput)
+import Hydra.Arbitrary (MinimumSized, Sized)
 import Hydra.Chain.Direct.State ()
 import Hydra.JSONSchema (prop_specIsComplete, prop_validateJSONSchema)
 import Hydra.Ledger.Cardano (Tx)
@@ -17,7 +18,7 @@ import Test.QuickCheck (conjoin, withMaxSuccess)
 
 spec :: Spec
 spec = parallel $ do
-  roundtripAndGoldenADTSpecsWithSettings defaultSettings{sampleSize = 1} $ Proxy @(MinimumSized (ServerOutput Tx))
+  roundtripAndGoldenADTSpecsWithSettings defaultSettings{sampleSize = 1} $ Proxy @(Sized 2 (ServerOutput Tx))
 
   prop "matches JSON schema" $
     withMaxSuccess 1 $

--- a/hydra-node/test/Hydra/Chain/Direct/WalletSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/WalletSpec.hs
@@ -22,6 +22,7 @@ import Control.Tracer (nullTracer)
 import Data.Map.Strict qualified as Map
 import Data.Sequence.Strict qualified as StrictSeq
 import Data.Set qualified as Set
+import Hydra.Arbitrary (reasonablySized)
 import Hydra.Cardano.Api (
   LedgerEra,
   PaymentCredential (PaymentCredentialByKey),

--- a/hydra-node/test/Hydra/Events/FileBasedSpec.hs
+++ b/hydra-node/test/Hydra/Events/FileBasedSpec.hs
@@ -9,6 +9,7 @@ import Hydra.Chain.Direct.State ()
 
 import Conduit (runConduitRes, sinkList, (.|))
 import Data.List (zipWith3)
+import Hydra.Arbitrary (MinimumSized)
 import Hydra.Events (EventSink (..), EventSource (..), StateEvent (..), getEvents, putEvent)
 import Hydra.Events.FileBased (eventPairFromPersistenceIncremental)
 import Hydra.HeadLogic (StateChanged)

--- a/hydra-prelude/hydra-prelude.cabal
+++ b/hydra-prelude/hydra-prelude.cabal
@@ -17,6 +17,7 @@ library
   hs-source-dirs:     src
   c-sources:          cbits/revision.c
   exposed-modules:
+    Hydra.Arbitrary
     Hydra.Prelude
     Hydra.Version
 

--- a/hydra-prelude/src/Hydra/Arbitrary.hs
+++ b/hydra-prelude/src/Hydra/Arbitrary.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE DataKinds #-}
+
+-- | Generator modifiers and newtypes to configure Arbitrary instances.
+module Hydra.Arbitrary where
+
+import Hydra.Prelude
+
+import GHC.TypeLits (Nat)
+import Test.QuickCheck (resize, scale)
+import Test.QuickCheck.Arbitrary.ADT (ADTArbitrary (..), ADTArbitrarySingleton (..), ConstructorArbitraryPair (..), ToADTArbitrary (..))
+
+-- | Resize a generator to grow with the size parameter, but remains reasonably
+-- sized. That is handy when testing on data-structures that can be arbitrarily
+-- large and, when large entities don't really bring any value to the test
+-- itself.
+--
+-- It uses a square root function which makes the size parameter grows
+-- quadratically slower than normal. That is,
+--
+--     +-------------+------------------+
+--     | Normal Size | Reasonable Size  |
+--     | ----------- + ---------------- +
+--     | 0           | 0                |
+--     | 1           | 1                |
+--     | 10          | 3                |
+--     | 100         | 10               |
+--     | 1000        | 31               |
+--     +-------------+------------------+
+reasonablySized :: Gen a -> Gen a
+reasonablySized = scale (ceiling . sqrt @Double . fromIntegral)
+
+-- | A QuickCheck modifier to make use of `reasonablySized` on existing types.
+newtype ReasonablySized a = ReasonablySized a
+  deriving newtype (Show, ToJSON, FromJSON)
+
+instance Arbitrary a => Arbitrary (ReasonablySized a) where
+  arbitrary = ReasonablySized <$> reasonablySized arbitrary
+
+-- | A QuickCheck modifier that only generates values with given size.
+newtype Sized (size :: Nat) a = Sized a
+  deriving newtype (Show, Eq, ToJSON, FromJSON, Generic)
+
+instance (KnownNat size, Arbitrary a) => Arbitrary (Sized size a) where
+  arbitrary = Sized <$> resize (fromIntegral . natVal $ Proxy @size) arbitrary
+
+instance (KnownNat size, ToADTArbitrary a) => ToADTArbitrary (Sized size a) where
+  toADTArbitrarySingleton _ = do
+    adt <- resize (fromIntegral . natVal $ Proxy @size) $ toADTArbitrarySingleton (Proxy @a)
+    let mappedCAP = adtasCAP adt & \cap -> cap{capArbitrary = Sized $ capArbitrary cap}
+    pure adt{adtasCAP = mappedCAP}
+
+  toADTArbitrary _ = do
+    adt <- resize (fromIntegral . natVal $ Proxy @size) $ toADTArbitrary (Proxy @a)
+    let mappedCAPs = adtCAPs adt <&> \adtPair -> adtPair{capArbitrary = Sized $ capArbitrary adtPair}
+    pure adt{adtCAPs = mappedCAPs}
+
+-- | A QuickCheck modifier that only generates values with size = 1.
+type MinimumSized a = Sized 1 a

--- a/hydra-prelude/src/Hydra/Prelude.hs
+++ b/hydra-prelude/src/Hydra/Prelude.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds #-}
 -- NOTE: Usage of 'trace' in 'spy' is accepted here.
 {-# OPTIONS_GHC -Wno-deprecations #-}
 
@@ -31,10 +30,6 @@ module Hydra.Prelude (
   genericShrink,
   generateWith,
   shrinkListAggressively,
-  reasonablySized,
-  ReasonablySized,
-  Sized,
-  MinimumSized,
   padRight,
   Except,
   encodeBase16,
@@ -105,7 +100,6 @@ import Data.Aeson.Encode.Pretty (
 import Data.ByteString.Base16 qualified as Base16
 import Data.Text qualified as T
 import GHC.Generics (Rep)
-import GHC.TypeLits (Nat)
 import Generic.Random qualified as Random
 import Generic.Random.Internal.Generic qualified as Random
 import Relude hiding (
@@ -159,10 +153,7 @@ import Test.QuickCheck (
   Arbitrary (..),
   Gen,
   genericShrink,
-  resize,
-  scale,
  )
-import Test.QuickCheck.Arbitrary.ADT (ADTArbitrary (..), ADTArbitrarySingleton (..), ConstructorArbitraryPair (..), ToADTArbitrary (..))
 import Test.QuickCheck.Gen (Gen (..))
 import Test.QuickCheck.Random (mkQCGen)
 import Text.Pretty.Simple (pShow)
@@ -193,54 +184,6 @@ shrinkListAggressively :: [a] -> [[a]]
 shrinkListAggressively = \case
   [] -> []
   xs -> [[], take (length xs `div` 2) xs, drop 1 xs]
-
--- | Resize a generator to grow with the size parameter, but remains reasonably
--- sized. That is handy when testing on data-structures that can be arbitrarily
--- large and, when large entities don't really bring any value to the test
--- itself.
---
--- It uses a square root function which makes the size parameter grows
--- quadratically slower than normal. That is,
---
---     +-------------+------------------+
---     | Normal Size | Reasonable Size  |
---     | ----------- + ---------------- +
---     | 0           | 0                |
---     | 1           | 1                |
---     | 10          | 3                |
---     | 100         | 10               |
---     | 1000        | 31               |
---     +-------------+------------------+
-reasonablySized :: Gen a -> Gen a
-reasonablySized = scale (ceiling . sqrt @Double . fromIntegral)
-
--- | A QuickCheck modifier to make use of `reasonablySized` on existing types.
-newtype ReasonablySized a = ReasonablySized a
-  deriving newtype (Show, ToJSON, FromJSON)
-
-instance Arbitrary a => Arbitrary (ReasonablySized a) where
-  arbitrary = ReasonablySized <$> reasonablySized arbitrary
-
--- | A QuickCheck modifier that only generates values with given size.
-newtype Sized (size :: Nat) a = Sized a
-  deriving newtype (Show, Eq, ToJSON, FromJSON, Generic)
-
-instance (KnownNat size, Arbitrary a) => Arbitrary (Sized size a) where
-  arbitrary = Sized <$> resize (fromIntegral . natVal $ Proxy @size) arbitrary
-
-instance (KnownNat size, ToADTArbitrary a) => ToADTArbitrary (Sized size a) where
-  toADTArbitrarySingleton _ = do
-    adt <- resize (fromIntegral . natVal $ Proxy @size) $ toADTArbitrarySingleton (Proxy @a)
-    let mappedCAP = adtasCAP adt & \cap -> cap{capArbitrary = Sized $ capArbitrary cap}
-    pure adt{adtasCAP = mappedCAP}
-
-  toADTArbitrary _ = do
-    adt <- resize (fromIntegral . natVal $ Proxy @size) $ toADTArbitrary (Proxy @a)
-    let mappedCAPs = adtCAPs adt <&> \adtPair -> adtPair{capArbitrary = Sized $ capArbitrary adtPair}
-    pure adt{adtCAPs = mappedCAPs}
-
--- | A QuickCheck modifier that only generates values with size = 1.
-type MinimumSized a = Sized 1 a
 
 -- | Pad a text-string to right with the given character until it reaches the given
 -- length.

--- a/hydra-test-utils/src/Test/Hydra/Prelude.hs
+++ b/hydra-test-utils/src/Test/Hydra/Prelude.hs
@@ -4,7 +4,7 @@ module Test.Hydra.Prelude (
   location,
   failAfter,
   reasonablySized,
-  ReasonablySized (..),
+  ReasonablySized,
   genericCoverTable,
   pickBlind,
   module Test.Hspec,

--- a/hydra-test-utils/src/Test/Hydra/Prelude.hs
+++ b/hydra-test-utils/src/Test/Hydra/Prelude.hs
@@ -3,8 +3,6 @@ module Test.Hydra.Prelude (
   HUnitFailure (..),
   location,
   failAfter,
-  reasonablySized,
-  ReasonablySized,
   genericCoverTable,
   pickBlind,
   module Test.Hspec,

--- a/hydra-tx/test/Hydra/Tx/IsTxSpec.hs
+++ b/hydra-tx/test/Hydra/Tx/IsTxSpec.hs
@@ -14,6 +14,7 @@ import Cardano.Ledger.Api qualified as Ledger
 import Control.Lens ((.~), (^.))
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Base16 qualified as Base16
+import Hydra.Arbitrary (ReasonablySized)
 import Hydra.Cardano.Api (Tx, UTxO, fromLedgerTx, getTxId, toLedgerTx, pattern Tx)
 import Hydra.Tx.IsTx (txId)
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)


### PR DESCRIPTION
Some refactoring I was doing today. Not sure if the `Sized 2` (or different sizes) will become useful. Originally I wanted to use custom generators through such a newtype to solve #1966, but the solution there was more pragmatic.

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
