### PR TITLE
Deposit value fix

### DIFF
--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Value.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Value.hs
@@ -14,6 +14,13 @@ import PlutusLedgerApi.V3 qualified as Plutus
 
 -- * Extras
 
+-- | Check whether left contains right.
+containsValue :: Value -> Value -> Bool
+containsValue a b =
+  all positive . toList $ a <> negateValue b
+ where
+  positive (_, q) = q >= 0
+
 -- | Calculate minimum ada as 'Value' for a 'TxOut'.
 minUTxOValue ::
   PParams LedgerEra ->

--- a/hydra-tx/hydra-tx.cabal
+++ b/hydra-tx/hydra-tx.cabal
@@ -130,7 +130,6 @@ library testlib
     , cardano-ledger-conway:testlib
     , cardano-ledger-core
     , cardano-ledger-mary
-    , cardano-ledger-shelley
     , cardano-strict-containers
     , cborg
     , containers

--- a/hydra-tx/test/Hydra/Tx/Contract/ContractSpec.hs
+++ b/hydra-tx/test/Hydra/Tx/Contract/ContractSpec.hs
@@ -21,6 +21,7 @@ import Hydra.Cardano.Api (
   toPlutusTxOut,
   toShelleyNetwork,
  )
+import Hydra.Cardano.Api.Pretty (renderTxWithUTxO)
 import Hydra.Contract.Commit qualified as Commit
 import Hydra.Contract.Head (verifySnapshotSignature)
 import Hydra.Contract.Util qualified as OnChain
@@ -43,12 +44,13 @@ import Hydra.Tx.Contract.Contest.ContestCurrent (genContestMutation)
 import Hydra.Tx.Contract.Contest.ContestDec (genContestDecMutation)
 import Hydra.Tx.Contract.Contest.Healthy (healthyContestTx)
 import Hydra.Tx.Contract.Decrement (genDecrementMutation, healthyDecrementTx)
-import Hydra.Tx.Contract.Deposit (healthyDepositTx)
+import Hydra.Tx.Contract.Deposit (genDepositMutation, healthyDepositTx)
 import Hydra.Tx.Contract.FanOut (genFanoutMutation, healthyFanoutTx)
 import Hydra.Tx.Contract.Increment (genIncrementMutation, healthyIncrementTx)
 import Hydra.Tx.Contract.Init (genInitMutation, healthyInitTx)
 import Hydra.Tx.Contract.Recover (genRecoverMutation, healthyRecoverTx)
 import Hydra.Tx.Crypto (aggregate, sign, toPlutusSignatures)
+import Hydra.Tx.Observe (observeDepositTx)
 import PlutusLedgerApi.V3 (fromBuiltin, toBuiltin)
 import Test.Hydra.Tx.Fixture (testNetworkId)
 import Test.Hydra.Tx.Gen (
@@ -56,9 +58,10 @@ import Test.Hydra.Tx.Gen (
   genUTxOWithSimplifiedAddresses,
   shrinkUTxO,
  )
-import Test.Hydra.Tx.Mutation (propMutation)
+import Test.Hydra.Tx.Mutation (SomeMutation (..), applyMutation, propMutation)
 import Test.QuickCheck (
   Property,
+  checkCoverage,
   conjoin,
   counterexample,
   forAll,
@@ -122,8 +125,19 @@ spec = parallel $ do
     prop "does not survive random adversarial mutations" $
       propMutation healthyDecrementTx genDecrementMutation
   describe "Deposit" $ do
-    prop "is healthy" $
+    prop "healthy evaluates" $
       propTransactionEvaluates healthyDepositTx
+    prop "healthy observed" $
+      isJust $
+        observeDepositTx testNetworkId (fst healthyDepositTx)
+    prop "mutated not observed" $
+      forAll (genDepositMutation healthyDepositTx) $ \SomeMutation{label, mutation} -> do
+        let (tx, utxo) = healthyDepositTx & applyMutation mutation
+        counterexample ("Mutated transaction: " <> renderTxWithUTxO utxo tx) $
+          property (isNothing $ observeDepositTx testNetworkId tx)
+            & counterexample "Mutated transaction still observed"
+            & genericCoverTable [label]
+            & checkCoverage
   describe "Recover" $ do
     prop "is healthy" $
       propTransactionEvaluates healthyRecoverTx

--- a/hydra-tx/test/Hydra/Tx/Contract/Deposit.hs
+++ b/hydra-tx/test/Hydra/Tx/Contract/Deposit.hs
@@ -15,7 +15,7 @@ import Hydra.Tx.Deposit (depositTx)
 import Test.Hydra.Tx.Fixture (depositDeadline, testNetworkId, testPolicyId)
 import Test.Hydra.Tx.Gen (genUTxO)
 import Test.Hydra.Tx.Mutation (Mutation (ChangeOutput), SomeMutation (..))
-import Test.QuickCheck (chooseInteger, elements, oneof)
+import Test.QuickCheck (chooseInteger, elements, oneof, resize)
 
 healthyDepositTx :: (Tx, UTxO)
 healthyDepositTx =
@@ -29,7 +29,7 @@ healthyDepositTx =
       depositDeadline
 
 healthyDepositUTxO :: UTxO
-healthyDepositUTxO = genUTxO `generateWith` 42
+healthyDepositUTxO = resize 3 genUTxO `generateWith` 42
 
 data DepositMutation
   = -- | Change the output value to a subset of the deposited value. This

--- a/hydra-tx/test/Hydra/Tx/Contract/Deposit.hs
+++ b/hydra-tx/test/Hydra/Tx/Contract/Deposit.hs
@@ -14,7 +14,7 @@ import Hydra.Tx.Deposit (depositTx)
 import Test.Hydra.Tx.Fixture (depositDeadline, testNetworkId, testPolicyId)
 import Test.Hydra.Tx.Gen (genUTxOSized)
 import Test.Hydra.Tx.Mutation (Mutation (ChangeOutput), SomeMutation (..))
-import Test.QuickCheck (chooseInteger, elements, oneof)
+import Test.QuickCheck (chooseInteger, elements)
 
 genHealthyDepositTx :: Gen (Tx, UTxO)
 genHealthyDepositTx = do
@@ -39,13 +39,11 @@ data DepositMutation
 
 genDepositMutation :: (Tx, UTxO) -> Gen SomeMutation
 genDepositMutation (tx, _utxo) =
-  oneof
-    [ SomeMutation [] MutateDepositOutputValue <$> do
-        change <- do
-          (asset, Quantity q) <- elements (GHC.toList $ txOutValue depositTxOut)
-          diff <- fromInteger <$> chooseInteger (1, q)
-          pure $ GHC.fromList [(asset, diff)]
-        pure $ ChangeOutput 0 (depositTxOut & modifyTxOutValue (<> negateValue change))
-    ]
+  SomeMutation [] MutateDepositOutputValue <$> do
+    change <- do
+      (asset, Quantity q) <- elements (GHC.toList $ txOutValue depositTxOut)
+      diff <- fromInteger <$> chooseInteger (1, q)
+      pure $ GHC.fromList [(asset, diff)]
+    pure $ ChangeOutput 0 (depositTxOut & modifyTxOutValue (<> negateValue change))
  where
   depositTxOut = List.head $ txOuts' tx

--- a/hydra-tx/test/Hydra/Tx/Contract/Increment.hs
+++ b/hydra-tx/test/Hydra/Tx/Contract/Increment.hs
@@ -32,7 +32,7 @@ import Hydra.Tx.Utils (adaOnly)
 import PlutusLedgerApi.V2 qualified as Plutus
 import PlutusTx.Builtins (toBuiltin)
 import Test.Hydra.Tx.Fixture (aliceSk, bobSk, carolSk, depositDeadline, slotLength, systemStart, testNetworkId, testPolicyId)
-import Test.Hydra.Tx.Gen (genForParty, genScriptRegistry, genUTxO, genUTxOSized, genValue, genVerificationKey)
+import Test.Hydra.Tx.Gen (genForParty, genScriptRegistry, genUTxOSized, genValue, genVerificationKey)
 import Test.Hydra.Tx.Mutation (
   Mutation (..),
   SomeMutation (..),
@@ -88,7 +88,7 @@ healthyDepositInput :: TxIn
 healthyDepositInput = arbitrary `generateWith` 123
 
 healthyDeposited :: UTxO
-healthyDeposited = genUTxO `generateWith` 42
+healthyDeposited = genUTxOSized 3 `generateWith` 42
 
 somePartyCardanoVerificationKey :: VerificationKey PaymentKey
 somePartyCardanoVerificationKey =

--- a/hydra-tx/test/Hydra/Tx/Contract/Increment.hs
+++ b/hydra-tx/test/Hydra/Tx/Contract/Increment.hs
@@ -4,14 +4,6 @@ module Hydra.Tx.Contract.Increment where
 
 import Hydra.Cardano.Api
 import Hydra.Prelude hiding (label)
-import Test.Hydra.Tx.Mutation (
-  Mutation (..),
-  SomeMutation (..),
-  addParticipationTokens,
-  modifyInlineDatum,
-  replaceParties,
-  replaceSnapshotVersion,
- )
 
 import Cardano.Api.UTxO qualified as UTxO
 import Data.Maybe (fromJust)
@@ -41,6 +33,14 @@ import PlutusLedgerApi.V2 qualified as Plutus
 import PlutusTx.Builtins (toBuiltin)
 import Test.Hydra.Tx.Fixture (aliceSk, bobSk, carolSk, depositDeadline, slotLength, systemStart, testNetworkId, testPolicyId)
 import Test.Hydra.Tx.Gen (genForParty, genScriptRegistry, genUTxO, genUTxOSized, genValue, genVerificationKey)
+import Test.Hydra.Tx.Mutation (
+  Mutation (..),
+  SomeMutation (..),
+  addParticipationTokens,
+  modifyInlineDatum,
+  replaceParties,
+  replaceSnapshotVersion,
+ )
 import Test.QuickCheck (arbitrarySizedNatural, elements, oneof, suchThat)
 import Test.QuickCheck.Instances ()
 

--- a/hydra-tx/testlib/Test/Hydra/Tx/Mutation.hs
+++ b/hydra-tx/testlib/Test/Hydra/Tx/Mutation.hs
@@ -182,7 +182,7 @@ import Test.QuickCheck.Instances ()
 -- structurally valid and having passed "level 1" checks.
 propMutation :: (Tx, UTxO) -> ((Tx, UTxO) -> Gen SomeMutation) -> Property
 propMutation (tx, utxo) genMutation =
-  forAll @_ @Property (genMutation (tx, utxo)) $ \SomeMutation{label, mutation, expectedErrors} ->
+  forAll (genMutation (tx, utxo)) $ \SomeMutation{label, mutation, expectedErrors} ->
     (tx, utxo)
       & applyMutation mutation
       & propTransactionFailsPhase2 expectedErrors


### PR DESCRIPTION
This makes sure that the deposited value as claimed in the datum is actually available at the deposit script output to be incremented.

Related to this paragraph in the specification:

![image](https://github.com/user-attachments/assets/a24f685e-68e2-4a23-8e0c-5e19095a4817)

---

* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [x] Haddocks updated
* [x] No new TODOs introduced
