### PR TITLE
Model spec fixes

### DIFF
--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -351,6 +351,7 @@ test-suite tests
     , regex-tdfa
     , req
     , silently
+    , temporary
     , text
     , time
     , tls

--- a/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxTraceSpec.hs
@@ -47,6 +47,7 @@ import Hydra.Chain.Direct.State (ChainContext (..), CloseTxError, ContestTxError
 import Hydra.Contract.HeadState qualified as Head
 import Hydra.Ledger.Cardano (Tx, adjustUTxO)
 import Hydra.Ledger.Cardano.Evaluate (evaluateTx)
+import Hydra.ModelSpec (propIsDistributive)
 import Hydra.Tx (CommitBlueprintTx (..))
 import Hydra.Tx.ContestationPeriod qualified as CP
 import Hydra.Tx.Crypto (MultiSignature, aggregate, sign)
@@ -70,7 +71,7 @@ import Test.Hydra.Tx.Gen (
   genVerificationKey,
  )
 import Test.Hydra.Tx.Mutation (addParticipationTokens)
-import Test.QuickCheck (Confidence (..), Property, Smart (..), Testable, checkCoverage, checkCoverageWith, cover, elements, frequency, ioProperty, (===))
+import Test.QuickCheck (Confidence (..), Property, Smart (..), Testable, checkCoverage, checkCoverageWith, cover, elements, frequency, ioProperty)
 import Test.QuickCheck.Monadic (monadic)
 import Test.QuickCheck.StateModel (
   ActionWithPolarity (..),
@@ -92,8 +93,8 @@ import Text.Show (Show (..))
 
 spec :: Spec
 spec = do
-  prop "realWorldModelUTxO preserves addition" $ \u1 u2 ->
-    realWorldModelUTxO (u1 <> u2) === (realWorldModelUTxO u1 <> realWorldModelUTxO u2)
+  prop "realWorldModelUTxO is distributive" $
+    propIsDistributive realWorldModelUTxO
   prop "generates interesting transaction traces" $ \actions ->
     checkCoverage $ coversInterestingActions actions True
   prop "all valid transactions" $

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -394,11 +394,11 @@ instance StateModel WorldState where
       StopTheWorld -> s
 
   shrinkAction _ctx _st = \case
-    seed@Seed{seedKeys, toCommit} ->
-      [ Some seed{seedKeys = seedKeys', toCommit = toCommit'}
-      | seedKeys' <- shrink seedKeys
-      , let toCommit' = Map.filterWithKey (\p _ -> p `elem` (deriveParty . fst <$> seedKeys')) toCommit
-      ]
+    seed@Seed{seedKeys, toCommit} -> do
+      seedKeys' <- shrink seedKeys
+      guard $ length seedKeys' < length seedKeys
+      let toCommit' = Map.filterWithKey (\p _ -> p `elem` (deriveParty . fst <$> seedKeys')) toCommit
+      pure $ Some $ seed{seedKeys = seedKeys', toCommit = toCommit'}
     _other -> []
 
 instance HasVariables WorldState where


### PR DESCRIPTION
Various fixes and improvements to the `ModelSpec` test suite. Notably this contains additional preconditions which should get rid of those `Exception thrown while showing test case: Map.!: given key is not an element in the map` CI errors, e.g. https://github.com/cardano-scaling/hydra/actions/runs/14677697442/job/41196353239

---

* [x] CHANGELOG update not needed
* [x] Documentation update not needed
* [x] Haddocks update not needed
* [x] No new TODOs introduced