### PR TITLE
Add no-srp linter

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1632,11 +1632,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740398896,
-        "narHash": "sha256-aQ/VUSCziEqAxglr9OU2Qzwz2ZawnsCvtTkux8MIHc4=",
+        "lastModified": 1745917180,
+        "narHash": "sha256-PPo7GwCwhENsX5NuxiEdxmy++OoxUpxV+fOpTGaWYoM=",
         "owner": "homotopic",
         "repo": "lint-utils",
-        "rev": "eebbc96c3b1705b324a13f3565e3ed9be5a6a126",
+        "rev": "62c2fa87ba9620e2d5470d957827175c6e1c128f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -187,6 +187,10 @@
               ];
               treefmt = pkgs.treefmt;
             };
+            no-srp = lu.no-srp {
+              src = self;
+              cabal-project-file = ./cabal.project;
+            };
             weeder = hydra-weeder;
           } // lib.attrsets.mergeAttrsList (map (x: componentsToWerrors x hsPkgs.${x}) hydraPackageNames);
 


### PR DESCRIPTION
This will fail if any "source-repository-package" field is found in cabal.project, and prevent it from merging to master.