### PR TITLE
fix 404 docs search

### DIFF
--- a/docs/src/theme/Navbar/Search/index.js
+++ b/docs/src/theme/Navbar/Search/index.js
@@ -19,8 +19,15 @@ export default function NavbarSearch({ children, className }) {
           const url = item.url || ''
           const isItemUnstable = url.includes('/head-protocol/unstable/')
           return isUnstable ? isItemUnstable : !isItemUnstable
-        })
+        }).map((item) => ({
+          ...item,
+          url: removeTrailingSlash(item.url),
+        }))
       }}
     />
   )
+}
+
+const removeTrailingSlash = url => {
+  return url.endsWith('/') ? url.slice(0, -1) : url
 }


### PR DESCRIPTION
<!-- Describe your change here -->

Closes #1975 

Remove URL trailing slashes on indexed search items returned by Algolia.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
