### PR TITLE
Separate orphan instances into cardano-api-orphans

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,6 +16,7 @@ index-state:
   , cardano-haskell-packages 2025-04-29T20:52:57Z
 
 packages:
+  cardano-api-orphans
   hydra-prelude
   hydra-cardano-api
   hydra-test-utils

--- a/cardano-api-orphans/LICENSE
+++ b/cardano-api-orphans/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2021-2022] [IOG]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cardano-api-orphans/NOTICE
+++ b/cardano-api-orphans/NOTICE
@@ -1,0 +1,14 @@
+Copyright 2021-2022 Input Output Global Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/cardano-api-orphans/README.md
+++ b/cardano-api-orphans/README.md
@@ -1,0 +1,3 @@
+# cardano-api-orphans
+
+Orphans JSON and CBOR instances for cardano-api types.

--- a/cardano-api-orphans/cardano-api-orphans.cabal
+++ b/cardano-api-orphans/cardano-api-orphans.cabal
@@ -1,0 +1,57 @@
+cabal-version: 3.0
+name:          cardano-api-orphans
+version:       0.1.0
+synopsis:      A Haskell API for Cardano, tailored to the Hydra project.
+author:        IOG
+copyright:     2025 IOG
+license:       Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+source-repository head
+  type:     git
+  location: https://github.com/cardano-scaling/hydra
+
+common project-config
+  default-language:   GHC2021
+  default-extensions:
+    DataKinds
+    DefaultSignatures
+    DeriveAnyClass
+    DerivingStrategies
+    FunctionalDependencies
+    GADTs
+    LambdaCase
+    MultiWayIf
+    OverloadedStrings
+    PartialTypeSignatures
+    PatternSynonyms
+    TypeFamilies
+    ViewPatterns
+
+  ghc-options:
+    -Wall -Wcompat -Widentities -Wincomplete-record-updates
+    -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+    -Wmissing-deriving-strategies -fprint-potential-instances
+    -Wno-orphans
+
+library
+  import:          project-config
+  hs-source-dirs:  src
+  ghc-options:     -haddock
+  exposed-modules:
+    Cardano.Api.Orphans
+    Cardano.Api.Orphans.NetworkId
+    Cardano.Api.Orphans.NetworkMagic
+    Cardano.Api.Orphans.TxId
+
+  build-depends:
+    , aeson
+    , base
+    , cardano-api
+    , cardano-api:gen
+    , cardano-binary
+    , hedgehog-quickcheck
+    , QuickCheck
+    , text

--- a/cardano-api-orphans/src/Cardano/Api/Orphans.hs
+++ b/cardano-api-orphans/src/Cardano/Api/Orphans.hs
@@ -1,0 +1,5 @@
+module Cardano.Api.Orphans where
+
+import Cardano.Api.Orphans.NetworkId ()
+import Cardano.Api.Orphans.NetworkMagic ()
+import Cardano.Api.Orphans.TxId ()

--- a/cardano-api-orphans/src/Cardano/Api/Orphans/NetworkId.hs
+++ b/cardano-api-orphans/src/Cardano/Api/Orphans/NetworkId.hs
@@ -1,12 +1,12 @@
-{-# OPTIONS_GHC -Wno-orphans #-}
+module Cardano.Api.Orphans.NetworkId where
 
-module Hydra.Cardano.Api.NetworkId where
-
-import Hydra.Cardano.Api.Prelude
-
-import Data.Aeson (Value (String), object, withObject, (.:), (.=))
-import Hydra.Cardano.Api.NetworkMagic ()
-import Test.QuickCheck (oneof)
+import Cardano.Api (NetworkId (..))
+import Cardano.Api.Orphans.NetworkMagic ()
+import Data.Aeson (FromJSON (..), ToJSON (..), Value (..), object, withObject, (.:), (.=))
+import Data.Text
+import Test.Gen.Cardano.Api.Typed (genNetworkId)
+import Test.QuickCheck.Arbitrary (Arbitrary (..))
+import Test.QuickCheck.Hedgehog (hedgehog)
 
 -- * Orphans
 
@@ -28,7 +28,7 @@ instance FromJSON NetworkId where
       _ -> fail "Expected tag to be Mainnet | Testnet"
 
 instance Arbitrary NetworkId where
-  arbitrary = oneof [pure Mainnet, Testnet <$> arbitrary]
+  arbitrary = hedgehog genNetworkId
   shrink = \case
     Mainnet -> []
     Testnet magic -> Testnet <$> shrink magic

--- a/cardano-api-orphans/src/Cardano/Api/Orphans/NetworkMagic.hs
+++ b/cardano-api-orphans/src/Cardano/Api/Orphans/NetworkMagic.hs
@@ -1,12 +1,12 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Hydra.Cardano.Api.NetworkMagic where
+module Cardano.Api.Orphans.NetworkMagic where
 
 import Cardano.Api (NetworkMagic (..))
 import Data.Aeson (FromJSON (..), ToJSON (..))
-import Test.QuickCheck (Arbitrary (..))
-
--- * Orphans
+import Test.Gen.Cardano.Api.Typed (genNetworkMagic)
+import Test.QuickCheck.Arbitrary (Arbitrary (..))
+import Test.QuickCheck.Hedgehog (hedgehog)
 
 instance ToJSON NetworkMagic where
   toJSON (NetworkMagic magic) = toJSON magic
@@ -15,5 +15,5 @@ instance FromJSON NetworkMagic where
   parseJSON = fmap NetworkMagic . parseJSON
 
 instance Arbitrary NetworkMagic where
-  arbitrary = NetworkMagic <$> arbitrary
+  arbitrary = hedgehog genNetworkMagic
   shrink (NetworkMagic x) = NetworkMagic <$> shrink x

--- a/cardano-api-orphans/src/Cardano/Api/Orphans/TxId.hs
+++ b/cardano-api-orphans/src/Cardano/Api/Orphans/TxId.hs
@@ -1,0 +1,14 @@
+module Cardano.Api.Orphans.TxId where
+
+import Cardano.Api (AsType (AsTxId), TxId, deserialiseFromRawBytes, serialiseToRawBytes)
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+
+instance ToCBOR TxId where
+  toCBOR = toCBOR . serialiseToRawBytes
+
+instance FromCBOR TxId where
+  fromCBOR = do
+    bs <- fromCBOR
+    case deserialiseFromRawBytes AsTxId bs of
+      Left err -> fail (show err)
+      Right v -> pure v

--- a/hydra-cardano-api/hydra-cardano-api.cabal
+++ b/hydra-cardano-api/hydra-cardano-api.cabal
@@ -49,8 +49,6 @@ library
     Hydra.Cardano.Api.ExecutionUnits
     Hydra.Cardano.Api.Hash
     Hydra.Cardano.Api.Network
-    Hydra.Cardano.Api.NetworkId
-    Hydra.Cardano.Api.NetworkMagic
     Hydra.Cardano.Api.PolicyId
     Hydra.Cardano.Api.Prelude
     Hydra.Cardano.Api.Pretty
@@ -78,6 +76,7 @@ library
     , base                    >=4.16
     , bytestring
     , cardano-api             ^>=10.15
+    , cardano-api-orphans
     , cardano-api:gen
     , cardano-binary
     , cardano-crypto-class

--- a/hydra-cardano-api/src/Hydra/Cardano/Api.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api.hs
@@ -86,6 +86,7 @@ import Cardano.Api.Experimental as X (UnsignedTx (..))
 import Cardano.Api.Ledger as X (
   PParams,
  )
+import Cardano.Api.Orphans ()
 import Cardano.Api.Shelley as X (
   AcquiringFailure (..),
   Hash (HeaderHash),
@@ -126,8 +127,6 @@ import Hydra.Cardano.Api.BlockHeader as Extras
 import Hydra.Cardano.Api.ChainPoint as Extras
 import Hydra.Cardano.Api.ExecutionUnits as Extras
 import Hydra.Cardano.Api.Hash as Extras
-import Hydra.Cardano.Api.NetworkId ()
-import Hydra.Cardano.Api.NetworkMagic ()
 import Hydra.Cardano.Api.PolicyId as Extras
 import Hydra.Cardano.Api.ReferenceScript as Extras
 import Hydra.Cardano.Api.ScriptData as Extras

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/TxId.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/TxId.hs
@@ -4,22 +4,9 @@ module Hydra.Cardano.Api.TxId where
 
 import Hydra.Cardano.Api.Prelude
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Crypto.Hash.Class qualified as CC
 import Cardano.Ledger.Hashes qualified as Ledger
 import Cardano.Ledger.TxIn qualified as Ledger
-
--- missing CBOR instances
-
-instance ToCBOR TxId where
-  toCBOR = toCBOR . serialiseToRawBytes
-
-instance FromCBOR TxId where
-  fromCBOR = do
-    bs <- fromCBOR
-    case deserialiseFromRawBytes AsTxId bs of
-      Left err -> fail (show err)
-      Right v -> pure v
 
 -- * Type Conversions
 


### PR DESCRIPTION
Orphans should be separated by library to control inclusion.

The Arbitrary instances should be removed and both hydra and hydra-explorer should use the hedgehog-quickcheck compatibility function `hedgehog gen<X>` where `gen<X>` is taken from `Test.Gen.Cardano.Api.Typed`.