### PR TITLE
Tutorial: Cover etcd install and fix cardano-cli commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 As a minor extension, we also keep a semantic version for the `UNRELEASED`
 changes.
 
-## Unreleased
+## [0.22.0] - UNRELEASED
+
+- Tested with `cardano-node 10.1.2` and `cardano-cli 10.1.1.0`.
+
+- Fix tutorial usage of `cardano-cli` and include download of `etcd`.
 
 * **BREAKING** Update scripts to plutus 1.45.0.0.
 


### PR DESCRIPTION
The cardano-cli we include in the tutorial has a changed command line now. Also, show where to get etcd for this plain binary based install.

Both things have been discovered while onboarding new operators through the midnight glacier drop.

---

* [x] CHANGELOG updated
* [x] Documentation updated
* [x] Haddocks update not needed
* [x] No new TODOs introduced