### PR TITLE
Embed etcd into hydra-node

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -6,6 +6,7 @@ on:
     branches:
     - master
     - release
+    - embed-etcd
     tags:
     - "*.*.*"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ changes.
 - Fix tutorial usage of `cardano-cli` and include download of `etcd`.
 
 - Remove runtime dependency to `etcd` by embedding and shipping it with `hydra-node`.
+  - New option `--use-system-etcd` to prefer the system etcd instead of the embedded one.
 
 - **BREAKING** Update scripts to plutus 1.45.0.0.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ changes.
 
 - Fix tutorial usage of `cardano-cli` and include download of `etcd`.
 
-* **BREAKING** Update scripts to plutus 1.45.0.0.
+- Remove runtime dependency to `etcd` by embedding and shipping it with `hydra-node`.
+
+- **BREAKING** Update scripts to plutus 1.45.0.0.
 
 ## [0.21.0] - 2025-04-28
 

--- a/docs/adr/2025-02-12_032-network-properties-etcd.md
+++ b/docs/adr/2025-02-12_032-network-properties-etcd.md
@@ -57,6 +57,7 @@ Accepted
 
 - Using `etcd` as-is adds a run-time dependency onto that binary.
   - Docker image users should not see any different UX
+  - We can ship the binary through `hydra-node`.
 
 - Introspectability network as the `etcd` cluster is queriable could improve debugging experience
 

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -23,7 +23,7 @@ import Hydra.API.HTTPServer (DraftCommitTxRequest (..), DraftCommitTxResponse (.
 import Hydra.Cluster.Util (readConfigFile)
 import Hydra.HeadLogic.State (SeenSnapshot)
 import Hydra.Logging (Tracer, Verbosity (..), traceWith)
-import Hydra.Network (Host (Host), NodeId (NodeId))
+import Hydra.Network (Host (Host), NodeId (NodeId), WhichEtcd (EmbeddedEtcd))
 import Hydra.Network qualified as Network
 import Hydra.Options (ChainConfig (..), DirectChainConfig (..), LedgerConfig (..), RunOptions (..), defaultDirectChainConfig, toArgs)
 import Hydra.Tx (ConfirmedSnapshot)
@@ -399,6 +399,7 @@ prepareHydraNode chainConfig workDir hydraNodeId hydraSKey hydraVKeys allNodeIds
       , hydraVerificationKeys
       , persistenceDir = stateDir
       , chainConfig
+      , whichEtcd = EmbeddedEtcd
       , ledgerConfig =
           CardanoLedgerConfig
             { cardanoLedgerProtocolParametersFile
@@ -518,6 +519,7 @@ withHydraNode tracer chainConfig workDir hydraNodeId hydraSKey hydraVKeys allNod
                 , hydraVerificationKeys
                 , persistenceDir = stateDir
                 , chainConfig
+                , whichEtcd = EmbeddedEtcd
                 , ledgerConfig =
                     CardanoLedgerConfig
                       { cardanoLedgerProtocolParametersFile

--- a/hydra-node/golden/RunOptions.json
+++ b/hydra-node/golden/RunOptions.json
@@ -1,271 +1,341 @@
 {
     "samples": [
         {
-            "advertise": {
-                "hostname": "0.0.104.150",
-                "port": 25104
-            },
-            "apiHost": {
-                "ipv4": "0.0.56.31",
-                "tag": "IPv4"
-            },
-            "apiPort": 7070,
-            "chainConfig": {
-                "cardanoSigningKey": "a/a/a/b/b.sk",
-                "cardanoVerificationKeys": [
-                    "a.vk",
-                    "a.vk",
-                    "c.vk",
-                    "b.vk"
-                ],
-                "contestationPeriod": 604800,
-                "depositDeadline": 298,
-                "hydraScriptsTxId": [
-                    "ec756b2ab289ff697789a6aee1380033b6a963a210ca04191c1d7aa72c2ce881",
-                    "4255516d2847775a82faa4750cf520eb0e6d74d6ceaca166756aa33b5d5ddee7",
-                    "df0769105fd3d807a291b9d50feb4bbcd140296e2e82698b8167d33740a0fe66",
-                    "b5a174bb8766bccd366f7dfe03937fea12d0dc47861509678f134c6983ddc263",
-                    "09dbf30c67912d155e8353dfd40e9622278dcf1e6b6fd055370a9792f547b378",
-                    "eda0d6c2892e4a8eda922e7e1e97f783bc068ae31e98d7ca2c83bac074443966",
-                    "a514236f52bcc6c46e41063cc1d7ccbf765284b802ad0697e0190f947a93c796",
-                    "a7c0f04c5291a19d8aeceeb3646a513c9d0658d60d5ed74de75ff3bccb9d3e46",
-                    "6b46a42d2ba685ff0666a3aec9d8f93a81dfdc6cea6ef77b0010f8527d563bbd",
-                    "4ae13f30c9fc60e6073e1310b1de22af14f17da3661d5a0771cb4f6cafcc01a2",
-                    "67a0a3133157082fac734eae1d470f5ca4c36545af6d2d4a754798265c7215cf",
-                    "36d529ad2119f9efd7b5cd6ccecc64e7c935f04076420c3e306508f5161df62b",
-                    "364a62d5594f19e8dfeff8dd7dc961725d217adfbd8e736f1317663473159832",
-                    "8712d110beeb70d02dc58f0b77b25432a371449657fcf00d22f68b4c322a5df7",
-                    "f4ff018fb6f380824f662173b55cf331ee85f71c13ce601c183ef2efba1825f5",
-                    "c9c8f4eb6c2e57cec2aa519ca6515edaad5056a445ba9c3d452360429ba75e47",
-                    "3988aaa7698e877bfff9e06ee197dd398ef73fe5053beef34ad884ccabe055d3"
-                ],
-                "networkId": {
-                    "magic": 11218,
-                    "tag": "Testnet"
-                },
-                "nodeSocket": "b.socket",
-                "startChainFrom": null,
-                "tag": "DirectChainConfig"
-            },
-            "hydraSigningKey": "a/a.sk",
-            "hydraVerificationKeys": [
-                "a/b/a.vk"
-            ],
-            "ledgerConfig": {
-                "cardanoLedgerProtocolParametersFile": "a/a/a/a/b.json"
-            },
-            "listen": {
-                "hostname": "0.0.97.216",
-                "port": 28643
-            },
-            "monitoringPort": 14992,
-            "nodeId": "tcznkrxa",
-            "peers": [],
-            "persistenceDir": "a/c/a/a/a",
-            "tlsCertPath": "b.pem",
-            "tlsKeyPath": null,
-            "useSystemEtcd": false,
-            "verbosity": {
-                "tag": "Quiet"
-            }
-        },
-        {
-            "advertise": {
-                "hostname": "0.0.14.204",
-                "port": 28041
-            },
-            "apiHost": {
-                "ipv4": "0.0.63.142",
-                "tag": "IPv4"
-            },
-            "apiPort": 27782,
-            "chainConfig": {
-                "cardanoSigningKey": "a.sk",
-                "cardanoVerificationKeys": [
-                    "a/a.vk",
-                    "c/a/b.vk",
-                    "b.vk",
-                    "b.vk"
-                ],
-                "contestationPeriod": 31536000,
-                "depositDeadline": 267,
-                "hydraScriptsTxId": [
-                    "067c83c0543316a0abcb6203934b654e7335b1609625c61911fee90ec35a9d42",
-                    "3f7b6c883a869707dc953851ab4a1dd1d91ea5527e8063ae2e380b6a96f4dd33",
-                    "ebe449ce17106fa4f490ad6ee3847f156ab232d8e61df0f2b1615cf0c22259da",
-                    "60323f89ae812de0d5c0d5a85bef78f3a4c3e4b5c3d9b9c98567541cd209a328",
-                    "2084043255100bf7022c0f5dcbda57dcea713ca91b63b2e8d431425c0add6160",
-                    "5e897840b769e926d140229b07700cd62ab456cb44d6e4313fcfe816e18fc8f4",
-                    "41cbeb972875450ef0b8d5630e7ea9b16618e3a03a839eb5abb6f21844210781",
-                    "80d4b3de5dcd944ba8b329f14c6e5a5553de6a3e173eb262ba07f352ae838a89",
-                    "be43ee983f69224616930bab8ac7c31a639fb3ccfa70c34488e3d304e610ef37",
-                    "d3cb9ec1c44871b13eb0306bee5dcdbe66448ead246b61035a67d848660d1a08",
-                    "46b4a75545d6e991029e91b04cc21a388e1e349313e464f5868480271868f21d",
-                    "2452e3ebc22df02478f7e2b4c774826e5e1f07ac03ba2875eec30751942e2c39",
-                    "fdf37b20292f91aa2cdbb6a138af58c43b16a13d67cd15afb392a61dcb7592e2",
-                    "c2936272356f67931a1fa27c1c40d85a3d6462a40f5c1c96472a864a87bc4556",
-                    "d049b777a4080bb0e2800416bf38d958178c00fb190077df93d8de5e2d021335",
-                    "3e0d272b01ec922010b35a96fb0f75e9b9db32737cea513a5d0378b40e15b1bb",
-                    "51008bae5dfe547bfb7f18bf4ce6130ee8e78c0a5065cd1521178721e24b1561"
-                ],
-                "networkId": {
-                    "magic": 24259,
-                    "tag": "Testnet"
-                },
-                "nodeSocket": "b/b/c.socket",
-                "startChainFrom": null,
-                "tag": "DirectChainConfig"
-            },
-            "hydraSigningKey": "b/b/a/b/a/c.sk",
-            "hydraVerificationKeys": [
-                "b/c.vk",
-                "b.vk",
-                "c.vk",
-                "a/b/b.vk"
-            ],
-            "ledgerConfig": {
-                "cardanoLedgerProtocolParametersFile": "c/c/b/a/c/c.json"
-            },
-            "listen": {
-                "hostname": "0.0.101.119",
-                "port": 5414
-            },
-            "monitoringPort": null,
-            "nodeId": "kbgvamrgebpczozbfcrivn",
-            "peers": [
-                {
-                    "hostname": "0.0.0.8",
-                    "port": 3
-                },
-                {
-                    "hostname": "0.0.0.2",
-                    "port": 7
-                }
-            ],
-            "persistenceDir": "c/b/c/b/b",
-            "tlsCertPath": null,
-            "tlsKeyPath": "a/a/a/a.key",
-            "useSystemEtcd": true,
-            "verbosity": {
-                "contents": "HydraNode",
-                "tag": "Verbose"
-            }
-        },
-        {
             "advertise": null,
             "apiHost": {
-                "ipv4": "0.0.43.218",
+                "ipv4": "0.0.76.68",
                 "tag": "IPv4"
             },
-            "apiPort": 395,
+            "apiPort": 28651,
             "chainConfig": {
-                "cardanoSigningKey": "b/a/c/b.sk",
+                "cardanoSigningKey": "c.sk",
                 "cardanoVerificationKeys": [
-                    "a/a/a.vk"
+                    "b/a/a.vk",
+                    "a/a/a.vk",
+                    "b/b/c.vk",
+                    "b/b.vk",
+                    "a/c/a.vk"
                 ],
-                "contestationPeriod": 68767,
-                "depositDeadline": 207,
+                "contestationPeriod": 11010,
+                "depositDeadline": 130,
                 "hydraScriptsTxId": [
-                    "01b5d6a2a38a907c4b7445cae7f5fd98d212825071409de367ba7e4e4890a5a7",
-                    "0bb0a7ba9b1a59fc4ef7eb15a43d46ee1b930b68c1df7a19bb0743acfdf5bf7b",
-                    "2c1e609129627c68b1c43cd5652cd15cd39e45dc0c46b1b85e0d0610285b218b",
-                    "5c3fab44cb7e20f7c0a2e3acb1e8aa6210e1322f3e419fa71d3dfa423b523e03",
-                    "b22da4802047247fc9d7145eda1238c2ddf789baf938a33360096eb3101eecc7",
-                    "a5a00d9270ce417bff755801b6d6500214dfc4880162006784da6208c0daff49",
-                    "60eb8e8ffcad0ac033de105ba37036fd9d23b07c4e16177909ea5d59ffa59649",
-                    "685ca0c431fff6421fc2daeaac0b9b8e3b182e39e64a72d6fb730482b99ad1a2",
-                    "466a63d03ec6f5ae4507437a9a4695b8233af0df5060afde1a09e47494527d41",
-                    "b43c6d3fea2b7fa087dc4a2252b31387b6b6037a5a375135f3d0dd7e400fdd66",
-                    "8829004b3fc484ee93af5b28f9a7b866ad5cc5b5f0fe28b8949728dfd3e8324f",
-                    "66a11e0ac4513728b65fa41f326eb776e683425cb2ce0e0a0019700548183d71",
-                    "c3a618d8be7aac76242a7bfb117b69718a6b6ec5e06d6ded84bfcfff4c742127",
-                    "9fb7afc8a5d6cd27187ee938947eea5eccb1658adbb624680da912d090f19232",
-                    "9a1bdb8d0589b75e82b47c8924eedbaf8c0dd040ddf5cb6820389ef679564a44",
-                    "c2371a1b9ad666664146ab837014323777024556f7219b2d8faa5093e8dae6c7",
-                    "b7abbef3c4d5b24878d239df09e97ca02a78b90e1186b52f7224a85d5cab293b",
-                    "97bfbf4df64d63e69c4065c2e4ecc8194e2a08c08876f350e757587fe7db3b95",
-                    "45bcc2be6872d2aa480bc61b2f43363560bfb989f75786b1465f1172d08869db",
-                    "e2b311e67f4dd35b0aca6021859f9ab24859d229a110702c6731d85765992712"
+                    "88e381408dcd681c0f0bbd894c5202feede5c8790dbdff3a5de50b2fdeca0396",
+                    "52aea27bb01d5f1c3fdccde7d40f8d743cc397c0d1d810bfb1d96fd3ac934f09",
+                    "7ac013be0386ba006230e2f5ca7cba3cd6ffa141482090295316040a44f3baad",
+                    "9511f25390a2a1fb31ea3b0dc50a2cba229454bf91ac39a7d0f6c418531bd6cf"
                 ],
                 "networkId": {
-                    "magic": 31076,
+                    "magic": 17173,
                     "tag": "Testnet"
                 },
-                "nodeSocket": "a/b/c/a/a/a.socket",
+                "nodeSocket": "c/b/c/b.socket",
                 "startChainFrom": {
-                    "blockHash": "b66ce482ba9c6f0545222bdffe4378934e359788e8202320c64e8644b6d301e6",
-                    "slot": 8975678,
+                    "blockHash": "e91d38ce75292b953dff607a22049f145e2a863af3b699fef80282e3302fe26d",
+                    "slot": 7277012,
                     "tag": "ChainPoint"
                 },
                 "tag": "DirectChainConfig"
             },
-            "hydraSigningKey": "a/b/c.sk",
+            "hydraSigningKey": "b/c/b/b/a/b.sk",
             "hydraVerificationKeys": [
-                "a.vk",
-                "b/b/b.vk",
-                "a/a.vk"
+                "c/a.vk",
+                "c.vk",
+                "c/a/b.vk",
+                "a/c/c.vk"
             ],
             "ledgerConfig": {
-                "cardanoLedgerProtocolParametersFile": "a.json"
+                "cardanoLedgerProtocolParametersFile": "b/c/a/a/b.json"
             },
             "listen": {
-                "hostname": "0.0.50.96",
-                "port": 23647
+                "hostname": "0.0.27.20",
+                "port": 7314
             },
-            "monitoringPort": 12112,
-            "nodeId": "vjmjxhhvaqks",
-            "peers": [],
-            "persistenceDir": "c/b/c/a/b/a",
-            "tlsCertPath": null,
-            "tlsKeyPath": null,
-            "useSystemEtcd": true,
+            "monitoringPort": 20361,
+            "nodeId": "gxncorgj",
+            "peers": [
+                {
+                    "hostname": "0.0.0.7",
+                    "port": 5
+                },
+                {
+                    "hostname": "0.0.0.0",
+                    "port": 1
+                }
+            ],
+            "persistenceDir": "b/a/a/c/a",
+            "tlsCertPath": "b/a/a/b.pem",
+            "tlsKeyPath": "a/b/b/b.key",
             "verbosity": {
-                "contents": "HydraNode",
-                "tag": "Verbose"
-            }
+                "tag": "Quiet"
+            },
+            "whichEtcd": "EmbeddedEtcd"
         },
         {
             "advertise": {
-                "hostname": "0.0.18.232",
-                "port": 27204
+                "hostname": "0.0.51.24",
+                "port": 24914
             },
             "apiHost": {
-                "ipv4": "0.0.22.104",
+                "ipv4": "0.0.45.96",
                 "tag": "IPv4"
             },
-            "apiPort": 27608,
+            "apiPort": 21824,
             "chainConfig": {
-                "initialUTxOFile": "c/b/a/a.json",
-                "ledgerGenesisFile": "a/c/c.json",
-                "offlineHeadSeed": "999c822bbefa1a92fb246a6362bdb3ba",
-                "tag": "OfflineChainConfig"
+                "cardanoSigningKey": "c/c/a.sk",
+                "cardanoVerificationKeys": [
+                    "a/c/c.vk"
+                ],
+                "contestationPeriod": 43200,
+                "depositDeadline": 276,
+                "hydraScriptsTxId": [
+                    "78f200fbf81bfd7f6f811d34087e6cd06a72bf807244916d98692af49a975333",
+                    "99eb953e33a038bd0439480eb9127808b4c75c38a4d2da1ea037bb519edf42ed",
+                    "83e830b4dd023557bcca04ca01e0e38bffea112a768122eec3539adfd61d3647",
+                    "f72387516313f58c624c1f2ebeafba9179b689a0f92b2b57e68d1c8e69adeb61",
+                    "a6af8d534b0c444f7e66399f6bbdf43c913a4e7804439da219570654d7be09d3",
+                    "c9f4fc68734893b785feec5285339e2e4646dabc5d12b98ba97f9163a28715b7"
+                ],
+                "networkId": {
+                    "magic": 20635,
+                    "tag": "Testnet"
+                },
+                "nodeSocket": "a.socket",
+                "startChainFrom": null,
+                "tag": "DirectChainConfig"
             },
-            "hydraSigningKey": "c/c/c.sk",
-            "hydraVerificationKeys": [
-                "c/c.vk",
-                "b.vk",
-                "a.vk",
-                "b/b/c.vk",
-                "a/b/b.vk",
-                "b/c/c.vk"
-            ],
+            "hydraSigningKey": "a/c/b.sk",
+            "hydraVerificationKeys": [],
             "ledgerConfig": {
-                "cardanoLedgerProtocolParametersFile": "a/b.json"
+                "cardanoLedgerProtocolParametersFile": "b/c.json"
             },
             "listen": {
-                "hostname": "0.0.83.136",
-                "port": 7280
+                "hostname": "0.0.76.120",
+                "port": 29656
             },
-            "monitoringPort": 22254,
-            "nodeId": "pqwkwpnkchpxfrv",
+            "monitoringPort": null,
+            "nodeId": "hdsjxdpkyggdqnbxzqngnwqcoecp",
             "peers": [
                 {
-                    "hostname": "0.0.0.5",
+                    "hostname": "0.0.0.1",
+                    "port": 6
+                },
+                {
+                    "hostname": "0.0.0.6",
+                    "port": 0
+                }
+            ],
+            "persistenceDir": "c/c/c/b/c/b",
+            "tlsCertPath": null,
+            "tlsKeyPath": null,
+            "verbosity": {
+                "tag": "Quiet"
+            },
+            "whichEtcd": "EmbeddedEtcd"
+        },
+        {
+            "advertise": {
+                "hostname": "0.0.109.12",
+                "port": 19561
+            },
+            "apiHost": {
+                "ipv4": "0.0.74.209",
+                "tag": "IPv4"
+            },
+            "apiPort": 9075,
+            "chainConfig": {
+                "cardanoSigningKey": "c/a/a.sk",
+                "cardanoVerificationKeys": [
+                    "c/b/c.vk",
+                    "a/c/b.vk",
+                    "a/c/a.vk",
+                    "b/c/a.vk"
+                ],
+                "contestationPeriod": 86400,
+                "depositDeadline": 127,
+                "hydraScriptsTxId": [
+                    "d24e0f81e846d16c252517b3ded6dfaa6113dcb21e2126061ccc06777e2ac0a9",
+                    "b7867e38c9bacf628b1381aa846cbbf8eee9d12d63ae8c8eaa21787181518d0d",
+                    "f1a3037acfcdf078a9dc396067e94a76f2ba9f83a18f5ae80884bdc66fc26d66",
+                    "a6933ec59bd6fadbba45ee28724284d118eec905a33c925a5a292b7d7a5c0bed",
+                    "15e1f608e89afd1f2964f9cf1e297151328f523bcc36efbcf4f9d7cfd85fdfc3",
+                    "727ad1baf77c1c62b6c24beeadb8092911ec067c1f53b9ba001b64e7ff05c90a",
+                    "edfccbe82c9ab63213d77d24e068880034fd0d5a8cc95e0bdafec4c4e7e0a3b1",
+                    "9beda0aed3eb215bac64481fb46651c05192c919e3824915e012c5426be6052e",
+                    "261a72d1046c0d90a27845f074f4e91c40a689af6ed140f1fa209b19919a47c9",
+                    "53f2c7a61b5c88851d4c36e769454bb427266dd44c66974ec180f2a784cfe31f"
+                ],
+                "networkId": {
+                    "magic": 5794,
+                    "tag": "Testnet"
+                },
+                "nodeSocket": "c.socket",
+                "startChainFrom": null,
+                "tag": "DirectChainConfig"
+            },
+            "hydraSigningKey": "c/c/c/c.sk",
+            "hydraVerificationKeys": [
+                "b/a.vk",
+                "a.vk",
+                "c/b.vk",
+                "a/b/a.vk"
+            ],
+            "ledgerConfig": {
+                "cardanoLedgerProtocolParametersFile": "b/b/c/c/c.json"
+            },
+            "listen": {
+                "hostname": "0.0.34.158",
+                "port": 22668
+            },
+            "monitoringPort": 29858,
+            "nodeId": "gbehmhrh",
+            "peers": [
+                {
+                    "hostname": "0.0.0.6",
+                    "port": 2
+                },
+                {
+                    "hostname": "0.0.0.4",
+                    "port": 4
+                },
+                {
+                    "hostname": "0.0.0.0",
+                    "port": 2
+                },
+                {
+                    "hostname": "0.0.0.0",
                     "port": 3
+                }
+            ],
+            "persistenceDir": "b",
+            "tlsCertPath": null,
+            "tlsKeyPath": null,
+            "verbosity": {
+                "contents": "HydraNode",
+                "tag": "Verbose"
+            },
+            "whichEtcd": "SystemEtcd"
+        },
+        {
+            "advertise": {
+                "hostname": "0.0.85.38",
+                "port": 21288
+            },
+            "apiHost": {
+                "ipv4": "0.0.54.165",
+                "tag": "IPv4"
+            },
+            "apiPort": 6700,
+            "chainConfig": {
+                "cardanoSigningKey": "c/c/a/b/a/b.sk",
+                "cardanoVerificationKeys": [
+                    "c/b.vk",
+                    "c.vk",
+                    "c/a.vk"
+                ],
+                "contestationPeriod": 2592000,
+                "depositDeadline": 80,
+                "hydraScriptsTxId": [
+                    "83683fb93e6b35eea8ab0979be707b0a7870dd6a3a929abb9a24438b884a8703",
+                    "fdbc1cdcdd654a2e0985407b71e5ae5cb4754358628ce5e46b1f29c22e96041b",
+                    "d2f518bf1a2ad88b10609952e70a864ea52b0d87c016a3a74a8805e4ddf1c0e1",
+                    "4e52a122265ccfd49c01ee46419b2166897fefcd072e714aeb5f474c92bd2d2d",
+                    "1122a671449c6503361f6d9121d064514621ae789c831b0edc73eac97a7127ad",
+                    "80561210ca02e94224c845c9bb5c40613de695db9a03090ace1c6f1666bd63dd",
+                    "edf610eb3d58df02c0061afb84f7caf217eaeb38420586da7d39b396a27e5fb5",
+                    "a1f0ae57e88098fb1679c2fdad95950ee86292847a35b6102a36d1f623aaa489",
+                    "9410f9c50a546e7c4f47482a7e79a8a81781d67d815db97d746f7265c22bdd5d",
+                    "52c58d65dd811c16b1405ff46ac9dbda460bc314fcd8e9a0588f1129d3d3a3f9",
+                    "965e84d7dadc652379b5ebc56b4a5796626fa32a05fd526ea3996c4a346fa6d5"
+                ],
+                "networkId": {
+                    "magic": 25749,
+                    "tag": "Testnet"
+                },
+                "nodeSocket": "c/c/c/b/b/c.socket",
+                "startChainFrom": {
+                    "blockHash": "339fd8d359095560ebaaffa0d782854b6fd38f641ec178562871a75b1778f94a",
+                    "slot": 4949497,
+                    "tag": "ChainPoint"
+                },
+                "tag": "DirectChainConfig"
+            },
+            "hydraSigningKey": "b/c/b/b/b.sk",
+            "hydraVerificationKeys": [
+                "c.vk"
+            ],
+            "ledgerConfig": {
+                "cardanoLedgerProtocolParametersFile": "c.json"
+            },
+            "listen": {
+                "hostname": "0.0.5.65",
+                "port": 16855
+            },
+            "monitoringPort": null,
+            "nodeId": "nctwwoixqe",
+            "peers": [
+                {
+                    "hostname": "0.0.0.7",
+                    "port": 8
                 },
                 {
                     "hostname": "0.0.0.3",
                     "port": 6
+                }
+            ],
+            "persistenceDir": "b/a/b/b/b/c",
+            "tlsCertPath": "b.pem",
+            "tlsKeyPath": null,
+            "verbosity": {
+                "tag": "Quiet"
+            },
+            "whichEtcd": "SystemEtcd"
+        },
+        {
+            "advertise": {
+                "hostname": "0.0.46.109",
+                "port": 20431
+            },
+            "apiHost": {
+                "ipv4": "0.0.33.44",
+                "tag": "IPv4"
+            },
+            "apiPort": 23691,
+            "chainConfig": {
+                "initialUTxOFile": "c/b/a/b.json",
+                "ledgerGenesisFile": null,
+                "offlineHeadSeed": "5eeaf4c64cbdbb85ec74965e4ae576bb",
+                "tag": "OfflineChainConfig"
+            },
+            "hydraSigningKey": "b/b/c.sk",
+            "hydraVerificationKeys": [
+                "b/c.vk",
+                "c.vk",
+                "c.vk",
+                "a/c/b.vk",
+                "b/c.vk",
+                "b.vk"
+            ],
+            "ledgerConfig": {
+                "cardanoLedgerProtocolParametersFile": "b/b.json"
+            },
+            "listen": {
+                "hostname": "0.0.99.238",
+                "port": 9530
+            },
+            "monitoringPort": 19938,
+            "nodeId": "szetrvfdphtjfezlgzbyepiwygypse",
+            "peers": [
+                {
+                    "hostname": "0.0.0.7",
+                    "port": 7
+                },
+                {
+                    "hostname": "0.0.0.6",
+                    "port": 3
+                },
+                {
+                    "hostname": "0.0.0.1",
+                    "port": 5
                 },
                 {
                     "hostname": "0.0.0.1",
@@ -273,78 +343,17 @@
                 },
                 {
                     "hostname": "0.0.0.3",
-                    "port": 2
-                },
-                {
-                    "hostname": "0.0.0.2",
-                    "port": 2
-                },
-                {
-                    "hostname": "0.0.0.0",
-                    "port": 6
+                    "port": 7
                 }
             ],
-            "persistenceDir": "b/a/c/c",
-            "tlsCertPath": "c/a/c/a/b.pem",
-            "tlsKeyPath": null,
-            "useSystemEtcd": false,
+            "persistenceDir": "b/b/a/c/a/b",
+            "tlsCertPath": "c/c/b/b/a.pem",
+            "tlsKeyPath": "b/c/a/b/b/c.key",
             "verbosity": {
-                "contents": "HydraNode",
-                "tag": "Verbose"
-            }
-        },
-        {
-            "advertise": {
-                "hostname": "0.0.41.150",
-                "port": 27693
+                "tag": "Quiet"
             },
-            "apiHost": {
-                "ipv4": "0.0.76.203",
-                "tag": "IPv4"
-            },
-            "apiPort": 25019,
-            "chainConfig": {
-                "initialUTxOFile": "b.json",
-                "ledgerGenesisFile": "a.json",
-                "offlineHeadSeed": "9ac8aca56b5c8438af4da4048a81f988",
-                "tag": "OfflineChainConfig"
-            },
-            "hydraSigningKey": "b/c/a.sk",
-            "hydraVerificationKeys": [
-                "c.vk"
-            ],
-            "ledgerConfig": {
-                "cardanoLedgerProtocolParametersFile": "b/a/a/b/b.json"
-            },
-            "listen": {
-                "hostname": "0.0.28.218",
-                "port": 29061
-            },
-            "monitoringPort": 4562,
-            "nodeId": "metpfcfmfbjbsod",
-            "peers": [
-                {
-                    "hostname": "0.0.0.6",
-                    "port": 2
-                },
-                {
-                    "hostname": "0.0.0.6",
-                    "port": 1
-                },
-                {
-                    "hostname": "0.0.0.6",
-                    "port": 2
-                }
-            ],
-            "persistenceDir": "c/a/a/b",
-            "tlsCertPath": null,
-            "tlsKeyPath": null,
-            "useSystemEtcd": true,
-            "verbosity": {
-                "contents": "HydraNode",
-                "tag": "Verbose"
-            }
+            "whichEtcd": "SystemEtcd"
         }
     ],
-    "seed": 872371396
+    "seed": 629907744
 }

--- a/hydra-node/golden/RunOptions.json
+++ b/hydra-node/golden/RunOptions.json
@@ -2,287 +2,349 @@
     "samples": [
         {
             "advertise": {
-                "hostname": "0.0.0.143",
-                "port": 16367
+                "hostname": "0.0.104.150",
+                "port": 25104
             },
             "apiHost": {
-                "ipv4": "0.0.125.56",
+                "ipv4": "0.0.56.31",
                 "tag": "IPv4"
             },
-            "apiPort": 14924,
+            "apiPort": 7070,
             "chainConfig": {
-                "initialUTxOFile": "c/c/c/a/a/c.json",
-                "ledgerGenesisFile": "a/c/c/c.json",
-                "offlineHeadSeed": "3c628286fcf0615fa5ffda3a7bae19ce",
-                "tag": "OfflineChainConfig"
+                "cardanoSigningKey": "a/a/a/b/b.sk",
+                "cardanoVerificationKeys": [
+                    "a.vk",
+                    "a.vk",
+                    "c.vk",
+                    "b.vk"
+                ],
+                "contestationPeriod": 604800,
+                "depositDeadline": 298,
+                "hydraScriptsTxId": [
+                    "ec756b2ab289ff697789a6aee1380033b6a963a210ca04191c1d7aa72c2ce881",
+                    "4255516d2847775a82faa4750cf520eb0e6d74d6ceaca166756aa33b5d5ddee7",
+                    "df0769105fd3d807a291b9d50feb4bbcd140296e2e82698b8167d33740a0fe66",
+                    "b5a174bb8766bccd366f7dfe03937fea12d0dc47861509678f134c6983ddc263",
+                    "09dbf30c67912d155e8353dfd40e9622278dcf1e6b6fd055370a9792f547b378",
+                    "eda0d6c2892e4a8eda922e7e1e97f783bc068ae31e98d7ca2c83bac074443966",
+                    "a514236f52bcc6c46e41063cc1d7ccbf765284b802ad0697e0190f947a93c796",
+                    "a7c0f04c5291a19d8aeceeb3646a513c9d0658d60d5ed74de75ff3bccb9d3e46",
+                    "6b46a42d2ba685ff0666a3aec9d8f93a81dfdc6cea6ef77b0010f8527d563bbd",
+                    "4ae13f30c9fc60e6073e1310b1de22af14f17da3661d5a0771cb4f6cafcc01a2",
+                    "67a0a3133157082fac734eae1d470f5ca4c36545af6d2d4a754798265c7215cf",
+                    "36d529ad2119f9efd7b5cd6ccecc64e7c935f04076420c3e306508f5161df62b",
+                    "364a62d5594f19e8dfeff8dd7dc961725d217adfbd8e736f1317663473159832",
+                    "8712d110beeb70d02dc58f0b77b25432a371449657fcf00d22f68b4c322a5df7",
+                    "f4ff018fb6f380824f662173b55cf331ee85f71c13ce601c183ef2efba1825f5",
+                    "c9c8f4eb6c2e57cec2aa519ca6515edaad5056a445ba9c3d452360429ba75e47",
+                    "3988aaa7698e877bfff9e06ee197dd398ef73fe5053beef34ad884ccabe055d3"
+                ],
+                "networkId": {
+                    "magic": 11218,
+                    "tag": "Testnet"
+                },
+                "nodeSocket": "b.socket",
+                "startChainFrom": null,
+                "tag": "DirectChainConfig"
             },
-            "hydraSigningKey": "c/c.sk",
+            "hydraSigningKey": "a/a.sk",
             "hydraVerificationKeys": [
-                "b/b.vk",
-                "b.vk",
-                "c/b.vk",
-                "b/a.vk"
+                "a/b/a.vk"
             ],
             "ledgerConfig": {
-                "cardanoLedgerProtocolParametersFile": "a/a.json"
+                "cardanoLedgerProtocolParametersFile": "a/a/a/a/b.json"
             },
             "listen": {
-                "hostname": "0.0.12.2",
-                "port": 6738
+                "hostname": "0.0.97.216",
+                "port": 28643
             },
-            "monitoringPort": 28641,
-            "nodeId": "kjnedflwzpysgbpmeglqhiipbhg",
+            "monitoringPort": 14992,
+            "nodeId": "tcznkrxa",
+            "peers": [],
+            "persistenceDir": "a/c/a/a/a",
+            "tlsCertPath": "b.pem",
+            "tlsKeyPath": null,
+            "useSystemEtcd": false,
+            "verbosity": {
+                "tag": "Quiet"
+            }
+        },
+        {
+            "advertise": {
+                "hostname": "0.0.14.204",
+                "port": 28041
+            },
+            "apiHost": {
+                "ipv4": "0.0.63.142",
+                "tag": "IPv4"
+            },
+            "apiPort": 27782,
+            "chainConfig": {
+                "cardanoSigningKey": "a.sk",
+                "cardanoVerificationKeys": [
+                    "a/a.vk",
+                    "c/a/b.vk",
+                    "b.vk",
+                    "b.vk"
+                ],
+                "contestationPeriod": 31536000,
+                "depositDeadline": 267,
+                "hydraScriptsTxId": [
+                    "067c83c0543316a0abcb6203934b654e7335b1609625c61911fee90ec35a9d42",
+                    "3f7b6c883a869707dc953851ab4a1dd1d91ea5527e8063ae2e380b6a96f4dd33",
+                    "ebe449ce17106fa4f490ad6ee3847f156ab232d8e61df0f2b1615cf0c22259da",
+                    "60323f89ae812de0d5c0d5a85bef78f3a4c3e4b5c3d9b9c98567541cd209a328",
+                    "2084043255100bf7022c0f5dcbda57dcea713ca91b63b2e8d431425c0add6160",
+                    "5e897840b769e926d140229b07700cd62ab456cb44d6e4313fcfe816e18fc8f4",
+                    "41cbeb972875450ef0b8d5630e7ea9b16618e3a03a839eb5abb6f21844210781",
+                    "80d4b3de5dcd944ba8b329f14c6e5a5553de6a3e173eb262ba07f352ae838a89",
+                    "be43ee983f69224616930bab8ac7c31a639fb3ccfa70c34488e3d304e610ef37",
+                    "d3cb9ec1c44871b13eb0306bee5dcdbe66448ead246b61035a67d848660d1a08",
+                    "46b4a75545d6e991029e91b04cc21a388e1e349313e464f5868480271868f21d",
+                    "2452e3ebc22df02478f7e2b4c774826e5e1f07ac03ba2875eec30751942e2c39",
+                    "fdf37b20292f91aa2cdbb6a138af58c43b16a13d67cd15afb392a61dcb7592e2",
+                    "c2936272356f67931a1fa27c1c40d85a3d6462a40f5c1c96472a864a87bc4556",
+                    "d049b777a4080bb0e2800416bf38d958178c00fb190077df93d8de5e2d021335",
+                    "3e0d272b01ec922010b35a96fb0f75e9b9db32737cea513a5d0378b40e15b1bb",
+                    "51008bae5dfe547bfb7f18bf4ce6130ee8e78c0a5065cd1521178721e24b1561"
+                ],
+                "networkId": {
+                    "magic": 24259,
+                    "tag": "Testnet"
+                },
+                "nodeSocket": "b/b/c.socket",
+                "startChainFrom": null,
+                "tag": "DirectChainConfig"
+            },
+            "hydraSigningKey": "b/b/a/b/a/c.sk",
+            "hydraVerificationKeys": [
+                "b/c.vk",
+                "b.vk",
+                "c.vk",
+                "a/b/b.vk"
+            ],
+            "ledgerConfig": {
+                "cardanoLedgerProtocolParametersFile": "c/c/b/a/c/c.json"
+            },
+            "listen": {
+                "hostname": "0.0.101.119",
+                "port": 5414
+            },
+            "monitoringPort": null,
+            "nodeId": "kbgvamrgebpczozbfcrivn",
             "peers": [
                 {
-                    "hostname": "0.0.0.5",
-                    "port": 2
-                },
-                {
-                    "hostname": "0.0.0.4",
-                    "port": 1
+                    "hostname": "0.0.0.8",
+                    "port": 3
                 },
                 {
                     "hostname": "0.0.0.2",
+                    "port": 7
+                }
+            ],
+            "persistenceDir": "c/b/c/b/b",
+            "tlsCertPath": null,
+            "tlsKeyPath": "a/a/a/a.key",
+            "useSystemEtcd": true,
+            "verbosity": {
+                "contents": "HydraNode",
+                "tag": "Verbose"
+            }
+        },
+        {
+            "advertise": null,
+            "apiHost": {
+                "ipv4": "0.0.43.218",
+                "tag": "IPv4"
+            },
+            "apiPort": 395,
+            "chainConfig": {
+                "cardanoSigningKey": "b/a/c/b.sk",
+                "cardanoVerificationKeys": [
+                    "a/a/a.vk"
+                ],
+                "contestationPeriod": 68767,
+                "depositDeadline": 207,
+                "hydraScriptsTxId": [
+                    "01b5d6a2a38a907c4b7445cae7f5fd98d212825071409de367ba7e4e4890a5a7",
+                    "0bb0a7ba9b1a59fc4ef7eb15a43d46ee1b930b68c1df7a19bb0743acfdf5bf7b",
+                    "2c1e609129627c68b1c43cd5652cd15cd39e45dc0c46b1b85e0d0610285b218b",
+                    "5c3fab44cb7e20f7c0a2e3acb1e8aa6210e1322f3e419fa71d3dfa423b523e03",
+                    "b22da4802047247fc9d7145eda1238c2ddf789baf938a33360096eb3101eecc7",
+                    "a5a00d9270ce417bff755801b6d6500214dfc4880162006784da6208c0daff49",
+                    "60eb8e8ffcad0ac033de105ba37036fd9d23b07c4e16177909ea5d59ffa59649",
+                    "685ca0c431fff6421fc2daeaac0b9b8e3b182e39e64a72d6fb730482b99ad1a2",
+                    "466a63d03ec6f5ae4507437a9a4695b8233af0df5060afde1a09e47494527d41",
+                    "b43c6d3fea2b7fa087dc4a2252b31387b6b6037a5a375135f3d0dd7e400fdd66",
+                    "8829004b3fc484ee93af5b28f9a7b866ad5cc5b5f0fe28b8949728dfd3e8324f",
+                    "66a11e0ac4513728b65fa41f326eb776e683425cb2ce0e0a0019700548183d71",
+                    "c3a618d8be7aac76242a7bfb117b69718a6b6ec5e06d6ded84bfcfff4c742127",
+                    "9fb7afc8a5d6cd27187ee938947eea5eccb1658adbb624680da912d090f19232",
+                    "9a1bdb8d0589b75e82b47c8924eedbaf8c0dd040ddf5cb6820389ef679564a44",
+                    "c2371a1b9ad666664146ab837014323777024556f7219b2d8faa5093e8dae6c7",
+                    "b7abbef3c4d5b24878d239df09e97ca02a78b90e1186b52f7224a85d5cab293b",
+                    "97bfbf4df64d63e69c4065c2e4ecc8194e2a08c08876f350e757587fe7db3b95",
+                    "45bcc2be6872d2aa480bc61b2f43363560bfb989f75786b1465f1172d08869db",
+                    "e2b311e67f4dd35b0aca6021859f9ab24859d229a110702c6731d85765992712"
+                ],
+                "networkId": {
+                    "magic": 31076,
+                    "tag": "Testnet"
+                },
+                "nodeSocket": "a/b/c/a/a/a.socket",
+                "startChainFrom": {
+                    "blockHash": "b66ce482ba9c6f0545222bdffe4378934e359788e8202320c64e8644b6d301e6",
+                    "slot": 8975678,
+                    "tag": "ChainPoint"
+                },
+                "tag": "DirectChainConfig"
+            },
+            "hydraSigningKey": "a/b/c.sk",
+            "hydraVerificationKeys": [
+                "a.vk",
+                "b/b/b.vk",
+                "a/a.vk"
+            ],
+            "ledgerConfig": {
+                "cardanoLedgerProtocolParametersFile": "a.json"
+            },
+            "listen": {
+                "hostname": "0.0.50.96",
+                "port": 23647
+            },
+            "monitoringPort": 12112,
+            "nodeId": "vjmjxhhvaqks",
+            "peers": [],
+            "persistenceDir": "c/b/c/a/b/a",
+            "tlsCertPath": null,
+            "tlsKeyPath": null,
+            "useSystemEtcd": true,
+            "verbosity": {
+                "contents": "HydraNode",
+                "tag": "Verbose"
+            }
+        },
+        {
+            "advertise": {
+                "hostname": "0.0.18.232",
+                "port": 27204
+            },
+            "apiHost": {
+                "ipv4": "0.0.22.104",
+                "tag": "IPv4"
+            },
+            "apiPort": 27608,
+            "chainConfig": {
+                "initialUTxOFile": "c/b/a/a.json",
+                "ledgerGenesisFile": "a/c/c.json",
+                "offlineHeadSeed": "999c822bbefa1a92fb246a6362bdb3ba",
+                "tag": "OfflineChainConfig"
+            },
+            "hydraSigningKey": "c/c/c.sk",
+            "hydraVerificationKeys": [
+                "c/c.vk",
+                "b.vk",
+                "a.vk",
+                "b/b/c.vk",
+                "a/b/b.vk",
+                "b/c/c.vk"
+            ],
+            "ledgerConfig": {
+                "cardanoLedgerProtocolParametersFile": "a/b.json"
+            },
+            "listen": {
+                "hostname": "0.0.83.136",
+                "port": 7280
+            },
+            "monitoringPort": 22254,
+            "nodeId": "pqwkwpnkchpxfrv",
+            "peers": [
+                {
+                    "hostname": "0.0.0.5",
+                    "port": 3
+                },
+                {
+                    "hostname": "0.0.0.3",
+                    "port": 6
+                },
+                {
+                    "hostname": "0.0.0.1",
                     "port": 1
                 },
+                {
+                    "hostname": "0.0.0.3",
+                    "port": 2
+                },
+                {
+                    "hostname": "0.0.0.2",
+                    "port": 2
+                },
+                {
+                    "hostname": "0.0.0.0",
+                    "port": 6
+                }
+            ],
+            "persistenceDir": "b/a/c/c",
+            "tlsCertPath": "c/a/c/a/b.pem",
+            "tlsKeyPath": null,
+            "useSystemEtcd": false,
+            "verbosity": {
+                "contents": "HydraNode",
+                "tag": "Verbose"
+            }
+        },
+        {
+            "advertise": {
+                "hostname": "0.0.41.150",
+                "port": 27693
+            },
+            "apiHost": {
+                "ipv4": "0.0.76.203",
+                "tag": "IPv4"
+            },
+            "apiPort": 25019,
+            "chainConfig": {
+                "initialUTxOFile": "b.json",
+                "ledgerGenesisFile": "a.json",
+                "offlineHeadSeed": "9ac8aca56b5c8438af4da4048a81f988",
+                "tag": "OfflineChainConfig"
+            },
+            "hydraSigningKey": "b/c/a.sk",
+            "hydraVerificationKeys": [
+                "c.vk"
+            ],
+            "ledgerConfig": {
+                "cardanoLedgerProtocolParametersFile": "b/a/a/b/b.json"
+            },
+            "listen": {
+                "hostname": "0.0.28.218",
+                "port": 29061
+            },
+            "monitoringPort": 4562,
+            "nodeId": "metpfcfmfbjbsod",
+            "peers": [
                 {
                     "hostname": "0.0.0.6",
                     "port": 2
                 },
                 {
-                    "hostname": "0.0.0.4",
-                    "port": 6
-                },
-                {
-                    "hostname": "0.0.0.5",
-                    "port": 4
-                }
-            ],
-            "persistenceDir": "b/c/a/a",
-            "tlsCertPath": null,
-            "tlsKeyPath": "a/b/b.key",
-            "verbosity": {
-                "tag": "Quiet"
-            }
-        },
-        {
-            "advertise": {
-                "hostname": "0.0.42.133",
-                "port": 12408
-            },
-            "apiHost": {
-                "ipv4": "0.0.75.60",
-                "tag": "IPv4"
-            },
-            "apiPort": 14910,
-            "chainConfig": {
-                "cardanoSigningKey": "c.sk",
-                "cardanoVerificationKeys": [
-                    "b/a.vk",
-                    "c/c/b.vk",
-                    "c/b.vk"
-                ],
-                "contestationPeriod": 31536000,
-                "depositDeadline": 100,
-                "hydraScriptsTxId": [
-                    "0b4f405710b5bec99644dd0abcec871ba079e6958a725b94e5a2cabeaef1ed9b",
-                    "5e5d8043122e339f4f3f85942dfd69baa5fb3614b3d011a361ea9158273bc1cc",
-                    "beed04fd1e1c277a39ae72b531a5dad531d7657a4d2a655d15748e0d8f086c70",
-                    "fd0bca1d45ee9deba83db3c1f2863e0f398500bd566581fdc91ea7a3a972cd66",
-                    "efdacffa8fec9a9a02264ad8205edb126ba5caf0350ee75039179cfd531e7c8b",
-                    "69f7291ee42576bfbf7aa0e4819ed65cc02a272d982ab13331834bd08b8042bd",
-                    "f4664312f10c106fbae0869d660fd616e6964e3d7a524856c0d163c9d54ae0d0",
-                    "c08bd7ed45971221be609136887a4e3815ea31564144031646950057513fce4f",
-                    "d0d9df2b1c145781a5c39b7121123df7f29ac35314301e59e449618ec169b112",
-                    "5fbe233b27ffa0626121805dbef320513f5e5c550d1d80dcc8f0f7d121160283",
-                    "0d7db0c8b1265802b65a61b78c68e432e3fc9e0ac0edec20223610a363e2a628",
-                    "7eb296376da8ab6f0083a5bfcd47ac5f7d76bc8ed8f3c203224326fa66171616",
-                    "ff8d2a7736c84f1a67a2ac93c29fb9826956ccc39aedfb117c546949ba60e93d",
-                    "4aced0f61cc5c714ce6ffaa00e497d5f2a42456c98293507ef909194a879b570",
-                    "6669f9b7057c087fe8d960d38e4e6995c990432de7e5d76e5be53c5069689fd1",
-                    "5effc96ff3977f6d8795faaab65c41cbb41808bef1405dc2f60ff052b619a6a8",
-                    "15494380164c9b19c46708cab64c76bb6807606dd1fd4077c857dae9dd4f2c0f",
-                    "2971ea7ff565b4334613808bbe479526d7fde684c75b328ea28d78f118f289b4",
-                    "6c52a29f2fe2dac7ea84ccadccd5409e5ab190f52d6ad0a6314567d92ebfdc3c",
-                    "fd76b9c0ac22d2d5fb5ac01c5497a0fff3d3b2e9a74083b347e3ddd0d396d52d",
-                    "46f88f359dfdf822d63bedcfb3b540256bdd88140c077764759754fd7b4bbd5b"
-                ],
-                "networkId": {
-                    "magic": 7147,
-                    "tag": "Testnet"
-                },
-                "nodeSocket": "a/a/b/a.socket",
-                "startChainFrom": null,
-                "tag": "DirectChainConfig"
-            },
-            "hydraSigningKey": "b/b/a.sk",
-            "hydraVerificationKeys": [
-                "c/b/b.vk",
-                "b/b/a.vk",
-                "a/a/c.vk"
-            ],
-            "ledgerConfig": {
-                "cardanoLedgerProtocolParametersFile": "b/c/b/b/a/b.json"
-            },
-            "listen": {
-                "hostname": "0.0.62.172",
-                "port": 17754
-            },
-            "monitoringPort": 1256,
-            "nodeId": "onjlkjokxncuqjwmzorzjc",
-            "peers": [],
-            "persistenceDir": "c/c/c/c/a",
-            "tlsCertPath": null,
-            "tlsKeyPath": null,
-            "verbosity": {
-                "contents": "HydraNode",
-                "tag": "Verbose"
-            }
-        },
-        {
-            "advertise": {
-                "hostname": "0.0.121.25",
-                "port": 16440
-            },
-            "apiHost": {
-                "ipv4": "0.0.70.171",
-                "tag": "IPv4"
-            },
-            "apiPort": 4914,
-            "chainConfig": {
-                "initialUTxOFile": "b.json",
-                "ledgerGenesisFile": "a/c/c.json",
-                "offlineHeadSeed": "d103b145f2e8ef83397d273e5e099c13",
-                "tag": "OfflineChainConfig"
-            },
-            "hydraSigningKey": "a.sk",
-            "hydraVerificationKeys": [
-                "b/b.vk",
-                "b/b.vk"
-            ],
-            "ledgerConfig": {
-                "cardanoLedgerProtocolParametersFile": "a/a/c/c/a.json"
-            },
-            "listen": {
-                "hostname": "0.0.73.68",
-                "port": 2102
-            },
-            "monitoringPort": null,
-            "nodeId": "crvsxxqfwiacm",
-            "peers": [],
-            "persistenceDir": "a/c/b/a/c/c",
-            "tlsCertPath": "c/c.pem",
-            "tlsKeyPath": "a/c/c/a.key",
-            "verbosity": {
-                "tag": "Quiet"
-            }
-        },
-        {
-            "advertise": {
-                "hostname": "0.0.66.12",
-                "port": 3079
-            },
-            "apiHost": {
-                "ipv4": "0.0.43.74",
-                "tag": "IPv4"
-            },
-            "apiPort": 11925,
-            "chainConfig": {
-                "initialUTxOFile": "a/b/a.json",
-                "ledgerGenesisFile": null,
-                "offlineHeadSeed": "770d66d67484dbb38746acb971c515d3",
-                "tag": "OfflineChainConfig"
-            },
-            "hydraSigningKey": "b.sk",
-            "hydraVerificationKeys": [],
-            "ledgerConfig": {
-                "cardanoLedgerProtocolParametersFile": "b/c/b/b/b/b.json"
-            },
-            "listen": {
-                "hostname": "0.0.62.18",
-                "port": 26337
-            },
-            "monitoringPort": null,
-            "nodeId": "uyom",
-            "peers": [
-                {
-                    "hostname": "0.0.0.1",
-                    "port": 0
-                },
-                {
-                    "hostname": "0.0.0.5",
-                    "port": 5
-                },
-                {
-                    "hostname": "0.0.0.4",
-                    "port": 7
-                },
-                {
-                    "hostname": "0.0.0.5",
-                    "port": 2
-                },
-                {
-                    "hostname": "0.0.0.0",
-                    "port": 5
-                },
-                {
-                    "hostname": "0.0.0.1",
-                    "port": 6
-                }
-            ],
-            "persistenceDir": "b/a/b/a/a/b",
-            "tlsCertPath": null,
-            "tlsKeyPath": "b/b/b.key",
-            "verbosity": {
-                "contents": "HydraNode",
-                "tag": "Verbose"
-            }
-        },
-        {
-            "advertise": {
-                "hostname": "0.0.114.198",
-                "port": 17907
-            },
-            "apiHost": {
-                "ipv4": "0.0.23.86",
-                "tag": "IPv4"
-            },
-            "apiPort": 22603,
-            "chainConfig": {
-                "initialUTxOFile": "a/a/a/c/b.json",
-                "ledgerGenesisFile": "c/a/b/b.json",
-                "offlineHeadSeed": "0d53a78b05b4521daf80cecb4b7ceedd",
-                "tag": "OfflineChainConfig"
-            },
-            "hydraSigningKey": "a/b/a/b/c.sk",
-            "hydraVerificationKeys": [],
-            "ledgerConfig": {
-                "cardanoLedgerProtocolParametersFile": "b/c/b/a/b/c.json"
-            },
-            "listen": {
-                "hostname": "0.0.42.39",
-                "port": 6767
-            },
-            "monitoringPort": 9249,
-            "nodeId": "unyaibyymqkxmdszwrweduhbja",
-            "peers": [
-                {
-                    "hostname": "0.0.0.3",
+                    "hostname": "0.0.0.6",
                     "port": 1
                 },
                 {
-                    "hostname": "0.0.0.8",
-                    "port": 0
+                    "hostname": "0.0.0.6",
+                    "port": 2
                 }
             ],
-            "persistenceDir": "a/b/c/b/c/a",
-            "tlsCertPath": "b/c/c/a.pem",
+            "persistenceDir": "c/a/a/b",
+            "tlsCertPath": null,
             "tlsKeyPath": null,
+            "useSystemEtcd": true,
             "verbosity": {
                 "contents": "HydraNode",
                 "tag": "Verbose"
             }
         }
     ],
-    "seed": -11993528
+    "seed": 872371396
 }

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -82,6 +82,7 @@ library
     Hydra.Network.Etcd
     Hydra.Network.Message
     Hydra.Node
+    Hydra.Node.EmbedTH
     Hydra.Node.InputQueue
     Hydra.Node.Network
     Hydra.Node.ParameterMismatch
@@ -118,6 +119,7 @@ library
     , crypton
     , data-default
     , directory
+    , file-embed
     , filepath
     , grapesy
     , grapesy-etcd                    >=0.3
@@ -150,10 +152,12 @@ library
     , serialise
     , sop-extras
     , stm
+    , template-haskell
     , text
     , time
     , transformers
     , typed-process
+    , unix
     , unliftio
     , wai
     , wai-cors

--- a/hydra-node/src/Hydra/Network.hs
+++ b/hydra-node/src/Hydra/Network.hs
@@ -53,6 +53,14 @@ data NetworkCallback msg m = NetworkCallback
 -- A `NetworkComponent` can have different inbound and outbound message types.
 type NetworkComponent m inbound outbound a = NetworkCallback inbound m -> (Network m outbound -> m a) -> m a
 
+data WhichEtcd = EmbeddedEtcd | SystemEtcd
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance Arbitrary WhichEtcd where
+  shrink = genericShrink
+  arbitrary = genericArbitrary
+
 -- * Types used by concrete implementations
 
 -- | Configuration for a `Node` network layer.
@@ -71,7 +79,7 @@ data NetworkConfiguration = NetworkConfiguration
   -- ^ Addresses and ports of remote peers.
   , nodeId :: NodeId
   -- ^ This node's id.
-  , useSystemEtcd :: Bool
+  , whichEtcd :: WhichEtcd
   -- ^ Whether to use the system etcd (on the path) or the embedded one.
   }
 

--- a/hydra-node/src/Hydra/Network.hs
+++ b/hydra-node/src/Hydra/Network.hs
@@ -71,6 +71,8 @@ data NetworkConfiguration = NetworkConfiguration
   -- ^ Addresses and ports of remote peers.
   , nodeId :: NodeId
   -- ^ This node's id.
+  , useSystemEtcd :: Bool
+  -- ^ Whether to use the system etcd (on the path) or the embedded one.
   }
 
 -- ** IP (Orphans)

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -73,6 +73,7 @@ import Hydra.Network (
   NetworkComponent,
   NetworkConfiguration (..),
   ProtocolVersion,
+  WhichEtcd (..),
  )
 import Hydra.Node.EmbedTH (embedExecutable)
 import Network.GRPC.Client (
@@ -128,7 +129,7 @@ withEtcdNetwork ::
   NetworkConfiguration ->
   NetworkComponent IO msg msg ()
 withEtcdNetwork tracer protocolVersion config callback action = do
-  etcdBinPath <- getEtcdBinary persistenceDir useSystemEtcd
+  etcdBinPath <- getEtcdBinary persistenceDir whichEtcd
   -- TODO: fail if cluster config / members do not match --peer
   -- configuration? That would be similar to the 'acks' persistence
   -- bailing out on loading.
@@ -234,13 +235,13 @@ withEtcdNetwork tracer protocolVersion config callback action = do
 
   httpUrl (Host h p) = "http://" <> toString h <> ":" <> show p
 
-  NetworkConfiguration{persistenceDir, listen, advertise, peers, useSystemEtcd} = config
+  NetworkConfiguration{persistenceDir, listen, advertise, peers, whichEtcd} = config
 
 -- | Return the path of the etcd binary. Will either install it first, or just
 -- assume there is one available on the system path.
-getEtcdBinary :: FilePath -> Bool -> IO FilePath
-getEtcdBinary _ True = pure "etcd"
-getEtcdBinary persistenceDir False =
+getEtcdBinary :: FilePath -> WhichEtcd -> IO FilePath
+getEtcdBinary _ SystemEtcd = pure "etcd"
+getEtcdBinary persistenceDir EmbeddedEtcd =
   let path = persistenceDir </> "bin" </> "etcd"
    in installEtcd path >> pure path
 

--- a/hydra-node/src/Hydra/Node/EmbedTH.hs
+++ b/hydra-node/src/Hydra/Node/EmbedTH.hs
@@ -1,0 +1,19 @@
+-- | Template haskell expression to embed executables.
+module Hydra.Node.EmbedTH where
+
+import Hydra.Prelude
+
+import Data.FileEmbed (embedFile)
+import Language.Haskell.TH (Exp, Q, runIO)
+import System.Directory (findExecutable)
+
+-- | Template haskell expression to find and embed an executable with given name.
+embedExecutable :: String -> Q Exp
+embedExecutable exe = do
+  fp <- runIO $ do
+    findExecutable exe >>= \case
+      Nothing -> fail $ exe <> " not found, ensure it is in PATH when compiling (and do a cabal clean)"
+      Just fp -> do
+        putStrLn $ "Embedding " <> exe <> " from: " <> fp
+        pure fp
+  embedFile fp

--- a/hydra-node/src/Hydra/Node/Run.hs
+++ b/hydra-node/src/Hydra/Node/Run.hs
@@ -103,7 +103,7 @@ run opts = do
                     , advertise = fromMaybe listen advertise
                     , peers
                     , nodeId
-                    , useSystemEtcd
+                    , whichEtcd
                     }
             withNetwork
               (contramap Network tracer)
@@ -143,7 +143,7 @@ run opts = do
     , apiPort
     , tlsCertPath
     , tlsKeyPath
-    , useSystemEtcd
+    , whichEtcd
     } = opts
 
 getGlobalsForChain :: ChainConfig -> IO Globals

--- a/hydra-node/src/Hydra/Node/Run.hs
+++ b/hydra-node/src/Hydra/Node/Run.hs
@@ -103,6 +103,7 @@ run opts = do
                     , advertise = fromMaybe listen advertise
                     , peers
                     , nodeId
+                    , useSystemEtcd
                     }
             withNetwork
               (contramap Network tracer)
@@ -142,6 +143,7 @@ run opts = do
     , apiPort
     , tlsCertPath
     , tlsKeyPath
+    , useSystemEtcd
     } = opts
 
 getGlobalsForChain :: ChainConfig -> IO Globals

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -75,6 +75,7 @@ import Options.Applicative (
   short,
   showDefault,
   strOption,
+  switch,
   value,
  )
 import Options.Applicative.Builder (str)
@@ -185,6 +186,7 @@ data RunOptions = RunOptions
   , persistenceDir :: FilePath
   , chainConfig :: ChainConfig
   , ledgerConfig :: LedgerConfig
+  , useSystemEtcd :: Bool
   }
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
@@ -211,6 +213,7 @@ instance Arbitrary RunOptions where
     persistenceDir <- genDirPath
     chainConfig <- arbitrary
     ledgerConfig <- arbitrary
+    useSystemEtcd <- arbitrary
     pure $
       RunOptions
         { verbosity
@@ -228,6 +231,7 @@ instance Arbitrary RunOptions where
         , persistenceDir
         , chainConfig
         , ledgerConfig
+        , useSystemEtcd
         }
 
   shrink = genericShrink
@@ -251,6 +255,7 @@ defaultRunOptions =
     , persistenceDir = "./"
     , chainConfig = Direct defaultDirectChainConfig
     , ledgerConfig = defaultLedgerConfig
+    , useSystemEtcd = False
     }
  where
   localhost = IPv4 $ toIPv4 [127, 0, 0, 1]
@@ -274,6 +279,14 @@ runOptionsParser =
     <*> persistenceDirParser
     <*> chainConfigParser
     <*> ledgerConfigParser
+    <*> useSystemEtcdParser
+
+useSystemEtcdParser :: Parser Bool
+useSystemEtcdParser =
+  switch
+    ( long "use-system-etcd"
+        <> help "Use the `etcd` binary found on the path instead of the embedded one."
+    )
 
 chainConfigParser :: Parser ChainConfig
 chainConfigParser =

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -54,6 +54,7 @@ spec = do
                       , peers = []
                       , nodeId = "alice"
                       , persistenceDir = tmp </> "alice"
+                      , useSystemEtcd = False
                       }
               (recordingCallback, waitNext, _) <- newRecordingCallback
               withEtcdNetwork tracer v1 config recordingCallback $ \n -> do
@@ -213,6 +214,7 @@ setup2Peers tmp = do
             , peers = [bobHost]
             , nodeId = "alice"
             , persistenceDir = tmp </> "alice"
+            , useSystemEtcd = False
             }
       , bobConfig =
           NetworkConfiguration
@@ -223,6 +225,7 @@ setup2Peers tmp = do
             , peers = [aliceHost]
             , nodeId = "bob"
             , persistenceDir = tmp </> "bob"
+            , useSystemEtcd = False
             }
       }
 
@@ -249,6 +252,7 @@ setup3Peers tmp = do
             , peers = [bobHost, carolHost]
             , nodeId = "alice"
             , persistenceDir = tmp </> "alice"
+            , useSystemEtcd = False
             }
       , bobConfig =
           NetworkConfiguration
@@ -259,6 +263,7 @@ setup3Peers tmp = do
             , peers = [aliceHost, carolHost]
             , nodeId = "bob"
             , persistenceDir = tmp </> "bob"
+            , useSystemEtcd = False
             }
       , carolConfig =
           NetworkConfiguration
@@ -269,6 +274,7 @@ setup3Peers tmp = do
             , peers = [aliceHost, bobHost]
             , nodeId = "carol"
             , persistenceDir = tmp </> "carol"
+            , useSystemEtcd = False
             }
       }
 

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -21,6 +21,7 @@ import Hydra.Network (
   Network (..),
   NetworkCallback (..),
   ProtocolVersion (..),
+  WhichEtcd (..),
  )
 import Hydra.Network.Etcd (withEtcdNetwork)
 import Hydra.Network.Message (Message (..))
@@ -54,7 +55,7 @@ spec = do
                       , peers = []
                       , nodeId = "alice"
                       , persistenceDir = tmp </> "alice"
-                      , useSystemEtcd = False
+                      , whichEtcd = EmbeddedEtcd
                       }
               (recordingCallback, waitNext, _) <- newRecordingCallback
               withEtcdNetwork tracer v1 config recordingCallback $ \n -> do
@@ -214,7 +215,7 @@ setup2Peers tmp = do
             , peers = [bobHost]
             , nodeId = "alice"
             , persistenceDir = tmp </> "alice"
-            , useSystemEtcd = False
+            , whichEtcd = EmbeddedEtcd
             }
       , bobConfig =
           NetworkConfiguration
@@ -225,7 +226,7 @@ setup2Peers tmp = do
             , peers = [aliceHost]
             , nodeId = "bob"
             , persistenceDir = tmp </> "bob"
-            , useSystemEtcd = False
+            , whichEtcd = EmbeddedEtcd
             }
       }
 
@@ -252,7 +253,7 @@ setup3Peers tmp = do
             , peers = [bobHost, carolHost]
             , nodeId = "alice"
             , persistenceDir = tmp </> "alice"
-            , useSystemEtcd = False
+            , whichEtcd = EmbeddedEtcd
             }
       , bobConfig =
           NetworkConfiguration
@@ -263,7 +264,7 @@ setup3Peers tmp = do
             , peers = [aliceHost, carolHost]
             , nodeId = "bob"
             , persistenceDir = tmp </> "bob"
-            , useSystemEtcd = False
+            , whichEtcd = EmbeddedEtcd
             }
       , carolConfig =
           NetworkConfiguration
@@ -274,7 +275,7 @@ setup3Peers tmp = do
             , peers = [aliceHost, bobHost]
             , nodeId = "carol"
             , persistenceDir = tmp </> "carol"
-            , useSystemEtcd = False
+            , whichEtcd = EmbeddedEtcd
             }
       }
 

--- a/nix/hydra/demo.nix
+++ b/nix/hydra/demo.nix
@@ -46,7 +46,6 @@
       hydra-node-alice = {
         command = pkgs.writeShellApplication {
           name = "hydra-node-alice";
-          runtimeInputs = [ pkgs.etcd ];
           checkPhase = ""; # not shellcheck and choke on sourcing .env
           text = ''
             # (Re-)Export all variables from .env
@@ -78,7 +77,6 @@
       hydra-node-bob = {
         command = pkgs.writeShellApplication {
           name = "hydra-node-bob";
-          runtimeInputs = [ pkgs.etcd ];
           checkPhase = ""; # not shellcheck and choke on sourcing .env
           text = ''
             # (Re-)Export all variables from .env
@@ -110,7 +108,6 @@
       hydra-node-carol = {
         command = pkgs.writeShellApplication {
           name = "hydra-node-carol";
-          runtimeInputs = [ pkgs.etcd ];
           checkPhase = ""; # not shellcheck and choke on sourcing .env
           text = ''
             # (Re-)Export all variables from .env

--- a/nix/hydra/docker.nix
+++ b/nix/hydra/docker.nix
@@ -11,7 +11,6 @@
     created = "now";
     contents = [
       pkgs.busybox
-      pkgs.etcd
     ];
     config = {
       Entrypoint = [ "${hydraPackages.hydra-node-static}/bin/hydra-node" ];
@@ -25,7 +24,6 @@
     contents = [
       pkgs.iproute2
       pkgs.busybox
-      pkgs.etcd
     ];
     config = {
       Entrypoint = [ "${hydraPackages.hydra-node-static}/bin/hydra-node" ];

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -143,7 +143,6 @@ rec {
     name = "hydra-node-tests";
     buildInputs = [
       nativePkgs.hydra-node.components.tests.tests
-      pkgs.etcd
       pkgs.check-jsonschema
     ];
   };
@@ -153,7 +152,6 @@ rec {
       [
         nativePkgs.hydra-cluster.components.tests.tests
         hydra-node
-        pkgs.etcd
         hydra-chain-observer
         pkgs.cardano-node
         pkgs.cardano-cli
@@ -170,7 +168,6 @@ rec {
         hydra-node
         pkgs.cardano-node
         pkgs.cardano-cli
-        pkgs.etcd
       ];
   };
 
@@ -190,7 +187,6 @@ rec {
         pkgs.cardano-node
         pkgs.cardano-cli
         pkgs.dstat
-        pkgs.etcd
       ];
   };
 

--- a/nix/hydra/project.nix
+++ b/nix/hydra/project.nix
@@ -82,5 +82,9 @@ pkgs.haskell-nix.project {
       packages.proto-lens-protobuf-types.components.library.build-tools = [ pkgs.protobuf ];
       packages.proto-lens-etcd.components.library.build-tools = [ pkgs.protobuf ];
     }
+    # Add etcd as build dependency of hydra-node (template haskell embedding not tracked by cabal)
+    {
+      packages.hydra-node.components.library.build-tools = [ pkgs.etcd ];
+    }
   ];
 }

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -62,7 +62,7 @@ let
     pkgs.secp256k1
     pkgs.xz
     pkgs.zlib
-    pkgs.etcd # Run-time dependency of hydra-node
+    pkgs.etcd # Build-time dependency (static binary to be embedded)
   ]
   ++
   pkgs.lib.optionals (pkgs.stdenv.isLinux) [


### PR DESCRIPTION
By compiling `etcd` into `hydra-node` we can get rid of the runtime dependency onto `etcd` in exchange for a build-time dependency and bigger binary size.

![image](https://github.com/user-attachments/assets/9cc82b87-3d92-4ad3-aec8-ef0895375d0f)

While I was worried that we would need a static compiled `etcd`, it turns out the default one is already a static binary (likely because it's a go project!):

```
λ ldd $(realpath $(which etcd))
	not a dynamic executable
```

That means, all our `hydra-node` builds contain a statically linked `etcd` binary now.

## File sizes

Dynamic linked `hydra-node`:
```
λ ll $(nix build .#hydra-node --print-out-paths)/bin/hydra-node
warning: Git tree '/home/ch1bo/code/iog/hydra' is dirty
warning: Git tree '/home/ch1bo/code/iog/hydra' is dirty
.r-xr-xr-x root root 90 MB Thu Jan  1 01:00:01 1970  /nix/store/mca588qi4glryha0d1kkg4s0lmbw6xqk-hydra-node/bin/hydra-node
```

Static linked `hydra-node`:
```
λ ll $(nix build .#hydra-node-static --print-out-paths)/bin/hydra-node
warning: Git tree '/home/ch1bo/code/iog/hydra' is dirty
warning: Git tree '/home/ch1bo/code/iog/hydra' is dirty
.r-xr-xr-x root root 94 MB Thu Jan  1 01:00:01 1970  /nix/store/q3dr4fa7w3iy2rqrwp0xgr8bk364s6ka-hydra-node-x86_64-unknown-linux-musl/bin/hydra-node
```

Compressed (and darwin):
![image](https://github.com/user-attachments/assets/329680e3-f830-4310-8710-4a2ad22a8d56)

## Try it please
It's unclear whether this works for all target platforms. To try it, download the binary of your platform from this CI action https://github.com/cardano-scaling/hydra/actions/workflows/binaries.yaml?query=branch%3Aembed-etcd and run

```
echo "{}" > utxo.json
./bin/hydra-node --offline-head-seed 01 --initial-utxo utxo.json --ledger-protocol-parameters hydra-cluster/config/protocol-parameters.json --persistence-dir ./tmp-etcd --node-id foo --hydra-signing-key demo/alice.sk
```

from within a hydra working copy.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated
* [x] Documentation updated
* [x] Haddocks updated
* [x] No new TODOs introduced
