### PR TITLE
Rename UTxO.resolve to UTxO.resolveTxIn

### DIFF
--- a/hydra-cardano-api/src/Cardano/Api/UTxO.hs
+++ b/hydra-cardano-api/src/Cardano/Api/UTxO.hs
@@ -53,8 +53,8 @@ singleton :: TxIn -> out -> UTxO' out
 singleton i o = UTxO $ Map.singleton i o
 
 -- | Find an 'out' for a given 'TxIn'.
-resolve :: TxIn -> UTxO' out -> Maybe out
-resolve k = Map.lookup k . toMap
+resolveTxIn :: TxIn -> UTxO' out -> Maybe out
+resolveTxIn k = Map.lookup k . toMap
 
 -- | Turn a 'UTxO' into a list of pairs.
 toList :: UTxO' out -> [(TxIn, out)]

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/Pretty.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/Pretty.hs
@@ -72,7 +72,7 @@ renderTxWithUTxO utxo (Tx body _wits) =
       Api.TxInsCollateral refInputs -> refInputs
 
   prettyTxIn i =
-    case UTxO.resolve i utxo of
+    case UTxO.resolveTxIn i utxo of
       Nothing -> T.unpack $ renderTxIn i
       Just o ->
         T.unpack (renderTxIn i)

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/UTxO.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/UTxO.hs
@@ -38,7 +38,7 @@ utxoFromTx (Tx body@(ShelleyTxBody _ ledgerBody _ _ _ _) _) =
 resolveInputsUTxO :: UTxO -> Tx Era -> UTxO
 resolveInputsUTxO utxo tx =
   UTxO.fromList $
-    mapMaybe (\txIn -> (txIn,) <$> UTxO.resolve txIn utxo) (txIns' tx)
+    mapMaybe (\txIn -> (txIn,) <$> UTxO.resolveTxIn txIn utxo) (txIns' tx)
 
 -- * Type Conversions
 

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -424,7 +424,7 @@ genCommitTxMutation utxo tx =
 
   resolvedInputs =
     UTxO.fromList $
-      mapMaybe (\txIn -> (txIn,) <$> UTxO.resolve txIn utxo) (txIns' tx)
+      mapMaybe (\txIn -> (txIn,) <$> UTxO.resolveTxIn txIn utxo) (txIns' tx)
 
   initialRedeemer =
     fromMaybe (error "not found redeemer") $

--- a/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/TxSpec.hs
@@ -336,7 +336,7 @@ prop_interestingBlueprintTx = do
 
   spendsFromPubKey (utxo, tx) =
     any
-      ( \txIn -> case UTxO.resolve (fromLedgerTxIn txIn) utxo of
+      ( \txIn -> case UTxO.resolveTxIn (fromLedgerTxIn txIn) utxo of
           Just (TxOut (ShelleyAddressInEra (ShelleyAddress _ (KeyHashObj _) _)) _ _ _) -> True
           _ -> False
       )
@@ -347,7 +347,7 @@ prop_interestingBlueprintTx = do
   -- and would not detect if redeemers are missing.
   spendsFromScript (utxo, tx) =
     any
-      ( \txIn -> case UTxO.resolve (fromLedgerTxIn txIn) utxo of
+      ( \txIn -> case UTxO.resolveTxIn (fromLedgerTxIn txIn) utxo of
           Just (TxOut (ShelleyAddressInEra (ShelleyAddress _ (ScriptHashObj _) _)) _ _ _) -> True
           _ -> False
       )

--- a/hydra-tx/exe/Main.hs
+++ b/hydra-tx/exe/Main.hs
@@ -29,7 +29,7 @@ main =
       eitherDecodeFileStrict utxoFilePath >>= \case
         Left err -> die $ "failed to parse provided UTXO file! " <> err
         Right (utxo :: UTxO) -> do
-          case UTxO.resolve (TxIn recoverTxId (TxIx 0)) utxo of
+          case UTxO.resolveTxIn (TxIn recoverTxId (TxIx 0)) utxo of
             Nothing -> die "failed to resolve deposited UTxO with provided TxIn"
             Just depositedTxOut -> do
               case observeDepositTxOut network depositedTxOut of

--- a/hydra-tx/src/Hydra/Tx/Commit.hs
+++ b/hydra-tx/src/Hydra/Tx/Commit.hs
@@ -128,7 +128,7 @@ commitTx networkId scriptRegistry headId party commitBlueprintTx (initialInput, 
     mkScriptAddress networkId commitValidatorScript
 
   utxoToCommit =
-    UTxO.fromList $ mapMaybe (\txin -> (txin,) <$> UTxO.resolve txin lookupUTxO) committedTxIns
+    UTxO.fromList $ mapMaybe (\txin -> (txin,) <$> UTxO.resolveTxIn txin lookupUTxO) committedTxIns
 
   commitValue =
     txOutValue out <> foldMap txOutValue utxoToCommit

--- a/hydra-tx/testlib/Test/Hydra/Tx/Mutation.hs
+++ b/hydra-tx/testlib/Test/Hydra/Tx/Mutation.hs
@@ -317,7 +317,7 @@ applyMutation mutation (tx@(Tx body wits), utxo) = case mutation of
             ConwayVoting i -> unAsIx i
             ConwayProposing i -> unAsIx i
           txIn = Set.elemAt (fromIntegral k) ledgerInputs -- NOTE: calls 'error' if out of bounds
-       in case UTxO.resolve (fromLedgerTxIn txIn) utxo of
+       in case UTxO.resolveTxIn (fromLedgerTxIn txIn) utxo of
             Nothing -> error $ "txIn not resolvable: " <> show txIn
             Just o -> o
 


### PR DESCRIPTION
This is the expected name when we migrate to `Cardano.Api.Tx.UTxO`.