### PR TITLE
Contestation period must be specified in seconds explicitly

### DIFF
--- a/demo/docker-compose.yaml
+++ b/demo/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       , "--testnet-magic", "42"
       , "--node-socket", "/devnet/node.socket"
       , "--persistence-dir", "/devnet/persistence/alice"
-      , "--contestation-period", "3"
+      , "--contestation-period", "3s"
       ]
     networks:
       hydra_net:
@@ -86,7 +86,7 @@ services:
       , "--testnet-magic", "42"
       , "--node-socket", "/devnet/node.socket"
       , "--persistence-dir", "/devnet/persistence/bob"
-      , "--contestation-period", "3"
+      , "--contestation-period", "3s"
       ]
     networks:
       hydra_net:
@@ -123,7 +123,7 @@ services:
       , "--testnet-magic", "42"
       , "--node-socket", "/devnet/node.socket"
       , "--persistence-dir", "/devnet/persistence/carol"
-      , "--contestation-period", "3"
+      , "--contestation-period", "3s"
       ]
     networks:
       hydra_net:

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -1255,12 +1255,15 @@ canRecoverDeposit tracer workDir node hydraScriptsTxId =
       refuelIfNeeded tracer node Bob 30_000_000
       -- NOTE: Directly expire deposits
       contestationPeriod <- CP.fromNominalDiffTime 1
+      let depositPeriod = 1
       aliceChainConfig <-
         chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [Bob] contestationPeriod
           <&> setNetworkId networkId
+            . modifyConfig (\c -> c{depositPeriod})
       bobChainConfig <-
         chainConfigFor Bob workDir nodeSocket hydraScriptsTxId [Alice] contestationPeriod
           <&> setNetworkId networkId
+            . modifyConfig (\c -> c{depositPeriod})
       withHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [bobVk] [2] $ \n1 -> do
         headId <- withHydraNode hydraTracer bobChainConfig workDir 2 bobSk [aliceVk] [1] $ \n2 -> do
           send n1 $ input "Init" []

--- a/hydra-node/test/Hydra/OptionsSpec.hs
+++ b/hydra-node/test/Hydra/OptionsSpec.hs
@@ -177,6 +177,7 @@ spec = parallel $
               defaultRunOptions
                 { chainConfig = Direct defaultDirectChainConfig{contestationPeriod}
                 }
+      shouldNotParse ["--contestation-period", "3"]
       shouldNotParse ["--contestation-period", "abc"]
       shouldNotParse ["--contestation-period", "s"]
       shouldNotParse ["--contestation-period", "-1"]

--- a/nix/hydra/demo.nix
+++ b/nix/hydra/demo.nix
@@ -68,7 +68,7 @@
               --testnet-magic 42 \
               --node-socket devnet/node.socket \
               --persistence-dir devnet/persistence/alice \
-              --contestation-period 3
+              --contestation-period 3s
           '';
         };
         ready_log_line = "NodeIsLeader";
@@ -99,7 +99,7 @@
             --testnet-magic 42 \
             --node-socket devnet/node.socket \
             --persistence-dir devnet/persistence/bob \
-            --contestation-period 3
+            --contestation-period 3s
           '';
         };
         ready_log_line = "NodeIsLeader";
@@ -130,7 +130,7 @@
             --testnet-magic 42 \
             --node-socket devnet/node.socket \
             --persistence-dir devnet/persistence/carol \
-            --contestation-period 3
+            --contestation-period 3s
           '';
         };
         ready_log_line = "NodeIsLeader";


### PR DESCRIPTION
Quick fix to pass the "s" suffix when specifying the `--contestation-period`.

I noticed the failure here in the network tests https://github.com/cardano-scaling/hydra/actions/runs/15045228713/job/42312248561

It was easiest to see it by running the demo locally; `nix run .#demo`:

![image](https://github.com/user-attachments/assets/4c069bc6-3ce8-4c06-9e6e-b19eff77f207)

It's fairly common that it's a command-line change that breaks the network tests, these days 😅 

-- Edit:

Also fixes a regression in a test where we lost a small deposit period that was required for the test to pass.