### PR TITLE
Investigate deleting the etcd peristence and reconnecting

### DIFF
--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -152,6 +152,7 @@ import Network.HTTP.Req (
 import Network.HTTP.Simple (getResponseBody, httpJSON, setRequestBodyJSON)
 import Network.HTTP.Types (urlEncode)
 import System.Directory (removeDirectoryRecursive, removeFile)
+import System.Environment.Blank (setEnv)
 import System.FilePath ((</>))
 import System.Process (proc, readCreateProcessWithExitCode)
 import Test.Hydra.Tx.Fixture (testNetworkId)
@@ -240,11 +241,12 @@ oneOfThreeNodesStopsForAWhile tracer workDir cardanoNode hydraScriptsTxId = do
       -- waitForAllMatch (100 * blockTime) [n1, n2] $ \v -> do
       --   guard $ v ^? key "tag" == Just "PeerDisconnected"
 
-      threadDelay 10
       -- HACK: Carol deletes her etcd persistence
       let carolDir = workDir </> "state-3"
       removeDirectoryRecursive (carolDir </> "etcd")
       removeFile (carolDir </> "last-known-revision")
+
+      setEnv "ETCD_INITIAL_CLUSTER_STATE" "existing" True
 
       -- Alice never-the-less submits a transaction
       utxo <- getSnapshotUTxO n1

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -58,6 +58,7 @@ import Hydra.Cluster.Scenarios (
   canSideLoadSnapshot,
   canSubmitTransactionThroughAPI,
   checkFanout,
+  etcdStopsWhenNodeStops,
   headIsInitializingWith,
   initWithWrongKeys,
   nodeCanSupportMultipleEtcdClusters,
@@ -191,6 +192,11 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
 
   describe "End-to-end on Cardano devnet" $ do
     describe "single party hydra head" $ do
+      it "stops etcd when the node stops" $ \tracer -> do
+        withClusterTempDir $ \tmpDir -> do
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
+            publishHydraScriptsAs node Faucet
+              >>= etcdStopsWhenNodeStops tracer tmpDir node
       it "full head life-cycle" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
           withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -136,6 +136,7 @@ withEtcdNetwork tracer protocolVersion config callback action = do
   -- configuration? That would be similar to the 'acks' persistence
   -- bailing out on loading.
   envVars <- Map.fromList <$> getEnvironment
+
   withProcessInterrupt (etcdCmd etcdBinPath envVars) $ \p -> do
     race_ (waitExitCode p >>= \ec -> fail $ "Sub-process etcd exited with: " <> show ec) $ do
       race_ (traceStderr p) $ do


### PR DESCRIPTION
TODO:

- [x] Work out why the main test fails (seems etcd stays running?!)
- [x] Make the test correct (set the env var)

This ultimately fails with:

![image](https://github.com/user-attachments/assets/c9900369-b811-4505-999c-b428dfc04b9e)


```
go.etcd.io/etcd/server/v3/etcdserver.(*zapRaftLogger).Panicf
  go.etcd.io/etcd/server/v3/etcdserver/zap_raft.go:101
  go.etcd.io/etcd/raft/v3.(*raftLog).commitTo
  go.etcd.io/etcd/raft/v3@v3.5.16/log.go:237
  go.etcd.io/etcd/raft/v3.(*raft).handleHeartbeat
  go.etcd.io/etcd/raft/v3@v3.5.16/raft.go:1508
  go.etcd.io/etcd/raft/v3.stepFollower
  go.etcd.io/etcd/raft/v3@v3.5.16/raft.go:1434
  go.etcd.io/etcd/raft/v3.(*raft).Step
  go.etcd.io/etcd/raft/v3@v3.5.16/raft.go:975
  go.etcd.io/etcd/raft/v3.(*node).run
  go.etcd.io/etcd/raft/v3@v3.5.16/node.go:356
```

even when setting `ETCD_INITIAL_CLUSTER_STATE=existing`. So I think we can rule it out for now.