### PR TITLE
hydra-coding-standards: 0.3.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1513,16 +1513,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1747931137,
-        "narHash": "sha256-xO7c1bRaEYbOgq5ArYDq0utiaGNIdBGLHgvtIMNNFAo=",
+        "lastModified": 1748278221,
+        "narHash": "sha256-cKRaKMugNgSKD4MlqfJ/yvpAlQaY2dynY2vsTjg3ACw=",
         "owner": "cardano-scaling",
         "repo": "hydra-coding-standards",
-        "rev": "2384cef4dddc7e82f5ffd233ae44d01b0a4cb91c",
+        "rev": "4a574643a06c63c0231e94b4da2ae2ad142987e5",
         "type": "github"
       },
       "original": {
         "owner": "cardano-scaling",
-        "ref": "0.3.0",
+        "ref": "0.3.1",
         "repo": "hydra-coding-standards",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     cardano-node.url = "github:intersectmbo/cardano-node/10.1.4";
     flake-parts.url = "github:hercules-ci/flake-parts";
     haskellNix.url = "github:input-output-hk/haskell.nix";
-    hydra-coding-standards.url = "github:cardano-scaling/hydra-coding-standards/0.3.0";
+    hydra-coding-standards.url = "github:cardano-scaling/hydra-coding-standards/0.3.1";
     hydra-spec.url = "github:cardano-scaling/hydra-formal-specification";
     iohk-nix.url = "github:input-output-hk/iohk-nix";
     lint-utils = {
@@ -62,6 +62,7 @@
                 apply-refact = pkgs.haskell-nix.tool compiler "apply-refact" "0.15.0.0";
                 cabal-install = pkgs.haskell-nix.tool compiler "cabal-install" "3.10.3.0";
                 cabal-plan = pkgs.haskell-nix.tool compiler "cabal-plan" "0.7.5.0";
+                cabal-fmt = config.treefmt.programs.cabal-fmt.package;
                 fourmolu = config.treefmt.programs.fourmolu.package;
                 haskell-language-server = pkgs.haskell-nix.tool compiler "haskell-language-server" "2.9.0.0";
                 weeder = pkgs.haskell-nix.tool compiler "weeder" "2.9.0";

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -13,6 +13,7 @@ let
   buildInputs = [
     # To compile hydra scripts
     pkgs.aiken
+    pkgs.cabal-fmt
     pkgs.cabal-install
     # Handy tool to debug the cabal build plan
     pkgs.cabal-plan


### PR DESCRIPTION
Fixes executable name of fourmolu. Add cabal-fmt to shell tools