### PR TITLE
Restore fourmolu.yaml

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1513,16 +1513,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1748278221,
-        "narHash": "sha256-cKRaKMugNgSKD4MlqfJ/yvpAlQaY2dynY2vsTjg3ACw=",
+        "lastModified": 1748416319,
+        "narHash": "sha256-Wo+YNL4w6IU3neLsbFeIyvI94KHrYEMec1Ot6S1/gHA=",
         "owner": "cardano-scaling",
         "repo": "hydra-coding-standards",
-        "rev": "4a574643a06c63c0231e94b4da2ae2ad142987e5",
+        "rev": "f86edeb52593dc89c26c1cc8bf71d302d4288910",
         "type": "github"
       },
       "original": {
         "owner": "cardano-scaling",
-        "ref": "0.3.1",
+        "ref": "0.4.0",
         "repo": "hydra-coding-standards",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     cardano-node.url = "github:intersectmbo/cardano-node/10.1.4";
     flake-parts.url = "github:hercules-ci/flake-parts";
     haskellNix.url = "github:input-output-hk/haskell.nix";
-    hydra-coding-standards.url = "github:cardano-scaling/hydra-coding-standards/0.3.1";
+    hydra-coding-standards.url = "github:cardano-scaling/hydra-coding-standards/0.4.0";
     hydra-spec.url = "github:cardano-scaling/hydra-formal-specification";
     iohk-nix.url = "github:input-output-hk/iohk-nix";
     lint-utils = {

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,0 +1,18 @@
+indentation: 2
+comma-style: leading # for lists, tuples etc. - can also be 'trailing'
+record-brace-space: false # rec {x = 1} vs. rec{x = 1}
+indent-wheres: false # 'false' means save space by only half-indenting the 'where' keyword
+diff-friendly-import-export: true # 'false' uses Ormolu-style lists
+respectful: true # don't be too opinionated about newlines etc.
+haddock-style: single-line # '--' vs. '{-'
+newlines-between-decls: 1 # number of newlines between top-level declarations
+single-constraint-parens: never # whether or not to put braces around single constraints: https://fourmolu.github.io/config/single-constraint-parens/
+fixities:
+  - infixr 0 $
+  - infixr 1 &
+  - infixl 3 <|>
+  - infixr 2 ||
+  - infixr 3 &&
+  - infixl 1 <&>
+  - infixl 4 <$>
+  - infixl 4 <*>


### PR DESCRIPTION
This is still needed for formatting using a system-installed fourmolu.