### PR TITLE
Update CHaP and haskell.nix

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -12,8 +12,8 @@ repository cardano-haskell-packages
 
 -- See CONTRIBUTING.md for information about when and how to update these.
 index-state:
-  , hackage.haskell.org 2025-05-12T23:09:36Z
-  , cardano-haskell-packages 2025-05-12T17:34:03Z
+  , hackage.haskell.org 2025-05-27T12:29:12Z
+  , cardano-haskell-packages 2025-05-28T12:02:33Z
 
 packages: **/*.cabal
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1747073061,
-        "narHash": "sha256-Ts/+6Xlh++ePF4VjWIVdvkmnBJR5Vde1c/0KqraUv/8=",
+        "lastModified": 1748435077,
+        "narHash": "sha256-UPrlvOFpiwqky/IBZCmTWRbS0l3UMitADiphhJnI9Jc=",
         "owner": "IntersectMBO",
         "repo": "cardano-haskell-packages",
-        "rev": "5f473b88ec38382dd9d05bdf50ecc03a26461fa8",
+        "rev": "d674eaf4d6a4c8406d17a502bad323c5ee84a20f",
         "type": "github"
       },
       "original": {
@@ -916,11 +916,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1747095974,
-        "narHash": "sha256-snkejzpqHk/mIPtczDlFL+NzK3QIjvqNv1ZPjAQVRMk=",
+        "lastModified": 1748478391,
+        "narHash": "sha256-2s+f5HRQmqY70ZLun6qqupx6Y/xhqHe1A4efLlAnJIk=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "0febe273eb68da5fa044e7931fe2b9369d9eb425",
+        "rev": "6b7aee219ac8837669f56fd9420bc9e87443d28d",
         "type": "github"
       },
       "original": {
@@ -932,11 +932,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1747095964,
-        "narHash": "sha256-RKf/s0Imxwiiru0NI/U2v0BAiZxnabakLQROO/Ez2+Q=",
+        "lastModified": 1748478380,
+        "narHash": "sha256-tL9oo3kqsGggwyu+6SzqmwvxMgP9TW4kYr7wrcT4F9Y=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "bb50b04f20e7708187bc7c6dd1800f49f663a751",
+        "rev": "4c1cfe985a6d2f0e8c6d903d2b5297fece257382",
         "type": "github"
       },
       "original": {
@@ -1057,11 +1057,11 @@
         "stackage": "stackage_2"
       },
       "locked": {
-        "lastModified": 1747097525,
-        "narHash": "sha256-JF+i78Rfp0+2mKI8Y4hTFwJDIrrmD4OLBnBdyXBE0/M=",
+        "lastModified": 1748516483,
+        "narHash": "sha256-nqtbSbs2G/Ldjkt7KLgePqyDjd+zZtj3YxAbRk1M8wo=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "d4fd88915d1582b21a5968c0fb4d6532b80e31cf",
+        "rev": "7707658389458461553071792fa744f80663ee30",
         "type": "github"
       },
       "original": {
@@ -1649,11 +1649,11 @@
     "iserv-proxy_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1742121966,
-        "narHash": "sha256-x4bg4OoKAPnayom0nWc0BmlxgRMMHk6lEPvbiyFBq1s=",
+        "lastModified": 1747047742,
+        "narHash": "sha256-PCDULyZSIPdDdF8Lanbcy+Dl6AJ5z6H2ng3sRsv+gwc=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "e9dc86ed6ad71f0368c16672081c8f26406c3a7e",
+        "rev": "dea34de4bde325aca22472c18d659bee7800b477",
         "type": "github"
       },
       "original": {
@@ -2113,11 +2113,11 @@
     },
     "nixpkgs-2411": {
       "locked": {
-        "lastModified": 1739151041,
-        "narHash": "sha256-uNszcul7y++oBiyYXjHEDw/AHeLNp8B6pyWOB+RLA/4=",
+        "lastModified": 1746566971,
+        "narHash": "sha256-I40weT0FZWth1IEjgR5a0zC9LLyrPwTC0DAQcejtTJE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "94792ab2a6beaec81424445bf917ca2556fbeade",
+        "rev": "209c5b3b0f5cf5b5a7e12ddea59bf19699f97e75",
         "type": "github"
       },
       "original": {
@@ -2233,11 +2233,11 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1737110817,
-        "narHash": "sha256-DSenga8XjPaUV5KUFW/i3rNkN7jm9XmguW+qQ1ZJTR4=",
+        "lastModified": 1746576598,
+        "narHash": "sha256-FshoQvr6Aor5SnORVvh/ZdJ1Sa2U4ZrIMwKBX5k2wu0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "041c867bad68dfe34b78b2813028a2e2ea70a23c",
+        "rev": "b3582c75c7f21ce0b429898980eddbbf05c68e55",
         "type": "github"
       },
       "original": {
@@ -2717,11 +2717,11 @@
     "stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1747008829,
-        "narHash": "sha256-0AKG0uIdYxDTubB6W4X5iopNmlYzZ4YB0ysLaP6e1ks=",
+        "lastModified": 1748477586,
+        "narHash": "sha256-XlNzJApYAlnV+rPcFIHgxaA304jbfY00JbbkDpsd6bs=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "61a5af32071b6f090ab8f9245ec633337b5338b7",
+        "rev": "c04f95ad0731ff773c027ed1390aca827d9ca902",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -139,6 +139,7 @@
               hydra-tui
               hydraw
             ];
+            inherit (pkgs) weeder;
           };
 
           checks = let lu = inputs.lint-utils.linters.${system}; in {

--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -218,7 +218,7 @@ defaultDescription = ""
 
 -- | Collect OS-level stats while running some 'IO' action.
 --
--- __NOTE__: This function relies on [dstat](https://linux.die.net/man/1/dstat). If the executable is not in the @PATH@
+-- __NOTE__: This function relies on [dool](https://man.archlinux.org/man/extra/dool/dool.1.en). If the executable is not in the @PATH@
 -- it's basically a no-op.
 --
 -- Writes into given `TVar` containing one line every 5 second with share of user/free memory load.
@@ -243,7 +243,7 @@ defaultDescription = ""
 -- TODO: add more data points for memory and network consumption
 withOSStats :: FilePath -> TVar IO SystemStats -> IO a -> IO a
 withOSStats workDir tvar action =
-  findExecutable "dstat" >>= \case
+  findExecutable "dool" >>= \case
     Nothing -> action
     Just _ ->
       withCreateProcess process{std_out = CreatePipe} $ \_stdin out _stderr _processHandle ->
@@ -255,10 +255,10 @@ withOSStats workDir tvar action =
           )
           action
           >>= \case
-            Left _ -> failure "dstat process failed unexpectedly"
+            Left _ -> failure "dool process failed unexpectedly"
             Right a -> pure a
  where
-  process = (proc "dstat" ["-cm", "-n", "-N", "lo", "--noheaders", "--noupdate", "5"]){cwd = Just workDir}
+  process = (proc "dool" ["-cm", "-n", "-N", "lo", "--noheaders", "--noupdate", "5"]){cwd = Just workDir}
 
   collectStats _ Nothing = pure ()
   collectStats tvar' (Just hdl) =

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -185,7 +185,7 @@ rec {
         hydra-node
         pkgs.cardano-node
         pkgs.cardano-cli
-        pkgs.dstat
+        pkgs.dool
       ];
   };
 

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -48,9 +48,9 @@ let
     pkgs.yarn
     pkgs.yq
   ] ++
-  # `dstat` is required by the benchmark tests; but it's not supported on
+  # `dool` is required by the benchmark tests; but it's not supported on
   # darwin; so we just don't include it.
-  (pkgs.lib.optionals pkgs.hostPlatform.isLinux [ pkgs.dstat ]);
+  (pkgs.lib.optionals pkgs.hostPlatform.isLinux [ pkgs.dool ]);
 
   libs = [
     pkgs.glibcLocales


### PR DESCRIPTION
Switches pkgs.dstat to pkgs.dool due to nixpkgs upgrade.

Set coding.standards.hydra.weeder explicitly due to nixpkgs upgrade.