### PR TITLE
Every file is a flake parts module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1688,6 +1688,21 @@
         "type": "github"
       }
     },
+    "import-tree_4": {
+      "locked": {
+        "lastModified": 1745565707,
+        "narHash": "sha256-ccFeWWQ9RLgCd1k+xwV/ASUkJ7AGTTaGDhlRWZgytxY=",
+        "owner": "vic",
+        "repo": "import-tree",
+        "rev": "ed504db425c363b13f13d5ca52f1a2600c4a7703",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vic",
+        "repo": "import-tree",
+        "type": "github"
+      }
+    },
     "incl": {
       "inputs": {
         "nixlib": [
@@ -2894,6 +2909,7 @@
         "haskellNix": "haskellNix_2",
         "hydra-coding-standards": "hydra-coding-standards",
         "hydra-spec": "hydra-spec",
+        "import-tree": "import-tree_4",
         "iohk-nix": "iohk-nix",
         "lint-utils": "lint-utils_2",
         "mithril": "mithril",

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,7 @@
     haskellNix.url = "github:input-output-hk/haskell.nix";
     hydra-coding-standards.url = "github:cardano-scaling/hydra-coding-standards/0.6.5";
     hydra-spec.url = "github:cardano-scaling/hydra-formal-specification/7f78e005b95ff3b9c55995632ceb3d6ab96a305e";
+    import-tree.url = "github:vic/import-tree";
     iohk-nix.url = "github:input-output-hk/iohk-nix";
     lint-utils = {
       url = "github:homotopic/lint-utils";
@@ -22,128 +23,7 @@
     process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
   };
 
-  outputs = { self, ... }@inputs:
-    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
-      imports = [
-        inputs.hydra-coding-standards.flakeModule
-        inputs.process-compose-flake.flakeModule
-        ./nix/hydra/demo.nix
-        ./nix/hydra/docker.nix
-      ];
-      systems = [
-        "x86_64-linux"
-        "x86_64-darwin"
-        "aarch64-darwin"
-        "aarch64-linux"
-      ];
-      perSystem = { config, lib, system, ... }:
-        let
-          compiler = "ghc967";
-
-          # nixpkgs enhanced with haskell.nix and crypto libs as used by iohk
-
-          pkgs = import inputs.nixpkgs {
-            inherit system;
-            overlays = [
-              # This overlay contains libsodium and libblst libraries
-              inputs.iohk-nix.overlays.crypto
-              # This overlay contains pkg-config mappings via haskell.nix to use the
-              # crypto libraries above
-              inputs.iohk-nix.overlays.haskell-nix-crypto
-              # Keep haskell.nix as the last overlay!
-              #
-              # Reason: haskell.nix modules/overlays needs to be last
-              # https://github.com/input-output-hk/haskell.nix/issues/1954
-              inputs.haskellNix.overlay
-              # Custom static libs used for darwin build
-              (import ./nix/static-libs.nix)
-              inputs.nix-npm-buildpackage.overlays.default
-              # Specific versions of tools we require
-              (final: _prev: {
-                inherit (inputs.aiken.packages.${system}) aiken;
-                apply-refact = final.haskell-nix.tool compiler "apply-refact" "0.15.0.0";
-                cabal-install = final.haskell-nix.tool compiler "cabal-install" "3.10.3.0";
-                cabal-plan = final.haskell-nix.tool compiler "cabal-plan" { version = "0.7.5.0"; cabalProjectLocal = "package cabal-plan\nflags: +exe"; };
-                cabal-fmt = config.treefmt.programs.cabal-fmt.package;
-                fourmolu = config.treefmt.programs.fourmolu.package;
-                haskell-language-server = final.haskell-nix.tool compiler "haskell-language-server" "2.11.0.0";
-                weeder = final.haskell-nix.tool compiler "weeder" "2.9.0";
-                inherit (inputs.cardano-node.packages.${system}) cardano-cli;
-                inherit (inputs.cardano-node.packages.${system}) cardano-node;
-                inherit (inputs.mithril.packages.${system}) mithril-client-cli;
-                mithril-client-cli-unstable =
-                  final.writeShellScriptBin "mithril-client-unstable" ''
-                    exec ${inputs.mithril-unstable.packages.${system}.mithril-client-cli}/bin/mithril-client "$@"
-                  '';
-              })
-            ];
-          };
-
-          inputMap = { "https://intersectmbo.github.io/cardano-haskell-packages" = inputs.CHaP; };
-
-          hsPkgs = import ./nix/hydra/project.nix {
-            inherit pkgs inputMap;
-            compiler-nix-name = compiler;
-          };
-
-          hydraPackages = import ./nix/hydra/packages.nix {
-            inherit pkgs inputs hsPkgs self;
-            gitRev = self.rev or "dirty";
-          };
-
-          tx-cost-diff =
-            pkgs.writers.writeHaskellBin
-              "tx-cost-diff"
-              {
-                libraries =
-                  with pkgs.haskellPackages;
-                  [ aeson text bytestring lens lens-aeson shh ];
-              } ''${builtins.readFile scripts/tx-cost-diff.hs}'';
-
-          allComponents = x:
-            [ x.components.library ]
-            ++ lib.concatMap
-              (y: builtins.attrValues x.components."${y}")
-              [ "benchmarks" "exes" "sublibs" "tests" ];
-        in
-        {
-
-          _module.args = { inherit pkgs; };
-
-          legacyPackages = pkgs // hsPkgs;
-
-          packages =
-            hydraPackages //
-            {
-              spec = inputs.hydra-spec.packages.${system}.default;
-              inherit tx-cost-diff;
-            };
-
-          coding.standards.hydra = {
-            enable = true;
-            haskellPackages = with hsPkgs; builtins.concatMap allComponents [
-              hydra-cardano-api
-              hydra-chain-observer
-              hydra-cluster
-              hydra-node
-              hydra-tx
-              hydra-prelude
-              hydra-plutus
-              hydra-plutus-extras
-              hydra-test-utils
-              hydra-tui
-              hydraw
-            ];
-            inherit (pkgs) weeder;
-            haskellType = "haskell.nix";
-          };
-
-          devShells = import ./nix/hydra/shell.nix {
-            inherit pkgs hsPkgs hydraPackages system;
-            ghc = pkgs.buildPackages.haskell-nix.compiler.${compiler};
-          };
-        };
-    };
+  outputs = inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } (inputs.import-tree ./nix);
 
   nixConfig = {
     extra-substituters = [

--- a/nix/coding-standards.nix
+++ b/nix/coding-standards.nix
@@ -1,0 +1,35 @@
+_: {
+
+  perSystem = { pkgs, hsPkgs, lib, ... }:
+    let
+      allComponents = x:
+        [ x.components.library ]
+        ++ lib.concatMap
+          (y: builtins.attrValues x.components."${y}")
+          [ "benchmarks" "exes" "sublibs" "tests" ];
+
+    in
+    {
+
+
+      coding.standards.hydra = {
+        enable = true;
+        haskellPackages = with hsPkgs; builtins.concatMap allComponents [
+          hydra-cardano-api
+          hydra-chain-observer
+          hydra-cluster
+          hydra-node
+          hydra-tx
+          hydra-prelude
+          hydra-plutus
+          hydra-plutus-extras
+          hydra-test-utils
+          hydra-tui
+          hydraw
+        ];
+        inherit (pkgs) weeder;
+        haskellType = "haskell.nix";
+      };
+
+    };
+}

--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -1,0 +1,17 @@
+{ inputs, ... }: {
+
+  imports = [
+    inputs.hydra-coding-standards.flakeModule
+    inputs.process-compose-flake.flakeModule
+  ];
+
+  perSystem = { pkgs, hsPkgs, ... }:
+    let
+      compiler = "ghc967";
+      inputMap = { "https://intersectmbo.github.io/cardano-haskell-packages" = inputs.CHaP; };
+    in
+    {
+      _module.args = { inherit compiler inputMap; };
+      legacyPackages = pkgs // hsPkgs;
+    };
+}

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -1,217 +1,213 @@
 # A set of buildables we typically build for releases
 
-{ hsPkgs # as defined in default.nix
-, pkgs
-, gitRev ? "unknown"
-, ...
-}:
-let
-  inherit (pkgs) lib;
+{ self, ... }: {
+  perSystem = { pkgs, lib, asZip, hsPkgs, ... }: {
+    packages =
+      let
+        # Creates a fixed length string by padding with given filler as suffix.
+        padSuffix = width: filler: str:
+          let
+            strw = lib.stringLength str;
+            reqWidth = width - (lib.stringLength filler);
+          in
+          assert lib.assertMsg (strw <= width)
+            "padSuffix: requested string length (${toString width}) must not be shorter than actual length (${toString strw})";
+          if strw == width then str else padSuffix reqWidth filler str + filler;
 
-  packaging = import ../packaging.nix { inherit pkgs; };
+        paddedRevision = padSuffix 40 " " (self.rev or "dirty");
 
-  # Creates a fixed length string by padding with given filler as suffix.
-  padSuffix = width: filler: str:
-    let
-      strw = lib.stringLength str;
-      reqWidth = width - (lib.stringLength filler);
-    in
-    assert lib.assertMsg (strw <= width)
-      "padSuffix: requested string length (${toString width}) must not be shorter than actual length (${toString strw})";
-    if strw == width then str else padSuffix reqWidth filler str + filler;
+        # Placeholder used to 'embedRevision'. See also hydra-prelude/cbits/revision.c
+        placeholder = "0000000001000000000100000000010000000001";
 
-  paddedRevision = padSuffix 40 " " gitRev;
+        # Takes a derivation with a single executable and embeds the given revision
+        # into this executable.
+        embedRevision = drv: exe: rev:
+          assert lib.assertMsg
+            (lib.stringLength placeholder == lib.stringLength rev)
+            "Mismatching length of placeholder (${placeholder}) and rev (${rev})";
 
-  # Placeholder used to 'embedRevision'. See also hydra-prelude/cbits/revision.c
-  placeholder = "0000000001000000000100000000010000000001";
+          # Using mkDerivation instead of runCommand to make sure to use the same
+          # stdenv as the original drv (important to determine targetPlatform).
+          drv.stdenv.mkDerivation {
+            name = "${exe}";
+            phases = [ "buildPhase" ];
+            buildPhase = ''
+              set -e
 
-  # Takes a derivation with a single executable and embeds the given revision
-  # into this executable.
-  embedRevision = drv: exe: rev:
-    assert lib.assertMsg
-      (lib.stringLength placeholder == lib.stringLength rev)
-      "Mismatching length of placeholder (${placeholder}) and rev (${rev})";
+              echo "Patching embedded git revision in ${exe} to ${rev} ..."
 
-    # Using mkDerivation instead of runCommand to make sure to use the same
-    # stdenv as the original drv (important to determine targetPlatform).
-    drv.stdenv.mkDerivation {
-      name = "${exe}";
-      phases = [ "buildPhase" ];
-      buildPhase = ''
-        set -e
+              # Ensure only one occurrence of placeholder
+              if [[ $(grep -c -a ${placeholder} ${drv}/bin/${exe}) -ne 1 ]]; then
+                echo "Not exactly one occurrence of ${placeholder} in ${drv}/bin/${exe}!"
+                exit 1
+              fi
 
-        echo "Patching embedded git revision in ${exe} to ${rev} ..."
+              mkdir -p $out/bin
+              sed 's/${placeholder}/${rev}/' ${drv}/bin/${exe} > $out/bin/${exe}
+              chmod +x $out/bin/${exe}
+            '';
+          };
 
-        # Ensure only one occurrence of placeholder
-        if [[ $(grep -c -a ${placeholder} ${drv}/bin/${exe}) -ne 1 ]]; then
-          echo "Not exactly one occurrence of ${placeholder} in ${drv}/bin/${exe}!"
-          exit 1
-        fi
+        nativePkgs = hsPkgs;
+        # Allow reinstallation of terminfo as it's not installed with cross compilers.
+        patchedForCrossProject = hsPkgs.appendModule
+          ({ lib, ... }: { options.nonReinstallablePkgs = lib.mkOption { apply = lib.remove "terminfo"; }; });
+        musl64Pkgs = patchedForCrossProject.projectCross.musl64.hsPkgs;
+      in
+      rec {
+        release =
+          asZip
+            { name = "hydra-${pkgs.hostPlatform.system}"; }
+            [ hydra-node hydra-tui ];
 
-        mkdir -p $out/bin
-        sed 's/${placeholder}/${rev}/' ${drv}/bin/${exe} > $out/bin/${exe}
-        chmod +x $out/bin/${exe}
-      '';
-    };
+        release-static =
+          asZip
+            { name = "hydra-${pkgs.hostPlatform.system}"; }
+            [ hydra-node-static hydra-tui-static ];
 
-  nativePkgs = hsPkgs;
-  # Allow reinstallation of terminfo as it's not installed with cross compilers.
-  patchedForCrossProject = hsPkgs.appendModule
-    ({ lib, ... }: { options.nonReinstallablePkgs = lib.mkOption { apply = lib.remove "terminfo"; }; });
-  musl64Pkgs = patchedForCrossProject.projectCross.musl64.hsPkgs;
-in
-rec {
-  release =
-    packaging.asZip
-      { name = "hydra-${pkgs.hostPlatform.system}"; }
-      [ hydra-node hydra-tui ];
+        hydra-node =
+          embedRevision
+            nativePkgs.hydra-node.components.exes.hydra-node
+            "hydra-node"
+            paddedRevision;
 
-  release-static =
-    packaging.asZip
-      { name = "hydra-${pkgs.hostPlatform.system}"; }
-      [ hydra-node-static hydra-tui-static ];
+        hydra-node-static =
+          embedRevision
+            musl64Pkgs.hydra-node.components.exes.hydra-node
+            "hydra-node"
+            paddedRevision;
 
-  hydra-node =
-    embedRevision
-      nativePkgs.hydra-node.components.exes.hydra-node
-      "hydra-node"
-      paddedRevision;
+        hydra-chain-observer =
+          embedRevision
+            nativePkgs.hydra-chain-observer.components.exes.hydra-chain-observer
+            "hydra-chain-observer"
+            paddedRevision;
 
-  hydra-node-static =
-    embedRevision
-      musl64Pkgs.hydra-node.components.exes.hydra-node
-      "hydra-node"
-      paddedRevision;
+        hydra-chain-observer-static =
+          embedRevision
+            musl64Pkgs.hydra-chain-observer.components.exes.hydra-chain-observer
+            "hydra-chain-observer"
+            paddedRevision;
 
-  hydra-chain-observer =
-    embedRevision
-      nativePkgs.hydra-chain-observer.components.exes.hydra-chain-observer
-      "hydra-chain-observer"
-      paddedRevision;
+        hydra-cluster = pkgs.writers.writeBashBin "hydra-cluster" ''
+          export PATH=$PATH:${hydra-node}/bin
+          ${nativePkgs.hydra-cluster.components.exes.hydra-cluster}/bin/hydra-cluster "$@"
+        '';
 
-  hydra-chain-observer-static =
-    embedRevision
-      musl64Pkgs.hydra-chain-observer.components.exes.hydra-chain-observer
-      "hydra-chain-observer"
-      paddedRevision;
+        inherit (nativePkgs.hydra-node.components.benchmarks) tx-cost;
 
-  hydra-cluster = pkgs.writers.writeBashBin "hydra-cluster" ''
-    export PATH=$PATH:${hydra-node}/bin
-    ${nativePkgs.hydra-cluster.components.exes.hydra-cluster}/bin/hydra-cluster "$@"
-  '';
+        hydra-tui =
+          embedRevision
+            nativePkgs.hydra-tui.components.exes.hydra-tui
+            "hydra-tui"
+            paddedRevision;
 
-  inherit (nativePkgs.hydra-node.components.benchmarks) tx-cost;
+        hydra-tui-static =
+          embedRevision
+            musl64Pkgs.hydra-tui.components.exes.hydra-tui
+            "hydra-tui"
+            paddedRevision;
 
-  hydra-tui =
-    embedRevision
-      nativePkgs.hydra-tui.components.exes.hydra-tui
-      "hydra-tui"
-      paddedRevision;
+        inherit (nativePkgs.hydraw.components.exes) hydraw;
 
-  hydra-tui-static =
-    embedRevision
-      musl64Pkgs.hydra-tui.components.exes.hydra-tui
-      "hydra-tui"
-      paddedRevision;
+        hydraw-static = musl64Pkgs.hydraw.components.exes.hydraw;
 
-  inherit (nativePkgs.hydraw.components.exes) hydraw;
+        hydra-plutus-tests = pkgs.mkShellNoCC {
+          name = "hydra-plutus-tests";
+          buildInputs = [
+            nativePkgs.hydra-plutus.components.tests.tests
+            pkgs.aiken
+          ];
+        };
+        hydra-tx-tests = pkgs.mkShellNoCC {
+          name = "hydra-tx-tests";
+          buildInputs = [
+            nativePkgs.hydra-tx.components.tests.tests
+          ];
+        };
+        hydra-chain-observer-tests = pkgs.mkShellNoCC {
+          name = "hydra-chain-observer-tests";
+          buildInputs = [
+            nativePkgs.hydra-chain-observer.components.tests.tests
+          ];
+        };
+        hydra-node-tests = pkgs.mkShellNoCC {
+          name = "hydra-node-tests";
+          buildInputs = [
+            nativePkgs.hydra-node.components.tests.tests
+            pkgs.check-jsonschema
+          ];
+        };
+        hydra-cluster-tests = pkgs.mkShellNoCC {
+          name = "hydra-cluster-tests";
+          buildInputs =
+            [
+              nativePkgs.hydra-cluster.components.tests.tests
+              hydra-node
+              hydra-chain-observer
+              pkgs.cardano-node
+              pkgs.cardano-cli
+              pkgs.mithril-client-cli
+              pkgs.mithril-client-cli-unstable
+              pkgs.check-jsonschema
+            ];
+        };
+        hydra-tui-tests = pkgs.mkShellNoCC {
+          name = "hydra-tui-tests";
+          buildInputs =
+            [
+              nativePkgs.hydra-tui.components.tests.tests
+              hydra-node
+              pkgs.cardano-node
+              pkgs.cardano-cli
+            ];
+        };
 
-  hydraw-static = musl64Pkgs.hydraw.components.exes.hydraw;
+        hydra-node-bench = pkgs.mkShellNoCC {
+          name = "hydra-node-bench";
+          buildInputs = [
+            nativePkgs.hydra-node.components.benchmarks.tx-cost
+            nativePkgs.hydra-node.components.benchmarks.micro
+          ];
+        };
+        hydra-cluster-bench = pkgs.mkShellNoCC {
+          name = "hydra-cluster-bench";
+          buildInputs =
+            [
+              nativePkgs.hydra-cluster.components.benchmarks.bench-e2e
+              hydra-node
+              pkgs.cardano-node
+              pkgs.cardano-cli
+              pkgs.dool
+            ];
+        };
 
-  hydra-plutus-tests = pkgs.mkShellNoCC {
-    name = "hydra-plutus-tests";
-    buildInputs = [
-      nativePkgs.hydra-plutus.components.tests.tests
-      pkgs.aiken
-    ];
+        haddocks = pkgs.runCommand "hydra-haddocks"
+          {
+            paths = [
+              hsPkgs.hydra-prelude.components.library.doc
+              hsPkgs.hydra-cardano-api.components.library.doc
+              hsPkgs.hydra-plutus.components.library.doc
+              hsPkgs.hydra-node.components.library.doc
+              hsPkgs.hydra-tx.components.library.doc
+              hsPkgs.hydra-tx.components.tests.tests.doc
+              hsPkgs.hydra-node.components.tests.tests.doc
+              hsPkgs.hydra-cluster.components.library.doc
+              hsPkgs.hydra-tui.components.library.doc
+            ];
+          }
+          ''
+            set -ex
+            mkdir -p $out
+            for p in $paths; do
+              cd $p
+              for html in $(find $haddockRoot -name html -type d); do
+                package=$(basename $(dirname $html))
+                mkdir -p $out/$package
+                cp -a $html/* $out/$package/
+              done
+            done
+          '';
+      };
   };
-  hydra-tx-tests = pkgs.mkShellNoCC {
-    name = "hydra-tx-tests";
-    buildInputs = [
-      nativePkgs.hydra-tx.components.tests.tests
-    ];
-  };
-  hydra-chain-observer-tests = pkgs.mkShellNoCC {
-    name = "hydra-chain-observer-tests";
-    buildInputs = [
-      nativePkgs.hydra-chain-observer.components.tests.tests
-    ];
-  };
-  hydra-node-tests = pkgs.mkShellNoCC {
-    name = "hydra-node-tests";
-    buildInputs = [
-      nativePkgs.hydra-node.components.tests.tests
-      pkgs.check-jsonschema
-    ];
-  };
-  hydra-cluster-tests = pkgs.mkShellNoCC {
-    name = "hydra-cluster-tests";
-    buildInputs =
-      [
-        nativePkgs.hydra-cluster.components.tests.tests
-        hydra-node
-        hydra-chain-observer
-        pkgs.cardano-node
-        pkgs.cardano-cli
-        pkgs.mithril-client-cli
-        pkgs.mithril-client-cli-unstable
-        pkgs.check-jsonschema
-      ];
-  };
-  hydra-tui-tests = pkgs.mkShellNoCC {
-    name = "hydra-tui-tests";
-    buildInputs =
-      [
-        nativePkgs.hydra-tui.components.tests.tests
-        hydra-node
-        pkgs.cardano-node
-        pkgs.cardano-cli
-      ];
-  };
-
-  hydra-node-bench = pkgs.mkShellNoCC {
-    name = "hydra-node-bench";
-    buildInputs = [
-      nativePkgs.hydra-node.components.benchmarks.tx-cost
-      nativePkgs.hydra-node.components.benchmarks.micro
-    ];
-  };
-  hydra-cluster-bench = pkgs.mkShellNoCC {
-    name = "hydra-cluster-bench";
-    buildInputs =
-      [
-        nativePkgs.hydra-cluster.components.benchmarks.bench-e2e
-        hydra-node
-        pkgs.cardano-node
-        pkgs.cardano-cli
-        pkgs.dool
-      ];
-  };
-
-  haddocks = pkgs.runCommand "hydra-haddocks"
-    {
-      paths = [
-        hsPkgs.hydra-prelude.components.library.doc
-        hsPkgs.hydra-cardano-api.components.library.doc
-        hsPkgs.hydra-plutus.components.library.doc
-        hsPkgs.hydra-node.components.library.doc
-        hsPkgs.hydra-tx.components.library.doc
-        hsPkgs.hydra-tx.components.tests.tests.doc
-        hsPkgs.hydra-node.components.tests.tests.doc
-        hsPkgs.hydra-cluster.components.library.doc
-        hsPkgs.hydra-tui.components.library.doc
-      ];
-    }
-    ''
-      set -ex
-      mkdir -p $out
-      for p in $paths; do
-        cd $p
-        for html in $(find $haddockRoot -name html -type d); do
-          package=$(basename $(dirname $html))
-          mkdir -p $out/$package
-          cp -a $html/* $out/$package/
-        done
-      done
-    '';
 }

--- a/nix/hydra/project.nix
+++ b/nix/hydra/project.nix
@@ -1,94 +1,100 @@
-{ compiler-nix-name
+{ self, ... }: {
 
-, inputMap
+  perSystem = { compiler, inputMap, pkgs, ... }:
 
-, pkgs
 
-}:
+    let
+      hsPkgs = pkgs.haskell-nix.project {
+        src = pkgs.haskell-nix.haskellLib.cleanSourceWith {
+          name = "hydra";
+          src = self;
+          filter = path: _type:
+            # Blacklist of paths which do not affect the haskell build. The smaller
+            # the resulting list of files is, the less likely we have redundant
+            # rebuilds.
+            builtins.all (x: baseNameOf path != x) [
+              "flake.nix"
+              "flake.lock"
+              "nix"
+              ".github"
+              "demo"
+              "docs"
+              "sample-node-config"
+              "spec"
+              "testnets"
+            ];
+        };
+        projectFileName = "cabal.project";
 
-pkgs.haskell-nix.project {
-  src = pkgs.haskell-nix.haskellLib.cleanSourceWith {
-    name = "hydra";
-    src = ./../..;
-    filter = path: _type:
-      # Blacklist of paths which do not affect the haskell build. The smaller
-      # the resulting list of files is, the less likely we have redundant
-      # rebuilds.
-      builtins.all (x: baseNameOf path != x) [
-        "flake.nix"
-        "flake.lock"
-        "nix"
-        ".github"
-        "demo"
-        "docs"
-        "sample-node-config"
-        "spec"
-        "testnets"
-      ];
-  };
-  projectFileName = "cabal.project";
+        inherit inputMap;
 
-  inherit inputMap compiler-nix-name;
+        compiler-nix-name = compiler;
 
-  modules = [
-    # Strip debugging symbols from exes (smaller closures)
-    {
-      packages = {
-        hydra-cardano-api.writeHieFiles = true;
-        hydra-chain-observer.writeHieFiles = true;
-        hydra-cluster.writeHieFiles = true;
-        hydra-node.writeHieFiles = true;
-        hydra-plutus.writeHieFiles = true;
-        hydra-plutus-extras.writeHieFiles = true;
-        hydra-prelude.writeHieFiles = true;
-        hydra-test-utils.writeHieFiles = true;
-        hydra-tx.writeHieFiles = true;
-        hydra-tui.writeHieFiles = true;
-        hydraw.writeHieFiles = true;
-        hydra-node.dontStrip = false;
-        hydra-tui.dontStrip = false;
-        hydraw.dontStrip = false;
+        modules = [
+          # Strip debugging symbols from exes (smaller closures)
+          {
+            packages = {
+              hydra-cardano-api.writeHieFiles = true;
+              hydra-chain-observer.writeHieFiles = true;
+              hydra-cluster.writeHieFiles = true;
+              hydra-node.writeHieFiles = true;
+              hydra-plutus.writeHieFiles = true;
+              hydra-plutus-extras.writeHieFiles = true;
+              hydra-prelude.writeHieFiles = true;
+              hydra-test-utils.writeHieFiles = true;
+              hydra-tx.writeHieFiles = true;
+              hydra-tui.writeHieFiles = true;
+              hydraw.writeHieFiles = true;
+              hydra-node.dontStrip = false;
+              hydra-tui.dontStrip = false;
+              hydraw.dontStrip = false;
+            };
+          }
+          # Use different static libs on darwin
+          # TODO: Always use these?
+          (pkgs.lib.mkIf pkgs.hostPlatform.isDarwin {
+            packages.hydra-node.ghcOptions = with pkgs; [
+              "-L${lib.getLib static-gmp}/lib"
+              "-L${lib.getLib static-libsodium-vrf}/lib"
+              "-L${lib.getLib static-secp256k1}/lib"
+              "-L${lib.getLib static-openssl}/lib"
+              "-L${lib.getLib static-libblst}/lib"
+              "-L${lib.getLib static-snappy}/lib"
+            ];
+          })
+          # Always use static snappy (from overlay, see nix/static-libs.nix)
+          {
+            # XXX: Instead of patching to the static-snappy here for all binaries, we
+            # could try have both static and dynamic libs in the pkgs.snappy
+            # derivation? Using only the static libs in pkgs.snappy results in
+            # libHSsnappy relocation / symbol not found errors.
+            packages = {
+              hydra-node.ghcOptions = [ "-L${pkgs.lib.getLib pkgs.static-snappy}/lib" ];
+              hydra-tui.ghcOptions = [ "-L${pkgs.lib.getLib pkgs.static-snappy}/lib" ];
+              hydra-chain-observer.ghcOptions = [ "-L${pkgs.lib.getLib pkgs.static-snappy}/lib" ];
+              hydraw.ghcOptions = [ "-L${pkgs.lib.getLib pkgs.static-snappy}/lib" ];
+            };
+          }
+          {
+            # lib:ghc is a bit annoying in that it comes with it's own build-type:Custom, and then tries
+            # to call out to all kinds of silly tools that GHC doesn't really provide.
+            # For this reason, we try to get away without re-installing lib:ghc for now.
+            reinstallableLibGhc = false;
+          }
+          # XXX: Fix missing dependency onto protobuf in the haskell.nix derivation
+          {
+            packages.proto-lens-protobuf-types.components.library.build-tools = [ pkgs.protobuf ];
+            packages.proto-lens-etcd.components.library.build-tools = [ pkgs.protobuf ];
+          }
+          # Add etcd as build dependency of hydra-node (template haskell embedding not tracked by cabal)
+          {
+            packages.hydra-node.components.library.build-tools = [ pkgs.etcd ];
+          }
+        ];
       };
-    }
-    # Use different static libs on darwin
-    # TODO: Always use these?
-    (pkgs.lib.mkIf pkgs.hostPlatform.isDarwin {
-      packages.hydra-node.ghcOptions = with pkgs; [
-        "-L${lib.getLib static-gmp}/lib"
-        "-L${lib.getLib static-libsodium-vrf}/lib"
-        "-L${lib.getLib static-secp256k1}/lib"
-        "-L${lib.getLib static-openssl}/lib"
-        "-L${lib.getLib static-libblst}/lib"
-        "-L${lib.getLib static-snappy}/lib"
-      ];
-    })
-    # Always use static snappy (from overlay, see nix/static-libs.nix)
+
+    in
     {
-      # XXX: Instead of patching to the static-snappy here for all binaries, we
-      # could try have both static and dynamic libs in the pkgs.snappy
-      # derivation? Using only the static libs in pkgs.snappy results in
-      # libHSsnappy relocation / symbol not found errors.
-      packages = {
-        hydra-node.ghcOptions = [ "-L${pkgs.lib.getLib pkgs.static-snappy}/lib" ];
-        hydra-tui.ghcOptions = [ "-L${pkgs.lib.getLib pkgs.static-snappy}/lib" ];
-        hydra-chain-observer.ghcOptions = [ "-L${pkgs.lib.getLib pkgs.static-snappy}/lib" ];
-        hydraw.ghcOptions = [ "-L${pkgs.lib.getLib pkgs.static-snappy}/lib" ];
-      };
-    }
-    {
-      # lib:ghc is a bit annoying in that it comes with it's own build-type:Custom, and then tries
-      # to call out to all kinds of silly tools that GHC doesn't really provide.
-      # For this reason, we try to get away without re-installing lib:ghc for now.
-      reinstallableLibGhc = false;
-    }
-    # XXX: Fix missing dependency onto protobuf in the haskell.nix derivation
-    {
-      packages.proto-lens-protobuf-types.components.library.build-tools = [ pkgs.protobuf ];
-      packages.proto-lens-etcd.components.library.build-tools = [ pkgs.protobuf ];
-    }
-    # Add etcd as build dependency of hydra-node (template haskell embedding not tracked by cabal)
-    {
-      packages.hydra-node.components.library.build-tools = [ pkgs.etcd ];
-    }
-  ];
+      _module.args = { inherit hsPkgs; };
+    };
 }

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -2,181 +2,174 @@
 # environment. The main shell environment is based on haskell.nix and uses the
 # same nixpkgs as the default nix builds (see default.nix).
 
-{ hsPkgs
-, pkgs
-, ghc
-, hydraPackages
-, system
-}:
-let
+{ self, ... }: {
 
-  buildInputs = [
-    # To compile hydra scripts
-    pkgs.aiken
-    pkgs.cabal-fmt
-    pkgs.cabal-install
-    # Handy tool to debug the cabal build plan
-    pkgs.cabal-plan
-    # To interact with cardano-node and integration tests
-    pkgs.cardano-cli
-    # For integration tests
-    pkgs.cardano-node
-    # For validating JSON instances against a pre-defined schema
-    pkgs.check-jsonschema
-    pkgs.fourmolu
-    pkgs.git
-    # For plotting results of hydra-cluster benchmarks
-    pkgs.gnuplot
-    pkgs.haskell-language-server
-    pkgs.haskellPackages.hspec-discover
-    # The interactive Glasgow Haskell Compiler as a Daemon
-    pkgs.haskellPackages.ghcid
-    # Generate a graph of the module dependencies in the "dot" format
-    pkgs.haskellPackages.graphmod
-    # To interact with mithril and integration tests
-    pkgs.jq
-    pkgs.mithril-client-cli
-    pkgs.mithril-client-cli-unstable
-    pkgs.nixpkgs-fmt
-    pkgs.nodejs
-    pkgs.pkg-config
-    # For generating plantuml drawings
-    pkgs.plantuml
-    # Handy to interact with the hydra-node via websockets
-    pkgs.websocat
-    pkgs.weeder
-    pkgs.yarn
-    pkgs.yq
-  ] ++
-  # `dool` is required by the benchmark tests; but it's not supported on
-  # darwin; so we just don't include it.
-  (pkgs.lib.optionals pkgs.hostPlatform.isLinux [ pkgs.dool ]);
+  perSystem = { pkgs, hsPkgs, compiler, self', ... }:
+    let
 
-  libs = [
-    pkgs.glibcLocales
-    pkgs.libsodium-vrf # from iohk-nix overlay
-    pkgs.secp256k1
-    pkgs.xz
-    pkgs.zlib
-    pkgs.libblst
-    pkgs.snappy
-    pkgs.etcd # Build-time dependency (static binary to be embedded)
-  ]
-  ++
-  pkgs.lib.optionals pkgs.stdenv.isLinux [
-    pkgs.systemd
-  ];
+      buildInputs = [
+        # To compile hydra scripts
+        pkgs.aiken
+        pkgs.cabal-fmt
+        pkgs.cabal-install
+        # Handy tool to debug the cabal build plan
+        pkgs.cabal-plan
+        # To interact with cardano-node and integration tests
+        pkgs.cardano-cli
+        # For integration tests
+        pkgs.cardano-node
+        # For validating JSON instances against a pre-defined schema
+        pkgs.check-jsonschema
+        pkgs.fourmolu
+        pkgs.git
+        # For plotting results of hydra-cluster benchmarks
+        pkgs.gnuplot
+        pkgs.haskell-language-server
+        pkgs.haskellPackages.hspec-discover
+        # The interactive Glasgow Haskell Compiler as a Daemon
+        pkgs.haskellPackages.ghcid
+        # Generate a graph of the module dependencies in the "dot" format
+        pkgs.haskellPackages.graphmod
+        # To interact with mithril and integration tests
+        pkgs.jq
+        pkgs.mithril-client-cli
+        pkgs.mithril-client-cli-unstable
+        pkgs.nixpkgs-fmt
+        pkgs.nodejs
+        pkgs.pkg-config
+        # For generating plantuml drawings
+        pkgs.plantuml
+        # Handy to interact with the hydra-node via websockets
+        pkgs.websocat
+        pkgs.weeder
+        pkgs.yarn
+        pkgs.yq
+      ] ++
+      # `dool` is required by the benchmark tests; but it's not supported on
+      # darwin; so we just don't include it.
+      (pkgs.lib.optionals pkgs.hostPlatform.isLinux [ pkgs.dool ]);
 
-  haskellNixShell = (hsPkgs.shellFor {
-    buildInputs = libs ++ buildInputs;
+      libs = [
+        pkgs.glibcLocales
+        pkgs.libsodium-vrf # from iohk-nix overlay
+        pkgs.secp256k1
+        pkgs.xz
+        pkgs.zlib
+        pkgs.etcd # Build-time dependency (static binary to be embedded)
+      ]
+      ++
+      pkgs.lib.optionals pkgs.stdenv.isLinux [
+        pkgs.systemd
+      ];
 
-    withHoogle = true;
+      haskellNixShell = (hsPkgs.shellFor {
+        buildInputs = libs ++ buildInputs;
+        # Always create missing golden files
+        shellHook = ''
+          if ! which cardano-node > /dev/null 2>&1; then
+            echo "WARNING: 'cardano-node' not found"
+          fi
+          if ! which cardano-cli > /dev/null 2>&1; then
+            echo "WARNING: 'cardano-cli' not found"
+          fi
+        '';
+      }).overrideAttrs {
 
-    # Always create missing golden files
-    shellHook = ''
-      if ! which cardano-node > /dev/null 2>&1; then
-        echo "WARNING: 'cardano-node' not found"
-      fi
-      if ! which cardano-cli > /dev/null 2>&1; then
-        echo "WARNING: 'cardano-cli' not found"
-      fi
-    '';
-  }).overrideAttrs {
+        CREATE_MISSING_GOLDEN = 1;
 
-    CREATE_MISSING_GOLDEN = 1;
+        # Force a UTF-8 locale because many Haskell programs and tests
+        # assume this.
+        LANG = "en_US.UTF-8";
 
-    # Force a UTF-8 locale because many Haskell programs and tests
-    # assume this.
-    LANG = "en_US.UTF-8";
+        GIT_SSL_CAINFO = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
 
-    GIT_SSL_CAINFO = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+      };
+      # A "cabal-only" shell which does not use haskell.nix
+      cabalShell = pkgs.mkShell {
+        name = "hydra-node-cabal-shell";
 
-  };
+        buildInputs = libs ++ [
+          pkgs.buildPackages.haskell-nix.compiler.${compiler}
+          pkgs.cabal-install
+          pkgs.pkg-config
+        ] ++ buildInputs;
 
-  # A "cabal-only" shell which does not use haskell.nix
-  cabalShell = pkgs.mkShell {
-    name = "hydra-node-cabal-shell";
+        # Ensure that libz.so and other libraries are available to TH splices.
+        LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath libs;
 
-    buildInputs = libs ++ [
-      ghc
-      pkgs.cabal-install
-      pkgs.pkg-config
-    ] ++ buildInputs;
+        # Force a UTF-8 locale because many Haskell programs and tests
+        # assume this.
+        LANG = "en_US.UTF-8";
 
-    # Ensure that libz.so and other libraries are available to TH splices.
-    LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath libs;
+        # Make the shell suitable for the stack nix integration
+        # <nixpkgs/pkgs/development/haskell-modules/generic-stack-builder.nix>
+        GIT_SSL_CAINFO = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+        STACK_IN_NIX_SHELL = "true";
+      };
 
-    # Force a UTF-8 locale because many Haskell programs and tests
-    # assume this.
-    LANG = "en_US.UTF-8";
+      # A shell which does provide hydra-node and hydra-cluster executables along
+      # with cardano-node, cardano-cli and mithril-client.
+      exeShell = pkgs.mkShell {
+        name = "hydra-node-exe-shell";
 
-    # Make the shell suitable for the stack nix integration
-    # <nixpkgs/pkgs/development/haskell-modules/generic-stack-builder.nix>
-    GIT_SSL_CAINFO = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
-    STACK_IN_NIX_SHELL = "true";
-  };
+        buildInputs = [
+          self'.packages.hydra-node
+          self'.packages.hydra-cluster
+          pkgs.cardano-node
+          pkgs.cardano-cli
+          pkgs.mithril-client-cli
+          pkgs.mithril-client-cli-unstable
+        ];
+      };
 
-  # A shell which does provide hydra-node and hydra-cluster executables along
-  # with cardano-node, cardano-cli and mithril-client.
-  exeShell = pkgs.mkShell {
-    name = "hydra-node-exe-shell";
+      # A shell setup providing build tools and utilities for the demo
+      demoShell = pkgs.mkShell {
+        name = "hydra-demo-shell";
+        buildInputs = [
+          self'.packages.hydra-node
+          self'.packages.hydra-tui
+          run-tmux
+          pkgs.cardano-node
+          pkgs.cardano-cli
+        ];
+      };
 
-    buildInputs = [
-      hydraPackages.hydra-node
-      hydraPackages.hydra-cluster
-      pkgs.cardano-node
-      pkgs.cardano-cli
-      pkgs.mithril-client-cli
-      pkgs.mithril-client-cli-unstable
-    ];
-  };
+      # Shell for CI activities
+      ciShell = pkgs.mkShell {
+        name = "hydra-ci-shell";
+        buildInputs = [
+          # For building docs
+          pkgs.plantuml
+          pkgs.jq
+          pkgs.weeder
+        ];
+      };
 
-  # A shell setup providing build tools and utilities for the demo
-  demoShell = pkgs.mkShell {
-    name = "hydra-demo-shell";
-    buildInputs = [
-      hydraPackages.hydra-node
-      hydraPackages.hydra-tui
-      run-tmux
-      pkgs.cardano-node
-      pkgs.cardano-cli
-    ];
-  };
+      # Shell for computing tx-cost-differences
+      costDifferencesShell = pkgs.mkShell {
+        name = "tx-cost-differences-shell";
+        buildInputs = [
+          pkgs.pandoc
+          (pkgs.python3.withPackages (ps: with ps; [ pandas html5lib beautifulsoup4 tabulate ]))
+        ];
+      };
 
-  # Shell for CI activities
-  ciShell = pkgs.mkShell {
-    name = "hydra-ci-shell";
-    buildInputs = [
-      # For building docs
-      pkgs.plantuml
-      pkgs.jq
-      pkgs.weeder
-    ];
-  };
-
-  # Shell for computing tx-cost-differences
-  costDifferencesShell = pkgs.mkShell {
-    name = "tx-cost-differences-shell";
-    buildInputs = [
-      pkgs.pandoc
-      (pkgs.python3.withPackages (ps: with ps; [ pandas html5lib beautifulsoup4 tabulate ]))
-    ];
-  };
-
-  # If you want to modify `Python` code add `libtmux` and pyyaml to the
-  # `buildInputs` then enter it and then run `Python` module directly so you
-  # have fast devel cycle.
-  run-tmux = pkgs.writers.writePython3Bin
-    "run-tmux"
-    { libraries = with pkgs.python3Packages; [ libtmux pyyaml ]; }
-    # TODO: should use project relative path (via flake inputs.self?)
-    (builtins.readFile ./../../demo/run-tmux.py);
-in
-{
-  default = haskellNixShell;
-  cabalOnly = cabalShell;
-  exes = exeShell;
-  demo = demoShell;
-  ci = ciShell;
-  costDifferences = costDifferencesShell;
+      # If you want to modify `Python` code add `libtmux` and pyyaml to the
+      # `buildInputs` then enter it and then run `Python` module directly so you
+      # have fast devel cycle.
+      run-tmux = pkgs.writers.writePython3Bin
+        "run-tmux"
+        { libraries = with pkgs.python3Packages; [ libtmux pyyaml ]; }
+        (builtins.readFile "${self}/demo/run-tmux.py");
+    in
+    {
+      devShells = {
+        default = haskellNixShell;
+        cabalOnly = cabalShell;
+        exes = exeShell;
+        demo = demoShell;
+        ci = ciShell;
+        costDifferences = costDifferencesShell;
+      };
+    };
 }

--- a/nix/hydra/spec.nix
+++ b/nix/hydra/spec.nix
@@ -1,0 +1,7 @@
+{ inputs, ... }: {
+
+  perSystem = { system, ... }: {
+    packages.spec = inputs.hydra-spec.packages.${system}.default;
+  };
+
+}

--- a/nix/hydra/tx-cost-diff.nix
+++ b/nix/hydra/tx-cost-diff.nix
@@ -1,0 +1,12 @@
+{ self, ... }: {
+  perSystem = { pkgs, ... }: {
+    packages.tx-cost-diff =
+      pkgs.writers.writeHaskellBin
+        "tx-cost-diff"
+        {
+          libraries =
+            with pkgs.haskellPackages;
+            [ aeson text bytestring lens lens-aeson shh ];
+        } ''${builtins.readFile "${self}/scripts/tx-cost-diff.hs"}'';
+  };
+}

--- a/nix/packaging.nix
+++ b/nix/packaging.nix
@@ -1,79 +1,81 @@
 # Vendored from https://github.com/input-output-hk/haskell-nix-example/blob/2247d445b91b0cc21eda4359e060d76b3cc0ce41/packaging.nix
 #
 # Modified to not be an overlay and changed the resultin zip format slightly.
-{ pkgs }:
 {
-  # Given one or more 'drvs', this produces a single zip containing all binaries
-  # potentially patched for better distribution.
-  asZip = { name ? null }: drvs:
-    let
-      drv = if builtins.isList drvs then builtins.head drvs else drvs;
-      name' = if name == null then drv.pname or drv.name else name;
-      combined = pkgs.symlinkJoin { name = "${name'}-binaries"; paths = drvs; };
-      inherit (drv.stdenv) targetPlatform;
-      interpForSystem = sys:
+  perSystem = { pkgs, ... }:
+    {
+      # Given one or more 'drvs', this produces a single zip containing all binaries
+      # potentially patched for better distribution.
+      _module.args.asZip = { name ? null }: drvs:
         let
-          s = {
-            "i686-linux" = "/lib/ld-linux.so.2";
-            "x86_64-linux" = "/lib64/ld-linux-x86-64.so.2";
-            "aarch64-linux" = "/lib/ld-linux-aarch64.so.1";
-            "armv7l-linux" = "/lib/ld-linux-armhf.so.3";
-            "armv7a-linux" = "/lib/ld-linux-armhf.so.3";
+          drv = if builtins.isList drvs then builtins.head drvs else drvs;
+          name' = if name == null then drv.pname or drv.name else name;
+          combined = pkgs.symlinkJoin { name = "${name'}-binaries"; paths = drvs; };
+          inherit (drv.stdenv) targetPlatform;
+          interpForSystem = sys:
+            let
+              s = {
+                "i686-linux" = "/lib/ld-linux.so.2";
+                "x86_64-linux" = "/lib64/ld-linux-x86-64.so.2";
+                "aarch64-linux" = "/lib/ld-linux-aarch64.so.1";
+                "armv7l-linux" = "/lib/ld-linux-armhf.so.3";
+                "armv7a-linux" = "/lib/ld-linux-armhf.so.3";
+              };
+            in
+              s.${sys} or (builtins.abort "Unsupported system ${sys}. Supported systms are: ${builtins.concatStringsSep ", " (builtins.attrNames s)}.");
+          fixup-nix-deps = pkgs.writeShellApplication {
+            name = "fixup-nix-deps";
+            text = ''
+              for nixlib in $(otool -L "$1" |awk '/nix\/store/{ print $1 }'); do
+                  case "$nixlib" in
+                  *libiconv.dylib) install_name_tool -change "$nixlib" /usr/lib/libiconv.dylib "$1" ;;
+                  *libffi.*.dylib) install_name_tool -change "$nixlib" /usr/lib/libffi.dylib   "$1" ;;
+                  *libc++.*.dylib) install_name_tool -change "$nixlib" /usr/lib/libc++.dylib   "$1" ;;
+                  *libz.dylib)     install_name_tool -change "$nixlib" /usr/lib/libz.dylib     "$1" ;;
+                  *) ;;
+                  esac
+              done
+            '';
           };
         in
-          s.${sys} or (builtins.abort "Unsupported system ${sys}. Supported systms are: ${builtins.concatStringsSep ", " (builtins.attrNames s)}.");
-      fixup-nix-deps = pkgs.writeShellApplication {
-        name = "fixup-nix-deps";
-        text = ''
-          for nixlib in $(otool -L "$1" |awk '/nix\/store/{ print $1 }'); do
-              case "$nixlib" in
-              *libiconv.dylib) install_name_tool -change "$nixlib" /usr/lib/libiconv.dylib "$1" ;;
-              *libffi.*.dylib) install_name_tool -change "$nixlib" /usr/lib/libffi.dylib   "$1" ;;
-              *libc++.*.dylib) install_name_tool -change "$nixlib" /usr/lib/libc++.dylib   "$1" ;;
-              *libz.dylib)     install_name_tool -change "$nixlib" /usr/lib/libz.dylib     "$1" ;;
-              *) ;;
-              esac
-          done
-        '';
-      };
-    in
-    pkgs.stdenv.mkDerivation {
-      name = "${name'}.zip";
-      buildInputs = with pkgs; [ patchelf zip fixup-nix-deps ];
+        pkgs.stdenv.mkDerivation {
+          name = "${name'}.zip";
+          buildInputs = with pkgs; [ patchelf zip fixup-nix-deps ];
 
-      phases = [ "buildPhase" "installPhase" ];
+          phases = [ "buildPhase" "installPhase" ];
 
-      buildPhase = ''
-        mkdir -p bin
-        cp ${combined}/bin/* bin/
-      ''
-      # set the interpreter to the default expected location on linux. (See interpForSystem above)
-      + pkgs.lib.optionalString (targetPlatform.isLinux && targetPlatform.isGnu) ''
-        for bin in bin/*; do
-          mode=$(stat -c%a $bin)
-          chmod +w $bin
-          patchelf --set-interpreter ${interpForSystem targetPlatform.system} $bin
-          chmod $mode $bin
-        done
-      '' + pkgs.lib.optionalString targetPlatform.isDarwin ''
-        for bin in bin/*; do
-          mode=$(stat -c%a $bin)
-          chmod +w $bin
-          fixup-nix-deps $bin
-          chmod $mode $bin
-        done
-      '';
+          buildPhase = ''
+            mkdir -p bin
+            cp ${combined}/bin/* bin/
+          ''
+          # set the interpreter to the default expected location on linux. (See interpForSystem above)
+          + pkgs.lib.optionalString (targetPlatform.isLinux && targetPlatform.isGnu) ''
+            for bin in bin/*; do
+              mode=$(stat -c%a $bin)
+              chmod +w $bin
+              patchelf --set-interpreter ${interpForSystem targetPlatform.system} $bin
+              chmod $mode $bin
+            done
+          '' + pkgs.lib.optionalString targetPlatform.isDarwin ''
+            for bin in bin/*; do
+              mode=$(stat -c%a $bin)
+              chmod +w $bin
+              fixup-nix-deps $bin
+              chmod $mode $bin
+            done
+          '';
 
-      # compress and put into hydra products
-      installPhase = ''
-        mkdir -p $out/
-        cd bin/
-        zip -r -9 $out/${name'}.zip .
-      '';
+          # compress and put into hydra products
+          installPhase = ''
+            mkdir -p $out/
+            cd bin/
+            zip -r -9 $out/${name'}.zip .
+          '';
 
-      passthru = {
-        isPackage = true;
-        packageName = "${name'}.zip";
-      };
+          passthru = {
+            isPackage = true;
+            packageName = "${name'}.zip";
+          };
+        };
     };
 }

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,0 +1,45 @@
+{ inputs, self, ... }: {
+  perSystem = { config, system, compiler, ... }:
+    let
+      pkgs = import inputs.nixpkgs {
+        inherit system;
+        overlays = [
+          # This overlay contains libsodium and libblst libraries
+          inputs.iohk-nix.overlays.crypto
+          # This overlay contains pkg-config mappings via haskell.nix to use the
+          # crypto libraries above
+          inputs.iohk-nix.overlays.haskell-nix-crypto
+          # Keep haskell.nix as the last overlay!
+          #
+          # Reason: haskell.nix modules/overlays needs to be last
+          # https://github.com/input-output-hk/haskell.nix/issues/1954
+          inputs.haskellNix.overlay
+          # Custom static libs used for darwin build
+          self.overlays.static-libs
+          inputs.nix-npm-buildpackage.overlays.default
+          # Specific versions of tools we require
+          (_final: _prev: {
+            inherit (inputs.aiken.packages.${system}) aiken;
+            apply-refact = pkgs.haskell-nix.tool compiler "apply-refact" "0.15.0.0";
+            cabal-install = pkgs.haskell-nix.tool compiler "cabal-install" "3.10.3.0";
+            cabal-plan = pkgs.haskell-nix.tool compiler "cabal-plan" { version = "0.7.5.0"; cabalProjectLocal = "package cabal-plan\nflags: +exe"; };
+            cabal-fmt = config.treefmt.programs.cabal-fmt.package;
+            fourmolu = config.treefmt.programs.fourmolu.package;
+            haskell-language-server = pkgs.haskell-nix.tool compiler "haskell-language-server" "2.11.0.0";
+            weeder = pkgs.haskell-nix.tool compiler "weeder" "2.9.0";
+            inherit (inputs.cardano-node.packages.${system}) cardano-cli;
+            inherit (inputs.cardano-node.packages.${system}) cardano-node;
+            inherit (inputs.mithril.packages.${system}) mithril-client-cli;
+            mithril-client-cli-unstable =
+              pkgs.writeShellScriptBin "mithril-client-unstable" ''
+                exec ${inputs.mithril-unstable.packages.${system}.mithril-client-cli}/bin/mithril-client "$@"
+              '';
+          })
+        ];
+      };
+    in
+    {
+      _module.args = { inherit pkgs; };
+    };
+
+}

--- a/nix/static-libs.nix
+++ b/nix/static-libs.nix
@@ -1,22 +1,25 @@
 # Overlay vendored from https://github.com/input-output-hk/haskell-nix-example/blob/2247d445b91b0cc21eda4359e060d76b3cc0ce41/flake.nix#L53C17-L53C17
-final: _prev: {
-  static-libsodium-vrf = final.libsodium-vrf.overrideDerivation (old: {
-    configureFlags = old.configureFlags ++ [ "--disable-shared" ];
-  });
-  static-secp256k1 = final.secp256k1.overrideDerivation (old: {
-    configureFlags = old.configureFlags ++ [ "--enable-static" "--disable-shared" ];
-  });
-  static-gmp = (final.gmp.override { withStatic = true; }).overrideDerivation (old: {
-    configureFlags = old.configureFlags ++ [ "--enable-static" "--disable-shared" ];
-  });
-  static-libblst = (final.libblst.override { enableShared = false; }).overrideDerivation (_old: {
-    postFixup = "";
-  });
-  static-openssl = final.openssl.override { static = true; };
-  static-zlib = final.zlib.override { shared = false; };
-  static-pcre = final.pcre.override { shared = false; };
-  # XXX: Not replicate the cmakeFlags but just drop the -DBUILD_SHARED_LIBS=ON from it
-  static-snappy = final.snappy.overrideDerivation (_old: {
-    cmakeFlags = [ "-DSNAPPY_BUILD_TESTS=OFF" "-DSNAPPY_BUILD_BENCHMARKS=OFF" ];
-  });
+{
+  flake.overlays.static-libs =
+    final: _prev: {
+      static-libsodium-vrf = final.libsodium-vrf.overrideDerivation (old: {
+        configureFlags = old.configureFlags ++ [ "--disable-shared" ];
+      });
+      static-secp256k1 = final.secp256k1.overrideDerivation (old: {
+        configureFlags = old.configureFlags ++ [ "--enable-static" "--disable-shared" ];
+      });
+      static-gmp = (final.gmp.override { withStatic = true; }).overrideDerivation (old: {
+        configureFlags = old.configureFlags ++ [ "--enable-static" "--disable-shared" ];
+      });
+      static-libblst = (final.libblst.override { enableShared = false; }).overrideDerivation (_old: {
+        postFixup = "";
+      });
+      static-openssl = final.openssl.override { static = true; };
+      static-zlib = final.zlib.override { shared = false; };
+      static-pcre = final.pcre.override { shared = false; };
+      # XXX: Not replicate the cmakeFlags but just drop the -DBUILD_SHARED_LIBS=ON from it
+      static-snappy = final.snappy.overrideDerivation (_old: {
+        cmakeFlags = [ "-DSNAPPY_BUILD_TESTS=OFF" "-DSNAPPY_BUILD_BENCHMARKS=OFF" ];
+      });
+    };
 }

--- a/nix/systems.nix
+++ b/nix/systems.nix
@@ -1,0 +1,8 @@
+{
+  systems = [
+    "x86_64-linux"
+    "x86_64-darwin"
+    "aarch64-darwin"
+    "aarch64-linux"
+  ];
+}


### PR DESCRIPTION
Uses import-tree to turn every file into a flake-parts module.
Passes compiler, inputMap and hsPkgs through the module argument system.
Passes lib.asZip through the module argument system
Passes static-libs through the flake.overlays attribute

No "./*.nix" files are mentioned throughout and so they can be freely renamed.