### PR TITLE
hydra-coding-standards: 0.6.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1548,16 +1548,16 @@
         "werrorwolf": "werrorwolf"
       },
       "locked": {
-        "lastModified": 1748542676,
-        "narHash": "sha256-XD006KdRZYdtKY32pBleVnmcBXmwuYEHKZoLuyCCCqk=",
+        "lastModified": 1748769822,
+        "narHash": "sha256-pZrE965wjDfKxU/MU5r7Vk9GDSd5w+exeYXRzOeta08=",
         "owner": "cardano-scaling",
         "repo": "hydra-coding-standards",
-        "rev": "73da02a050b2ae6a85940a901043bc07d41cb70e",
+        "rev": "e34955ec6d0c0b4e0d4ec976a1117760cc3b0bbb",
         "type": "github"
       },
       "original": {
         "owner": "cardano-scaling",
-        "ref": "0.5.0",
+        "ref": "0.6.0",
         "repo": "hydra-coding-standards",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     cardano-node.url = "github:intersectmbo/cardano-node/10.1.4";
     flake-parts.url = "github:hercules-ci/flake-parts";
     haskellNix.url = "github:input-output-hk/haskell.nix";
-    hydra-coding-standards.url = "github:cardano-scaling/hydra-coding-standards/0.5.0";
+    hydra-coding-standards.url = "github:cardano-scaling/hydra-coding-standards/0.6.0";
     hydra-spec.url = "github:cardano-scaling/hydra-formal-specification";
     iohk-nix.url = "github:input-output-hk/iohk-nix";
     lint-utils = {
@@ -36,7 +36,7 @@
         "aarch64-darwin"
         "aarch64-linux"
       ];
-      perSystem = { pkgs, config, lib, system, ... }:
+      perSystem = { config, lib, system, ... }:
         let
           compiler = "ghc966";
 
@@ -59,20 +59,20 @@
               (import ./nix/static-libs.nix)
               inputs.nix-npm-buildpackage.overlays.default
               # Specific versions of tools we require
-              (final: prev: {
+              (final: _prev: {
                 inherit (inputs.aiken.packages.${system}) aiken;
-                apply-refact = pkgs.haskell-nix.tool compiler "apply-refact" "0.15.0.0";
-                cabal-install = pkgs.haskell-nix.tool compiler "cabal-install" "3.10.3.0";
-                cabal-plan = pkgs.haskell-nix.tool compiler "cabal-plan" "0.7.5.0";
+                apply-refact = final.haskell-nix.tool compiler "apply-refact" "0.15.0.0";
+                cabal-install = final.haskell-nix.tool compiler "cabal-install" "3.10.3.0";
+                cabal-plan = final.haskell-nix.tool compiler "cabal-plan" "0.7.5.0";
                 cabal-fmt = config.treefmt.programs.cabal-fmt.package;
                 fourmolu = config.treefmt.programs.fourmolu.package;
-                haskell-language-server = pkgs.haskell-nix.tool compiler "haskell-language-server" "2.9.0.0";
-                weeder = pkgs.haskell-nix.tool compiler "weeder" "2.9.0";
+                haskell-language-server = final.haskell-nix.tool compiler "haskell-language-server" "2.9.0.0";
+                weeder = final.haskell-nix.tool compiler "weeder" "2.9.0";
                 inherit (inputs.cardano-node.packages.${system}) cardano-cli;
                 inherit (inputs.cardano-node.packages.${system}) cardano-node;
                 inherit (inputs.mithril.packages.${system}) mithril-client-cli;
                 mithril-client-cli-unstable =
-                  pkgs.writeShellScriptBin "mithril-client-unstable" ''
+                  final.writeShellScriptBin "mithril-client-unstable" ''
                     exec ${inputs.mithril-unstable.packages.${system}.mithril-client-cli}/bin/mithril-client "$@"
                   '';
               })
@@ -92,9 +92,6 @@
           };
 
           tx-cost-diff =
-            let
-              pyEnv = pkgs.python3.withPackages (ps: with ps; [ pandas html5lib beautifulsoup4 tabulate ]);
-            in
             pkgs.writers.writeHaskellBin
               "tx-cost-diff"
               {
@@ -122,14 +119,6 @@
               inherit tx-cost-diff;
             };
 
-          treefmt.programs.typos = {
-            enable = true;
-            includes = [
-              "*.md"
-              "*.hs"
-              "*.cabal"
-            ];
-          };
           coding.standards.hydra = {
             enable = true;
             haskellPackages = with hsPkgs; builtins.concatMap allComponents [

--- a/nix/hydra/demo.nix
+++ b/nix/hydra/demo.nix
@@ -1,5 +1,5 @@
 # A demo using process-compose
-{ inputs, self, ... }:
+{ self, ... }:
 {
 
   perSystem = { pkgs, self', ... }:

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -2,9 +2,8 @@
 
 { hsPkgs # as defined in default.nix
 , pkgs
-, inputs
 , gitRev ? "unknown"
-, self
+, ...
 }:
 let
   inherit (pkgs) lib;

--- a/nix/hydra/project.nix
+++ b/nix/hydra/project.nix
@@ -10,7 +10,7 @@ pkgs.haskell-nix.project {
   src = pkgs.haskell-nix.haskellLib.cleanSourceWith {
     name = "hydra";
     src = ./../..;
-    filter = path: type:
+    filter = path: _type:
       # Blacklist of paths which do not affect the haskell build. The smaller
       # the resulting list of files is, the less likely we have redundant
       # rebuilds.

--- a/nix/static-libs.nix
+++ b/nix/static-libs.nix
@@ -1,5 +1,5 @@
 # Overlay vendored from https://github.com/input-output-hk/haskell-nix-example/blob/2247d445b91b0cc21eda4359e060d76b3cc0ce41/flake.nix#L53C17-L53C17
-final: prev: {
+final: _prev: {
   static-libsodium-vrf = final.libsodium-vrf.overrideDerivation (old: {
     configureFlags = old.configureFlags ++ [ "--disable-shared" ];
   });
@@ -9,14 +9,14 @@ final: prev: {
   static-gmp = (final.gmp.override { withStatic = true; }).overrideDerivation (old: {
     configureFlags = old.configureFlags ++ [ "--enable-static" "--disable-shared" ];
   });
-  static-libblst = (final.libblst.override { enableShared = false; }).overrideDerivation (old: {
+  static-libblst = (final.libblst.override { enableShared = false; }).overrideDerivation (_old: {
     postFixup = "";
   });
   static-openssl = final.openssl.override { static = true; };
   static-zlib = final.zlib.override { shared = false; };
   static-pcre = final.pcre.override { shared = false; };
   # XXX: Not replicate the cmakeFlags but just drop the -DBUILD_SHARED_LIBS=ON from it
-  static-snappy = final.snappy.overrideDerivation (old: {
+  static-snappy = final.snappy.overrideDerivation (_old: {
     cmakeFlags = [ "-DSNAPPY_BUILD_TESTS=OFF" "-DSNAPPY_BUILD_BENCHMARKS=OFF" ];
   });
 }

--- a/sample-node-config/another-nixos/configuration.nix
+++ b/sample-node-config/another-nixos/configuration.nix
@@ -1,5 +1,4 @@
-{ config
-, pkgs
+{ pkgs
 , lib
 , system
 , cardano-node

--- a/sample-node-config/another-nixos/flake.nix
+++ b/sample-node-config/another-nixos/flake.nix
@@ -13,14 +13,13 @@
 
 
   outputs =
-    { self
-    , nixpkgs
+    { nixpkgs
     , nixos-generators
     , cardano-node
     , hydra
     , mithril
     , ...
-    }@inputs:
+    }:
     let
       system = "x86_64-linux";
     in

--- a/sample-node-config/nixos/hydraw.nix
+++ b/sample-node-config/nixos/hydraw.nix
@@ -1,6 +1,6 @@
 # Hydraw running on hydra running on cardano
 
-{ config, pkgs, lib, ... }:
+{ pkgs, ... }:
 
 let
   cardano-node = import


### PR DESCRIPTION
Moves typos check upstream.
Adds deadnix check and formatter for nix dead code elimination.