### PR TITLE
Enable cluster tests on blockfrost network

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -12,6 +12,8 @@ on:
         - preprod
         - mainnet
         - sanchonet
+        - blockfrost-preview
+
 
       hydra-scripts-tx-id:
         description: "TxId of already published scripts (leave empty to publish)"
@@ -60,7 +62,13 @@ jobs:
         if ${{inputs.use-mithril}}; then
           USE_MITHRIL_ARG="--use-mithril"
         fi
-        nix develop .#exes --command bash -c "hydra-cluster --${{inputs.network}} --state-directory ${state_dir} ${HYDRA_SCRIPTS_ARG} ${USE_MITHRIL_ARG}"
+
+        if [[ ${{secrets.blockfrost_token}} != '' ]]; then
+          echo "${{secrets.blockfrost_token}}" > blockfrost-project.txt
+          nix develop .#exes --command bash -c "hydra-cluster --${{inputs.network}} --state-directory ${state_dir} ${HYDRA_SCRIPTS_ARG} ${USE_MITHRIL_ARG}"
+        else
+          echo "::warning file=blockfrost-project.txt,title=BLOCKFROST::Missing blockfrost project file."
+        fi
 
     - name: 💾 Upload logs
       if: always()

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -65,10 +65,10 @@ jobs:
 
         if [[ ${{secrets.blockfrost_token}} != '' ]]; then
           echo "${{secrets.blockfrost_token}}" > blockfrost-project.txt
-          nix develop .#exes --command bash -c "hydra-cluster --${{inputs.network}} --state-directory ${state_dir} ${HYDRA_SCRIPTS_ARG} ${USE_MITHRIL_ARG}"
         else
           echo "::warning file=blockfrost-project.txt,title=BLOCKFROST::Missing blockfrost project file."
         fi
+        nix develop .#exes --command bash -c "hydra-cluster --${{inputs.network}} --state-directory ${state_dir} ${HYDRA_SCRIPTS_ARG} ${USE_MITHRIL_ARG}"
 
     - name: 💾 Upload logs
       if: always()

--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -330,13 +330,14 @@ movingAverage confirmations =
 -- dataset.
 seedNetwork :: ChainBackend backend => backend -> Dataset -> Tracer IO FaucetLog -> IO ()
 seedNetwork backend Dataset{fundingTransaction, hydraNodeKeys} tracer = do
-  fundClients
+  fundClients hydraNodeKeys
   forM_ hydraNodeKeys fuelWith100Ada
  where
-  fundClients = do
+  fundClients hydraSKeys = do
     putTextLn "Fund scenario from faucet"
     Backend.submitTransaction backend fundingTransaction
-    void $ Backend.awaitTransaction backend fundingTransaction
+    let vks = getVerificationKey <$> hydraSKeys
+    mapM_ (Backend.awaitTransaction backend fundingTransaction) vks
 
   fuelWith100Ada signingKey = do
     let vk = getVerificationKey signingKey

--- a/hydra-cluster/exe/hydra-cluster/Main.hs
+++ b/hydra-cluster/exe/hydra-cluster/Main.hs
@@ -64,7 +64,7 @@ run options =
         action blockTime backend
       Nothing -> do
         when (useMithril == UseMithril) $ do
-          removeDirectoryRecursive $ workDir </> "db"
+          removeDirectoryRecursive (workDir </> "db") `catch` (\(_ :: SomeException) -> pure ())
           downloadLatestSnapshotTo (contramap FromMithril tracer) network workDir
         withCardanoNodeOnKnownNetwork (contramap FromCardanoNode tracer) workDir network action
 

--- a/hydra-cluster/exe/hydra-cluster/Main.hs
+++ b/hydra-cluster/exe/hydra-cluster/Main.hs
@@ -1,18 +1,27 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+
 module Main where
 
 import Hydra.Prelude
 
 import CardanoNode (findRunningCardanoNode, waitForFullySynchronized, withCardanoNodeDevnet, withCardanoNodeOnKnownNetwork)
+import Hydra.Cardano.Api (TxId)
+import Hydra.Chain.Backend (ChainBackend)
+import Hydra.Chain.Blockfrost (BlockfrostBackend (..))
 import Hydra.Cluster.Faucet (publishHydraScriptsAs)
-import Hydra.Cluster.Fixture (Actor (Faucet))
+import Hydra.Cluster.Fixture (Actor (Faucet), KnownNetwork (..))
 import Hydra.Cluster.Mithril (downloadLatestSnapshotTo)
 import Hydra.Cluster.Options (Options (..), PublishOrReuse (Publish, Reuse), Scenario (..), UseMithril (UseMithril), parseOptions)
 import Hydra.Cluster.Scenarios (EndToEndLog (..), respendUTxO, singlePartyHeadFullLifeCycle, singlePartyOpenAHead)
-import Hydra.Logging (Verbosity (Verbose), traceWith, withTracer)
+import Hydra.Logging (Tracer, Verbosity (Verbose), traceWith, withTracer)
+import Hydra.Options (BlockfrostOptions (..))
 import Options.Applicative (ParserInfo, execParser, fullDesc, header, helper, info, progDesc)
 import System.Directory (removeDirectoryRecursive)
 import System.FilePath ((</>))
 import Test.Hydra.Prelude (withTempDir)
+
+blockfrostProjectPath :: FilePath
+blockfrostProjectPath = "./blockfrost-project.txt"
 
 main :: IO ()
 main =
@@ -23,17 +32,23 @@ run options =
   withTracer (Verbose "hydra-cluster") $ \tracer -> do
     traceWith tracer ClusterOptions{options}
     let fromCardanoNode = contramap FromCardanoNode tracer
+    let blockfrostNetworks = [BlockfrostPreview]
     withStateDirectory $ \workDir ->
       case knownNetwork of
-        Just network ->
-          withRunningCardanoNode tracer workDir network $ \node -> do
-            waitForFullySynchronized fromCardanoNode node
-            publishOrReuseHydraScripts tracer node
-              >>= singlePartyHeadFullLifeCycle tracer workDir node
+        Just network -> do
+          if network `notElem` blockfrostNetworks
+            then withRunningCardanoNode tracer workDir network $ \_ backend -> do
+              waitForFullySynchronized fromCardanoNode backend
+              publishOrReuseHydraScripts tracer backend
+                >>= singlePartyHeadFullLifeCycle tracer workDir backend
+            else do
+              let backend = BlockfrostBackend $ BlockfrostOptions{projectPath = blockfrostProjectPath}
+              publishOrReuseHydraScripts tracer backend
+                >>= singlePartyHeadFullLifeCycle tracer workDir backend
         Nothing -> do
-          withCardanoNodeDevnet fromCardanoNode workDir $ \node -> do
-            txId <- publishOrReuseHydraScripts tracer node
-            singlePartyOpenAHead tracer workDir node txId $ \client walletSk _headId -> do
+          withCardanoNodeDevnet fromCardanoNode workDir $ \_ backend -> do
+            txId <- publishOrReuseHydraScripts tracer backend
+            singlePartyOpenAHead tracer workDir backend txId $ \client walletSk _headId -> do
               case scenario of
                 Idle -> forever $ pure ()
                 RespendUTxO -> do
@@ -45,8 +60,8 @@ run options =
 
   withRunningCardanoNode tracer workDir network action =
     findRunningCardanoNode (contramap FromCardanoNode tracer) workDir network >>= \case
-      Just node ->
-        action node
+      Just (blockTime, backend) ->
+        action blockTime backend
       Nothing -> do
         when (useMithril == UseMithril) $ do
           removeDirectoryRecursive $ workDir </> "db"
@@ -57,10 +72,11 @@ run options =
     Nothing -> withTempDir ("hydra-cluster-" <> show knownNetwork) action
     Just sd -> action sd
 
-  publishOrReuseHydraScripts tracer node =
+  publishOrReuseHydraScripts :: ChainBackend backend => Tracer IO EndToEndLog -> backend -> IO [TxId]
+  publishOrReuseHydraScripts tracer backend =
     case publishHydraScripts of
       Publish -> do
-        hydraScriptsTxId <- publishHydraScriptsAs node Faucet
+        hydraScriptsTxId <- publishHydraScriptsAs backend Faucet
         traceWith tracer $ PublishedHydraScriptsAt{hydraScriptsTxId}
         pure hydraScriptsTxId
       Reuse hydraScriptsTxId -> do

--- a/hydra-cluster/exe/hydra-cluster/Main.hs
+++ b/hydra-cluster/exe/hydra-cluster/Main.hs
@@ -6,7 +6,7 @@ import Hydra.Prelude
 
 import CardanoNode (findRunningCardanoNode, waitForFullySynchronized, withCardanoNodeDevnet, withCardanoNodeOnKnownNetwork)
 import Hydra.Cardano.Api (TxId)
-import Hydra.Chain.Backend (ChainBackend)
+import Hydra.Chain.Backend (ChainBackend, blockfrostProjectPath)
 import Hydra.Chain.Blockfrost (BlockfrostBackend (..))
 import Hydra.Cluster.Faucet (publishHydraScriptsAs)
 import Hydra.Cluster.Fixture (Actor (Faucet), KnownNetwork (..))
@@ -19,9 +19,6 @@ import Options.Applicative (ParserInfo, execParser, fullDesc, header, helper, in
 import System.Directory (removeDirectoryRecursive)
 import System.FilePath ((</>))
 import Test.Hydra.Prelude (withTempDir)
-
-blockfrostProjectPath :: FilePath
-blockfrostProjectPath = "./blockfrost-project.txt"
 
 main :: IO ()
 main =

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -127,6 +127,7 @@ executable hydra-cluster
   build-depends:
     , directory
     , filepath
+    , hydra-cardano-api
     , hydra-cluster
     , hydra-node
     , hydra-prelude

--- a/hydra-cluster/src/Hydra/Cluster/Faucet.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Faucet.hs
@@ -9,17 +9,9 @@ import Test.Hydra.Prelude
 import Cardano.Api.UTxO qualified as UTxO
 import CardanoClient (
   QueryPoint (QueryTip),
-  RunningNode (..),
   SubmitTransactionException,
-  awaitTransaction,
-  awaitTransactionId,
   buildAddress,
-  buildTransaction,
-  buildTransactionWithPParams',
-  queryUTxO,
-  queryUTxOFor,
   sign,
-  submitTransaction,
  )
 import Control.Exception (IOException)
 import Control.Monad.Class.MonadThrow (Handler (Handler), catches)
@@ -27,15 +19,15 @@ import Control.Tracer (Tracer, traceWith)
 import Data.Set qualified as Set
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import GHC.IO.Exception (IOErrorType (ResourceExhausted), IOException (ioe_type))
+import Hydra.Chain.Backend (ChainBackend, buildTransaction, buildTransactionWithPParams')
+import Hydra.Chain.Backend qualified as Backend
 import Hydra.Chain.Blockfrost.Client qualified as Blockfrost
-import Hydra.Chain.Direct (DirectBackend (..))
 import Hydra.Chain.ScriptRegistry (
   publishHydraScripts,
  )
 import Hydra.Cluster.Fixture (Actor (Faucet))
 import Hydra.Cluster.Util (keysFor)
 import Hydra.Ledger.Cardano ()
-import Hydra.Options (DirectOptions (..))
 import Hydra.Tx (balance, txId)
 
 data FaucetException
@@ -55,42 +47,45 @@ data FaucetLog
 -- | Create a specially marked "seed" UTXO containing requested 'Lovelace' by
 -- redeeming funds available to the well-known faucet.
 seedFromFaucet ::
-  RunningNode ->
+  ChainBackend backend =>
+  backend ->
   -- | Recipient of the funds
   VerificationKey PaymentKey ->
   -- | Amount to get from faucet
   Coin ->
   Tracer IO FaucetLog ->
   IO UTxO
-seedFromFaucet node@RunningNode{networkId, nodeSocket} receivingVerificationKey lovelace tracer = do
+seedFromFaucet backend receivingVerificationKey lovelace tracer = do
   (faucetVk, faucetSk) <- keysFor Faucet
-  seedTx <- retryOnExceptions tracer $ submitSeedTx faucetVk faucetSk
-  producedUTxO <- awaitTransaction networkId nodeSocket seedTx
-  pure $ UTxO.filter (== toCtxUTxOTxOut theOutput) producedUTxO
+  networkId <- Backend.queryNetworkId backend
+  seedTx <- retryOnExceptions tracer $ submitSeedTx faucetVk faucetSk networkId
+  producedUTxO <- Backend.awaitTransaction backend seedTx
+  pure $ UTxO.filter (== toCtxUTxOTxOut (theOutput networkId)) producedUTxO
  where
-  submitSeedTx faucetVk faucetSk = do
-    faucetUTxO <- findFaucetUTxO node lovelace
+  submitSeedTx faucetVk faucetSk networkId = do
+    faucetUTxO <- findFaucetUTxO networkId backend lovelace
     let changeAddress = mkVkAddress networkId faucetVk
-    buildTransaction networkId nodeSocket changeAddress faucetUTxO [] [theOutput] >>= \case
+
+    buildTransaction backend changeAddress faucetUTxO [] [theOutput networkId] >>= \case
       Left e -> throwIO $ FaucetFailedToBuildTx{reason = e}
       Right tx -> do
         let signedTx = sign faucetSk $ getTxBody tx
-        submitTransaction networkId nodeSocket signedTx
+        Backend.submitTransaction backend signedTx
         pure signedTx
 
-  receivingAddress = buildAddress receivingVerificationKey networkId
+  receivingAddress = buildAddress receivingVerificationKey
 
-  theOutput =
+  theOutput networkId =
     TxOut
-      (shelleyAddressInEra shelleyBasedEra receivingAddress)
+      (shelleyAddressInEra shelleyBasedEra (receivingAddress networkId))
       (lovelaceToValue lovelace)
       TxOutDatumNone
       ReferenceScriptNone
 
-findFaucetUTxO :: RunningNode -> Coin -> IO UTxO
-findFaucetUTxO RunningNode{networkId, nodeSocket} lovelace = do
+findFaucetUTxO :: ChainBackend backend => NetworkId -> backend -> Coin -> IO UTxO
+findFaucetUTxO networkId backend lovelace = do
   (faucetVk, _) <- keysFor Faucet
-  faucetUTxO <- queryUTxO networkId nodeSocket QueryTip [buildAddress faucetVk networkId]
+  faucetUTxO <- Backend.queryUTxO backend [buildAddress faucetVk networkId]
   let foundUTxO = UTxO.filter (\o -> (selectLovelace . txOutValue) o >= lovelace) faucetUTxO
   when (null foundUTxO) $
     throwIO $
@@ -148,36 +143,40 @@ seedFromFaucetBlockfrost receivingVerificationKey lovelace = do
 
 -- | Like 'seedFromFaucet', but without returning the seeded 'UTxO'.
 seedFromFaucet_ ::
-  RunningNode ->
+  ChainBackend backend =>
+  backend ->
   -- | Recipient of the funds
   VerificationKey PaymentKey ->
   -- | Amount to get from faucet
   Coin ->
   Tracer IO FaucetLog ->
   IO ()
-seedFromFaucet_ node vk ll tracer =
-  void $ seedFromFaucet node vk ll tracer
+seedFromFaucet_ backend vk ll tracer =
+  void $ seedFromFaucet backend vk ll tracer
 
 -- | Return the remaining funds to the faucet
 returnFundsToFaucet ::
+  ChainBackend backend =>
   Tracer IO FaucetLog ->
-  RunningNode ->
+  backend ->
   Actor ->
   IO ()
-returnFundsToFaucet tracer node sender = do
+returnFundsToFaucet tracer backend sender = do
   senderKeys <- keysFor sender
-  void $ returnFundsToFaucet' tracer node (snd senderKeys)
+  void $ returnFundsToFaucet' tracer backend (snd senderKeys)
 
 returnFundsToFaucet' ::
+  ChainBackend backend =>
   Tracer IO FaucetLog ->
-  RunningNode ->
+  backend ->
   SigningKey PaymentKey ->
   IO Coin
-returnFundsToFaucet' tracer RunningNode{networkId, nodeSocket} senderSk = do
+returnFundsToFaucet' tracer backend senderSk = do
   (faucetVk, _) <- keysFor Faucet
+  networkId <- Backend.queryNetworkId backend
   let faucetAddress = mkVkAddress networkId faucetVk
   let senderVk = getVerificationKey senderSk
-  utxo <- queryUTxOFor networkId nodeSocket QueryTip senderVk
+  utxo <- Backend.queryUTxOFor backend QueryTip senderVk
   returnAmount <-
     if null utxo
       then pure 0
@@ -185,8 +184,8 @@ returnFundsToFaucet' tracer RunningNode{networkId, nodeSocket} senderSk = do
         let utxoValue = balance @Tx utxo
         let allLovelace = selectLovelace utxoValue
         tx <- sign senderSk <$> buildTxBody utxo faucetAddress
-        submitTransaction networkId nodeSocket tx
-        void $ awaitTransaction networkId nodeSocket tx
+        Backend.submitTransaction backend tx
+        void $ Backend.awaitTransaction backend tx
         pure allLovelace
   traceWith tracer $ ReturnedFunds{returnAmount}
   pure returnAmount
@@ -194,42 +193,35 @@ returnFundsToFaucet' tracer RunningNode{networkId, nodeSocket} senderSk = do
   buildTxBody utxo faucetAddress =
     -- Here we specify no outputs in the transaction so that a change output with the
     -- entire value is created and paid to the faucet address.
-    buildTransaction networkId nodeSocket faucetAddress utxo [] [] >>= \case
+    buildTransaction backend faucetAddress utxo [] [] >>= \case
       Left e -> throwIO $ FaucetFailedToBuildTx{reason = e}
       Right tx -> pure $ getTxBody tx
 
 -- Use the Faucet utxo to create the output at specified address
 createOutputAtAddress ::
-  RunningNode ->
+  ChainBackend backend =>
+  NetworkId ->
+  backend ->
   AddressInEra ->
   TxOutDatum CtxTx ->
   Value ->
   IO (TxIn, TxOut CtxUTxO)
-createOutputAtAddress node@RunningNode{networkId, nodeSocket} atAddress datum val = do
+createOutputAtAddress networkId backend atAddress datum val = do
   (faucetVk, faucetSk) <- keysFor Faucet
-  utxo <- findFaucetUTxO node 0
+  utxo <- findFaucetUTxO networkId backend 0
   let collateralTxIns = mempty
   let output = TxOut atAddress val datum ReferenceScriptNone
-  buildTransaction
-    networkId
-    nodeSocket
-    (changeAddress faucetVk)
-    utxo
-    collateralTxIns
-    [output]
-    >>= \case
-      Left e ->
-        throwErrorAsException e
-      Right x -> do
-        let body = getTxBody x
-        let tx = makeSignedTransaction [makeShelleyKeyWitness body (WitnessPaymentKey faucetSk)] body
-        submitTransaction networkId nodeSocket tx
-        newUtxo <- awaitTransaction networkId nodeSocket tx
-        case UTxO.find (\out -> txOutAddress out == atAddress) newUtxo of
-          Nothing -> failure $ "Could not find script output: " <> decodeUtf8 (encodePretty newUtxo)
-          Just u -> pure u
- where
-  changeAddress = mkVkAddress networkId
+  buildTransaction backend (mkVkAddress networkId faucetVk) utxo collateralTxIns [output] >>= \case
+    Left e ->
+      throwErrorAsException e
+    Right x -> do
+      let body = getTxBody x
+      let tx = makeSignedTransaction [makeShelleyKeyWitness body (WitnessPaymentKey faucetSk)] body
+      Backend.submitTransaction backend tx
+      newUtxo <- Backend.awaitTransaction backend tx
+      case UTxO.find (\out -> txOutAddress out == atAddress) newUtxo of
+        Nothing -> failure $ "Could not find script output: " <> decodeUtf8 (encodePretty newUtxo)
+        Just u -> pure u
 
 -- | Try to submit tx and retry when some caught exception/s take place.
 retryOnExceptions :: (MonadCatch m, MonadDelay m) => Tracer m FaucetLog -> m a -> m a
@@ -256,9 +248,7 @@ retryOnExceptions tracer action =
 --
 -- The key of the given Actor is used to pay for fees in required transactions,
 -- it is expected to have sufficient funds.
-publishHydraScriptsAs :: RunningNode -> Actor -> IO [TxId]
-publishHydraScriptsAs RunningNode{networkId, nodeSocket} actor = do
+publishHydraScriptsAs :: ChainBackend backend => backend -> Actor -> IO [TxId]
+publishHydraScriptsAs backend actor = do
   (_, sk) <- keysFor actor
-  txIds <- publishHydraScripts (DirectBackend $ DirectOptions{networkId, nodeSocket}) sk
-  mapM_ (awaitTransactionId networkId nodeSocket) txIds
-  pure txIds
+  publishHydraScripts backend sk

--- a/hydra-cluster/src/Hydra/Cluster/Fixture.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Fixture.hs
@@ -75,6 +75,9 @@ data KnownNetwork
   | Preproduction
   | Mainnet
   | Sanchonet
+  | BlockfrostPreview
+  | BlockfrostPreprod
+  | BlockfrostMainnet
   deriving stock (Generic, Show, Eq, Enum, Bounded)
   deriving anyclass (ToJSON)
 
@@ -84,3 +87,6 @@ toNetworkId = \case
   Preproduction -> Api.Testnet (Api.NetworkMagic 1)
   Preview -> Api.Testnet (Api.NetworkMagic 2)
   Sanchonet -> Api.Testnet (Api.NetworkMagic 4)
+  BlockfrostPreview -> Api.Testnet (Api.NetworkMagic 2)
+  BlockfrostPreprod -> Api.Testnet (Api.NetworkMagic 1)
+  BlockfrostMainnet -> Api.Mainnet

--- a/hydra-cluster/src/Hydra/Cluster/Mithril.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Mithril.hs
@@ -63,15 +63,24 @@ downloadLatestSnapshotTo tracer network directory = do
     Preproduction -> "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/genesis.vkey"
     Preview -> "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/pre-release-preview/genesis.vkey"
     Sanchonet -> "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/testing-sanchonet/genesis.vkey"
+    BlockfrostPreview -> ""
+    BlockfrostPreprod -> ""
+    BlockfrostMainnet -> ""
 
   ancillaryKeyURL = case network of
     Mainnet -> "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-mainnet/ancillary.vkey"
     Preproduction -> "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/ancillary.vkey"
     Preview -> "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/pre-release-preview/ancillary.vkey"
     Sanchonet -> "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/testing-sanchonet/ancillary.vkey"
+    BlockfrostPreview -> ""
+    BlockfrostPreprod -> ""
+    BlockfrostMainnet -> ""
 
   aggregatorEndpoint = case network of
     Mainnet -> "https://aggregator.release-mainnet.api.mithril.network/aggregator"
     Preproduction -> "https://aggregator.release-preprod.api.mithril.network/aggregator"
     Preview -> "https://aggregator.pre-release-preview.api.mithril.network/aggregator"
     Sanchonet -> "https://aggregator.testing-sanchonet.api.mithril.network/aggregator"
+    BlockfrostPreview -> ""
+    BlockfrostPreprod -> ""
+    BlockfrostMainnet -> ""

--- a/hydra-cluster/src/Hydra/Cluster/Mithril.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Mithril.hs
@@ -24,21 +24,24 @@ data MithrilLog
 downloadLatestSnapshotTo :: Tracer IO MithrilLog -> KnownNetwork -> FilePath -> IO ()
 downloadLatestSnapshotTo tracer network directory = do
   traceWith tracer StartSnapshotDownload{network, directory}
-  genesisKey <- parseRequest genesisKeyURL >>= httpBS <&> getResponseBody
-  ancillaryKey <- parseRequest ancillaryKeyURL >>= httpBS <&> getResponseBody
-  let cmd =
-        setStderr createPipe $
-          proc mithrilExe $
-            concat
-              [ ["--origin-tag", "HYDRA"]
-              , ["--aggregator-endpoint", aggregatorEndpoint]
-              , ["cardano-db", "download", "latest"]
-              , ["--genesis-verification-key", decodeUtf8 genesisKey]
-              , ["--ancillary-verification-key", decodeUtf8 ancillaryKey]
-              , ["--download-dir", directory]
-              , ["--json"]
-              ]
-  withProcessWait_ cmd traceStderr
+  case (genesisKeyURL, ancillaryKeyURL, aggregatorEndpoint) of
+    (Just genesisKeyURL', Just ancillaryKeyURL', Just aggregatorEndpoint') -> do
+      genesisKey <- parseRequest genesisKeyURL' >>= httpBS <&> getResponseBody
+      ancillaryKey <- parseRequest ancillaryKeyURL' >>= httpBS <&> getResponseBody
+      let cmd =
+            setStderr createPipe $
+              proc mithrilExe $
+                concat
+                  [ ["--origin-tag", "HYDRA"]
+                  , ["--aggregator-endpoint", aggregatorEndpoint']
+                  , ["cardano-db", "download", "latest"]
+                  , ["--genesis-verification-key", decodeUtf8 genesisKey]
+                  , ["--ancillary-verification-key", decodeUtf8 ancillaryKey]
+                  , ["--download-dir", directory]
+                  , ["--json"]
+                  ]
+      withProcessWait_ cmd traceStderr
+    _ -> error "Mithril should not be used with blockfrost chain backend"
  where
   -- Note: Minor hack; we use a different version of the mithril-client for
   -- these networks. Hopefully this can be removed, one day.
@@ -59,28 +62,28 @@ downloadLatestSnapshotTo tracer network directory = do
     handleJust (guard . isEOFError) (const $ pure ())
 
   genesisKeyURL = case network of
-    Mainnet -> "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-mainnet/genesis.vkey"
-    Preproduction -> "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/genesis.vkey"
-    Preview -> "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/pre-release-preview/genesis.vkey"
-    Sanchonet -> "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/testing-sanchonet/genesis.vkey"
-    BlockfrostPreview -> ""
-    BlockfrostPreprod -> ""
-    BlockfrostMainnet -> ""
+    Mainnet -> Just "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-mainnet/genesis.vkey"
+    Preproduction -> Just "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/genesis.vkey"
+    Preview -> Just "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/pre-release-preview/genesis.vkey"
+    Sanchonet -> Just "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/testing-sanchonet/genesis.vkey"
+    BlockfrostPreview -> Nothing
+    BlockfrostPreprod -> Nothing
+    BlockfrostMainnet -> Nothing
 
   ancillaryKeyURL = case network of
-    Mainnet -> "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-mainnet/ancillary.vkey"
-    Preproduction -> "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/ancillary.vkey"
-    Preview -> "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/pre-release-preview/ancillary.vkey"
-    Sanchonet -> "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/testing-sanchonet/ancillary.vkey"
-    BlockfrostPreview -> ""
-    BlockfrostPreprod -> ""
-    BlockfrostMainnet -> ""
+    Mainnet -> Just "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-mainnet/ancillary.vkey"
+    Preproduction -> Just "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/ancillary.vkey"
+    Preview -> Just "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/pre-release-preview/ancillary.vkey"
+    Sanchonet -> Just "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/testing-sanchonet/ancillary.vkey"
+    BlockfrostPreview -> Nothing
+    BlockfrostPreprod -> Nothing
+    BlockfrostMainnet -> Nothing
 
   aggregatorEndpoint = case network of
-    Mainnet -> "https://aggregator.release-mainnet.api.mithril.network/aggregator"
-    Preproduction -> "https://aggregator.release-preprod.api.mithril.network/aggregator"
-    Preview -> "https://aggregator.pre-release-preview.api.mithril.network/aggregator"
-    Sanchonet -> "https://aggregator.testing-sanchonet.api.mithril.network/aggregator"
-    BlockfrostPreview -> ""
-    BlockfrostPreprod -> ""
-    BlockfrostMainnet -> ""
+    Mainnet -> Just "https://aggregator.release-mainnet.api.mithril.network/aggregator"
+    Preproduction -> Just "https://aggregator.release-preprod.api.mithril.network/aggregator"
+    Preview -> Just "https://aggregator.pre-release-preview.api.mithril.network/aggregator"
+    Sanchonet -> Just "https://aggregator.testing-sanchonet.api.mithril.network/aggregator"
+    BlockfrostPreview -> Nothing
+    BlockfrostPreprod -> Nothing
+    BlockfrostMainnet -> Nothing

--- a/hydra-cluster/src/Hydra/Cluster/Options.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Options.hs
@@ -46,6 +46,9 @@ parseOptions =
       <|> flag' (Just Preproduction) (long "preprod" <> help "The pre-production testnet")
       <|> flag' (Just Mainnet) (long "mainnet" <> help "The mainnet")
       <|> flag' (Just Sanchonet) (long "sanchonet" <> help "The sanchonet preview testnet")
+      <|> flag' (Just BlockfrostPreview) (long "blockfrost-preview" <> help "The preview testnet using Blockfrost")
+      <|> flag' (Just BlockfrostPreprod) (long "blockfrost-preprod" <> help "The pre-production testnet using Blockfrost")
+      <|> flag' (Just BlockfrostMainnet) (long "blockfrost-mainnet" <> help "The mainnet using Blockfrost")
       <|> flag'
         Nothing
         ( long "devnet"

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -692,7 +692,7 @@ singlePartyUsesScriptOnL2 tracer workDir backend hydraScriptsTxId =
               guard $ v ^? key "tag" == Just "HeadIsClosed"
               v ^? key "contestationDeadline" . _JSON
             remainingTime <- diffUTCTime deadline <$> getCurrentTime
-            waitFor hydraTracer (remainingTime + 3 * blockTime) [n1] $
+            waitFor hydraTracer (remainingTime + 10 * blockTime) [n1] $
               output "ReadyToFanout" ["headId" .= headId]
             send n1 $ input "Fanout" []
             waitMatch (10 * blockTime) n1 $ \v ->

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -19,12 +19,6 @@ import Cardano.Ledger.Credential (Credential (ScriptHashObj))
 import Cardano.Ledger.Plutus.Language (Language (PlutusV3))
 import CardanoClient (
   QueryPoint (QueryTip),
-  RunningNode (..),
-  buildTransaction,
-  buildTransactionWithPParams,
-  queryTip,
-  queryUTxOFor,
-  submitTx,
   waitForUTxO,
  )
 import CardanoNode (NodeLog)
@@ -97,18 +91,20 @@ import Hydra.Cardano.Api (
   pattern TxOut,
   pattern TxOutDatumNone,
  )
+import Hydra.Chain.Backend (ChainBackend, buildTransaction, buildTransactionWithPParams, buildTransactionWithPParams')
+import Hydra.Chain.Backend qualified as Backend
 import Hydra.Cluster.Faucet (FaucetLog, createOutputAtAddress, seedFromFaucet, seedFromFaucet_)
 import Hydra.Cluster.Faucet qualified as Faucet
 import Hydra.Cluster.Fixture (Actor (..), actorName, alice, aliceSk, aliceVk, bob, bobSk, bobVk, carol, carolSk, carolVk)
 import Hydra.Cluster.Mithril (MithrilLog)
 import Hydra.Cluster.Options (Options)
-import Hydra.Cluster.Util (chainConfigFor, keysFor, modifyConfig, setNetworkId)
+import Hydra.Cluster.Util (chainConfigFor, chainConfigFor', keysFor, modifyConfig, setNetworkId)
 import Hydra.Contract.Dummy (dummyRewardingScript)
 import Hydra.Ledger.Cardano (mkSimpleTx, mkTransferTx, unsafeBuildTransaction)
 import Hydra.Ledger.Cardano.Evaluate (maxTxExecutionUnits)
 import Hydra.Logging (Tracer, traceWith)
 import Hydra.Node.DepositPeriod (DepositPeriod (..))
-import Hydra.Options (CardanoChainConfig (..), startChainFrom)
+import Hydra.Options (CardanoChainConfig (..), ChainBackendOptions (..), DirectOptions (..), startChainFrom)
 import Hydra.Tx (HeadId, IsTx (balance), Party, txId)
 import Hydra.Tx.ContestationPeriod qualified as CP
 import Hydra.Tx.Utils (dummyValidatorScript, verificationKeyToOnChainId)
@@ -172,29 +168,29 @@ data EndToEndLog
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON)
 
-oneOfThreeNodesStopsForAWhile :: Tracer IO EndToEndLog -> FilePath -> RunningNode -> [TxId] -> IO ()
-oneOfThreeNodesStopsForAWhile tracer workDir cardanoNode hydraScriptsTxId = do
+oneOfThreeNodesStopsForAWhile :: ChainBackend backend => Tracer IO EndToEndLog -> FilePath -> backend -> [TxId] -> IO ()
+oneOfThreeNodesStopsForAWhile tracer workDir backend hydraScriptsTxId = do
   let clients = [Alice, Bob, Carol]
   [(aliceCardanoVk, aliceCardanoSk), (bobCardanoVk, _), (carolCardanoVk, _)] <- forM clients keysFor
-  seedFromFaucet_ cardanoNode aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
-  seedFromFaucet_ cardanoNode bobCardanoVk 100_000_000 (contramap FromFaucet tracer)
-  seedFromFaucet_ cardanoNode carolCardanoVk 100_000_000 (contramap FromFaucet tracer)
+  seedFromFaucet_ backend aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
+  seedFromFaucet_ backend bobCardanoVk 100_000_000 (contramap FromFaucet tracer)
+  seedFromFaucet_ backend carolCardanoVk 100_000_000 (contramap FromFaucet tracer)
+  networkId <- Backend.queryNetworkId backend
 
   let contestationPeriod = 1
   aliceChainConfig <-
-    chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [Bob, Carol] contestationPeriod
+    chainConfigFor Alice workDir backend hydraScriptsTxId [Bob, Carol] contestationPeriod
       <&> setNetworkId networkId
 
   bobChainConfig <-
-    chainConfigFor Bob workDir nodeSocket hydraScriptsTxId [Alice, Carol] contestationPeriod
-      <&> setNetworkId networkId
+    chainConfigFor Bob workDir backend hydraScriptsTxId [Alice, Carol] contestationPeriod <&> setNetworkId networkId
 
   carolChainConfig <-
-    chainConfigFor Carol workDir nodeSocket hydraScriptsTxId [Alice, Bob] contestationPeriod
+    chainConfigFor Carol workDir backend hydraScriptsTxId [Alice, Bob] contestationPeriod
       <&> setNetworkId networkId
-
+  blockTime <- Backend.getBlockTime backend
   withHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [bobVk, carolVk] [1, 2, 3] $ \n1 -> do
-    aliceUTxO <- seedFromFaucet cardanoNode aliceCardanoVk 1_000_000 (contramap FromFaucet tracer)
+    aliceUTxO <- seedFromFaucet backend aliceCardanoVk 1_000_000 (contramap FromFaucet tracer)
     withHydraNode hydraTracer bobChainConfig workDir 2 bobSk [aliceVk, carolVk] [1, 2, 3] $ \n2 -> do
       withHydraNode hydraTracer carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] $ \n3 -> do
         -- Init
@@ -202,10 +198,10 @@ oneOfThreeNodesStopsForAWhile tracer workDir cardanoNode hydraScriptsTxId = do
         headId <- waitForAllMatch (10 * blockTime) [n1, n2, n3] $ headIsInitializingWith (Set.fromList [alice, bob, carol])
 
         -- Alice commits something
-        requestCommitTx n1 aliceUTxO >>= submitTx cardanoNode
+        requestCommitTx n1 aliceUTxO >>= Backend.submitTransaction backend
 
         -- Everyone else commits nothing
-        mapConcurrently_ (\n -> requestCommitTx n mempty >>= submitTx cardanoNode) [n2, n3]
+        mapConcurrently_ (\n -> requestCommitTx n mempty >>= Backend.submitTransaction backend) [n2, n3]
 
         -- Observe open with the relevant UTxOs
         waitFor hydraTracer (20 * blockTime) [n1, n2, n3] $
@@ -243,23 +239,23 @@ oneOfThreeNodesStopsForAWhile tracer workDir cardanoNode hydraScriptsTxId = do
             let sigs = v ^.. key "signatures" . key "multiSignature" . values
             guard $ length sigs == 3
  where
-  RunningNode{nodeSocket, networkId, blockTime} = cardanoNode
   hydraTracer = contramap FromHydraNode tracer
 
-restartedNodeCanObserveCommitTx :: Tracer IO EndToEndLog -> FilePath -> RunningNode -> [TxId] -> IO ()
-restartedNodeCanObserveCommitTx tracer workDir cardanoNode hydraScriptsTxId = do
+restartedNodeCanObserveCommitTx :: ChainBackend backend => Tracer IO EndToEndLog -> FilePath -> backend -> [TxId] -> IO ()
+restartedNodeCanObserveCommitTx tracer workDir backend hydraScriptsTxId = do
   let clients = [Alice, Bob]
   [(aliceCardanoVk, _), (bobCardanoVk, _)] <- forM clients keysFor
-  seedFromFaucet_ cardanoNode aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
-  seedFromFaucet_ cardanoNode bobCardanoVk 100_000_000 (contramap FromFaucet tracer)
+  seedFromFaucet_ backend aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
+  seedFromFaucet_ backend bobCardanoVk 100_000_000 (contramap FromFaucet tracer)
 
   let contestationPeriod = 1
+  networkId <- Backend.queryNetworkId backend
   aliceChainConfig <-
-    chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [Bob] contestationPeriod
+    chainConfigFor Alice workDir backend hydraScriptsTxId [Bob] contestationPeriod
       <&> setNetworkId networkId
 
   bobChainConfig <-
-    chainConfigFor Bob workDir nodeSocket hydraScriptsTxId [Alice] contestationPeriod
+    chainConfigFor Bob workDir backend hydraScriptsTxId [Alice] contestationPeriod
       <&> setNetworkId networkId
 
   let hydraTracer = contramap FromHydraNode tracer
@@ -270,7 +266,7 @@ restartedNodeCanObserveCommitTx tracer workDir cardanoNode hydraScriptsTxId = do
       waitForAllMatch 10 [n1, n2] $ headIsInitializingWith (Set.fromList [alice, bob])
 
     -- n1 does a commit while n2 is down
-    requestCommitTx n1 mempty >>= submitTx cardanoNode
+    requestCommitTx n1 mempty >>= Backend.submitTransaction backend
     waitFor hydraTracer 10 [n1] $
       output "Committed" ["party" .= bob, "utxo" .= object mempty, "headId" .= headId]
 
@@ -278,14 +274,12 @@ restartedNodeCanObserveCommitTx tracer workDir cardanoNode hydraScriptsTxId = do
     withHydraNode hydraTracer aliceChainConfig workDir 2 aliceSk [bobVk] [1, 2] $ \n2 -> do
       waitFor hydraTracer 10 [n2] $
         output "Committed" ["party" .= bob, "utxo" .= object mempty, "headId" .= headId]
- where
-  RunningNode{nodeSocket, networkId} = cardanoNode
 
-restartedNodeCanAbort :: Tracer IO EndToEndLog -> FilePath -> RunningNode -> [TxId] -> IO ()
-restartedNodeCanAbort tracer workDir cardanoNode hydraScriptsTxId = do
-  refuelIfNeeded tracer cardanoNode Alice 100_000_000
+restartedNodeCanAbort :: ChainBackend backend => Tracer IO EndToEndLog -> FilePath -> backend -> [TxId] -> IO ()
+restartedNodeCanAbort tracer workDir backend hydraScriptsTxId = do
+  refuelIfNeeded tracer backend Alice 100_000_000
   aliceChainConfig <-
-    chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [] 2
+    chainConfigFor Alice workDir backend hydraScriptsTxId [] 2
       -- we delibelately do not start from a chain point here to highlight the
       -- need for persistence
       <&> modifyConfig (\config -> config{startChainFrom = Nothing})
@@ -309,29 +303,29 @@ restartedNodeCanAbort tracer workDir cardanoNode hydraScriptsTxId = do
       guard $ v ^? key "headStatus" == Just (toJSON Idle)
       guard $ v ^? key "me" == Just (toJSON alice)
       guard $ isJust (v ^? key "hydraNodeVersion")
- where
-  RunningNode{nodeSocket} = cardanoNode
 
-nodeReObservesOnChainTxs :: Tracer IO EndToEndLog -> FilePath -> RunningNode -> [TxId] -> IO ()
-nodeReObservesOnChainTxs tracer workDir cardanoNode hydraScriptsTxId = do
-  refuelIfNeeded tracer cardanoNode Alice 100_000_000
-  refuelIfNeeded tracer cardanoNode Bob 100_000_000
+nodeReObservesOnChainTxs :: ChainBackend backend => Tracer IO EndToEndLog -> FilePath -> backend -> [TxId] -> IO ()
+nodeReObservesOnChainTxs tracer workDir backend hydraScriptsTxId = do
+  refuelIfNeeded tracer backend Alice 100_000_000
+  refuelIfNeeded tracer backend Bob 100_000_000
+  networkId <- Backend.queryNetworkId backend
   -- Start hydra-node on chain tip
-  tip <- queryTip networkId nodeSocket
+  tip <- Backend.queryTip backend
+  blockTime <- Backend.getBlockTime backend
 
   -- NOTE: Adapt periods to block times
   let contestationPeriod = truncate $ 10 * blockTime
       depositPeriod = truncate $ 50 * blockTime
   aliceChainConfig <-
-    chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [Bob] contestationPeriod
+    chainConfigFor Alice workDir backend hydraScriptsTxId [Bob] contestationPeriod
       <&> modifyConfig (\config -> config{startChainFrom = Nothing, depositPeriod})
 
   bobChainConfig <-
-    chainConfigFor Bob workDir nodeSocket hydraScriptsTxId [Alice] contestationPeriod
+    chainConfigFor Bob workDir backend hydraScriptsTxId [Alice] contestationPeriod
       <&> modifyConfig (\config -> config{startChainFrom = Nothing, depositPeriod})
 
   (aliceCardanoVk, aliceCardanoSk) <- keysFor Alice
-  commitUTxO <- seedFromFaucet cardanoNode aliceCardanoVk 5_000_000 (contramap FromFaucet tracer)
+  commitUTxO <- seedFromFaucet backend aliceCardanoVk 5_000_000 (contramap FromFaucet tracer)
 
   let hydraTracer = contramap FromHydraNode tracer
 
@@ -342,8 +336,8 @@ nodeReObservesOnChainTxs tracer workDir cardanoNode hydraScriptsTxId = do
       headId <- waitMatch (20 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice, bob])
       _ <- waitMatch (20 * blockTime) n2 $ headIsInitializingWith (Set.fromList [alice, bob])
 
-      requestCommitTx n1 mempty >>= submitTx cardanoNode
-      requestCommitTx n2 mempty >>= submitTx cardanoNode
+      requestCommitTx n1 mempty >>= Backend.submitTransaction backend
+      requestCommitTx n2 mempty >>= Backend.submitTransaction backend
 
       waitFor hydraTracer (20 * blockTime) [n1, n2] $
         output "HeadIsOpen" ["utxo" .= object mempty, "headId" .= headId]
@@ -356,7 +350,7 @@ nodeReObservesOnChainTxs tracer workDir cardanoNode hydraScriptsTxId = do
       let depositTransaction = getResponseBody resp :: Tx
       let tx = signTx aliceCardanoSk depositTransaction
 
-      submitTx cardanoNode tx
+      Backend.submitTransaction backend tx
 
       waitFor hydraTracer (2 * realToFrac depositPeriod) [n1, n2] $
         output "CommitApproved" ["headId" .= headId, "utxoToCommit" .= commitUTxO]
@@ -388,7 +382,7 @@ nodeReObservesOnChainTxs tracer workDir cardanoNode hydraScriptsTxId = do
       waitFor hydraTracer 10 [n1, n2] $
         output "DecommitApproved" ["headId" .= headId, "decommitTxId" .= decommitTxId, "utxoToDecommit" .= decommitUTxO]
 
-      failAfter 10 $ waitForUTxO cardanoNode decommitUTxO
+      failAfter 10 $ waitForUTxO backend decommitUTxO
 
       distributedUTxO <- waitForAllMatch 10 [n1, n2] $ \v -> do
         guard $ v ^? key "tag" == Just "DecommitFinalized"
@@ -400,7 +394,7 @@ nodeReObservesOnChainTxs tracer workDir cardanoNode hydraScriptsTxId = do
       pure (headId, decommitUTxO)
 
     bobChainConfigFromTip <-
-      chainConfigFor Bob workDir nodeSocket hydraScriptsTxId [Alice] contestationPeriod
+      chainConfigFor Bob workDir backend hydraScriptsTxId [Alice] contestationPeriod
         <&> modifyConfig (\config -> config{startChainFrom = Just tip})
 
     withTempDir "blank-state" $ \tmpDir -> do
@@ -434,32 +428,33 @@ nodeReObservesOnChainTxs tracer workDir cardanoNode hydraScriptsTxId = do
 
         waitForAllMatch (10 * blockTime) [n1, n2] $ checkFanout headId' mempty
  where
-  RunningNode{nodeSocket, networkId, blockTime} = cardanoNode
-
   hydraNodeBaseUrl HydraClient{hydraNodeId} = "http://127.0.0.1:" <> show (4000 + hydraNodeId)
 
 -- | Step through the full life cycle of a Hydra Head with only a single
 -- participant. This scenario is also used by the smoke test run via the
 -- `hydra-cluster` executable.
 singlePartyHeadFullLifeCycle ::
+  ChainBackend backend =>
   Tracer IO EndToEndLog ->
   FilePath ->
-  RunningNode ->
+  backend ->
   [TxId] ->
   IO ()
-singlePartyHeadFullLifeCycle tracer workDir node hydraScriptsTxId =
+singlePartyHeadFullLifeCycle tracer workDir backend hydraScriptsTxId =
   ( `finally`
       do
-        returnFundsToFaucet tracer node Alice
-        returnFundsToFaucet tracer node AliceFunds
+        returnFundsToFaucet tracer backend Alice
+        returnFundsToFaucet tracer backend AliceFunds
   )
     $ do
-      refuelIfNeeded tracer node Alice 55_000_000
+      refuelIfNeeded tracer backend Alice 55_000_000
       -- Start hydra-node on chain tip
-      tip <- queryTip networkId nodeSocket
+      tip <- Backend.queryTip backend
+      blockTime <- Backend.getBlockTime backend
+      networkId <- Backend.queryNetworkId backend
       contestationPeriod <- CP.fromNominalDiffTime $ 10 * blockTime
       aliceChainConfig <-
-        chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [] contestationPeriod
+        chainConfigFor' Alice workDir backend hydraScriptsTxId [] contestationPeriod (DepositPeriod 100)
           <&> modifyConfig (\config -> config{startChainFrom = Just tip})
             . setNetworkId networkId
       withHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
@@ -470,8 +465,8 @@ singlePartyHeadFullLifeCycle tracer workDir node hydraScriptsTxId =
         -- Commit something from external key
         (walletVk, walletSk) <- keysFor AliceFunds
         amount <- Coin <$> generate (choose (10_000_000, 50_000_000))
-        utxoToCommit <- seedFromFaucet node walletVk amount (contramap FromFaucet tracer)
-        requestCommitTx n1 utxoToCommit <&> signTx walletSk >>= submitTx node
+        utxoToCommit <- seedFromFaucet backend walletVk amount (contramap FromFaucet tracer)
+        requestCommitTx n1 utxoToCommit <&> signTx walletSk >>= Backend.submitTransaction backend
 
         waitFor hydraTracer (10 * blockTime) [n1] $
           output "HeadIsOpen" ["utxo" .= toJSON utxoToCommit, "headId" .= headId]
@@ -492,31 +487,30 @@ singlePartyHeadFullLifeCycle tracer workDir node hydraScriptsTxId =
  where
   hydraTracer = contramap FromHydraNode tracer
 
-  RunningNode{networkId, nodeSocket, blockTime} = node
-
   traceRemainingFunds actor = do
     (actorVk, _) <- keysFor actor
-    utxo <- queryUTxOFor networkId nodeSocket QueryTip actorVk
+    utxo <- Backend.queryUTxOFor backend QueryTip actorVk
     traceWith tracer RemainingFunds{actor = actorName actor, utxo}
 
 -- | Open a Hydra Head with only a single participant but some arbitrary UTxO
 -- committed.
 singlePartyOpenAHead ::
+  ChainBackend backend =>
   Tracer IO EndToEndLog ->
   FilePath ->
-  RunningNode ->
+  backend ->
   [TxId] ->
   -- | Continuation called when the head is open
   (HydraClient -> SigningKey PaymentKey -> HeadId -> IO a) ->
   IO a
-singlePartyOpenAHead tracer workDir node hydraScriptsTxId callback =
-  (`finally` returnFundsToFaucet tracer node Alice) $ do
-    refuelIfNeeded tracer node Alice 25_000_000
+singlePartyOpenAHead tracer workDir backend hydraScriptsTxId callback =
+  (`finally` returnFundsToFaucet tracer backend Alice) $ do
+    refuelIfNeeded tracer backend Alice 25_000_000
     -- Start hydra-node on chain tip
-    tip <- queryTip networkId nodeSocket
+    tip <- Backend.queryTip backend
     let contestationPeriod = 100
     aliceChainConfig <-
-      chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [] contestationPeriod
+      chainConfigFor Alice workDir backend hydraScriptsTxId [] contestationPeriod
         <&> modifyConfig (\config -> config{startChainFrom = Just tip})
 
     (walletVk, walletSk) <- generate genKeyPair
@@ -524,46 +518,47 @@ singlePartyOpenAHead tracer workDir node hydraScriptsTxId callback =
     _ <- writeFileTextEnvelope (File keyPath) Nothing walletSk
     traceWith tracer CreatedKey{keyPath}
 
-    utxoToCommit <- seedFromFaucet node walletVk 100_000_000 (contramap FromFaucet tracer)
+    utxoToCommit <- seedFromFaucet backend walletVk 100_000_000 (contramap FromFaucet tracer)
 
     let hydraTracer = contramap FromHydraNode tracer
     withHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
       -- Initialize & open head
       send n1 $ input "Init" []
+      blockTime <- Backend.getBlockTime backend
       headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
-      requestCommitTx n1 utxoToCommit <&> signTx walletSk >>= submitTx node
+      requestCommitTx n1 utxoToCommit <&> signTx walletSk >>= Backend.submitTransaction backend
       waitFor hydraTracer (10 * blockTime) [n1] $
         output "HeadIsOpen" ["utxo" .= toJSON utxoToCommit, "headId" .= headId]
 
       callback n1 walletSk headId
- where
-  RunningNode{networkId, nodeSocket, blockTime} = node
 
 -- | Single hydra-node where the commit is done using some wallet UTxO.
 singlePartyCommitsFromExternal ::
+  ChainBackend backend =>
   Tracer IO EndToEndLog ->
   FilePath ->
-  RunningNode ->
+  backend ->
   [TxId] ->
   IO ()
-singlePartyCommitsFromExternal tracer workDir node hydraScriptsTxId =
+singlePartyCommitsFromExternal tracer workDir backend hydraScriptsTxId =
   ( `finally`
       do
-        returnFundsToFaucet tracer node Alice
-        returnFundsToFaucet tracer node AliceFunds
+        returnFundsToFaucet tracer backend Alice
+        returnFundsToFaucet tracer backend AliceFunds
   )
     $ do
-      refuelIfNeeded tracer node Alice 25_000_000
+      refuelIfNeeded tracer backend Alice 25_000_000
       let contestationPeriod = 100
-      aliceChainConfig <- chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [] contestationPeriod
+      aliceChainConfig <- chainConfigFor Alice workDir backend hydraScriptsTxId [] contestationPeriod
       let hydraNodeId = 1
       let hydraTracer = contramap FromHydraNode tracer
+      blockTime <- Backend.getBlockTime backend
       withHydraNode hydraTracer aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
         send n1 $ input "Init" []
         headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
 
         (walletVk, walletSk) <- keysFor AliceFunds
-        utxoToCommit <- seedFromFaucet node walletVk 5_000_000 (contramap FromFaucet tracer)
+        utxoToCommit <- seedFromFaucet backend walletVk 5_000_000 (contramap FromFaucet tracer)
         res <-
           runReq defaultHttpConfig $
             req
@@ -574,34 +569,34 @@ singlePartyCommitsFromExternal tracer workDir node hydraScriptsTxId =
               (port $ 4000 + hydraNodeId)
 
         let DraftCommitTxResponse{commitTx} = responseBody res
-        submitTx node $ signTx walletSk commitTx
+        Backend.submitTransaction backend $ signTx walletSk commitTx
 
         lockedUTxO <- waitMatch (10 * blockTime) n1 $ \v -> do
           guard $ v ^? key "headId" == Just (toJSON headId)
           guard $ v ^? key "tag" == Just "HeadIsOpen"
           pure $ v ^? key "utxo"
         lockedUTxO `shouldBe` Just (toJSON utxoToCommit)
- where
-  RunningNode{nodeSocket, blockTime} = node
 
 singlePartyUsesScriptOnL2 ::
+  ChainBackend backend =>
   Tracer IO EndToEndLog ->
   FilePath ->
-  RunningNode ->
+  backend ->
   [TxId] ->
   IO ()
-singlePartyUsesScriptOnL2 tracer workDir node hydraScriptsTxId =
+singlePartyUsesScriptOnL2 tracer workDir backend hydraScriptsTxId =
   ( `finally`
       do
-        returnFundsToFaucet tracer node Alice
-        returnFundsToFaucet tracer node AliceFunds
+        returnFundsToFaucet tracer backend Alice
+        returnFundsToFaucet tracer backend AliceFunds
   )
     $ do
-      refuelIfNeeded tracer node Alice 250_000_000
+      refuelIfNeeded tracer backend Alice 250_000_000
       let contestationPeriod = 1
-      aliceChainConfig <- chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [] contestationPeriod
+      aliceChainConfig <- chainConfigFor Alice workDir backend hydraScriptsTxId [] contestationPeriod
       let hydraNodeId = 1
       let hydraTracer = contramap FromHydraNode tracer
+      blockTime <- Backend.getBlockTime backend
       withHydraNode hydraTracer aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
         send n1 $ input "Init" []
         headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
@@ -610,18 +605,19 @@ singlePartyUsesScriptOnL2 tracer workDir node hydraScriptsTxId =
 
         -- Create money on L1
         let commitAmount = 100_000_000
-        utxoToCommit <- seedFromFaucet node walletVk commitAmount (contramap FromFaucet tracer)
+        utxoToCommit <- seedFromFaucet backend walletVk commitAmount (contramap FromFaucet tracer)
 
         -- Push it into L2
         requestCommitTx n1 utxoToCommit
           <&> signTx walletSk >>= \tx -> do
-            submitTx node tx
+            Backend.submitTransaction backend tx
 
         -- Check UTxO is present in L2
         waitFor hydraTracer (10 * blockTime) [n1] $
           output "HeadIsOpen" ["utxo" .= toJSON utxoToCommit, "headId" .= headId]
 
         pparams <- getProtocolParameters n1
+        networkId <- Backend.queryNetworkId backend
 
         -- Send the UTxO to a script; in preparation for running the script
         let serializedScript = dummyValidatorScript
@@ -634,104 +630,108 @@ singlePartyUsesScriptOnL2 tracer workDir node hydraScriptsTxId =
                 (mkTxOutDatumHash ())
                 ReferenceScriptNone
 
-        Right tx <- buildTransactionWithPParams pparams networkId nodeSocket (mkVkAddress networkId walletVk) utxoToCommit [] [scriptOutput]
+        systemStart <- Backend.querySystemStart backend QueryTip
+        eraHistory <- Backend.queryEraHistory backend QueryTip
+        stakePools <- Backend.queryStakePools backend QueryTip
+        case buildTransactionWithPParams' pparams systemStart eraHistory stakePools (mkVkAddress networkId walletVk) utxoToCommit [] [scriptOutput] of
+          Left e -> error $ show e
+          Right tx -> do
+            let signedL2tx = signTx walletSk tx
+            send n1 $ input "NewTx" ["transaction" .= signedL2tx]
 
-        let signedL2tx = signTx walletSk tx
-        send n1 $ input "NewTx" ["transaction" .= signedL2tx]
+            waitMatch 10 n1 $ \v -> do
+              guard $ v ^? key "tag" == Just "SnapshotConfirmed"
+              guard $
+                toJSON signedL2tx
+                  `elem` (v ^.. key "snapshot" . key "confirmed" . values)
 
-        waitMatch 10 n1 $ \v -> do
-          guard $ v ^? key "tag" == Just "SnapshotConfirmed"
-          guard $
-            toJSON signedL2tx
-              `elem` (v ^.. key "snapshot" . key "confirmed" . values)
+            -- Now, spend the money from the script
+            let scriptWitness =
+                  BuildTxWith $
+                    ScriptWitness scriptWitnessInCtx $
+                      PlutusScriptWitness
+                        serializedScript
+                        (mkScriptDatum ())
+                        (toScriptData ())
+                        maxTxExecutionUnits
 
-        -- Now, spend the money from the script
-        let scriptWitness =
-              BuildTxWith $
-                ScriptWitness scriptWitnessInCtx $
-                  PlutusScriptWitness
-                    serializedScript
-                    (mkScriptDatum ())
-                    (toScriptData ())
-                    maxTxExecutionUnits
+            let txIn = mkTxIn signedL2tx 0
+            let remainder = mkTxIn signedL2tx 1
 
-        let txIn = mkTxIn signedL2tx 0
-        let remainder = mkTxIn signedL2tx 1
+            let outAmt = foldMap txOutValue (txOuts' tx)
+            let body =
+                  defaultTxBodyContent
+                    & addTxIns [(txIn, scriptWitness), (remainder, BuildTxWith $ KeyWitness KeyWitnessForSpending)]
+                    & addTxInsCollateral [remainder]
+                    & addTxOuts [TxOut (mkVkAddress networkId walletVk) outAmt TxOutDatumNone ReferenceScriptNone]
+                    & setTxProtocolParams (BuildTxWith $ Just $ LedgerProtocolParameters pparams)
 
-        let outAmt = foldMap txOutValue (txOuts' tx)
-        let body =
-              defaultTxBodyContent
-                & addTxIns [(txIn, scriptWitness), (remainder, BuildTxWith $ KeyWitness KeyWitnessForSpending)]
-                & addTxInsCollateral [remainder]
-                & addTxOuts [TxOut (mkVkAddress networkId walletVk) outAmt TxOutDatumNone ReferenceScriptNone]
-                & setTxProtocolParams (BuildTxWith $ Just $ LedgerProtocolParameters pparams)
+            -- TODO: Instead of using `createAndValidateTransactionBody`, we
+            -- should be able to just construct the Tx with autobalancing via
+            -- `buildTransactionWithBody`. Unfortunately this is broken in the
+            -- version of cardano-api that we presently use; in a future upgrade
+            -- of that library we can try again.
+            -- tx' <- either (failure . show) pure =<< buildTransactionWithBody networkId nodeSocket (mkVkAddress networkId walletVk) body utxoToCommit
+            txBody <- either (failure . show) pure (createAndValidateTransactionBody body)
 
-        -- TODO: Instead of using `createAndValidateTransactionBody`, we
-        -- should be able to just construct the Tx with autobalancing via
-        -- `buildTransactionWithBody`. Unfortunately this is broken in the
-        -- version of cardano-api that we presently use; in a future upgrade
-        -- of that library we can try again.
-        -- tx' <- either (failure . show) pure =<< buildTransactionWithBody networkId nodeSocket (mkVkAddress networkId walletVk) body utxoToCommit
-        txBody <- either (failure . show) pure (createAndValidateTransactionBody body)
+            let spendTx' = makeSignedTransaction [] txBody
+                spendTx = fromLedgerTx $ recomputeIntegrityHash pparams [PlutusV3] (toLedgerTx spendTx')
+            let signedTx = signTx walletSk spendTx
 
-        let spendTx' = makeSignedTransaction [] txBody
-            spendTx = fromLedgerTx $ recomputeIntegrityHash pparams [PlutusV3] (toLedgerTx spendTx')
-        let signedTx = signTx walletSk spendTx
+            send n1 $ input "NewTx" ["transaction" .= signedTx]
 
-        send n1 $ input "NewTx" ["transaction" .= signedTx]
+            waitMatch 10 n1 $ \v -> do
+              guard $ v ^? key "tag" == Just "SnapshotConfirmed"
+              guard $
+                toJSON signedTx
+                  `elem` (v ^.. key "snapshot" . key "confirmed" . values)
 
-        waitMatch 10 n1 $ \v -> do
-          guard $ v ^? key "tag" == Just "SnapshotConfirmed"
-          guard $
-            toJSON signedTx
-              `elem` (v ^.. key "snapshot" . key "confirmed" . values)
+            -- And check that we can close and fanout the head successfully
+            send n1 $ input "Close" []
+            deadline <- waitMatch (10 * blockTime) n1 $ \v -> do
+              guard $ v ^? key "tag" == Just "HeadIsClosed"
+              v ^? key "contestationDeadline" . _JSON
+            remainingTime <- diffUTCTime deadline <$> getCurrentTime
+            waitFor hydraTracer (remainingTime + 3 * blockTime) [n1] $
+              output "ReadyToFanout" ["headId" .= headId]
+            send n1 $ input "Fanout" []
+            waitMatch (10 * blockTime) n1 $ \v ->
+              guard $ v ^? key "tag" == Just "HeadIsFinalized"
 
-        -- And check that we can close and fanout the head successfully
-        send n1 $ input "Close" []
-        deadline <- waitMatch (10 * blockTime) n1 $ \v -> do
-          guard $ v ^? key "tag" == Just "HeadIsClosed"
-          v ^? key "contestationDeadline" . _JSON
-        remainingTime <- diffUTCTime deadline <$> getCurrentTime
-        waitFor hydraTracer (remainingTime + 3 * blockTime) [n1] $
-          output "ReadyToFanout" ["headId" .= headId]
-        send n1 $ input "Fanout" []
-        waitMatch (10 * blockTime) n1 $ \v ->
-          guard $ v ^? key "tag" == Just "HeadIsFinalized"
-
-        -- Assert final wallet balance
-        (balance <$> queryUTxOFor networkId nodeSocket QueryTip walletVk)
-          `shouldReturn` lovelaceToValue commitAmount
- where
-  RunningNode{networkId, nodeSocket, blockTime} = node
+            -- Assert final wallet balance
+            (balance <$> Backend.queryUTxOFor backend QueryTip walletVk)
+              `shouldReturn` lovelaceToValue commitAmount
 
 -- | Open a head and run a script using 'Rewarding' script purpose and a zero
 -- lovelace withdrawal.
-singlePartyUsesWithdrawZeroTrick :: Tracer IO EndToEndLog -> FilePath -> RunningNode -> [TxId] -> IO ()
-singlePartyUsesWithdrawZeroTrick tracer workDir node hydraScriptsTxId =
+singlePartyUsesWithdrawZeroTrick :: ChainBackend backend => Tracer IO EndToEndLog -> FilePath -> backend -> [TxId] -> IO ()
+singlePartyUsesWithdrawZeroTrick tracer workDir backend hydraScriptsTxId =
   -- Seed/return fuel
-  bracket_ (refuelIfNeeded tracer node Alice 250_000_000) (returnFundsToFaucet tracer node Alice) $ do
+  bracket_ (refuelIfNeeded tracer backend Alice 250_000_000) (returnFundsToFaucet tracer backend Alice) $ do
     -- Seed/return funds
     (walletVk, walletSk) <- keysFor AliceFunds
     bracket
-      (seedFromFaucet node walletVk 100_000_000 (contramap FromFaucet tracer))
-      (\_ -> returnFundsToFaucet tracer node AliceFunds)
+      (seedFromFaucet backend walletVk 100_000_000 (contramap FromFaucet tracer))
+      (\_ -> returnFundsToFaucet tracer backend AliceFunds)
       $ \utxoToCommit -> do
         -- Start hydra-node and open a head
         let contestationPeriod = 1
-        aliceChainConfig <- chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [] contestationPeriod
+        aliceChainConfig <- chainConfigFor Alice workDir backend hydraScriptsTxId [] contestationPeriod
         let hydraNodeId = 1
         let hydraTracer = contramap FromHydraNode tracer
+        blockTime <- Backend.getBlockTime backend
+        networkId <- Backend.queryNetworkId backend
         withHydraNode hydraTracer aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
           send n1 $ input "Init" []
           headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
-          requestCommitTx n1 utxoToCommit <&> signTx walletSk >>= submitTx node
+          requestCommitTx n1 utxoToCommit <&> signTx walletSk >>= Backend.submitTransaction backend
           waitFor hydraTracer (10 * blockTime) [n1] $
             output "HeadIsOpen" ["utxo" .= toJSON utxoToCommit, "headId" .= headId]
 
           -- Prepare a tx that re-spends everything owned by walletVk
           pparams <- getProtocolParameters n1
           let change = mkVkAddress networkId walletVk
-          Right tx <- buildTransactionWithPParams pparams networkId nodeSocket change utxoToCommit [] []
+          Right tx <- buildTransactionWithPParams pparams backend change utxoToCommit [] []
 
           -- Modify the tx to run a script via the withdraw 0 trick
           let redeemer = toLedgerData $ toScriptData ()
@@ -757,8 +757,6 @@ singlePartyUsesWithdrawZeroTrick tracer workDir node hydraScriptsTxId =
             guard $
               toJSON signedL2tx
                 `elem` (v ^.. key "snapshot" . key "confirmed" . values)
- where
-  RunningNode{networkId, nodeSocket, blockTime} = node
 
 -- | Compute the integrity hash of a transaction using a list of plutus languages.
 recomputeIntegrityHash ::
@@ -777,19 +775,21 @@ recomputeIntegrityHash pp languages tx = do
       (tx ^. witsTxL . datsTxWitsL)
 
 singlePartyCommitsScriptBlueprint ::
+  ChainBackend backend =>
   Tracer IO EndToEndLog ->
   FilePath ->
-  RunningNode ->
+  backend ->
   [TxId] ->
   IO ()
-singlePartyCommitsScriptBlueprint tracer workDir node hydraScriptsTxId =
-  (`finally` returnFundsToFaucet tracer node Alice) $ do
-    refuelIfNeeded tracer node Alice 20_000_000
+singlePartyCommitsScriptBlueprint tracer workDir backend hydraScriptsTxId =
+  (`finally` returnFundsToFaucet tracer backend Alice) $ do
+    refuelIfNeeded tracer backend Alice 20_000_000
+    blockTime <- Backend.getBlockTime backend
     -- NOTE: Adapt periods to block times
     let contestationPeriod = truncate $ 10 * blockTime
         depositPeriod = truncate $ 50 * blockTime
     aliceChainConfig <-
-      chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [] contestationPeriod
+      chainConfigFor Alice workDir backend hydraScriptsTxId [] contestationPeriod
         <&> modifyConfig (\c -> c{depositPeriod})
     let hydraNodeId = 1
     let hydraTracer = contramap FromHydraNode tracer
@@ -810,7 +810,7 @@ singlePartyCommitsScriptBlueprint tracer workDir node hydraScriptsTxId =
             (port $ 4000 + hydraNodeId)
 
       let commitTx = responseBody res
-      submitTx node commitTx
+      Backend.submitTransaction backend commitTx
 
       lockedUTxO <- waitMatch (10 * blockTime) n1 $ \v -> do
         guard $ v ^? key "headId" == Just (toJSON headId)
@@ -832,7 +832,7 @@ singlePartyCommitsScriptBlueprint tracer workDir node hydraScriptsTxId =
       let depositTransaction = responseBody res'
       let tx = signTx walletSk depositTransaction
 
-      submitTx node tx
+      Backend.submitTransaction backend tx
 
       waitFor hydraTracer (2 * realToFrac depositPeriod) [n1] $
         output "CommitApproved" ["headId" .= headId, "utxoToCommit" .= scriptUTxO']
@@ -842,9 +842,10 @@ singlePartyCommitsScriptBlueprint tracer workDir node hydraScriptsTxId =
       getSnapshotUTxO n1 `shouldReturn` scriptUTxO <> scriptUTxO'
  where
   prepareScriptPayload lovelaceAmt = do
+    networkId <- Backend.queryNetworkId backend
     let scriptAddress = mkScriptAddress networkId dummyValidatorScript
     let datumHash = mkTxOutDatumHash ()
-    (scriptIn, scriptOut) <- createOutputAtAddress node scriptAddress datumHash (lovelaceToValue lovelaceAmt)
+    (scriptIn, scriptOut) <- createOutputAtAddress networkId backend scriptAddress datumHash (lovelaceToValue lovelaceAmt)
     let scriptUTxO = UTxO.singleton scriptIn scriptOut
 
     let scriptWitness =
@@ -863,26 +864,26 @@ singlePartyCommitsScriptBlueprint tracer workDir node hydraScriptsTxId =
       , scriptUTxO
       )
 
-  RunningNode{networkId, nodeSocket, blockTime} = node
-
 persistenceCanLoadWithEmptyCommit ::
+  ChainBackend backend =>
   Tracer IO EndToEndLog ->
   FilePath ->
-  RunningNode ->
+  backend ->
   [TxId] ->
   IO ()
-persistenceCanLoadWithEmptyCommit tracer workDir node hydraScriptsTxId =
-  (`finally` returnFundsToFaucet tracer node Alice) $ do
-    refuelIfNeeded tracer node Alice 20_000_000
+persistenceCanLoadWithEmptyCommit tracer workDir backend hydraScriptsTxId =
+  (`finally` returnFundsToFaucet tracer backend Alice) $ do
+    refuelIfNeeded tracer backend Alice 20_000_000
     let contestationPeriod = 100
-    aliceChainConfig <- chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [] contestationPeriod
+    aliceChainConfig <- chainConfigFor Alice workDir backend hydraScriptsTxId [] contestationPeriod
     let hydraNodeId = 1
     let hydraTracer = contramap FromHydraNode tracer
+    blockTime <- Backend.getBlockTime backend
     headId <- withHydraNode hydraTracer aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
       send n1 $ input "Init" []
       headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
 
-      requestCommitTx n1 mempty >>= submitTx node
+      requestCommitTx n1 mempty >>= Backend.submitTransaction backend
       waitFor hydraTracer (10 * blockTime) [n1] $
         output "HeadIsOpen" ["utxo" .= object mempty, "headId" .= headId]
       pure headId
@@ -898,31 +899,32 @@ persistenceCanLoadWithEmptyCommit tracer workDir node hydraScriptsTxId =
             output "HeadIsOpen" ["utxo" .= object mempty, "headId" .= headId]
 
           getSnapshotUTxO n1 `shouldReturn` mempty
- where
-  RunningNode{nodeSocket, blockTime} = node
 
 -- | Single hydra-node where the commit is done from a raw transaction
 -- blueprint.
 singlePartyCommitsFromExternalTxBlueprint ::
+  ChainBackend backend =>
   Tracer IO EndToEndLog ->
   FilePath ->
-  RunningNode ->
+  backend ->
   [TxId] ->
   IO ()
-singlePartyCommitsFromExternalTxBlueprint tracer workDir node hydraScriptsTxId =
-  (`finally` returnFundsToFaucet tracer node Alice) $ do
-    refuelIfNeeded tracer node Alice 20_000_000
+singlePartyCommitsFromExternalTxBlueprint tracer workDir backend hydraScriptsTxId =
+  (`finally` returnFundsToFaucet tracer backend Alice) $ do
+    refuelIfNeeded tracer backend Alice 20_000_000
     let contestationPeriod = 100
-    aliceChainConfig <- chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [] contestationPeriod
+    aliceChainConfig <- chainConfigFor Alice workDir backend hydraScriptsTxId [] contestationPeriod
     let hydraNodeId = 1
     let hydraTracer = contramap FromHydraNode tracer
     (someExternalVk, someExternalSk) <- generate genKeyPair
+    blockTime <- Backend.getBlockTime backend
     withHydraNode hydraTracer aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
       send n1 $ input "Init" []
       headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
 
-      someUTxO <- seedFromFaucet node someExternalVk 10_000_000 (contramap FromFaucet tracer)
-      utxoToCommit <- seedFromFaucet node someExternalVk 5_000_000 (contramap FromFaucet tracer)
+      someUTxO <- seedFromFaucet backend someExternalVk 10_000_000 (contramap FromFaucet tracer)
+      utxoToCommit <- seedFromFaucet backend someExternalVk 5_000_000 (contramap FromFaucet tracer)
+      networkId <- Backend.queryNetworkId backend
       let someAddress = mkVkAddress networkId someExternalVk
       let someOutput =
             TxOut
@@ -930,7 +932,7 @@ singlePartyCommitsFromExternalTxBlueprint tracer workDir node hydraScriptsTxId =
               (lovelaceToValue $ Coin 2_000_000)
               TxOutDatumNone
               ReferenceScriptNone
-      buildTransaction networkId nodeSocket someAddress utxoToCommit (fst <$> UTxO.toList someUTxO) [someOutput] >>= \case
+      buildTransaction backend someAddress utxoToCommit (fst <$> UTxO.toList someUTxO) [someOutput] >>= \case
         Left e -> failure $ show e
         Right tx -> do
           let unsignedTx = makeSignedTransaction [] $ getTxBody tx
@@ -950,40 +952,40 @@ singlePartyCommitsFromExternalTxBlueprint tracer workDir node hydraScriptsTxId =
 
           let commitTx = responseBody res
           let signedTx = signTx someExternalSk commitTx
-          submitTx node signedTx
+          Backend.submitTransaction backend signedTx
 
           lockedUTxO <- waitMatch (10 * blockTime) n1 $ \v -> do
             guard $ v ^? key "headId" == Just (toJSON headId)
             guard $ v ^? key "tag" == Just "HeadIsOpen"
             pure $ v ^? key "utxo"
           lockedUTxO `shouldBe` Just (toJSON utxoToCommit)
- where
-  RunningNode{networkId, nodeSocket, blockTime} = node
 
 -- | Initialize open and close a head on a real network and ensure contestation
 -- period longer than the time horizon is possible. For this it is enough that
 -- we can close a head and not wait for the deadline.
 canCloseWithLongContestationPeriod ::
+  ChainBackend backend =>
   Tracer IO EndToEndLog ->
   FilePath ->
-  RunningNode ->
+  backend ->
   [TxId] ->
   IO ()
-canCloseWithLongContestationPeriod tracer workDir node hydraScriptsTxId = do
-  refuelIfNeeded tracer node Alice 100_000_000
+canCloseWithLongContestationPeriod tracer workDir backend hydraScriptsTxId = do
+  refuelIfNeeded tracer backend Alice 100_000_000
   -- Start hydra-node on chain tip
-  tip <- queryTip networkId nodeSocket
+  tip <- Backend.queryTip backend
   let oneWeek = 60 * 60 * 24 * 7
   aliceChainConfig <-
-    chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [] oneWeek
+    chainConfigFor Alice workDir backend hydraScriptsTxId [] oneWeek
       <&> modifyConfig (\config -> config{startChainFrom = Just tip})
   let hydraTracer = contramap FromHydraNode tracer
+  blockTime <- Backend.getBlockTime backend
   withHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
     -- Initialize & open head
     send n1 $ input "Init" []
     headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
     -- Commit nothing for now
-    requestCommitTx n1 mempty >>= submitTx node
+    requestCommitTx n1 mempty >>= Backend.submitTransaction backend
     waitFor hydraTracer (10 * blockTime) [n1] $
       output "HeadIsOpen" ["utxo" .= object mempty, "headId" .= headId]
     -- Close head
@@ -993,32 +995,32 @@ canCloseWithLongContestationPeriod tracer workDir node hydraScriptsTxId = do
         guard $ v ^? key "tag" == Just "HeadIsClosed"
   traceRemainingFunds Alice
  where
-  RunningNode{networkId, nodeSocket, blockTime} = node
-
   traceRemainingFunds actor = do
     (actorVk, _) <- keysFor actor
-    utxo <- queryUTxOFor networkId nodeSocket QueryTip actorVk
+    utxo <- Backend.queryUTxOFor backend QueryTip actorVk
     traceWith tracer RemainingFunds{actor = actorName actor, utxo}
 
 canSubmitTransactionThroughAPI ::
+  ChainBackend backend =>
   Tracer IO EndToEndLog ->
   FilePath ->
-  RunningNode ->
+  backend ->
   [TxId] ->
   IO ()
-canSubmitTransactionThroughAPI tracer workDir node hydraScriptsTxId =
-  (`finally` returnFundsToFaucet tracer node Alice) $ do
-    refuelIfNeeded tracer node Alice 25_000_000
+canSubmitTransactionThroughAPI tracer workDir backend hydraScriptsTxId =
+  (`finally` returnFundsToFaucet tracer backend Alice) $ do
+    refuelIfNeeded tracer backend Alice 25_000_000
     let contestationPeriod = 100
-    aliceChainConfig <- chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [] contestationPeriod
+    aliceChainConfig <- chainConfigFor Alice workDir backend hydraScriptsTxId [] contestationPeriod
     let hydraNodeId = 1
     let hydraTracer = contramap FromHydraNode tracer
     withHydraNode hydraTracer aliceChainConfig workDir hydraNodeId aliceSk [] [hydraNodeId] $ \_ -> do
       -- let's prepare a _user_ transaction from Bob to Carol
       (cardanoBobVk, cardanoBobSk) <- keysFor Bob
       (cardanoCarolVk, _) <- keysFor Carol
+      networkId <- Backend.queryNetworkId backend
       -- create output for Bob to be sent to carol
-      bobUTxO <- seedFromFaucet node cardanoBobVk 5_000_000 (contramap FromFaucet tracer)
+      bobUTxO <- seedFromFaucet backend cardanoBobVk 5_000_000 (contramap FromFaucet tracer)
       let carolsAddress = mkVkAddress networkId cardanoCarolVk
           bobsAddress = mkVkAddress networkId cardanoBobVk
           carolsOutput =
@@ -1028,7 +1030,7 @@ canSubmitTransactionThroughAPI tracer workDir node hydraScriptsTxId =
               TxOutDatumNone
               ReferenceScriptNone
       -- prepare fully balanced tx body
-      buildTransaction networkId nodeSocket bobsAddress bobUTxO (fst <$> UTxO.toList bobUTxO) [carolsOutput] >>= \case
+      buildTransaction backend bobsAddress bobUTxO (fst <$> UTxO.toList bobUTxO) [carolsOutput] >>= \case
         Left e -> failure $ show e
         Right tx -> do
           let unsignedTx = makeSignedTransaction [] $ getTxBody tx
@@ -1041,7 +1043,6 @@ canSubmitTransactionThroughAPI tracer workDir node hydraScriptsTxId =
           (sendRequest hydraNodeId signedRequest <&> responseBody)
             `shouldReturn` TransactionSubmitted
  where
-  RunningNode{networkId, nodeSocket} = node
   sendRequest hydraNodeId tx =
     runReq defaultHttpConfig $
       req
@@ -1054,8 +1055,8 @@ canSubmitTransactionThroughAPI tracer workDir node hydraScriptsTxId =
 -- | Three hydra nodes open a head and we assert that none of them sees errors.
 -- This was particularly misleading when everyone tries to post the collect
 -- transaction concurrently.
-threeNodesNoErrorsOnOpen :: Tracer IO EndToEndLog -> FilePath -> RunningNode -> [TxId] -> IO ()
-threeNodesNoErrorsOnOpen tracer tmpDir node@RunningNode{nodeSocket} hydraScriptsTxId = do
+threeNodesNoErrorsOnOpen :: ChainBackend backend => Tracer IO EndToEndLog -> FilePath -> backend -> [TxId] -> IO ()
+threeNodesNoErrorsOnOpen tracer tmpDir backend hydraScriptsTxId = do
   aliceKeys@(aliceCardanoVk, _) <- generate genKeyPair
   bobKeys@(bobCardanoVk, _) <- generate genKeyPair
   carolKeys@(carolCardanoVk, _) <- generate genKeyPair
@@ -1065,20 +1066,25 @@ threeNodesNoErrorsOnOpen tracer tmpDir node@RunningNode{nodeSocket} hydraScripts
 
   let contestationPeriod = 2
   let hydraTracer = contramap FromHydraNode tracer
-  withHydraCluster hydraTracer tmpDir nodeSocket 1 cardanoKeys hydraKeys hydraScriptsTxId contestationPeriod $ \clients -> do
+  let nodeSocket' =
+        case Backend.getOptions backend of
+          Direct DirectOptions{nodeSocket} -> nodeSocket
+          Blockfrost _ -> error "Unexpected Blockfrost options"
+
+  withHydraCluster hydraTracer tmpDir nodeSocket' 1 cardanoKeys hydraKeys hydraScriptsTxId contestationPeriod $ \clients -> do
     let leader = head clients
     waitForNodesConnected hydraTracer 20 clients
 
     -- Funds to be used as fuel by Hydra protocol transactions
-    seedFromFaucet_ node aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
-    seedFromFaucet_ node bobCardanoVk 100_000_000 (contramap FromFaucet tracer)
-    seedFromFaucet_ node carolCardanoVk 100_000_000 (contramap FromFaucet tracer)
+    seedFromFaucet_ backend aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
+    seedFromFaucet_ backend bobCardanoVk 100_000_000 (contramap FromFaucet tracer)
+    seedFromFaucet_ backend carolCardanoVk 100_000_000 (contramap FromFaucet tracer)
 
     send leader $ input "Init" []
     void . waitForAllMatch 10 (toList clients) $
       headIsInitializingWith (Set.fromList [alice, bob, carol])
 
-    mapConcurrently_ (\n -> requestCommitTx n mempty >>= submitTx node) clients
+    mapConcurrently_ (\n -> requestCommitTx n mempty >>= Backend.submitTransaction backend) clients
 
     mapConcurrently_ shouldNotReceivePostTxError clients
  where
@@ -1100,18 +1106,18 @@ threeNodesNoErrorsOnOpen tracer tmpDir node@RunningNode{nodeSocket} hydraScripts
 -- Hydra nodes BC run on BC cluster and connect to each other.
 -- Hydra nodes BC shut down.
 -- Hydra nodes BC run and connect ABC cluster again.
-nodeCanSupportMultipleEtcdClusters :: Tracer IO EndToEndLog -> FilePath -> RunningNode -> [TxId] -> IO ()
-nodeCanSupportMultipleEtcdClusters tracer workDir RunningNode{networkId, nodeSocket} hydraScriptsTxId = do
+nodeCanSupportMultipleEtcdClusters :: ChainBackend backend => Tracer IO EndToEndLog -> FilePath -> backend -> [TxId] -> IO ()
+nodeCanSupportMultipleEtcdClusters tracer workDir backend hydraScriptsTxId = do
   let contestationPeriod = 2
-
+  networkId <- Backend.queryNetworkId backend
   aliceChainConfig <-
-    chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [Bob, Carol] contestationPeriod
+    chainConfigFor Alice workDir backend hydraScriptsTxId [Bob, Carol] contestationPeriod
       <&> setNetworkId networkId
   bobChainConfig <-
-    chainConfigFor Bob workDir nodeSocket hydraScriptsTxId [Alice, Carol] contestationPeriod
+    chainConfigFor Bob workDir backend hydraScriptsTxId [Alice, Carol] contestationPeriod
       <&> setNetworkId networkId
   carolChainConfig <-
-    chainConfigFor Carol workDir nodeSocket hydraScriptsTxId [Alice, Bob] contestationPeriod
+    chainConfigFor Carol workDir backend hydraScriptsTxId [Alice, Bob] contestationPeriod
       <&> setNetworkId networkId
 
   let hydraTracer = contramap FromHydraNode tracer
@@ -1122,10 +1128,10 @@ nodeCanSupportMultipleEtcdClusters tracer workDir RunningNode{networkId, nodeSoc
         waitForNodesConnected hydraTracer 30 $ n1 :| [n2, n3]
 
     bobChainConfig' <-
-      chainConfigFor Bob workDir nodeSocket hydraScriptsTxId [Carol] contestationPeriod
+      chainConfigFor Bob workDir backend hydraScriptsTxId [Carol] contestationPeriod
         <&> setNetworkId networkId
     carolChainConfig' <-
-      chainConfigFor Carol workDir nodeSocket hydraScriptsTxId [Bob] contestationPeriod
+      chainConfigFor Carol workDir backend hydraScriptsTxId [Bob] contestationPeriod
         <&> setNetworkId networkId
 
     waitForNodesDisconnected hydraTracer 60 $ n1 :| []
@@ -1141,19 +1147,19 @@ nodeCanSupportMultipleEtcdClusters tracer workDir RunningNode{networkId, nodeSoc
 -- | Two hydra node setup where Alice is wrongly configured to use Carol's
 -- cardano keys instead of Bob's which will prevent him to be notified the
 -- `HeadIsInitializing` but he should still receive some notification.
-initWithWrongKeys :: FilePath -> Tracer IO EndToEndLog -> RunningNode -> [TxId] -> IO ()
-initWithWrongKeys workDir tracer node@RunningNode{nodeSocket} hydraScriptsTxId = do
+initWithWrongKeys :: ChainBackend backend => FilePath -> Tracer IO EndToEndLog -> backend -> [TxId] -> IO ()
+initWithWrongKeys workDir tracer backend hydraScriptsTxId = do
   (aliceCardanoVk, _) <- keysFor Alice
   (carolCardanoVk, _) <- keysFor Carol
 
   let contestationPeriod = 2
-  aliceChainConfig <- chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [Carol] contestationPeriod
-  bobChainConfig <- chainConfigFor Bob workDir nodeSocket hydraScriptsTxId [Alice] contestationPeriod
+  aliceChainConfig <- chainConfigFor Alice workDir backend hydraScriptsTxId [Carol] contestationPeriod
+  bobChainConfig <- chainConfigFor Bob workDir backend hydraScriptsTxId [Alice] contestationPeriod
 
   let hydraTracer = contramap FromHydraNode tracer
   withHydraNode hydraTracer aliceChainConfig workDir 3 aliceSk [bobVk] [3, 4] $ \n1 -> do
     withHydraNode hydraTracer bobChainConfig workDir 4 bobSk [aliceVk] [3, 4] $ \n2 -> do
-      seedFromFaucet_ node aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
+      seedFromFaucet_ backend aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
 
       send n1 $ input "Init" []
       headId <-
@@ -1173,19 +1179,19 @@ initWithWrongKeys workDir tracer node@RunningNode{nodeSocket} hydraScriptsTxId =
 
       participants `shouldMatchList` expectedParticipants
 
-startWithWrongPeers :: FilePath -> Tracer IO EndToEndLog -> RunningNode -> [TxId] -> IO ()
-startWithWrongPeers workDir tracer node@RunningNode{nodeSocket} hydraScriptsTxId = do
+startWithWrongPeers :: ChainBackend backend => FilePath -> Tracer IO EndToEndLog -> backend -> [TxId] -> IO ()
+startWithWrongPeers workDir tracer backend hydraScriptsTxId = do
   (aliceCardanoVk, _) <- keysFor Alice
 
   let contestationPeriod = 2
-  aliceChainConfig <- chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [Carol] contestationPeriod
-  bobChainConfig <- chainConfigFor Bob workDir nodeSocket hydraScriptsTxId [Alice] contestationPeriod
+  aliceChainConfig <- chainConfigFor Alice workDir backend hydraScriptsTxId [Carol] contestationPeriod
+  bobChainConfig <- chainConfigFor Bob workDir backend hydraScriptsTxId [Alice] contestationPeriod
 
   let hydraTracer = contramap FromHydraNode tracer
   withHydraNode hydraTracer aliceChainConfig workDir 3 aliceSk [bobVk] [3, 4] $ \n1 -> do
     -- NOTE: here we deliberately use the wrong peer list for Bob
     withHydraNode hydraTracer bobChainConfig workDir 4 bobSk [aliceVk] [4] $ \_ -> do
-      seedFromFaucet_ node aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
+      seedFromFaucet_ backend aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
 
       (clusterPeers, configuredPeers) <- waitMatch 20 n1 $ \v -> do
         guard $ v ^? key "tag" == Just (Aeson.String "NetworkClusterIDMismatch")
@@ -1199,38 +1205,37 @@ startWithWrongPeers workDir tracer node@RunningNode{nodeSocket} hydraScriptsTxId
       configuredPeers `shouldBe` "0.0.0.0:5004=http://0.0.0.0:5004"
 
 -- | Open a a two participant head and incrementally commit to it.
-canCommit :: Tracer IO EndToEndLog -> FilePath -> RunningNode -> [TxId] -> IO ()
-canCommit tracer workDir node hydraScriptsTxId =
-  (`finally` returnFundsToFaucet tracer node Alice) $ do
-    (`finally` returnFundsToFaucet tracer node Bob) $ do
-      refuelIfNeeded tracer node Alice 30_000_000
-      refuelIfNeeded tracer node Bob 30_000_000
+canCommit :: ChainBackend backend => Tracer IO EndToEndLog -> FilePath -> NominalDiffTime -> backend -> [TxId] -> IO ()
+canCommit tracer workDir blockTime backend hydraScriptsTxId =
+  (`finally` returnFundsToFaucet tracer backend Alice) $ do
+    (`finally` returnFundsToFaucet tracer backend Bob) $ do
+      refuelIfNeeded tracer backend Alice 30_000_000
+      refuelIfNeeded tracer backend Bob 30_000_000
       -- NOTE: Adapt periods to block times
       let contestationPeriod = truncate $ 10 * blockTime
-          depositPeriod = truncate $ 50 * blockTime
+          depositPeriod = truncate $ 100 * blockTime
+      networkId <- Backend.queryNetworkId backend
       aliceChainConfig <-
-        chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [Bob] contestationPeriod
-          <&> setNetworkId networkId
-            . modifyConfig (\c -> c{depositPeriod})
+        chainConfigFor Alice workDir backend hydraScriptsTxId [Bob] contestationPeriod
+          <&> setNetworkId networkId . modifyConfig (\c -> c{depositPeriod})
       bobChainConfig <-
-        chainConfigFor Bob workDir nodeSocket hydraScriptsTxId [Alice] contestationPeriod
-          <&> setNetworkId networkId
-            . modifyConfig (\c -> c{depositPeriod})
+        chainConfigFor Bob workDir backend hydraScriptsTxId [Alice] contestationPeriod
+          <&> setNetworkId networkId . modifyConfig (\c -> c{depositPeriod})
       withHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [bobVk] [2] $ \n1 -> do
         withHydraNode hydraTracer bobChainConfig workDir 2 bobSk [aliceVk] [1] $ \n2 -> do
           send n1 $ input "Init" []
           headId <- waitMatch (10 * blockTime) n2 $ headIsInitializingWith (Set.fromList [alice, bob])
 
           -- Commit nothing
-          requestCommitTx n1 mempty >>= submitTx node
-          requestCommitTx n2 mempty >>= submitTx node
+          requestCommitTx n1 mempty >>= Backend.submitTransaction backend
+          requestCommitTx n2 mempty >>= Backend.submitTransaction backend
           waitFor hydraTracer (20 * blockTime) [n1, n2] $
             output "HeadIsOpen" ["utxo" .= object mempty, "headId" .= headId]
 
           -- Get some L1 funds
           (walletVk, walletSk) <- generate genKeyPair
-          commitUTxO <- seedFromFaucet node walletVk 5_000_000 (contramap FromFaucet tracer)
-          commitUTxO2 <- seedFromFaucet node walletVk 5_000_000 (contramap FromFaucet tracer)
+          commitUTxO <- seedFromFaucet backend walletVk 5_000_000 (contramap FromFaucet tracer)
+          commitUTxO2 <- seedFromFaucet backend walletVk 5_000_000 (contramap FromFaucet tracer)
 
           resp <-
             parseUrlThrow ("POST " <> hydraNodeBaseUrl n2 <> "/commit")
@@ -1240,7 +1245,7 @@ canCommit tracer workDir node hydraScriptsTxId =
           let depositTransaction = getResponseBody resp :: Tx
           let tx = signTx walletSk depositTransaction
 
-          submitTx node tx
+          Backend.submitTransaction backend tx
 
           waitFor hydraTracer (2 * realToFrac depositPeriod) [n1, n2] $
             output "CommitApproved" ["headId" .= headId, "utxoToCommit" .= commitUTxO]
@@ -1257,7 +1262,7 @@ canCommit tracer workDir node hydraScriptsTxId =
           let depositTransaction' = getResponseBody resp2 :: Tx
           let tx' = signTx walletSk depositTransaction'
 
-          submitTx node tx'
+          Backend.submitTransaction backend tx'
 
           waitFor hydraTracer (2 * realToFrac depositPeriod) [n1, n2] $
             output "CommitApproved" ["headId" .= headId, "utxoToCommit" .= commitUTxO2]
@@ -1280,41 +1285,39 @@ canCommit tracer workDir node hydraScriptsTxId =
             guard $ v ^? key "tag" == Just "HeadIsFinalized"
 
           -- Assert final wallet balance
-          (balance <$> queryUTxOFor networkId nodeSocket QueryTip walletVk)
+          (balance <$> Backend.queryUTxOFor backend QueryTip walletVk)
             `shouldReturn` balance (commitUTxO <> commitUTxO2)
  where
-  RunningNode{networkId, nodeSocket, blockTime} = node
-
   hydraTracer = contramap FromHydraNode tracer
 
   hydraNodeBaseUrl HydraClient{hydraNodeId} = "http://127.0.0.1:" <> show (4000 + hydraNodeId)
 
 -- | Open a a single participant head, deposit and then recover it.
-canRecoverDeposit :: Tracer IO EndToEndLog -> FilePath -> RunningNode -> [TxId] -> IO ()
-canRecoverDeposit tracer workDir node hydraScriptsTxId =
-  (`finally` returnFundsToFaucet tracer node Alice) $
-    (`finally` returnFundsToFaucet tracer node Bob) $ do
-      refuelIfNeeded tracer node Alice 30_000_000
-      refuelIfNeeded tracer node Bob 30_000_000
+canRecoverDeposit :: ChainBackend backend => Tracer IO EndToEndLog -> FilePath -> backend -> [TxId] -> IO ()
+canRecoverDeposit tracer workDir backend hydraScriptsTxId =
+  (`finally` returnFundsToFaucet tracer backend Alice) $
+    (`finally` returnFundsToFaucet tracer backend Bob) $ do
+      refuelIfNeeded tracer backend Alice 30_000_000
+      refuelIfNeeded tracer backend Bob 30_000_000
       -- NOTE: Directly expire deposits
       contestationPeriod <- CP.fromNominalDiffTime 1
+      blockTime <- Backend.getBlockTime backend
       let depositPeriod = 1
+      networkId <- Backend.queryNetworkId backend
       aliceChainConfig <-
-        chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [Bob] contestationPeriod
-          <&> setNetworkId networkId
-            . modifyConfig (\c -> c{depositPeriod})
+        chainConfigFor Alice workDir backend hydraScriptsTxId [Bob] contestationPeriod
+          <&> setNetworkId networkId . modifyConfig (\c -> c{depositPeriod})
       bobChainConfig <-
-        chainConfigFor Bob workDir nodeSocket hydraScriptsTxId [Alice] contestationPeriod
-          <&> setNetworkId networkId
-            . modifyConfig (\c -> c{depositPeriod})
+        chainConfigFor Bob workDir backend hydraScriptsTxId [Alice] contestationPeriod
+          <&> setNetworkId networkId . modifyConfig (\c -> c{depositPeriod})
       withHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [bobVk] [2] $ \n1 -> do
         headId <- withHydraNode hydraTracer bobChainConfig workDir 2 bobSk [aliceVk] [1] $ \n2 -> do
           send n1 $ input "Init" []
           headId <- waitMatch 10 n1 $ headIsInitializingWith (Set.fromList [alice, bob])
 
           -- Commit nothing
-          requestCommitTx n1 mempty >>= submitTx node
-          requestCommitTx n2 mempty >>= submitTx node
+          requestCommitTx n1 mempty >>= Backend.submitTransaction backend
+          requestCommitTx n2 mempty >>= Backend.submitTransaction backend
 
           waitFor hydraTracer (20 * blockTime) [n1, n2] $
             output "HeadIsOpen" ["utxo" .= object mempty, "headId" .= headId]
@@ -1325,9 +1328,9 @@ canRecoverDeposit tracer workDir node hydraScriptsTxId =
         -- Get some L1 funds
         (walletVk, walletSk) <- generate genKeyPair
         let commitAmount = 5_000_000
-        commitUTxO <- seedFromFaucet node walletVk commitAmount (contramap FromFaucet tracer)
+        commitUTxO <- seedFromFaucet backend walletVk commitAmount (contramap FromFaucet tracer)
 
-        (balance <$> queryUTxOFor networkId nodeSocket QueryTip walletVk)
+        (balance <$> Backend.queryUTxOFor backend QueryTip walletVk)
           `shouldReturn` lovelaceToValue commitAmount
 
         depositTransaction <-
@@ -1337,13 +1340,13 @@ canRecoverDeposit tracer workDir node hydraScriptsTxId =
             <&> getResponseBody
 
         let tx = signTx walletSk depositTransaction
-        submitTx node tx
+        Backend.submitTransaction backend tx
 
         deadline <- waitForAllMatch 10 [n1] $ \v -> do
           guard $ v ^? key "tag" == Just "CommitRecorded"
           v ^? key "deadline" >>= parseMaybe parseJSON
 
-        (selectLovelace . balance <$> queryUTxOFor networkId nodeSocket QueryTip walletVk)
+        (selectLovelace . balance <$> Backend.queryUTxOFor backend QueryTip walletVk)
           `shouldReturn` 0
 
         let path = BSC.unpack $ urlEncode False $ encodeUtf8 $ T.pack $ show (getTxId $ getTxBody tx)
@@ -1360,7 +1363,7 @@ canRecoverDeposit tracer workDir node hydraScriptsTxId =
           guard $ v ^? key "tag" == Just "CommitRecovered"
           guard $ v ^? key "recoveredUTxO" == Just (toJSON commitUTxO)
 
-        (balance <$> queryUTxOFor networkId nodeSocket QueryTip walletVk)
+        (balance <$> Backend.queryUTxOFor backend QueryTip walletVk)
           `shouldReturn` lovelaceToValue commitAmount
         send n1 $ input "Close" []
 
@@ -1376,41 +1379,39 @@ canRecoverDeposit tracer workDir node hydraScriptsTxId =
           guard $ v ^? key "tag" == Just "HeadIsFinalized"
 
         -- Assert final wallet balance
-        (balance <$> queryUTxOFor networkId nodeSocket QueryTip walletVk)
+        (balance <$> Backend.queryUTxOFor backend QueryTip walletVk)
           `shouldReturn` balance commitUTxO
  where
-  RunningNode{networkId, nodeSocket, blockTime} = node
-
   hydraTracer = contramap FromHydraNode tracer
 
   hydraNodeBaseUrl HydraClient{hydraNodeId} = "http://127.0.0.1:" <> show (4000 + hydraNodeId)
 
 -- | Make sure to be able to see pending deposits.
-canSeePendingDeposits :: Tracer IO EndToEndLog -> FilePath -> RunningNode -> [TxId] -> IO ()
-canSeePendingDeposits tracer workDir node hydraScriptsTxId =
-  (`finally` returnFundsToFaucet tracer node Alice) $
-    (`finally` returnFundsToFaucet tracer node Bob) $ do
-      refuelIfNeeded tracer node Alice 30_000_000
-      refuelIfNeeded tracer node Bob 30_000_000
+canSeePendingDeposits :: ChainBackend backend => Tracer IO EndToEndLog -> FilePath -> NominalDiffTime -> backend -> [TxId] -> IO ()
+canSeePendingDeposits tracer workDir blockTime backend hydraScriptsTxId =
+  (`finally` returnFundsToFaucet tracer backend Alice) $
+    (`finally` returnFundsToFaucet tracer backend Bob) $ do
+      refuelIfNeeded tracer backend Alice 30_000_000
+      refuelIfNeeded tracer backend Bob 30_000_000
       -- NOTE: Adapt periods to block times
       let contestationPeriod = truncate $ 10 * blockTime
-          depositPeriod = truncate $ 50 * blockTime
+          depositPeriod = truncate $ 100 * blockTime
+
+      networkId <- Backend.queryNetworkId backend
       aliceChainConfig <-
-        chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [Bob] contestationPeriod
-          <&> setNetworkId networkId
-            . modifyConfig (\c -> c{depositPeriod})
+        chainConfigFor Alice workDir backend hydraScriptsTxId [Bob] contestationPeriod
+          <&> setNetworkId networkId . modifyConfig (\c -> c{depositPeriod})
       bobChainConfig <-
-        chainConfigFor Bob workDir nodeSocket hydraScriptsTxId [Alice] contestationPeriod
-          <&> setNetworkId networkId
-            . modifyConfig (\c -> c{depositPeriod})
+        chainConfigFor Bob workDir backend hydraScriptsTxId [Alice] contestationPeriod
+          <&> setNetworkId networkId . modifyConfig (\c -> c{depositPeriod})
       withHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [bobVk] [2] $ \n1 -> do
         _ <- withHydraNode hydraTracer bobChainConfig workDir 2 bobSk [aliceVk] [1] $ \n2 -> do
           send n1 $ input "Init" []
           headId <- waitMatch 10 n1 $ headIsInitializingWith (Set.fromList [alice, bob])
 
           -- Commit nothing
-          requestCommitTx n1 mempty >>= submitTx node
-          requestCommitTx n2 mempty >>= submitTx node
+          requestCommitTx n1 mempty >>= Backend.submitTransaction backend
+          requestCommitTx n2 mempty >>= Backend.submitTransaction backend
 
           waitFor hydraTracer (20 * blockTime) [n1, n2] $
             output "HeadIsOpen" ["utxo" .= object mempty, "headId" .= headId]
@@ -1420,9 +1421,9 @@ canSeePendingDeposits tracer workDir node hydraScriptsTxId =
 
         -- Get some L1 funds
         (walletVk, walletSk) <- generate genKeyPair
-        commitUTxO <- seedFromFaucet node walletVk 5_000_000 (contramap FromFaucet tracer)
-        commitUTxO2 <- seedFromFaucet node walletVk 4_000_000 (contramap FromFaucet tracer)
-        commitUTxO3 <- seedFromFaucet node walletVk 3_000_000 (contramap FromFaucet tracer)
+        commitUTxO <- seedFromFaucet backend walletVk 5_000_000 (contramap FromFaucet tracer)
+        commitUTxO2 <- seedFromFaucet backend walletVk 4_000_000 (contramap FromFaucet tracer)
+        commitUTxO3 <- seedFromFaucet backend walletVk 3_000_000 (contramap FromFaucet tracer)
 
         deposited <- forM [commitUTxO, commitUTxO2, commitUTxO3] $ \utxo -> do
           depositTransaction <-
@@ -1434,7 +1435,7 @@ canSeePendingDeposits tracer workDir node hydraScriptsTxId =
           let tx = signTx walletSk depositTransaction
           let depositTxId = getTxId (getTxBody tx)
 
-          liftIO $ submitTx node tx
+          liftIO $ Backend.submitTransaction backend tx
 
           liftIO $ waitForAllMatch 10 [n1] $ \v ->
             guard $ v ^? key "tag" == Just "CommitRecorded"
@@ -1468,20 +1469,20 @@ canSeePendingDeposits tracer workDir node hydraScriptsTxId =
 
         pendingDeposits `shouldBe` []
  where
-  RunningNode{networkId, nodeSocket, blockTime} = node
-
   hydraTracer = contramap FromHydraNode tracer
 
   hydraNodeBaseUrl HydraClient{hydraNodeId} = "http://127.0.0.1:" <> show (4000 + hydraNodeId)
 
 -- | Open a a single participant head with some UTxO and incrementally decommit it.
-canDecommit :: Tracer IO EndToEndLog -> FilePath -> RunningNode -> [TxId] -> IO ()
-canDecommit tracer workDir node hydraScriptsTxId =
-  (`finally` returnFundsToFaucet tracer node Alice) $ do
-    refuelIfNeeded tracer node Alice 30_000_000
+canDecommit :: ChainBackend backend => Tracer IO EndToEndLog -> FilePath -> backend -> [TxId] -> IO ()
+canDecommit tracer workDir backend hydraScriptsTxId =
+  (`finally` returnFundsToFaucet tracer backend Alice) $ do
+    refuelIfNeeded tracer backend Alice 30_000_000
     let contestationPeriod = 1
+    networkId <- Backend.queryNetworkId backend
+    blockTime <- Backend.getBlockTime backend
     aliceChainConfig <-
-      chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [] contestationPeriod
+      chainConfigFor Alice workDir backend hydraScriptsTxId [] contestationPeriod
         <&> setNetworkId networkId
     withHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
       -- Initialize & open head
@@ -1491,10 +1492,10 @@ canDecommit tracer workDir node hydraScriptsTxId =
       (walletVk, walletSk) <- generate genKeyPair
       let headAmount = 8_000_000
       let commitAmount = 5_000_000
-      headUTxO <- seedFromFaucet node walletVk headAmount (contramap FromFaucet tracer)
-      commitUTxO <- seedFromFaucet node walletVk commitAmount (contramap FromFaucet tracer)
+      headUTxO <- seedFromFaucet backend walletVk headAmount (contramap FromFaucet tracer)
+      commitUTxO <- seedFromFaucet backend walletVk commitAmount (contramap FromFaucet tracer)
 
-      requestCommitTx n1 (headUTxO <> commitUTxO) <&> signTx walletSk >>= submitTx node
+      requestCommitTx n1 (headUTxO <> commitUTxO) <&> signTx walletSk >>= Backend.submitTransaction backend
 
       waitFor hydraTracer 10 [n1] $
         output "HeadIsOpen" ["utxo" .= toJSON (headUTxO <> commitUTxO), "headId" .= headId]
@@ -1511,7 +1512,7 @@ canDecommit tracer workDir node hydraScriptsTxId =
 
       -- After decommit Head UTxO should not contain decommitted outputs and wallet owns the funds on L1
       getSnapshotUTxO n1 `shouldReturn` headUTxO
-      (balance <$> queryUTxOFor networkId nodeSocket QueryTip walletVk)
+      (balance <$> Backend.queryUTxOFor backend QueryTip walletVk)
         `shouldReturn` lovelaceToValue commitAmount
 
       -- Close and Fanout whatever is left in the Head back to L1
@@ -1527,7 +1528,7 @@ canDecommit tracer workDir node hydraScriptsTxId =
         guard $ v ^? key "tag" == Just "HeadIsFinalized"
 
       -- Assert final wallet balance
-      (balance <$> queryUTxOFor networkId nodeSocket QueryTip walletVk)
+      (balance <$> Backend.queryUTxOFor backend QueryTip walletVk)
         `shouldReturn` lovelaceToValue (headAmount + commitAmount)
  where
   expectSuccessOnSignedDecommitTx n headId decommitTx = do
@@ -1543,7 +1544,7 @@ canDecommit tracer workDir node hydraScriptsTxId =
       output "DecommitRequested" ["headId" .= headId, "decommitTx" .= decommitTx, "utxoToDecommit" .= decommitUTxO]
     waitFor hydraTracer 10 [n] $
       output "DecommitApproved" ["headId" .= headId, "decommitTxId" .= decommitTxId, "utxoToDecommit" .= decommitUTxO]
-    failAfter 10 $ waitForUTxO node decommitUTxO
+    failAfter 10 $ waitForUTxO backend decommitUTxO
 
     distributedUTxO <- waitForAllMatch 10 [n] $ \v -> do
       guard $ v ^? key "tag" == Just "DecommitFinalized"
@@ -1570,30 +1571,30 @@ canDecommit tracer workDir node hydraScriptsTxId =
 
   hydraTracer = contramap FromHydraNode tracer
 
-  RunningNode{networkId, nodeSocket, blockTime} = node
-
 -- | Can side load snapshot and resume agreement after a peer comes back online with healthy configuration
-canSideLoadSnapshot :: Tracer IO EndToEndLog -> FilePath -> RunningNode -> [TxId] -> IO ()
-canSideLoadSnapshot tracer workDir cardanoNode hydraScriptsTxId = do
+canSideLoadSnapshot :: ChainBackend backend => Tracer IO EndToEndLog -> FilePath -> backend -> [TxId] -> IO ()
+canSideLoadSnapshot tracer workDir backend hydraScriptsTxId = do
   let clients = [Alice, Bob, Carol]
   [(aliceCardanoVk, aliceCardanoSk), (bobCardanoVk, _), (carolCardanoVk, _)] <- forM clients keysFor
-  seedFromFaucet_ cardanoNode aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
-  seedFromFaucet_ cardanoNode bobCardanoVk 100_000_000 (contramap FromFaucet tracer)
-  seedFromFaucet_ cardanoNode carolCardanoVk 100_000_000 (contramap FromFaucet tracer)
-
+  seedFromFaucet_ backend aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
+  seedFromFaucet_ backend bobCardanoVk 100_000_000 (contramap FromFaucet tracer)
+  seedFromFaucet_ backend carolCardanoVk 100_000_000 (contramap FromFaucet tracer)
+  blockTime <- Backend.getBlockTime backend
   let contestationPeriod = 1
+
+  networkId <- Backend.queryNetworkId backend
   aliceChainConfig <-
-    chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [Bob, Carol] contestationPeriod
+    chainConfigFor Alice workDir backend hydraScriptsTxId [Bob, Carol] contestationPeriod
       <&> setNetworkId networkId
   bobChainConfig <-
-    chainConfigFor Bob workDir nodeSocket hydraScriptsTxId [Alice, Carol] contestationPeriod
+    chainConfigFor Bob workDir backend hydraScriptsTxId [Alice, Carol] contestationPeriod
       <&> setNetworkId networkId
   carolChainConfig <-
-    chainConfigFor Carol workDir nodeSocket hydraScriptsTxId [Alice, Bob] contestationPeriod
+    chainConfigFor Carol workDir backend hydraScriptsTxId [Alice, Bob] contestationPeriod
       <&> setNetworkId networkId
 
   withHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [bobVk, carolVk] [1, 2, 3] $ \n1 -> do
-    aliceUTxO <- seedFromFaucet cardanoNode aliceCardanoVk 1_000_000 (contramap FromFaucet tracer)
+    aliceUTxO <- seedFromFaucet backend aliceCardanoVk 1_000_000 (contramap FromFaucet tracer)
     withHydraNode hydraTracer bobChainConfig workDir 2 bobSk [aliceVk, carolVk] [1, 2, 3] $ \n2 -> do
       -- Carol starts its node misconfigured
       let pparamsDecorator = atKey "maxTxSize" ?~ toJSON (Aeson.Number 0)
@@ -1603,10 +1604,10 @@ canSideLoadSnapshot tracer workDir cardanoNode hydraScriptsTxId = do
         headId <- waitForAllMatch (10 * blockTime) [n1, n2, n3] $ headIsInitializingWith (Set.fromList [alice, bob, carol])
 
         -- Alice commits something
-        requestCommitTx n1 aliceUTxO >>= submitTx cardanoNode
+        requestCommitTx n1 aliceUTxO >>= Backend.submitTransaction backend
 
         -- Everyone else commits nothing
-        mapConcurrently_ (\n -> requestCommitTx n mempty >>= submitTx cardanoNode) [n2, n3]
+        mapConcurrently_ (\n -> requestCommitTx n mempty >>= Backend.submitTransaction backend) [n2, n3]
 
         -- Observe open with the relevant UTxOs
         waitFor hydraTracer (20 * blockTime) [n1, n2, n3] $
@@ -1693,28 +1694,29 @@ canSideLoadSnapshot tracer workDir cardanoNode hydraScriptsTxId = do
         seenSn3' <- getSnapshotLastSeen n3
         seenSn2' `shouldBe` seenSn3'
  where
-  RunningNode{nodeSocket, networkId, blockTime} = cardanoNode
   hydraTracer = contramap FromHydraNode tracer
 
 -- | Three hydra nodes open a head and we assert that none of them sees errors if a party is duplicated.
-threeNodesWithMirrorParty :: Tracer IO EndToEndLog -> FilePath -> RunningNode -> [TxId] -> IO ()
-threeNodesWithMirrorParty tracer workDir cardanoNode@RunningNode{nodeSocket, networkId, blockTime} hydraScriptsTxId = do
+threeNodesWithMirrorParty :: ChainBackend backend => Tracer IO EndToEndLog -> FilePath -> backend -> [TxId] -> IO ()
+threeNodesWithMirrorParty tracer workDir backend hydraScriptsTxId = do
   let parties = [Alice, Bob]
 
   [(aliceCardanoVk, aliceCardanoSk), (bobCardanoVk, _)] <- forM parties keysFor
-  seedFromFaucet_ cardanoNode aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
-  seedFromFaucet_ cardanoNode bobCardanoVk 100_000_000 (contramap FromFaucet tracer)
+  seedFromFaucet_ backend aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
+  seedFromFaucet_ backend bobCardanoVk 100_000_000 (contramap FromFaucet tracer)
+  networkId <- Backend.queryNetworkId backend
 
   let contestationPeriod = 1
   aliceChainConfig <-
-    chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [Bob] contestationPeriod
+    chainConfigFor Alice workDir backend hydraScriptsTxId [Bob] contestationPeriod
       <&> setNetworkId networkId
   bobChainConfig <-
-    chainConfigFor Bob workDir nodeSocket hydraScriptsTxId [Alice] contestationPeriod
+    chainConfigFor Bob workDir backend hydraScriptsTxId [Alice] contestationPeriod
       <&> setNetworkId networkId
 
   let hydraTracer = contramap FromHydraNode tracer
   let allNodeIds = [1, 2, 3]
+  blockTime <- Backend.getBlockTime backend
   withHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [bobVk] allNodeIds $ \n1 -> do
     withHydraNode hydraTracer bobChainConfig workDir 2 bobSk [aliceVk] allNodeIds $ \n2 -> do
       -- One party will participate using same hydra credentials
@@ -1725,14 +1727,14 @@ threeNodesWithMirrorParty tracer workDir cardanoNode@RunningNode{nodeSocket, net
 
         -- N1 & N3 commit the same thing at the same time
         -- XXX: one will fail but the head will still open
-        aliceUTxO <- seedFromFaucet cardanoNode aliceCardanoVk 1_000_000 (contramap FromFaucet tracer)
+        aliceUTxO <- seedFromFaucet backend aliceCardanoVk 1_000_000 (contramap FromFaucet tracer)
         race_
-          (requestCommitTx n1 aliceUTxO >>= submitTx cardanoNode)
-          (requestCommitTx n3 aliceUTxO >>= submitTx cardanoNode)
+          (requestCommitTx n1 aliceUTxO >>= Backend.submitTransaction backend)
+          (requestCommitTx n3 aliceUTxO >>= Backend.submitTransaction backend)
 
         -- N2 commits something
-        bobUTxO <- seedFromFaucet cardanoNode bobCardanoVk 1_000_000 (contramap FromFaucet tracer)
-        requestCommitTx n2 bobUTxO >>= submitTx cardanoNode
+        bobUTxO <- seedFromFaucet backend bobCardanoVk 1_000_000 (contramap FromFaucet tracer)
+        requestCommitTx n2 bobUTxO >>= Backend.submitTransaction backend
 
         -- Observe open with relevant UTxO
         waitFor hydraTracer (20 * blockTime) clients $
@@ -1793,26 +1795,26 @@ respendUTxO client sk delay = do
 
 -- | Refuel given 'Actor' with given 'Lovelace' if current marked UTxO is below that amount.
 refuelIfNeeded ::
+  ChainBackend backend =>
   Tracer IO EndToEndLog ->
-  RunningNode ->
+  backend ->
   Actor ->
   Coin ->
   IO ()
-refuelIfNeeded tracer node actor amount = do
+refuelIfNeeded tracer backend actor amount = do
   (actorVk, _) <- keysFor actor
-  existingUtxo <- queryUTxOFor networkId nodeSocket QueryTip actorVk
+  existingUtxo <- Backend.queryUTxOFor backend QueryTip actorVk
   traceWith tracer $ StartingFunds{actor = actorName actor, utxo = existingUtxo}
   let currentBalance = selectLovelace $ balance @Tx existingUtxo
   when (currentBalance < amount) $ do
-    utxo <- seedFromFaucet node actorVk amount (contramap FromFaucet tracer)
+    utxo <- seedFromFaucet backend actorVk amount (contramap FromFaucet tracer)
     traceWith tracer $ RefueledFunds{actor = actorName actor, refuelingAmount = amount, utxo}
- where
-  RunningNode{networkId, nodeSocket} = node
 
 -- | Return the remaining funds to the faucet
 returnFundsToFaucet ::
+  ChainBackend backend =>
   Tracer IO EndToEndLog ->
-  RunningNode ->
+  backend ->
   Actor ->
   IO ()
 returnFundsToFaucet tracer =

--- a/hydra-cluster/src/Hydra/Generator.hs
+++ b/hydra-cluster/src/Hydra/Generator.hs
@@ -4,12 +4,15 @@ import Hydra.Cardano.Api
 import Hydra.Prelude hiding (size)
 
 import Cardano.Api.UTxO qualified as UTxO
-import CardanoClient (QueryPoint (QueryTip), buildTransaction, mkGenesisTx, queryUTxOFor)
+import CardanoClient (QueryPoint (QueryTip), mkGenesisTx, queryUTxOFor)
 import Control.Monad (foldM)
 import Data.Aeson (object, withObject, (.:), (.=))
+import Hydra.Chain.Backend (buildTransaction)
+import Hydra.Chain.Direct (DirectBackend (..))
 import Hydra.Cluster.Faucet (FaucetException (..))
 import Hydra.Cluster.Fixture (availableInitialFunds)
 import Hydra.Ledger.Cardano (mkTransferTx)
+import Hydra.Options qualified as Options
 import Test.Hydra.Tx.Gen (genSigningKey)
 import Test.QuickCheck (choose, generate, sized)
 
@@ -144,7 +147,8 @@ generateDemoUTxODataset network nodeSocket faucetSk nClients nTxs = do
               (lovelaceToValue ll)
               TxOutDatumNone
               ReferenceScriptNone
-    buildTransaction network nodeSocket faucetAddress faucetUTxO [] recipientOutputs >>= \case
+
+    buildTransaction (DirectBackend $ Options.DirectOptions{Options.networkId = network, Options.nodeSocket}) faucetAddress faucetUTxO [] recipientOutputs >>= \case
       Left e -> throwIO $ FaucetFailedToBuildTx{reason = e}
       Right tx -> pure $ signTx faucetSk tx
   generate $ do

--- a/hydra-cluster/test/Test/BlockfrostChainSpec.hs
+++ b/hydra-cluster/test/Test/BlockfrostChainSpec.hs
@@ -16,6 +16,7 @@ import Hydra.Chain (
   PostChainTx (..),
   initHistory,
  )
+import Hydra.Chain.Backend (blockfrostProjectPath)
 import Hydra.Chain.Blockfrost (BlockfrostBackend (..), withBlockfrostChain)
 import Hydra.Chain.Blockfrost.Client qualified as Blockfrost
 import Hydra.Chain.Cardano (loadChainContext, mkTinyWallet)
@@ -60,9 +61,6 @@ import Test.DirectChainSpec (
  )
 import Test.Hydra.Tx.Gen (genKeyPair)
 import Test.QuickCheck (generate)
-
-blockfrostProjectPath :: FilePath
-blockfrostProjectPath = "./../blockfrost-project.txt"
 
 spec :: Spec
 spec = around (onlyWithBlockfrostProjectFile . showLogsOnFailure "BlockfrostChainSpec") $ do

--- a/hydra-cluster/test/Test/CardanoClientSpec.hs
+++ b/hydra-cluster/test/Test/CardanoClientSpec.hs
@@ -3,11 +3,11 @@ module Test.CardanoClientSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import CardanoClient (QueryPoint (..), RunningNode (..), queryGenesisParameters)
 import CardanoNode (withCardanoNodeDevnet)
 import Data.Aeson ((.:))
 import Data.Aeson qualified as Aeson
 import Hydra.Cardano.Api (GenesisParameters (..))
+import Hydra.Chain.Backend qualified as Backend
 import Hydra.Logging (showLogsOnFailure)
 import Hydra.Utils (readJsonFileThrow)
 import System.FilePath ((</>))
@@ -22,9 +22,9 @@ spec =
           -- This uses the hydra-cluster/config/devnet and updates the
           -- systemStart to some current time making it the perfect target to
           -- test against.
-          withCardanoNodeDevnet tracer tmpDir $ \RunningNode{nodeSocket, networkId} -> do
+          withCardanoNodeDevnet tracer tmpDir $ \_ backend -> do
             GenesisParameters{protocolParamSystemStart = queriedSystemStart} <-
-              queryGenesisParameters networkId nodeSocket QueryTip
+              Backend.queryGenesisParameters backend
 
             let parseSystemStart =
                   Aeson.withObject "GenesisShelley" $ \o -> o .: "systemStart"

--- a/hydra-cluster/test/Test/CardanoNodeSpec.hs
+++ b/hydra-cluster/test/Test/CardanoNodeSpec.hs
@@ -10,13 +10,13 @@ import CardanoNode (
   withCardanoNodeOnKnownNetwork,
  )
 
-import Hydra.Cardano.Api (NetworkId (Testnet), NetworkMagic (NetworkMagic), chainPointToSlotNo, unFile)
+import Hydra.Cardano.Api (NetworkId (Testnet), NetworkMagic (NetworkMagic), unFile)
 import Hydra.Chain.Backend qualified as Backend
 import Hydra.Cluster.Fixture (KnownNetwork (..), toNetworkId)
 import Hydra.Logging (Tracer, showLogsOnFailure)
 import Hydra.Options (ChainBackendOptions (..), DirectOptions (..))
 import System.Directory (doesFileExist)
-import Test.Hydra.Cluster.Utils (forEachKnownNetwork)
+import Test.Hydra.Cluster.Utils (chainPointToSlot, forEachKnownNetwork)
 
 supportedNetworks :: [KnownNetwork]
 supportedNetworks = [Mainnet, Preproduction, Preview]
@@ -53,9 +53,9 @@ spec = do
         networkId `shouldBe` Testnet (NetworkMagic 42)
         blockTime `shouldBe` 0.1
         -- Should produce blocks (tip advances)
-        slot1 <- fromMaybe 0 . chainPointToSlotNo <$> Backend.queryTip backend
+        slot1 <- chainPointToSlot <$> Backend.queryTip backend
         threadDelay 1
-        slot2 <- fromMaybe 0 . chainPointToSlotNo <$> Backend.queryTip backend
+        slot2 <- chainPointToSlot <$> Backend.queryTip backend
         slot2 `shouldSatisfy` (> slot1)
 
     describe "findRunningCardanoNode" $ do
@@ -76,9 +76,9 @@ spec = do
         networkId `shouldBe` toNetworkId network
         blockTime `shouldBe` 20
         -- Should synchronize blocks (tip advances)
-        slot1 <- fromMaybe 0 . chainPointToSlotNo <$> Backend.queryTip backend
+        slot1 <- chainPointToSlot <$> Backend.queryTip backend
         threadDelay 10
-        slot2 <- fromMaybe 0 . chainPointToSlotNo <$> Backend.queryTip backend
+        slot2 <- chainPointToSlot <$> Backend.queryTip backend
         slot2 `shouldSatisfy` (> slot1)
 
 setupTracerAndTempDir :: ToJSON msg => ((Tracer IO msg, FilePath) -> IO a) -> IO a

--- a/hydra-cluster/test/Test/CardanoNodeSpec.hs
+++ b/hydra-cluster/test/Test/CardanoNodeSpec.hs
@@ -10,10 +10,11 @@ import CardanoNode (
   withCardanoNodeOnKnownNetwork,
  )
 
-import CardanoClient (RunningNode (..), queryTipSlotNo)
-import Hydra.Cardano.Api (NetworkId (Testnet), NetworkMagic (NetworkMagic), unFile)
+import Hydra.Cardano.Api (NetworkId (Testnet), NetworkMagic (NetworkMagic), chainPointToSlotNo, unFile)
+import Hydra.Chain.Backend qualified as Backend
 import Hydra.Cluster.Fixture (KnownNetwork (..), toNetworkId)
 import Hydra.Logging (Tracer, showLogsOnFailure)
+import Hydra.Options (ChainBackendOptions (..), DirectOptions (..))
 import System.Directory (doesFileExist)
 import Test.Hydra.Cluster.Utils (forEachKnownNetwork)
 
@@ -40,38 +41,44 @@ spec = do
 
   around (failAfter 5 . setupTracerAndTempDir) $ do
     it "withCardanoNodeDevnet does start a block-producing devnet within 5 seconds" $ \(tr, tmp) ->
-      withCardanoNodeDevnet tr tmp $ \RunningNode{nodeSocket, networkId, blockTime} -> do
-        doesFileExist (unFile nodeSocket) `shouldReturn` True
+      withCardanoNodeDevnet tr tmp $ \blockTime backend -> do
+        let nodeSocket' =
+              case Backend.getOptions backend of
+                Direct DirectOptions{Hydra.Options.nodeSocket} -> nodeSocket
+                Blockfrost _ -> error "Unexpected Blockfrost options"
+        doesFileExist (unFile nodeSocket') `shouldReturn` True
+        networkId <- Backend.queryNetworkId backend
         -- NOTE: We hard-code the expected networkId and blockTime here to
         -- detect any change to the genesis-shelley.json
         networkId `shouldBe` Testnet (NetworkMagic 42)
         blockTime `shouldBe` 0.1
         -- Should produce blocks (tip advances)
-        slot1 <- queryTipSlotNo networkId nodeSocket
+        slot1 <- fromMaybe 0 . chainPointToSlotNo <$> Backend.queryTip backend
         threadDelay 1
-        slot2 <- queryTipSlotNo networkId nodeSocket
+        slot2 <- fromMaybe 0 . chainPointToSlotNo <$> Backend.queryTip backend
         slot2 `shouldSatisfy` (> slot1)
 
     describe "findRunningCardanoNode" $ do
       it "returns Nothing on non-matching network" $ \(tr, tmp) -> do
-        withCardanoNodeOnKnownNetwork tr tmp Preview $ \_ -> do
+        withCardanoNodeOnKnownNetwork tr tmp Preview $ \_ _ -> do
           findRunningCardanoNode tr tmp Preproduction `shouldReturn` Nothing
 
       it "returns Just running node on matching network" $ \(tr, tmp) -> do
-        withCardanoNodeOnKnownNetwork tr tmp Preview $ \runningNode -> do
-          findRunningCardanoNode tr tmp Preview `shouldReturn` Just runningNode
+        withCardanoNodeOnKnownNetwork tr tmp Preview $ \blockTime backend -> do
+          findRunningCardanoNode tr tmp Preview `shouldReturn` Just (blockTime, backend)
 
   forSupportedKnownNetworks "withCardanoNodeOnKnownNetwork starts synchronizing within 10 seconds" $ \network -> do
     -- NOTE: This implies that withCardanoNodeOnKnownNetwork does not
     -- synchronize the whole chain before continuing.
     setupTracerAndTempDir $ \(tr, tmp) ->
-      withCardanoNodeOnKnownNetwork tr tmp network $ \RunningNode{nodeSocket, networkId, blockTime} -> do
+      withCardanoNodeOnKnownNetwork tr tmp network $ \blockTime backend -> do
+        networkId <- Backend.queryNetworkId backend
         networkId `shouldBe` toNetworkId network
         blockTime `shouldBe` 20
         -- Should synchronize blocks (tip advances)
-        slot1 <- queryTipSlotNo networkId nodeSocket
+        slot1 <- fromMaybe 0 . chainPointToSlotNo <$> Backend.queryTip backend
         threadDelay 10
-        slot2 <- queryTipSlotNo networkId nodeSocket
+        slot2 <- fromMaybe 0 . chainPointToSlotNo <$> Backend.queryTip backend
         slot2 `shouldSatisfy` (> slot1)
 
 setupTracerAndTempDir :: ToJSON msg => ((Tracer IO msg, FilePath) -> IO a) -> IO a

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -8,12 +8,6 @@ import Test.Hydra.Prelude
 
 import Cardano.Api.UTxO qualified as UTxO
 import CardanoClient (
-  QueryPoint (..),
-  RunningNode (..),
-  queryGenesisParameters,
-  queryTip,
-  queryTipSlotNo,
-  submitTx,
   waitForUTxO,
  )
 import CardanoNode (
@@ -32,6 +26,8 @@ import Data.Set qualified as Set
 import Data.Text (isInfixOf)
 import Data.Time (secondsToDiffTime)
 import Hydra.Cardano.Api hiding (Value, cardanoEra, queryGenesisParameters)
+import Hydra.Chain.Backend (ChainBackend)
+import Hydra.Chain.Backend qualified as Backend
 import Hydra.Chain.Direct.State ()
 import Hydra.Cluster.Faucet (
   publishHydraScriptsAs,
@@ -249,113 +245,113 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
     describe "single party hydra head" $ do
       it "full head life-cycle" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-            publishHydraScriptsAs node Faucet
-              >>= singlePartyHeadFullLifeCycle tracer tmpDir node
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
+            publishHydraScriptsAs backend Faucet
+              >>= singlePartyHeadFullLifeCycle tracer tmpDir backend
       it "can close with long deadline" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-            publishHydraScriptsAs node Faucet
-              >>= canCloseWithLongContestationPeriod tracer tmpDir node
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
+            publishHydraScriptsAs backend Faucet
+              >>= canCloseWithLongContestationPeriod tracer tmpDir backend
       it "can submit a timed tx" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-            publishHydraScriptsAs node Faucet
-              >>= timedTx tmpDir tracer node
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend ->
+            publishHydraScriptsAs backend Faucet
+              >>= timedTx tmpDir tracer backend
       it "commits from external with utxo" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-            publishHydraScriptsAs node Faucet
-              >>= singlePartyCommitsFromExternal tracer tmpDir node
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
+            publishHydraScriptsAs backend Faucet
+              >>= singlePartyCommitsFromExternal tracer tmpDir backend
       it "can spend from a script on L2" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-            publishHydraScriptsAs node Faucet
-              >>= singlePartyUsesScriptOnL2 tracer tmpDir node
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
+            publishHydraScriptsAs backend Faucet
+              >>= singlePartyUsesScriptOnL2 tracer tmpDir backend
       it "can use withdraw zero on L2" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-            publishHydraScriptsAs node Faucet
-              >>= singlePartyUsesWithdrawZeroTrick tracer tmpDir node
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
+            publishHydraScriptsAs backend Faucet
+              >>= singlePartyUsesWithdrawZeroTrick tracer tmpDir backend
       it "can submit a signed user transaction" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-            publishHydraScriptsAs node Faucet
-              >>= canSubmitTransactionThroughAPI tracer tmpDir node
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
+            publishHydraScriptsAs backend Faucet
+              >>= canSubmitTransactionThroughAPI tracer tmpDir backend
       it "commits from external with tx blueprint" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-            publishHydraScriptsAs node Faucet
-              >>= singlePartyCommitsFromExternalTxBlueprint tracer tmpDir node
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
+            publishHydraScriptsAs backend Faucet
+              >>= singlePartyCommitsFromExternalTxBlueprint tracer tmpDir backend
       it "can decommit utxo" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-            publishHydraScriptsAs node Faucet
-              >>= canDecommit tracer tmpDir node
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
+            publishHydraScriptsAs backend Faucet
+              >>= canDecommit tracer tmpDir backend
       it "can incrementally commit" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-            publishHydraScriptsAs node Faucet
-              >>= canCommit tracer tmpDir node
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \blockTime backend -> do
+            publishHydraScriptsAs backend Faucet
+              >>= canCommit tracer tmpDir blockTime backend
       it "can recover deposit" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-            publishHydraScriptsAs node Faucet
-              >>= canRecoverDeposit tracer tmpDir node
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
+            publishHydraScriptsAs backend Faucet
+              >>= canRecoverDeposit tracer tmpDir backend
       it "can see pending deposits" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-            publishHydraScriptsAs node Faucet
-              >>= canSeePendingDeposits tracer tmpDir node
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \blockTime backend -> do
+            publishHydraScriptsAs backend Faucet
+              >>= canSeePendingDeposits tracer tmpDir blockTime backend
       it "incrementally commit script using blueprint tx" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-            publishHydraScriptsAs node Faucet
-              >>= singlePartyCommitsScriptBlueprint tracer tmpDir node
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend ->
+            publishHydraScriptsAs backend Faucet
+              >>= singlePartyCommitsScriptBlueprint tracer tmpDir backend
       it "persistence can load with empty commit" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-            publishHydraScriptsAs node Faucet
-              >>= persistenceCanLoadWithEmptyCommit tracer tmpDir node
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend ->
+            publishHydraScriptsAs backend Faucet
+              >>= persistenceCanLoadWithEmptyCommit tracer tmpDir backend
       it "node re-observes on-chain txs" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-            publishHydraScriptsAs node Faucet
-              >>= nodeReObservesOnChainTxs tracer tmpDir node
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend ->
+            publishHydraScriptsAs backend Faucet
+              >>= nodeReObservesOnChainTxs tracer tmpDir backend
 
     describe "three hydra nodes scenario" $ do
       it "can survive a bit of downtime of 1 in 3 nodes" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-            publishHydraScriptsAs node Faucet
-              >>= oneOfThreeNodesStopsForAWhile tracer tmpDir node
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend ->
+            publishHydraScriptsAs backend Faucet
+              >>= oneOfThreeNodesStopsForAWhile tracer tmpDir backend
 
       it "does not error when all nodes open the head concurrently" $ \tracer ->
         failAfter 60 $
           withClusterTempDir $ \tmpDir -> do
-            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node -> do
-              publishHydraScriptsAs node Faucet
-                >>= threeNodesNoErrorsOnOpen tracer tmpDir node
+            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
+              publishHydraScriptsAs backend Faucet
+                >>= threeNodesNoErrorsOnOpen tracer tmpDir backend
 
       it "node can support multiple etcd clusters" $ \tracer ->
         failAfter 60 $
           withClusterTempDir $ \tmpDir -> do
-            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node -> do
-              publishHydraScriptsAs node Faucet
-                >>= nodeCanSupportMultipleEtcdClusters tracer tmpDir node
+            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
+              publishHydraScriptsAs backend Faucet
+                >>= nodeCanSupportMultipleEtcdClusters tracer tmpDir backend
 
       it "inits a Head, processes a single Cardano transaction and closes it again" $ \tracer ->
         failAfter 60 $
           withClusterTempDir $ \tmpDir -> do
-            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node -> do
-              hydraScriptsTxId <- publishHydraScriptsAs node Faucet
-              initAndClose tmpDir tracer 1 hydraScriptsTxId node
+            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
+              hydraScriptsTxId <- publishHydraScriptsAs backend Faucet
+              initAndClose tmpDir tracer 1 hydraScriptsTxId backend
 
       it "inits a Head and closes it immediately" $ \tracer ->
         failAfter 60 $
           withClusterTempDir $ \tmpDir -> do
             let clusterIx = 0
-            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node@RunningNode{nodeSocket} -> do
+            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
               aliceKeys@(aliceCardanoVk, _) <- generate genKeyPair
               bobKeys@(bobCardanoVk, _) <- generate genKeyPair
               carolKeys@(carolCardanoVk, _) <- generate genKeyPair
@@ -365,17 +361,21 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
 
               let firstNodeId = clusterIx * 3
 
-              hydraScriptsTxId <- publishHydraScriptsAs node Faucet
+              hydraScriptsTxId <- publishHydraScriptsAs backend Faucet
               let contestationPeriod = 2
               let hydraTracer = contramap FromHydraNode tracer
-              withHydraCluster hydraTracer tmpDir nodeSocket firstNodeId cardanoKeys hydraKeys hydraScriptsTxId contestationPeriod $ \nodes -> do
+
+              let nodeSocket' = case Backend.getOptions backend of
+                    Direct DirectOptions{nodeSocket} -> nodeSocket
+                    _ -> error "Unexpected Blockfrost backend"
+              withHydraCluster hydraTracer tmpDir nodeSocket' firstNodeId cardanoKeys hydraKeys hydraScriptsTxId contestationPeriod $ \nodes -> do
                 waitForNodesConnected hydraTracer 20 nodes
                 let [n1, n2, n3] = toList nodes
 
                 -- Funds to be used as fuel by Hydra protocol transactions
-                seedFromFaucet_ node aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
-                seedFromFaucet_ node bobCardanoVk 100_000_000 (contramap FromFaucet tracer)
-                seedFromFaucet_ node carolCardanoVk 100_000_000 (contramap FromFaucet tracer)
+                seedFromFaucet_ backend aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
+                seedFromFaucet_ backend bobCardanoVk 100_000_000 (contramap FromFaucet tracer)
+                seedFromFaucet_ backend carolCardanoVk 100_000_000 (contramap FromFaucet tracer)
 
                 send n1 $ input "Init" []
                 headId <-
@@ -383,14 +383,14 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
 
                 -- Get some UTXOs to commit to a head
                 (aliceExternalVk, aliceExternalSk) <- generate genKeyPair
-                committedUTxOByAlice <- seedFromFaucet node aliceExternalVk aliceCommittedToHead (contramap FromFaucet tracer)
-                requestCommitTx n1 committedUTxOByAlice <&> signTx aliceExternalSk >>= submitTx node
+                committedUTxOByAlice <- seedFromFaucet backend aliceExternalVk aliceCommittedToHead (contramap FromFaucet tracer)
+                requestCommitTx n1 committedUTxOByAlice <&> signTx aliceExternalSk >>= Backend.submitTransaction backend
 
                 (bobExternalVk, bobExternalSk) <- generate genKeyPair
-                committedUTxOByBob <- seedFromFaucet node bobExternalVk bobCommittedToHead (contramap FromFaucet tracer)
-                requestCommitTx n2 committedUTxOByBob <&> signTx bobExternalSk >>= submitTx node
+                committedUTxOByBob <- seedFromFaucet backend bobExternalVk bobCommittedToHead (contramap FromFaucet tracer)
+                requestCommitTx n2 committedUTxOByBob <&> signTx bobExternalSk >>= Backend.submitTransaction backend
 
-                requestCommitTx n3 mempty >>= submitTx node
+                requestCommitTx n3 mempty >>= Backend.submitTransaction backend
 
                 let u0 = committedUTxOByAlice <> committedUTxOByBob
 
@@ -415,35 +415,35 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
       it "supports mirror party" $ \tracer ->
         failAfter 60 $
           withClusterTempDir $ \tmpDir -> do
-            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node -> do
-              publishHydraScriptsAs node Faucet
-                >>= threeNodesWithMirrorParty tracer tmpDir node
+            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
+              publishHydraScriptsAs backend Faucet
+                >>= threeNodesWithMirrorParty tracer tmpDir backend
 
     describe "restarting nodes" $ do
       it "can abort head after restart" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-            publishHydraScriptsAs node Faucet
-              >>= restartedNodeCanAbort tracer tmpDir node
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend ->
+            publishHydraScriptsAs backend Faucet
+              >>= restartedNodeCanAbort tracer tmpDir backend
 
       it "can observe a commit tx after a restart, even when a tx happened while down" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-            publishHydraScriptsAs node Faucet
-              >>= restartedNodeCanObserveCommitTx tracer tmpDir node
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend ->
+            publishHydraScriptsAs backend Faucet
+              >>= restartedNodeCanObserveCommitTx tracer tmpDir backend
 
       it "can start chain from the past and replay on-chain events" $ \tracer ->
         withClusterTempDir $ \tmp ->
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmp $ \node@RunningNode{nodeSocket, networkId} -> do
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmp $ \_ backend -> do
             (aliceCardanoVk, _aliceCardanoSk) <- keysFor Alice
             let contestationPeriod = 10
-            hydraScriptsTxId <- publishHydraScriptsAs node Faucet
-            aliceChainConfig <- chainConfigFor Alice tmp nodeSocket hydraScriptsTxId [] contestationPeriod
+            hydraScriptsTxId <- publishHydraScriptsAs backend Faucet
+            aliceChainConfig <- chainConfigFor Alice tmp backend hydraScriptsTxId [] contestationPeriod
             let nodeId = 1
             let hydraTracer = contramap FromHydraNode tracer
             (tip, aliceHeadId) <- withHydraNode hydraTracer aliceChainConfig tmp nodeId aliceSk [] [1] $ \n1 -> do
-              seedFromFaucet_ node aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
-              tip <- queryTip networkId nodeSocket
+              seedFromFaucet_ backend aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
+              tip <- Backend.queryTip backend
               send n1 $ input "Init" []
               headId <- waitForAllMatch 10 [n1] $ headIsInitializingWith (Set.fromList [alice])
               return (tip, headId)
@@ -462,20 +462,20 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
 
       it "close of an initial snapshot from re-initialized node is contested" $ \tracer ->
         withClusterTempDir $ \tmp ->
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmp $ \node@RunningNode{nodeSocket, networkId} -> do
-            hydraScriptsTxId <- publishHydraScriptsAs node Faucet
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmp $ \_ backend -> do
+            hydraScriptsTxId <- publishHydraScriptsAs backend Faucet
 
             (aliceCardanoVk, _aliceCardanoSk) <- keysFor Alice
             (bobCardanoVk, _bobCardanoSk) <- keysFor Bob
 
-            seedFromFaucet_ node aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
-            seedFromFaucet_ node bobCardanoVk 100_000_000 (contramap FromFaucet tracer)
+            seedFromFaucet_ backend aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
+            seedFromFaucet_ backend bobCardanoVk 100_000_000 (contramap FromFaucet tracer)
 
-            tip <- queryTip networkId nodeSocket
+            tip <- Backend.queryTip backend
             let startFromTip = modifyConfig $ \x -> x{startChainFrom = Just tip}
             let contestationPeriod = 10
-            aliceChainConfig <- chainConfigFor Alice tmp nodeSocket hydraScriptsTxId [Bob] contestationPeriod <&> startFromTip
-            bobChainConfig <- chainConfigFor Bob tmp nodeSocket hydraScriptsTxId [Alice] contestationPeriod <&> startFromTip
+            aliceChainConfig <- chainConfigFor Alice tmp backend hydraScriptsTxId [Bob] contestationPeriod <&> startFromTip
+            bobChainConfig <- chainConfigFor Bob tmp backend hydraScriptsTxId [Alice] contestationPeriod <&> startFromTip
 
             let hydraTracer = contramap FromHydraNode tracer
             let aliceNodeId = 1
@@ -494,11 +494,11 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
                 headId <- waitForAllMatch 10 [n1, n2] $ headIsInitializingWith (Set.fromList [alice, bob])
 
                 (aliceExternalVk, aliceExternalSk) <- generate genKeyPair
-                committedUTxOByAlice <- seedFromFaucet node aliceExternalVk aliceCommittedToHead (contramap FromFaucet tracer)
-                requestCommitTx n1 committedUTxOByAlice <&> signTx aliceExternalSk >>= submitTx node
+                committedUTxOByAlice <- seedFromFaucet backend aliceExternalVk aliceCommittedToHead (contramap FromFaucet tracer)
+                requestCommitTx n1 committedUTxOByAlice <&> signTx aliceExternalSk >>= Backend.submitTransaction backend
 
                 (bobExternalVk, _bobExternalSk) <- generate genKeyPair
-                requestCommitTx n2 mempty >>= submitTx node
+                requestCommitTx n2 mempty >>= Backend.submitTransaction backend
 
                 waitFor hydraTracer 10 [n1, n2] $ output "HeadIsOpen" ["utxo" .= committedUTxOByAlice, "headId" .= headId]
 
@@ -546,50 +546,50 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
 
       it "can side load snapshot" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-            publishHydraScriptsAs node Faucet
-              >>= canSideLoadSnapshot tracer tmpDir node
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend ->
+            publishHydraScriptsAs backend Faucet
+              >>= canSideLoadSnapshot tracer tmpDir backend
 
     describe "two hydra heads scenario" $ do
       it "two heads on the same network do not conflict" $ \tracer ->
         failAfter 60 $
           withClusterTempDir $ \tmpDir -> do
-            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node -> do
-              hydraScriptsTxId <- publishHydraScriptsAs node Faucet
+            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
+              hydraScriptsTxId <- publishHydraScriptsAs backend Faucet
               concurrently_
-                (initAndClose tmpDir tracer 0 hydraScriptsTxId node)
-                (initAndClose tmpDir tracer 1 hydraScriptsTxId node)
+                (initAndClose tmpDir tracer 0 hydraScriptsTxId backend)
+                (initAndClose tmpDir tracer 1 hydraScriptsTxId backend)
 
       it "alice inits a Head with incorrect keys preventing bob from observing InitTx" $ \tracer ->
         failAfter 60 $
           withClusterTempDir $ \tmpDir -> do
-            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node -> do
-              publishHydraScriptsAs node Faucet
-                >>= initWithWrongKeys tmpDir tracer node
+            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
+              publishHydraScriptsAs backend Faucet
+                >>= initWithWrongKeys tmpDir tracer backend
 
       it "cluster id mismatch provides useful info in the logs" $ \tracer ->
         failAfter 60 $
           withClusterTempDir $ \tmpDir -> do
-            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node -> do
-              publishHydraScriptsAs node Faucet
-                >>= startWithWrongPeers tmpDir tracer node
+            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
+              publishHydraScriptsAs backend Faucet
+                >>= startWithWrongPeers tmpDir tracer backend
 
       it "bob cannot abort alice's head" $ \tracer -> do
         failAfter 60 $
           withClusterTempDir $ \tmpDir -> do
-            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node@RunningNode{nodeSocket} -> do
+            withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
               (aliceCardanoVk, _aliceCardanoSk) <- keysFor Alice
               (bobCardanoVk, _bobCardanoSk) <- keysFor Bob
               let contestationPeriod = 10
-              hydraScriptsTxId <- publishHydraScriptsAs node Faucet
-              aliceChainConfig <- chainConfigFor Alice tmpDir nodeSocket hydraScriptsTxId [] contestationPeriod
-              bobChainConfig <- chainConfigFor Bob tmpDir nodeSocket hydraScriptsTxId [Alice] contestationPeriod
+              hydraScriptsTxId <- publishHydraScriptsAs backend Faucet
+              aliceChainConfig <- chainConfigFor Alice tmpDir backend hydraScriptsTxId [] contestationPeriod
+              bobChainConfig <- chainConfigFor Bob tmpDir backend hydraScriptsTxId [Alice] contestationPeriod
               let hydraTracer = contramap FromHydraNode tracer
               withHydraNode hydraTracer aliceChainConfig tmpDir 1 aliceSk [] allNodeIds $ \n1 ->
                 withHydraNode hydraTracer bobChainConfig tmpDir 2 bobSk [aliceVk] allNodeIds $ \n2 -> do
                   -- Funds to be used as fuel by Hydra protocol transactions
-                  seedFromFaucet_ node aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
-                  seedFromFaucet_ node bobCardanoVk 100_000_000 (contramap FromFaucet tracer)
+                  seedFromFaucet_ backend aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
+                  seedFromFaucet_ backend bobCardanoVk 100_000_000 (contramap FromFaucet tracer)
 
                   send n1 $ input "Init" []
                   headIdAliceOnly <- waitMatch 10 n1 $ headIsInitializingWith (Set.fromList [alice])
@@ -604,7 +604,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
                     output "HeadIsAborted" ["utxo" .= Object mempty, "headId" .= headIdAliceAndBob]
 
                   -- Alice should be able to continue working with her Head
-                  requestCommitTx n1 mempty >>= submitTx node
+                  requestCommitTx n1 mempty >>= Backend.submitTransaction backend
                   waitFor hydraTracer 10 [n1] $
                     output "HeadIsOpen" ["utxo" .= Object mempty, "headId" .= headIdAliceOnly]
 
@@ -612,19 +612,19 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
       it "Node exposes Prometheus metrics on port 6001" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
           (aliceCardanoVk, _) <- keysFor Alice
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node@RunningNode{nodeSocket} -> do
-            hydraScriptsTxId <- publishHydraScriptsAs node Faucet
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
+            hydraScriptsTxId <- publishHydraScriptsAs backend Faucet
             let hydraTracer = contramap FromHydraNode tracer
             let contestationPeriod = 10
-            aliceChainConfig <- chainConfigFor Alice tmpDir nodeSocket hydraScriptsTxId [Bob, Carol] contestationPeriod
-            bobChainConfig <- chainConfigFor Bob tmpDir nodeSocket hydraScriptsTxId [Alice, Carol] contestationPeriod
-            carolChainConfig <- chainConfigFor Carol tmpDir nodeSocket hydraScriptsTxId [Alice, Bob] contestationPeriod
+            aliceChainConfig <- chainConfigFor Alice tmpDir backend hydraScriptsTxId [Bob, Carol] contestationPeriod
+            bobChainConfig <- chainConfigFor Bob tmpDir backend hydraScriptsTxId [Alice, Carol] contestationPeriod
+            carolChainConfig <- chainConfigFor Carol tmpDir backend hydraScriptsTxId [Alice, Bob] contestationPeriod
             failAfter 20 $
               withHydraNode hydraTracer aliceChainConfig tmpDir 1 aliceSk [bobVk, carolVk] allNodeIds $ \n1 ->
                 withHydraNode hydraTracer bobChainConfig tmpDir 2 bobSk [aliceVk, carolVk] allNodeIds $ \n2 ->
                   withHydraNode hydraTracer carolChainConfig tmpDir 3 carolSk [aliceVk, bobVk] allNodeIds $ \n3 -> do
                     -- Funds to be used as fuel by Hydra protocol transactions
-                    seedFromFaucet_ node aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
+                    seedFromFaucet_ backend aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
                     waitForNodesConnected hydraTracer 20 $ n1 :| [n2, n3]
                     send n1 $ input "Init" []
                     void $ waitForAllMatch 3 [n1] $ headIsInitializingWith (Set.fromList [alice, bob, carol])
@@ -635,7 +635,10 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
     describe "withHydraNode" $ do
       it "detects crashes" $ \tracer -> do
         withClusterTempDir $ \dir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) dir $ \RunningNode{nodeSocket} -> do
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) dir $ \_ backend -> do
+            let nodeSocket' = case Backend.getOptions backend of
+                  Direct DirectOptions{nodeSocket} -> nodeSocket
+                  _ -> error "Unexpected Blockfrost backend"
             -- NOTE: Deliberately broken configuration so we expect the node to not start.
             let chainConfig =
                   Cardano
@@ -645,7 +648,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
                           Direct
                             DirectOptions
                               { networkId = Hydra.Options.networkId defaultDirectOptions
-                              , nodeSocket = nodeSocket
+                              , nodeSocket = nodeSocket'
                               }
                       }
             withHydraNode (contramap FromHydraNode tracer) chainConfig dir 1 aliceSk [] [1] (const $ pure ())
@@ -655,11 +658,11 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
 
       it "stops gracefully" $ \tracer -> do
         withClusterTempDir $ \dir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) dir $ \node@RunningNode{nodeSocket} -> do
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) dir $ \_ backend -> do
             let hydraTracer = contramap FromHydraNode tracer
-            hydraScriptsTxId <- publishHydraScriptsAs node Faucet
+            hydraScriptsTxId <- publishHydraScriptsAs backend Faucet
             let contestationPeriod = 100
-            aliceChainConfig <- chainConfigFor Alice dir nodeSocket hydraScriptsTxId [] contestationPeriod
+            aliceChainConfig <- chainConfigFor Alice dir backend hydraScriptsTxId [] contestationPeriod
 
             -- XXX: Need to do something in 'action' otherwise always green?
             withHydraNode hydraTracer aliceChainConfig dir 1 aliceSk [] [1] $ \_ -> do
@@ -667,11 +670,11 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
 
       it "can be restarted" $ \tracer -> do
         withClusterTempDir $ \dir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) dir $ \node@RunningNode{nodeSocket} -> do
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) dir $ \_ backend -> do
             let hydraTracer = contramap FromHydraNode tracer
-            hydraScriptsTxId <- publishHydraScriptsAs node Faucet
+            hydraScriptsTxId <- publishHydraScriptsAs backend Faucet
             let contestationPeriod = 100
-            aliceChainConfig <- chainConfigFor Alice dir nodeSocket hydraScriptsTxId [] contestationPeriod
+            aliceChainConfig <- chainConfigFor Alice dir backend hydraScriptsTxId [] contestationPeriod
 
             -- XXX: Need to do something in 'action' otherwise always green?
             failAfter 10 $
@@ -683,12 +686,12 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
 
       it "logs to a logfile" $ \tracer -> do
         withClusterTempDir $ \dir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) dir $ \node@RunningNode{nodeSocket} -> do
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) dir $ \_ backend -> do
             let hydraTracer = contramap FromHydraNode tracer
-            hydraScriptsTxId <- publishHydraScriptsAs node Faucet
-            refuelIfNeeded tracer node Alice 100_000_000
+            hydraScriptsTxId <- publishHydraScriptsAs backend Faucet
+            refuelIfNeeded tracer backend Alice 100_000_000
             let contestationPeriod = 2
-            aliceChainConfig <- chainConfigFor Alice dir nodeSocket hydraScriptsTxId [] contestationPeriod
+            aliceChainConfig <- chainConfigFor Alice dir backend hydraScriptsTxId [] contestationPeriod
             withHydraNode hydraTracer aliceChainConfig dir 1 aliceSk [] [1] $ \n1 -> do
               send n1 $ input "Init" []
 
@@ -697,17 +700,17 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
             BS.length logfile `shouldSatisfy` (> 0)
             logfile `shouldSatisfy` BS.isInfixOf "NodeOptions"
 
-timedTx :: FilePath -> Tracer IO EndToEndLog -> RunningNode -> [TxId] -> IO ()
-timedTx tmpDir tracer node@RunningNode{networkId, nodeSocket} hydraScriptsTxId = do
+timedTx :: ChainBackend backend => FilePath -> Tracer IO EndToEndLog -> backend -> [TxId] -> IO ()
+timedTx tmpDir tracer backend hydraScriptsTxId = do
   (aliceCardanoVk, _) <- keysFor Alice
   let contestationPeriod = 2
-  aliceChainConfig <- chainConfigFor Alice tmpDir nodeSocket hydraScriptsTxId [] contestationPeriod
+  aliceChainConfig <- chainConfigFor Alice tmpDir backend hydraScriptsTxId [] contestationPeriod
   let hydraTracer = contramap FromHydraNode tracer
   withHydraNode hydraTracer aliceChainConfig tmpDir 1 aliceSk [] [1] $ \n1 -> do
     let lovelaceBalanceValue = 100_000_000
 
     -- Funds to be used as fuel by Hydra protocol transactions
-    seedFromFaucet_ node aliceCardanoVk lovelaceBalanceValue (contramap FromFaucet tracer)
+    seedFromFaucet_ backend aliceCardanoVk lovelaceBalanceValue (contramap FromFaucet tracer)
     send n1 $ input "Init" []
     headId <-
       waitForAllMatch 10 [n1] $
@@ -715,14 +718,14 @@ timedTx tmpDir tracer node@RunningNode{networkId, nodeSocket} hydraScriptsTxId =
 
     -- Get some UTXOs to commit to a head
     (aliceExternalVk, aliceExternalSk) <- generate genKeyPair
-    committedUTxOByAlice <- seedFromFaucet node aliceExternalVk aliceCommittedToHead (contramap FromFaucet tracer)
-    requestCommitTx n1 committedUTxOByAlice <&> signTx aliceExternalSk >>= submitTx node
+    committedUTxOByAlice <- seedFromFaucet backend aliceExternalVk aliceCommittedToHead (contramap FromFaucet tracer)
+    _ <- requestCommitTx n1 committedUTxOByAlice <&> signTx aliceExternalSk >>= Backend.submitTransaction backend
 
     waitFor hydraTracer 3 [n1] $ output "HeadIsOpen" ["utxo" .= committedUTxOByAlice, "headId" .= headId]
 
     -- Acquire a current point in time
-    slotLengthSec <- protocolParamSlotLength <$> queryGenesisParameters networkId nodeSocket QueryTip
-    currentSlot <- queryTipSlotNo networkId nodeSocket
+    slotLengthSec <- protocolParamSlotLength <$> Backend.queryGenesisParameters backend
+    currentSlot <- fromMaybe 0 . chainPointToSlotNo <$> Backend.queryTip backend
 
     -- Create an arbitrary transaction using some input.
     let firstCommittedUTxO = Prelude.head $ UTxO.toList committedUTxOByAlice
@@ -759,8 +762,8 @@ timedTx tmpDir tracer node@RunningNode{networkId, nodeSocket} hydraScriptsTxId =
       v ^? key "snapshot" . key "confirmed"
     confirmedTransactions ^.. values `shouldBe` [toJSON tx]
 
-initAndClose :: FilePath -> Tracer IO EndToEndLog -> Int -> [TxId] -> RunningNode -> IO ()
-initAndClose tmpDir tracer clusterIx hydraScriptsTxId node@RunningNode{nodeSocket} = do
+initAndClose :: ChainBackend backend => FilePath -> Tracer IO EndToEndLog -> Int -> [TxId] -> backend -> IO ()
+initAndClose tmpDir tracer clusterIx hydraScriptsTxId backend = do
   aliceKeys@(aliceCardanoVk, _) <- generate genKeyPair
   bobKeys@(bobCardanoVk, _) <- generate genKeyPair
   carolKeys@(carolCardanoVk, _) <- generate genKeyPair
@@ -771,14 +774,17 @@ initAndClose tmpDir tracer clusterIx hydraScriptsTxId node@RunningNode{nodeSocke
   let firstNodeId = clusterIx * 3
   let contestationPeriod = 2
   let hydraTracer = contramap FromHydraNode tracer
-  withHydraCluster hydraTracer tmpDir nodeSocket firstNodeId cardanoKeys hydraKeys hydraScriptsTxId contestationPeriod $ \nodes -> do
+  let nodeSocket' = case Backend.getOptions backend of
+        Direct DirectOptions{nodeSocket} -> nodeSocket
+        _ -> error "Unexpected Blockfrost backend"
+  withHydraCluster hydraTracer tmpDir nodeSocket' firstNodeId cardanoKeys hydraKeys hydraScriptsTxId contestationPeriod $ \nodes -> do
     let [n1, n2, n3] = toList nodes
     waitForNodesConnected hydraTracer 20 $ n1 :| [n2, n3]
 
     -- Funds to be used as fuel by Hydra protocol transactions
-    seedFromFaucet_ node aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
-    seedFromFaucet_ node bobCardanoVk 100_000_000 (contramap FromFaucet tracer)
-    seedFromFaucet_ node carolCardanoVk 100_000_000 (contramap FromFaucet tracer)
+    seedFromFaucet_ backend aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
+    seedFromFaucet_ backend bobCardanoVk 100_000_000 (contramap FromFaucet tracer)
+    seedFromFaucet_ backend carolCardanoVk 100_000_000 (contramap FromFaucet tracer)
 
     send n1 $ input "Init" []
     headId <-
@@ -787,14 +793,14 @@ initAndClose tmpDir tracer clusterIx hydraScriptsTxId node@RunningNode{nodeSocke
 
     -- Get some UTXOs to commit to a head
     (aliceExternalVk, aliceExternalSk) <- generate genKeyPair
-    committedUTxOByAlice <- seedFromFaucet node aliceExternalVk aliceCommittedToHead (contramap FromFaucet tracer)
-    requestCommitTx n1 committedUTxOByAlice <&> signTx aliceExternalSk >>= submitTx node
+    committedUTxOByAlice <- seedFromFaucet backend aliceExternalVk aliceCommittedToHead (contramap FromFaucet tracer)
+    requestCommitTx n1 committedUTxOByAlice <&> signTx aliceExternalSk >>= Backend.submitTransaction backend
 
     (bobExternalVk, bobExternalSk) <- generate genKeyPair
-    committedUTxOByBob <- seedFromFaucet node bobExternalVk bobCommittedToHead (contramap FromFaucet tracer)
-    requestCommitTx n2 committedUTxOByBob <&> signTx bobExternalSk >>= submitTx node
+    committedUTxOByBob <- seedFromFaucet backend bobExternalVk bobCommittedToHead (contramap FromFaucet tracer)
+    requestCommitTx n2 committedUTxOByBob <&> signTx bobExternalSk >>= Backend.submitTransaction backend
 
-    requestCommitTx n3 mempty >>= submitTx node
+    requestCommitTx n3 mempty >>= Backend.submitTransaction backend
 
     waitFor hydraTracer 10 [n1, n2, n3] $ output "HeadIsOpen" ["utxo" .= (committedUTxOByAlice <> committedUTxOByBob), "headId" .= headId]
 
@@ -875,7 +881,7 @@ initAndClose tmpDir tracer clusterIx hydraScriptsTxId node@RunningNode{nodeSocke
         failure $ "newUTxO isn't valid JSON?: " <> err
       Data.Aeson.Success u -> do
         waitForAllMatch 3 [n1] $ checkFanout headId u
-        failAfter 5 $ waitForUTxO node u
+        failAfter 5 $ waitForUTxO backend u
 
 -- * Fixtures
 

--- a/hydra-cluster/test/Test/Hydra/Cluster/HydraClientSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/HydraClientSpec.hs
@@ -249,6 +249,9 @@ scenarioSetup ::
   IO a
 scenarioSetup tracer tmpDir action = do
   withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \blockTime backend -> do
+    let nodeSocket' = case Backend.getOptions backend of
+          Direct DirectOptions{nodeSocket} -> nodeSocket
+          _ -> error "Unexpected Blockfrost backend"
     aliceKeys@(aliceCardanoVk, _) <- generate genKeyPair
     bobKeys@(bobCardanoVk, _) <- generate genKeyPair
     carolKeys@(carolCardanoVk, _) <- generate genKeyPair
@@ -261,9 +264,6 @@ scenarioSetup tracer tmpDir action = do
     let contestationPeriod = 2
     let hydraTracer = contramap FromHydraNode tracer
 
-    let nodeSocket' = case Backend.getOptions backend of
-          Direct DirectOptions{nodeSocket} -> nodeSocket
-          _ -> error "Unexpected Blockfrost backend"
     withHydraCluster hydraTracer tmpDir nodeSocket' firstNodeId cardanoKeys hydraKeys hydraScriptsTxId contestationPeriod $ \nodes -> do
       let [n1, n2, n3] = toList nodes
       waitForNodesConnected hydraTracer 20 $ n1 :| [n2, n3]

--- a/hydra-cluster/test/Test/Hydra/Cluster/MithrilSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/MithrilSpec.hs
@@ -6,7 +6,7 @@ import Test.Hydra.Prelude
 import Control.Concurrent.Class.MonadSTM (newTVarIO, readTVarIO)
 import Control.Lens ((^?))
 import Data.Aeson.Lens (key)
-import Hydra.Cluster.Fixture (KnownNetwork (Sanchonet))
+import Hydra.Cluster.Fixture (KnownNetwork (..))
 import Hydra.Cluster.Mithril (MithrilLog (..), downloadLatestSnapshotTo)
 import Hydra.Logging (Envelope (..), Tracer, traceInTVar)
 import System.Directory (doesDirectoryExist)
@@ -17,7 +17,9 @@ spec :: Spec
 spec = parallel $ do
   describe "downloadLatestSnapshotTo" $
     forEachKnownNetwork "invokes mithril-client correctly" $ \network -> do
+      let blockfrostNetworks = [BlockfrostPreview, BlockfrostPreprod, BlockfrostMainnet]
       when (network == Sanchonet) $ pendingWith "Sanchonet not available anymore"
+      when (network `elem` blockfrostNetworks) $ pendingWith "Blockfrost doesn't need mithril to run"
       (tracer, getTraces) <- captureTracer "MithrilSpec"
       withTempDir ("mithril-download-" <> show network) $ \tmpDir -> do
         let dbPath = tmpDir </> "db"

--- a/hydra-cluster/test/Test/Hydra/Cluster/Utils.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/Utils.hs
@@ -3,6 +3,7 @@ module Test.Hydra.Cluster.Utils where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
+import Hydra.Cardano.Api (ChainPoint, SlotNo, chainPointToSlotNo)
 import Hydra.Cluster.Fixture (KnownNetwork (..))
 
 -- | Creates test cases for each 'KnownNetwork'.
@@ -10,3 +11,7 @@ forEachKnownNetwork :: String -> (KnownNetwork -> IO ()) -> Spec
 forEachKnownNetwork msg action =
   forM_ (enumFromTo minBound maxBound) $ \network ->
     it (msg <> " (" <> show network <> ")") $ action network
+
+chainPointToSlot :: ChainPoint -> SlotNo
+chainPointToSlot chainPoint =
+  fromMaybe 0 $ chainPointToSlotNo chainPoint

--- a/hydra-node/src/Hydra/Chain/Backend.hs
+++ b/hydra-node/src/Hydra/Chain/Backend.hs
@@ -8,6 +8,9 @@ import Hydra.Chain.CardanoClient qualified as CardanoClient
 import Hydra.Options (ChainBackendOptions)
 import Hydra.Tx (ScriptRegistry)
 
+blockfrostProjectPath :: FilePath
+blockfrostProjectPath = "./blockfrost-project.txt"
+
 class ChainBackend a where
   queryGenesisParameters :: (MonadIO m, MonadThrow m) => a -> m (GenesisParameters ShelleyEra)
   queryScriptRegistry :: (MonadIO m, MonadThrow m) => a -> [TxId] -> m ScriptRegistry

--- a/hydra-node/src/Hydra/Chain/Backend.hs
+++ b/hydra-node/src/Hydra/Chain/Backend.hs
@@ -2,25 +2,10 @@ module Hydra.Chain.Backend where
 
 import Hydra.Prelude
 
-import Hydra.Cardano.Api (
-  Address,
-  ChainPoint,
-  EraHistory,
-  GenesisParameters,
-  LedgerEra,
-  NetworkId,
-  PParams,
-  PaymentKey,
-  PoolId,
-  ShelleyAddr,
-  ShelleyEra,
-  SystemStart (..),
-  Tx,
-  TxId,
-  UTxO,
-  VerificationKey,
- )
+import Cardano.Api.UTxO qualified as UTxO
+import Hydra.Cardano.Api
 import Hydra.Chain.CardanoClient qualified as CardanoClient
+import Hydra.Options (ChainBackendOptions)
 import Hydra.Tx (ScriptRegistry)
 
 class ChainBackend a where
@@ -29,6 +14,7 @@ class ChainBackend a where
   queryNetworkId :: (MonadIO m, MonadThrow m) => a -> m NetworkId
   queryTip :: (MonadIO m, MonadThrow m) => a -> m ChainPoint
   queryUTxO :: (MonadIO m, MonadThrow m) => a -> [Address ShelleyAddr] -> m UTxO
+  queryUTxOByTxIn :: (MonadIO m, MonadThrow m) => a -> [TxIn] -> m UTxO
   queryEraHistory :: (MonadIO m, MonadThrow m) => a -> CardanoClient.QueryPoint -> m EraHistory
   querySystemStart :: (MonadIO m, MonadThrow m) => a -> CardanoClient.QueryPoint -> m SystemStart
   queryProtocolParameters :: (MonadIO m, MonadThrow m) => a -> CardanoClient.QueryPoint -> m (PParams LedgerEra)
@@ -36,3 +22,119 @@ class ChainBackend a where
   queryUTxOFor :: (MonadIO m, MonadThrow m) => a -> CardanoClient.QueryPoint -> VerificationKey PaymentKey -> m UTxO
   submitTransaction :: (MonadIO m, MonadThrow m) => a -> Tx -> m ()
   awaitTransaction :: (MonadIO m, MonadThrow m) => a -> Tx -> m UTxO
+  getOptions :: a -> ChainBackendOptions
+  getBlockTime :: a -> (MonadIO m, MonadThrow m) => m NominalDiffTime
+
+buildTransaction ::
+  ChainBackend backend =>
+  backend ->
+  -- | Change address to send
+  AddressInEra ->
+  -- | Unspent transaction outputs to spend.
+  UTxO ->
+  -- | Collateral inputs.
+  [TxIn] ->
+  -- | Outputs to create.
+  [TxOut CtxTx] ->
+  IO (Either (TxBodyErrorAutoBalance Era) Tx)
+buildTransaction backend changeAddress body utxoToSpend outs = do
+  pparams <- queryProtocolParameters backend CardanoClient.QueryTip
+  buildTransactionWithPParams pparams backend changeAddress body utxoToSpend outs
+
+-- | Construct a simple payment consuming some inputs and producing some
+-- outputs (no certificates or withdrawals involved).
+--
+-- On success, the returned transaction is fully balanced. On error, return
+-- `TxBodyErrorAutoBalance`.
+buildTransactionWithPParams ::
+  ChainBackend backend =>
+  -- | Protocol parameters
+  PParams LedgerEra ->
+  backend ->
+  -- | Change address to send
+  AddressInEra ->
+  -- | Unspent transaction outputs to spend.
+  UTxO ->
+  -- | Collateral inputs.
+  [TxIn] ->
+  -- | Outputs to create.
+  [TxOut CtxTx] ->
+  IO (Either (TxBodyErrorAutoBalance Era) Tx)
+buildTransactionWithPParams pparams backend changeAddress utxoToSpend collateral outs = do
+  systemStart <- querySystemStart backend CardanoClient.QueryTip
+  eraHistory <- queryEraHistory backend CardanoClient.QueryTip
+  stakePools <- queryStakePools backend CardanoClient.QueryTip
+  pure $ buildTransactionWithPParams' pparams systemStart eraHistory stakePools changeAddress utxoToSpend collateral outs
+
+buildTransactionWithPParams' ::
+  -- | Protocol parameters
+  PParams LedgerEra ->
+  SystemStart ->
+  EraHistory ->
+  Set PoolId ->
+  -- | Change address to send
+  AddressInEra ->
+  -- | Unspent transaction outputs to spend.
+  UTxO ->
+  -- | Collateral inputs.
+  [TxIn] ->
+  -- | Outputs to create.
+  [TxOut CtxTx] ->
+  Either (TxBodyErrorAutoBalance Era) Tx
+buildTransactionWithPParams' pparams systemStart eraHistory stakePools changeAddress utxoToSpend collateral outs = do
+  buildTransactionWithBody pparams systemStart eraHistory stakePools changeAddress bodyContent utxoToSpend
+ where
+  -- NOTE: 'makeTransactionBodyAutoBalance' overwrites this.
+  bodyContent =
+    TxBodyContent
+      (withWitness <$> toList (UTxO.inputSet utxoToSpend))
+      (TxInsCollateral collateral)
+      TxInsReferenceNone
+      outs
+      TxTotalCollateralNone
+      TxReturnCollateralNone
+      (TxFeeExplicit 0)
+      TxValidityNoLowerBound
+      TxValidityNoUpperBound
+      TxMetadataNone
+      TxAuxScriptsNone
+      TxExtraKeyWitnessesNone
+      (BuildTxWith $ Just $ LedgerProtocolParameters pparams)
+      TxWithdrawalsNone
+      TxCertificatesNone
+      TxUpdateProposalNone
+      TxMintValueNone
+      TxScriptValidityNone
+      Nothing
+      Nothing
+      Nothing
+      Nothing
+
+buildTransactionWithBody ::
+  -- | Protocol parameters
+  PParams LedgerEra ->
+  -- | System start
+  SystemStart ->
+  -- | Change address to send
+  EraHistory ->
+  Set PoolId ->
+  AddressInEra ->
+  -- | Body
+  TxBodyContent BuildTx ->
+  -- | Unspent transaction outputs to spend.
+  UTxO ->
+  Either (TxBodyErrorAutoBalance Era) Tx
+buildTransactionWithBody pparams systemStart eraHistory stakePools changeAddress body utxoToSpend = do
+  second (flip Tx [] . balancedTxBody) $
+    makeTransactionBodyAutoBalance
+      shelleyBasedEra
+      systemStart
+      (toLedgerEpochInfo eraHistory)
+      (LedgerProtocolParameters pparams)
+      stakePools
+      mempty
+      mempty
+      (UTxO.toApi utxoToSpend)
+      body
+      changeAddress
+      Nothing

--- a/hydra-node/src/Hydra/Chain/Backend.hs
+++ b/hydra-node/src/Hydra/Chain/Backend.hs
@@ -21,7 +21,7 @@ class ChainBackend a where
   queryStakePools :: (MonadIO m, MonadThrow m) => a -> CardanoClient.QueryPoint -> m (Set PoolId)
   queryUTxOFor :: (MonadIO m, MonadThrow m) => a -> CardanoClient.QueryPoint -> VerificationKey PaymentKey -> m UTxO
   submitTransaction :: (MonadIO m, MonadThrow m) => a -> Tx -> m ()
-  awaitTransaction :: (MonadIO m, MonadThrow m) => a -> Tx -> m UTxO
+  awaitTransaction :: (MonadIO m, MonadThrow m) => a -> Tx -> VerificationKey PaymentKey -> m UTxO
   getOptions :: a -> ChainBackendOptions
   getBlockTime :: a -> (MonadIO m, MonadThrow m) => m NominalDiffTime
 

--- a/hydra-node/src/Hydra/Chain/Blockfrost.hs
+++ b/hydra-node/src/Hydra/Chain/Blockfrost.hs
@@ -100,9 +100,9 @@ instance ChainBackend BlockfrostBackend where
     prj <- liftIO $ Blockfrost.projectFromFile projectPath
     void $ Blockfrost.runBlockfrostM prj $ Blockfrost.submitTransaction tx
 
-  awaitTransaction (BlockfrostBackend BlockfrostOptions{projectPath}) tx = do
+  awaitTransaction (BlockfrostBackend BlockfrostOptions{projectPath}) tx vk = do
     prj <- liftIO $ Blockfrost.projectFromFile projectPath
-    Blockfrost.runBlockfrostM prj $ Blockfrost.awaitTransaction tx
+    Blockfrost.runBlockfrostM prj $ Blockfrost.awaitTransaction tx vk
 
   getOptions (BlockfrostBackend blockfrostOptions) = Blockfrost blockfrostOptions
 

--- a/hydra-node/src/Hydra/Chain/Blockfrost/Client.hs
+++ b/hydra-node/src/Hydra/Chain/Blockfrost/Client.hs
@@ -520,11 +520,11 @@ queryStakePools = do
   stakePools' <- Blockfrost.listPools
   pure $ Set.fromList (toCardanoPoolId <$> stakePools')
 
-awaitTransaction :: Tx -> BlockfrostClientT IO UTxO
-awaitTransaction tx = do
+awaitTransaction :: Tx -> VerificationKey PaymentKey -> BlockfrostClientT IO UTxO
+awaitTransaction tx vk = do
   Blockfrost.Genesis{_genesisNetworkMagic} <- queryGenesisParameters
   let networkId = toCardanoNetworkId _genesisNetworkMagic
-  queryUTxOByTxIn networkId (txIns' tx)
+  awaitUTxO networkId [makeShelleyAddress networkId (PaymentCredentialByKey $ verificationKeyHash vk) NoStakeAddress] (getTxId $ getTxBody tx) 300
 
 -- | Await for specific UTxO at address - the one that is produced by the given 'TxId'.
 awaitUTxO ::

--- a/hydra-node/src/Hydra/Chain/Blockfrost/Client.hs
+++ b/hydra-node/src/Hydra/Chain/Blockfrost/Client.hs
@@ -36,7 +36,6 @@ import Data.Time.Clock.POSIX
 import Hydra.Cardano.Api hiding (LedgerState, fromNetworkMagic, queryGenesisParameters)
 
 import Cardano.Api.UTxO qualified as UTxO
-import Cardano.Crypto.Hash (hashToTextAsHex)
 import Cardano.Ledger.Api.PParams
 import Cardano.Ledger.BaseTypes (EpochInterval (..), EpochSize (..), NonNegativeInterval, UnitInterval, boundRational, unsafeNonZero)
 import Cardano.Ledger.Binary.Version (mkVersion)
@@ -112,8 +111,8 @@ queryScriptRegistry txIds = do
     } <-
     queryGenesisParameters
   let networkId = toCardanoNetworkId _genesisNetworkMagic
-  utxoList <- forM candidates $ \(TxIn (TxId candidateHash) _) -> queryUTxOByTxIn networkId $ hashToTextAsHex candidateHash
-  case newScriptRegistry $ fold utxoList of
+  utxo <- queryUTxOByTxIn networkId candidates
+  case newScriptRegistry utxo of
     Left e -> liftIO $ throwIO e
     Right sr -> pure sr
  where
@@ -415,14 +414,15 @@ queryEraHistory = do
       } = boundStart /= 0 && boundEnd /= 0
 
 -- | Query the Blockfrost API to get the 'UTxO' for 'TxIn' and convert to cardano 'UTxO'.
-queryUTxOByTxIn :: NetworkId -> Text -> BlockfrostClientT IO UTxO
-queryUTxOByTxIn networkId txHash = go (300 :: Int) -- TODO: make this configurable
+-- FIXME: make blockfrost wait times configurable.
+queryUTxOByTxIn :: NetworkId -> [TxIn] -> BlockfrostClientT IO UTxO
+queryUTxOByTxIn networkId = foldMapM (\(TxIn txid _) -> go (300 :: Int) (serialiseToRawBytesHexText txid))
  where
-  go 0 = liftIO $ throwIO $ BlockfrostError $ FailedUTxOForHash txHash
-  go n = do
+  go 0 txHash = liftIO $ throwIO $ BlockfrostError $ FailedUTxOForHash txHash
+  go n txHash = do
     res <- Blockfrost.tryError $ Blockfrost.getTxUtxos (Blockfrost.TxHash txHash)
     case res of
-      Left _e -> liftIO (threadDelay 1) >> go (n - 1)
+      Left _e -> liftIO (threadDelay 1) >> go (n - 1) txHash
       Right Blockfrost.TransactionUtxos{_transactionUtxosInputs, _transactionUtxosOutputs} ->
         foldMapM
           ( \Blockfrost.UtxoOutput{_utxoOutputOutputIndex, _utxoOutputAddress, _utxoOutputAmount, _utxoOutputDataHash, _utxoOutputInlineDatum, _utxoOutputReferenceScriptHash} ->
@@ -450,7 +450,7 @@ queryScript scriptHashTxt = do
 queryUTxO :: NetworkId -> [Address ShelleyAddr] -> BlockfrostClientT IO UTxO
 queryUTxO networkId addresses = do
   let address' = Blockfrost.Address . serialiseAddress $ List.head addresses
-  utxoWithAddresses <- Blockfrost.getAddressUtxos' address' (Blockfrost.paged 1 1) Blockfrost.desc
+  utxoWithAddresses <- Blockfrost.getAddressUtxos address'
 
   foldMapM
     ( \Blockfrost.AddressUtxo
@@ -524,8 +524,7 @@ awaitTransaction :: Tx -> BlockfrostClientT IO UTxO
 awaitTransaction tx = do
   Blockfrost.Genesis{_genesisNetworkMagic} <- queryGenesisParameters
   let networkId = toCardanoNetworkId _genesisNetworkMagic
-  let TxId txhash = getTxId $ getTxBody tx
-  queryUTxOByTxIn networkId (hashToTextAsHex txhash)
+  queryUTxOByTxIn networkId (txIns' tx)
 
 -- | Await for specific UTxO at address - the one that is produced by the given 'TxId'.
 awaitUTxO ::

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -120,7 +120,7 @@ instance ChainBackend DirectBackend where
   submitTransaction (DirectBackend DirectOptions{networkId, nodeSocket}) tx =
     liftIO $ CardanoClient.submitTransaction networkId nodeSocket tx
 
-  awaitTransaction (DirectBackend DirectOptions{networkId, nodeSocket}) tx =
+  awaitTransaction (DirectBackend DirectOptions{networkId, nodeSocket}) tx _ =
     liftIO $ CardanoClient.awaitTransaction networkId nodeSocket tx
 
   getOptions (DirectBackend directOptions) = Direct directOptions

--- a/hydra-node/src/Hydra/Chain/ScriptRegistry.hs
+++ b/hydra-node/src/Hydra/Chain/ScriptRegistry.hs
@@ -81,7 +81,7 @@ publishHydraScripts backend sk = do
   txs <- buildScriptPublishingTxs pparams systemStart networkId eraHistory stakePools utxo sk
   forM txs $ \tx -> do
     submitTransaction backend tx
-    void $ awaitTransaction backend tx
+    void $ awaitTransaction backend tx vk
     pure $ txId tx
  where
   vk = getVerificationKey sk


### PR DESCRIPTION
fix #2048 

- Idea was to be able to run our smoke-test using blockfrost network but turned out we could enable all cluster test to be  potentially run on blockfrost more easily.

- Successfull smoke-test run https://github.com/cardano-scaling/hydra/actions/runs/15754166894/job/44405708211
---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
