### PR TITLE
Add missing dep for cabalOnly shell

### DIFF
--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -97,6 +97,7 @@ let
       ghc
       pkgs.cabal-install
       pkgs.pkg-config
+      pkgs.snappy
     ] ++ buildInputs;
 
     # Ensure that libz.so and other libraries are available to TH splices.

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -58,6 +58,8 @@ let
     pkgs.secp256k1
     pkgs.xz
     pkgs.zlib
+    pkgs.libblst
+    pkgs.snappy
     pkgs.etcd # Build-time dependency (static binary to be embedded)
   ]
   ++
@@ -97,7 +99,6 @@ let
       ghc
       pkgs.cabal-install
       pkgs.pkg-config
-      pkgs.snappy
     ] ++ buildInputs;
 
     # Ensure that libz.so and other libraries are available to TH splices.


### PR DESCRIPTION
This was a missing dep on my NixOS system; perhaps not many Nix people have attempted to use this particular shell :)