### PR TITLE
Workaround to restart on member already bootstrapped

### DIFF
--- a/docs/docs/known-issues.md
+++ b/docs/docs/known-issues.md
@@ -33,7 +33,7 @@ Known errors are:
       - `configuredPeers` - peers info coming from `hydra-node` arguments.
 
  - `member ... has already been bootstrapped` - missing information in `<persistence-dir>/etcd`
-   - need to restart your hydra-node using `ETCD_INITIAL_CLUSTER_STATE` env variable set to `existing` (`new` is used by default), see also https://etcd.io/docs/v3.3/op-guide/configuration/
+   - restart your hydra-node with the `ETCD_INITIAL_CLUSTER_STATE` environment variable set to `existing` (`new` is the default), see also https://etcd.io/docs/v3.3/op-guide/configuration/
 
 We should be able to work around these UX issues using [etcd discovery](https://etcd.io/docs/v3.5/op-guide/clustering/#etcd-discovery) eventually.
 

--- a/docs/docs/known-issues.md
+++ b/docs/docs/known-issues.md
@@ -33,7 +33,7 @@ Known errors are:
       - `configuredPeers` - peers info coming from `hydra-node` arguments.
 
  - `member ... has already been bootstrapped` - missing information in `<persistence-dir>/etcd`
-   - need to bootstrap new cluster or manual workarounds, see also https://etcd.io/docs/v3.5/op-guide/failures/
+   - need to restart your hydra-node using `ETCD_INITIAL_CLUSTER_STATE` env variable set to `existing` (`new` is used by default), see also https://etcd.io/docs/v3.3/op-guide/configuration/
 
 We should be able to work around these UX issues using [etcd discovery](https://etcd.io/docs/v3.5/op-guide/clustering/#etcd-discovery) eventually.
 

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -149,12 +149,12 @@ import Network.HTTP.Req (
  )
 import Network.HTTP.Simple (getResponseBody, httpJSON, setRequestBodyJSON)
 import Network.HTTP.Types (urlEncode)
+import System.Environment (setEnv)
 import System.FilePath ((</>))
 import System.Process (callProcess)
 import Test.Hydra.Tx.Fixture (testNetworkId)
 import Test.Hydra.Tx.Gen (genDatum, genKeyPair, genTxOutWithReferenceScript)
 import Test.QuickCheck (choose, elements, generate)
-import System.Environment (setEnv)
 
 data EndToEndLog
   = ClusterOptions {options :: Options}
@@ -1744,8 +1744,8 @@ canSideLoadSnapshot tracer workDir backend hydraScriptsTxId = do
  where
   hydraTracer = contramap FromHydraNode tracer
 
-canResumeOnMemberAlreadyBoostrapped :: Tracer IO EndToEndLog -> FilePath -> RunningNode -> [TxId] -> IO ()
-canResumeOnMemberAlreadyBoostrapped tracer workDir cardanoNode hydraScriptsTxId = do
+canResumeOnMemberAlreadyBootstrapped :: Tracer IO EndToEndLog -> FilePath -> RunningNode -> [TxId] -> IO ()
+canResumeOnMemberAlreadyBootstrapped tracer workDir cardanoNode hydraScriptsTxId = do
   let clients = [Alice, Bob]
   [(aliceCardanoVk, _aliceCardanoSk), (bobCardanoVk, _)] <- forM clients keysFor
   seedFromFaucet_ cardanoNode aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -154,6 +154,7 @@ import System.Process (callProcess)
 import Test.Hydra.Tx.Fixture (testNetworkId)
 import Test.Hydra.Tx.Gen (genDatum, genKeyPair, genTxOutWithReferenceScript)
 import Test.QuickCheck (choose, elements, generate)
+import System.Environment (setEnv)
 
 data EndToEndLog
   = ClusterOptions {options :: Options}
@@ -1772,9 +1773,12 @@ canResumeOnMemberAlreadyBoostrapped tracer workDir cardanoNode hydraScriptsTxId 
     callProcess "rm" ["-rf", workDir </> "state-2"]
 
     withHydraNode hydraTracer bobChainConfig workDir 2 bobSk [aliceVk] [1, 2] (const $ pure ())
-              `shouldThrow` \(e :: SomeException) ->
-                "hydra-node" `isInfixOf` show e
-                  && "etcd" `isInfixOf` show e
+      `shouldThrow` \(e :: SomeException) ->
+        "hydra-node" `isInfixOf` show e
+          && "etcd" `isInfixOf` show e
+
+    setEnv "ETCD_INITIAL_CLUSTER_STATE" "existing"
+    withHydraNode hydraTracer bobChainConfig workDir 2 bobSk [aliceVk] [1, 2] (const $ pure ())
  where
   RunningNode{nodeSocket, networkId} = cardanoNode
   hydraTracer = contramap FromHydraNode tracer

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -149,7 +149,7 @@ import Network.HTTP.Req (
  )
 import Network.HTTP.Simple (getResponseBody, httpJSON, setRequestBodyJSON)
 import Network.HTTP.Types (urlEncode)
-import System.Environment (setEnv)
+import System.Environment (setEnv, unsetEnv)
 import System.FilePath ((</>))
 import System.Process (callProcess)
 import Test.Hydra.Tx.Fixture (testNetworkId)
@@ -1779,6 +1779,7 @@ canResumeOnMemberAlreadyBootstrapped tracer workDir cardanoNode hydraScriptsTxId
 
     setEnv "ETCD_INITIAL_CLUSTER_STATE" "existing"
     withHydraNode hydraTracer bobChainConfig workDir 2 bobSk [aliceVk] [1, 2] (const $ pure ())
+    unsetEnv "ETCD_INITIAL_CLUSTER_STATE"
  where
   RunningNode{nodeSocket, networkId} = cardanoNode
   hydraTracer = contramap FromHydraNode tracer

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -52,7 +52,7 @@ import Hydra.Cluster.Scenarios (
   canCommit,
   canDecommit,
   canRecoverDeposit,
-  canResumeOnMemberAlreadyBoostrapped,
+  canResumeOnMemberAlreadyBootstrapped,
   canSeePendingDeposits,
   canSideLoadSnapshot,
   canSubmitTransactionThroughAPI,
@@ -657,11 +657,11 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
             publishHydraScriptsAs backend Faucet
               >>= canSideLoadSnapshot tracer tmpDir backend
 
-      fit "can resume when member has already been bootstrapped" $ \tracer -> do
+      it "can resume when member has already been bootstrapped" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
           withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
             publishHydraScriptsAs node Faucet
-              >>= canResumeOnMemberAlreadyBoostrapped tracer tmpDir node
+              >>= canResumeOnMemberAlreadyBootstrapped tracer tmpDir node
 
     describe "two hydra heads scenario" $ do
       it "two heads on the same network do not conflict" $ \tracer ->

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -52,6 +52,7 @@ import Hydra.Cluster.Scenarios (
   canCommit,
   canDecommit,
   canRecoverDeposit,
+  canResumeOnMemberAlreadyBoostrapped,
   canSeePendingDeposits,
   canSideLoadSnapshot,
   canSubmitTransactionThroughAPI,
@@ -655,6 +656,12 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
           withBackend (contramap FromCardanoNode tracer) tmpDir $ \_ backend ->
             publishHydraScriptsAs backend Faucet
               >>= canSideLoadSnapshot tracer tmpDir backend
+
+      fit "can resume when member has already been bootstrapped" $ \tracer -> do
+        withClusterTempDir $ \tmpDir -> do
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
+            publishHydraScriptsAs node Faucet
+              >>= canResumeOnMemberAlreadyBoostrapped tracer tmpDir node
 
     describe "two hydra heads scenario" $ do
       it "two heads on the same network do not conflict" $ \tracer ->

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -12,6 +12,7 @@ import CardanoClient (
  )
 import CardanoNode (
   withBackend,
+  withCardanoNodeDevnet,
  )
 import Control.Lens ((^..), (^?))
 import Control.Monad (foldM_)
@@ -659,9 +660,9 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
 
       it "can resume when member has already been bootstrapped" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \node ->
-            publishHydraScriptsAs node Faucet
-              >>= canResumeOnMemberAlreadyBootstrapped tracer tmpDir node
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend ->
+            publishHydraScriptsAs backend Faucet
+              >>= canResumeOnMemberAlreadyBootstrapped tracer tmpDir backend
 
     describe "two hydra heads scenario" $ do
       it "two heads on the same network do not conflict" $ \tracer ->


### PR DESCRIPTION
<!-- Describe your change here -->

Closes #1937 

Add workaround for known etcd cluster join issue by setting the ETCD_INITIAL_CLUSTER_STATE environment variable to "existing" (default is "new").

Notes:
- This workaround is effective as long as the peer maintains its network configuration; which determines its etcd member ID and keeps it stable upon restarts, even on newly created persistence.
- When set to "existing", the etcd member attempts to join an already bootstrapped cluster.
- If the value is incorrect, etcd will attempt to start but fail safely.

---

<!-- Consider each and tick it off one way or the other -->
* [X] CHANGELOG updated or not needed
* [X] Documentation updated or not needed
* [X] Haddocks updated or not needed
* [X] No new TODOs introduced or explained herafter
