### PR TITLE
Set the networkId for the smoke-tests

### DIFF
--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -461,6 +461,7 @@ singlePartyHeadFullLifeCycle tracer workDir node hydraScriptsTxId =
       aliceChainConfig <-
         chainConfigFor Alice workDir nodeSocket hydraScriptsTxId [] contestationPeriod
           <&> modifyConfig (\config -> config{startChainFrom = Just tip})
+            . setNetworkId networkId
       withHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
         -- Initialize & open head
         send n1 $ input "Init" []


### PR DESCRIPTION
Fixes the smoke-tests from using the wrong networkId 

```
cardano-cli: HandshakeError (Refused NodeToClientV_18 "version data mismatch: NodeToClientVersionData {networkMagic = NetworkMagic {unNetworkMagic = 2}, query = False} /= NodeToClientVersionData {networkMagic = NetworkMagic {unNetworkMagic = 42}, query = False}")hydra-cluster: readCreateProcess: cardano-cli "conway" "query" "protocol-parameters" "--socket-path" "/data/cardano/preview/node.socket" "--testnet-magic" "42" "--out-file" "/dev/stdout" (exit 1): failed
```