### PR TITLE
chain state does not retain non-policy outputs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ changes.
 
 - Provide `--network` option to hydra-node in order to use pre-published hydra scripts.
 
+- chain state does not retain non-policy outputs in the spendable UTxO.
+
 ## [0.21.0] - 2025-04-28
 
 - New metric for counting the number of active peers: `hydra_head_peers_connected`

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -22,6 +22,7 @@ import Data.Text qualified as T
 import Hydra.API.HTTPServer (DraftCommitTxRequest (..), DraftCommitTxResponse (..))
 import Hydra.Chain.Blockfrost.Client qualified as Blockfrost
 import Hydra.Cluster.Util (readConfigFile)
+import Hydra.HeadLogic (HeadState)
 import Hydra.HeadLogic.State (SeenSnapshot)
 import Hydra.Logging (Tracer, Verbosity (..), traceWith)
 import Hydra.Network (Host (Host), NodeId (NodeId), WhichEtcd (EmbeddedEtcd))
@@ -250,6 +251,19 @@ getSnapshotLastSeen HydraClient{apiHost = Host{hostname, port}} =
       (Req.http hostname /: "snapshot" /: "last-seen")
       NoReqBody
       (Proxy :: Proxy (JsonResponse (SeenSnapshot Tx)))
+      (Req.port (fromInteger . toInteger $ port))
+
+-- | Get the latest head state from the hydra-node.
+getHeadState :: HydraClient -> IO (HeadState Tx)
+getHeadState HydraClient{apiHost = Host{hostname, port}} =
+  runReq defaultHttpConfig request <&> responseBody
+ where
+  request =
+    Req.req
+      GET
+      (Req.http hostname /: "head")
+      NoReqBody
+      (Proxy :: Proxy (JsonResponse (HeadState Tx)))
       (Req.port (fromInteger . toInteger $ port))
 
 getMetrics :: HasCallStack => HydraClient -> IO ByteString

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -56,6 +56,7 @@ import Hydra.Cluster.Scenarios (
   canSideLoadSnapshot,
   canSubmitTransactionThroughAPI,
   checkFanout,
+  checkSpendableUTxODoesNotRetainOldHeadOutput,
   headIsInitializingWith,
   initWithWrongKeys,
   nodeCanSupportMultipleEtcdClusters,
@@ -249,6 +250,11 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
           withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
             publishHydraScriptsAs backend Faucet
               >>= singlePartyHeadFullLifeCycle tracer tmpDir backend
+      it "spendableUTxO does not retain old head outputs" $ \tracer -> do
+        withClusterTempDir $ \tmpDir -> do
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
+            publishHydraScriptsAs backend Faucet
+              >>= checkSpendableUTxODoesNotRetainOldHeadOutput tracer tmpDir backend
       it "can close with long deadline" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
           withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -325,15 +325,15 @@ chainSyncHandler tracer callback getTimeHandle ctx localChainState =
       Just observedTx -> do
         let newChainState =
               ChainStateAt
-                { spendableUTxO = toPolicyUTxO (adjustUTxO tx spendableUTxO)
+                { spendableUTxO = onlyPolicyUTxO (adjustUTxO tx spendableUTxO)
                 , recordedAt = Just point
                 }
         pushNew newChainState
         pure $ Just Observation{observedTx, newChainState}
 
-toPolicyUTxO :: UTxO -> UTxO
-toPolicyUTxO =
-  UTxO.fromList . toPolicyOutputs . UTxO.toList
+onlyPolicyUTxO :: UTxO -> UTxO
+onlyPolicyUTxO =
+  UTxO.fromList . onlyPolicyOutputs . UTxO.toList
  where
   filterPolicyAssets =
     filter
@@ -345,7 +345,7 @@ toPolicyUTxO =
       . IsList.toList
       . txOutValue
 
-  toPolicyOutputs =
+  onlyPolicyOutputs =
     fmap (\(txin, txout, _) -> (txin, txout))
       . filter (\(_, _, assets) -> not . null $ assets)
       . fmap (\(txin, txout) -> (txin, txout, filterPolicyAssets txout))


### PR DESCRIPTION
<!-- Describe your change here -->

Closes #2037

This change ensures that the chain state no longer retains non-policy (Ada-only) outputs in the spendable UTxO.

By filtering out these irrelevant outputs, it prevents the chain state from growing unnecessarily large over time.

This is especially useful when debugging the head state after an abort or fan-out, as lingering outputs in the spendable set can be confusing to users.

Notes:
- Non-policy outputs are change outputs, resulting from submitting transactions from the fuel wallet.  
- By applying this change, the chain state will no longer retain outputs from old heads.

---

<!-- Consider each and tick it off one way or the other -->
* [X] CHANGELOG updated or not needed
* [X] Documentation updated or not needed
* [X] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
