### PR TITLE
Easily start a node from --busy exec out folder

### DIFF
--- a/hydra-cluster/exe/hydra-cluster/Main.hs
+++ b/hydra-cluster/exe/hydra-cluster/Main.hs
@@ -5,7 +5,7 @@ module Main where
 import Hydra.Prelude
 
 import CardanoNode (findRunningCardanoNode, waitForFullySynchronized, withCardanoNodeDevnet, withCardanoNodeOnKnownNetwork)
-import Hydra.Cardano.Api (TxId)
+import Hydra.Cardano.Api (TxId, serialiseToRawBytesHexText)
 import Hydra.Chain.Backend (ChainBackend, blockfrostProjectPath)
 import Hydra.Chain.Blockfrost (BlockfrostBackend (..))
 import Hydra.Cluster.Faucet (publishHydraScriptsAs)
@@ -45,6 +45,9 @@ run options =
         Nothing -> do
           withCardanoNodeDevnet fromCardanoNode workDir $ \_ backend -> do
             txId <- publishOrReuseHydraScripts tracer backend
+            let hydraScriptsTxId = intercalate "," $ toString . serialiseToRawBytesHexText <$> txId
+            let envPath = workDir </> ".env"
+            writeFile envPath $ "HYDRA_SCRIPTS_TX_ID=" <> hydraScriptsTxId
             singlePartyOpenAHead tracer workDir backend txId $ \client walletSk _headId -> do
               case scenario of
                 Idle -> forever $ pure ()


### PR DESCRIPTION
<!-- Describe your change here -->

By creating a .env file containing HYDRA_SCRIPTS_TX_ID, similarly to how the demo works, we facilitate running a hydra-node on top after a busy exec out folder.

---

### Instructions: how to run a `hydra-node` on top of a --busy exec state

1. **Run a busy cluster (this publishes hydra scripts on dev)**

   ```bash
   cabal run hydra-cluster -- \
     --busy \
     --devnet \
     --publish-hydra-scripts \
     --state-directory baz
   ```

   > Let it run for 10+ minutes to accumulate a realistic state (`baz/state-1/state` grows \~15MB+).

2. **Start a `cardano-node` with matching devnet config**

   ```bash
   nix run github:IntersectMBO/cardano-node/10.4.1#cardano-node -- run \
     --config baz/cardano-node.json \
     --topology baz/topology.json \
     --database-path baz/db \
     --socket-path baz/node.socket \
     --shelley-operational-certificate baz/opcert.cert \
     --shelley-kes-key baz/kes.skey \
     --shelley-vrf-key baz/vrf.skey
   ```

3. **Run a `hydra-node` using the generated`.env` and `state` files**

   ```bash
   source baz/.env && cabal run hydra-node -- \
     --node-id 1 \
     --listen 127.0.0.1:5001 \
     --api-port 4001 \
     --monitoring-port 6001 \
     --hydra-signing-key baz/state-1/me.sk \
     --hydra-scripts-tx-id $HYDRA_SCRIPTS_TX_ID \
     --cardano-signing-key baz/alice.sk \
     --ledger-protocol-parameters baz/state-1/protocol-parameters.json \
     --testnet-magic 42 \
     --node-socket baz/node.socket \
     --persistence-dir baz/state-1 \
     --contestation-period 100s \
     --persistence-rotate-after 10000
    ```

> Note: both cardano and hydra nodes (from steps #2 and #3) are meant to be started on top of after busy exec output folder (result from step #1)

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
