### PR TITLE
Persistent queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ changes.
 
 - Don't keep around invalid transactions as they could lead to stuck Head.
 
+- Hydra node internal input queue is now persisted to disk.
+
 - Hydra API server responds with the correct `Content-Type` header `application-json`.
 
 - Add `Environment` to `Greetings` message, enabling clients to access runtime settings.

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -164,6 +164,7 @@ test-suite tests
     , async
     , base                >=4.7 && <5
     , bytestring
+    , cardano-binary
     , cardano-ledger-api
     , containers
     , directory

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -794,7 +794,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
               withHydraNode hydraTracer aliceChainConfig dir 1 aliceSk [] [1] $ \_ -> do
                 threadDelay 0.1
 
-      fit "load persistent queue with capacity exceeded" $ \tracer -> do
+      it "load persistent queue with capacity exceeded" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
           (aliceCardanoVk, _aliceCardanoSk) <- keysFor Alice
           initialUTxO <- generate $ genUTxOFor aliceCardanoVk

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -101,6 +101,7 @@ library
     Hydra.Node.Util
     Hydra.Options
     Hydra.Persistence
+    Hydra.PersistentQueue
     Hydra.Utils
 
   other-modules:   Paths_hydra_node

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -161,6 +161,7 @@ library
     , QuickCheck
     , quickcheck-arbitrary-adt
     , quickcheck-instances
+    , random
     , resourcet
     , retry
     , safe-money

--- a/hydra-node/src/Hydra/API/ClientInput.hs
+++ b/hydra-node/src/Hydra/API/ClientInput.hs
@@ -24,6 +24,12 @@ deriving stock instance IsTx tx => Show (ClientInput tx)
 deriving anyclass instance IsTx tx => ToJSON (ClientInput tx)
 deriving anyclass instance IsTx tx => FromJSON (ClientInput tx)
 
+instance IsTx tx => ToCBOR (ClientInput tx) where
+  toCBOR = toCBOR
+
+instance IsTx tx => FromCBOR (ClientInput tx) where
+  fromCBOR = fromCBOR
+
 instance (Arbitrary tx, Arbitrary (TxIdType tx), Arbitrary (UTxOType tx), IsTx tx) => Arbitrary (ClientInput tx) where
   arbitrary = genericArbitrary
 

--- a/hydra-node/src/Hydra/API/ClientInput.hs
+++ b/hydra-node/src/Hydra/API/ClientInput.hs
@@ -24,12 +24,6 @@ deriving stock instance IsTx tx => Show (ClientInput tx)
 deriving anyclass instance IsTx tx => ToJSON (ClientInput tx)
 deriving anyclass instance IsTx tx => FromJSON (ClientInput tx)
 
-instance IsTx tx => ToCBOR (ClientInput tx) where
-  toCBOR = toCBOR
-
-instance IsTx tx => FromCBOR (ClientInput tx) where
-  fromCBOR = fromCBOR
-
 instance (Arbitrary tx, Arbitrary (TxIdType tx), Arbitrary (UTxOType tx), IsTx tx) => Arbitrary (ClientInput tx) where
   arbitrary = genericArbitrary
 

--- a/hydra-node/src/Hydra/API/ClientInput.hs
+++ b/hydra-node/src/Hydra/API/ClientInput.hs
@@ -24,6 +24,32 @@ deriving stock instance IsTx tx => Show (ClientInput tx)
 deriving anyclass instance IsTx tx => ToJSON (ClientInput tx)
 deriving anyclass instance IsTx tx => FromJSON (ClientInput tx)
 
+instance IsTx tx => ToCBOR (ClientInput tx) where
+  toCBOR = \case
+    Init -> toCBOR ("Init" :: Text)
+    Abort -> toCBOR ("Abort" :: Text)
+    NewTx tx -> toCBOR ("NewTx" :: Text) <> toCBOR tx
+    Recover txid -> toCBOR ("Recover" :: Text) <> toCBOR txid
+    Decommit tx -> toCBOR ("Decommit" :: Text) <> toCBOR tx
+    Close -> toCBOR ("Close" :: Text)
+    Contest -> toCBOR ("Contest" :: Text)
+    Fanout -> toCBOR ("Fanout" :: Text)
+    SideLoadSnapshot snapshot -> toCBOR ("SideLoadSnapshot" :: Text) <> toCBOR snapshot
+
+instance IsTx tx => FromCBOR (ClientInput tx) where
+  fromCBOR =
+    fromCBOR >>= \case
+      ("Init" :: Text) -> pure Init
+      ("Abort" :: Text) -> pure Abort
+      ("NewTx" :: Text) -> NewTx <$> fromCBOR
+      ("Recover" :: Text) -> Recover <$> fromCBOR
+      ("Decommit" :: Text) -> Decommit <$> fromCBOR
+      ("Close" :: Text) -> pure Close
+      ("Contest" :: Text) -> pure Contest
+      ("Fanout" :: Text) -> pure Fanout
+      ("SideLoadSnapshot" :: Text) -> SideLoadSnapshot <$> fromCBOR
+      msg -> fail $ show msg <> " is not a proper CBOR-encoded Message"
+
 instance (Arbitrary tx, Arbitrary (TxIdType tx), Arbitrary (UTxOType tx), IsTx tx) => Arbitrary (ClientInput tx) where
   arbitrary = genericArbitrary
 

--- a/hydra-node/src/Hydra/Chain.hs
+++ b/hydra-node/src/Hydra/Chain.hs
@@ -241,7 +241,7 @@ instance IsTx tx => FromCBOR (OnChainTx tx) where
       ("OnAbortTx" :: Text) -> OnAbortTx <$> fromCBOR
       ("OnRecoverTx" :: Text) -> OnRecoverTx <$> fromCBOR <*> fromCBOR <*> fromCBOR
       ("OnCollectComTx" :: Text) -> OnCollectComTx <$> fromCBOR
-      ("OnDepositComTx" :: Text) -> OnDepositTx <$> fromCBOR <*> fromCBOR <*> fromCBOR <*> fromCBOR <*> fromCBOR
+      ("OnDepositTx" :: Text) -> OnDepositTx <$> fromCBOR <*> fromCBOR <*> fromCBOR <*> fromCBOR <*> fromCBOR
       ("OnIncrementTx" :: Text) -> OnIncrementTx <$> fromCBOR <*> fromCBOR <*> fromCBOR
       ("OnDecrementTx" :: Text) -> OnDecrementTx <$> fromCBOR <*> fromCBOR <*> fromCBOR
       ("OnCloseTx" :: Text) -> OnCloseTx <$> fromCBOR <*> fromCBOR <*> fromCBOR

--- a/hydra-node/src/Hydra/Chain.hs
+++ b/hydra-node/src/Hydra/Chain.hs
@@ -207,7 +207,6 @@ data OnChainTx tx
 deriving stock instance IsTx tx => Eq (OnChainTx tx)
 deriving stock instance IsTx tx => Show (OnChainTx tx)
 deriving anyclass instance IsTx tx => ToJSON (OnChainTx tx)
-deriving anyclass instance IsTx tx => FromJSON (OnChainTx tx)
 
 instance IsTx tx => ToCBOR (OnChainTx tx) where
   toCBOR = \case
@@ -479,7 +478,6 @@ data ChainEvent tx
 deriving stock instance (IsTx tx, IsChainState tx) => Eq (ChainEvent tx)
 deriving stock instance (IsTx tx, IsChainState tx) => Show (ChainEvent tx)
 deriving anyclass instance (IsTx tx, IsChainState tx) => ToJSON (ChainEvent tx)
-deriving anyclass instance (IsTx tx, IsChainState tx) => FromJSON (ChainEvent tx)
 
 instance IsChainState tx => ToCBOR (ChainEvent tx) where
   toCBOR = \case

--- a/hydra-node/src/Hydra/Chain.hs
+++ b/hydra-node/src/Hydra/Chain.hs
@@ -163,6 +163,7 @@ data OnChainTx tx
 deriving stock instance IsTx tx => Eq (OnChainTx tx)
 deriving stock instance IsTx tx => Show (OnChainTx tx)
 deriving anyclass instance IsTx tx => ToJSON (OnChainTx tx)
+deriving anyclass instance IsTx tx => FromJSON (OnChainTx tx)
 
 instance ArbitraryIsTx tx => Arbitrary (OnChainTx tx) where
   arbitrary = genericArbitrary
@@ -314,6 +315,7 @@ data ChainEvent tx
 deriving stock instance (IsTx tx, IsChainState tx) => Eq (ChainEvent tx)
 deriving stock instance (IsTx tx, IsChainState tx) => Show (ChainEvent tx)
 deriving anyclass instance (IsTx tx, IsChainState tx) => ToJSON (ChainEvent tx)
+deriving anyclass instance (IsTx tx, IsChainState tx) => FromJSON (ChainEvent tx)
 
 instance (ArbitraryIsTx tx, IsChainState tx) => Arbitrary (ChainEvent tx) where
   arbitrary = genericArbitrary

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -161,7 +161,6 @@ instance ToCBOR ChainPoint where
         <> toCBOR slotNo
         <> toCBOR (serialiseToRawBytes bHash)
 
--- TODO: HasBlockHeader needs to be exported from cardano-api but it is not
 instance FromCBOR ChainPoint where
   fromCBOR =
     fromCBOR >>= \case
@@ -170,10 +169,9 @@ instance FromCBOR ChainPoint where
         ChainPoint
           <$> fromCBOR
           <*> ( fromCBOR >>= \bs ->
-                  pure $
-                    case deserialiseFromRawBytes (AsHash AsBlockHeader) bs of
-                      Left e -> fail (show e)
-                      Right h -> h
+                  case deserialiseFromRawBytes (AsHash (proxyToAsType (Proxy :: Proxy BlockHeader))) bs of
+                    Left e -> fail (show e)
+                    Right h -> pure h
               )
       msg -> fail $ show msg <> " is not a proper CBOR-encoded ChainPoint"
 

--- a/hydra-node/src/Hydra/HeadLogic/Input.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Input.hs
@@ -31,6 +31,12 @@ deriving stock instance IsChainState tx => Eq (Input tx)
 deriving stock instance IsChainState tx => Show (Input tx)
 deriving anyclass instance IsChainState tx => ToJSON (Input tx)
 
+instance IsChainState tx => ToCBOR (Input tx) where
+  toCBOR = toCBOR
+
+instance IsChainState tx => FromCBOR (Input tx) where
+  fromCBOR = fromCBOR
+
 instance (ArbitraryIsTx tx, IsChainState tx) => Arbitrary (Input tx) where
   arbitrary = genericArbitrary
   shrink = genericShrink

--- a/hydra-node/src/Hydra/HeadLogic/Input.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Input.hs
@@ -30,7 +30,6 @@ data Input tx
 deriving stock instance IsChainState tx => Eq (Input tx)
 deriving stock instance IsChainState tx => Show (Input tx)
 deriving anyclass instance IsChainState tx => ToJSON (Input tx)
-deriving anyclass instance IsChainState tx => FromJSON (Input tx)
 
 instance IsChainState tx => ToCBOR (Input tx) where
   toCBOR = \case

--- a/hydra-node/src/Hydra/HeadLogic/Input.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Input.hs
@@ -30,12 +30,7 @@ data Input tx
 deriving stock instance IsChainState tx => Eq (Input tx)
 deriving stock instance IsChainState tx => Show (Input tx)
 deriving anyclass instance IsChainState tx => ToJSON (Input tx)
-
-instance IsChainState tx => ToCBOR (Input tx) where
-  toCBOR = toCBOR
-
-instance IsChainState tx => FromCBOR (Input tx) where
-  fromCBOR = fromCBOR
+deriving anyclass instance IsChainState tx => FromJSON (Input tx)
 
 instance (ArbitraryIsTx tx, IsChainState tx) => Arbitrary (Input tx) where
   arbitrary = genericArbitrary

--- a/hydra-node/src/Hydra/Ledger/Simple.hs
+++ b/hydra-node/src/Hydra/Ledger/Simple.hs
@@ -106,7 +106,7 @@ instance IsTx SimpleTx where
 newtype SimpleChainState = SimpleChainState {slot :: ChainSlot}
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
-  deriving newtype (Arbitrary,  ToCBOR, FromCBOR)
+  deriving newtype (Arbitrary, ToCBOR, FromCBOR)
 
 instance IsChainState SimpleTx where
   type ChainStateType SimpleTx = SimpleChainState

--- a/hydra-node/src/Hydra/Ledger/Simple.hs
+++ b/hydra-node/src/Hydra/Ledger/Simple.hs
@@ -106,7 +106,7 @@ instance IsTx SimpleTx where
 newtype SimpleChainState = SimpleChainState {slot :: ChainSlot}
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
-  deriving newtype (Arbitrary)
+  deriving newtype (Arbitrary,  ToCBOR, FromCBOR)
 
 instance IsChainState SimpleTx where
   type ChainStateType SimpleTx = SimpleChainState

--- a/hydra-node/src/Hydra/Network.hs
+++ b/hydra-node/src/Hydra/Network.hs
@@ -190,7 +190,6 @@ data Connectivity
       }
   deriving stock (Generic, Eq, Show)
   deriving anyclass (ToJSON)
-  deriving anyclass (FromJSON)
 
 instance ToCBOR Connectivity where
   toCBOR = \case

--- a/hydra-node/src/Hydra/Network.hs
+++ b/hydra-node/src/Hydra/Network.hs
@@ -190,6 +190,7 @@ data Connectivity
       }
   deriving stock (Generic, Eq, Show)
   deriving anyclass (ToJSON)
+  deriving anyclass (FromJSON)
 
 instance Arbitrary Connectivity where
   arbitrary = genericArbitrary

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -336,7 +336,7 @@ broadcastMessages ::
   IO ()
 broadcastMessages tracer conn ourHost queue =
   withGrpcContext "broadcastMessages" . forever $ do
-    msg <- peekPersistentQueue queue
+    (_, msg) <- peekPersistentQueue queue
     (putMessage conn ourHost msg >> popPersistentQueue queue msg)
       `catch` \case
         GrpcException{grpcError, grpcErrorMessage}

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -79,7 +79,7 @@ import Hydra.PersistentQueue (
   newPersistentQueue,
   peekPersistentQueue,
   popPersistentQueue,
-  writePersistentQueue,
+  writeDurablePersistentQueue,
  )
 import Network.GRPC.Client (
   Address (..),
@@ -155,7 +155,7 @@ withEtcdNetwork tracer protocolVersion config callback action = do
                 race_ (broadcastMessages tracer conn advertise queue) $ do
                   action
                     Network
-                      { broadcast = writePersistentQueue queue
+                      { broadcast = writeDurablePersistentQueue queue
                       }
                   atomically (writeTVar doneVar True)
  where

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -151,7 +151,7 @@ withEtcdNetwork tracer protocolVersion config callback action = do
           withAsync (checkVersion tracer conn protocolVersion callback) $ \_ -> do
             race_ (pollConnectivity tracer conn advertise callback) $
               race_ (waitMessages tracer conn persistenceDir callback) $ do
-                queue <- newPersistentQueue (persistenceDir </> "pending-broadcast") 100
+                queue <- newPersistentQueue serialize' (fmap (first (T.unpack . show)) decodeFull') (persistenceDir </> "pending-broadcast") 100
                 race_ (broadcastMessages tracer conn advertise queue) $ do
                   action
                     Network

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -391,7 +391,6 @@ waitMessages tracer conn directory NetworkCallback{deliver} = do
  where
   process res = do
     let revision = fromIntegral $ res ^. #header . #revision
-    putLastKnownRevision directory revision
     forM_ (res ^. #events) $ \event -> do
       let value = event ^. #kv . #value
       case decodeFull' value of
@@ -403,7 +402,9 @@ waitMessages tracer conn directory NetworkCallback{deliver} = do
               , value = encodeBase16 value
               , reason = show err
               }
-        Right msg -> deliver msg
+        Right msg -> do
+          deliver msg
+          putLastKnownRevision directory revision
 
 getLastKnownRevision :: MonadIO m => FilePath -> m Natural
 getLastKnownRevision directory = do

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -151,7 +151,7 @@ withEtcdNetwork tracer protocolVersion config callback action = do
           withAsync (checkVersion tracer conn protocolVersion callback) $ \_ -> do
             race_ (pollConnectivity tracer conn advertise callback) $
               race_ (waitMessages tracer conn persistenceDir callback) $ do
-                queue <- newPersistentQueue serialize' (fmap (first (T.unpack . show)) decodeFull') (persistenceDir </> "pending-broadcast") 100
+                queue <- newPersistentQueue serialize' (fmap (first (T.unpack . show)) decodeFull') (persistenceDir </> "pending-broadcast")
                 race_ (broadcastMessages tracer conn advertise queue) $ do
                   action
                     Network

--- a/hydra-node/src/Hydra/Network/Message.hs
+++ b/hydra-node/src/Hydra/Network/Message.hs
@@ -26,6 +26,18 @@ data NetworkEvent msg
   deriving anyclass (ToJSON)
   deriving anyclass (FromJSON)
 
+instance ToCBOR msg => ToCBOR (NetworkEvent msg) where
+  toCBOR = \case
+    ConnectivityEvent connectivity -> toCBOR ("ConnectivityEvent" :: Text) <> toCBOR connectivity
+    ReceivedMessage sender msg -> toCBOR ("ReceivedMessage" :: Text) <> toCBOR sender <> toCBOR msg
+
+instance FromCBOR msg => FromCBOR (NetworkEvent msg) where
+  fromCBOR =
+    fromCBOR >>= \case
+      ("ConnectivityEvent" :: Text) -> ConnectivityEvent <$> fromCBOR
+      "ReceivedMessage" -> ReceivedMessage <$> fromCBOR <*> fromCBOR
+      msg -> fail $ show msg <> " is not a proper CBOR-encoded NetworkEvent"
+
 instance Arbitrary msg => Arbitrary (NetworkEvent msg) where
   arbitrary = genericArbitrary
 

--- a/hydra-node/src/Hydra/Network/Message.hs
+++ b/hydra-node/src/Hydra/Network/Message.hs
@@ -24,7 +24,6 @@ data NetworkEvent msg
   | ReceivedMessage {sender :: Party, msg :: msg}
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON)
-  deriving anyclass (FromJSON)
 
 instance ToCBOR msg => ToCBOR (NetworkEvent msg) where
   toCBOR = \case

--- a/hydra-node/src/Hydra/Network/Message.hs
+++ b/hydra-node/src/Hydra/Network/Message.hs
@@ -24,6 +24,7 @@ data NetworkEvent msg
   | ReceivedMessage {sender :: Party, msg :: msg}
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON)
+  deriving anyclass (FromJSON)
 
 instance Arbitrary msg => Arbitrary (NetworkEvent msg) where
   arbitrary = genericArbitrary

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -326,8 +326,8 @@ stepHydraNode node = do
       processStateChanges node stateChanges
       maybeReenqueue i
     Error{} -> pure ()
-  traceWith tracer EndInput{by = party, inputId = queuedId}
   done queuedItem
+  traceWith tracer EndInput{by = party, inputId = queuedId}
  where
   maybeReenqueue q@Queued{queuedId, queuedItem} =
     case queuedItem of

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -320,8 +320,8 @@ stepHydraNode node = do
   traceWith tracer (LogicOutcome party outcome)
   case outcome of
     Continue{stateChanges, effects} -> do
-      processStateChanges node stateChanges
       processEffects node tracer queuedId effects
+      processStateChanges node stateChanges
     Wait{stateChanges} -> do
       processStateChanges node stateChanges
       maybeReenqueue i

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -212,7 +212,7 @@ hydrate tracer env ledger initialChainState persistenceDir EventStore{eventSourc
     sourceEvents eventSource .| mapM_C (\e -> lift $ putEventsToSinks eventSinks [e])
 
   nodeState <- createNodeState (getLast lastEventId) headState
-  inputQueue <- createPersistentInputQueue persistenceDir
+  inputQueue <- createPersistentInputQueue persistenceDir 100
   pure
     DraftHydraNode
       { tracer

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -212,7 +212,7 @@ hydrate tracer env ledger initialChainState persistenceDir EventStore{eventSourc
     sourceEvents eventSource .| mapM_C (\e -> lift $ putEventsToSinks eventSinks [e])
 
   nodeState <- createNodeState (getLast lastEventId) headState
-  inputQueue <- createPersistentInputQueue persistenceDir 100
+  inputQueue <- createPersistentInputQueue persistenceDir
   pure
     DraftHydraNode
       { tracer

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -192,7 +192,7 @@ hydrate ::
   EventStore (StateEvent tx) m ->
   [EventSink (StateEvent tx) m] ->
   m (DraftHydraNode tx m)
-hydrate tracer env ledger initialChainState persistenceDir EventStore{eventSource, eventSink} eventSinks  = do
+hydrate tracer env ledger initialChainState persistenceDir EventStore{eventSource, eventSink} eventSinks = do
   traceWith tracer LoadingState
   (lastEventId, (headState, chainStateHistory)) <-
     runConduitRes $
@@ -327,6 +327,7 @@ stepHydraNode node = do
       maybeReenqueue i
     Error{} -> pure ()
   traceWith tracer EndInput{by = party, inputId = queuedId}
+  done queuedItem
  where
   maybeReenqueue q@Queued{queuedId, queuedItem} =
     case queuedItem of
@@ -336,7 +337,7 @@ stepHydraNode node = do
 
   Environment{party} = env
 
-  HydraNode{tracer, inputQueue = InputQueue{dequeue, reenqueue}, env} = node
+  HydraNode{tracer, inputQueue = InputQueue{dequeue, reenqueue, done}, env} = node
 
 -- | The maximum number of times to re-enqueue a network messages upon 'Wait'.
 -- outcome.

--- a/hydra-node/src/Hydra/Node/InputQueue.hs
+++ b/hydra-node/src/Hydra/Node/InputQueue.hs
@@ -88,13 +88,14 @@ createPersistentInputQueue ::
   , FromCBOR e
   ) =>
   FilePath ->
-  Natural ->
   m (InputQueue m e)
-createPersistentInputQueue persistenceDir capacity = do
-  q <- newPersistentQueue serialize' (fmap (first (T.unpack . show)) decodeFull') (persistenceDir </> "input-queue") capacity
+createPersistentInputQueue persistenceDir = do
+  q <- newPersistentQueue serialize' (fmap (first (T.unpack . show)) decodeFull') (persistenceDir </> "input-queue")
   pure
     InputQueue
-      { enqueue = writePersistentQueue q
+      { enqueue = \i -> do
+          threadDelay 0.1
+          writePersistentQueue q i
       , reenqueue = \delay e -> do
           threadDelay delay
           writePersistentQueue q (queuedItem e)

--- a/hydra-node/src/Hydra/Node/InputQueue.hs
+++ b/hydra-node/src/Hydra/Node/InputQueue.hs
@@ -18,10 +18,10 @@ import Control.Concurrent.Class.MonadSTM (
 import Control.Monad.Class.MonadAsync (async)
 import Hydra.PersistentQueue (
   PersistentQueue (..),
-  newPersistentQueueJson,
+  newPersistentQueue,
   peekPersistentQueue,
   popPersistentQueue,
-  writePersistentQueueJson,
+  writePersistentQueue,
  )
 import System.FilePath ((</>))
 
@@ -82,20 +82,20 @@ createPersistentInputQueue ::
   , MonadCatch m
   , MonadFail m
   , Eq e
-  , ToJSON e
-  , FromJSON e
+  , ToCBOR e
+  , FromCBOR e
   ) =>
   FilePath ->
   Natural ->
   m (InputQueue m e)
 createPersistentInputQueue persistenceDir capacity = do
-  q <- newPersistentQueueJson (persistenceDir </> "input-queue") capacity
+  q <- newPersistentQueue (persistenceDir </> "input-queue") capacity
   pure
     InputQueue
-      { enqueue = writePersistentQueueJson q
+      { enqueue = writePersistentQueue q
       , reenqueue = \delay e -> do
           threadDelay delay
-          writePersistentQueueJson q (queuedItem e)
+          writePersistentQueue q (queuedItem e)
       , dequeue = do
           (n, item) <- peekPersistentQueue q
           pure $ Queued{queuedId = fromIntegral n, queuedItem = item}

--- a/hydra-node/src/Hydra/Node/InputQueue.hs
+++ b/hydra-node/src/Hydra/Node/InputQueue.hs
@@ -3,6 +3,7 @@ module Hydra.Node.InputQueue where
 
 import Hydra.Prelude
 
+import Cardano.Binary (decodeFull', serialize')
 import Control.Concurrent.Class.MonadSTM (
   MonadLabelledSTM,
   isEmptyTBQueue,
@@ -16,6 +17,7 @@ import Control.Concurrent.Class.MonadSTM (
   writeTQueue,
  )
 import Control.Monad.Class.MonadAsync (async)
+import Data.Text qualified as T
 import Hydra.PersistentQueue (
   PersistentQueue (..),
   newPersistentQueue,
@@ -89,7 +91,7 @@ createPersistentInputQueue ::
   Natural ->
   m (InputQueue m e)
 createPersistentInputQueue persistenceDir capacity = do
-  q <- newPersistentQueue (persistenceDir </> "input-queue") capacity
+  q <- newPersistentQueue serialize' (fmap (first (T.unpack . show)) decodeFull') (persistenceDir </> "input-queue") capacity
   pure
     InputQueue
       { enqueue = writePersistentQueue q

--- a/hydra-node/src/Hydra/Node/InputQueue.hs
+++ b/hydra-node/src/Hydra/Node/InputQueue.hs
@@ -88,7 +88,7 @@ createPersistentInputQueue ::
   FilePath ->
   m (InputQueue m e)
 createPersistentInputQueue persistenceDir = do
-  q <- newPersistentQueue (persistenceDir </> "input-queue") 100
+  q <- newPersistentQueue (persistenceDir </> "input-queue") 1000
   pure
     InputQueue
       { enqueue = writePersistentQueue q

--- a/hydra-node/src/Hydra/Node/InputQueue.hs
+++ b/hydra-node/src/Hydra/Node/InputQueue.hs
@@ -81,7 +81,6 @@ createPersistentInputQueue ::
   ( MonadDelay m
   , MonadIO m
   , MonadSTM m
-  , MonadCatch m
   , MonadFail m
   , Eq e
   , ToCBOR e

--- a/hydra-node/src/Hydra/Node/InputQueue.hs
+++ b/hydra-node/src/Hydra/Node/InputQueue.hs
@@ -93,9 +93,7 @@ createPersistentInputQueue persistenceDir = do
   q <- newPersistentQueue serialize' (fmap (first (T.unpack . show)) decodeFull') (persistenceDir </> "input-queue")
   pure
     InputQueue
-      { enqueue = \i -> do
-          threadDelay 0.1
-          writePersistentQueue q i
+      { enqueue = writePersistentQueue q
       , reenqueue = \delay e -> do
           threadDelay delay
           writePersistentQueue q (queuedItem e)

--- a/hydra-node/src/Hydra/Node/Run.hs
+++ b/hydra-node/src/Hydra/Node/Run.hs
@@ -98,7 +98,7 @@ run opts = do
             =<< createPersistenceIncremental stateFile
         -- NOTE: Add any custom sinks here
         let eventSinks :: [EventSink (StateEvent Tx) IO] = []
-        wetHydraNode <- hydrate (contramap Node tracer) env ledger initialChainState eventStore eventSinks
+        wetHydraNode <- hydrate (contramap Node tracer) env ledger initialChainState persistenceDir eventStore eventSinks
         -- Chain
         withChain <- prepareChainComponent tracer env chainConfig
         withChain (chainStateHistory wetHydraNode) (wireChainInput wetHydraNode) $ \chain -> do

--- a/hydra-node/src/Hydra/PersistentQueue.hs
+++ b/hydra-node/src/Hydra/PersistentQueue.hs
@@ -67,9 +67,9 @@ writePersistentQueue PersistentQueue{queue, nextIx, directory} item = do
 
 -- | Get the next value from the queue without removing it, blocking if the
 -- queue is empty.
-peekPersistentQueue :: MonadSTM m => PersistentQueue m a -> m a
+peekPersistentQueue :: MonadSTM m => PersistentQueue m a -> m (Natural, a)
 peekPersistentQueue PersistentQueue{queue} = do
-  snd <$> atomically (peekTBQueue queue)
+  atomically (peekTBQueue queue)
 
 -- | Remove an element from the queue if it matches the given item. Use
 -- 'peekPersistentQueue' to wait for next items before popping it.

--- a/hydra-node/src/Hydra/PersistentQueue.hs
+++ b/hydra-node/src/Hydra/PersistentQueue.hs
@@ -14,7 +14,7 @@ import Control.Concurrent.Class.MonadSTM (
 import Control.Exception (IOException)
 import Data.Aeson (eitherDecode', encode)
 import Data.List qualified as List
-import System.Directory (createDirectoryIfMissing, doesPathExist, listDirectory, removeFile)
+import System.Directory (createDirectoryIfMissing, listDirectory, removeFile)
 import System.FilePath ((</>))
 import UnliftIO.IO.File (writeBinaryFileDurable)
 
@@ -142,7 +142,4 @@ popPersistentQueue PersistentQueue{queue, directory} item = do
     Nothing -> pure ()
     Just index -> do
       let path = directory </> show index
-      fileExists <- liftIO $ doesPathExist path
-      when fileExists $
-        liftIO $
-          removeFile path
+      liftIO $ removeFile path

--- a/hydra-node/src/Hydra/PersistentQueue.hs
+++ b/hydra-node/src/Hydra/PersistentQueue.hs
@@ -42,7 +42,9 @@ newPersistentQueue encode decode path = do
       then do
         paths <- liftIO $ listDirectory path
         pure (paths, fromIntegral $ max (length paths) 100)
-      else pure ([], 100)
+      else do
+        liftIO $ createDirectoryIfMissing True path
+        pure ([], 100)
   queue <- newTBQueueIO capacity
   highestId <- loadExisting queue paths
   nextIx <- newTVarIO $ highestId + 1

--- a/hydra-node/src/Hydra/PersistentQueue.hs
+++ b/hydra-node/src/Hydra/PersistentQueue.hs
@@ -15,6 +15,7 @@ import Control.Exception (IOException)
 import Data.List qualified as List
 import System.Directory (createDirectoryIfMissing, listDirectory, removeFile)
 import System.FilePath ((</>))
+import UnliftIO.IO.File (writeBinaryFileDurable)
 
 -- * Persistent queue
 
@@ -62,7 +63,7 @@ writePersistentQueue PersistentQueue{queue, nextIx, directory} item = do
     next <- readTVar nextIx
     modifyTVar' nextIx (+ 1)
     pure next
-  writeFileBS (directory </> show next) $ serialize' item
+  writeBinaryFileDurable (directory </> show next) $ serialize' item
   atomically $ writeTBQueue queue (next, item)
 
 -- | Get the next value from the queue without removing it, blocking if the

--- a/hydra-node/src/Hydra/PersistentQueue.hs
+++ b/hydra-node/src/Hydra/PersistentQueue.hs
@@ -98,7 +98,6 @@ writeDurablePersistentQueue PersistentQueue{queue, nextIx, directory} item = do
   writeBinaryFileDurable (directory </> show next) $ serialize' item
   atomically $ writeTBQueue queue (next, item)
 
-
 -- | Write a value to the queue, blocking if the queue is full.
 writePersistentQueueJson :: (ToJSON a, MonadSTM m, MonadIO m) => PersistentQueue m a -> a -> m ()
 writePersistentQueueJson PersistentQueue{queue, nextIx, directory} item = do

--- a/hydra-node/src/Hydra/PersistentQueue.hs
+++ b/hydra-node/src/Hydra/PersistentQueue.hs
@@ -1,0 +1,86 @@
+module Hydra.PersistentQueue where
+
+import Hydra.Prelude
+
+import Cardano.Binary (decodeFull', serialize')
+import Control.Concurrent.Class.MonadSTM (
+  modifyTVar',
+  newTBQueueIO,
+  newTVarIO,
+  peekTBQueue,
+  readTBQueue,
+  writeTBQueue,
+ )
+import Control.Exception (IOException)
+import Data.List qualified as List
+import System.Directory (createDirectoryIfMissing, listDirectory, removeFile)
+import System.FilePath ((</>))
+
+-- * Persistent queue
+
+data PersistentQueue m a = PersistentQueue
+  { queue :: TBQueue m (Natural, a)
+  , nextIx :: TVar m Natural
+  , directory :: FilePath
+  }
+
+-- | Create a new persistent queue at file path and given capacity.
+newPersistentQueue ::
+  (MonadSTM m, MonadIO m, FromCBOR a, MonadCatch m, MonadFail m) =>
+  FilePath ->
+  Natural ->
+  m (PersistentQueue m a)
+newPersistentQueue path capacity = do
+  queue <- newTBQueueIO capacity
+  highestId <-
+    try (loadExisting queue) >>= \case
+      Left (_ :: IOException) -> do
+        liftIO $ createDirectoryIfMissing True path
+        pure 0
+      Right highest -> pure highest
+  nextIx <- newTVarIO $ highestId + 1
+  pure PersistentQueue{queue, nextIx, directory = path}
+ where
+  loadExisting queue = do
+    paths <- liftIO $ listDirectory path
+    case sort $ mapMaybe readMaybe paths of
+      [] -> pure 0
+      idxs -> do
+        forM_ idxs $ \(idx :: Natural) -> do
+          bs <- readFileBS (path </> show idx)
+          case decodeFull' bs of
+            Left err ->
+              fail $ "Failed to decode item: " <> show err
+            Right item ->
+              atomically $ writeTBQueue queue (idx, item)
+        pure $ List.last idxs
+
+-- | Write a value to the queue, blocking if the queue is full.
+writePersistentQueue :: (ToCBOR a, MonadSTM m, MonadIO m) => PersistentQueue m a -> a -> m ()
+writePersistentQueue PersistentQueue{queue, nextIx, directory} item = do
+  next <- atomically $ do
+    next <- readTVar nextIx
+    modifyTVar' nextIx (+ 1)
+    pure next
+  writeFileBS (directory </> show next) $ serialize' item
+  atomically $ writeTBQueue queue (next, item)
+
+-- | Get the next value from the queue without removing it, blocking if the
+-- queue is empty.
+peekPersistentQueue :: MonadSTM m => PersistentQueue m a -> m a
+peekPersistentQueue PersistentQueue{queue} = do
+  snd <$> atomically (peekTBQueue queue)
+
+-- | Remove an element from the queue if it matches the given item. Use
+-- 'peekPersistentQueue' to wait for next items before popping it.
+popPersistentQueue :: (MonadSTM m, MonadIO m, Eq a) => PersistentQueue m a -> a -> m ()
+popPersistentQueue PersistentQueue{queue, directory} item = do
+  popped <- atomically $ do
+    (ix, next) <- peekTBQueue queue
+    if next == item
+      then readTBQueue queue $> Just ix
+      else pure Nothing
+  case popped of
+    Nothing -> pure ()
+    Just index -> do
+      liftIO . removeFile $ directory </> show index

--- a/hydra-node/test/Hydra/API/ClientInputSpec.hs
+++ b/hydra-node/test/Hydra/API/ClientInputSpec.hs
@@ -15,6 +15,7 @@ import Test.Aeson.GenericSpecs (
   roundtripAndGoldenADTSpecsWithSettings,
  )
 import Test.QuickCheck (counterexample, forAll, property)
+import Test.Util (roundtripCBOR)
 
 spec :: Spec
 spec = parallel $ do
@@ -36,3 +37,5 @@ spec = parallel $ do
          in case fromJSON @Tx envelope of
               Success{} -> property True
               Error e -> counterexample (toString $ toText e) $ property False
+
+  prop "Roundtrip CBOR encoding ClientInput" $ roundtripCBOR @(ClientInput Tx)

--- a/hydra-node/test/Hydra/Events/RotationSpec.hs
+++ b/hydra-node/test/Hydra/Events/RotationSpec.hs
@@ -33,9 +33,10 @@ spec = parallel $ do
           ) ->
           IO ()
         setupHydrate action =
-          showLogsOnFailure "RotationSpec" $ \tracer -> do
-            let testHydrate = hydrate tracer testEnvironment simpleLedger SimpleChainState{slot = ChainSlot 0}
-            action testHydrate
+          showLogsOnFailure "RotationSpec" $ \tracer ->
+            withTempDir "persistence-dir" $ \tmpDir -> do
+              let testHydrate = hydrate tracer testEnvironment simpleLedger SimpleChainState{slot = ChainSlot 0} tmpDir
+              action testHydrate
     around setupHydrate $ do
       it "rotates while running" $ \testHydrate -> do
         failAfter 1 $ do

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -70,6 +70,7 @@ import Test.Hydra.Tx.Fixture (alice, aliceSk, bob, bobSk, carol, carolSk, derive
 import Test.Hydra.Tx.Gen (genKeyPair, genOutput)
 import Test.QuickCheck (Property, counterexample, elements, forAll, forAllShrink, oneof, shuffle, suchThat)
 import Test.QuickCheck.Monadic (assert, monadicIO, pick, run)
+import Test.Util (roundtripCBOR)
 
 spec :: Spec
 spec =
@@ -962,6 +963,8 @@ spec =
       update bobEnv ledger st input `shouldSatisfy` \case
         Wait WaitOnNotApplicableDecommitTx{notApplicableReason = DecommitTxInvalid{}} _ -> True
         _ -> False
+
+    prop "Roundtrip CBOR encoding Input" $ roundtripCBOR @(Input SimpleTx)
 
 -- * Properties
 

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -107,8 +107,8 @@ spec = do
                 broadcast n1 456
                 -- Carol starts again
                 withEtcdNetwork @Int tracer v1 carolConfig recordReceived $ \_ -> do
-                  -- Carol should receive messages sent by alice while offline
-                  -- (without duplication of 123)
+                  -- Carol should receive all messages sent by alice even while offline
+                  waitNext `shouldReturn` 123
                   waitNext `shouldReturn` 456
 
       it "emits connectivity events" $ \tracer -> do

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -158,7 +158,7 @@ spec = do
 
       it "resends messages" $ \tracer -> do
         withTempDir "test-etcd" $ \tmp -> do
-          failAfter 20 $ do
+          failAfter 40 $ do
             PeerConfig3{aliceConfig, bobConfig, carolConfig} <- setup3Peers tmp
             (recordBob, waitBob, _) <- newRecordingCallback
             (recordCarol, waitCarol, _) <- newRecordingCallback

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -24,7 +24,7 @@ import Hydra.Network (
   WhichEtcd (..),
  )
 import Hydra.Network.Etcd (withEtcdNetwork)
-import Hydra.Network.Message (Message (..))
+import Hydra.Network.Message (Message (..), NetworkEvent (..))
 import Hydra.Node.Network (NetworkConfiguration (..))
 import System.Directory (removeFile)
 import System.FilePath ((</>))
@@ -205,6 +205,9 @@ spec = do
 
   describe "Serialisation" $ do
     prop "can roundtrip CBOR encoding/decoding of Hydra Message" $ prop_canRoundtripCBOREncoding @(Message SimpleTx)
+    prop "can roundtrip CBOR encoding/decoding of Connectivity" $ prop_canRoundtripCBOREncoding @Connectivity
+    prop "can roundtrip CBOR encoding/decoding of Host" $ prop_canRoundtripCBOREncoding @Host
+    prop "can roundtrip CBOR encoding/decoding of NetworkEvent" $ prop_canRoundtripCBOREncoding @(NetworkEvent (Message SimpleTx))
 
     roundtripAndGoldenADTSpecsWithSettings defaultSettings{sampleSize = 1} $ Proxy @(Message SimpleTx)
 

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -69,9 +69,10 @@ spec = parallel $ do
         ) ->
         IO ()
       setupHydrate action =
-        showLogsOnFailure "NodeSpec" $ \tracer -> do
-          let testHydrate = hydrate tracer testEnvironment simpleLedger SimpleChainState{slot = ChainSlot 0}
-          action testHydrate
+        showLogsOnFailure "NodeSpec" $ \tracer ->
+          withTempDir "persistence-dir" $ \tmpDir -> do
+            let testHydrate = hydrate tracer testEnvironment simpleLedger SimpleChainState{slot = ChainSlot 0} tmpDir
+            action testHydrate
 
   describe "hydrate" $ do
     around setupHydrate $ do
@@ -444,7 +445,7 @@ runToCompletion node@HydraNode{inputQueue = InputQueue{isEmpty}} = go
 -- | Creates a full 'HydraNode' with given parameters and primed 'Input's. Note
 -- that this node is 'notConnect'ed to any components.
 testHydraNode ::
-  (MonadDelay m, MonadAsync m, MonadLabelledSTM m, MonadThrow m, MonadUnliftIO m) =>
+  (MonadDelay m, MonadLabelledSTM m, MonadUnliftIO m, MonadCatch m, MonadFail m) =>
   Tracer m (HydraNodeLog SimpleTx) ->
   SigningKey HydraKey ->
   [Party] ->
@@ -454,9 +455,10 @@ testHydraNode ::
 testHydraNode tracer signingKey otherParties contestationPeriod inputs = do
   let eventStore :: Monad m => EventStore (StateEvent SimpleTx) m
       eventStore = mockEventStore []
-  hydrate tracer env simpleLedger SimpleChainState{slot = ChainSlot 0} eventStore []
-    >>= notConnect
-    >>= primeWith inputs
+  withTempDir "persistence-dir" $ \tmpDir ->
+    hydrate tracer env simpleLedger SimpleChainState{slot = ChainSlot 0} tmpDir eventStore []
+      >>= notConnect
+      >>= primeWith inputs
  where
   env =
     Environment

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -70,7 +70,7 @@ spec = parallel $ do
         IO ()
       setupHydrate action =
         showLogsOnFailure "NodeSpec" $ \tracer ->
-          withTempDir "persistence-dir" $ \tmpDir -> do
+          withTempDir "node-spec" $ \tmpDir -> do
             let testHydrate = hydrate tracer testEnvironment simpleLedger SimpleChainState{slot = ChainSlot 0} tmpDir
             action testHydrate
 
@@ -234,7 +234,7 @@ spec = parallel $ do
 
         getNetworkEvents `shouldReturn` [AckSn (sign bobSk sn1) 1, ReqSn 0 2 [1] Nothing Nothing]
 
-    it "processes out-of-order AckSn" $
+    it "processes out-of-order AckSn" $ do
       showLogsOnFailure "NodeSpec" $ \tracer -> do
         let snapshot = testSnapshot 1 0 [] (utxoRefs [1, 2, 3])
             sigBob = sign bobSk snapshot

--- a/hydra-node/test/Test/Util.hs
+++ b/hydra-node/test/Test/Util.hs
@@ -5,6 +5,7 @@ module Test.Util where
 import Hydra.Prelude
 import Test.Hydra.Prelude hiding (shouldBe)
 
+import Cardano.Binary (decodeFull', serialize')
 import Control.Concurrent.Class.MonadSTM (modifyTVar', newTVarIO, readTVarIO)
 import Control.Monad.Class.MonadSay (say)
 import Control.Monad.IOSim (
@@ -175,3 +176,10 @@ waitMatch waitNext delay match = do
 
   align _ [] = []
   align n (h : q) = h : fmap (Text.replicate n " " <>) q
+
+roundtripCBOR :: (Eq a, Show a, ToCBOR a, FromCBOR a) => a -> Property
+roundtripCBOR a =
+  let encoded = serialize' a
+      decoded = decodeFull' encoded
+   in decoded == Right a
+        & counterexample ("encoded: " <> show encoded <> ". decode: " <> show decoded)

--- a/hydra-tx/hydra-tx.cabal
+++ b/hydra-tx/hydra-tx.cabal
@@ -172,6 +172,7 @@ test-suite tests
     Hydra.Tx.Contract.Init
     Hydra.Tx.Contract.Recover
     Hydra.Tx.HeadIdSpec
+    Hydra.Tx.HeadParametersSpec
     Hydra.Tx.IsTxSpec
     Spec
 

--- a/hydra-tx/src/Hydra/Chain/ChainState.hs
+++ b/hydra-tx/src/Hydra/Chain/ChainState.hs
@@ -33,7 +33,6 @@ class
   -- encountered, we assume monotonically increasing slots.
   chainStateSlot :: ChainStateType tx -> ChainSlot
 
-
 instance ToCBOR ChainSlot where
   toCBOR = \case
     ChainSlot n -> toCBOR ("ChainSlot" :: Text) <> toCBOR n

--- a/hydra-tx/src/Hydra/Chain/ChainState.hs
+++ b/hydra-tx/src/Hydra/Chain/ChainState.hs
@@ -20,6 +20,8 @@ class
   , FromJSON (ChainStateType tx)
   , ToJSON (ChainStateType tx)
   , Arbitrary (ChainStateType tx)
+  , ToCBOR (ChainStateType tx)
+  , FromCBOR (ChainStateType tx)
   ) =>
   IsChainState tx
   where
@@ -30,3 +32,14 @@ class
   -- | Get the chain slot for a chain state. NOTE: For any sequence of 'a'
   -- encountered, we assume monotonically increasing slots.
   chainStateSlot :: ChainStateType tx -> ChainSlot
+
+
+instance ToCBOR ChainSlot where
+  toCBOR = \case
+    ChainSlot n -> toCBOR ("ChainSlot" :: Text) <> toCBOR n
+
+instance FromCBOR ChainSlot where
+  fromCBOR =
+    fromCBOR >>= \case
+      ("ChainSlot" :: Text) -> ChainSlot <$> fromCBOR
+      msg -> fail $ show msg <> " is not a proper CBOR-encoded Message"

--- a/hydra-tx/src/Hydra/Tx/ContestationPeriod.hs
+++ b/hydra-tx/src/Hydra/Tx/ContestationPeriod.hs
@@ -14,7 +14,7 @@ import Text.Show (Show (..))
 -- values of unknown sign.
 newtype ContestationPeriod = UnsafeContestationPeriod Natural
   deriving stock (Eq, Ord)
-  deriving newtype (Real, Integral, ToJSON, FromJSON)
+  deriving newtype (Real, Integral, ToJSON, FromJSON, ToCBOR, FromCBOR)
 
 instance Show ContestationPeriod where
   show (UnsafeContestationPeriod s) = show s <> "s"

--- a/hydra-tx/src/Hydra/Tx/Crypto.hs
+++ b/hydra-tx/src/Hydra/Tx/Crypto.hs
@@ -268,7 +268,7 @@ verify (HydraVerificationKey vk) (HydraSignature sig) a =
 -- | Naiively aggregated multi-signatures.
 newtype MultiSignature a = HydraMultiSignature {multiSignature :: [Signature a]}
   deriving stock (Eq, Show, Generic)
-  deriving newtype (Semigroup, Monoid)
+  deriving newtype (Semigroup, Monoid, FromCBOR, ToCBOR)
 
 deriving anyclass instance ToJSON a => ToJSON (MultiSignature a)
 deriving anyclass instance FromJSON a => FromJSON (MultiSignature a)

--- a/hydra-tx/src/Hydra/Tx/HeadId.hs
+++ b/hydra-tx/src/Hydra/Tx/HeadId.hs
@@ -30,6 +30,16 @@ instance SerialiseAsRawBytes HeadId where
   serialiseToRawBytes (UnsafeHeadId bytes) = bytes
   deserialiseFromRawBytes _ = Right . UnsafeHeadId
 
+instance ToCBOR HeadId where
+  toCBOR = toCBOR . serialiseToRawBytes
+
+instance FromCBOR HeadId where
+  fromCBOR = do
+    bs <- fromCBOR
+    case deserialiseFromRawBytes AsHeadId bs of
+      Left err -> fail (show err)
+      Right v -> pure v
+
 instance HasTypeProxy HeadId where
   data AsType HeadId = AsHeadId
   proxyToAsType _ = AsHeadId
@@ -60,6 +70,7 @@ mkHeadId = UnsafeHeadId . serialiseToRawBytes
 newtype HeadSeed = UnsafeHeadSeed ByteString
   deriving stock (Show, Eq, Ord, Generic)
   deriving (ToJSON, FromJSON) via (UsingRawBytesHex HeadSeed)
+  deriving newtype (ToCBOR, FromCBOR)
 
 instance IsString HeadSeed where
   fromString = UnsafeHeadSeed . fromString

--- a/hydra-tx/src/Hydra/Tx/HeadParameters.hs
+++ b/hydra-tx/src/Hydra/Tx/HeadParameters.hs
@@ -14,6 +14,16 @@ data HeadParameters = HeadParameters
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
+instance ToCBOR HeadParameters where
+  toCBOR HeadParameters{contestationPeriod, parties} =
+    toCBOR ("HeadParameters" :: Text) <> toCBOR contestationPeriod <> toCBOR parties
+
+instance FromCBOR HeadParameters where
+  fromCBOR =
+    fromCBOR >>= \case
+      ("HeadParameters" :: Text) -> HeadParameters <$> fromCBOR <*> fromCBOR
+      msg -> fail $ show msg <> " is not a proper CBOR-encoded Message"
+
 instance Arbitrary HeadParameters where
   arbitrary = dedupParties <$> genericArbitrary
    where

--- a/hydra-tx/src/Hydra/Tx/IsTx.hs
+++ b/hydra-tx/src/Hydra/Tx/IsTx.hs
@@ -174,4 +174,3 @@ instance IsTx Tx where
   outputsOfUTxO = UTxO.txOutputs
 
   withoutUTxO = UTxO.difference
-

--- a/hydra-tx/src/Hydra/Tx/IsTx.hs
+++ b/hydra-tx/src/Hydra/Tx/IsTx.hs
@@ -174,3 +174,4 @@ instance IsTx Tx where
   outputsOfUTxO = UTxO.txOutputs
 
   withoutUTxO = UTxO.difference
+

--- a/hydra-tx/src/Hydra/Tx/OnChainId.hs
+++ b/hydra-tx/src/Hydra/Tx/OnChainId.hs
@@ -19,6 +19,7 @@ import Hydra.Cardano.Api (
 newtype OnChainId = UnsafeOnChainId ByteString
   deriving stock (Show, Eq, Ord, Generic)
   deriving (ToJSON, FromJSON) via (UsingRawBytesHex OnChainId)
+  deriving newtype (ToCBOR, FromCBOR)
 
 instance SerialiseAsRawBytes OnChainId where
   serialiseToRawBytes (UnsafeOnChainId bytes) = bytes

--- a/hydra-tx/src/Hydra/Tx/Snapshot.hs
+++ b/hydra-tx/src/Hydra/Tx/Snapshot.hs
@@ -120,9 +120,8 @@ instance IsTx tx => ToCBOR (Snapshot tx) where
 instance IsTx tx => FromCBOR (Snapshot tx) where
   fromCBOR =
     fromCBOR >>= \case
-     ("Snapshot" :: Text) -> Snapshot <$> fromCBOR <*> fromCBOR <*> fromCBOR <*> fromCBOR <*> fromCBOR <*> fromCBOR <*> fromCBOR
-     msg -> fail $ show msg <> " is not a proper CBOR-encoded Message"
-
+      ("Snapshot" :: Text) -> Snapshot <$> fromCBOR <*> fromCBOR <*> fromCBOR <*> fromCBOR <*> fromCBOR <*> fromCBOR <*> fromCBOR
+      msg -> fail $ show msg <> " is not a proper CBOR-encoded Message"
 
 instance (Arbitrary tx, Arbitrary (UTxOType tx)) => Arbitrary (Snapshot tx) where
   arbitrary = genericArbitrary
@@ -186,7 +185,6 @@ instance IsTx tx => FromCBOR (ConfirmedSnapshot tx) where
       ("InitialSnapshot" :: Text) -> InitialSnapshot <$> fromCBOR <*> fromCBOR
       ("ConfirmedSnapshot" :: Text) -> ConfirmedSnapshot <$> fromCBOR <*> fromCBOR
       msg -> fail $ show msg <> " is not a proper CBOR-encoded Message"
-
 
 instance (Arbitrary tx, Arbitrary (UTxOType tx), IsTx tx) => Arbitrary (ConfirmedSnapshot tx) where
   arbitrary = do

--- a/hydra-tx/src/Hydra/Tx/Snapshot.hs
+++ b/hydra-tx/src/Hydra/Tx/Snapshot.hs
@@ -115,7 +115,7 @@ instance IsTx tx => FromJSON (Snapshot tx) where
 
 instance IsTx tx => ToCBOR (Snapshot tx) where
   toCBOR Snapshot{headId, version, number, confirmed, utxo, utxoToCommit, utxoToDecommit} =
-    toCBOR ("Snapshot" :: Text) <> toCBOR headId <> toCBOR version <> toCBOR number <> foldMap toCBOR confirmed <> toCBOR utxo <> toCBOR utxoToCommit <> toCBOR utxoToDecommit
+    toCBOR ("Snapshot" :: Text) <> toCBOR headId <> toCBOR version <> toCBOR number <> toCBOR confirmed <> toCBOR utxo <> toCBOR utxoToCommit <> toCBOR utxoToDecommit
 
 instance IsTx tx => FromCBOR (Snapshot tx) where
   fromCBOR =

--- a/hydra-tx/test/Hydra/Tx/HeadIdSpec.hs
+++ b/hydra-tx/test/Hydra/Tx/HeadIdSpec.hs
@@ -4,7 +4,8 @@ import Hydra.Prelude
 import Test.Hydra.Prelude
 
 import Hydra.Contract.HeadTokens (headPolicyId)
-import Hydra.Tx.HeadId (currencySymbolToHeadId, headIdToCurrencySymbol, headIdToPolicyId, headSeedToTxIn, mkHeadId, txInToHeadSeed)
+import Hydra.Tx.HeadId (HeadId, currencySymbolToHeadId, headIdToCurrencySymbol, headIdToPolicyId, headSeedToTxIn, mkHeadId, txInToHeadSeed)
+import Hydra.Tx.IsTxSpec (roundtripCBOR)
 import Test.QuickCheck (counterexample, (===))
 import Test.QuickCheck.Monadic (monadicIO)
 
@@ -28,3 +29,4 @@ spec =
         let cs = headIdToCurrencySymbol headId
         headId' <- currencySymbolToHeadId cs
         pure $ headId' === headId
+      prop "Roundtrip CBOR encoding HeadId" $ roundtripCBOR @HeadId

--- a/hydra-tx/test/Hydra/Tx/HeadParametersSpec.hs
+++ b/hydra-tx/test/Hydra/Tx/HeadParametersSpec.hs
@@ -1,0 +1,14 @@
+module Hydra.Tx.HeadParametersSpec where
+
+import Hydra.Prelude
+import Test.Hydra.Prelude
+
+import Hydra.Tx.HeadParameters (HeadParameters)
+import Hydra.Tx.IsTxSpec (roundtripCBOR)
+
+spec :: Spec
+spec =
+  parallel $ do
+    describe "HeadParameters (cardano)" $
+      prop "Roundtrip CBOR encoding HeadParameters" $
+        roundtripCBOR @HeadParameters

--- a/hydra-tx/test/Hydra/Tx/IsTxSpec.hs
+++ b/hydra-tx/test/Hydra/Tx/IsTxSpec.hs
@@ -16,6 +16,7 @@ import Data.Aeson qualified as Aeson
 import Data.ByteString.Base16 qualified as Base16
 import Hydra.Cardano.Api (Tx, UTxO, fromLedgerTx, getTxId, toLedgerTx, pattern Tx)
 import Hydra.Tx.IsTx (txId)
+import Hydra.Tx.Snapshot (ConfirmedSnapshot, Snapshot)
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
 import Test.QuickCheck (Property, counterexample, forAll, property, (.&&.), (===))
 
@@ -32,6 +33,8 @@ spec =
       prop "Same TxId as TxBody after JSON decoding" roundtripTxId'
       prop "Roundtrip to and from Ledger" roundtripLedger
       prop "Roundtrip CBOR encoding" $ roundtripCBOR @Tx
+      prop "Roundtrip CBOR encoding Snapshot" $ roundtripCBOR @(Snapshot Tx)
+      prop "Roundtrip CBOR encoding ConfirmedSnapshot" $ roundtripCBOR @(ConfirmedSnapshot Tx)
       prop "JSON decode Babbage era transactions" $
         forAll genConwayCompatibleBabbageTx $ \tx ->
           case Aeson.eitherDecode $ Aeson.encode $ fromLedgerTx tx of


### PR DESCRIPTION
In order to fix a bug/improve resilience of hydra-node during crashes we now persist hydra-node's input queue.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
