### PR TITLE
Fix demo seed Killed: 9 error on macos

### DIFF
--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -30,8 +30,8 @@
           # stdenv as the original drv (important to determine targetPlatform).
           drv.stdenv.mkDerivation {
             name = "${exe}";
-            buildInputs = [ pkgs.cctools ];
-            phases = [ "buildPhase" "postFixup" ];
+            buildInputs = pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.cctools ];
+            phases = [ "buildPhase" ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ "postFixup" ];
             buildPhase = ''
               set -e
 
@@ -47,7 +47,7 @@
               sed 's/${placeholder}/${rev}/' ${drv}/bin/${exe} > $out/bin/${exe}
               chmod +x $out/bin/${exe}
             '';
-            postFixup = ''
+            postFixup = pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
               install_name_tool -add_rpath ${pkgs.zlib}/lib $out/bin/${exe}
               install_name_tool -add_rpath ${pkgs.lmdb}/lib $out/bin/${exe}
               install_name_tool -add_rpath ${pkgs.libcxx}/lib $out/bin/${exe}

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -30,7 +30,8 @@
           # stdenv as the original drv (important to determine targetPlatform).
           drv.stdenv.mkDerivation {
             name = "${exe}";
-            phases = [ "buildPhase" ];
+            buildInputs = [ pkgs.cctools ];
+            phases = [ "buildPhase" "postFixup" ];
             buildPhase = ''
               set -e
 
@@ -45,6 +46,13 @@
               mkdir -p $out/bin
               sed 's/${placeholder}/${rev}/' ${drv}/bin/${exe} > $out/bin/${exe}
               chmod +x $out/bin/${exe}
+            '';
+            postFixup = ''
+              install_name_tool -add_rpath ${pkgs.zlib}/lib $out/bin/${exe}
+              install_name_tool -add_rpath ${pkgs.lmdb}/lib $out/bin/${exe}
+              install_name_tool -add_rpath ${pkgs.libcxx}/lib $out/bin/${exe}
+              install_name_tool -add_rpath ${pkgs.libiconv}/lib $out/bin/${exe}
+              install_name_tool -add_rpath ${pkgs.libffi}/lib $out/bin/${exe}
             '';
           };
 

--- a/nix/hydra/project.nix
+++ b/nix/hydra/project.nix
@@ -45,9 +45,12 @@
               hydra-tx.writeHieFiles = true;
               hydra-tui.writeHieFiles = true;
               hydraw.writeHieFiles = true;
-              hydra-node.dontStrip = false;
-              hydra-tui.dontStrip = false;
-              hydraw.dontStrip = false;
+              # NOTE: This is needed to fix the "Killed: 9" error on macOS aarch64
+              # where the executable is being killed by the OS.
+              # See also: https://github.com/NixOS/nixpkgs/issues/112296
+              hydra-node.dontStrip = true;
+              hydra-tui.dontStrip = true;
+              hydraw.dontStrip = true;
             };
           }
           # Use different static libs on darwin
@@ -89,6 +92,11 @@
           # Add etcd as build dependency of hydra-node (template haskell embedding not tracked by cabal)
           {
             packages.hydra-node.components.library.build-tools = [ pkgs.etcd ];
+          }
+          {
+            packages.hydra-node.components.exes.hydra-node.preCheck = ''
+              export HOME=$(mktemp -d)
+            '';
           }
         ];
       };

--- a/nix/hydra/project.nix
+++ b/nix/hydra/project.nix
@@ -45,12 +45,9 @@
               hydra-tx.writeHieFiles = true;
               hydra-tui.writeHieFiles = true;
               hydraw.writeHieFiles = true;
-              # NOTE: This is needed to fix the "Killed: 9" error on macOS aarch64
-              # where the executable is being killed by the OS.
-              # See also: https://github.com/NixOS/nixpkgs/issues/112296
-              hydra-node.dontStrip = true;
-              hydra-tui.dontStrip = true;
-              hydraw.dontStrip = true;
+              hydra-node.dontStrip = false;
+              hydra-tui.dontStrip = false;
+              hydraw.dontStrip = false;
             };
           }
           # Use different static libs on darwin
@@ -92,11 +89,6 @@
           # Add etcd as build dependency of hydra-node (template haskell embedding not tracked by cabal)
           {
             packages.hydra-node.components.library.build-tools = [ pkgs.etcd ];
-          }
-          {
-            packages.hydra-node.components.exes.hydra-node.preCheck = ''
-              export HOME=$(mktemp -d)
-            '';
           }
         ];
       };


### PR DESCRIPTION
We've been encountering a persistent issue when running the `hydra-node` demo on macOS with Apple Silicon (aarch64-darwin). The seed-devnet process was consistently failing with a `Killed: 9` error.

The root cause of this issue was related to how the hydra-node executable was being linked on macOS. The dynamic linker (dyld) was unable to find the required shared libraries at runtime, which caused the operating system to terminate the process.

Initially, I suspected aa code signing issue (which apparently is a common cause for these types of errors on aarch64-darwin, as googling suggested). But in the end, the problem was with the library search paths embedded in the executable.

### Solution

The fix involved modifying the Nix build process to set the runtime search paths for its library dependencies correctly. This is done by using the `install_name_tool` command in the `postFixup` phase of the Nix derivation.

Now it all seems to work (tested on my Mac machine).

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
