### PR TITLE
Reduce AckSn spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 As a minor extension, we also keep a semantic version for the `UNRELEASED`
 changes.
 
+## [0.22.4] - UNRELEASED
+
+- Ignore snapshot signatures of already confirmed snapshots. This was previously
+  resulting in the node waiting for the accompanying snapshot request and
+  occurred when running heads with mirror nodes.
+
 ## [0.22.3] - 2025-07-21
 
 * Change behavior of `Hydra.Network.Etcd` to fallback to earliest possible

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               hydra-node
-version:            0.22.3
+version:            0.22.4
 synopsis:           The Hydra node
 author:             IOG
 copyright:          2022 IOG

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -647,6 +647,11 @@ onOpenNetworkAckSn Environment{party} openState otherParty snapshotSignature sn 
 
   waitOnSeenSnapshot continue =
     case seenSnapshot of
+      -- NOTE: Ignore any redundant AckSn for snapshots we have already seen as
+      -- confirmed. This is for example happening if a party runs multiple
+      -- instances of hydra-node using the same keys.
+      LastSeenSnapshot{lastSeen}
+        | sn <= lastSeen -> noop
       SeenSnapshot snapshot sigs
         | seenSn == sn -> continue snapshot sigs
       _ -> wait WaitOnSeenSnapshot

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -46,6 +46,7 @@ import Hydra.HeadLogic (
   WaitReason (..),
   aggregateState,
   cause,
+  noop,
   update,
  )
 import Hydra.HeadLogic.State (SeenSnapshot (..), getHeadParameters)
@@ -63,7 +64,7 @@ import Hydra.Tx.Crypto (aggregate, generateSigningKey, sign)
 import Hydra.Tx.Crypto qualified as Crypto
 import Hydra.Tx.HeadParameters (HeadParameters (..))
 import Hydra.Tx.IsTx (IsTx (..))
-import Hydra.Tx.Party (Party (..))
+import Hydra.Tx.Party (Party (..), deriveParty)
 import Hydra.Tx.Snapshot (ConfirmedSnapshot (..), Snapshot (..), SnapshotNumber, SnapshotVersion, getSnapshot)
 import Test.Hydra.Node.Fixture qualified as Fixture
 import Test.Hydra.Tx.Fixture (alice, aliceSk, bob, bobSk, carol, carolSk, deriveOnChainId, testHeadId, testHeadSeed)
@@ -389,6 +390,21 @@ spec =
           `shouldSatisfy` \case
             Error (RequireFailed SnapshotAlreadySigned{receivedSignature}) -> receivedSignature == carol
             _ -> False
+
+      it "ignores valid AckSn if snapshot already confirmed" $ do
+        let reqSn = receiveMessage $ ReqSn 0 1 [] Nothing Nothing
+            snapshot1 = Snapshot testHeadId 0 1 [] mempty Nothing Nothing
+            ackFrom sk = receiveMessageFrom (deriveParty sk) $ AckSn (sign sk snapshot1) 1
+
+        s0 <- runHeadLogic bobEnv ledger (inOpenState threeParties) $ do
+          step reqSn
+          step (ackFrom carolSk)
+          step (ackFrom bobSk)
+          step (ackFrom aliceSk)
+          getState
+
+        update bobEnv ledger s0 (ackFrom carolSk)
+          `shouldBe` noop
 
       it "rejects snapshot request with transaction not applicable to previous snapshot" $ do
         let reqTx42 = receiveMessage $ ReqTx (SimpleTx 42 mempty (utxoRef 1))


### PR DESCRIPTION
Ignores valid `AckSn` messages in case we have seen the acknowledged snapshot already as confirmed.

This was discovered when running so-called "mirror nodes" where a counter-party runs multiple `hydra-node` instances with the same set of keys.

---

* [x] CHANGELOG updated
* [x] Documentation update not needed
* [x] Haddocks update not needed
* [x] No new TODOs introduced