### PR TITLE
Hotfix Checkpoint handling of API server projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ changes.
 
 ## [0.22.4] - UNRELEASED
 
+- Fix API not correctly handling event log rotation. This was evident in not
+  being able to use `/commit` although the head is initializing or outdated
+  information in the `Greetings` message.
+
 - Ignore snapshot signatures of already confirmed snapshots. This was previously
   resulting in the node waiting for the accompanying snapshot request and
   occurred when running heads with mirror nodes.

--- a/hydra-node/src/Hydra/API/WSServer.hs
+++ b/hydra-node/src/Hydra/API/WSServer.hs
@@ -40,12 +40,11 @@ import Hydra.Chain.ChainState (
   IsChainState,
  )
 import Hydra.Chain.Direct.State ()
-import Hydra.HeadLogic (ClosedState (ClosedState, readyToFanoutSent), HeadState, StateChanged)
+import Hydra.HeadLogic (ClosedState (ClosedState, readyToFanoutSent), HeadState, InitialState (..), OpenState (..), StateChanged)
 import Hydra.HeadLogic.State qualified as HeadState
 import Hydra.Logging (Tracer, traceWith)
 import Hydra.NetworkVersions qualified as NetworkVersions
 import Hydra.Tx (Party)
-import Hydra.Tx.HeadId (HeadId (..))
 import Network.WebSockets (
   PendingConnection (pendingRequest),
   RequestHead (..),
@@ -66,13 +65,11 @@ wsApp ::
   (ClientInput tx -> IO ()) ->
   -- | Read model to enhance 'Greetings' messages with 'HeadStatus'.
   Projection STM.STM (StateChanged tx) (HeadState tx) ->
-  -- | Read model to enhance 'Greetings' messages with 'HeadId'.
-  Projection STM.STM (StateChanged tx) (Maybe HeadId) ->
   TChan (Either (TimedServerOutput tx) (ClientMessage tx)) ->
   ServerOutputFilter tx ->
   PendingConnection ->
   IO ()
-wsApp party tracer history callback headStateP headIdP responseChannel ServerOutputFilter{txContainsAddr} pending = do
+wsApp party tracer history callback headStateP responseChannel ServerOutputFilter{txContainsAddr} pending = do
   traceWith tracer NewAPIConnection
   let path = requestPath $ pendingRequest pending
   queryParams <- uriQuery <$> mkURIBs path
@@ -95,20 +92,18 @@ wsApp party tracer history callback headStateP headIdP responseChannel ServerOut
   -- client.
   forwardGreetingOnly config con = do
     headState <- atomically getLatest
-    hydraHeadId <- atomically getLatestHeadId
     sendTextData con $
       handleUtxoInclusion config (atKey "snapshotUtxo" .~ Nothing) $
         Aeson.encode
           Greetings
             { me = party
             , headStatus = getHeadStatus headState
-            , hydraHeadId
+            , hydraHeadId = getHeadId headState
             , snapshotUtxo = getSnapshotUtxo headState
             , hydraNodeVersion = showVersion NetworkVersions.hydraNodeVersion
             }
 
   Projection{getLatest} = headStateP
-  Projection{getLatest = getLatestHeadId} = headIdP
 
   mkServerOutputConfig qp =
     ServerOutputConfig
@@ -176,12 +171,16 @@ wsApp party tracer history callback headStateP headIdP responseChannel ServerOut
         WithAddressedTx addr -> txContainsAddr tx addr
         WithoutAddressedTx -> True
 
--- | Get the content of 'headStatus' field in 'Greetings' message from the full 'HeadState'.
-getHeadStatus :: HeadState tx -> HeadStatus
-getHeadStatus = \case
-  HeadState.Idle{} -> Idle
-  HeadState.Initial{} -> Initializing
-  HeadState.Open{} -> Open
-  HeadState.Closed ClosedState{readyToFanoutSent}
-    | readyToFanoutSent -> FanoutPossible
-    | otherwise -> Closed
+  getHeadStatus = \case
+    HeadState.Idle{} -> Idle
+    HeadState.Initial{} -> Initializing
+    HeadState.Open{} -> Open
+    HeadState.Closed ClosedState{readyToFanoutSent}
+      | readyToFanoutSent -> FanoutPossible
+      | otherwise -> Closed
+
+  getHeadId = \case
+    HeadState.Idle{} -> Nothing
+    HeadState.Initial InitialState{headId} -> Just headId
+    HeadState.Open OpenState{headId} -> Just headId
+    HeadState.Closed ClosedState{headId} -> Just headId


### PR DESCRIPTION
The projections in the API server were not correctly handing `Checkpoint` events (introduced with event log rotation).

I tried to create a regression test, but we don't have a `Gen [StateChanged tx]` generators that honors the constraints required for `aggregate` so I could not get hold of an expected list of `StateChanged` events with a consistent `Checkpoint` to do property testing.

The whole `Projection` business is a bit contrived since we have the full `StateChanged` event stream available (the API server is now an `EventSink`). As we are also not needing to track changes onto the projected values (resource-specific websockets / subscriptions would require that), we should consider dropping the whole mechanism and just stick with a `getHeadState :: STM (HeadState tx)` + getter functions (or lenses) to acquire the relevant things in the HTTP and WS API.

This PR though is a hotfix and I kept the diff to a minimum (especially as its not covered by tests!)

---

* [x] CHANGELOG updated
* [x] Documentation update not needed
* [x] Haddocks updated
* [ ] No new TODOs introduced
  - An XXX note on the same as above