### PR TITLE
Fix rotation log id after restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,12 @@ changes.
 
 - Tested with `cardano-node 10.4.1` and `cardano-cli 10.8.0.0`.
 
-- Fix rotation log id after restart.
+Fix rotation log id consistency after restart by changing the rotation check to trigger only
+when the number of persisted `StateChanged` events exceeds the configured `--persistence-rotate-after` threshold.
+  * This also prevents immediate rotation on startup when the threshold is set to 1.
+  * `Checkpoint` event ids now match the suffix of their preceding rotated log file and the last `StateChanged` event id within it,
+  preserving sequential order and making it easier to identify which rotated log file was used to compute it.
+
 
 ## [0.22.2] - 2025.06.30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ changes.
 
 - Tested with `cardano-node 10.4.1` and `cardano-cli 10.8.0.0`.
 
+- Fix rotation log id after restart.
+
 ## [0.22.2] - 2025.06.30
 
 * Fix wrong hydra-script-tx-ids in networks.json

--- a/docs/docs/dev/architecture/event-sourcing.md
+++ b/docs/docs/dev/architecture/event-sourcing.md
@@ -45,9 +45,12 @@ Event log rotation was introduced to improve recovery times by reducing the numb
 
 Only rotated log files are saved with an incrementing `logId` suffix in their names, while the main `state` log file remains unchanged to preserve backward compatibility. This `logId` suffix corresponds to the ID of the last event included in that file.
 Rotation can be enabled via the optional `--persistence-rotate-after` command-line argument, which specifies the number of events after which rotation should occur.
-> For example, with `--persistence-rotate-after 100`, you’ll get rotated files named: state-99, state-199, state-299, and so on, each containing 100 events. This is because event IDs start at 0.
+> For example, with `--persistence-rotate-after 100`, you’ll get rotated files named: state-100, state-200, state-300, and so on, each containing 101 events. This is because event IDs start at 0, so state-100 includes 101 state changed events (0–100) without a checkpoint. Subsequent rotated files include a checkpoint plus 100 new state changed events.
 
-Note that, depending on the rotation configuration used, the current `state` file may already contain more events than the specified threshold, causing a rotation to occur immediately on startup before any new inputs are processed.
+Note that a checkpoint event id matches the last persisted event id from the previous rotated log file, preserving the sequential order of event ids across logs.
+This also makes it easier to identify which rotated log file was used to compute the checkpoint, as its event id matches the file name suffix.
+
+Depending on the rotation configuration used, the current `state` file may already contain more events than the specified threshold, causing a rotation to occur immediately on startup before any new inputs are processed.
 
 Upon rotation, a server output is produced to notify external agents when a checkpoint occurs, allowing them to perform archival or cleanup actions without interrupting the Hydra Head.
 

--- a/hydra-cluster/src/Hydra/Cluster/Options.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Options.hs
@@ -10,6 +10,7 @@ import Hydra.Options (persistenceRotateAfterParser)
 import Hydra.Prelude
 import Options.Applicative (Parser, eitherReader, flag, flag', help, long, metavar, strOption)
 import Options.Applicative.Builder (option)
+import Test.QuickCheck (Positive)
 
 data Options = Options
   { knownNetwork :: Maybe KnownNetwork
@@ -17,7 +18,7 @@ data Options = Options
   , publishHydraScripts :: PublishOrReuse
   , useMithril :: UseMithril
   , scenario :: Scenario
-  , persistenceRotateAfter :: Maybe Natural
+  , persistenceRotateAfter :: Maybe (Positive Natural)
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (ToJSON)

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -154,7 +154,7 @@ import System.FilePath ((</>))
 import System.Process (callProcess)
 import Test.Hydra.Tx.Fixture (testNetworkId)
 import Test.Hydra.Tx.Gen (genDatum, genKeyPair, genTxOutWithReferenceScript)
-import Test.QuickCheck (choose, elements, generate)
+import Test.QuickCheck (Positive, choose, elements, generate)
 
 data EndToEndLog
   = ClusterOptions {options :: Options}
@@ -501,7 +501,7 @@ singlePartyOpenAHead ::
   FilePath ->
   backend ->
   [TxId] ->
-  Maybe Natural ->
+  Maybe (Positive Natural) ->
   -- | Continuation called when the head is open
   (HydraClient -> SigningKey PaymentKey -> HeadId -> IO a) ->
   IO a

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -108,7 +108,7 @@ import System.FilePath ((</>))
 import Test.Hydra.Cluster.Utils (chainPointToSlot)
 import Test.Hydra.Tx.Fixture (testNetworkId)
 import Test.Hydra.Tx.Gen (genKeyPair, genUTxOFor)
-import Test.QuickCheck (generate)
+import Test.QuickCheck (Positive (..), generate)
 import Prelude qualified
 
 allNodeIds :: [Int]
@@ -206,7 +206,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
 
         -- Measure restart after rotation
         options <- prepareHydraNode offlineConfig tmpDir 1 aliceSk [] [] id
-        let options' = options{persistenceRotateAfter = Just 10}
+        let options' = options{persistenceRotateAfter = Just (Positive 10)}
         t1 <- getCurrentTime
         diff2 <- withPreparedHydraNode (contramap FromHydraNode tracer) tmpDir 1 options' $ \_ -> do
           t2 <- getCurrentTime

--- a/hydra-node/src/Hydra/Events/Rotation.hs
+++ b/hydra-node/src/Hydra/Events/Rotation.hs
@@ -6,8 +6,9 @@ import Conduit (MonadUnliftIO, runConduit, runResourceT, (.|))
 import Control.Concurrent.Class.MonadSTM (modifyTVar', newTVarIO, readTVarIO, writeTVar)
 import Data.Conduit.Combinators qualified as C
 import Hydra.Events (EventId, EventSink (..), EventSource (..), HasEventId (..))
+import Test.QuickCheck (Positive (..))
 
-newtype RotationConfig = RotateAfter Natural
+newtype RotationConfig = RotateAfter (Positive Natural)
 
 type LogId = EventId
 
@@ -52,7 +53,7 @@ newRotatedEventStore config s0 aggregator checkpointer eventStore = do
         rotate = const . const $ pure ()
       }
  where
-  RotateAfter rotateAfterX = config
+  RotateAfter (Positive rotateAfterX) = config
 
   aggregateEvents (!n, !_evId, !acc) e = (n + 1, getEventId e, aggregator acc e)
 

--- a/hydra-node/src/Hydra/Events/Rotation.hs
+++ b/hydra-node/src/Hydra/Events/Rotation.hs
@@ -66,9 +66,7 @@ newRotatedEventStore config s0 aggregator checkpointer eventStore = do
       -- aggregate new state
       modifyTVar' aggregateStateV (`aggregator` event)
       -- bump numberOfEvents
-      numberOfEvents <- readTVar numberOfEventsV
-      let numberOfEvents' = numberOfEvents + 1
-      writeTVar numberOfEventsV numberOfEvents'
+      modifyTVar' numberOfEventsV (+ 1)
     -- check rotation
     whenM (shouldRotate numberOfEventsV) $ do
       let eventId = getEventId event

--- a/hydra-node/src/Hydra/Events/Rotation.hs
+++ b/hydra-node/src/Hydra/Events/Rotation.hs
@@ -58,7 +58,10 @@ newRotatedEventStore config s0 aggregator checkpointer eventStore = do
 
   shouldRotate numberOfEventsV = do
     currentNumberOfEvents <- readTVarIO numberOfEventsV
-    pure $ currentNumberOfEvents >= rotateAfterX
+    -- since rotateAfterX can be any positive number (including 1),
+    -- we use (>) instead of (>=) to avoid triggering a rotation immediately after a checkpoint,
+    -- which would lead to an infinite loop
+    pure $ currentNumberOfEvents > rotateAfterX
 
   rotatedPutEvent numberOfEventsV aggregateStateV event = do
     putEvent event
@@ -73,14 +76,18 @@ newRotatedEventStore config s0 aggregator checkpointer eventStore = do
       rotateEventLog numberOfEventsV aggregateStateV eventId
 
   rotateEventLog numberOfEventsV aggregateStateV lastEventId = do
-    -- build checkpoint event
+    -- build the checkpoint event
     now <- getCurrentTime
     aggregateState <- readTVarIO aggregateStateV
-    let checkpoint = checkpointer aggregateState (lastEventId + 1) now
-    -- rotate with checkpoint
+    -- the checkpoint has the same event id as the last event persisted
+    let checkpoint = checkpointer aggregateState lastEventId now
+    -- the rotated log file name suffix (logId) matches the last event persisted,
+    -- while the checkpoint event is appended to the new (current) state log file
     rotate lastEventId checkpoint
-    -- clear numberOfEvents + bump logId
+    -- reset `numberOfEvents` to 1 because
+    -- the checkpoint event was just appended during rotation
+    -- and will be sourced from the event store on restart
     atomically $ do
-      writeTVar numberOfEventsV 0
+      writeTVar numberOfEventsV 1
 
   EventStore{eventSource, eventSink = EventSink{putEvent}, rotate} = eventStore

--- a/hydra-node/test/Hydra/Events/RotationSpec.hs
+++ b/hydra-node/test/Hydra/Events/RotationSpec.hs
@@ -43,7 +43,7 @@ spec = parallel $ do
           eventStore <- createMockEventStore
           -- NOTE: because there will be 5 inputs processed in total,
           -- this is hardcoded to ensure we get a checkpoint + a single event at the end
-          let rotationConfig = RotateAfter 3
+          let rotationConfig = RotateAfter (Positive 3)
           let s0 = Idle IdleState{chainState = SimpleChainState{slot = ChainSlot 0}}
           rotatingEventStore <- newRotatedEventStore rotationConfig s0 mkAggregator mkCheckpoint eventStore
           testHydrate rotatingEventStore []
@@ -57,7 +57,7 @@ spec = parallel $ do
           eventStore <- createMockEventStore
           -- NOTE: because there will be 6 inputs processed in total,
           -- this is hardcoded to ensure we get a single checkpoint event at the end
-          let rotationConfig = RotateAfter 1
+          let rotationConfig = RotateAfter (Positive 1)
           let s0 = Idle IdleState{chainState = SimpleChainState{slot = ChainSlot 0}}
           rotatingEventStore <- newRotatedEventStore rotationConfig s0 mkAggregator mkCheckpoint eventStore
           testHydrate rotatingEventStore []
@@ -85,7 +85,7 @@ spec = parallel $ do
           eventStore <- createMockEventStore
           -- NOTE: because there will be 6 inputs processed in total,
           -- this is hardcoded to ensure we get a single checkpoint event at the end
-          let rotationConfig = RotateAfter 1
+          let rotationConfig = RotateAfter (Positive 1)
           -- run rotated event store with prepared inputs
           let s0 = Idle IdleState{chainState = SimpleChainState{slot = ChainSlot 0}}
           rotatingEventStore <- newRotatedEventStore rotationConfig s0 mkAggregator mkCheckpoint eventStore
@@ -116,7 +116,7 @@ spec = parallel $ do
           let s0 = Idle IdleState{chainState = SimpleChainState{slot = ChainSlot 0}}
           -- NOTE: because there will be 6 inputs processed in total,
           -- this is hardcoded to ensure we get a single checkpoint event at the end
-          let rotationConfig = RotateAfter 1
+          let rotationConfig = RotateAfter (Positive 1)
           -- run restarted node with prepared inputs
           eventStore <- createMockEventStore
           rotatingEventStore1 <- newRotatedEventStore rotationConfig s0 mkAggregator mkCheckpoint eventStore
@@ -153,7 +153,7 @@ spec = parallel $ do
         mapM_ (putEvent eventSink) events
         unrotatedHistory <- getEvents eventSource
         toInteger (length unrotatedHistory) `shouldBe` totalEvents
-        let rotationConfig = RotateAfter x
+        let rotationConfig = RotateAfter (Positive x)
         let s0 :: [TrivialEvent]
             s0 = []
         let aggregator :: [TrivialEvent] -> TrivialEvent -> [TrivialEvent]
@@ -171,7 +171,7 @@ spec = parallel $ do
     prop "rotates after configured number of events" $
       \(Positive x, Positive y) -> do
         mockEventStore <- createMockEventStore
-        let rotationConfig = RotateAfter x
+        let rotationConfig = RotateAfter (Positive x)
         let s0 :: [TrivialEvent]
             s0 = []
         let aggregator :: [TrivialEvent] -> TrivialEvent -> [TrivialEvent]
@@ -195,7 +195,7 @@ spec = parallel $ do
       \(Positive y, Positive delta) -> do
         let x = y + delta
         mockEventStore <- createMockEventStore
-        let rotationConfig = RotateAfter x
+        let rotationConfig = RotateAfter (Positive x)
         let s0 :: [TrivialEvent]
             s0 = []
         let aggregator :: [TrivialEvent] -> TrivialEvent -> [TrivialEvent]
@@ -212,7 +212,7 @@ spec = parallel $ do
         trivialCheckpoint expectRotated `shouldBe` List.head currentHistory
 
     prop "a restarted and non-restarted store have consistent rotation" $
-      \(Positive x, ChunkedEvents chunks) -> do
+      \(x, ChunkedEvents chunks) -> do
         let rotationConfig = RotateAfter x
         let s0 :: [TrivialEvent]
             s0 = []

--- a/hydra-node/test/Hydra/Events/RotationSpec.hs
+++ b/hydra-node/test/Hydra/Events/RotationSpec.hs
@@ -40,7 +40,8 @@ spec = parallel $ do
       it "rotates while running" $ \testHydrate -> do
         failAfter 1 $ do
           eventStore <- createMockEventStore
-          -- NOTE: this is hardcoded to ensure we get a checkpoint + a single event at the end
+          -- NOTE: because there will be 5 inputs processed in total,
+          -- this is hardcoded to ensure we get a checkpoint + a single event at the end
           let rotationConfig = RotateAfter 4
           let s0 = Idle IdleState{chainState = SimpleChainState{slot = ChainSlot 0}}
           rotatingEventStore <- newRotatedEventStore rotationConfig s0 mkAggregator mkCheckpoint eventStore
@@ -53,7 +54,8 @@ spec = parallel $ do
       it "consistent state after restarting with rotation" $ \testHydrate -> do
         failAfter 1 $ do
           eventStore <- createMockEventStore
-          -- NOTE: this is hardcoded to ensure we get a single checkpoint event at the end
+          -- NOTE: because there will be 6 inputs processed in total,
+          -- this is hardcoded to ensure we get a single checkpoint event at the end
           let rotationConfig = RotateAfter 3
           let s0 = Idle IdleState{chainState = SimpleChainState{slot = ChainSlot 0}}
           rotatingEventStore <- newRotatedEventStore rotationConfig s0 mkAggregator mkCheckpoint eventStore
@@ -81,7 +83,8 @@ spec = parallel $ do
         failAfter 1 $
           do
             eventStore <- createMockEventStore
-            -- NOTE: this is hardcoded to ensure we get a single checkpoint event at the end
+            -- NOTE: because there will be 6 inputs processed in total,
+            -- this is hardcoded to ensure we get a single checkpoint event at the end
             let rotationConfig = RotateAfter 3
             -- run rotated event store with prepared inputs
             let s0 = Idle IdleState{chainState = SimpleChainState{slot = ChainSlot 0}}
@@ -107,16 +110,17 @@ spec = parallel $ do
         let contestationDeadline = toNominalDiffTime cperiod `addUTCTime` now
         let closeInput = observationInput $ OnCloseTx testHeadId 0 contestationDeadline
         let inputs = inputsToOpenHead ++ [closeInput]
+        let inputs1 = take 3 inputs
+        let inputs2 = drop 3 inputs
         failAfter 1 $
           do
-            -- NOTE: this is hardcoded to ensure we get a single checkpoint event at the end
-            let rotationConfig = RotateAfter 3
             let s0 = Idle IdleState{chainState = SimpleChainState{slot = ChainSlot 0}}
+            -- NOTE: because there will be 6 inputs processed in total,
+            -- this is hardcoded to ensure we get a single checkpoint event at the end
+            let rotationConfig = RotateAfter 3
             -- run restarted node with prepared inputs
             eventStore <- createMockEventStore
             rotatingEventStore1 <- newRotatedEventStore rotationConfig s0 mkAggregator mkCheckpoint eventStore
-            let inputs1 = take 3 inputs
-            let inputs2 = drop 3 inputs
             testHydrate rotatingEventStore1 []
               >>= notConnect
               >>= primeWith inputs1

--- a/hydra-node/test/Hydra/OptionsSpec.hs
+++ b/hydra-node/test/Hydra/OptionsSpec.hs
@@ -197,6 +197,16 @@ spec = parallel $
                   )
             }
 
+    it "parses --persistence-rotate-after option as a positive number" $ do
+      let defaultWithRotateAfter rotateAfterX =
+            Run
+              defaultRunOptions
+                { persistenceRotateAfter = Just rotateAfterX
+                }
+      shouldNotParse ["--persistence-rotate-after", "-1"]
+      shouldNotParse ["--persistence-rotate-after", "0"]
+      ["--persistence-rotate-after", "1"] `shouldParse` defaultWithRotateAfter 1
+
     it "parses --contestation-period option as a number of seconds" $ do
       let defaultWithContestationPeriod contestationPeriod =
             Run

--- a/hydra-node/test/Hydra/OptionsSpec.hs
+++ b/hydra-node/test/Hydra/OptionsSpec.hs
@@ -42,7 +42,7 @@ import Hydra.Options (
   validateRunOptions,
  )
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
-import Test.QuickCheck (Property, chooseEnum, counterexample, forAll, property, vectorOf, (===))
+import Test.QuickCheck (Positive (..), Property, chooseEnum, counterexample, forAll, property, vectorOf, (===))
 import Text.Regex.TDFA ((=~))
 
 spec :: Spec
@@ -205,7 +205,7 @@ spec = parallel $
                 }
       shouldNotParse ["--persistence-rotate-after", "-1"]
       shouldNotParse ["--persistence-rotate-after", "0"]
-      ["--persistence-rotate-after", "1"] `shouldParse` defaultWithRotateAfter 1
+      ["--persistence-rotate-after", "1"] `shouldParse` defaultWithRotateAfter (Positive 1)
 
     it "parses --contestation-period option as a number of seconds" $ do
       let defaultWithContestationPeriod contestationPeriod =


### PR DESCRIPTION
<!-- Describe your change here -->

After rotation, we now reset the number of events to 1 (not 0),
because the checkpoint event is sourced on restart. This avoids
a mismatch between the rotation check on startup and during normal operation.
That discrepancy was the cause of inconsistent rotation log ids after restarts.

Also, we changed the rotation condition to use (>) instead of (>=),
preventing a follow up rotation on start up when the configured threshold is 1
(since checkpointing would immediately trigger a new rotation).

Lastly, a checkpoint event id now matches the last persisted event id
from its preceding rotated log file, preserving sequential order of event ids across logs.

This also makes it easier to identify which rotated log file was used to compute the checkpoint,
as its event id matches the file name suffix.

---

<!-- Consider each and tick it off one way or the other -->
* [X] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
