### PR TITLE
Timeout and retry broadcast after 3 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ changes.
 - Fix an internal persistent queue blocking after restart when it reached
   capacity.
 
+- Timeout and retry broadcast of network messages after 3 seconds in case the
+  `etcd` grpc server is not responsive. This should avoid build-up on the
+  outbound persistent queue.
+
 - Handle failing lease keep alive in network component and avoid bursts in
   heartbeating.
 


### PR DESCRIPTION
Client-side timeout of grpc to `put` messages to the etcd cluster. Blocking without a timeout on this is the only explanation we could find to see the `pending-broadcast` queue fill up.

---

* [x] CHANGELOG updated
* [x] Documentation update not needed
* [x] Haddocks update not needed
* [x] No new TODOs introduced