### PR TITLE
Fix tutorial installation steps for macos

### DIFF
--- a/docs/docs/tutorial/index.md
+++ b/docs/docs/tutorial/index.md
@@ -77,8 +77,8 @@ unzip -d bin hydra-aarch64-darwin-${hydra_version}.zip
 
 cardano_node_version=10.4.1
 curl -L -O https://github.com/IntersectMBO/cardano-node/releases/download/${cardano_node_version}/cardano-node-${cardano_node_version}-macos.tar.gz
-tar xf cardano-node-${cardano_node_version}-macos.tar.gz --wildcards ./bin/cardano-node ./bin/cardano-cli './bin/*.dylib'
-tar xf cardano-node-${cardano_node_version}-macos.tar.gz ./share/preprod --strip-components=3
+tar xf cardano-node-${cardano_node_version}-macos.tar.gz ./bin/cardano-node ./bin/cardano-cli './bin/*.dylib'
+tar xf cardano-node-${cardano_node_version}-macos.tar.gz --strip-components=3 ./share/preprod/
 
 curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-client -d latest -p bin
 


### PR DESCRIPTION
<!-- Describe your change here -->

macOS uses BSD tar, which has slightly different behavior or flag handling compared to GNU tar.
This fix ensures that the cardano-node extraction work seamlessly on macOS.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
