### PR TITLE
Label threads, queues and vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ when the number of persisted `StateChanged` events exceeds the configured `--per
   * `Checkpoint` event ids now match the suffix of their preceding rotated log file and the last `StateChanged` event id within it,
   preserving sequential order and making it easier to identify which rotated log file was used to compute it.
 
+- Label threads, queues and vars.
 
 ## [0.22.2] - 2025-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ changes.
 
 - **BREAKING** Rename `--script-info` option to `--hydra-script-catalogue` in the `hydra-node` CLI.
 
-Fix rotation log id consistency after restart by changing the rotation check to trigger only
+- Fix rotation log id consistency after restart by changing the rotation check to trigger only
 when the number of persisted `StateChanged` events exceeds the configured `--persistence-rotate-after` threshold.
   * This also prevents immediate rotation on startup when the threshold is set to 1.
   * `Checkpoint` event ids now match the suffix of their preceding rotated log file and the last `StateChanged` event id within it,

--- a/hydra-chain-observer/src/Hydra/Blockfrost/ChainObserver.hs
+++ b/hydra-chain-observer/src/Hydra/Blockfrost/ChainObserver.hs
@@ -11,7 +11,6 @@ import Blockfrost.Client (
 import Blockfrost.Client qualified as Blockfrost
 import Control.Concurrent.Class.MonadSTM (
   MonadSTM (readTVarIO),
-  newTVarIO,
   writeTVar,
  )
 import Control.Retry (RetryPolicyM, RetryStatus, constantDelay, retrying)
@@ -96,7 +95,7 @@ blockfrostClient tracer projectPath blockConfirmations = do
 
           let blockHash = fromChainPoint chainPoint genesisBlockHash
 
-          stateTVar <- newTVarIO (blockHash, mempty)
+          stateTVar <- newLabelledTVarIO "blockfrost-client-state" (blockHash, mempty)
           void $
             retrying (retryPolicy blockTime) shouldRetry $ \_ -> do
               loop tracer prj networkId blockTime observerHandler blockConfirmations stateTVar

--- a/hydra-cluster/src/CardanoNode.hs
+++ b/hydra-cluster/src/CardanoNode.hs
@@ -322,7 +322,9 @@ withCardanoNode tr stateDirectory args action = do
     withCreateProcess process{std_out = UseHandle out, std_err = CreatePipe} $
       \_stdin _stdout mError processHandle ->
         (`finally` cleanupSocketFile) $
-          race (checkProcessHasNotDied "cardano-node" processHandle mError) waitForNode
+          raceLabelled
+            ("check-cardano-node-process-not-died", checkProcessHasNotDied "cardano-node" processHandle mError)
+            ("wait-for-node", waitForNode)
             <&> either absurd id
  where
   CardanoNodeArgs{nodeSocket} = args

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -1896,9 +1896,9 @@ threeNodesWithMirrorParty tracer workDir backend hydraScriptsTxId = do
         -- N1 & N3 commit the same thing at the same time
         -- XXX: one will fail but the head will still open
         aliceUTxO <- seedFromFaucet backend aliceCardanoVk 1_000_000 (contramap FromFaucet tracer)
-        race_
-          (requestCommitTx n1 aliceUTxO >>= Backend.submitTransaction backend)
-          (requestCommitTx n3 aliceUTxO >>= Backend.submitTransaction backend)
+        raceLabelled_
+          ("request-commit-tx-n1", requestCommitTx n1 aliceUTxO >>= Backend.submitTransaction backend)
+          ("request-commit-tx-n3", requestCommitTx n3 aliceUTxO >>= Backend.submitTransaction backend)
 
         -- N2 commits something
         bobUTxO <- seedFromFaucet backend bobCardanoVk 1_000_000 (contramap FromFaucet tracer)

--- a/hydra-cluster/test/Test/BlockfrostChainSpec.hs
+++ b/hydra-cluster/test/Test/BlockfrostChainSpec.hs
@@ -6,7 +6,7 @@ import Hydra.Prelude
 import Test.Hydra.Prelude
 
 import Cardano.Api.UTxO qualified as UTxO
-import Control.Concurrent.STM (newEmptyTMVarIO, takeTMVar)
+import Control.Concurrent.STM (takeTMVar)
 import Control.Concurrent.STM.TMVar (putTMVar)
 import Control.Exception (IOException)
 import Hydra.Chain (
@@ -164,7 +164,7 @@ withBlockfrostChainTest tracer config party action = do
           _ -> failure $ "unexpected chainBackendOptions: " <> show chainBackendOptions
       otherConfig -> failure $ "unexpected chainConfig: " <> show otherConfig
   ctx <- loadChainContext backend configuration party
-  eventMVar <- newEmptyTMVarIO
+  eventMVar <- newLabelledEmptyTMVarIO "blockfrost-chain-events"
 
   let callback event = atomically $ putTMVar eventMVar event
 

--- a/hydra-cluster/test/Test/ChainObserverSpec.hs
+++ b/hydra-cluster/test/Test/ChainObserverSpec.hs
@@ -11,7 +11,7 @@ import Test.Hydra.Prelude
 
 import Cardano.Api.UTxO qualified as UTxO
 import CardanoNode (NodeLog, withCardanoNodeDevnet)
-import Control.Concurrent.Class.MonadSTM (modifyTVar', newTVarIO, readTVarIO)
+import Control.Concurrent.Class.MonadSTM (modifyTVar', readTVarIO)
 import Control.Lens ((^?))
 import Data.Aeson as Aeson
 import Data.Aeson.Lens (key, _JSON, _String)
@@ -114,7 +114,7 @@ chainObserverSees observer txType headId =
 
 awaitMatch :: HasCallStack => ChainObserverHandle -> DiffTime -> (Aeson.Value -> Maybe a) -> IO a
 awaitMatch chainObserverHandle delay f = do
-  seenMsgs <- newTVarIO []
+  seenMsgs <- newLabelledTVarIO "await-match-seen-msgs" []
   timeout delay (go seenMsgs) >>= \case
     Just x -> pure x
     Nothing -> do

--- a/hydra-cluster/test/Test/DirectChainSpec.hs
+++ b/hydra-cluster/test/Test/DirectChainSpec.hs
@@ -12,7 +12,7 @@ import CardanoClient (
   waitForUTxO,
  )
 import CardanoNode (NodeLog, withCardanoNodeDevnet)
-import Control.Concurrent.STM (newEmptyTMVarIO, takeTMVar)
+import Control.Concurrent.STM (takeTMVar)
 import Control.Concurrent.STM.TMVar (putTMVar)
 import Control.Lens ((<>~))
 import Data.List.Split (splitWhen)
@@ -548,7 +548,7 @@ withDirectChainTest tracer config party action = do
           _ -> failure $ "unexpected chainBackendOptions: " <> show chainBackendOptions
       otherConfig -> failure $ "unexpected chainConfig: " <> show otherConfig
   ctx <- loadChainContext backend configuration party
-  eventMVar <- newEmptyTMVarIO
+  eventMVar <- newLabelledEmptyTMVarIO "direct-chain-events"
 
   let callback event = atomically $ putTMVar eventMVar event
 

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -676,9 +676,9 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
           withClusterTempDir $ \tmpDir -> do
             withBackend (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
               hydraScriptsTxId <- publishHydraScriptsAs backend Faucet
-              concurrently_
-                (initAndClose tmpDir tracer 0 hydraScriptsTxId backend)
-                (initAndClose tmpDir tracer 1 hydraScriptsTxId backend)
+              concurrentlyLabelled_
+                ("init-and-close-0", initAndClose tmpDir tracer 0 hydraScriptsTxId backend)
+                ("init-and-close-1", initAndClose tmpDir tracer 1 hydraScriptsTxId backend)
 
       it "alice inits a Head with incorrect keys preventing bob from observing InitTx" $ \tracer ->
         failAfter 60 $

--- a/hydra-cluster/test/Test/OfflineChainSpec.hs
+++ b/hydra-cluster/test/Test/OfflineChainSpec.hs
@@ -5,7 +5,7 @@ module Test.OfflineChainSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import Control.Concurrent.Class.MonadSTM (modifyTVar', newTChanIO, newTVarIO, readTChan, readTVarIO, writeTChan)
+import Control.Concurrent.Class.MonadSTM (modifyTVar', newTChanIO, readTChan, readTVarIO, writeTChan)
 import Control.Lens ((^?))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Lens (key, _Number)
@@ -102,7 +102,7 @@ monitorCallbacks = do
 -- XXX: Dry with the other waitMatch utilities
 waitMatch :: (HasCallStack, ToJSON a) => IO a -> DiffTime -> (a -> Maybe b) -> IO b
 waitMatch waitNext seconds match = do
-  seen <- newTVarIO []
+  seen <- newLabelledTVarIO "wait-match-seen" []
   timeout seconds (go seen) >>= \case
     Just x -> pure x
     Nothing -> do

--- a/hydra-node/exe/hydra-node/Main.hs
+++ b/hydra-node/exe/hydra-node/Main.hs
@@ -4,7 +4,7 @@ module Main where
 
 import Hydra.Prelude hiding (fromList, intercalate)
 
-import Control.Concurrent (mkWeakThreadId, myThreadId)
+import Control.Concurrent (mkWeakThreadId)
 import Control.Exception (AsyncException (UserInterrupt), throwTo)
 import Data.ByteString (intercalate)
 import GHC.Weak (deRefWeak)

--- a/hydra-node/src/Hydra/API/Projection.hs
+++ b/hydra-node/src/Hydra/API/Projection.hs
@@ -17,7 +17,7 @@ module Hydra.API.Projection where
 
 import Hydra.Prelude
 
-import Control.Concurrent.Class.MonadSTM (MonadLabelledSTM, labelTVarIO, modifyTVar', newTVarIO)
+import Control.Concurrent.Class.MonadSTM (MonadLabelledSTM, modifyTVar')
 
 -- | 'Projection' type used to alter/project the API output to suit the client needs.
 data Projection stm event model = Projection
@@ -38,8 +38,7 @@ mkProjection ::
   (model -> event -> model) ->
   m (Projection (STM m) event model)
 mkProjection lbl startingModel project = do
-  tv <- newTVarIO startingModel
-  labelTVarIO tv ("api-server-projection-" <> lbl)
+  tv <- newLabelledTVarIO ("api-server-projection-" <> lbl) startingModel
   pure
     Projection
       { getLatest = readTVar tv

--- a/hydra-node/src/Hydra/API/Projection.hs
+++ b/hydra-node/src/Hydra/API/Projection.hs
@@ -17,7 +17,7 @@ module Hydra.API.Projection where
 
 import Hydra.Prelude
 
-import Control.Concurrent.Class.MonadSTM (MonadLabelledSTM, modifyTVar')
+import Control.Concurrent.Class.MonadSTM (modifyTVar')
 
 -- | 'Projection' type used to alter/project the API output to suit the client needs.
 data Projection stm event model = Projection

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -10,7 +10,6 @@ import Conduit (mapM_C, runConduitRes, (.|))
 import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
 import Control.Concurrent.STM.TChan (newBroadcastTChanIO, writeTChan)
 import Control.Exception (IOException)
-import Control.Monad.Class.MonadFork (labelThread, myThreadId)
 import Data.Conduit.Combinators (map)
 import Data.Conduit.List (catMaybes)
 import Data.Map qualified as Map
@@ -128,8 +127,7 @@ withAPIServer config env party eventSource tracer chain pparams serverOutputFilt
             & setBeforeMainLoop notifyServerRunning
     race_
       ( do
-          tid <- myThreadId
-          labelThread tid "api-server"
+          threadLabelMe "api-server"
           traceWith tracer (APIServerStarted port)
           startServer serverSettings
             . simpleCors
@@ -150,8 +148,7 @@ withAPIServer config env party eventSource tracer chain pparams serverOutputFilt
               )
       )
       ( do
-          tid <- myThreadId
-          labelThread tid "api-server-eventsink"
+          threadLabelMe "api-server-eventsink"
           waitForServerRunning
           action
             ( EventSink

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -127,7 +127,7 @@ withAPIServer config env party eventSource tracer chain pparams serverOutputFilt
             & setBeforeMainLoop notifyServerRunning
     race_
       ( do
-          threadLabelMe "api-server"
+          labelMyThread "api-server"
           traceWith tracer (APIServerStarted port)
           startServer serverSettings
             . simpleCors
@@ -148,7 +148,7 @@ withAPIServer config env party eventSource tracer chain pparams serverOutputFilt
               )
       )
       ( do
-          threadLabelMe "api-server-eventsink"
+          labelMyThread "api-server-eventsink"
           waitForServerRunning
           action
             ( EventSink

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -125,9 +125,9 @@ withAPIServer config env party eventSource tracer chain pparams serverOutputFilt
             & setOnException (\_ e -> traceWith tracer $ APIConnectionError{reason = show e})
             & setOnExceptionResponse (responseLBS status500 [] . show)
             & setBeforeMainLoop notifyServerRunning
-    race_
-      ( do
-          labelMyThread "api-server"
+    raceLabelled_
+      ( "api-server"
+      , do
           traceWith tracer (APIServerStarted port)
           startServer serverSettings
             . simpleCors
@@ -147,8 +147,8 @@ withAPIServer config env party eventSource tracer chain pparams serverOutputFilt
                   responseChannel
               )
       )
-      ( do
-          labelMyThread "api-server-eventsink"
+      ( "api-server-eventsink"
+      , do
           waitForServerRunning
           action
             ( EventSink

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -10,6 +10,7 @@ import Conduit (mapM_C, runConduitRes, (.|))
 import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
 import Control.Concurrent.STM.TChan (newBroadcastTChanIO, writeTChan)
 import Control.Exception (IOException)
+import Control.Monad.Class.MonadFork (labelThread, myThreadId)
 import Data.Conduit.Combinators (map)
 import Data.Conduit.List (catMaybes)
 import Data.Map qualified as Map
@@ -127,6 +128,8 @@ withAPIServer config env party eventSource tracer chain pparams serverOutputFilt
             & setBeforeMainLoop notifyServerRunning
     race_
       ( do
+          tid <- myThreadId
+          labelThread tid "api-server"
           traceWith tracer (APIServerStarted port)
           startServer serverSettings
             . simpleCors
@@ -147,6 +150,8 @@ withAPIServer config env party eventSource tracer chain pparams serverOutputFilt
               )
       )
       ( do
+          tid <- myThreadId
+          labelThread tid "api-server-eventsink"
           waitForServerRunning
           action
             ( EventSink

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -99,12 +99,12 @@ withAPIServer config env party eventSource tracer chain pparams serverOutputFilt
     responseChannel <- newBroadcastTChanIO
     -- Initialize our read models from stored events
     -- NOTE: we do not keep the stored events around in memory
-    headStateP <- mkProjection (Idle $ IdleState mkChainState) aggregate
+    headStateP <- mkProjection "headStateP" (Idle $ IdleState mkChainState) aggregate
     -- XXX: We never subscribe to changes of commitInfoP et al directly so a
     -- single read model and normal functions mapping from HeadState ->
     -- CommitInfo etc. would suffice and are less fragile
-    commitInfoP <- mkProjection CannotCommit projectCommitInfo
-    pendingDepositsP <- mkProjection [] projectPendingDeposits
+    commitInfoP <- mkProjection "commitInfoP" CannotCommit projectCommitInfo
+    pendingDepositsP <- mkProjection "pendingDepositsP" [] projectPendingDeposits
     let historyTimedOutputs = sourceEvents .| map mkTimedServerOutputFromStateEvent .| catMaybes
     _ <-
       runConduitRes $

--- a/hydra-node/src/Hydra/API/WSServer.hs
+++ b/hydra-node/src/Hydra/API/WSServer.hs
@@ -9,6 +9,7 @@ import Conduit (ConduitT, ResourceT, mapM_C, runConduitRes, (.|))
 import Control.Concurrent.STM (TChan, dupTChan, readTChan)
 import Control.Concurrent.STM qualified as STM
 import Control.Lens ((.~))
+import Control.Monad.Class.MonadFork (labelThread, myThreadId)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Lens (atKey)
 import Data.Conduit.Combinators (filter)
@@ -87,7 +88,17 @@ wsApp env party tracer history callback headStateP responseChannel ServerOutputF
   forwardGreetingOnly outConfig con
 
   withPingThread con 30 (pure ()) $
-    race_ (receiveInputs con) (sendOutputs chan con outConfig)
+    race_
+      ( do
+          tid <- myThreadId
+          labelThread tid "ws-con-receive-inputs"
+          receiveInputs con
+      )
+      ( do
+          tid <- myThreadId
+          labelThread tid "ws-con-send-outputs"
+          sendOutputs chan con outConfig
+      )
  where
   -- NOTE: We will add a 'Greetings' message on each API server start. This is
   -- important to make sure the latest configured 'party' is reaching the

--- a/hydra-node/src/Hydra/Chain/Blockfrost.hs
+++ b/hydra-node/src/Hydra/Chain/Blockfrost.hs
@@ -143,13 +143,13 @@ withBlockfrostChain backend tracer config ctx wallet chainStateHistory callback 
 
   let handler = chainSyncHandler tracer callback getTimeHandle ctx localChainState
   res <-
-    race
-      ( handle onIOException $ do
-          labelMyThread "blockfrost-chain-connection"
+    raceLabelled
+      ( "blockfrost-chain-connection"
+      , handle onIOException $ do
           prj <- Blockfrost.projectFromFile projectPath
           blockfrostChain tracer queue prj chainPoint handler wallet
       )
-      (action chainHandle)
+      ("blockfrost-chain-handle", action chainHandle)
   case res of
     Left () -> error "'connectTo' cannot terminate but did?"
     Right a -> pure a

--- a/hydra-node/src/Hydra/Chain/Blockfrost.hs
+++ b/hydra-node/src/Hydra/Chain/Blockfrost.hs
@@ -145,7 +145,7 @@ withBlockfrostChain backend tracer config ctx wallet chainStateHistory callback 
   res <-
     race
       ( handle onIOException $ do
-          threadLabelMe "blockfrost-chain-connection"
+          labelMyThread "blockfrost-chain-connection"
           prj <- Blockfrost.projectFromFile projectPath
           blockfrostChain tracer queue prj chainPoint handler wallet
       )

--- a/hydra-node/src/Hydra/Chain/Blockfrost.hs
+++ b/hydra-node/src/Hydra/Chain/Blockfrost.hs
@@ -2,7 +2,7 @@ module Hydra.Chain.Blockfrost where
 
 import Hydra.Prelude
 
-import Control.Concurrent.Class.MonadSTM (MonadLabelledSTM, putTMVar, readTQueue, readTVarIO, takeTMVar, writeTQueue, writeTVar)
+import Control.Concurrent.Class.MonadSTM (putTMVar, readTQueue, readTVarIO, takeTMVar, writeTQueue, writeTVar)
 import Control.Exception (IOException)
 import Control.Retry (RetryPolicyM, constantDelay, retrying)
 import Data.ByteString.Base16 qualified as Base16

--- a/hydra-node/src/Hydra/Chain/Blockfrost.hs
+++ b/hydra-node/src/Hydra/Chain/Blockfrost.hs
@@ -2,7 +2,7 @@ module Hydra.Chain.Blockfrost where
 
 import Hydra.Prelude
 
-import Control.Concurrent.Class.MonadSTM (MonadLabelledSTM, labelTMVar, labelTVarIO, newEmptyTMVar, newTQueueIO, newTVarIO, putTMVar, readTQueue, readTVarIO, takeTMVar, writeTQueue, writeTVar)
+import Control.Concurrent.Class.MonadSTM (MonadLabelledSTM, labelTMVar, labelTQueueIO, labelTVarIO, newEmptyTMVar, newTQueueIO, newTVarIO, putTMVar, readTQueue, readTVarIO, takeTMVar, writeTQueue, writeTVar)
 import Control.Exception (IOException)
 import Control.Retry (RetryPolicyM, constantDelay, retrying)
 import Data.ByteString.Base16 qualified as Base16
@@ -124,6 +124,7 @@ withBlockfrostChain backend tracer config ctx wallet chainStateHistory callback 
   -- Last known point on chain as loaded from persistence.
   let persistedPoint = recordedAt (currentState chainStateHistory)
   queue <- newTQueueIO
+  labelTQueueIO queue "blockfrost-chain-queue"
   -- Select a chain point from which to start synchronizing
   chainPoint <- maybe (queryTip backend) pure $ do
     (max <$> startChainFrom <*> persistedPoint)

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -10,6 +10,7 @@ module Hydra.Chain.Direct (
 import Hydra.Prelude
 
 import Control.Concurrent.Class.MonadSTM (
+  labelTMVar,
   newEmptyTMVar,
   newTQueueIO,
   putTMVar,
@@ -198,6 +199,7 @@ withDirectChain backend tracer config ctx wallet chainStateHistory callback acti
   submitTx queue tx = do
     response <- atomically $ do
       response <- newEmptyTMVar
+      labelTMVar response "direct-chain-submit-tx-response"
       writeTQueue queue (tx, response)
       return response
     atomically (takeTMVar response)

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -11,6 +11,7 @@ import Hydra.Prelude
 
 import Control.Concurrent.Class.MonadSTM (
   labelTMVar,
+  labelTQueueIO,
   newEmptyTMVar,
   newTQueueIO,
   putTMVar,
@@ -144,6 +145,7 @@ withDirectChain backend tracer config ctx wallet chainStateHistory callback acti
   -- Last known point on chain as loaded from persistence.
   let persistedPoint = recordedAt (currentState chainStateHistory)
   queue <- newTQueueIO
+  labelTQueueIO queue "direct-chain-queue"
   -- Select a chain point from which to start synchronizing
   chainPoint <- maybe (queryTip backend) pure $ do
     (max <$> startChainFrom <*> persistedPoint)

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -160,14 +160,14 @@ withDirectChain backend tracer config ctx wallet chainStateHistory callback acti
 
   let handler = chainSyncHandler tracer callback getTimeHandle ctx localChainState
   res <-
-    race
-      ( handle onIOException $ do
-          labelMyThread "direct-chain-connection"
+    raceLabelled
+      ( "direct-chain-connection"
+      , handle onIOException $ do
           connectToLocalNode
             (connectInfo networkId nodeSocket)
             (clientProtocols chainPoint queue handler)
       )
-      (action chainHandle)
+      ("direct-chain-chain-handle", action chainHandle)
   case res of
     Left () -> error "'connectTo' cannot terminate but did?"
     Right a -> pure a

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -162,7 +162,7 @@ withDirectChain backend tracer config ctx wallet chainStateHistory callback acti
   res <-
     race
       ( handle onIOException $ do
-          threadLabelMe "direct-chain-connection"
+          labelMyThread "direct-chain-connection"
           connectToLocalNode
             (connectInfo networkId nodeSocket)
             (clientProtocols chainPoint queue handler)

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -20,6 +20,7 @@ import Control.Concurrent.Class.MonadSTM (
   writeTQueue,
  )
 import Control.Exception (IOException)
+import Control.Monad.Class.MonadFork (labelThread, myThreadId)
 import Hydra.Cardano.Api (
   BlockInMode (..),
   CardanoEra (..),
@@ -166,7 +167,9 @@ withDirectChain backend tracer config ctx wallet chainStateHistory callback acti
   let handler = chainSyncHandler tracer callback getTimeHandle ctx localChainState
   res <-
     race
-      ( handle onIOException $
+      ( handle onIOException $ do
+          tid <- myThreadId
+          labelThread tid "direct-chain-connection"
           connectToLocalNode
             (connectInfo networkId nodeSocket)
             (clientProtocols chainPoint queue handler)

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -12,7 +12,7 @@ import Hydra.Prelude
 import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Ledger.Core (PParams)
 import Cardano.Slotting.Slot (SlotNo (..))
-import Control.Concurrent.Class.MonadSTM (MonadLabelledSTM, labelTVarIO, modifyTVar, newTVarIO, writeTVar)
+import Control.Concurrent.Class.MonadSTM (MonadLabelledSTM, modifyTVar, writeTVar)
 import Control.Monad.Class.MonadSTM (throwSTM)
 import Data.List qualified as List
 import Hydra.Cardano.Api (
@@ -114,8 +114,7 @@ newLocalChainState ::
   ChainStateHistory tx ->
   m (LocalChainState m tx)
 newLocalChainState chainState = do
-  tv <- newTVarIO chainState
-  labelTVarIO tv "local-chain-state"
+  tv <- newLabelledTVarIO "local-chain-state" chainState
   pure
     LocalChainState
       { getLatest = getLatest tv

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -12,7 +12,7 @@ import Hydra.Prelude
 import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Ledger.Core (PParams)
 import Cardano.Slotting.Slot (SlotNo (..))
-import Control.Concurrent.Class.MonadSTM (MonadLabelledSTM, modifyTVar, writeTVar)
+import Control.Concurrent.Class.MonadSTM (modifyTVar, writeTVar)
 import Control.Monad.Class.MonadSTM (throwSTM)
 import Data.List qualified as List
 import Hydra.Cardano.Api (

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -12,7 +12,7 @@ import Hydra.Prelude
 import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Ledger.Core (PParams)
 import Cardano.Slotting.Slot (SlotNo (..))
-import Control.Concurrent.Class.MonadSTM (modifyTVar, newTVarIO, writeTVar)
+import Control.Concurrent.Class.MonadSTM (MonadLabelledSTM, labelTVarIO, modifyTVar, newTVarIO, writeTVar)
 import Control.Monad.Class.MonadSTM (throwSTM)
 import Data.List qualified as List
 import Hydra.Cardano.Api (
@@ -110,11 +110,12 @@ data LocalChainState m tx = LocalChainState
 -- | Initialize a new local chain state from a given chain state history.
 newLocalChainState ::
   forall m tx.
-  (MonadSTM m, IsChainState tx) =>
+  (IsChainState tx, MonadLabelledSTM m) =>
   ChainStateHistory tx ->
   m (LocalChainState m tx)
 newLocalChainState chainState = do
   tv <- newTVarIO chainState
+  labelTVarIO tv "local-chain-state"
   pure
     LocalChainState
       { getLatest = getLatest tv

--- a/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
@@ -65,7 +65,7 @@ import Cardano.Ledger.Shelley.API qualified as Ledger
 import Cardano.Ledger.Val (invert)
 import Cardano.Slotting.EpochInfo (EpochInfo)
 import Cardano.Slotting.Time (SystemStart (..))
-import Control.Concurrent.Class.MonadSTM (labelTVarIO, newTVarIO, readTVarIO, writeTVar)
+import Control.Concurrent.Class.MonadSTM (readTVarIO, writeTVar)
 import Control.Lens (view, (%~), (.~), (^.))
 import Data.List qualified as List
 import Data.Map.Strict ((!))
@@ -156,8 +156,7 @@ newTinyWallet ::
   IO (PParams ConwayEra) ->
   IO (TinyWallet IO)
 newTinyWallet tracer networkId (vk, sk) queryWalletInfo queryEpochInfo querySomePParams = do
-  walletInfoVar <- newTVarIO =<< initialize
-  labelTVarIO walletInfoVar "tiny-wallet"
+  walletInfoVar <- newLabelledTVarIO "tiny-wallet" =<< initialize
   let getUTxO = readTVar walletInfoVar <&> walletUTxO
   pure
     TinyWallet

--- a/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
@@ -65,7 +65,7 @@ import Cardano.Ledger.Shelley.API qualified as Ledger
 import Cardano.Ledger.Val (invert)
 import Cardano.Slotting.EpochInfo (EpochInfo)
 import Cardano.Slotting.Time (SystemStart (..))
-import Control.Concurrent.Class.MonadSTM (newTVarIO, readTVarIO, writeTVar)
+import Control.Concurrent.Class.MonadSTM (labelTVarIO, newTVarIO, readTVarIO, writeTVar)
 import Control.Lens (view, (%~), (.~), (^.))
 import Data.List qualified as List
 import Data.Map.Strict ((!))
@@ -157,6 +157,7 @@ newTinyWallet ::
   IO (TinyWallet IO)
 newTinyWallet tracer networkId (vk, sk) queryWalletInfo queryEpochInfo querySomePParams = do
   walletInfoVar <- newTVarIO =<< initialize
+  labelTVarIO walletInfoVar "tiny-wallet"
   let getUTxO = readTVar walletInfoVar <&> walletUTxO
   pure
     TinyWallet

--- a/hydra-node/src/Hydra/Chain/Offline.hs
+++ b/hydra-node/src/Hydra/Chain/Offline.hs
@@ -7,7 +7,6 @@ import Cardano.Api.Internal.GenesisParameters (fromShelleyGenesis)
 import Cardano.Ledger.Slot (unSlotNo)
 import Cardano.Slotting.Time (SystemStart (SystemStart), mkSlotLength)
 import Control.Monad.Class.MonadAsync (link)
-import Control.Monad.Class.MonadFork (labelThread, myThreadId)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Types qualified as Aeson
 import Hydra.Cardano.Api (GenesisParameters (..), ShelleyEra, ShelleyGenesis (..), Tx)
@@ -70,7 +69,7 @@ withOfflineChain ::
 withOfflineChain config party otherParties chainStateHistory callback action = do
   initializeOfflineHead
   genesis <- loadGenesisFile ledgerGenesisFile
-  withAsync (tickForever genesis callback) $ \tickThread -> do
+  withAsyncLabelled ("offline-chain-tickForever", tickForever genesis callback) $ \tickThread -> do
     link tickThread
     action chainHandle
  where
@@ -144,8 +143,6 @@ withOfflineChain config party otherParties chainStateHistory callback action = d
 
 tickForever :: GenesisParameters ShelleyEra -> (ChainEvent Tx -> IO ()) -> IO ()
 tickForever genesis callback = do
-  tid <- myThreadId
-  labelThread tid "offline-chain-tickForever"
   initialSlot <- slotNoFromUTCTime systemStart slotLength <$> getCurrentTime
   traverse_ nextTick [initialSlot ..]
  where

--- a/hydra-node/src/Hydra/Chain/Offline.hs
+++ b/hydra-node/src/Hydra/Chain/Offline.hs
@@ -7,6 +7,7 @@ import Cardano.Api.Internal.GenesisParameters (fromShelleyGenesis)
 import Cardano.Ledger.Slot (unSlotNo)
 import Cardano.Slotting.Time (SystemStart (SystemStart), mkSlotLength)
 import Control.Monad.Class.MonadAsync (link)
+import Control.Monad.Class.MonadFork (labelThread, myThreadId)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Types qualified as Aeson
 import Hydra.Cardano.Api (GenesisParameters (..), ShelleyEra, ShelleyGenesis (..), Tx)
@@ -143,6 +144,8 @@ withOfflineChain config party otherParties chainStateHistory callback action = d
 
 tickForever :: GenesisParameters ShelleyEra -> (ChainEvent Tx -> IO ()) -> IO ()
 tickForever genesis callback = do
+  tid <- myThreadId
+  labelThread tid "offline-chain-tickForever"
   initialSlot <- slotNoFromUTCTime systemStart slotLength <$> getCurrentTime
   traverse_ nextTick [initialSlot ..]
  where

--- a/hydra-node/src/Hydra/Events/FileBased.hs
+++ b/hydra-node/src/Hydra/Events/FileBased.hs
@@ -6,7 +6,7 @@ module Hydra.Events.FileBased where
 import Hydra.Prelude
 
 import Conduit (mapMC, (.|))
-import Control.Concurrent.Class.MonadSTM (labelTVarIO, newTVarIO, writeTVar)
+import Control.Concurrent.Class.MonadSTM (writeTVar)
 import Hydra.Events (EventSink (..), EventSource (..), HasEventId (..))
 import Hydra.Events.Rotation (EventStore (..))
 import Hydra.Persistence (PersistenceIncremental (..))
@@ -20,8 +20,7 @@ mkFileBasedEventStore ::
   PersistenceIncremental e IO ->
   IO (EventStore e IO)
 mkFileBasedEventStore stateDir persistence = do
-  eventIdV <- newTVarIO Nothing
-  labelTVarIO eventIdV "file-based-event-store-event-id"
+  eventIdV <- newLabelledTVarIO "file-based-event-store-event-id" Nothing
   let
     getLastSeenEventId = readTVar eventIdV
 

--- a/hydra-node/src/Hydra/Events/FileBased.hs
+++ b/hydra-node/src/Hydra/Events/FileBased.hs
@@ -6,7 +6,7 @@ module Hydra.Events.FileBased where
 import Hydra.Prelude
 
 import Conduit (mapMC, (.|))
-import Control.Concurrent.Class.MonadSTM (newTVarIO, writeTVar)
+import Control.Concurrent.Class.MonadSTM (labelTVarIO, newTVarIO, writeTVar)
 import Hydra.Events (EventSink (..), EventSource (..), HasEventId (..))
 import Hydra.Events.Rotation (EventStore (..))
 import Hydra.Persistence (PersistenceIncremental (..))
@@ -21,6 +21,7 @@ mkFileBasedEventStore ::
   IO (EventStore e IO)
 mkFileBasedEventStore stateDir persistence = do
   eventIdV <- newTVarIO Nothing
+  labelTVarIO eventIdV "file-based-event-store-event-id"
   let
     getLastSeenEventId = readTVar eventIdV
 

--- a/hydra-node/src/Hydra/Events/Rotation.hs
+++ b/hydra-node/src/Hydra/Events/Rotation.hs
@@ -3,7 +3,7 @@ module Hydra.Events.Rotation where
 import Hydra.Prelude
 
 import Conduit (MonadUnliftIO, runConduit, runResourceT, (.|))
-import Control.Concurrent.Class.MonadSTM (MonadLabelledSTM, modifyTVar', readTVarIO, writeTVar)
+import Control.Concurrent.Class.MonadSTM (modifyTVar', readTVarIO, writeTVar)
 import Data.Conduit.Combinators qualified as C
 import Hydra.Events (EventId, EventSink (..), EventSource (..), HasEventId (..))
 import Test.QuickCheck (Positive (..))

--- a/hydra-node/src/Hydra/Events/Rotation.hs
+++ b/hydra-node/src/Hydra/Events/Rotation.hs
@@ -3,7 +3,7 @@ module Hydra.Events.Rotation where
 import Hydra.Prelude
 
 import Conduit (MonadUnliftIO, runConduit, runResourceT, (.|))
-import Control.Concurrent.Class.MonadSTM (modifyTVar', newTVarIO, readTVarIO, writeTVar)
+import Control.Concurrent.Class.MonadSTM (MonadLabelledSTM, labelTVarIO, modifyTVar', newTVarIO, readTVarIO, writeTVar)
 import Data.Conduit.Combinators qualified as C
 import Hydra.Events (EventId, EventSink (..), EventSource (..), HasEventId (..))
 import Test.QuickCheck (Positive (..))
@@ -23,7 +23,7 @@ data EventStore e m
 
 -- | Creates an event store that rotates according to given config and 'StateAggregate'.
 newRotatedEventStore ::
-  (HasEventId e, MonadSTM m, MonadUnliftIO m, MonadTime m) =>
+  (HasEventId e, MonadUnliftIO m, MonadTime m, MonadLabelledSTM m) =>
   RotationConfig ->
   -- | Starting state of aggregate
   s ->
@@ -38,7 +38,9 @@ newRotatedEventStore config s0 aggregator checkpointer eventStore = do
     runResourceT . runConduit $
       sourceEvents eventSource .| C.foldl aggregateEvents (0, 0, s0)
   aggregateStateV <- newTVarIO currentAggregateState
+  labelTVarIO aggregateStateV "rotated-event-store-aggregate-state"
   numberOfEventsV <- newTVarIO currentNumberOfEvents
+  labelTVarIO numberOfEventsV "rotated-event-store-number-of-events"
   -- check rotation on startup
   whenM (shouldRotate numberOfEventsV) $ do
     rotateEventLog numberOfEventsV aggregateStateV lastEventId

--- a/hydra-node/src/Hydra/Logging.hs
+++ b/hydra-node/src/Hydra/Logging.hs
@@ -28,7 +28,6 @@ import Cardano.BM.Tracing (ToObject (..), TracingVerbosity (..))
 import Control.Concurrent.Class.MonadSTM (
   flushTBQueue,
   modifyTVar,
-  newTVarIO,
   readTBQueue,
   readTVarIO,
   writeTBQueue,
@@ -132,12 +131,12 @@ withTracerOutputTo hdl namespace action = do
 -- given 'action'. This tracer is wrapping 'msg' into an 'Envelope' with
 -- metadata.
 showLogsOnFailure ::
-  (MonadSTM m, MonadCatch m, MonadFork m, MonadTime m, MonadSay m, ToJSON msg) =>
+  (MonadLabelledSTM m, MonadCatch m, MonadFork m, MonadTime m, MonadSay m, ToJSON msg) =>
   Text ->
   (Tracer m msg -> m a) ->
   m a
 showLogsOnFailure namespace action = do
-  tvar <- newTVarIO []
+  tvar <- newLabelledTVarIO "show-logs-on-failure" []
   action (traceInTVar tvar namespace)
     `onException` (readTVarIO tvar >>= mapM_ (say . decodeUtf8 . Aeson.encode) . reverse)
 

--- a/hydra-node/src/Hydra/Logging.hs
+++ b/hydra-node/src/Hydra/Logging.hs
@@ -35,7 +35,7 @@ import Control.Concurrent.Class.MonadSTM (
   readTVarIO,
   writeTBQueue,
  )
-import Control.Monad.Class.MonadFork (myThreadId)
+import Control.Monad.Class.MonadFork (labelThread, myThreadId)
 import Control.Monad.Class.MonadSay (MonadSay, say)
 import Control.Tracer (
   Tracer (..),
@@ -120,7 +120,9 @@ withTracerOutputTo hdl namespace action = do
     Tracer $
       mkEnvelope namespace >=> liftIO . atomically . writeTBQueue queue
 
-  writeLogs queue =
+  writeLogs queue = do
+    tid <- myThreadId
+    labelThread tid "logging-writeLogs-"
     forever $ do
       atomically (readTBQueue queue) >>= write . Aeson.encode
       hFlush hdl

--- a/hydra-node/src/Hydra/Logging.hs
+++ b/hydra-node/src/Hydra/Logging.hs
@@ -27,6 +27,7 @@ import Hydra.Prelude
 import Cardano.BM.Tracing (ToObject (..), TracingVerbosity (..))
 import Control.Concurrent.Class.MonadSTM (
   flushTBQueue,
+  labelTBQueueIO,
   modifyTVar,
   newTBQueueIO,
   newTVarIO,
@@ -111,6 +112,7 @@ withTracerOutputTo ::
   IO a
 withTracerOutputTo hdl namespace action = do
   msgQueue <- newTBQueueIO @_ @(Envelope msg) defaultQueueSize
+  labelTBQueueIO msgQueue "logging-msg-queue"
   withAsync (writeLogs msgQueue) $ \_ ->
     action (tracer msgQueue) `finally` flushLogs msgQueue
  where

--- a/hydra-node/src/Hydra/Logging.hs
+++ b/hydra-node/src/Hydra/Logging.hs
@@ -27,15 +27,12 @@ import Hydra.Prelude
 import Cardano.BM.Tracing (ToObject (..), TracingVerbosity (..))
 import Control.Concurrent.Class.MonadSTM (
   flushTBQueue,
-  labelTBQueueIO,
   modifyTVar,
-  newTBQueueIO,
   newTVarIO,
   readTBQueue,
   readTVarIO,
   writeTBQueue,
  )
-import Control.Monad.Class.MonadFork (labelThread, myThreadId)
 import Control.Monad.Class.MonadSay (MonadSay, say)
 import Control.Tracer (
   Tracer (..),
@@ -111,18 +108,15 @@ withTracerOutputTo ::
   (Tracer m msg -> IO a) ->
   IO a
 withTracerOutputTo hdl namespace action = do
-  msgQueue <- newTBQueueIO @_ @(Envelope msg) defaultQueueSize
-  labelTBQueueIO msgQueue "logging-msg-queue"
-  withAsync (writeLogs msgQueue) $ \_ ->
+  msgQueue <- newLabelledTBQueueIO @_ @(Envelope msg) "logging-msg-queue" defaultQueueSize
+  withAsyncLabelled ("logging-writeLogs", writeLogs msgQueue) $ \_ ->
     action (tracer msgQueue) `finally` flushLogs msgQueue
  where
   tracer queue =
     Tracer $
       mkEnvelope namespace >=> liftIO . atomically . writeTBQueue queue
 
-  writeLogs queue = do
-    tid <- myThreadId
-    labelThread tid "logging-writeLogs-"
+  writeLogs queue =
     forever $ do
       atomically (readTBQueue queue) >>= write . Aeson.encode
       hFlush hdl

--- a/hydra-node/src/Hydra/Logging/Monitoring.hs
+++ b/hydra-node/src/Hydra/Logging/Monitoring.hs
@@ -13,7 +13,7 @@ module Hydra.Logging.Monitoring (
 
 import Hydra.Prelude
 
-import Control.Concurrent.Class.MonadSTM (MonadLabelledSTM, modifyTVar', readTVarIO)
+import Control.Concurrent.Class.MonadSTM (modifyTVar', readTVarIO)
 import Control.Tracer (Tracer (Tracer))
 import Data.Map.Strict as Map
 import Hydra.HeadLogic (

--- a/hydra-node/src/Hydra/Logging/Monitoring.hs
+++ b/hydra-node/src/Hydra/Logging/Monitoring.hs
@@ -13,7 +13,7 @@ module Hydra.Logging.Monitoring (
 
 import Hydra.Prelude
 
-import Control.Concurrent.Class.MonadSTM (modifyTVar', newTVarIO, readTVarIO)
+import Control.Concurrent.Class.MonadSTM (MonadLabelledSTM, labelTVarIO, modifyTVar', newTVarIO, readTVarIO)
 import Control.Tracer (Tracer (Tracer))
 import Data.Map.Strict as Map
 import Hydra.HeadLogic (
@@ -38,7 +38,7 @@ import System.Metrics.Prometheus.Registry (Registry, new, registerCounter, regis
 -- This is a no-op if given `Nothing`. This function is not polymorphic over the type of
 -- messages because it needs to understand them in order to provide meaningful metrics.
 withMonitoring ::
-  (MonadIO m, MonadAsync m, IsTx tx, MonadMonotonicTime m) =>
+  (MonadIO m, MonadAsync m, IsTx tx, MonadMonotonicTime m, MonadLabelledSTM m) =>
   Maybe PortNumber ->
   Tracer m (HydraLog tx) ->
   (Tracer m (HydraLog tx) -> m ()) ->
@@ -55,9 +55,10 @@ withMonitoring (Just monitoringPort) (Tracer tracer) action = do
 -- | Register all relevant metrics.
 -- Returns an updated `Registry` which is needed to `serveMetrics` or any other form of publication
 -- of metrics, whether push or pull, and a function for updating metrics given some trace event.
-prepareRegistry :: forall m tx. (MonadIO m, MonadSTM m, MonadMonotonicTime m, IsTx tx) => m (HydraLog tx -> m (), Registry)
+prepareRegistry :: forall m tx. (MonadIO m, MonadMonotonicTime m, IsTx tx, MonadLabelledSTM m) => m (HydraLog tx -> m (), Registry)
 prepareRegistry = do
   transactionsMap <- newTVarIO mempty
+  labelTVarIO transactionsMap "monitoring-txs-map-registry"
   first (monitor transactionsMap) <$> registerMetrics
  where
   registerMetrics = foldlM registerMetric (mempty, new) allMetrics

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -43,7 +43,6 @@ import Hydra.Prelude
 import Cardano.Binary (decodeFull', serialize')
 import Cardano.Crypto.Hash (SHA256, hashToStringAsHex, hashWithSerialiser)
 import Control.Concurrent.Class.MonadSTM (
-  MonadLabelledSTM,
   modifyTVar',
   peekTBQueue,
   readTBQueue,

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -139,7 +139,7 @@ withEtcdNetwork tracer protocolVersion config callback action = do
   withProcessInterrupt (etcdCmd etcdBinPath envVars) $ \p -> do
     race_
       ( do
-          labelMyThread "etcd-waitExitCode-2"
+          labelMyThread "etcd-withEtcdNetwork-waitExitCode"
           waitExitCode p >>= \ec -> fail $ "Sub-process etcd exited with: " <> show ec
       )
       ( race_ (traceStderr p callback) $ do
@@ -546,7 +546,7 @@ withProcessInterrupt config =
   signalAndStopProcess p = liftIO $ do
     interruptProcessGroupOf (unsafeProcessHandle p)
     raceLabelled_
-      ("etcd-waitExitCode-1", void $ waitExitCode p)
+      ("etcd-signalAndStopProcess-waitExitCode", void $ waitExitCode p)
       ("etcd-stopProcess", threadDelay 5 >> stopProcess p)
 
 -- * Persistent queue

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -12,9 +12,6 @@ import Hydra.Prelude
 
 import Conduit (MonadUnliftIO, ZipSink (..), foldMapC, foldlC, mapC, mapM_C, runConduitRes, (.|))
 import Control.Concurrent.Class.MonadSTM (
-  MonadLabelledSTM,
-  labelTVarIO,
-  newTVarIO,
   stateTVar,
   writeTVar,
  )
@@ -422,10 +419,8 @@ createNodeState ::
   HeadState tx ->
   m (NodeState tx m)
 createNodeState lastSeenEventId initialState = do
-  nextEventIdV <- newTVarIO $ maybe 0 (+ 1) lastSeenEventId
-  labelTVarIO nextEventIdV "next-event-id"
-  hs <- newTVarIO initialState
-  labelTVarIO hs "head-state"
+  nextEventIdV <- newLabelledTVarIO "next-event-id" $ maybe 0 (+ 1) lastSeenEventId
+  hs <- newLabelledTVarIO "head-state" initialState
   pure
     NodeState
       { modifyHeadState = stateTVar hs

--- a/hydra-node/src/Hydra/Node/InputQueue.hs
+++ b/hydra-node/src/Hydra/Node/InputQueue.hs
@@ -4,13 +4,8 @@ module Hydra.Node.InputQueue where
 import Hydra.Prelude
 
 import Control.Concurrent.Class.MonadSTM (
-  MonadLabelledSTM,
   isEmptyTQueue,
-  labelTQueueIO,
-  labelTVarIO,
   modifyTVar',
-  newTQueue,
-  newTVarIO,
   readTQueue,
   writeTQueue,
  )
@@ -36,11 +31,9 @@ createInputQueue ::
   ) =>
   m (InputQueue m e)
 createInputQueue = do
-  numThreads <- newTVarIO (0 :: Integer)
-  nextId <- newTVarIO 0
-  labelTVarIO numThreads "num-threads"
-  q <- atomically newTQueue
-  labelTQueueIO q "input-queue"
+  numThreads <- newLabelledTVarIO "num-threads" (0 :: Integer)
+  nextId <- newLabelledTVarIO "nex-id" 0
+  q <- newLabelledTQueueIO "input-queue"
   pure
     InputQueue
       { enqueue = \queuedItem ->

--- a/hydra-node/src/Hydra/Node/InputQueue.hs
+++ b/hydra-node/src/Hydra/Node/InputQueue.hs
@@ -9,7 +9,6 @@ import Control.Concurrent.Class.MonadSTM (
   readTQueue,
   writeTQueue,
  )
-import Control.Monad.Class.MonadAsync (async)
 
 -- | The single, required queue in the system from which a hydra head is "fed".
 -- NOTE(SN): this probably should be bounded and include proper logging
@@ -43,7 +42,7 @@ createInputQueue = do
             modifyTVar' nextId succ
       , reenqueue = \delay e -> do
           atomically $ modifyTVar' numThreads succ
-          void . async $ do
+          void . asyncLabelled "input-queue-reenqueue" $ do
             threadDelay delay
             atomically $ do
               modifyTVar' numThreads pred

--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -9,8 +9,6 @@ import Conduit (yieldMany)
 import Control.Concurrent.Class.MonadSTM (
   check,
   modifyTVar',
-  newTQueue,
-  newTVarIO,
   readTQueue,
   readTVarIO,
   tryReadTQueue,
@@ -91,13 +89,14 @@ spec =
                 version `shouldBe` toJSON (showVersion NetworkVersions.hydraNodeVersion)
 
     it "sends server outputs to all connected clients" $ do
-      queue <- atomically newTQueue
+      queue <- newLabelledTQueueIO "queue"
       showLogsOnFailure "ServerSpec" $ \tracer -> failAfter 5 $
         withFreePort $ \port -> do
           withTestAPIServer port alice (mockSource []) tracer $ \(EventSink{putEvent}, _) -> do
-            semaphore <- newTVarIO 0
-            withAsync
-              ( concurrently_
+            semaphore <- newLabelledTVarIO "semaphore" 0
+            withAsyncLabelled
+              ( "concurrent-test-clients"
+              , concurrently_
                   (withClient port "/" $ testClient queue semaphore)
                   (withClient port "/" $ testClient queue semaphore)
               )
@@ -125,13 +124,14 @@ spec =
                   mkTimedServerOutputFromStateEvent stateEvent
         let eventSource = mockSource [stateEvent]
 
-        queue1 <- atomically newTQueue
-        queue2 <- atomically newTQueue
+        queue1 <- newLabelledTQueueIO "queue1"
+        queue2 <- newLabelledTQueueIO "queue2"
         withFreePort $ \port -> do
           withTestAPIServer port alice eventSource tracer $ \_ -> do
-            semaphore <- newTVarIO 0
-            withAsync
-              ( concurrently_
+            semaphore <- newLabelledTVarIO "semaphore" 0
+            withAsyncLabelled
+              ( "concurrent-test-clients"
+              , concurrently_
                   (withClient port "/?history=yes" $ testClient queue1 semaphore)
                   (withClient port "/?history=yes" $ testClient queue2 semaphore)
               )
@@ -433,7 +433,7 @@ waitForValue port f =
 -- | Wait up to some time for an API server output to match the given predicate.
 waitMatch :: HasCallStack => Natural -> Connection -> (Aeson.Value -> Maybe a) -> IO a
 waitMatch delay con match = do
-  seenMsgs <- newTVarIO []
+  seenMsgs <- newLabelledTVarIO "wait-match-seen-msgs" []
   timeout (fromIntegral delay) (go seenMsgs) >>= \case
     Just x -> pure x
     Nothing -> do

--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -96,9 +96,9 @@ spec =
             semaphore <- newLabelledTVarIO "semaphore" 0
             withAsyncLabelled
               ( "concurrent-test-clients"
-              , concurrently_
-                  (withClient port "/" $ testClient queue semaphore)
-                  (withClient port "/" $ testClient queue semaphore)
+              , concurrentlyLabelled_
+                  ("concurrent-test-client-1", withClient port "/" $ testClient queue semaphore)
+                  ("concurrent-test-client-2", withClient port "/" $ testClient queue semaphore)
               )
               $ \_ -> do
                 waitForClients semaphore
@@ -131,9 +131,9 @@ spec =
             semaphore <- newLabelledTVarIO "semaphore" 0
             withAsyncLabelled
               ( "concurrent-test-clients"
-              , concurrently_
-                  (withClient port "/?history=yes" $ testClient queue1 semaphore)
-                  (withClient port "/?history=yes" $ testClient queue2 semaphore)
+              , concurrentlyLabelled_
+                  ("concurrent-test-client-queue1", withClient port "/?history=yes" $ testClient queue1 semaphore)
+                  ("concurrent-test-client-queue2", withClient port "/?history=yes" $ testClient queue2 semaphore)
               )
               $ \_ -> do
                 waitForClients semaphore

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -17,7 +17,7 @@ import Control.Concurrent.Class.MonadSTM (
   writeTQueue,
   writeTVar,
  )
-import Control.Monad.Class.MonadAsync (Async, MonadAsync (async), cancel, forConcurrently)
+import Control.Monad.Class.MonadAsync (MonadAsync (async), cancel, forConcurrently)
 import Control.Monad.IOSim (IOSim, runSimTrace, selectTraceEventsDynamic)
 import Data.List ((!!))
 import Data.List qualified as List

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -1048,7 +1048,7 @@ dummySimulatedChainNetwork =
 -- initial chain state to play back to our test nodes.
 -- NOTE: The simulated network has a block time of 20 (simulated) seconds.
 withSimulatedChainAndNetwork ::
-  (MonadTime m, MonadDelay m, MonadAsync m, MonadThrow m) =>
+  (MonadTime m, MonadDelay m, MonadAsync m, MonadThrow m, MonadLabelledSTM m) =>
   (SimulatedChainNetwork SimpleTx m -> m a) ->
   m a
 withSimulatedChainAndNetwork =
@@ -1062,7 +1062,7 @@ withSimulatedChainAndNetwork =
 -- possible.
 simulatedChainAndNetwork ::
   forall m.
-  (MonadTime m, MonadDelay m, MonadAsync m) =>
+  (MonadTime m, MonadDelay m, MonadAsync m, MonadLabelledSTM m) =>
   ChainStateType SimpleTx ->
   m (SimulatedChainNetwork SimpleTx m)
 simulatedChainAndNetwork initialChainState = do

--- a/hydra-node/test/Hydra/Events/S3Spec.hs
+++ b/hydra-node/test/Hydra/Events/S3Spec.hs
@@ -53,9 +53,9 @@ spec = do
 
     it "allows concurrent usage" $ \bucketName -> do
       withS3EventStore bucketName $ \(source, sink) -> do
-        concurrently_
-          (putEvent sink 123)
-          (putEvent sink 456)
+        concurrentlyLabelled_
+          ("concurrent-put-event-123", putEvent sink 123)
+          ("concurrent-put-event-456", putEvent sink 456)
         getEvents source `shouldReturn` [123, 456 :: EventId]
 
     it "supports multiple instances" $ \bucketName ->

--- a/hydra-node/test/Hydra/Events/UDPSpec.hs
+++ b/hydra-node/test/Hydra/Events/UDPSpec.hs
@@ -26,7 +26,7 @@ spec = do
     it "allows concurrent usage" $ do
       withFreePort $ \port -> do
         withUDPEventSink @EventId "0.0.0.0" (show port) $ \EventSink{putEvent} -> do
-          concurrently_ (putEvent 123) (putEvent 456)
+          concurrentlyLabelled_ ("put-event-123", putEvent 123) ("put-event-456", putEvent 456)
 
   it "supports multiple instances" $ do
     withFreePort $ \port -> do

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -31,7 +31,7 @@ import Control.Concurrent.Class.MonadSTM (
   newTVarIO,
   readTVarIO,
  )
-import Control.Monad.Class.MonadAsync (Async, async, cancel, link)
+import Control.Monad.Class.MonadAsync (async, cancel, link)
 import Control.Monad.Class.MonadFork (labelThisThread)
 import Data.List (nub, (\\))
 import Data.List qualified as List

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -26,7 +26,7 @@ import Control.Concurrent.Class.MonadSTM (
   modifyTVar,
   readTVarIO,
  )
-import Control.Monad.Class.MonadAsync (async, cancel, link)
+import Control.Monad.Class.MonadAsync (cancel, link)
 import Data.List (nub, (\\))
 import Data.List qualified as List
 import Data.Map ((!))
@@ -649,8 +649,8 @@ seedWorld seedKeys seedCP futureCommits = do
     let party = deriveParty hsk
         otherParties = filter (/= party) parties
     (testClient, nodeThread) <- lift $ do
-      outputs <- newLabelledTQueueIO ("outputs-" <> shortLabel hsk)
-      messages <- newLabelledTQueueIO ("messages-" <> shortLabel hsk)
+      outputs <- newLabelledTQueueIO ("seed-world-outputs-" <> shortLabel hsk)
+      messages <- newLabelledTQueueIO ("seed-world-messages-" <> shortLabel hsk)
       outputHistory <- newLabelledTVarIO "seed-world-output-history" []
       node <-
         createHydraNode
@@ -666,7 +666,7 @@ seedWorld seedKeys seedCP futureCommits = do
           seedCP
           testDepositPeriod
       let testClient = createTestHydraClient outputs messages outputHistory node
-      nodeThread <- async $ labelThisThread ("node-" <> shortLabel hsk) >> runHydraNode node
+      nodeThread <- asyncLabelled ("seed-world-node-" <> shortLabel hsk) $ runHydraNode node
       link nodeThread
       pure (testClient, nodeThread)
     pushThread nodeThread

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -666,7 +666,7 @@ seedWorld seedKeys seedCP futureCommits = do
           seedCP
           testDepositPeriod
       let testClient = createTestHydraClient outputs messages outputHistory node
-      nodeThread <- async $ labelMyThread ("node-" <> shortLabel hsk) >> runHydraNode node
+      nodeThread <- async $ labelThisThread ("node-" <> shortLabel hsk) >> runHydraNode node
       link nodeThread
       pure (testClient, nodeThread)
     pushThread nodeThread

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -27,7 +27,6 @@ import Control.Concurrent.Class.MonadSTM (
   readTVarIO,
  )
 import Control.Monad.Class.MonadAsync (async, cancel, link)
-import Control.Monad.Class.MonadFork (labelThisThread)
 import Data.List (nub, (\\))
 import Data.List qualified as List
 import Data.Map ((!))
@@ -667,7 +666,7 @@ seedWorld seedKeys seedCP futureCommits = do
           seedCP
           testDepositPeriod
       let testClient = createTestHydraClient outputs messages outputHistory node
-      nodeThread <- async $ labelThisThread ("node-" <> shortLabel hsk) >> runHydraNode node
+      nodeThread <- async $ labelMyThread ("node-" <> shortLabel hsk) >> runHydraNode node
       link nodeThread
       pure (testClient, nodeThread)
     pushThread nodeThread

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -23,12 +23,7 @@ import Hydra.Prelude hiding (Any, label, lookup, toList)
 import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Binary (serialize', unsafeDeserialize')
 import Control.Concurrent.Class.MonadSTM (
-  MonadLabelledSTM,
-  labelTQueueIO,
-  labelTVarIO,
   modifyTVar,
-  newTQueue,
-  newTVarIO,
   readTVarIO,
  )
 import Control.Monad.Class.MonadAsync (async, cancel, link)
@@ -655,12 +650,9 @@ seedWorld seedKeys seedCP futureCommits = do
     let party = deriveParty hsk
         otherParties = filter (/= party) parties
     (testClient, nodeThread) <- lift $ do
-      outputs <- atomically newTQueue
-      labelTQueueIO outputs ("outputs-" <> shortLabel hsk)
-      messages <- atomically newTQueue
-      labelTQueueIO messages ("messages-" <> shortLabel hsk)
-      outputHistory <- newTVarIO []
-      labelTVarIO outputHistory ("history-" <> shortLabel hsk)
+      outputs <- newLabelledTQueueIO ("outputs-" <> shortLabel hsk)
+      messages <- newLabelledTQueueIO ("messages-" <> shortLabel hsk)
+      outputHistory <- newLabelledTVarIO "seed-world-output-history" []
       node <-
         createHydraNode
           (contramap Node tr)
@@ -693,7 +685,7 @@ seedWorld seedKeys seedCP futureCommits = do
     s{threads = t : threads s}
 
 performCommit ::
-  (MonadThrow m, MonadTimer m, MonadAsync m) =>
+  (MonadThrow m, MonadTimer m, MonadAsync m, MonadLabelledSTM m) =>
   HeadId ->
   Party ->
   [(CardanoSigningKey, Value)] ->
@@ -708,7 +700,7 @@ performCommit headId party paymentUTxO = do
       _ -> Nothing
 
 performDeposit ::
-  (MonadThrow m, MonadTimer m, MonadAsync m, MonadTime m) =>
+  (MonadThrow m, MonadTimer m, MonadAsync m, MonadTime m, MonadLabelledSTM m) =>
   HeadId ->
   [(CardanoSigningKey, Value)] ->
   RunMonad m ()
@@ -729,7 +721,7 @@ performDeposit headId utxoToDeposit = do
       _ -> Nothing
 
 performDecommit ::
-  (MonadThrow m, MonadTimer m, MonadAsync m, MonadDelay m) =>
+  (MonadThrow m, MonadTimer m, MonadAsync m, MonadDelay m, MonadLabelledSTM m) =>
   Party ->
   Payment ->
   RunMonad m ()
@@ -758,7 +750,7 @@ performDecommit party tx = do
     _ -> Nothing
 
 performNewTx ::
-  (MonadThrow m, MonadAsync m, MonadTimer m, MonadDelay m) =>
+  (MonadThrow m, MonadAsync m, MonadTimer m, MonadDelay m, MonadLabelledSTM m) =>
   Party ->
   Payment ->
   RunMonad m Payment
@@ -817,7 +809,7 @@ getActorNode party = do
     Nothing -> throwIO $ UnexpectedParty party
     Just actorNode -> pure actorNode
 
-performInit :: (MonadThrow m, MonadAsync m, MonadTimer m) => Party -> RunMonad m HeadId
+performInit :: (MonadThrow m, MonadAsync m, MonadTimer m, MonadLabelledSTM m) => Party -> RunMonad m HeadId
 performInit party = do
   party `sendsInput` Input.Init
   nodes <- gets nodes
@@ -825,7 +817,7 @@ performInit party = do
     HeadIsInitializing{headId} -> Just headId
     _ -> Nothing
 
-performAbort :: (MonadThrow m, MonadAsync m, MonadTimer m) => Party -> RunMonad m ()
+performAbort :: (MonadThrow m, MonadAsync m, MonadTimer m, MonadLabelledSTM m) => Party -> RunMonad m ()
 performAbort party = do
   party `sendsInput` Input.Abort
 
@@ -834,7 +826,7 @@ performAbort party = do
     HeadIsAborted{} -> Just ()
     _ -> Nothing
 
-performClose :: (MonadThrow m, MonadAsync m, MonadTimer m, MonadDelay m) => Party -> RunMonad m ()
+performClose :: (MonadThrow m, MonadAsync m, MonadTimer m, MonadDelay m, MonadLabelledSTM m) => Party -> RunMonad m ()
 performClose party = do
   nodes <- gets nodes
   let thisNode = nodes ! party
@@ -867,7 +859,7 @@ performFanout party = do
     HeadIsFinalized{} -> True
     _otherwise -> False
 
-performCloseWithInitialSnapshot :: (MonadThrow m, MonadTimer m, MonadDelay m, MonadAsync m) => WorldState -> Party -> RunMonad m ()
+performCloseWithInitialSnapshot :: (MonadThrow m, MonadTimer m, MonadDelay m, MonadAsync m, MonadLabelledSTM m) => WorldState -> Party -> RunMonad m ()
 performCloseWithInitialSnapshot st party = do
   nodes <- gets nodes
   let thisNode = nodes ! party

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -102,7 +102,7 @@ mockChainAndNetwork tr seedKeys commits = do
   nodes <- newLabelledTVarIO "nodes" []
   queue <- newLabelledTQueueIO "chain-queue"
   chain <- newLabelledTVarIO "mock-chain-state" (0 :: ChainSlot, 0 :: Natural, Empty, initialUTxO)
-  tickThread <- async (labelMyThread "chain" >> simulateChain nodes chain queue)
+  tickThread <- async (labelThisThread "chain" >> simulateChain nodes chain queue)
   link tickThread
   pure
     SimulatedChainNetwork

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -16,7 +16,7 @@ import Control.Concurrent.Class.MonadSTM (
   writeTQueue,
   writeTVar,
  )
-import Control.Monad.Class.MonadAsync (async, link)
+import Control.Monad.Class.MonadAsync (link)
 import Data.Sequence (Seq (Empty, (:|>)))
 import Data.Sequence qualified as Seq
 import Data.Time (secondsToNominalDiffTime)
@@ -99,10 +99,10 @@ mockChainAndNetwork ::
   UTxO ->
   m (SimulatedChainNetwork Tx m)
 mockChainAndNetwork tr seedKeys commits = do
-  nodes <- newLabelledTVarIO "nodes" []
-  queue <- newLabelledTQueueIO "chain-queue"
+  nodes <- newLabelledTVarIO "mock-chain-nodes" []
+  queue <- newLabelledTQueueIO "mock-chain-chain-queue"
   chain <- newLabelledTVarIO "mock-chain-state" (0 :: ChainSlot, 0 :: Natural, Empty, initialUTxO)
-  tickThread <- async (labelThisThread "chain" >> simulateChain nodes chain queue)
+  tickThread <- asyncLabelled "mock-chain-tick" (simulateChain nodes chain queue)
   link tickThread
   pure
     SimulatedChainNetwork

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -8,13 +8,8 @@ import Hydra.Prelude hiding (Any, label)
 
 import Cardano.Api.UTxO qualified as UTxO
 import Control.Concurrent.Class.MonadSTM (
-  MonadLabelledSTM,
-  MonadSTM (newTVarIO, writeTVar),
-  labelTQueueIO,
-  labelTVarIO,
+  MonadSTM (writeTVar),
   modifyTVar,
-  newTQueueIO,
-  newTVarIO,
   readTVarIO,
   throwSTM,
   tryReadTQueue,
@@ -105,11 +100,9 @@ mockChainAndNetwork ::
   UTxO ->
   m (SimulatedChainNetwork Tx m)
 mockChainAndNetwork tr seedKeys commits = do
-  nodes <- newTVarIO []
-  labelTVarIO nodes "nodes"
-  queue <- newTQueueIO
-  labelTQueueIO queue "chain-queue"
-  chain <- newTVarIO (0 :: ChainSlot, 0 :: Natural, Empty, initialUTxO)
+  nodes <- newLabelledTVarIO "nodes" []
+  queue <- newLabelledTQueueIO "chain-queue"
+  chain <- newLabelledTVarIO "mock-chain-state" (0 :: ChainSlot, 0 :: Natural, Empty, initialUTxO)
   tickThread <- async (labelThisThread "chain" >> simulateChain nodes chain queue)
   link tickThread
   pure

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -17,7 +17,6 @@ import Control.Concurrent.Class.MonadSTM (
   writeTVar,
  )
 import Control.Monad.Class.MonadAsync (async, link)
-import Control.Monad.Class.MonadFork (labelThisThread)
 import Data.Sequence (Seq (Empty, (:|>)))
 import Data.Sequence qualified as Seq
 import Data.Time (secondsToNominalDiffTime)
@@ -103,7 +102,7 @@ mockChainAndNetwork tr seedKeys commits = do
   nodes <- newLabelledTVarIO "nodes" []
   queue <- newLabelledTQueueIO "chain-queue"
   chain <- newLabelledTVarIO "mock-chain-state" (0 :: ChainSlot, 0 :: Natural, Empty, initialUTxO)
-  tickThread <- async (labelThisThread "chain" >> simulateChain nodes chain queue)
+  tickThread <- async (labelMyThread "chain" >> simulateChain nodes chain queue)
   link tickThread
   pure
     SimulatedChainNetwork

--- a/hydra-node/test/Hydra/ModelSpec.hs
+++ b/hydra-node/test/Hydra/ModelSpec.hs
@@ -81,7 +81,6 @@ import Hydra.Prelude
 import Test.Hydra.Prelude hiding (after)
 
 import Cardano.Api.UTxO qualified as UTxO
-import Control.Concurrent.Class.MonadSTM (newTVarIO)
 import Control.Monad.Class.MonadTimer ()
 import Control.Monad.IOSim (Failure (FailureException), IOSim, SimTrace, runSimTrace, traceResult)
 import Data.Map ((!))
@@ -368,7 +367,8 @@ runRunMonadIOSimGen f = do
     IOSim s a
   sim eval = do
     v <-
-      newTVarIO
+      newLabelledTVarIO
+        "sim-nodes"
         Nodes
           { nodes = mempty
           , logger = traceInIOSim

--- a/hydra-node/test/Hydra/Network/AuthenticateSpec.hs
+++ b/hydra-node/test/Hydra/Network/AuthenticateSpec.hs
@@ -1,7 +1,7 @@
 module Hydra.Network.AuthenticateSpec where
 
 import Cardano.Crypto.Util (SignableRepresentation)
-import Control.Concurrent.Class.MonadSTM (MonadSTM (readTVarIO), modifyTVar', newTVarIO)
+import Control.Concurrent.Class.MonadSTM (MonadSTM (readTVarIO), modifyTVar')
 import Control.Monad.IOSim (runSimOrThrow)
 import Data.ByteString (pack)
 import Hydra.Ledger.Simple (SimpleTx)
@@ -37,7 +37,7 @@ spec = parallel $ do
 
   it "pass the authenticated messages around" $ do
     let receivedMsgs = runSimOrThrow $ do
-          receivedMessages <- newTVarIO []
+          receivedMessages <- newLabelledTVarIO "received-msgs" []
 
           withAuthentication
             @(Message SimpleTx)
@@ -59,7 +59,7 @@ spec = parallel $ do
   it "drop message coming from unknown party" $ do
     unexpectedMessage <- ReqTx <$> generate arbitrary
     let receivedMsgs = runSimOrThrow $ do
-          receivedMessages <- newTVarIO []
+          receivedMessages <- newLabelledTVarIO "received-msgs" []
 
           withAuthentication
             @(Message SimpleTx)
@@ -82,7 +82,7 @@ spec = parallel $ do
 
   it "drop message coming from party with wrong signature" $ do
     let receivedMsgs = runSimOrThrow $ do
-          receivedMessages <- newTVarIO []
+          receivedMessages <- newLabelledTVarIO "received-msgs" []
 
           withAuthentication
             @(Message SimpleTx)
@@ -104,7 +104,7 @@ spec = parallel $ do
   it "authenticate the message to broadcast" $ do
     let someMessage = msg
         sentMsgs = runSimOrThrow $ do
-          sentMessages <- newTVarIO []
+          sentMessages <- newLabelledTVarIO "received-msgs" []
 
           withAuthentication
             @(Message SimpleTx)
@@ -127,7 +127,7 @@ spec = parallel $ do
     let signature = sign carolSk msg
     let signedMsg = Signed msg signature bob
     let traced = runSimOrThrow $ do
-          traces <- newTVarIO []
+          traces <- newLabelledTVarIO "traces" []
 
           let tracer = traceInTVar traces "AuthenticateSpec"
           withAuthentication

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -6,7 +6,7 @@ import Hydra.Prelude hiding (label)
 import Test.Hydra.Prelude
 
 import Conduit (MonadUnliftIO, yieldMany)
-import Control.Concurrent.Class.MonadSTM (MonadLabelledSTM, labelTVarIO, modifyTVar, newTVarIO, readTVarIO, writeTVar)
+import Control.Concurrent.Class.MonadSTM (modifyTVar, readTVarIO, writeTVar)
 import Hydra.API.ClientInput (ClientInput (..))
 import Hydra.API.Server (Server (..), mkTimedServerOutputFromStateEvent)
 import Hydra.API.ServerOutput (ClientMessage (..), ServerOutput (..), TimedServerOutput (..))
@@ -319,7 +319,7 @@ spec = parallel $ do
           `shouldThrow` \(_ :: ParameterMismatch) -> True
 
     it "log error given configuration mismatches head state" $ do
-      logs <- newTVarIO []
+      logs <- newLabelledTVarIO "logs" []
       let invalidPeriodEnv = defaultEnv{otherParties = []}
           isContestationPeriodMismatch :: HydraNodeLog SimpleTx -> Bool
           isContestationPeriodMismatch = \case
@@ -392,8 +392,7 @@ createRecordingSink = do
 
 createMockEventStore :: MonadLabelledSTM m => m (EventStore a m)
 createMockEventStore = do
-  tvar <- newTVarIO []
-  labelTVarIO tvar "in-memory-source-sink"
+  tvar <- newLabelledTVarIO "in-memory-source-sink" []
   let source =
         EventSource
           { sourceEvents = do

--- a/hydra-node/test/Hydra/PersistenceSpec.hs
+++ b/hydra-node/test/Hydra/PersistenceSpec.hs
@@ -65,9 +65,9 @@ spec = do
             p <- createPersistenceIncremental $ tmpDir <> "/data"
             forM_ items $ append p
             loadAll p `shouldReturn` items
-            race_
-              (forever $ threadDelay 0.01 >> loadAll p)
-              (forM_ moreItems $ \item -> append p item >> threadDelay 0.01)
+            raceLabelled_
+              ("forever-load-all", forever $ threadDelay 0.01 >> loadAll p)
+              ("append-more-items", forM_ moreItems $ \item -> append p item >> threadDelay 0.01)
 
 genPersistenceItem :: Gen Aeson.Value
 genPersistenceItem =

--- a/hydra-node/test/Test/Util.hs
+++ b/hydra-node/test/Test/Util.hs
@@ -5,7 +5,7 @@ module Test.Util where
 import Hydra.Prelude
 import Test.Hydra.Prelude hiding (shouldBe)
 
-import Control.Concurrent.Class.MonadSTM (modifyTVar', newTVarIO, readTVarIO)
+import Control.Concurrent.Class.MonadSTM (modifyTVar', readTVarIO)
 import Control.Monad.Class.MonadSay (say)
 import Control.Monad.IOSim (
   Failure (FailureException),
@@ -155,7 +155,7 @@ waitEq waitNext delay expected =
 -- | Wait up to some time for a function to return a value that satisfies given predicate.
 waitMatch :: (HasCallStack, Show a) => IO a -> NominalDiffTime -> (a -> Maybe b) -> IO b
 waitMatch waitNext delay match = do
-  seenMsgs <- newTVarIO []
+  seenMsgs <- newLabelledTVarIO "wait-match-seen-msgs" []
   timeout (realToFrac delay) (go seenMsgs) >>= \case
     Just x -> pure x
     Nothing -> do

--- a/hydra-prelude/src/Hydra/Prelude.hs
+++ b/hydra-prelude/src/Hydra/Prelude.hs
@@ -3,13 +3,20 @@
 
 module Hydra.Prelude (
   module Relude,
-  module Control.Monad.Class.MonadSTM,
+  MonadLabelledSTM,
+  MonadSTM,
+  STM,
+  atomically,
   module Control.Monad.Class.MonadTime.SI,
   module Control.Monad.Class.MonadST,
-  module Control.Monad.Class.MonadAsync,
+  MonadAsync,
+  Async,
   module Control.Monad.Class.MonadEventlog,
   module Control.Monad.Class.MonadTimer.SI,
-  module Control.Monad.Class.MonadFork,
+  Control.Monad.Class.MonadFork.MonadFork,
+  Control.Monad.Class.MonadFork.MonadThread,
+  Control.Monad.Class.MonadFork.myThreadId,
+  labelThisThread,
   module Control.Monad.Class.MonadThrow,
   module Control.Concurrent.Class.MonadSTM.TBQueue,
   module Control.Concurrent.Class.MonadSTM.TMVar,
@@ -41,13 +48,11 @@ module Hydra.Prelude (
   withFile,
   spy,
   spy',
-  MonadLabelledSTM,
   newLabelledTVar,
   newLabelledTVarIO,
   newLabelledEmptyTMVar,
   newLabelledTQueueIO,
   newLabelledEmptyTMVarIO,
-  labelMyThread,
   concurrentlyLabelled,
   concurrentlyLabelled_,
   raceLabelled,
@@ -70,20 +75,16 @@ import Control.Concurrent.Class.MonadSTM.TVar (TVar, readTVar)
 import Control.Exception (IOException)
 import Control.Monad.Class.MonadAsync (
   Async,
-  MonadAsync (concurrently, concurrently_, race, race_, withAsync),
+  MonadAsync (concurrently, race, withAsync),
  )
 import Control.Monad.Class.MonadEventlog (
   MonadEventlog,
  )
-import Control.Monad.Class.MonadFork (MonadFork, MonadThread, labelThread, myThreadId, labelThisThread)
+import Control.Monad.Class.MonadFork (MonadFork, MonadThread, labelThisThread, myThreadId)
 import Control.Monad.Class.MonadST (
   MonadST,
  )
-import Control.Monad.Class.MonadSTM (
-  MonadSTM,
-  STM,
-  atomically,
- )
+import Control.Monad.Class.MonadSTM ()
 import Control.Monad.Class.MonadThrow (
   MonadCatch (..),
   MonadEvaluate (..),

--- a/hydra-prelude/src/Hydra/Prelude.hs
+++ b/hydra-prelude/src/Hydra/Prelude.hs
@@ -55,6 +55,7 @@ module Hydra.Prelude (
   newLabelledEmptyTMVarIO,
   concurrentlyLabelled,
   concurrentlyLabelled_,
+  asyncLabelled,
   raceLabelled,
   raceLabelled_,
   withAsyncLabelled,
@@ -75,7 +76,7 @@ import Control.Concurrent.Class.MonadSTM.TVar (TVar, readTVar)
 import Control.Exception (IOException)
 import Control.Monad.Class.MonadAsync (
   Async,
-  MonadAsync (concurrently, race, withAsync),
+  MonadAsync (async, concurrently, race, withAsync),
  )
 import Control.Monad.Class.MonadEventlog (
   MonadEventlog,
@@ -372,3 +373,6 @@ concurrentlyLabelled (lblA, mA) (lblB, mB) =
 
 concurrentlyLabelled_ :: (MonadThread m, MonadAsync m) => (String, m a) -> (String, m b) -> m ()
 concurrentlyLabelled_ = (void .) . concurrentlyLabelled
+
+asyncLabelled :: MonadAsync m => String -> m a -> m (Async m a)
+asyncLabelled lbl mA = async $ labelThisThread lbl >> mA

--- a/hydra-prelude/src/Hydra/Prelude.hs
+++ b/hydra-prelude/src/Hydra/Prelude.hs
@@ -351,26 +351,23 @@ newLabelledTBQueueIO = (atomically .) . newLabelledTBQueue
 
 -- * Helpers for labeling Threads
 
-labelMyThread :: MonadThread m => String -> m ()
-labelMyThread = labelThisThread
-
 raceLabelled :: (MonadThread m, MonadAsync m) => (String, m a) -> (String, m b) -> m (Either a b)
 raceLabelled (lblA, mA) (lblB, mB) =
   race
-    (labelMyThread lblA >> mA)
-    (labelMyThread lblB >> mB)
+    (labelThisThread lblA >> mA)
+    (labelThisThread lblB >> mB)
 
 raceLabelled_ :: (MonadThread m, MonadAsync m) => (String, m a) -> (String, m b) -> m ()
 raceLabelled_ = (void .) . raceLabelled
 
 withAsyncLabelled :: MonadAsync m => (String, m a) -> (Async m a -> m b) -> m b
-withAsyncLabelled (lbl, ma) = withAsync (labelMyThread lbl >> ma)
+withAsyncLabelled (lbl, ma) = withAsync (labelThisThread lbl >> ma)
 
 concurrentlyLabelled :: (MonadThread m, MonadAsync m) => (String, m a) -> (String, m b) -> m (a, b)
 concurrentlyLabelled (lblA, mA) (lblB, mB) =
   concurrently
-    (labelMyThread lblA >> mA)
-    (labelMyThread lblB >> mB)
+    (labelThisThread lblA >> mA)
+    (labelThisThread lblB >> mB)
 
 concurrentlyLabelled_ :: (MonadThread m, MonadAsync m) => (String, m a) -> (String, m b) -> m ()
 concurrentlyLabelled_ = (void .) . concurrentlyLabelled

--- a/hydra-prelude/src/Hydra/Prelude.hs
+++ b/hydra-prelude/src/Hydra/Prelude.hs
@@ -73,7 +73,7 @@ import Control.Monad.Class.MonadAsync (
 import Control.Monad.Class.MonadEventlog (
   MonadEventlog,
  )
-import Control.Monad.Class.MonadFork (MonadFork, MonadThread, labelThread, myThreadId)
+import Control.Monad.Class.MonadFork (MonadFork, MonadThread, labelThread, myThreadId, labelThisThread)
 import Control.Monad.Class.MonadST (
   MonadST,
  )
@@ -350,7 +350,7 @@ newLabelledTBQueueIO = (atomically .) . newLabelledTBQueue
 -- * Helpers for labeling Threads
 
 labelMyThread :: MonadThread m => String -> m ()
-labelMyThread lbl = myThreadId >>= flip labelThread lbl
+labelMyThread = labelThisThread
 
 raceLabelled :: (MonadThread m, MonadAsync m) => (String, m a) -> (String, m b) -> m (Either a b)
 raceLabelled (lblA, mA) (lblB, mB) =

--- a/hydra-prelude/src/Hydra/Prelude.hs
+++ b/hydra-prelude/src/Hydra/Prelude.hs
@@ -48,6 +48,8 @@ module Hydra.Prelude (
   newLabelledTQueueIO,
   newLabelledEmptyTMVarIO,
   labelMyThread,
+  concurrentlyLabelled,
+  concurrentlyLabelled_,
   raceLabelled,
   raceLabelled_,
   withAsyncLabelled,
@@ -363,3 +365,12 @@ raceLabelled_ = (void .) . raceLabelled
 
 withAsyncLabelled :: MonadAsync m => (String, m a) -> (Async m a -> m b) -> m b
 withAsyncLabelled (lbl, ma) = withAsync (labelMyThread lbl >> ma)
+
+concurrentlyLabelled :: (MonadThread m, MonadAsync m) => (String, m a) -> (String, m b) -> m (a, b)
+concurrentlyLabelled (lblA, mA) (lblB, mB) =
+  concurrently
+    (labelMyThread lblA >> mA)
+    (labelMyThread lblB >> mB)
+
+concurrentlyLabelled_ :: (MonadThread m, MonadAsync m) => (String, m a) -> (String, m b) -> m ()
+concurrentlyLabelled_ = (void .) . concurrentlyLabelled

--- a/hydra-prelude/src/Hydra/Prelude.hs
+++ b/hydra-prelude/src/Hydra/Prelude.hs
@@ -44,9 +44,6 @@ module Hydra.Prelude (
   newLabelledTVar,
   newLabelledTVarIO,
   newLabelledEmptyTMVar,
-  newLabelledEmptyTMVarIO,
-  newLabelledTMVar,
-  newLabelledTMVarIO,
   newLabelledTQueueIO,
   threadLabelMe,
   raceLabelled,
@@ -322,18 +319,6 @@ newLabelledEmptyTMVar lbl = do
   tmv <- newEmptyTMVar
   labelTMVar tmv lbl
   pure tmv
-
-newLabelledEmptyTMVarIO :: MonadLabelledSTM m => String -> m (TMVar m a)
-newLabelledEmptyTMVarIO = atomically . newLabelledEmptyTMVar
-
-newLabelledTMVar :: MonadLabelledSTM m => String -> a -> STM m (TMVar m a)
-newLabelledTMVar lbl val = do
-  tmv <- newTMVar val
-  labelTMVar tmv lbl
-  pure tmv
-
-newLabelledTMVarIO :: MonadLabelledSTM m => String -> a -> m (TMVar m a)
-newLabelledTMVarIO = (atomically .) . newLabelledTMVar
 
 -- * Helpers for labeling TQueue
 

--- a/hydra-prelude/src/Hydra/Prelude.hs
+++ b/hydra-prelude/src/Hydra/Prelude.hs
@@ -41,10 +41,12 @@ module Hydra.Prelude (
   withFile,
   spy,
   spy',
+  MonadLabelledSTM,
   newLabelledTVar,
   newLabelledTVarIO,
   newLabelledEmptyTMVar,
   newLabelledTQueueIO,
+  newLabelledEmptyTMVarIO,
   labelMyThread,
   raceLabelled,
   raceLabelled_,
@@ -319,6 +321,9 @@ newLabelledEmptyTMVar lbl = do
   tmv <- newEmptyTMVar
   labelTMVar tmv lbl
   pure tmv
+
+newLabelledEmptyTMVarIO :: MonadLabelledSTM m => String -> m (TMVar m a)
+newLabelledEmptyTMVarIO = atomically . newLabelledEmptyTMVar
 
 -- * Helpers for labeling TQueue
 

--- a/hydra-prelude/src/Hydra/Prelude.hs
+++ b/hydra-prelude/src/Hydra/Prelude.hs
@@ -45,7 +45,7 @@ module Hydra.Prelude (
   newLabelledTVarIO,
   newLabelledEmptyTMVar,
   newLabelledTQueueIO,
-  threadLabelMe,
+  labelMyThread,
   raceLabelled,
   raceLabelled_,
   withAsyncLabelled,
@@ -344,17 +344,17 @@ newLabelledTBQueueIO = (atomically .) . newLabelledTBQueue
 
 -- * Helpers for labeling Threads
 
-threadLabelMe :: MonadThread m => String -> m ()
-threadLabelMe lbl = myThreadId >>= flip labelThread lbl
+labelMyThread :: MonadThread m => String -> m ()
+labelMyThread lbl = myThreadId >>= flip labelThread lbl
 
 raceLabelled :: (MonadThread m, MonadAsync m) => (String, m a) -> (String, m b) -> m (Either a b)
 raceLabelled (lblA, mA) (lblB, mB) =
   race
-    (threadLabelMe lblA >> mA)
-    (threadLabelMe lblB >> mB)
+    (labelMyThread lblA >> mA)
+    (labelMyThread lblB >> mB)
 
 raceLabelled_ :: (MonadThread m, MonadAsync m) => (String, m a) -> (String, m b) -> m ()
 raceLabelled_ = (void .) . raceLabelled
 
 withAsyncLabelled :: MonadAsync m => (String, m a) -> (Async m a -> m b) -> m b
-withAsyncLabelled (lbl, ma) = withAsync (threadLabelMe lbl >> ma)
+withAsyncLabelled (lbl, ma) = withAsync (labelMyThread lbl >> ma)

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -27,7 +27,7 @@ import Hydra.TUI.Style
 runWithVty :: IO Vty -> Options -> IO RootState
 runWithVty buildVty options@Options{hydraNodeHost, cardanoNetworkId, cardanoNodeSocket} = do
   eventChan <- newBChan 10
-  withAsync (timer eventChan) $ \_ ->
+  withAsyncLabelled ("run-vty-timer", timer eventChan) $ \_ ->
     -- REVIEW(SN): what happens if callback blocks?
     withClient @Tx options (writeBChan eventChan) $ \hydraClient -> do
       initialVty <- buildVty

--- a/hydraw/app/Main.hs
+++ b/hydraw/app/Main.hs
@@ -70,9 +70,9 @@ websocketApp :: Host -> WS.PendingConnection -> IO ()
 websocketApp host pendingConnection = do
   frontend <- WS.acceptRequest pendingConnection
   withClient host $ \backend ->
-    race_
-      (forever $ WS.receive frontend >>= WS.send backend)
-      (forever $ WS.receive backend >>= WS.send frontend)
+    raceLabelled_
+      ("forever-receive-frontend-send-backend", forever $ WS.receive frontend >>= WS.send backend)
+      ("forever-receive-backend-send-frontend", forever $ WS.receive backend >>= WS.send frontend)
 
 httpApp :: NetworkId -> FilePath -> Host -> Application
 httpApp networkId key host req send =

--- a/hydraw/app/Main.hs
+++ b/hydraw/app/Main.hs
@@ -2,7 +2,6 @@ module Main where
 
 import Hydra.Prelude
 
-import Control.Monad.Class.MonadAsync (async)
 import Hydra.Cardano.Api (NetworkId (..), NetworkMagic (..))
 import Hydra.Network (Host, readHost)
 import Hydra.Painter (Pixel (..), paintPixel, withClient, withClientNoRetry)
@@ -82,7 +81,7 @@ httpApp networkId key host req send =
         Just [x, y, red, green, blue] -> do
           putStrLn $ show (x, y) <> " -> " <> show (red, green, blue)
           -- \| spawn a connection in a new thread
-          void $ async $ withClientNoRetry host $ \cnx ->
+          void $ asyncLabelled "client-paint-pixel" $ withClientNoRetry host $ \cnx ->
             paintPixel networkId key host cnx Pixel{x, y, red, green, blue}
           send $ responseLBS status200 corsHeaders "OK"
         _ ->

--- a/hydraw/hydraw.cabal
+++ b/hydraw/hydraw.cabal
@@ -50,7 +50,6 @@ executable hydraw
     , hydra-node
     , hydra-prelude
     , hydraw
-    , io-classes
     , safe
     , wai
     , wai-websockets

--- a/hydraw/src/Hydra/Painter.hs
+++ b/hydraw/src/Hydra/Painter.hs
@@ -37,7 +37,7 @@ paintPixel networkId signingKeyPath host cnx pixel = do
     Nothing -> fail "Head UTxO is empty"
  where
   flushQueue =
-    race_ (threadDelay 0.25) (void (receive cnx) >> flushQueue)
+    raceLabelled_ ("thread-delay", threadDelay 0.25) ("flush-queue", void (receive cnx) >> flushQueue)
 
 requestHeadUTxO :: Host -> IO (Maybe UTxO)
 requestHeadUTxO host = do


### PR DESCRIPTION
<!-- Describe your change here -->

#### Motivation

Labels make it easier to track the origin and lifecycle of threads, queues, and transactional variables, especially when used in simulations (e.g. `IOSim`) or debugging tools.

#### 🔄 Changes

This PR introduces **labelled variants** of common concurrency primitives and combinators to improve observability and debugging.

Replaced existing constructors/combinators with labelled versions:

* **STM / TVars / Queues**

  * `newTVar`         → `newLabelledTVar`
  * `newTVarIO`       → `newLabelledTVarIO`
  * `newEmptyTMVar`   → `newLabelledEmptyTMVar`
  * `newEmptyTMVarIO` → `newLabelledEmptyTMVarIO`
  * `newTQueue`       → `newLabelledTQueue`
  * `newTQueueIO`     → `newLabelledTQueueIO`
  * `newTBQueue`      → `newLabelledTBQueue`
  * `newTBQueueIO`    → `newLabelledTBQueueIO`

* **Async / Thread combinators**
  (based on `Control.Monad.Class.MonadFork.labelThisThread`)

  * `race`            → `raceLabelled`
  * `race_`           → `raceLabelled_`
  * `withAsync`       → `withAsyncLabelled`
  * `async`           → `asyncLabelled`
  * `concurrently`    → `concurrentlyLabelled`
  * `concurrently_`   → `concurrentlyLabelled_`

#### 🔍 Usage not found

* `newTMVar`, `newTMVarIO`
* `forkIO` and its variants

#### ⚠️ Unresolved

* `newEmptyMVar`
* `newMVar`

> **Reason:** Labelled versions exist in
>
> * [`MonadMVar` docs](https://hackage.haskell.org/package/io-classes-1.8.0.1/docs/Control-Concurrent-Class-MonadMVar.html)
> * [`io-classes` changelog](https://github.com/input-output-hk/io-sim/blob/aadd3602b9b75640b042a02e0e62d10dd399b610/io-classes/CHANGELOG.md?plain=1#L23)
>
> However, their `IO` implementations are no-ops (labels are only effective under `IOSim`). 
> We need to decide whether to wrap these in our codebase or leave them unlabelled for now.

---

<!-- Consider each and tick it off one way or the other -->
* [X] CHANGELOG updated or not needed
* [X] Documentation updated or not needed
* [X] Haddocks updated or not needed
* [X] No new TODOs introduced or explained herafter
