### PR TITLE
Fix log rotation id after restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ changes.
   but is enough to resolve the problem until we can identify the central cause
   of the issue.
 
+- Fix rotation log id consistency after restart by changing the rotation check to trigger only
+when the number of persisted `StateChanged` events exceeds the configured `--persistence-rotate-after` threshold.
+  * This also prevents immediate rotation on startup when the threshold is set to 1.
+  * `Checkpoint` event ids now match the suffix of their preceding rotated log file and the last `StateChanged` event id within it,
+  preserving sequential order and making it easier to identify which rotated log file was used to compute it.
+
 ## [0.22.3] - 2025-07-21
 
 * Change behavior of `Hydra.Network.Etcd` to fallback to earliest possible

--- a/hydra-cluster/exe/hydra-cluster/Main.hs
+++ b/hydra-cluster/exe/hydra-cluster/Main.hs
@@ -33,7 +33,7 @@ run options =
         Nothing -> do
           withCardanoNodeDevnet fromCardanoNode workDir $ \node -> do
             txId <- publishOrReuseHydraScripts tracer node
-            singlePartyOpenAHead tracer workDir node txId $ \client walletSk _headId -> do
+            singlePartyOpenAHead tracer workDir node txId persistenceRotateAfter $ \client walletSk _headId -> do
               case scenario of
                 Idle -> forever $ pure ()
                 RespendUTxO -> do
@@ -41,7 +41,7 @@ run options =
                   -- XXX: Should make this configurable
                   respendUTxO client walletSk 0.1
  where
-  Options{knownNetwork, stateDirectory, publishHydraScripts, useMithril, scenario} = options
+  Options{knownNetwork, stateDirectory, publishHydraScripts, useMithril, scenario, persistenceRotateAfter} = options
 
   withRunningCardanoNode tracer workDir network action =
     findRunningCardanoNode (contramap FromCardanoNode tracer) workDir network >>= \case

--- a/hydra-cluster/src/Hydra/Cluster/Options.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Options.hs
@@ -6,9 +6,11 @@ import Data.ByteString.Char8 qualified as BSC
 import Data.List qualified as List
 import Hydra.Cardano.Api (TxId, deserialiseFromRawBytesHex)
 import Hydra.Cluster.Fixture (KnownNetwork (..))
+import Hydra.Options (persistenceRotateAfterParser)
 import Hydra.Prelude
 import Options.Applicative (Parser, eitherReader, flag, flag', help, long, metavar, strOption)
 import Options.Applicative.Builder (option)
+import Test.QuickCheck (Positive)
 
 data Options = Options
   { knownNetwork :: Maybe KnownNetwork
@@ -16,6 +18,7 @@ data Options = Options
   , publishHydraScripts :: PublishOrReuse
   , useMithril :: UseMithril
   , scenario :: Scenario
+  , persistenceRotateAfter :: Maybe (Positive Natural)
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (ToJSON)
@@ -40,6 +43,7 @@ parseOptions =
     <*> parsePublishHydraScripts
     <*> parseUseMithril
     <*> parseScenario
+    <*> optional persistenceRotateAfterParser
  where
   parseKnownNetwork =
     flag' (Just Preview) (long "preview" <> help "The preview testnet")

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -108,7 +108,7 @@ import System.Directory (removeDirectoryRecursive, removeFile)
 import System.FilePath ((</>))
 import Test.Hydra.Tx.Fixture (testNetworkId)
 import Test.Hydra.Tx.Gen (genKeyPair, genUTxOFor)
-import Test.QuickCheck (generate)
+import Test.QuickCheck (Positive (..), generate)
 import Prelude qualified
 
 allNodeIds :: [Int]
@@ -206,7 +206,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
 
         -- Measure restart after rotation
         options <- prepareHydraNode offlineConfig tmpDir 1 aliceSk [] [] id
-        let options' = options{persistenceRotateAfter = Just 10}
+        let options' = options{persistenceRotateAfter = Just (Positive 10)}
         t1 <- getCurrentTime
         diff2 <- withPreparedHydraNode (contramap FromHydraNode tracer) tmpDir 1 options' $ \_ -> do
           t2 <- getCurrentTime

--- a/hydra-node/test/Hydra/Events/RotationSpec.hs
+++ b/hydra-node/test/Hydra/Events/RotationSpec.hs
@@ -3,6 +3,7 @@ module Hydra.Events.RotationSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
+import Control.Monad (foldM)
 import Data.List qualified as List
 import Hydra.Chain (OnChainTx (..))
 import Hydra.Chain.ChainState (ChainSlot (..), IsChainState)
@@ -17,7 +18,7 @@ import Hydra.NodeSpec (createMockEventStore, inputsToOpenHead, notConnect, obser
 import Hydra.Tx.ContestationPeriod (toNominalDiffTime)
 import Test.Hydra.Node.Fixture (testEnvironment, testHeadId)
 import Test.Hydra.Tx.Fixture (cperiod)
-import Test.QuickCheck (Positive (..))
+import Test.QuickCheck (Positive (..), choose, sized)
 import Test.QuickCheck.Instances.Natural ()
 
 spec :: Spec
@@ -32,8 +33,9 @@ spec = parallel $ do
       it "rotates while running" $ \testHydrate -> do
         failAfter 1 $ do
           eventStore <- createMockEventStore
-          -- NOTE: this is hardcoded to ensure we get a checkpoint + a single event at the end
-          let rotationConfig = RotateAfter 4
+          -- NOTE: because there will be 5 inputs processed in total,
+          -- this is hardcoded to ensure we get a checkpoint + a single event at the end
+          let rotationConfig = RotateAfter (Positive 3)
           let s0 = Idle IdleState{chainState = SimpleChainState{slot = ChainSlot 0}}
           rotatingEventStore <- newRotatedEventStore rotationConfig s0 mkAggregator mkCheckpoint eventStore
           testHydrate rotatingEventStore []
@@ -45,8 +47,9 @@ spec = parallel $ do
       it "consistent state after restarting with rotation" $ \testHydrate -> do
         failAfter 1 $ do
           eventStore <- createMockEventStore
-          -- NOTE: this is hardcoded to ensure we get a single checkpoint event at the end
-          let rotationConfig = RotateAfter 3
+          -- NOTE: because there will be 6 inputs processed in total,
+          -- this is hardcoded to ensure we get a single checkpoint event at the end
+          let rotationConfig = RotateAfter (Positive 1)
           let s0 = Idle IdleState{chainState = SimpleChainState{slot = ChainSlot 0}}
           rotatingEventStore <- newRotatedEventStore rotationConfig s0 mkAggregator mkCheckpoint eventStore
           testHydrate rotatingEventStore []
@@ -70,29 +73,67 @@ spec = parallel $ do
         let contestationDeadline = toNominalDiffTime cperiod `addUTCTime` now
         let closeInput = observationInput $ OnCloseTx testHeadId 0 contestationDeadline
         let inputs = inputsToOpenHead ++ [closeInput]
-        failAfter 1 $
-          do
-            eventStore <- createMockEventStore
-            -- NOTE: this is hardcoded to ensure we get a single checkpoint event at the end
-            let rotationConfig = RotateAfter 3
-            -- run rotated event store with prepared inputs
-            let s0 = Idle IdleState{chainState = SimpleChainState{slot = ChainSlot 0}}
-            rotatingEventStore <- newRotatedEventStore rotationConfig s0 mkAggregator mkCheckpoint eventStore
-            testHydrate rotatingEventStore []
-              >>= notConnect
-              >>= primeWith inputs
-              >>= runToCompletion
-            -- run non-rotated event store with prepared inputs
-            eventStore' <- createMockEventStore
-            testHydrate eventStore' []
-              >>= notConnect
-              >>= primeWith inputs
-              >>= runToCompletion
-            -- aggregating stored events should yield consistent states
-            [StateEvent{stateChanged = checkpoint}] <- getEvents (eventSource rotatingEventStore)
-            events' <- getEvents (eventSource eventStore')
-            let checkpoint' = foldl' mkAggregator s0 events'
-            checkpoint `shouldBe` Checkpoint checkpoint'
+        failAfter 1 $ do
+          eventStore <- createMockEventStore
+          -- NOTE: because there will be 6 inputs processed in total,
+          -- this is hardcoded to ensure we get a single checkpoint event at the end
+          let rotationConfig = RotateAfter (Positive 1)
+          -- run rotated event store with prepared inputs
+          let s0 = Idle IdleState{chainState = SimpleChainState{slot = ChainSlot 0}}
+          rotatingEventStore <- newRotatedEventStore rotationConfig s0 mkAggregator mkCheckpoint eventStore
+          testHydrate rotatingEventStore []
+            >>= notConnect
+            >>= primeWith inputs
+            >>= runToCompletion
+          -- run non-rotated event store with prepared inputs
+          eventStore' <- createMockEventStore
+          testHydrate eventStore' []
+            >>= notConnect
+            >>= primeWith inputs
+            >>= runToCompletion
+          -- aggregating stored events should yield consistent states
+          [StateEvent{stateChanged = checkpoint}] <- getEvents (eventSource rotatingEventStore)
+          events' <- getEvents (eventSource eventStore')
+          let checkpoint' = foldl' mkAggregator s0 events'
+          checkpoint `shouldBe` Checkpoint checkpoint'
+      it "a restarted and non-restarted node have consistent rotation" $ \testHydrate -> do
+        -- prepare inputs
+        now <- getCurrentTime
+        let contestationDeadline = toNominalDiffTime cperiod `addUTCTime` now
+        let closeInput = observationInput $ OnCloseTx testHeadId 0 contestationDeadline
+        let inputs = inputsToOpenHead ++ [closeInput]
+        let inputs1 = take 3 inputs
+        let inputs2 = drop 3 inputs
+        failAfter 1 $ do
+          let s0 = Idle IdleState{chainState = SimpleChainState{slot = ChainSlot 0}}
+          -- NOTE: because there will be 6 inputs processed in total,
+          -- this is hardcoded to ensure we get a single checkpoint event at the end
+          let rotationConfig = RotateAfter (Positive 1)
+          -- run restarted node with prepared inputs
+          eventStore <- createMockEventStore
+          rotatingEventStore1 <- newRotatedEventStore rotationConfig s0 mkAggregator mkCheckpoint eventStore
+          testHydrate rotatingEventStore1 []
+            >>= notConnect
+            >>= primeWith inputs1
+            >>= runToCompletion
+          rotatingEventStore2 <- newRotatedEventStore rotationConfig s0 mkAggregator mkCheckpoint rotatingEventStore1
+          testHydrate rotatingEventStore2 []
+            >>= notConnect
+            >>= primeWith inputs2
+            >>= runToCompletion
+          -- run non-restarted node with prepared inputs
+          eventStore' <- createMockEventStore
+          rotatingEventStore' <- newRotatedEventStore rotationConfig s0 mkAggregator mkCheckpoint eventStore'
+          testHydrate rotatingEventStore' []
+            >>= notConnect
+            >>= primeWith inputs
+            >>= runToCompletion
+          -- stored events should yield consistent checkpoint events
+          [StateEvent{eventId = eventId, stateChanged = checkpoint}] <- getEvents (eventSource rotatingEventStore2)
+          [StateEvent{eventId = eventId', stateChanged = checkpoint'}] <- getEvents (eventSource rotatingEventStore')
+          checkpoint `shouldBe` checkpoint'
+          -- stored events should yield consistent event ids
+          eventId `shouldBe` eventId'
 
   describe "Rotation algorithm" $ do
     prop "rotates on startup" $
@@ -104,7 +145,7 @@ spec = parallel $ do
         mapM_ (putEvent eventSink) events
         unrotatedHistory <- getEvents eventSource
         toInteger (length unrotatedHistory) `shouldBe` totalEvents
-        let rotationConfig = RotateAfter x
+        let rotationConfig = RotateAfter (Positive x)
         let s0 = []
         let aggregator s e = e : s
         let checkpointer s _ _ = trivialCheckpoint s
@@ -114,34 +155,33 @@ spec = parallel $ do
 
     -- given some event store (source + sink)
     -- lets configure a rotated event store that rotates after x events
-    -- forall y > 0: put x*y events
+    -- forall y > 0: put x*y+1 events
     -- load all events returns a suffix of put events with length <= x
     prop "rotates after configured number of events" $
       \(Positive x, Positive y) -> do
         mockEventStore <- createMockEventStore
-        let rotationConfig = RotateAfter x
+        let rotationConfig = RotateAfter (Positive x)
         let s0 = []
         let aggregator s e = e : s
         let checkpointer s _ _ = trivialCheckpoint s
         rotatingEventStore <- newRotatedEventStore rotationConfig s0 aggregator checkpointer mockEventStore
         let EventStore{eventSource, eventSink = EventSink{putEvent}} = rotatingEventStore
-        let totalEvents = toInteger x * y
+        let totalEvents = toInteger x * y + 1
         let events = TrivialEvent . fromInteger <$> [1 .. totalEvents]
         forM_ events putEvent
         currentHistory <- getEvents eventSource
-        let rotatedElements = fromInteger totalEvents
-        let expectRotated = take rotatedElements events
-        let expectRemaining = drop rotatedElements events
+        let expectRotated = events
+        let expectRemaining :: [TrivialEvent] = []
         let expectedCurrentHistory = trivialCheckpoint expectRotated : expectRemaining
         expectedCurrentHistory `shouldBe` currentHistory
 
     -- forall y. y > 0 && y < x: put x+y events (= ensures rotation)
-    -- load one event === checkpoint of first x of events
+    -- checkpoint of first x + 1 of events === load first event
     prop "puts checkpoint event as first event" $
       \(Positive y, Positive delta) -> do
         let x = y + delta
         mockEventStore <- createMockEventStore
-        let rotationConfig = RotateAfter x
+        let rotationConfig = RotateAfter (Positive x)
         let s0 = []
         let aggregator s e = e : s
         let checkpointer s _ _ = trivialCheckpoint s
@@ -151,11 +191,61 @@ spec = parallel $ do
         let events = TrivialEvent . fromInteger <$> [1 .. totalEvents]
         forM_ events putEvent
         currentHistory <- getEvents eventSource
-        let expectRotated = take (fromInteger $ toInteger x) events
+        let expectRotated = take (fromInteger $ toInteger x + 1) events
         trivialCheckpoint expectRotated `shouldBe` List.head currentHistory
+
+    prop "a restarted and non-restarted store have consistent rotation" $
+      \(x, ChunkedEvents chunks) -> do
+        let rotationConfig = RotateAfter x
+        let s0 = []
+        let aggregator s e = e : s
+        let checkpointer s _ _ = trivialCheckpoint s
+        failAfter 1 $ do
+          -- run restarted in chunks
+          mockEventStore <- createMockEventStore
+          EventStore{eventSource = restartedEventSource} <-
+            foldM
+              ( \store chunk -> do
+                  rotated <- newRotatedEventStore rotationConfig s0 aggregator checkpointer store
+                  let EventStore{eventSink = EventSink{putEvent}} = rotated
+                  forM_ chunk putEvent
+                  pure rotated
+              )
+              mockEventStore
+              chunks
+          -- run non-restarted full
+          mockEventStore' <- createMockEventStore
+          rotated' <- newRotatedEventStore rotationConfig s0 aggregator checkpointer mockEventStore'
+          let EventStore{eventSource = nonRestartedEventSource, eventSink = EventSink{putEvent}} = rotated'
+          let events = concat chunks
+          forM_ events putEvent
+          -- stored events should yield consistent checkpoint event ids
+          restartedHistory <- getEvents restartedEventSource
+          nonRestartedHistory <- getEvents nonRestartedEventSource
+          getEventId (List.last restartedHistory) `shouldBe` getEventId (List.last nonRestartedHistory)
 
 newtype TrivialEvent = TrivialEvent Word64
   deriving newtype (Num, Show, Eq)
+
+newtype ChunkedEvents = ChunkedEvents [[TrivialEvent]]
+  deriving (Show)
+
+instance Arbitrary ChunkedEvents where
+  arbitrary = sized $ \n -> do
+    -- ensure at least one event
+    let total = fromInteger . toInteger $ 1 `max` n
+    let events = map TrivialEvent [1 .. total]
+    chunks <- chunkRandomly (events, [])
+    pure (ChunkedEvents chunks)
+   where
+    chunkRandomly :: ([a], [[a]]) -> Gen [[a]]
+    chunkRandomly = \case
+      ([], acc) -> pure (reverse acc)
+      (xs, acc) -> do
+        -- allow random-sized chunks, including empty ones
+        chunkSize <- choose (0, length xs)
+        let (chunk, rest) = splitAt chunkSize xs
+        chunkRandomly (rest, chunk : acc)
 
 instance HasEventId TrivialEvent where
   getEventId (TrivialEvent w) = w

--- a/hydra-node/test/Hydra/OptionsSpec.hs
+++ b/hydra-node/test/Hydra/OptionsSpec.hs
@@ -42,7 +42,7 @@ import Hydra.Options (
   validateRunOptions,
  )
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
-import Test.QuickCheck (Property, chooseEnum, counterexample, forAll, property, vectorOf, (===))
+import Test.QuickCheck (Positive (..), Property, chooseEnum, counterexample, forAll, property, vectorOf, (===))
 import Text.Regex.TDFA ((=~))
 
 spec :: Spec
@@ -196,6 +196,16 @@ spec = parallel $
                             }
                   )
             }
+
+    it "parses --persistence-rotate-after option as a positive number" $ do
+      let defaultWithRotateAfter rotateAfterX =
+            Run
+              defaultRunOptions
+                { persistenceRotateAfter = Just rotateAfterX
+                }
+      shouldNotParse ["--persistence-rotate-after", "-1"]
+      shouldNotParse ["--persistence-rotate-after", "0"]
+      ["--persistence-rotate-after", "1"] `shouldParse` defaultWithRotateAfter (Positive 1)
 
     it "parses --contestation-period option as a number of seconds" $ do
       let defaultWithContestationPeriod contestationPeriod =


### PR DESCRIPTION
<!-- Describe your change here -->

After rotation, we now reset the number of events to 1 (not 0),
because the checkpoint event is sourced on restart. This avoids
a mismatch between the rotation check on startup and during normal operation.
That discrepancy was the cause of inconsistent rotation log ids after restarts.

Also, we changed the rotation condition to use (>) instead of (>=),
preventing a follow up rotation on start up when the configured threshold is 1
(since checkpointing would immediately trigger a new rotation).

Lastly, a checkpoint event id now matches the last persisted event id
from its preceding rotated log file, preserving sequential order of event ids across logs.

This also makes it easier to identify which rotated log file was used to compute the checkpoint,
as its event id matches the file name suffix.

---

<!-- Consider each and tick it off one way or the other -->
* [X] CHANGELOG updated or not needed
* [X] Documentation updated or not needed
* [X] Haddocks updated or not needed
* [X] No new TODOs introduced or explained herafter
