### PR TITLE
Visualise logs

### DIFF
--- a/hydra-node/exe/visualize-logs/Main.hs
+++ b/hydra-node/exe/visualize-logs/Main.hs
@@ -5,19 +5,30 @@ module Main where
 
 import Hydra.Cardano.Api
 import Hydra.Prelude hiding (encodeUtf8)
+import Hydra.Prelude qualified as P
 
 import Conduit
 import Control.Lens ((^?))
 import Data.Aeson (eitherDecode')
 import Data.Aeson.Lens (key, _String)
 import Data.ByteString.Lazy.Char8 qualified as C8
+import Data.Text qualified as T
 import Data.Text.Encoding (encodeUtf8)
+import GHC.Show (show)
+import Hydra.Chain (ChainEvent (..))
+import Hydra.HeadLogic (Effect (..), Input (..), Outcome (..))
 import Hydra.Logging (Envelope (..))
 import Hydra.Logging.Messages (HydraLog (..))
+import Hydra.Node (HydraNodeLog (..))
 
-newtype Decoded tx
+data Decoded tx
   = DecodedHydraLog Text
-  deriving newtype (Show)
+  | DropLog
+  deriving (Eq)
+
+instance Show (Decoded tx) where
+  show (DecodedHydraLog txt) = T.unpack txt
+  show DropLog = ""
 
 main :: IO ()
 main = do
@@ -28,20 +39,51 @@ main = do
         .| mapMC
           ( \l ->
               case l ^? key "message" . _String of
-                Nothing -> error "Failed to find key 'message' which was expected"
+                Nothing -> P.error "Failed to find key 'message' which was expected"
                 Just line ->
                   let envelope = fromStrict $ encodeUtf8 line
                    in case decodeAs envelope (undefined :: Envelope (HydraLog Tx)) of
-                        Left e -> error $ show e <> line
+                        Left e -> P.error $ P.show e <> line
                         Right decoded ->
                           case decoded.message of
-                            NodeOptions opt -> pure $ DecodedHydraLog $ "NODE STARTING: " <> show opt
-                            Node msg -> pure $ DecodedHydraLog $ "NODE LOG: " <> show msg
-                            _ -> pure $ DecodedHydraLog "_____"
+                            NodeOptions opt -> pure $ DecodedHydraLog $ "NODE STARTING: \n" <> P.show opt
+                            Node msg ->
+                              case msg of
+                                BeginInput{input} ->
+                                  case input of
+                                    ClientInput{clientInput} ->
+                                      pure $ DecodedHydraLog $ "NODE LOG: \n" <> P.show clientInput
+                                    NetworkInput{} -> pure DropLog
+                                    ChainInput{chainEvent} ->
+                                      case chainEvent of
+                                        Observation{observedTx} -> pure $ DecodedHydraLog $ "OBESERVATION: " <> P.show observedTx
+                                        Rollback{} -> pure DropLog
+                                        Tick{} -> pure DropLog
+                                        PostTxError{postTxError} ->
+                                          pure $ DecodedHydraLog $ "ERROR: " <> P.show postTxError
+                                EndInput{} -> pure DropLog
+                                BeginEffect{effect} ->
+                                  case effect of
+                                    ClientEffect{} -> pure DropLog
+                                    NetworkEffect{message} -> pure $ DecodedHydraLog $ P.show message
+                                    OnChainEffect{postChainTx} -> pure $ DecodedHydraLog $ "POSTING: " <> P.show postChainTx
+                                EndEffect{} -> pure DropLog
+                                LogicOutcome{outcome} ->
+                                  case outcome of
+                                    Continue{} -> pure DropLog
+                                    Wait{} -> pure DropLog
+                                    Error{error = err} -> pure $ DecodedHydraLog $ "LOGIC ERROR: " <> P.show err
+                                DroppedFromQueue{} -> pure DropLog
+                                LoadingState -> pure $ DecodedHydraLog "Loading state..."
+                                LoadedState{} -> pure $ DecodedHydraLog "Loaded."
+                                ReplayingState -> pure $ DecodedHydraLog "Replaying state..."
+                                Misconfiguration{} -> pure $ DecodedHydraLog "MISCONFIG!"
+                            _ -> pure DropLog
           )
+        .| filterC (\a -> P.show a /= ("" :: Text))
         .| sinkList
   forM_ decodedLines $ \l ->
-    putTextLn (show l)
+    putTextLn (P.show l)
 
 decodeAs :: forall a. FromJSON a => C8.ByteString -> a -> Either String a
 decodeAs l _ =

--- a/hydra-node/exe/visualize-logs/Main.hs
+++ b/hydra-node/exe/visualize-logs/Main.hs
@@ -79,7 +79,30 @@ visualize paths = do
                                     Continue{stateChanges} ->
                                       foldM
                                         ( \b a -> case a of
+                                            HeadInitialized{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "HeadInitialized" "" green)
                                             HeadOpened{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "HeadOpened" "" green)
+                                            CommittedUTxO{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "CommittedUTxO" "" green)
+                                            HeadAborted{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "HeadAborted" "" green)
+                                            SnapshotRequestDecided{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "SnapshotRequestDecided" "" green)
+                                            SnapshotRequested{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "SnapshotRequested" "" green)
+                                            PartySignedSnapshot{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "PartySignedSnapshot" "" green)
+                                            SnapshotConfirmed{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "SnapshotConfirmed" "" green)
+                                            DepositRecorded{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DepositRecorded" "" green)
+                                            DepositActivated{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DepositActivated" "" green)
+                                            DepositExpired{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DepositExpired" "" red)
+                                            DepositRecovered{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DepositRecovered" "" green)
+                                            CommitApproved{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "CommitApproved" "" green)
+                                            CommitFinalized{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "CommitFinalized" "" green)
+                                            DecommitRecorded{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DecommitRecorded" "" green)
+                                            DecommitApproved{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DecommitApproved" "" green)
+                                            DecommitInvalid{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DecommitInvalid" "" green)
+                                            DecommitFinalized{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DecommitFinalized" "" green)
+                                            HeadClosed{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "HeadClosed" "" green)
+                                            HeadContested{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "HeadContested" "" green)
+                                            HeadIsReadyToFanout{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "HeadIsReadyToFanout" "" green)
+                                            HeadFannedOut{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "HeadFannedOut" "" green)
+                                            IgnoredHeadInitializing{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "IgnoredHeadInitializing" "" red)
+                                            TxInvalid{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "TxInvalid" "" red)
                                             _ -> pure b
                                         )
                                         DropLog

--- a/hydra-node/exe/visualize-logs/Main.hs
+++ b/hydra-node/exe/visualize-logs/Main.hs
@@ -3,7 +3,7 @@
 
 module Main where
 
-import Hydra.Cardano.Api
+import Hydra.Cardano.Api (Tx)
 import Hydra.Prelude hiding (encodeUtf8)
 import Hydra.Prelude qualified as P
 
@@ -71,7 +71,7 @@ visualize paths = do
                                 BeginEffect{effect} ->
                                   case effect of
                                     ClientEffect{} -> pure DropLog
-                                    NetworkEffect{message} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "NETWORK EFFECT" (show message) green)
+                                    NetworkEffect{message} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "NETWORK EFFECT" (show message) magenta)
                                     OnChainEffect{postChainTx} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "POSTING" (show postChainTx) blue)
                                 EndEffect{} -> pure DropLog
                                 LogicOutcome{outcome} ->
@@ -79,28 +79,28 @@ visualize paths = do
                                     Continue{stateChanges} ->
                                       foldM
                                         ( \b a -> case a of
-                                            HeadInitialized{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "HeadInitialized" "" green)
-                                            HeadOpened{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "HeadOpened" "" green)
-                                            CommittedUTxO{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "CommittedUTxO" "" green)
-                                            HeadAborted{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "HeadAborted" "" green)
-                                            SnapshotRequestDecided{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "SnapshotRequestDecided" "" green)
-                                            SnapshotRequested{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "SnapshotRequested" "" green)
-                                            PartySignedSnapshot{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "PartySignedSnapshot" "" green)
-                                            SnapshotConfirmed{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "SnapshotConfirmed" "" green)
-                                            DepositRecorded{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DepositRecorded" "" green)
-                                            DepositActivated{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DepositActivated" "" green)
+                                            HeadInitialized{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "HeadInitialized" "" cyan)
+                                            HeadOpened{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "HeadOpened" "" cyan)
+                                            CommittedUTxO{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "CommittedUTxO" "" cyan)
+                                            HeadAborted{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "HeadAborted" "" red)
+                                            SnapshotRequestDecided{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "SnapshotRequestDecided" "" cyan)
+                                            SnapshotRequested{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "SnapshotRequested" "" cyan)
+                                            PartySignedSnapshot{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "PartySignedSnapshot" "" cyan)
+                                            SnapshotConfirmed{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "SnapshotConfirmed" "" cyan)
+                                            DepositRecorded{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DepositRecorded" "" cyan)
+                                            DepositActivated{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DepositActivated" "" cyan)
                                             DepositExpired{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DepositExpired" "" red)
-                                            DepositRecovered{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DepositRecovered" "" green)
-                                            CommitApproved{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "CommitApproved" "" green)
-                                            CommitFinalized{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "CommitFinalized" "" green)
-                                            DecommitRecorded{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DecommitRecorded" "" green)
-                                            DecommitApproved{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DecommitApproved" "" green)
-                                            DecommitInvalid{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DecommitInvalid" "" green)
-                                            DecommitFinalized{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DecommitFinalized" "" green)
+                                            DepositRecovered{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DepositRecovered" "" cyan)
+                                            CommitApproved{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "CommitApproved" "" cyan)
+                                            CommitFinalized{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "CommitFinalized" "" cyan)
+                                            DecommitRecorded{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DecommitRecorded" "" cyan)
+                                            DecommitApproved{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DecommitApproved" "" cyan)
+                                            DecommitInvalid{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DecommitInvalid" "" red)
+                                            DecommitFinalized{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "DecommitFinalized" "" cyan)
                                             HeadClosed{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "HeadClosed" "" green)
-                                            HeadContested{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "HeadContested" "" green)
-                                            HeadIsReadyToFanout{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "HeadIsReadyToFanout" "" green)
-                                            HeadFannedOut{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "HeadFannedOut" "" green)
+                                            HeadContested{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "HeadContested" "" cyan)
+                                            HeadIsReadyToFanout{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "HeadIsReadyToFanout" "" cyan)
+                                            HeadFannedOut{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "HeadFannedOut" "" cyan)
                                             IgnoredHeadInitializing{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "IgnoredHeadInitializing" "" red)
                                             TxInvalid{} -> pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine "TxInvalid" "" red)
                                             _ -> pure b
@@ -129,7 +129,8 @@ decodeAs l _ =
 
 render :: Decoded tx -> IO ()
 render = \case
-  DecodedHydraLog{t, n, info = InfoLine{header, line, color}} -> putTextLn $ color <> unlines ["[" <> show t <> "]", "NAMESPACE:" <> show n, header, line]
+  DecodedHydraLog{t, n, info = InfoLine{header, line, color}} -> do
+    putTextLn $ color <> unlines ["[" <> show t <> "]", "NAMESPACE:" <> show n, header, line] <> reset
   DropLog -> putTextLn ""
 
 -- ANSI escape codes for colors
@@ -141,6 +142,12 @@ green = "\ESC[32m"
 
 blue :: Text
 blue = "\ESC[34m"
+
+cyan :: Text
+cyan = "\ESC[36m"
+
+magenta :: Text
+magenta = "\ESC[45m"
 
 reset :: Text
 reset = "\ESC[0m"

--- a/hydra-node/exe/visualize-logs/Main.hs
+++ b/hydra-node/exe/visualize-logs/Main.hs
@@ -1,12 +1,41 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+
 module Main where
 
 import Hydra.Cardano.Api
-import Hydra.Prelude
+import Hydra.Prelude hiding (encodeUtf8)
 
+import Control.Lens ((^?))
+import Data.Aeson (eitherDecode')
+import Data.Aeson.Lens (key, _String)
+import Data.ByteString.Lazy.Char8 qualified as C8
+import Data.Text.Encoding (encodeUtf8)
+import Hydra.Logging (Envelope (..))
 import Hydra.Logging.Messages (HydraLog)
-import Hydra.Utils (readJsonFileThrow)
+import Hydra.Node (HydraNodeLog)
+
+data Decoded tx
+  = DecodedHydraLog (HydraLog tx)
+  | DecodedHydraNodeLog (HydraNodeLog tx)
+  deriving (Show)
 
 main :: IO ()
 main = do
-  results <- readJsonFileThrow parseJSON "devnet/alice-logs.txt" :: IO (Either String (HydraLog Tx))
+  logLines <- readFileLBS "../devnet/alice-logs.txt"
+  let allLogLines = zip [1 :: Int ..] (C8.lines logLines)
+  decodedLines <- forM allLogLines $ \(ix, l) ->
+    case l ^? key "message" . _String of
+      Nothing -> error "Failed to find key 'message' which was expected"
+      Just line ->
+        let envelope = fromStrict $ encodeUtf8 line
+         in case decodeAs envelope (undefined :: Envelope (HydraLog Tx)) of
+              Left e -> error $ "Line " <> show ix <> ": error - " <> show e <> " line: " <> show line
+              Right decoded -> pure $ DecodedHydraLog $ decoded.message
+  print decodedLines
   pure ()
+
+decodeAs :: forall a. FromJSON a => C8.ByteString -> a -> Either String a
+decodeAs l _ =
+  case eitherDecode' l :: Either String a of
+    Left e -> Left e
+    Right decoded -> pure decoded

--- a/hydra-node/exe/visualize-logs/Main.hs
+++ b/hydra-node/exe/visualize-logs/Main.hs
@@ -1,0 +1,12 @@
+module Main where
+
+import Hydra.Cardano.Api
+import Hydra.Prelude
+
+import Hydra.Logging.Messages (HydraLog)
+import Hydra.Utils (readJsonFileThrow)
+
+main :: IO ()
+main = do
+  results <- readJsonFileThrow parseJSON "devnet/alice-logs.txt" :: IO (Either String (HydraLog Tx))
+  pure ()

--- a/hydra-node/exe/visualize-logs/Main.hs
+++ b/hydra-node/exe/visualize-logs/Main.hs
@@ -1,38 +1,47 @@
 {-# LANGUAGE OverloadedRecordDot #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Main where
 
 import Hydra.Cardano.Api
 import Hydra.Prelude hiding (encodeUtf8)
 
+import Conduit
 import Control.Lens ((^?))
 import Data.Aeson (eitherDecode')
 import Data.Aeson.Lens (key, _String)
 import Data.ByteString.Lazy.Char8 qualified as C8
 import Data.Text.Encoding (encodeUtf8)
 import Hydra.Logging (Envelope (..))
-import Hydra.Logging.Messages (HydraLog)
-import Hydra.Node (HydraNodeLog)
+import Hydra.Logging.Messages (HydraLog (..))
 
-data Decoded tx
-  = DecodedHydraLog (HydraLog tx)
-  | DecodedHydraNodeLog (HydraNodeLog tx)
-  deriving (Show)
+newtype Decoded tx
+  = DecodedHydraLog Text
+  deriving newtype (Show)
 
 main :: IO ()
 main = do
-  logLines <- readFileLBS "../devnet/alice-logs.txt"
-  let allLogLines = zip [1 :: Int ..] (C8.lines logLines)
-  decodedLines <- forM allLogLines $ \(ix, l) ->
-    case l ^? key "message" . _String of
-      Nothing -> error "Failed to find key 'message' which was expected"
-      Just line ->
-        let envelope = fromStrict $ encodeUtf8 line
-         in case decodeAs envelope (undefined :: Envelope (HydraLog Tx)) of
-              Left e -> error $ "Line " <> show ix <> ": error - " <> show e <> " line: " <> show line
-              Right decoded -> pure $ DecodedHydraLog $ decoded.message
-  print decodedLines
-  pure ()
+  decodedLines <-
+    runConduitRes $
+      sourceFileBS "../devnet/alice-logs.txt"
+        .| linesUnboundedAsciiC
+        .| mapMC
+          ( \l ->
+              case l ^? key "message" . _String of
+                Nothing -> error "Failed to find key 'message' which was expected"
+                Just line ->
+                  let envelope = fromStrict $ encodeUtf8 line
+                   in case decodeAs envelope (undefined :: Envelope (HydraLog Tx)) of
+                        Left e -> error $ show e <> line
+                        Right decoded ->
+                          case decoded.message of
+                            NodeOptions opt -> pure $ DecodedHydraLog $ "NODE STARTING: " <> show opt
+                            Node msg -> pure $ DecodedHydraLog $ "NODE LOG: " <> show msg
+                            _ -> pure $ DecodedHydraLog "_____"
+          )
+        .| sinkList
+  forM_ decodedLines $ \l ->
+    putTextLn (show l)
 
 decodeAs :: forall a. FromJSON a => C8.ByteString -> a -> Either String a
 decodeAs l _ =

--- a/hydra-node/exe/visualize-logs/Main.hs
+++ b/hydra-node/exe/visualize-logs/Main.hs
@@ -98,60 +98,60 @@ decodeAndProcess l =
             Left e -> P.error $ "Decoding failed" <> show e <> "for line: " <> line
             Right decoded -> lift $ processLogs decoded
 
--- | Ideally we would have Data instances for all types so we could get data type String representation
--- instead of providing strings but that would add some compilation time overhead so not worth it.
+-- | Ideally we would have Data instances for all types so we could get data type string representation
+-- instead of providing strings directly but that would add some compilation time overhead so not worth it.
 processLogs :: Envelope (HydraLog Tx) -> IO (Decoded Tx)
 processLogs decoded =
   case decoded.message of
-    NodeOptions opt -> logIt NodeOptionsLabel (show opt)
+    NodeOptions opt -> logIt NodeOptionsLabel opt
     Node msg ->
       case msg of
         BeginInput{input} ->
           case input of
-            ClientInput{clientInput} -> logIt ClientSentLabel (show clientInput)
+            ClientInput{clientInput} -> logIt ClientSentLabel clientInput
             NetworkInput{} -> pure DropLog
             ChainInput{chainEvent} ->
               case chainEvent of
-                Observation{observedTx} -> logIt ObservationLabel (show observedTx)
+                Observation{observedTx} -> logIt ObservationLabel observedTx
                 Rollback{} -> pure DropLog
                 Tick{} -> pure DropLog
-                PostTxError{postTxError} -> logIt ErrorLabel (show postTxError)
+                PostTxError{postTxError} -> logIt ErrorLabel postTxError
         EndInput{} -> pure DropLog
         BeginEffect{effect} ->
           case effect of
             ClientEffect{} -> pure DropLog
-            NetworkEffect{message} -> logIt NetworkLabel (show message)
-            OnChainEffect{postChainTx} -> logIt ChainEffectLabel (show postChainTx)
+            NetworkEffect{message} -> logIt NetworkLabel message
+            OnChainEffect{postChainTx} -> logIt ChainEffectLabel postChainTx
         EndEffect{} -> pure DropLog
         LogicOutcome{outcome} ->
           case outcome of
             Continue{stateChanges} ->
               foldM
                 ( \_ a -> case a of
-                    HeadInitialized{} -> logIt (LogicLabel "HeadInitialized") ""
-                    HeadOpened{} -> logIt (LogicLabel "HeadOpened") ""
-                    CommittedUTxO{} -> logIt (LogicLabel "CommittedUTxO") ""
-                    HeadAborted{} -> logIt (LogicLabel "HeadAborted") ""
-                    SnapshotRequestDecided{} -> logIt (LogicLabel "SnapshotRequestDecided") ""
-                    SnapshotRequested{} -> logIt (LogicLabel "SnapshotRequested") ""
-                    PartySignedSnapshot{} -> logIt (LogicLabel "PartySignedSnapshot") ""
-                    SnapshotConfirmed{} -> logIt (LogicLabel "SnapshotConfirmed") ""
-                    DepositRecorded{} -> logIt (LogicLabel "DepositRecorded") ""
-                    DepositActivated{} -> logIt (LogicLabel "DepositActivated") ""
-                    DepositExpired{} -> logIt (LogicLabel "DepositExpired") ""
-                    DepositRecovered{} -> logIt (LogicLabel "DepositRecovered") ""
-                    CommitApproved{} -> logIt (LogicLabel "CommitApproved") ""
-                    CommitFinalized{} -> logIt (LogicLabel "CommitFinalized") ""
-                    DecommitRecorded{} -> logIt (LogicLabel "DecommitRecorded") ""
-                    DecommitApproved{} -> logIt (LogicLabel "DecommitApproved") ""
-                    DecommitInvalid{} -> logIt (LogicLabel "DecommitInvalid") ""
-                    DecommitFinalized{} -> logIt (LogicLabel "DecommitFinalized") ""
-                    HeadClosed{} -> logIt (LogicLabel "HeadClosed") ""
-                    HeadContested{} -> logIt (LogicLabel "HeadContested") ""
-                    HeadIsReadyToFanout{} -> logIt (LogicLabel "HeadIsReadyToFanout") ""
-                    HeadFannedOut{} -> logIt (LogicLabel "HeadFannedOut") ""
-                    IgnoredHeadInitializing{} -> logIt (LogicLabel "IgnoredHeadInitializing") ""
-                    TxInvalid{} -> logIt (LogicLabel "TxInvalid") ""
+                    details@HeadInitialized{} -> logIt (LogicLabel "HeadInitialized") details
+                    details@HeadOpened{} -> logIt (LogicLabel "HeadOpened") details
+                    details@CommittedUTxO{} -> logIt (LogicLabel "CommittedUTxO") details
+                    details@HeadAborted{} -> logIt (LogicLabel "HeadAborted") details
+                    details@SnapshotRequestDecided{} -> logIt (LogicLabel "SnapshotRequestDecided") details
+                    details@SnapshotRequested{} -> logIt (LogicLabel "SnapshotRequested") details
+                    details@PartySignedSnapshot{} -> logIt (LogicLabel "PartySignedSnapshot") details
+                    details@SnapshotConfirmed{} -> logIt (LogicLabel "SnapshotConfirmed") details
+                    details@DepositRecorded{} -> logIt (LogicLabel "DepositRecorded") details
+                    details@DepositActivated{} -> logIt (LogicLabel "DepositActivated") details
+                    details@DepositExpired{} -> logIt (LogicLabel "DepositExpired") details
+                    details@DepositRecovered{} -> logIt (LogicLabel "DepositRecovered") details
+                    details@CommitApproved{} -> logIt (LogicLabel "CommitApproved") details
+                    details@CommitFinalized{} -> logIt (LogicLabel "CommitFinalized") details
+                    details@DecommitRecorded{} -> logIt (LogicLabel "DecommitRecorded") details
+                    details@DecommitApproved{} -> logIt (LogicLabel "DecommitApproved") details
+                    details@DecommitInvalid{} -> logIt (LogicLabel "DecommitInvalid") details
+                    details@DecommitFinalized{} -> logIt (LogicLabel "DecommitFinalized") details
+                    details@HeadClosed{} -> logIt (LogicLabel "HeadClosed") details
+                    details@HeadContested{} -> logIt (LogicLabel "HeadContested") details
+                    details@HeadIsReadyToFanout{} -> logIt (LogicLabel "HeadIsReadyToFanout") details
+                    details@HeadFannedOut{} -> logIt (LogicLabel "HeadFannedOut") details
+                    details@IgnoredHeadInitializing{} -> logIt (LogicLabel "IgnoredHeadInitializing") details
+                    details@TxInvalid{} -> logIt (LogicLabel "TxInvalid") details
                     NetworkConnected{} -> pure DropLog
                     NetworkDisconnected{} -> pure DropLog
                     PeerConnected{} -> pure DropLog
@@ -168,17 +168,17 @@ processLogs decoded =
                 DropLog
                 stateChanges
             Wait{} -> pure DropLog
-            Error{error = err} -> logIt (LogicError "LOGIC ERROR") (show err)
+            Error{error = err} -> logIt (LogicError "LOGIC ERROR") err
         DroppedFromQueue{} -> pure DropLog
-        LoadingState -> logIt (Other "Loading state...") ""
-        LoadedState{} -> logIt (Other "Loaded.") ""
-        ReplayingState -> logIt (Other "Replaying state...") ""
-        Misconfiguration{} -> logIt (Other "MISCONFIG!") ""
+        LoadingState -> logIt (Other "Loading state...") ()
+        LoadedState{} -> logIt (Other "Loaded.") ()
+        ReplayingState -> logIt (Other "Replaying state...") ()
+        details@Misconfiguration{} -> logIt (Other "MISCONFIG!") details
     _ -> pure DropLog
  where
-  logIt :: LogType -> Text -> IO (Decoded Tx)
+  logIt :: Show x => LogType -> x -> IO (Decoded Tx)
   logIt l s =
-    pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine l s)
+    pure $ DecodedHydraLog decoded.timestamp decoded.namespace (InfoLine l (show s))
 
 render :: Decoded tx -> IO ()
 render = \case

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -252,14 +252,20 @@ executable visualize-logs
   hs-source-dirs: exe/visualize-logs
   main-is:        Main.hs
   build-depends:
+    , aeson
     , base
     , bytestring
+    , containers
     , hydra-cardano-api
     , hydra-node
     , hydra-prelude
+    , lens
+    , lens-aeson
+    , text
     , unix
 
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N4
+
 benchmark tx-cost
   import:         project-config
   hs-source-dirs: bench/tx-cost

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -255,15 +255,13 @@ executable visualize-logs
     , aeson
     , base
     , conduit
-    , bytestring
-    , containers
     , hydra-cardano-api
     , hydra-node
     , hydra-prelude
     , lens
     , lens-aeson
+    , optparse-applicative
     , text
-    , unix
 
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N4
 

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -247,6 +247,19 @@ executable hydra-node
 
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N4
 
+executable visualize-logs
+  import:         project-config
+  hs-source-dirs: exe/visualize-logs
+  main-is:        Main.hs
+  build-depends:
+    , base
+    , bytestring
+    , hydra-cardano-api
+    , hydra-node
+    , hydra-prelude
+    , unix
+
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N4
 benchmark tx-cost
   import:         project-config
   hs-source-dirs: bench/tx-cost

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -254,6 +254,7 @@ executable visualize-logs
   build-depends:
     , aeson
     , base
+    , conduit
     , bytestring
     , containers
     , hydra-cardano-api

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -253,6 +253,7 @@ executable visualize-logs
   main-is:        Main.hs
   build-depends:
     , aeson
+    , attoparsec
     , base
     , conduit
     , hydra-cardano-api

--- a/hydra-node/src/Hydra/API/APIServerLog.hs
+++ b/hydra-node/src/Hydra/API/APIServerLog.hs
@@ -1,8 +1,9 @@
 module Hydra.API.APIServerLog where
 
-import Hydra.Prelude
+import Hydra.Prelude hiding (encodeUtf8)
 
 import Data.Aeson qualified as Aeson
+import Data.Text.Encoding (encodeUtf8)
 import Hydra.Network (PortNumber)
 
 data APIServerLog
@@ -18,7 +19,7 @@ data APIServerLog
       }
   | APITransactionSubmitted {submittedTxId :: String}
   deriving stock (Eq, Show, Generic)
-  deriving anyclass (ToJSON)
+  deriving anyclass (ToJSON, FromJSON)
 
 -- | New type wrapper to define JSON instances.
 newtype PathInfo = PathInfo ByteString
@@ -27,6 +28,10 @@ newtype PathInfo = PathInfo ByteString
 instance ToJSON PathInfo where
   toJSON (PathInfo bytes) =
     Aeson.String $ decodeUtf8 bytes
+
+instance FromJSON PathInfo where
+  parseJSON = Aeson.withText "PathInfo" $ \t ->
+    pure $ PathInfo $ encodeUtf8 t
 
 -- | New type wrapper to define JSON instances.
 --
@@ -38,3 +43,7 @@ newtype Method = Method ByteString
 instance ToJSON Method where
   toJSON (Method bytes) =
     Aeson.String $ decodeUtf8 bytes
+
+instance FromJSON Method where
+  parseJSON = Aeson.withText "Method" $ \t ->
+    pure $ Method $ encodeUtf8 t

--- a/hydra-node/src/Hydra/Chain.hs
+++ b/hydra-node/src/Hydra/Chain.hs
@@ -163,6 +163,7 @@ data OnChainTx tx
 deriving stock instance IsTx tx => Eq (OnChainTx tx)
 deriving stock instance IsTx tx => Show (OnChainTx tx)
 deriving anyclass instance IsTx tx => ToJSON (OnChainTx tx)
+deriving anyclass instance IsTx tx => FromJSON (OnChainTx tx)
 
 instance ArbitraryIsTx tx => Arbitrary (OnChainTx tx) where
   arbitrary = genericArbitrary
@@ -316,6 +317,7 @@ data ChainEvent tx
 deriving stock instance (IsTx tx, IsChainState tx) => Eq (ChainEvent tx)
 deriving stock instance (IsTx tx, IsChainState tx) => Show (ChainEvent tx)
 deriving anyclass instance (IsTx tx, IsChainState tx) => ToJSON (ChainEvent tx)
+deriving anyclass instance (IsTx tx, IsChainState tx) => FromJSON (ChainEvent tx)
 
 instance (ArbitraryIsTx tx, IsChainState tx) => Arbitrary (ChainEvent tx) where
   arbitrary = genericArbitrary

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -507,4 +507,4 @@ data CardanoChainLog
   | RolledBackward {point :: ChainPoint}
   | Wallet TinyWalletLog
   deriving stock (Eq, Show, Generic)
-  deriving anyclass (ToJSON)
+  deriving anyclass (ToJSON, FromJSON)

--- a/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
@@ -452,3 +452,4 @@ data TinyWalletLog
   deriving stock (Eq, Generic, Show)
 
 deriving anyclass instance ToJSON TinyWalletLog
+deriving anyclass instance FromJSON TinyWalletLog

--- a/hydra-node/src/Hydra/HeadLogic/Error.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Error.hs
@@ -49,6 +49,14 @@ deriving anyclass instance
   ) =>
   ToJSON (LogicError tx)
 
+deriving anyclass instance
+  ( FromJSON (HeadState tx)
+  , FromJSON (Input tx)
+  , FromJSON (RequirementFailure tx)
+  , FromJSON (SideLoadRequirementFailure tx)
+  ) =>
+  FromJSON (LogicError tx)
+
 data RequirementFailure tx
   = ReqSnNumberInvalid {requestedSn :: SnapshotNumber, lastSeenSn :: SnapshotNumber}
   | ReqSvNumberInvalid {requestedSv :: SnapshotVersion, lastSeenSv :: SnapshotVersion}
@@ -66,6 +74,7 @@ data RequirementFailure tx
 deriving stock instance Eq (TxIdType tx) => Eq (RequirementFailure tx)
 deriving stock instance Show (TxIdType tx) => Show (RequirementFailure tx)
 deriving anyclass instance ToJSON (TxIdType tx) => ToJSON (RequirementFailure tx)
+deriving anyclass instance FromJSON (TxIdType tx) => FromJSON (RequirementFailure tx)
 
 data SideLoadRequirementFailure tx
   = SideLoadInitialSnapshotMismatch
@@ -79,3 +88,4 @@ data SideLoadRequirementFailure tx
 deriving stock instance Eq (UTxOType tx) => Eq (SideLoadRequirementFailure tx)
 deriving stock instance Show (UTxOType tx) => Show (SideLoadRequirementFailure tx)
 deriving anyclass instance ToJSON (UTxOType tx) => ToJSON (SideLoadRequirementFailure tx)
+deriving anyclass instance FromJSON (UTxOType tx) => FromJSON (SideLoadRequirementFailure tx)

--- a/hydra-node/src/Hydra/HeadLogic/Input.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Input.hs
@@ -30,6 +30,7 @@ data Input tx
 deriving stock instance IsChainState tx => Eq (Input tx)
 deriving stock instance IsChainState tx => Show (Input tx)
 deriving anyclass instance IsChainState tx => ToJSON (Input tx)
+deriving anyclass instance IsChainState tx => FromJSON (Input tx)
 
 instance (ArbitraryIsTx tx, IsChainState tx) => Arbitrary (Input tx) where
   arbitrary = genericArbitrary

--- a/hydra-node/src/Hydra/HeadLogic/Outcome.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Outcome.hs
@@ -48,6 +48,7 @@ data Effect tx
 deriving stock instance IsChainState tx => Eq (Effect tx)
 deriving stock instance IsChainState tx => Show (Effect tx)
 deriving anyclass instance IsChainState tx => ToJSON (Effect tx)
+deriving anyclass instance IsChainState tx => FromJSON (Effect tx)
 
 -- | Head state changed event. These events represent all the internal state
 -- changes, get persisted and processed in an event sourcing manner.
@@ -208,6 +209,7 @@ instance Semigroup (Outcome tx) where
 deriving stock instance IsChainState tx => Eq (Outcome tx)
 deriving stock instance IsChainState tx => Show (Outcome tx)
 deriving anyclass instance IsChainState tx => ToJSON (Outcome tx)
+deriving anyclass instance IsChainState tx => FromJSON (Outcome tx)
 
 noop :: Outcome tx
 noop = Continue [] []
@@ -244,3 +246,4 @@ data WaitReason tx
 deriving stock instance IsTx tx => Eq (WaitReason tx)
 deriving stock instance IsTx tx => Show (WaitReason tx)
 deriving anyclass instance IsTx tx => ToJSON (WaitReason tx)
+deriving anyclass instance IsTx tx => FromJSON (WaitReason tx)

--- a/hydra-node/src/Hydra/Logging.hs
+++ b/hydra-node/src/Hydra/Logging.hs
@@ -76,6 +76,14 @@ instance ToJSON a => ToJSON (Envelope a) where
         , "message" .= message
         ]
 
+instance FromJSON a => FromJSON (Envelope a) where
+  parseJSON = Aeson.withObject "Envelope" $ \o -> do
+    timestamp <- o Aeson..: "timestamp"
+    threadId <- o Aeson..: "threadId"
+    namespace <- o Aeson..: "namespace"
+    message <- o Aeson..: "message"
+    pure Envelope{timestamp, threadId, namespace, message}
+
 defaultQueueSize :: Natural
 defaultQueueSize = 500
 

--- a/hydra-node/src/Hydra/Logging/Messages.hs
+++ b/hydra-node/src/Hydra/Logging/Messages.hs
@@ -28,3 +28,4 @@ data HydraLog tx
 deriving stock instance Eq (HydraNodeLog tx) => Eq (HydraLog tx)
 deriving stock instance Show (HydraNodeLog tx) => Show (HydraLog tx)
 deriving anyclass instance ToJSON (HydraNodeLog tx) => ToJSON (HydraLog tx)
+deriving anyclass instance FromJSON (HydraNodeLog tx) => FromJSON (HydraLog tx)

--- a/hydra-node/src/Hydra/Network.hs
+++ b/hydra-node/src/Hydra/Network.hs
@@ -189,7 +189,7 @@ data Connectivity
       { clusterPeers :: Text
       }
   deriving stock (Generic, Eq, Show)
-  deriving anyclass (ToJSON)
+  deriving anyclass (ToJSON, FromJSON)
 
 instance Arbitrary Connectivity where
   arbitrary = genericArbitrary

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -616,4 +616,4 @@ data EtcdLog
   | NoKeepAliveResponse
   | MatchingProtocolVersion {version :: ProtocolVersion}
   deriving stock (Eq, Show, Generic)
-  deriving anyclass (ToJSON)
+  deriving anyclass (ToJSON, FromJSON)

--- a/hydra-node/src/Hydra/Network/Message.hs
+++ b/hydra-node/src/Hydra/Network/Message.hs
@@ -23,7 +23,7 @@ data NetworkEvent msg
   = ConnectivityEvent Connectivity
   | ReceivedMessage {sender :: Party, msg :: msg}
   deriving stock (Eq, Show, Generic)
-  deriving anyclass (ToJSON)
+  deriving anyclass (ToJSON, FromJSON)
 
 instance Arbitrary msg => Arbitrary (NetworkEvent msg) where
   arbitrary = genericArbitrary

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -454,3 +454,4 @@ data HydraNodeLog tx
 deriving stock instance IsChainState tx => Eq (HydraNodeLog tx)
 deriving stock instance IsChainState tx => Show (HydraNodeLog tx)
 deriving anyclass instance IsChainState tx => ToJSON (HydraNodeLog tx)
+deriving anyclass instance IsChainState tx => FromJSON (HydraNodeLog tx)

--- a/hydra-node/src/Hydra/Node/Network.hs
+++ b/hydra-node/src/Hydra/Node/Network.hs
@@ -84,3 +84,4 @@ data NetworkLog
   | Etcd EtcdLog
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON)
+  deriving anyclass (FromJSON)

--- a/hydra-node/src/Hydra/Node/ParameterMismatch.hs
+++ b/hydra-node/src/Hydra/Node/ParameterMismatch.hs
@@ -20,4 +20,4 @@ data ParamMismatch
   | PartiesMismatch {loadedParties :: [Party], configuredParties :: [Party]}
   | SavedNetworkPartiesInconsistent {numberOfParties :: Int}
   deriving stock (Generic, Eq, Show)
-  deriving anyclass (ToJSON)
+  deriving anyclass (ToJSON, FromJSON)


### PR DESCRIPTION
fix #2047 

New executable accepts one or more log file paths as the argument and then parses the logs back to the original types, sorts them on the timestamp field and displays using different colors for network entries, observations, messages from Head logic etc.

If we like this then we could go further and use brick to conditionally show details to reduce the clutter a bit more.

Since this is for internal usage I didn't bother with proper exception handling.

`cabal run hydra-node:exe:visualize-logs -- log-path-1 log-path-2 log-path-3`
<img width="3391" height="1357" alt="logs" src="https://github.com/user-attachments/assets/014072b5-1d89-4b0a-a334-ddf29f26292a" />

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
