### PR TITLE
Fix: Blockfrost API TLS "unknown CA" error in Docker

### DIFF
--- a/nix/hydra/docker.nix
+++ b/nix/hydra/docker.nix
@@ -14,6 +14,7 @@
             name = "hydra-node-env";
             paths = [
               pkgs.busybox
+              pkgs.dockerTools.caCertificates
             ];
           };
           config = {


### PR DESCRIPTION
## Summary

This pull request resolves the Blockfrost API TLS error encountered in the Hydra Docker image:
```
BlockfrostAPIError "ServantClientError (ConnectionError (HttpExceptionRequest Request {
  host                 = "cardano-preprod.blockfrost.io"
  port                 = 443
  secure               = True
  requestHeaders       = [("Accept","application/json;charset=utf-8,application/json"),
                          ("User-Agent","blockfrost-haskell/0.13.0.0"),
                          ("project_id","{project_id}")]
  path                 = "/api/v0/genesis"
  method               = "GET"
  ...
} (InternalException (HandshakeFailed (Error_Protocol "certificate has unknown CA" UnknownCa)))))"
```
The underlying cause was missing or outdated CA certificates in the Docker container, resulting in the container not trusting Blockfrost's certificate authority.

## Changes
- Include dockerTools.cacert bundle to /etc/ssl/certs for NixOS base image

## Scope & Justification
- Only Docker build/config files were modified.
- No speculative changes or refactoring performed.

## Related issue
https://discord.com/channels/826816523368005654/890903732462710836/1407283922496393227

## Reference
https://ryantm.github.io/nixpkgs/builders/images/dockertools/#ssec-pkgs-dockerTools-buildImage
https://ryantm.github.io/nixpkgs/builders/images/dockertools/#ssec-pkgs-dockerTools-helpers