### PR TITLE
Fix tui recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ changes.
 
 ## [0.23.0] - UNRELEASED
 
-- Fix bug where TUI would have out-of-date head status information in the
-  presence of event rotation.
+- Fix bug where TUI would have out-of-date head status information
+  after restarting on a rotated node (due to event rotation).
 
 - Accept additional field `tokens` when depositing to specify different (non-ADA) assets that should be depositted to a Head returning any leftover to the user.
 

--- a/hydra-node/golden/Greetings/Greetings.json
+++ b/hydra-node/golden/Greetings/Greetings.json
@@ -20,8 +20,10 @@
             },
             "networkInfo": {
                 "networkConnected": true,
-                "peersConnected": [],
-                "peersDisconnected": []
+                "peersInfo": {
+                    "127.0.0.1:5000": true,
+                    "peer.local:5001": false
+                }
             },
             "snapshotUtxo": {
                 "0101010101010001010001010001010101010001010000000100010101010100#30": {

--- a/hydra-node/golden/Greetings/Greetings.json
+++ b/hydra-node/golden/Greetings/Greetings.json
@@ -2,23 +2,39 @@
     "samples": [
         {
             "env": {
-                "configuredPeers": "",
+                "configuredPeers": "s",
                 "contestationPeriod": 43200,
-                "depositPeriod": 61129,
+                "depositPeriod": 60080,
                 "otherParties": [],
-                "participants": [
-                    "01000000000001000101000101010101000101000001000000010100"
-                ],
+                "participants": [],
                 "party": {
-                    "vkey": "35719d612496ce0f320cd39e4693a2997194cec954ec602064f67a5c81150136"
+                    "vkey": "348cdf360a866dedf92cb18cfb736c2da212ea44d2f1270fe60dad88801be97c"
                 },
-                "signingKey": "c659b97ce8782bc64476a5e82a14cbd38d0413cb15b18fa87d281b44272fa476"
+                "signingKey": "23db2c1b05cc1c905486253e1a39b0df087217f33180f7d5cf4aa1ec8c0b6634"
             },
             "headStatus": "Closed",
             "hydraHeadId": "01000001000001000000000001000101",
-            "hydraNodeVersion": "",
+            "hydraNodeVersion": "G",
             "me": {
                 "vkey": "3d8fb298d77d2fda814e9530b5539758751d27ad1c234080e04ec2e15dea1490"
+            },
+            "networkInfo": {
+                "networkConnected": true,
+                "peersConnected": [],
+                "peersDisconnected": []
+            },
+            "snapshotUtxo": {
+                "0101010101010001010001010001010101010001010000000100010101010100#30": {
+                    "address": "addr_test1xqqxwuptvt44m42v49ux7l37cy6zg9ylxpr0ltmsnaedfx9frwx7crjjl27pwadu3a4vere9d2cmrm8x2xey5rmzw73sfcqwk4",
+                    "datum": null,
+                    "datumhash": "da0beccb4644ffb9db547cb2c058ee0b27abe96774d43dd85884483b5452b696",
+                    "inlineDatum": null,
+                    "inlineDatumRaw": null,
+                    "referenceScript": null,
+                    "value": {
+                        "lovelace": 45000000000000000
+                    }
+                }
             },
             "tag": "Greetings"
         }

--- a/hydra-node/golden/ServerOutput/EventLogRotated.json
+++ b/hydra-node/golden/ServerOutput/EventLogRotated.json
@@ -1,6 +1,452 @@
 {
     "samples": [
         {
+            "checkpoint": {
+                "contents": {
+                    "chainState": {
+                        "recordedAt": {
+                            "tag": "ChainPointAtGenesis"
+                        },
+                        "spendableUTxO": {
+                            "0101000001000000010100010001010000010100010001010101000000010000#51": {
+                                "address": "addr_test1xpn5lq5sj5s9dfrrsrcuq3pkna7lxc4ekwq7j8lm0u0jyvnjwzq57kfut3d6rhellnl4kjcph4p3s28dmwz3kdqngwyqzndcrp",
+                                "datum": null,
+                                "inlineDatum": {
+                                    "map": [
+                                        {
+                                            "k": {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "map": [
+                                                                {
+                                                                    "k": {
+                                                                        "int": -1
+                                                                    },
+                                                                    "v": {
+                                                                        "bytes": ""
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "bytes": "5431eb"
+                                                                    },
+                                                                    "v": {
+                                                                        "bytes": ""
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        "v": {
+                                                            "constructor": 4,
+                                                            "fields": []
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "int": -5
+                                                        },
+                                                        "v": {
+                                                            "constructor": 1,
+                                                            "fields": [
+                                                                {
+                                                                    "int": -5
+                                                                },
+                                                                {
+                                                                    "bytes": "6a6c15"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "constructor": 1,
+                                                            "fields": [
+                                                                {
+                                                                    "int": 0
+                                                                },
+                                                                {
+                                                                    "bytes": "10"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "v": {
+                                                            "bytes": "00bc08f8"
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "map": [
+                                                                {
+                                                                    "k": {
+                                                                        "bytes": "4b"
+                                                                    },
+                                                                    "v": {
+                                                                        "int": -3
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "int": 3
+                                                                    },
+                                                                    "v": {
+                                                                        "int": -1
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "bytes": "67"
+                                                                    },
+                                                                    "v": {
+                                                                        "int": 1
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        "v": {
+                                                            "map": [
+                                                                {
+                                                                    "k": {
+                                                                        "bytes": "616f90c4"
+                                                                    },
+                                                                    "v": {
+                                                                        "int": 0
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "bytes": "33"
+                                                                    },
+                                                                    "v": {
+                                                                        "bytes": ""
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "bytes": "8a70"
+                                                                    },
+                                                                    "v": {
+                                                                        "bytes": ""
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "int": 3
+                                                                    },
+                                                                    "v": {
+                                                                        "bytes": "3f45"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "bytes": "bb8444b0"
+                                                                    },
+                                                                    "v": {
+                                                                        "int": -3
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "int": 4
+                                                        },
+                                                        "v": {
+                                                            "int": -1
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "v": {
+                                                "int": -1
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "list": []
+                                                        },
+                                                        "v": {
+                                                            "map": []
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "list": [
+                                                                {
+                                                                    "int": -3
+                                                                },
+                                                                {
+                                                                    "bytes": "d126688f"
+                                                                },
+                                                                {
+                                                                    "int": -1
+                                                                },
+                                                                {
+                                                                    "int": -4
+                                                                },
+                                                                {
+                                                                    "bytes": "15"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "v": {
+                                                            "list": []
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "v": {
+                                                "int": 2
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "bytes": "b09bd16e"
+                                                        },
+                                                        "v": {
+                                                            "int": 4
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "list": [
+                                                                {
+                                                                    "bytes": "c09b550a"
+                                                                },
+                                                                {
+                                                                    "int": -4
+                                                                },
+                                                                {
+                                                                    "bytes": "1adeab"
+                                                                },
+                                                                {
+                                                                    "int": -5
+                                                                }
+                                                            ]
+                                                        },
+                                                        "v": {
+                                                            "map": [
+                                                                {
+                                                                    "k": {
+                                                                        "int": -4
+                                                                    },
+                                                                    "v": {
+                                                                        "bytes": "96a1"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "bytes": "1de96567"
+                                                                    },
+                                                                    "v": {
+                                                                        "int": 0
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "v": {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "int": -4
+                                                        },
+                                                        "v": {
+                                                            "constructor": 5,
+                                                            "fields": []
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "bytes": "3e0d62"
+                                                        },
+                                                        "v": {
+                                                            "map": [
+                                                                {
+                                                                    "k": {
+                                                                        "int": -3
+                                                                    },
+                                                                    "v": {
+                                                                        "bytes": "f687"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "int": -5
+                                                                    },
+                                                                    "v": {
+                                                                        "int": -5
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "list": [
+                                                                {
+                                                                    "int": -4
+                                                                },
+                                                                {
+                                                                    "int": 2
+                                                                },
+                                                                {
+                                                                    "bytes": "5592"
+                                                                },
+                                                                {
+                                                                    "bytes": "404c"
+                                                                },
+                                                                {
+                                                                    "int": -5
+                                                                }
+                                                            ]
+                                                        },
+                                                        "v": {
+                                                            "bytes": "52"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                },
+                                "inlineDatumRaw": "a3a5a22040435431eb40d87d8024d87a9f24436a6c15ffd87a9f004110ff4400bc08f8a3414b220320416701a544616f90c400413340428a704003423f4544bb8444b022042020a280a09f2244d126688f20234115ff8002a244b09bd16e049f44c09b550a23431adeab24ffa2234296a1441de9656700a323d87e80433e0d62a22242f68724249f230242559242404c24ff4152",
+                                "inlineDatumhash": "60678d77c1d87a67b2bb1e5627b007c571ccac0ffecbb02c73574d3786b17028",
+                                "referenceScript": null,
+                                "value": {
+                                    "lovelace": 1646420
+                                }
+                            }
+                        }
+                    },
+                    "coordinatedHeadState": {
+                        "allTxs": {
+                            "0101000000010000010100010001000001010101000101000101000100010001": {
+                                "cborHex": "84ae00d90102800dd90102818258200f09c1148a623a361720b08cfa1347827db0fdb951bfa25ae418e03bcb82aad90112d9010281825820792cebc8bdb84eca30ba07f889ce040ef781cb5cf061e6fe9a3ce84d4fd429d8010181a400583931e4491c453da8bfd5cdad0d928a3958d4b43dd8780aa158528fd1b1ac30c6706a04c1714ffc97554e3a39aed472e184d479922751b3a85f0601821b7f06bb6566046d28a1581c02a41503e8ad438f517d0c19d76c1a0071c8b43a36e4dee21781fc71a14fc96b7a8ed047f11f702b9761d136570102820058202c168f6650804d54f1f0cfcbce86617aec9d13a385a57943846a1b380c13b59003d8184582008204011082583930e58569ddb7abb0fab04181371cfd2ead71d1f24f50c1447a120736d04d29a5afe870af389c0f27e608b202372612081adafc61526efac40c8200a1581c4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebea1413601111a00066292021a0002dbac05a1581de0c59f0942092bec4785cecadbd39b06239260f392b694e33d19e2e4111a0006923e08010ed9010281581cc93ee11b796f24d551c595be519abb3c402cadf95c848b535429d63309a1581c94a3d23924698b0d28690d7c3480ae1f63e444476e66b6969b2e039fa141363b1a66e70fd53a1037075820ba0476dd60b6a084f28a4a4cbaaa92c374600881fe897d0456b324bf300ee8260f00161a0008dbcfa300d901028182582047f60129b2b7a3e2f4d688ec9ec0266a0f1fa6474c7ab3a383ad17912c073b525840b8616621b7f193252681c9b66c42c6713e900e8e12eb07b78e6d59079719e79a8373e9486364beae0f409579af9d911fc076e17cd3e8e542a3d140ac21582ad801d90102818201838201828200581cd0171fc510bb612b22914c080996a35f8c93581ab2832d835f7a1772830302848200581cd3354818457f2166d7edb735da07a4f59950b7320b9893564bed4d7d8200581cb4bdcd67e81a1b946aecbe5d7f5120220b8b3494c90b2be61629f2628200581c9dea8efb7226a7123de7d96a0b3e5a0a98373c70a30a601a212600048200581c920694120fdabb696808ba1b94a5a27a0c0fd97054d2b145b8763ef5820181830302828200581cd382063b79a408bb414c7ee00756bf88fe8d3c89b80626e8b2db6c0a8200581ccd73e7eceec0e650b3ab68aa8b4316ab91cb412f1180b19387ec92ac8200581c665873a738d7f1a8dc48dcc6c0bc22e00a56597b828e45d4be7ac43604d90102819f01fff4d90103a0",
+                                "description": "",
+                                "txId": "d52c80c5191daf4a5a5db15dbf4b6a3ae6a823280fadd7648a23289f613a893d",
+                                "type": "Tx ConwayEra"
+                            }
+                        },
+                        "confirmedSnapshot": {
+                            "signatures": {
+                                "multiSignature": [
+                                    "f2f5c3ca82df52d54d32fae06deeab46d9d8a6e3537a4fb3e2caef111d8d3ba4c50caba08e7b6207d90e6c311348aa4dd9e4b3723d866376bec6a8ca3a92e30e"
+                                ]
+                            },
+                            "snapshot": {
+                                "confirmed": [],
+                                "headId": "01000001010000010001000001010000",
+                                "number": 2,
+                                "utxo": {
+                                    "0100000101010001000000010101000000010000010000000001000100000100#21": {
+                                        "address": "addr_test1xqwfnk5xfht36576zrkgqgncwslr2fckpppp3uwecjxm5deyqyjtf76rlhx9rzf7pgq2kflzcr98n52yaerqgrstfjkqt5jqys",
+                                        "datum": null,
+                                        "datumhash": "35afff6244b98e37f029d3f75e12efd20b4a56d114f6d510223e37cb2d91bb1d",
+                                        "inlineDatum": null,
+                                        "inlineDatumRaw": null,
+                                        "referenceScript": null,
+                                        "value": {
+                                            "lovelace": 1116290
+                                        }
+                                    }
+                                },
+                                "utxoToCommit": {
+                                    "0101010001010100000101000101010001000000000000010101000000000100#17": {
+                                        "address": "addr_test1wrah3edu7gpnsy06d3unxcq6tn4zjgtqm7hq8mkspa5cvcqdscwrx",
+                                        "datum": null,
+                                        "datumhash": "b91be94ef19e89f8b516b9ce4207d92169ea25f4542d2c56a4608c983e5e3ffd",
+                                        "inlineDatum": null,
+                                        "inlineDatumRaw": null,
+                                        "referenceScript": null,
+                                        "value": {
+                                            "lovelace": 45000000000000000
+                                        }
+                                    }
+                                },
+                                "utxoToDecommit": {
+                                    "0101010001010101010000000100010000000100010001010101000000000101#81": {
+                                        "address": "addr_test1yqewauak8t2p3hejpssjyeyhm2q35p69uzxkg0amglkz84nez89a6x45v3n743lkd0ndj0z2yj74eu4zpkd4qkrwrtpqgt0hdv",
+                                        "datum": null,
+                                        "datumhash": null,
+                                        "inlineDatum": null,
+                                        "inlineDatumRaw": null,
+                                        "referenceScript": null,
+                                        "value": {
+                                            "118adc8a26403680252b176b5c466de8d02f30407a5fac7a592adffd": {
+                                                "12df462121d6e8ddb8ae0878c4334c65d2d485d4e54912c5443439e6c726b4ff": 1
+                                            },
+                                            "lovelace": 1262830
+                                        }
+                                    }
+                                },
+                                "version": 0
+                            },
+                            "tag": "ConfirmedSnapshot"
+                        },
+                        "currentDepositTxId": "0001010101000100010101000100000001000101000000010001010001010101",
+                        "decommitTx": null,
+                        "localTxs": [],
+                        "localUTxO": {
+                            "0001010000000000000100000000000100010101000100010101000000000001#47": {
+                                "address": "addr_test1ypnm9pd0hj4f9wmvwec8c02parr7e0hrdytjyz8dgng2u4dv9ra49qvewdeuvwkxkntyqe8sa5c84udl4ngr50xvzf7s5xjwkd",
+                                "datum": null,
+                                "datumhash": "0df036e8bdc37c350645358a4a9180cbc8aed1e745a18742bc469ba1619d18db",
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "lovelace": 45000000000000000
+                                }
+                            }
+                        },
+                        "pendingDeposits": {
+                            "0001010100010000010001010000010101010100000001000101000001010101": {
+                                "created": "1864-05-09T16:20:48.252405586448Z",
+                                "deadline": "1864-05-08T00:16:58.432041140382Z",
+                                "deposited": {
+                                    "0000010001000100000101010100000000000001000001000100010000010100#11": {
+                                        "address": "addr_test1qqn9es52q9egls5c7rwyus5z8ya99l22u7q5srnwpzpqsqhn77p0tm5gq54933ehppnnxy47hg7peujthj58jz4a7muqwrep83",
+                                        "datum": null,
+                                        "datumhash": "cc99806c9410c56195f66c06bfde41d7d2fb946aa840e74bf08d734e7e513fa5",
+                                        "inlineDatum": null,
+                                        "inlineDatumRaw": null,
+                                        "referenceScript": null,
+                                        "value": {
+                                            "lovelace": 45000000000000000
+                                        }
+                                    }
+                                },
+                                "headId": "01010101000100000100000000010100",
+                                "status": "Inactive"
+                            }
+                        },
+                        "seenSnapshot": {
+                            "lastSeen": 0,
+                            "requested": 1,
+                            "tag": "RequestedSnapshot"
+                        },
+                        "version": 0
+                    },
+                    "currentSlot": 1,
+                    "headId": "00000001010101000101000000000101",
+                    "headSeed": "00000100010101010001010101010000",
+                    "parameters": {
+                        "contestationPeriod": 31536000,
+                        "parties": []
+                    }
+                },
+                "tag": "Open"
+            },
             "tag": "EventLogRotated"
         }
     ],

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -872,6 +872,7 @@ components:
         - headStatus
         - hydraNodeVersion
         - env
+        - networkInfo
       properties:
         tag:
           type: string
@@ -2987,6 +2988,26 @@ components:
           $ref: "api.yaml#/components/schemas/DepositPeriod"
         configuredPeers:
           type: string
+
+    NetworkInfo:
+      type: object
+      description: |
+        L2 Hydra network status information.
+      required:
+      - networkConnected
+      - peersInfo
+      additionalProperties: false
+      properties:
+        networkConnected:
+          type: boolean
+        peersInfo:
+          type: object
+          description: Mapping from peer Host to connection status.
+          additionalProperties:
+            type: boolean
+          example:
+            "127.0.0.1:5000": true
+            "peer.local:5001": false
 
     SequenceNumber:
       type: integer

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -1773,7 +1773,7 @@ components:
       required:
         - tag
         - seq
-        - state
+        - checkpoint
         - timestamp
       properties:
         tag:
@@ -1781,7 +1781,7 @@ components:
           enum: ["EventLogRotated"]
         seq:
           $ref: "api.yaml#/components/schemas/SequenceNumber"
-        state:
+        checkpoint:
           $ref: "api.yaml#/components/schemas/HeadState"
         timestamp:
           $ref: "api.yaml#/components/schemas/UTCTime"

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -1773,6 +1773,7 @@ components:
       required:
         - tag
         - seq
+        - state
         - timestamp
       properties:
         tag:
@@ -1780,6 +1781,8 @@ components:
           enum: ["EventLogRotated"]
         seq:
           $ref: "api.yaml#/components/schemas/SequenceNumber"
+        state:
+          $ref: "api.yaml#/components/schemas/HeadState"
         timestamp:
           $ref: "api.yaml#/components/schemas/UTCTime"
 

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -216,7 +216,7 @@ setupServerNotification = do
   pure (putMVar mv (), takeMVar mv)
 
 -- | Defines the subset of 'StateEvent' that should be sent as 'TimedServerOutput' to clients.
-mkTimedServerOutputFromStateEvent :: IsTx tx => StateEvent tx -> Maybe (TimedServerOutput tx)
+mkTimedServerOutputFromStateEvent :: IsChainState tx => StateEvent tx -> Maybe (TimedServerOutput tx)
 mkTimedServerOutputFromStateEvent event =
   case mapStateChangedToServerOutput stateChanged of
     Nothing -> Nothing
@@ -261,7 +261,7 @@ mkTimedServerOutputFromStateEvent event =
     StateChanged.ChainRolledBack{} -> Nothing
     StateChanged.TickObserved{} -> Nothing
     StateChanged.LocalStateCleared{..} -> Just SnapshotSideLoaded{..}
-    StateChanged.Checkpoint{} -> Just EventLogRotated
+    StateChanged.Checkpoint{state} -> Just $ EventLogRotated state
 
 -- | Projection to obtain the list of pending deposits.
 projectPendingDeposits :: IsTx tx => [TxIdType tx] -> StateChanged.StateChanged tx -> [TxIdType tx]

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -318,6 +318,7 @@ data CommitInfo
   | NormalCommit HeadId
   | IncrementalCommit HeadId
 
+-- | L2 Hydra network status information.
 data NetworkInfo = NetworkInfo
   { networkConnected :: Bool
   , peersInfo :: Map Host Bool

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -11,7 +11,7 @@ import Data.Aeson.Lens (atKey, key)
 import Data.ByteString.Lazy qualified as LBS
 import Hydra.API.ClientInput (ClientInput)
 import Hydra.Chain (PostChainTx, PostTxError)
-import Hydra.Chain.ChainState (IsChainState)
+import Hydra.Chain.ChainState (IsChainState, ChainStateType)
 import Hydra.HeadLogic.State (ClosedState (..), HeadState (..), InitialState (..), OpenState (..), SeenSnapshot (..))
 import Hydra.HeadLogic.State qualified as HeadState
 import Hydra.Ledger (ValidationError)
@@ -212,7 +212,7 @@ data ServerOutput tx
     -- The local state has been reset, meaning pending transactions were pruned.
     -- Any signing round has been discarded, and the snapshot leader has changed accordingly.
     SnapshotSideLoaded {headId :: HeadId, snapshotNumber :: SnapshotNumber}
-  | EventLogRotated
+  | EventLogRotated {checkpoint :: HeadState tx}
   deriving stock (Generic)
 
 deriving stock instance IsChainState tx => Eq (ServerOutput tx)
@@ -220,7 +220,7 @@ deriving stock instance IsChainState tx => Show (ServerOutput tx)
 deriving anyclass instance IsChainState tx => FromJSON (ServerOutput tx)
 deriving anyclass instance IsChainState tx => ToJSON (ServerOutput tx)
 
-instance ArbitraryIsTx tx => Arbitrary (ServerOutput tx) where
+instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (ServerOutput tx) where
   arbitrary = genericArbitrary
   shrink = recursivelyShrink
 

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -320,8 +320,7 @@ data CommitInfo
 
 data NetworkInfo = NetworkInfo
   { networkConnected :: Bool
-  , peersConnected :: [Host]
-  , peersDisconnected :: [Host]
+  , peersInfo :: Map Host Bool
   }
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -11,7 +11,7 @@ import Data.Aeson.Lens (atKey, key)
 import Data.ByteString.Lazy qualified as LBS
 import Hydra.API.ClientInput (ClientInput)
 import Hydra.Chain (PostChainTx, PostTxError)
-import Hydra.Chain.ChainState (IsChainState, ChainStateType)
+import Hydra.Chain.ChainState (ChainStateType, IsChainState)
 import Hydra.HeadLogic.State (ClosedState (..), HeadState (..), InitialState (..), OpenState (..), SeenSnapshot (..))
 import Hydra.HeadLogic.State qualified as HeadState
 import Hydra.Ledger (ValidationError)
@@ -103,6 +103,7 @@ data Greetings tx = Greetings
   , snapshotUtxo :: Maybe (UTxOType tx)
   , hydraNodeVersion :: String
   , env :: Environment
+  , networkInfo :: NetworkInfo
   }
   deriving (Generic)
 
@@ -316,6 +317,17 @@ data CommitInfo
   = CannotCommit
   | NormalCommit HeadId
   | IncrementalCommit HeadId
+
+data NetworkInfo = NetworkInfo
+  { networkConnected :: Bool
+  , peersConnected :: [Host]
+  , peersDisconnected :: [Host]
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance Arbitrary NetworkInfo where
+  arbitrary = genericArbitrary
 
 -- | Get latest confirmed snapshot UTxO from 'HeadState'.
 getSnapshotUtxo :: Monoid (UTxOType tx) => HeadState tx -> Maybe (UTxOType tx)

--- a/hydra-node/src/Hydra/Network.hs
+++ b/hydra-node/src/Hydra/Network.hs
@@ -17,8 +17,11 @@ module Hydra.Network (
 import Hydra.Prelude hiding (show)
 
 import Cardano.Ledger.Orphans ()
+import Data.Aeson (FromJSONKeyFunction (FromJSONKeyTextParser), ToJSONKey (..))
+import Data.Aeson.Types (FromJSONKey (..), toJSONKeyText)
 import Data.IP (IP, toIPv4w)
 import Data.Text (pack, unpack)
+import Data.Text qualified as T
 import Hydra.Cardano.Api (Key (SigningKey))
 import Hydra.Tx (Party)
 import Hydra.Tx.Crypto (HydraKey)
@@ -159,6 +162,12 @@ instance Arbitrary Host where
   arbitrary = do
     ip <- toIPv4w <$> arbitrary
     Host (toText $ show ip) <$> arbitrary
+
+instance ToJSONKey Host where
+  toJSONKey = toJSONKeyText (T.pack . show)
+
+instance FromJSONKey Host where
+  fromJSONKey = FromJSONKeyTextParser (readHost . T.unpack)
 
 showHost :: Host -> String
 showHost Host{hostname, port} =

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -1299,7 +1299,7 @@ createTestHydraClient outputs messages outputHistory HydraNode{inputQueue, nodeS
     }
 
 createHydraNode ::
-  (IsTx tx, MonadDelay m, MonadAsync m, MonadLabelledSTM m, MonadThrow m) =>
+  (IsChainState tx, MonadDelay m, MonadAsync m, MonadLabelledSTM m, MonadThrow m) =>
   Tracer m (HydraNodeLog tx) ->
   Ledger tx ->
   ChainStateType tx ->

--- a/hydra-tui/src/Hydra/TUI/Handlers.hs
+++ b/hydra-tui/src/Hydra/TUI/Handlers.hs
@@ -37,7 +37,6 @@ import Hydra.TUI.Logging.Types (LogMessage, LogState, LogVerbosity (..), Severit
 import Hydra.TUI.Model
 import Hydra.TUI.Style (own)
 import Hydra.Tx (IsTx (..), Party, Snapshot (..), balance)
-import Hydra.Tx.ContestationPeriod qualified as CP
 import Lens.Micro.Mtl (use, (%=), (.=))
 
 handleEvent ::
@@ -87,10 +86,12 @@ handleHydraEventsConnectedState = \case
 
 handleHydraEventsConnection :: UTCTime -> HydraEvent Tx -> EventM Name Connection ()
 handleHydraEventsConnection now = \case
-  e@(Update (ApiGreetings API.Greetings{me, env = Environment{configuredPeers}})) -> do
+  -- Note: Greetings is the last event seen after restart.
+  Update (ApiGreetings API.Greetings{me, env = Environment{configuredPeers}}) -> do
     meL .= Identified me
     if T.null configuredPeers
-      then
+      then do
+        networkStateL .= Just NetworkDisconnected
         peersL .= mempty
       else do
         let peerStrs = map T.unpack (T.splitOn "," configuredPeers)
@@ -98,6 +99,7 @@ handleHydraEventsConnection now = \case
         case traverse readHost peerAddrs of
           Left err -> do
             liftIO $ putStrLn $ "Failed to parse configured peers: " <> err
+            networkStateL .= Just NetworkDisconnected
             peersL .= mempty
           Right parsedPeers -> do
             existing <- use peersL
@@ -107,8 +109,8 @@ handleHydraEventsConnection now = \case
                     [ (p, Map.findWithDefault PeerIsUnknown p existingMap)
                     | p <- parsedPeers
                     ]
+            networkStateL .= Just NetworkConnected -- FIXME!
             peersL .= Map.toList updatedMap
-    zoom headStateL $ handleHydraEventsHeadState now e
   Update (ApiTimedServerOutput TimedServerOutput{output = API.PeerConnected p}) ->
     peersL %= updatePeerStatus p PeerIsConnected
   Update (ApiTimedServerOutput TimedServerOutput{output = API.PeerDisconnected p}) ->
@@ -127,39 +129,16 @@ handleHydraEventsConnection now = \case
 
 handleHydraEventsHeadState :: UTCTime -> HydraEvent Tx -> EventM Name HeadState ()
 handleHydraEventsHeadState now e = do
+  st <- get
   case e of
     Update (ApiTimedServerOutput TimedServerOutput{time, output = API.HeadIsInitializing{parties, headId}}) ->
-      put $ Active (newActiveLink (toList parties) headId (initState parties))
-    -- Note: We only need to use the greetings when there is a headId present.
-    Update (ApiGreetings API.Greetings{headStatus, hydraHeadId = Just headId, env = Environment{party, otherParties, contestationPeriod}}) -> do
-      let parties = party : otherParties
-      case headStatus of
-        API.Initializing{} ->
-          put $ Active (newActiveLink (toList parties) headId (initState parties))
-        API.Open{} ->
-          put $ Active (newActiveLink (toList parties) headId (Open OpenHome))
-        API.Closed{} ->
-          put $ Active (newActiveLink (toList parties) headId (closedState contestationPeriod))
-        API.FanoutPossible{} ->
-          put $ Active (newActiveLink (toList parties) headId FanoutPossible)
-        _ -> put Idle
+      put $ Active (newActiveLink (toList parties) headId)
+    Update (ApiTimedServerOutput TimedServerOutput{time, output = API.EventLogRotated{checkpoint}}) -> do
+      modify $ \current -> recoverHeadState now current checkpoint
     Update (ApiTimedServerOutput TimedServerOutput{time, output = API.HeadIsAborted{}}) ->
       put Idle
     _ -> pure ()
   zoom activeLinkL $ handleHydraEventsActiveLink e
- where
-  initState parties =
-    Initializing
-      { initializingState =
-          InitializingState
-            { remainingParties = parties
-            , initializingScreen = InitializingHome
-            }
-      }
-  closedState contestationPeriod =
-    Closed
-      { closedState = ClosedState{contestationDeadline = addUTCTime (CP.toNominalDiffTime contestationPeriod) now}
-      }
 
 handleHydraEventsActiveLink :: HydraEvent Tx -> EventM Name ActiveLink ()
 handleHydraEventsActiveLink e = do

--- a/hydra-tui/src/Hydra/TUI/Handlers.hs
+++ b/hydra-tui/src/Hydra/TUI/Handlers.hs
@@ -92,7 +92,7 @@ handleHydraEventsConnection now = \case
         API.Greetings
           { me
           , env = Environment{configuredPeers}
-          , networkInfo = NetworkInfo{networkConnected, peersConnected, peersDisconnected}
+          , networkInfo = NetworkInfo{networkConnected, peersInfo}
           }
       ) -> do
       meL .= Identified me
@@ -109,10 +109,11 @@ handleHydraEventsConnection now = \case
           existing <- use peersL
           let existingMap = Map.fromList existing
 
-              statusFor p
-                | p `elem` peersConnected = PeerIsConnected
-                | p `elem` peersDisconnected = PeerIsDisconnected
-                | otherwise = Map.findWithDefault PeerIsUnknown p existingMap
+              statusFor p =
+                case Map.lookup p peersInfo of
+                  Just True -> PeerIsConnected
+                  Just False -> PeerIsDisconnected
+                  Nothing -> Map.findWithDefault PeerIsUnknown p existingMap
 
           peersL .= [(p, statusFor p) | p <- parsedPeers]
   Update (ApiTimedServerOutput TimedServerOutput{output = API.PeerConnected p}) ->

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -74,7 +74,7 @@ spec = do
         shouldNotRender "Connecting"
 
     around setupRotatedStateTUI $ do
-      fit "tui-rotated starts" $ do
+      it "tui-rotated starts" $ do
         \TUIRotatedTest
           { tuiTest = TUITest{sendInputEvent, shouldRender, shouldNotRender}
           , nodeHandle = HydraNodeHandle{restartNode}


### PR DESCRIPTION
<!-- Describe your change here -->

Follow-up on https://github.com/cardano-scaling/hydra/pull/2159

Fixes https://github.com/cardano-scaling/hydra/issues/2156

#### Motivation

To fix WS clients trying to recover their state when reconnecting to a rotated node

#### 🔄 Changes

- Added head state to rotated log event

- Added network info type + projection from network state changed events

- Extended greetings message with network info

#### ⚠️ Unresolved

- To recover pending Increments

> note FIXME! comments

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
