### PR TITLE
Fix nightly CI process

### DIFF
--- a/.github/workflows/nightly-ci.yaml
+++ b/.github/workflows/nightly-ci.yaml
@@ -40,7 +40,7 @@ jobs:
           export HYDRA_BACKEND="blockfrost"
           nix build .#${{ matrix.package }}-tests
           nix develop
-          cabal test hydra-cluster --test-options '-m "End-to-end on Cardano devnet"'
+          cabal test --test-options '-m "End-to-end on Cardano devnet"'
         else
           echo "::warning file=blockfrost-project.txt,title=BLOCKFROST::Missing blockfrost project file."
         fi

--- a/.github/workflows/nightly-ci.yaml
+++ b/.github/workflows/nightly-ci.yaml
@@ -44,3 +44,26 @@ jobs:
         else
           echo "::warning file=blockfrost-project.txt,title=BLOCKFROST::Missing blockfrost project file."
         fi
+
+
+  other-nightly-tests:
+    name: "Nightly tests"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - package: hydra-plutus
+          - package: hydra-tx
+          - package: hydra-chain-observer
+          - package: hydra-node
+          - package: hydra-cluster
+          # Note: Missing hydra-tui
+
+    - name: Nightly tests
+      env:
+        CI_NIGHTLY: True
+      run: |
+        cd ${{ matrix.package }}
+        nix build .#${{ matrix.package }}-tests
+        nix develop
+        cabal test --test-options '-m "@nightly"'

--- a/hydra-node/test/Hydra/Events/S3Spec.hs
+++ b/hydra-node/test/Hydra/Events/S3Spec.hs
@@ -12,7 +12,7 @@ import Hydra.Events.S3 (fromObjectKey, newS3EventStore, purgeEvents, toObjectKey
 import Test.QuickCheck (chooseBoundedIntegral, counterexample, forAllShrink, ioProperty, sized, sublistOf, withMaxSuccess, (===))
 
 spec :: Spec
-spec = do
+spec = around_ onlyNightly $ describe "AWS S3 @nightly" $ do
   prop "ObjectKey <-> EventId" $ \eventId ->
     let key = toObjectKey eventId
      in fromObjectKey @(Either String) key === Right eventId

--- a/hydra-test-utils/src/Test/Hydra/Prelude.hs
+++ b/hydra-test-utils/src/Test/Hydra/Prelude.hs
@@ -15,6 +15,7 @@ module Test.Hydra.Prelude (
   checkProcessHasNotDied,
   exceptionContaining,
   withClearedPATH,
+  onlyNightly,
 ) where
 
 import Hydra.Prelude
@@ -206,3 +207,17 @@ withClearedPATH act =
     env <- getEnv "PATH"
     setEnv "PATH" ""
     pure env
+
+-- | Only run this task when the CI_NIGHTLY environment variable is set (to
+-- anything).
+--
+-- If you're using this, you want to tag the test with `@nightly` as well;
+-- like:
+--
+--  spec = around_ onlyNightly $ describe "... @nightly" $ do
+--    ...
+onlyNightly :: IO () -> IO ()
+onlyNightly action = do
+  lookupEnv "CI_NIGHTLY" >>= \case
+    Nothing -> pendingWith "Only runs nightly"
+    Just _ -> action


### PR DESCRIPTION
Just some simple fixes to the nightly ci:

- Actually run the blockfrost tests 😅 instead of skipping
- Make the AWS S3 tests only run nightly (mostly just to indicate how)

Fixes https://github.com/cardano-scaling/hydra/issues/2191

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
