### PR TITLE
Replace code-quality.yaml and nix flake check with om-ci-run.yaml

### DIFF
--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -186,34 +186,6 @@ jobs:
         body-file: comment-body.md
         reactions: rocket
 
-  nix-flake-check:
-    name: "nix flake check"
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    steps:
-    - name: Reclaim the bytes
-      uses: data-intuitive/reclaim-the-bytes@v2
-      with:
-        # NOTE: Remove more when needed, but these take also time
-        # See https://github.com/marketplace/actions/reclaim-the-bytes
-        remove-android-sdk: false
-        remove-docker-images: false
-
-    - name: 📥 Checkout repository
-      uses: actions/checkout@v4
-
-    - name: ❄ Setup Nix/Cachix
-      uses: ./.github/actions/nix-cachix-setup
-      with:
-        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
-
-    - name: ❄ Nix Flake Check
-      run: |
-        nix flake check -L
-
-
   build-specification:
     name: "Build specification using nix"
     runs-on: ubuntu-latest

--- a/.github/workflows/om-ci-run.yaml
+++ b/.github/workflows/om-ci-run.yaml
@@ -1,20 +1,17 @@
-name: Check Code Quality
+name: Om CI Run
 
 on:
-  # We're using merge-chains; so this needs to run then.
   merge_group:
   pull_request:
 
 jobs:
   quality:
-    name: Check Code Quality
+    name: Om Ci Run
     runs-on: ubuntu-latest
     steps:
     - name: Reclaim the bytes
       uses: data-intuitive/reclaim-the-bytes@v2
       with:
-        # NOTE: Remove more when needed, but these take also time
-        # See https://github.com/marketplace/actions/reclaim-the-bytes
         remove-android-sdk: false
         remove-docker-images: false
 
@@ -26,10 +23,6 @@ jobs:
       with:
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
-    - name: 📐 Check treefmt
+    - name: 📐 Om Ci Run
       run: |
-        nix build .#checks.x86_64-linux.treefmt
-
-    - name: 📐 Check weeder
-      run: |
-        nix build .#checks.x86_64-linux.weeder
+        nix run github:juspay/omnix -- ci run


### PR DESCRIPTION
This reduces yaml volume and will reduce it further when we remove github artifact dependencies.

`om ci run` will build every flake output.