### PR TITLE
Fix up blockfrost logic in CI

### DIFF
--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -47,6 +47,7 @@ jobs:
     - name: ❓ Test
       if: ${{ matrix.package != 'hydra-tui' }}
       run: |
+        cd ${{ matrix.package }} # To ensure the `./golden` files are available.
         nix develop .#${{ matrix.package }}-tests --command tests
 
     # This one is special, as it requires a tty.

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -47,14 +47,7 @@ jobs:
     - name: ❓ Test
       if: ${{ matrix.package != 'hydra-tui' }}
       run: |
-        if [[ "${{secrets.blockfrost_token}}" != '' ]]; then
-          echo "${{secrets.blockfrost_token}}" > blockfrost-project.txt
-          cd ${{ matrix.package }}
-          nix build .#${{ matrix.package }}-tests
-          nix develop .#${{ matrix.package }}-tests --command tests
-        else
-          echo "::warning file=blockfrost-project.txt,title=BLOCKFROST::Missing blockfrost project file."
-        fi
+        nix develop .#${{ matrix.package }}-tests --command tests
 
     # This one is special, as it requires a tty.
     - name: ❓ Test (TUI)
@@ -67,7 +60,6 @@ jobs:
         TERM: "xterm"
       run: |
         cd ${{ matrix.package  }}
-        nix build .#${{ matrix.package }}-tests
         nix develop .#${{ matrix.package }}-tests --command tests
 
     # NOTE: This depends on the path used in hydra-cluster e2e tests

--- a/.github/workflows/nightly-ci.yaml
+++ b/.github/workflows/nightly-ci.yaml
@@ -37,8 +37,8 @@ jobs:
     - name: ❓ E2E Blockfrost Test
       run: |
         if [[ "${{secrets.blockfrost_token}}" != '' ]]; then
-          echo "${{secrets.blockfrost_token}}" > blockfrost-project.txt
           cd ${{ matrix.package }}
+          echo "${{secrets.blockfrost_token}}" > blockfrost-project.txt
           nix develop .#${{ matrix.package }}-tests --command tests -m "End-to-end on Cardano devnet"
         else
           echo "::warning file=blockfrost-project.txt,title=BLOCKFROST::Missing blockfrost project file."


### PR DESCRIPTION
- Don't need to write blockfrost-project.txt for each package
- Only run blockfrost nightly
- No need to build just develop (it already builds).
