### PR TITLE
Fix the check on invalid decommit

### DIFF
--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -1683,12 +1683,10 @@ canDecommit tracer workDir backend hydraScriptsTxId =
   expectFailureOnUnsignedDecommitTx :: HydraClient -> HeadId -> Tx -> IO ()
   expectFailureOnUnsignedDecommitTx n headId decommitTx = do
     let unsignedDecommitTx = makeSignedTransaction [] $ getTxBody decommitTx
-    join . generate $
-      elements
-        [ send n $ input "Decommit" ["decommitTx" .= unsignedDecommitTx]
-        , postDecommit n unsignedDecommitTx
-        ]
-
+    -- Note: Just send to websocket, as that's how the following code checks
+    -- that it failed. We could do the same for the HTTP endpoint, but doesn't
+    -- quite seem worth the effort.
+    send n $ input "Decommit" ["decommitTx" .= unsignedDecommitTx]
     validationError <- waitMatch 10 n $ \v -> do
       guard $ v ^? key "headId" == Just (toJSON headId)
       guard $ v ^? key "tag" == Just (Aeson.String "DecommitInvalid")


### PR DESCRIPTION
Before we were sending the invalid decommit to both the websocket and the HTTP endpoint, but only checking the failure in the case of it going to the websocket. Let's not worry about over-doing the test here; just send to the websocket and assume that the /decommit endpoint will just work the same (we tested it above anyway, for the valid decommit).

Fixes https://github.com/cardano-scaling/hydra/issues/2212