### PR TITLE
Increase timeout for etcd lease test

### DIFF
--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -164,7 +164,7 @@ spec = do
 
       it "handles expired lease" $ \tracer -> do
         withTempDir "test-etcd" $ \tmp -> do
-          failAfter 5 $ do
+          failAfter 15 $ do
             PeerConfig2{aliceConfig, bobConfig} <- setup2Peers tmp
             -- Record and assert connectivity events from alice's perspective
             (recordReceived, _, waitConnectivity) <- newRecordingCallback


### PR DESCRIPTION
This test works; but it was just timing out. Increasing the timeout fixes it; it shouldn't be flakey anymore.
