### PR TITLE
Fixes docker image tagging

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -60,7 +60,7 @@ jobs:
         # Compute tags. We want the following behaviour:
         #
         # 1. Building on tag:      image tagged `tag`
-        # 2. Building on release:  image tagged `release`
+        # 2. Building on release:  image tagged `latest`
         # 3. Building on master:   image tagged `unstable`.
 
         # Let's default to 'unstable'.

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -56,14 +56,15 @@ jobs:
         nix build .#docker-${{ matrix.target }}
         docker load < result
 
-        # Determine whether we are building a tag and if yes, set a VERSION_NAME
+    - name: Tag images
+      run: |
+
+        # Determine whether we are building a tag and if yes, set a
+        # VERSION_NAME, if not, use `unstable` as the version name.
         BUILDING_TAG=${{github.ref_type == 'tag'}}
+        VERSION_NAME=unstable
         [[ ${BUILDING_TAG} = true ]] && \
           VERSION_NAME=${{github.ref_name}}
-
-        # Determine if we are building on master
-        BUILDING_ON_MASTER=false
-        [[ ${GITHUB_REF_NAME} == 'master' ]] && BUILDING_ON_MASTER=true
 
         # Use 'FROM' instruction to use docker build with --label
         echo "FROM ${{matrix.target}}" | docker build \
@@ -71,20 +72,21 @@ jobs:
           --label org.opencontainers.image.licenses=Apache-2.0 \
           --label org.opencontainers.image.created=$(date -Is) \
           --label org.opencontainers.image.revision=${{github.sha}} \
-          --label org.opencontainers.image.version=${VERSION_NAME:-unstable} \
-          --tag ${IMAGE_NAME}:unstable -
+          --label org.opencontainers.image.version=${VERSION_NAME} \
+          --tag ${IMAGE_NAME}:${VERSION_NAME} -
 
-        # Also tag with 'latest' if we are building on master
-        [[ ${BUILDING_ON_MASTER} = true ]] && \
-          docker tag ${IMAGE_NAME}:unstable ${IMAGE_NAME}:latest
+        [[ ${GITHUB_REF_NAME} = "release" ]] && \
+          docker tag ${IMAGE_NAME} ${IMAGE_NAME}:latest
+
         # Also tag with version if we are building a tag
         [[ ${BUILDING_TAG} = true && ${{matrix.target}} != "hydraw" ]] && \
-          docker tag ${IMAGE_NAME}:unstable ${IMAGE_NAME}:${VERSION_NAME}
+          docker tag ${IMAGE_NAME} ${IMAGE_NAME}:${VERSION_NAME}
+
         # Also tag with ref name when manually dispatched
         [[ ${{github.event_name == 'workflow_dispatch'}} = true ]] && \
-          docker tag ${IMAGE_NAME}:unstable ${IMAGE_NAME}:workflow_dispatch-${{github.event.inputs.ref_name}}
+          docker tag ${IMAGE_NAME} ${IMAGE_NAME}:workflow_dispatch-${{github.event.inputs.ref_name}}
 
-        docker inspect ${IMAGE_NAME}:unstable
+        docker inspect ${IMAGE_NAME}
         docker images
 
     - name: 📤 Push to registry

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -61,10 +61,9 @@ jobs:
         [[ ${BUILDING_TAG} = true ]] && \
           VERSION_NAME=${{github.ref_name}}
 
+        # Determine if we are building on master
         BUILDING_ON_MASTER=false
-        if (git merge-base --is-ancestor HEAD origin/master); then
-          BUILDING_ON_MASTER=true
-        fi
+        [[ ${GITHUB_REF_NAME} == 'master' ]] && BUILDING_ON_MASTER=true
 
         # Use 'FROM' instruction to use docker build with --label
         echo "FROM ${{matrix.target}}" | docker build \
@@ -76,7 +75,7 @@ jobs:
           --tag ${IMAGE_NAME}:unstable -
 
         # Also tag with 'latest' if we are building on master
-        [[ ${BUIDING_TAG} && ${BUILDING_ON_MASTER} = true ]] && \
+        [[ ${BUILDING_ON_MASTER} = true ]] && \
           docker tag ${IMAGE_NAME}:unstable ${IMAGE_NAME}:latest
         # Also tag with version if we are building a tag
         [[ ${BUILDING_TAG} = true && ${{matrix.target}} != "hydraw" ]] && \

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -49,45 +49,57 @@ jobs:
       with:
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
-    - name: 🔨 Build image using nix
+    - name: 🔨 🏷️ Build and tag images
       run: |
+
         IMAGE_NAME=ghcr.io/${{github.repository_owner}}/${{matrix.target}}
         echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
         nix build .#docker-${{ matrix.target }}
         docker load < result
 
-    - name: 🏷️ Tag images
-      run: |
+        # Compute tags. We want the following behaviour:
+        #
+        # 1. Building on tag:      image tagged `tag`
+        # 2. Building on release:  image tagged `release`
+        # 3. Building on master:   image tagged `unstable`.
 
-        # Determine whether we are building a tag and if yes, set a
-        # VERSION_NAME, if not, use `unstable` as the version name.
+        # Let's default to 'unstable'.
+        IMAGE_LABEL=unstable
+        # And the version as the git commit.
+        VERSION=${{github.sha}}
+
+        # Determine whether we are building a tag and if yes, set the label
+        # name to be the tag name, and the version to be the tag.
         BUILDING_TAG=${{github.ref_type == 'tag'}}
-        VERSION_NAME=unstable
         [[ ${BUILDING_TAG} = true ]] && \
-          VERSION_NAME=${{github.ref_name}}
+          IMAGE_LABEL=${{github.ref_name}} && \
+          VERSION=${{github.ref_name}}
 
-        # Use 'FROM' instruction to use docker build with --label
+        # If we're running on the release branch, tag it as `latest`,
+        # and leave the version as the git commit.
+        [[ ${GITHUB_REF_NAME} = "release" ]] && \
+          IMAGE_LABEL=latest
+
+        # If we're running on master, tag it as "unstable" and
+        # and again leave the version as the git commit.
+        [[ ${GITHUB_REF_NAME} = "master" ]] && \
+          IMAGE_LABEL=unstable
+
+        # Use 'FROM' instruction to use docker build with --label, as
+        # well as setting the tag directly.
         echo "FROM ${{matrix.target}}" | docker build \
           --label org.opencontainers.image.source=https://github.com/cardano-scaling/hydra \
           --label org.opencontainers.image.licenses=Apache-2.0 \
           --label org.opencontainers.image.created=$(date -Is) \
           --label org.opencontainers.image.revision=${{github.sha}} \
-          --label org.opencontainers.image.version=${VERSION_NAME} \
-          --tag ${IMAGE_NAME}:${VERSION_NAME} -
-
-        # If we're running on the release branch, tag it as `latest`
-        [[ ${GITHUB_REF_NAME} = "release" ]] && \
-          docker tag ${IMAGE_NAME} ${IMAGE_NAME}:latest
-
-        # Also tag with version if we are building a tag
-        [[ ${BUILDING_TAG} = true && ${{matrix.target}} != "hydraw" ]] && \
-          docker tag ${IMAGE_NAME} ${IMAGE_NAME}:${VERSION_NAME}
+          --label org.opencontainers.image.version=${VERSION} \
+          --tag ${IMAGE_NAME}:${IMAGE_LABEL} -
 
         # Also tag with ref name when manually dispatched
         [[ ${{github.event_name == 'workflow_dispatch'}} = true ]] && \
-          docker tag ${IMAGE_NAME} ${IMAGE_NAME}:workflow_dispatch-${{github.event.inputs.ref_name}}
+          docker tag ${IMAGE_NAME}:${IMAGE_LABEL} ${IMAGE_NAME}:workflow_dispatch-${{github.event.inputs.ref_name}}
 
-        docker inspect ${IMAGE_NAME}
+        docker inspect ${IMAGE_NAME}:${VERSION_NAME}
         docker images
 
     - name: 📤 Push to registry

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -59,8 +59,13 @@ jobs:
 
         # Compute tags. We want the following behaviour:
         #
-        # 1. Building on tag:      image tagged `tag`
-        # 2. Building on release:  image tagged `latest`
+        # 1. Building on tag:
+        #
+        #    a. Image tagged `<tag>`
+        #
+        #    b. If the tag is the "latest" one for the present major release,
+        #    then also tag it as "latest"
+        #
         # 3. Building on master:   image tagged `unstable`.
 
         # Let's default to 'unstable'.
@@ -75,13 +80,8 @@ jobs:
           IMAGE_LABEL=${{github.ref_name}} && \
           VERSION=${{github.ref_name}}
 
-        # If we're running on the release branch, tag it as `latest`,
-        # and leave the version as the git commit.
-        [[ ${GITHUB_REF_NAME} = "release" ]] && \
-          IMAGE_LABEL=latest
-
         # If we're running on master, tag it as "unstable" and
-        # and again leave the version as the git commit.
+        # and leave the version as the git commit.
         [[ ${GITHUB_REF_NAME} = "master" ]] && \
           IMAGE_LABEL=unstable
 
@@ -94,6 +94,27 @@ jobs:
           --label org.opencontainers.image.revision=${{github.sha}} \
           --label org.opencontainers.image.version=${VERSION} \
           --tag ${IMAGE_NAME}:${IMAGE_LABEL} -
+
+        # Tag the build as 'latest' if it's the latest tag.
+        if [[ ${BUILDING_TAG} = true ]]; then
+          # Build a sorted list of tags . We have to grep-exclude some tags
+          # that we don't want to include; i.e. ones that don't point to our
+          # actual releases.
+          git tag -l | grep -P '^\d+.\d+.\d+$' >tags.txt
+
+          # Get the largest one (sort -V sorts as versions).
+          sort -V tags.txt | tail -n1 >latest.txt
+
+          # Compare it to mine; and if it's the same, then I am the latest, so
+          # we can tag it as such.
+          echo ${{ github.ref_name }}>mine.txt
+
+          # Note: This will also print the diff if it fails, which is useful
+          # for debugging.
+          if (diff mine.txt latest.txt); then
+            docker tag ${IMAGE_NAME}:${IMAGE_LABEL} ${IMAGE_NAME}:latest
+          fi
+        fi
 
         # Also tag with ref name when manually dispatched
         [[ ${{github.event_name == 'workflow_dispatch'}} = true ]] && \

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -75,6 +75,7 @@ jobs:
           --label org.opencontainers.image.version=${VERSION_NAME} \
           --tag ${IMAGE_NAME}:${VERSION_NAME} -
 
+        # If we're running on the release branch, tag it as `latest`
         [[ ${GITHUB_REF_NAME} = "release" ]] && \
           docker tag ${IMAGE_NAME} ${IMAGE_NAME}:latest
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -56,7 +56,7 @@ jobs:
         nix build .#docker-${{ matrix.target }}
         docker load < result
 
-    - name: Tag images
+    - name: 🏷️ Tag images
       run: |
 
         # Determine whether we are building a tag and if yes, set a


### PR DESCRIPTION
This attempts to simplify and tidy-up the logic for image labelling.

We would like the following behaviour:

- A build on `master` updates the `unstable` tag
- A build on a tag updates the `tag` tag, and also sets it to `latest` if it has decided it's the latest tag.

The caveat above is that if we have released _0.23.0_ and then choose to release _0.22.100_`, we don't want _0.22.100_ to become the `latest` release. Only the "next" version.

Consider:

```sh
> cat a.txt
0.22.100
0.23.00
0.22.1
> sort -V a.txt
0.22.1
0.22.100
0.23.00

```

Fixes https://github.com/cardano-scaling/hydra/pull/2224

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
