### PR TITLE
Resume node from latest observed tick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ changes.
 - **BREAKING** Enable handling client recover in all head states.
   - See [Issue #1812](https://github.com/cardano-scaling/hydra/issues/1812) and [PR #2217](https://github.com/cardano-scaling/hydra/pull/2217).
 
+- **BREAKING** Resume node from the latest observed tick when `--start-chain-from` is not set.
+  - See [Issue #2206](https://github.com/cardano-scaling/hydra/issues/2206) and [PR #2232](https://github.com/cardano-scaling/hydra/pull/2232)
+
 ## [0.22.4] - 2025-08-05
 
 - Fix API not correctly handling event log rotation. This was evident in not

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -1996,7 +1996,7 @@ resumeFromLatestKnownPoint tracer workDir backend hydraScriptsTxId = do
     chainConfigFor Alice workDir backend hydraScriptsTxId [] contestationPeriod
       <&> setNetworkId networkId
 
-  pointObserved :: ChainPoint <-
+  chainPoint :: ChainPoint <-
     withHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
       waitMatch 20 n1 $ \v -> do
         guard $ v ^? key "tag" == Just "Greetings"
@@ -2007,7 +2007,9 @@ resumeFromLatestKnownPoint tracer workDir backend hydraScriptsTxId = do
         point <- v ^? key "point"
         parseMaybe parseJSON point
 
-  pointObserved' :: ChainPoint <-
+  let chainSlot = chainSlotFromPoint chainPoint
+
+  chainPoint' :: ChainPoint <-
     withHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
       waitMatch 20 n1 $ \v -> do
         guard $ v ^? key "tag" == Just "Greetings"
@@ -2018,7 +2020,9 @@ resumeFromLatestKnownPoint tracer workDir backend hydraScriptsTxId = do
         point <- v ^? key "point"
         parseMaybe parseJSON point
 
-  chainSlotFromPoint pointObserved `shouldBe` chainSlotFromPoint pointObserved'
+  let chainSlot' = chainSlotFromPoint chainPoint'
+
+  chainSlot `shouldSatisfy` (< chainSlot')
  where
   hydraTracer = contramap FromHydraNode tracer
 

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -508,7 +508,7 @@ withConnectionToNodeHost tracer hydraNodeId apiHost@Host{hostname, port} mQueryP
           retryOrThrow :: forall proxy e. Exception e => proxy e -> e -> IO a
           retryOrThrow _ e =
             readIORef connectedOnce >>= \case
-              False -> threadDelay 0.1 >> tryConnect connectedOnce (n - 1)
+              False -> threadDelay 1 >> tryConnect connectedOnce (n - 1)
               True -> throwIO e
         doConnect connectedOnce
           `catches` [ Handler $ retryOrThrow (Proxy @IOException)

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -71,6 +71,7 @@ import Hydra.Cluster.Scenarios (
   rejectCommit,
   restartedNodeCanAbort,
   restartedNodeCanObserveCommitTx,
+  resumeFromLatestKnownPoint,
   singlePartyCommitsFromExternal,
   singlePartyCommitsFromExternalTxBlueprint,
   singlePartyCommitsScriptBlueprint,
@@ -675,6 +676,12 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
           withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend ->
             publishHydraScriptsAs backend Faucet
               >>= canResumeOnMemberAlreadyBootstrapped tracer tmpDir backend
+
+      it "resume from latest observed point" $ \tracer -> do
+        withClusterTempDir $ \tmpDir -> do
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend ->
+            publishHydraScriptsAs backend Faucet
+              >>= resumeFromLatestKnownPoint tracer tmpDir backend
 
     describe "two hydra heads scenario" $ do
       it "two heads on the same network do not conflict" $ \tracer ->

--- a/hydra-cluster/test/Test/OfflineChainSpec.hs
+++ b/hydra-cluster/test/Test/OfflineChainSpec.hs
@@ -11,6 +11,7 @@ import Data.Aeson qualified as Aeson
 import Data.Aeson.Lens (key, _Number)
 import Hydra.Cardano.Api (Tx, UTxO)
 import Hydra.Chain (ChainCallback, ChainEvent (..), ChainStateHistory, OnChainTx (..), initHistory)
+import Hydra.Chain.ChainState (IsChainState (chainPointSlot))
 import Hydra.Chain.Direct.State (initialChainState)
 import Hydra.Chain.Offline (withOfflineChain)
 import Hydra.Cluster.Fixture (alice)
@@ -55,7 +56,7 @@ spec = do
       withOfflineChain offlineConfig alice [] noHistory callback $ \_chain -> do
         -- Expect to see a tick of slot 1 within 2 seconds
         waitMatch waitNext 2 $ \case
-          Tick{chainSlot} -> guard $ chainSlot > 0
+          Tick{point} -> guard $ chainPointSlot point > 0
           _ -> Nothing
 
   it "does not start on slot 0 with real genesis file" $ do
@@ -73,7 +74,7 @@ spec = do
       withOfflineChain offlineConfig alice [] noHistory callback $ \_chain -> do
         -- Should not start at 0
         waitMatch waitNext 1 $ \case
-          Tick{chainSlot} -> guard $ chainSlot > 1000
+          Tick{point} -> guard $ chainPointSlot point > 1000
           _ -> Nothing
         -- Should produce ticks on each slot, which is defined by genesis.json
         Just slotLength <- readFileBS (tmpDir </> "genesis.json") >>= \bs -> pure $ bs ^? key "slotLength" . _Number

--- a/hydra-node/golden/ServerOutput/TickObserved.json
+++ b/hydra-node/golden/ServerOutput/TickObserved.json
@@ -1,0 +1,9 @@
+{
+    "samples": [
+        {
+            "chainSlot": 1,
+            "tag": "TickObserved"
+        }
+    ],
+    "seed": 1965245731
+}

--- a/hydra-node/golden/ServerOutput/TickObserved.json
+++ b/hydra-node/golden/ServerOutput/TickObserved.json
@@ -1,7 +1,17 @@
 {
     "samples": [
         {
-            "chainSlot": 1,
+            "point": {
+                "tag": "ChainPointAtGenesis"
+            },
+            "tag": "TickObserved"
+        },
+        {
+            "point": {
+                "blockHash": "0100010001000101010001010001000001010101000001010100000000000101",
+                "slot": 1,
+                "tag": "ChainPoint"
+            },
             "tag": "TickObserved"
         }
     ],

--- a/hydra-node/golden/StateChanged/TickObserved.json
+++ b/hydra-node/golden/StateChanged/TickObserved.json
@@ -1,7 +1,9 @@
 {
     "samples": [
         {
-            "chainSlot": 1,
+            "point": {
+                "tag": "ChainPointAtGenesis"
+            },
             "tag": "TickObserved"
         }
     ],

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -775,6 +775,13 @@ components:
       payload:
         $ref: "api.yaml#/components/schemas/EventLogRotated"
 
+    TickObserved:
+      title: TickObserved
+      description: |
+        Chain point observed by the node from the connected chain backend.
+      payload:
+        $ref: "api.yaml#/components/schemas/TickObserved"
+
     # Other messages
 
     DraftCommitTxRequest:
@@ -858,6 +865,7 @@ components:
         - $ref: "api.yaml#/components/schemas/CommitRecovered"
         - $ref: "api.yaml#/components/schemas/SnapshotSideLoaded"
         - $ref: "api.yaml#/components/schemas/EventLogRotated"
+        - $ref: "api.yaml#/components/schemas/TickObserved"
 
     ClientMessage:
       oneOf:
@@ -1784,6 +1792,28 @@ components:
           $ref: "api.yaml#/components/schemas/SequenceNumber"
         checkpoint:
           $ref: "api.yaml#/components/schemas/NodeState"
+        timestamp:
+          $ref: "api.yaml#/components/schemas/UTCTime"
+
+    TickObserved:
+      title: TickObserved
+      description: |
+        Chain point observed by the node from the connected chain backend.
+      additionalProperties: false
+      type: object
+      required:
+        - tag
+        - seq
+        - chainSlot
+        - timestamp
+      properties:
+        tag:
+          type: string
+          enum: ["TickObserved"]
+        seq:
+          $ref: "api.yaml#/components/schemas/SequenceNumber"
+        chainSlot:
+          $ref: "api.yaml#/components/schemas/ChainSlot"
         timestamp:
           $ref: "api.yaml#/components/schemas/UTCTime"
 

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -1799,12 +1799,13 @@ components:
       title: TickObserved
       description: |
         Chain point observed by the node from the connected chain backend.
+        It represents the node's current view of the chain tip at a given time.
       additionalProperties: false
       type: object
       required:
         - tag
         - seq
-        - chainSlot
+        - point
         - timestamp
       properties:
         tag:
@@ -1812,12 +1813,45 @@ components:
           enum: ["TickObserved"]
         seq:
           $ref: "api.yaml#/components/schemas/SequenceNumber"
-        chainSlot:
-          $ref: "api.yaml#/components/schemas/ChainSlot"
+        point:
+          $ref: "api.yaml#/components/schemas/ChainPoint"
         timestamp:
           $ref: "api.yaml#/components/schemas/UTCTime"
 
     # END OF SERVER OUTPUT SCHEMAS
+
+    ChainPoint:
+      oneOf:
+        - title: ChainPointAtGenesis
+          description: |
+            Special chain point representing the beginning of the chain, before any blocks have been produced.
+          additionalProperties: false
+          type: object
+          required:
+            - tag
+          properties:
+            tag:
+              type: string
+              enum: ["ChainPointAtGenesis"]
+        - title: ChainPoint
+          description: |
+            Concrete chain point referencing a block on-chain by its slot number and header hash.
+          additionalProperties: false
+          type: object
+          required:
+            - tag
+            - slot
+            - blockHash
+          properties:
+            tag:
+              type: string
+              enum: ["ChainPoint"]
+            slot:
+              type: integer
+              minimum: 0
+            blockHash:
+              type: string
+              contentEncoding: base16
 
     Address:
       type: string

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -262,7 +262,7 @@ mkTimedServerOutputFromStateEvent event =
     StateChanged.SnapshotRequestDecided{} -> Nothing
     StateChanged.PartySignedSnapshot{} -> Nothing
     StateChanged.ChainRolledBack{} -> Nothing
-    StateChanged.TickObserved{} -> Nothing
+    StateChanged.TickObserved{..} -> Just TickObserved{..}
     StateChanged.LocalStateCleared{..} -> Just SnapshotSideLoaded{..}
     StateChanged.Checkpoint{state} -> Just $ EventLogRotated state
 

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -11,7 +11,7 @@ import Data.Aeson.Lens (atKey, key)
 import Data.ByteString.Lazy qualified as LBS
 import Hydra.API.ClientInput (ClientInput)
 import Hydra.Chain (PostChainTx, PostTxError)
-import Hydra.Chain.ChainState (ChainStateType, IsChainState)
+import Hydra.Chain.ChainState (ChainSlot, ChainStateType, IsChainState)
 import Hydra.HeadLogic.State (ClosedState (..), HeadState (..), InitialState (..), NodeState, OpenState (..), SeenSnapshot (..))
 import Hydra.HeadLogic.State qualified as HeadState
 import Hydra.Ledger (ValidationError)
@@ -214,6 +214,7 @@ data ServerOutput tx
     -- Any signing round has been discarded, and the snapshot leader has changed accordingly.
     SnapshotSideLoaded {headId :: HeadId, snapshotNumber :: SnapshotNumber}
   | EventLogRotated {checkpoint :: NodeState tx}
+  | TickObserved {chainSlot :: ChainSlot}
   deriving stock (Generic)
 
 deriving stock instance IsChainState tx => Eq (ServerOutput tx)
@@ -287,6 +288,7 @@ prepareServerOutput config response =
     PeerDisconnected{} -> encodedResponse
     SnapshotSideLoaded{} -> encodedResponse
     EventLogRotated{} -> encodedResponse
+    TickObserved{} -> encodedResponse
  where
   encodedResponse = encode response
 

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -11,7 +11,7 @@ import Data.Aeson.Lens (atKey, key)
 import Data.ByteString.Lazy qualified as LBS
 import Hydra.API.ClientInput (ClientInput)
 import Hydra.Chain (PostChainTx, PostTxError)
-import Hydra.Chain.ChainState (ChainSlot, ChainStateType, IsChainState)
+import Hydra.Chain.ChainState (ChainPointType, ChainStateType, IsChainState)
 import Hydra.HeadLogic.State (ClosedState (..), HeadState (..), InitialState (..), NodeState, OpenState (..), SeenSnapshot (..))
 import Hydra.HeadLogic.State qualified as HeadState
 import Hydra.Ledger (ValidationError)
@@ -214,7 +214,7 @@ data ServerOutput tx
     -- Any signing round has been discarded, and the snapshot leader has changed accordingly.
     SnapshotSideLoaded {headId :: HeadId, snapshotNumber :: SnapshotNumber}
   | EventLogRotated {checkpoint :: NodeState tx}
-  | TickObserved {chainSlot :: ChainSlot}
+  | TickObserved {point :: ChainPointType tx}
   deriving stock (Generic)
 
 deriving stock instance IsChainState tx => Eq (ServerOutput tx)
@@ -222,7 +222,7 @@ deriving stock instance IsChainState tx => Show (ServerOutput tx)
 deriving anyclass instance IsChainState tx => FromJSON (ServerOutput tx)
 deriving anyclass instance IsChainState tx => ToJSON (ServerOutput tx)
 
-instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (ServerOutput tx) where
+instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx), Arbitrary (ChainPointType tx)) => Arbitrary (ServerOutput tx) where
   arbitrary = genericArbitrary
   shrink = recursivelyShrink
 

--- a/hydra-node/src/Hydra/Chain.hs
+++ b/hydra-node/src/Hydra/Chain.hs
@@ -314,7 +314,7 @@ data ChainEvent tx
     -- another round trip / state to keep there.
     Tick
       { chainTime :: UTCTime
-      , chainSlot :: ChainSlot
+      , point :: ChainPointType tx
       }
   | -- | Event to re-ingest errors from 'postTx' for further processing.
     PostTxError {postChainTx :: PostChainTx tx, postTxError :: PostTxError tx, failingTx :: Maybe tx}

--- a/hydra-node/src/Hydra/Chain.hs
+++ b/hydra-node/src/Hydra/Chain.hs
@@ -23,7 +23,7 @@ import Hydra.Cardano.Api (
   PolicyAssets,
   PolicyId,
  )
-import Hydra.Chain.ChainState (ChainSlot, IsChainState (..))
+import Hydra.Chain.ChainState (ChainSlot, IsChainState (..), chainStateSlot)
 import Hydra.Tx (
   CommitBlueprintTx,
   ConfirmedSnapshot,

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -355,8 +355,7 @@ chainSyncHandler tracer callback getTimeHandle ctx localChainState =
           Left reason ->
             throwIO TimeConversionException{slotNo, reason}
           Right utcTime -> do
-            let chainSlot = ChainSlot . fromIntegral $ unSlotNo slotNo
-            callback (Tick{chainTime = utcTime, chainSlot})
+            callback (Tick{chainTime = utcTime, point})
 
     forM_ receivedTxs $
       maybeObserveSomeTx timeHandle point >=> \case

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -156,8 +156,15 @@ instance Arbitrary ChainStateAt where
 instance IsChainState Tx where
   type ChainStateType Tx = ChainStateAt
 
+  type ChainPointType Tx = ChainPoint
+
   chainStateSlot ChainStateAt{recordedAt} =
     maybe (ChainSlot 0) chainSlotFromPoint recordedAt
+
+  chainStatePoint ChainStateAt{recordedAt} =
+    fromMaybe ChainPointAtGenesis recordedAt
+
+  chainPointSlot = chainSlotFromPoint
 
 -- | Get a generic 'ChainSlot' from a Cardano 'ChainPoint'. Slot 0 is used for
 -- the genesis point.

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -166,6 +166,8 @@ instance IsChainState Tx where
 
   chainPointSlot = chainSlotFromPoint
 
+  modifyStatePoint chainState point = chainState{recordedAt = Just point}
+
 -- | Get a generic 'ChainSlot' from a Cardano 'ChainPoint'. Slot 0 is used for
 -- the genesis point.
 chainSlotFromPoint :: ChainPoint -> ChainSlot

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -158,9 +158,6 @@ instance IsChainState Tx where
 
   type ChainPointType Tx = ChainPoint
 
-  chainStateSlot ChainStateAt{recordedAt} =
-    maybe (ChainSlot 0) chainSlotFromPoint recordedAt
-
   chainStatePoint ChainStateAt{recordedAt} =
     fromMaybe ChainPointAtGenesis recordedAt
 

--- a/hydra-node/src/Hydra/Chain/Offline.hs
+++ b/hydra-node/src/Hydra/Chain/Offline.hs
@@ -2,6 +2,7 @@ module Hydra.Chain.Offline where
 
 import Hydra.Prelude
 
+import Cardano.Api (ChainPoint (ChainPoint))
 import Cardano.Api.Internal.Genesis (shelleyGenesisDefaults)
 import Cardano.Api.Internal.GenesisParameters (fromShelleyGenesis)
 import Cardano.Ledger.Slot (unSlotNo)
@@ -17,7 +18,6 @@ import Hydra.Chain (
   ChainStateHistory,
   OnChainTx (..),
   PostTxError (..),
-  chainSlot,
   chainTime,
   initHistory,
  )
@@ -150,10 +150,11 @@ tickForever genesis callback = do
     let timeToSleepUntil = slotNoToUTCTime systemStart slotLength upcomingSlot
     sleepDelay <- diffUTCTime timeToSleepUntil <$> getCurrentTime
     threadDelay $ realToFrac sleepDelay
+    let chainSlot = ChainSlot . fromIntegral $ unSlotNo upcomingSlot
     callback $
       Tick
         { chainTime = timeToSleepUntil
-        , chainSlot = ChainSlot . fromIntegral $ unSlotNo upcomingSlot
+        , point = ChainPoint undefined undefined
         }
   systemStart = SystemStart protocolParamSystemStart
 

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1814,7 +1814,10 @@ aggregateChainStateHistory history = \case
   HeadFannedOut{chainState} -> pushNewState chainState history
   ChainRolledBack{chainState} ->
     rollbackHistory (chainStateSlot chainState) history
-  TickObserved{} -> history
+  TickObserved{point} ->
+    let currentChainState = currentState history
+        chainState = modifyStatePoint currentChainState point
+     in pushNewState chainState history
   CommitApproved{} -> history
   DecommitApproved{} -> history
   DecommitInvalid{} -> history

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -39,7 +39,7 @@ import Hydra.Chain (
   pushNewState,
   rollbackHistory,
  )
-import Hydra.Chain.ChainState (ChainSlot, IsChainState (..))
+import Hydra.Chain.ChainState (ChainSlot, IsChainState (..), chainStateSlot)
 import Hydra.HeadLogic.Error (
   LogicError (..),
   RequirementFailure (..),

--- a/hydra-node/src/Hydra/HeadLogic/Outcome.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Outcome.hs
@@ -7,7 +7,7 @@ import Hydra.Prelude
 
 import Hydra.API.ServerOutput (ClientMessage, DecommitInvalidReason)
 import Hydra.Chain (PostChainTx)
-import Hydra.Chain.ChainState (ChainSlot, ChainStateType, IsChainState)
+import Hydra.Chain.ChainState (ChainPointType, ChainStateType, IsChainState)
 import Hydra.HeadLogic.Error (LogicError)
 import Hydra.HeadLogic.State (Deposit, NodeState)
 import Hydra.Ledger (ValidationError)
@@ -136,7 +136,7 @@ data StateChanged tx
   | HeadIsReadyToFanout {headId :: HeadId}
   | HeadFannedOut {headId :: HeadId, utxo :: UTxOType tx, chainState :: ChainStateType tx}
   | ChainRolledBack {chainState :: ChainStateType tx}
-  | TickObserved {chainSlot :: ChainSlot}
+  | TickObserved {point :: ChainPointType tx}
   | IgnoredHeadInitializing
       { headId :: HeadId
       , contestationPeriod :: ContestationPeriod

--- a/hydra-node/src/Hydra/HeadLogic/State.hs
+++ b/hydra-node/src/Hydra/HeadLogic/State.hs
@@ -7,7 +7,7 @@ module Hydra.HeadLogic.State where
 import Hydra.Prelude
 
 import Data.Map qualified as Map
-import Hydra.Chain.ChainState (ChainSlot, IsChainState (..))
+import Hydra.Chain.ChainState (ChainSlot, IsChainState (..), chainStateSlot)
 import Hydra.Tx (
   HeadId,
   HeadParameters,

--- a/hydra-node/src/Hydra/Ledger/Simple.hs
+++ b/hydra-node/src/Hydra/Ledger/Simple.hs
@@ -111,7 +111,13 @@ newtype SimpleChainState = SimpleChainState {slot :: ChainSlot}
 instance IsChainState SimpleTx where
   type ChainStateType SimpleTx = SimpleChainState
 
+  type ChainPointType SimpleTx = ChainSlot
+
   chainStateSlot SimpleChainState{slot} = slot
+
+  chainStatePoint SimpleChainState{slot} = slot
+
+  chainPointSlot = id
 
 -- * A simple ledger
 

--- a/hydra-node/src/Hydra/Ledger/Simple.hs
+++ b/hydra-node/src/Hydra/Ledger/Simple.hs
@@ -113,8 +113,6 @@ instance IsChainState SimpleTx where
 
   type ChainPointType SimpleTx = ChainSlot
 
-  chainStateSlot SimpleChainState{slot} = slot
-
   chainStatePoint SimpleChainState{slot} = slot
 
   chainPointSlot = id

--- a/hydra-node/src/Hydra/Ledger/Simple.hs
+++ b/hydra-node/src/Hydra/Ledger/Simple.hs
@@ -119,6 +119,8 @@ instance IsChainState SimpleTx where
 
   chainPointSlot = id
 
+  modifyStatePoint chainState point = chainState{slot = point}
+
 -- * A simple ledger
 
 simpleLedger :: Ledger SimpleTx

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -1320,6 +1320,7 @@ createHydraNode tracer ledger chainState signingKey otherParties outputs message
           { putEvent = \event ->
               case mkTimedServerOutputFromStateEvent event of
                 Nothing -> pure ()
+                Just TimedServerOutput{output = TickObserved{}} -> pure ()
                 Just TimedServerOutput{output} -> atomically $ do
                   writeTQueue outputs output
                   modifyTVar' outputHistory (output :)

--- a/hydra-node/test/Hydra/Chain/Direct/HandlersSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/HandlersSpec.hs
@@ -9,7 +9,7 @@ import Control.Tracer (nullTracer)
 import Data.Maybe (fromJust)
 import Hydra.Cardano.Api (
   BlockHeader (..),
-  ChainPoint (ChainPointAtGenesis),
+  ChainPoint (..),
   PaymentKey,
   SlotNo (..),
   Tx,
@@ -23,7 +23,7 @@ import Hydra.Cardano.Api (
 import Cardano.Ledger.Api (IsValid (..), isValidTxL)
 import Control.Lens ((.~))
 import Hydra.Chain (ChainEvent (..), OnChainTx (..), currentState, initHistory, maximumNumberOfParties)
-import Hydra.Chain.ChainState (ChainSlot (..), chainStateSlot)
+import Hydra.Chain.ChainState (chainStateSlot)
 import Hydra.Chain.Direct.Handlers (
   ChainSyncHandler (..),
   GetTimeHandle,
@@ -108,7 +108,10 @@ spec = do
           run $
             either (failure . ("Time conversion failed: " <>) . toString) pure $
               slotToUTCTime timeHandle slot
-        void . stop $ events === [Tick expectedUTCTime (ChainSlot . fromIntegral $ unSlotNo slot)]
+
+        let (BlockHeader _ blockHash _) = header
+        let point = ChainPoint slot blockHash
+        void . stop $ events === [Tick expectedUTCTime point]
 
     prop "roll forward fails with outdated TimeHandle" $
       monadicIO $ do

--- a/hydra-tx/src/Hydra/Chain/ChainState.hs
+++ b/hydra-tx/src/Hydra/Chain/ChainState.hs
@@ -35,10 +35,6 @@ class
   -- | Type of what to keep as L1 chain point.
   type ChainPointType tx = c | c -> tx
 
-  -- | Get the chain slot for a chain state. NOTE: For any sequence of 'a'
-  -- encountered, we assume monotonically increasing slots.
-  chainStateSlot :: ChainStateType tx -> ChainSlot
-
   -- | Get the chain point for a chain state.
   chainStatePoint :: ChainStateType tx -> ChainPointType tx
 
@@ -47,3 +43,8 @@ class
 
   -- | Update the chain point in a chain state.
   modifyStatePoint :: ChainStateType tx -> ChainPointType tx -> ChainStateType tx
+
+-- | Get the chain slot for a chain state. NOTE: For any sequence of 'a'
+-- encountered, we assume monotonically increasing slots.
+chainStateSlot :: IsChainState tx => ChainStateType tx -> ChainSlot
+chainStateSlot = chainPointSlot . chainStatePoint

--- a/hydra-tx/src/Hydra/Chain/ChainState.hs
+++ b/hydra-tx/src/Hydra/Chain/ChainState.hs
@@ -20,6 +20,11 @@ class
   , FromJSON (ChainStateType tx)
   , ToJSON (ChainStateType tx)
   , Arbitrary (ChainStateType tx)
+  , Eq (ChainPointType tx)
+  , Show (ChainPointType tx)
+  , FromJSON (ChainPointType tx)
+  , ToJSON (ChainPointType tx)
+  , Arbitrary (ChainPointType tx)
   ) =>
   IsChainState tx
   where
@@ -27,6 +32,15 @@ class
   -- XXX: Why is this not always UTxOType?
   type ChainStateType tx = c | c -> tx
 
+  -- | Type of what to keep as L1 chain point.
+  type ChainPointType tx = c | c -> tx
+
   -- | Get the chain slot for a chain state. NOTE: For any sequence of 'a'
   -- encountered, we assume monotonically increasing slots.
   chainStateSlot :: ChainStateType tx -> ChainSlot
+
+  -- | Get the chain point for a chain state.
+  chainStatePoint :: ChainStateType tx -> ChainPointType tx
+
+  -- | Get the chain slot for a chain point.
+  chainPointSlot :: ChainPointType tx -> ChainSlot

--- a/hydra-tx/src/Hydra/Chain/ChainState.hs
+++ b/hydra-tx/src/Hydra/Chain/ChainState.hs
@@ -44,3 +44,6 @@ class
 
   -- | Get the chain slot for a chain point.
   chainPointSlot :: ChainPointType tx -> ChainSlot
+
+  -- | Update the chain point in a chain state.
+  modifyStatePoint :: ChainStateType tx -> ChainPointType tx -> ChainStateType tx


### PR DESCRIPTION
<!-- Describe your change here -->

🔑 **Motivation** 
> Closes #2206 

Currently, the node only records the latest `chainState` when observing a head transition.  
This impacts catch-up times during periods of inactivity, and we want to reduce the time required to synchronize after such periods.

🔄 **Breaking Changes**

* The `TickObserved` event schema has changed: the `chainSlot` field has been replaced with `chainPoint`.  
  > This ensures that upon restart, the node can resume from the latest observed tick, even if no head transition has occurred.

📝 **Notes**

* A new server output for `TickObserved` has been introduced.
* Increased the delay when connecting to `hydra-node` in end-to-end specs to avoid exit exceptions during restarts.
* ⚠️ Offline mode now generates random block header hashes to simulate activity.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [X] Documentation updated or not needed
* [X] Haddocks updated or not needed
* [X] No new TODOs introduced or explained herafter
