### PR TITLE
Permissive-reading of the state file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ changes.
 - **BREAKING** Enable handling client recover in all head states.
   - See [Issue #1812](https://github.com/cardano-scaling/hydra/issues/1812) and [PR #2217](https://github.com/cardano-scaling/hydra/pull/2217).
 
+- Optimistic approach to statefile corruption by just ignoring invalid JSON
+  lines [#2253](https://github.com/cardano-scaling/hydra/issues/2253)
+
 ## [0.22.4] - 2025-08-05
 
 - Fix API not correctly handling event log rotation. This was evident in not

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -102,6 +102,7 @@ library
     Hydra.Node.Util
     Hydra.Options
     Hydra.Persistence
+    Hydra.PersistenceLog
     Hydra.Utils
 
   other-modules:   Paths_hydra_node

--- a/hydra-node/src/Hydra/Logging/Messages.hs
+++ b/hydra-node/src/Hydra/Logging/Messages.hs
@@ -15,6 +15,7 @@ import Hydra.Chain.Direct.Handlers (CardanoChainLog)
 import Hydra.Node (HydraNodeLog)
 import Hydra.Node.Network (NetworkLog)
 import Hydra.Options (RunOptions)
+import Hydra.PersistenceLog (PersistenceLog)
 
 data HydraLog tx
   = DirectChain {directChain :: CardanoChainLog}
@@ -22,6 +23,7 @@ data HydraLog tx
   | Network {network :: NetworkLog}
   | Node {node :: HydraNodeLog tx}
   | NodeOptions {runOptions :: RunOptions}
+  | Persistence {persistenceLog :: PersistenceLog}
   | EnteringMainloop
   deriving stock (Generic)
 

--- a/hydra-node/src/Hydra/Node/Run.hs
+++ b/hydra-node/src/Hydra/Node/Run.hs
@@ -95,7 +95,7 @@ run opts = do
         eventStore@EventStore{eventSource} <-
           prepareEventStore
             =<< mkFileBasedEventStore stateFile
-            =<< createPersistenceIncremental stateFile
+            =<< createPersistenceIncremental (contramap Persistence tracer) stateFile
         -- NOTE: Add any custom sinks here
         let eventSinks :: [EventSink (StateEvent Tx) IO] = []
         wetHydraNode <- hydrate (contramap Node tracer) env ledger initialChainState eventStore eventSinks

--- a/hydra-node/src/Hydra/PersistenceLog.hs
+++ b/hydra-node/src/Hydra/PersistenceLog.hs
@@ -1,0 +1,24 @@
+module Hydra.PersistenceLog where
+
+import Data.Aeson (defaultOptions, genericParseJSON, genericToJSON, tagSingleConstructors)
+import Hydra.Prelude
+
+data PersistenceLog
+  = FailedToDecodeJson {reason :: String, filepath :: FilePath, contents :: String}
+  deriving stock (Eq, Show, Generic)
+
+-- Note: Specific Aeson instances, so that we don't hide the tags when emitting
+-- this log.
+instance ToJSON PersistenceLog where
+  toJSON =
+    genericToJSON
+      defaultOptions
+        { tagSingleConstructors = True
+        }
+
+instance FromJSON PersistenceLog where
+  parseJSON =
+    genericParseJSON
+      defaultOptions
+        { tagSingleConstructors = True
+        }


### PR DESCRIPTION
This change allows us to read the state file even in the presence of malformed JSON. This is a kind of "best-effort" hack; we don't ever _expect_ malformed JSON; but if we find it, the best thing we can try to do is ignore it and see if things still work correctly. That's what we do here; when we find an invalid parse we emit a warning.

Fixes #2253 

**Todo**

- [x] Maybe add a test to check that we get the expected log msg
- [x] Changelog


---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
