### PR TITLE
Resume node from latest observed tick

### DIFF
--- a/hydra-cluster/test/Test/OfflineChainSpec.hs
+++ b/hydra-cluster/test/Test/OfflineChainSpec.hs
@@ -11,6 +11,7 @@ import Data.Aeson qualified as Aeson
 import Data.Aeson.Lens (key, _Number)
 import Hydra.Cardano.Api (Tx, UTxO)
 import Hydra.Chain (ChainCallback, ChainEvent (..), ChainStateHistory, OnChainTx (..), initHistory)
+import Hydra.Chain.ChainState (IsChainState (chainPointSlot))
 import Hydra.Chain.Direct.State (initialChainState)
 import Hydra.Chain.Offline (withOfflineChain)
 import Hydra.Cluster.Fixture (alice)
@@ -55,7 +56,7 @@ spec = do
       withOfflineChain offlineConfig alice [] noHistory callback $ \_chain -> do
         -- Expect to see a tick of slot 1 within 2 seconds
         waitMatch waitNext 2 $ \case
-          Tick{chainSlot} -> guard $ chainSlot > 0
+          Tick{point} -> guard $ chainPointSlot point > 0
           _ -> Nothing
 
   it "does not start on slot 0 with real genesis file" $ do
@@ -73,7 +74,7 @@ spec = do
       withOfflineChain offlineConfig alice [] noHistory callback $ \_chain -> do
         -- Should not start at 0
         waitMatch waitNext 1 $ \case
-          Tick{chainSlot} -> guard $ chainSlot > 1000
+          Tick{point} -> guard $ chainPointSlot point > 1000
           _ -> Nothing
         -- Should produce ticks on each slot, which is defined by genesis.json
         Just slotLength <- readFileBS (tmpDir </> "genesis.json") >>= \bs -> pure $ bs ^? key "slotLength" . _Number

--- a/hydra-node/golden/ReasonablySized (NodeState (Tx ConwayEra)).json
+++ b/hydra-node/golden/ReasonablySized (NodeState (Tx ConwayEra)).json
@@ -1,7 +1,9 @@
 {
     "samples": [
         {
-            "currentSlot": 3,
+            "currentPoint": {
+                "tag": "ChainPointAtGenesis"
+            },
             "headState": {
                 "contents": {
                     "chainState": {
@@ -2250,7 +2252,11 @@
             }
         },
         {
-            "currentSlot": 6,
+            "currentPoint": {
+                "blockHash": "0804010201050707040200020303030103070705000401080704050406020004",
+                "slot": 12,
+                "tag": "ChainPoint"
+            },
             "headState": {
                 "contents": {
                     "chainState": {
@@ -2672,7 +2678,11 @@
             }
         },
         {
-            "currentSlot": 6,
+            "currentPoint": {
+                "blockHash": "0506040805040006040103060302070402020701060501060205070705080002",
+                "slot": 3,
+                "tag": "ChainPoint"
+            },
             "headState": {
                 "contents": {
                     "chainState": {
@@ -4518,7 +4528,11 @@
             }
         },
         {
-            "currentSlot": 2,
+            "currentPoint": {
+                "blockHash": "0805040501010604080107080206000004080307050808060204030506080108",
+                "slot": 15,
+                "tag": "ChainPoint"
+            },
             "headState": {
                 "contents": {
                     "chainState": {
@@ -5089,7 +5103,11 @@
             }
         },
         {
-            "currentSlot": 6,
+            "currentPoint": {
+                "blockHash": "0703000704050203000800070301040005060505070605010307040507080404",
+                "slot": 7,
+                "tag": "ChainPoint"
+            },
             "headState": {
                 "contents": {
                     "chainState": {

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -1789,6 +1789,39 @@ components:
 
     # END OF SERVER OUTPUT SCHEMAS
 
+    ChainPoint:
+      oneOf:
+        - title: ChainPointAtGenesis
+          description: |
+            Special chain point representing the beginning of the chain, before any blocks have been produced.
+          additionalProperties: false
+          type: object
+          required:
+            - tag
+          properties:
+            tag:
+              type: string
+              enum: ["ChainPointAtGenesis"]
+        - title: ChainPoint
+          description: |
+            Concrete chain point referencing a block on-chain by its slot number and header hash.
+          additionalProperties: false
+          type: object
+          required:
+            - tag
+            - slot
+            - blockHash
+          properties:
+            tag:
+              type: string
+              enum: ["ChainPoint"]
+            slot:
+              type: integer
+              minimum: 0
+            blockHash:
+              type: string
+              contentEncoding: base16
+
     Address:
       type: string
       description: |
@@ -3437,8 +3470,8 @@ components:
             $ref: "api.yaml#/components/schemas/TxId"
           items:
             $ref: "api.yaml#/components/schemas/Deposit"
-        currentSlot:
-          $ref: "api.yaml#/components/schemas/ChainSlot"
+        currentPoint:
+          $ref: "api.yaml#/components/schemas/ChainPoint"
 
     SubmitL2TxResponse:
       oneOf:

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -11,7 +11,7 @@ import Data.Aeson.Lens (atKey, key)
 import Data.ByteString.Lazy qualified as LBS
 import Hydra.API.ClientInput (ClientInput)
 import Hydra.Chain (PostChainTx, PostTxError)
-import Hydra.Chain.ChainState (ChainStateType, IsChainState)
+import Hydra.Chain.ChainState (ChainPointType, ChainStateType, IsChainState)
 import Hydra.HeadLogic.State (ClosedState (..), HeadState (..), InitialState (..), NodeState, OpenState (..), SeenSnapshot (..))
 import Hydra.HeadLogic.State qualified as HeadState
 import Hydra.Ledger (ValidationError)
@@ -221,7 +221,7 @@ deriving stock instance IsChainState tx => Show (ServerOutput tx)
 deriving anyclass instance IsChainState tx => FromJSON (ServerOutput tx)
 deriving anyclass instance IsChainState tx => ToJSON (ServerOutput tx)
 
-instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (ServerOutput tx) where
+instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx), Arbitrary (ChainPointType tx)) => Arbitrary (ServerOutput tx) where
   arbitrary = genericArbitrary
   shrink = recursivelyShrink
 

--- a/hydra-node/src/Hydra/Chain.hs
+++ b/hydra-node/src/Hydra/Chain.hs
@@ -313,7 +313,7 @@ data ChainEvent tx
     -- another round trip / state to keep there.
     Tick
       { chainTime :: UTCTime
-      , chainSlot :: ChainSlot
+      , point :: ChainPointType tx
       }
   | -- | Event to re-ingest errors from 'postTx' for further processing.
     PostTxError {postChainTx :: PostChainTx tx, postTxError :: PostTxError tx, failingTx :: Maybe tx}

--- a/hydra-node/src/Hydra/Chain.hs
+++ b/hydra-node/src/Hydra/Chain.hs
@@ -23,7 +23,7 @@ import Hydra.Cardano.Api (
   PolicyAssets,
   PolicyId,
  )
-import Hydra.Chain.ChainState (ChainSlot, IsChainState (..))
+import Hydra.Chain.ChainState (ChainSlot, IsChainState (..), chainStateSlot)
 import Hydra.Tx (
   CommitBlueprintTx,
   ConfirmedSnapshot,

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -355,8 +355,7 @@ chainSyncHandler tracer callback getTimeHandle ctx localChainState =
           Left reason ->
             throwIO TimeConversionException{slotNo, reason}
           Right utcTime -> do
-            let chainSlot = ChainSlot . fromIntegral $ unSlotNo slotNo
-            callback (Tick{chainTime = utcTime, chainSlot})
+            callback (Tick{chainTime = utcTime, point})
 
     forM_ receivedTxs $
       maybeObserveSomeTx timeHandle point >=> \case

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -156,8 +156,12 @@ instance Arbitrary ChainStateAt where
 instance IsChainState Tx where
   type ChainStateType Tx = ChainStateAt
 
-  chainStateSlot ChainStateAt{recordedAt} =
-    maybe (ChainSlot 0) chainSlotFromPoint recordedAt
+  type ChainPointType Tx = ChainPoint
+
+  chainStatePoint ChainStateAt{recordedAt} =
+    fromMaybe ChainPointAtGenesis recordedAt
+
+  chainPointSlot = chainSlotFromPoint
 
 -- | Get a generic 'ChainSlot' from a Cardano 'ChainPoint'. Slot 0 is used for
 -- the genesis point.

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1383,11 +1383,11 @@ update env ledger NodeState{headState = st, pendingDeposits, currentSlot} ev = c
         newState DepositRecorded{chainState = newChainState, headId, depositTxId, deposited, created, deadline}
     | otherwise ->
         Error NotOurHead{ourHeadId, otherHeadId = headId}
-  (Open openState@OpenState{}, ChainInput Tick{chainTime, chainSlot}) ->
+  (Open openState@OpenState{}, ChainInput Tick{chainTime, point}) ->
     -- XXX: We originally forgot the normal TickObserved state event here and so
     -- time did not advance in an open head anymore. This is a hint that we
     -- should compose event handling better.
-    newState TickObserved{chainSlot}
+    newState TickObserved{point}
       <> onOpenChainTick env pendingDeposits openState chainTime
   (Open openState@OpenState{headId = ourHeadId}, ChainInput Observation{observedTx = OnIncrementTx{headId, newVersion, depositTxId}, newChainState})
     | ourHeadId == headId ->
@@ -1406,9 +1406,9 @@ update env ledger NodeState{headState = st, pendingDeposits, currentSlot} ev = c
         onClosedChainContestTx closedState newChainState snapshotNumber contestationDeadline
     | otherwise ->
         Error NotOurHead{ourHeadId, otherHeadId = headId}
-  (Closed ClosedState{contestationDeadline, readyToFanoutSent, headId}, ChainInput Tick{chainTime, chainSlot})
+  (Closed ClosedState{contestationDeadline, readyToFanoutSent, headId}, ChainInput Tick{chainTime, point})
     | chainTime > contestationDeadline && not readyToFanoutSent ->
-        newState TickObserved{chainSlot}
+        newState TickObserved{point}
           <> newState HeadIsReadyToFanout{headId}
   (Closed closedState, ClientInput Fanout) ->
     onClosedClientFanout closedState
@@ -1425,8 +1425,8 @@ update env ledger NodeState{headState = st, pendingDeposits, currentSlot} ev = c
   -- General
   (_, ChainInput Rollback{rolledBackChainState}) ->
     newState ChainRolledBack{chainState = rolledBackChainState}
-  (_, ChainInput Tick{chainSlot}) ->
-    newState TickObserved{chainSlot}
+  (_, ChainInput Tick{point}) ->
+    newState TickObserved{point}
   (_, ChainInput PostTxError{postChainTx, postTxError}) ->
     cause . ClientEffect $ ServerOutput.PostTxOnChainFailed{postChainTx, postTxError}
   (_, ClientInput{clientInput}) ->
@@ -1480,8 +1480,8 @@ aggregateNodeState nodeState sc =
               ns
                 { pendingDeposits = Map.delete depositTxId pendingDeposits
                 }
-        TickObserved{chainSlot} ->
-          ns{currentSlot = chainSlot}
+        TickObserved{point} ->
+          ns{currentSlot = chainPointSlot point}
         _ -> ns
 
 -- * HeadState aggregate

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -38,7 +38,7 @@ import Hydra.Chain (
   pushNewState,
   rollbackHistory,
  )
-import Hydra.Chain.ChainState (ChainSlot, IsChainState (..))
+import Hydra.Chain.ChainState (ChainSlot, IsChainState (..), chainStateSlot)
 import Hydra.HeadLogic.Error (
   LogicError (..),
   RequirementFailure (..),

--- a/hydra-node/src/Hydra/HeadLogic/Outcome.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Outcome.hs
@@ -7,7 +7,7 @@ import Hydra.Prelude
 
 import Hydra.API.ServerOutput (ClientMessage, DecommitInvalidReason)
 import Hydra.Chain (PostChainTx)
-import Hydra.Chain.ChainState (ChainSlot, ChainStateType, IsChainState)
+import Hydra.Chain.ChainState (ChainPointType, ChainStateType, IsChainState)
 import Hydra.HeadLogic.Error (LogicError)
 import Hydra.HeadLogic.State (Deposit, NodeState)
 import Hydra.Ledger (ValidationError)
@@ -136,7 +136,7 @@ data StateChanged tx
   | HeadIsReadyToFanout {headId :: HeadId}
   | HeadFannedOut {headId :: HeadId, utxo :: UTxOType tx, chainState :: ChainStateType tx}
   | ChainRolledBack {chainState :: ChainStateType tx}
-  | TickObserved {chainSlot :: ChainSlot}
+  | TickObserved {point :: ChainPointType tx}
   | IgnoredHeadInitializing
       { headId :: HeadId
       , contestationPeriod :: ContestationPeriod

--- a/hydra-node/src/Hydra/HeadLogic/State.hs
+++ b/hydra-node/src/Hydra/HeadLogic/State.hs
@@ -7,7 +7,7 @@ module Hydra.HeadLogic.State where
 import Hydra.Prelude
 
 import Data.Map qualified as Map
-import Hydra.Chain.ChainState (ChainSlot, IsChainState (..))
+import Hydra.Chain.ChainState (ChainSlot, IsChainState (..), chainStateSlot)
 import Hydra.Tx (
   HeadId,
   HeadParameters,

--- a/hydra-node/src/Hydra/HeadLogic/State.hs
+++ b/hydra-node/src/Hydra/HeadLogic/State.hs
@@ -7,7 +7,7 @@ module Hydra.HeadLogic.State where
 import Hydra.Prelude
 
 import Data.Map qualified as Map
-import Hydra.Chain.ChainState (ChainSlot, IsChainState (..), chainStateSlot)
+import Hydra.Chain.ChainState (ChainSlot, IsChainState (..))
 import Hydra.Tx (
   HeadId,
   HeadParameters,
@@ -34,24 +34,24 @@ data NodeState tx = NodeState
   -- ^ Pending deposits as observed on chain.
   -- TODO: could even move the chain state here (also see todo below)
   -- , chainState :: ChainStateType tx
-  , currentSlot :: ChainSlot
+  , currentPoint :: ChainPointType tx
   }
   deriving stock (Generic)
 
-instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (NodeState tx) where
+instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx), Arbitrary (ChainPointType tx)) => Arbitrary (NodeState tx) where
   arbitrary = genericArbitrary
 
-deriving stock instance (IsTx tx, Eq (ChainStateType tx)) => Eq (NodeState tx)
-deriving stock instance (IsTx tx, Show (ChainStateType tx)) => Show (NodeState tx)
-deriving anyclass instance (IsTx tx, ToJSON (ChainStateType tx)) => ToJSON (NodeState tx)
-deriving anyclass instance (IsTx tx, FromJSON (ChainStateType tx)) => FromJSON (NodeState tx)
+deriving stock instance (IsTx tx, Eq (ChainStateType tx), Eq (ChainPointType tx)) => Eq (NodeState tx)
+deriving stock instance (IsTx tx, Show (ChainStateType tx), Show (ChainPointType tx)) => Show (NodeState tx)
+deriving anyclass instance (IsTx tx, ToJSON (ChainStateType tx), ToJSON (ChainPointType tx)) => ToJSON (NodeState tx)
+deriving anyclass instance (IsTx tx, FromJSON (ChainStateType tx), FromJSON (ChainPointType tx)) => FromJSON (NodeState tx)
 
 initNodeState :: IsChainState tx => ChainStateType tx -> NodeState tx
 initNodeState chainState =
   NodeState
     { headState = Idle IdleState{chainState}
     , pendingDeposits = mempty
-    , currentSlot = chainStateSlot chainState
+    , currentPoint = chainStatePoint chainState
     }
 
 -- | The main state of the Hydra protocol state machine. It holds both, the

--- a/hydra-node/src/Hydra/Ledger/Simple.hs
+++ b/hydra-node/src/Hydra/Ledger/Simple.hs
@@ -111,7 +111,11 @@ newtype SimpleChainState = SimpleChainState {slot :: ChainSlot}
 instance IsChainState SimpleTx where
   type ChainStateType SimpleTx = SimpleChainState
 
-  chainStateSlot SimpleChainState{slot} = slot
+  type ChainPointType SimpleTx = ChainSlot
+
+  chainStatePoint SimpleChainState{slot} = slot
+
+  chainPointSlot = id
 
 -- * A simple ledger
 

--- a/hydra-node/test/Hydra/API/HTTPServerSpec.hs
+++ b/hydra-node/test/Hydra/API/HTTPServerSpec.hs
@@ -25,13 +25,13 @@ import Hydra.API.HTTPServer (
 import Hydra.API.ServerOutput (ClientMessage (..), CommitInfo (..), DecommitInvalidReason (..), ServerOutput (..), TimedServerOutput (..), getConfirmedSnapshot, getSeenSnapshot, getSnapshotUtxo)
 import Hydra.API.ServerSpec (dummyChainHandle)
 import Hydra.Cardano.Api (
+  ChainPoint (ChainPointAtGenesis),
   mkTxOutDatumInline,
   modifyTxOutDatum,
   renderTxIn,
   serialiseToTextEnvelope,
  )
 import Hydra.Chain (Chain (draftCommitTx), PostTxError (..), draftDepositTx)
-import Hydra.Chain.ChainState (ChainSlot (ChainSlot))
 import Hydra.Chain.Direct.Handlers (checkAmount, rejectLowDeposits)
 import Hydra.HeadLogic.State (ClosedState (..), HeadState (..), NodeState (..), SeenSnapshot (..))
 import Hydra.HeadLogicSpec (inIdleState)
@@ -363,7 +363,7 @@ apiServerSpec = do
                   dummyChainHandle
                   testEnvironment
                   defaultPParams
-                  (pure NodeState{headState = Closed closedState, pendingDeposits = mempty, currentSlot = ChainSlot 0})
+                  (pure NodeState{headState = Closed closedState, pendingDeposits = mempty, currentPoint = ChainPointAtGenesis})
                   cantCommit
                   getPendingDeposits
                   putClientInput
@@ -523,7 +523,7 @@ apiServerSpec = do
                 dummyChainHandle
                 testEnvironment
                 defaultPParams
-                (pure NodeState{headState = Closed closedState', pendingDeposits = mempty, currentSlot = ChainSlot 0})
+                (pure NodeState{headState = Closed closedState', pendingDeposits = mempty, currentPoint = ChainPointAtGenesis})
                 cantCommit
                 getPendingDeposits
                 putClientInput
@@ -557,7 +557,7 @@ apiServerSpec = do
               workingChainHandle
               testEnvironment
               defaultPParams
-              (pure NodeState{headState = initialHeadState, pendingDeposits = mempty, currentSlot = ChainSlot 0})
+              (pure NodeState{headState = initialHeadState, pendingDeposits = mempty, currentPoint = ChainPointAtGenesis})
               getHeadId
               getPendingDeposits
               putClientInput
@@ -613,7 +613,7 @@ apiServerSpec = do
                 (failingChainHandle postTxError)
                 testEnvironment
                 defaultPParams
-                (pure NodeState{headState = openHeadState, pendingDeposits = mempty, currentSlot = ChainSlot 0})
+                (pure NodeState{headState = openHeadState, pendingDeposits = mempty, currentPoint = ChainPointAtGenesis})
                 getHeadId
                 getPendingDeposits
                 putClientInput

--- a/hydra-node/test/Hydra/Chain/Direct/HandlersSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/HandlersSpec.hs
@@ -9,7 +9,7 @@ import Control.Tracer (nullTracer)
 import Data.Maybe (fromJust)
 import Hydra.Cardano.Api (
   BlockHeader (..),
-  ChainPoint (ChainPointAtGenesis),
+  ChainPoint (..),
   PaymentKey,
   SlotNo (..),
   Tx,
@@ -23,7 +23,7 @@ import Hydra.Cardano.Api (
 import Cardano.Ledger.Api (IsValid (..), isValidTxL)
 import Control.Lens ((.~))
 import Hydra.Chain (ChainEvent (..), OnChainTx (..), currentState, initHistory, maximumNumberOfParties)
-import Hydra.Chain.ChainState (ChainSlot (..), chainStateSlot)
+import Hydra.Chain.ChainState (chainStateSlot)
 import Hydra.Chain.Direct.Handlers (
   ChainSyncHandler (..),
   GetTimeHandle,
@@ -108,7 +108,9 @@ spec = do
           run $
             either (failure . ("Time conversion failed: " <>) . toString) pure $
               slotToUTCTime timeHandle slot
-        void . stop $ events === [Tick expectedUTCTime (ChainSlot . fromIntegral $ unSlotNo slot)]
+        let (BlockHeader _ blockHash _) = header
+        let point = ChainPoint slot blockHash
+        void . stop $ events === [Tick expectedUTCTime point]
 
     prop "roll forward fails with outdated TimeHandle" $
       monadicIO $ do

--- a/hydra-tx/src/Hydra/Chain/ChainState.hs
+++ b/hydra-tx/src/Hydra/Chain/ChainState.hs
@@ -20,6 +20,11 @@ class
   , FromJSON (ChainStateType tx)
   , ToJSON (ChainStateType tx)
   , Arbitrary (ChainStateType tx)
+  , Eq (ChainPointType tx)
+  , Show (ChainPointType tx)
+  , FromJSON (ChainPointType tx)
+  , ToJSON (ChainPointType tx)
+  , Arbitrary (ChainPointType tx)
   ) =>
   IsChainState tx
   where
@@ -27,6 +32,16 @@ class
   -- XXX: Why is this not always UTxOType?
   type ChainStateType tx = c | c -> tx
 
-  -- | Get the chain slot for a chain state. NOTE: For any sequence of 'a'
-  -- encountered, we assume monotonically increasing slots.
-  chainStateSlot :: ChainStateType tx -> ChainSlot
+  -- | Type of what to keep as L1 chain point.
+  type ChainPointType tx = c | c -> tx
+
+  -- | Get the chain point for a chain state.
+  chainStatePoint :: ChainStateType tx -> ChainPointType tx
+
+  -- | Get the chain slot for a chain point.
+  chainPointSlot :: ChainPointType tx -> ChainSlot
+
+-- | Get the chain slot for a chain state. NOTE: For any sequence of 'a'
+-- encountered, we assume monotonically increasing slots.
+chainStateSlot :: IsChainState tx => ChainStateType tx -> ChainSlot
+chainStateSlot = chainPointSlot . chainStatePoint


### PR DESCRIPTION
<!-- Describe your change here -->

🔑 **Motivation** 
> Closes #2206 

Currently, the node only records the latest `chainState` when observing a head transition.  
This impacts catch-up times during periods of inactivity, and we want to reduce the time required to synchronize after such periods.

🔄 **Changes**

* 🏗️ WIP

📝 **Notes**

* ⚠️ Offline mode now generates random block header hashes to simulate activity.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [X] Documentation updated or not needed
* [X] Haddocks updated or not needed
* [X] No new TODOs introduced or explained herafter
