### PR TITLE
Fix broken links for head-protocol/ docs

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,1 +1,1 @@
-See the [user manual 📖](https://hydra.family/head-protocol/docs/getting-started/demo/).
+See the [user manual 📖](https://hydra.family/head-protocol/docs/getting-started).

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -213,7 +213,7 @@ Hydra supports an offline mode that allows for disabling the layer 1 interface â
 
 As an offline head will not connect to any chain, we need to provide an `--offline-head-seed` manually, which is a hexadecimal byte string. Offline heads can still use the L2 network and to make multiple `hydra-node` "see" the same offline head, the offline head seed needs to match along with provided [hydra keys](#hydra-keys).
 
-To initialize UTxO state available on the L2 ledger, offline mode takes an obligatory `--initial-utxo` parameter, which points to a JSON-encoded UTxO file. See the [API reference](https://hydra.family/head-protocol/api-reference/#schema-UTxO) for the schema.
+To initialize UTxO state available on the L2 ledger, offline mode takes an obligatory `--initial-utxo` parameter, which points to a JSON-encoded UTxO file. See the [API reference](https://hydra.family/head-protocol/api-reference#schema-UTxO) for the schema.
 
 For example, the following UTxO contains 100 ADA owned by test key [alice-funds.sk](https://github.com/cardano-scaling/hydra/tree/master/hydra-cluster/config/credentials/alice-funds.sk):
 ```json utxo.json

--- a/docs/docs/dev/architecture/index.md
+++ b/docs/docs/dev/architecture/index.md
@@ -61,4 +61,4 @@ The Hydra node logs all internal side effects as JSON-formatted messages to its 
 
 ### Monitoring
 
-The Hydra node [optionally](https://hydra.family/head-protocol/docs/getting-started/quickstart#hydra-node-options) exposes [Prometheus](https://prometheus.io/)-compliant _metrics_ through an HTTP server, on the standard `/metrics` endpoint.
+The Hydra node [optionally](https://hydra.family/head-protocol/docs/getting-started#monitoring) exposes [Prometheus](https://prometheus.io/)-compliant _metrics_ through an HTTP server, on the standard `/metrics` endpoint.

--- a/docs/docs/known-issues.md
+++ b/docs/docs/known-issues.md
@@ -6,11 +6,11 @@ Before running a Hydra node on the Cardano mainnet, it is important to be aware 
 
 Due to the limitations on transaction sizes and execution budgets on Cardano, the Hydra protocol has the following constraints:
 
-- The protocol can only handle a maximum number of participants in a head (see [the cost of CollectCom transaction](https://hydra.family/head-protocol/benchmarks/transaction-cost/#cost-of-collectcom-transaction)). When attempting to configure too many peers, the Hydra node will inform you of the current configured maximum.
+- The protocol can only handle a maximum number of participants in a head (see [the cost of CollectCom transaction](https://hydra.family/head-protocol/benchmarks/transaction-cost#collectcom-transaction-costs)). When attempting to configure too many peers, the Hydra node will inform you of the current configured maximum.
 
 Currently, participants may be denied access to their funds by other protocol participants at different stages within a Hydra head because of the complexity or size of the UTXO being committed or created while the head is open:
 
-- The Hydra head cannot be _finalized_ if it holds more than approximately 80 assets (see [the cost of FanOut transaction](https://hydra.family/head-protocol/benchmarks/transaction-cost/#cost-of-fanout-transaction) for latest numbers), although it can be _closed_
+- The Hydra head cannot be _finalized_ if it holds more than approximately 80 assets (see [the cost of FanOut transaction](https://hydra.family/head-protocol/benchmarks/transaction-cost#fanout-transaction-costs) for latest numbers), although it can be _closed_
 - Tokens that are minted and not burned within an open Hydra head will prevent the head from being _finalized_
 - If one or more participants commit UTXOs that are too large to be processed together in a `CollectCom` or  `Abort` transaction, the Hydra head will remain stuck in the _initialising_ stage.
 

--- a/docs/standalone/contribute.md
+++ b/docs/standalone/contribute.md
@@ -2,7 +2,7 @@
 
 ### *Run* the hydra demo
 
-See Hydra in action by following [these instructions](https://hydra.family/head-protocol/docs/getting-started/demo/).
+See Hydra in action by following [these instructions](https://hydra.family/head-protocol/docs/getting-started).
 
 ### *Tell* us about your use cases
 Are you already building on Cardano? Could Hydra help you scale? We’d love to get your thoughts on payments and auctions use cases.

--- a/docs/use-cases/payments/lighting-network-like-payments/index.md
+++ b/docs/use-cases/payments/lighting-network-like-payments/index.md
@@ -9,7 +9,7 @@ Furthermore, this cluster can connect to different base network clusters on the 
 
 Oracle nodes will play a crucial role in managing routing within this network. They will analyze the DAG and the pool of incoming payment requests (known as 'invoices' in the Lightning Network context, though this terminology may change). These oracle nodes will compete to identify the shortest paths within the DAG to process payments efficiently.
 
-From a technical perspective, this network's base layer will mirror that described in the [delegated head network scenario](https://hydra.family/head-protocol/topologies/delegated-head/).
+From a technical perspective, this network's base layer will mirror that described in the [delegated head network scenario](https://hydra.family/head-protocol/topologies/delegated-head).
 
 **Pros:**
 - Faster transaction speed

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -11,7 +11,7 @@ info:
 
     They can interact with their node by pushing events to it, some are local, and some will have consequences on the rest of the head.
 
-    See [the documentation](https://hydra.family/head-protocol/docs/dev/api-behavior/) for more details on the overall API behavior.
+    See [the documentation](https://hydra.family/head-protocol/docs/dev/architecture#api) for more details on the overall API behavior.
 
   license:
     name: Apache 2.0

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -4,7 +4,7 @@
 -- | Top-level module to run a single Hydra node.
 --
 -- Checkout [Hydra
--- Documentation](https://hydra.family/head-protocol/dev/architecture)
+-- Documentation](https://hydra.family/head-protocol/docs/dev/architecture)
 -- for some details about the overall architecture of the `Node`.
 module Hydra.Node where
 

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -487,7 +487,7 @@ spec = parallel $ do
           shouldRunInSim $
             withSimulatedChainAndNetwork $ \chain -> do
               -- NOTE: Only a maximum difference of 600 seconds is handled by the HeadLogic. See
-              -- https://hydra.family/head-protocol/unstable/docs/known-issues/#deposit-periods
+              -- https://hydra.family/head-protocol/unstable/docs/known-issues#deposit-periods
               let dpShort = DepositPeriod 60
               let dpLong = DepositPeriod 600
               withHydraNode' dpShort aliceSk [bob] chain $ \n1 ->

--- a/sample-node-config/aws/README.md
+++ b/sample-node-config/aws/README.md
@@ -5,7 +5,7 @@
 
 # Example Hydra Node Infrastructure
 
-This directory contains some [Terraform](https://www.hashicorp.com/products/terraform) and AWS based infrastructure code to setup a single [Hydra node](https://hydra.family/head-protocol/docs/getting-started/installation) connected to a [Cardano node](https://docs.cardano.org/getting-started/installing-the-cardano-node) running on `preview` testnet. It's not a complete turnkey solution and requires some tweaking and parameterisation to be completely usable but we thought it would be good starting point for new Hydra users.
+This directory contains some [Terraform](https://www.hashicorp.com/products/terraform) and AWS based infrastructure code to setup a single [Hydra node](https://hydra.family/head-protocol/docs/installation) connected to a [Cardano node](https://docs.cardano.org/getting-started/installing-the-cardano-node) running on `preview` testnet. It's not a complete turnkey solution and requires some tweaking and parameterisation to be completely usable but we thought it would be good starting point for new Hydra users.
 
 ### Pre-requisites
 1.  **AWS Account**: You need access to an AWS account with privileges to create EC2 instances and related resources.

--- a/sample-node-config/gcp/README.md
+++ b/sample-node-config/gcp/README.md
@@ -1,7 +1,7 @@
 # Example Hydra Node Infrastructure
 
 This directory contains some [Terraform](https://www.hashicorp.com/products/terraform) and GCP based infrastructure code to:
-* Setup a single [Hydra node](https://hydra.family/head-protocol/docs/getting-started/installation),
+* Setup a single [Hydra node](https://hydra.family/head-protocol/docs/installation),
 * Connected to a [Cardano node](https://docs.cardano.org/getting-started/installing-the-cardano-node) running on `preview` testnet,
 * Primed by [mithril](https://mithril.network) latest snapshot,
 * Serving [hydraw](../../hydraw) application on port 80.
@@ -67,15 +67,15 @@ $ terraform plan -out vm.plan
 
 The configuration process expects to find some files which are not provided by default and which are required for starting the Hydra node:
 * A Hydra signing key file `keys/arnaud-hydra.sk` which will be used in the Head to sign snapshots.
-  This can be generated using [hydra-node](https://hydra.family/head-protocol/docs/getting-started/quickstart#hydra-keys),
+  This can be generated using [hydra-node](https://hydra.family/head-protocol/docs/configuration#hydra-keyss),
 * A cardano signing key file  `keys/arnaud.sk` which is required to identify the parties on-chain and sign transactions.
-  This is a standard Cardano key so one can reuse an existing key or [generate a new one](https://hydra.family/head-protocol/docs/getting-started/quickstart#cardano-keys),
+  This is a standard Cardano key so one can reuse an existing key or [generate a new one](https://hydra.family/head-protocol/docs/configuration#cardano-keys),
 * 0 or more hydra verification keys and cardano verification keys for the other Head parties,
 * The IP addresses and ports of _peer_ nodes,
 * Configuration files [prometheus](https://prometheus.io/) which is run as part of the stack, for monitoring purpose,
 * Configuration files for the off-chain ledger.
 
-The key files should be put in a `keys/` directory. Then the [docker-compose.yaml](./docker-compose.yaml) should be edited to reflect the above parameters as [command-line arguments](https://hydra.family/head-protocol/docs/getting-started/quickstart) to the `hydra-node` container.
+The key files should be put in a `keys/` directory. Then the [docker-compose.yaml](./docker-compose.yaml) should be edited to reflect the above parameters as [command-line arguments](https://hydra.family/head-protocol/docs/configuration) to the `hydra-node` container.
 
 ### Starting VM
 


### PR DESCRIPTION
I noticed that many links didn't work. So I tried to grep on `head-protocol` and manually check if they were fine. Fixed many of them
<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
