### PR TITLE
Enhance IntersectionNotFoundException error message

### DIFF
--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -230,7 +230,14 @@ newtype IntersectionNotFoundException = IntersectionNotFound
   }
   deriving newtype (Show)
 
-instance Exception IntersectionNotFoundException
+instance Exception IntersectionNotFoundException where
+  displayException (IntersectionNotFound point) =
+    printf
+      "The requested intersection point %s was not found on the local node. \
+      \This may happen if the point is too recent and the node has not yet \
+      \synchronized that far, or if the point is too old and has been pruned \
+      \from the local node. Please try again with a different point."
+      (show point :: String)
 
 data EraNotSupportedException
   = EraNotSupportedAnymore {otherEraName :: Text}


### PR DESCRIPTION
This pull request improves error reporting for intersection point lookup failures in the `hydra-node` codebase. The main change provides a more informative error message when an `IntersectionNotFoundException` occurs, making it easier for users to understand why their requested intersection point was not found.

Error reporting improvements:

* Enhanced the `Exception` instance for `IntersectionNotFoundException` in `hydra-node/src/Hydra/Chain/Direct.hs` to include a detailed explanation in the error message, clarifying possible reasons for the failure (e.g., the point is too recent, not yet synchronized, or too old and pruned).

Related to #2254. The error now appears as:

```
The requested intersection point ChainPoint (SlotNo 100001101135460) (HeaderHash
"\EOT[R(%o\r\217&\130}\188\175\198\US\178p\147\180\155\NAKyA\SUBV\171\204e\134we\163") was not found on the local node. This may happen if the point is too recent
and the node has not yet synchronized that far, or if the point is too old and has been pruned from the local node. Please try again with a different point.
```

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
