### PR TITLE
Ensure enough lovelace in genOutput fn in tests

### DIFF
--- a/hydra-node/bench/tx-cost/TxCost.hs
+++ b/hydra-node/bench/tx-cost/TxCost.hs
@@ -63,7 +63,7 @@ import Hydra.Plutus.Orphans ()
 import Hydra.Tx.Snapshot (genConfirmedSnapshot)
 import PlutusLedgerApi.V3 (toBuiltinData)
 import PlutusTx.Builtins (lengthOfByteString, serialiseData)
-import Test.Hydra.Tx.Gen (genOutput, genUTxOAdaOnlyOfSize)
+import Test.Hydra.Tx.Gen (genOutputFor, genUTxOAdaOnlyOfSize)
 import Test.QuickCheck (oneof)
 
 computeInitCost :: Gen [(NumParties, TxSize, MemUnit, CpuUnit, Coin)]
@@ -85,7 +85,7 @@ computeInitCost = do
     ctx <- genHydraContextFor numParties
     cctx <- pickChainContext ctx
     seedInput <- genTxIn
-    seedOutput <- genOutput =<< arbitrary
+    seedOutput <- genOutputFor =<< arbitrary
     let utxo = UTxO.singleton seedInput seedOutput
     pure (initialize cctx seedInput (ctxParticipants ctx) (ctxHeadParameters ctx), utxo)
 

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -123,7 +123,7 @@ import Hydra.Tx.Utils (dummyValidatorScript, splitUTxO)
 import PlutusLedgerApi.V3 qualified as Plutus
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
 import Test.Hydra.Tx.Fixture (slotLength, systemStart, testNetworkId)
-import Test.Hydra.Tx.Gen (genOutput, genTxOut, genTxOutAdaOnly, genTxOutByron, genUTxO1, genUTxOSized)
+import Test.Hydra.Tx.Gen (genOutputFor, genTxOut, genTxOutAdaOnly, genTxOutByron, genUTxO1, genUTxOSized)
 import Test.Hydra.Tx.Mutation (
   Mutation (..),
   applyMutation,
@@ -600,7 +600,7 @@ forAllInit ::
 forAllInit action =
   forAllBlind (genHydraContext maximumNumberOfParties) $ \ctx ->
     forAll (pickChainContext ctx) $ \cctx -> do
-      forAll ((,) <$> genTxIn <*> genOutput (ownVerificationKey cctx)) $ \(seedIn, seedOut) -> do
+      forAll ((,) <$> genTxIn <*> genOutputFor (ownVerificationKey cctx)) $ \(seedIn, seedOut) -> do
         let tx = initialize cctx seedIn (ctxParticipants ctx) (ctxHeadParameters ctx)
             utxo = UTxO.singleton seedIn seedOut <> getKnownUTxO cctx
          in action utxo tx

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -51,7 +51,7 @@ import Hydra.Tx.Party (Party (..), deriveParty)
 import Hydra.Tx.Snapshot (ConfirmedSnapshot (..), Snapshot (..), SnapshotNumber, SnapshotVersion, getSnapshot)
 import Test.Hydra.Node.Fixture qualified as Fixture
 import Test.Hydra.Tx.Fixture (alice, aliceSk, bob, bobSk, carol, carolSk, deriveOnChainId, testHeadId, testHeadSeed)
-import Test.Hydra.Tx.Gen (genKeyPair, genOutput)
+import Test.Hydra.Tx.Gen (genKeyPair, genOutputFor)
 import Test.QuickCheck (Property, counterexample, elements, forAll, forAllShrink, oneof, shuffle, suchThat)
 import Test.QuickCheck.Gen (generate)
 import Test.QuickCheck.Monadic (assert, monadicIO, pick, run)
@@ -933,7 +933,7 @@ spec =
         (vk, sk) <- pick genKeyPair
         -- helper to build deposit tx
         let mkDepositTx = do
-              txOut <- genOutput vk
+              txOut <- genOutputFor vk
               utxo <- (,txOut) <$> genTxIn
               mkSimpleTx
                 utxo
@@ -1030,7 +1030,7 @@ spec =
       prop "any tx with expiring upper validity range gets pruned" $ \slotNo -> monadicIO $ do
         (utxo, expiringTransaction) <- pick $ do
           (vk, sk) <- genKeyPair
-          txOut <- genOutput vk
+          txOut <- genOutputFor vk
           utxo <- (,txOut) <$> genTxIn
           mkRangedTx
             utxo

--- a/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
+++ b/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
@@ -21,7 +21,7 @@ import Hydra.Ledger.Cardano (cardanoLedger, genSequenceOfSimplePaymentTransactio
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
 import Test.Cardano.Ledger.Babbage.Arbitrary ()
 import Test.Hydra.Node.Fixture (defaultGlobals, defaultLedgerEnv, defaultPParams)
-import Test.Hydra.Tx.Gen (genOneUTxOFor, genOutput, genTxOut, genUTxOFor, genValue)
+import Test.Hydra.Tx.Gen (genOneUTxOFor, genOutputFor, genTxOut, genUTxOFor, genValue)
 import Test.QuickCheck (
   Property,
   checkCoverage,
@@ -78,9 +78,9 @@ spec =
         it "does generate good values" $
           forAll genTxOut propGeneratesGoodTxOut
 
-      describe "genOutput" $
+      describe "genOutputFor" $
         it "has enough lovelace to cover assets" $
-          forAll (arbitrary >>= genOutput) propHasEnoughLovelace
+          forAll (arbitrary >>= genOutputFor) propHasEnoughLovelace
 
       describe "genValue" $
         it "produces realistic values" $

--- a/hydra-tx/test/Hydra/Tx/Contract/FanOut.hs
+++ b/hydra-tx/test/Hydra/Tx/Contract/FanOut.hs
@@ -24,7 +24,7 @@ import Hydra.Tx.Party (Party, partyToChain, vkey)
 import Hydra.Tx.Utils (adaOnly, splitUTxO)
 import PlutusTx.Builtins (toBuiltin)
 import Test.Hydra.Tx.Fixture (slotLength, systemStart, testNetworkId, testPolicyId, testSeedInput)
-import Test.Hydra.Tx.Gen (genOutput, genScriptRegistry, genUTxOWithSimplifiedAddresses, genValue)
+import Test.Hydra.Tx.Gen (genOutputFor, genScriptRegistry, genUTxOWithSimplifiedAddresses, genValue)
 import Test.Hydra.Tx.Mutation (Mutation (..), SomeMutation (..), changeMintedTokens)
 import Test.QuickCheck (choose, elements, oneof, suchThat)
 import Test.QuickCheck.Instances ()
@@ -129,7 +129,7 @@ genFanoutMutation (tx, _utxo) =
     , -- Spec: The first m outputs are distributing funds according to η. That is, the outputs exactly
       -- correspond to the UTxO canonically combined U
       SomeMutation (pure $ toErrorCode FanoutUTxOHashMismatch) MutateAddUnexpectedOutput . PrependOutput <$> do
-        arbitrary >>= genOutput
+        arbitrary >>= genOutputFor
     , -- Spec: The following n outputs are distributing funds according to η∆ .
       -- That is, the outputs exactly # correspond to the UTxO canonically combined U∆
       SomeMutation (pure $ toErrorCode FanoutUTxOHashMismatch) MutateFanoutOutputValue <$> do


### PR DESCRIPTION
Rename `genOutput` -> `genOutputFor`

Resolves #2284 

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
