### PR TITLE
Longer delay in hydra-cluster smoke-tests

### DIFF
--- a/hydra-cluster/src/CardanoNode.hs
+++ b/hydra-cluster/src/CardanoNode.hs
@@ -4,7 +4,7 @@ module CardanoNode where
 
 import Hydra.Prelude
 
-import Cardano.Slotting.Time (RelativeTime, diffRelativeTime, getRelativeTime, toRelativeTime)
+import Cardano.Slotting.Time (diffRelativeTime, getRelativeTime, toRelativeTime)
 import CardanoClient (QueryPoint (QueryTip))
 import Control.Lens ((?~), (^?!))
 import Control.Tracer (Tracer, traceWith)
@@ -60,7 +60,7 @@ data NodeLog
   | MsgCLIRetryResult Text Int
   | MsgNodeStarting {stateDirectory :: FilePath}
   | MsgSocketIsReady SocketPath
-  | MsgSynchronizing {percentDone :: Centi, blockTime :: NominalDiffTime, tipTime :: NominalDiffTime, targetTime :: NominalDiffTime}
+  | MsgSynchronizing {percentDone :: Centi, timeDifference :: NominalDiffTime, blockTime :: NominalDiffTime, tipTime :: NominalDiffTime, targetTime :: NominalDiffTime}
   | MsgQueryGenesisParametersFailed {err :: Text}
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON)
@@ -424,7 +424,7 @@ waitForFullySynchronized tracer backend = do
     let timeDifference = diffRelativeTime targetTime tipTime
     let percentDone = realToFrac (100.0 * getRelativeTime tipTime / getRelativeTime targetTime)
     blockTime <- Backend.getBlockTime backend
-    traceWith tracer $ MsgSynchronizing{percentDone, blockTime, tipTime = getRelativeTime tipTime, targetTime = getRelativeTime targetTime}
+    traceWith tracer $ MsgSynchronizing{percentDone, blockTime, tipTime = getRelativeTime tipTime, targetTime = getRelativeTime targetTime, timeDifference}
     if timeDifference < blockTime
       then pure ()
       else threadDelay 3 >> check systemStart

--- a/hydra-cluster/src/CardanoNode.hs
+++ b/hydra-cluster/src/CardanoNode.hs
@@ -4,7 +4,7 @@ module CardanoNode where
 
 import Hydra.Prelude
 
-import Cardano.Slotting.Time (diffRelativeTime, getRelativeTime, toRelativeTime)
+import Cardano.Slotting.Time (RelativeTime, diffRelativeTime, getRelativeTime, toRelativeTime)
 import CardanoClient (QueryPoint (QueryTip))
 import Control.Lens ((?~), (^?!))
 import Control.Tracer (Tracer, traceWith)
@@ -60,7 +60,7 @@ data NodeLog
   | MsgCLIRetryResult Text Int
   | MsgNodeStarting {stateDirectory :: FilePath}
   | MsgSocketIsReady SocketPath
-  | MsgSynchronizing {percentDone :: Centi}
+  | MsgSynchronizing {percentDone :: Centi, blockTime :: NominalDiffTime, tipTime :: NominalDiffTime, targetTime :: NominalDiffTime}
   | MsgQueryGenesisParametersFailed {err :: Text}
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON)
@@ -424,7 +424,7 @@ waitForFullySynchronized tracer backend = do
     let timeDifference = diffRelativeTime targetTime tipTime
     let percentDone = realToFrac (100.0 * getRelativeTime tipTime / getRelativeTime targetTime)
     blockTime <- Backend.getBlockTime backend
-    traceWith tracer $ MsgSynchronizing{percentDone}
+    traceWith tracer $ MsgSynchronizing{percentDone, blockTime, tipTime = getRelativeTime tipTime, targetTime = getRelativeTime targetTime}
     if timeDifference < blockTime
       then pure ()
       else threadDelay 3 >> check systemStart

--- a/hydra-cluster/src/CardanoNode.hs
+++ b/hydra-cluster/src/CardanoNode.hs
@@ -425,7 +425,7 @@ waitForFullySynchronized tracer backend = do
     let percentDone = realToFrac (100.0 * getRelativeTime tipTime / getRelativeTime targetTime)
     blockTime <- Backend.getBlockTime backend
     traceWith tracer $ MsgSynchronizing{percentDone, blockTime, tipTime = getRelativeTime tipTime, targetTime = getRelativeTime targetTime, timeDifference}
-    if timeDifference < 20*blockTime
+    if timeDifference < 20 * blockTime
       then pure ()
       else threadDelay 3 >> check systemStart
 

--- a/hydra-cluster/src/CardanoNode.hs
+++ b/hydra-cluster/src/CardanoNode.hs
@@ -425,7 +425,7 @@ waitForFullySynchronized tracer backend = do
     let percentDone = realToFrac (100.0 * getRelativeTime tipTime / getRelativeTime targetTime)
     blockTime <- Backend.getBlockTime backend
     traceWith tracer $ MsgSynchronizing{percentDone, blockTime, tipTime = getRelativeTime tipTime, targetTime = getRelativeTime targetTime, timeDifference}
-    if timeDifference < blockTime
+    if timeDifference < 10*blockTime
       then pure ()
       else threadDelay 3 >> check systemStart
 

--- a/hydra-cluster/src/CardanoNode.hs
+++ b/hydra-cluster/src/CardanoNode.hs
@@ -425,7 +425,7 @@ waitForFullySynchronized tracer backend = do
     let percentDone = realToFrac (100.0 * getRelativeTime tipTime / getRelativeTime targetTime)
     blockTime <- Backend.getBlockTime backend
     traceWith tracer $ MsgSynchronizing{percentDone, blockTime, tipTime = getRelativeTime tipTime, targetTime = getRelativeTime targetTime, timeDifference}
-    if timeDifference < 10*blockTime
+    if timeDifference < 20*blockTime
       then pure ()
       else threadDelay 3 >> check systemStart
 

--- a/hydra-cluster/src/Hydra/Cluster/Options.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Options.hs
@@ -3,7 +3,6 @@
 module Hydra.Cluster.Options where
 
 import Data.ByteString.Char8 qualified as BSC
-import Data.List qualified as List
 import Hydra.Cardano.Api (TxId, deserialiseFromRawBytesHex)
 import Hydra.Cluster.Fixture (KnownNetwork (..))
 import Hydra.Options (persistenceRotateAfterParser)
@@ -93,7 +92,7 @@ parseOptions =
    where
     parseTxIds :: String -> Either String [TxId]
     parseTxIds str =
-      let parsed = fmap (deserialiseFromRawBytesHex . BSC.pack) (List.lines str)
+      let parsed = fmap deserialiseFromRawBytesHex (BSC.split ',' (BSC.pack str))
        in if null (lefts parsed) then Right (rights parsed) else Left ("Invalid TxId" :: String)
 
   parseUseMithril =

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -486,7 +486,7 @@ singlePartyHeadFullLifeCycle tracer workDir backend hydraScriptsTxId =
           guard $ v ^? key "headId" == Just (toJSON headId)
           v ^? key "contestationDeadline" . _JSON
         remainingTime <- diffUTCTime deadline <$> getCurrentTime
-        waitFor hydraTracer (remainingTime + 10 * blockTime) [n1] $
+        waitFor hydraTracer (remainingTime + 50 * blockTime) [n1] $
           output "ReadyToFanout" ["headId" .= headId]
         send n1 $ input "Fanout" []
 


### PR DESCRIPTION
When preparing a recent release we have noticed that the timeout for "waiting for fully synch'd cardano-node" was a bit too optimistic. It seems that we were always about ~200 seconds behind, instead of < 20 seconds.

So I changed the computation to be `< 20 * blockTime`.

Similarly, I noticed a need to change the delay in the scenario itself to wait a little longer.

Both of these changes led to getting a pass for the Smoketests on preprod - https://github.com/cardano-scaling/hydra/actions/runs/18340105438/job/52233329143.

Preview is still presently not working; and I haven't tried mainnet yet.

This PR also changes the `--hydra-scripts-txid` parsing to match that of the hydra-node, as it was really confusing that they were different.