### PR TITLE
Update docs banner link to stable docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -170,7 +170,7 @@ const config = {
       announcementBar: isUnstable
         ? {
           id: "unstable_docs_banner",
-          content: `This is the documentation for the unstable version of Hydra. For the latest stable version, see <a target="_blank" rel="noopener noreferrer" href="${SITE_URL}${BASE_URL}docs">here</a>.`,
+          content: `This is the documentation for the unstable version of Hydra. For the latest stable version, see <a target="_blank" rel="noopener noreferrer" href="https://hydra.family/head-protocol/docs">here</a>.`,
           isCloseable: false,
         }
         : undefined,


### PR DESCRIPTION
Currently, it was pointing to tyhe unstable docs.
I hardcoded the link here, so that the deploy process etc. won't mess up with the base url and any other link in this banner part.

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
