### PR TITLE
Do not replace stable link to unstable in the banner

### DIFF
--- a/nix/hydra/docs.nix
+++ b/nix/hydra/docs.nix
@@ -34,7 +34,7 @@
 
       docs-unstable = docs.overrideAttrs {
         configurePhase = ''
-          sed -i 's|head-protocol|head-protocol/unstable|' docusaurus.config.js
+          sed -i '/^const BASE_URL/s|head-protocol|head-protocol/unstable|' docusaurus.config.js
         '';
       };
     };


### PR DESCRIPTION
This was tricky, we actually were replacing the link ourselves 😄 

Now I only replace it in the const, leaving the banner untouched.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
