### PR TITLE
SafeClose client command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ changes.
 
 ## [1.2.0] - UNRELEASED
 
+- There is a new `SafeClose` client command which prevents closing the Head in case there are non-ADA assets in the confirmed snapshot UTxO [#2330](https://github.com/cardano-scaling/hydra/issues/2330).
+
 - Add support for Blockfrost to the `hydra-tui` [#2032](https://github.com/cardano-scaling/hydra/issues/2032).
 
 - `hydra-node` has a new endpoint `GET /head-initialization` which serves the timestamp of the last Head initialization.

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -141,6 +141,7 @@ import HydraNode (
   waitForNodesConnected,
   waitForNodesDisconnected,
   waitMatch,
+  waitNoMatch,
   withHydraCluster,
   withHydraNode,
   withPreparedHydraNode,
@@ -1597,6 +1598,12 @@ canDepositPartially tracer workDir blockTime backend hydraScriptsTxId =
           (balance <$> Backend.queryUTxOFor backend QueryTip walletVk)
             `shouldReturn` lovelaceToValue (seedAmount - commitAmount + fromMaybe 0 (CAPI.valueToLovelace $ UTxO.totalValue leftoverTokenUTxO))
             <> returnedAssets
+
+          send n2 $ input "SafeClose" []
+          -- closing fails because we have non-ada assets in the UTxO
+          _ <- waitNoMatch (10 * blockTime) n2 $ \v -> do
+            guard $ v ^? key "tag" == Just "HeadIsClosed"
+            pure ()
 
           send n2 $ input "Close" []
 

--- a/hydra-node/golden/ClientInput/SafeClose.json
+++ b/hydra-node/golden/ClientInput/SafeClose.json
@@ -1,0 +1,8 @@
+{
+    "samples": [
+        {
+            "tag": "SafeClose"
+        }
+    ],
+    "seed": 2101779825
+}

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -518,6 +518,13 @@ components:
       payload:
         $ref: "api.yaml#/components/schemas/Close"
 
+    SafeClose:
+      title: SafeClose
+      description: |
+        Terminate a head with the latest known snapshot with additional check that confirmed snapshot UTxO does not contain any non-ADA assets. This effectively moves the head from the Open state to the Close state where the contestation phase begin. As a result of closing a head, no more transactions can be submitted via NewTx.
+      payload:
+        $ref: "api.yaml#/components/schemas/SafeClose"
+
     Contest:
       title: Contest
       description: |
@@ -835,6 +842,7 @@ components:
         - $ref: "api.yaml#/components/schemas/Recover"
         - $ref: "api.yaml#/components/schemas/Decommit"
         - $ref: "api.yaml#/components/schemas/Close"
+        - $ref: "api.yaml#/components/schemas/SafeClose"
         - $ref: "api.yaml#/components/schemas/Contest"
         - $ref: "api.yaml#/components/schemas/Fanout"
         - $ref: "api.yaml#/components/schemas/SideLoadSnapshot"
@@ -977,6 +985,16 @@ components:
         tag:
           type: string
           enum: ["Close"]
+
+    SafeClose:
+      title: SafeClose
+      type: object
+      required:
+        - tag
+      properties:
+        tag:
+          type: string
+          enum: ["SafeClose"]
 
     Contest:
       title: Contest
@@ -1413,6 +1431,7 @@ components:
             - $ref: "api.yaml#/components/messages/Decommit/payload"
             - $ref: "api.yaml#/components/messages/Recover/payload"
             - $ref: "api.yaml#/components/messages/Close/payload"
+            - $ref: "api.yaml#/components/messages/SafeClose/payload"
             - $ref: "api.yaml#/components/messages/Contest/payload"
             - $ref: "api.yaml#/components/messages/Fanout/payload"
             - $ref: "api.yaml#/components/messages/SideLoadSnapshot/payload"

--- a/hydra-node/src/Hydra/API/ClientInput.hs
+++ b/hydra-node/src/Hydra/API/ClientInput.hs
@@ -14,6 +14,7 @@ data ClientInput tx
   | Recover {recoverTxId :: TxIdType tx}
   | Decommit {decommitTx :: tx}
   | Close
+  | SafeClose
   | Contest
   | Fanout
   | SideLoadSnapshot {snapshot :: ConfirmedSnapshot tx}
@@ -37,6 +38,7 @@ instance (Arbitrary tx, Arbitrary (TxIdType tx), Arbitrary (UTxOType tx), IsTx t
     Recover tx -> Recover <$> shrink tx
     Decommit tx -> Decommit <$> shrink tx
     Close -> []
+    SafeClose -> []
     Contest -> []
     Fanout -> []
     SideLoadSnapshot sn -> SideLoadSnapshot <$> shrink sn

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -134,7 +134,7 @@ withAPIServer config env stateFile party eventSource tracer chain pparams server
             . simpleCors
             $ websocketsOr
               defaultConnectionOptions
-              (wsApp env party tracer historyTimedOutputs callback nodeStateP networkInfoP responseChannel serverOutputFilter)
+              (wsApp env party tracer chain historyTimedOutputs callback nodeStateP networkInfoP responseChannel serverOutputFilter)
               ( httpApp
                   tracer
                   chain

--- a/hydra-node/src/Hydra/API/WSServer.hs
+++ b/hydra-node/src/Hydra/API/WSServer.hs
@@ -14,7 +14,7 @@ import Data.Aeson.Lens (atKey)
 import Data.Conduit.Combinators (filter)
 import Data.Version (showVersion)
 import Hydra.API.APIServerLog (APIServerLog (..))
-import Hydra.API.ClientInput (ClientInput)
+import Hydra.API.ClientInput (ClientInput (SafeClose))
 import Hydra.API.Projection (Projection (..))
 import Hydra.API.ServerOutput (
   ClientMessage,
@@ -37,6 +37,7 @@ import Hydra.API.ServerOutput (
 import Hydra.API.ServerOutputFilter (
   ServerOutputFilter (..),
  )
+import Hydra.Chain (Chain (..))
 import Hydra.Chain.ChainState (
   IsChainState,
  )
@@ -65,6 +66,7 @@ wsApp ::
   Environment ->
   Party ->
   Tracer IO APIServerLog ->
+  Chain tx IO ->
   ConduitT () (TimedServerOutput tx) (ResourceT IO) () ->
   (ClientInput tx -> IO ()) ->
   -- | Read model to enhance 'Greetings' messages with 'HeadStatus'.
@@ -75,7 +77,7 @@ wsApp ::
   ServerOutputFilter tx ->
   PendingConnection ->
   IO ()
-wsApp env party tracer history callback nodeStateP networkInfoP responseChannel ServerOutputFilter{txContainsAddr} pending = do
+wsApp env party tracer chain history callback nodeStateP networkInfoP responseChannel ServerOutputFilter{txContainsAddr} pending = do
   traceWith tracer NewAPIConnection
   let path = requestPath $ pendingRequest pending
   queryParams <- uriQuery <$> mkURIBs path
@@ -164,12 +166,25 @@ wsApp env party tracer history callback nodeStateP networkInfoP responseChannel 
         sendTextData con (handleUtxoInclusion outConfig removeSnapshotUTxO $ Aeson.encode response)
         traceWith tracer (APIOutputSent $ toJSON response)
 
+  Chain{checkNonADAAssets} = chain
+
   receiveInputs con = forever $ do
     msg <- receiveData con
     case Aeson.eitherDecode msg of
       Right input -> do
         traceWith tracer (APIInputReceived $ toJSON input)
-        callback input
+        NodeState{headState} <- atomically getLatestNodeState
+        case HeadState.getOpenStateConfirmedSnapshot headState of
+          Nothing -> callback input
+          Just confirmedSnapshot ->
+            case input of
+              SafeClose -> do
+                case checkNonADAAssets confirmedSnapshot of
+                  Left nonADAValue -> do
+                    let clientInput = decodeUtf8With lenientDecode $ toStrict msg
+                    traceWith tracer (APIInvalidInput ("Cannot SafeClose with non-ADA assets present: " <> show nonADAValue) clientInput)
+                  Right _ -> callback input
+              _ -> callback input
       Left e -> do
         -- XXX(AB): toStrict might be problematic as it implies consuming the full
         -- message to memory

--- a/hydra-node/src/Hydra/Chain.hs
+++ b/hydra-node/src/Hydra/Chain.hs
@@ -23,6 +23,7 @@ import Hydra.Cardano.Api (
   LedgerEra,
   PolicyAssets,
   PolicyId,
+  Value,
  )
 import Hydra.Chain.ChainState (ChainSlot, IsChainState (..))
 import Hydra.Tx (
@@ -293,6 +294,7 @@ data Chain tx m = Chain
   --
   -- XXX: While technically they could be any of 'PostTxError tx', only
   -- `FailedToPostTx` errors are expected here.
+  , checkNonADAAssets :: ConfirmedSnapshot tx -> Either Value ()
   }
 
 data ChainEvent tx

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -74,6 +74,7 @@ import Hydra.Chain.Direct.Wallet (
  )
 import Hydra.Ledger.Cardano (adjustUTxO, fromChainSlot)
 import Hydra.Logging (Tracer, traceWith)
+import Hydra.Node.Util (checkNonADAAssetsUTxO)
 import Hydra.Tx (
   CommitBlueprintTx (..),
   HeadParameters (..),
@@ -97,6 +98,7 @@ import Hydra.Tx.Observe (
   observeHeadTx,
  )
 import Hydra.Tx.Recover (RecoverObservation (..))
+import Hydra.Tx.Snapshot (Snapshot (..), getSnapshot)
 import System.IO.Error (userError)
 
 -- | Handle of a mutable local chain state that is kept in the direct chain layer.
@@ -209,6 +211,10 @@ mkChain tracer queryTimeHandle wallet ctx LocalChainState{getLatest} submitTx =
     , -- Submit a cardano transaction to the cardano-node using the
       -- LocalTxSubmission protocol.
       submitTx
+    , checkNonADAAssets = \confirmedSnapshot -> do
+        let Snapshot{utxo, utxoToCommit, utxoToDecommit} = getSnapshot confirmedSnapshot
+        let snapshotUTxO = utxo <> fromMaybe mempty utxoToCommit <> fromMaybe mempty utxoToDecommit
+        checkNonADAAssetsUTxO snapshotUTxO
     }
 
 -- Check each UTxO entry against the minADAUTxO value.

--- a/hydra-node/src/Hydra/Chain/Offline.hs
+++ b/hydra-node/src/Hydra/Chain/Offline.hs
@@ -129,6 +129,7 @@ withOfflineChain config party otherParties chainStateHistory callback action = d
       , draftCommitTx = \_ _ -> pure $ Left FailedToDraftTxNotInitializing
       , draftDepositTx = \_ _ _ _ _ -> pure $ Left FailedToConstructDepositTx{failureReason = "not implemented"}
       , postTx = const $ pure ()
+      , checkNonADAAssets = const $ pure ()
       }
 
   initializeOfflineHead = do

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1362,6 +1362,8 @@ update env ledger NodeState{headState = st, pendingDeposits, currentSlot} ev = c
   -- Open
   (Open openState, ClientInput Close) ->
     onOpenClientClose openState
+  (Open openState, ClientInput SafeClose) ->
+    onOpenClientClose openState
   (Open{}, ClientInput (NewTx tx)) ->
     onOpenClientNewTx tx
   (Open openState, NetworkInput ttl (ReceivedMessage{msg = ReqTx tx})) ->

--- a/hydra-node/src/Hydra/HeadLogic/State.hs
+++ b/hydra-node/src/Hydra/HeadLogic/State.hs
@@ -76,6 +76,14 @@ getHeadParameters = \case
   Open OpenState{parameters} -> Just parameters
   Closed ClosedState{parameters} -> Just parameters
 
+-- | Get the head parameters in any 'HeadState'.
+getOpenStateConfirmedSnapshot :: HeadState tx -> Maybe (ConfirmedSnapshot tx)
+getOpenStateConfirmedSnapshot = \case
+  Idle _ -> Nothing
+  Initial InitialState{} -> Nothing
+  Open OpenState{coordinatedHeadState = CoordinatedHeadState{confirmedSnapshot}} -> Just confirmedSnapshot
+  Closed ClosedState{} -> Nothing
+
 -- ** Idle
 
 -- | An 'Idle' head only having a chain state with things seen on chain so far.

--- a/hydra-node/src/Hydra/Node/Util.hs
+++ b/hydra-node/src/Hydra/Node/Util.hs
@@ -4,12 +4,17 @@ module Hydra.Node.Util where
 
 import Hydra.Prelude
 
+import Cardano.Api.UTxO (totalValue)
 import Hydra.Cardano.Api (
+  AssetId (..),
   File (..),
   HasTextEnvelope,
   PaymentKey,
   SigningKey,
+  UTxO,
+  Value,
   VerificationKey,
+  filterValue,
   getVerificationKey,
   readFileTextEnvelope,
  )
@@ -26,3 +31,11 @@ readFileTextEnvelopeThrow ::
   IO a
 readFileTextEnvelopeThrow fileContents =
   either (fail . show) pure =<< readFileTextEnvelope (File fileContents)
+
+-- | Filter and return any non-ADA assets as 'Left' if they are present in the 'UTxO' value.
+checkNonADAAssetsUTxO :: UTxO -> Either Value ()
+checkNonADAAssetsUTxO utxo =
+  let nonADA = filterValue (/= AdaAssetId) $ totalValue utxo
+   in if nonADA == mempty
+        then Right ()
+        else Left nonADA

--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -29,6 +29,7 @@ import Hydra.API.ServerOutput (InvalidInput (..), input)
 import Hydra.API.ServerOutputFilter (ServerOutputFilter (..))
 import Hydra.Chain (
   Chain (Chain),
+  checkNonADAAssets,
   draftCommitTx,
   draftDepositTx,
   mkChainState,
@@ -381,6 +382,7 @@ dummyChainHandle =
     , draftCommitTx = \_ -> error "unexpected call to draftCommitTx"
     , draftDepositTx = \_ -> error "unexpected call to draftDepositTx"
     , submitTx = \_ -> error "unexpected call to submitTx"
+    , checkNonADAAssets = \_ -> error "unexpected call to checkNonADAAssets"
     }
 
 allowEverythingServerOutputFilter :: ServerOutputFilter tx

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -1084,6 +1084,7 @@ simulatedChainAndNetwork initialChainState = do
                   , draftCommitTx = \_ -> error "unexpected call to draftCommitTx"
                   , draftDepositTx = \_ -> error "unexpected call to draftDepositTx"
                   , submitTx = \_ -> error "unexpected call to submitTx"
+                  , checkNonADAAssets = \_ -> error "unexpected call to checkNonADAAssets"
                   }
               mockNetwork = createMockNetwork draftNode nodes
               mockServer :: Server tx m

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -363,6 +363,7 @@ mockChain =
     , draftCommitTx = \_ _ -> failure "mockChain: unexpected draftCommitTx"
     , draftDepositTx = \_ _ _ _ _ -> failure "mockChain: unexpected draftDepositTx"
     , submitTx = \_ -> failure "mockChain: unexpected submitTx"
+    , checkNonADAAssets = \_ -> error "mockChain: unexpected checkNonADAAssets"
     }
 
 mockSink :: Monad m => EventSink a m
@@ -523,5 +524,6 @@ throwExceptionOnPostTx exception node =
             , draftCommitTx = \_ -> error "draftCommitTx not implemented"
             , draftDepositTx = \_ -> error "draftDepositTx not implemented"
             , submitTx = \_ -> error "submitTx not implemented"
+            , checkNonADAAssets = \_ -> error "checkNonADAAssets not implemented"
             }
       }


### PR DESCRIPTION

fix #2330 


Add new client command for safe closing the Head `SafeClose`. 

This one will only issue closing in case there are non-ADA assets in the confirmed snapshot UTxO. 

In case there are some non-ADA tokens there will be corresponding log entry and a InvalidInput message over websocket -  close command will not be issued until these tokens are burned. 

This was requested by DeltaDeFi team to prevent accidental Head closing when there are still some tokens in the Head.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
