### PR TITLE
write-all isn't even valid

### DIFF
--- a/.github/workflows/tx-cost-diff.yaml
+++ b/.github/workflows/tx-cost-diff.yaml
@@ -10,8 +10,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  checks: write-all
-  pull-requests: write-all
+  checks: write
+  pull-requests: write
 
 
 jobs:


### PR DESCRIPTION
This got changed during a PR from a non-permissioned contributor in attempt to make their PR not fail. Unfortunately, the value provided does not work (and indeed causes the entire workflow to fail.)