### PR TITLE
Run binaries on aarm

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -8,11 +8,18 @@ on:
     - release
     tags:
     - "*.*.*"
+  # Allows to trigger runs on any branch
+  workflow_dispatch:
 
 jobs:
   build-linux:
-    name: "Build for x86_64-linux"
-    runs-on: ubuntu-latest
+    name: "Build for ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
     steps:
     - name: 📥 Checkout repository
       uses: actions/checkout@v4


### PR DESCRIPTION
Run the binaries task on aarm64 always; and allow it to be triggered on branches.

Fixes https://github.com/cardano-scaling/hydra/issues/2367