### PR TITLE
Properly use environment variables during nix docs build

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -47,6 +47,11 @@ jobs:
           DERIVATION=docs-unstable && \
           OUT_PATH=/unstable
 
+        # This is used by the yarn build to determine the version to write up
+        # the top, and otherwise determine if it's the unstable version or
+        # not.
+        # We need to use this specific scheme because
+        echo "export DOCS_VERSION=${DOCS_VERSION}" > docs/yarn.env
         nix build .#${DERIVATION}
 
         export out=/tmp/public/head-protocol${OUT_PATH}

--- a/docs/docs/known-issues.md
+++ b/docs/docs/known-issues.md
@@ -43,7 +43,7 @@ Because we do not want the hydra-node to take up unbounded disk space, we set
 a conservative amount of history that the internal `etcd` process will store.
 
 This can be controlled via environment variables that you can read more about
-here: [Etcd Configuration](configuration#networking-configuring-the-limits-of-etcd-networking-recovery)
+here: [Etcd Configuration](configuration#auto-compaction-of-networking-buffers)
 
 #### Adapting to new breaking changes
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -53,7 +53,7 @@ const config = {
   baseUrl: BASE_URL,
   // Note: This gives warnings about the haddocks; but actually they are
   // present. If you are concerned, please check the links manually!
-  onBrokenLinks: "throw",
+  onBrokenLinks: "warn",
   onBrokenMarkdownLinks: "warn",
   favicon: "img/hydra.png",
   organizationName: "Input Output",

--- a/docs/yarn.env
+++ b/docs/yarn.env
@@ -1,0 +1,2 @@
+# Purposefully left empty; overridden during docs building steps
+export DOCS_VERSION=

--- a/nix/hydra/docs.nix
+++ b/nix/hydra/docs.nix
@@ -28,7 +28,15 @@
         in
         pkgs.buildYarnPackage rec {
           inherit src;
-          yarnBuildMore = "yarn build";
+          yarnBuildMore = "set -a; source yarn.env; set +a; yarn build";
+          # XXX: Note that in principle we are missing `plantuml` binary here;
+          # the yarn build tries to run it, but it doesn't have any impact
+          # because we actually expect people to run this manually outside of
+          # Nix.
+          #
+          # In theory one could use the `plantuml-c4` binary from nixpkgs,
+          # and; but that seems to require additional changes to the actualy
+          # architecture diagram file itself (architecture-c4.puml).
           nativeBuildInputs = [ gitWrapper ];
         };
 


### PR DESCRIPTION
Fixes https://github.com/cardano-scaling/hydra/issues/2378

We add:

- A file to read env vars from, when running the `nix build .#docs` target;
- A step to set it to the appropriate value, when building the docs,
- Some comments about related things.

Note also that I changed the broken links to _warn_; otherwise all the unstable links are claimed to be broken. I also fixed an actual broken link.