### PR TITLE
Bump blockfrost-client to 0.11.0.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -12,7 +12,7 @@ repository cardano-haskell-packages
 
 -- See CONTRIBUTING.md for information about when and how to update these.
 index-state:
-  , hackage.haskell.org 2025-10-17T00:26:22Z
+  , hackage.haskell.org 2025-12-03T10:32:49Z
   , cardano-haskell-packages 2025-10-21T11:16:53Z
 
 packages: **/*.cabal

--- a/flake.lock
+++ b/flake.lock
@@ -846,11 +846,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1760920046,
-        "narHash": "sha256-l0PCGkvAp1Uq9uuo9VReBbfEiGsx2N0k0apud3Wf6PU=",
+        "lastModified": 1764758753,
+        "narHash": "sha256-XwRx7/ffzdivIWfKD+ES6THoOp3Unn8cfc4jGYfM4rs=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "b9aba0fb684dacb6f8a5f398f0a1dd762b2f0419",
+        "rev": "5830b9744f8f344d9a5b1d08044dd537848a3118",
         "type": "github"
       },
       "original": {

--- a/hydra-chain-observer/hydra-chain-observer.cabal
+++ b/hydra-chain-observer/hydra-chain-observer.cabal
@@ -43,7 +43,7 @@ library
   build-depends:
     , base                         >=4.8.0
     , base16-bytestring
-    , blockfrost-client            >=0.9.2.0
+    , blockfrost-client            >=0.11.0.0
     , http-conduit
     , hydra-cardano-api
     , hydra-node

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -111,7 +111,7 @@ library
     , aeson
     , base
     , base16-bytestring
-    , blockfrost-client               >=0.9.2.0
+    , blockfrost-client               >=0.11.0.0
     , bytestring
     , cardano-api
     , cardano-binary

--- a/hydra-node/src/Hydra/Chain/Blockfrost/Client.hs
+++ b/hydra-node/src/Hydra/Chain/Blockfrost/Client.hs
@@ -457,13 +457,12 @@ queryUTxO BlockfrostOptions{queryTimeout} networkId addresses = do
   -- NOTE: We can't know at the time of doing a query if the information on specific address UTxO is _fresh_ or not
   -- so we try to wait for sufficient period of time and hope for best.
   liftIO $ threadDelay $ fromIntegral queryTimeout
-  let address = List.head addresses
-  let address' = Blockfrost.Address . serialiseAddress $ List.head addresses
+  let address = Blockfrost.Address . serialiseAddress $ List.head addresses
   utxoWithAddresses <-
-    Blockfrost.getAddressUtxos address'
+    Blockfrost.getAddressUtxos address
       `catchError` \case
-        Blockfrost.BlockfrostNotFound ->
-          liftIO (throwIO (BlockfrostError (NoUTxOFound address)))
+        Blockfrost.BlockfrostNotFound err ->
+          liftIO (throwIO (BlockfrostError (BlockfrostAPIError err)))
         err ->
           throwError err
 


### PR DESCRIPTION
This PR is the outcome of our user request to give more information on blockfrost specific 404 error. Now we can see which endpoint actually failed to deliver the data.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
