### PR TITLE
Just use normal binary for netem/Network tests

### DIFF
--- a/nix/hydra/docker.nix
+++ b/nix/hydra/docker.nix
@@ -34,7 +34,7 @@
             ];
           };
           config = {
-            Entrypoint = [ "${self'.packages.hydra-node-static}/bin/hydra-node" ];
+            Entrypoint = [ "${self'.packages.hydra-node}/bin/hydra-node" ];
           };
         };
 


### PR DESCRIPTION
Should save a _lot_ of build time; i.e. we don't need a static one just for our own internal testing.