### PR TITLE
Wait for node to be in sync depending on chain backend

### DIFF
--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -448,8 +448,10 @@ withPreparedHydraNodeInSync tracer workDir hydraNodeId runOptions action =
  where
   action' client = do
     getHydraBackend >>= \case
-      DirectBackendType -> waitForNodesSynced tracer 1 $ client :| []
-      BlockfrostBackendType -> waitForNodesSynced tracer 5 $ client :| []
+      DirectBackendType ->
+        waitForNodesSynced tracer 1 $ client :| []
+      BlockfrostBackendType ->
+        waitForNodesSynced tracer 10 $ client :| []
     action client
 
 -- | Run a hydra-node with given 'RunOptions'.

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -447,7 +447,9 @@ withPreparedHydraNodeInSync tracer workDir hydraNodeId runOptions action =
   withPreparedHydraNode tracer workDir hydraNodeId runOptions action'
  where
   action' client = do
-    waitForNodesSynced tracer 1 $ client :| []
+    getHydraBackend >>= \case
+      DirectBackendType -> waitForNodesSynced tracer 1 $ client :| []
+      BlockfrostBackendType -> waitForNodesSynced tracer 5 $ client :| []
     action client
 
 -- | Run a hydra-node with given 'RunOptions'.

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -187,7 +187,7 @@ defaultBlockfrostOptions =
     }
 
 defaultBFQueryTimeout :: Int
-defaultBFQueryTimeout = 20
+defaultBFQueryTimeout = 30
 
 defaultBFRetryTimeout :: Int
 defaultBFRetryTimeout = 300

--- a/hydra-node/test/Hydra/OptionsSpec.hs
+++ b/hydra-node/test/Hydra/OptionsSpec.hs
@@ -486,7 +486,7 @@ spec = parallel $
                     Blockfrost
                       BlockfrostOptions
                         { projectPath = "baz"
-                        , queryTimeout = 20
+                        , queryTimeout = 30
                         , retryTimeout = 300
                         }
                 , publishSigningKey = "cardano.sk"


### PR DESCRIPTION
<!-- Describe your change here -->

Closes https://github.com/cardano-scaling/hydra/issues/2411

Hydra nodes were not given enough time to fully sync with the chain when using the Blockfrost backend, leading to flaky failures in CI.

To address this, the hydra-node startup logic for e2e tests now waits for nodes to be in sync with a backend-specific threshold: 
- a shorter wait for the direct backend
- and a longer one for Blockfrost.

> This makes the sync assumptions explicit and fixes nightly tests without affecting existing direct-backend behaviour.

---

<!-- Consider each and tick it off one way or the other -->
* [X] CHANGELOG updated or not needed
* [X] Documentation updated or not needed
* [X] Haddocks updated or not needed
* [X] No new TODOs introduced or explained herafter
