### PR TITLE
ci: enable Docker builds for pull requests

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -13,6 +13,8 @@ on:
   push:
     branches: [ "master" ]
     tags: [ "*.*.*" ]
+  pull_request:
+    branches: [ "master" ]
   workflow_dispatch:
     inputs:
       ref_name:
@@ -72,6 +74,12 @@ jobs:
         IMAGE_LABEL=unstable
         # And the version as the git commit.
         VERSION=${{github.sha}}
+
+        # For PRs, tag as pr-<number>
+        if [[ "${{github.event_name}}" == "pull_request" ]]; then
+          IMAGE_LABEL=pr-${{github.event.pull_request.number}}
+          VERSION=${{github.event.pull_request.head.sha}}
+        fi
 
         # Determine whether we are building a tag and if yes, set the label
         # name to be the tag name, and the version to be the tag.


### PR DESCRIPTION
## Summary
- Add `pull_request` trigger to Docker workflow for PRs targeting master branch
- Tag PR builds as `pr-<number>` for easy identification and testing
- Use PR head SHA as version for traceability

## Changes
- Modified `.github/workflows/docker.yaml` to build Docker images on PRs
- PR images will be tagged as `ghcr.io/cardano-scaling/hydra:pr-<number>`

## Testing
This PR will test itself - once merged, subsequent PRs will generate Docker images that can be pulled and tested before merging.