### PR TITLE
ci: add disk cleanup step to prevent space exhaustion

### DIFF
--- a/.github/actions/nix-cachix-setup/action.yml
+++ b/.github/actions/nix-cachix-setup/action.yml
@@ -9,6 +9,21 @@ runs:
   using: composite
 
   steps:
+  - name: 🧹 Free disk space
+    if: runner.os == 'Linux'
+    shell: bash
+    run: |
+      echo "Disk space before cleanup:"
+      df -h /
+      # Remove unnecessary tools to free up disk space
+      sudo rm -rf /usr/share/dotnet
+      sudo rm -rf /usr/local/lib/android
+      sudo rm -rf /opt/ghc
+      sudo rm -rf /opt/hostedtoolcache/CodeQL
+      sudo docker image prune --all --force || true
+      echo "Disk space after cleanup:"
+      df -h /
+
   - name: ❄ Prepare nix
     uses: cachix/install-nix-action@v30
     with:


### PR DESCRIPTION
## Summary

GitHub Actions runners have limited disk space (~14GB available). When building uncached Nix derivations, the build can exhaust disk space during compilation.

This adds a cleanup step to the `nix-cachix-setup` action that removes unused tools before the build:
- .NET SDK (~1.8GB)
- Android SDK (~9GB)
- GHC (~5GB)
- CodeQL (~2.5GB)
- Unused Docker images

This frees up ~20GB of disk space, ensuring builds complete successfully even when cache misses occur.

## Changes

- Added disk cleanup step to `.github/actions/nix-cachix-setup/action.yml`