### PR TITLE
Bound the input queue to provide back pressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ changes.
 - Bounded the number of transactions that will be approved per snapshot
   [#2444](https://github.com/cardano-scaling/hydra/pull/2444).
 - Buffer and batch logging so it's faster [#2452](https://github.com/cardano-scaling/hydra/pull/2452)
+- Make the input queue bounded and align its size with other bounded queues (logging, etcd-pending-broadcast)
+  [#2430](https://github.com/cardano-scaling/hydra/pull/2430).
 
 ## [1.2.0] - 2025.11.28
 

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -62,7 +62,7 @@ import Data.List ((\\))
 import Data.List qualified as List
 import Data.Map qualified as Map
 import Data.Text qualified as T
-import Hydra.Logging (Tracer, traceWith)
+import Hydra.Logging (Tracer, defaultQueueSize, traceWith)
 import Hydra.Network (
   Connectivity (..),
   Host (..),
@@ -155,7 +155,7 @@ withEtcdNetwork tracer protocolVersion config callback action = do
                         ("etcd-waitMessages", waitMessages tracer conn persistenceDir callback)
                         ( "etcd-callback-4"
                         , do
-                            queue <- newPersistentQueue (persistenceDir </> "pending-broadcast") 100
+                            queue <- newPersistentQueue (persistenceDir </> "pending-broadcast") defaultQueueSize
                             raceLabelled_
                               ("etcd-broadcastMessages", broadcastMessages tracer config advertise queue)
                               ( "etcd-network-component-action"

--- a/hydra-node/src/Hydra/Node/InputQueue.hs
+++ b/hydra-node/src/Hydra/Node/InputQueue.hs
@@ -32,6 +32,11 @@ createInputQueue ::
 createInputQueue = do
   numThreads <- newLabelledTVarIO "num-threads" (0 :: Integer)
   nextId <- newLabelledTVarIO "nex-id" 0
+  -- XXX: We bound the _input_ queue by the _logging_ queue size! This is a
+  -- hack; but we do it because it seems that the logging queue blocking
+  -- prevents further processing, _unless_ the input queue is also bounded.
+  -- In truth it probably makes sense for this queue to be bounded anyway.
+  -- See: <https://github.com/cardano-scaling/hydra/issues/2442>
   q <- newLabelledTBQueueIO "input-queue" defaultQueueSize
   pure
     InputQueue

--- a/hydra-node/src/Hydra/Node/InputQueue.hs
+++ b/hydra-node/src/Hydra/Node/InputQueue.hs
@@ -4,14 +4,13 @@ module Hydra.Node.InputQueue where
 import Hydra.Prelude
 
 import Control.Concurrent.Class.MonadSTM (
-  isEmptyTQueue,
+  isEmptyTBQueue,
   modifyTVar',
-  readTQueue,
-  writeTQueue,
+  readTBQueue,
+  writeTBQueue,
  )
 
 -- | The single, required queue in the system from which a hydra head is "fed".
--- NOTE(SN): this probably should be bounded and include proper logging
 -- NOTE(SN): handle pattern, but likely not required as there is no need for an
 -- alternative implementation
 data InputQueue m e = InputQueue
@@ -32,13 +31,13 @@ createInputQueue ::
 createInputQueue = do
   numThreads <- newLabelledTVarIO "num-threads" (0 :: Integer)
   nextId <- newLabelledTVarIO "nex-id" 0
-  q <- newLabelledTQueueIO "input-queue"
+  q <- newLabelledTBQueueIO "input-queue" 100
   pure
     InputQueue
       { enqueue = \queuedItem ->
           atomically $ do
             queuedId <- readTVar nextId
-            writeTQueue q Queued{queuedId, queuedItem}
+            writeTBQueue q Queued{queuedId, queuedItem}
             modifyTVar' nextId succ
       , reenqueue = \delay e -> do
           atomically $ modifyTVar' numThreads succ
@@ -46,12 +45,12 @@ createInputQueue = do
             threadDelay delay
             atomically $ do
               modifyTVar' numThreads pred
-              writeTQueue q e
+              writeTBQueue q e
       , dequeue =
-          atomically $ readTQueue q
+          atomically $ readTBQueue q
       , isEmpty = do
           atomically $ do
             n <- readTVar numThreads
-            isEmpty' <- isEmptyTQueue q
+            isEmpty' <- isEmptyTBQueue q
             pure (isEmpty' && n == 0)
       }

--- a/hydra-node/src/Hydra/Node/InputQueue.hs
+++ b/hydra-node/src/Hydra/Node/InputQueue.hs
@@ -9,6 +9,7 @@ import Control.Concurrent.Class.MonadSTM (
   readTBQueue,
   writeTBQueue,
  )
+import Hydra.Logging (defaultQueueSize)
 
 -- | The single, required queue in the system from which a hydra head is "fed".
 -- NOTE(SN): handle pattern, but likely not required as there is no need for an
@@ -31,7 +32,7 @@ createInputQueue ::
 createInputQueue = do
   numThreads <- newLabelledTVarIO "num-threads" (0 :: Integer)
   nextId <- newLabelledTVarIO "nex-id" 0
-  q <- newLabelledTBQueueIO "input-queue" 100
+  q <- newLabelledTBQueueIO "input-queue" defaultQueueSize
   pure
     InputQueue
       { enqueue = \queuedItem ->


### PR DESCRIPTION
This was resolving an issue where (likely for another reason), rapidly submitted transactions required re-enqeueing of ReqTx inputs.

Hypothesis: When the input queue was not bounded, another bounded queue (in Hydra.Logging) was creating delays leading to the re-enqeued retrying of applying transactions start to fail (because they time out).

It is not known why the chain of transactions we used (see hydra-cluster bench) was even requiring the re-enqeuing in the first place though.

TODO: Some kind of test and argument about the queue size

NOTE: To reproduce, uncomment this line https://github.com/cardano-scaling/hydra/blob/1d45267ee2929606d7ffd268ec584d279fafac6d/hydra-cluster/bench/Bench/EndToEnd.hs#L381 and run `cabal run bench-e2e -- single --cluster-size 3 --scaling-factor 100`

Fixes https://github.com/cardano-scaling/hydra/issues/2328#issuecomment-3805536284

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
