### PR TITLE
Make unsynced period configurable via --unsynced-period CLI option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ changes.
   (43200 seconds) to align with Cardano's safe zone for mainnet safety. See
   [#2389](https://github.com/cardano-scaling/hydra/issues/2389).
 - Fix the `cabalOnly` development environment to allow for `cabal build hydra-node` without `haskell.nix`.
+- Add `--unsynced-period` CLI option to configure when the node considers itself
+  out of sync with the chain. Defaults to half the contestation period.
 
 ## [1.2.0] - 2025.11.28
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -74,7 +74,7 @@ Currently, the `hydra-node` does not handle this situation. Each client applicat
 In addition to governing on-chain disputes, the contestation period is also used to determine when a Hydra node is considered **in sync** with the Cardano chain.
 
 :::important
-If a node has not observed a new block for **_half the contestation period_**, it is considered **out of sync** and transitions to a **catching up** state.
+By default, if a node has not observed a new block for **_half the contestation period_**, it is considered **out of sync** and transitions to a **catching up** state.
 Beyond this period, the node will reject client inputs and refuse to process new transactions or sign snapshots. This ensures that nodes process inputs only when their view of the chain is recent enough to safely enforce L2 interactions on L1, preserving head safety.
 :::
 
@@ -112,6 +112,26 @@ As a rule of thumb:
 
 :::info
 The API server notifies clients whenever the node falls out of sync or returns to a synchronized state.
+:::
+
+#### Custom unsynced period
+
+If the default behavior (half the contestation period) does not fit your use case, you can explicitly configure the unsynced period using the `--unsynced-period` option:
+
+```
+hydra-node --unsynced-period 3600
+```
+
+This sets the period (in seconds) after which the node considers itself out of sync with the chain. For example, with `--unsynced-period 3600`, if no new block is observed for 1 hour, the node will transition to the "catching up" state.
+
+:::warning
+The unsynced period should generally be shorter than the contestation period to ensure safety. Setting it too large may cause the node to continue processing L2 transactions when it can no longer safely enforce them on L1.
+:::
+
+If not provided, the unsynced period defaults to half the contestation period, maintaining the safety property that an in-sync node always has sufficient time to react to on-chain events.
+
+:::info
+This option only applies when connected to a Cardano chain. In [offline mode](#offline-mode), there is no real chain to sync with, so the node is always considered in sync.
 :::
 
 ### Deposit period

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -119,7 +119,7 @@ import Hydra.Ledger.Cardano.Evaluate (maxTxExecutionUnits)
 import Hydra.Logging (Tracer, traceWith)
 import Hydra.Node.DepositPeriod (DepositPeriod (..))
 import Hydra.Node.State (SyncedStatus (..))
-import Hydra.Node.UnsyncedPeriod (unsyncedPeriodToNominalDiffTime)
+import Hydra.Node.UnsyncedPeriod (defaultUnsyncedPeriodFor, unsyncedPeriodToNominalDiffTime)
 import Hydra.Options (CardanoChainConfig (..), ChainBackendOptions (..), ChainConfig (..), DirectOptions (..), RunOptions (..), startChainFrom)
 import Hydra.Tx (HeadId (..), IsTx (balance), Party, headIdToCurrencySymbol, txId)
 import Hydra.Tx.ContestationPeriod qualified as CP
@@ -2313,7 +2313,9 @@ waitsForChainInSyncAndSecure tracer workDir backend hydraScriptsTxId = do
         guard $ v ^? key "tag" == Just "PeerDisconnected"
 
       -- Wait for some blocks to roll forward
-      let Cardano CardanoChainConfig{unsyncedPeriod} = carolChainConfig
+      let unsyncedPeriod = case carolChainConfig of
+            Cardano CardanoChainConfig{unsyncedPeriod = up} -> up
+            Offline{} -> defaultUnsyncedPeriodFor contestationPeriod
       threadDelay $ realToFrac (unsyncedPeriodToNominalDiffTime unsyncedPeriod + 50 * blockTime)
 
       -- Alice closes the head while Carol offline

--- a/hydra-cluster/src/Hydra/Cluster/Util.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Util.hs
@@ -19,6 +19,7 @@ import Hydra.Chain.Backend (ChainBackend)
 import Hydra.Chain.Backend qualified as Backend
 import Hydra.Cluster.Fixture (Actor, actorName, fundsOf)
 import Hydra.Node.DepositPeriod (DepositPeriod)
+import Hydra.Node.UnsyncedPeriod (defaultUnsyncedPeriodFor)
 import Hydra.Options (
   CardanoChainConfig (..),
   ChainBackendOptions (..),
@@ -110,6 +111,7 @@ chainConfigFor' me targetDir backend hydraScriptsTxId them contestationPeriod de
         , cardanoVerificationKeys = [actorFilePath himOrHer "vk" | himOrHer <- them]
         , contestationPeriod
         , depositPeriod
+        , unsyncedPeriod = defaultUnsyncedPeriodFor contestationPeriod
         , chainBackendOptions = Backend.getOptions backend
         }
  where

--- a/hydra-node/golden/Greetings/Greetings.json
+++ b/hydra-node/golden/Greetings/Greetings.json
@@ -11,7 +11,8 @@
                 "party": {
                     "vkey": "5802383116b8d8cfad0561849f98fa19652316ba794b06a4e2f74ac3f8d570b8"
                 },
-                "signingKey": "9e018c699d771741dc68d7d877a67520b68eacc6a76725f8be4034d18cd285d6"
+                "signingKey": "9e018c699d771741dc68d7d877a67520b68eacc6a76725f8be4034d18cd285d6",
+                "unsyncedPeriod": 21600
             },
             "headStatus": "Open",
             "hydraNodeVersion": "\u000c",

--- a/hydra-node/golden/RunOptions.json
+++ b/hydra-node/golden/RunOptions.json
@@ -40,7 +40,8 @@
                     "slot": 16016247,
                     "tag": "ChainPoint"
                 },
-                "tag": "CardanoChainConfig"
+                "tag": "CardanoChainConfig",
+                "unsyncedPeriod": 302400
             },
             "hydraSigningKey": "b/c.sk",
             "hydraVerificationKeys": [
@@ -177,7 +178,8 @@
                     "slot": 14063413,
                     "tag": "ChainPoint"
                 },
-                "tag": "CardanoChainConfig"
+                "tag": "CardanoChainConfig",
+                "unsyncedPeriod": 302400
             },
             "hydraSigningKey": "a.sk",
             "hydraVerificationKeys": [
@@ -295,7 +297,8 @@
                     "0600000601040000050806020308060804060304000305050500070706000801"
                 ],
                 "startChainFrom": null,
-                "tag": "CardanoChainConfig"
+                "tag": "CardanoChainConfig",
+                "unsyncedPeriod": 19870
             },
             "hydraSigningKey": "b/c/c/b/a/b.sk",
             "hydraVerificationKeys": [

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -100,6 +100,7 @@ library
     Hydra.Node.ParameterMismatch
     Hydra.Node.Run
     Hydra.Node.State
+    Hydra.Node.UnsyncedPeriod
     Hydra.Node.Util
     Hydra.Options
     Hydra.Persistence

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -3102,6 +3102,13 @@ components:
         A length of time, measured in whole seconds, to be used in deposit validity.
       example: 60
 
+    UnsyncedPeriod:
+      type: number
+      description: |
+        A length of time, measured in whole seconds, after which we consider the node
+        out of sync with the chain.
+      example: 21600
+
     Environment:
       type: object
       description: |
@@ -3113,6 +3120,7 @@ components:
       - participants
       - contestationPeriod
       - depositPeriod
+      - unsyncedPeriod
       - configuredPeers
       additionalProperties: false
       properties:
@@ -3132,6 +3140,8 @@ components:
           $ref: "api.yaml#/components/schemas/ContestationPeriod"
         depositPeriod:
           $ref: "api.yaml#/components/schemas/DepositPeriod"
+        unsyncedPeriod:
+          $ref: "api.yaml#/components/schemas/UnsyncedPeriod"
         configuredPeers:
           type: string
 

--- a/hydra-node/src/Hydra/Chain/Offline.hs
+++ b/hydra-node/src/Hydra/Chain/Offline.hs
@@ -189,7 +189,7 @@ withOfflineChain config party otherParties chainStateHistory callback action = d
 -- | Continuously produces offline chain ticks according to wall-clock time.
 -- Each tick is aligned with the expected slot time, ensuring the node
 -- state stays synchronized with the offline chain.
--- This prevents the node from violating the `ContestationPeriod.unsyncedPolicy`
+-- This prevents the node from violating the configured unsynced period
 -- which guarantees that client and network inputs are always processed safely.
 tickForever :: GenesisParameters ShelleyEra -> (ChainEvent Tx -> IO ()) -> IO ()
 tickForever genesis callback = do

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -77,6 +77,7 @@ import Hydra.Network.Message (Message (..), NetworkEvent (..))
 import Hydra.Node.DepositPeriod (DepositPeriod (..))
 import Hydra.Node.Environment (Environment (..), mkHeadParameters)
 import Hydra.Node.State (Deposit (..), DepositStatus (..), NodeState (..), PendingDeposits, SyncedStatus (..), depositsForHead, syncedStatus)
+import Hydra.Node.UnsyncedPeriod (UnsyncedPeriod (..))
 import Hydra.Tx (
   HeadId,
   HeadSeed,
@@ -87,7 +88,6 @@ import Hydra.Tx (
   utxoFromTx,
   withoutUTxO,
  )
-import Hydra.Tx.ContestationPeriod qualified as CP
 import Hydra.Tx.Crypto (
   Signature,
   Verified (..),
@@ -1337,11 +1337,11 @@ handleOutOfSync ::
   UTCTime ->
   SyncedStatus ->
   Outcome tx
-handleOutOfSync Environment{contestationPeriod} now chainTime syncStatus
+handleOutOfSync Environment{unsyncedPeriod} now chainTime syncStatus
   -- We consider the node out of sync when:
-  -- the last observed chainTime plus the delta allowed by the unsyncedPolicy
+  -- the last observed chainTime plus the delta allowed by the unsyncedPeriod
   -- falls behind the current system time.
-  | chainTime `plus` CP.unsyncedPolicy contestationPeriod < now =
+  | chainTime `plus` unsyncedPeriodToNominalDiffTime unsyncedPeriod < now =
       case syncStatus of
         InSync -> newState NodeUnsynced
         CatchingUp -> noop

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -55,6 +55,7 @@ import Hydra.Node.Environment (Environment (..))
 import Hydra.Node.InputQueue (InputQueue (..), Queued (..), createInputQueue)
 import Hydra.Node.ParameterMismatch (ParamMismatch (..), ParameterMismatch (..))
 import Hydra.Node.State (NodeState (..), initNodeState)
+import Hydra.Node.UnsyncedPeriod (UnsyncedPeriod (..))
 import Hydra.Node.Util (readFileTextEnvelopeThrow)
 import Hydra.Options (CardanoChainConfig (..), ChainConfig (..), RunOptions (..), defaultContestationPeriod, defaultDepositPeriod)
 import Hydra.Tx (HasParty (..), HeadParameters (..), Party (..), deriveParty)
@@ -76,6 +77,7 @@ initEnvironment options = do
       , participants
       , contestationPeriod
       , depositPeriod
+      , unsyncedPeriod
       , configuredPeers
       }
  where
@@ -99,6 +101,11 @@ initEnvironment options = do
   depositPeriod = case chainConfig of
     Offline{} -> defaultDepositPeriod
     Cardano CardanoChainConfig{depositPeriod = dp} -> dp
+  -- In offline mode, there's no real chain to sync with, so we use a very large
+  -- unsynced period to effectively disable the unsynced check.
+  unsyncedPeriod = case chainConfig of
+    Offline{} -> UnsyncedPeriod (365 * 24 * 60 * 60) -- 1 year
+    Cardano CardanoChainConfig{unsyncedPeriod = up} -> up
 
   loadParty p =
     Party <$> readFileTextEnvelopeThrow p

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -104,7 +104,7 @@ initEnvironment options = do
   -- In offline mode, there's no real chain to sync with, so we use a very large
   -- unsynced period to effectively disable the unsynced check.
   unsyncedPeriod = case chainConfig of
-    Offline{} -> UnsyncedPeriod (365 * 24 * 60 * 60) -- 1 year
+    Offline{} -> UnsyncedPeriod (fromIntegral (maxBound :: Int))
     Cardano CardanoChainConfig{unsyncedPeriod = up} -> up
 
   loadParty p =

--- a/hydra-node/src/Hydra/Node/Environment.hs
+++ b/hydra-node/src/Hydra/Node/Environment.hs
@@ -4,6 +4,7 @@ import Hydra.Prelude
 import Test.Hydra.Prelude
 
 import Hydra.Node.DepositPeriod (DepositPeriod)
+import Hydra.Node.UnsyncedPeriod (UnsyncedPeriod)
 import Hydra.Tx.ContestationPeriod (ContestationPeriod)
 import Hydra.Tx.Crypto (HydraKey, SigningKey)
 import Hydra.Tx.HeadParameters (HeadParameters (..))
@@ -23,6 +24,9 @@ data Environment = Environment
     participants :: [OnChainId]
   , contestationPeriod :: ContestationPeriod
   , depositPeriod :: DepositPeriod
+  , unsyncedPeriod :: UnsyncedPeriod
+  -- ^ Period of time after which we consider the node becoming unsynced with the chain.
+  -- Beyond this period the node will refuse to process new transactions and signing snapshots.
   , configuredPeers :: Text
   -- ^ Configured peers for the network layer, used for comparison on etcd errors.
   }

--- a/hydra-node/src/Hydra/Node/UnsyncedPeriod.hs
+++ b/hydra-node/src/Hydra/Node/UnsyncedPeriod.hs
@@ -1,0 +1,28 @@
+module Hydra.Node.UnsyncedPeriod where
+
+import Hydra.Prelude
+
+import Hydra.Tx.ContestationPeriod (ContestationPeriod, toNominalDiffTime)
+import Test.QuickCheck (choose)
+
+-- | Period of time after which we consider the node becoming unsynced with the chain.
+-- Beyond this period the node will refuse to process new transactions and signing snapshots.
+newtype UnsyncedPeriod = UnsyncedPeriod {unsyncedPeriodToNominalDiffTime :: NominalDiffTime}
+  deriving stock (Eq, Ord)
+  deriving newtype (Show, Read, Num, Enum, Real, ToJSON, FromJSON)
+
+-- | Truncates to whole seconds.
+instance Integral UnsyncedPeriod where
+  quotRem (UnsyncedPeriod a) (UnsyncedPeriod b) = (UnsyncedPeriod $ fromInteger q, UnsyncedPeriod r)
+   where
+    (q, r) = properFraction (a / b)
+
+  toInteger (UnsyncedPeriod a) = round a
+
+instance Arbitrary UnsyncedPeriod where
+  arbitrary = UnsyncedPeriod . fromInteger <$> choose (1, 86400)
+
+-- | Compute a default 'UnsyncedPeriod' based on the 'ContestationPeriod'.
+-- This is the legacy behavior: half of the contestation period.
+defaultUnsyncedPeriodFor :: ContestationPeriod -> UnsyncedPeriod
+defaultUnsyncedPeriodFor cp = UnsyncedPeriod $ toNominalDiffTime cp * 0.5

--- a/hydra-node/src/Hydra/Node/UnsyncedPeriod.hs
+++ b/hydra-node/src/Hydra/Node/UnsyncedPeriod.hs
@@ -1,6 +1,7 @@
 module Hydra.Node.UnsyncedPeriod where
 
 import Hydra.Prelude
+import Test.Hydra.Prelude
 
 import Hydra.Tx.ContestationPeriod (ContestationPeriod, toNominalDiffTime)
 import Test.QuickCheck (choose)

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -59,6 +59,7 @@ import Hydra.Node.DepositPeriod qualified as DP
 import Hydra.Node.Environment (Environment (..))
 import Hydra.Node.InputQueue (InputQueue (enqueue), createInputQueue)
 import Hydra.Node.State (NodeState (..), initNodeState)
+import Hydra.Node.UnsyncedPeriod (defaultUnsyncedPeriodFor)
 import Hydra.NodeSpec (createMockEventStore)
 import Hydra.Options (defaultContestationPeriod, defaultDepositPeriod)
 import Hydra.Tx (HeadId)
@@ -1377,8 +1378,9 @@ createHydraNode tracer ledger chainState signingKey otherParties outputs message
       , signingKey
       , otherParties
       , contestationPeriod = cp
-      , participants
       , depositPeriod = dp
+      , unsyncedPeriod = defaultUnsyncedPeriodFor cp
+      , participants
       , configuredPeers = ""
       }
   party = deriveParty signingKey

--- a/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
@@ -14,7 +14,7 @@ import Hydra.Ledger.Simple (SimpleTx (..), aValidTx, simpleLedger, utxoRef)
 import Hydra.Network.Message (Message (..))
 import Hydra.Node.Environment (Environment (..))
 import Hydra.Node.State (NodeState (headState), currentSlot)
-import Hydra.Options (defaultContestationPeriod, defaultDepositPeriod)
+import Hydra.Options (defaultContestationPeriod, defaultDepositPeriod, defaultUnsyncedPeriod)
 import Hydra.Tx.Crypto (sign)
 import Hydra.Tx.HeadParameters (HeadParameters (..))
 import Hydra.Tx.IsTx (txId)
@@ -47,6 +47,7 @@ spec = do
                 , otherParties
                 , contestationPeriod = defaultContestationPeriod
                 , depositPeriod = defaultDepositPeriod
+                , unsyncedPeriod = defaultUnsyncedPeriod
                 , participants = deriveOnChainId <$> threeParties
                 , configuredPeers = ""
                 }
@@ -203,6 +204,7 @@ prop_singleMemberHeadAlwaysSnapshotOnReqTx sn = monadicIO $ do
             , otherParties = []
             , contestationPeriod = defaultContestationPeriod
             , depositPeriod = defaultDepositPeriod
+            , unsyncedPeriod = defaultUnsyncedPeriod
             , participants = [deriveOnChainId party]
             , configuredPeers = ""
             }

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -46,7 +46,8 @@ import Hydra.Node (mkNetworkInput)
 import Hydra.Node.DepositPeriod (toNominalDiffTime)
 import Hydra.Node.Environment (Environment (..))
 import Hydra.Node.State (Deposit (..), DepositStatus (Active), NodeState (..), initNodeState)
-import Hydra.Options (defaultContestationPeriod, defaultDepositPeriod)
+import Hydra.Node.UnsyncedPeriod (UnsyncedPeriod (..), unsyncedPeriodToNominalDiffTime)
+import Hydra.Options (defaultContestationPeriod, defaultDepositPeriod, defaultUnsyncedPeriod)
 import Hydra.Prelude qualified as Prelude
 import Hydra.Tx (HeadId)
 import Hydra.Tx.ContestationPeriod qualified as CP
@@ -76,6 +77,7 @@ spec =
             , otherParties = [alice, carol]
             , contestationPeriod = defaultContestationPeriod
             , depositPeriod = defaultDepositPeriod
+            , unsyncedPeriod = defaultUnsyncedPeriod
             , participants = deriveOnChainId <$> threeParties
             , configuredPeers = ""
             }
@@ -86,6 +88,7 @@ spec =
             , otherParties = [bob, carol]
             , contestationPeriod = defaultContestationPeriod
             , depositPeriod = defaultDepositPeriod
+            , unsyncedPeriod = defaultUnsyncedPeriod
             , participants = deriveOnChainId <$> threeParties
             , configuredPeers = ""
             }
@@ -812,7 +815,7 @@ spec =
                 _ -> False
 
               nodeOutOfSync <- run $ do
-                let delta = CP.unsyncedPolicy bobEnv.contestationPeriod
+                let delta = unsyncedPeriodToNominalDiffTime bobEnv.unsyncedPeriod
                     -- make chain time too old: beyond unsynced threshold
                     oldChainTime = addUTCTime (negate (delta + 1)) now
                 runHeadLogic bobEnv ledger nodeInSync $ do

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -38,7 +38,8 @@ import Hydra.Node.Environment as Environment
 import Hydra.Node.InputQueue (InputQueue (..))
 import Hydra.Node.ParameterMismatch (ParameterMismatch (..))
 import Hydra.Node.State (NodeState (..))
-import Hydra.Options (defaultContestationPeriod, defaultDepositPeriod)
+import Hydra.Node.UnsyncedPeriod (defaultUnsyncedPeriodFor)
+import Hydra.Options (defaultContestationPeriod, defaultDepositPeriod, defaultUnsyncedPeriod)
 import Hydra.Tx.ContestationPeriod (ContestationPeriod (..))
 import Hydra.Tx.Crypto (HydraKey, sign)
 import Hydra.Tx.HeadParameters (HeadParameters (..))
@@ -298,6 +299,7 @@ spec = parallel $ do
             , otherParties = [bob]
             , contestationPeriod = defaultContestationPeriod
             , depositPeriod = defaultDepositPeriod
+            , unsyncedPeriod = defaultUnsyncedPeriod
             , participants = error "should not be recorded in head state"
             , configuredPeers = ""
             }
@@ -471,6 +473,7 @@ testHydraNode tracer signingKey otherParties contestationPeriod inputs = do
       , otherParties
       , contestationPeriod
       , depositPeriod = defaultDepositPeriod
+      , unsyncedPeriod = defaultUnsyncedPeriodFor contestationPeriod
       , participants
       , configuredPeers = ""
       }

--- a/hydra-node/test/Hydra/OptionsSpec.hs
+++ b/hydra-node/test/Hydra/OptionsSpec.hs
@@ -16,6 +16,7 @@ import Hydra.Cardano.Api (
  )
 import Hydra.Chain (maximumNumberOfParties)
 import Hydra.Network (Host (Host))
+import Hydra.Node.UnsyncedPeriod (defaultUnsyncedPeriodFor)
 import Hydra.Options (
   BlockfrostOptions (..),
   CardanoChainConfig (..),
@@ -209,10 +210,15 @@ spec = parallel $
       ["--persistence-rotate-after", "1"] `shouldParse` defaultWithRotateAfter (Positive 1)
 
     it "parses --contestation-period option as a number of seconds" $ do
-      let defaultWithContestationPeriod contestationPeriod =
+      let defaultWithContestationPeriod cp =
             Run
               defaultRunOptions
-                { chainConfig = Cardano defaultCardanoChainConfig{contestationPeriod}
+                { chainConfig =
+                    Cardano
+                      defaultCardanoChainConfig
+                        { contestationPeriod = cp
+                        , unsyncedPeriod = defaultUnsyncedPeriodFor cp
+                        }
                 }
       shouldNotParse ["--contestation-period", "3"]
       shouldNotParse ["--contestation-period", "abc"]

--- a/hydra-node/testlib/Test/Hydra/Node/Fixture.hs
+++ b/hydra-node/testlib/Test/Hydra/Node/Fixture.hs
@@ -13,6 +13,7 @@ import Hydra.Cardano.Api (LedgerEra, SystemStart (..))
 import Hydra.Ledger.Cardano (Globals, LedgerEnv, newLedgerEnv)
 import Hydra.Node.DepositPeriod (DepositPeriod (..))
 import Hydra.Node.Environment (Environment (..))
+import Hydra.Node.UnsyncedPeriod (defaultUnsyncedPeriodFor)
 import Test.Hydra.Tx.Fixture as Fixture
 
 -- | Default environment for the L2 ledger using the fixed L1 'pparams' with
@@ -49,6 +50,7 @@ testEnvironment =
     , otherParties = [bob, carol]
     , contestationPeriod = cperiod
     , depositPeriod = DepositPeriod 20
+    , unsyncedPeriod = defaultUnsyncedPeriodFor cperiod
     , participants = deriveOnChainId <$> [alice, bob, carol]
     , configuredPeers = ""
     }

--- a/hydra-tx/src/Hydra/Tx/ContestationPeriod.hs
+++ b/hydra-tx/src/Hydra/Tx/ContestationPeriod.hs
@@ -65,12 +65,3 @@ fromChain cp =
   UnsafeContestationPeriod
     . truncate
     $ toInteger (OnChain.milliseconds cp) % 1000
-
--- | Period of time after which we consider the node becoming unsynced with the chain.
--- Beyond this period the node will refuse to process new transactions and signing snapshots.
---
--- Deprecated: Use 'Hydra.Node.UnsyncedPeriod.defaultUnsyncedPeriodFor' instead or configure
--- the unsynced period via the CLI option @--unsynced-period@.
-{-# DEPRECATED unsyncedPolicy "Use CLI option --unsynced-period or Hydra.Node.UnsyncedPeriod.defaultUnsyncedPeriodFor instead" #-}
-unsyncedPolicy :: ContestationPeriod -> NominalDiffTime
-unsyncedPolicy cp = toNominalDiffTime cp * 0.5

--- a/hydra-tx/src/Hydra/Tx/ContestationPeriod.hs
+++ b/hydra-tx/src/Hydra/Tx/ContestationPeriod.hs
@@ -68,6 +68,9 @@ fromChain cp =
 
 -- | Period of time after which we consider the node becoming unsynced with the chain.
 -- Beyond this period the node will refuse to process new transactions and signing snapshots.
--- FIXME: this is implicit, consider making it configurable.
+--
+-- Deprecated: Use 'Hydra.Node.UnsyncedPeriod.defaultUnsyncedPeriodFor' instead or configure
+-- the unsynced period via the CLI option @--unsynced-period@.
+{-# DEPRECATED unsyncedPolicy "Use CLI option --unsynced-period or Hydra.Node.UnsyncedPeriod.defaultUnsyncedPeriodFor instead" #-}
 unsyncedPolicy :: ContestationPeriod -> NominalDiffTime
 unsyncedPolicy cp = toNominalDiffTime cp * 0.5


### PR DESCRIPTION
I saw the FIXME comment while workingv on the contestation period, so decided to fix it.
Now we have an additional CLI option to specify the `unsynced-period`.
<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
