### PR TITLE
Use full llink to unstable docs, not relative path

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -38,8 +38,8 @@ const contributingLinks = [
 
 // If it's not the unstable docs themselves, make sure there's a link in the
 // footer to the unstable docs.
-if ( !isUnstable ) {
-  contributingLinks.push( { label: "Unstable documentation", to: "/unstable/docs" })
+if (!isUnstable) {
+  contributingLinks.push({ label: "Unstable documentation", to: "https://hydra.family/head-protocol/unstable/docs" })
 }
 
 


### PR DESCRIPTION
<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
