### PR TITLE
Limit number of transactions in snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,14 @@ changes.
 - Add `--unsynced-period` CLI option to configure when the node considers itself
   out of sync with the chain. Defaults to half the contestation period.
 - Support non-encoded DELETE `/commit/:tx-id` requests [#2445](https://github.com/cardano-scaling/hydra/pull/2445)
-
 - **BREAKING** Reduced the time required to synchronize the node with the chain after long periods of inactivity (without head transitions).
   - When restarting, the node now resumes from the last seen tick while catching up with the chain, instead of from the last seen head transition.
   - The chain backend now uses a non-empty list of starting points as a prefix to find a valid intersection when reconnecting to the chain.
   - `TickObserved` event schema has changed: the `chainSlot` field has been replaced with `chainPoint`
   - `Greetings` message now also contains a new field `currentSlot` that indicates the last known slot while catching up.
   - See [Issue #2206](https://github.com/cardano-scaling/hydra/issues/2206) and [PR #2407](https://github.com/cardano-scaling/hydra/pull/2407).
+- Bounded the number of transactions that will be approved per snapshot
+  [#2444](https://github.com/cardano-scaling/hydra/pull/2444).
 
 ## [1.2.0] - 2025.11.28
 

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -106,6 +106,8 @@ import Hydra.Tx.Snapshot (ConfirmedSnapshot (..), Snapshot (..), SnapshotNumber,
 -- | Maximum number of transaction ids per snapshot. This effectively limits our
 -- "block size" and ensures it does not grow arbitrarily with the backlog of
 -- pending transactions (localTxs).
+-- TODO: Investigate what a good value is for this, in relation to memory
+-- usage
 maxTxsPerSnapshot :: Int
 maxTxsPerSnapshot = 100
 

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -104,7 +104,7 @@ import Hydra.Tx.Snapshot (ConfirmedSnapshot (..), Snapshot (..), SnapshotNumber,
 -- * The Coordinated Head protocol
 
 -- | Maximum number of transaction ids per snapshot. This effectively limits our
--- "block size" and ensures it does not grow arbitrarly with the backlog of
+-- "block size" and ensures it does not grow arbitrarily with the backlog of
 -- pending transactions (localTxs).
 maxTxsPerSnapshot :: Int
 maxTxsPerSnapshot = 100


### PR DESCRIPTION
We encountered a limit of maximum messages we can submit through the etcd-backed network layer (2MB) when we had scenarios with expensive to validate or just lots of transactions queuing up. This led to very big snapshots which eventually hit that limit.

Limiting the number of transactions in a snapshot effectively results in a bounded block size for the Hydra L2. It must not be configurable or it becomes a protocol parameter.

This could be related / a root cause to the symptoms we see in #2422 and similar recent performance problems. Also #2431 should have exposed more of this because validation is just so much more expensive with big utxo sets. Besides this, #2442 might be sensible thing to do anyways (Indeed, both together improve the behavior a lot)

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
