### PR TITLE
Revert input and etcd bounded queues sizes back to 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ changes.
 - Buffer and batch logging so it's faster [#2452](https://github.com/cardano-scaling/hydra/pull/2452)
 - Make the input queue bounded and align its size with other bounded queues (logging, etcd-pending-broadcast)
   [#2430](https://github.com/cardano-scaling/hydra/pull/2430).
+- Ensure input and etcd-pending-broadcast bounded queue sizes are smaller than the logging queue
+  [#2466](https://github.com/cardano-scaling/hydra/pull/2466).
+
 
 ## [1.2.0] - 2025.11.28
 

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -62,7 +62,7 @@ import Data.List ((\\))
 import Data.List qualified as List
 import Data.Map qualified as Map
 import Data.Text qualified as T
-import Hydra.Logging (Tracer, defaultQueueSize, traceWith)
+import Hydra.Logging (Tracer, traceWith)
 import Hydra.Network (
   Connectivity (..),
   Host (..),
@@ -155,7 +155,7 @@ withEtcdNetwork tracer protocolVersion config callback action = do
                         ("etcd-waitMessages", waitMessages tracer conn persistenceDir callback)
                         ( "etcd-callback-4"
                         , do
-                            queue <- newPersistentQueue (persistenceDir </> "pending-broadcast") defaultQueueSize
+                            queue <- newPersistentQueue (persistenceDir </> "pending-broadcast") 100
                             raceLabelled_
                               ("etcd-broadcastMessages", broadcastMessages tracer config advertise queue)
                               ( "etcd-network-component-action"

--- a/hydra-node/src/Hydra/Node/InputQueue.hs
+++ b/hydra-node/src/Hydra/Node/InputQueue.hs
@@ -9,7 +9,6 @@ import Control.Concurrent.Class.MonadSTM (
   readTBQueue,
   writeTBQueue,
  )
-import Hydra.Logging (defaultQueueSize)
 
 -- | The single, required queue in the system from which a hydra head is "fed".
 -- NOTE(SN): handle pattern, but likely not required as there is no need for an
@@ -37,7 +36,7 @@ createInputQueue = do
   -- prevents further processing, _unless_ the input queue is also bounded.
   -- In truth it probably makes sense for this queue to be bounded anyway.
   -- See: <https://github.com/cardano-scaling/hydra/issues/2442>
-  q <- newLabelledTBQueueIO "input-queue" defaultQueueSize
+  q <- newLabelledTBQueueIO "input-queue" 100
   pure
     InputQueue
       { enqueue = \queuedItem ->


### PR DESCRIPTION
<!-- Describe your change here -->

Follow-up https://github.com/cardano-scaling/hydra/pull/2430

> Reduce the size of the input and etcd pending broadcast queues so they are smaller than the logging queue. When running `cabal run bench-e2e -- single --cluster-size 3 --scaling-factor 100`, having upstream queues as large as or larger than the logging queue led to invalid transactions under load. This change enforces proper back pressure and prevents that behavior.

---

<!-- Consider each and tick it off one way or the other -->
* [X] CHANGELOG updated or not needed
* [X] Documentation updated or not needed
* [X] Haddocks updated or not needed
* [X] No new TODOs introduced or explained herafter
