### PR TITLE
Remove checks for the snapshot version in logic layer

### DIFF
--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -38,6 +38,7 @@ common project-config
     PatternSynonyms
     TypeFamilies
     ViewPatterns
+    StrictData
 
   ghc-options:
     -Wall -Wcompat -Widentities -Wincomplete-record-updates

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1853,6 +1853,8 @@ aggregate st = \case
                       , localTxs = mempty
                       , allTxs = mempty
                       , seenSnapshot = LastSeenSnapshot snapshotNumber
+                      , decommitTx = Nothing
+                      , currentDepositTxId = Nothing
                       }
             }
       _otherState -> st

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1076,6 +1076,59 @@ onOpenChainDecrementTx openState newChainState newVersion distributedUTxO =
  where
   OpenState{headId} = openState
 
+-- | On rollback, re-post the IncrementTx if there is a pending deposit whose
+-- confirmed snapshot contains a matching utxoToCommit. The rollback may have
+-- erased the original on-chain IncrementTx observation.
+maybeRepostIncrementTx ::
+  IsTx tx =>
+  HeadId ->
+  HeadParameters ->
+  PendingDeposits tx ->
+  Maybe (TxIdType tx) ->
+  ConfirmedSnapshot tx ->
+  Outcome tx
+maybeRepostIncrementTx headId parameters pendingDeposits mDepositTxId confirmedSnapshot =
+  case (mDepositTxId, confirmedSnapshot) of
+    (Just depositTxId, ConfirmedSnapshot{snapshot = snapshot@Snapshot{utxoToCommit}, signatures}) ->
+      case find (\(_, Deposit{deposited}) -> Just deposited == utxoToCommit) $ Map.toList pendingDeposits of
+        Just (_, Deposit{}) ->
+          cause
+            OnChainEffect
+              { postChainTx =
+                  IncrementTx
+                    { headId
+                    , headParameters = parameters
+                    , incrementingSnapshot = ConfirmedSnapshot{snapshot, signatures}
+                    , depositTxId
+                    }
+              }
+        _ -> noop
+    _ -> noop
+
+-- | On rollback, re-post the DecrementTx if there is a pending decommit whose
+-- confirmed snapshot contains a matching utxoToDecommit. The rollback may have
+-- erased the original on-chain DecrementTx observation.
+maybeRepostDecrementTx ::
+  IsTx tx =>
+  HeadId ->
+  HeadParameters ->
+  Maybe tx ->
+  ConfirmedSnapshot tx ->
+  Outcome tx
+maybeRepostDecrementTx headId parameters mDecommitTx confirmedSnapshot =
+  case (mDecommitTx, confirmedSnapshot) of
+    (Just _, ConfirmedSnapshot{snapshot = snapshot@Snapshot{utxoToDecommit = Just _}, signatures}) ->
+      cause
+        OnChainEffect
+          { postChainTx =
+              DecrementTx
+                { headId
+                , headParameters = parameters
+                , decrementingSnapshot = ConfirmedSnapshot{snapshot, signatures}
+                }
+          }
+    _ -> noop
+
 isLeader :: HeadParameters -> Party -> SnapshotNumber -> Bool
 isLeader HeadParameters{parties} p sn =
   case p `elemIndex` parties of
@@ -1504,6 +1557,24 @@ handleChainInput env _ledger now _currentSlot pendingDeposits st ev syncStatus =
     newState DepositRecorded{chainState = newChainState, headId, depositTxId, deposited, created, deadline}
   (_, ChainInput Observation{observedTx = OnRecoverTx{headId, recoveredTxId, recoveredUTxO}, newChainState}) ->
     newState DepositRecovered{chainState = newChainState, headId, depositTxId = recoveredTxId, recovered = recoveredUTxO}
+  -- Open + Rollback: re-post IncrementTx/DecrementTx if they were in-flight
+  ( Open
+      OpenState
+        { headId
+        , parameters
+        , coordinatedHeadState =
+          CoordinatedHeadState
+            { currentDepositTxId
+            , confirmedSnapshot
+            , decommitTx
+            }
+        }
+    , ChainInput Rollback{rolledBackChainState, chainTime}
+    ) ->
+      newState ChainRolledBack{chainState = rolledBackChainState}
+        <> handleOutOfSync env now chainTime syncStatus
+        <> maybeRepostIncrementTx headId parameters pendingDeposits currentDepositTxId confirmedSnapshot
+        <> maybeRepostDecrementTx headId parameters decommitTx confirmedSnapshot
   -- General
   (_, ChainInput Rollback{rolledBackChainState, chainTime}) ->
     newState ChainRolledBack{chainState = rolledBackChainState}

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedRecordDot #-}
-{-# LANGUAGE StrictData #-}
 {-# OPTIONS_GHC -Wno-ambiguous-fields #-}
 
 -- | Implements the Head Protocol's /state machine/ as /pure functions/ in an event sourced manner.

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE StrictData #-}
 {-# OPTIONS_GHC -Wno-ambiguous-fields #-}
 
 -- | Implements the Head Protocol's /state machine/ as /pure functions/ in an event sourced manner.

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -294,10 +294,11 @@ onOpenNetworkReqTx ::
   ChainSlot ->
   OpenState tx ->
   TTL ->
+  PendingDeposits tx ->
   -- | The transaction to be submitted to the head.
   tx ->
   Outcome tx
-onOpenNetworkReqTx env ledger currentSlot st ttl tx =
+onOpenNetworkReqTx env ledger currentSlot st ttl pendingDeposits tx =
   -- Keep track of transactions by-id
   (newState TransactionReceived{tx} <>) $
     -- Spec: wait L̂ ◦ tx ≠ ⊥
@@ -330,12 +331,16 @@ onOpenNetworkReqTx env ledger currentSlot st ttl tx =
   maybeRequestSnapshot nextSn outcome =
     if not snapshotInFlight && isLeader parameters party nextSn
       then
-        outcome
-          -- XXX: This state update has no equivalence in the
-          -- spec. Do we really need to store that we have
-          -- requested a snapshot? If yes, should update spec.
-          <> newState SnapshotRequestDecided{snapshotNumber = nextSn}
-          <> cause (NetworkEffect $ ReqSn version nextSn (txId <$> take maxTxsPerSnapshot localTxs') decommitTx currentDepositTxId)
+        let existingDeposit = do
+              depositTxId <- currentDepositTxId
+              _ <- Map.lookup depositTxId pendingDeposits
+              currentDepositTxId
+         in outcome
+              -- XXX: This state update has no equivalence in the
+              -- spec. Do we really need to store that we have
+              -- requested a snapshot? If yes, should update spec.
+              <> newState SnapshotRequestDecided{snapshotNumber = nextSn}
+              <> cause (NetworkEffect $ ReqSn version nextSn (txId <$> take maxTxsPerSnapshot localTxs') decommitTx existingDeposit)
       else outcome
 
   Environment{party} = env
@@ -485,10 +490,10 @@ onOpenNetworkReqSn env ledger pendingDeposits currentSlot st otherParty sv sn re
     case mDepositTxId of
       Nothing -> cont (activeUTxOAfterDecommit, Nothing)
       Just depositTxId ->
-        -- XXX: We may need to wait quite long here and this makes losing
-        -- the 'ReqSn' due to a restart (fail-recovery) quite likely
         case Map.lookup depositTxId pendingDeposits of
-          Nothing -> wait WaitOnDepositObserved{depositTxId}
+          Nothing ->
+            -- Error out in case we receive a ReqSn that doesn't match local deposit
+            Error $ RequireFailed RequestedDepositNotFoundLocally{depositTxId}
           Just Deposit{status, deposited}
             | status == Inactive -> wait WaitOnDepositActivation{depositTxId}
             | status == Expired -> Error $ RequireFailed RequestedDepositExpired{depositTxId}
@@ -685,9 +690,13 @@ onOpenNetworkAckSn Environment{party} pendingDeposits openState otherParty snaps
     let nextSn = previous.number + 1
     if isLeader parameters party nextSn && not (null localTxs)
       then
-        outcome
-          <> newState SnapshotRequestDecided{snapshotNumber = nextSn}
-          <> cause (NetworkEffect $ ReqSn version nextSn (txId <$> take maxTxsPerSnapshot localTxs) decommitTx currentDepositTxId)
+        let existingDeposit = do
+              depositTxId <- currentDepositTxId
+              _ <- Map.lookup depositTxId pendingDeposits
+              currentDepositTxId
+         in outcome
+              <> newState SnapshotRequestDecided{snapshotNumber = nextSn}
+              <> cause (NetworkEffect $ ReqSn version nextSn (txId <$> take maxTxsPerSnapshot localTxs) decommitTx existingDeposit)
       else outcome
 
   maybePostIncrementTx snapshot@Snapshot{utxoToCommit} signatures outcome =
@@ -1526,7 +1535,7 @@ handleNetworkInput env ledger _now currentSlot pendingDeposits st ev = case (st,
     onConnectionEvent env.configuredPeers conn
   -- Open
   (Open openState, NetworkInput ttl (ReceivedMessage{msg = ReqTx tx})) ->
-    onOpenNetworkReqTx env ledger currentSlot openState ttl tx
+    onOpenNetworkReqTx env ledger currentSlot openState ttl pendingDeposits tx
   (Open openState@OpenState{headId = ourHeadId}, NetworkInput _ (ReceivedMessage{sender, msg = ReqSn sv sn txIds decommitTx depositTxId})) ->
     onOpenNetworkReqSn env ledger (depositsForHead ourHeadId pendingDeposits) currentSlot openState sender sv sn txIds decommitTx depositTxId
   (Open openState@OpenState{headId = ourHeadId}, NetworkInput _ (ReceivedMessage{sender, msg = AckSn snapshotSignature sn})) ->
@@ -1621,6 +1630,8 @@ aggregateNodeState nodeState sc =
         DepositExpired{depositTxId, deposit} ->
           nodeState
             { headState = st
+            -- NB: We keep expired deposits in a map since we actually need it when Recovering.
+            -- There is a corresponding error RequestedDepositExpired which gives users context on stale ReqSn.
             , pendingDeposits = Map.insert depositTxId deposit currentPendingDeposits
             }
         DepositRecovered{depositTxId} ->

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1745,6 +1745,10 @@ aggregateNodeState nodeState sc =
                                       -- depositTxId, but we should not verify this here.
                                       currentDepositTxId = Nothing
                                     , localUTxO = localUTxO <> newUTxO
+                                    , seenSnapshot =
+                                        LastSeenSnapshot
+                                          { lastSeen = seenSnapshotNumber (seenSnapshot coordinatedHeadState)
+                                          }
                                     }
                               }
                       , pendingDeposits = Map.delete depositTxId currentPendingDeposits
@@ -1988,6 +1992,10 @@ aggregate st = \case
                   coordinatedHeadState
                     { decommitTx = Nothing
                     , version = newVersion
+                    , seenSnapshot =
+                        LastSeenSnapshot
+                          { lastSeen = seenSnapshotNumber (seenSnapshot coordinatedHeadState)
+                          }
                     }
               }
       _otherState -> st

--- a/hydra-node/src/Hydra/HeadLogic/Error.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Error.hs
@@ -69,6 +69,7 @@ data RequirementFailure tx
   | SnapshotDoesNotApply {requestedSn :: SnapshotNumber, txid :: TxIdType tx, error :: ValidationError}
   | NoMatchingDeposit
   | RequestedDepositExpired {depositTxId :: TxIdType tx}
+  | RequestedDepositNotFoundLocally {depositTxId :: TxIdType tx}
   deriving stock (Generic)
 
 deriving stock instance Eq (TxIdType tx) => Eq (RequirementFailure tx)

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -28,7 +28,7 @@ import Hydra.Cardano.Api.Gen (genTxIn)
 import Hydra.Chain (
   ChainEvent (..),
   OnChainTx (..),
-  PostChainTx (CollectComTx, ContestTx),
+  PostChainTx (CollectComTx, ContestTx, DecrementTx, IncrementTx),
  )
 import Hydra.Chain.ChainState (ChainSlot (..), IsChainState, chainStateSlot)
 import Hydra.Chain.Direct.State (ChainStateAt (..))
@@ -810,6 +810,168 @@ spec =
           let reqSnOutcome = update aliceEnv' ledger now s7 staleReqSn
           -- Fix bug: Error out instead of waiting for deposit to be observed forever
           reqSnOutcome `shouldBe` Error (RequireFailed $ RequestedDepositNotFoundLocally depositTxId)
+
+        it "re-posts IncrementTx on chain rollback when deposit is pending" $ do
+          -- After a snapshot is confirmed with a deposit (CommitApproved + IncrementTx posted),
+          -- if a chain rollback occurs, the node should re-post the IncrementTx because
+          -- the rollback may have erased the original on-chain observation.
+          now <- getCurrentTime
+          let aliceEnv' =
+                aliceEnv
+                  { depositPeriod = 60
+                  , contestationPeriod = 60
+                  , otherParties = []
+                  , participants = deriveOnChainId <$> [alice]
+                  }
+          let depositTime = plusTime now
+              deadline = depositTime 600
+              depositTxId = 42 :: Integer
+              depositedUtxo = utxoRef depositTxId
+              deposit =
+                OnDepositTx
+                  { headId = testHeadId
+                  , depositTxId
+                  , deposited = depositedUtxo
+                  , created = depositTime 1
+                  , deadline
+                  }
+
+          -- Observe deposit, activate it via tick, process ReqSn and AckSn
+          -- to reach a state where CommitApproved happened and IncrementTx was posted
+          s1 <- runHeadLogic aliceEnv' ledger (inOpenState singleParty) $ do
+            step (observeTxAtSlot 1 deposit)
+            getState
+
+          let chainTime = depositTime 2 `plusTime` toNominalDiffTime (depositPeriod aliceEnv')
+              tickInput = ChainInput $ Tick{chainTime, chainPoint = 2}
+          s2 <- runHeadLogic aliceEnv' ledger s1 $ do
+            step tickInput
+            getState
+
+          let reqSnWithDeposit = receiveMessage $ ReqSn 0 1 [] Nothing (Just depositTxId)
+          s3 <- runHeadLogic aliceEnv' ledger s2 $ do
+            step reqSnWithDeposit
+            getState
+
+          let snapshot1 =
+                Snapshot
+                  { headId = testHeadId
+                  , version = 0
+                  , number = 1
+                  , confirmed = []
+                  , utxo = mempty
+                  , utxoToCommit = Just depositedUtxo
+                  , utxoToDecommit = Nothing
+                  }
+              ackSn = receiveMessage $ AckSn (sign aliceSk snapshot1) 1
+          s4 <- runHeadLogic aliceEnv' ledger s3 $ do
+            step ackSn
+            getState
+
+          -- Verify we are in the expected state: currentDepositTxId set, snapshot confirmed
+          case headState s4 of
+            Open OpenState{coordinatedHeadState = CoordinatedHeadState{currentDepositTxId, confirmedSnapshot}} -> do
+              currentDepositTxId `shouldBe` Just depositTxId
+              case confirmedSnapshot of
+                ConfirmedSnapshot{snapshot = Snapshot{number}} -> number `shouldBe` 1
+                _ -> expectationFailure "Expected ConfirmedSnapshot"
+            other -> expectationFailure $ "Expected Open state, got: " <> show other
+
+          -- Chain rollback should re-post the IncrementTx
+          let rollbackInput = ChainInput Rollback{rolledBackChainState = SimpleChainState 0, chainTime = now}
+          let rollbackOutcome = update aliceEnv' ledger now s4 rollbackInput
+
+          rollbackOutcome `hasEffectSatisfying` \case
+            OnChainEffect{postChainTx} ->
+              case postChainTx of
+                IncrementTx{} -> True
+                _ -> False
+            _ -> False
+
+        it "re-posts DecrementTx on chain rollback when decommit is pending" $ do
+          -- After a snapshot is confirmed with a decommit (DecommitApproved + DecrementTx posted),
+          -- if a chain rollback occurs, the node should re-post the DecrementTx because
+          -- the rollback may have erased the original on-chain observation.
+          now <- getCurrentTime
+          let aliceEnv' =
+                aliceEnv
+                  { depositPeriod = 60
+                  , contestationPeriod = 60
+                  , otherParties = []
+                  , participants = deriveOnChainId <$> [alice]
+                  }
+
+          -- Start with localUTxO containing utxoRef 1, so we can decommit from it.
+          -- The confirmedSnapshot must also contain this UTxO since ReqSn applies
+          -- the decommit tx against the confirmed snapshot's UTxO.
+          let initialUtxo = utxoRefs [1]
+              decommitTx' = SimpleTx 10 (utxoRef 1) (utxoRef 3)
+              s0 =
+                inOpenState' singleParty $
+                  coordinatedHeadState
+                    { localUTxO = initialUtxo
+                    , confirmedSnapshot = InitialSnapshot testHeadId initialUtxo
+                    }
+
+          -- Step 1: Submit decommit request
+          s1 <- runHeadLogic aliceEnv' ledger s0 $ do
+            step $ receiveMessage ReqDec{transaction = decommitTx'}
+            getState
+
+          -- Verify decommitTx is recorded
+          case headState s1 of
+            Open OpenState{coordinatedHeadState = CoordinatedHeadState{decommitTx}} ->
+              decommitTx `shouldBe` Just decommitTx'
+            other -> expectationFailure $ "Expected Open state, got: " <> show other
+
+          -- Step 2: Process ReqSn with the decommit tx
+          let reqSnWithDecommit = receiveMessage $ ReqSn 0 1 [] (Just decommitTx') Nothing
+          s2 <- runHeadLogic aliceEnv' ledger s1 $ do
+            step reqSnWithDecommit
+            getState
+
+          -- Step 3: AckSn from alice → SnapshotConfirmed + DecommitApproved + DecrementTx posted
+          -- The snapshot after applying decommit:
+          --   confirmedUTxO = initialUtxo = {1}
+          --   applyTransactions {1} [SimpleTx 10 {1} {3}] = {3}
+          --   utxoToDecommit = utxoFromTx decommitTx' = txOutputs = {3}
+          --   activeUTxO = {3} \ {3} = {}
+          let snapshot1 =
+                Snapshot
+                  { headId = testHeadId
+                  , version = 0
+                  , number = 1
+                  , confirmed = []
+                  , utxo = mempty -- activeUTxO after decommit
+                  , utxoToCommit = Nothing
+                  , utxoToDecommit = Just (utxoRef 3) -- outputs of decommit tx
+                  }
+              ackSn = receiveMessage $ AckSn (sign aliceSk snapshot1) 1
+          s3 <- runHeadLogic aliceEnv' ledger s2 $ do
+            step ackSn
+            getState
+
+          -- Verify SnapshotConfirmed happened and decommitTx is still set
+          case headState s3 of
+            Open OpenState{coordinatedHeadState = CoordinatedHeadState{decommitTx, confirmedSnapshot}} -> do
+              decommitTx `shouldBe` Just decommitTx'
+              case confirmedSnapshot of
+                ConfirmedSnapshot{snapshot = Snapshot{number, utxoToDecommit}} -> do
+                  number `shouldBe` 1
+                  utxoToDecommit `shouldBe` Just (utxoRef 3)
+                _ -> expectationFailure "Expected ConfirmedSnapshot"
+            other -> expectationFailure $ "Expected Open state, got: " <> show other
+
+          -- Step 4: Chain rollback should re-post the DecrementTx
+          let rollbackInput = ChainInput Rollback{rolledBackChainState = SimpleChainState 0, chainTime = now}
+          let rollbackOutcome = update aliceEnv' ledger now s3 rollbackInput
+
+          rollbackOutcome `hasEffectSatisfying` \case
+            OnChainEffect{postChainTx} ->
+              case postChainTx of
+                DecrementTx{} -> True
+                _ -> False
+            _ -> False
 
       it "ignores in-flight ReqTx when closed" $ do
         let s0 = inClosedState threeParties


### PR DESCRIPTION
Remove checks for the snapshot version as they seem to make the Head stuck under heavy load of txs on L2.
Let's think about the implications of these changes before doing anything further.

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
