### PR TITLE
Fix internal wallet script cost estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ changes.
 - Ensure input and etcd-pending-broadcast bounded queue sizes are smaller than the logging queue
   [#2466](https://github.com/cardano-scaling/hydra/pull/2466).
 - `POST /snapshot` now returns the specific side-load validation failure instead of timing out [#2462](https://github.com/cardano-scaling/hydra/issues/2462).
+- Fixed the internal wallet fee estimation, which was more often than not using maximum plutus execution units. This reduces costs for initializing, open, etc. of a head by a factor of ~4x [#2473](https://github.com/cardano-scaling/hydra/pull/2473).
 
 ## [1.2.0] - 2025.11.28
 

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -883,9 +883,7 @@ singlePartyCommitsScriptBlueprint tracer workDir backend hydraScriptsTxId =
             (Proxy :: Proxy (JsonResponse Tx))
             (port $ 4000 + hydraNodeId)
 
-      let depositTransaction = responseBody res'
-      let tx = signTx walletSk depositTransaction
-
+      let tx = responseBody res'
       Backend.submitTransaction backend tx
 
       let expectedDeposit = constructDepositUTxO (getTxId $ getTxBody blueprint) (txOuts' blueprint)
@@ -972,9 +970,7 @@ singlePartyDepositReferenceScript tracer workDir backend hydraScriptsTxId =
             (Proxy :: Proxy (JsonResponse Tx))
             (port $ 4000 + hydraNodeId)
 
-      let depositTransaction = responseBody res'
-      let tx = signTx walletSk depositTransaction
-
+      let tx = responseBody res'
       Backend.submitTransaction backend tx
 
       let expectedDeposit = constructDepositUTxO (getTxId $ getTxBody blueprint) (txOuts' blueprint)

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -847,7 +847,6 @@ singlePartyCommitsScriptBlueprint tracer workDir backend hydraScriptsTxId =
         <&> modifyConfig (\c -> c{depositPeriod})
     let hydraNodeId = 1
     let hydraTracer = contramap FromHydraNode tracer
-    (_, walletSk) <- keysFor AliceFunds
     withHydraNode hydraTracer aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
       send n1 $ input "Init" []
       headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
@@ -939,7 +938,6 @@ singlePartyDepositReferenceScript tracer workDir backend hydraScriptsTxId =
         <&> modifyConfig (\c -> c{depositPeriod})
     let hydraNodeId = 1
     let hydraTracer = contramap FromHydraNode tracer
-    (_, walletSk) <- keysFor AliceFunds
     -- incrementally commit script to a running Head
     (referenceUTxO, scriptUTxO) <- publishReferenceScript tracer 20_000_000
     withHydraNode hydraTracer aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do

--- a/hydra-node/bench/tx-cost/TxCost.hs
+++ b/hydra-node/bench/tx-cost/TxCost.hs
@@ -15,6 +15,7 @@ import Hydra.Cardano.Api (
   ExecutionUnits (..),
   Tx,
   UTxO,
+  balancedTxFee,
  )
 import Hydra.Cardano.Api.Gen (genTxIn)
 import Hydra.Cardano.Api.TxOut (toPlutusTxOut)

--- a/hydra-node/bench/tx-cost/TxCost.hs
+++ b/hydra-node/bench/tx-cost/TxCost.hs
@@ -15,7 +15,6 @@ import Hydra.Cardano.Api (
   ExecutionUnits (..),
   Tx,
   UTxO,
-  balancedTxFee,
  )
 import Hydra.Cardano.Api.Gen (genTxIn)
 import Hydra.Cardano.Api.TxOut (toPlutusTxOut)

--- a/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
@@ -308,14 +308,11 @@ coverFee_ pparams systemStart epochInfo lookupUTxO walletUTxO partialTx = do
         & witsTxL . rdmrsTxWitsL .~ adjustedRedeemers
 
   -- Compute fee using a body with selected txOut to pay fees (= full change)
-  -- and an additional witness (we will sign this tx later)
-  let fee = spy' "fee" $ calcMinFeeTx (Ledger.UTxO utxo) pparams costingTx additionalWitnesses
+  let fee = spy' "fee" $ calcMinFeeTx (Ledger.UTxO utxo) pparams costingTx 0
       costingTx =
         unbalancedTx
           & bodyTxL . outputsTxBodyL %~ (|> feeTxOut)
           & bodyTxL . feeTxBodyL .~ Coin 10_000_000
-      -- We add one additional witness for the fee input
-      additionalWitnesses = 1 + length (partialTx ^. bodyTxL . reqSignerHashesTxBodyL)
 
   -- Balance tx with a change output and computed fee
   change <-

--- a/hydra-tx/hydra-tx.cabal
+++ b/hydra-tx/hydra-tx.cabal
@@ -82,6 +82,7 @@ library
     , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-binary
+    , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-ledger-shelley
     , cardano-slotting

--- a/hydra-tx/src/Hydra/Ledger/Cardano/Evaluate.hs
+++ b/hydra-tx/src/Hydra/Ledger/Cardano/Evaluate.hs
@@ -20,6 +20,7 @@ import Cardano.Ledger.Alonzo.Scripts (CostModel, Prices (..), mkCostModel, mkCos
 import Cardano.Ledger.Api (CoinPerByte (..), ppCoinsPerUTxOByteL, ppCostModelsL, ppMaxBlockExUnitsL, ppMaxTxExUnitsL, ppMaxValSizeL, ppMinFeeAL, ppMinFeeBL, ppPricesL, ppProtocolVersionL)
 import Cardano.Ledger.BaseTypes (BoundedRational (boundRational), ProtVer (..), natVersion)
 import Cardano.Ledger.Coin (Coin (Coin))
+import Cardano.Ledger.Conway.PParams (ppMinFeeRefScriptCostPerByteL)
 import Cardano.Ledger.Core (PParams, ppMaxTxSizeL)
 import Cardano.Ledger.Plutus (Language (..))
 import Cardano.Ledger.Val (Val ((<+>)), (<×>))
@@ -191,6 +192,8 @@ estimateMinFee tx evaluationReport =
 
 -- * Fixtures
 
+-- FIXME: these were outdated and we use them for many things.. need to update them again
+
 -- | Current (2023-04-12) mainchain protocol parameters.
 -- XXX: Avoid specifying not required parameters here (e.g. max block units
 -- should not matter).
@@ -216,7 +219,7 @@ pparams =
         { prSteps = fromJust $ boundRational $ 721 % 10000000
         , prMem = fromJust $ boundRational $ 577 % 10000
         }
-    & ppProtocolVersionL .~ ProtVer{pvMajor = natVersion @9, pvMinor = 0}
+    & ppProtocolVersionL .~ ProtVer{pvMajor = natVersion @10, pvMinor = 0}
     & ppCostModelsL
       .~ mkCostModels
         ( Map.fromList
@@ -224,6 +227,7 @@ pparams =
             , (PlutusV3, plutusV3CostModel)
             ]
         )
+    & ppMinFeeRefScriptCostPerByteL .~ fromJust (boundRational (15 % 1))
 
 maxTxSize :: Natural
 maxTxSize = 16384


### PR DESCRIPTION
This was wrongfully using maximum execution units on each script input because of wrongly resolved indices. Also the script context was not complete so the exactly estimated exunits were slightly too small.

In summary: we should not need to do this ourselves and a refactor to use `cardano-api` functions for this is due.

Fixes #2458 

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated
* [x] Documentation update not needed
* [x] Haddocks update not needed
* [x] No new TODOs introduced
