### PR TITLE
Disable logs buffering in smoke tests

### DIFF
--- a/hydra-cluster/exe/hydra-cluster/Main.hs
+++ b/hydra-cluster/exe/hydra-cluster/Main.hs
@@ -19,7 +19,7 @@ import Hydra.Cluster.Fixture (Actor (Faucet), KnownNetwork (..))
 import Hydra.Cluster.Mithril (downloadLatestSnapshotTo)
 import Hydra.Cluster.Options (Options (..), PublishOrReuse (Publish, Reuse), Scenario (..), UseMithril (UseMithril), parseOptions)
 import Hydra.Cluster.Scenarios (EndToEndLog (..), respendUTxO, singlePartyHeadFullLifeCycle, singlePartyOpenAHead)
-import Hydra.Logging (Tracer, Verbosity (Verbose), traceWith, withTracer)
+import Hydra.Logging (Tracer, traceWith, withTracerOutputTo)
 import Hydra.Options (BlockfrostOptions (..), defaultBlockfrostOptions)
 import Options.Applicative (ParserInfo, execParser, fullDesc, header, helper, info, progDesc)
 import System.Directory (removeDirectoryRecursive)
@@ -32,7 +32,7 @@ main =
 
 run :: Options -> IO ()
 run options =
-  withTracer (Verbose "hydra-cluster") $ \tracer -> do
+  withTracerOutputTo NoBuffering stdout "hydra-cluster" $ \tracer -> do
     traceWith tracer ClusterOptions{options}
     let fromCardanoNode = contramap FromCardanoNode tracer
     let blockfrostNetworks = [BlockfrostPreview]


### PR DESCRIPTION
<!-- Describe your change here -->

Follow-up to https://github.com/cardano-scaling/hydra/pull/2472

After noticing "No files were found" in the [Smoke test on mainnet](https://github.com/cardano-scaling/hydra/actions/runs/21641681403/job/62382805438#logs), we decided to disable log buffering for smoke tests, ensuring they go back to their original "write as soon as possible" behavior.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [X] Documentation updated or not needed
* [X] Haddocks updated or not needed
* [X] No new TODOs introduced or explained herafter
