### PR TITLE
Enhance start up logs

### DIFF
--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -84,7 +84,7 @@ bench startingNodeId timeoutSeconds workDir dataset = do
           putStrLn $ "Starting hydra cluster in " <> workDir
           let hydraTracer = contramap FromHydraNode tracer
 
-          withHydraCluster hydraTracer workDir nodeSocket' startingNodeId cardanoKeys hydraKeys hydraScriptsTxId 10 $ \clients -> do
+          withHydraCluster hydraTracer backend workDir nodeSocket' startingNodeId cardanoKeys hydraKeys hydraScriptsTxId 10 $ \clients -> do
             waitForNodesConnected hydraTracer 20 clients
             scenario hydraTracer backend workDir dataset clients
         systemStats <- readTVarIO statsTvar

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -120,16 +120,7 @@ import Hydra.Logging (Tracer, traceWith)
 import Hydra.Node.DepositPeriod (DepositPeriod (..))
 import Hydra.Node.State (SyncedStatus (..))
 import Hydra.Node.UnsyncedPeriod (defaultUnsyncedPeriodFor, unsyncedPeriodToNominalDiffTime)
-import Hydra.Options (
-  CardanoChainConfig (..),
-  ChainBackendOptions (..),
-  ChainConfig (..),
-  DirectOptions (..),
-  RunOptions (..),
-  defaultContestationPeriod,
-  defaultDepositPeriod,
-  startChainFrom,
- )
+import Hydra.Options (CardanoChainConfig (..), ChainBackendOptions (..), ChainConfig (..), DirectOptions (..), RunOptions (..), startChainFrom)
 import Hydra.Tx (HeadId (..), IsTx (balance), Party, headIdToCurrencySymbol, txId)
 import Hydra.Tx.ContestationPeriod qualified as CP
 import Hydra.Tx.Deposit (constructDepositUTxO)
@@ -510,10 +501,9 @@ singlePartyHeadFullLifeCycle tracer workDir backend hydraScriptsTxId =
       tip <- Backend.queryTip backend
       blockTime <- Backend.getBlockTime backend
       networkId <- Backend.queryNetworkId backend
-      let contestationPeriod = defaultContestationPeriod
-          depositPeriod = defaultDepositPeriod
+      contestationPeriod <- CP.fromNominalDiffTime $ 10 * blockTime
       aliceChainConfig <-
-        chainConfigFor' Alice workDir backend hydraScriptsTxId [] contestationPeriod depositPeriod
+        chainConfigFor' Alice workDir backend hydraScriptsTxId [] contestationPeriod (DepositPeriod 100)
           <&> modifyConfig (\config -> config{startChainFrom = Just tip})
             . setNetworkId networkId
       withHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -208,10 +208,10 @@ oneOfThreeNodesStopsForAWhile tracer workDir backend hydraScriptsTxId = do
     chainConfigFor Carol workDir backend hydraScriptsTxId [Alice, Bob] contestationPeriod
       <&> setNetworkId networkId
   blockTime <- Backend.getBlockTime backend
-  withHydraNode hydraTracer backend aliceChainConfig workDir 1 aliceSk [bobVk, carolVk] [1, 2, 3] $ \n1 -> do
+  withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk, carolVk] [1, 2, 3] $ \n1 -> do
     aliceUTxO <- seedFromFaucet backend aliceCardanoVk (lovelaceToValue 1_000_000) (contramap FromFaucet tracer)
-    withHydraNode hydraTracer backend bobChainConfig workDir 2 bobSk [aliceVk, carolVk] [1, 2, 3] $ \n2 -> do
-      withHydraNode hydraTracer backend carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] $ \n3 -> do
+    withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk, carolVk] [1, 2, 3] $ \n2 -> do
+      withHydraNode hydraTracer blockTime carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] $ \n3 -> do
         -- Init
         send n1 $ input "Init" []
         headId <- waitForAllMatch (10 * blockTime) [n1, n2, n3] $ headIsInitializingWith (Set.fromList [alice, bob, carol])
@@ -246,7 +246,7 @@ oneOfThreeNodesStopsForAWhile tracer workDir backend hydraScriptsTxId = do
       send n1 $ input "NewTx" ["transaction" .= tx]
 
       -- Carol reconnects, and then the snapshot can be confirmed
-      withHydraNode hydraTracer backend carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] $ \n3 -> do
+      withHydraNode hydraTracer blockTime carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] $ \n3 -> do
         -- Note: We can't use `waitForAlMatch` here as it expects them to
         -- emit the exact same datatype; but Carol will be behind in sequence
         -- numbers as she was offline.
@@ -269,6 +269,7 @@ restartedNodeCanObserveCommitTx tracer workDir backend hydraScriptsTxId = do
 
   let contestationPeriod = 1
   networkId <- Backend.queryNetworkId backend
+  blockTime <- Backend.getBlockTime backend
   aliceChainConfig <-
     chainConfigFor Alice workDir backend hydraScriptsTxId [Bob] contestationPeriod
       <&> setNetworkId networkId
@@ -278,8 +279,8 @@ restartedNodeCanObserveCommitTx tracer workDir backend hydraScriptsTxId = do
       <&> setNetworkId networkId
 
   let hydraTracer = contramap FromHydraNode tracer
-  withHydraNode hydraTracer backend bobChainConfig workDir 1 bobSk [aliceVk] [1, 2] $ \n1 -> do
-    headId <- withHydraNode hydraTracer backend aliceChainConfig workDir 2 aliceSk [bobVk] [1, 2] $ \n2 -> do
+  withHydraNode hydraTracer blockTime bobChainConfig workDir 1 bobSk [aliceVk] [1, 2] $ \n1 -> do
+    headId <- withHydraNode hydraTracer blockTime aliceChainConfig workDir 2 aliceSk [bobVk] [1, 2] $ \n2 -> do
       send n1 $ input "Init" []
       -- XXX: might need to tweak the wait time
       waitForAllMatch 10 [n1, n2] $ headIsInitializingWith (Set.fromList [alice, bob])
@@ -290,7 +291,7 @@ restartedNodeCanObserveCommitTx tracer workDir backend hydraScriptsTxId = do
       output "Committed" ["party" .= bob, "utxo" .= object mempty, "headId" .= headId]
 
     -- n2 is back and does observe the commit
-    withHydraNode hydraTracer backend aliceChainConfig workDir 2 aliceSk [bobVk] [1, 2] $ \n2 -> do
+    withHydraNode hydraTracer blockTime aliceChainConfig workDir 2 aliceSk [bobVk] [1, 2] $ \n2 -> do
       waitFor hydraTracer 10 [n2] $
         output "Committed" ["party" .= bob, "utxo" .= object mempty, "headId" .= headId]
 
@@ -337,18 +338,18 @@ restartedNodeCanAbort tracer workDir backend hydraScriptsTxId = do
       <&> modifyConfig (\config -> config{startChainFrom = Nothing})
 
   let hydraTracer = contramap FromHydraNode tracer
-  headId1 <- withHydraNode hydraTracer backend aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+  headId1 <- withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
     send n1 $ input "Init" []
     waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
 
-  withHydraNode hydraTracer backend aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+  withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
     -- Also expect to see past server outputs replayed
     headId2 <- waitMatch (20 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
     headId1 `shouldBe` headId2
     send n1 $ input "Abort" []
     waitFor hydraTracer 20 [n1] $
       output "HeadIsAborted" ["utxo" .= object mempty, "headId" .= headId2]
-  withHydraNode hydraTracer backend aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+  withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
     waitMatch (20 * blockTime) n1 $ \v -> do
       guard $ v ^? key "tag" == Just "Greetings"
       guard $ v ^? key "headStatus" == Just (toJSON Idle)
@@ -380,8 +381,8 @@ nodeReObservesOnChainTxs tracer workDir backend hydraScriptsTxId = do
 
   let hydraTracer = contramap FromHydraNode tracer
 
-  withHydraNode hydraTracer backend aliceChainConfig workDir 1 aliceSk [bobVk] [2] $ \n1 -> do
-    (headId', decrementOuts) <- withHydraNode hydraTracer backend bobChainConfig workDir 2 bobSk [aliceVk] [1] $ \n2 -> do
+  withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk] [2] $ \n1 -> do
+    (headId', decrementOuts) <- withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk] [1] $ \n2 -> do
       send n1 $ input "Init" []
 
       headId <- waitMatch (20 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice, bob])
@@ -452,7 +453,7 @@ nodeReObservesOnChainTxs tracer workDir backend hydraScriptsTxId = do
       callProcess "cp" ["-r", workDir </> "state-2", tmpDir]
       callProcess "rm" ["-rf", tmpDir </> "state-2" </> "state*"]
       callProcess "rm" ["-rf", tmpDir </> "state-2" </> "last-known-revision"]
-      withHydraNode hydraTracer backend bobChainConfigFromTip tmpDir 2 bobSk [aliceVk] [1] $ \n2 -> do
+      withHydraNode hydraTracer blockTime bobChainConfigFromTip tmpDir 2 bobSk [aliceVk] [1] $ \n2 -> do
         -- Also expect to see past server outputs replayed
         headId2 <- waitMatch (10 * blockTime) n2 $ headIsInitializingWith (Set.fromList [alice, bob])
         headId2 `shouldBe` headId'
@@ -506,7 +507,7 @@ singlePartyHeadFullLifeCycle tracer workDir backend hydraScriptsTxId =
         chainConfigFor' Alice workDir backend hydraScriptsTxId [] contestationPeriod (DepositPeriod 100)
           <&> modifyConfig (\config -> config{startChainFrom = Just tip})
             . setNetworkId networkId
-      withHydraNode hydraTracer backend aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+      withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
         -- Initialize & open head
         send n1 $ input "Init" []
         headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
@@ -573,10 +574,10 @@ singlePartyOpenAHead tracer workDir backend hydraScriptsTxId persistenceRotateAf
     let hydraTracer = contramap FromHydraNode tracer
     options <- prepareHydraNode aliceChainConfig workDir 1 aliceSk [] [] id
     let options' = options{persistenceRotateAfter}
-    withPreparedHydraNodeInSync hydraTracer backend workDir 1 options' $ \n1 -> do
+    blockTime <- Backend.getBlockTime backend
+    withPreparedHydraNodeInSync hydraTracer blockTime workDir 1 options' $ \n1 -> do
       -- Initialize & open head
       send n1 $ input "Init" []
-      blockTime <- Backend.getBlockTime backend
       headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
       requestCommitTx n1 utxoToCommit <&> signTx walletSk >>= Backend.submitTransaction backend
       waitFor hydraTracer (10 * blockTime) [n1] $
@@ -605,7 +606,7 @@ singlePartyCommitsFromExternal tracer workDir backend hydraScriptsTxId =
       let hydraNodeId = 1
       let hydraTracer = contramap FromHydraNode tracer
       blockTime <- Backend.getBlockTime backend
-      withHydraNode hydraTracer backend aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
+      withHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
         send n1 $ input "Init" []
         headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
 
@@ -650,7 +651,7 @@ singlePartyUsesScriptOnL2 tracer workDir backend hydraScriptsTxId =
       let hydraNodeId = 1
       let hydraTracer = contramap FromHydraNode tracer
       blockTime <- Backend.getBlockTime backend
-      withHydraNode hydraTracer backend aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
+      withHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
         send n1 $ input "Init" []
         headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
 
@@ -775,7 +776,7 @@ singlePartyUsesWithdrawZeroTrick tracer workDir backend hydraScriptsTxId =
         let hydraTracer = contramap FromHydraNode tracer
         blockTime <- Backend.getBlockTime backend
         networkId <- Backend.queryNetworkId backend
-        withHydraNode hydraTracer backend aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
+        withHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
           send n1 $ input "Init" []
           headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
           requestCommitTx n1 utxoToCommit <&> signTx walletSk >>= Backend.submitTransaction backend
@@ -847,7 +848,7 @@ singlePartyCommitsScriptBlueprint tracer workDir backend hydraScriptsTxId =
         <&> modifyConfig (\c -> c{depositPeriod})
     let hydraNodeId = 1
     let hydraTracer = contramap FromHydraNode tracer
-    withHydraNode hydraTracer backend aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
+    withHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
       send n1 $ input "Init" []
       headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
       (clientPayload, scriptUTxO, _) <- prepareScriptPayload 7_000_000 0
@@ -940,7 +941,7 @@ singlePartyDepositReferenceScript tracer workDir backend hydraScriptsTxId =
     let hydraTracer = contramap FromHydraNode tracer
     -- incrementally commit script to a running Head
     (referenceUTxO, scriptUTxO) <- publishReferenceScript tracer 20_000_000
-    withHydraNode hydraTracer backend aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
+    withHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
       send n1 $ input "Init" []
       headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
       res <-
@@ -1064,7 +1065,7 @@ singlePartyCommitsScriptToTheRightHead tracer workDir backend hydraScriptsTxId =
         <&> modifyConfig (\c -> c{depositPeriod})
     let hydraNodeId = 1
     let hydraTracer = contramap FromHydraNode tracer
-    withHydraNode hydraTracer backend aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
+    withHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
       send n1 $ input "Init" []
       headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
 
@@ -1148,7 +1149,7 @@ persistenceCanLoadWithEmptyCommit tracer workDir backend hydraScriptsTxId =
     let hydraNodeId = 1
     let hydraTracer = contramap FromHydraNode tracer
     blockTime <- Backend.getBlockTime backend
-    headId <- withHydraNode hydraTracer backend aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
+    headId <- withHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
       send n1 $ input "Init" []
       headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
 
@@ -1163,7 +1164,7 @@ persistenceCanLoadWithEmptyCommit tracer workDir backend hydraScriptsTxId =
       Nothing -> error "Failed to find HeadIsOpened in the state file"
       Just headIsOpen -> do
         headIsOpen `shouldBe` "HeadOpened"
-        withHydraNode hydraTracer backend aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
+        withHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
           waitFor hydraTracer (10 * blockTime) [n1] $
             output "HeadIsOpen" ["utxo" .= object mempty, "headId" .= headId]
 
@@ -1187,7 +1188,7 @@ singlePartyCommitsFromExternalTxBlueprint tracer workDir backend hydraScriptsTxI
     let hydraTracer = contramap FromHydraNode tracer
     (someExternalVk, someExternalSk) <- generate genKeyPair
     blockTime <- Backend.getBlockTime backend
-    withHydraNode hydraTracer backend aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
+    withHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
       send n1 $ input "Init" []
       headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
 
@@ -1249,7 +1250,7 @@ canCloseWithLongContestationPeriod tracer workDir backend hydraScriptsTxId = do
       <&> modifyConfig (\config -> config{startChainFrom = Just tip})
   let hydraTracer = contramap FromHydraNode tracer
   blockTime <- Backend.getBlockTime backend
-  withHydraNode hydraTracer backend aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+  withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
     -- Initialize & open head
     send n1 $ input "Init" []
     headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
@@ -1283,7 +1284,8 @@ canSubmitTransactionThroughAPI tracer workDir backend hydraScriptsTxId =
     aliceChainConfig <- chainConfigFor Alice workDir backend hydraScriptsTxId [] contestationPeriod
     let hydraNodeId = 1
     let hydraTracer = contramap FromHydraNode tracer
-    withHydraNode hydraTracer backend aliceChainConfig workDir hydraNodeId aliceSk [] [hydraNodeId] $ \_ -> do
+    blockTime <- Backend.getBlockTime backend
+    withHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] [hydraNodeId] $ \_ -> do
       -- let's prepare a _user_ transaction from Bob to Carol
       (cardanoBobVk, cardanoBobSk) <- keysFor Bob
       (cardanoCarolVk, _) <- keysFor Carol
@@ -1340,8 +1342,8 @@ threeNodesNoErrorsOnOpen tracer tmpDir backend hydraScriptsTxId = do
         case Backend.getOptions backend of
           Direct DirectOptions{nodeSocket} -> nodeSocket
           Blockfrost _ -> error "Unexpected Blockfrost options"
-
-  withHydraCluster hydraTracer backend tmpDir nodeSocket' 1 cardanoKeys hydraKeys hydraScriptsTxId contestationPeriod $ \clients -> do
+  blockTime <- Backend.getBlockTime backend
+  withHydraCluster hydraTracer blockTime tmpDir nodeSocket' 1 cardanoKeys hydraKeys hydraScriptsTxId contestationPeriod $ \clients -> do
     let leader = head clients
     waitForNodesConnected hydraTracer 20 clients
 
@@ -1393,9 +1395,10 @@ nodeCanSupportMultipleEtcdClusters tracer workDir backend hydraScriptsTxId = do
 
   let hydraTracer = contramap FromHydraNode tracer
 
-  withHydraNode hydraTracer backend aliceChainConfig workDir 1 aliceSk [bobVk, carolVk] [1, 2, 3] $ \n1 -> do
-    withHydraNode hydraTracer backend bobChainConfig workDir 2 bobSk [aliceVk, carolVk] [1, 2, 3] $ \n2 -> do
-      withHydraNode hydraTracer backend carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] $ \n3 -> do
+  blockTime <- Backend.getBlockTime backend
+  withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk, carolVk] [1, 2, 3] $ \n1 -> do
+    withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk, carolVk] [1, 2, 3] $ \n2 -> do
+      withHydraNode hydraTracer blockTime carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] $ \n3 -> do
         waitForNodesConnected hydraTracer 30 $ n1 :| [n2, n3]
 
     bobChainConfig' <-
@@ -1407,12 +1410,12 @@ nodeCanSupportMultipleEtcdClusters tracer workDir backend hydraScriptsTxId = do
 
     waitForNodesDisconnected hydraTracer 60 $ n1 :| []
 
-    withHydraNode hydraTracer backend bobChainConfig' workDir 2 bobSk [carolVk] [2, 3] $ \n2 -> do
-      withHydraNode hydraTracer backend carolChainConfig' workDir 3 carolSk [bobVk] [2, 3] $ \n3 -> do
+    withHydraNode hydraTracer blockTime bobChainConfig' workDir 2 bobSk [carolVk] [2, 3] $ \n2 -> do
+      withHydraNode hydraTracer blockTime carolChainConfig' workDir 3 carolSk [bobVk] [2, 3] $ \n3 -> do
         waitForNodesConnected hydraTracer 30 $ n2 :| [n3]
 
-    withHydraNode hydraTracer backend bobChainConfig workDir 2 bobSk [aliceVk, carolVk] [1, 2, 3] $ \n2 -> do
-      withHydraNode hydraTracer backend carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] $ \n3 -> do
+    withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk, carolVk] [1, 2, 3] $ \n2 -> do
+      withHydraNode hydraTracer blockTime carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] $ \n3 -> do
         waitForNodesConnected hydraTracer 30 $ n1 :| [n2, n3]
 
 -- | Two hydra node setup where Alice is wrongly configured to use Carol's
@@ -1428,8 +1431,9 @@ initWithWrongKeys workDir tracer backend hydraScriptsTxId = do
   bobChainConfig <- chainConfigFor Bob workDir backend hydraScriptsTxId [Alice] contestationPeriod
 
   let hydraTracer = contramap FromHydraNode tracer
-  withHydraNode hydraTracer backend aliceChainConfig workDir 3 aliceSk [bobVk] [3, 4] $ \n1 -> do
-    withHydraNode hydraTracer backend bobChainConfig workDir 4 bobSk [aliceVk] [3, 4] $ \n2 -> do
+  blockTime <- Backend.getBlockTime backend
+  withHydraNode hydraTracer blockTime aliceChainConfig workDir 3 aliceSk [bobVk] [3, 4] $ \n1 -> do
+    withHydraNode hydraTracer blockTime bobChainConfig workDir 4 bobSk [aliceVk] [3, 4] $ \n2 -> do
       seedFromFaucet_ backend aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
       send n1 $ input "Init" []
       headId <-
@@ -1442,7 +1446,6 @@ initWithWrongKeys workDir tracer backend hydraScriptsTxId = do
 
       -- We want the client to observe headId being opened without bob (node 2)
       -- being part of it
-      blockTime <- Backend.getBlockTime backend
       participants <- waitMatch (10 * blockTime) n2 $ \v -> do
         guard $ v ^? key "tag" == Just (Aeson.String "IgnoredHeadInitializing")
         guard $ v ^? key "headId" == Just (toJSON headId)
@@ -1460,9 +1463,9 @@ startWithWrongPeers workDir tracer backend hydraScriptsTxId = do
   bobChainConfig <- chainConfigFor Bob workDir backend hydraScriptsTxId [Alice] contestationPeriod
 
   let hydraTracer = contramap FromHydraNode tracer
-  withHydraNode hydraTracer backend aliceChainConfig workDir 3 aliceSk [bobVk] [3, 4] $ \n1 -> do
+  withHydraNode hydraTracer blockTime aliceChainConfig workDir 3 aliceSk [bobVk] [3, 4] $ \n1 -> do
     -- NOTE: here we deliberately use the wrong peer list for Bob
-    withHydraNode hydraTracer backend bobChainConfig workDir 4 bobSk [aliceVk] [4] $ \_ -> do
+    withHydraNode hydraTracer blockTime bobChainConfig workDir 4 bobSk [aliceVk] [4] $ \_ -> do
       seedFromFaucet_ backend aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
 
       (clusterPeers, configuredPeers) <- waitMatch (20 * blockTime) n1 $ \v -> do
@@ -1493,8 +1496,8 @@ canCommit tracer workDir blockTime backend hydraScriptsTxId =
       bobChainConfig <-
         chainConfigFor Bob workDir backend hydraScriptsTxId [Alice] contestationPeriod
           <&> setNetworkId networkId . modifyConfig (\c -> c{depositPeriod})
-      withHydraNode hydraTracer backend aliceChainConfig workDir 1 aliceSk [bobVk] [2] $ \n1 -> do
-        withHydraNode hydraTracer backend bobChainConfig workDir 2 bobSk [aliceVk] [1] $ \n2 -> do
+      withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk] [2] $ \n1 -> do
+        withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk] [1] $ \n2 -> do
           send n1 $ input "Init" []
           headId <- waitMatch (10 * blockTime) n2 $ headIsInitializingWith (Set.fromList [alice, bob])
 
@@ -1578,8 +1581,8 @@ canDepositPartially tracer workDir blockTime backend hydraScriptsTxId =
       bobChainConfig <-
         chainConfigFor Bob workDir backend hydraScriptsTxId [Alice] contestationPeriod
           <&> setNetworkId networkId . modifyConfig (\c -> c{depositPeriod})
-      withHydraNode hydraTracer backend aliceChainConfig workDir 1 aliceSk [bobVk] [2] $ \n1 -> do
-        withHydraNode hydraTracer backend bobChainConfig workDir 2 bobSk [aliceVk] [1] $ \n2 -> do
+      withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk] [2] $ \n1 -> do
+        withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk] [1] $ \n2 -> do
           send n1 $ input "Init" []
           headId <- waitMatch (10 * blockTime) n2 $ headIsInitializingWith (Set.fromList [alice, bob])
 
@@ -1694,8 +1697,7 @@ rejectCommit tracer workDir blockTime backend hydraScriptsTxId =
 
     let pparamsDecorator = atKey "utxoCostPerByte" ?~ toJSON (Aeson.Number 4310)
     optionsWithUTxOCostPerByte <- prepareHydraNode aliceChainConfig workDir 1 aliceSk [] [] pparamsDecorator
-
-    withPreparedHydraNodeInSync hydraTracer backend workDir 1 optionsWithUTxOCostPerByte $ \n1 -> do
+    withPreparedHydraNodeInSync hydraTracer blockTime workDir 1 optionsWithUTxOCostPerByte $ \n1 -> do
       send n1 $ input "Init" []
       headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
 
@@ -1744,8 +1746,8 @@ canRecoverDeposit tracer workDir backend hydraScriptsTxId =
       bobChainConfig <-
         chainConfigFor Bob workDir backend hydraScriptsTxId [Alice] contestationPeriod
           <&> setNetworkId networkId . modifyConfig (\c -> c{depositPeriod})
-      withHydraNode hydraTracer backend aliceChainConfig workDir 1 aliceSk [bobVk] [2] $ \n1 -> do
-        headId <- withHydraNode hydraTracer backend bobChainConfig workDir 2 bobSk [aliceVk] [1] $ \n2 -> do
+      withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk] [2] $ \n1 -> do
+        headId <- withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk] [1] $ \n2 -> do
           send n1 $ input "Init" []
           headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice, bob])
 
@@ -1833,7 +1835,7 @@ canRecoverDepositInAnyState tracer workDir backend hydraScriptsTxId =
     aliceChainConfig <-
       chainConfigFor Alice workDir backend hydraScriptsTxId [] contestationPeriod
         <&> setNetworkId networkId . modifyConfig (\c -> c{depositPeriod})
-    withHydraNode hydraTracer backend aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+    withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
       -- Init the head
       send n1 $ input "Init" []
       headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
@@ -1959,8 +1961,8 @@ canSeePendingDeposits tracer workDir blockTime backend hydraScriptsTxId =
       bobChainConfig <-
         chainConfigFor Bob workDir backend hydraScriptsTxId [Alice] contestationPeriod
           <&> setNetworkId networkId . modifyConfig (\c -> c{depositPeriod})
-      withHydraNode hydraTracer backend aliceChainConfig workDir 1 aliceSk [bobVk] [2] $ \n1 -> do
-        _ <- withHydraNode hydraTracer backend bobChainConfig workDir 2 bobSk [aliceVk] [1] $ \n2 -> do
+      withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk] [2] $ \n1 -> do
+        _ <- withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk] [1] $ \n2 -> do
           send n1 $ input "Init" []
           headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice, bob])
 
@@ -2036,7 +2038,7 @@ canDecommit tracer workDir backend hydraScriptsTxId =
     aliceChainConfig <-
       chainConfigFor Alice workDir backend hydraScriptsTxId [] contestationPeriod
         <&> setNetworkId networkId
-    withHydraNode hydraTracer backend aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+    withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
       -- Initialize & open head
       send n1 $ input "Init" []
       headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
@@ -2144,13 +2146,13 @@ canSideLoadSnapshot tracer workDir backend hydraScriptsTxId = do
     chainConfigFor Carol workDir backend hydraScriptsTxId [Alice, Bob] contestationPeriod
       <&> setNetworkId networkId
 
-  withHydraNode hydraTracer backend aliceChainConfig workDir 1 aliceSk [bobVk, carolVk] [1, 2, 3] $ \n1 -> do
+  withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk, carolVk] [1, 2, 3] $ \n1 -> do
     aliceUTxO <- seedFromFaucet backend aliceCardanoVk (lovelaceToValue 1_000_000) (contramap FromFaucet tracer)
-    withHydraNode hydraTracer backend bobChainConfig workDir 2 bobSk [aliceVk, carolVk] [1, 2, 3] $ \n2 -> do
+    withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk, carolVk] [1, 2, 3] $ \n2 -> do
       -- Carol starts its node misconfigured
       let pparamsDecorator = atKey "maxTxSize" ?~ toJSON (Aeson.Number 0)
       wrongOptions <- prepareHydraNode carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] pparamsDecorator
-      tx <- withPreparedHydraNodeInSync hydraTracer backend workDir 3 wrongOptions $ \n3 -> do
+      tx <- withPreparedHydraNodeInSync hydraTracer blockTime workDir 3 wrongOptions $ \n3 -> do
         send n1 $ input "Init" []
         headId <- waitForAllMatch (10 * blockTime) [n1, n2, n3] $ headIsInitializingWith (Set.fromList [alice, bob, carol])
 
@@ -2193,7 +2195,7 @@ canSideLoadSnapshot tracer workDir backend hydraScriptsTxId = do
         guard $ v ^? key "tag" == Just "PeerDisconnected"
 
       -- Carol reconnects with healthy reconfigured node
-      withHydraNode hydraTracer backend carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] $ \n3 -> do
+      withHydraNode hydraTracer blockTime carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] $ \n3 -> do
         -- Carol re-submits the same transaction
         send n3 $ input "NewTx" ["transaction" .= tx]
         -- Carol accepts it
@@ -2309,10 +2311,10 @@ waitsForChainInSyncAndSecure tracer workDir backend hydraScriptsTxId = do
     chainConfigFor Carol workDir backend hydraScriptsTxId [Alice, Bob] contestationPeriod
       <&> setNetworkId networkId
 
-  withHydraNode hydraTracer backend aliceChainConfig workDir 1 aliceSk [bobVk, carolVk] [1, 2, 3] $ \n1 -> do
-    withHydraNode hydraTracer backend bobChainConfig workDir 2 bobSk [aliceVk, carolVk] [1, 2, 3] $ \n2 -> do
+  withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk, carolVk] [1, 2, 3] $ \n1 -> do
+    withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk, carolVk] [1, 2, 3] $ \n2 -> do
       -- Open a head while Carol online
-      headId <- withHydraNode hydraTracer backend carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] $ \n3 -> do
+      headId <- withHydraNode hydraTracer blockTime carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] $ \n3 -> do
         send n1 $ input "Init" []
         headId <- waitForAllMatch (10 * blockTime) [n1, n2, n3] $ headIsInitializingWith (Set.fromList [alice, bob, carol])
 
@@ -2398,10 +2400,10 @@ threeNodesWithMirrorParty tracer workDir backend hydraScriptsTxId = do
   let hydraTracer = contramap FromHydraNode tracer
   let allNodeIds = [1, 2, 3]
   blockTime <- Backend.getBlockTime backend
-  withHydraNode hydraTracer backend aliceChainConfig workDir 1 aliceSk [bobVk] allNodeIds $ \n1 -> do
-    withHydraNode hydraTracer backend bobChainConfig workDir 2 bobSk [aliceVk] allNodeIds $ \n2 -> do
+  withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk] allNodeIds $ \n1 -> do
+    withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk] allNodeIds $ \n2 -> do
       -- One party will participate using same hydra credentials
-      withHydraNode hydraTracer backend aliceChainConfig workDir 3 aliceSk [bobVk] allNodeIds $ \n3 -> do
+      withHydraNode hydraTracer blockTime aliceChainConfig workDir 3 aliceSk [bobVk] allNodeIds $ \n3 -> do
         let clients = [n1, n2, n3]
         send n1 $ input "Init" []
         headId <- waitForAllMatch (10 * blockTime) clients $ headIsInitializingWith (Set.fromList [alice, bob])

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -501,7 +501,7 @@ singlePartyHeadFullLifeCycle tracer workDir backend hydraScriptsTxId =
       tip <- Backend.queryTip backend
       blockTime <- Backend.getBlockTime backend
       networkId <- Backend.queryNetworkId backend
-      contestationPeriod <- CP.fromNominalDiffTime $ 10 * blockTime
+      contestationPeriod <- CP.fromNominalDiffTime $ 20 * blockTime
       aliceChainConfig <-
         chainConfigFor' Alice workDir backend hydraScriptsTxId [] contestationPeriod (DepositPeriod 100)
           <&> modifyConfig (\config -> config{startChainFrom = Just tip})

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -120,7 +120,16 @@ import Hydra.Logging (Tracer, traceWith)
 import Hydra.Node.DepositPeriod (DepositPeriod (..))
 import Hydra.Node.State (SyncedStatus (..))
 import Hydra.Node.UnsyncedPeriod (defaultUnsyncedPeriodFor, unsyncedPeriodToNominalDiffTime)
-import Hydra.Options (CardanoChainConfig (..), ChainBackendOptions (..), ChainConfig (..), DirectOptions (..), RunOptions (..), startChainFrom)
+import Hydra.Options (
+  CardanoChainConfig (..),
+  ChainBackendOptions (..),
+  ChainConfig (..),
+  DirectOptions (..),
+  RunOptions (..),
+  defaultContestationPeriod,
+  defaultDepositPeriod,
+  startChainFrom,
+ )
 import Hydra.Tx (HeadId (..), IsTx (balance), Party, headIdToCurrencySymbol, txId)
 import Hydra.Tx.ContestationPeriod qualified as CP
 import Hydra.Tx.Deposit (constructDepositUTxO)
@@ -501,9 +510,10 @@ singlePartyHeadFullLifeCycle tracer workDir backend hydraScriptsTxId =
       tip <- Backend.queryTip backend
       blockTime <- Backend.getBlockTime backend
       networkId <- Backend.queryNetworkId backend
-      contestationPeriod <- CP.fromNominalDiffTime $ 10 * blockTime
+      let contestationPeriod = defaultContestationPeriod
+          depositPeriod = defaultDepositPeriod
       aliceChainConfig <-
-        chainConfigFor' Alice workDir backend hydraScriptsTxId [] contestationPeriod (DepositPeriod 100)
+        chainConfigFor' Alice workDir backend hydraScriptsTxId [] contestationPeriod depositPeriod
           <&> modifyConfig (\config -> config{startChainFrom = Just tip})
             . setNetworkId networkId
       withHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -583,7 +583,7 @@ singlePartyOpenAHead tracer workDir backend hydraScriptsTxId persistenceRotateAf
     let hydraTracer = contramap FromHydraNode tracer
     options <- prepareHydraNode aliceChainConfig workDir 1 aliceSk [] [] id
     let options' = options{persistenceRotateAfter}
-    withPreparedHydraNodeInSync hydraTracer workDir 1 options' $ \n1 -> do
+    withPreparedHydraNodeInSync hydraTracer aliceChainConfig workDir 1 options' $ \n1 -> do
       -- Initialize & open head
       send n1 $ input "Init" []
       blockTime <- Backend.getBlockTime backend
@@ -1705,7 +1705,7 @@ rejectCommit tracer workDir blockTime backend hydraScriptsTxId =
     let pparamsDecorator = atKey "utxoCostPerByte" ?~ toJSON (Aeson.Number 4310)
     optionsWithUTxOCostPerByte <- prepareHydraNode aliceChainConfig workDir 1 aliceSk [] [] pparamsDecorator
 
-    withPreparedHydraNodeInSync hydraTracer workDir 1 optionsWithUTxOCostPerByte $ \n1 -> do
+    withPreparedHydraNodeInSync hydraTracer aliceChainConfig workDir 1 optionsWithUTxOCostPerByte $ \n1 -> do
       send n1 $ input "Init" []
       headId <- waitMatch (10 * blockTime) n1 $ headIsInitializingWith (Set.fromList [alice])
 
@@ -2160,7 +2160,7 @@ canSideLoadSnapshot tracer workDir backend hydraScriptsTxId = do
       -- Carol starts its node misconfigured
       let pparamsDecorator = atKey "maxTxSize" ?~ toJSON (Aeson.Number 0)
       wrongOptions <- prepareHydraNode carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] pparamsDecorator
-      tx <- withPreparedHydraNodeInSync hydraTracer workDir 3 wrongOptions $ \n3 -> do
+      tx <- withPreparedHydraNodeInSync hydraTracer carolChainConfig workDir 3 wrongOptions $ \n3 -> do
         send n1 $ input "Init" []
         headId <- waitForAllMatch (10 * blockTime) [n1, n2, n3] $ headIsInitializingWith (Set.fromList [alice, bob, carol])
 

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -455,7 +455,7 @@ withPreparedHydraNodeInSync tracer backend workDir hydraNodeId runOptions action
  where
   waitFactor = 5
   action' waitTime client = do
-    waitForNodesSynced tracer waitTime $ client :| []
+    waitForNodesSynced waitTime $ client :| []
     action client
 
 -- | Run a hydra-node with given 'RunOptions'.

--- a/hydra-cluster/test/Test/ChainObserverSpec.hs
+++ b/hydra-cluster/test/Test/ChainObserverSpec.hs
@@ -47,7 +47,7 @@ spec = do
             hydraScriptsTxId <- publishHydraScriptsAs backend Faucet
             (aliceCardanoVk, _) <- keysFor Alice
             aliceChainConfig <- chainConfigFor Alice tmpDir backend hydraScriptsTxId [] cperiod
-            withHydraNode hydraTracer aliceChainConfig tmpDir 1 aliceSk [] [1] $ \hydraNode -> do
+            withHydraNode hydraTracer backend aliceChainConfig tmpDir 1 aliceSk [] [1] $ \hydraNode -> do
               withChainObserver backend $ \observer -> do
                 seedFromFaucet_ backend aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
 

--- a/hydra-cluster/test/Test/ChainObserverSpec.hs
+++ b/hydra-cluster/test/Test/ChainObserverSpec.hs
@@ -41,13 +41,13 @@ spec = do
       showLogsOnFailure "ChainObserverSpec" $ \tracer -> do
         withTempDir "hydra-cluster" $ \tmpDir -> do
           -- Start a cardano devnet
-          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ backend -> do
+          withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \blockTime backend -> do
             -- Prepare a hydra-node
             let hydraTracer = contramap FromHydraNode tracer
             hydraScriptsTxId <- publishHydraScriptsAs backend Faucet
             (aliceCardanoVk, _) <- keysFor Alice
             aliceChainConfig <- chainConfigFor Alice tmpDir backend hydraScriptsTxId [] cperiod
-            withHydraNode hydraTracer backend aliceChainConfig tmpDir 1 aliceSk [] [1] $ \hydraNode -> do
+            withHydraNode hydraTracer blockTime aliceChainConfig tmpDir 1 aliceSk [] [1] $ \hydraNode -> do
               withChainObserver backend $ \observer -> do
                 seedFromFaucet_ backend aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
 

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -214,7 +214,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
         options <- prepareHydraNode offlineConfig tmpDir 1 aliceSk [] [] id
         let options' = options{persistenceRotateAfter = Just (Positive 10)}
         t1 <- getCurrentTime
-        diff2 <- withPreparedHydraNodeInSync (contramap FromHydraNode tracer) tmpDir 1 options' $ \_ -> do
+        diff2 <- withPreparedHydraNodeInSync (contramap FromHydraNode tracer) offlineConfig tmpDir 1 options' $ \_ -> do
           t2 <- getCurrentTime
           let diff = diffUTCTime t2 t1
           pure diff

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -146,7 +146,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
                   , initialUTxOFile = tmpDir </> "utxo.json"
                   , ledgerGenesisFile = Nothing
                   }
-        let blockTime = 1
+        let blockTime = 5
         -- Start a hydra-node in offline mode and submit a transaction from alice to bob
         aliceToBob <- withHydraNode (contramap FromHydraNode tracer) blockTime offlineConfig tmpDir 1 aliceSk [] [1] $ \node -> do
           let Just (aliceSeedTxIn, aliceSeedTxOut) = UTxO.find (isVkTxOut aliceCardanoVk) initialUTxO
@@ -185,7 +185,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
                   , initialUTxOFile = tmpDir </> "utxo.json"
                   , ledgerGenesisFile = Nothing
                   }
-        let blockTime = 1
+        let blockTime = 5
         -- Start a hydra-node in offline mode and submit several self-txs
         withHydraNode (contramap FromHydraNode tracer) blockTime offlineConfig tmpDir 1 aliceSk [] [] $ \node -> do
           foldM_
@@ -242,7 +242,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
                   , ledgerGenesisFile = Nothing
                   }
         let tr = contramap FromHydraNode tracer
-        let blockTime = 1
+        let blockTime = 5
         -- Start two hydra-nodes in offline mode and submit a transaction from alice to bob
         withHydraNode tr blockTime offlineConfig tmpDir 1 aliceSk [bobVk] [1, 2] $ \aliceNode -> do
           withHydraNode tr blockTime offlineConfig tmpDir 2 bobSk [aliceVk] [1, 2] $ \bobNode -> do

--- a/hydra-cluster/test/Test/Hydra/Cluster/HydraClientSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/HydraClientSpec.hs
@@ -264,7 +264,7 @@ scenarioSetup tracer tmpDir action = do
     let contestationPeriod = 2
     let hydraTracer = contramap FromHydraNode tracer
 
-    withHydraCluster hydraTracer backend tmpDir nodeSocket' firstNodeId cardanoKeys hydraKeys hydraScriptsTxId contestationPeriod $ \nodes -> do
+    withHydraCluster hydraTracer blockTime tmpDir nodeSocket' firstNodeId cardanoKeys hydraKeys hydraScriptsTxId contestationPeriod $ \nodes -> do
       let [n1, n2, n3] = toList nodes
       waitForNodesConnected hydraTracer 20 $ n1 :| [n2, n3]
 

--- a/hydra-cluster/test/Test/Hydra/Cluster/HydraClientSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/HydraClientSpec.hs
@@ -264,7 +264,7 @@ scenarioSetup tracer tmpDir action = do
     let contestationPeriod = 2
     let hydraTracer = contramap FromHydraNode tracer
 
-    withHydraCluster hydraTracer tmpDir nodeSocket' firstNodeId cardanoKeys hydraKeys hydraScriptsTxId contestationPeriod $ \nodes -> do
+    withHydraCluster hydraTracer backend tmpDir nodeSocket' firstNodeId cardanoKeys hydraKeys hydraScriptsTxId contestationPeriod $ \nodes -> do
       let [n1, n2, n3] = toList nodes
       waitForNodesConnected hydraTracer 20 $ n1 :| [n2, n3]
 

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -1575,7 +1575,7 @@ components:
         chainTime:
           $ref: "api.yaml#/components/schemas/UTCTime"
         drift:
-          $ref: "api.yaml#/components/schemas/Natural"
+          $ref: "api.yaml#/components/schemas/NominalDiffTime"
         synced:
           $ref: "api.yaml#/components/schemas/SyncedStatus"
 

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -76,6 +76,7 @@ channels:
           - $ref: "api.yaml#/components/messages/CommandFailed"
           - $ref: "api.yaml#/components/messages/RejectedInputBecauseUnsynced"
           - $ref: "api.yaml#/components/messages/SideLoadSnapshotRejected"
+          - $ref: "api.yaml#/components/messages/SyncedStatusReport"
           - $ref: "api.yaml#/components/messages/PostTxOnChainFailed"
           - $ref: "api.yaml#/components/messages/PeerConnected"
           - $ref: "api.yaml#/components/messages/PeerDisconnected"
@@ -749,6 +750,13 @@ components:
       payload:
         $ref: "api.yaml#/components/schemas/SideLoadSnapshotRejected"
 
+    SyncedStatusReport:
+      title: SyncedStatusReport
+      description: |
+        Emitted by the server while the node is catching-up with the chain or while in sync but near to become unsynced.
+      payload:
+        $ref: "api.yaml#/components/schemas/SyncedStatusReport"
+
     IgnoredHeadInitializing:
       title: IgnoredHeadInitializing
       description: |
@@ -937,6 +945,7 @@ components:
         - $ref: "api.yaml#/components/schemas/CommandFailed"
         - $ref: "api.yaml#/components/schemas/RejectedInputBecauseUnsynced"
         - $ref: "api.yaml#/components/schemas/SideLoadSnapshotRejected"
+        - $ref: "api.yaml#/components/schemas/SyncedStatusReport"
 
     Greetings:
       type: object
@@ -1548,6 +1557,27 @@ components:
             - $ref: "api.yaml#/components/messages/SideLoadSnapshot/payload"
         requirementFailure:
           $ref: "api.yaml#/components/schemas/SideLoadRequirementFailure"
+
+    SyncedStatusReport:
+      type: object
+      required:
+        - tag
+        - chainSlot
+        - chainTime
+        - drift
+        - synced
+      properties:
+        tag:
+          type: string
+          enum: ["SyncedStatusReport"]
+        chainSlot:
+          $ref: "api.yaml#/components/schemas/ChainSlot"
+        chainTime:
+          $ref: "api.yaml#/components/schemas/UTCTime"
+        drift:
+          $ref: "api.yaml#/components/schemas/Natural"
+        synced:
+          $ref: "api.yaml#/components/schemas/SyncedStatus"
 
     SideLoadRequirementFailure:
       oneOf:

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -69,12 +69,7 @@ data ClientMessage tx
   | PostTxOnChainFailed {postChainTx :: PostChainTx tx, postTxError :: PostTxError tx}
   | RejectedInputBecauseUnsynced {clientInput :: ClientInput tx, drift :: NominalDiffTime}
   | SideLoadSnapshotRejected {clientInput :: ClientInput tx, requirementFailure :: SideLoadRequirementFailure tx}
-  | SyncedStatus
-      { chainSlot :: ChainSlot
-      , chainTime :: UTCTime
-      , drift :: NominalDiffTime
-      , synced :: SyncedStatus
-      }
+  | SyncedStatusReport {chainSlot :: ChainSlot, chainTime :: UTCTime, drift :: Natural, synced :: SyncedStatus}
   deriving (Eq, Show, Generic)
 
 instance IsChainState tx => ToJSON (ClientMessage tx) where

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -69,7 +69,7 @@ data ClientMessage tx
   | PostTxOnChainFailed {postChainTx :: PostChainTx tx, postTxError :: PostTxError tx}
   | RejectedInputBecauseUnsynced {clientInput :: ClientInput tx, drift :: NominalDiffTime}
   | SideLoadSnapshotRejected {clientInput :: ClientInput tx, requirementFailure :: SideLoadRequirementFailure tx}
-  | SyncedStatusReport {chainSlot :: ChainSlot, chainTime :: UTCTime, drift :: Natural, synced :: SyncedStatus}
+  | SyncedStatusReport {chainSlot :: ChainSlot, chainTime :: UTCTime, drift :: NominalDiffTime, synced :: SyncedStatus}
   deriving (Eq, Show, Generic)
 
 instance IsChainState tx => ToJSON (ClientMessage tx) where

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -69,6 +69,12 @@ data ClientMessage tx
   | PostTxOnChainFailed {postChainTx :: PostChainTx tx, postTxError :: PostTxError tx}
   | RejectedInputBecauseUnsynced {clientInput :: ClientInput tx, drift :: NominalDiffTime}
   | SideLoadSnapshotRejected {clientInput :: ClientInput tx, requirementFailure :: SideLoadRequirementFailure tx}
+  | SyncedStatus
+      { chainSlot :: ChainSlot
+      , chainTime :: UTCTime
+      , drift :: NominalDiffTime
+      , synced :: SyncedStatus
+      }
   deriving (Eq, Show, Generic)
 
 instance IsChainState tx => ToJSON (ClientMessage tx) where

--- a/hydra-node/src/Hydra/Chain/Offline.hs
+++ b/hydra-node/src/Hydra/Chain/Offline.hs
@@ -4,7 +4,6 @@ import Hydra.Prelude
 
 import Cardano.Api.Genesis (fromShelleyGenesis, shelleyGenesisDefaults)
 import Cardano.Slotting.Time (SystemStart (SystemStart), mkSlotLength)
-import Control.Exception (ErrorCall (..))
 import Control.Monad.Class.MonadAsync (link)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Types qualified as Aeson
@@ -28,7 +27,6 @@ import Hydra.Chain (
   chainTime,
   initHistory,
  )
-import Hydra.Chain.Backend (ChainBackend (..))
 import Hydra.Chain.Direct.State (initialChainState)
 import Hydra.Ledger.Cardano.Time (slotNoFromUTCTime, slotNoToUTCTime)
 import Hydra.Node.Util (checkNonADAAssetsUTxO)
@@ -183,58 +181,3 @@ tickForever genesis callback = do
 
 offlineBlockHash :: Hash BlockHeader
 offlineBlockHash = unsafeBlockHeaderHashFromBytes "offline-blockhash-00000000000000"
-
-newtype OfflineOptions = OfflineOptions {blockTime :: NominalDiffTime}
-  deriving stock (Generic, Show, Eq)
-  deriving anyclass (ToJSON, FromJSON)
-
-newtype OfflineBackend = OfflineBackend {options :: OfflineOptions} deriving (Eq, Show)
-
-offline :: MonadIO m => String -> m a
-offline msg = liftIO $ throwIO (ErrorCall msg)
-
-instance ChainBackend OfflineBackend where
-  queryGenesisParameters _ =
-    offline "OfflineBackend: queryGenesisParameters not available"
-
-  queryScriptRegistry _ _ =
-    offline "OfflineBackend: queryScriptRegistry not available"
-
-  queryNetworkId _ =
-    offline "OfflineBackend: queryNetworkId not available"
-
-  queryTip _ =
-    offline "OfflineBackend: queryTip not available"
-
-  queryUTxO _ _ =
-    offline "OfflineBackend: queryUTxO not available"
-
-  queryUTxOByTxIn _ _ =
-    offline "OfflineBackend: queryUTxOByTxIn not available"
-
-  queryEraHistory _ _ =
-    offline "OfflineBackend: queryEraHistory not available"
-
-  querySystemStart _ _ =
-    offline "OfflineBackend: querySystemStart not available"
-
-  queryProtocolParameters _ _ =
-    offline "OfflineBackend: queryProtocolParameters not available"
-
-  queryStakePools _ _ =
-    offline "OfflineBackend: queryStakePools not available"
-
-  queryUTxOFor _ _ _ =
-    offline "OfflineBackend: queryUTxOFor not available"
-
-  submitTransaction _ _ =
-    offline "OfflineBackend: submitTransaction not available"
-
-  awaitTransaction _ _ _ =
-    offline "OfflineBackend: awaitTransaction not available"
-
-  getOptions _ =
-    error "OfflineBackend: getOptions not available"
-
-  getBlockTime (OfflineBackend OfflineOptions{blockTime}) =
-    pure blockTime

--- a/hydra-node/src/Hydra/Chain/Offline.hs
+++ b/hydra-node/src/Hydra/Chain/Offline.hs
@@ -4,6 +4,7 @@ import Hydra.Prelude
 
 import Cardano.Api.Genesis (fromShelleyGenesis, shelleyGenesisDefaults)
 import Cardano.Slotting.Time (SystemStart (SystemStart), mkSlotLength)
+import Control.Exception (ErrorCall (..))
 import Control.Monad.Class.MonadAsync (link)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Types qualified as Aeson
@@ -27,6 +28,7 @@ import Hydra.Chain (
   chainTime,
   initHistory,
  )
+import Hydra.Chain.Backend (ChainBackend (..))
 import Hydra.Chain.Direct.State (initialChainState)
 import Hydra.Ledger.Cardano.Time (slotNoFromUTCTime, slotNoToUTCTime)
 import Hydra.Node.Util (checkNonADAAssetsUTxO)
@@ -181,3 +183,58 @@ tickForever genesis callback = do
 
 offlineBlockHash :: Hash BlockHeader
 offlineBlockHash = unsafeBlockHeaderHashFromBytes "offline-blockhash-00000000000000"
+
+newtype OfflineOptions = OfflineOptions {blockTime :: NominalDiffTime}
+  deriving stock (Generic, Show, Eq)
+  deriving anyclass (ToJSON, FromJSON)
+
+newtype OfflineBackend = OfflineBackend {options :: OfflineOptions} deriving (Eq, Show)
+
+offline :: MonadIO m => String -> m a
+offline msg = liftIO $ throwIO (ErrorCall msg)
+
+instance ChainBackend OfflineBackend where
+  queryGenesisParameters _ =
+    offline "OfflineBackend: queryGenesisParameters not available"
+
+  queryScriptRegistry _ _ =
+    offline "OfflineBackend: queryScriptRegistry not available"
+
+  queryNetworkId _ =
+    offline "OfflineBackend: queryNetworkId not available"
+
+  queryTip _ =
+    offline "OfflineBackend: queryTip not available"
+
+  queryUTxO _ _ =
+    offline "OfflineBackend: queryUTxO not available"
+
+  queryUTxOByTxIn _ _ =
+    offline "OfflineBackend: queryUTxOByTxIn not available"
+
+  queryEraHistory _ _ =
+    offline "OfflineBackend: queryEraHistory not available"
+
+  querySystemStart _ _ =
+    offline "OfflineBackend: querySystemStart not available"
+
+  queryProtocolParameters _ _ =
+    offline "OfflineBackend: queryProtocolParameters not available"
+
+  queryStakePools _ _ =
+    offline "OfflineBackend: queryStakePools not available"
+
+  queryUTxOFor _ _ _ =
+    offline "OfflineBackend: queryUTxOFor not available"
+
+  submitTransaction _ _ =
+    offline "OfflineBackend: submitTransaction not available"
+
+  awaitTransaction _ _ _ =
+    offline "OfflineBackend: awaitTransaction not available"
+
+  getOptions _ =
+    error "OfflineBackend: getOptions not available"
+
+  getBlockTime (OfflineBackend OfflineOptions{blockTime}) =
+    pure blockTime

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1399,18 +1399,18 @@ handleOutOfSync Environment{unsyncedPeriod} now chainPoint chainTime syncStatus
   -- falls behind the current system time.
   | chainTime `plus` unsyncedPeriodToNominalDiffTime unsyncedPeriod < now =
       case syncStatus of
-        InSync -> newState (NodeUnsynced{chainSlot, chainTime, drift}) <> output
-        CatchingUp -> output
+        InSync -> newState (NodeUnsynced{chainSlot, chainTime, drift}) <> output CatchingUp
+        CatchingUp -> output CatchingUp
   | otherwise =
       case syncStatus of
-        InSync -> output
-        CatchingUp -> newState (NodeSynced{chainSlot, chainTime, drift}) <> output
+        InSync -> output InSync
+        CatchingUp -> newState (NodeSynced{chainSlot, chainTime, drift}) <> output InSync
  where
   plus = flip addUTCTime
   chainSlot = chainPointSlot chainPoint
   drift = now `diffUTCTime` chainTime
-  output =
-    cause . ClientEffect $ ServerOutput.SyncedStatus chainSlot chainTime drift syncStatus
+  output synced =
+    cause . ClientEffect $ ServerOutput.SyncedStatus chainSlot chainTime drift synced
 
 -- | Validate whether a current deposit in the local state actually exists
 --   in the map of pending deposits.

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1545,11 +1545,11 @@ handleChainInput env _ledger now _chainPointTime pendingDeposits st ev syncStatu
   (Open{}, ChainInput PostTxError{postChainTx = CollectComTx{}}) ->
     noop
   (Open openState@OpenState{headId = ourHeadId}, ChainInput Tick{chainTime, chainPoint}) ->
-    -- XXX: We originally forgot the normal TickObserved state event here and so
-    -- time did not advance in an open head anymore. This is a hint that we
-    -- should compose event handling better.
-    newState TickObserved{chainPoint}
-      <> handleOutOfSync env now chainPoint chainTime syncStatus
+    handleOutOfSync env now chainPoint chainTime syncStatus
+      -- XXX: We originally forgot the normal TickObserved state event here and so
+      -- time did not advance in an open head anymore. This is a hint that we
+      -- should compose event handling better.
+      <> newState TickObserved{chainPoint}
       <> onChainTick env pendingDeposits chainTime
       <> onOpenChainTick env chainTime (depositsForHead ourHeadId pendingDeposits) openState
   (Open openState@OpenState{headId = ourHeadId}, ChainInput Observation{observedTx = OnIncrementTx{headId, newVersion, depositTxId}, newChainState})
@@ -1571,8 +1571,8 @@ handleChainInput env _ledger now _chainPointTime pendingDeposits st ev syncStatu
         Error NotOurHead{ourHeadId, otherHeadId = headId}
   (Closed ClosedState{contestationDeadline, readyToFanoutSent, headId}, ChainInput Tick{chainTime, chainPoint})
     | chainTime > contestationDeadline && not readyToFanoutSent ->
-        newState TickObserved{chainPoint}
-          <> handleOutOfSync env now chainPoint chainTime syncStatus
+        handleOutOfSync env now chainPoint chainTime syncStatus
+          <> newState TickObserved{chainPoint}
           <> onChainTick env pendingDeposits chainTime
           <> newState HeadIsReadyToFanout{headId}
   (Closed closedState@ClosedState{headId = ourHeadId}, ChainInput Observation{observedTx = OnFanoutTx{headId, fanoutUTxO}, newChainState})
@@ -1605,11 +1605,11 @@ handleChainInput env _ledger now _chainPointTime pendingDeposits st ev syncStatu
         <> maybeRepostDecrementTx headId parameters decommitTx confirmedSnapshot
   -- General
   (_, ChainInput Rollback{rolledBackChainState, chainTime}) ->
-    newState ChainRolledBack{chainState = rolledBackChainState}
-      <> handleOutOfSync env now (chainStatePoint rolledBackChainState) chainTime syncStatus
+    handleOutOfSync env now (chainStatePoint rolledBackChainState) chainTime syncStatus
+      <> newState ChainRolledBack{chainState = rolledBackChainState}
   (_, ChainInput Tick{chainTime, chainPoint}) ->
-    newState TickObserved{chainPoint}
-      <> handleOutOfSync env now chainPoint chainTime syncStatus
+    handleOutOfSync env now chainPoint chainTime syncStatus
+      <> newState TickObserved{chainPoint}
       <> onChainTick env pendingDeposits chainTime
   (_, ChainInput PostTxError{postChainTx, postTxError}) ->
     cause . ClientEffect $ ServerOutput.PostTxOnChainFailed{postChainTx, postTxError}

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1393,24 +1393,38 @@ handleOutOfSync ::
   UTCTime ->
   SyncedStatus ->
   Outcome tx
-handleOutOfSync Environment{unsyncedPeriod} now chainPoint chainTime syncStatus
-  -- We consider the node out of sync when:
-  -- the last observed chainTime plus the delta allowed by the unsyncedPeriod
-  -- falls behind the current system time.
-  | chainTime `plus` unsyncedPeriodToNominalDiffTime unsyncedPeriod < now =
-      case syncStatus of
-        InSync -> newState (NodeUnsynced{chainSlot, chainTime, drift}) <> output CatchingUp
-        CatchingUp -> output CatchingUp
-  | otherwise =
-      case syncStatus of
-        InSync -> output InSync
-        CatchingUp -> newState (NodeSynced{chainSlot, chainTime, drift}) <> output InSync
+handleOutOfSync Environment{unsyncedPeriod} now chainPoint chainTime syncStatus =
+  stateTransition <> outputIfNeeded
  where
   plus = flip addUTCTime
   chainSlot = chainPointSlot chainPoint
+
+  threshold = unsyncedPeriodToNominalDiffTime unsyncedPeriod
   drift = now `diffUTCTime` chainTime
+
+  -- We consider the node out of sync when:
+  -- the last observed chainTime plus the delta allowed by the unsyncedPeriod (threshold)
+  -- falls behind the current system time (now).
+  -- NOTE: this is the same as drift > threshold
+  nodeOutOfSync = chainTime `plus` threshold < now
+  newSyncStatus = if nodeOutOfSync then CatchingUp else InSync
+  stateTransition =
+    case (syncStatus, newSyncStatus) of
+      (InSync, CatchingUp) -> newState NodeUnsynced{chainSlot, chainTime, drift}
+      (CatchingUp, InSync) -> newState NodeSynced{chainSlot, chainTime, drift}
+      _ -> noop
+
+  -- We have consumed 80% of the allowed drift
+  nearThreshold = drift >= threshold * 0.8
+  shouldOutput =
+    case newSyncStatus of
+      CatchingUp -> True
+      InSync -> nearThreshold
+  outputIfNeeded
+    | shouldOutput = output newSyncStatus
+    | otherwise = noop
   output synced =
-    cause . ClientEffect $ ServerOutput.SyncedStatus chainSlot chainTime drift synced
+    cause . ClientEffect $ ServerOutput.SyncedStatusReport{chainSlot, chainTime, drift, synced}
 
 -- | Validate whether a current deposit in the local state actually exists
 --   in the map of pending deposits.

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1394,17 +1394,13 @@ handleOutOfSync ::
   SyncedStatus ->
   Outcome tx
 handleOutOfSync Environment{unsyncedPeriod} now chainPoint chainTime syncStatus =
-  case maybeDrift of
-    Nothing -> Error $ AssertionFailed "Non-positive time delta between system clock and chain time"
-    Just drift -> stateTransition drift <> outputIfNeeded drift
+  stateTransition <> outputIfNeeded
  where
   plus = flip addUTCTime
   chainSlot = chainPointSlot chainPoint
 
   threshold = unsyncedPeriodToNominalDiffTime unsyncedPeriod
   drift = now `diffUTCTime` chainTime
-  maybeDrift =
-    if drift < 0 then Nothing else Just (floor drift)
 
   -- We consider the node out of sync when:
   -- the last observed chainTime plus the delta allowed by the unsyncedPeriod (threshold)
@@ -1412,7 +1408,7 @@ handleOutOfSync Environment{unsyncedPeriod} now chainPoint chainTime syncStatus 
   -- NOTE: this is the same as drift > threshold
   nodeOutOfSync = chainTime `plus` threshold < now
   newSyncStatus = if nodeOutOfSync then CatchingUp else InSync
-  stateTransition drift =
+  stateTransition =
     case (syncStatus, newSyncStatus) of
       (InSync, CatchingUp) -> newState NodeUnsynced{chainSlot, chainTime, drift}
       (CatchingUp, InSync) -> newState NodeSynced{chainSlot, chainTime, drift}
@@ -1424,10 +1420,10 @@ handleOutOfSync Environment{unsyncedPeriod} now chainPoint chainTime syncStatus 
     case newSyncStatus of
       CatchingUp -> True
       InSync -> nearThreshold
-  outputIfNeeded drift
-    | shouldOutput = output newSyncStatus drift
+  outputIfNeeded
+    | shouldOutput = output newSyncStatus
     | otherwise = noop
-  output synced drift =
+  output synced =
     cause . ClientEffect $ ServerOutput.SyncedStatusReport{chainSlot, chainTime, drift, synced}
 
 -- | Validate whether a current deposit in the local state actually exists

--- a/hydra-node/src/Hydra/Logging/Messages.hs
+++ b/hydra-node/src/Hydra/Logging/Messages.hs
@@ -25,6 +25,10 @@ data HydraLog tx
   | NodeOptions {runOptions :: RunOptions}
   | Persistence {persistenceLog :: PersistenceLog}
   | EnteringMainloop
+  | NodeHydrated
+  | ChainBackendStarted
+  | NetworkStarted
+  | StartingMainLoop
   deriving stock (Generic)
 
 deriving stock instance Eq (HydraNodeLog tx) => Eq (HydraLog tx)

--- a/hydra-node/src/Hydra/Logging/Messages.hs
+++ b/hydra-node/src/Hydra/Logging/Messages.hs
@@ -28,7 +28,6 @@ data HydraLog tx
   | NodeHydrated
   | ChainBackendStarted
   | NetworkStarted
-  | StartingMainLoop
   deriving stock (Generic)
 
 deriving stock instance Eq (HydraNodeLog tx) => Eq (HydraLog tx)

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -22,14 +22,8 @@ import Hydra.API.Server (Server, sendMessage)
 import Hydra.Cardano.Api (
   getVerificationKey,
  )
-import Hydra.Chain (
-  Chain (..),
-  ChainEvent (..),
-  ChainStateHistory,
-  PostTxError,
-  initHistory,
- )
-import Hydra.Chain.ChainState (ChainStateType, IsChainState)
+import Hydra.Chain (Chain (..), ChainEvent (..), ChainStateHistory (lastKnown), PostTxError, initHistory)
+import Hydra.Chain.ChainState (IsChainState (..))
 import Hydra.Events (EventId, EventSink (..), EventSource (..), getEventId, putEventsToSinks)
 import Hydra.Events.Rotation (EventStore (..))
 import Hydra.HeadLogic (
@@ -199,6 +193,7 @@ hydrate tracer env ledger initialChainState EventStore{eventSource, eventSink} e
               <$> ZipSink (foldMapC (Last . pure . getEventId))
               <*> ZipSink recoverNodeStateC
           )
+  traceWith tracer $ LoadedChainState{lastKnownChainPoint = lastKnown chainStateHistory}
   traceWith tracer $ LoadedState{lastEventId, nodeState}
   -- Check whether the loaded state matches our configuration (env)
   -- XXX: re-stream events just for this?
@@ -451,6 +446,7 @@ data HydraNodeLog tx
   | DroppedFromQueue {inputId :: Word64, input :: Input tx}
   | LoadingState
   | LoadedState {lastEventId :: Last EventId, nodeState :: NodeState tx}
+  | LoadedChainState {lastKnownChainPoint :: ChainPointType tx}
   | ReplayingState
   | Misconfiguration {misconfigurationErrors :: [ParamMismatch]}
   deriving stock (Generic)

--- a/hydra-node/src/Hydra/Node/Run.hs
+++ b/hydra-node/src/Hydra/Node/Run.hs
@@ -129,7 +129,7 @@ run opts = do
                 node <-
                   connect chain network server wetHydraNode
                     <&> addEventSink apiSink
-                traceWith tracer' StartingMainLoop
+                traceWith tracer' EnteringMainloop
                 runHydraNode node
  where
   addEventSink :: EventSink (StateEvent tx) m -> HydraNode tx m -> HydraNode tx m

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -347,7 +347,7 @@ setupNodeAndTUI' hostname lovelace action =
         -- Some ADA to commit
         seedFromFaucet_ backend externalVKey 42_000_000 (contramap FromFaucet tracer)
         let DirectBackend DirectOptions{nodeSocket, networkId} = backend
-        withHydraNode (contramap FromHydra tracer) chainConfig tmpDir nodeId aliceSk [] [nodeId] $ \HydraClient{hydraNodeId} -> do
+        withHydraNode (contramap FromHydra tracer) backend chainConfig tmpDir nodeId aliceSk [] [nodeId] $ \HydraClient{hydraNodeId} -> do
           seedFromFaucet_ backend aliceCardanoVk lovelace (contramap FromFaucet tracer)
 
           withTUITest (150, 10) $ \brickTest@TUITest{buildVty} -> do

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -333,7 +333,7 @@ setupNodeAndTUI' hostname lovelace action =
   showLogsOnFailure "TUISpec" $ \tracer ->
     withTempDir "tui-end-to-end" $ \tmpDir -> do
       (aliceCardanoVk, _) <- keysFor Alice
-      withCardanoNodeDevnet (contramap FromCardano tracer) tmpDir $ \_ backend -> do
+      withCardanoNodeDevnet (contramap FromCardano tracer) tmpDir $ \blockTime backend -> do
         hydraScriptsTxId <- publishHydraScriptsAs backend Faucet
         chainConfig <- chainConfigFor Alice tmpDir backend hydraScriptsTxId [] tuiContestationPeriod
         -- XXX(SN): API port id is inferred from nodeId, in this case 4001
@@ -347,7 +347,7 @@ setupNodeAndTUI' hostname lovelace action =
         -- Some ADA to commit
         seedFromFaucet_ backend externalVKey 42_000_000 (contramap FromFaucet tracer)
         let DirectBackend DirectOptions{nodeSocket, networkId} = backend
-        withHydraNode (contramap FromHydra tracer) backend chainConfig tmpDir nodeId aliceSk [] [nodeId] $ \HydraClient{hydraNodeId} -> do
+        withHydraNode (contramap FromHydra tracer) blockTime chainConfig tmpDir nodeId aliceSk [] [nodeId] $ \HydraClient{hydraNodeId} -> do
           seedFromFaucet_ backend aliceCardanoVk lovelace (contramap FromFaucet tracer)
 
           withTUITest (150, 10) $ \brickTest@TUITest{buildVty} -> do

--- a/visualize-logs/src/VisualizeLogs.hs
+++ b/visualize-logs/src/VisualizeLogs.hs
@@ -231,6 +231,7 @@ processLogs decoded =
         DroppedFromQueue{} -> pure DropLog
         LoadingState -> logIt (Other "Loading state...") ()
         LoadedState{} -> logIt (Other "Loaded.") ()
+        LoadedChainState{} -> logIt (Other "LoadedChainState ...") ()
         ReplayingState -> logIt (Other "Replaying state...") ()
         details@Misconfiguration{} -> logIt (Other "MISCONFIG!") details
     _ -> pure DropLog


### PR DESCRIPTION
<!-- Describe your change here -->

Closes https://github.com/cardano-scaling/hydra/issues/2483

🔑 Motivation

Improve node observability by introducing structured lifecycle and sync-status logs.
These logs make startup, hydration, and sync transitions explicit, and provide better insight into drift before going out of sync.

Overall, this PR makes node startup phases and sync health easier to trace and reason about, while reducing noise when fully in sync.

> This PR also fixes the smoke tests by allowing enough time (depending on the actual chain backend used during tests) to observe the node becoming `InSync` before starting the scenario.

🔄 Changes

**New Logs Introduced**

* `LoadedChainState`
  Emitted during hydration with the last known chain point loaded into `chainStateHistory`.

* `NodeHydrated`
  Emitted once node hydration completes.

* `StartingDecision`
  Emitted by the chain layer to report the first chain point used as prefix when selecting an intersection during chain-sync.

* `ChainBackendStarted`
  Emitted after successfully establishing the chain layer connection.

* `NetworkStarted`
  Emitted after successfully establishing the network layer connection.

* `EnteringMainloop`
  Emitted right before starting the `runHydraNode` main loop.

* `SyncedStatusReport`
  Emitted:
  * On every tick while `CatchingUp`
  * On every tick when drift exceeds 80% of the unsynced policy while `InSync`

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
