### PR TITLE
Small refactor of drift

### DIFF
--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -1522,7 +1522,7 @@ components:
             - $ref: "api.yaml#/components/messages/Fanout/payload"
             - $ref: "api.yaml#/components/messages/SideLoadSnapshot/payload"
         drift:
-          $ref: "api.yaml#/components/schemas/Natural"
+          $ref: "api.yaml#/components/schemas/NominalDiffTime"
 
     SideLoadSnapshotRejected:
       type: object
@@ -2061,7 +2061,7 @@ components:
           description: |
             Difference between the current system wall-clock time and the chain time
             of the latest observed chain point (now − chainTime).
-          $ref: "api.yaml#/components/schemas/Natural"
+          $ref: "api.yaml#/components/schemas/NominalDiffTime"
         seq:
           $ref: "api.yaml#/components/schemas/SequenceNumber"
         timestamp:
@@ -2099,7 +2099,7 @@ components:
           description: |
             Difference between the current system wall-clock time and the chain time
             of the latest observed chain point (now − chainTime).
-          $ref: "api.yaml#/components/schemas/Natural"
+          $ref: "api.yaml#/components/schemas/NominalDiffTime"
         seq:
           $ref: "api.yaml#/components/schemas/SequenceNumber"
         timestamp:
@@ -3275,11 +3275,12 @@ components:
       description: |
         A length of time, measured in whole seconds, to be used in deposit validity.
       example: 60
-    
-    Natural:
-      # XXX: UInt64 in cardanonical, but Natural in cardano-api
-      type: integer
-      minimum: 0
+
+    NominalDiffTime:
+      type: number
+      description: |
+        A unit of time, measured in seconds.
+      example: 5
 
     UnsyncedPeriod:
       type: number
@@ -3777,7 +3778,7 @@ components:
         currentChainTime:
           $ref: "api.yaml#/components/schemas/UTCTime"
         drift:
-          $ref: "api.yaml#/components/schemas/Natural"
+          $ref: "api.yaml#/components/schemas/NominalDiffTime"
 
     NodeState:
       oneOf:

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -67,7 +67,7 @@ instance (FromJSON (TxIdType tx), FromJSON (UTxOType tx)) => FromJSON (DecommitI
 data ClientMessage tx
   = CommandFailed {clientInput :: ClientInput tx, state :: HeadState tx}
   | PostTxOnChainFailed {postChainTx :: PostChainTx tx, postTxError :: PostTxError tx}
-  | RejectedInputBecauseUnsynced {clientInput :: ClientInput tx, drift :: Natural}
+  | RejectedInputBecauseUnsynced {clientInput :: ClientInput tx, drift :: NominalDiffTime}
   | SideLoadSnapshotRejected {clientInput :: ClientInput tx, requirementFailure :: SideLoadRequirementFailure tx}
   deriving (Eq, Show, Generic)
 
@@ -204,8 +204,8 @@ data ServerOutput tx
     -- Any signing round has been discarded, and the snapshot leader has changed accordingly.
     SnapshotSideLoaded {headId :: HeadId, snapshotNumber :: SnapshotNumber}
   | EventLogRotated {checkpoint :: NodeState tx}
-  | NodeUnsynced {chainSlot :: ChainSlot, chainTime :: UTCTime, drift :: Natural}
-  | NodeSynced {chainSlot :: ChainSlot, chainTime :: UTCTime, drift :: Natural}
+  | NodeUnsynced {chainSlot :: ChainSlot, chainTime :: UTCTime, drift :: NominalDiffTime}
+  | NodeSynced {chainSlot :: ChainSlot, chainTime :: UTCTime, drift :: NominalDiffTime}
   deriving stock (Generic)
 
 deriving stock instance IsChainState tx => Eq (ServerOutput tx)

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -26,7 +26,6 @@ import Data.List (elemIndex, minimumBy)
 import Data.Map.Strict qualified as Map
 import Data.Set ((\\))
 import Data.Set qualified as Set
-import Data.Time.Clock (nominalDiffTimeToSeconds)
 import Hydra.API.ClientInput (ClientInput (..))
 import Hydra.API.ServerOutput (DecommitInvalidReason (..))
 import Hydra.API.ServerOutput qualified as ServerOutput
@@ -1395,17 +1394,6 @@ handleOutOfSync ::
   SyncedStatus ->
   Outcome tx
 handleOutOfSync Environment{unsyncedPeriod} now chainPoint chainTime syncStatus
-  -- We throw an error on situations where the system clock is _behind_
-  -- the chain time.
-  | delta < 0 =
-      Error . AssertionFailed $
-        "handleOutOfSync: delta < 0. delta = "
-          <> show delta
-          <> ", now = "
-          <> show now
-          <> ", chainTime = "
-          <> show chainTime
-          <> "."
   -- We consider the node out of sync when:
   -- the last observed chainTime plus the delta allowed by the unsyncedPeriod
   -- falls behind the current system time.
@@ -1420,8 +1408,7 @@ handleOutOfSync Environment{unsyncedPeriod} now chainPoint chainTime syncStatus
  where
   plus = flip addUTCTime
   chainSlot = chainPointSlot chainPoint
-  delta = now `diffUTCTime` chainTime
-  drift = floor $ nominalDiffTimeToSeconds delta
+  drift = now `diffUTCTime` chainTime
 
 -- | Validate whether a current deposit in the local state actually exists
 --   in the map of pending deposits.

--- a/hydra-node/src/Hydra/HeadLogic/Outcome.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Outcome.hs
@@ -142,8 +142,8 @@ data StateChanged tx
   | TxInvalid {headId :: HeadId, utxo :: UTxOType tx, transaction :: tx, validationError :: ValidationError}
   | LocalStateCleared {headId :: HeadId, snapshotNumber :: SnapshotNumber}
   | Checkpoint {state :: NodeState tx}
-  | NodeUnsynced {chainSlot :: ChainSlot, chainTime :: UTCTime, drift :: Natural}
-  | NodeSynced {chainSlot :: ChainSlot, chainTime :: UTCTime, drift :: Natural}
+  | NodeUnsynced {chainSlot :: ChainSlot, chainTime :: UTCTime, drift :: NominalDiffTime}
+  | NodeSynced {chainSlot :: ChainSlot, chainTime :: UTCTime, drift :: NominalDiffTime}
   deriving stock (Generic)
 
 deriving stock instance (IsChainState tx, IsTx tx, Eq (NodeState tx), Eq (ChainStateType tx)) => Eq (StateChanged tx)

--- a/hydra-node/src/Hydra/Node/State.hs
+++ b/hydra-node/src/Hydra/Node/State.hs
@@ -20,7 +20,7 @@ data ChainPointTime = ChainPointTime
   -- ^ Latest chain slot as observed on chain.
   , currentChainTime :: UTCTime
   -- ^ Time corresponding to `currentSlot`.
-  , drift :: Natural
+  , drift :: NominalDiffTime
   -- ^ Time difference with current system wall-clock measured in seconds
   }
   deriving stock (Eq, Show, Generic)


### PR DESCRIPTION
So that it's more clear that we want an error when it's less than zero.

-- Edit:

In the end we think it's best to drop the `Natural` representation entirely; as it seems like it may be fine to have negative "drift".

Todo:

- [x] Remove the `Natural` rep entirely
- [x] Go back to merely `NominalDiffTime`