### PR TITLE
Improve error reporting on missing script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ changes.
 
 - Hydra node now correctly handles deposits and decommits on chain rollbacks and handles its local state correctly in terms of keeping track of pending deposits. [#2491](https://github.com/cardano-scaling/hydra/pull/2491)
 
+- Improved error reporting for transactions with missing script witnesses. Users now receive a clear error message indicating which script is missing from the transaction witnesses. [#2506](https://github.com/cardano-scaling/hydra/pull/2506)
+
 - **BREAKING** A Hydra node will now start rejecting both network and client inputs once its view of the chain has been out of sync for more than 50% of the configured `--contestation-period`, based on **system wall-clock time**.
   - Added `NodeUnsynced` and `NodeSynced` state events and server outputs.
   - Added `RejectedInputBecauseUnsynced` client message.

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -259,6 +259,15 @@ finalizeTx TinyWallet{sign, coverFee} ctx utxo userUTxO partialTx = do
             } ::
             PostTxError Tx
         )
+    Left ErrMissingScript{scriptHash, purpose} ->
+      throwIO
+        ( ScriptFailedInWallet
+            { redeemerPtr = purpose
+            , failureReason = "Missing script witness for " <> scriptHash
+            , failingTx = partialTx
+            } ::
+            PostTxError Tx
+        )
     Left e ->
       throwIO
         ( InternalWalletError

--- a/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Wallet.hs
@@ -445,7 +445,7 @@ estimateScriptsCost pparams systemStart epochInfo utxo tx = do
     Left failure ->
       case failure of
         -- Missing script witness - provide helpful error message
-        MissingScript rdmrPtr scriptHash ->
+        MissingScript _ scriptHash ->
           Left $
             ErrMissingScript
               { scriptHash = Text.pack $ show scriptHash

--- a/hydra-node/test/Hydra/Chain/Direct/WalletSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/WalletSpec.hs
@@ -8,7 +8,7 @@ import Test.Hydra.Prelude
 
 import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
-import Cardano.Ledger.Alonzo.TxWits (Redeemers (..), unRedeemers)
+import Cardano.Ledger.Alonzo.TxWits (Redeemers (..))
 import Cardano.Ledger.Api (AlonzoEraTxWits (rdmrsTxWitsL), ConwayEra, EraTx (getMinFeeTx, witsTxL), EraTxBody (feeTxBodyL, inputsTxBodyL), PParams, bodyTxL, coinTxOutL, outputsTxBodyL, pattern SpendingPurpose)
 import Cardano.Ledger.Babbage.Tx (AlonzoTx (..))
 import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..))
@@ -76,7 +76,6 @@ import Test.QuickCheck (
   suchThat,
   vectorOf,
   (.&&.),
-  (==>),
  )
 import Prelude qualified
 

--- a/hydra-node/test/Hydra/Chain/Direct/WalletSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/WalletSpec.hs
@@ -7,7 +7,9 @@ import Hydra.Prelude
 import Test.Hydra.Prelude
 
 import Cardano.Api.UTxO qualified as UTxO
-import Cardano.Ledger.Api (AlonzoEraTxWits (rdmrsTxWitsL), ConwayEra, EraTx (getMinFeeTx, witsTxL), EraTxBody (feeTxBodyL, inputsTxBodyL), PParams, bodyTxL, coinTxOutL, outputsTxBodyL)
+import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
+import Cardano.Ledger.Alonzo.TxWits (Redeemers (..), unRedeemers)
+import Cardano.Ledger.Api (AlonzoEraTxWits (rdmrsTxWitsL), ConwayEra, EraTx (getMinFeeTx, witsTxL), EraTxBody (feeTxBodyL, inputsTxBodyL), PParams, bodyTxL, coinTxOutL, outputsTxBodyL, pattern SpendingPurpose)
 import Cardano.Ledger.Babbage.Tx (AlonzoTx (..))
 import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..))
 import Cardano.Ledger.BaseTypes qualified as Ledger
@@ -15,6 +17,7 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.TxBody (ConwayTxBody (..))
 import Cardano.Ledger.Core (Tx, Value)
 import Cardano.Ledger.Hashes (hashAnnotated)
+import Cardano.Ledger.Plutus (Data, ExUnits (..))
 import Cardano.Ledger.Shelley.API qualified as Ledger
 import Cardano.Ledger.Slot (EpochInfo)
 import Cardano.Ledger.Val (Val (..), invert)
@@ -44,6 +47,7 @@ import Hydra.Chain.CardanoClient (QueryPoint (..))
 import Hydra.Chain.Direct.Wallet (
   Address,
   ChainQuery,
+  ErrCoverFee (..),
   TinyWallet (..),
   TxIn,
   TxOut,
@@ -72,6 +76,7 @@ import Test.QuickCheck (
   suchThat,
   vectorOf,
   (.&&.),
+  (==>),
  )
 import Prelude qualified
 
@@ -88,6 +93,7 @@ spec = parallel $ do
     prop "sets min utxo values" prop_setsMinUTxOValue
     prop "balances transaction with fees" prop_balanceTransaction
     prop "prefers largest utxo" prop_picksLargestUTxOToPayTheFees
+    prop "reports ErrMissingScript when script witness is missing" prop_detectsMissingScript
 
   describe "newTinyWallet" $ do
     prop "initialises wallet by querying UTxO" $
@@ -410,3 +416,51 @@ knownInputBalance utxo = foldMap resolve . toList . view (bodyTxL . inputsTxBody
 outputBalance :: Tx LedgerEra -> Value LedgerEra
 outputBalance =
   foldMap getValue . view (bodyTxL . outputsTxBodyL)
+
+-- | Test that coverFee detects missing script witnesses.
+-- Generates transactions that spend from script-locked UTxOs but omit the script witness.
+prop_detectsMissingScript :: Property
+prop_detectsMissingScript =
+  forAllBlind genScriptSpendingTx $ \(tx, scriptUTxO) ->
+    forAllBlind (reasonablySized genUTxO) $ \walletUTxO ->
+      forAll arbitrary $ \(arbitraryData :: Data LedgerEra) -> do
+        let
+          -- Add a redeemer for the script input but DON'T add the script witness.
+          -- This creates the missing script scenario: redeemer present but script absent.
+          -- NB: ExUnits are irrelevant since script execution will fail due to missing script.
+          redeemers = Redeemers $ Map.singleton (SpendingPurpose (AsIx 0)) (arbitraryData, ExUnits 0 0)
+          txWithRedeemer = tx & witsTxL . rdmrsTxWitsL .~ redeemers
+
+        case coverFee_ Fixture.pparams Fixture.systemStart Fixture.epochInfo scriptUTxO walletUTxO txWithRedeemer of
+          Left (ErrMissingScript scriptHash purpose) ->
+            property True
+              & counterexample "✓ Correctly detected missing script"
+              & counterexample ("  Script hash: " <> toString scriptHash)
+              & counterexample ("  Purpose: " <> toString purpose)
+          Left otherError ->
+            property False
+              & counterexample ("Expected ErrMissingScript but got: " <> show otherError)
+          Right _balancedTx ->
+            property False
+              & counterexample "Expected ErrMissingScript but transaction succeeded"
+ where
+  -- Generate a transaction that spends from a script-locked UTxO
+  genScriptSpendingTx :: Gen (Tx LedgerEra, Map TxIn TxOut)
+  genScriptSpendingTx = do
+    -- Generate a dummy script hash
+    scriptHash <- arbitrary
+
+    -- Create a script-locked output
+    baseOutput <- arbitrary
+    let scriptAddress = Ledger.Addr Ledger.Testnet (Ledger.ScriptHashObj scriptHash) Ledger.StakeRefNull
+        scriptTxOut = baseOutput & (\(BabbageTxOut _ val dat ref) -> BabbageTxOut scriptAddress val dat ref)
+
+    -- Create an input spending from this script output
+    scriptTxIn <- toLedgerTxIn <$> genTxIn
+
+    -- Generate a transaction with this input
+    baseTx <- genLedgerTx
+    let txSpendingScript = baseTx & bodyTxL . inputsTxBodyL .~ Set.singleton scriptTxIn
+        lookupUTxO = Map.singleton scriptTxIn scriptTxOut
+
+    pure (txSpendingScript, lookupUTxO)


### PR DESCRIPTION
fix #2507 

We had a user report where the user is confused about the deposit that was not coming through and the reason was missing script utxo in the API request for deposit. This PR introduces a check in the internal wallet that should provide more info for the users in this specific case of missing script.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
