### PR TITLE
AckSn loop after de/commit is finalized on leader node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ changes.
 - `POST /snapshot` now returns the specific side-load validation failure instead of timing out [#2462](https://github.com/cardano-scaling/hydra/issues/2462).
 - Fixed the internal wallet fee estimation, which was more often than not using maximum plutus execution units. This reduces costs for initializing, open, etc. of a head by a factor of ~4x [#2473](https://github.com/cardano-scaling/hydra/pull/2473).
 - Fixed another race-condition around incremental commits/decommits [#2500](https://github.com/cardano-scaling/hydra/issues/2500)
+- Fixed infinite AckSn requeue loop after decommit when DecommitFinalized arrives before snapshot confirmation on the leader node [#2510](https://github.com/cardano-scaling/hydra/pull/2510)
 - **BREAKING** Improved reporting of chain synchronization status by exposing the node's chain time and drift.
   - `NodeSynced` and `NodeUnsynced` state-changed events, and their corresponding server outputs, now include the observed chain time and drift.
   - `NodeState` now tracks the latest observed chan slot in addition to the chain time (`UTCTime`) and its drift measured in seconds.

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -475,7 +475,6 @@ spec =
             Continue{} -> True
             Error{} -> True
             Wait{} -> False -- Must NOT Wait (infinite AckSn requeue)
-
         it "DecommitFinalized with SeenSnapshot state extracts correct snapshot number" $ do
           let localUTxO = utxoRefs [1]
               decommitTx = SimpleTx 10 mempty (utxoRef 99)

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -379,10 +379,13 @@ spec =
           let s1 = aggregateState s0 decommitFinalizedOutcome
 
           -- Verify seenSnapshot was reset (not stuck as RequestedSnapshot)
+          -- After DecommitFinalized, lastSeen should be the snapshot number that
+          -- included the decommit (snapshot 1), not the previously confirmed snapshot (0).
+          -- This prevents incoming AckSn messages for snapshot 1 from being requeued infinitely.
           case s1 of
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
               chs.version `shouldBe` 4
-              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 0}
+              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 1}
               chs.decommitTx `shouldBe` Nothing
             _ -> fail "expected Open state"
 
@@ -403,11 +406,108 @@ spec =
             getState
 
           -- Verify the head is not stuck: seenSnapshot should have advanced
+          -- (snapshot number will be based on confirmedSnapshot.number, not lastSeen)
           case s2 of
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} ->
               chs.seenSnapshot `shouldSatisfy` \case
                 RequestedSnapshot{} -> True
                 _ -> False
+            _ -> fail "expected Open state"
+
+        it "DecommitFinalized with RequestedSnapshot uses requested number not lastSeen" $ do
+          let localUTxO = utxoRefs [1]
+              confirmedSn =
+                ConfirmedSnapshot
+                  { snapshot = testSnapshot 0 3 [] localUTxO
+                  , signatures = Crypto.aggregate []
+                  }
+              -- State: leader sent ReqSn(v=3, sn=1) with lastSeen=0
+              s0 =
+                inOpenState' threeParties $
+                  coordinatedHeadState
+                    { localUTxO
+                    , version = 3
+                    , confirmedSnapshot = confirmedSn
+                    , seenSnapshot = RequestedSnapshot{lastSeen = 0, requested = 1}
+                    , decommitTx = Just (SimpleTx 10 mempty (utxoRef 99))
+                    }
+
+          -- DecommitFinalized arrives before AckSn messages
+          let decrementObservation = observeTx $ OnDecrementTx{headId = testHeadId, newVersion = 4, distributedUTxO = mempty}
+          now <- nowFromSlot s0.chainPointTime.currentSlot
+          let decommitFinalizedOutcome = update aliceEnv ledger now s0 decrementObservation
+          let s1 = aggregateState s0 decommitFinalizedOutcome
+
+          -- Verify seenSnapshot uses requested (1), not lastSeen (0)
+          case s1 of
+            NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
+              chs.version `shouldBe` 4
+              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 1}
+              chs.decommitTx `shouldBe` Nothing
+            _ -> fail "expected Open state"
+
+        it "AckSn for decommit snapshot is noop after DecommitFinalized" $ do
+          let localUTxO = utxoRefs [1]
+              snapshot1 = testSnapshot 0 4 [] localUTxO & \s -> s{number = 1}
+              confirmedSn =
+                ConfirmedSnapshot
+                  { snapshot = testSnapshot 0 3 [] localUTxO
+                  , signatures = Crypto.aggregate []
+                  }
+              -- State after DecommitFinalized: lastSeen=1
+              s0 =
+                inOpenState' threeParties $
+                  coordinatedHeadState
+                    { localUTxO
+                    , version = 4
+                    , confirmedSnapshot = confirmedSn
+                    , seenSnapshot = LastSeenSnapshot{lastSeen = 1}
+                    , decommitTx = Nothing
+                    }
+
+          -- AckSn for snapshot 1 arrives late
+          let ackSn = AckSn (sign aliceSk snapshot1) 1
+              input = receiveMessageFrom alice ackSn
+          now <- nowFromSlot s0.chainPointTime.currentSlot
+
+          -- Should be noop (or error), not Wait
+          update aliceEnv ledger now s0 input `shouldSatisfy` \case
+            Continue{} -> True
+            Error{} -> True
+            Wait{} -> False -- Must NOT Wait (infinite AckSn requeue)
+
+        it "DecommitFinalized with SeenSnapshot state extracts correct snapshot number" $ do
+          let localUTxO = utxoRefs [1]
+              decommitTx = SimpleTx 10 mempty (utxoRef 99)
+              snapshot1 = testSnapshot 0 3 [] localUTxO & \s -> s{number = 1}
+              confirmedSn =
+                ConfirmedSnapshot
+                  { snapshot = testSnapshot 0 3 [] localUTxO
+                  , signatures = Crypto.aggregate []
+                  }
+              -- State: follower has seen ReqSn and is collecting signatures
+              s0 =
+                inOpenState' threeParties $
+                  coordinatedHeadState
+                    { localUTxO
+                    , version = 3
+                    , confirmedSnapshot = confirmedSn
+                    , seenSnapshot = SeenSnapshot{snapshot = snapshot1, signatories = mempty}
+                    , decommitTx = Just decommitTx
+                    }
+
+          -- DecommitFinalized arrives while collecting signatures
+          let decrementObservation = observeTx $ OnDecrementTx{headId = testHeadId, newVersion = 4, distributedUTxO = mempty}
+          now <- nowFromSlot s0.chainPointTime.currentSlot
+          let decommitFinalizedOutcome = update bobEnv ledger now s0 decrementObservation
+          let s1 = aggregateState s0 decommitFinalizedOutcome
+
+          -- Verify DecommitFinalized correctly extracted snapshot number from SeenSnapshot
+          case s1 of
+            NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
+              chs.version `shouldBe` 4
+              chs.decommitTx `shouldBe` Nothing
+              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 1}
             _ -> fail "expected Open state"
 
       describe "Tracks Transaction Ids" $ do


### PR DESCRIPTION
  ## Fix: Prevent Infinite AckSn Loop After De/commit
                                                 
  ### Problem
                                                            
  After an incremental decommit, snapshot confirmation could get stuck in an infinite loop where `AckSn` messages were requeued repeatedly, preventing the snapshot from ever reaching `SnapshotConfirmed` state and blocking all subsequent snapshots.
                                                          
  **Root Cause:** Race condition on the leader node when `DecommitFinalized` arrives before `AckSn` messages:
                                                                                                                                                                                                                                                                                                                                                 
  1. Leader requests snapshot N with decommit → state becomes `RequestedSnapshot{lastSeen=N-1, requested=N}`
  2. `DecrementTx` is observed on-chain before `AckSn` messages arrive
  3. `DecommitFinalized` aggregate incorrectly used `seenSnapshotNumber()` which returned `lastSeen` (N-1) instead of `requested` (N)
  4. When `AckSn(N)` messages arrived, they failed the guard check `N <= N-1` and were requeued infinitely

Same scenarion goes also for incremental commits.

  ### Solution

  Modified the `De/commitFinalized` aggregate in `HeadLogic.hs` to use explicit pattern matching instead of `seenSnapshotNumber()`:

  - `NoSeenSnapshot` → `LastSeenSnapshot{lastSeen = 0}`
  - `LastSeenSnapshot{lastSeen}` → `LastSeenSnapshot{lastSeen}` (unchanged)
  - `RequestedSnapshot{requested}` → `LastSeenSnapshot{lastSeen = requested}` ✅ **The fix**
  - `SeenSnapshot{snapshot}` → `LastSeenSnapshot{lastSeen = number}`

  The key insight: when the leader is in `RequestedSnapshot` state and `DecommitFinalized` arrives, the decommit belongs to the **requested** snapshot (N), not the previously confirmed snapshot (N-1).


---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
