### PR TITLE
Use cabal-version: 3.0 everywhere.

### DIFF
--- a/hydra-prelude/hydra-prelude.cabal
+++ b/hydra-prelude/hydra-prelude.cabal
@@ -1,4 +1,4 @@
-cabal-version: 2.2
+cabal-version: 3.0
 name:          hydra-prelude
 version:       1.2.0
 synopsis:      Custom Hydra Prelude used across other Hydra packages.

--- a/hydra-tui/hydra-tui.cabal
+++ b/hydra-tui/hydra-tui.cabal
@@ -1,4 +1,4 @@
-cabal-version: 2.2
+cabal-version: 3.0
 name:          hydra-tui
 version:       1.2.0
 synopsis:      TUI for managing a Hydra node

--- a/hydraw/hydraw.cabal
+++ b/hydraw/hydraw.cabal
@@ -1,4 +1,4 @@
-cabal-version: 2.2
+cabal-version: 3.0
 name:          hydraw
 version:       0.0.1
 build-type:    Simple


### PR DESCRIPTION
This is to allow sublibrary syntax.