### PR TITLE
Fixes for de/commits in presence of L2 tx spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ changes.
 - Fixed the internal wallet fee estimation, which was more often than not using maximum plutus execution units. This reduces costs for initializing, open, etc. of a head by a factor of ~4x [#2473](https://github.com/cardano-scaling/hydra/pull/2473).
 - Fixed another race-condition around incremental commits/decommits [#2500](https://github.com/cardano-scaling/hydra/issues/2500)
 - Fixed infinite AckSn requeue loop after decommit when DecommitFinalized arrives before snapshot confirmation on the leader node [#2510](https://github.com/cardano-scaling/hydra/pull/2510)
+- Fix snapshots getting stuck under high L2 load by preventing duplicate snapshot requests and duplicate deposit/decommit inclusion across consecutive snapshots [#2519](https://github.com/cardano-scaling/hydra/pull/2519)
 - **BREAKING** Improved reporting of chain synchronization status by exposing the node's chain time and drift.
   - `NodeSynced` and `NodeUnsynced` state-changed events, and their corresponding server outputs, now include the observed chain time and drift.
   - `NodeState` now tracks the latest observed chan slot in addition to the chain time (`UTCTime`) and its drift measured in seconds.

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/ChainPoint.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/ChainPoint.hs
@@ -4,9 +4,25 @@ module Hydra.Cardano.Api.ChainPoint where
 
 import Hydra.Cardano.Api.Prelude
 
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import Data.Aeson (eitherDecodeStrict', encode)
+import Data.ByteString.Lazy qualified as BSL
+
 -- | Get the chain point corresponding to a given 'BlockHeader'.
 getChainPoint :: BlockHeader -> ChainPoint
 getChainPoint header =
   ChainPoint slotNo headerHash
  where
   (BlockHeader slotNo headerHash _) = header
+
+-- Orphan instances for serialization
+-- We serialize ChainPoint via JSON encoding since it already has ToJSON/FromJSON instances
+instance ToCBOR ChainPoint where
+  toCBOR = toCBOR . BSL.toStrict . encode
+
+instance FromCBOR ChainPoint where
+  fromCBOR =
+    fromCBOR >>= \bytes ->
+      case eitherDecodeStrict' bytes of
+        Left err -> fail $ "Failed to deserialize ChainPoint: " <> err
+        Right chainPoint -> pure chainPoint

--- a/hydra-node/golden/Message/AckSn.json
+++ b/hydra-node/golden/Message/AckSn.json
@@ -1,8 +1,10 @@
 {
     "samples": [
         {
+            "pendingDecommitVersion": null,
+            "pendingDepositVersion": null,
             "signed": "4d44ff7a183c026dc686323c60900ae176eb0e97b74bb4445fa19c067df79a264b77d6b66b4e1297d7efc5d6ae870d6e22b55e783d3d2e6449fad5be2db7c404",
-            "snapshotNumber": 7,
+            "snapshotNumber": 27,
             "tag": "AckSn"
         }
     ],

--- a/hydra-node/golden/ReasonablySized (HeadState (Tx ConwayEra)).json
+++ b/hydra-node/golden/ReasonablySized (HeadState (Tx ConwayEra)).json
@@ -4,9 +4,7 @@
             "contents": {
                 "chainState": {
                     "recordedAt": {
-                        "blockHash": "0001040400050303020704060708070401010605000008070506070707050106",
-                        "slot": 6,
-                        "tag": "ChainPoint"
+                        "tag": "ChainPointAtGenesis"
                     },
                     "spendableUTxO": {
                         "0002010707050703030305000500080203030202000805070705010307010604#75": {
@@ -407,8 +405,8 @@
             "contents": {
                 "chainState": {
                     "recordedAt": {
-                        "blockHash": "0804000304030802080808050700030401060806000201010203060703040403",
-                        "slot": 8,
+                        "blockHash": "0507020301050200000405020500040501050003080203040207010305000202",
+                        "slot": 6,
                         "tag": "ChainPoint"
                     },
                     "spendableUTxO": {
@@ -1094,6 +1092,8 @@
                         }
                     ]
                 },
+                "pendingDecommitVersion": null,
+                "pendingDepositVersion": null,
                 "readyToFanoutSent": false,
                 "version": 0
             },
@@ -1103,58 +1103,91 @@
             "contents": {
                 "chainState": {
                     "recordedAt": {
-                        "tag": "ChainPointAtGenesis"
+                        "blockHash": "0401070705050008040800020401080704070306070101040506040406050003",
+                        "slot": 6,
+                        "tag": "ChainPoint"
                     },
                     "spendableUTxO": {
-                        "0005080302040204070808070401070407010201070704080006050506080700#69": {
-                            "address": "addr_test1xrrnepkcxeuk03t8pxeseckdc5ycx8j2vhl9kccqk4rv483lssqeap6gyhy7crj93n298x5wfgca070jetlk7jwe5dzsf5nz6g",
+                        "0103080601070005060301010605050706010604080404080501060806000703#71": {
+                            "address": "addr_test1wqn3ru75dlezu3uau5hwnc7mm2zq7u8x4xh8p84fx20aysgh0eews",
                             "datum": null,
-                            "datumhash": "af236ec3a6e58b537b63799d6ac94c9a7dda8f367ded4e6bd5f84576e80544ad",
+                            "datumhash": null,
                             "inlineDatum": null,
                             "inlineDatumRaw": null,
                             "referenceScript": null,
                             "value": {
+                                "e3ff60196f727f055712b70afeb8a80e92902a9e19961f73f4a7508f": {
+                                    "8d5fbaeec6b4d1887c9b2ffd293a93c6a20dd13109d7": 7632161555909430033
+                                },
                                 "lovelace": 7500000000000000
                             }
                         },
-                        "0201060505030400040605010005050702050403080404070808000503050103#58": {
-                            "address": "addr_test1vzf3nvrrj87ttjnqxxwh6y6tk6unmuvpt5avu9pkzahzxmgv35pvq",
+                        "0208040008070707020106060303060500040703070201040802030702060807#96": {
+                            "address": "addr_test1qzmve6447tpqa3zmje8v9lln2gss9aaprpsvzcssqu6ytr3mw439vswmz7en87dlfh9sgmruwwz0n3akptv6rkc4xhls5usux4",
+                            "datum": null,
+                            "datumhash": "b1bd647dfdf0486d2f40c7e9d47d1596cc882234dc9b24d6ae1b461c414b8197",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "2d725128406dc832eb74c4709aca0512499b3c7b17e00d7cb2e6d1b1": {
+                                    "33": 2
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0401050700010801060202080102040307020403050108020307050707040304#51": {
+                            "address": "addr_test1yqw420zp088kguvek8cn026mfpsa7vemqru40wrh4u7ntf8edwzxx8dgkpekse74375fauqnr660fvk0fn0mdm40nc5s3m8p8r",
                             "datum": null,
                             "inlineDatum": {
-                                "int": 0
+                                "list": [
+                                    {
+                                        "int": 2
+                                    }
+                                ]
                             },
-                            "inlineDatumRaw": "00",
-                            "inlineDatumhash": "03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314",
+                            "inlineDatumRaw": "9f02ff",
+                            "inlineDatumhash": "72e7cd92d18af576248b5fbe02fd68a7659aa334a0e1fa37c798e5cacce82daa",
                             "referenceScript": null,
                             "value": {
-                                "lovelace": 887860
+                                "lovelace": 1017160
                             }
                         },
-                        "0303080208000402000001070708020407040007010204050802040401040206#81": {
-                            "address": "addr_test1qzzztwrg3ukmn2tzh5zg5wg9sfherdwy5u9256rs4dv4l24hwl26zlpfccrfj2m46nqgyymh43jqh066r2mf3dn4qs0q64t7q6",
+                        "0507010105000304010506020703040808030506030308070103020302020507#92": {
+                            "address": "addr_test1ypkh2z74gxcr36vpl3fca45c9wupcttmhagzc800y2c9lz3tzhphelslmj23npayku5y06a20lny7gkmlr54dmf8p7pquvyv2d",
                             "datum": null,
-                            "datumhash": "ba43fd1802d17d2002aea37675ca0dbb96fffaf7b3bd621a28aeb363c92594e9",
+                            "datumhash": "e81921dab33ab574e948c7aa471eb2eed0cba7249d660f1dc5ccd6edcdd1c93d",
                             "inlineDatum": null,
                             "inlineDatumRaw": null,
                             "referenceScript": null,
                             "value": {
-                                "lovelace": 7500000000000000
+                                "dcfd15cb603f8fc37eeba9f85b96660e99f4c0f3d5df1352bb03e8ab": {
+                                    "8090aaeaee64c817": 6421558423574801086
+                                },
+                                "lovelace": 1336100
                             }
                         },
-                        "0308020801020503030805070801010203030406040100020705080505060603#47": {
-                            "address": "addr_test1yr4alqeyst9rrdslgv79k29rym4r400kqu905du8j5mxsslxpa3dr6msu7ama0vtqvdg3rt5z57qqxd8s296jjtf50aq0lr723",
+                        "0705060203020605060408020105070705040608050302000305010602030200#12": {
+                            "address": "addr_test1vq0zufvqjpezthhmdveztykymaf4tmunup5re79q0lm73yg76keh5",
                             "datum": null,
                             "inlineDatum": {
                                 "map": [
                                     {
                                         "k": {
-                                            "constructor": 5,
-                                            "fields": [
+                                            "list": [
                                                 {
                                                     "map": [
                                                         {
                                                             "k": {
-                                                                "bytes": "36ea"
+                                                                "int": 0
+                                                            },
+                                                            "v": {
+                                                                "bytes": "750c5425"
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "int": 5
                                                             },
                                                             "v": {
                                                                 "int": -2
@@ -1162,35 +1195,22 @@
                                                         },
                                                         {
                                                             "k": {
-                                                                "int": 4
+                                                                "bytes": "4a"
                                                             },
                                                             "v": {
-                                                                "bytes": "066b57ad"
+                                                                "int": 5
                                                             }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "constructor": 2,
+                                                    "fields": [
+                                                        {
+                                                            "int": 1
                                                         },
                                                         {
-                                                            "k": {
-                                                                "bytes": "856df6ef"
-                                                            },
-                                                            "v": {
-                                                                "bytes": ""
-                                                            }
-                                                        },
-                                                        {
-                                                            "k": {
-                                                                "bytes": ""
-                                                            },
-                                                            "v": {
-                                                                "int": 1
-                                                            }
-                                                        },
-                                                        {
-                                                            "k": {
-                                                                "int": -5
-                                                            },
-                                                            "v": {
-                                                                "int": -1
-                                                            }
+                                                            "bytes": "9dc55675"
                                                         }
                                                     ]
                                                 },
@@ -1200,40 +1220,91 @@
                                             ]
                                         },
                                         "v": {
+                                            "int": -2
+                                        }
+                                    },
+                                    {
+                                        "k": {
+                                            "constructor": 5,
+                                            "fields": [
+                                                {
+                                                    "map": [
+                                                        {
+                                                            "k": {
+                                                                "int": -1
+                                                            },
+                                                            "v": {
+                                                                "int": 5
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "int": -4
+                                                            },
+                                                            "v": {
+                                                                "int": 1
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "int": 3
+                                                },
+                                                {
+                                                    "constructor": 5,
+                                                    "fields": []
+                                                }
+                                            ]
+                                        },
+                                        "v": {
+                                            "bytes": ""
+                                        }
+                                    },
+                                    {
+                                        "k": {
+                                            "map": []
+                                        },
+                                        "v": {
                                             "list": [
+                                                {
+                                                    "bytes": "cfce95eb"
+                                                },
+                                                {
+                                                    "list": [
+                                                        {
+                                                            "int": 1
+                                                        },
+                                                        {
+                                                            "bytes": "377ee260"
+                                                        },
+                                                        {
+                                                            "bytes": "6e92"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "bytes": "a136876b"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "k": {
+                                            "int": -3
+                                        },
+                                        "v": {
+                                            "constructor": 0,
+                                            "fields": [
+                                                {
+                                                    "int": 0
+                                                },
                                                 {
                                                     "constructor": 5,
                                                     "fields": [
                                                         {
-                                                            "bytes": "1e96a5"
+                                                            "bytes": "d2"
                                                         }
                                                     ]
-                                                },
-                                                {
-                                                    "bytes": ""
-                                                },
-                                                {
-                                                    "constructor": 4,
-                                                    "fields": [
-                                                        {
-                                                            "int": 2
-                                                        },
-                                                        {
-                                                            "int": -1
-                                                        },
-                                                        {
-                                                            "int": 3
-                                                        },
-                                                        {
-                                                            "int": -3
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "bytes": "086e"
-                                                },
-                                                {
-                                                    "map": []
                                                 }
                                             ]
                                         }
@@ -1245,435 +1316,294 @@
                                         "v": {
                                             "list": [
                                                 {
-                                                    "list": [
-                                                        {
-                                                            "bytes": "58"
-                                                        },
-                                                        {
-                                                            "bytes": "8fc9b3"
-                                                        },
-                                                        {
-                                                            "int": 4
-                                                        }
-                                                    ]
+                                                    "bytes": "1255"
                                                 },
-                                                {
-                                                    "bytes": "d11c"
-                                                },
-                                                {
-                                                    "map": [
-                                                        {
-                                                            "k": {
-                                                                "bytes": "2f1b47"
-                                                            },
-                                                            "v": {
-                                                                "bytes": "5d759a40"
-                                                            }
-                                                        },
-                                                        {
-                                                            "k": {
-                                                                "bytes": "bb"
-                                                            },
-                                                            "v": {
-                                                                "int": 5
-                                                            }
-                                                        },
-                                                        {
-                                                            "k": {
-                                                                "int": -1
-                                                            },
-                                                            "v": {
-                                                                "bytes": "5db211d2"
-                                                            }
-                                                        },
-                                                        {
-                                                            "k": {
-                                                                "bytes": ""
-                                                            },
-                                                            "v": {
-                                                                "bytes": "54"
-                                                            }
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "k": {
-                                            "map": [
-                                                {
-                                                    "k": {
-                                                        "bytes": "1da82d"
-                                                    },
-                                                    "v": {
-                                                        "map": [
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "b1"
-                                                                },
-                                                                "v": {
-                                                                    "bytes": ""
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": ""
-                                                                },
-                                                                "v": {
-                                                                    "int": 3
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "int": 1
-                                                                },
-                                                                "v": {
-                                                                    "bytes": "1e"
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "666b79"
-                                                                },
-                                                                "v": {
-                                                                    "bytes": "eb6655"
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "cbd0d22c"
-                                                                },
-                                                                "v": {
-                                                                    "int": -3
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "constructor": 4,
-                                                        "fields": [
-                                                            {
-                                                                "int": 2
-                                                            },
-                                                            {
-                                                                "int": 2
-                                                            },
-                                                            {
-                                                                "bytes": "0fd72345"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "v": {
-                                                        "int": 4
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "map": [
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "47b537"
-                                                                },
-                                                                "v": {
-                                                                    "bytes": ""
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "31cf8d"
-                                                                },
-                                                                "v": {
-                                                                    "int": -1
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "1f513c4d"
-                                                                },
-                                                                "v": {
-                                                                    "bytes": ""
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "c1"
-                                                                },
-                                                                "v": {
-                                                                    "int": -1
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "af"
-                                                                },
-                                                                "v": {
-                                                                    "bytes": "c5e6c512"
-                                                                }
-                                                            }
-                                                        ]
-                                                    },
-                                                    "v": {
-                                                        "list": [
-                                                            {
-                                                                "int": -3
-                                                            },
-                                                            {
-                                                                "bytes": ""
-                                                            },
-                                                            {
-                                                                "bytes": "c0"
-                                                            },
-                                                            {
-                                                                "bytes": "877b7767"
-                                                            },
-                                                            {
-                                                                "int": -4
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "int": 3
-                                                    },
-                                                    "v": {
-                                                        "map": [
-                                                            {
-                                                                "k": {
-                                                                    "int": -1
-                                                                },
-                                                                "v": {
-                                                                    "bytes": "1d"
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "7380b2df"
-                                                                },
-                                                                "v": {
-                                                                    "int": 1
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "int": -3
-                                                                },
-                                                                "v": {
-                                                                    "int": -2
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        },
-                                        "v": {
-                                            "constructor": 2,
-                                            "fields": [
-                                                {
-                                                    "map": [
-                                                        {
-                                                            "k": {
-                                                                "bytes": "11bd4205"
-                                                            },
-                                                            "v": {
-                                                                "bytes": "e0"
-                                                            }
-                                                        },
-                                                        {
-                                                            "k": {
-                                                                "bytes": "cf8c"
-                                                            },
-                                                            "v": {
-                                                                "int": -2
-                                                            }
-                                                        },
-                                                        {
-                                                            "k": {
-                                                                "int": 4
-                                                            },
-                                                            "v": {
-                                                                "int": 5
-                                                            }
-                                                        },
-                                                        {
-                                                            "k": {
-                                                                "int": 0
-                                                            },
-                                                            "v": {
-                                                                "bytes": ""
-                                                            }
-                                                        },
-                                                        {
-                                                            "k": {
-                                                                "int": 0
-                                                            },
-                                                            "v": {
-                                                                "int": 5
-                                                            }
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "int": 4
-                                                },
-                                                {
-                                                    "list": [
-                                                        {
-                                                            "bytes": "4cab"
-                                                        },
-                                                        {
-                                                            "int": -1
-                                                        },
-                                                        {
-                                                            "int": -1
-                                                        },
-                                                        {
-                                                            "int": -2
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "k": {
-                                            "constructor": 4,
-                                            "fields": [
                                                 {
                                                     "constructor": 1,
-                                                    "fields": [
-                                                        {
-                                                            "bytes": "da"
-                                                        },
-                                                        {
-                                                            "int": -3
-                                                        }
-                                                    ]
+                                                    "fields": []
                                                 },
                                                 {
-                                                    "list": [
-                                                        {
-                                                            "bytes": ""
-                                                        },
-                                                        {
-                                                            "bytes": ""
-                                                        },
-                                                        {
-                                                            "bytes": ""
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        "v": {
-                                            "list": [
-                                                {
-                                                    "list": []
-                                                },
-                                                {
-                                                    "constructor": 0,
-                                                    "fields": [
-                                                        {
-                                                            "bytes": "9f12c0"
-                                                        },
-                                                        {
-                                                            "int": 4
-                                                        },
-                                                        {
-                                                            "bytes": "8a"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "list": [
-                                                        {
-                                                            "bytes": "3203"
-                                                        },
-                                                        {
-                                                            "bytes": ""
-                                                        },
-                                                        {
-                                                            "int": 3
-                                                        },
-                                                        {
-                                                            "int": -5
-                                                        },
-                                                        {
-                                                            "bytes": "ae"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "map": [
-                                                        {
-                                                            "k": {
-                                                                "bytes": "1ce838b3"
-                                                            },
-                                                            "v": {
-                                                                "bytes": "ab"
-                                                            }
-                                                        },
-                                                        {
-                                                            "k": {
-                                                                "int": 3
-                                                            },
-                                                            "v": {
-                                                                "bytes": "f182"
-                                                            }
-                                                        },
-                                                        {
-                                                            "k": {
-                                                                "int": 5
-                                                            },
-                                                            "v": {
-                                                                "int": 3
-                                                            }
-                                                        },
-                                                        {
-                                                            "k": {
-                                                                "bytes": "45"
-                                                            },
-                                                            "v": {
-                                                                "bytes": "4d658338"
-                                                            }
-                                                        }
-                                                    ]
+                                                    "bytes": "b276"
                                                 }
                                             ]
                                         }
                                     }
                                 ]
                             },
-                            "inlineDatumRaw": "a4d87e9fa54236ea210444066b57ad44856df6ef4040012420a0ff9fd87e9f431e96a5ff40d87d9f02200322ff42086ea0ff019f9f4158438fc9b304ff42d11ca4432f1b47445d759a4041bb0520445db211d2404154ffa4431da82da541b140400301411e43666b7943eb665544cbd0d22c22d87d9f0202440fd72345ff04a54347b537404331cf8d20441f513c4d4041c12041af44c5e6c5129f224041c044877b776723ff03a320411d447380b2df012221d87b9fa54411bd420541e042cf8c21040500400005049f424cab202021ffffd87d9fd87a9f41da22ff9f404040ffff9f80d8799f439f12c004418aff9f42320340032441aeffa4441ce838b341ab0342f18205034145444d658338ff",
-                            "inlineDatumhash": "508ad4b9375603bfa1abeb1ee5afe6f8b8853c33b76d580b1fc2e1e1399d9755",
+                            "inlineDatumRaw": "a59fa30044750c54250521414a05d87b9f01449dc55675ffa0ff21d87e9fa22005230103d87e80ff40a09f44cfce95eb9f0144377ee260426e92ff44a136876bff22d8799f00d87e9f41d2ffff019f421255d87a8042b276ff",
+                            "inlineDatumhash": "1e972f8b96ad08df947c1295080bd250860ce2c4160832c32bff753160155d36",
                             "referenceScript": null,
                             "value": {
-                                "2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56": {
-                                    "35": 2876491030407242206
+                                "105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5": {
+                                    "33": 3751863074033990862
                                 },
-                                "lovelace": 2370500
+                                "lovelace": 7500000000000000
                             }
                         },
-                        "0508070302070006060803070105050402080008020504010508020406060000#51": {
-                            "address": "addr_test1qqge8txacw7f4xfcwpdhalkjl7xnec2exqv38sz5j2vac09xdglhgtsyu54ptdrv72uhjgnjqv2ras43758qmx0c7kgs03xq8x",
+                        "0805070701010405000106060508050301050002000503020707050506030408#79": {
+                            "address": "addr_test1xqsfq2r4rmmxh9m8c4znmvqnektzyhvccwp2uwmuuqwurz7xw677l68h3xwzru44v9h3y66qess2cs6scge8uz7uze6qmasuyk",
                             "datum": null,
-                            "datumhash": "c2c4601fe38049b0f1ac6f68cda6a7267d3c549a51934c6a8a032a524453692e",
+                            "datumhash": "8e5c8377a754f4b8b1c721b2aad575519fbc2d452a25599852875873ecf5068e",
                             "inlineDatum": null,
                             "inlineDatumRaw": null,
                             "referenceScript": null,
                             "value": {
-                                "da83e15e67ff16dff55208faf864a095149a7a5be181f4575e7e5969": {
-                                    "4877cbc8b0777c": 2
+                                "lovelace": 7500000000000000
+                            }
+                        }
+                    }
+                },
+                "coordinatedHeadState": {
+                    "allTxs": {
+                        "0201080504080805030006010002030801050405000806070203070306060503": {
+                            "cborHex": "84b000d90102848258201fde5cfeabad70cc1f44bf6ce1b977f5dbf8c53f1fa6f9c83c52d842566fdec2008258208e47e7ca3f2026a3022863c3111ba0ee75bbf97aa57b1798ebd48c432a017c0303825820c3964f4b840df52b05c2a1009561802c946af23e96b573c74a466083c406eb8d05825820ebed5cd109202316cc58ed34f0b999bfbff96f3c473cf5fda84a5c7668c17115060dd9010286825820069276cf6ce79f13863b2d5f5e1596b410e1622a0c3c11a368e004cf1a35561f008258201466dbe6951d5d9ff63a4686ed69f6df6b022030edc1ed86978f0a95e93d35150382582087158f38b72663a35546609962128b4a405239cec6e83a8dff4aa97f04bcd36e08825820d0510cdcb5e912582cb64cb3f8230a57615545648c34a03399256d214c1dab3104825820edfd2273d0037d605057c8844fe1568cb71e3836fde26d6ed1392169752ed71003825820fa65559d66fac7722d28b9693672154a6082088de246961ffe13e15380af4113050181a40058390111f5fee4ac3df0b3df33e7abeaa2879aaa74e8a0822e9999144103dd6f131bd446c728702194905c63ef9103c646b5ce511eab98d31e8ab001821b1c5bd899bd8e9e9da1581c4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888da15185bf05a57e1ad433ce3376990d0c02fe6401028201d818583ca34255279fd87e9f43514bcf44431f5822ffff9fa10400a0a0447d626bb1ff05a1009f05ff9f9f230143f5b5a84396ce5502ffd87e9f002224ff05ff03d818582282008200581c13acace227b9f66931fee881ffed18afd0e7334f21296436bb98997710a300583911ea2324469382248a41ab57a804db641d2baa77ca90a3dd5db03d2ee38a2348979f226578e9804b422c04c49c5ad2d280ccae83b0d293810101821b69186abe1ca91aa1a1581c049b36ca225bff8c032fe9c642f9a34f5a772a8909dd991a27a54553a14cd931f581c0ba919427deee1c1b2e12785ef50b5a07028201d81843d87d80111a000573360219167604d9010286840a8201581cbc2458a13cdaee6236f5fe6aa1a470611426daf62bcf60e5af5e7159581c5e3dd2899db7390ed7727e319c078fffd6c73122e968f890dee4805381028304581c089f9ce53f7549cca312cf52775f1b988bdd51cea068cafd5244d2560a83028201581c4b7c655ec5c8946131ed468008bce86d4671bcf6d9009156faa084ef581c82e97b4bbc3b241972941174aef80f860e5497743bb08b3bcb61ec0c83028201581c60d802ccbd9ded4faaee82bb88f6fe68be49d774d11e04fbdec0b7f8581c2d687a0313af4f85ce7c2ae3cb4f9103b693d9a3d0f8c647f7a1346a83078201581c6f050e463085a76d8742fef54d7742e66f3f893debad3691d2813df91a00047e01830f8201581c6205804f706aed0d203cd31c7cbd6970bf7c1a2d929f518de68a7d82f605a6581df08e99edd59c451dc5d59f8a5e7f96a11bd6f135f0032e1bc74d8414321a00020e91581de04a6f839dfd6e97f695b9c6f308315210fdc5cb7cc2d5182fc66126691a000706a2581df107854dac1a8b91cdbfed11c485d16bac44b2792eb6763217623bf2bd1a00032157581df1994aa2cde2423b5bbaa652fb894b30d0410b1190d883ab437e14f0d31a000d157b581df1eec800a666bd9b74cf6fdafa0d8f3080c622661cd63768507d1782611a000757b1581de1aec206d1ffe4fa5caeada45b8b60141466fb1dbcbc54a15af22c4e3d1a000a32b408020ed9010283581c1bccb9a4e31b35c3410d61f80bda6e725e5b70814ce81584d56d7585581c72030e572c241572a973b6ccbdddcacc5678660c81f20d273972bad4581cd970b318ec6f2fcf20828015e7a852331adc3065378acfa9fa724a2409a1581c8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3a1577850ac1c01b9fdcd1ae52a76c68ec1d9f06ef082a61b9a1b68ecc517468783d30b5820e20dc04ec682998c16df4b25fbd8bd0f1047f831803e48ba47c6deb41db8ee330f0113a18201581c0370b0cc0d5ef205b14bfb630a3462d115d187597d59889bb3b3740ba382582034d38af70317310436629d6ccaa28233064f2339f59a297091275d35cef8a58e088201f6825820a4af59c4e4166b6ef7ea9233ab97a546c7fd101f2c23609448ff7ed129a1323f068201f6825820b6d314a9da37076d44cc71277da9ac486e85e288ba95b5af080de6058eecb08905820082781968747470733a2f2f43323157786f4354326c4a59502e636f6d5820c37046bc0e947b444c5ae47b3a8f5712dba43bd34437ad4a7c7a4c6b329c14d2151a0007bb6d161a000d8874a500d901028282582012b5a36b379a7694877a36e514e87c3c4d6a721ce64367ba3d2562fd7e7c7a4a5840161e644a8b816c106848bc4205d756ddbc6bc985aa634338ac841a6a18d5fc08fff387eefc6781252ff88a1596992f79adb1b79df60123f08200539c9afbed458258206a0864ad3af34706673dbfdb0780e132b6219a002c9f2c3f647ec0337c09c07158401bebb611a33c5d7a002a3f95dfda1bdadf1145dd6a4a6ac2746846af276131128c2b1fc100905ffd05c980ba770fb81303df5b02c35755f89169d52e8910d89f02d9010286845820f1c84b1e826116f8a7f4096f2e0545b18a88276dae839022ab4541f0da5ba4565840e6951ba4ad2fa993a949fa87210983c2d7036566a826e3c5e8b455217a2719de5b70e9ed74487e7309ba16f90784b7930cb2d00be7dab63a946f08209a2961da44a9a2dc0841df8458207ddc1ac6eb24a140d14a66cc6f126ad6b076f3e9bc82e05e28e6b93b7422f780584057720be92efe6a69411cf50c0820cce7dc286423d25a91cbef8e0979c1b7cae5655359fec05807d612bfb3710a1b82b9a36421eb5edc2e206fa3b1f5927f73ac4527b4672d2d43848bed845820bc4b6d3f685069c547da1b41dfbed25cecd9d41dc66dcb93114aea6171ab5b3e5840abd2a94d86a6501345c503227d7d1bd64cb621f0b193d7cc41a6d0c49b04890cd553872d2e8740fc82bbe0f4fc3593a2923c09e1840235eb62dab33f7355ede94565d89b27f343c8f76184582011faa3cc1915ae9bf3c1f03cc985ebe32b242d5b37e6b191347f8e68e0824b475840f11c02e057f29a4d42245ad537c1b558e7466a4ecf78e3a6f018e5d020dd767f848c04581b01a578b71a8084508547c57b47888f5fcb359f0ebd610dc29e18aa45d253c95ab6413b845820d3262b18769c028d869b167bcdb754f33fba985863018441588d4d526252543e58405e98cab0ed700db969b083fb7a0ee13f57e43d254802199042c4c9617426263790f8a4dacb20366aa4714f2b1c53c417219f07d4d7707d24280a1ec54c968c0f4042aa078458203ed135cdb602f9b08df6d6a54ea8d3994530e183749d5db7933b1f2a5ab741235840f9091a65059b2ccb8b5e28247d380961fa48c89252e00a5ea7ae0a2967b4209f0113be04a7e03c2bddd83e37e4c8237f34b1b105574960898cbb31dbd8622460419d4001d9010286830300808205048202808204048201848202838202808201828200581cf9678f886e758f8d211342235bdf616ccca273fa4f393190c9a13ce48200581ccdb0820638950254fc991a25e94c6a2ecc3a204c4fc075686198e2ce8200581c8157b3332c0f6f7bf9074a7422e03a63616cb983272f16ac355e4740830300838200581c92aac9626b2e6a1af3192319da5c28137e3212cd85e1982268b51c1e8201828200581c4d5c4c4891ed15ef51f5a8919f0321f167de59cdac31123b0d31f7528200581c102c5f5e03d36432f3fd64730e587a937b36007b42e4f3c985e02f9b8202828200581c206f5c889af7c1de9c7b22031c85a1120282fc33a740940a3086face8200581c593b15dec4bd0784eefdd56b9560b47a93a8828bea494c3ffbd21e3d8200581c4d05802b20e17e9f3b8f512f79a32b20f27d1e1b1b8330e947a5a4818200581c392ee82ababee47db7beb57c329238a81d8230bba609d4a97da1569182018004d9010284d8799f9fd87a9f00ffa0a5020444607a26b10242693f40443e591d9c030320a52440419d244490067fea242143ddf2854119426ca1d87980ffff421f62412d0105a482000482a480d87b9f9f0420ffd87d9f222200ffffd87a9fd87d9f00ff9f404040ffffa544c03519724304f93d404226ead87b9f4315b5ef20ffa444d356845f2343881d6e432dc7344315eef6232142f3b541b6416e0580d87a9fd87a9f4133ffff40d87b9fa44229372142391d224044bd40f190000240a30444be1bbcc3054268662120a50541000522400342f82c2444589ce73f23ff4373d23b821b1bf1abdfe0e26f261b671cb719bd314ddb82020682d87c9f42f869230044bd0df55540ff821b68e176ade5fa9e4b1b56f9dbcbe6c80e8682030482a1442228236d4182821b214564e86fd1a8961b0ab7b2e6c529815c82050882a5804346739f4342f4a94431834d04d87e9fa0ff417d80d87d9fd87d9f2100ff80d87a9f40419bff204457b86dbdff8080821b65248b8677206da11b46f3f1e8495d1099f4d90103a300a10e2101848200581ce47d15a2c37887cff76e74829dd6fadd08db26c28858dcf2bfcbe83e830301818200581cd377591d62e9537ea0f0c26a19531645bb3b75512c4f9e2b9bfdb760820518188202838202808202828202818200581c1f39597be414778893b18ff3723c0610f545ec6a078ff3c438fd860d830300838200581c6e728c140acf1a969b59ddb2027424e0ccbd19879f1dda62fc7657848200581ce9b715ccc87aee657917a1a2a0e7fb1bc0eb0d5ead82298b1527aab18200581c1d8e455fe21567639eee53c7ed6cc773a8e94f06c3bed2e461878cd48201828202848200581ce3b73e68df91a13e1e5c1dce95669ed105e95c69cb0670b198fd66648200581c0a7cd366a661107164a51dd6ef155c4d92d530552d4ac2aef1014d1c8200581c140f83ae37a4b37be3d54bef2a07a6c8fcba494877525759235c2b218200581cb24ab24b61cded67bb792f40a66a2035686e5808e41d068d987d748c8201848200581c9c3c62e3a102d73a8328be576766f10fc1c9bf0b94f611a80f46e43a8200581c88ee91c1847a2289f61b08826ec1c7f3c5f5fdced22dc1b20223dd1b8200581ccfba4830d2ecd0a2b363ccecc2a81839458422eba0b0e7155f5fd4d28200581c8e373e167449fac030274bf89c70905ee82d4eecd4de7751ad6b7bbb02824847010000222200114746010000220011",
+                            "description": "",
+                            "txId": "50929140b933c799ead772afe86cf669ff4028f8d4e45bf2b2744af4648449a2",
+                            "type": "Tx ConwayEra"
+                        },
+                        "0300020206010207030504000608000108040106010606000507060500000600": {
+                            "cborHex": "84b100d901028282582015343f1665bca835fd197bcccdddb45927fdb60d08cd7a52408d62d3cdc35015068258204bef44f9990185eba41c36dd69b08c24dbb0de89d13e233802e7b8e9e521c897080dd901028382582030290bfebdf5999a5dd477cf98f460176e98053c1869ddacf253c8d77508ea580682582045c938be34d33d24ff53e5cca1cb62741a80881455bd0f9c4140acf2fc43aa2204825820df7f18cf744e7a7ff02d34096667445ff4b7a32e55c102a07597995279f3f5de07018683583911f22bbdd9c9c17a0a1b7803904398c04992dead191343809ad1d6ad7e65f3b51ea8277622f2d3c9431cfa2a35ccbee419b4fae3d8f3229dbf821b18bc2a7c1b3f0519a1581c206c6e2360aca128a81d9281e1178a89e4cc17ebc4920a5187190c19a1581f348d382ecdb170f6f5117f34b0235d3ada3657ab2d7334952162629bdb00be1b325511dfca915178582046838d12a36e28ef195010b17dad6361b1eced0dfb8660da275d63ea86ec19bba300585782d818584d83581cb61e0e7900f7b718ca40b5cf3fa91aa1baf393d5ec48cf7e4f4a4371a201582258202fdf14292db09a1aa62a3a87eff897b0a36745e56f8ecc6af0f6021618b2d31702451ac1d2659d001ab6e76fb901821b0b10eb57c11c2510a1581cb0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165a1546320de224329a8e38dbcbc0b12f22830826a0db01b2842ea7affb36ef203d818458200820516a400583282d818582883581cf13459ec07212490697cd76072a6b930398b200e442dc08956a08699a102451a2db66d60001a1c170a20018200a1581c105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5a1582025bc919ce5f04c36d50485294d50f64e4aa58bb4a0dcc85db13c938fda956c5c01028201d818412203d8184b8202484701000022200101a400583921983c96c3229ce538d3deb867997f050608b2d40bd7ae72e7c7d5c789ac0d1198418713ceacdac8d84a1f0d8db5998a2eb2d14c4dc101c4d2018200a1581c1f55fe7ddb82856bd9fef07fad5fd04b389fcf51395c0b34aa01ce87a15819914d6cc1a25b04189ffd3b91ae325efa214679160a444564431b717fe2d91539b1b1028201d8185883a59fd87e9f022042472fff4298289f42e7a70104ff4194ff2402414ea5439277c19f004277a4ff9f034044db51223301ff9f242402440724e434ff9f4043742e74ffa5230421024217df214003443f56a45144be46b5e42224a541ec2140431af6894207ce20004394252042a34b20a342265d05030042f4de21a0224040443cb0b66503d81845820082050fa400582b82d818582183581cc79d709659baa0720e3fc35bd3d079b62448f16db88cc8581ee52b8fa0001ab9466eb301821b14cac5d46c45d4eca1581cb0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165a1581f62ceb97ff23bdf067c4f58da825e7d6665ba82ccfe86959c2428dea400a39901028201d818589ad8799fa4a323200343c943680041b3a42101431634b74363665d20004043b36364443d0814a342158780d87c9f4222a6054290d50442e85fff9f22432c0d6effa42240044460e0bcc8417803447a572ff840d87980a3a440040541a143fba8f3030242b23f40d87e80d87d9f404306db4d425e9542a707ff43cc045bd8799f42591e41ab41770200ffd87c9f05d87e9f00419c00234154ffffff03d81858768200830302848202808201828200581c705aa5fe44a76711e44000c4bb0e055487b94394ecde8fcb27f255868202818200581c6adc1aebdc8142684fc43f0d5a8ead59d44dc37a023574275434f29d830300818200581c810fe7f6984113167df1f54b0111c5e3c3b409f00cc0106bcb053d04820280a300581d7035282ebc3e14165bb9ed57b323b06bab526ea858c93b5f3420f927d0018200a1581c2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2a14eaf59b8478d0aa3f96f6a26a2c2a81b3d5159f65f6591eb03d8184a8203474601000022001110a4005839000f27f5297b4ded98c5e8146ef0cda6d4a30dcc209c9610a6caf91aa64709bfb0ddee753e70d7451dc41bc3d92d01cd3a41e5db70fb08c8ac018200a1581c62b7908aca305acba24e1877d1fe248e362964d9872a86bfbe178e67a157434435ebd75c844d0d490b50939e1a3bf0c7aa6326743e1b7fd5007c62d40760028201d818587ca49f409f0503ffd87a9f23416e44b2f1a1c80321ffd87c9f42d75e03ffffa40080229f0305ff2104a042bae5d87e9f409f022243bad138413740ffffa0d87b9fd8799f0202202200ffffa441a8a3402202417f0340a5426a1c0441e302433b67742040234397971404427669a04458b18c28d87e9f20ff418241d72403d8184a82014746010000220011111a0008fdec021a00065a68030204d9010281830f8200581c0051bd7586bd3476d6d2240516e991338c15b520b64a6176a2c7817bf605a2581de033a79c85b4adba6777bb5a2ffcd2c948845359dc305927deab7154731a0003e9c8581df1d1cdf901099fef88da6269fd4fc51f9080d8d121203eb06260aa57431a000caacb08010ed9010286581c090989611c004f0cb4c7242aeb5d3da674e581d43198a7a9d0c02b34581c1f96c932eaac33c11d9bd9e2767238a0a833b141b2c7cd83b1cb1458581c205063b73f7700027513ddab18798774fe7d8d70ca4fdd5a5a344436581c782422ffe4175beed8b5032c5215aed94a34c6584ad19630039ff717581cbbbaf043553b876c74b965a2550ce2c49c4f1250be34fee1e77d1cd8581cbbd7416e46ee9055acbed5609fcb87cbea573f0e51747f6aafe44bb809a1581c3242aea2cb2f9cb61fb432da8c5e8fcf31f9d2c3d8a83135177052c3a14462c9b46d1b00af817888f44eb40758206836cda66a6c7c990ec5d51e45bde19c812e3c6648d45390ed5ff5bddf7156bc13a58200581cc47b4c45e582630a3e26cfd17dc66e684244fdcbe7f868351ce9212aa582582036f78d864cae1b48f159826ce89eef4487df0bd26a75d5620ca32717b4b1a2e5018200827268747470733a2f2f67305534594a2e636f6d58200dc02bdc2665dd6ba2e77c0433fefc93344ea26da76cd04191976c3036e68ff98258204016cb247096da73e40bdd72704d440ddd86809e31ecafa1da790cd09317a553008201f6825820541efc900268d55aed86408f58c304af2b0e956c2dcd1cbb287a3f4ad4378a9206820282781a68747470733a2f2f35614542537839516438464c482d2e636f6d582024556707a3ee38f9b44fc7748b6dc85dbb74944f8959794e824da299385053438258208cc9a0ee2c63ea3c0850a448d4d7a00a92030356b0fc7a985acfb8e64ecee42f08820182781d68747470733a2f2f6e63484731346d6e76554a4b777a77684e2e636f6d582024a34c0fc7b10e2a2c10c4b8f2a97e461326d49492da5095aaea648cc256e32d825820a927daf2058675fe8d42ebd11daf984fe2262d706a31dd5dc5b4c55f0ca392c2048200f68203581c99a576f332deabc95e7828d14626d28a595bd17c3fd49a5a252da3fba4825820036ef4d6afe8c02b4a2b95e57948a28114a86268834555b87702e2cccab1f173038201827468747470733a2f2f73656a65493652382e636f6d5820a12e858d2ee72d1b26836b7af5b503d59a656b1c7b675647f5938c7c16bad25982582072a736df153985c84c298c04a45b8f357c0f87a1422cff46d14d3c737f8f86e0058201826d68747470733a2f2f682e636f6d58206bc29bb7ab9e8da9659cb652db685da412bd9ad2809db6ad7b039e610790e47f8258208216af6532215b537b5acbd29e9c30bf858e578ba8c6d840ea4e7570fcf7a30300820082782968747470733a2f2f6e53613271743558567442643173456f7773672d2e63667045686976462e636f6d582050d3e6e9775a7b7325b9483bc18f9c35b09cd6d7ac1cfe6b1f0cc24a4a5c0e0a825820a8e1c08b04a66950a3b437c0a27b6b454e669b3860cb0c543c26c734df1f07b4048200827468747470733a2f2f32344768675961352e636f6d58206d87d51f49bcadd1e9d50aa7e0c2a7d97ebd72e681f7a46340507a3bcf0bb4fc8202581ce591a0df17c965e1b2c0558e55e0a4088f029c20433f7df4bae1a7cba582582011234e2f9bb1c51e6acd651095516da9930e2d350a39ad218bf06cfa0387659200820082782268747470733a2f2f303873492e495838415465534e63464f65364b3853302e636f6d58208f5129d0623750f963effdc0af54f60bf32f99b7f0f56a5e9c29301a148918b0825820462e393fc985f3f0ae7f317c68c9f7af717e629e3005c514a2d5dda6a56a8bc602820082783868747470733a2f2f656a50334433625a583769566a533064356e6867754531594634557732666f2d373647517a6143537236324f2e636f6d58204f0e8dbea33089dcd5bb964659d82971a701000c4b93a488a451f5694d6c42708258206260e7a1aba610d64e184fd2e316d0e64fcc8c39fea9bcd2748a26319c450035038201f6825820a83490aa96de64e289088827d65ae9de982b80d241ea8277f7f3c6a4688b984b00820082783568747470733a2f2f6b4557694a315630565242466c7075425a7962754f53664f6e2e705272786b6c77474a4d6d626d79502e636f6d58205a3beb5a40b5ca20367bc1b7b13ec5ccc1f7679443724c5cc4da30661f351f99825820b20843d6f03b46df6bc4670cb0ea4e71ba0a7c058bdf7eaf3f9060dee182a6e606820082782968747470733a2f2f566f63552d45315436715931643870534a664d6f382d5a4f646831556f2e636f6d58201e43ac3df43de09dc1e2a1ce1bbc25d4938cf80ea6bcd1fb00f03e765b4fbe8a8202581cf404a81e98e8a4581349d7d8c4ae98836d859d3f3b2652fcbfd1526aa28258207bf562212aab93989a40f658e65e2825168eab12863c3ada088d716b9c204502058200f6825820c3040329c150165cf10d6ab922649e072b4095ca9a4b1f56a3243e0c8bb2c07e01820082782b68747470733a2f2f65346558396549635a486850547a76704841634d2e4e2e36586236663477382e636f6d5820f45be2d321d3ba2c6a5d8b31baf93650dfacb63143492e928aa7d844811877fd8204581cbde6d8a63b2451a7d93417d28b682fab46dc95671d063a556b04408fa3825820b40a6c6a0e7a2d5f1b03fe8aa9fb235d55ffc13a8983cad0adf80b53d5d507af088202f6825820ceeff115a8526101c06df6488f0d648996c4a7545381c32013f777a8678476de03820082783f68747470733a2f2f62513142614e55637642735a4b706b51697a725342754c6b42324f6c7737734535545348786b6145564269686a68506238506d2e636f6d5820e409111909114fa87dadb9e02ed4fbbcc18de003f75ce0c8ca9394f3aa5ad5a1825820ff40351f984ba94dfb7241583c51a0a463debf0eb03bae7decb056e01d93623c088201826f68747470733a2f2f5a352d2e636f6d582064c06f0ec543c9de810a42e2465d8a89aa870127befe3eee00cfdb58a4dcd34f14d9010285841a000b1faf581de03f7dba62ca32c41592471625f9cf1962c96387d84e4d1570fe8ec0b7840082582058829c6c1e182ea3d033e2e2eb257980a94e3ad992997e65bab1696789dfc2f205b818001a000ca223020403020401061975710702080309d81e821b01b142484c117c211a002625a00ad81e8201010bd81e820001101a0009aaa0111a000795ce14821b2f39fa9437f3c1e41b0f8b9faa3f6e6d3015821b5cb7002baf56499c1b67937d70a7d339041706181805181985d81e82190fe519c350d81e821b007acbcd0d71cf151b00b1a2bc2ec50000d81e821b000007c764bde1f31b000009184e72a000d81e821adc7f2c111b000000012a05f200d81e8219026d1903e8181a8ad81e821a16921a171a1dcd6500d81e821a001148891a002625a0d81e821b0000e074d8c936351b00038d7ea4c68000d81e82190f63191388d81e821b0004e246bef9194d1b0011c37937e08000d81e821b01553aabe0ad394d1b016345785d8a0000d81e821b0000000bcd5264131b000000e8d4a51000d81e821a01bf43851a1dcd6500d81e8218181819d81e821b000001f43d0746631b000009184e72a000181b07181c01181d03181f1a000181841820051821d81e821b0fe40a8c10ed123b1a4a817c80581c6864e131e583aabe02fb0acfe028f1ecfe3afae6c3964f7f5d714d23826e68747470733a2f2f6c512e636f6d5820b6039b9ffe9d2d5066d7f695ddfeb69079342e28b2875f6a1564ddeff4f0833c8419acf1581de0b90b8c26c8d9391ffc4837abe4cb9dd7a48a9ea7a9a36062fbd2ec4b8302a6581df00a6de2ca4d68aa69d40c9e1cbd0650d5d24ab03056b7764ee806eab41a000e5236581df00f7a723deb3874af83d98a643639115a46a39dd6b1e60ef217d32c491a000af904581df09a0cd561b496a7a202349c21f9b804b179d6326d8b21d96fa03b33351a000681df581df0d85d9cdf541329cdac48acd2dcd1d3dcd1b5bf7cf0e397aabab81a4a1987a5581de0cb316d71106d79bb4a478e0a07d0777d73808adaf91e7774ff2a24021a0006fbf7581df1ec8045027cbe38570fdf813f0634aaf1741aa0d79285d7b97cb515ba1a00027d6a581c9b9d5d89d46257bbeac4b836ec79481730a27a7ae219c820aad9cb5482781868747470733a2f2f4a59734148544f696f6358342e636f6d58204f416fa4e393f7d176ec8b14bc28314c1efeac225feafd045d35f9bc43ab1bc7841a0006277b581de0edfd1b71f77909a34c0be31635f8f208d59e42fe8dc0fe0d841e62fe84008258201687bb17560f444bac6a73f70cbaf472e1d0b9c4a3cf8750fe7d6c696d13e80303b5001a000a0b5a0305051a000be172061a000464620704080409d81e821b06cdb24fd59e23c71a077359400ad81e82182718640bd81e821b001751f515745b271b002386f26fc10000101987a5111a000e5db214821b075c3398986c3cc21b04fec3e2d77f9a5615821b19c0d13d6b3e6a511b67a0d2b5e0a248d816051708181800181a8ad81e821b000019ff011762f51b00005af3107a4000d81e821b00052074d985089b1b0011c37937e08000d81e821b00000001d019cc0d1b00000002540be400d81e82198b991a001312d0d81e821b0083e03282d51e631b011c37937e080000d81e821a041a84bf1a05f5e100d81e821b01350d6bc50ff6591b016345785d8a0000d81e821a887461231b000000012a05f200d81e820001d81e820105181d05181f1a000da5f71820041821d81e821b05bd8aa32e459c4601581c74d3fc1669621deea8a55a0d881358f022ac155f69678759ccadf03182783d68747470733a2f2f6b6346555476646576337931544e582e55594a6f674c6f7150474b4f45463934456b333871646834764f766743396c4f4c2e636f6d5820e29c0d3e5782362bc64b81386918049eaff40f66d1a9a2826bd87ea941e10068841a000ad1e9581de1f327549c54340c03000cb1dffe455e45b5f9546234141d51fc2fbc738305825820bb9fdd169c77d6133fb9f932500bad8cd03783c980b1e16511a927313c2d0d02038282781968747470733a2f2f784f5343735766504e6d306a312e636f6d5820dd681175cc8b43d91bfa90c25eaf45b724e1782678adce2074564e8d1c81e4b9581ca0c68a429c69d33267ce34b3546e291aef5ec2f58f04d910b9a5361c82781f68747470733a2f2f6e47575248396649756a787a42526a313542702e636f6d58208ce5117294e982e989f9607da723fd0fbd770ee6c6f1685cf750d44229c7042e841a000b17d6581df103c971dd2a28ae35f54d7555232224932659005e861c1912a5a087d48305825820398c271792ae96400a3d3ff6d80bcbbc8e25e7978af920f9d4a26dca38d1a54c028282781968747470733a2f2f4a562d414c496d4477304a4f732e636f6d5820b774e07c0727ee145207d7b09fae7a3d178febfe141fbcccf905a723a6112663581c00b82882d559bcdd3e8eb9bab010af80fd426aa640ea07ba918e88ce827468747470733a2f2f42496e5a5a2e42632e636f6d582040c899110ecfd97fb5a76b0e779e84cf8aa304de7220d685c254f4852dbae2fd151a000373031619b681a400d90102818258206be43f57f0c99a0a474087a36ecb9e35b7b61a0d90ab29f9acfee08c06a1fbb758409a08057ad245d11e4bcaf7f8fbd4907aec1cc8eddf5226229e71ee6e8dc32583cf8261f958ae2a8f5fc82b6940e6a9efbefb442211fe643bbc4eb0c7b68babb002d9010285845820cface27ab687693a42a9e6653b9c7255390b80192d5a7fd8974a8be7e6520e0b584062b227f553abb25058d7d745859682f8b7d004cf115d1d7b89d0bcda2dd1fb530538671ead5b74c5cf774959848677f2a7722437596e8005968d3207c312a6f844a556e5d2434920cf84582001c2917238e04f380d2f8c4be294ae275ce9d1e3341801ea33f225c0956e63b75840b224e42315fe97aab0b19a01ac2208783eb1e211329d796af68d9ab90c1da50b30100f37a4141adb5b8badd8cef618fa500a83fc3a2e540274c0915b3cec12f543cea584429cbe845820423ff8cf74b249847d9299ab2f615977ec209f9baccfc07c4c10bc52d8b497b358404d1dc4ed6c0a83ff0ba3788d80200993660f505d340851a87c3babfde4d4712d96f9e3305986740d48c8aea386e9113627d26ace1efaf28654358dc5721fe4b3425d63433edd6f845820f50218d31f80c75df2569021bfa34f602b3d8abfa09bc14b7614c12a6d96619a5840b42341fdb452b34f11a1cebf9f22750ab0ec03c11774dec196ff37952e4a13cdd7e816d428c34d39820f45ac8705d1ec052d21c50e246e7c5e61f2d3517faf9945bf9d4e478d4519d7bcbe06845820837b3817e2e8fc45a402e6bf21a33f5aca0fe6e6478f757715a98b430020cb7558404aea2bf6b30d0b58b97dfebb1ecb612cee41cca7175e230699a5a9d6061460e12a84b6f8ac8c7298e28f16e168308a717214d717b6c99c1f4ca8299ffb1cb9e9415b446398d52701d901028182050704d9010283d87c9f9fa104439040cea0d87c9f4003ffffd87d9fd87a9f010324ff44c37aea6ca2445315db39240021ffffd87a9f21d87e9f43d647a9ffa341d3a5050421414b4040431553a443540b622342fbde4423d0aabe22a241d1222442954ba201052100ff43dc038af4d90103a200a50384232385242403654def96b224437d9762a34002439a5c7904422e622206824191a007a1820165f0a4b3862766f3bcb38477050f41c4108169f0a5869b6ff0b284a1028146450100002601",
+                            "description": "",
+                            "txId": "58b3f3e1cc427a5b37b36f7ffed819e25f61750942bf04fd143e281204c95586",
+                            "type": "Tx ConwayEra"
+                        },
+                        "0402050008080203040300080001050601030603010706070102010606040306": {
+                            "cborHex": "84b000d9010281825820644dab5972ced668628ee6196a5e157ef33cc9069eb557490ff0f85bdf2ba594020dd90102868258202fce1a26b652eb7ab3f9ef4b4c4d841ef2f10053409fa5372afa3f008b7769d9018258204ad6616a23445d7a1fbb41a8b503767aa3fe8d86d72035a1e7bc952e96a9eb8a01825820614e0161c098292098715c29e8216065cc2847c142759373117e1cecf16020ba0782582079276ea672d532648742aafc0dd5f7035141ea09f3bfcb0c89440d6d19a55ebc06825820a1faa0fd0696d27189180a43730f19c9652e6560a8e7b9604e22554a30f9cdef03825820ab2626faca7a57b148296f79342c5604462fe911f3d757b3dd2a75d82465a9070712d9010283825820042d5d49f98748f7ba5ce7772af33634a880ac10db8012898a83360dd8f296cd04825820059b792f47b57c676a33358c2944a6beb0345966b2d5f5a67678f167bc1c00e60482582076b2403b251a9d17626b641fb5e01871384f5b8be0ed6fec600fa8841477a760050183a400583901ae562c36508e668be0fcecbdbfb83a435f46eae137a8cfad48c167684533b40de8dbde4366e0f358d8039be83f957c6502001786dfc786cd018200a1581c467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22a14fd5e9aa90acf2828da7c574f0bf23931b1d80e45c3e37d5c002820058201287a591df84f63216e71fb94d73d3a2183f5aca12edb8da7203d8b254f613d203d81845820082050da30058391187314403deb57176ef5e3fb90733738508ced5a67acd069e9f643cdca3ad0a6fef716f0c53e44a128edbf235f931f86be1379f54323dc21301821b08a47acd8c5141d4a1581c0c22728dbd7145a9c97b5340a5ce29487bd5218233f7477042cd9a87a141340103d8185902378200830302838200581ce9edd5ef84c29a0215e531f38179c2c04c558e7563e515e525f3d3b38200581c40fe6316db5317f58169e0ef77f8751de5161be376d46d3fcef6ff05820284830302848200581c3a8a70c28bb5349d5aabf1d6877405683668d4a17971390a8bee8f188200581c4df6006ac344f4a09ad8de8bab28dbde3e3084ff76cbaf09138e5bc68200581cbcff0768a45d227fbb1f1e6b18d4ca8cff54f3bf3fe437be13e055008200581c22fcf26aaacec513afff1361c5cf0d992f551ccb0a88f02970b47caf8201848200581c5781108d7ca2499dc1b72c69f4648a42f4f1ac08dd0e0c625e9fe98f8200581c2d3984a0418e6f3a22b83973bc4cc42d233c0d0533b20f740fc2f4ba8200581c675c3887cbcf44d2126f06f1cf007097c7092bfb00e5be7bc70a49968200581c0e2e2a99b0c1852fbb623710b92ea0db0d18f8e864ea40c4b35e3227830302838200581c22fe4fa832e39535a0abbcb5a180db5aa186bef28afdf802ca243ac28200581cf8ea00a8c2ee1a6dea61cab2a1b27899445c0f35372a840ebb9964538200581ce9edf6fd051f72d9d97428d75d364619361be80a6bd2358212321f218202848200581cad03c048c63164f9ab86b2958754283f6030122101d5a35c4fe011958200581c6671f4670f72b087f273fc5cf590d3b493966d8a161d2196e49ab4708200581c3f1aa1eaa8b340729d9f0a8822c6437d4d147015f3481e9fb6b87bf08200581c525e9e334d1129d0e1fcf730efc133a48d6256bcf7bd7176dbc42fe1a4005839012af41f0011858550774efbd9e0921614f6aa6ab0565ec7d2b16a53498a2a0fe546069077a0e02a96d89446bbd0c1a4e95d90e6e3e51a68f601821b3c0e1ef6be7644a4a1581c2d725128406dc832eb74c4709aca0512499b3c7b17e00d7cb2e6d1b1a1413401028201d818582cd87d9f9f414affd87c9fa44328a3094438cd610e23204004447daa85a2402441f3ff9f20404231de2080ffff03d81859013a82008201828201818202848200581cb0d17d50e413873091c5605cf4071b93858f007ab1635896d6b6f4368200581c880c1fd828427549eef9d96b49ad1545815dd2aa3ead119a077c45648200581c3ff4f41d2ab9821175ed6f9ac783035f264e5a4ad957fefdec945b5a8200581c9ec68fb7d43a59733c746904524d8e62f00a1dcfb0f98b0cda1dda4f830300838202828200581c54ace6dcdb50d523c2c0109e9a1d56b97ca3a7c96e76baee11df7aa48200581c0b9325ff7449a52d065cfa274c231ed9dc9240001c27658c7f46b93483030080830301838200581c3e5ea19d103653ec819528a22ed147a8937faa8050e599f7f4b84efd8200581c2e155e98696d9e0922bb7b00cd2273d05c4db27285b1507edaf043138200581cadbe3e09c0ee7868af540371b4957b158078253ee7b152e2eaa6649410a300583930d1e4479c66bc387c427f88b7cd9ff212b053919955d331f4657958825826692947ff8fb3c689173605c4ce638dbdfe5df417421ca1d7fce0018200a1581c4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888da15818ebadb3ffded475226862b26ae111e511f3e5adf9abe47acf0103d81849820346450100002601111a000d7f99021a0003854905a1581de17cb25e3c14945bb79eb6ad93628877cafdc816e1c011822f70520a4a1a00057bc00ed9010284581c1e6879a925828feb12aa37403a4beb027cda550e656e3ef5e10cfe81581c40cde191a9f77e629e111d26fcd64c83aca795b6b3c7dbbb01e92b30581cb4178a197f79d6c35afb43fa9a4a734cbbf0532a7e4b08d5d2d92857581ce339d3f043cce003c1e5d4fe31a168db71a0d3cff837239b93b7308309a1581c3ea63e3d6b70ca9f7f46a1e9b00c7ed90220d634a586ce8a1c3e68e2a143a02b5a1b6f43992c22ec8b1a0b5820c6cc61ea757e49e306d8afd33a9385f8e7883a3935de68ca2146532b96b464fd0758204271b6c448ebf22d14a5b621baf5b219b95fa7219f78231e13a83c7b8beaf4b80f0013a58200581c139e2769e9d664d71ebd3ac6d6b064511bfab5aeb222d1be78d7a116a68258200612d22618bd17c5fb1f1a83f6bb1e2ea7c762b73f8998dc94990959bbcac5e705820182782f68747470733a2f2f345a69764f374a462d336d716e737967736e72304c6c616d56344a6e7a6236756e75562e636f6d582053c538fdd4147eae765e0ab055a4e8a9e56518f7ac21dc88038939cd8196a5aa8258204d735764b67a3b7f5e02d0688dfa57351eac93df5faf616579ea31a897fce05206820282783d68747470733a2f2f7a343447442d4c2e4c4f3863426e6d2d4c6c724d5859727868614457345a2d4d6c346d57584b5147674d37326d534a6d672e636f6d5820882e01eaa7ab2e3557ced099e3300333d1a58c337cd2975bc1321b7caa2fb4d08258204ea20edf84cf370aeddbb7564bceaaa106f714e35df4ff5d4aa7c6940ab0f6f101820182783d68747470733a2f2f416a2d6263535854414f76647461616e7145524249344633312e782d7058706b497357395264493161685551326c7346772e636f6d58204d42a5c0c1c6cea7c6985fa4aee748953517ff6abb708d0e3e2940e5fe4c7d23825820a522c4b5bcc528e3510c26edf0e0019af4927c260b35d633c656bb7933b9c71a058201f6825820d27fbd3130285c6a4743e0ecdc3ec4712df7916e5f450e8469dc32e3dab1679306820082782668747470733a2f2f78352e6a4a69746d48774d63714f7648385a5a4f6d41314176422e636f6d5820b68e81150ff782ad28767685b4a50fa8bc93003e4f5c28ddf27b5c21403d67e9825820d5912b325fff98ef70f9b14e14a65007f9373be646859ffa4da76a2ea2fe184801820282781968747470733a2f2f383272416d6f6f7535586766442e636f6d5820b57e729e68aa12f583fce2d7b8a1b997eb07532389087a8d260e728fbe215a878203581c0363a211ea9ffc91aae5f1d3860cba36521a8e3b8abee5d1fbc07203a48258201325016ab8b6cf412c98f3622eb42e75d30f8254007d2cd17cb8977ab7a6e7cd08820182783c68747470733a2f2f4b5265466f513233694655424b34672d7355707068302e36642e786b48394f5a3976503837446e76522e5a45576a6e2e2e636f6d58202ed3aa4a06b55437c6747157948541560db0691e355479746cc25a8093d28d64825820485032b792e9b2e1526e9371ed698f52279443175825cafc82effb1e3d84a6e703820082782b68747470733a2f2f4b346b6650306f3741362e456a346b394d5a3346572d794274313675314c4a2e636f6d5820273efbb0397361ac5b30c823267104b11633e37cdd6d10259f2dbb7e19b1edac825820d5ea11e5622a0702a842c7c2b724edb88a28523a6d48b8f8fb709773250aa01f04820282783368747470733a2f2f614d304b596e3149533438746c4970356b706b6b433765384c5a39322d38526f79317a664243762e636f6d5820b6ef1e0746b2e93d39c40bd752a4bcc59597076067f7d0f0a04d4c34f0ab2efd825820dbcd469334072e91bca481ca80c69c7efacd65103aa5d0b2ba2098155b89f8d1068202f68202581c954023c187bd53eb5624ff8cab8e58ee505ad5b02c5ed884ca21f72aa482582011cbc5a94490b8c11f9f902172338e4dd861cebecfc8476367d457e5d4e6910000820082781f68747470733a2f2f364a3072556c554c32372d6e694c63506971762e636f6d5820fbb55ea0ad789bd3bf2f4e38b8b3ee90f21cc9ac3ce99732cbdbf56be75bc81482582015546ec5a180bd9102c0958fafa1d334107d9895b640a6c4bdccc8c40aff985d028200f6825820515e2192b5d95e89662c8cbcecf4aa7790c1c3df46eae420f03d34ff8015c55d058200826f68747470733a2f2f512d702e636f6d582047a9c26a281395ec89c90a24f6b54b07d7501917c473fff95e2b974cdb4a8adb8258207993c328bab9136e17e228f19d9106f669d7fc6457ef6fc622143157dedea23206820082783a68747470733a2f2f533453513459724c6d6642632e4e4a424a446436634478467573726738642e44554a78716c62463554564e7069392e636f6d582048132bf2bdc8cbfddb705bd19f3df72c117147eb92b6171d27f701c06fe789588204581c4b92f5b6a52cbc15f37ff1871e35479b12f17ba8f046a091e8fbe7aaa382582032d3edc1e25cf2610c4bda3e3090e5d6f428723f27581e0ac174ed041024f51f078200f68258205c6b7e549e5c43ae30d19f0a7a351383172994306b2a6f750b72c40d4c3b2c70018200827268747470733a2f2f447950764b4b2e636f6d5820a6d9810660f2cd349eb880c4c36febf092f8209d284c06208293f558bc97aef9825820cc91e1e53dc587dc5c8417f006e13eb6bc396ce01d798e22923189e8fa6589c102820282781a68747470733a2f2f4b6b3749786e72467735564e537a2e636f6d582036567138df206448bea1e714979bfbbc227b9268eae934272ca083e320aec42f8204581c76b9f9ae9aea19e2d37dd5e26543f0320301ebf40f95020ff732dca1a1825820ee03902f064d81c7597d3a31f7f8112f00b3ede77897c999b4db171be61d40ea068200f6151a00052feb161a000a7d10a300d90102848258208e70123d8064d9ba8bb49887e7a90301607b3d559a2f6680bd83ed2e204d1a515840b50c45c68a5f10e04e42a611f6dd733bf0f5cd6a5b5820d6f61006aa9a3d185f90e37fd5e60178fd7c7640df618f221e5136be88d1e17ec04aa2f771af80d4cb825820c99e35834ba626274835d4453e9996e279392ba9192d7608d665602e930f84e5584020715509762d8a6736001bbfa921f904746d29d88ba32d8f54c16545a1d6068855b0a0154169d1825abd12c8617350b8713a101f53bd4d7d7a76144878ca42e5825820d82181f500b2758a9575d79ca24d65d5ec813b0a6b84196c46a159d71b67c87558408feef1f96582cc798eb232145cefc1721a3869a265236484f92458cf40281f8b89f7284812c93909ac3465dfd72db01cac19ec286307bf4af97baa47383c75518258204f7aaa879bcbe88d80ed59b6f037a744b66c35ac853721b9d875c023dff3785b584091ab95578bfc72707cae8c62b7b187f4d7051dfa3ff4dc7335bcd9f20062aff893c9bd2c0baa671438561fb01d9090d38ca40d73931cdd145fb45f2e4f8cb2b301d901028182050605a2820102829f80a1249f224042e77044af889071ffa39f40244126ff420dd1a543a51e810342a0a823446f998ed041612200400541c90080d87d9f41f9ffff821b0147529da12dd3831b29e87bcc8d6b7c9082020782a5a4a544a0c594af40420b16426759448b93dd1b42963244fafd301644902439e842376d4307d5aa9f2405ff9f02412004ffa3433314b442866722224005d87d9f400400ff4446fd6a114191a302447f9d318b20447f3b42b32044c9064d1cd87d80a2429c5880427073d87e80d87d9f44858d6a1effd87e9f4004a5234297822000404043d60f9942428f0021a540234041aa40445c456b7d050043343bba43e66197437f7332ff9f44ff483229049f41b3ffd87e9f2000244001ffa342169d426fcb2143b55e0c2021ff9f2243719357ff20a2d8799f4455ebd278404020ff4386fdb8d87e9f4279812340234211d5ff4040821b6faac39f02b3a0fd1b2c3229e69dd92af3f5f6",
+                            "description": "",
+                            "txId": "1e0f1af64929f6ec2484142dfbb9ae27e5cb472bb7846e1befdc40d994f995a4",
+                            "type": "Tx ConwayEra"
+                        },
+                        "0702070804060003060800030201070300050503080001050203070501010108": {
+                            "cborHex": "84b100d90102868258200211c7ebfb461b606bd9ed7094b3efc22155a460fa36d81a02532e1b23dbefc3058258201f5df436b29747c9766296e96da1fa1c2fa14422b376cf860cb5ec78f268ad64088258206c124efa80a30706d274454324f0a6308c3d93b0ddd6c0195ddd669837d8ea1b06825820874ee6729fa310b55c8887841cc254e37b835ee28b3b478d0c84e8803db97f9103825820ad7e2f3858f03fa309c7d8c3c318dfa23f3956cd5db071d281cc23c4aabca76308825820efe98697b4bc81f4af9316f37462afd0839ff3928e337d50f357145ff386263e040dd9010285825820258355d469a9790416d7d877caae453435c71ba7869da93cb93a240d1500d20601825820352e8b6078ae86ce7c4ca323c6b4b620a4bcc3b05595b2995e4c87bdd302d1c9088258205f37d9f23486b476d6812ad8881cc397ee0cb79af37ec46e33980e94f14df155058258209ec4b40b34c62738be00b59d93c26984c11516c6626d61f9553612c0a5a97dbd02825820b165261eea7b33d34f27f7644890c13a876fbc89dd84f52834e092b10768c48e0412d9010284825820397abdee6bb14261b5086fc720a2825857f432322d921d69ae91d9fbe93e0bae018258203ce31da9b154e1621e933c3f63a8076f88a77773103e8ea56dd6638f86a1dd6507825820b8872ea16274137bfc532ebfbad64eae5cb6ed587fc8c38061870fcd277a322002825820e4178185f153589d18f17d2bec6d862e9b21733821a12a85275d4722c753c723080184a400585782d818584d83581c412ac2419902f0a0f56fc8e8252dbb29b877e79b7ea7d235138618a7a201582258206779636d786a7a6f7561787a6a696d7568706b7777797a676178797170666e6802451ac7e4f9e7021a6a24d88d01821b08764e4ceb5c0041a1581c8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3a149405c9e60824278cbaa01028201d8184342d68103d81849820146450100002261a4005839303c2bec3a5a2e3eaf915b37a1d875d9e814131478b6bda2df61e42d9b1339ab05108c5ce8868edb955ca6182c4c89a2f4e803662c9e0cc2f101821b0a1de90408999950a1581c2d725128406dc832eb74c4709aca0512499b3c7b17e00d7cb2e6d1b1a141381b2999c90da79a4b34028201d818581a9f42e6fba3d87e80417da20243a30a63430db557411f40a004ff03d81859026e820082018483030080830303838202818200581c8c97ea88f4f6975e901320b90644d363e8190c3fc5c7655cac768e948201818200581ca5b9502325a9f71c495bfbd3f2d53f7d7f444e16085392ce1fd4f1418202848200581ca01c23cc9e3a1f1842e5200255c55276d1bc6c67f7b9526c145e989f8200581c1f562298c25f24567936887ca2b79a43e9098504a54763499ab2bf0d8200581c5bd90ebce1cad471221890667e853a4894655f63b00b8c3119969b9b8200581c3d7ec2e439e61de52ff302038ef61ee6ba5634938e4a926c8bfe364d830303848200581c96515aecde4b5584da378c8d65017c8737a9241bfc2906727353181e8202838200581c799ae99594486d12b93cf3ff73b214b45b5031a6fa9b820cb5ec36428200581cb2168f588fc76f30f785365dd9f0d7809492d4d566341fe1ae3c1f5d8200581c43cfa46043b473f0c7c82765089cb1998a22296716e99a1c41d383dd8200581c5bd641cc7ca7f369baddc2b86d4462a0d694ef863ca51a6fb9f029c38200581cfd571750f71d9ba86b219a086b402536cbaed5084eaa5fcc42bd0ae48202848201818200581c752d2dd9b17ceeb99c9cd869d61c2c88b225336867657b1a70b1c6288201838200581c6a295a1866e4879280e4924255d04f8664309d88ec91cd82864eafa28200581c7fd9afffd77f31b5a3df14955c9e9e76afd8aa70c1986ab725da35aa8200581c99479bb0a279af988c8545de1e4a9c1404423c36699cadc06c3a5eca830301818200581c95094810fe75f0b5f0b9fe30904e7180e6785037f434e6fed62b0fd8830300818200581c82a9bcf2bc1c452a0d929be9e36ad774cda29312a13133908fb052cda40058390004ef8531dcac143ea9b6094322668997643e504078942c3e89b0188826c640ce7483ab27de148c2f5689cf7f0d927bf182d56cb7f45f1b04018200a1581c787db42c0458764cd00339ce8a4f6904387c1843547f35668396d046a1581f716074d60f651bc3d169e214ab3460d49737c660981a1ae6bae3a599cff4ec1b72325e82fff66826028201d818581e9f42caada1a5400140050302020144d490b00941549f05ffa042336a80ff03d81845820082040d835839305dbe5dd87ddc46e16c6367fbb90f56c2c333a12f76298dfb213d8d23e77eff08386067d8af37799a7cf4f29dee9c14b01449046baa591dd78200a1581cd67fd480191e8f690a32bfe32bbda2572170c6d9e1d6556fc037adc3a158206a9bc920d7ca72a8de7ffb8d7cb5d3b00f42014fe2801a5d5c7863df1a5b24d01b32feb2bdfd04632f58204c8c8e79474bed23103695cc65cc7c670d8286ed2d6745903be2648113c815ea10a300581d603f0fab412dc99ffbb10fb31227f71ce0423b00cd1e28623fcf66ccb9018200a1581c2b558631ce4a00dbfff5533b8c53668eb95e34304652d2550206221ca1493cbc633d25c47000041b4549d799e13d35ef03d81846820083030080111a000c0e72021a00084d35030104d901028282008201581c3ccf2fe11e2bf949d374f409bda6eca4740737ca945d65cefba7c7d58a03581cb346276d677b8ba14591349813eda567c728e32a0841c3977b7eba49582001ecdac6b947b23a17b59963a4509d3ab0000b20e58551168944ff9d95cdfd291a0002cddd1a0007d390d81e821b000000952261d55d1b000000e8d4a51000581df1ec513921fb288c0538bed35a1d702d2ffc30528bfcc924b874097522d9010281581c45156caf3f69ac6ebf76d9f6c661caa1819b4d4dd9bbee17858d96018684000744000000065006000000050000000100000000000000830107752e3267664c626d6c4259566a394f4966732e636f6d8202783d505a68666e7255554f4e4941622d35454b71484f6e5559387775642e667357667a506c672e4a3238424242674d50574641724a426f6a69685a2e636f6d82027838325a5533733579503853787a324e594b584431496f477a4a4b4457706f6c636866723648612e6749563977416b38636446346d2e2e636f6d82027366393953394d6a716b4c63706a45642e636f6d820265702e636f6df605a1581de1a9ec8324a8fc168e24fd1fd02e49ce3900fe9398e39b14d1546b85b619d0cd0ed9010286581c150531059eb627b86d2a038511d43939e04e54e584f8fc8d0a119138581c3c8c7544d090ca38a77b065e0b531e2b8989712393376fc6de8c6a5a581c631477330ba85baad0620c4406d6cae55f10cfba4b6acac3140f7af5581ca262e24902b49af19c3f99c2a48ae84dd36c96afbc7c6da73ed57f27581cfb03dad520a8e85b621dc52de07ae5d9e798733ebda9f3590d8998a5581cfdb4c65bc998fd1d5bbc1c85ac97cbaeeaaa0e4edfecd1d5a5b063e309a1581c245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abaea141341b09f4cfc7ec18da200f0113a58201581c46bb9b6f205398cbdf14f6bc339d7fc650769b367740391c5bbd5cc1a1825820345d4fb685efbd74fa2342f5db7338dbbec6717cfd69bfdcca0ff119528568dd078200f68203581c500bb504314f4a2c9256187248f34c7e4fb4c30b1b016eda21368a4da1825820978cec26aadd1efec259d809d6e75224c236a12b863ccc296d9409ceea6a1c0b02820082783a68747470733a2f2f5a5641324b4554454a6f55484d4346545446337831444c51764d49546867422e704530335a34663363423557486d2e636f6d5820d35d5af5fd7fc4385bdb183748cf4d3b9b00eeda5d47e09ce5371732cc95b0f08203581c9ffe84b5542ab4c94beb4167ac408e9e42f07f4799035ba4097dad8ca28258200e2c88dc043b9f68d63219fba92bf80a21320e5dc11c19cbdf6ff320ac23852d08820282781d68747470733a2f2f3654396b5675552e4667684e7a587237482e636f6d58201f655ed5a836003f68de553495192875982e095a33ad13171416e769be8809c3825820fcabd530a06979b88da485cbf6c32063aeabf80aa82ec20337028bb9668832cd08820082783468747470733a2f2f454847416e5039734662686d58697146427352576c596f7a666649334461527a46712e75546958482e636f6d5820f1c010d4404bbd3f91c6ffa2cd23b0590bdab8d10f71954460b9b169afd24a358203581cc0cad532e80bb39f0e90b059303330f8f88bf208f4e46af04f3ee270a48258203e5b23a644744eb4a69b31a6ef355e9b49e1d529d2c8febbb4cbce474458dad207820082783c68747470733a2f2f6f78414b582d336462306457725733654b5a614553536e7668632d7a4c632e7675464673495a4c57444d6a685062732e2e636f6d58202c3b2b7ce162bcf4015a724e6b68552b7488a58ae1a12728b36f1f81072318098258204acda37af0bd8caef83bdd4592d506a31e1b4f836915a2dd476888b905daf904018202f6825820e0a08628c17ce1cfad2fc3aeedd442afd3a6bab108d41825734ea9abfe35123007820082781b68747470733a2f2f77622d314a6650515970686a3955352e636f6d58209251331cc78ed2d8b4a682da48253b3411b1b29572878d762420b3abef00d85e825820f717a3d002bfbef0f68a3117df214e56abcea5449a7ae31d5f4866935866d8a9048200827568747470733a2f2f73765a4b70425830562e636f6d5820edede59f7abf395d3283a826f414396c803fd7b997bde4213ed52f8cc564d5698204581cc1d09e89db31bd3592f8c0e92625f9a8ec3444748398c362d5df1b75a18258204c5ee85d8795c8ebbee45e40f61357442e0aefe78f596f62c100767a42b6026d028200f614d9010285841a000adc68581df1c6973b5dccc466699da3379fd80d444a58c843a5a859b31022fd1bc4850482582095dab7fceb6a4279703cfa220c7f8e69982669e131e70b70951c0fa6f0b36aaf03d90102848201581c40a37c448aeb5c2de717ca231a96e456600e25239bb2c52e2a4f73948201581c9bfca9a578bfaf30f53ecf429b3e9c74b2c44dfba21b3a61c39b43488201581ceef2ff7d9bad59571e5bf58ccd2d33e27c85640c2369c1bfed53d0b18200581c8d30dcfaf6cf2338c0b62a309ff92591db63d2a7183746742f566662a18201581cbb824d45e147de4b6b472c61d0e32e103e1b809190c16c2638f28bd105d81e821b14651b6e91ff431f1b4563918244f40000826f68747470733a2f2f7257712e636f6d5820be316f261efe499eb7528ec9ae7f0312903b93c770bad63ac7f09c25582919d6841a0007943e581de10ac13eda8484bba63d462ed2d2be4d9c256f00c21fce85434c3727cd8302a1581de1636bfed4f855afd3108185913a19e541d2a07a74ced698ee6b89ca6b1a000b2e39581c0c8e9d407dbea673c1ef4d14ec9daf62a18a2f75e8e5621e6de357c982781f68747470733a2f2f383973774d6d4a505a755872367436616a74342e636f6d5820a6b459aa7a38f393e7611e19c252f7714124f82dedcb8ea43d4a6890de3dc94d841a000a0b35581de144de7f2a724788cf9a94b5b102c0a342407f755b8139bfdd89191f848301825820d8a7882991c6b30c508c5abc41504c2e9d2a919aa228f62939d11b6ff515ea5808820b0082781b68747470733a2f2f425434536d4e4f47366337326549392e636f6d5820ed44eaa89cb706f01b6bbeb3bded99671e17eb49911c62446d6fadcbda293637841a00042e46581df0734ab9a9775b16f93cb5f60c9cb97edde124efa62073c7ffdd2d9b828302a2581de0421a68514b6ad1503009e6b4251b7a042723e8ba5d0c40d04be587cc1a000a43ac581df1a23436229139cf81776d30dc571e637a32c841af75577b898787a1221a000909bd581c1f0d9198d4711863f665efce62f0693c549b3bc4fd2b6969ff7b59ae82783268747470733a2f2f4a62733575386f67516d32584d484345426251414b39554637714164475653474879632d41432e636f6d58201d99793d8f1abff9bacf1ddbd205783be1caa90c64183a7413515e2e4ae53382841a000450c0581de12c5611ebb8d8dbe1a8402d1880766bfae7e5b11a9246fdc1392846558301825820354edc9ba0bba5aa93b41f13961613d6f7a52dc290b7139162d62e3035c545b10282040382783f68747470733a2f2f6361467a514c364674513750474535647533464363342d3145686e334e7431704464756d3173336c735677714d374e4c41787a2e636f6d58205cf1b2c21c1e2d008b125b2c69483d23cd90a5f44c3d0d9019c5089fe16f47fd151a000c02ca161a0005722ea500d90102858258203252deab917ec2af6301324fdcc126a98260b2283abf3dac4d731b0370c34fdc584077fa92146c16adcfee6d4d4ab0a5a5e3672091835eb628f552ea8dc87a47523a137139b82ec28396c608188fb25e33b7c89b38dfbf967417f8f6d5a92b5ab28182582080fac48664fce4341a7c5ab6f0242aa5afc6c3c2cf149b6943c5a029593983e35840833259128356b855186c62f2a7cfbdf6b7b2add5e8aa6cc422bdd205bf100e5a310a3e9502b7e7e80e641dd1d2ca787594a83763ce0cdfd28d85ee4b467f6d68825820044652648daadb24468ccf8ff323bc544d0091dde829b197fbc63ab9acba724b5840f9b3bd37f9000ef76d167fa81b5d4554c6f2db933ab80eda8606f0d5504d0bcb0bf919ae543e3ba314fcf5941b6d2480a5e552d9d9a6be0449fdfb16cbf16a8b825820d0df4d5df35b3e1fa8180ae49f4813469a4a85551efa211354f8744223881e205840be86d1aba626933a6beb6d1e771876fc11ab9c5e00e29af6fce7dbd028d7a21b978f0ea932bc9114fb37de540260b62f0a30621e33ec939477939c5026a00a7d825820665ea622ec8f030c846a372fef964fb6827ea33d376317cc8a4de1e1d28bf6595840427c30ab5c73ebfd84a9b19f5042ea03730edd20dae8ce2f6557d80fc9f903c8b73c5832db640655a7501849abb02c171f5d9a3d1dd93e02e85d1acc770fa39302d9010284845820f4b6a93528f238b9943503ddb4b109a0011e7a5523c79a8416dc4600079f4f045840403a7963fcb59f4b9fa52ac0ca312ceb529fd6072d75b33b02630731763378f81dc9e12276a786a10b14b9f4e49db711acb26af32d936cfbd146ad179cbd45f14498748cb441d684582036dcf893334d74859036d0a9e990cf420186df4549d8602753330ab59c96a41f58408ec918c044ad48762e034a305f1900c00ed76f430f44d0d98a5cfdf694186afc814c29650113d4ddcf311cbff927aa0c7122840f042489948102a9f83053240e415a40845820e1ff3c1fed84dbe08f1d78853d909c88f25600059bc4937a0b49a6a7588e6f655840fea458e147e0db1d2f181c9d3db8c6a48054e403d4b549abc92777304d07a2e31634ffea1fa644a7af254ed69a9170ef1f7411f187c4855353fd7c044597daa74528b8cc7ceb40845820d20f66dac15e367ea11ff23e2c04ee0ffc604263516af64f60d16121808b33465840f290e440b6960ee86a1a4998b45a57c5ca6c48d099e567848326fba145d093166183b1f6a059a2dfab8d68913e070bc4306fed88486faf1c721383199e466f1a40434a1f7d01d9010282830300848202848202828200581c30236254b39ed970b8e3a28b1b34f96b0c3148b754d03dc764f9b8b98200581c1bd0a3a2105bf905f3bbde0e974603260ac670dd5a7078ae461603088201828200581c62a1151e2950a3bb38b9fe35c08946c2f9c1ddba25b2f51d571bd4d38200581ccdf4265875bc4c4baebd318ebcc135363836ecf8cf227c3f21a61cbc8202848200581c8b9143b4354b53d3d3d1595f6770d6b8f8e08e5a5bf09c9ce446934d8200581ce887d3dd938803372afd6a89e529da53e54ed4d9177f1cdac1dacb9b8200581c4469d23b1fb705e515fa55892e1b01dc01f59662c377764af92972778200581cd32f49724c71ee76082aa01c57a5ec28e312d750a2fadde4af80c02c830300848200581cab1d88a98fb6d7e8501094454bae6153cb0a302e97713a780b6cb1988200581c59ea5db2776adc650e4ec4f4bcf27ce833984d199bd955b901d5f1418200581cf004da1f1e658c06b425591d53f55d179a8120cf26013edd3caaea2a8200581c00ff85bdeeb9cdb9f937413a18fc079eb960104e547d4ce796501a6d8200581c636f0b90ce4ef26fa4c5fe1a6e7e29ba1b127c7a2ee91cb1081d561b8200581c7af2a140d3d4cd6974d9f4d5080ef352cd315bb5fc68456be24d8852830301828200581c709835b635822e7d2b37177a9716d22af63770028ef335df34602a838200581c9f0726481ac27cc41212041c2083c8b2cc2f427b03c3c846fae1888483030284830300818202848200581cefff2a97b7a4ddea9a0f739fd2fc79c292c7c9a091e6493fb9501c908200581c6517cdb7d68814295a92bb8222294c83dbc033a673ed7835a03b52cf8200581c62c894fd73c2270572ff519167c191bf3fbefcc6b4e32d1dec88200e8200581c4f430f50ea04c1826113829b0af6b38de20133fc4dfc50dc588f190d8200581c706bb13d7e13556e9068038e03984e508b589842d59861c973e7c71f8202848202808201818200581c89dc47efda134b57c820062eff06ed5f98ac2e2bf2e1aa5836d2a0bc8201808201828200581c14da77128bdd445c56e6be937f850950d500b5b2fce330ab8d988b1e8200581c1e1958dcfb4a35e1ad8793cf6c38f9ff3419063378616166d548728a82018004d901028241052405a68202088243b1976e821b4192cd02c31363411b6928a48715c065cd82030182442c7a91cb821b6d48b8b18acb455c1b7a69a0c76d90e0048203028241b6821b0b7f0eb8538125891b4e50e06f28cb5e488203078280821b5e3c10d635f5423d1b2544f049fd8dc08e820308829fa1a50340052402432aff0924421d62424d4f428dda05a2a100214324d29ca2200443a2f85a409f43fa4c7443a9ad9c042040ffd87c9f9f44e0229fc422430615090005ffd87e9f442114908b43575f08ff0103d87a9f00411bffffff821b0c91a2984a3451eb1b74ec1599692465c582050382d87e9fd87b9f42591affd87e9fd87e9f0500024023ff9f436591c0214310f25e44f160727905ff80ff22ff821b1ca24679cf6d084c1b0ecfbc0693b1e436f5d90103a300a20981400da1449dd35603a243ab4213693563f0b19f8fec9aa441cf41660184830300808204068205068202838200581cb9aa72a5cb4b60d603fba60e47d2be528b1a4ccf4f7e8366a3356593830300818202838200581c83f4a5707fe3f8d22797d8d3c94e7715b5e8392c13bd37ef62076f618200581c083b084a10c4a3a3942c60e45380517b2a98b64751fb68e5c00b1e6a8200581c6eace0c4bcfcbcbca02a502b9ff3f80c7fb37964b659874e50fc9e5f8200581c9f30432e4586baa747bdab032b434a983484bd78297364e187c6aa9d0481484701000022200101",
+                            "description": "",
+                            "txId": "b1c0163589e027b14b24dd231b3ccaadf1ef02bb93b3a021143cc27a95f27535",
+                            "type": "Tx ConwayEra"
+                        }
+                    },
+                    "confirmedSnapshot": {
+                        "signatures": {
+                            "multiSignature": [
+                                "a071100013561dc1798e56a63a93ae287e34d5a4d5f6db8f6e9ba110c5fbd447b01a323d92ae4fe5beec328f8956639c53d213215d9f1e0c8ba69df404cb1d06",
+                                "da1c500ba63bd91c6b773239590ddea0b302517ceb9a919ef5145613188e25b7714decc49ef4dfd699de049eae5d56e9c3189f0e56937a9b73692a6a0837eb0c"
+                            ]
+                        },
+                        "snapshot": {
+                            "confirmed": [],
+                            "headId": "08030104060007070002020105070806",
+                            "number": 2,
+                            "utxo": {
+                                "0201050206020407030308020207040001070200010204030108080507000500#17": {
+                                    "address": "addr_test1wqys9jn3vprrjenvq245657ymrs20tvfccfcna97fprq5qqwzwc3s",
+                                    "datum": null,
+                                    "datumhash": "10be20c77a7709cd3f8545be059f50ad65949b13e0c8ed4d0246cad40d3b73a7",
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 7500000000000000
+                                    }
                                 },
-                                "lovelace": 1297310
+                                "0301000200080203000108030702050508060304070605050307070801030801#21": {
+                                    "address": "addr_test1vpvslaymu3e329jj0mr8972hfhzseg43zff5gsmx7resfuc0qckad",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888d": {
+                                            "3381ceaef80b6f919c520153ef": 1
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0508020805040708070203040308060100040808080300030102060408070204#39": {
+                                    "address": "addr_test1yr4wpph4tetvkyawqm7yfrnth5jn5uh0ku6ma79xrdyvj4nn73aj55ql083sguq7rxwcnywyfxrv7yh93n0svs5msxgqc6pjfl",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 969750
+                                    }
+                                },
+                                "0508070401040002070808040602010507000706050505020007010803000603#19": {
+                                    "address": "addr_test1qpwjqw52j5nhav4kpesy4cgv8f9c2nrvn90sne5tnvdvkulj7vq0fslyg9rlx2lun3uzfnv0d7epr0hq5m9r9rcaz6tsm89ttn",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0601080302020506030803050007070504080606010806020105060205080503#76": {
+                                    "address": "addr_test1xz4a0pceggs89mxund22f6tv584elwlqt0yrwcej4vpvjcqskxst6ns835259fprzhdn6pnd9x5lexhsj7tntfhuwnaqfj9z9w",
+                                    "datum": null,
+                                    "datumhash": "63e58191d6f4d884e16b5a4e4c96ad6bcd6784023e0407eb0f4718743fcbdc84",
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0703040603050806000202010002010007070008080804010507070104000206#1": {
+                                    "address": "addr_test1qp5q4laeu0smu2c5t5wurtete27d6decpcmk45dthyjx35fpg9yeserc3mgdt9ava9mkry46h404puf98844gg0afydqayccgm",
+                                    "datum": null,
+                                    "datumhash": "3a35003dc0e832f4cf7d28d4ae836b9db0c3797a34429d0d4630a6c6b2f4a9bd",
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56": {
+                                            "35": 4357578385940393344
+                                        },
+                                        "lovelace": 1305930
+                                    }
+                                }
+                            },
+                            "utxoToCommit": null,
+                            "utxoToDecommit": {
+                                "0006010302060702040001050100040308060804020003080600040103050608#79": {
+                                    "address": "addr_test1qr5x24grpu9wgn9tgsv8lfypasnu9crx5xlk9wyth383p9lmfz9lgct3a3729wazsuk43jnd67338j4qpd7qre3uuz3qwesg5d",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "00a00939c4efa4d1e540e5aee3aa3d34ea3763251e520a8b460f785a": {
+                                            "33": 1
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0101050501070708010503050208010805030504010004040802050105020504#43": {
+                                    "address": "addr_test1qzk97hqngs40p8e92dvru0rkvmkt66r2gp8jg2szu79jw44gkuces2yf838gg54583ukyu5veujzdejm6up27g5xvk3q25v8eq",
+                                    "datum": null,
+                                    "datumhash": "66025ea266de6abb964f5c1d1350110b2c2f7c7021ed79c0a7573fbb1492b0b1",
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0601020506080500020205080007060805010605060101040707070707000203#19": {
+                                    "address": "addr_test1xrrrn5xmwr42jzfwaps8rkhyd88d5kvf055ts3rsdsnz8785v0g3jnd49mqnwapfex0jl9ragdhkl2anqp8k9kdt3qeqc9urd4",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 969750
+                                    }
+                                },
+                                "0705060206000703060808030101030306060506000507070103080403030307#32": {
+                                    "address": "addr_test1zq8qk5uddw4axhsekwttj4tr9klas74rm085dfu6g9nu0kmrqxaq57xm6h9ms7nhy0gu9fqk6tjp4ynhrkpanyuzd0eshpsxul",
+                                    "datum": null,
+                                    "datumhash": "6e9f19a19e8425ba41ee6146a3ae19c223dec7593438431b6cd27ab61da4eeba",
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "b49da52b28c13162c731969077ac050d1586d983e24693c6c50db3e7": {
+                                            "33": 2307415519495357740
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0708070800070100030101020804000208070005060106010500030507080701#71": {
+                                    "address": "addr_test1xp4hmrue7tdc6xk3fuhfgwgh96a5u0um5pfskzvr5rl640cxj65u70f27zclf2y40v0j29wwjs4qpp6j3uncdputz08qxtc5pv",
+                                    "datum": null,
+                                    "inlineDatum": {
+                                        "map": [
+                                            {
+                                                "k": {
+                                                    "int": 5
+                                                },
+                                                "v": {
+                                                    "bytes": "b02b11a0"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "inlineDatumRaw": "a10544b02b11a0",
+                                    "inlineDatumhash": "4353c40b38f25c9403c2bc8d6afcc8711a206c7eb384dc14944eb8d6f3814292",
+                                    "referenceScript": null,
+                                    "value": {
+                                        "2d725128406dc832eb74c4709aca0512499b3c7b17e00d7cb2e6d1b1": {
+                                            "30": 7866186353409476000
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0808060804020600040807060400070605060604050302020107060407000000#97": {
+                                    "address": "addr_test1xr7349w77fg86fa845thy3wlmam6dpzyp2yut3cgdffsjn8xksmhr7ufwy63rn3t8fyar4qpjy7qslm22rq7v2xg9rqsal2x23",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56": {
+                                            "32": 1895820374913759104
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                }
+                            },
+                            "version": 0
+                        },
+                        "tag": "ConfirmedSnapshot"
+                    },
+                    "currentDepositTxId": "0501010407010105080000030606020500080106010700010603000202020500",
+                    "decommitChainStateAcks": {
+                        "bb5a85f0e1af0a6add91234db51800b7352af4ca6213ff443337811f45e5b6c3": 3,
+                        "bbbdb42e11964b39060e48fce6759d28cda2ba05ca8668a5a4fd8bbea5066687": null,
+                        "d734c448cbfe0f04b9614a5ed4167740bfa14f5d97072eb703e7246460ec54e9": 2,
+                        "f0c35c7a39f56c85aa06adcd0a45024c49311cf7525fdb7ebeb735599886cb89": 1
+                    },
+                    "decommitTx": {
+                        "cborHex": "84b200d90102818258207e31bb8cf0798603e89c6b4e6fb4d69d1c7a79f95fd9900915f22cb2ad655296010dd90102858258201fe1c9faf05cb2ad3a27aabc3038405ab915f00b93e23282d6c8020b22d543f6008258209f344cd773d01aaf4307297cb96297e82cc2596ea6961a853922e54bdc36a77b00825820b70d67a3b1c21df01f5f8746ba030f5759363d1780c6f66109ae2857e54c20d400825820bf8a929440ebc6cb4dfa30fcd6354188e034a08c395cc40ca8f3d637565b111406825820c2b99704f4017b8ab495288d89f1c3ffe5d6ea4b513cec0eff5fd8cb3c8383e30612d90102858258201fcde6fb827a8f4b3fd5c728e989c1c0d4cefc3627b7bcf41bc2675087a3058c03825820598e8c00a325dcac4fd5dc401047b902e2819898d74148fa971860fea7b6b09c0782582072221f28d2734b94728bcbd7f2305f7731ec05ac925795cbd1abd4007213c4d20782582087016615ec2e2e55366b918bdeef2d42e895954242e0ae3ee7b62f3b8cfa967a0682582088ff6e3ff08e8a22221a49a782ad917a53788874bbfbaa37049715b15eaff4b0080183a4005839000843dc3658f5c41ca6ea55090a157c3054099deae71b7d8766775ecadc15aadf42c1cc698f3943d67bae6bdbb395df710f51f4d5ce6e5ee401821b4bf719ac0922645ca1581c25eff942e5ec6eef0ff730149e7eb98f01ca21990b0f2b19a1dce71aa1581b1df06d472b4ecce76c6531559913a34b2684556152c87304ae4ab31b274ed97b229d28bb02820058205c48db50b4696d039a22dd8bdc4ea9e59da8948e372c93a119dfd8900307eadb03d818582582008202818200581cdad3e9cf9273323d34d0ea36a3bdd41a9cef73cfe57d8e16140841f6a400583910be03128e016b54e5c5d1060f3fb94c6f4c198dc7cb7d8dab5f772c1d5d896d15971d16148a9515b8af410398a2256d64ad11788e2b54e474018200a1581c4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888da141361b53cbad629799b934028200582002f11cad989bc7815c2d86778baede659cd94626945f6eda90c57bd11b6ce1bb03d818582282008200581c64c16cd65c2a4787ed20aa3268531fa2e96750c316dd266496e5ac7fa30058392033941ff9d60faf37ec1081cb87dd9b5eb30912b7ac70722b29c61e9c5b145f08a70b9be699fa4fd42e8b42da899ab41519014f89f22c75ca01821b07a7f7df2673fd52a1581cf1a894353562cf123a6b19c5f26ff40683523452fe43d74469b636a0a141381b653ba1d1a9f2e5aa03d818584c8200830300838200581c03f354703cf526e7970838799a8d39c4298988e2b7a0deb46a7da8f98202818200581c375c5d0b8332444c02b71bb8a509a697ce2c1ebc928c0ff7986843a78202801082583921b6ac5c7ad499112b5876d794f367aef2550919ae276cd17443b50f35be7e3a592652d0da6aa4993b9f11a1d5f1d8a9059f6730466f9c3430821b458450ed755f81f0a1581c8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3a141301b1a252585933bd439111a000c5a30021a000e248f04d9010286830e8200581ce74d7e251fb254a6d8487361955e0c2a03ac403f2731f0dc141fe87c8201581c4196ad68ece285c7ff802bd398c55080bf6fc219f971ee78b464a17b830f8200581c2b4b685e67f6466c4bbf8e61fae3379ee6b5ce7c72d632d73569cfb2f682008201581cc6333d96c0557a24535c4fe9c3c4cee23d45a1395f13ae2ae3ebad4f850d8201581ce66a61f5b0256786312c2142f7cf83c3a8c4556d2349f74f1e7cb04f581cf45640e736a7efcb7f39818be0abf76912c17941f9c58f2bdc44582581021a0003b4e183078201581cadb145100c305556221fdd32a949d1c8e19f0ae4470ce4446ab56fc81a0004338084108200581cb205e1d351acc6fea7059dcccc55e5c5c5ee745fc3256ebfc7c765f01a000bbd1a82782168747470733a2f2f444b6f7a526e574c474f396b4f70626f4952344d342e636f6d5820d0b76bf2371dcb7c75521c0ebee52c4e5a38c9dd84529464f9bd1525443d6dcc05a6581df0efaea22917d340e8894facf6cb794c68f89d5f0ffff617e8304393311a00026603581de04903a7d0396e8a5c46a406ba429c2fcc911202505351d6fe5052c717193cd9581de053e5412ae16b727ddf6b0617cb1515c6090742991ea479ba859918881a000a30df581de07d14c8dd267666aae5e51940a086fd430a3e9ba593774caed79f402e1a000c378a581df1e900488013f249fdab551db8ea2bab066a5ca7e0fd352d0a79ddb6b41a000130b8581de189649d5a8d028d8ecedb53c4b980c84d125201466c2eef3a1fb396c51a000d5b6708010ed9010285581c399d7a2658cb9262c2b9aaa6de335c0897b918bc3de5d996c2bde09e581c3c1efade03096a0779cf24e78de3e840301ae0e12080dd91d57f5a4a581c76d04cde9fa93ed511310dd47e3fa6a8116e64a2f97ad8d874fbf3f0581c7f6c64c55850d58211844561dc55aa1a82b908854622b0634e3ca87d581cbb185106cbf0106a3a1aff87f87761e1f32a23578efe3246ced2f71709a1581ce45e97e20e2774d24d989d3368b78a78ded1280d2fc2aeeb14a97e6ba141301b2ed3d15d2add15500b5820348ef3e8346e888f86fe1603ff73ac749154fbe7da6dee9400f2b2d2ac0bd2380758208b20972b3c46a82cc014f3cee27d90c3710c8e12caa5bc0c9d08ec27c44465030f0014d9010281841a00075c06581df1cc6307182e2af598980bcf03c58a319e7e4b9028568647df1b9979038203825820d5d318379f68b7e7486525a1ee992a3b12bb634f702b1f45c0a337d541ce6a050582783868747470733a2f2f71353436316652496238476261567a494837384a543341574837635450436463776358465048474f562d71492e636f6d582048ab111dfcdba5c28161f54701d1947aee955df48fbd887cd339b78cfa3dc7d0151a000216a8161a00093958a600d90102858258200189b21b1d51fd94bd90b980178e9fe9d5a77041eb8adedd0080c34f84894a3f5840138985b9196eff1e9a3e535ded0d75d05673ed5e95824617b31407c914401113da58bf0466a27bddf15f71886c0b05ef370e4be84d5909aa9ccd953fa8dd276a825820990329e74a886b7b1ca1719208675ade8a8027c11c06af5b53e0fa32ffae51c15840d819db8617cd939176af3d041f6c2eb897f25565ec9421b2249d200c5981eaa0a4a0cd8964c984195ab7bcebc53a06a3fcd77025b8e5ffac6deb8a3917b67df582582052cad6d25f8814093c1331700c977003b51715bde5c1970cc5e811227483f05258402dc189c2b6058422a205430ae7f567d918994b790f9f7a8624737db8cfaa6e802af792f6a7ff5fedfb4a44b1ae1401b91120ae7e5f84352c042f70f9328864fb8258202eb9698754b02382774d7a1f0074f129e682783b420360abeb6ee21c532d702b58409df5ce5fb0b929f48bc0088f178673c2f948243127e994e029896d3cc043061af4858886a3fe61bfe3ee2de875326dde8464407b1c8b36dec1345928fb2bc197825820c052102a7154229e373e9aff0a075aeedf80984fff8cf12d544219b632c3590f5840406b446643fca82f87753a71c5f64c4bee05f492d3ea3e042c44bb42ab07af3982d0422b86c32640aa743ce19f866ec10d399d552b9a3a9e0783004a3f6b947402d9010281845820a85c0a24247162679f39797283eda9e8914858820f9ec644252df39e7929daeb5840c34f085a99fb4f518af086e6c67edf9135447c64e26479b958cd01788712599076acf4a80104de53a0b7d42501c8b4b35a2ee27561d9750b4cfe1b75de7791894437e072ee4251ae01d901028282050b830304848202838200581ce63b8670f82bfa877deed30bc6bb4be504b0a4d1fa529b899491993b8201808202838200581c6a144699c26325c460b843f43f5e151a4b75f0526b8c97ed837596588200581c3defb41a467de0a95c5bac83b7c8f15ebb560ebfc7fd9086c96fb8718200581cc97d05560bc1dd089a0fcd1102eba8a953e7c6b4f439cfbe6be79556830301828200581c7e77d1062056b38d215aa6853ffaccba2496197403a6fe20bae42588830300808200581c49f565cf6c750db59a955435fa503f42aee133eab323025a452f88a28202838200581c84ff74d39db50187c24c2669f6418e56f666d8620c76b91e2f81591e8201838200581c49fe8976efa96600a4cf340f0ff90d474e114ec159c18aeaecc92a128200581cde2695b0ad5072871f253e28f97199324723bf130945947ab6c0b0228200581cae88566824e1965ac3ef17ed7aa23a18bdd9226118be7258c1d10c458303008003d901028148470100002220010104d9010282a50444264c21d8d87a9f4128d87b9f04ffd87b9f442103fe704193ffff40a0a4417dd87d9f0042a02dff427abba34405a56ef540212040409f44c789d049ffd8799f0321204043dc8d90ffd87d9f40ff41629f0141d3a004ffd8799fa3400042dd094392c89f23209f22ff80409f0543c4992341cd05ffff009fa09f42279cff43140a9fffd87c9fd87c9fd87c9f2244233d2ea9ff80ffd87c9f24029f20ffd87a9f04ff24ffa1d87a9f435a7b14ff44361ad10ad87a9fa3242302419d43a7257e4080d8799f434259684043c1082643c5bdd123ffffff05a18200058201821b7608be0ac26b77311b71ea2c2aaddda3cbf4d90103a400a1054001828200581c937295e0b0fc21a96fac235a8c4595b3f669431ed0f8c42af7a3dad48205181d0282484701000022200101484701000022220011038146450100002601",
+                        "description": "",
+                        "txId": "867734ef48c80babddfe2a1ab0d3d4ec77372b7931263a8ab56579a337423e15",
+                        "type": "Tx ConwayEra"
+                    },
+                    "depositChainStateAcks": {
+                        "2f5b55b934c49546fe9e89084be64d1d75c11b14e96db1d814dab11ac406e39c": 3,
+                        "5be79a8caa390a78d99f3c934f3883c867c68fe92a363900491cde2d5ddea21b": 2,
+                        "b5fed801289921270e15c63fc35bfe501d9f2995d5aacae32e15b1c9a899cdcc": 2
+                    },
+                    "localTxs": [
+                        {
+                            "cborHex": "84b100d90102848258207b689554be48a13cce843ce1290358bc9a685e9455647d6085b327461e278a3a06825820ace99d968865a85681049516340427cefd54bf96bc4b376d7218c31e6ddb7da408825820db68b112e0b58ebdb8d1551d0e9c91c1874d6db5933e2f77ac78a115cf3d31cf04825820e3179022a73c4d5bf27e3b49a543f7def98b3cd223ad2be0010e6269852efb99060dd9010281825820b56732e74ba95271672eab151d07b76467df900620f40ce94726c325a511527f0812d9010286825820681e754c221cb447558624b52f20ef924bd628d73bc12d700d711374b2e902ba0482582075a6b76acdaa033f03320c4b58489796394ddeeefa7a3470ddf49fb7594d078105825820863e48082f19ada2dfb1871c4f8d7b5f382ceb7b07d74728b4f952a6cceb849c05825820a00df0b4f8f16bb72c1b16d30866cce3e3c05ef38c7c809cf1beddd97d0d870600825820d7f38a3f33b00af24f4c7295775a132b6317bc4585787e59b216b9bb1101eed103825820e144bf6d699c9d623562d6efcc685c2c1c0387c87b183a58b42c919df93e2221030183a4005820418ac860cc72fca1d8d35cdef3a32e55bae5e44c853521110117c39dfd030007018200a1581c3c83d45abb77cd7e01ad02e333a8c1f22b584fb5ecd895b9044c4f23a1413501028201d818499f80441323167b03ff03d81859010f82008202828200581c2c278b30658ca55d86cf37dd9fe856b0c38971a180fa7e3d3969b95c830300838202848200581c17ee6a35802aa4a6eb074be9deeb7a7b8b134ef2d53ec2c565db728f8200581c6deca09d00d79e9137010746b948498ce920568441da4b048978676f8200581c8161606abc712b878ec3d0204654172011313103bc6dde43ac0164348200581c2e703a588e6e7e52c62860add2cf783531773bf4af51a2ed75fa10fc8201828200581c29e11e8b2600be1007bb3000dedd2f3d9cf779e831d01b9ebfd081d08200581cec7d1fa0407e162608c4d06c1f6ddc02e4bc70707439e0332c3409528200581c789c5d38c1fa0f1598d45f018cbfb820ffe0972bcfab480c48768561a40058390120dae523bc66bbb8b177340aa63f4ac997f559fc04def2987b47107a295ed1cb302a90b5e5536aed792a555c487815a363830c2b3581618401821b6d02302ae10c17d0a1581c105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5a1413901028201d818549fd8799fd87b9f04ff20a140014379e06540ffff03d818458200820501a4005839102a0f68c4f465aae6e5f7e36ba2a5c070fcc645bcc555b712dbc45c82b7545e4bf5c8b4179b98077eeee5f2ec1c8d5f629be96c78f957bd9601821b66426d8bf6f70704a1581cb3b94115156a88da3ac1553c26ba1162e65777f0aaf0fef4b923b2e9a14773d5f978c6755b1b726c54a1656ef037028200582044b6ed1a00494ca3f57ca5025e362887cea15eecf1601378fa92cc3796f41b6a03d818582282008200581cfc579b06606f6a703d41d93b0cb1675e827496257fcd0e2d99a7b59b111a0008c4d1021a00013dff030104d901028184108200581cd027ac30c0aea09a8dfd6cf2c653699e485d5cc1f7e7b1442216a2881a000da14e82782868747470733a2f2f666b344e633335544d544c634974337562684d376e4b38515367496f2e636f6d5820617e21daca9b6e042bec9088947d75018f947d5681cf2ddd5d4b55af5a11fbd205a3581df02053cfb2aee8889af8209c583160e7ef77b3af2376f0c7a8222075bc1a00045d10581df05fbedcfafeef01a98ec3e83e505d699936d6dc02e0b550b85c1f98c41a000db7b3581df1321e3f365be6beeeba2cd816cf126e8991868243400d95643976797e1a000b7a120ed9010283581c148d1b5c7c1507a6613e20aa91cbcf157b31e4b0e03ff3f22d3f811e581c88ec41f0e5d2f8fb7cf3b7813aa571bac511f237cf7726a3f5ee749a581c93bd6cb090ecb7f3306989474255331dba1c44547e465306bc97c1c609a1581c245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abaea1581878fd81798b71899215d41984c2ff577693fdc18827c978af3b078ea02fd749ee160b5820f9b4f6f7052aae70e8953135286a0bfaf3c4db7080fe79d960d12733459a493e075820a80197fdeefa0d5900f8eba419a79fcb42ae3b826f62d82a987c39504d363a560f0013a38202581c7293d8aface40dc6b2d3e8314022bab44b4ed075a1568b4e31b2298ca282582008eadcf34d85cc89819a53aca8c5045c11ad100fbf0eadb1a364a569e150fe2d03820282782a68747470733a2f2f48332e577930766c743949636550714a366961396c317a2e7a38534c46622e636f6d582016acc3b4898d3ce5a7d8a74f686d5bbf67f194cc95fd703b4919b7aa750f91fb82582055eae2c1a90ff6977d4fea9cf1db48d2a5a7b73805d54259b8b6203d2980060705820182782568747470733a2f2f3169774a6d55503476717030383765487a71766449476179332e636f6d5820037fc3e39a9bb70884e5b8ca29ec1cddbb3f73d5eebd8cce23314e2cba5860558202581c97070bc063219189685e4b3d76a766f847ffc49f1c204b19336acba5a282582035ce2a4ce635412ea93c5f09464c8549aa0efb012e714fc0469e358c69ab043208820182782968747470733a2f2f6f4e796b7171346b63576a59704e7762394e43446f50574e64724b54652e636f6d5820fd772ad615087a9cfb3bfd2c76f658b1fe5656bfca85ea58b7d0ec34a384de5d825820f98daa3d15a4e1779a7f03a53d4e90d505cff0f7c7e4cdceac50dc41167f661001820182783e68747470733a2f2f31314572597739676268543565386157325a6e71574d432d6c79552e486e334c454c4d4673434457444d36385868456668362e636f6d58206dfe1b7b7e72784b12c0eb7a00b1b4e1d279960fde98702c346d9f99bc231da78204581cef08fcc75dd55e9f0aba3cd266794730c68956971e372490c8a85755a582582008a2499a422865d26d0b99a3026cf7a83e71b1b3af50c7edbc811f55e1dcba3a06820282783d68747470733a2f2f4b755678304b497639737a69476f42666b644174374d4255753633555265356c4e414d41693154584735467150716846552e636f6d5820dadd5e983a6f7984f1b8e27b06335948530382d9121e108099157052ab4eaca78258204a0a81d65adf4cb3b7e64ba776ff8c07b2c1e5fc6b89599b87a3c6c1f1fda91204820282783568747470733a2f2f313769303151565755383734506375586c61566b7537482e347a6c524172643332325963667375596c2e636f6d5820b5ef52bae4155f30fbb9b7ad1e302106f239707fd888bdb2eeb366ab6368c02f825820adc496507fb7f270c5300bfb56ea5837d024530aa4d7c894d41234767c8b0a0205820182783268747470733a2f2f486f342d35574c435a3556456c475a66513168572e526b6e776f456b447230474b72744c75322e636f6d5820f031032e63141528171f6f389d813475884075fba81f20a45f4f0676b8c83162825820f33df54c3717cce868b97a35593a23b8eeeb1cbea16a9932080a89a0e9debcbc02820282783468747470733a2f2f587243552e31544e4847686377654f55714373764334686754766834624d3849786a634a4771372e2e636f6d5820c44eb82993e740234e3b50bfe7d2ec5b730b02352ba1543a55ffbdbc6ecbf3a3825820fa57a3ed723ef1928b7e0fd55dfba50fae645dc7b79a6b8db14ef45de18f3938038201f614d9010282841a0009a127581df1cf5306625b583cedbd3b30f419649da192d160e9ff3c21520a6376e78203f682782e68747470733a2f2f71473761324376593654436c786b51584d315771546f31335a7942713957637564412e636f6d5820bf5e0179d6e387537ee0b68bf4babcb72d92788d32f1d85ac0733f630ce81aa2841a000934e4581df10eb180bcba74c916d6f91cb486ac647eda3a8f6167897f25a05c774584008258209cd32da9d614998a8f6ea316eb49e35d910ad3e8276aba35d9d99cd9ddb3d00d08b81a001a000cd148011a000d02e5020303030407051a0006b6fc061a00018b230706080109d81e821b0b94f10b401dac211913880ad81e821a182a79ff1a9502f9000bd81e821b00008099e62507a31b0000b5e620f48000101a000a61af11191c161382d81e821b431f5515f2d483bb1a05f5e100d81e821b0bb9cab7a0469fe71a3b9aca0015821b36d2ac07018ebf201b3d823d47543771cd16081706181803181985d81e821b000031a19cad05391b00005af3107a4000d81e821b038b07b579c31cd11b4563918244f40000d81e821a0b1c9e791a3b9aca00d81e821a001fd1fb1a00bebc20d81e821b000000211c06a2e31b0000009184e72a00181b06181c00181d04181e1a0009db29181f1a000e706a1821d81e821b412fad9436b6dceb1b06f05b59d3b20000f682782868747470733a2f2f3952723638657a51615259465072384459417254797050615745446b2e636f6d5820b504731635e2b6d8fd9a099e10484dc0b707f93e97bced99aca1f5be88d67ef1161a000d2273a600d9010282825820234bed9ca3ca3a67ac2d9b2cf6086c3739fcedce731ed862bb8eab50d11a828458406cba0708c2a0e6d006ffab1ed6619ccf7afcfa0a4a73ffd14c2759da1f2ac990dfa1c103e8d7df85e1b8fc45aa6c11f94f920ad756fd074218b8f60c7385d0d08258202c3bcea91788b582485d57c8dd6d2fbd23b52cea096cb4471ebd28652ed330ef584004b12ac3c4352ec66fa4aca477399515decfa76c0ab3ea7bb28a640aba338f2e7f5f11f8ad046423147726a6991df2d2dbacb06b24de202be2787dcc12c7e60d02d9010281845820181b68ab7cf7427bbab8d7b745bbebab310711ac441a16fe803bd4b7d44051785840ee295e55db6fbdaa87e510b42adf54350c8787e8dfc7e58511ea54cd7687f98db27652f674fa78392c978cb0a58fa1a724207c33199e9355fb16290c49d6f4ae425e9c43cf46c301d9010283820501820182830300808200581ceb7dc561b7dbeea89c2f2323375edc5f9e8bdc61b41d4e7378d7dc8c82040b03d901028148470100002220010104d9010281443260c09605a382010682a5a4209f448eb043334414148d060341d84439ea4043ffd87a9f244267b144148b7c04ff0140222421a504a144c4bc8b8f449e9876910521d87e9f402124419e4432905a4dffa0d87a8024a0a0054408e03c110024409fa54204d942b6eb41a52442eaa243fcaebc404200e80005ffa242391dd87c9f438bdb5c436ade2f04ff239f204123ffa2402005a12024821b4a2a3516b711a3f41b3db3467c462e5f6d8201088240821b2caf95fc33366a371b2602e660a71d93eb820300829fd87e9fa005ffa044ce2ab4b522a59f214296fd2123ff4249be9f01ff42b2f70343477d6a0443c8f516a40520411d4284b022400305d87c80ff821b4218261ac1f7bb541b3251dfd562595a18f5f6",
+                            "description": "",
+                            "txId": "9ab29b096b7ad7674c5fc0ca71524cbebc932fee1c870c2f05784075450a03dc",
+                            "type": "Tx ConwayEra"
+                        }
+                    ],
+                    "localUTxO": {
+                        "0101020105070601070702070303070108030600040100010303060604070701#36": {
+                            "address": "addr_test1ypa9u77r9djmrewun398l9f82j4mzquyyyf4gasj5ql6x5vg37a3qugvldjmjmn6pf85l3wdpkpwnuwel8lg9f5t8t6qhgvcdy",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "2d725128406dc832eb74c4709aca0512499b3c7b17e00d7cb2e6d1b1": {
+                                    "d5cb29d5648b1901f16360dade9fd57e5a9069": 1
+                                },
+                                "lovelace": 1202490
                             }
                         },
-                        "0801050803020505070507050504020501000503020402070806060503070208#69": {
-                            "address": "addr_test1wqq0dzw4ypvk8rp23jmlcxmgjgmysxs64gytaf3wxzhfrwc3xzye8",
+                        "0406040602070108020105050402010301030800020505060400080602040208#9": {
+                            "address": "addr_test1yrkq7h2smuegem3rvcc590927ucdj9hxjut50gqtse2442l04rprfuq3qyg4d89jtlclq6a069tnz9cy3g3ntfljcmzq2nlav2",
                             "datum": null,
                             "inlineDatum": {
                                 "list": []
@@ -1682,8 +1612,181 @@
                             "inlineDatumhash": "45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0",
                             "referenceScript": null,
                             "value": {
-                                "2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56": {
-                                    "14475f1a3121699374d883": 1
+                                "2a1260705a5529d4ea206ff01f2b9f8f23faa595e6e7ce9d15803994": {
+                                    "6b40b7": 1923199230200262713
+                                },
+                                "lovelace": 1206800
+                            }
+                        },
+                        "0407060203050205040207020100010708020601050107050704080207010407#53": {
+                            "address": "addr_test1qp23ft86e3mfeetsfh64q55zgwpct52weqe634mcv008nwd52299vva053lkm2vad00rp3680nuv4zjkp63pady9pazqmtqpu3",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0508000505050802080004070308060601030505000301070405050205080405#99": {
+                            "address": "addr_test1wpnmzsgzpfs4gzg06h7kqzpv7unxycuvs6a78vd2p92ep3cu3paxa",
+                            "datum": null,
+                            "datumhash": "769254017dfe006cb6514d22b34b2481592860fc8acf4ac0d589a76ff0dc9b27",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "06a9981fe81d84b52b49b6fcdd3110e9350b79c8c9d41604a1bb2e0f": {
+                                    "7bde9a78fe40c9070727e6": 6759064715422806205
+                                },
+                                "lovelace": 1228350
+                            }
+                        },
+                        "0602080305060403080106020806050103020105060005070503030000070304#33": {
+                            "address": "addr_test1qpjg22e39lxfls3p6eyreghrrn64yvmj8wftrlc8axpmltzy2ama6lc7q0e9h4rjhvm0yd5y9lwkk3lwd4zpvpknx7ss7vqp0n",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0607070603060203050006020803010008040803080307000105060408040602#97": {
+                            "address": "addr_test1zzmfemjs33s3hw7sqjw5sz6g563pyxcjmzr8vw43c7c7t53sk9c6cmwz7g7alky056mga3yzrqnkny9g3rdk056yq43szt38e9",
+                            "datum": null,
+                            "inlineDatum": {
+                                "bytes": ""
+                            },
+                            "inlineDatumRaw": "40",
+                            "inlineDatumhash": "39df024ac52722fe8ae4c1a8740e4c5624a38c3820e504a059aae8728421f8bd",
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        }
+                    },
+                    "pendingDecommitVersion": 1,
+                    "pendingDepositVersion": 1,
+                    "seenSnapshot": {
+                        "lastSeen": 4,
+                        "tag": "LastSeenSnapshot"
+                    },
+                    "version": 0
+                },
+                "headId": "00030506020505030807070507070303",
+                "headSeed": "02040200030102080101040806050005",
+                "parameters": {
+                    "contestationPeriod": 56462,
+                    "parties": [
+                        {
+                            "vkey": "536d58da44bac7cdb2f3377b5c7856ed8be7804208bf266eb57657b5d0442501"
+                        },
+                        {
+                            "vkey": "bfe79623de8d42cfe196274e2f8013fadd6bab0e2dc650d1c738ef79f14e0628"
+                        },
+                        {
+                            "vkey": "4660c9b961edb9f1e4a7591aba19d74525a32319415051c3cd881c96a4865491"
+                        },
+                        {
+                            "vkey": "fcab074b098d6fffa4a6f3346e5aab35b00d78f73b5e3fc50f408cb893d66e0c"
+                        },
+                        {
+                            "vkey": "3b77faa4cb8f9ccdae18b1fbbc37a9f48c4296f9a186a8ed6355c6a47b251fe5"
+                        },
+                        {
+                            "vkey": "95c1c508a6d7204e1bdf4839867ee88865e462521ca77731e7254054d33cf582"
+                        }
+                    ]
+                }
+            },
+            "tag": "Open"
+        },
+        {
+            "contents": {
+                "chainState": {
+                    "recordedAt": {
+                        "blockHash": "0203010103050103000303020008070204060803050407040005080508030305",
+                        "slot": 4,
+                        "tag": "ChainPoint"
+                    },
+                    "spendableUTxO": {
+                        "0101050103080404080300060007040508010806080700060606050608050308#3": {
+                            "address": "addr_test1yp3v4z7hvw22dre8e0grljytfnj3hkjd5qz2l3psz96n43kvzyft207tnhew6x96u0wqh50ck9ndkz2qjj68cekr0nlq54a76a",
+                            "datum": null,
+                            "datumhash": "dd286a9560f3d3e1796dc083cc9de9f53fff9c24fdf3fff7c46e9c676852ef52",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0105040300010008050700030405020802040507050302040801040100080404#19": {
+                            "address": "addr_test1zpch2tsrat63tp3evk44hyu3t8u8pc4e8khw7cpd33tetpykrcsv9zyrhklkdanc9px3u5l80nc8ua8xzws7kxvax4fsp3a02d",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 969750
+                            }
+                        },
+                        "0402060304010301050200040805080204000101020503010205010105000207#2": {
+                            "address": "addr_test1wqyz4lpgu5qny6aty0mvaduxk0v5avapcjpt2kclvh5a96q80lhzv",
+                            "datum": null,
+                            "datumhash": "88a951766c018b39248c4caf007a463712efc986ca65a28a8a490deceda14e83",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
+                                    "45a9b83bc12c": 1
+                                },
+                                "lovelace": 1172320
+                            }
+                        },
+                        "0600050807040000020807050707020704080105030205030101060707050408#41": {
+                            "address": "addr_test1vrqev3egyvy05wj856t6nm67trn27vlqxtrle9acrvq0s8gxnp9jz",
+                            "datum": null,
+                            "datumhash": "62d8ab09e06d52f20811c3f5b10db7e1b68b65caa95d0ceecea808d39292249a",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0703030607030401080603060400000707050100040300060600080806060700#95": {
+                            "address": "addr_test1xp0hswws8chjyde6cvg36qx2kscxg4ykp5rxfea8dkt0xgpeeu40k4jlj24xsusl0j90r6qm4ppwefdyprutf7g2pajsjlvv93",
+                            "datum": null,
+                            "inlineDatum": {
+                                "constructor": 1,
+                                "fields": []
+                            },
+                            "inlineDatumRaw": "d87a80",
+                            "inlineDatumhash": "8392f0c940435c06888f9bdb8c74a95dc69f156367d6a089cf008ae05caae01e",
+                            "referenceScript": null,
+                            "value": {
+                                "8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3": {
+                                    "2c58906965b3bd109ad91834ec15": 2874514031113974447
+                                },
+                                "lovelace": 1262830
+                            }
+                        },
+                        "0804010302070204040307070501080706000804010007030004020202050205#74": {
+                            "address": "addr_test1qpwumtu3uny33cj6x5wjcr93q923xclrc64y8esvt2sdc3qpmjyvuq0tfqw0n0j6hcmk0edpcnswcdmyt2q9xu5r7ctstc3xhn",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5": {
+                                    "6a75ff771264fbb3d139faeec32662a6097f697dcc57e1a3c585": 8347017148646772984
                                 },
                                 "lovelace": 7500000000000000
                             }
@@ -1692,37 +1795,1480 @@
                 },
                 "coordinatedHeadState": {
                     "allTxs": {
-                        "0402060501020104020605000501000304060100020603040506050207080801": {
-                            "cborHex": "84af00d901028482582001ba3fa8d466815dc57701d657650f3d34569c074f1286f322f11c0f31b257c60582582017626c85d415daf43b089e51a6934a469afb51cf7fee0d8913c03634efe334e80782582085094847efb6ccaaba1849957832b8ecee4025b94af401eabd207c1c039639e707825820afe111518c7fdfb773c00aae05906b2581fd469b358ff3333423b9cbb31960eb050dd901028682582001a9e4259e00d307175527863282f0ce030774c7ed9cf061746217a41da347e40882582024a1713b76dd9a9079ff63f38accd6f915730768ba8f50caf239bc707f8faea006825820510ec007d10800e44f8e97032efa447de6a8be33910c41622237d461eb998fd50182582078f7287b42bf14fe7b27a547cb9300c035b591d333668e24d7cb6a2e1de578aa03825820aee25fc80dfdcc450c8f2236d4eafc251fc4a229b636bb814972cb25fdf37b5d01825820bb75636d8acfce04dc2c53f2592961f2d4a8db7c3bc8648fd66ef6d0dca1edee0812d901028182582081c6113a3d1f645a7d54f742e5e376db3396fb537176bab98ea9c624d3a2967805018182583910e2011a50c503c8b8673ea548ce276e10abdf1c66218bb8ee1850bd4d6ccd9ab9a0d0438a8eab0b50429a97beb3b171977800eba13a74c3af821b282ee72833053b1ca1581c2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56a14b7af24e79b04e0b4d9d07dc01111a00043cbc021a0008423104d90102848a03581cce412bf13cde07d0d00c5a9a37f2dee8c9b408f6ccc50562af547b5e58204a6e5e429884deec11beffa62e740c8314e1a147c844809820b2e8e8fc3ba8e2194f541a0008fa73d81e821b000000c920ac927f1b000002d79883d200581df0e06e08a12839b215693057ede9d4c36a1f2036c8a6785bfb74ffa5ddd9010282581c2a4ed0b4e6a93b236968c327e1ce8c31c251cd0af6ab1d9ff9f6cb35581c3caeb6484431e6a2a8b8c1cf63ae738e3c3f03b12726c232907158c18683010378236a4e4545644642696c7768736e57616f63376b5a4e56624e737761345052342e636f6d84000844000000025006000000040000000200000006000000840007f650040000000400000003000000030000008202781d4e636a32487635784a42424e6e78636d4346336e474b7a4c2e2e636f6d840000440000000650020000000500000001000000020000008202781e2e614969503475313162312d5677633033477a3351554d5a54332e636f6d82782e68747470733a2f2f72636a6a39375565516c42497a657463766c6e787a2d76764136746e3569666944562e636f6d44968d6a7b830e8201581c374dd2f2f3d81b5317bdeecb228922507c8d467067823ca8157d5feb8200581c98194ccbc49796a646d865be0a19d66d6861aef874216b75c388ff0a8304581c6119661b598f8be86fb6d91911ebd996ffc2a423c2845999f9a385160a830e8201581c9e6076bbc063b9f8171c7ebbc5a9cb968001650b3391374461383f538200581c980784d71cb7d3f2bee10181a8487849bcddba7f72477083bae5878d05a3581de13b5b1ee4dfe086e8649b0163ea49800b7f0a8cf777b756b105a11dfc1a00040974581de14a36c639a2e8f0e118366740e608551986af542be16306f76930f45619b2ad581de154d49046f6f57fe52f57278e5ee9792a614b6d498e3f59632d19821e1a000d8e6f0ed9010284581c31311a5d18e6a8736ad4087a8c1dd7ca3f82756fa64a3a7bc2de544d581c38c3611c7d14a12904365c1a9caaee8ad3e0eec851d65535b31e5be6581ce7e0da64c364bebeac5cb14e63f8fcb35e8c6c90b138d37a1a068b32581cf3f16fed5cb03239e9727ddc571d7bdfe9cc20a138587fe7c562bfc909a1581c2fa38e09c871579c3c10d98540232d258fc72b5cfe1003ad5f72e65aa141371b005f4c1090fd5d6f0b582086939047d367d61dc6c3e36e67adb90da636bd83da124336c10a5e5b144077fc13a48201581c12531b4ae7cd53c277327e59618f02fb04df0200bf3c0a1e4163a57ba482582051eb38969a272540f74945280c098042e254f7bcd53e003adca052234070ce6704820182783468747470733a2f2f584c305852624a654e732d456531694f346b37567749474a444f764e7536624a4c583138664249312e636f6d582005f027dc6a1dd12681feed9aac4118d35047567b89c62da6767f972e464d6607825820a69ca835dec03340bbcc5bcb5f996e03543b84bd49232aece7db9edcafbe155a05820182782968747470733a2f2f764f302d38662e796c7a5457517136494968666276396157612d5233382e636f6d58209c179b3357585d0d3d7c38617eb56afe8f53f650836ecb0181d5ca8c568dc5ab825820cad642b01e9fa4d431d22a9a373e4ea419d1fbe2a43b2c941f206606f01b357303820182781968747470733a2f2f76307a5479466c4749414c57512e636f6d5820300623a6cdf553a9c92a67495d95d8b3b6cfae488644390158e6b7923c7d0ac7825820d1dcd2e09c94a02b3fbfd4ab48aef44494f4f6412b428a3bf223961594a740e607820082782d68747470733a2f2f6d6f5a4f5959583042503242524a2e5231526f52725158566f786a53415a6531422e636f6d5820bda922372116808ffae7fb25273ba58e095ef5c6abcc3de394a878636ff565648203581caf06ef11e3807fe7fd7648e2c9baa99fdf643736d32d95980e8268d8a18258206c2b1bc58f1031a375da7d48c0837cd8c51a8548568fed6f1a70a56a9cff157a088202f68204581cb6394d3b193af8700d48af486019c0d17923e67beb1d22e9a2c4c71aa38258200bee95f9a7ac386dd5f75a8cf3b834c2122c69631a553c57ef59079462dd5d41058202827668747470733a2f2f4e5844714d50674e346d2e636f6d5820d9707235e850b89de910cebee82f078d9d0d98c45a6548854bf51ffbbc3b760f82582035ebdb02968ae1119025a7a064b818ca13f54ff9440613b54fac6eb44633735707820082783768747470733a2f2f586d536b4967725535473178387a7a474a48467051566c5a48725179693645512d466f326f6d32537262772e636f6d5820e84b5c3cb3873df7bfe44cef313b2f28712aed2c22ae1f5830632d4c5c96a7a7825820b0ad4852f26671cf7e8a3800c9f68b0deebfffce32537d2a43acccf330b4166f018202f68204581ccafb5721332dd294a4ba88706c6102d363879301bbc4ec03285f4925a6825820b12065a8b3e4fef01c503d83e2e708b9b975c8b063f7352e4d61cb9eb1d17b13018201826d68747470733a2f2f782e636f6d58201ee342aa00c601fa704dde9c3ed3f3812167c5ade79b37c52845d41e94c23082825820b26e2e823415f2969b848643c618b9d48093866dddbde79b7a4e8c1de889f93d08820282782468747470733a2f2f34656b6e7377764c4461426e654d66536d343853546f6c672e636f6d58209b76ffa1da296bfe49475f8ee6726c78f2cebce0375fc98cfad0ffef60d199c1825820ca31fd391bd87684329eef9f177a328bb5f5cfb05463d08205d88a53caa10cd908820082784068747470733a2f2f4c526c4f386358344362773566372d6d4d787a6a5039536c7575492d5871756f63763658616e765a39372d2d6871414e764a6e562e636f6d58209a72be46aa0d0a996908cb0b315c35d2e7f9d3c5164773b2d1fb3b0adccd3c34825820ea1254f891ee99a373710b7481779875312d352598cd837a8e4e00c0922222b1008200827768747470733a2f2f596a706e6e7978583372552e636f6d5820af8d80d04260d84e212c9e9c0701580f781211c5806f5f54c85c2b6320e24c9c825820ed2a32bfa028b8b03064874dc71b59844eaa83c9e16f2017398dc867f0f34e1c018202827268747470733a2f2f7a653861447a2e636f6d5820a62ef73cc568ab90a1a716ee7bf6ccd00581b735eef31843369c13178fadc8dc825820f0d1613b452188605d1711a7eb8432b7eca46e04da8d7f12ae4c24717df1d0ef008201f614d9010283841a000815b7581df1fb30a4f7f8328b5ff6a46e1150fdda3aee4ea440ec60f93fc45bc02c8504825820b2fb2474eea863d9ba6e00ea0afbacbf026905ed281d15eff5e927e13f00d97d03d90102818201581ca35e07ee8c58238086bdaf976e096729e802901e8cd6012463461d59a68201581c4849eb97f3ca19bc0625f2657371f10db5751cda5d4da1eb0a2c5c55048201581c623625774a2955ed49494ebb85ae1639e7f5cef50d051ee1ab14b107048201581ca0eee7cc904d500c570d5f424830fcf8afa17ae994e1d22e0679b99d0f8201581cca4aea7670dab639fc31a6b43c2aef18a46acfba467d90ddd0c6ff75078200581c476dd3385abe3b9b2e9a9ad6d8e161a9dda98e1e47226168537d712e0b8200581cdb2e65772bbc9ce453b97905e1cd32e0d515beda92531fc56c2c651f0cd81e821b00000431f7f20a6f1b0000048c2739500082782568747470733a2f2f517a6f73754377347a344232625162634e35414a63367835392e636f6d58202e6d143a0d0f6083633fe71e9c03ba5e9557cc9f1b7c92ed646ae1d614d8387d841a00023ea3581de16759b2f7f4068873d39203c7c7ea528e87445db386000845f80e3ff482038258204dd55085544af5f6f90cadd1ff042827f3df300e4707a93d56deaa17892e1eb00682781e68747470733a2f2f6b34555a553275525153734b527a733776772e636f6d5820ee3bc23db00f099e2adb54856c546905e83708bd994cd6aa3f24bf6e9c81227b841a000d0995581de1fd9aa1a7d686f22df02e02f2e8a64e490bc71864f38e84373cb6b3a28400f6b81a001a000b6c5b011a000b480c030704080519c39e061a00082a72070808050ad81e821b000000025c41f5071b00000002e90edd000bd81e821b00000001e3dd5ce11b00000002540be400101a0003df08111a000e4ef612a4009f09242a0d0d202b29202823212e23022204040d102d0305030e2a0a100209212a10250900240d21262f22250f270c2e032a08212e0009030b0e28240d08220322070d260d262700212f29250c0e1023040502022f2b0b0f22220f2a01202800260f08090c0e210e2e0c0921262f200722240d20090c102a2b06032400000a2b02230a0927102e0f2e092526230e09282704080f2a2222032a042c2a0a2a0a0d040a0a292a010dff019f0a02291005272b220c02090f232d10042b272c2a050a2f0409250a05022f030b0f2520252f010b212d220c10100e0526202126032425252c000a0307282021050c250c2c2a0906070503062b2c2f252e02250f2f2b2b2a00222b232b2e07082522070520212328272f060f00020c03070e0e100901232700050e0b26050f08222b230302082127010a090a0e230c04200e250709202525260a2804212d27232c2928010e2f26250326240d2b070f03ff029f052b0820002e0907092d290c0302232b29220504080d2a2506070d09062f222c2e100d2d2b26072403272526230a042005272a0c2c030126260e030d272c082e2e01220a24012d09042c0f0f09040f2c080c222625000e26242d28270e280b2d0b08102e030c2a27010b29230702082f080d062701020f270921022806002f2b2320262723002527210c0700232a0b25020a0d0e2c0a2c002600242a2e2922262821060f2700102c070903030c01032b102807072f2c03000f00002e240f052c26002225030023240107090e00022e0a202908232c012d080c0926250d03012208012b240d030eff1879801382d81e821b3ee53dcbcffe568b1a0007a120d81e821b1e9c703429236f1d1b00000005d21dba0014821b3a935d4af012836a1b448aa9a2f020755e15821b1a9aa0ae48cbe2621b686bdf8674f6e9d4181805181985d81e820001d81e821833191388d81e821b003d661c4ab1b5b31b016345785d8a0000d81e821a035622031a0ee6b280d81e821b000022a501db70251b00002d79883d2000181a8ad81e821876187dd81e821b0000030af8065f771b0000038d7ea4c680d81e8219035f1904e2d81e821b0000548ddf4026211b002386f26fc10000d81e821b00000038be2205471b000001d1a94a2000d81e821a286c6bbb1a9502f900d81e820b1819d81e820914d81e821b001d75e534fdfa711b002386f26fc10000d81e821b031a320b1f211ec11b1158e460913d0000181b00181c03181d02181e1a0003b5ec181f1a0005b5f61820021821d81e821b0cac1ec0bc4173a91b00000b5e620f4800f682782068747470733a2f2f574d714a6c41377462573972697467304a31362e2e636f6d5820c047028eca0d2193faeb47d78e424f4145a5f1815aa8509ca5537fe46523a0e9151a00069923161a000c5791a600d9010282825820790dfadfbee2d97938d32857e08849c275172074f8ed02691677cbc6387b950b58408df7ca4aa9c086c39a2db44adbcc4b296a9139b1c6fab5d8cebf9f8233d8fed8c162e83fd0514d9ecb722c71d9a177523adfcb3ec9530522725b727cf342a92d82582099029fb2531a14a6ef78c2cb95015eb7d80d99d676e22c3d7838701d1a75c37a5840a6da2e330e21f77fa100390b39bf23f23752520c6f811a301f99ad4bcae6eca44e0563e7497dccbc04cfb0e18558968c31b3cf505fa101dcd5d7e9aaa5f7a04302d9010283845820de8e7f665133eebdf989e59185ea19830e0e564ef7bf3f99fe21f258932b688f58400da85c0e05203487b7468d1299ad29bd64f9ebe614943595964f90d31b645ca9063115148d1cb825e3f4998245d22ae3bb3cae4d776d6199f7f8ef5ff394207043b815fd408458201f7c24e848ee63113c57dedda96c9196a2999690eb61030228df46865a99ce645840f18aac286a26dafed4b53de999151d1e172c0337c97254b37dd024104c391794f0b5211b0342130dca4462851cff36d11cb22926fd21436188d9e8fd103cdf30421545408458203aad57be0a27dcc69d9f4417206e075d634ab967c818d45c164997ca6da7761d5840290300ad8060f4317bfe751832134d44a4bdd6256091330c63b2e1079015cbd205a80f2fed8cdb68df07ea12531cef95d29f3881c63091e6054d22cf9978ea5b45a34fe9defe418201d90102848200581c3dbcc6c0405197d5d47fbdbd9d93e51c15241845cca0c0327710e9af8303008082050482050c06d901028148470100002222001104d9010284409fa39f4494d50ca640ff44af7c586ed87a9f0041572221ff9f2041764322cd9442c02120ff9f4246e901400543bcc09dff4267a103ff428d052405a282020782421d5d821b4ff34862903ccdbe1b143285aa6593f7248204048204821b2e0e06be36d96a1f1b4f6cf6915621ce92f4d90103a400a20b84a0a16555696e715f44777dc20c6634f48ebf9d7144a9bee1420c81677ef487ada91b1701838202808202818200581c4c5bb05c49985920cd07342d2905636512870cd0422160bef919577d8303028283030284830302848200581cee3b6705ae37e1b32440ab6b9d34bbd8c8c6417f24a7095c2ca942868200581c273f728fc29520a65c4299a7573aabae7ce5d18ba39d3f39ddf12bda8200581c71e66fd4acef4d0cf065cedce5cdbd1b8ab09f90cfef6b39c8d3cd738200581c2de04c60c58072eeec3acc3c4d87cdaea82649abc3ae51a3fb8db1308202828200581c2b06e80fa6a5187d6baccfdbc6bbeaa347275b959bb1f15b44c4c6af8200581c0801f9294d67797aa93048d9d24e173ba8c110fbe3d619bdc72f2d41830300818200581c13e462691fa3ee9e33e1d952185ad61dc3088f7fb02ed5eaa998deb78202808202838201838200581c46878e49f417793da0c30742ab0cc5d91f9cf4a94d9182b26ceeec2f8200581c706121ae92dbc729002439e82b2076ba36e942eeda97c0f8b42b9a1a8200581cf45cf0508523f9dbc3e8515b4dd645c559a20409024d83b4e1d06c8f820280830300800281464501000022610481484701000022220011",
+                        "0004080508020604070404080604030401020206060405030100050208060300": {
+                            "cborHex": "84b200d9010283825820965f75a4ace58ff0464c9eb377cfaaff85f7ee93b1a13bd1b87385ab5aa6ef1703825820969fb782e7ac4ac368c994ad3069319543eb7fc97264c934ffa82fad9c4064d902825820ac06a919f4beaae0b211afce1fba38a3e3cdbaeb0c5792042d937d71ccf7ad16060dd9010282825820812edb9073ecb28b846f4e61c8a1b14a4ed468ba65ab44773655916b8ab256e204825820ce3577722ce9adee31e8708a4b63ecb41dccf9569a436b7c8892de8e02a26ece0012d9010286825820146a378f325d10089f29e9d203b2627f9371b51c34789f539fbcb10f3f26ce9e06825820287b73932a2005306de0cf3fce4c1a7cc59dc6b4b86c0c28cbf59b478df481ad088258205850474ccb5e1002056dbefd5b0b133274e3a75fac0b59950aba23b5fccf16be0482582069aa2e010b9d43352a096b73dd2b315e020d21eaf7cf1aa02f91a72bad5bdaf705825820cf9731c6ffd086339159d2928961c8792300c4f2616c37e0fb2b1c4da2589ee703825820f67e63e3fa4998bf4f00d0bf9fa80bf18814721ae221614e7b29e8f3b9f5c4ab080181a4005839302fc137ed986b4e812a7c30f95875790c4cc225538932364556dd042cdb23f559bd4a582e825e086cf0f354a46bd5f61f528c3de4f4c27b76018200a1581c83d6a64a8c2a7c38bac764632016d8c414f11878c412e9565dd94394a15820f483cc2b3627cee3404e9d02a1a6dd44840aeff2bea8f689a77c3ecc5b60bdd21b2f23b51a5abe6e3102820058203a7648209cc6d25020ba1d7fa90e8fc10f9287de2b4165becb243739bf85523403d81848820082028182018010a300581d61c3c9c636a695a96289f9f6de1c60cc9d99d2296779e7d18d4f46735c018200a1581cb0ad04bc8676674c9e755d55385cbcb48fd4d7fcb675f79c9192d7aca14247b91b297e54cf9ff763be03d81845820082040b111a000c44f1021a0006310a04d9010285830f8200581ce6908a735f2562dddf66a96d6d29a707ef2724995bc393a3539ec0c5827768747470733a2f2f37446b4b423647696a52342e636f6d5820425ce423426451adde808184475dad70bfb20c64a8403ca2b71b47f0224a0a478304581c985d78ddad1fef8c8e29b00728cb160109e88a7bade637615135b2f004830e8201581c58a4e4be797a10a5244d0e55f4f5c14cbd37dc31df3bde048e87b14d8201581cdae15e691f33ae4817c987d2a351996fc09af9df4559cf1ea6985f8682008201581c7f3a1fd7b44a748c2a46e12913e0addd53f058a787c4a32f57dea37383078201581c67bcb27ac65ff8326bd036ba18b02c475b7d26e8b38cbaf410feecfd1a0002960308010ed9010281581cdf976a5ae4fe700807ec790d445d804b2509fed11d2c669f24ad8f8009a1581c8fd451290047665d016cb77c78901767eaee08a73a24a46ccb428c4ba1581cb0db2c67150d41eae01b1dc543d64491975f2b2991a1d0ab3d69c2271b2bd8ceac41acb4bf0b58208471d37d219bf763758f0c86708895b73877a607d8434290aa4521f49f62e15c075820498f7c9d80d35e65a5704bffd8c46529068e9b29aaa6c363fc95983ead318bbe0f0113a58201581ca2c1253d15839bfd1d4f6ce087405d8d108ebceec4d3cfb694e9838ea48258208d3aaadaf1b84289e14950e84a6c94d15d6725f3bcd444eeeceebe37e80e6416048202f6825820abaa05f780f44d9df0e667005c8d53cdd3ad9e45b14501543ec94363b9bd7b0206820282783268747470733a2f2f4d4c7938315437677730493063554e306e34304e34554c625979376862655449522e6b4b79652e636f6d5820cc5edfb728b12d614763f8aac35248f28f8781420acbff62c5c3689e5f7e6301825820d33d9526cc9a43eaa6c6aefa39dd72541e4c9b21db1841078a04fc620e7d037806820282782d68747470733a2f2f577231713973577a4166305231325341462d6f6561386161504d33424a554656772e636f6d5820ecdd442146b43dc2010569564244ed74253ce9715a99e4df226c1d705fdd545e825820e656be463090ad30656f4da6133732385da649305861f44167ea73c54d77276107820182784068747470733a2f2f66394f49634b4e50384c5a364c2d364c4e6f5951516151713734616c6c344b52564150763967677577754d56494b6d56424e46492e636f6d582052f51b6b434568cba2290ed1bf0e89bd66b6da78a8c3d42d13e72cbaf01323fc8202581ce557a4dd6e829a1daff512475080a83a33d6343e555a7e28dafa0425a38258205ea7b80cb00d8c2dabb12d59b903e77e83b64244b50dc4175975c2df96806bdb038202f6825820bce5cbfe6b69a4d6c304ed14647e5506da804b04cd8d44d95e0671e27ea3b969038200827368747470733a2f2f6e7167573973572e636f6d58207042d855268764a91f676801a8d8140ae6b81695d4286aa641bbfbfe2978c83e825820f30273c8ae5c4b6a2702ee59292fcf77e013a6f926d4b7b4f4a2f8904ff04ddb008201f68204581c83d3e8f230a73c1c9075783975f8aba8612027f2d3755857071bb09ba382582024c0bbef0075d5f4e73ee80162e488a7d076062faecb9307fc5d8b59290d6364018201f6825820d486726ec5a7f39fa9c54d00451db8959926455784f566c1469804f684dabcd300820082783e68747470733a2f2f737272674a46347147656579336d4e3176737363477046666556513059594b756f354c6579636b4a664e71506b4b467963412e636f6d5820fdbdcb147b54b48e78147165ab3594da9e9b60cf41504e221be0aea5ea55e477825820fe771ec4195d1237c32f5be007caa7e89795226784cb15507ea6d6e2778a4979058202827268747470733a2f2f4550666d68362e636f6d58209d184b2fa539fd79afe2cb972ad02f87aafeb703057791083fe834e811bce51b8204581ca2cd4e40bd16cc1e0a757ad18b795f99f7eab856a33151ecf6652e3fa38258205dea9910f9c0d857cabc645a1bed95892ad5806c0ffffa454868725fe3c202e0028200f682582072441c392fcc796d92cef892487a2e1f1f984ff196aebe65febe004ecdfea71b03820082781d68747470733a2f2f6d423735486558642e4f47364e4c4d4d662e636f6d58204ba51b4bcf1317447c29025d9e5d51c28f8e551ab89968c505e986e0ac342935825820f16f1e51a68c9171b872e3ec37fe1fff652780cb81941f6b463e1e28d6ac506d04820182783268747470733a2f2f44632d4c7835395672416e366451526952796a78704833303265644b5931386d3452652d48752e636f6d58205b2abd510e5735713f307c194b99ddd71564a7c6027902a1519e79a9d564384c8204581ced930cbc904653c0eae7d65d2795650a6daf7502c9ed5f63f492fa30a48258200e8b3d44689c9a9ec562ecc3bcd6c01e3d2dab589e5a9d67da0e72055d5a0014008202f68258205cae9f13e807e9008e063a973cb26f1ce5400df328dd6e1110c6f9952bcd80d0088200827168747470733a2f2f353373596f2e636f6d5820bd3c140cfafd82d7ba30130044568768e40644ac3f5fc17f1cc221f572f2243282582065c905bdeaa5ca9c380438639d7b33f5e06c435e550ac3dd27d684e4afd4513e058202826d68747470733a2f2f5a2e636f6d5820bf648345d2b649371f436c056892f42f8f63cb872091764a4225cdc0c7e5dd8c82582066d5a8b3857f99fd3d45dfce98f094e7991e3cdc0e9293d53536a56128f5f74a08820282782668747470733a2f2f65376b342d67636751384f734c794a756259563338412d5438482e636f6d58206f749069b7733ee5b4864ef827073c29e06c4acfe2bdd7c94f96c5c88dc4e77614d9010285841a000b8d29581df16becf3ffde233c77f26b2e24e37622edf159e9f73408fc9d76b7c078850482582030abeee6c019fe7d4276c9da5d9f96c882d33eb0786e04e53d8b7f52566298be03d90102848201581c21852eb835b242f17ec643f1b408a4653bc4b32542057d1ec752cbba8200581c3f412a7ccace697bb56efc1255bfbdf52bd3d73f35c254c483a8cc8c8200581c5741591d20ae025c4cb21d55b11b568e3a43df78cdb1157c8dd1eedc8200581cf46a7b9011c902ffd37d5be1412da79a988b72bc8a5eb0861607fb11a38201581c2548057fa90e8536eaf4b4b46f06b667afb0c554d7c6650565adbacf0d8201581c773316bfead01924e322d5448ad950751430889d0de9ada314cadc890b8201581cb261859ae71e1cb441b312ddecccd8fe985844e69f873303361a362402d81e821a0054e41b1a00bebc2082782268747470733a2f2f3475363339687248576a66585770645a6c45463664472e636f6d5820a0a0376c378b5754064fb0fe52d5ae73bf03a8b4d92bf459fd35a61813f50755841a0001dd4e581de1d5ad2c9d43f1c157a596d55ca26a0a55c0488658ed3e07b1a098499b8400825820cd3b0f756bf9be846e2c273d064c4d661b01dede91daaba7295fe73de92988df01b6001a00074a48011a0001f9ff0407051a00067487061a000aa460070408070ad81e821b0007f9d5af0f0a5d1b0008e1bc9bf040000bd81e821b0004b99f2a56130b1b002386f26fc10000111a000a44091382d81e821b00b364945f052e7601d81e821b089c055b049065991a0098968014821b1724b4009728b3d61b59573f18e376164215821b704f3a6b3a55ef9c1b02d54d38cfb625f016031707181808181985d81e82197fc31a000186a0d81e821901331901f4d81e8218211832d81e82182f1903e8d81e821b0028eff9a0168a531b0058d15e17628000181a8ad81e821a03a8d4271a05f5e100d81e821a066195eb1a1dcd6500d81e821b000010c4195ad6031b0000b5e620f48000d81e821b000000aa297fb2c11b000000e8d4a51000d81e821b000000022868d3a71b00000009502f9000d81e821b000001c3b6daa2191b0000048c27395000d81e821a0002e5151a0003d090d81e821a0001292d1a0007a120d81e821a02f5cee11a02faf080d81e821b000000c9bfba8bab1b00000246139ca800181d00181e1a000182e4181f1a0003b1b51821d81e821b2f492d0fa25fc9ad1b0000000ba43b7400581c66e34f8c4c7b2901aded8001b69dc6bbcf0d5e96012239037dd156e282783868747470733a2f2f63697957546275344f346b6c35786572524b76484a796f3466383461564b54563238442d737a61627a7a4e6d2e636f6d582055e46bcd50daf3fc2dd54b533b5df494a4442b78e4baa5e267da08447885d1aa841a0008e649581df1cd45528590402b9f8d94bf23760815af0787b33fd00ba9774e6408a68203825820b512e7b61ef1873cf4df5a3a5fa29a55e3d123e6be62853faab474d873c39a9c0582783968747470733a2f2f62514a4946756f364b46556441377642373663426a5979514c6e437638556757694c72767833364174416b73592e636f6d5820de4dda413286292cf1007c35463a1c7e9e296baa082b3511b2396927e4ae8aff841a0003d707581de04aca6c542538e6441dfced764514bce4554c2b5293e93d9e70f445d483018258208124b565ee4ee07968dec5b712762b111a84e9d41bf730270426e148732ec2420382030282782668747470733a2f2f79545a67486376564a30304365772e495541436e677a4f634a4c2e636f6d582007f3338de85cf9c51e606fb2a24edb065bb0448a0f824abeccd32190821e4245841a0008f692581df021ab56397a9656cfe68ae157f32f4f6570cade22098997c5a8b191108203825820d2900d6bf421d1ab795353e893670589bd438c2374a6b714fadd98de7af3e1f408826e68747470733a2f2f70352e636f6d58204f7c6044239d67c3b023117a307d30cf6778da573e5a8f9a267e836edcf1750e151a00082c48161a000d1f13a500d901028582582017d45887eeeccbf5df7c30861f56e7aad5a7794786a0cfbd46e246a7c4e1a12558402b5af0ee2dd57e19f9a6fa5f36ebf78cb495639102c324670f3af6182db44ada279bfedcd8573b215b9d6e0c5b1066ccff1558d4d6bfac146e08ce1c8e44f49b82582086b27a0fd5436956c6a7e6082087a6991b4c02d9bd13dda6ded962f3f05c7ccf58406b60121d06d92c9cebb93df696327597b5e554a125169881ac118920e2b0b49119b0ff32975a2c5f047c0323a3c6e18b5d25f2a3f95c5a18f6f167d89e5e1990825820361a8c6beb770a565367878ded83bea98a74f0632e4be7b124e28dd893ef50125840ae2ac14e4f1513cd78e876a759c0b81433921921c9920c2daddcaaffd12ae199e70499562c27f7b886c6c4431627cdb535aaa082a23e420cb1a6fc61282faa7b825820da3e7612ca7f5a8f9c4fdbd5da951fb0a511ef2672df5123c217cbb28eaaf9a55840c6b651f6d8e122c035789678b132fedbc4edd221c6645a11ea7c1e7fb11af2a6aad1a1781448446de6c7c9389d35dfb7c2d122552f7948457848dfd6209fda9d825820a36efacd7ccba0d033efe39f309e6b7f0d5cc10215b1e798b409d39763c15d5d5840cf814fd7adeb2a0ca082da4e175949f5558ac2f4595be4794d9c83c6d8a2ad7a7b8e534f0e4c2534b880df9e698b1d4b851c3cda0e591b81d694a232e581cab902d9010283845820108e745102f9175cc91a89bdf7491d52ec955c87fd6f558aa53bd2c988f328fb5840a2fd6145228ac5cfff755f5fb7e9b419c1b8f30a6fcbd85c1baa4e387496b28896f3b86aba774419f2c6a29bbb42e81e5e70ba3e51a96e6dd1f60d3e29c7eb974310cffc42d9ae845820d5ab564011e2529a7b2e3ba3ae01675954620d4f79671e4c87bcd497638a7cc45840fec43bfb68d00b3c8da1d96aa94c3880c4f3125603738dc7088a828ebe7dc992069c1e2ec13b67b5b6fd6c4d9fd391363892cf213b1c5945325e5f3a5f7099b6452797f4b4834518baf9d0f1845820f47986e7d5d9540605a3fc862a10367c736f6e47e269e506a07738e8835929385840249d37a6d2479b8aa388a58392ec8b8d4c419956ca909f029fbddf90398f007976b90dd93970ef730a23418e64cae428e62cbae8e3882781f4f960002954352f45b6864c79d545785e3a84b501d901028182050a04d901028680a1418f049fa1a540446e2450f9230541bb23210024409f4101ff04ff4285b4418c0105a282020182a1a5a044e0bb8b369f43876a8901012123ff43084e39209f44e66a562402234023ff42f4ddd87e9f44c5e1f03effa440447666de4005020140428cb4417cd87d9f20204295ceffd87980821b7d79d412a33c38931b7aaced3ec8df760c82050282d87d9fd87c9f04a143ad9d9e22ffff821b68e51b790a5a6d2e1b0f53eca9b53049edf4d90103a300a30c250e031042550c0183820406820281830302848201848200581cbc268ae6eef38053952fdb2c21f1283994c5c8c7448f44349b933ef38200581c8956fb6b2676c316fc4d30b3d9e4e26f44a5d67dce9095e7e8f891238200581c6e8e0e69514f4f1545d8058893687e9f99fae2329c860f1c44f6a07c8200581cea70637ac070e383b3108c85952783872d1610d210266c62be3cd5a3830300818200581c4257cfdfc8ba05b3f1a58d62abc0fc21a64f146f9234ae18b0bbfbc08202838200581ce76eb013540343a32e65b07ae574c20cfcb9e30bc1db8dda61aa692e8200581c29dd01b8d6956d3aff45a0565389645059d7cdbaf954e70e6b72f1fa8200581c0fcdd944487d4e243a9881989e31498ac28ec2ec285d3cc00dd4d66b8200581c676c2794dc28a54e5a0706bb9e8fa5e416f6f84a99cf11e20e99eeaf82050b0481484701000022200101",
                             "description": "",
-                            "txId": "bc269387b44fc6ea78de884a56428350aa2799c86ba8bdd69e1d9be356aa2bcc",
+                            "txId": "9dd0906095613b900c94c8226d968936eec2a0dbc06444bfe78fcc8de8e55a78",
                             "type": "Tx ConwayEra"
                         },
-                        "0702080803020604020303030106020400020206010808060704050806020108": {
-                            "cborHex": "84b300d90102848258204c42d014281db6e16e96acc509659bac8a9415772b52ffd1aff77ed7f794c34f0282582057acbddb2493d2ecca3aa7d36318125687017da8e5be03f231db773525d296380182582079fd2ab4bb128b51cf3675d3640759a5219842d7be610ef69f33617169f35ba503825820a3b7e590a42343449d80f340d04d96b15193d0dcf062aceb6b47fe13e5755dd0050dd901028582582012ccff08e97812f1f7c998fd71733f65a9afe7e2e2d46e4f81a1befdc64eaaea0182582039a3c280df9ed46bd7327512b4698b93c17751ca0b444a7ad5069a47e2c6ba2603825820a1881f6d2a1531b863afce65f653b6142e4fb09191f4ee08e37fdc5fc006717207825820aef7a76aa56d56514af2984a40c813757d904205ba9a715116c9c6cff704315906825820e1df742d05209648661f90316ea9174a6e4d8b150e6693ffddacb676616f55c50112d901028582582018f695c7ef341165384a01dd51c90f43dd53940ca033057436f76758fdd7b0cd01825820470d61a5ffd65498fc37944593d88401cc9ea13ba5065db1701c02a456f3617802825820558b14649f36666cd3451e6328d1d75029ca8c3d079c13791518dd7a253a5e5b00825820d3f5cbf730164de5b63d39b336ac7ad8b05c2012204d26e9dc31594e7da4c69108825820de33a45ef23636d68b2a3f7b59016bbc53a7a4b7b3754c5a2dbfbf9e9e79b92d010184a300583901e3b059fbb0de2103a090fa1a781299ee5751cc3a11c9ba03cac595c61b25788b52846e5d734a6bf0d9254a08ff6ab487255fd160f139e2db018200a1581c4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebea141301b6d25512986bb3d7603d818582282008200581c7f2173de7452f5efde11149ff1a8b1c6b1b081e88b7e9ee560345c02a30058205015011c5b49db4317382bea117555f82c2805203e9018b635152fdb63080301018200a1581ce098effd8800c865fdc3131280a35bd63cd656cd77028028717b5ee8a146c1a1038a557e1b3ef8566a51a4307503d818458200820507a40058393190cb3dc89c9ec63847ebbc82ec633f7196609ce632630fc3cd3a8b474ac383418e4b960ebbdade1cbd70390497e4bf95af4c1078248eeefc018200a1581cd528f252542e33f22adbeb859b316a807c4a5cea48f1111d47a316b1a1581db94ef069ea60598edd4ad62a4264cce964bb9c11f8bb87f12723e7cec71b3c1a9567f461ba620282005820b91cbdbc89807a7db326ea388c75d1013f987c8a9075d3dfa5d3896c0f43170503d81845820082050da400583282d818582883581ca644b5f1c817d8d3afdd3b24b8c50683e26de75f7153e3b03f22bf74a102451af4adca47021a5b05fde301821b257a912757aaa090a1581c523a30fcdb6b94f71643f41e3259de63da46391af6e5332d35f3c952a141351b572e7a97efe9c91e028201d818581d9fd87e9f9f0344082afb7a4436bc54ceff05d87c9f417b418cffff20ff03d81845820082040e10a400585782d818584d83581cd3e1da7f5196c752b7248fbcd333cad6be723907dd72567d6bd132e7a2015822582068776972746f6e6a79796c6e6265686a6a626e6c696e6f6d6570796f7363717602451ac2044c57021aa56123b2018200a1581ca090907b066d89718647375a570f5907870bce8ba490adbefd333483a1460e85fc89c4471b09f6d7c87de21f270282005820c125a576a37acdce7732a75f8813f3ec5d505581c6e6c44ec182691521aaf45403d818458200820503111a0009fdc2021a0003b309030104d9010282830e8200581cf18d35907a2f967590ef64e03c5c5332b9b66e94c0640a6151042f9e8201581c40c25330eb5bdb5020777c6a15fdfb4b273e2f4ffaad629870ab3d8a83088200581c3199bac3a6b78b49edcaae500f0e48a2dae736650e1f43deb46217e81a000cd8ad05a4581df00579d8dd694f6bd0d9273bccbe1e537a29c0cf546d3fb626dcebb73f1a000425b9581de09eac03c434fed2e0634b23dc9af64fc68691b52da5ebccde810f465f1a000d53ac581df107d72daaa373cbda8ba48acc3b0214141498801ae593521d4e101acb1a00065e39581de11d1b2159d0ab371f9c16ec7569b7bdaa90857e1b6d10bd70cc663ae61a000a1f4808010ed9010282581c4ae8ba1e1870d631d8d6ab96a7306b7c90855a496283e5dbce3a9166581cb49ba532afafe09edcc9bd0983d11557441db9cfc1b72adee315607009a1581c6966dbd4c32c2635b7c3720b0c05dbf8567c52b22a5dacf4f4537da6a1581f552f75b6c8949b1eb35ef3bcb4e2ca76adad0d1ba5e0d0983ca873ced3bf4b1b2a8dc13f3b420e6607582062d4b97b97e5c8c9edc6760203acd5f68117aae6f3ce514a72f41a0d473d11fb0f0113a38201581cdf0f6e26992d70e6751332ce27ab0c2d6a8c0b1e4df1fe96203c4413a3825820b83d74090858b538f59551166a9fb3f86f980f59ffc9568f1241851eae771bba018202f6825820e97061e53ccbd1731c58de7c37c6c69fc3bac2c7e7bd71a2d7e30265c29fa782088201f6825820ef63c1ff4d84bff78d443777939dcaa8ac56515e7fe6f40e371509888955c2db068201f68204581c10541b426f60c0e1437f8b25e9e98633e95901b64091e5f03b15eb17a38258201afb2c9945e500d90a3c60b06eb5bfa877bc7863102ed813554da59d38966fd104820282782368747470733a2f2f5634683362534d454e354a4a4d344265537152676f52572e636f6d5820d2d47d2fb2719c02c758f67fd3079b9bad586b4993b153804bdd5549c55adaab82582066c9990dc55819ac7c000461c1803eb0a0ca27c6c9345dd9a616e292edb42358068201826e68747470733a2f2f33792e636f6d58202812c74ea30afe9ad6e54ed0089e69d8f22ffd504c68d065aa83eafebac4c82c825820b807a653ea0efdc94189ad49cf27f0aa392a8d01800ce6481f89fbfab6c622b5018201827768747470733a2f2f4b6f4a4a35614e466a2d312e636f6d5820d1267c5f04670967f352334082f27d41f3cff500edc26f0ebb8fb2f85cd784ce8204581c479010e22a19683848119cad66ed44577754203950afaff0c29ceda2a38258206ccabbcd84f5043cb9ce4108cd244e49302210bc2354be22c90dadf9ea12f59901820282783768747470733a2f2f66773430547348646d61496567306e766854676a51455671785839656162774f582e584749533877452e492e636f6d5820d143cf086523a8045fa2611fb65375c7b11eadde1befca9ca8b3841dd72b4f3c8258209503ddc8e5ed421aa3455baf63dbcfe057e4ac5e34d7c1a32edc3732549ed607058200827668747470733a2f2f447a554b6833707a73352e636f6d582005abf8f75f226e4661e9ff911c87a7a6458a8bbb4c035208583fc58ebb5a6699825820a91a6226444f5b4782a4006b94d366ce3b146fdc7b16bb8510f2ee69fb479257078200f614d9010282841a000e7c46581de021304999f0d2cb42817f5694085b5264c3074c555f155241b17382ea8305f68282783768747470733a2f2f66533561553957386a4b6d3536654b2e4d546270487558423178763465496269477336386a5864777651462e636f6d5820a929216fcb3aef2c31a84873b3c2957867cbcc9d851ae89f950108b0c4d16375581cda50ad223f9fc9db03cb9a83f1a515792bb581f03800d61a4a35e14c82782468747470733a2f2f796d62697058677535624d6b5a7a6f76675a324561466f6c2e636f6d58201f79e4a7e90dadf1c242ce3ac3bd5f846ca4a50cdf3483bb7570ddd581b7a91a841a0006258f581de119252de7289d30c02833f159b9bf09949e267891b9ac4f7fd132d5c68305f68282783868747470733a2f2f546855384f48636b456a57364d785854746451646275364771366b63383772686b55522d2d584a63564773632e636f6d58200debceff95c2e6ad8e2a940933c06fcde0fedce6a35e0ced5d8fac71c8ce61e5581c2b0593e91933454be4639968f764b6fc480c1dbfb32399dff351d46e82782568747470733a2f2f74553965334d3763614a557962517349357554496b577951392e636f6d58200901e1be05e6c439cef3e2f9b375b8073ce79c9cafad375315489e62cd6897c9151a000719a1161a00077b7ba500d901028482582033b539347405e3d2fb741ba12d39961d97a9b1510312e7103de8b1b878e545fa58406bc94173875f279886fad27380010f14578d1d1527ec9912b8028b996d5550b5df871aa8293e6fd664bfe65e79dd59312db38fb111394442b7ac7daed72d101582582095a1f77093a19ff1b5f1c6f64011d9a8874ec431d35963623974bc51bb20c5105840f02f35b53e69cb150e568e5c8187c5da1531d9252774db5102eba05e0214a2782bd6d29b3a30fbd7af80c84f598124e81d260cb912399e58251ee4eddcbe68be82582065652a8ce4f4505663d25b654ef05fcff45a91c75c7e7c2663fb9ccc189d43b95840994dae127098953bc765c73087aac37923f85f71553d51c3c223242bae41d51b45516850902e566700d9713ef472da08178920227569c8bf93da0a9be6e66c378258206f8b8898846594deb1f890456167eac5cdd7684bd0ef074efe0a399b66776da05840778404ea05e5a7ac13d0c772b90eab31486804ec9b0156248c76bc3cbb6e0e90a4bd916174e261cf6b96d50e6df1ec32897487598d9d41a5b508c1dafacd9e4302d9010281845820badc32dbe0336b87a08e83e56c6d35270fe4c9c398c22a6a3a34aa1114888c795840fd7f6a4f3b65d2a981d4d5f149d9d44fb17d22bdea4ca905400e04b743ccbe9f7e0e562d6e66a4b1c1c281af76b15e3c2f0aa12789eca063aceaa13f8eeef6e041c244fe0f560101d90102828205058201828200581c772ceecc30af4537f72e02d0c9a9a3f738aa39120693efdaa5c333c983030084830300818200581c3d6c7a8f35896f68bcb12d8ea6dae84c2c9cf23f4680b65b7d7ced488200581c5cfdba428904d1ba8dba7d8338c1fff6fc6d29693db54665f28ca30a8202818200581cd6a536d5f17256af03ad10e8ca7e7a47d5c5a8248687159a4090f6cf8200581c43119424035e2d95570e0c8d2b1dc4fccff4b1905367c02c7a48693b04d90102818005a482000382d8799fd87e9f00a1220305d8799f02ff4238ecff4170a4d87d9f410b4005ffa444c18e63b701442331419e414340427c640503a040d8799f43ca81cc4489339ca60341b903ffa5414d400404404118002044b18b13cc22d8799f4459ffe4dbffd8799f0241f0ffff821b782f4e63c3b64bf01b758f67619d668b5982030182423806821b7f1d38134a59092b1b0a4159d1a430642e820308824100821b43bca4bfb928b57e1b73c98c33071ac60c82050382a4d87c9f2422ff9f22ff9f42b420a441604327680d42650f43faa4c84472c3d9d540404336a3a7ffa38022409f044104ffd87a9f42a63b44085e376822004199ffa4415c442b8c737841370343219b32012144a4b078d0a59f4434a61b85ff4040d87c9f40ff204138a324425cf341b30422249f00ff9f234391844541f303ff40a001a240d87c9f410441c4ffd87d9f0223435bcb1341acff21821b3c6ac19c6d41b5c61b3c40669f8c0d3ba5f4f6",
+                        "0005030602030503080403010200040600040103050508060506020707070408": {
+                            "cborHex": "84b300d90102828258200e981969a9bc64cbff9777f916eb28e7c489f967db2b5e2e933c82cc7666c7ff078258202c8ef1fcf3445dc5056a423da298d1e47926ab91defb30dc02dde828449c7e53050dd90102868258203579089bd984f48f2c10bf2d6e9ae44edd9812da99b2c2a8dba561dcaec3c9ff0882582054a869c2770bb485d82161c831a6dd3e829f6b5ebc9e3608a6fd9e22194f54f103825820674ab609bc4167b008001e6a54140a683fa570047f3cb321ca5ee8401d63115a05825820aace22c3675341518b51b7617a987e076851b92286bc9271822f7c931380fe5504825820b507f4a810568040b1f7b92c79079fbc2baa4515af9e08ba9322cdc9b5dcb2d608825820b9b17740bc96e689082ee3f489c03ee7f9cd28678b96aad71c9e545c2ce531380012d9010285825820bc83f8dcf8b28aa56791554bb1d1d576820c20c7d86b5ef401b68b54fbd074cd05825820c804cd020e249474bb047a1c8a91f45f7947a7a4f123d98fc520e00eca8ace7501825820d82fe0d284a0b77a5df98b49144e783e96a9069b00e17461109fb0e7568ee02303825820e4216adddaae31f4831ae3b8ca25a380b3c969704b3cf6df974d5ce5aa56838606825820fee7b19b86b02ccaf18d84211bff5d525df09a9315d62c6583e9115646f3d45c040183a300583901400ca01bffc111f01d59dc3ae17bdcfd8f947a57c14a819e16093e524d6ccbd17d5f21d3bf701cd1775b00a4ee9ed8dc710c08dbcf4db600018200a1581ca41e59d5b65608a52df1043bb876f48990c30c1316ef5ff9f1abce03a1413102028201d81842416ba400581d705aa4e720e70038ed67b9f490fa596554aece5d249f2b611a9fc93297018200a1581c2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2a142e9cd1b2f273139a1eff67e028201d818412403d81859024b8200830300848202848200581caf4cf25080e3037714bb063c2d02dcbc808f66ce7432690adc6737cf830301818200581c73cad23cc5aec41d9fc663b497ccaad8727f9593f05e38db72a6727c8201808200581cd49765e928a8277ef756d0d44f4b9d3a3bff47b702e89fcc07e5edbb820282830302838200581c3ace5c5b45cb204d1ffc8a59c8b2673fa7631d25bf49f56e7dcbe4fd8200581c3e70b0a7fd20369a53787e2ad107b30683d450348625a7c7ef20e29e8200581c2630f898448709c629fba20e31593efdfde381717fe5a47a5c237f598202848200581c3b58609d3db5a894106310103115cd8ce250ef23b78a5c282342ba4d8200581ca55ea61e1ca23fdec5a7dd049713f62338f23dae6573ee76052acba28200581cf543b38e823af46aa915a0e3dd3d725db779027267e24c3821cebfe08200581c75849239457f848022ab4783f0aaa2044d97f00d939058b1cace4c63830301838200581ce910b4994fa0741f3db3e6d5b206ef3fbd0baf92f277214368500d158201838200581cb254b74ea9aedc1c52b0f0628740eb901679d5f685d37e9659af1c928200581c124fc18038628c04ee7a0cc8be48cad5dbb0adb4359e09b091a5920b8200581c2465a9eaca414dc42a72fdd7a47c6ae849f6e46f49be05dd923b30cd830303838200581c474f9ce0356140bd7f2245fe0eb1d596be2a81a3ee3bdb1b931502d98200581cdf26600bcfb3bdbf69a3a36d32caa43ac3e7807dc6baf91ccb7c0dea8200581c9fafef1f08d8dadc3b94c47100e954672ec3928fec76dcc822965414820181820180a300583921a9376065fd4b359263f77da43ae552403e01c964b7d6fca391b268603f6b2eea180ad4e6c8d8312491ebd5b354b156b26c794affc33f05c401821b46967bcf2c6d116ea1581caa009a7bedeb70ce62ec938036803e0239188907ba7820d6f5b2c983a14e851a161dc1cd0b13486befa7011c0103d8185901bf820083030283820182830303838200581cac831b709851c1f3725b8cc396baeeefbb55c3150f6fd04a2e433cdc8200581c4fb44bb2b66de62a267f24e02f3f0772fc815c99093d715dcf8427e18200581cb4d3cbb14d4d8f044e3ef8b04f05cdedf0f09ce94fd56ab506618a088200581c6be91712cefcd6e02dfbe614725a142a8091f8a92e0ba167734bc29a8200581c2e0b226904bbdf231874b85e5c4b61336004e4f6ef75d261dc34e1298303038482028083030080830303848200581cfef7b68f990448bc0559f32508d96ab7a16a1329d437c6a1f94268b08200581cd3c73a7d84f76e81ebe39978cd03f3813e7e513c538344d59c7a3bcd8200581c5887551cd61ceb750dbf9ff4cdf81ad609c190c2461be10faa0baad78200581c733aab32ba251db6d23b9ecb3a82878ef5f4f12bb652fc029172ec118201848200581cb8aee6a9cafa03c7ec66dbb8f7dc9449131a0cddc652ebce520d78c08200581c02d40debbe5e61057dcd12ee564722cd426e598c4b2ae81a03f7e26b8200581c8a23679cca0af9da23a3a21515d4afda917dc4fa3e7c79605736db218200581c8170c100de6c8d93500f1e4a17fa61da5ac43b1cef3f4943fb472a271083581d608db95ef096a62359be90f38bf55885395f239d6837badf21de2fdb868200a1581c467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22a14132015820ac059a4c2efab33f708bdab5aa1833961ecc1a6957711498813d8dd76462ad22111a0009e842021a000ed02f030104d90102868304581c8dfb5e1f11881e9e0236db51fb28e5e1541444e754e84f03a45aa3ae078a03581c9711016dfcd24f0ca23ef36e9d121de2f6134b3cc8dd3f36af4ac1db5820f513f0e4d1ab5e926c36fe790bb9a15a36fe4fb9912b92f81413a1463d3b57621a0001832c1a0007c2a0d81e821b000000fdd45b231b1b000001d1a94a2000581de1f72956ab3b50cdfd264f5aac753b1e2372d556def874672fd429e7dbd9010285581c65c01219f3ef14d4c5d393aa9a34992ba2366b20abad3d3cc18ba623581c883ccee20cff400f30922066d9dac0cac90d0307f02a6ce39a8eb336581cbd17f21ee040715d10fdc932350392e63e97d88f6c964140406be06e581cd4acb98f7f4ca26dd7d2e58adeddad19ad13f3b6779ea0f3a65dd592581ceabe3b3b06bb6cf15b46052429ecfb63f561f71e73ccf0e2875478c983840007440000000050000000000700000001000000050000008202781e37354b7044654b6c345a70316a7569463662392e2e4666304c572e636f6d830107781a336235524e66486c3144424172564d2d77786c576b412e636f6d82782a68747470733a2f2f3759596737726e4d4841343376566c526555797765722d37326c4f4f6f492e636f6d45c2b45887cb83118200581c2d55ab3906e57e5b5a11d401f876e1ef796523b0e70248ed1f22c6d01a000ba4cd830e8200581cfa49267cf45fe3f133048fd6d4275f159ab9d0b2b66fb06c5dc38dcf8200581cb9974a190d6caa16714362ff31435d22f83585d4ccad318c9788a61483088200581c873d8020ad4f7a1c2a5f4f2ede9a4c2d95ca5ab6d0134850327814531a0007e8d083098200581c7ee324de099be1e64b6a58cfe60168a094d0905b0317e366f64507dd810305a2581df00fd5681af6f466f4814769ebdd8c5a5fbf3e48ef3d7e4b25b8013cf51a00041bd0581de1c02c7cb710a797a1ef121b0bfb38a3a4fda1b974a11fcee3dd6539cf1a0004137b08010ed9010285581c395db69b2c35c6786b778a84b67862a5208b99d97ce7f2f8efb1c21b581c54c36a7dfa2657bf8e861e08a04d8088c96efb8c39a2e41e37d938a2581c8d40e0f7533a5140b6eb090b07f805fcb80c5d08f5096d5bc7561209581c9f9fc15818511d9eb37f7b7c29d94877a970dced9955d177ae7d7b97581cfb3dbd987246b4d6069298504e1d248fbcebd68eb8d0944007b3dc1a09a1581cff56cae44851dbc53dfadbc2df15f6da16b2c122477bbe58aeea6b2da141391b70d93e69f8b1fb7e0b58201e631b79596ad3dbf979b24cefe63e036aa7aaae106a1619d882f5dca297c57e0758205f9db89eb23ff3b9057ef6c114c03e9ff8857ba2d2dfe0539d55fa2b07ebdadc0f0014d9010284841a0006be20581de098b9f0ed73523fa7dc6df6ac7cf0fb4bcbefb0cbf9e41bbbab59a33d8301825820a45e354fded3b8b54c652577a070a56d77b14e71f623254941b85009472883f70282030582782a68747470733a2f2f685855494c7836597070696f71514447396f51576f344535324b554f39592e636f6d58205251542d1d68669d776601e65a34efd46db042ba24937ac98840d3f07078988b841a0007434a581df001b22c2cf474a0c16aed3b423cba2a8be85c9186fbcc89444d1269bd8106826e68747470733a2f2f6c352e636f6d5820345ee0551a0c7ba412f40f0929814649a11dc980a8ba564a728916df519aeb24841a000ccf85581de00bef3348fdb3a0ae900d117f505933b677ac5806cc27ec89ff3886ba8302a1581de00288620cee64c21b8b8deb05578aff3305e0b207daf52a3da9fd4bec1947c1581ced6aeb692f9f3ab317f41a9f7749891dd5d1393327e7ced9898e8d0882782868747470733a2f2f3058345a514778374955346151434a356a73617a685a6e7453654c592e636f6d5820d801ed8beb79c548146fe676985448b1ae26ead31583d9672d682cc2d931177b841a0003afc5581df1e3d6a13d39c0f9e5808a03399c8f011b886def3d2270b0d63a41a0868504825820695e4bd92e1c142445b5c6c646a443b73f760a2766531c8d5d96bea80449cece07d90102838201581c3141dd660382cb1a87f1ec54fff3cbd4ebab92a225329eb4e6969e878201581cb1c3172ceb6f544dffd86d3091e8a0fa27c88bb4739256ec5016e2d78200581ce334130cd46506c10afa958734b8b3cca3879f4eb7fea6131d236062a58201581c36c295d39351eaf848c60561a78803f36f7b0a91726ee92652580114048201581c89260c2284dd6dc8c364a1c8da510130ca95a28db6ccf2389fa06824098201581ccf83691371607c731a3f4e5acb2a31d9fe84333f5239b8be2f3f3dd00a8200581c0600cc0776349f5efbe80f3bba9403323674d9ba06e7d0d88ff870ff0c8200581c91fb9645aed50018f21b604b1e8db261c41b89454a6b56fd5d2140cb0cd81e821b0000a500d70dfa551b0001c6bf5263400082781d68747470733a2f2f586f6c376a5a6f35463346386d337435372e636f6d58204265a9820e3e79cc6846f70b13c60784f153413a90b974a453d7b1aae60570da151a0007225a161a0009dd23a500d9010283825820c9f8149053d341d64c4bf6eabda9a1e341550ff85e11c7796e4d527a55609c115840229ffe0d2310f37b5fea65550a20f6a37660aebe75421c14d8a0ba1cab9a3c5a8e4572e8b61d91956d546b706cc6b0fe4a7fdab11a0f46c7c050d8529e46d3cc8258202befcb071aae0e3457e4ac33872848a7580fd6efdbce81be887383e87b892c7b58403ca541f47749ebb9636bf8f398954ca6168ccb3e455176413a349c396f4cfe01d3a4e13e4e193b9f9088e4661f04f3a37ee7f2aa068818b00ce292f3b273bd8a825820743f9ab177eb4601745513495c10a76b959faed317fc875d7d9b5e0b68a40a3358401618078eb3da33e8627352813002fa2677aa85ad97482cabd49ee8f4d56fb53a23e9b574f31b9f23e5bae5e2c70e248a9da2696ce53919280c554de6bf5eaf6302d901028384582018ff1f00495a2c27b81cf1e46a0fc49562cfc05add1bbe977a7e41fb73ac67145840269ab5929450914ce0fd5c6ce79ac7f55debc29bcd16f4b3ada6a69aaf890bfc0dd4feb264aca2eb12fa80550c8ed0f1ba9717ad29abb1efd80c952fa72f820f45e2c189e424446a9ad62c8458207e4d460fac0c17e43ab343a40e9015a69037ef1129c3ac512f6f509bc90c12a75840400f5d280e8e7e32133ea53d6ce21d66b9babc9181096b8df85b983c25255f685b7067ed26125a30e9113b38fdfc4685676115ce16c661a2270448b1ded4a51e41c544ce1cfbdf845820f211bd22b67bd5dcef47685b6604baeaeabd63e008356115201b9c917ba9c9dd5840feb922e5ee16cdaefe74020dd09ccd49aaa47b29b0b33f8c0354e5858472c9d48219e4833dfbc3cbeba79e66b8ac1baf8622078048d2dd92bed646e01824cd79443222483a4001d90102838201848201848201828200581c8feef7fac4f92cbe98ee7765a49331ba6fef5bf33ebf41e62a993b9e8200581c0e764714a9099782c87c595a01599b315342cc8f6544418d9c9fdbff820280830301848200581c03f03409842248e70a002bdbf6c8d3d53070ea9a404160a62bcafcf58200581c65836b77e795cf5c020e8ee0437b3bbecf7955e6fa2650475ed105438200581ce06689762183ef53678c3523cc44f35032f50f95d29a91342b3fae0f8200581c0da708e12c8c4c0bda8a9e37f37f0640b0bd0e4c7d5fd94346dfef978200581c5bbdf69d736f58d3df656f9db8aad38c067e4eba28657174171096a78303008183030080820183830301818200581cd1a7c1a48c66d4318351bd116e32d787bd65cbef0b2560042c8da32a8202838200581ce7622dca9478b00562307cf7c007e2e0b63abee90d8e90d52ca4bec58200581c18b6043aea919ce59781b8177d407451df7289eafccd8b6addbdb02f8200581c70823b3f344e79fd5601a39daee0ba37616b160a400ddf54e89512b28200581c8ebe095766ecc50632c7f8103d53ea11e9ef197f4013702ff68530ae830303838200581ce9ad3eeb5ef7341bbdfbe3e9e8bb8f8b3b82daaf48922cb4093e511b8201838200581cd7c8265d7316feaaf7cb7a5d8165866589de95843839e34e3599fa168200581cb3ad9e3fc0138a9d62e0369040caaadaf8b8ba7aedc9f5b0a46da0d28200581cf44b872e9c1a80fe44a6d6a9979d2c453d06b6e1f047ea346dc2d259830300818200581ceff7644878b5cdcdb5f4f462d9015e54b7c8d9be0d3c625aae4acd28820184820180820280830304848202828200581ca36f52e5c5afb80ede914d14cfd096ff7e3ddcd34aa87af3d2b053358200581c7dddb4b7b0fe3bc678d7b4d48fc3d6d39602abe9d41b99338cf00ded830303838200581cd698b72be1f8dad142bbf879182a8c86f6b26b2063f29e7a23f6bac88200581cb4a24bb0e15406ac9ed9803df2fd73a3bd6c0959a486c0ad95f9dbb28200581c4f82c8c0702908da9222365838eb043d3a47ce017622a2549bf3b3bd8202828200581c556ee464dcc84bcc5ca4aab2b8b1993b62ddeeb7142811b824ff431f8200581c143ccce054867da907e799518f7f3a931893ba8ebbadcdba44d4a6398202848200581c59e59688323c1506de19734cafe4163c34dd020c19a6ddfc5cde0db58200581cf3009109e04546f614c105a8d77034a5cf9ec2dee316cc51862057088200581c7c29e6385f65e307cbcab8830893946d3303c55fe1e1675a13aa4be58200581c2e1c7ebbc0bdc9367bdd6e3f86a73ac1c5ace91fb02f14bb1e4fc13f830300848201828200581cd8845720f3921cf6db982d78d4ed45189b316d9e8de456d4c82e95418200581ca6fd38ca867b397ea9fbbb7cae156a123c1a6f75be5c26f1599880828201838200581cb462cb3452ec12e124723dbf334f0c6b4e218277e00aeb343a6caec98200581c2497d7789a207fc1565ebbe27779854a61abf34643d5ca7a094c93c68200581c3322c36919074c783f5efa0939cac9b5153b15919242ec456c4a1958830302838200581c3deaf4295c0138d3f836e829fad254acf4c48c3feb7827ad53ae052d8200581c406aef311de8d68f099eace80bd4689f2d4aeb7f69f1c62ef4253d1e8200581c9abe4f938d8eec17d76ec2756937115de470231386273d24b4151ff4830303848200581c5709f1bce12d8cb7396c46ab576329925bd8910edf486a2d895641488200581c317a49c0dba1fd937de49b38a74c57bda4acb01d705350aeaf39b9ee8200581cf4c1964291079d90eb111f96796ba30ff9636b03758175bc40b1ffd58200581c9b3b3cad57b3aef0b7fc533ac352423bb1679944bca09b6cf5bcc6898303008007d9010282474601000022260148470100002220010104d901028521a200059fa444d816b4a10240432e571404417e42327841e3d87d9f2424ffa54201d80140004452925e924483ac7e90411b43f8995f01412dffa19f0303234262f3ffa0413ed87a9fd87d80d87e9f22a2002441a604430a014600ffff05f5f6",
                             "description": "",
-                            "txId": "b4b4362d6463f3fe265f74326d9ab9c6ca2ea9f008cf64ed2afd9d42c69c3ae9",
+                            "txId": "06b8afa0354b1ef9b53ef29cd04d5a6e3131057d6bdf6f463d32e088077afc81",
+                            "type": "Tx ConwayEra"
+                        },
+                        "0200000608000008040003000105020801070203030305010300080506000103": {
+                            "cborHex": "84b200d901028382582012a16108dc794745c9cdbc22588b9bdee571477f85c762bcf8ec5d059dcdfc72078258207213ba1334367dcca92ee5f8af1c73fe12dc337cfa95adc4579f84752190172404825820771fafcf6e18044d40b16244002cc69b10ea0da16909b2c13e7c9a09ef8dfd0f070dd901028382582007d3b5ba7340f0c68e7431e04cbc077b95e9e5694ebf6a46693bd94a3099a44f018258203e2c99df55829f528c774c3b1d03d142819b19368a681dabdcc53dbd99d3e9c3058258209cead6c8289a1f33aa5b8ff786bad27a52fd71aab86b249e98b14cecf4e6044b0112d901028182582053cb362b4512ebc80daeb550c9253e1ea96eff935773f8cc712c5bde38e63e7202018582583931d02254eb12b7d27928bc31cc023c7838d1862028782e3fffd9616ef4eae16523de9b9d9c9c9d6f31e12c07ea28084264b7e1e18258085076821b6538f980f9c9c979a1581c5421427bd6c5d89c3c9d5f80a92a104896ff4c55da23be0c3c22c167a1413402a400581d7117c547499192d8174f629acaa0a5d536d216e5142c2449cac8a9918201821b1e5c67afbb76db76a1581c15e1467e8ff14595af915461ab68f8c73d80755dc3af3a180e310148a141351b765fc46cd321a4aa028201d81844432ba81e03d8184a8201474601000022001183583910f5f67a98e6b0195ab6a56135ea915542f1b9ffa0b6d422e263f6861164eca7f1d8ec59dfff5048352f2a1e30ae99d4b6e7167d358848b3e78200a1581c82e4dd8c844e4dc81c44bd5bf74c0b397a45bca65052b2d686652852a1581855b436a928052fb6c2378f59492b1a535ced968a91988b3c015820f4c45a70678d5a0b8dc8cffb7cf6f45b313808672451cec98c62bd3ec0561753a300583921fa5429aa15a775bad87045ca0eb33da4d2ca9c1411874aa4235201defd43068aa1a128690c03294884680f9eea95be1995a9a5324fe0725f01821b2dc6181c1936b5cfa1581c4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebea14388339f0103d818488200820281820180a400583900fc6954dc6f7d86e42e125e8516d5333076a70732157ad6fb968580784a7396875bc42ed189675c1f212d24ded22809dcbb11a7e22d4f148c018200a1581c1a5722c7cfcc0c27f677c60f973a6f8b49888a320ee3b696ed65b1b4a14d391fdad196a18d1321d63b99231b754166a286a96b110282005820873eb3a05a6333bf6950af8e3ecffceaaa4f753322768c377a379f224d026cb503d81858d382008201838200581caa631d53401baa22665bdaefa0ac33921b1eeed22750b3d9decd21118201818201828200581ce0cba41261f275e17a643c5096e2ad7e5885a9241818c8fafc5b2dcb8200581c6670a3f8fa2f3e8e2c912d9ad633aff3d7e7e333c168ff5c825ab8b3830300828200581ca96208d9519ca3e4ed10429b386031996fb8d24775438e4029334307830301828200581c34a8b4c529f78001e75a48793f8af48892f1c361a7ca56ad939abcbe8200581cf945314f67c834b783a9032f29f5dfdee664023bcdf9eca15d24d70910a400583911f7cdd12fba08443d8673d7cdc8d56f656bace74c1d279dac747651bce35bab4ba4a134c24a2f5e1897e2ce1a781f427977b6997ea5c2d239018200a1581c467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22a14f158e3f65f4172e8b54f56ae6b9511501028200582096155734bafb91994d90c8e53bc5731326335dc67ef26c7e2dba9bde2df1d14403d818458200820505111a00092175021a0001dfd0030104d9010281830f8201581ca55bf0f903826fa96df1f613a8b6d65171f1b3b65f52eddabdac979c82783668747470733a2f2f585950467061647047454c546d7071766d5a414266695a7a486e59533548364f5030546a506639514d422e636f6d58203dae94845d86e7fdf8eeacf9c1425ebb10391d8e32ed8aa56b38764284ea8e6905a4581df00bd67f1c501e0df71d60ed176feb6afda599ff5957c4acefe5a3675c1a000b32e0581de03eb00f6f024e743effa11406cfce9fa0dbb417ffcb4eae3ba0db063b1a0005e3d0581de0c43e6f3fcb537579e67b91e4bcfb3f65acc80429fe4b3845dd75048b1a0003cda1581de1d0563ec6b370dc2368189e27b50e1c018dbf3c34aab554eaf9d03cf51a0002bcaa08010ed9010286581c13f7f9d2b5f0cb3ef078865e13be94ecdd6915ef6a65e65ca7b7c741581c58ed59937ad338360c00fcdd9ecd1e23668257febde210ba61f46c48581c801cc733f9997a2bcdfbfb2a0de381ff306aea731fad91b986964e09581c94c4d9d47675026d0472ae9d38ca420506fda07058e87a60d27ca9ed581cbdaf1e87bba10bb02274c5e3ab4ff059619f0c7d4c12b29924a59291581cc56066c1854ab73e02f10bcbe4b1dfb77048f5bf23cf09fd5d03e62a09a1581c105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5a141363b193e803bb93300c00b5820e003c9b9b8bbae2f2fb7d674653c83471b87bb0c378f2cc8046b234cc4b81aa1075820f2be21b8994ba025881173e74cadfb7ded64f7ec42158750aa8a881d6ed5003f13a28202581c27cd1f804ac356a3f488f9a813b6d03a415ad9725cbd7c9d586bfaeda38258203b4d9939357554ba5172e92878b2da659d3dce44a0de3e648320d1d5bf814664088200f6825820988cb4479d6eb0bb41731745510c1e19047c440777643f3e70392d69f698744805820282782968747470733a2f2f666d336870664e4b7141774630542e546f58674c4e6a6f5954342d4e5a2e636f6d58209d2f04f882a69241d4e727b8e8ea479c4b4e06e2d38179287a561cdc819a86be825820f67b9794a786d46d77ae2093649930a51143e6e3f9b90616ff99e397c166729e06820082782568747470733a2f2f36746357527336512e7879545544695471376e616d4c62624d2e636f6d5820efcb99061dd0d62bd1dd51763d8c9bf82a47f6c4c24e30833b00e023146b4e1c8204581c71998e15f7b9770a2c1eba6f0c50eecd708345a371a29d4e88a56184a282582060fc5375128e6cd4e3314d8f0251a812e7333ced1e574f6f411482614af59678058201f68258206a53a4e089fd14f76685d4702c4018aa6ed40ab1937a708b7dc5ad51a7bc837b08820082783f68747470733a2f2f716632434b72676a6f2e3151613747594f3354455239376b3362366a494d534a763648566c2e395a7050397045654e444632692e636f6d582096e427341e253238f32714d27dc6044cc6e8191c42eacb1696d9856adfc3984714d9010286841a000b2896581df1926dec9a7e117c08e05e9fa1b81ba8538bc87cb2acc740e74a14ecf18301825820a2327030f5eba7186e0f7db93f5162a201fae0d0c83f7bbed9ae704951c68c2702820904827568747470733a2f2f783863462d2d706c712e636f6d5820cf47488f15c8a70048f41c631e6a610dddbd9cea203bf481a8aa45f654dc95ac841a000b8f8f581de1eb3f0d7d2ce67376d37b45fc6a1e825297d1790f3079d795f23a144b84008258208afc9e4f05db6aca36dbc60fa2e1604d48039b7dda0aa9818e833a58a848661805b81a001a00057323011a000e7386020603070406051a00019c28061a000726000703080409d81e821b6a0c688d8b14dffd1a009896800ad81e821b00003794e23a02fd1b00005af3107a40000bd81e821938fd194e20101a00080c09111a000cd9fd12a41826801835822e2118b0822f0a18fb82252f1382d81e821b2d46ccf9e8ea66a51b000000012a05f200d81e821b2f3154aaa170efcf1b000000746a52880014821b679a784884ecb8221b5db3360a044413cf15821b3e54655bc82952131b04d00736717369fe16061708181805181a8ad81e821b0000000367f666451b00000004a817c800d81e820001d81e820105d81e821b0085e2939d4a3ad91b008e1bc9bf040000d81e82070ad81e820001d81e82010ad81e821b0e1f750377d6f5411b22b1c8c1227a0000d81e821b00000286b87e357b1b0000048c27395000d81e820102181b07181c04181e1a0004d99c181f1a0001c7af581cfe7c78a2dee50a54d66f79087dfa914ea0c328a6b63a5ab3a7c69f3582783668747470733a2f2f5645314c34634753566f7231627141674359616c48686834786a6f306d586475356d54593568547449652e636f6d5820e0669646bbcdcba558e852df1e0f1a5743097d4efbf583e7a63a17dd99606047841a000ad16a581de12824957872d3efb32a88beb553154dba103017a628ead83970bf3d0e8301825820b5be363cb51323db68dddd93b5dda742fc51b94b510c2e0718892d1591c5f2f806820b0382782c68747470733a2f2f464b486e2e5742374231374a30492d385257596f4854415a416631417a6171702e636f6d582089d30ed4d3d3c84e7689cd7109924b43ddfa68373c2f9319f4824d9b91b6e108841a0002f5c9581de1b7ee53eb55a8d70dc7559b172fdb4fc854f4670cfd6164607b4d91a38400825820450e84a9c285259174c9f27fb0b1680b103bea67c7ddeca45e561d4a5555ceb102b818001a00064f410119e274020603050403051a0009f82607070ad81e821b000000021a7fe6c11b00000002e90edd000bd81e821a002fdebb1a00989680101a000829d5111a0008060a1382d81e821b1100e883b27f07c31b0000b5e620f48000d81e821b585ae64f6600efdf1b000000e8d4a5100014821b200f6c9c23b8f8201b10742b5288d7331d15821b76800ef42ca5c2651b5ae2d94edc0034f916061708181806181985d81e821b00110698ca463a3d1b00470de4df820000d81e82195fe719c350d81e821b000006744358d45f1b000009184e72a000d81e821a009287231a00989680d81e821a0005f5c51a000f4240181b00181c01181d01181e1a000794b71820041821d81e821b88db914d17ba01791b000000e8d4a51000f682783d68747470733a2f2f33712d675a386367382e4a726d78766a70394a623763654975654a6561305348596a6151675738744e2d7a7650615158552e636f6d5820d39d1a9c7b042633c6a7db3393bd15fb9a654d39128a56bd5b2be3aed4d0a755841934b4581df048963f0b2d21d0cf252ba94b4d66f7bcfcf6a9f6a544a6919573796583018258205e1022b88e834970d7abf60b976f92b62eb63cda23c93daf0a942268c84d162f0582010482782268747470733a2f2f52457a48676b6a616a642d65764a486c63593135537a2e636f6d58206669731420b44093cff74272459c64d87474ec8663628873f88c2ecd16db60308419faaa581de03c17a429ad328b447830899dda468ef31ddad512d9ce6b36209698948305f68282781b68747470733a2f2f596a68432e536b53425a735875624c2e636f6d5820f44d78bcacccf23f4c2bc975214beba4d73fd2cc61e073b7a92bcb60340cec0f581c4812f8360dc60ff89d52dfc882b38018898f9eb55d530cf05d0a7e54827668747470733a2f2f39756c6f6441645636542e636f6d58209db1111c2d8f75b0d32626e4eb5ea109a18f58b059c69edc69d6e811f7a8d343161a00082c4ea402d90102868458201b823212225a1a035253765d02e4dc6574b6fcefba6a232264605fec5078c0605840bf2a2290e53c34909ed6cc07b040efd9d47af7f43e63d02d24671ffcf9c28f370a4369e342e5707d9c3bcd191a217b519eeae7e4e1baa25ab3c833ae8f1f746444e863f355448e8a2da7845820ffbfde1ddb7d041460495d563a2b16f1845ffed967fcc826a54569b38eb40dfd5840bd4c878a8ba7e883a24e98f6456b266ae306d3e5efe4d5adf2ecd64dc28c23226d51b429412b70291138479b17b044dab40650173128f7ecb491b7952d09046642b96c4084582026d3857a2637979db74d78cf89e0ccb401db8645b41c38d6afbf462ebf41dcf1584057476a2ea866e4e6495cf1f5aadb75f5da05a83acbc852674ceb01ec5ce9093493b170efbe50d8634a0b84a71cc5c3b346b21004c68bf84348f39dc44d73422e41ae449f781d1f8458204dc5ec1f4b53fee9f029baa46e08c589a0ee7d73ca96dab7af2307203c11bd8f584036bd8cb2ba0adfab9ffea296ff844a6c58d341685d4ddee339c54d3852a10543b4b7b4042ab9b5f9cabc24e93cc27582503f5d4283d248a918c4cfb740c4498341274188845820560d5e636b4f9ef663e193d1f85b9117444a557588fca2046fbe506b1692cb8e584028359af0256ee4486fb962ba040a9e1fb4b45ea9877451ae84508dd6ae41ba573d9c1952fc39d3e4dd1229d6fcd635eaca864999202cc9bf4a2653444fe5b49942fc5b459ca6a0dfb584582021d122c0b448dfd1a2280bfc20c08179d1c78087dff93a9d4aee2df045b7a385584094c2eba05279ca5d565cecf96261b5c290adf87aab32ed39c27196b6f1d527b5e8b1caa1c9ec62c9eed09c03a8ae1499eb5db7b38fa49153fe62c69fd3ea6b2c440bd0fdaa44c8fb2abc01d9010284820182830300808201848200581cf3a34a756289604d577f9b8265bf7685f724067aed104786218c0c8a8200581c724e261c4ac32d2bfcc1ae6fafd37777f7be557e39ad67323ca8abda830302828200581c596e3b65320737db282370e537a09e99ac53888e98dccd8fdb8ab98f8200581c6e7864ffa905a0fbecd515d2edb7927bdb519376b490d58d074936b18202828200581c5da88f953900d05a8bc9b75bda087c86496d9e8fce2e57b97919d6b48200581c10eafba2cc5611acfc16626838d552f09155e907adb1ebd20a98a16f82040782018082040904d9010282a59fa143f3d7d143f6940ca323427ea02003418d4247a4ffd87d9f4342cd16a2404421ca520e4129430a0f01a3413a446a9b2598448379775d242342e115a121435c1627ffa0a340a3404300bbfb44f360cc96030240a09f0341194003ff0240012444dbdc60829fd87e9f42c70c24439b5d3822ffd87e9f0141f144740a09f00042b17cffd8799f0505439c5b2b441a152aa0ff804259eaffa3d87b9f4415366ff9414c4333d53741a2ff9f24ff409f04ff9f404001ffa300212421423a22437118459f448a0d36cf9f01ffff420f7605a6820003824192821b23f8802953a719321b66ff8042b82333c682010782d87d9fa14264b7d87b9f44c2bc924d22ffff821b410899ec48c17a971b1fabcda9133ae77382020782d87b9f9f43dbc8f9234465144d3b433f2de7ffd8799fd87e9f2441f6414a41ce436bb0d8ffd87a9f411841e2449e27d11e421fc8ffffff821b276e3ca15083dfe71b2e7ea04736245b8c82030282a524a3d87b9f200143fc199442902642c61effa144811fb53b438fc55c9f2041334022ff23d87b9f212444d006add0ff9f02044342d5242444e01b0765ffa244644a4ab9d87e9f436383c4ffa440417f43a1a7fd40428e66012043f3a74903d87e9f9f445e779356404361503103ffffd87a80a4a40224449846291e20440b43486c427ff222434f44dfd8799f422ff501ffd87b9f2005ff9f4040002143eb0fc6ffa40442689d05437ec0bd42d91a440db318ed43b01fb62022d87d9f42faf9429f41438d852223ff44ae3a0c8e42b7d1d87c9f9f40445c5f1daeff229f41890043ac8b832222ff04ffd87c9f425850ffa3d87d9f43620f4e21447a34aaae04ffa30103224226d344ae066add42c72c409f42021043664b0d41430301ffa34040448e8786d50544274a15952002821b51ddeea5dd249c431b7d10c2c77fe54dc982040182a19fa20024423ce442fe398001ff42f858821b38beee8794418f941b2a452c5bfb884e6e82050282d8799fd87b9f21ff23ff821b510113f2b2df92791b1ccc921b446045fcf5d90103a400a5030207600ca00e433614710f25018482051082040c82050c8204060281484701000022200101038146450100002601",
+                            "description": "",
+                            "txId": "f0d73fced0fa16651d77bdd6f7d042c0f29b4bb744a92331fc9a67cc8618347d",
+                            "type": "Tx ConwayEra"
+                        },
+                        "0505040108080001010405000100040505030106060503020401020006000608": {
+                            "cborHex": "84b200d90102828258206100cbe944ceab8c4ab212cb3157ac4773e01037d88a689a43cfb10887f65beb03825820cdabc9b1c47b6a1247d36d4f77e7c07d6b6385e9f64bc6ba90f49eab3fcdab8e080dd90102838258201fdfaa0b7356041b799a2bfdbc70acdc6653e0ecd03c552c0e27c9bf705a55f701825820d082371856ae454bd9e7fefea51594d40b591768235a742e3bd45bbbe4ea1bc401825820e711271f40f4cf77ea940753e406d52871a2135b18d0010a0740548fe090edc00612d90102848258202b23de528019f50dcc798db91cbebb7d21af40e7432d083c0853663d2ec112710582582058c6a8c2c6ce919aeb7d0264c51c421fc7be2d6b92fbb6f6b6ad3acbdd2571d70282582080efe2b6d05a92e7c6e735dc07283685f42a70bdc9a0d2d1f3fe0998d4d1dc4405825820eacb7807bf2b7b5ba916a7ff2bd1097cf88c15e4734d674ade7ea5977fa3d9000801858358392069ea646f6e753c4d7644c8d2178e4b61ac3741054a1f5a4b6b4d7235e457b9602ed51af29b850d3fb3ffab4d5b2780a992b76ef24ba8f4008200a1581cb0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165a1581f88dba3e29c6390cc1da415b9453244e588ba9213f3e1044bbd9606b08a44321b39b7bc54b686b87e58205efa0b3ff403b4efa5fa2abe951301b7cb6dc53b603188b1486d5e4a7c394483a400583901a8665b58e6afe91d99a1d3ec30d1ac985dd84164e160bf430a604e6683dc8bed83a40d5e0ddf6247ff4f901d5f276ba21b4b002959bcfad4018200a1581c467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22a1581e8918aeb40e3acfc028a389e482765c6a54afd104d4c2934ba8843626d4b01b64a647cae9a87bcf028201d8185861d87b9fd87e80a4409f43152fad40ffd87d9f44feb9b5e3412fffa32204224041fb02d87a9f434aad1d22ffa4411f22422eba435cc02e03404002a54454ca3df64465b3da75440a77f012410004411c05014022d87a9f0142647fff447016d5c7ff03d8184a82024746010000220011a400585782d818584d83581cffd28bab3caf9d085d4c9808d9c911bb7c2205d92052c8fedf7872c0a2015822582062227d64ed25204d10eac45ef8662ba3c8b1024b7a5119fb70d67fd39c5cd0de02451a1e7bfa21001ae0e6f299018200a1581c8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3a1455d767d769102028201d818587aa3a59f42d8d2420535ff409f444045378644e818f9e24257e621ffa3010144ccd77079222203209f030142105dff22a0a0d87c9f0443eb2ba6ff9fd87b9f4476c63bf10241f440ff42d6edff01029f4104ffd87d9f9f4102ffa343a1c385224465b3ec3e41db434635cc44287107c8d87b9f220542c20305ffff03d81859019f8200830302838202828202818200581cfc0ebe49c1104b9a1f5d6f5220144cee35d2a2d6b691e497c5e2dbec8200581c048b1a322308e823967ad2bbbe5e67e5d6120dc80a9598b893aa2b168201838200581c6d327fcc15f31e84afe2b55f32b69dccaaa471808950b33f6be35aa3830303838200581ca104888a25107bed18c11ff17ab1d261e21368ac9fc94e0b0dd635f18200581caf60ab024a18a4cb711f5f03a96886fe95a4755aa2912eb20f9a24918200581cc711bb1d837b6523ba5df596cd5d47691eaa055039eaf78462f3fb138200581c516872476364f889c640d914725465fdd74d8409be6f4dbba83de02f8201838202818200581cde59c2dee0270651ae65f25dedd971944af395b9330afc95521797f18201838200581c33b5e3c75e6f96eb701d335fa27cd2391c63f91d273ecc8c06c29acd8200581c0fa761f3d7377fe28fe9878a4042480d066ad094f9fe8161bfa2ce088200581c97b3f9a436df1a5dc4bae4e6db4b8a1d70a50c5ea64873a359770d6e8201818200581cfcd43dddd488b00a1cfc7f477e89e656a33e4525f9282c5f62d7cffca4005839109f2e765dd3c129e14f46868b3b2e03a14d2d24891968fb4ea2cc132dde4968f8af11bc84bcc372a5c39734f18e94817093084f2f11a1e600018200a1581c245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abaea149f2107280e18d74787601028201d81858259f9f9f05ff009f22230142daee23ff9f2244c1573cacffffd87c9f4254da418b9f20ffffff03d8185901de82008202838201818201828200581ce4d1b26abada3abacd6ef193dbb7045c312217d71aa14b46d3ac000c8200581c58f814e875a242b3b47191499fbcb6a3723d33306a0075904f38e8798200581c81e2191ffee0e2314408552f75cdac17a880d8db270843278ac0f16083030284830302848200581c9ff49a1335ad3f98f8952c614d7b2684585ae4068360f1afca1a3d2c8200581c1ed67b9a01ab03a1e4f49b486f8860a94eeb4c96fcdcf904c3276a018200581c4cdd5c009b67fd1ea9182762de2b326e991ce097b2e236b81cea89c28200581c041784bb14c50996264837cda9302d28538e0cf1e74d260b4814aa938202818200581c25667b8d4a5d5bb5a9e99fce48b8903df3e72faa617b16c1f8d08ab7830303848200581cefe14785ced38b8e6ae44fd44455574e561238bf0710c6a4eeb239fe8200581ce420fe27a018c467919cb7efc370e402e41276f6cc8518d2533617ac8200581c2e59919ceb5186f3e7b81b8e983f453b3daeec4318d1cec831120e598200581cb97b4056e495e5bb2269e743606b4c9c740a1a9c9508641aaee3c025830300828200581c88485a9a7fc6f392c7fb05e4a0ab9414b9d62bae17839b85e422524e8200581c72ffddfabf6be3a356306f941d4f4c1c9a2c60c3953ff714acf443b7a400583930df5270e816b4313149fb69f6275f2cc5aefc719900b0faf49d804c3addb2b59541c1c6f6ef35789936f398ec281dd2b61953486d9c1840c8018200a1581c0efd90d9eecf25ce45099860970f6b30add29c11796169ddb96b7e5da141341b6e58b4f9d058c85c028201d81847d87e9f426a13ff03d81859013f820082028483030081830301828200581cee226ede46c32c86a41ce44165d7f7b572ad13b37719847dfe077faf8200581c17b08c218db549bb73837b13e166bde6847ea7822a7b184dfd229afa8200581cb7974c00b87560cc54bf9182b3968c2fc291ecddc2b6e79ddc484bdb8202828201808201818200581c0cde329c7861001cbcb0291f72e3eb2c0a4b7bf76878f8da9b7fb9d38202828202828200581cce222b3628d09b7834f4f8dadef4bb74a9c0c7b158503bb6965085b08200581cdbaf68aeab2440f315c4b4fcc1e59a4de21923aafd1db98bd058b7c08202838200581c4c67276128f2f1c9763bf553adc58d7873b6afcf9dd86618e15d76188200581cbb5862819857ef0be7a4a88b6e7719a94cb4016bc47b1b630c0349d18200581ced2d81525a33a30545e754d654cee51642539203ea7e390bbdc331a510a40058391008a87e60d60faa9e5141563648dac82c370143825710cbcf44fe446c0cbac4f55bbbf8bd43cfcd646c1d10a0934b9b93b070704918128b3e01821b0720d3a415f0b738a1581cc3d94658c57f55e503bf3043778327fd58fb527f981bbf8ecbb5ec16a143f347581b0a795b38a40870a0028200582065648aaf86fce512d44b27e9b8de14d1df9c9e8360adbb3bf79eac29a289424503d8184a82024746010000222601111a0003255f021a000272ed030104d901028283028201581c10a89181313b001daeae0cb2ec0213673bdd4eb9fc0e0a0bb9657fe1581cefcfa9e27bf9b092176bae0c0c270211983214903a647c9002dc9d6b8304581c0ba60457f905b7b61bd36aefebf1f0fb89a842c450e6d8aec5cd9a6f0305a6581df047a11bedadff59cc4843a59c6432dfbc6802fa18512969d59318a6591a0008cd1a581df056a403661daee7d62756fb12fdfff0da55d56768762472919154c4de1a0003b979581de10f352b6b8f4159bb194431fffa18083ac7c76562e272b73931d1d0951a0008adc9581de1274bcc71bc063dbb2cc65a307afd33731b045f7dfa779ea41632234f19594d581de17776debae4dd5ab2f9be42c8dd0300670a18031517e89d10dd822e551a000767f4581de1cb14179b0d8594f858aa25159ff94846b34083daf584fdc973af43c31a0002177908020ed9010285581c044679a1120bf2e20a32f79fb9f78cc467a0dae3b7857925ed21bf36581c8ec01531b544434d963737f5fc1cccb6163ed49d3dfdd8505323c698581cae402f92297f96aa72612db40c9e5327eed553c71c12e82c7ee1d324581cbcb8b68a456f81de26a9d3070fb511be2302f1d01baf7e591452191d581cdf474370d0669663b8e0bf377c94d49419105c38944ffeab25cef7d609a1581c467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22a1581cd23e9215be299b77e8a30ef09fe12e4b8464fd5eb74a06c2f2fa77c21b185fe19eeb7d5dd2075820ab942303dc82ed8e0964ce812a24cff95f2a14b83b9069e6466dd3b71fa8664b13a38201581c5a0ae796d8ce9850530fa9fd44c33988ad620ce50c83f46072fc94d5a48258205130adac255680a94973db2f49baec133adf806c280cf848d0c2351230182a12038201f6825820628ff0bf23df6dbd0979c70e3e8f13775490ccb6eafba32b15b739e54e007a6406820282781a68747470733a2f2f457a474f7346317254432e394a6b2e636f6d5820d2741fc4949c3e320334ebb64972e160b71d6c5c1c6cbd8c48e2b2a1ff92a214825820c4115355c3a8b2d8ba83b9e15e466f2ddd7937e4623c6ef18bf9ce83dc2021da06820182781968747470733a2f2f76304b543871557a4d6e4e30572e636f6d5820a0922f9c74b31be33d311a7d157ba833e88263bddd57119d373732e82a4b9937825820d5a0dd11e053d00b5dccd4d643e3258f3196f8dd102a503fb492cbf1c6f3652d08820182782668747470733a2f2f68427074324e5147556c543953462d696833486f7a7878596e4d2e636f6d5820313f7a00b355aeba14bad2921c3ce8a8a9650d094bcf74ea62edbdbb81461bdf8200581c601d862dc3b88b202d63c226070f1b40b1b72db944db03c19a9c2a01a682582045e90d88b609a00989ee8db31e9cc871a5698a6daf5e51c18182c0565359fc80068201827268747470733a2f2f6d637034564a2e636f6d582080fd1e0a460b26b66cb9b419087583f084014874d2dbccfb47570c6ca43098fa825820595a421ea03018fc7855a260265f6d4a99fdab21490f357159bf7990ccd9b9ad05820082783c68747470733a2f2f4672534733584d6d315a4b7a316f734f4f3857424b6c47334d6c54514b4d7752494d69676b2d2d6c47477575794658522e636f6d5820fc95cd2c05a415e433c6f2a8dfb3a9732b8ceb7b100dff540b507d53b0bfe46a825820636fb1ad512e15358eaa5b6f3d7bb3ec255295b2240144d5c700765dd9cbf68e058202f68258207814fa3b5a0fbf04e713f8df30100f557b2372a2471fac254a110817aae8d55e08820082781868747470733a2f2f3043436d53506351766351582e636f6d5820fd26f8f48e603b905241050d7887e2a3fb3a12fd1bd785f156bc8fb86a1f03ce825820ab522d709797edd585e685d8dc396ad28486e5e1e6f81c2a2f009a875553209404820182783e68747470733a2f2f6477526b2e43723444586a627945655543682e4e324773357866735a385642577a78626532412d5733656b576e3646365a682e636f6d582038906864e564f8bc3142052fa049ae7a1c2c35594e7e8e5a0c3657b0b6013571825820b73d901aec3103f99beec00ae874d3732cbc21e46f8c43e6e60fc4577e61ec1c07820282781b68747470733a2f2f5a7643654266446e534c582e6533632e636f6d58206f10ab0675271fe92f09c385890922d151d7838d3db1690c8b537e73beefb2378203581c59807e176726b3ad9a3e433baec3d0eba629273bb77bf8e557c22341a18258201e7727c560f6f1550b302080a64bbe869ac41b2dab532ca9eb240f402ebc6b68008202f614d9010285841a000306c5581df133c5c0d5642ef74e79c1512c6ba44951660e0a5bc02aa702ccd48d05810682781a68747470733a2f2f3277664e4430324748366778312d2e636f6d58203c116767431ad1e5b7c5b4733769875b9b555e9e03eb7f69290cdce6a29a26a5841a0002bf7f581df0a1a0ccb153e80b5eaf070e1a1a19cf3b34421c05b8c27607db3d706883018258201606cc229b52d799365b5fb1911cee50ae238e27502a89285c448468392e284f0782030482781b68747470733a2f2f46475151634173764a75476368397a2e636f6d58208c05f31662d3fdbc1a4f68ebf86457d46a36d8509ae86e1108afa057b91faac3841a000d145e581de1183689b5def1e7b61cb948bcf57e9d84a43ea013dfdbf68a0f5601dc850482582040f3a70d073e34b599a0ad5584eecf3e55f94f9a4f234703022c015d01da02a402d90102818201581c037285410914baa01ddc19b317fd30e00ea4e3d37031dd8cc0d2c0c9a0d81e821a016d53531a017d784082782368747470733a2f2f4f44653456736d48496171356b37445258414e6a6a43752e636f6d5820d39ad1a4dd66f82b6f320fcb4c92241329aa7ad3fa2be6d4689415a5edfdfc91841a0003c4d7581df1401ab2ce4f0ba38948f094f48ae3a3afe0171c70df3a2edcd0b818fe810682783a68747470733a2f2f35644a656f48556f786d555a6b315059614f2d77514b47496e4c502d737958466e5043685474504778695a58706a2e636f6d582084a1eb1187c080a1b01657bbd34a2f188baf6a0707a6b967ca98b4a70d481b7a841a0008260b581df0540fcc59479dbac7b9d131fb9e8683111658c937221bd911d982966a840082582009af172b9bb63954c6f50f500cdad233b1160b8654dab6dddb0f1f1258e25fd700b4001a000c0ca8011a0001c1cf020803070405051a000eab1106196f8507060bd81e821b000001a61139d38b1b000001d1a94a2000101a000b54e9111a000bd6131382d81e821b03d9f240cc80dab7192710d81e821b25153bca5e75412b1b0011c37937e0800014821b593d7d17a0fd1bb01b16f6caf40d43d29815821b5f3697223a80b4c01b2dbf370e953d3c2e181985d81e821b0000a86bc86174331b0000e35fa931a000d81e821b2257129987929eeb1b22b1c8c1227a0000d81e821b00000001d83b77391b00000004a817c800d81e821b0a68ba5c6064c1971b8ac7230489e80000d81e82191b2d19c350181c07181d00181e1a00087cf3181f1a0009436c182004581c1ce3b7ee79d1aa611f68aca630fb605420648afe874d0c688e35730682781f68747470733a2f2f48567a316b466f4468456179773044415843392e636f6d5820683471a3f449326b856aeaa0d8ee44fc7cd5c694e406fd3646a509f38bc7a8fb151a000250b1161a000cb584a400d9010283825820136f21ee588d95656296fa2743a66607c2d354ae0d7d94ff7de02d2ee3b6531b5840013527702d254d317f23135ef6e4ff984a7df7a2385fbb4ec1c20ef99b7525373749e2c57a53c9c50069d2a2996e8119391ed873570c5a4243a899b60eac8e1a82582086b68b64f7659e5dc0a1608b73b701a6a52e5c2f03d0506fcbeab2da63c053e658400b80dec3536487efb0cc015aca79dc5402d7dfc921b88d355701c38613d988482855a48579d59fdafe7050d61eb197383eed99a2ab2a1eabdf2135d2420c1cec825820da4a589b2eafd7665cdbbf798c12d51bbde2d437b96d01b4a7fbf800140eeb905840da2e8e2eda0e599e94fa21f5bb093b7fe0c1dfaf65ba4494395456a1072881ac493ed8ae1d213d81bbedb3fd7da7d825a16cdc6dd9d7b740b245df4d62f8157802d9010283845820b6cbf7e5e136eb3c649cc989c655770bf1c94366db6e1dfd5e436589458f415558408ffe7b1f764c6d69317b0d209ead43aa9cb59029e372aa3bce1b4416693b959e7d35983a45faee3cc12dbeffc8bda2723cf04651e6b5af6d7f71fec0abd26436404511857e8c7f845820eaca46dddd926eb035cc7cb51c63ace53ebbf2053f451330a88129601af900fb5840f7e07ae8dba0655ba32f4ec68fdbae4e0af98da858a9a619b7a5f86a790f1499dbc8d7e1e0aba796ceb0ff83d71908f36c3f2cda2231b58c954f0321b0db7d444045199eebe1c78458202a1a84f081afe87a62b3439e102ac52e5244bf1536579a495339950a1fa6b4775840f35c17a9976a36d44d5fa719921bc051417975b9a2641665a3392b31a7985b68d25b6bba415ef332f8fd9cffb4f364d5fdee0c04eae67244b9e44b31cadb5dde42507a45beab56341e04d901028280a1d87e9f0303ffd87a9f2000442d66ac8d43134968d87d9f032400ffff05a282020782d87e80821b3f2850c5b31bde9c1b7c91e3fdf50ece538204058244633fa0e2821b6ae229764472eb021b66889d5d6e06da11f4d90103a100a200a00da342a0c0655e4e2e2529224041d64181",
+                            "description": "",
+                            "txId": "3cd770944157a2f734a839570f1c780fb3b2cb4e8eae62eb4ec53d98ce760c2e",
+                            "type": "Tx ConwayEra"
+                        },
+                        "0506070304030302060302020107000503070408060200000806000707000700": {
+                            "cborHex": "84b400d9010282825820364aee79cf6473b79c12929a2e4deffe9905ef6ceeac19c9efb3238dd5401a1902825820849bc79323fbe5c6b7dae299c2bf35cd709e553d554644dcb09482156249f32f080dd9010284825820113f3a7171e53abd329b56430786908f2d7e8bb22a8e6e291c97396c0215b41802825820303e75c4d06cdf1d7dbc37374795618188f6e1e76b3e8089c291545eb4f5740f018258209716379d46afe822a936c84fa578cb6f75ef86ed2cdfcbe6e43f1fecf33a5cf900825820ed3b410001c6138a961bab508189ecbfc9cce6e4b992595362a990673d4ba4e20512d901028682582018e630abe61a6c9a36cbe5be866e7f4e9c5c163bff2796b1482d4e23d8662ed90882582047140500253dba5ec9ec116f2e3bb5bd8770a82fd1a6865b02ef9de81feb3b9f058258204b068954bc2e4cf86822ec2f0152edcf88f1fd24dbceb3ad1377298336078fb30582582058340bcc5b647dcdd0a75ca641a14b9bb31923d6edbaf3d8bd18eb58ea3c707703825820f2a7daa2934de2804bcb453c8e6fdb6cffb2b5a12caa0176300a733134285c3002825820f8fa3819f15c2a2e38ae82a9d845c3495d5a72e458c15ae883d178fe86a169f2060184a4005839314e8a411440a8a7658d3aca304b75e04871858a96eaab57aa53db2ba16092e2175bd417d8975471fa05cf511f2a64f41d038423057a8beb2101821b07b21dfba1b715efa1581c467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22a1476abc56e2ef74301b0f7e7f5ada246ceb028201d818410403d81849820146450100002601a4005839110b1917f5e9d400d05c657445654401e71b73d6188f5edfab0f7d947f89cc50ae1ba62694fabad20a119604d7c98bcfc1a5f161641b8306d301821b7f399f514b715092a1581c577b33025c22cb4084c137b9dff300324fb686f5737392345fd770c7a1581d3de96514bdc044b9e7dbae9f8790295188c27bd635c12adbd1e9f2f48f1b19e7638b1836377b028200582054967194825bd95c5a2c18ccdd632d56c507df77ce3553806cbb487f709d4e6f03d81845820082050aa40058391126b06b5f5c622d6b47a9def1a0679c27bbf7b420f49e822d7bb4546450c474c220a70651101a626dd399b580ef4ea20b3423af069a69fa1f01821b2d78bbe9a48d7a28a1581c44fcdae2105495be16455d1c47c05262839ccb5addb4dbfb99fc73aca14f22263ec0b14fe6b231b53faa4dda1e0202820058201ea1d987508d6aeb36192f359bb2d3864af74db9ebebf16876a35515315a1ed203d81845820082040ea4005839018479760c46f62d4f9b946c0d98ce65ceb65d30be09e4e0b3f975f9146c4ebb26a804e964d238d78ce2b28c460bca14d8fad42c2a6807438101821b3165813a4488e5f2a1581ca64fad2f14e4c9f845765d6ffcb0bf5a95554521575b9e6109d4d4baa1413001028200582061758fc56726b587be72c43fbec1f13c7e47206e72b53a1178bdb8b3b35c45e803d81845820082040510a4005839200985f6af8d95d95198b94a50e12cca81ce848ff8ab3d1f82dad6ddd436edd6ad402f300783759e7790e33faf8ca0781e35bd1eb2e9faf52701821b233646f451cc2784a1581c624c9ad57a3fa3d6596b64ebec5365732ab2336a34aa812d34724cdfa14bd7bcb94517399b222eabb901028201d8185871a49fd87b9f21ff04d8799f4213be4043d73020ff03d87d80ff01809fa043f2e233d87d9f42d85f01014040ff42cd6cd87c9f40232244cde1b531ffffd87c809f416503d87d9f240421ffa09f002302446aea04de24ffffd87b9fd87a9f05222042e0d4ff4349552d44fe18d514ff4206b103d8185902a58200820184820284820180830300828200581c75fb642a92492cd394298214d80427e0ffb4f61aab98bb0ac19807b38200581c17e4a444a58a36828d6af1128077e513e9971144ecdfcbe16cead5128200581c203c0de28458e0868f9413aa5d8196e6cf48695aec478fa389842cee8202838200581c8acce624ef6625175a2a376f536db121517fc20f1ba269fec46a36448200581c15f8f89959da1128042998ac440adefa497a4ecb312aea68548bb9c08200581c459b7e5f6c07949bdeb2d582ee9caa36613365ab1cdf6ddf2011b61a8200581c4fe3723d86fd039bb117b708b51c56c4454a4af2689eccf357e01fed820282830301818200581c8e48b59299a3431b68ed3f4f7a8f9516af7f43bf35669baf065fa1ef8201848200581caf2eb2165ae39f33ea97dacd418c839c2d73659df2cd17f6689d56f78200581cf01a86906fbb7fec9f5515c390424f301fc2b0edf7a997605b8021598200581c506cfc37daf325b893373478795061941c5545cc6fb60e95e23035f08200581c82eb4be73340ad8fbb94a757937ef555a12a2a1900e4908899e5a01a8201848201828200581cb8ed4f07749f750a0fa01397547b4670d4f15400567301369a33a7738200581c86432efa6b5006a9158c11d3ed25382da56de45b5582fe33ad190a178200581c8fb610478e98039e670bea2b7464b6d5af59c4cfb4d7b13785e3fadd8202848200581c9bba345e8c2506f90373e6aee6e294995cf21ea1a0d55d306a0eb87a8200581c53aa36e7d6912fc684bf0a23706b31483e082a9f76501fe379883bd88200581ce22248cd8a5e9bfae38629a00941c93162e3838d842eb22359841b748200581cdece57766ba554eaf1f27601c33af00b0fb563ffcd992c30b955ff438200581c0a44b0a6048214caadf58b94ceab7e600fee2b62558d544ad65dbe78111a000de63b021a00022dd8030104d9010282830f8200581cb785bfdd27bd757a77d4b31e17b322fefa159e46ef539a7e2bd9830ff68a03581cae6f0268ff82f1e94847578c5dba8a7c3cd4b09a2f43273da3ca99c958208b9f63d87d62ce0e8dfda7e74b6c550e958ce017295edc9f69a0544571825a241a00064f2d1a000ded5cd81e82192dbb19f424581df007eed130891369588fdc2235f70ce648113c6a1a657babe4a6b324b4d9010286581c200d34646a56c5c9c0b8c359d1ecac9228ab46e3080dbcc9cafee6bd581c479fbc3a656d25a05e8f3b5bc32aee8760dbd875a9f184c35e52a0a1581c6706939abeb9b02bc8ab3ed16eee041aefaa5c4ca04469138481523e581c6ab2e06405416fd8cd5e0b988633908a2245c1f2b360227152681054581c71972e5ce7b159053143ecda29e0261afe76b29a0b0a15f97586fe1f581c804842c4fbffbef70dd33f97a825ede4d29bcd167eef5e0db1650ad8828202782533496364667368466e6d7a6b325032564c65366b716e4765464a627a65446f48762e636f6d8400f64400000007f682782168747470733a2f2f304c655145434e34786769344c4d514974787635572e636f6d452311b94a6a05a6581de08e29e519d5131cb550fe6868f9813498ff9c657d4a2a83bb842125ca1a000addd4581de095b86a2a3c5d33aef887fb0a2a0ae7abdb829e4fe25cec79a475ca6a1a000ac2b9581de0a6bf63a134ac5fda6605ecd4183712b9e4ec615a1e5a8435e906ba521a000659d2581df1ea71f91236ad7ef6dece1105b97f4324917c43168ef09f1779e0ee1d1a000128b5581df1f317e8e0add7f1df05ae1b350a5732244f34c2041655a23759089ace19dc03581de1c64672976eca59f5190472e32de110983b4ed04e8cb045a2a7bdf3211a000a27af08010ed9010281581c945f8aa6507e8b00a4bfccab39a0d35a65025d9492de855fa4224a7409a1581c79a0c87d9b849e19466539055be9122690a88509e34c54984d1ee542a15819240bd84939eeb054753160e6201ea0fbb5a5e49de9484fa4473b5b86f3d8daf8617e0b58205cd7eabd09d12e78571fe8e9814fdaa29d64ca615c1949ef18bd5a04f07bc1eb075820f9b4d3b3172d21bcae838d776fe8cd847290f0644afe9ee26f567082d666be1c0f0113a58201581c7d3b11d5311dbbb96be66b5710a1b9fc96b1e125e38b948fbec09820a5825820097ff0e7ba0cdba06629952708191976def0e7975c4075cfa66d28814c6af3ce078201827368747470733a2f2f3061424c6867652e636f6d582015af831d6d3146de0a4772c9b24d76c0a4fa5073f14b3246e8a78f86306a33f78258201f730c9342e3f63d5e74d57219dfd45fcb7fc93f8d6de873e3ff5a33c9cb4bd607820282783b68747470733a2f2f5345316e583439444e7247694b7a716a657643374e41386d593975466f6b2d774f594637354e3671343634476f68462e636f6d582006f7e5e001f53c1903d080b9b99ea082f47a604dc4ca4d791130a459c483e5c98258203d660259f29b9ad11c52406b5be4ecf90b7c0c522e4f9c76a37d97e36c017be703820282783568747470733a2f2f4359502d4646652e59706e475a55336d4e4b696e544548352e6832666c5774446159614138736b537a2e636f6d58201b80bac85f4695ba95e243c716df2a44d7972e9338d9b009234c7da8277d1a6e825820f4c3dbc375218cb77c488ff20a3bd40f30ea24d545e1c5994d94dab5ec1377c200820282782468747470733a2f2f375947523251577a39576d61786b584e4f5265655a6e33722e636f6d5820e35d8c6b4b83bde2e3ffdd1561adedeb09d995a6f29aa5e5e0b49a6bc8edfb3c825820fc77589892a12cda8fa60cb525402e9a236667e8cae9f12a58e691ef8dd25a17058202827568747470733a2f2f495a4e6530304b38442e636f6d5820b7129d25a07d6cd393fa541d60cace6b95b0c4f7e5798bf5dd5afa225cf8ad1a8201581c9a23613a68832931ea0d1d37af62f6102bcc6b491ec3f558d83db7f1a482582000fe56990e96841c1e7861fdd2d30b0d50c569f870e25844fc92eb8401fcc86a008202827768747470733a2f2f67545968554564346e386f2e636f6d5820d21620ea3d03d37e89d11aa6b4b78464b7b7897799ddfe4844b59bc80e4522548258205599c94887b57e63f8be4d45f539484798cc03e53dc1ec9b259940e4b2ce7258078201f6825820821c2e41f59d2634f30b13e07e99e4ce3e179bcff66f21632a1e04040b30cbf000820282782768747470733a2f2f6e4b4a7a4d444c6932504e70647244664837703035384d36542d452e636f6d58206fe5f4e4536b4f5a4509595f1b50937f9131dc911dbfcc425be6e9a150feb3e582582086b4716b3b30b62f248f8cfec2742ef68040f7c07e3ab77b5c706e8d9abd561704820082782668747470733a2f2f7579424f705a44746e302d71336d67327a4631356470345469592e636f6d5820e7ea2466d8b2e0198ef0bb81ce01ec50335d03b00cafb45452f748c4bb24983c8200581c5b39dfb0c25b132f029cfc7f51d12b51e1443799e15ae1ab0cadfc2fa58258208d80b1308ca2bd6b31a5be49e5bc36a50675f9ce08242ecf954da328f9ca7326028201826d68747470733a2f2f332e636f6d582072417d48e417a4fd3e729e81ca9717b22691d1504d970c1520d8df490430245f825820addb381ebac5df2c7f39a6d7bc9bda73ac691b678a5f4d5570a3151313fe15ac06820082783968747470733a2f2f334c356734784a78454a463777496a79757a523130667150384f4e544361474334424c5348654b576a51556c692e636f6d5820acc1553fbebb0ec323edc10ba364881b6794ae7afef7f10b221f265005cc240b825820b7713d6bcb4ce2053bef9f4ac21f6f1cb228195288951a3da15c6da899e4a51701820182783c68747470733a2f2f2d44523753327864526e634843534c444c433366696e2e35626b6d7241544d636f484c41786e724c4f3859386e3276742e636f6d5820f550bb3869133d93a663c0d03ce15d8505af86deae851e30b0f86c8000dd612a825820b882a5512d74d305766a8d46a6d761ae1fe293e811b1d616eeebb10a7e9f6ef204820182781d68747470733a2f2f686c4e72756e6b71716f4a4c776c4932692e636f6d5820f9d78375be80d5686c2be8dc247678260cb39820168ecc81e70208a2c26f15fc825820ff5ac7c181680bddccadf7bd1b4ecaf7bb90bf4b96b33607c9c73bc41fdbf6ea088200f68204581c8d85971f788eead2d2552c524a29a3a219e6e3b61b0d6687f2e3df5ba2825820392c5b8e77ade1a3c81b42bb493faa45ee065b8b9abe24fe931041eb6c480919008200f6825820a17c267d024796c49532e32f338dc1b7482d6c05486b0e3bbfb4964e92ffdeec018200f68204581cfef13a5027ec784ff1014703937c735a34514b770714fa2a0febaf40a58258200da36284f12ce8144d75991b4ca3b8bc1b4511c944877b0437d4eda77312de85068200f68258205c17a3e441acdf8db8910f7f3fcb66d18bb2a0c9a949c4b87c2e30160bfffba000820182782168747470733a2f2f7a445333453436396751684f42454a646b545a597a2e636f6d5820fa37e290b3feea807a3afdc241b4b6e69daedb3a460b4ab89a5b960ab313ce7c82582089e6641971fb61480ccb1c83ea1bb2d18c40363bd80ae8dbafb3ee1ee3a235c7058202827768747470733a2f2f4c61447952365a647630792e636f6d58201c75fb6c8219d3c14f278641d016ec6b2bd35369d9c84fda36faed94ac38ff2d825820c065a1d9ca62f7644299675b245247e6e9c4debb27a8eccd0a8d2f752e2e6cda008200827768747470733a2f2f51674d774757746f47686b2e636f6d5820d4013a71fde670e5c8cb1a288c04b72887ee1d02fa03c91b16901f1afb3bc71f825820ea4092a26c63d13a89cf0e232b37b8396b5fba6060de6ad435f50e04380fdfdb068201f614d9010284841a0001262b581de1f819b39d09770f466a77183cfc39bd0dcecbe999a2bb52f9b177642c82038258203afc7af8ffdd899ece289003aab9b03e7a78b4cd6403775863f3eaf3ef7eb9950382781d68747470733a2f2f47356d2e4f6c6d2e6d327a686b66435a702e636f6d58208826e112305cc7631ea8bcbfdb6b1b496b4530e36961e5311de31c3aa8d933e8841a000d3da6581de13cac72ea08bee677330848d213473288b27625677dd8914259d09399810682782a68747470733a2f2f59704349716f4a4f756e30412e6b5730333262714c73507647526f3136482e636f6d582027e805cabce2bb702ed264345d0d456e8ffb8ef2c938f225da286486fb6e9e17841a00015c14581de1ad8bfe5012de0daf461ab1f8ba47357beb22100b9c1fdc7ab4cf8b258301825820b9bb833c05f4db9db216e41ecbf090941700b82c0541487f0fd2c0a4fa5f4fea00820503827668747470733a2f2f713563506173577a52432e636f6d5820f77343e0697ac25cf11b179e7a9290b170efcfe6c9f721061c519db8454505e7841a00064468581de0704ad2483ad6699aa45366192770353ca9f13600df1e8333ee3d10e283058258203dc79c61254edbcd1095a58fe467f605cfa933e64946eaf47d9e4f55607741bd078282783068747470733a2f2f6159586f774a6955414e5250616e693572747431766d706679646c465a666c6868745a4b2e636f6d58201a3baddbf715640fe5fb37e35c276ec099efedc3528c8889aa3d6a476038a937581c8ffac798b59c21d3bf1c7fee4c5f54978bba5c6ca8338c13214c5fed82781968747470733a2f2f5a4a50634a754a50784a6375792e636f6d582074f83b81c22a28ac0544fd2b40df8581796f87275b695916bd332ec72ead90aa151a000eebaf161a00074c89a400d9010283825820ded229c9565ed7b21b6c36c94f64dfc154f968b34dda6a286210451ef9ee928858405d789c331fde9da9973c1217a829d7c6d160ee8f9e28eb64f7158766c7a50530f19b2169ff9c121dc7a22a23a3151b4ebc732b143062d53315a69817e54db8708258203816e0d30b22c7a5afe7648c50f7ef1bda62b868f5d1cbc07eace7af3f9d1fb758401393e43703b358eb1edcfd93a550a35d28942edd4bf714614d425fcbead7631b5399ff1af1158cf343e2acaf90ab352c6cda2a5f6f2996cd4523a7e3e3e24cdc8258209b7911469adbe35049ba1828a27f1910958a67253d64049e4cd61c944bf51fad5840d776a7f5d63b2baf7efa8748395c334346e402caa92c81f24069ba91a49acb73e906a54f4d49a2e6cbead10b68d6498e1712738ad2ecc26e3c06823f183d12fa02d9010282845820f33f2be2f2c3f50bfd52ee65a105e76ceca370aebe149afbf0ba22a1bb348bac584059c56f2a858974cc5599237e8f3389a7cbb57b0e8e845d678fc3b7170553b77bd77924a0eb4cf93ab6272e3eda1a67e3e446b6c3ab52fbd496848b2109c0d0244042f1f78458200659fd2008ac02d360beb21874cbef440469e4f10551d0708c6db394773213025840865acbcf590e5bbbfba6642946d77cc0c0165b68b7b8ba5e845f08202f475dd79703ad2780e31bc20d0c2e51760f5d14e379023d8e0b65fd14915caa5be30b1244ee0a7e73410901d90102838200581c26fe0ceb62143a27fde0fd25d08161d2528ce46f5d280ed92e262911820283820284820180830300828200581cd382c813f35befedb69767684c8400ab83b415de00f37e3977fe82768200581c84b61fdcefc5a8b7a5fdbda7a40bea11a06461a3cdf7659e1ddfd614820180830300838200581c339b6c009d5f726cd54acccb70b11c98a0caa97ce5851c93c408ee3c8200581c0d2a47dda764a254f34b8bec5c64cb28e3e48a4bf39206d0426e50fc8200581ca36339026b5031222ef14d34dbc4a246fe8291a2a8253e9bc492e2118201838200581cb7d617d5f728f1d9384c51b30942f5647218c40f3b33f17fde7fc37e8200581cd1f248c356ab0de5e42181cde2950f7d9f30367d8dc86d3eb74822538200581cbe434b791a474efec3224a0e832fdedba179c6168b94d1fb54a65713830302828200581cc7792c52d39a335805b1a6c6ed94a4e77bd822cc01e5a8a9963443c782018083030081820182830301838200581c208bd21e72d577b15f7dc044eb5f9e18d21fc252ab5726926c3d5cab8200581c3f7698b08bb37c3d9564fbb81c5f6dd7e5858732434593b82b847d9f8200581cc85b31ad53bc6c28d49a0324000035136221a381de9aa9f1663c941a830301838200581cc6f4864032e0f610e71d7956271b9903bb1ce9f54ead5b7025b4ba738200581c228ee36481df84b4f1a66885588197ab0c439a7691622cbcd06ad6198200581cc1c4e1570d10c675ea6b52654d62b10689ee1ad630bc8e18b8f35e9c06d9010281484701000022220011f4d90103a200a400a14337f5d9a10140018340814244f42302240ba4228443bc7f97246004677567e98e87057a050325622759a00183830300808205018202818200581c2fd5355008b2bcb480b337fa24729b96d3498da66a1ed852d08c77e9",
+                            "description": "",
+                            "txId": "1ea302aac314bc48c87b46dc259489a2ca7c5123310d73dfcc97efbc21e530c6",
                             "type": "Tx ConwayEra"
                         }
                     },
                     "confirmedSnapshot": {
                         "signatures": {
                             "multiSignature": [
-                                "ce7ab14af9a2fabe1ac0bbfa625aed36377c849a4ee80ab5c133e65f6efc6530b395e068ddb878de011ba7d9ade1d578378a7f14f222deb0b4050283fea7df0b",
-                                "4f26e15f86736f87436a3cb536cca6a7cc021e47add9ccf8418c4fc7e36a118e3f4fba7fee7f82627548a1351d3734101e860fbf6c15e10155b8231a3e4f950e",
-                                "82e16ea3f1d2799ebb729999e126e1360c84205c0548c9222f15a23da99da97e7a71e70c5136550ef8b9e0d37580dc9111ae0ce9cf3c5190ee0f0f07407ba707",
-                                "41ae57b08097695f3a1a93796da1b69223981d05bbc3dc4033f894d545fd79947120b8e0a41a208ae1314b4aa0b56c27fab64bc421f9890bf97a8c5b70d2520b",
-                                "9dc90dcf1d5e3d353856b62b9ade27225258bfb7f192283b808e6ae6d676ca38806c4063f11ce5d0de98a497327a63357f1fe77cb9c4c28520d23b108721150b",
-                                "f887fe6c6b4c99f4e5ed17a46ea56a9f557b07386b2a1dfefa5bea22fc6f9620bb1bf0bf0ece5fb6d07c083305717826d17bb376fb9309a8b5fa5861cc17b80e"
+                                "6ac0a2a9c8f763f06733aeff3f89b276471fdb84b50f143244fe0dda753cb2d9e0da13b1c4ddbbbe5b2717596f53cdad1c0660cd335ddb749ca518673370df09"
                             ]
                         },
                         "snapshot": {
                             "confirmed": [],
-                            "headId": "06030508050400020102050002010306",
-                            "number": 2,
+                            "headId": "08050604080400010102050801010406",
+                            "number": 6,
                             "utxo": {
-                                "0101030404080201060405080301020000060404040107080704040007060707#76": {
-                                    "address": "addr_test1wqdvpp5wy43nl7jpr7ku4jn4dl3r8uafrt3gpn50k9p7lwsgr3mg0",
+                                "0001020105070806060703020000050403020402020203080701000105060700#68": {
+                                    "address": "addr_test1zrf82y470d5u0vcstehdc2jvpur6duntg6vpu4evqz4ct327eegvcv4uuq2cqwqewcnwxgyts79quypvht06ljv532fspe0s4z",
+                                    "datum": null,
+                                    "datumhash": "39af90624774d01144fa73779a6bc373a492fdb07b4aec2506c0ed70517f1b6b",
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888d": {
+                                            "33": 1
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0004020000040805020804030507020607050101020408040107060107040806#73": {
+                                    "address": "addr_test1qq84m4fgtvtvxh8c7rs53zty8qjuuhjh855w4gsdh0qqn29l64sf7dwmfy5mmc5yhqvcsu86sq9kq4q3cg0ekf2x6lxsth7z68",
+                                    "datum": null,
+                                    "datumhash": "49e59d9f9154e628166cc895d50ddcff2c0366beed36b366e19cf5ba06d01e64",
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
+                                            "34": 3088531911015464404
+                                        },
+                                        "lovelace": 1305930
+                                    }
+                                },
+                                "0101080607080806030000080700050408010506080201080501030608050501#59": {
+                                    "address": "addr_test1wr3u272wdrr9r0e7luuxamhu82ackz94xcmc8xld8j3gq4quhyah4",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888d": {
+                                            "1de18cb74124d11e264b79f605bb114ed91a29c85cfb38438f72ec0e62792f08": 2
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0107000201060407060308030701000506040204040002040701020308050406#34": {
+                                    "address": "addr_test1wz9m5h9qvmhv463ehy7kkt2yn8vq65sem0vp5r036pe464gfka8jt",
+                                    "datum": null,
+                                    "datumhash": "df9fd64dfc482e4ff34d29d8c73dde31c126124f33c42ae823406d025171cb48",
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0407040301060307050003050707080801080507070804040600010704010705#71": {
+                                    "address": "addr_test1yrvqgglr42rqkpmd79k6xq734evxrnr53e8kppr862rmvqjj837syq9pg6t2fv5dsx0mwxm9ydw33wgn37u4y4876ppqpxev56",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "f5f7e7442b19efb568f56cbc895b83861875e0ecf07d908382020900": {
+                                            "d6758b05fd321a007ed1ccf524be39": 1
+                                        },
+                                        "lovelace": 1185250
+                                    }
+                                },
+                                "0705070807080408030306020800030502010000000202040802000801040604#0": {
+                                    "address": "addr_test1yq6g6aeanzksfeck26jnqsnwvpe5knznq62x22rtetkcffczqqhrwaj5dejqzrpha6amwyerlwu7lnfvvuja5av4w26q8gmqwj",
+                                    "datum": null,
+                                    "inlineDatum": {
+                                        "map": [
+                                            {
+                                                "k": {
+                                                    "list": []
+                                                },
+                                                "v": {
+                                                    "constructor": 3,
+                                                    "fields": [
+                                                        {
+                                                            "bytes": "49ac"
+                                                        },
+                                                        {
+                                                            "constructor": 3,
+                                                            "fields": [
+                                                                {
+                                                                    "bytes": ""
+                                                                },
+                                                                {
+                                                                    "bytes": "6592d6a9"
+                                                                },
+                                                                {
+                                                                    "bytes": "28d8dc"
+                                                                },
+                                                                {
+                                                                    "int": 4
+                                                                },
+                                                                {
+                                                                    "int": -2
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "list": [
+                                                        {
+                                                            "constructor": 0,
+                                                            "fields": []
+                                                        },
+                                                        {
+                                                            "list": [
+                                                                {
+                                                                    "bytes": ""
+                                                                },
+                                                                {
+                                                                    "bytes": "51262c"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "int": 0
+                                                        }
+                                                    ]
+                                                },
+                                                "v": {
+                                                    "map": [
+                                                        {
+                                                            "k": {
+                                                                "map": [
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": "70"
+                                                                        },
+                                                                        "v": {
+                                                                            "int": 3
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "int": 3
+                                                                        },
+                                                                        "v": {
+                                                                            "int": -5
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "int": 3
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "eccf"
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "constructor": 1,
+                                                                "fields": [
+                                                                    {
+                                                                        "int": 3
+                                                                    },
+                                                                    {
+                                                                        "int": -4
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "map": [
+                                                                    {
+                                                                        "k": {
+                                                                            "int": 1
+                                                                        },
+                                                                        "v": {
+                                                                            "int": 0
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": "51b78948"
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "940fc0"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": "0bf459"
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "a6"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": ""
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "65"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "int": 5
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "08f2c7"
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "list": [
+                                                                    {
+                                                                        "int": -4
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "constructor": 0,
+                                                                "fields": [
+                                                                    {
+                                                                        "bytes": "b067d115"
+                                                                    },
+                                                                    {
+                                                                        "bytes": "71ee688e"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "list": []
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "list": [
+                                                                    {
+                                                                        "bytes": "ca"
+                                                                    },
+                                                                    {
+                                                                        "int": 2
+                                                                    },
+                                                                    {
+                                                                        "int": -5
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "map": [
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": ""
+                                                                        },
+                                                                        "v": {
+                                                                            "int": -3
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "constructor": 0,
+                                                                "fields": [
+                                                                    {
+                                                                        "bytes": "3c11"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "list": [
+                                                                    {
+                                                                        "int": -3
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "map": [
+                                                        {
+                                                            "k": {
+                                                                "list": [
+                                                                    {
+                                                                        "int": -5
+                                                                    },
+                                                                    {
+                                                                        "bytes": ""
+                                                                    },
+                                                                    {
+                                                                        "bytes": "cc"
+                                                                    },
+                                                                    {
+                                                                        "bytes": "eeb3ae"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "int": -4
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "v": {
+                                                    "map": [
+                                                        {
+                                                            "k": {
+                                                                "constructor": 3,
+                                                                "fields": [
+                                                                    {
+                                                                        "int": -1
+                                                                    },
+                                                                    {
+                                                                        "bytes": "f1"
+                                                                    },
+                                                                    {
+                                                                        "bytes": "56"
+                                                                    },
+                                                                    {
+                                                                        "int": 0
+                                                                    },
+                                                                    {
+                                                                        "int": 3
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "int": 3
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "int": 3
+                                                            },
+                                                            "v": {
+                                                                "constructor": 3,
+                                                                "fields": [
+                                                                    {
+                                                                        "bytes": "7731ad"
+                                                                    },
+                                                                    {
+                                                                        "int": -3
+                                                                    },
+                                                                    {
+                                                                        "int": 4
+                                                                    },
+                                                                    {
+                                                                        "int": 0
+                                                                    },
+                                                                    {
+                                                                        "bytes": "afde4a78"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "map": [
+                                                                    {
+                                                                        "k": {
+                                                                            "int": 3
+                                                                        },
+                                                                        "v": {
+                                                                            "int": -3
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "int": -3
+                                                                        },
+                                                                        "v": {
+                                                                            "int": -1
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "int": 3
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "e0"
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "constructor": 5,
+                                                                "fields": [
+                                                                    {
+                                                                        "bytes": "8d0311"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "constructor": 1,
+                                                    "fields": [
+                                                        {
+                                                            "int": 5
+                                                        }
+                                                    ]
+                                                },
+                                                "v": {
+                                                    "int": -4
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "bytes": "8e87a5de"
+                                                },
+                                                "v": {
+                                                    "int": 3
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "inlineDatumRaw": "a580d87c9f4249acd87c9f40446592d6a94328d8dc0421ffff9fd879809f404351262cff00ffa5a341700303240342eccfd87a9f0323ffa501004451b7894843940fc0430bf45941a6404165054308f2c79f23ffd8799f44b067d1154471ee688eff809f41ca0224ffa14022d8799f423c11ff9f22ffa19f244041cc43eeb3aeff23a3d87c9f2041f141560003ff0303d87c9f437731ad22040044afde4a78ffa3032222200341e0d87e9f438d0311ffd87a9f05ff23448e87a5de03",
+                                    "inlineDatumhash": "24426a071d277215745ee9367d560a4cdc88cc2b6f6f6afb4cb63185a366c668",
+                                    "referenceScript": null,
+                                    "value": {
+                                        "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
+                                            "6061a6a8d57cc261685ad506814b8b0027780ab74150319f08f6ae3aa0": 2180821204201390512
+                                        },
+                                        "lovelace": 2133450
+                                    }
+                                }
+                            },
+                            "utxoToCommit": {
+                                "0004080706080302050503050402080505020401000805080508040807030607#40": {
+                                    "address": "addr_test1qrq3mht0udgwek2fnhgu8grumyeglnq4f4z0f4swc2j5n4s4fusx8uq5379ns22u67c8jyxvkkt2xmkhhn4phje23jjsvk5u6e",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "9c039b6529bc097dc8749b3ea17cfc57b9dbe86019c2d4827d1e89db": {
+                                            "7b38a7641c64434c251df3": 1
+                                        },
+                                        "lovelace": 1168010
+                                    }
+                                },
+                                "0400080500040608000703080104030503020704020506040107000707070800#20": {
+                                    "address": "addr_test1qplh5656g4nh8azpauwj8a4gq0tt20je37se2w0kawy88rrtc8j0p0ttqvmyympmn2gkhdrz3y0qtx85m9aznwlksy0scqmvz5",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0501060504040100000106080805080200010803030404050403020802060507#57": {
+                                    "address": "addr_test1xz0ed8kz55jfvyu493f8kmy6pzfqqcxnjdkc0q034mgqv4hxaquvpktgumyl4r3q5sfhl5ddmp8e64754uqrafr283xqp88n8t",
+                                    "datum": null,
+                                    "datumhash": "349d2665ca8af2cab3c415f7d90d100eed6a739fa9fa72522bb4d2d13526140c",
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0501080403050007020104020700070302020301010608010502070306000108#39": {
+                                    "address": "addr_test1qqee79pp0t8nc3mzsdlej7dr7p89gqdsuzsdnqq0rcqsenzvyca07g7pcr8vesxsewvccd28ksxhfem4yxagutl8kdlsrpz5zq",
+                                    "datum": null,
+                                    "inlineDatum": {
+                                        "constructor": 1,
+                                        "fields": [
+                                            {
+                                                "constructor": 1,
+                                                "fields": []
+                                            },
+                                            {
+                                                "list": [
+                                                    {
+                                                        "map": [
+                                                            {
+                                                                "k": {
+                                                                    "int": -2
+                                                                },
+                                                                "v": {
+                                                                    "int": 0
+                                                                }
+                                                            },
+                                                            {
+                                                                "k": {
+                                                                    "int": 5
+                                                                },
+                                                                "v": {
+                                                                    "bytes": ""
+                                                                }
+                                                            },
+                                                            {
+                                                                "k": {
+                                                                    "bytes": ""
+                                                                },
+                                                                "v": {
+                                                                    "int": 5
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "list": [
+                                                            {
+                                                                "int": 0
+                                                            },
+                                                            {
+                                                                "bytes": "53"
+                                                            },
+                                                            {
+                                                                "int": 3
+                                                            },
+                                                            {
+                                                                "bytes": "50ee29"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "constructor": 5,
+                                                "fields": [
+                                                    {
+                                                        "constructor": 0,
+                                                        "fields": [
+                                                            {
+                                                                "bytes": "8daa"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "list": [
+                                                            {
+                                                                "bytes": "35bb"
+                                                            },
+                                                            {
+                                                                "int": 2
+                                                            },
+                                                            {
+                                                                "int": 4
+                                                            },
+                                                            {
+                                                                "bytes": "5dae39"
+                                                            },
+                                                            {
+                                                                "int": 1
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "int": 3
+                                                    },
+                                                    {
+                                                        "map": [
+                                                            {
+                                                                "k": {
+                                                                    "bytes": "a01017"
+                                                                },
+                                                                "v": {
+                                                                    "int": 0
+                                                                }
+                                                            },
+                                                            {
+                                                                "k": {
+                                                                    "int": -2
+                                                                },
+                                                                "v": {
+                                                                    "bytes": ""
+                                                                }
+                                                            },
+                                                            {
+                                                                "k": {
+                                                                    "int": 2
+                                                                },
+                                                                "v": {
+                                                                    "int": 1
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "int": 1
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "int": -3
+                                                        },
+                                                        "v": {
+                                                            "list": [
+                                                                {
+                                                                    "bytes": "dcd64c77"
+                                                                },
+                                                                {
+                                                                    "int": -2
+                                                                },
+                                                                {
+                                                                    "int": 2
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "constructor": 2,
+                                                            "fields": [
+                                                                {
+                                                                    "bytes": "192d13"
+                                                                },
+                                                                {
+                                                                    "bytes": "75828f5e"
+                                                                },
+                                                                {
+                                                                    "int": 0
+                                                                },
+                                                                {
+                                                                    "bytes": "c54b1a"
+                                                                },
+                                                                {
+                                                                    "bytes": "f85d"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "v": {
+                                                            "list": [
+                                                                {
+                                                                    "bytes": "37"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "bytes": "bb746e"
+                                                        },
+                                                        "v": {
+                                                            "map": [
+                                                                {
+                                                                    "k": {
+                                                                        "bytes": ""
+                                                                    },
+                                                                    "v": {
+                                                                        "bytes": "db1d"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "int": 5
+                                                                    },
+                                                                    "v": {
+                                                                        "int": 2
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "int": 5
+                                                                    },
+                                                                    "v": {
+                                                                        "int": -2
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "int": -3
+                                                                    },
+                                                                    "v": {
+                                                                        "bytes": "45a83d"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "list": [
+                                                                {
+                                                                    "bytes": "ad82"
+                                                                },
+                                                                {
+                                                                    "bytes": "2486"
+                                                                },
+                                                                {
+                                                                    "int": 1
+                                                                }
+                                                            ]
+                                                        },
+                                                        "v": {
+                                                            "int": 0
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "int": 0
+                                                        },
+                                                        "v": {
+                                                            "int": 0
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "constructor": 1,
+                                                "fields": [
+                                                    {
+                                                        "bytes": "a158"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "inlineDatumRaw": "d87a9fd87a809fa32100054040059f004153034350ee29ffffd87e9fd8799f428daaff9f4235bb0204435dae3901ff03a343a01017002140020101ffa5229f44dcd64c772102ffd87b9f43192d134475828f5e0043c54b1a42f85dff9f4137ff43bb746ea44042db1d05020521224345a83d9f42ad8242248601ff000000d87a9f42a158ffff",
+                                    "inlineDatumhash": "aa541cba52e30f6b0b455566069c627f6a372a974df6b53da1cd1141b6f054ae",
+                                    "referenceScript": null,
+                                    "value": {
+                                        "7fae163e91bc325a02677da3f798769cedd83c51e367289a065dc76f": {
+                                            "89bb50705333755e53d9b0d227a9231c": 1
+                                        },
+                                        "lovelace": 1805890
+                                    }
+                                },
+                                "0507070704020604080608040500020603030503070006010106020702040502#43": {
+                                    "address": "addr_test1qrkq4e7u58vnlyzq77tqfaqn97289zvew4t5j8dtm0uvlp0a7nwuk7sg8zvu9dyvtn6sch4t4tpapttcu7g3pcjnrfhqjn37em",
+                                    "datum": null,
+                                    "inlineDatum": {
+                                        "map": [
+                                            {
+                                                "k": {
+                                                    "constructor": 0,
+                                                    "fields": [
+                                                        {
+                                                            "map": [
+                                                                {
+                                                                    "k": {
+                                                                        "int": -2
+                                                                    },
+                                                                    "v": {
+                                                                        "int": -5
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "int": -5
+                                                                    },
+                                                                    "v": {
+                                                                        "bytes": "376556"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "int": 2
+                                                        },
+                                                        {
+                                                            "map": [
+                                                                {
+                                                                    "k": {
+                                                                        "bytes": "d46c"
+                                                                    },
+                                                                    "v": {
+                                                                        "bytes": "20"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "int": -2
+                                                                    },
+                                                                    "v": {
+                                                                        "bytes": ""
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "int": 4
+                                                                    },
+                                                                    "v": {
+                                                                        "int": -1
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "v": {
+                                                    "list": []
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "map": [
+                                                        {
+                                                            "k": {
+                                                                "int": -4
+                                                            },
+                                                            "v": {
+                                                                "list": []
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "v": {
+                                                    "map": [
+                                                        {
+                                                            "k": {
+                                                                "int": 3
+                                                            },
+                                                            "v": {
+                                                                "map": [
+                                                                    {
+                                                                        "k": {
+                                                                            "int": -3
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "9d"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "int": -4
+                                                                        },
+                                                                        "v": {
+                                                                            "int": -1
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "constructor": 0,
+                                                                "fields": [
+                                                                    {
+                                                                        "int": 2
+                                                                    },
+                                                                    {
+                                                                        "int": 0
+                                                                    },
+                                                                    {
+                                                                        "bytes": "6fd1d4"
+                                                                    },
+                                                                    {
+                                                                        "int": 5
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "list": [
+                                                                    {
+                                                                        "bytes": "025e"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "list": [
+                                                        {
+                                                            "int": 4
+                                                        },
+                                                        {
+                                                            "map": [
+                                                                {
+                                                                    "k": {
+                                                                        "int": 1
+                                                                    },
+                                                                    "v": {
+                                                                        "int": -5
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "int": 1
+                                                                    },
+                                                                    "v": {
+                                                                        "bytes": "92"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "int": 4
+                                                                    },
+                                                                    "v": {
+                                                                        "bytes": "39f18ddb"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "int": -1
+                                                                    },
+                                                                    "v": {
+                                                                        "bytes": "c37f"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "bytes": "efa9"
+                                                                    },
+                                                                    "v": {
+                                                                        "int": -4
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "v": {
+                                                    "list": [
+                                                        {
+                                                            "int": 1
+                                                        },
+                                                        {
+                                                            "int": 4
+                                                        },
+                                                        {
+                                                            "map": [
+                                                                {
+                                                                    "k": {
+                                                                        "int": -2
+                                                                    },
+                                                                    "v": {
+                                                                        "bytes": "73"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "int": -1
+                                                                    },
+                                                                    "v": {
+                                                                        "int": -3
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "int": -2
+                                                                    },
+                                                                    "v": {
+                                                                        "bytes": "0617"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "bytes": "6b3c"
+                                                },
+                                                "v": {
+                                                    "map": [
+                                                        {
+                                                            "k": {
+                                                                "list": [
+                                                                    {
+                                                                        "int": 4
+                                                                    },
+                                                                    {
+                                                                        "int": -2
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "int": -2
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "bytes": ""
+                                                            },
+                                                            "v": {
+                                                                "bytes": "80"
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "int": -3
+                                                },
+                                                "v": {
+                                                    "bytes": "f96860"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "inlineDatumRaw": "a5d8799fa22124244337655602a342d46c412021400420ff80a12380a203a222419d2320d8799f0200436fd1d405ff9f42025eff9f04a50124014192044439f18ddb2042c37f42efa923ff9f0104a3214173202221420617ff426b3ca29f0421ff214041802243f96860",
+                                    "inlineDatumhash": "4e823906907f977fe156b1e95fb3eb6c5c5cf0631b067e57fb7eaffb9bf0f573",
+                                    "referenceScript": null,
+                                    "value": {
+                                        "7dd780de1bca046b951a1f0ae5db72bf34f748bb44cd3333cf845bfd": {
+                                            "39": 8669683531769540133
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0700030404020502010104030201050701040505080806070805000000030302#80": {
+                                    "address": "addr_test1xrgvw9zpy8pnt567t7hn768vh85z0ql902ayd80zznadh6e5jwhelntwm8xfc2wcttfn0xgmxcsny57y7s3s4940sv5su35w3p",
+                                    "datum": null,
+                                    "inlineDatum": {
+                                        "map": [
+                                            {
+                                                "k": {
+                                                    "list": [
+                                                        {
+                                                            "map": []
+                                                        }
+                                                    ]
+                                                },
+                                                "v": {
+                                                    "map": [
+                                                        {
+                                                            "k": {
+                                                                "map": [
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": "95"
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "558f77e7"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "int": 3
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": ""
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "int": -2
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "constructor": 0,
+                                                                "fields": [
+                                                                    {
+                                                                        "bytes": "b8fda2"
+                                                                    },
+                                                                    {
+                                                                        "bytes": "bb"
+                                                                    },
+                                                                    {
+                                                                        "bytes": "978588f9"
+                                                                    },
+                                                                    {
+                                                                        "bytes": "590f29"
+                                                                    },
+                                                                    {
+                                                                        "bytes": "dc9cc7"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "constructor": 5,
+                                                                "fields": []
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "list": [
+                                                                    {
+                                                                        "int": -1
+                                                                    },
+                                                                    {
+                                                                        "int": 2
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "list": []
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "bytes": ""
+                                                            },
+                                                            "v": {
+                                                                "bytes": ""
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "int": -5
+                                                            },
+                                                            "v": {
+                                                                "bytes": "72988f"
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "map": [
+                                                        {
+                                                            "k": {
+                                                                "map": [
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": "33b5"
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "39"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "int": 4
+                                                                        },
+                                                                        "v": {
+                                                                            "int": 4
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "constructor": 1,
+                                                                "fields": [
+                                                                    {
+                                                                        "int": -2
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "bytes": "72"
+                                                            },
+                                                            "v": {
+                                                                "constructor": 0,
+                                                                "fields": [
+                                                                    {
+                                                                        "int": -5
+                                                                    },
+                                                                    {
+                                                                        "bytes": "5227d2c2"
+                                                                    },
+                                                                    {
+                                                                        "int": 0
+                                                                    },
+                                                                    {
+                                                                        "int": 3
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "map": [
+                                                                    {
+                                                                        "k": {
+                                                                            "int": -3
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "5d9b"
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "int": 4
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "bytes": "62"
+                                                            },
+                                                            "v": {
+                                                                "map": [
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": "4d0f"
+                                                                        },
+                                                                        "v": {
+                                                                            "int": -2
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "int": 2
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "e58ed8e4"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": "74"
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "eb"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "int": 3
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "a70dca"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": ""
+                                                                        },
+                                                                        "v": {
+                                                                            "int": 1
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "v": {
+                                                    "list": [
+                                                        {
+                                                            "bytes": ""
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "bytes": "97bf82"
+                                                },
+                                                "v": {
+                                                    "int": 4
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "inlineDatumRaw": "a39fa0ffa5a2419544558f77e7034021d8799f43b8fda241bb44978588f943590f2943dc9cc7ffd87e809f2002ff804040244372988fa4a24233b541390404d87a9f21ff4172d8799f24445227d2c20003ffa122425d9b044162a5424d0f210244e58ed8e4417441eb0343a70dca40019f40ff4397bf8204",
+                                    "inlineDatumhash": "81c3254e81a85bd4a91e3d4bfc0c69abb47e2c3931cf670a91bfd71b6394628a",
+                                    "referenceScript": null,
+                                    "value": {
+                                        "ba1171430003dc356b29edd29cf323f795f1ee8055ab993a649565cc": {
+                                            "37": 9194440939368573271
+                                        },
+                                        "lovelace": 1715380
+                                    }
+                                }
+                            },
+                            "utxoToDecommit": {
+                                "0004080102050300070808030506000008020107030200030604060202020203#18": {
+                                    "address": "addr_test1qzaqlp9dda2399enm0ecrqkc9dqa7k5ml7pya250q89xxurn2fpwxr6gqs7kkddt8gdschhruphg6gh7re3wlmks7zgqj0r2gr",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0204030006030101060108000403070808040402040105080007000003000006#48": {
+                                    "address": "addr_test1qqsra58hyavmkx47c87grszdlafvavcpsc7njarpyvy7vlegjqdfm980sd5ptnwx7eapl7p3wtnmqrfmnerepvkcz5hse7n46c",
+                                    "datum": null,
+                                    "datumhash": "55871d0d6ce695262ca451a5f569b598970591838cbd8889083b346205b7cd92",
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "a5f5f39d1c034171df532348f3c00340939cfd7762798c32974e1a06": {
+                                            "36": 6181287027269050830
+                                        },
+                                        "lovelace": 1305930
+                                    }
+                                },
+                                "0308050105070601080802000007050508010304030603030601050205030102#18": {
+                                    "address": "addr_test1zp7gd35dpff7kmp3lnksxmsc50qr7k4hhqvtryqm5kmpcelhkq8yut5hwt6mwyaz7frcu6ktvya5w264eewz8p6uqzjs0yvqny",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abae": {
+                                            "38": 7496859833698932396
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0401020008060302080703070407040603030801000806080506080303050502#89": {
+                                    "address": "addr_test1xzgmdeeurk6k3gzqkgzhjmxe3glnsczdgzpntk3a82zc92f2rcm407xdne3y2e53fkgtezr2pjwlrra528hg3yvdr77qx2d0z8",
+                                    "datum": null,
+                                    "inlineDatum": {
+                                        "constructor": 0,
+                                        "fields": [
+                                            {
+                                                "list": [
+                                                    {
+                                                        "list": [
+                                                            {
+                                                                "int": 0
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "bytes": "ca885d"
+                                                    },
+                                                    {
+                                                        "constructor": 3,
+                                                        "fields": [
+                                                            {
+                                                                "int": 2
+                                                            },
+                                                            {
+                                                                "bytes": "bc578a"
+                                                            },
+                                                            {
+                                                                "int": 1
+                                                            },
+                                                            {
+                                                                "int": -5
+                                                            },
+                                                            {
+                                                                "int": 1
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "list": [
+                                                            {
+                                                                "int": 3
+                                                            },
+                                                            {
+                                                                "int": 3
+                                                            },
+                                                            {
+                                                                "bytes": "2c"
+                                                            },
+                                                            {
+                                                                "int": -3
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "int": 2
+                                            },
+                                            {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "bytes": "8d0e0e"
+                                                        },
+                                                        "v": {
+                                                            "constructor": 5,
+                                                            "fields": [
+                                                                {
+                                                                    "int": -3
+                                                                },
+                                                                {
+                                                                    "int": -2
+                                                                },
+                                                                {
+                                                                    "bytes": ""
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "list": [
+                                                                {
+                                                                    "bytes": ""
+                                                                },
+                                                                {
+                                                                    "int": 0
+                                                                }
+                                                            ]
+                                                        },
+                                                        "v": {
+                                                            "list": []
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "map": []
+                                                        },
+                                                        "v": {
+                                                            "constructor": 3,
+                                                            "fields": [
+                                                                {
+                                                                    "bytes": "afa2"
+                                                                },
+                                                                {
+                                                                    "bytes": "d8"
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "inlineDatumRaw": "d8799f9f9f00ff43ca885dd87c9f0243bc578a012401ff9f0303412c22ffff02a3438d0e0ed87e9f222140ff9f4000ff80a0d87c9f42afa241d8ffff",
+                                    "inlineDatumhash": "6f7b39738db289f34edb88c9f2fa89faa1aa048009e233eacc6fefe8dbe9bd10",
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 1267140
+                                    }
+                                },
+                                "0800030401060403010200040400060006060407050802020504030602030805#78": {
+                                    "address": "addr_test1zz2srd47zsm7x2vvqnjjzddtp8kpqkx6jhals3wsp760qzkj3etwxqjf5wu03krr2mh7km9479hptmkvc0rn2k2wxwysehd2at",
                                     "datum": null,
                                     "inlineDatum": {
                                         "map": [
@@ -1731,21 +3277,171 @@
                                                     "map": [
                                                         {
                                                             "k": {
-                                                                "bytes": "f8"
+                                                                "list": [
+                                                                    {
+                                                                        "bytes": "1ab3"
+                                                                    }
+                                                                ]
                                                             },
                                                             "v": {
-                                                                "int": 3
+                                                                "bytes": "34cc7868"
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "v": {
+                                                    "bytes": "300232ce"
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "constructor": 2,
+                                                    "fields": [
+                                                        {
+                                                            "constructor": 3,
+                                                            "fields": [
+                                                                {
+                                                                    "int": 3
+                                                                },
+                                                                {
+                                                                    "int": 4
+                                                                },
+                                                                {
+                                                                    "bytes": "f775196a"
+                                                                },
+                                                                {
+                                                                    "bytes": ""
+                                                                },
+                                                                {
+                                                                    "int": 3
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "constructor": 5,
+                                                            "fields": [
+                                                                {
+                                                                    "bytes": "cd2b5e"
+                                                                },
+                                                                {
+                                                                    "int": -1
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "v": {
+                                                    "bytes": "6a12"
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "list": [
+                                                        {
+                                                            "list": [
+                                                                {
+                                                                    "int": 1
+                                                                },
+                                                                {
+                                                                    "bytes": "a2026b01"
+                                                                },
+                                                                {
+                                                                    "bytes": ""
+                                                                },
+                                                                {
+                                                                    "bytes": "802561"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "constructor": 1,
+                                                            "fields": []
+                                                        },
+                                                        {
+                                                            "map": [
+                                                                {
+                                                                    "k": {
+                                                                        "bytes": "3ee6"
+                                                                    },
+                                                                    "v": {
+                                                                        "int": -5
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "bytes": "f040"
+                                                                    },
+                                                                    "v": {
+                                                                        "int": 4
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "int": -3
+                                                                    },
+                                                                    "v": {
+                                                                        "int": -5
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "bytes": "8014e425"
+                                                                    },
+                                                                    "v": {
+                                                                        "bytes": "968120f0"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "bytes": ""
+                                                                    },
+                                                                    "v": {
+                                                                        "int": 5
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "int": 3
+                                                        },
+                                                        {
+                                                            "constructor": 3,
+                                                            "fields": []
+                                                        }
+                                                    ]
+                                                },
+                                                "v": {
+                                                    "constructor": 1,
+                                                    "fields": [
+                                                        {
+                                                            "constructor": 3,
+                                                            "fields": []
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "map": [
+                                                        {
+                                                            "k": {
+                                                                "bytes": "69e984e4"
+                                                            },
+                                                            "v": {
+                                                                "int": 2
                                                             }
                                                         },
                                                         {
                                                             "k": {
-                                                                "constructor": 3,
-                                                                "fields": [
+                                                                "int": -3
+                                                            },
+                                                            "v": {
+                                                                "list": [
                                                                     {
-                                                                        "bytes": "3c28"
+                                                                        "int": 1
                                                                     },
                                                                     {
-                                                                        "bytes": "f61fee32"
+                                                                        "bytes": "40b1"
                                                                     },
                                                                     {
                                                                         "int": -4
@@ -1754,24 +3450,87 @@
                                                                         "int": -5
                                                                     },
                                                                     {
-                                                                        "bytes": "28fb7d58"
+                                                                        "int": -5
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "int": 5
+                                                            },
+                                                            "v": {
+                                                                "map": [
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": "dd89a25d"
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "eb208964"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": ""
+                                                                        },
+                                                                        "v": {
+                                                                            "int": 2
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "int": 5
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "97ae3769"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": "e8"
+                                                                        },
+                                                                        "v": {
+                                                                            "int": -2
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "int": 1
+                                                                        },
+                                                                        "v": {
+                                                                            "int": 1
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "map": [
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": ""
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "c563"
+                                                                        }
                                                                     }
                                                                 ]
                                                             },
                                                             "v": {
-                                                                "constructor": 4,
+                                                                "constructor": 3,
                                                                 "fields": [
                                                                     {
-                                                                        "int": -2
+                                                                        "int": 1
                                                                     },
                                                                     {
-                                                                        "bytes": "8a"
+                                                                        "int": 3
                                                                     },
                                                                     {
-                                                                        "int": -1
+                                                                        "bytes": "5ec5af"
                                                                     },
                                                                     {
-                                                                        "bytes": ""
+                                                                        "int": 1
                                                                     }
                                                                 ]
                                                             }
@@ -1779,1541 +3538,49 @@
                                                     ]
                                                 },
                                                 "v": {
-                                                    "map": []
-                                                }
-                                            }
-                                        ]
-                                    },
-                                    "inlineDatumRaw": "a1a241f803d87c9f423c2844f61fee3223244428fb7d58ffd87d9f21418a2040ffa0",
-                                    "inlineDatumhash": "c47fcc5dbcfc57d0ce611a033f9ce38c7f8f516e00be123c1be2438fad3538fe",
-                                    "referenceScript": null,
-                                    "value": {
-                                        "lovelace": 7500000000000000
-                                    }
-                                },
-                                "0104050605080103010307020406070301050205050402030003060506010406#5": {
-                                    "address": "addr_test1yrpn2whx3hxmwt8dta09lheafwlulqpyynsq2cs4es7fxughfpuyju3jchatn87047ycr406xpxp98q9egnvrpgzplaskuvw7t",
-                                    "datum": null,
-                                    "datumhash": null,
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "6997903e9cbe6fa492136d973c18a1bfabe70ca1820619488e519a9f": {
-                                            "36": 7217517892387123064
-                                        },
-                                        "lovelace": 7500000000000000
-                                    }
-                                },
-                                "0306070806010001030700010604010506070404000105070805010502070300#91": {
-                                    "address": "addr_test1wpj9cpltyj5u6646x0d0kl08wf5jj4t842x7el3e9v8zg2c4fgqru",
-                                    "datum": null,
-                                    "datumhash": "10fbbd8fe81cb6f34c3deb5271785dc16d53dbfef0cecdf20ea9fb7d99ad030a",
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "lovelace": 7500000000000000
-                                    }
-                                },
-                                "0400050405070605050804010407030607070106050504020400000005050301#90": {
-                                    "address": "addr_test1qq6y8c0qe8yx5gnv3zsu09pq3dz6chrsg4w6kv7kmpnqtnqsu6a9pxgmrw6ep0tftf4wvspjd4kwqrdpq023wf260lwqya0jdw",
-                                    "datum": null,
-                                    "datumhash": null,
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "lovelace": 7500000000000000
-                                    }
-                                },
-                                "0606000406070503040507030103050007010402070201080000080402040802#1": {
-                                    "address": "addr_test1vzdrduva2c9wmmn8jxwf2kp823rexxmyvjl8d8dgn3gkwfsslm5l2",
-                                    "datum": null,
-                                    "inlineDatum": {
-                                        "int": -2
-                                    },
-                                    "inlineDatumRaw": "21",
-                                    "inlineDatumhash": "0268be9dbd0446eaa217e1dec8f399249305e551d7fc1437dd84521f74aa621c",
-                                    "referenceScript": null,
-                                    "value": {
-                                        "lovelace": 7500000000000000
-                                    }
-                                },
-                                "0702010606080403080606050206050802000303030300010607060506050002#38": {
-                                    "address": "addr_test1yrqv2v0lvlwvsu8chwm8vkrtlp42hawsv9lqqzgdhvadez4vvzj5yqx43aht49twvkfj9tqhyy2yk8nyzjrrz90an9jqhcph94",
-                                    "datum": null,
-                                    "datumhash": null,
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "lovelace": 7500000000000000
-                                    }
-                                }
-                            },
-                            "utxoToCommit": {
-                                "0000040708080204000502080602060707070300080700040505000202060400#88": {
-                                    "address": "addr_test1qzds4r0e30p25m0hggn0mcvhmzz9pqgy6ans3lx6a00ahy3j70txkvss8n389ftsl28d00k757rrxrtadtwsx5ud2djs36mt2v",
-                                    "datum": null,
-                                    "datumhash": "b0ee3f736ceb8be36e440285eb16c0ead1867b7d081ea87164743c1bcdbac031",
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "lovelace": 1116290
-                                    }
-                                },
-                                "0306040301070706050605050605000106000308030008010208010502000601#74": {
-                                    "address": "addr_test1zpcdlq5pnf3hzc93z298wu6p8tm2x0hs9j9qg2kwej7tkzz3dhfnkgek0mwu30n56nyfk4cff2dc6dq85zvmw5rgl63qsak8js",
-                                    "datum": null,
-                                    "datumhash": null,
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abae": {
-                                            "31": 286213190981694750
-                                        },
-                                        "lovelace": 1159390
-                                    }
-                                },
-                                "0500010800060405080807050607030004070200010302040405010207080706#52": {
-                                    "address": "addr_test1qpws0mgqgv63elc0yl9u5eysz2553gyym2e90249m5gqpm7cjph4wz26ldtwta3yftqda6atwln4au8znchytm380ycs07gezy",
-                                    "datum": null,
-                                    "datumhash": "3c5f605a9f6eb07605164b8b9d474d83b8d6e0b73ed9128dd6c293184ced2c37",
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "470f8998c13a1c61ec04fb6a3ac4eb8777e14e07d5e1c2273e999a8c": {
-                                            "38": 2249615110472900714
-                                        },
-                                        "lovelace": 7500000000000000
-                                    }
-                                },
-                                "0508040505020308050704030000020501020605050808070507030603030600#85": {
-                                    "address": "addr_test1xq625adrmla9d0p7ujw6429z95gz4twxrjfdfmhwpel8c6pmluj8yqlx9l9w5k2kplgc0qs55jr70kvtmhf3wz3tlwfqcm03wg",
-                                    "datum": null,
-                                    "datumhash": "00210da7a8d3a81a3bab74b16724d8467c9f78050497ceaeddf23c29b72af3e8",
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56": {
-                                            "0a4223c1412da012347766abc2a3bb0ad6ceb3e4cb89": 6267063498872478270
-                                        },
-                                        "lovelace": 7500000000000000
-                                    }
-                                },
-                                "0702080300040703070506010003080108020503060304070507060608070603#1": {
-                                    "address": "addr_test1ypk0y7gttw7k8auh6stnzwacpya06rrhj84jwxhcv2um5df7ln0akdj89d0jzhmark5hyts0dr4fhwxj7whw2wwkytcqpw8ehe",
-                                    "datum": null,
-                                    "datumhash": null,
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "lovelace": 969750
-                                    }
-                                },
-                                "0704070500050700040508050400070305040606080708030103050305040504#36": {
-                                    "address": "addr_test1wr3a3fsrm9wu3z0uthn933s6j7sumslm6c3gxh2avugp74cdqnyu9",
-                                    "datum": null,
-                                    "inlineDatum": {
-                                        "bytes": ""
-                                    },
-                                    "inlineDatumRaw": "40",
-                                    "inlineDatumhash": "39df024ac52722fe8ae4c1a8740e4c5624a38c3820e504a059aae8728421f8bd",
-                                    "referenceScript": null,
-                                    "value": {
-                                        "90e23c72b1f20443b73adc3cc2545f15b2f3f0f96230bacfed948f5f": {
-                                            "f50521bb69a9e5c44ea6f7ea7bad337367f9645ba9": 1
-                                        },
-                                        "lovelace": 7500000000000000
-                                    }
-                                }
-                            },
-                            "utxoToDecommit": {
-                                "0007030003050100080103080208070502020803030002070506030401020003#92": {
-                                    "address": "addr_test1zzmaap7ltjjrzgcvhmmr3yn5n6ykxr2lfxq6au7zh7w7zmhqgnf33x9e0pypm5akv3sdg0ft3zt0wkzx0chrcewazahs7mtr30",
-                                    "datum": null,
-                                    "datumhash": "a5a9e15e9e290b35af70ff5f8f4928538c5af014c660ea109fcae686ec3808ae",
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "lovelace": 7500000000000000
-                                    }
-                                },
-                                "0101080100030003030102080003010002050705020500000806050305080405#81": {
-                                    "address": "addr_test1xpecmtw75yh3upwdp9n3yu0zeljx5xm200f4kd8r7w9syqx9l5flzvzqqakua09tvcvl8nw4r2x9h4ce6x8v02936h8q3u9v2g",
-                                    "datum": null,
-                                    "datumhash": null,
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "95588ba4420de250a92b004313ae19f40f7ad888dc1febf0f284bc8f": {
-                                            "21e44ce946002a909b36e744e3898126c71d4afed39debe1676e56742d": 1
-                                        },
-                                        "lovelace": 1249900
-                                    }
-                                },
-                                "0102030006020006010400080405070200000601000100050005020505010605#97": {
-                                    "address": "addr_test1vz78ahgnj79lazrmwstgzrypw0z57v4cfa4628fw2j47qpq8yjwqp",
-                                    "datum": null,
-                                    "datumhash": "8e653984e300f2994dc93dc5d43da439123c4fcce59079fc003509b24564f507",
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "510e75adca9b2c61f9f21adea5e6ce95b9bba70865d8cc64303c0929": {
-                                            "2bd382": 6045402609655476847
-                                        },
-                                        "lovelace": 7500000000000000
-                                    }
-                                },
-                                "0303010007010308080302020404020700040702070402050403010304050600#32": {
-                                    "address": "addr_test1wq2syvawc96qwnxf3p6vglr5mfteredpd85cc43acdgc8psaa3flt",
-                                    "datum": null,
-                                    "datumhash": null,
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "lovelace": 7500000000000000
-                                    }
-                                },
-                                "0700080002020107040606060607000205080507070800040301020307010304#12": {
-                                    "address": "addr_test1xr2t2clus2cgmpz9k6td50qddc730kme7wvrfzne5fsrtypzjaqnhvwu3ll3cwdtscpaehz7fq7g4ry9wk4wwhyp5utsn5dygy",
-                                    "datum": null,
-                                    "datumhash": "155a0aaf5679bbeca8cbf656faee21871553b36182437d9b1a0da02cf845e871",
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "938f89b5a152d9bc1348028388319d5f458e8a7567e20db78880ab64": {
-                                            "37": 3731979934747921178
-                                        },
-                                        "lovelace": 7500000000000000
-                                    }
-                                },
-                                "0702000206040500080407060002050608040304020604040102010302040004#98": {
-                                    "address": "addr_test1qr89jtgsmuvp574mzxl5z5rp0yssz8pnre76r2wn6fc8mvdu3ge3e2r8ln0rsg9g053yz9wwsye8ey5zjap2mq7d4qlslk4fd3",
-                                    "datum": null,
-                                    "inlineDatum": {
-                                        "list": [
-                                            {
-                                                "constructor": 0,
-                                                "fields": [
-                                                    {
-                                                        "map": [
-                                                            {
-                                                                "k": {
-                                                                    "bytes": ""
-                                                                },
-                                                                "v": {
-                                                                    "bytes": ""
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "0c8d"
-                                                                },
-                                                                "v": {
-                                                                    "bytes": "cb"
-                                                                }
-                                                            }
-                                                        ]
-                                                    },
-                                                    {
-                                                        "constructor": 5,
-                                                        "fields": [
-                                                            {
-                                                                "int": -3
-                                                            },
-                                                            {
-                                                                "int": -1
-                                                            },
-                                                            {
-                                                                "bytes": "2928"
-                                                            },
-                                                            {
-                                                                "int": 3
-                                                            },
-                                                            {
-                                                                "int": -2
-                                                            }
-                                                        ]
-                                                    },
-                                                    {
-                                                        "bytes": "bb643d"
-                                                    },
-                                                    {
-                                                        "list": []
-                                                    },
-                                                    {
-                                                        "list": [
-                                                            {
-                                                                "bytes": "306e"
-                                                            }
-                                                        ]
-                                                    }
-                                                ]
-                                            },
-                                            {
-                                                "constructor": 2,
-                                                "fields": []
-                                            },
-                                            {
-                                                "list": [
-                                                    {
-                                                        "constructor": 1,
-                                                        "fields": []
-                                                    },
-                                                    {
-                                                        "int": -4
-                                                    },
-                                                    {
-                                                        "map": [
-                                                            {
-                                                                "k": {
-                                                                    "int": -3
-                                                                },
-                                                                "v": {
-                                                                    "bytes": "afe9a1"
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "58b402"
-                                                                },
-                                                                "v": {
-                                                                    "int": 2
-                                                                }
-                                                            }
-                                                        ]
-                                                    },
-                                                    {
-                                                        "int": 0
-                                                    }
-                                                ]
-                                            },
-                                            {
-                                                "map": [
-                                                    {
-                                                        "k": {
-                                                            "constructor": 5,
-                                                            "fields": []
-                                                        },
-                                                        "v": {
-                                                            "map": [
-                                                                {
-                                                                    "k": {
-                                                                        "bytes": "1194"
-                                                                    },
-                                                                    "v": {
-                                                                        "bytes": "301984aa"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "k": {
-                                                                        "int": 4
-                                                                    },
-                                                                    "v": {
-                                                                        "int": 0
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "k": {
-                                                                        "int": -3
-                                                                    },
-                                                                    "v": {
-                                                                        "bytes": "e6e38dee"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "k": {
-                                                                        "int": 0
-                                                                    },
-                                                                    "v": {
-                                                                        "int": 1
-                                                                    }
-                                                                }
-                                                            ]
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "map": [
-                                                                {
-                                                                    "k": {
-                                                                        "int": 2
-                                                                    },
-                                                                    "v": {
-                                                                        "int": 5
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "k": {
-                                                                        "bytes": "b5"
-                                                                    },
-                                                                    "v": {
-                                                                        "int": -1
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "k": {
-                                                                        "bytes": "7ddf60d2"
-                                                                    },
-                                                                    "v": {
-                                                                        "int": 4
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "k": {
-                                                                        "int": 4
-                                                                    },
-                                                                    "v": {
-                                                                        "bytes": "40416e6d"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "k": {
-                                                                        "bytes": "6ab2"
-                                                                    },
-                                                                    "v": {
-                                                                        "int": 1
-                                                                    }
-                                                                }
-                                                            ]
-                                                        },
-                                                        "v": {
-                                                            "bytes": ""
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "bytes": "4f27e0a8"
-                                                        },
-                                                        "v": {
-                                                            "list": [
-                                                                {
-                                                                    "bytes": "31d47cbe"
-                                                                },
-                                                                {
-                                                                    "bytes": "d94e"
-                                                                },
-                                                                {
-                                                                    "int": 4
-                                                                },
-                                                                {
-                                                                    "bytes": "def59487"
-                                                                }
-                                                            ]
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "constructor": 5,
-                                                            "fields": [
-                                                                {
-                                                                    "int": -2
-                                                                },
-                                                                {
-                                                                    "int": 1
-                                                                },
-                                                                {
-                                                                    "int": 5
-                                                                }
-                                                            ]
-                                                        },
-                                                        "v": {
-                                                            "int": -1
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "int": 3
-                                                        },
-                                                        "v": {
-                                                            "constructor": 3,
-                                                            "fields": [
-                                                                {
-                                                                    "int": -2
-                                                                },
-                                                                {
-                                                                    "bytes": ""
-                                                                },
-                                                                {
-                                                                    "int": -2
-                                                                },
-                                                                {
-                                                                    "bytes": "2001"
-                                                                },
-                                                                {
-                                                                    "bytes": "4acb"
-                                                                }
-                                                            ]
-                                                        }
-                                                    }
-                                                ]
-                                            },
-                                            {
-                                                "map": [
-                                                    {
-                                                        "k": {
-                                                            "int": 0
-                                                        },
-                                                        "v": {
-                                                            "int": 0
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "bytes": ""
-                                                        },
-                                                        "v": {
-                                                            "map": [
-                                                                {
-                                                                    "k": {
-                                                                        "bytes": ""
-                                                                    },
-                                                                    "v": {
-                                                                        "int": 5
-                                                                    }
-                                                                }
-                                                            ]
-                                                        }
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    "inlineDatumRaw": "9fd8799fa24040420c8d41cbd87e9f22204229280321ff43bb643d809f42306effffd87b809fd87a8023a22243afe9a14358b4020200ffa5d87e80a442119444301984aa04002244e6e38dee0001a5020541b520447ddf60d204044440416e6d426ab20140444f27e0a89f4431d47cbe42d94e0444def59487ffd87e9f210105ff2003d87c9f214021422001424acbffa2000040a14005ff",
-                                    "inlineDatumhash": "6a5d05c521d62d53467ba4975bda1bb18ef0491c330aaeaa615492d7a89617f3",
-                                    "referenceScript": null,
-                                    "value": {
-                                        "lovelace": 7500000000000000
-                                    }
-                                }
-                            },
-                            "version": 0
-                        },
-                        "tag": "ConfirmedSnapshot"
-                    },
-                    "currentDepositTxId": "0600050303060804040004060507060802070301040300080604030703040606",
-                    "decommitTx": {
-                        "cborHex": "84b100d90102868258202b212aba24cb23d414464f6912dd2ccefcaabfcace0a809dcc2388104eb57e3d07825820359d29361832b8f31e0176bbc914033a9dd2a3e75b155ada86415b1ac26ac3d40882582057b3f911468b96df140e88fc380a12b2079f55e609866691261d9050c515e84d0282582081f00d6e6469169f5e6bd781b4d8d3c1a3c459d7ebcbc92f48b38192a2ccc01900825820f2876543fd70478d0b73778d62d0faae8f0f0536c4ebb887253289cf83fc193001825820fd74830a3c014d1f2ce6b532bce4027b8e1a3d61ea1e9446e6c9ef838bdd93b7050dd901028482582017be86a804e81368a7dfd8ad36cb5bbfcdc08a088df92d568bb615327ccbb3880582582075e88b905b0427f8c43d891d270b083d56fb15bb8a3e640a8dc336f5a5ce784504825820a4419446fe5d8561a4d1dcc9d5e04a8fca9b9f04c9d8096a026f1cc0d8ed79fd08825820cc087b78a2ee21691128998f0ddd785dfa4305dbc28856705ccc6430ede014100812d90102838258201947f02a647e3a79171019219295b0e6c69153be6d178e044abd5f9af58e6c350282582019c06ae637553bb8e12d42788c5dc933af8c79bcc5314e77b462f776c5826689008258208d09432076ba62d927cebcbf768bbad0ef533b8f89e0e27e413550bc64143c03050185a300583911c2f029706d9888eb5bad91768ece9c5fa962f2d26b552f5ae9ee5d895ba4b61f3c29e1a71fc2c56c7d095778626c64c2e1c1e2941584749f01821b7c51eb5236b51608a1581c4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebea141351b233e4464772735e5028201d81843d87e80a40058390055ba8edbdd7cb014b43ba1ce64c3bb812d8dd3859547dfceb30d6624ce7bdca8a5b09a7aa078f41b379b272fc3c791944d1188ddf34c2acf01821b206e56acfb0b9dc7a1581c245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abaea1419e010282005820b5d75eea2029a0a392f040c980508f88349229e4dde8ec72ea84f1dfa8d3070103d8184b8201484701000022200101a400585082d818584683581c15a6d59a595b26002ae7b5f8ef14def46798c0351de78dfda9cf1991a1015822582005962053e779d70dfe5b93e56fccb3ca4e1ca48bef2fbae2e35f8b6fc9a46839021afb99beb6018200a1581ca08b72451d962be7a965b25550c576ef4e210f51380e82f0153f4c45a14a7609dabb515307c090441b6c3cf4d5c07ec0ac028201d818412203d81849820346450100002601a400585082d818584683581cbbf043f3a4a434b160636192565ac1d69cbf530d945d03a8fbf032baa101582258203ba0ccdcd7315f9e6f8d39a51e7695bb500dcd471a9a15374aa1175b0579eaef021a92806d4e018200a1581c26c113140eb3867d234413b9b82b0895c7d1824d6717115b623ca59fa14fa1c842290e33bc5a47c8ae83ec6ad91b636df35d6740614f028201d818410503d81845820082050fa400583910146d0ddd92b574acfacaa20dd3970a4ae96c07ab2ee69d5e373b402c37553200170b8ca4be52bc51fd2bba04bab612e3fb601e5634b2f773018200a1581c8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3a14b017e90643f6ca7e82d9b8c1b6be1199887a814bb0282005820203a2b52c4a242c747e109237f81ddb43270b45d1d27eb3b1bbeaf7fe036bb1a03d8184b820148470100002222001110a400585082d818584683581cb8e1ba123705b47615e7d5ff0a7f29037261da780176877119ca0f88a10158225820994df2c46ab7583613cf521ef67a5f874df1a2e99ab3099ad58bdea4064218b1021a0aff8e4901821b0158f33ccb8085d7a1581c718969137b6dc40512cead3455a3e7cf22ddec993e75a6134276cba0a141371b5dcf25a923449e9202820058208eda9a823d789f7c4000fc4df96b8a084b957c6d7a1224080aeb724743939add03d81849820146450100002261111a000511450219317a030104d90102818a03581c08b0587ca53a9da5119829f323953965fbd52182362d7c40ce973b64582094618f2a578bb1250ae288567d1b6fb0b466b65172b642fd54060f4393b0c34019cba01a000da6ded81e821a004fa1cf1a00989680581df03460e4b55793cf11661808e0dd8ca8c376be3ef2a0e30a39945d6014d9010284581c42da8f77a812eff04894ccfd6c798fdb1fe42e96ff21f575c22cafa2581c9d8daa4095770cb073659500ae211262e83a06dd61782c11c9cd838e581cd01c940f0f8d00386b81dc0858c819e7bf57d6809a309af9eabd56e5581cf17ce403dc1f8655db7d5c61e788af8d34d5dda911db6cce8e1ae9a48082782968747470733a2f2f32794b736d784e70727833585871586376697030396b386759496371392e636f6d44c46def2405a2581df0841af070d05207b9c41dfb49d942ca8644c7c2ed5b7b4ee6298b5a9d1a000386ae581de10cdcd6824321bc81d2adf24d6e73685c0e47bd581bf1a5777d71812d1a000796490ed9010281581cb7f9c43d86be0af62165edb2f02648f43b9e228c4396d870c214cce409a1581c2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2a141393b3bfdcc2c4a42e2980b5820cb11729556e6b2da6006231c470fd88d384d7c659195bb7a7b9503432529c93d13a18200581c7c78101e4a0c0caf6ca8ad5034da553c6125f3ecf0d458811889ccbfa68258200307e9be82c2c864e65653642756898bbf42136fd112fedcd1b12fa69cae2c94048200827768747470733a2f2f375231456246573074424d2e636f6d58206a966b6cc283a1380ead623ec28c4468ae2968874bc4555e69d9f6f6869126ac8258203eb4de33768e7fd4fcd6cd3d65f765c000238fc5b3aa6de08e9aaae5952b3bae048201826f68747470733a2f2f4c59622e636f6d5820779489c3e7cf1efe38f117bf1a844a55a1804e44485a5bdbab7207f0f856f94482582051cd119d34745bedb15054f2010be64f6c2420909c13ae18ba88766dbf583146058201f68258206b5c1949675c8271bd4a22752be17e37e047a0c15f2d94b16492c8bea63d358d03820282781968747470733a2f2f6f5a63783930736d71583241332e636f6d5820bc40280a3dcc3f657d2800ddd5581b8c5cd535550449a8f65476aa1ab64ac70982582079ab97e37ab5ae7af7179f8e49eb00fccc986b4b16c0165cba74b1af99995ffa08820282781d68747470733a2f2f71386973723543614178455444363369682e636f6d5820b4e4947888dae9eb7ad52f7ca5a7aa87b1bcf01b4153af860c5264e12b55b378825820c0eb871435339b58f67447e302080e883f26dd65aa886c06b31062c51c09a1e606820082782d68747470733a2f2f50672d6b6f314465636e424f355a3349747630437638385967436b535030304e332e636f6d5820aabd4c229cd21eddcfe535cf80873697d845fff606f86f708d4f8f63c24347d814d9010284841a0004492f581de1f68f836c5bf95c873c6d69cdd3dc5f58f2b839159238c2051db665e28305825820102cac62aec978804d0662dcecaf434570ab3e165bca11cd572574a1c4e79afa028282782668747470733a2f2f396d51794c7450697472624641667333682d6335426d4c6c686d2e636f6d582021d8aaa77a852d08b1ff097f2f2f7ecd0ba8769f3ae48941b206de3944a4b4c0581c2cde2a9192e7e00f62dde37650f680d7ac52f05315503eb18e0c8c04826e68747470733a2f2f62762e636f6d5820d9cc19616c739222d5129922e845e6bcfa886230cff606ea0ffdeefd0c690fbb841a00092b89581df11b46fc406275df5f4ab852c22575b7b902c0ba7e95d38bc7cdfc2de384008258201d5218f4ab63b07b8cc20caf315b7c91386513134dac213448dce51822293b3b07b5001a000b7215011a000ae7ae0305051a000e411a061a000790a9080709d81e821b0609cdd49478a7d31b0de0b6b3a76400000ad81e8201010bd81e821a01060d5b1a01312d0012a3181c830b2f23186382292618a5810114821b57ae57589a83917a1b0692ca16d00d0cb315821b180f495da7ae9add1b452e952878dcf9d816021701181801181985d81e820001d81e820305d81e820101d81e821a0367b6411a1dcd6500d81e821924d3192710181a8ad81e8219a58319c350d81e821953691a000f4240d81e821a001f2b8b1a00989680d81e821a04692acd1a05f5e100d81e821b000000076b1349bb1b0000000ba43b7400d81e821b02216049e07fb9111b06f05b59d3b20000d81e821b01b4754e86607b351b0de0b6b3a7640000d81e821b00000002080f5c051b00000005d21dba00d81e821318c8d81e821b0941dbb108df477f1b0de0b6b3a7640000181b03181c02181d081821d81e821b0dc4a4237471ebff1b00002d79883d2000581c771bac789887d8673c5609005f6169b1a9cb092ab1b5cce097f99e6d82782a68747470733a2f2f6d376b2e7953712d712d657a5869525a583533474b583952754f6c796b382e636f6d5820c5937f7c36109c274f0e8cb84def9062f75845ea2000b34a86bf6c87fd312076841a00077ec4581df1af98319177f2f3d84466ea062b85652bf5ea9f623fcf6345cc492be8810682782168747470733a2f2f75673735496d59724e784f704d76624436675a4c752e636f6d58203dfc79034139b2b26f37c3d5c21f57303aaab5986b3bfd28621cce7d68969d8a841a0007d30a581df035bcb8f7dd8ee178c9b5b50a890a4993fe6b8fc516a2a4b5dce18db98302a4581de095769dbc66e01d7939e30aacf26e196ac9b66921205e3bd2bc39d0571a000316b8581de0ad2fcb719c29086506f6abb159bd4568590562da96092f6bf9743f991a000e84ae581de12b9e3b30f73bbdd4d9820991629c790a4353a6157468c0098cfd478d1a0007e3f6581de15381646cf6060285fbcce4130ed4404795ccc580e7959fec18d249e31a000e368a581c8a8f2151e55ae432982d8dc179019f1ffd22361ccc8ec53c2ddac9c482782a68747470733a2f2f395a45557173426433326f446c6f32587558436a613262465a67634166342e636f6d58207b5dc7a7d700b3e041e40d08b416a44629ccb9f8ab84f711440092704926fdc4151a000af1af161a00063903a500d90102858258207f7a242629880473b19a326b945c6a940f8fdc896b962271af82d85617515f17584010e919a3ae2f12a85bad82df1206cc6ac406759474a362895fa38618af2bdcee5c3ebf2a088174ce31e5a1c5d75e9efe8bd432aa4e39d92c43c5ce73fb5608a382582076aad713672b467177e61e4b3bf92c810bde815ee1d589c4be4dcf2326fb45205840a00c22d55301478a0b2b23430b42f93a371b945c09fd6a8219a330dea01440d8cdb0b50b5cdd6589cecbb494f81cba2e831bbdfe7f30a876bd0af6a99b59f8858258204396c8b9e6c409cb72c551d62e13f12d7c4e7b25229a2f341937af8fadd2f993584022100beeeea0d3a9a69fd1310009a468ab8da1b99be7a0bc9f75a0593949473f16c332fa62c271d95efafd757af93533f7890ce2391309b7ae70775d396bc68a825820c2331b8b5e0d0ae5b7ea2d36b08c32544f02eeb07a2e028b43ef238d0ef988155840ff2655ba0e2853ceea06926ebc00c69abc3934bcc8e8f5be435037a1775443f8fe7969cf376fbc0dad07def5bb7dee0db707f5d61e556289e143ef03e7c390e882582019e725d94e30b9b9f3a9e45cb068c2bb6ad70571044371ebcb9cb62111eebfbf5840ad0211413c2e6d7edd9bebcb87a23d8179d9de6b463b7d6deb53b703e9378954afc9777371ac0a85e4ca66ae200f781f2ca3e3ab0609358f652ac93cad0403ef02d90102858458208ee13e77cc1e855e9998e10f175e6c6e0d087070a7d82e9d7c657be1eb4d50c55840322d3555bbf274fd4eb8a35a1065094703daa5cca9a4e6c66c5a0d99518c1d5cf00761d1032ebca443e15600d9aa9be65bac81a4fe7cb5720c76da525ca8668942bf5141b984582036a029546939dd5eb5fe590ae0f2180e35c8bb35016cb461a94a65d93a6989b1584041807d6bae61d01dfc550e1e5abec10a0f3346cd4a3c8f4a591de4a26ff0eb532741e8a7ee86154248d93382c823883d6b0b3e09bab1f74bef17f6d5c26751d341a74120845820c475c5366e6f900bc336f1351b9af3182f5320a922753f397c0aed2ca57f344a584034f247c7f7163b8a868e11261973969e5227b7855ac482ea703d78813797cf0e8a71a3b0623e0ed2b69a50909bef0e350a090d21bc4e5660ae3f20bc4d8745d54041f18458202d44c0252dfa46b43e9f27fd4ccec004a44aa5665a16ecd207a203ec5109f9135840ddd84f81aa6140a667dc5f7f81286f175ebb1182b01b8039af6f88d5e9c4c966823da67507141d5dcba6241df1a09dd5e297c7bcd4096ddda3decb827eea63224041308458206f33dbc7f66627addc176ff0cd01d2a8cf99fe311ec87da6dc81fd372f52941458409c267aedde35cd0d1fd4e2374349b0fbbb6cd06b7024520914ce41cd4b9c59bba5051a51e2d4d300d3465b15eb40a890709f10949704c117f223e996ab3f2125447dab083a4001d90102868201848202808200581ce368600e8496287e34a21b95673bcb5b5d4f71efcce9e4bad93af4908200581ccf9b935a21c2e5ca8706e807e783d71a5555f968ec2d134f4cc1b088820184830302848200581c4bf83a66351e10de702aa1fea67d52762a34fb42d35f9454f587f62d8200581c8bc6e93b0b7ec09a50d6e800c93e3baabf4454e1f3ac29a01ebdc2718200581cdbf443cbcb9f398dc2d87764e42624fb206b4bbdda543c3d9063085c8200581c381c13cccd9f9185391a1d71aa35d445655c0be2464f9f1decc7a8f78200581c50c0cae93f37dff4c919490b0b8d5d327589db6cba0a065f31c81a32830301818200581c4d00b6e67bdbc4250f767a99b1dd359cdbcb99a38659d2daf7693e478201808201818201818201828200581c94965ae442e66f0bdbc7c131fcf07c3df7b2be7b24fc5d22470513f18200581cfd6e97ec84f838244a2d65fd69bf85b0529c5d5aae6457de64e461ba8201848200581c7753af0ad3f9456005e7cd79095bfa0cdae132e315dfbe231b372ff4820280830304848200581ca282e90df9467028ad61ec36bac965a9fc66f776134f952f374044178201838200581c4d263c85e7fedeb92d645e1e1721743f42beb3e6df4eaf58c53d69668200581c85c9ae59c0fa052601dfe464f2a06806a2013c9b0627f0009c07ff8f8200581c749dc43d37fff3838faaabb09f498107af0f6d409ba0449d8d29bb0a8303008083030080830302828202848200581c4d95f3fa86c429c96aa5931a2754d9f93435bf699b253f3f4d7d8b318200581cc1a73d069393354baa2a1ecb1872216bb8b0e236aa4957177578dd3a8200581ccff0c10493b2be777deaa78a14af7d8e7b298dedbd3884f3178902968200581cb4a5b5fa1a115428a6549621f74a16f6c2a17a6f9ad3a03ef88b54ed8200581c22f49ce8bca51270c07502388011714164ea0343cc6bb79f21b4cdca8205018202848202818201828200581c773f3909c5c5f634f9b04fcefd2a56b24e71b6c99122d870f000ed008200581c9386a12563c984623034a86ba6ccd00a7edb18b5de3d1d1520f1e33f8202848201838200581c0d205277c64ee7e383e3a3ea6a20159be755947800a3208d0540dde18200581cf3473541efaeb59251314050beec2e4f258ca02559d82053c8633ebe8200581c714b6c437aa151be22c661ca28bcf3e07c4f040b53cb437bceb0cfe08201818200581c46714c053bb1d16c1f615f41ecec431475b5c78e9aef9fe894a56e9d8200581c5deb12983b66d8547be1fba72b91e5b550e0b90cc2edb063580a83d0830301828200581cdb68b8563a6bb3dfd9650872b62f5024b435c9f975735ac4b4fd66078200581c4c7056b3d8652ac09fb50269e66f9135c6bdd5b9af3a360a52ab317b8200581caf9942304591ed5c2f6ad9510277579306635dec190cf3d1dfbdbc1d8303008083030384820180820180830302838202838200581cd5bd09215698238a50fc0fd92191c1e74050c0020ec542612b8f041c8200581cec421fe720290e1bb58dbeefb41bd2f5cf4065fff58890e53fd82f7b8200581c3f62d606b0ea25892300f584da9a1e26fddce1674ca555b4cc66dcc98201838200581cd05f3492a88bcd32b415a3de6ada13846c7e376c2cc8097d378f583b8200581c8b6d1dd13e3ce05908e0a20b18130aade6633d488a4b58f870bd66ae8200581cac446eb73c006c772ae7542877d72a652d4c566082ca88e29c651c428200581c1cf2d49575e1d214245c36cb6eb7fc170458aa33b24222062a6eb5e08303008004d90102859f2323ffd87d809f00a09fa042311801d87c9f2224ffff2440ffa44040d87b8005a1a1417503019fd87e9f2342c3c8423c6d20447a5283a6ff0580a0ffd87a9fd87d9f422fdf427114004286c521ff9f2223ff9f20052400ff428efd42281fff40414c05a68200008240821b4d401fbdd22ada5f1b398e96dfce43b86282010582a502a1d87e9f438fc448427e704400ae1a4624448be564d8ff9f004382a256ffa50341679f05446e471d3002ff9f43a38d2fffd87a9f41bb4309c4db24ff9f44ebedc0eb0520ffd87d9f02425df442cec44158ff9f4252c341ba01004328a964ff019f05430336d54156ffd87e9fa20044909c49c805400404ff9fd87a80ff9fd87c9f449e0cccaa400221ffd87c9f425b6e40ffff430bd29822219fd8799f00400143d8aa74449f5951bcff410fa042a56504ff821b1384504c7afc39231b60ca1f9e01b2fa1e82020182a4d87c9fa0ff00d87e9f4237bcd87b9f0503426826417d42a13fff05ffd87c9f9f002004ff43372dc3d8799f042141d642891fffa44336d87c0021404225a201402340ffd87c9f9f400143847354ff41e2ffd87e9fd87d9f2043d2033a23ff44959d35c99f42df0a43470424ff447a46ad14ffa2a142ef30049f4351023d40ff040180821b35e1bab4370044331b35f562115685cbb782030182a0821b08d76a3e474d43ca1b05e243e1ac72fd7a82040482d87c9fd8799f40049f240041744223b94397e0d0ffffff821b68646f2a1102914c1b1c81d432152dfb8382050882a1d87d9f40a09f40ffffd87e9fa50143c999450121402420402121d87d9f42b5e8ffff821b779dbe417b172bd61b5204247519f47bacf5d90103a200a203800b050182820508820402",
-                        "description": "",
-                        "txId": "d6027fac0eed420dfca6aa6f6aa842eb7446f64e26f77cc96bff77fe0af81373",
-                        "type": "Tx ConwayEra"
-                    },
-                    "localTxs": [
-                        {
-                            "cborHex": "84af00d90102828258204d75d241f2d1fd0fdcc056940d3c6c7c619e3c5d327005e11a087a872e51ce3705825820913dc98e17442763722145725168c151fdc1ca3c8135d905af5365ac8c69e6de060dd9010281825820e20d1d5a79c3334fcb549724dba3085e55842361dd001cb681e89dfe6efddf850212d9010283825820511a3f4bfffb55c66bd101286dbb08a8ca0295cd6cf02e6869a8a6890894551e07825820e185009dd0cdbdbb1fa7fa4b1125faa8cfb06b666cff5af224924d9cb4a4598c03825820e8431283d3920919640894affaa42b0a010016e5751e41f1bb4344743825f750000184a400583931bb0df19a0000dcb9b0c13d489d1e0765ffc98c9407f3b1cb40b433086ed72966e234563d13e97dc3a146b293a08c6809073a1842877f8fd8018200a1581c245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abaea14133010282005820266409b2df645cf251baff416e40ead2e4b74bfd9fd8076d312e8fd0664d386d03d818458200820404a400581d61cc09d13a35cb26adff0cea28ac81fadf1a2d4d2c51c76c1d9363825c01821b0a10f918fb1dc66da1581cf1d1834eb74792624b108bf125b1953ab90dc80ed9ea1abe17ceadbaa1581c296ebe807967bf0930b6716ccd4574e6442170326f5e4780706b8b121b119800e0fcb29d40028200582030e503aa73b7674ea23f8f517ecfff96c7a47ea2166260a02f277e0478e361ca03d818458200820516a300583910232fa2347ddfea3f76cde0490666601b5c0a52e7f78f8866bfbe15d33f9c01ed8bf6fcf72959b8814c292308006f95f664b8140af4881bfa01821b578ae17fa636cfd6a1581c2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2a156f3ccfd4bb922004b257b8eaf6c6781e6b0f8dfe6a34d0103d81849820146450100002261a300581d707a7730288ef3f43f17fdeb91beef3a7949202e4d96d5d0b70e458f6401821b40f1b52c3061c607a1581cc714ad6dfdce910c7a33831418358abf5ee25435eb9efd96e1c61dc9a1451bbbe4f0f51b52dfa1e5caecdb1d03d8184b820248470100002220010110a300583931bd59d5b0a7f37ecb891f50036bad512993fa446ada40dbffd57facf5f32e0c1428b66b3725e6f9f42f9845cba38b5256cec61cf4c26df07d018200a1581c4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebea141361b30d73265d1e9652603d8184a82024746010000220011021a0005eb0b04d9010281830e8200581c4d96bc8cf30ed80a26542f7998e08494ca1e7fe4b215cc1cd360252f8201581c64b6485d329c9f8f89f3a3678e8dc9d9a596b71332e5b259a135640305a5581df083c7a75ad116f3a230a860a2b1eb3e4874aec674976327f565648b8e1a0008fa34581df0daed44ce93100e22a8a432f952df8719479807b963c2e2b69d6fcf711a000b9dff581de077f4b771704eee2b390baa12d31dc67cd948cfa7805ca1cc35a10d6c1a000ea603581df10a97ad03ccba43193db6bcb456017b3b2a8e8abb4cf763cf8f56c22d1a0002c8c7581de11e9f7f9ca5bc02531f8cddf9690e24151e10e96d4e704328b8a3bb9a1a0003974d08010ed9010283581c0e1d6ce0df0b87128be46f5c4e87c8b3e6a743608376a6462cfd4c78581c7e8db2be026e79b44d52a4c7b1b8a16403a3493d7455ba942f5b5fa4581cdb2306addc7d14993f32ef524184614108ad90df1775cbf35689341d09a1581c8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3a1491aa8d136397871cf601b678362c41ff3007a0b58200d81678dfde49780d0d21fb89742cb9ba50e51ff548a279ac472860d3ba442be13a28200581c5f6ab18eece0ec7abb37935921609f48d03a1007b8dd39808cce5f47a582582005629f1bfc725910f2c3802b224c42c465796c36ab510105d8185f454af81af506820282781c68747470733a2f2f5277775a6a70754b703365452e35486c2e636f6d5820e7771884bbe85fc46f65063205e911f39b26573cfa2aac5544eac466698200648258201aad97bd9d8b9a9c6eae9518e790f730590e3cd94c3d0fdbe9473b9348ff135904820082781d68747470733a2f2f7a6c78684f686b4c322e343444393257362e636f6d5820b3bfed33f98b3609c42e0271a2a23857434b80b100402476d92214ac24c833f2825820b892fb5e0b35aca7555bb461e203aed24ed9d2417e866165283070feaaaad43a03820182783b68747470733a2f2f6a7445645544567a353578446a41494f654861726e736a32713453695177346b457137765a5638775148476d482e6d2e636f6d58208e3e33c990028f73e75a26425271ed10fab0e8060516ee365635781fd18c35ad825820cbf8b66d9714f534e965a9917b874dab830aa068d1db5561ccaf871f91681ef5008201f6825820d0bcb2bd1bd592b2d938a6ccc9108679bec043b8e3286c2501397d94c8008c1c058200f68203581c21760c3f4d2e032585581c5d4cde3f5988db057d75cbaa0f7556baeda682582026f3eabdc04335f72e9d6c57959e70cf99b9e11b5e22e582c67171e4e162318904820282781b68747470733a2f2f68346c61674e584a324c436168692e2e636f6d58204748c6142018e1d9081284fa098441e8f0a96e4ab5e1c5edac0deaeaedc68a9f8258203fe021d092773127fcd1c2eff209d383db7db04e0f8c3973e569f4e01b47870b058200827768747470733a2f2f6951316b454763797834682e636f6d58209d549fe7478215a4719a1b0d74ac62afe2cd49f8bd52a195438cce5f6d26df648258205e5a09e0c75e84393e299e3414b6744d179741400b650f22fbf367c94de52f1c06820182783f68747470733a2f2f6f3661506c4833617a6a317979504748393254716368744a636567513555724f4a7a79614838437a6d63376d436d39624d66712e636f6d5820c72864bc22b1d59571eac89bf0a28adedbed684ef99c355ea92c41a6b6e401a0825820868568e1ec7c279e71ac8f0a1837cf2a1cfe5e32cacfdb3c6b13698e2618024807820082782f68747470733a2f2f434a4b69666b34704b2e756b737133466a58454e474653724844502e56323145422d432e636f6d5820beaa76949118dd9b39412b2867da39f5c83d3ffea67e00620c9e364ea9f820248258209170302fdf73e68fec4b90f2fdb8aba02f463d4064c96f866fc006a7a69b2aa1028202f6825820f2adba217bc5cf57a3c114457c7ad18ccd7503d474e145ecb4b0159bfe495db5028202f614d9010286841a0008e174581de0da87a9b1e23d92d8e223627e27fb17b8638bf1ff22b32c1b6bf3ccca8301825820d3ea34f02d214adcdeb9276154519abb178c08d3093cb45a5aaba7258b7ac71005820a0382782268747470733a2f2f4f3655716d7a6a6a434876394d6d7a4276614c6e714a2e636f6d582048e4c27c436ceaad9e81c37684c4629eadfeae8c61153611cd39b15940dcfc48841a000bca01581df0f944d4fc5ec25a61b339e579723d9fe67892d93de4937e222d493b808305825820c5aa8541bbfb8b948ebec132030175ecca2ded9ba567e7b0f72cf341473bd1d10182827268747470733a2f2f535a69386e542e636f6d5820856f7be66543bd5f87a94dc6c6e3d81be7bf06d486f4fe9b6beec9b4d961741c581cfbf9555b4f5d730ff5d5edce99faf54e4ca5f8493b8320b27163a49682783d68747470733a2f2f32694b57593147474c4b444e654d71736c5377394f4334566e78706e326b5151793955496353596f3768426e6a74554a4c2e636f6d582091a4f13f8dbca2fca1cf5167fc5c808dfe1c162ffd53d13c5b1b67eddd9ea953841a00062e7d581df00891cb1cc5c450c0d44709fe9e26f39d334038f47c369152354a40a3810682782d68747470733a2f2f6463464f4a796a38352e503530415046456e6d6541554c67566652776a74486c412e636f6d58206a44e657657d2742be84994cb4b2ea1be81497456527dc9561b3f83f3271f839841a000e9b91581df123beac60fa95a3df18331e46d4dbaaa9b87e9003f6e1a77f91a252cf83018258201f5f3b45c424be3b1f1290e438304a2fcedff5e56d0f6ebbba619cf228c823a90682020282783d68747470733a2f2f395a6968514a4c6161787a346c6e712e4e715055344b4461704b747141683662677277454c4f487a4b79506934755742572e636f6d5820aa4f4c699d54a926ce7c6ff7d86ab14ad747934e560179922b5f2624ebcca4c0841a0009bc5c581de146642af8ae2e4a3b22b5598f171e6e27502bdbc8906374e6dea0c03f8302a5581df044f7bb981f9bcfdbf484ff1447d24ae98fb9dcd6beb94de23f8a5e861a0003924d581df0acc328204abffe2373c52514ad551a7b379673ef13e40126bbe249fa1a00044272581de03413a922af0655bdbcdd126dd9cd87767b855ca6d1427fc1c55377ef1a0001fd70581de07dda87f4e1d91258a549d5c289b58010f240746d5d7786698328e9551a000a8284581df1f1e1f686caa644b21e9169a3582d628a6696be02b8a7c0ab7218e9181a00064778581c30a4d377479f2d7f7b983ce36edc5133d028e49d739fdafcb55d071a82783868747470733a2f2f65396e6677492e57567951347438434368716a616a67424b584864367a2e56743666545451674d74313243502e636f6d58204cebc24852fb5eca3387b492d6d508895e41a28479513d27829ded17ca6147e9841a0008f22b581de1e7cb3e41b3c4ecbfa303ef5bcc5ca98d13b1b942f6abc13474688fcf8504825820017db575738495ff456c3c0880a24902096e6e006ae3712d31cef762e43d419501d90102868201581c94d8a45f5dcb607fd7e80f35c54f0fe715617c2b227a6ef3fe2cd29c8201581cb17421d5ce4a3d560bb633ad30acdd6163fa2871b491c6fd9b9530f88201581ce4bdabb3c99b4fb90cf0ec100f97f88a227397e55c24b6c4199a4f3d8200581c51116b40101e98009a5bd59d0b1ff674caa77c86a941e770cab683258200581ca2fb6e859d5578c4ae1295c762945ebe1813ee9d179ad32b561daa288200581cc5ae5fddbc3b22bcab4877d2f21931f64d8fa62d09985fbd4def2747a38201581c3d720ffca2cf5b44e56635a244bda5dd56169514ab3a869d02d64901048201581c8a403437be132e4886f34c283019ecb16c1a815f9df06e9984b412b6078201581ca5ea52c14f8ee1df51e4767f18403b43637e6a48af708ad4801dea2a05d81e821a10e4da871a3b9aca00827168747470733a2f2f71586b6a4b2e636f6d5820bc4775aa024a9fd2b5144df6dd571227acb8fb48bad02a3052e6b1727abdc957161a000ad8a5a500d90102828258209420d30d33a91c38b12e182c18d3d71b70bfe6f0fc9ee469f149c5674d6ebb6758404aa06a473bf8b87c2513f79517eb3eea0e05d7cb792849378de30d1efca861b5025d371503dac31564441f21d4ae745e95e764d266784f4fd03a745ddec95faf825820d360b77dfcaaef0dcab3b34daff2244596ec880d69ea5851cbdf7cacedc001c6584075ccc220507bc2875d1f3d5cedbe91f652318114156f5135a3705ee2ba1b69ec7240f92083425ae12cbe8b42bc2d9ac182955e88049fe5c58440716adc29c70202d901028384582058be7b50fa126788e00838b978a29b8d7f8fef43e362e13f2f01d643ea07e3eb584010953421223fc94e76512d1bde8c700253bc173fa7af54a39083a28e5f1e734351f938b9ae6906619fbea1f822b362fa2556c7582fa5e1213dc4795ddbb46efb45aa2bb4f2de44f2299893845820e053694a0b079c4802e8f82a8b19593b94d6e5bef5039bd832dca9d4a2d61d0e584075e33d6a9e81eb2bba4f362d0ada92321a52f5863862f9ae46f37745a107f3a87e0996b00a3cb8c32fbd172b0de08e3850ad98a41d6eecd9cb3972a14ac604bb41f244a53db2e28458203f51938a3aa87342e604ea51f7083d3b18cbff5dbe4466470bde57d25705e1285840b0b9d3975f4b61f2026aae805651d1273ac3ebe416486daa9fde190ebc88b7dc570b5679d708e2a2da760e9f23bfafc2d0e421d63d7c4ff2ac7de05c8c0f3a36433b0d644520b234b7bb01d9010284820181830300808205181d8201838202828201828200581c2b7b3cf60c3bcd5d071e28435eded816da43b6997e6329bcdec000fe8200581c8ed64496958f677ef694274be1242f8c815e995d9ceeff5ae7cbdac28201838200581cb58f362102e7e09e7c6ad46efd31ba913eb3fd065f79bbfbcdee09298200581c7a9ff1a436cd02ede31fb2c309c770b4572e00a6b7f8c8ae66ba5a718200581c1d5fcdebda8aa964dd90fb3d3b0270bab1d81d3fd4730623a6ff06c08200581c1813e00aff7aa5591755947b6862657b8daa3c2e2b42cead028e1d048201848200581c168096caa78ee97bdba9a200bc70c2f498898f59f5e91c89b1b3036a8201808200581c786772ebd52e0df45a539f7d5d3adafdca012fb56e7e6bc72d02e0cf8202838200581c64bebce6baecd2975a83466f836b0f9aeea99c8ef5edf03656ead05b8200581c874c831b8c2649ccfd05a41e2f77030101a9597cd26ea48261e766758200581cd052512453b0b4f2cf3de6900a5db549d25c3df4d23749df85b509f7830303848201838200581cfdb66b8b705f4f476c44f21bf91d345bdb5ba820114bbddddeb5a09d8200581c44cffd194cf16136527839c3ec709577c3b5b861e5fecf6a39530f93830302828200581cb677f69e8003e9a5668401aafdd7924ca44372950b4cf1ab4bea55678200581c87f1c282adf7fe00ef4facbf2ebb9093be25ab8bcf0d57aeb69e1b0a820282830300808201818200581ccaf4eb9dc498e51f59d6d3e3f2c97d5569eb00483e246585d8e467a882028082018182028004d9010282d87b9f412a425e939fd87a9f04ffd87b9f4407db0ee5232421ff42893bd87a9f03ffd87c9f439457d10223ffffff9f40d87c9fd87e9f431c581123022242afa7ff22ffff05a582010182a3a2a2434fa8b80523414dd87e9f44c8ef56eb0041e705ffa22341ca2403a12300d8799f40ffd87b9fd87b9f44a6f6dac1417543e63cb542840bffa00200ffa22304238023d87a80821b3d68ec25abda1a6c1b5af03878f3fc7dbb820207829f2221ff821b61ac7df950697b951b49857b91882048f9820302829fa2a2032244fbcbb844424c6ca342011f2140212340d87c9f054020ffd87d9f43fd1165ff01ff821b7541b8e487e6d0511b310bb76c3fe37d4a82040382d87e9f2443946b76ff821b42ab6d8caa601c6f1b29af13ce9ae5578a8205028200821b7b367ef88023e1f41b4f661f897b18a580f5f6",
-                            "description": "",
-                            "txId": "fb9e01f583acffe394aa5a97ddd6ff396164b3f4e6e9a78f301c246c93dfe2a3",
-                            "type": "Tx ConwayEra"
-                        },
-                        {
-                            "cborHex": "84b000d901028282582027dc22f6a25fc736969e896a062ce8cb1363469c17c7b9378f558626a6350cf808825820c278efaa0f1d7b4aee363ad7f4a63014212ee03bb4ec124573a211473576f9260312d9010281825820fb83da45e4ed8b666efc8194593b6de8d798bb1d4d75fee416835e81ae4d7aeb010181a4005839203f1201faf64851b94b64904dd7a1eca6243f468bbc9162d26f1677f0534ccd909217d4eb6ecdb29b512689f44a33efce0b98780767fc431801821b142a2520002d26aca1581cf29586ba91b67c8b50746e6943e4b3f0217f734f5441dd56abfb22a7a14d42eaa8202a4c8160df2c461e7c1b327d237efc391145028201d8184443cb928d03d81845820082050910a30058390143896a39aad9642df8513b896db242c10a4b2695ca167d6b68c05d0d4fd86a497bfc6f1ce90751ec9450fd39ee485f4710c03e23bfa9d4b5018200a1581c4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebea1581bd2fd180573a4948f17951e4f8776acc4aa8b97841776716a0974e401028201d81849d87c9f44005596f8ff111a00088d52021a000456ed04d90102848a03581c89bb9ce793192947f9fc4c7928d68284202204718bdf5ef84bdfb6a65820bd6e0905205411398d0b09060845525e5ae5467d98ebe8ab1846b5be4cf9bb581a0005d4851a0009446ad81e820405581df0394653892ab71d0696ff81eea180239e3eac4f8285a53a62b25cc36dd901028082840001440000000250050000000100000005000000070000008301f66b585975444155382e636f6d82782a68747470733a2f2f7265642d6e38683256542e7963503034616d344b2e787a436241585078792e636f6d430888e0830e8201581cf5f2f03483faaa5fc7de876f7f43b55364d8850f546aef38073a960f8200581c1f807b0af4a21e61012986b249c925a7595202a8fe4fd0b8e5492bd783098200581ca87039022abfefcea50ad3f855041f6eff4e83e92c098e3fe72162ac8103830f8200581c31d64d2282334cfbbcc04418155facc0d2b9e589854f42d13d6bee4d827768747470733a2f2f38306c773168365a5776322e636f6d58203d4084b6481d091419d9ac57d640a95434eabf230b64cbad492cb0ee7ebfc01b05a3581de0075054e2cd1a6cc4b8234f1d0883c2502fd24430814cfb46a72b24b71a000b177d581df195c68b19f4e6d2eab64d1bcca65ccf70df24f1c3dc7052cc5f4dd0441a000b266a581de19300f3e0d82db9483609be0a23bd2e79b8b08365f806ea57a83626ec1a00033bf508010ed9010286581c440d084672d72104cb30d8a421f78872781bc3753af662173d2e8007581c4844be6a486f57e7070f5ccd3761ad89979a9e685dd92076518b14e5581c9530423200a7f311ae3add06dbd6e4d6d3e0f7c9a4a71751bcfedd08581cab3492db3f6b26a410b73b1dc6a742d9904c901a91101588e6f0d56d581ce83dbab87650bbfdc231cea60d686cab6602a04162e299423b315890581cfd8a29dbeb5bdde5931d4bea573df2d62401f2d48fa5ba8fb880b35109a1581c2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2a141371b758e3eb05f415fc00b5820f030bd94cf721017bed5987c6a2d318ac55185a635507e77ed8130d36ee630fa0f0114d9010285841a00041ee4581de114553c3f7e98ac2795b71297a3ac3f485868158093985d59cb3a0950810682782268747470733a2f2f4148784332574568423570654a3463565348476b43522e636f6d58207bcbf33fb82470eba210d9d360b29267e76d0730c2547ffdfd9175886de7c68d841a000e8c02581df04b84c7180c1a768e8e73a65fd9c577b53bccd683ea0a3d549a3a06fa830582582076ef768e798af206e13526a5ae5cf7c5c35d0e951537d8e869e8d4c5c0f36403038282782b68747470733a2f2f2e4c61734667324756477a6d425356654b564e585553485430676b4c446b532e636f6d5820843cc1fb02ac12fe7d28406e935edc2d292217abf2df4e372437689b35b146b0581c92a9cc3329aa2735bb531cdac24df2610c6801a6f1ea0723858db76c82783c68747470733a2f2f752d414876746c6131515a56564e2e734d4a7552745a3675586a6f4b6e31665a684f38692d4e6f3243764f32634673792e636f6d58208e5bd1962ffe3b1b475ef9fc8ad725743c361bb8447fa77bf611464f8ca64ca284199968581df07427a7686e1e490006038955c10aa2bf5770668eaeac344c973f6aca8305825820d47a6694e440e20ce8adf8ff6254a6565a26052ad7dfdc4a7371221266109f95068282781868747470733a2f2f634f6442487248474e35424b2e636f6d5820c271682ad766ce241bc5ccb9c9ca7e5814da77b8ebcc38b9b48f703fad4d050b581caad4ee48cff4f15dd9b80ec1869997edae42bf0c52283ece7619a78f82782468747470733a2f2f31763265554d632d326232582e45782e64524851686c68522e636f6d582055c70dfafb128d0775f2bdda825259a641797b38b78d9a6165148e4143c8bda6841a000a84a0581df0078da10a23beffe20bfb47596951bd4ee35fe59556fcdc5e594e7014810682782a68747470733a2f2f44443864424d4575436c34726e736572392d765a5130727a734158366a6d2e636f6d5820d4a241eef915e659a7e8eb57a83707a1043347c6dec04cc32b5cae4e104b5b92841a000b145a581de1c01180dc8c69a3427873d3eac48a60ab8486133e97d656f86af1b6eb8400825820a40b7f925fef712d558dca4ecc545a852c3ce99ba90e6eb4212df161864d844601b819001a0009514f020103060404051a0008f7b5061a000131b00704080109d81e821b754c8607cb576e031b0de0b6b3a76400000bd81e821a02292d651a02faf080101a000908b0111a00083e2312a6182a812c185b80186880187c862b032b0f2124188c80189885050e290c2b1382d81e821b52df12270a1e8d3b01d81e821b7db24f6e4c5cf5fd1a05f5e10014821b55ef9301d7f1f0591b1e774695614f173715821b2183933edce8319b1b41ce123347f44a4416061706181802181a8ad81e821b00e4ef13995268cf1b016345785d8a0000d81e82190a1b19186ad81e82191ec1192710d81e821a2f9ca00b1a3b9aca00d81e821905d51909c4d81e82183d1864d81e821a000578d11a000f4240d81e821b000012cf660581fd1b000016bcc41e9000d81e8218451864d81e821a1dadb7211a3b9aca00181b01181c03181e1a000bf497181f1a000ad824182006f682782a68747470733a2f2f566670356156623349543862454c305569774a334e766e424d58786d34552e636f6d582050a4681a5f1619f63d29483dfc37ad02594f97323b0121b8f1edc2d6dec78828151a000524b1161a0009bc07a700d90102868258203bbcb6fbcbf6b3b8fe402e9e7c7367362d9109f155848cd47f6d8ad5a31879a25840b335e057cf63f00f2d4f03d5893126234b8465b5b0d6a30fd32dacae528650acf410aefdab79c79cba595b26822881d20f48b694f48e1e8b77ea063139021f5a8258203995b75c12591c09bfa67e83512699407d0797502ea72bfbd3d37eecf3e2f1dd5840d4e133edc74cb2cb545844c3061ff30ac39b9a54ee02c97fef3be1406a1c94888d082961d67e6e884bac042127cbb779c2662f206fbabc301a78a6519aff820782582024289da5e1cf66c067987f6083ad9f8cb5466126eee8815ca92021fb99b03ea35840bb2ff02d13753b26e201fb11eb6ad19c2b7bd3da91fd9537e79046b41de1e4340e492ae57711263ba7d4f2ba1384daa4c24fb1099889335c7e1c1a958c165e4f82582068ebbf23ed31834423bb03542115d3970d0f384c4c6265a062626eea96527c7b58401251b7c3c899a43ea7aa48e355bd2b9871e5ed690307d5768af2e904dacfeadb5f35d6440ad64bca8e987fae49797bcadeb92c07cac63b5588216193ff41769b8258204d78a8520dc4a5517733dc5c369d88d5c1acf167a631a6d02aa042be0cfb20f558409ed42c88988ee14fa05296f2001aa227b7f0567b1e78aa0c1e99d8b0a1cf3fa9e23ab82cb7b0751aebb2f7ec658fce712930be50ff8f8504261830e35f08ebd282582073282e71519201ef6916ea055308dd1478b1d1d89714375b57f88cb277d68a5f5840c384a1d33f6bb84c4ae850ae1ac1fddcd0cbb186fde5fd6d1a12385e3b98c44504898805ed6a35957dc7ff7acfcc883053b091ff32b57cc5fdca8ce86c1834fe02d9010282845820444afaab1bc23bd742c334fffed48ee3d17191bf7680e34a0acd440bb7c75f445840ee3fca52c0d8eb095bf5875758f4d1bc617d5eb54a885ab212998992c8c0c64a9d81bd631f2b83130b9345d254090db1d8330a2e8c9b7da8d162c7a456df4fd8459af25f9d6842bbd18458203be44c750c995bce80b5faa32bf69ed7760a06bdc7c8327ca80313b25673cb8e584008fa6ba6e2d5889e00b584090e47af0e3b43794ce48da2fcbb527401219c3c9e69e68061c3c06a340766c56638b766e18559b74dc9f1846236d069e9c24d086a426b3045ed097635c301d901028182040b06d9010281474601000022260107d90102814645010000226104d9010286a3a542f5c6d87980a3431aa67f232042a2c301009f234246dbffd87a9f0343e2218bff9f20232123ffd87e80d87b9f21ffa12304d8799f4381c99d020240ffa49f01400001ff20019f044002ff4277c7411ea1404435a6d961d8799f2243e01fcc4479de273dffd87e9fd87b9f4444b161212000414e43bc328dffa54043e1563943e848014024010244c4fc749444d23c4d7f0541a3ff409f4276ada12422ff809fa0d87a9f427fd2ff432c597c427010ff409f9fd8799f42f81bffff80d87d9f9f04ffd8799f2220212040ffd87e9f415f44d035c12b416e04ffd87c9f04ffff80ffa00505a382000282a0821b105d9433aa4278071b15a3924164e95283820107829f9f4413205b27a303426eb2054168415602ffa403a5200242879140220401419c2144b6ef880480439ecda2a121054253be9f4253374043d506ed00ff9f41ddff9f8005ff21d87e80ff821b2ac681504c768cdc1b12d60f00c9a423158202058240821b440f4276739654a01b5262900374ebdefbf5d90103a101848201818200581ca338f2ed6ced96d35ef9c6427535c731936db5c2fd96ff1b274b795c82050a8201848200581cabd772895a784b529e0a6d47e22f8ec616f4a7b40e5868ea43cd391b8201838200581cb6d3c4a420ef3e09e1a68aa5bea28f0c5d2d182a3752575c97b960b48201828200581cb4433df0a2abe8f544444ae41e4c44fe7463060d71fc11a992a337048200581c4f46a72ccd0bb1196ec8e72d48e2ce5a4e3cf0555ff6c3ca3afdcee18200581c5c75d106a2d2f88ed5075e8d3b8002f5179e85df738efd45cc0e7a018200581c9548d0387cd1c0ed936369a512996e464a2b1fc91845b2adc17d4c058202828202838200581c757906fec82e225bcafa09aee536dc9119828dbd4645a16be4f1d87f8200581ce14004d3fcb1c5916d0be0781f32fd8de677283b04dc1b5d11c7f77e8200581c1fdb35273eeea4766fa512c57cb0ef54925eeb90eb3cdb1591623483830300848200581c6de29b968be90cab1a376255cb3181322575a0f51e975f0c7edf191c8200581c5249de502606b4fb8dc05065d7381a23542da954aa69f895139198b48200581cd47f6789f6df5f0197f8a9d82bcfc0218f514d21931b5dba005917fc8200581c78a8b218b44f47c22096fa807a45c06a2419081f7241f13e9ab97e2b8202828202848201828200581cfbfbe138a144ef0f57ebdfeecdfe397f3ad6d4f86920ee4f63ddd5528200581cf4cc7b902d02ba8a61d2cc62cfec132a338f24cd060fb88d5cb18fa48202838200581ca6b19cf79c8e51b8c2df38adbd08d49e24fabba2121d8ea51cb3fe178200581ca7959417186d202e7abe122b19b2ba8cc2d595a7cf39d61f82703f938200581cd3f77de611dfee4944eff8acf85d0abbbe7090b12206c89636760606820180830301818200581c4c354393a37d95e7fd1567f3a464ad8fc41a8df64297a0ffc56ed7f1830300838202828200581cc5fb20ed9e575de958cf9c62cd97142be749ee5ad19ca7f6b612aeb98200581c5a15de7d71aab6bf26a86738e067a34d5b69b36d90be775301ed8b368202808201828200581c6aab281bb2a4c3e95ce9dd54e8612e4de6f4de4d67f2119866278cd08200581cc5e6b82a5b75fd4fbbce1e2f95bfcfcadf307e0dbc1adf60cc12de6a",
-                            "description": "",
-                            "txId": "5e4ac9e1cc17b537a9503a502bf4954788c70d642e7054b95827768530d77a0d",
-                            "type": "Tx ConwayEra"
-                        },
-                        {
-                            "cborHex": "84b200d9010286825820086316e695d2e185e03c8cba97bb1a01c98412ac8826bea3ea68269394d1fa040282582008aba4fea25243ebaaa6afb1f3f723194effef07fa1573d3b3f93fb78d5c6f1500825820364c3cd8a6daf07b628f5e64d2ce9bbcf50f0b9e1cb6446273a04705cb895b3d0282582083590775cf536754e4a587a4059963856a70f34fa57facb5fea4cc4c7a2a00d102825820915c3a57d1b5a33795490443138abf694d39c5d4690ea8c328a6106af4e0417d03825820bd99b85b8998cdb8ed9c7ba88ab66cf474b94f98eab193103e32a709d6540a54010dd90102828258207ff90a5965ad770de41c43b143cdeb230a8cfa5da33941270f6239bc312740be01825820bd52547d964c9991b0c0705e8c02b202082a8b9b52928b8371a8aa48c2a7fa3d0412d90102818258204c6fea1484b054df72ae94b222a38ffcbecfa99efc9f1fbb2d1fff963c12ddb1060183a3005839303aec2fa7da606dddea280635275df0771800b3b88263abcf8f04a1d3f25fa58166e2b411c43851234a55a603e97888f5d5e352204b5cf72b018200a1581c245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abaea14e13514c4e65215e47c3e1127bc7d00103d818584582008201828200581cc9599a3732cc5728ce4ae2e5b5e63bc45acc5da596037204f684d1398200581c6b6b81d64472a572d8f0c30b415cbfa70431014a2b267af2cccf107ea400583910c719fab73157a83bf59461eb8c2e3c8eeea5a5030fce5fe40279439b8b76f8ba29a226a0ee48f115b547190c022cdcf1f78888c5459da6b7018200a1581c2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2a152c657ac5ae86f8c665c98886c27781a86d4cb1b18a3f36e89e33a42028200582004a54ce068a6bea5b48c933ee264daf9e4519efb0160799cd3229211c97b512603d818458200820507a30058391081d4b33083d618f02bf2c6c34cfd3ddee226e3e89649b7e2a90346c4e2198489555b0e378d6644ea5f75c80be448059886abde10e85b7ad4018200a1581c2d725128406dc832eb74c4709aca0512499b3c7b17e00d7cb2e6d1b1a149193de1b55c1e0485430103d818498201464501000022611083581d6196bb0ed4d34838a6f57bedcb091686c6fa5a807cb0d1ab624bcd2595821b72eeb64c2c57b20fa1581c105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5a1441fdf322c1b6dd8670d4ceb551e582065809847109e3aab5365da8711e47eab7f70ede6521ee20096520f6da52c019a111a000adbba021a000cf69104d90102848304581cca1e3e52183cd3d177ebefa4bcf8671421fa03cf9d3e01eb96af50420383118200581cf88b203eccfe6c64e18f2da1026d8cffea0dd3cedca0259b0fb8ce5f1a000abe258a03581c9d515e791bca08c765959e20c7cd5e00e797930d64004652ad2bd2c558201cb06063c082e22f7f5f2331a4d8bdbe976d304f3435d33011c0e4750683b35f1a000b34821a00037799d81e821b00010000ba8c97c11b00038d7ea4c68000581df03ed3d5def67c20dae967195367dd19d3b5ceb6f3a362c50ae2a7fa5bd9010285581c14ea418ae9fe8f0e4e9ddbb383deb20582ff8c745cbda86ec12f388b581c5cb728aacaa1b560ed1670c8b0570469d8cc1c2a94049c83be5ac690581c65fe4ee16a632fbfffe0f7eaf2cda290d805793fb90bf033dab42303581c7b3c66448b585ad9e83e7e5c2661fcf41d7feebebb4e7c4f6b2d5ba4581cd10d85d1df230b7fbc53f04151f049b2fd579a8ee1772ef15801e60982840001440000000150060000000000000008000000000000008400f644000000065008000000040000000500000000000000f68304581c0dce5f3b2e5ed28a10df9d211836569e5e11137c30ddbc0f23b4fd270705a6581df0203dd3d079c666d4a24b08c8058ad81c23aa1f8c5d5b94505f8fa5321a0005e8f0581df06eea1b481a5a09fff084bb0e2120bd7231cbe8e1c8388d67fd5cc5e71a000d2be5581df17c88f8fd842e8c34d38d0ab7877c9fc05949bf29881f1bba2f1204df1a000ab4a8581de125d2cecb8c01d3e7f88a8ae3eae83ce8bf979ddb0a10e4a8390ba5a81a00097321581de1a34d7f9a076733f714d6db304de33831c393ee346f55e0eb3e91085d1a000e32a2581de1b0aad2cd5e25dd98dd55e3e8c9bd445fac52815528e11a6277a6ffff1a000a9fdb08010ed9010285581c44195522b6c2a9d6e8b98d96b94a7b34863ed262e421bc1e42513e2d581c5bb9318671bef127802261f4fb10fc0e1f2adfe0745f41af7cfb79a6581ca7c04682dba94b4940fe39a639be2a06ccbd9195356e081c8377e95a581ccef66644312043ae56aa96da4968e6572e5be18b691693eb28ec123f581cec876c6e47feb526a24a6f268251ff651b644eecf91eee04b4e6054c09a1581c2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2a1523474748dcbaebc0c25ee3322e8752128f9001b7722a443a5cb62920b582046ad11db1c8a8f36ec0e27f6a5424fe1052cb7f1a74ce276dfd0fe7e7efb470d075820c151e0b0f09d1ab4dc944141b0b07c9837d9c58bdcca115e52b92f695b4d6df30f0014d9010284841a00083ebb581df001ff7f92aded49007a0ca7e58dd54378b589879ba45b1b4636f18c8c8301f682080382781e68747470733a2f2f732d6e70794975422d77657673436d6d425a2e636f6d5820e623ada8e1735545af471d1b58dab1ed0f861011bac9c754e0b0de36151a4db3841a0009ad61581de1ad6359b8fd8308b8772feccaaca3304ad51689cc6dc232979ab6b5178504825820c0f7317d088fba0ad8e048cbb4b1165ffbd9ba9455a5d8166dea10232cf7ec5b02d90102828201581cd8baef3ccfe8cce12f340be176219efd13a6f18b8f6ba755348bac2e8200581cf7dc239c127bfbc0bf61f1533545f7af19aa332cd597efa6c96d718ba48201581cccad1d9f2bfc005852e11238f631cfeba54bf919895914cf7058b736008200581c79abff33a904d023e8690ce2924b73a5dd3eb1735c34bd950d04e8d1038200581c9e3fa3244bbdee003ef9ed5e2886acf813acafb86ae16a2d56ca5235098200581cfb617f723b182b76478077ff7b3fa605db45a59b343bfbcd8f2a303a06d81e821b002c55e063acd3611b0058d15e1762800082783d68747470733a2f2f44566461796c7a6c625a5a677a3551726353793048374c723665745358584247672d795349385272577046715635716f312e636f6d58205c098ea3818458eb8576e4ac13c3211886c8a5e60624fc08aaa4caff86ea6321841a0009426f581de16822ed0ae5999b8a2373d29aaf9c631733f1fd7fa40942f229cd10f583058258207d386fbb62f1b34fba3e9e401ae14057286dbcb1f4f368fa2b7019c001ac2cb1028282783168747470733a2f2f6947616c5171696362743379686b5453536e642d79615a7570464d3272514a393077635a342e636f6d5820b8d5ed397c8875a2e59c5acea54e1fc3e4eab26d7d64e0f2e86ec80b405ccfdc581c896219b21f65599911e9a459738a86e2d51ec4ea3447e25f76d53b7682783168747470733a2f2f2e46795946454173577930335845507a61795259626535703351384467664b4e4a6973484e2e636f6d5820994facf19c8c72ec988a15202ef4e6cdf92864266f6a5525e226da6edfbede40841a00075671581df0590c2fb444d94b7c105a86a758b9439839a233926befaa2285af14a18301f6820806826d68747470733a2f2f502e636f6d58200107269166fb659fcb9e274e269e24bd33f656abf3c7ebf9d3cf1bacb0e54119151a000c82b0161a0005cbeda500d901028182582014b0e8357699de23a5998bbb8b6e27ecc9dfe1726a30f1e602a58a963f59c96658400f94a7cde6bd3807740760cd2b6973940a70665b2fe49600411150e26ae7a84e861fb2d0887642565611a818b9595dcb1291db0b37af35332580ef20784310c702d90102868458206b0f71884c1a520b02052a15d5dadea4b863f02f8ed2a634d8024c35a68ffa0b584079720ee323f721e2fec6ca161f58444fc04f389e702c046d92059ffe76abebc4c0d91f45ba7adda65ca8ed0f6109be535ed0b533b39d6fe22f2f61d22dcafc0540411b845820b286999c26e85a94d9a9a293fcb2cf09fdf525c0b80d6110465834fae552bac65840207f4212464db7ee144920cdd9476d288b6e07f47907d9c0c36f369c8e3534ac772b6d42a26322ab307bf1d623035a41c5580a34f268e3e5da0e28645f96bbac42e162441c33411d845820331074a409f48013d59f141a31181ed8ee0cf98679b78469c1590e915fafbbcc5840a262c97b38ff1546fd2f991a5b418d9372c3382b52e3f520e7b3b57450c5e8842255a23dc6b1a23632621b948d062b18bea47a1bf024b85229b2a14d665511b64574a1828b4f43d78ff9845820231b0cf40df2e7d67a7708e11426c9af62fcff187d20d673f4e3a6ec35d78976584019094c7deb2452dda97a0950b5ba59b90b8833325725bc271fe1bd4ae61ef65dc35d945f4bc785b754bef2c5234c43e364baf8f94d8eb2e0e856d093ce71f7af42253141b38458208290a29d05b8aae818e8ea2ff035aadde943f9a2247f7e3742169bab91380028584085ac1bf1a6d7bdd45b1360e621b888e51ab6c719e78029c655b49f9c90055567f2355f74b0ab2af63b178a9068f47efea6e628b88220727f2a0f8e6d5ec1ba464043701da184582065cc91d5e723b487a97a1f694ff25dcb399cbfbbe6eea6b86df80f4f5e8d8c7658407f99d407d3fa0a2a56790b75b54e53f3085b9adea120c8c06a49eb9080b6e0c99f603beae3aa879ea9285541f80c205bf536caea22949e6200cd79c25f1f5f4c4043c5ddc701d90102838200581c8b63bfbb995d72756b975980c85d1e1564d87a9c3ca3fbb690f84ad282050882018182028004d90102849f9f039f42e9102043b12e54ff00d87b9f23423691244003ffff42cfab80ffd87b9f9f9f40432defd80543c5f648ffa0202043bfb8beff9f23409f446411c805429d3b00ffff4142d87d9f9f240340ffffff9f44aae938124103ff43dc772c05a282030782d87e9fa29f42b0c802442eedaa65ffa1434323a24291f49f05443ecabfe0ff01409f9f004412ba4c1743f6aed940ff80a3412d214343b6ce0104028044542d94b3ff4219829fa4429497202142993c204163212244d89bf8fa9f000443c6a26dffffff821b032fafeaf1a58ee11b3e7272375bf8761282040682d8799f209fd87e9f427661020024ffffff821b249c8fd01bca95541b7b41adc3906a5be8f5d90103a300a3008162672901240d8143c53e580184830301848200581cdf9c63836953a205a69aec1b1d1780f8a742433ab090be3d10c67b2c830300818202818200581c5ecf1edeecb6200ab71fd447b698a068cd7321d93c42d0e2cc4ca9de830300808202848200581c6bdafc0e9b46394ba533c6ce8dd2c201437f39045e4c75028347aead8202848200581cbaaf87d7feafdddfd943f1f0b17afe1b5894b9553146d6bacb12e7028200581c174860cf6249019dc3a2e20d1248d560f40d9f52194d2631d54c98998200581c8ac0dc0c15273186c02cc8c207cbca6bb586eea5bb90ce8da3c075808200581c0dd28ab3ecd9f477abf6e48d8e6e77e66458ea42ee216688557593a4830303838200581c197f82fa6140a81e2682e8b4262fe9905cc335eeed73a7fd3ee21c808200581c72be1dd288f90abf23f9c54dc4c937fad1c9a6360fb7006af39a5f5e8200581c5fc4e6f1270700bc872daf84899fa5c0ffa3c28ceb011cf723cc052683030080820182830300808201808201808200581cc8329ba167878a44343c12b0146d641e4b525853115369aa7db082c804814746010000220011",
-                            "description": "",
-                            "txId": "ab9c8026debf67838e7176ada02ed81289db510ec64725262cf177bf3a75615c",
-                            "type": "Tx ConwayEra"
-                        },
-                        {
-                            "cborHex": "84b100d9010283825820197332aeccd9b21796aa77178b7c4b20f3202b97fe973e8ace6f8790c5c0d12403825820eb8ee47163eb300b706ee805d02811a5adc8656d156b32283a25a38b370c043607825820f6337dd6145c8491fb79cfdd5e411d6400327920f80ff7d6b4bcc35faae69f21020dd90102868258205e4a74dc223d634cb7bf7bcf4a1bec60520cdd9cbec950746a439393354226730182582077d53268807c95f62fe03c4b95f83110d7b9846b1ed740bf984ca899b2bf2a76078258207a9e8fd89d49616c20da04d94fbd609ed6c96607dffa9cdde6e154efae9a189008825820cac158db37121d422ff157a293a68008f66d04c5de01f003df3aa9d401d90e9207825820e8f73d55c668b90e317d167e775b6404c9220bffa6315cad41e7156d8690395805825820e9dbaca24e3ab7199ea4c51951c69a011521c49980f2d92822fbb904d77fd90d0112d901028282582059f0c31641b0916734e46e88dc08431e8f6b92063e8434513481c742feb2f88a01825820c600fd34909ae6347c8281a2ba74cf6fddaec07c5398bc1e9af2f5ff81f7452e030182a4005839303e4c6887b44989ca2d75cd470746c2c5f6ee73332c19d2e1ba6c5df10549a668694c5b93d3cc26bca8389a7b3927d47a39e076a07847ec74018200a1581c4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888da141311b38826c4628e95490028200582031f8f9cf16f9f08245c7372b8adfee8b7555436726622b76d320a1803ffc2f7503d818584882008201838200581caff3338950464f600f0014307a2e561224669ebdad64c0eeebd726f48201808200581cedb89caf7f3d22126f1e57da3ed58b9e54f0338ded5c990d53688acca4005839303a36690b20b5ccaec19f0e21ece3c364b103821aa8e3215578474e1170b974e395eead46215aa52c0dcb4ed7ef040280d0b4c2c1e751172001821b1c034b940d949ac3a1581cb0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165a14136010282005820bebc1eeaea9da213963d320c044ac00d9d9186b8c3843813951e171ff78fd73d03d81845820082050c021a000e27ff030405a4581df10ac2ee59ca5f8044f9092c6d73d19b82b0013c94831ba20a7866083219fdfc581df1ece266596e4afbee20a96c26050af588105de04f9cd17f714288a6191a000b8b29581de1213408160310f990f546727973428428e5eb7e4787c02a24ef7e53a91a000914ba581de188d062669b0541f8ea3dc469aa49d7bf61d5dd25fc4c02b5f18e8b011a0004a0d208010ed9010285581c185696b788a2a4c8f116fd7be9685b9a42b3123f9a686340fe7a90c4581c1bcfec96ca03a560e303b9b29c0ca03b13d45bcef59775bbb00cd7c6581c46bfd3bfd47956e8e49d7ac5c460ff8545b7322773ec1d3737cedcd2581ca10ac2223ed9028f45a0a1caef311f419d93f3a3405ed341a7fd85d6581cec899efeda85c4c2ed3cd4ba75b6621ee7d5061cfa42856179d733f309a1581c4d9a9b305bd990ee862961bdb11ec35784f093542cc0bab3b62b995fa141341b2e39027c75f9c9eb0b582051fbe28ccbfa6435f36a3effd68cab4eb7c9cd116f92d36ab860c341c74eaf700758203ac478276e333727378d1eca163c047903e70bd75cc86189d419b55f31722a0b0f0113a28200581c5c729253dfa1c60839adcb0b386a32d57c6cf1c5f7ccaf53cfcdfe16a182582074ea949f6efa1b3431d02266fcdadc58cd1db25bb12f9a5db570fcadbf23d1f003820182783768747470733a2f2f5375744d77303034786974334758504a6a57726b6a434d49556a4e4f7a5676594749485a33427036587a6d2e636f6d58203176029aeaec865f7dd7d88d76af6b097bb6417da1414ee2573ed1a4832274328204581ca9dadedacbfd68e043be9fb8cdadcc26bfb6bb3736b5c6a5697fc6f5a68258206c291643c3fa0db40d85856b6ac8e725af99a712b0a679b625f36e9e0551ec5e00820082782468747470733a2f2f4f4e43694e662d6a72584b786f4e412e7751393539466d7a2e636f6d5820217de66ef02b4c52ff31dc0d231c98ed70ee43da9cf7912c03db1c4636d840d4825820832df473c902441f373e79a69117d2216bd9cb4d7802ba29caf0fa07f4bd274c018202827268747470733a2f2f536b637346662e636f6d58200829ffa0b2859f0d273426cd12b37b09cfc0b75c0a72c4b3d099cfd24b9975a38258208c5984e0b3b07184e8819b502a94e4e04062a1e334c5f5776626779db43e45c4068202827568747470733a2f2f746f3636332d394e572e636f6d58204cfc363feaa84a072ce9e87982805af223cec9cdc3c954ddba529fef1dec37bc825820949859376127608bd1101d6264a5dcc945061b06a89401c2598d0b5faa05f3d704820082783568747470733a2f2f764a78376374624a7077794855755a4463794d496632585a6444783237346e4d5965796e346c77376e2e636f6d5820127ad1d0844afd7882bd6ff87f59f49a44f569c6b0e8114c34f965299a9f7734825820cfbbeb919cc0b243284689a5662f4895e96a4f868bc89ea73943110e57e7665206820082782a68747470733a2f2f792d74767431304b6f6d3977467743365a4755645573716468633667434b2e636f6d5820033b438726d38a1c91102346195fa4ecdb960935aedc5c57f3ac8d89885f3260825820d138e7b2bc461852ef9b4840de7444f3dcb21d60fe2cf2042e1726af193c3efc018201f614d9010282841a00062ecf581de1ba130bc830360fedd797b16f6c7da071fdcf1a01d07efab33f4511808504825820db7602f9bcd71069773a88eb3944a67df2c5b0bbbfcb8de11ce004fc10e2c94606d90102848201581c4920969e3921cc0c5246af9f8547d6bbb50c35176d1a3c908a9c274a8201581c7029f59dbcbed06d66a8effea86dde9074aec2fcbcc24da62dc8f3188200581c156280122757ae29b7174221d574bd4bda018760eaf35a7c72c2bded8200581c7ad1a63a65be1481d559cd3a25f7624dbb19ea922e688c254781e107a38201581c295044cd1c831e9dbe04e963079f3e3d192f7e319cfaba2ade7410d40e8201581cf4a987b80c67269586b7bca79eda42d70acc0fb09abb20b4dbbc80a6078200581cd825296a589f962a485f5b5238be588f721b4f343516c64bbfaafb7308d81e820205827368747470733a2f2f4a4434356438322e636f6d58203b61a4f7b9574b9b41401bf1639234e05b881c62d3eee3a50e04671405d1e36f841a000af26e581df123bc35f29436227fb7abd0c7b1dde55df45118e948d4508a87b6c3ee85048258202aa1e22eb38e91c455dd62909aa52b2d94bc82bc2b685cf40e50f15859cb3f3208d90102858201581c1b82b5d6b23a565cd1227d59271e64f2ad824ead6ea32653ede4df198201581cfd1c89f03e9f4bbe879d80921ac81fd027702bb34a517b0fac6c35988200581c3f057e6bf818f4923880dcaf3d0660c3651abc59216bc5374eb73e518200581c4d141a87490aad0f7d3ad7a60a1f30eaa8bd8864c3bcce467a2c3a708200581c9f24241f4a7201d70f01a0fff362d9df2e10180ea7365ff4fa28eb1da0d81e821b0000037ff613a1431b0000048c2739500082783f68747470733a2f2f5642767a38706f6e652e7671694354724f4e78346f686f79384b2d4864687a362e456b64433962337066765044692e356e36552e636f6d5820e2d10d982e32880972ef95723329a5f3633f44f20a1be3e48070267594be0558151a000f0abe161a00031048a400d9010283825820b7661bcc4066cc19d5cd988977b3c4e020c7db50c80b94737e211e2f057311e458405ad6f48a0c2bad285b548ac51464fc2bb8f0ded7a0947eaaf98fff4b62a5ac593544b61aab03d9b8193f5eae361fc2282592e1980a676ded15538748a0c64fcb8258206abe1097081305e78128deffdd603d155f518024dcb78b7bc34bb4c0b838f6f658404eb6b206b21863a66ef1224d8de44b4bd4e2e58db1969723e83829f4368f2227e625882f99dcd9eaa3479e59c917e4bcfeda0405f0c31cef69546af73699590382582027d49d8522c7a31756a1851c3a391a7a5c7edf751e3560f44becbea6fc44c6335840a7276a5d239d2543d32ba02bcbe1dfc8f9bfed4d2e119de08a2bebf0346ef787ed9721b11c4718eb3db0e17ba455a4efe240feb6b20f4663b91afa02c30db55a02d9010282845820eead7de97a838a11e1d6bbf30859fbef3bc008c7ab272a0055cff5f45848b9aa5840b8e53f63f504cd51c12349bca9db5c6c158cf35155e8259c375e69216f47a1f8d5424428dd99e504504369fa00332fe46efa4f9bc949120d5f804c8826f69fa745fc55c09a9f42ab9a845820df1bed812a17a524506417d580f6d1ab998f97fb26120d55866b84aaf322fd4a58405024051d7393bdc047e6c3b7cc333ffc120de351e5b65a4f335961535be2bb03750a40fb85f8b9d18b2287bd13a51914552366d3b70b7826373a50f098d570d0414e4001d90102858200581c63551f8bcdf16aa56f24dab55ab67fc3d5112e817e45bb4c1044f49f820182830300818202838200581c774cf66a23c7e8edf8110544d9e606d89431c2cbc16a20828a1efd798200581cc1aa95153a7d6062cfa81a1a7ece2685066ccede7c3e9a9971c9f1a48200581c9e12cef7938536e7c18df71294d9ad20917b5de3f187fd4de5e4d8498201818201848200581c96994964bae610a6febdeb97454d7791936cb987bbd4b9e9127160df8200581cdce533516229a96bbeab882b078566fb30bb55f9dee7e51bc71fef828200581cc2fcd33196b729c4127e92e0726bb952ba960a39434faf9394326f868200581c8defcc772b0b7536b9980e985bb87b13bd84f6890573db93e3dc341a8202818201838200581c2dcf5af2b83d5c58e16d457e37179332bca99305b1c3d85b0b6593988201838200581cc7ddab595e5ebf1f415c120adf749b3f2d73ede5ac550bd727c9180a8200581c35287f0804fd304e0cc02d6ac7cf61359831a8c9b9d80095991427f08200581c7c643b22cbc00731c89222bacdf9a10a97ec984454bb3d1936d254d58200581c52bf60e728657cb6f2b84011125c8ee5ceaf907b8b6cbe8ba279a1338200581c04e98a8aeabbd680e025d0fb0ad1ecf9e4dddab05890a48866aa9a608200581cc3f06547317fff7dbdd9b61a03f75770bd469e5db1ba686a6d8e438005a18205078202821b2efceab01f8e7d571b52d17605782f05e1f5d90103a20183820183820280830302848202808201848200581c99ce0a11782165833e8f61c4db2bfaa14654e38e36e5ffe7925cb62e8200581cde6494491b80acd80ac20894f8f773fd0fcc4b7d719505830faa12e38200581c06a394b6f8fa2754ea977f0ab23d9dafe1bf82d69db5a14dca9e912c8200581c1799b535ca2a474b7d2762add96dd3b6ed0082add5f601cb1b35da7b8201828200581c7868dc9940525596271581153f25448e0b5a3efab85cd7a084b3b7728200581cc5dedf066db5633e141f902c13e133deadc55d1c2b1f0bd1fab6f9f48201828200581c3758f45807545c49ca7557f053ba917c050b9b8a164f014bf2a97b1b8200581c2a2221856c21867ca35e897bb0d83392dea0cd654a27013838535b38820283830302848200581c954316c3cd83c01a7ef0b38cf03770c22f1a90e08389745e3d71ef2b8200581ceb39402d3bdca28a8f994c844e9316e6e88441cff2c42ddd46fa9b938200581c5831ca8788ec8012834e124a6242d50ec80285ebcea917a04857e1118200581c9d5b4833c4d6f0ef8ece2456fc6ba0e097d5678a3fd593d444bc3ca58202818200581ccec58609ac41e4a164922c874e23d09ff13cd42fd1b535573f25a2718201818200581cac551624555034ca8d2d02c3a50e83af12cf44cb41dcb472b2884dfc820501820280028146450100002601",
-                            "description": "",
-                            "txId": "e75e74ed5fd3c4f5c681fe294f2e4982f882005558fe13d56c31a7170ffa1890",
-                            "type": "Tx ConwayEra"
-                        }
-                    ],
-                    "localUTxO": {
-                        "0004060703030600010008060001040601060605040808040000010004080705#36": {
-                            "address": "addr_test1zqfwlnhw85ft3tutm5tdq8nr9f558yeuzk8caextc2zfjlgvxdw3zd78sant5e55cxsjusgr0llctxw7tmdqrljlwpgsltfjj2",
-                            "datum": null,
-                            "datumhash": "986b7fa35c279eb2ab036272ec79893fe8243393381bed1b843fa71ee2595bd8",
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0203070803000406020608020301040802060101050308020200010105080200#63": {
-                            "address": "addr_test1vqf35ahqvlelhwyxfq782av05u33wpvdkhtcgjdgd93uxrgaj93tx",
-                            "datum": null,
-                            "inlineDatum": {
-                                "list": [
-                                    {
-                                        "int": 4
-                                    },
-                                    {
-                                        "bytes": ""
-                                    },
-                                    {
-                                        "map": [
-                                            {
-                                                "k": {
-                                                    "bytes": "b3"
-                                                },
-                                                "v": {
                                                     "list": []
                                                 }
-                                            },
-                                            {
-                                                "k": {
-                                                    "bytes": "0fa38862"
-                                                },
-                                                "v": {
-                                                    "constructor": 0,
-                                                    "fields": []
-                                                }
-                                            },
-                                            {
-                                                "k": {
-                                                    "bytes": "b325"
-                                                },
-                                                "v": {
-                                                    "int": 2
-                                                }
-                                            },
-                                            {
-                                                "k": {
-                                                    "bytes": "53a7"
-                                                },
-                                                "v": {
-                                                    "list": [
-                                                        {
-                                                            "int": -2
-                                                        }
-                                                    ]
-                                                }
-                                            },
-                                            {
-                                                "k": {
-                                                    "list": []
-                                                },
-                                                "v": {
-                                                    "map": [
-                                                        {
-                                                            "k": {
-                                                                "int": 1
-                                                            },
-                                                            "v": {
-                                                                "bytes": "65"
-                                                            }
-                                                        },
-                                                        {
-                                                            "k": {
-                                                                "bytes": "16db48"
-                                                            },
-                                                            "v": {
-                                                                "int": 4
-                                                            }
-                                                        },
-                                                        {
-                                                            "k": {
-                                                                "int": -1
-                                                            },
-                                                            "v": {
-                                                                "bytes": "63"
-                                                            }
-                                                        },
-                                                        {
-                                                            "k": {
-                                                                "int": -4
-                                                            },
-                                                            "v": {
-                                                                "int": 4
-                                                            }
-                                                        }
-                                                    ]
-                                                }
                                             }
                                         ]
                                     },
-                                    {
+                                    "inlineDatumRaw": "a4a19f421ab3ff4434cc786844300232ced87b9fd87c9f030444f775196a4003ffd87e9f43cd2b5e20ffff426a129f9f0144a2026b014043802561ffd87a80a5423ee62442f040042224448014e42544968120f0400503d87c80ffd87a9fd87c80ffa44469e984e402229f014240b1232424ff05a544dd89a25d44eb2089644002054497ae376941e8210101a14042c563d87c9f0103435ec5af01ff80",
+                                    "inlineDatumhash": "ce1492492eb815bb9903b4e6a89910d9c8f3c27600ab8cc8ab81a79274e00387",
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 1685210
+                                    }
+                                },
+                                "0800040201020603030601060202010300000401020605060604080702070002#61": {
+                                    "address": "addr_test1vrq334q9e6lpcj92szwsse3zeqf84230h8t9lquqnr632kgvgucqr",
+                                    "datum": null,
+                                    "inlineDatum": {
                                         "constructor": 0,
                                         "fields": [
                                             {
-                                                "constructor": 3,
-                                                "fields": []
-                                            },
-                                            {
-                                                "bytes": "0c25"
-                                            },
-                                            {
-                                                "int": 4
+                                                "bytes": "3186"
                                             },
                                             {
                                                 "list": [
                                                     {
-                                                        "bytes": "e196fc"
+                                                        "map": []
                                                     }
                                                 ]
                                             },
                                             {
-                                                "constructor": 2,
+                                                "constructor": 3,
                                                 "fields": [
                                                     {
-                                                        "int": -4
-                                                    },
-                                                    {
-                                                        "bytes": "1945"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            "inlineDatumRaw": "9f0440a541b380440fa38862d8798042b325024253a79f21ff80a40141654316db48042041632304d8799fd87c80420c25049f43e196fcffd87b9f23421945ffffff",
-                            "inlineDatumhash": "59c6a17ff7ba7d0d7f9877e78c8765e906730a4dbd287eda6b3a19aeba9fd45c",
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 1172320
-                            }
-                        },
-                        "0300080008080605050501060002070303030601030607010701080000030205#43": {
-                            "address": "addr_test1yruk3uq2228nldhfwpt3wlc7zc8rqapyl7atjwjlxe3p7w3kld5u5dtdawyw4umzwyl4njayf30z9kvtfvn5ny8w3krs2lxv04",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0702080500020408080301010207080800000603030506080107070102030406#46": {
-                            "address": "addr_test1ypke7apxf5pynsk2x0x53u0h58g5c0cz02zcn4tedvua996ztujuyp0v48mvrcxr2rw9fem4jkzjuwhzemyykp4nqh4qnefngn",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 969750
-                            }
-                        },
-                        "0704050102040203060007060506070000010405050306020405030708050407#8": {
-                            "address": "addr_test1xrhf5sdcdpa3vuzw63350nk6jpjc77z2875waf5kvgwefufqg629r64875dra4sdqlgt29pda6k9suyhd00d5g0u59sscmsg6k",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
-                                    "36": 1
-                                },
-                                "lovelace": 1124910
-                            }
-                        },
-                        "0804070405020605060505030003070600010403050405060301010107040308#64": {
-                            "address": "addr_test1zpwshd2y8wya9v4x9td0ruhskp8yhh99s0dtxkdyhfhzfrdsvsdmgrapr7rlv03ltgaurj3w93670a955x5qrthq72wssngg69",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888d": {
-                                    "bcd7493710": 1
-                                },
-                                "lovelace": 1142150
-                            }
-                        }
-                    },
-                    "seenSnapshot": {
-                        "lastSeen": 6,
-                        "tag": "LastSeenSnapshot"
-                    },
-                    "version": 6
-                },
-                "headId": "07020001010706020408080606050806",
-                "headSeed": "02040200030102080101040806050005",
-                "parameters": {
-                    "contestationPeriod": 31536000,
-                    "parties": [
-                        {
-                            "vkey": "76ec478e3608c1632e6735b1b0e2bc1d17b963856e851b121d4c0759de50e437"
-                        },
-                        {
-                            "vkey": "cb01ec424a8c5b46c6da36cf142541169437c8bf9e50b2339029f7573571ae78"
-                        }
-                    ]
-                }
-            },
-            "tag": "Open"
-        },
-        {
-            "contents": {
-                "chainState": {
-                    "recordedAt": {
-                        "blockHash": "0504010207010304080200050800020607070005000604040301040507050104",
-                        "slot": 5,
-                        "tag": "ChainPoint"
-                    },
-                    "spendableUTxO": {
-                        "0206060804080805080201030504070601000605020703000401000705080007#3": {
-                            "address": "addr_test1xr79v6qmwncyv6nzxgs7qgzl7aymv9g24cl4hl0zcrpk7kyca3q359q3f33q9xcaewu2tuh727v62c8dzcq9hl7dffhsduhsgj",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebe": {
-                                    "33": 2
-                                },
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0306050505080601030808000005070804030007050500080801040000010408#82": {
-                            "address": "addr_test1wpkawn8mdx957kt7juyc9eamkd4td8fnqe20022quq98j0cfx5z6r",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0500060207010205000001010204060107000207040300010605040506010300#40": {
-                            "address": "addr_test1wpjackp6h0wfljw3g8ra3lxf0z60x5wc94v20tm8u3ax9hsvkk434",
-                            "datum": null,
-                            "datumhash": "fbdaf7f400ce586c1e6c0b4a8e278ebb8c5e46f4706581ba076dc5261338bf1a",
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "9bbf492834e736e68ac129ed9cb59b505abc5655395c8c5af1c002ec": {
-                                    "146a127136c5b6863d04": 3538251860117995084
-                                },
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0501030701080603060700020002040405060506070507050008010701070307#55": {
-                            "address": "addr_test1xzp0wt9ez42s33rrx5gsmdsszg0qq54ccrxlcx2z4pm46klk2cxmudu2glttdrxzp5v5ursshwgv7mlw73zrxhrjjc3sxgpezx",
-                            "datum": null,
-                            "datumhash": "dcdd35ff2882ca5fa90815af66741dac2a64894e2148e8a705adab551a8bd00f",
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "d5e4343794a7f7c017d6968d2e5f1e26b41a44c88bd000f1c4db30e3": {
-                                    "ab48bc476b0ab87a3c4f33e0710b30775b1f7cff954085c113a2a48d9349": 2
-                                },
-                                "lovelace": 1400750
-                            }
-                        },
-                        "0603050104070000080103010004000703050408040106060201060804070708#1": {
-                            "address": "addr_test1yr0k4k9sm5z868e0pvlrckhmgy5mqyv54egcu0l5u24fu6lrplt0eg020rq43ldpstysmkgn3ftx52h0tv6v9dn2d7uqj9dz70",
-                            "datum": null,
-                            "datumhash": "79cc03d473b7f77d99fb4b45fe8cae65a03efd1e74bddf30addacceee1018751",
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "1a30e5ccccef40c02c4dedab2a28fd94c583994b1f96f7a928dd9ef1": {
-                                    "33": 1
-                                },
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0805060404060702010000020607040306030408070200050108000001010701#24": {
-                            "address": "addr_test1yqpn2narq3hs45lju3mhga68lcpflr6lg25ptp4y0zjjj6tw39e77rmz45jdcca8t9lvjae63aprnsf2ph6kl69rcqms7jwwnc",
-                            "datum": null,
-                            "datumhash": "69a37c9cb6fdf3a5cf6b360600bcf62c3ce7a23cd89f1ac6246645c0dd3a2edc",
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888d": {
-                                    "242e01fff148f18ab183": 7488919547600102258
-                                },
-                                "lovelace": 7500000000000000
-                            }
-                        }
-                    }
-                },
-                "coordinatedHeadState": {
-                    "allTxs": {},
-                    "confirmedSnapshot": {
-                        "signatures": {
-                            "multiSignature": [
-                                "1a65c1acdca9862de4faf658b90226339f269cb8a82fcea1c1eaee26440c815028659bbe206ed4e0eaba144b24b67f9b974c5cea8163d5695bf87bf31c2ab70f",
-                                "364046dca0ddbc7a4815a5f1c5b4502eb503da9933dd195c16e26a0a8886ddafd21dc7ecff3bfaa35b47381cc15f04a20ec9ad8ec11698a99c59d85f5b87d00c",
-                                "66d670a861cd1c46135ec932031093ed2c81d7982559b2f4a5743f6b8d908e6bd5d9e59b956b3da19db14ffbc2dbc4a64c9cffa2b36f722877565ee58c4fff00",
-                                "f2aa562e9c33902377f8b89e5094d049b82a090597317a897c0432f36666eb3e31beab2cbc4cc34e7a3c64ef1b36bf1ef95ef7dfce2655be8538c78a40f31508",
-                                "b192e3a9e8a760afc30deb9f3f41bc0e140d6995f39e05111d61ff29344dc2554c7401c6f415a887723d6706c54f258a9fbf302472c1e2bea6347ff63c27df04"
-                            ]
-                        },
-                        "snapshot": {
-                            "confirmed": [],
-                            "headId": "00000100040400000107040607070305",
-                            "number": 3,
-                            "utxo": {
-                                "0000060100010703080004060702080407080806010603050406050308040506#62": {
-                                    "address": "addr_test1zzq0jcrp4clc8dtugz6dg26nm86vapwm7d7p97qjphcw8uu90avj2pf59am98r9tzhsv9esgzaf2mv2672u63ay5tftsk2fg6z",
-                                    "datum": null,
-                                    "datumhash": "dfd08a331dd3b31fedaa1c2e7e4aaae127515562049f26c4cc99c8900f1e781a",
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "lovelace": 7500000000000000
-                                    }
-                                },
-                                "0005070000050708050705040202000602020608080704070707050803000808#45": {
-                                    "address": "addr_test1zqp0lwvy6w4c9p22pfg8reqhxr596e2vgyv053uum5p2tjn5h3mgdgvu6jj8gj820wzztq69m9qtshcgtcm6kyu9gd6ssc02a2",
-                                    "datum": null,
-                                    "inlineDatum": {
-                                        "bytes": "f6c24a"
-                                    },
-                                    "inlineDatumRaw": "43f6c24a",
-                                    "inlineDatumhash": "e4a587096cc49c7babeda29ea2165f37a9b09d8529afa8fa579f4fc0a013189a",
-                                    "referenceScript": null,
-                                    "value": {
-                                        "8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3": {
-                                            "aa79689817363e408497c02fa0721900fb537f": 2099161387845765845
-                                        },
-                                        "lovelace": 7500000000000000
-                                    }
-                                },
-                                "0206000108050204050104040504050505050604080102040808030200020205#48": {
-                                    "address": "addr_test1qq0z5r9vnydul2s0c5em49kqmef49fwf537lt835ns3mr928rnywh53lp5v0vtetka7468wdyy0lzakvv6zqnldnxrzqthynkr",
-                                    "datum": null,
-                                    "datumhash": null,
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "lovelace": 969750
-                                    }
-                                },
-                                "0306050302030706050008010601070707030707010801010802050606020506#17": {
-                                    "address": "addr_test1qp4ddxp9k9t5mnz22ywrksfqzg44ferl76vnn3ujukzu72q3egu6uwnagt4frtmsx96lsf9gxyhfuvczprwl9ttetpus083e4s",
-                                    "datum": null,
-                                    "datumhash": "f6afe5b462b71966874e25657e2ec9383a22222479e5380d420e62026cebe534",
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "a4c0c873781e64a975eb814ebd1e2e8a3c548a11e7b476d4e51d68c9": {
-                                            "38": 4025265348991785196
-                                        },
-                                        "lovelace": 1305930
-                                    }
-                                },
-                                "0601030201080102020806070704060401060701000803020200040604080402#58": {
-                                    "address": "addr_test1qq5rep9nyvtf8g52dl4tg3qt76scts5d25nu2j8gjjy6gt6ut8ygtry4y8xzgudcrfngz66vy67r6jngc49jvj48g89qfgpv67",
-                                    "datum": null,
-                                    "datumhash": "91d49873029459836febf5261944c09d78e7d1381bbd518ac21cfe4f01c45010",
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "lovelace": 7500000000000000
-                                    }
-                                },
-                                "0808070102050507030505030600060606010708020000000304080702030503#65": {
-                                    "address": "addr_test1yqs5wtj8qwh2annnxfpyayujn86lfnyfrz3dqvd30fmgtv8g007a345dyc8l55w4k4ynvsvw874pfv3a4y26jeu9jweqnarkew",
-                                    "datum": null,
-                                    "datumhash": null,
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "lovelace": 969750
-                                    }
-                                }
-                            },
-                            "utxoToCommit": {
-                                "0008040300030602030603060305030106070305070304020704000006040404#25": {
-                                    "address": "addr_test1ypsjnn6jdglkag6smmx74g9y2s8aacp7wej2t6nhpl098ufns73pvpeapzdxnv9aawjvgva3gc9s084r74rv7uny778sqjrc3g",
-                                    "datum": null,
-                                    "inlineDatum": {
-                                        "list": [
-                                            {
-                                                "int": 0
-                                            },
-                                            {
-                                                "constructor": 4,
-                                                "fields": [
-                                                    {
-                                                        "list": [
-                                                            {
-                                                                "bytes": "7a"
-                                                            }
-                                                        ]
-                                                    },
-                                                    {
-                                                        "constructor": 1,
-                                                        "fields": []
-                                                    },
-                                                    {
-                                                        "map": [
-                                                            {
-                                                                "k": {
-                                                                    "int": 2
-                                                                },
-                                                                "v": {
-                                                                    "bytes": "5e24"
-                                                                }
-                                                            }
-                                                        ]
-                                                    },
-                                                    {
-                                                        "map": [
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "47"
-                                                                },
-                                                                "v": {
-                                                                    "int": 5
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "int": 4
-                                                                },
-                                                                "v": {
-                                                                    "bytes": "08b0"
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "int": 2
-                                                                },
-                                                                "v": {
-                                                                    "bytes": "ae298bc0"
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "d3b1d2ee"
-                                                                },
-                                                                "v": {
-                                                                    "int": 0
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "8dd35746"
-                                                                },
-                                                                "v": {
-                                                                    "int": 5
-                                                                }
-                                                            }
-                                                        ]
-                                                    },
-                                                    {
-                                                        "map": [
-                                                            {
-                                                                "k": {
-                                                                    "int": -2
-                                                                },
-                                                                "v": {
-                                                                    "bytes": ""
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "int": 0
-                                                                },
-                                                                "v": {
-                                                                    "bytes": "9f"
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "8c"
-                                                                },
-                                                                "v": {
-                                                                    "bytes": "cb7ecb"
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "int": -1
-                                                                },
-                                                                "v": {
-                                                                    "int": 4
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                ]
-                                            },
-                                            {
-                                                "map": [
-                                                    {
-                                                        "k": {
-                                                            "map": [
-                                                                {
-                                                                    "k": {
-                                                                        "int": 1
-                                                                    },
-                                                                    "v": {
-                                                                        "int": -2
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "k": {
-                                                                        "int": 2
-                                                                    },
-                                                                    "v": {
-                                                                        "int": -3
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "k": {
-                                                                        "int": 5
-                                                                    },
-                                                                    "v": {
-                                                                        "bytes": "ed3e"
-                                                                    }
-                                                                }
-                                                            ]
-                                                        },
-                                                        "v": {
-                                                            "bytes": "54e0"
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "map": [
-                                                                {
-                                                                    "k": {
-                                                                        "int": -5
-                                                                    },
-                                                                    "v": {
-                                                                        "int": -3
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "k": {
-                                                                        "bytes": "f7fd9c6e"
-                                                                    },
-                                                                    "v": {
-                                                                        "bytes": "68488e72"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "k": {
-                                                                        "bytes": "54ed6e68"
-                                                                    },
-                                                                    "v": {
-                                                                        "int": -5
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "k": {
-                                                                        "bytes": "ad85"
-                                                                    },
-                                                                    "v": {
-                                                                        "int": 1
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "k": {
-                                                                        "bytes": ""
-                                                                    },
-                                                                    "v": {
-                                                                        "bytes": "6b7a6a"
-                                                                    }
-                                                                }
-                                                            ]
-                                                        },
-                                                        "v": {
-                                                            "constructor": 2,
-                                                            "fields": [
-                                                                {
-                                                                    "bytes": "8397"
-                                                                },
-                                                                {
-                                                                    "bytes": "eefc"
-                                                                },
-                                                                {
-                                                                    "bytes": "76339785"
-                                                                },
-                                                                {
-                                                                    "int": -3
-                                                                },
-                                                                {
-                                                                    "int": -1
-                                                                }
-                                                            ]
-                                                        }
-                                                    }
-                                                ]
-                                            },
-                                            {
-                                                "constructor": 4,
-                                                "fields": [
-                                                    {
-                                                        "constructor": 2,
-                                                        "fields": [
-                                                            {
-                                                                "bytes": "8422ef0d"
-                                                            },
-                                                            {
-                                                                "bytes": ""
-                                                            },
-                                                            {
-                                                                "int": 1
-                                                            },
-                                                            {
-                                                                "int": -3
-                                                            },
-                                                            {
-                                                                "int": 2
-                                                            }
-                                                        ]
-                                                    }
-                                                ]
-                                            },
-                                            {
-                                                "constructor": 2,
-                                                "fields": [
-                                                    {
-                                                        "int": 4
-                                                    },
-                                                    {
-                                                        "map": [
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "a6f2"
-                                                                },
-                                                                "v": {
-                                                                    "bytes": "512c9db5"
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": ""
-                                                                },
-                                                                "v": {
-                                                                    "bytes": ""
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "int": 1
-                                                                },
-                                                                "v": {
-                                                                    "int": -1
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "5b"
-                                                                },
-                                                                "v": {
-                                                                    "bytes": "f27b"
-                                                                }
-                                                            }
-                                                        ]
-                                                    },
-                                                    {
-                                                        "map": [
-                                                            {
-                                                                "k": {
-                                                                    "bytes": ""
-                                                                },
-                                                                "v": {
-                                                                    "bytes": ""
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": ""
-                                                                },
-                                                                "v": {
-                                                                    "bytes": "e0d8"
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "int": -3
-                                                                },
-                                                                "v": {
-                                                                    "int": 2
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "2e09"
-                                                                },
-                                                                "v": {
-                                                                    "int": 2
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "int": -5
-                                                                },
-                                                                "v": {
-                                                                    "int": -2
-                                                                }
-                                                            }
-                                                        ]
+                                                        "int": -3
                                                     }
                                                 ]
                                             }
                                         ]
                                     },
-                                    "inlineDatumRaw": "9f00d87d9f9f417affd87a80a102425e24a5414705044208b00244ae298bc044d3b1d2ee00448dd3574605a4214000419f418c43cb7ecb2004ffa2a3012102220542ed3e4254e0a5242244f7fd9c6e4468488e724454ed6e682442ad850140436b7a6ad87b9f42839742eefc44763397852220ffd87d9fd87b9f448422ef0d40012202ffffd87b9f04a442a6f244512c9db540400120415b42f27ba540404042e0d82202422e09022421ffff",
-                                    "inlineDatumhash": "495991632a2541d3508302935749ace0390904641dba18b3f36ab1cd9c1b7a9f",
-                                    "referenceScript": null,
-                                    "value": {
-                                        "245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abae": {
-                                            "7ad840f1b1da458c": 1
-                                        },
-                                        "lovelace": 7500000000000000
-                                    }
-                                },
-                                "0105040306070802050406000502060308020402060408000101010601040508#3": {
-                                    "address": "addr_test1xq882a03z57rk6mf0gf86ytkw866wfgl03l9hwsgmtpgzc7txfn56dutvgaw29sd6047qjjceefkl3zpp9p6mmvu2hts634q59",
-                                    "datum": null,
-                                    "inlineDatum": {
-                                        "int": -3
-                                    },
-                                    "inlineDatumRaw": "22",
-                                    "inlineDatumhash": "95c3003a78585e0db8c9496f6deef4de0ff000994b8534cd66d4fe96bb21ddd3",
-                                    "referenceScript": null,
-                                    "value": {
-                                        "lovelace": 1008540
-                                    }
-                                },
-                                "0202020104080205010807030505080206070308050802060701060000030301#80": {
-                                    "address": "addr_test1wpxldplx9xr02jrejzu28uk2nv8pluyez2x97veln0xvgacw8l596",
-                                    "datum": null,
-                                    "datumhash": "fd73403a127e02bf7d5fd575ad135eacccc48bee88f7aaff59b6c1689c421078",
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "lovelace": 995610
-                                    }
-                                },
-                                "0300060803030403060005010602070802070506070408050603020706020808#47": {
-                                    "address": "addr_test1vq02m9n0nnqkc6sua0s6wm0u8wcz7aag53rtfzf7zmj5flsngxqdd",
-                                    "datum": null,
-                                    "datumhash": "d941f83d18907bdf9bdc53a6ac276f9a36544bd04045389c685c96bc9e3e999b",
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "b0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165": {
-                                            "39": 8167764634183162209
-                                        },
-                                        "lovelace": 1185250
-                                    }
-                                },
-                                "0508020602070400040706050504000006040705020606000508060001080205#52": {
-                                    "address": "addr_test1ypyfpvzj8nevv52jztfx20006g7zvkvkadvttfsvmnp0umx77pw6xxldg7lpz0r0yawp77z0y0vxvkp076569qdeagsq059dqw",
-                                    "datum": null,
-                                    "datumhash": "fd00f3486f7e9fd16ded7e314dbb0d8fb79e111a11f63aef3a248d9a039baed9",
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
-                                            "41b3c5034a466e844a68bcacb1047b0ddaca1e5b333328c21c7358d07635e8": 1
-                                        },
-                                        "lovelace": 1405060
-                                    }
-                                },
-                                "0707020502000703020602080108080007080000010005070407030402040502#70": {
-                                    "address": "addr_test1zr50fehlduwfyfmvg82q7j8xt0jekfvgkfwc25w5cek4k95uws7fut8h2swh69sd3gpfft9d7z66c6jc2ys6485t5wdsfymmnx",
-                                    "datum": null,
-                                    "datumhash": null,
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "d271e74f47d55e6b520017027603b5d8276303884444466e0b4a9e0e": {
-                                            "b71bee012cede82b110a213c0bae27e194e47f8bea50c667d72c": 3178419428838220594
-                                        },
-                                        "lovelace": 7500000000000000
-                                    }
-                                }
-                            },
-                            "utxoToDecommit": {
-                                "0100020702010105030503080702020700020408000102020204000107050303#50": {
-                                    "address": "addr_test1zph5q7f58pecp88wnkh65xaljxx30cu6ksja9lc2t55lm4j3chqxazy35g38lrew99q4u25f5xzj8acyrjl9lc2h84lszkdwyx",
-                                    "datum": null,
-                                    "datumhash": null,
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "185d2ee3acfe46ae7aba03b8783d5cccf30b574b6d2e177a037eb6ce": {
-                                            "8d09bb95a309d1e60eae73a28f5f803d2f9549cb8eaaadbaf4e2": 596887429188019313
-                                        },
-                                        "lovelace": 7500000000000000
-                                    }
-                                },
-                                "0100050501020501010100030601000606010306030802010405010308020402#58": {
-                                    "address": "addr_test1xp6tsak0483qmwrrfd7e3yer7ct3yat5yynqqf9lup2zsmljnj90xa9gfxpm7g2m64qd7zv5aq4aj28ve2c2sk2ayfdsn75ct5",
-                                    "datum": null,
-                                    "datumhash": "bb16778246f868bc747ece40a1c0730aedf508aa09c69c0f69967e1cab2ae009",
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "b0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165": {
-                                            "9caa912801e8a02f0d6551d1d251": 1
-                                        },
-                                        "lovelace": 7500000000000000
-                                    }
-                                },
-                                "0308080403020206050607080801020607040707050106040202060608080407#5": {
-                                    "address": "addr_test1qqut03vqnytqesfks6kacygce3f52ykdtftgy2spkr84sslfqjl4yqxran0t4m5jf0975gp7p3tadn8fuwnw3wg6883q2r5n6y",
-                                    "datum": null,
-                                    "datumhash": null,
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
+                                    "inlineDatumRaw": "d8799f4231869fa0ffd87c9f22ffff",
+                                    "inlineDatumhash": "6855796b66d0150848a5f94a4487a13047f793a0445e435e4b7fd437ea03cb61",
                                     "referenceScript": null,
                                     "value": {
                                         "lovelace": 7500000000000000
-                                    }
-                                },
-                                "0704070500030600070500040004000207000303020704050403070205070208#67": {
-                                    "address": "addr_test1zrfufrrrznhcn0ax78vt4dvlp5uhkcz6l2knfy3tfe2ld4tsruhlfpxxzer7n8mquph2wzhwyfk529y09evjqrytdn3sq2mzmy",
-                                    "datum": null,
-                                    "datumhash": "24ec70dc81c51030e634a590e0591ce381d18c5db5ea5c5d3602c02e4f1b4d34",
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "lovelace": 7500000000000000
-                                    }
-                                },
-                                "0802000400040603050100030604070001000100070400080206020006050201#98": {
-                                    "address": "addr_test1qpr4y3hyqh73jy5ynsw0scmmpmjzz3afu7lhu54vsrj2sdtdqzj2wvxhjh8e3u00cryaxs4cr0wmlynfs569adza5q4s2ptwps",
-                                    "datum": null,
-                                    "inlineDatum": {
-                                        "list": [
-                                            {
-                                                "int": 1
-                                            },
-                                            {
-                                                "int": 1
-                                            },
-                                            {
-                                                "bytes": "1c"
-                                            },
-                                            {
-                                                "map": [
-                                                    {
-                                                        "k": {
-                                                            "constructor": 3,
-                                                            "fields": []
-                                                        },
-                                                        "v": {
-                                                            "bytes": "de64de8c"
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "bytes": "52"
-                                                        },
-                                                        "v": {
-                                                            "bytes": "cc"
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "list": []
-                                                        },
-                                                        "v": {
-                                                            "list": [
-                                                                {
-                                                                    "int": -1
-                                                                },
-                                                                {
-                                                                    "int": 3
-                                                                },
-                                                                {
-                                                                    "int": 3
-                                                                }
-                                                            ]
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "list": [
-                                                                {
-                                                                    "int": -2
-                                                                },
-                                                                {
-                                                                    "bytes": "9d"
-                                                                },
-                                                                {
-                                                                    "int": -3
-                                                                }
-                                                            ]
-                                                        },
-                                                        "v": {
-                                                            "constructor": 3,
-                                                            "fields": [
-                                                                {
-                                                                    "bytes": ""
-                                                                },
-                                                                {
-                                                                    "int": -3
-                                                                },
-                                                                {
-                                                                    "int": 3
-                                                                },
-                                                                {
-                                                                    "int": -3
-                                                                },
-                                                                {
-                                                                    "bytes": "28be"
-                                                                }
-                                                            ]
-                                                        }
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    },
-                                    "inlineDatumRaw": "9f0101411ca4d87c8044de64de8c415241cc809f200303ff9f21419d22ffd87c9f402203224228beffff",
-                                    "inlineDatumhash": "d3edad23e23776b509fd74bfd81d146f38d028fb723f1d1f3028e7b79f4ad08d",
-                                    "referenceScript": null,
-                                    "value": {
-                                        "lovelace": 7500000000000000
-                                    }
-                                },
-                                "0805050103020505040702030606080704070501030803020001070208040103#16": {
-                                    "address": "addr_test1xqae305vhnzzw2a99l44lljx9ekzucx09ghffx5kkr3yp95fuggqjylxe8paj70yw4mw2ftsfpcxvy5afpqetempn6tshqgetj",
-                                    "datum": null,
-                                    "inlineDatum": {
-                                        "list": []
-                                    },
-                                    "inlineDatumRaw": "80",
-                                    "inlineDatumhash": "45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0",
-                                    "referenceScript": null,
-                                    "value": {
-                                        "5118e0d5cc2b71cea46a49e51d72a3215d925e161683ba8a4d5b7556": {
-                                            "306ec1b6254fb57ba99b": 1
-                                        },
-                                        "lovelace": 1202490
                                     }
                                 }
                             },
@@ -3321,135 +3588,42 @@
                         },
                         "tag": "ConfirmedSnapshot"
                     },
-                    "currentDepositTxId": "0602030206030800020603000803060507050005070605060506030508000506",
+                    "currentDepositTxId": "0205060207000803070401020708040106070706020002000700040405010407",
+                    "decommitChainStateAcks": {
+                        "016a82e6eef13c598b69a1edb6edb15b691165882807ec1249836781377243ce": 3,
+                        "8161b1c452224ec463028ab0c94cf586872726bbae506349ea9754f5abe4178f": 3,
+                        "d2b527009b744f157e6411bf4a9c1b9c9aec7d7329b361954c6fc82cbe9e0210": 5
+                    },
                     "decommitTx": {
-                        "cborHex": "84b200d9010282825820f2532d4c683a3b8d110ecd22273d1b4a5d89538b457916bab8a4afcf4ba7693705825820f4386eeefe49cc31f0c5add5723f9a746d7c703d29d682f9a55f2c0bc4d4319c030dd90102818258204683534d4582804b483c93f61aec0c0d0368e4c518fe8dd65fb5e46c00447db60212d901028482582036e671216e7d0697158827c9e3445639be2d125c45c8ffa28aa091a9273726d203825820af9182ec15a92079dc2f61fe20b47831bb90c6cfb52d49b1caf3401db851733a02825820bb3f49e914147a8596fc45f927e93a32eae46704adcbe7df7b19f0df1436bca805825820f76fb855d3c0f796bc31f6f9c843b914880fa8e55cedc10927959f14679427870501838258390081224226508cc45790ed5bd509e922d68bf29fb9fca4df3f7b4151a9fc5a742bbbf0a4b4b72bac8545298bea892b8c2a85e5cdd26d84cbac8200a1581cb0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165a1581f30441f4e70d3b55e99519cb5cc5763406d88575b57e3584b45dbfd231cf95401a400582b82d818582183581c19381056407d61cffe1cba9999134940c92456e50d21b54804e57b5aa0001af9c5f97901821b384b9faaf87f5ee9a1581cd12095ec20144db0b88cca060a7a8e921c3b14a7661f878513760252a14c50814b2c1925c7a289978fd001028201d8184544442d50c303d818590114820082028183030283830304848200581c6be34126a2cfef2ceec7a2843f05d515fb51fdea94b1b03a20c39bd98200581c0ab95a5b68adf63a20e172a1379561cfddbaa4a476dd57eabf69e3fe8200581c16bb0f3ef01f2db91a58fa1600a454d5f59df705def9e6da007a7b948200581c57be414abd3dcb757f730946c2eb2f89f21c9e8d7dfc075fac171459820180830302848200581c5a6dbc0bccb3faba5a99e339f0cb725ef29278d7d1a24bcbd2d25fa68200581c0dd48de0b1e88395cd58d4b25790d038f6b381d0dcb34e3f264eb42e8200581c29ad3a88b11000471744ff3c805c34a78fffc851618b614f4fc19f368200581c520e078071a7ac94eb2d78a57b3c7eced3eb6445c371480a3d42c274a300583920e7004e36b9ba2b6cac97795699a3150af2aa3c033758449771b3d5fb000738bc0469c124cf7ca5f8cddc0b1083d02354ad698fc2bd9ff0ae018200a1581cfc644a34a391a04771ede895b3acc7cbc7fbfacd08a8b7485a22f450a1581dcfaecc0f3c4f90625dfc1c37a5ec4734069486496b36717ae89f512fed01028201d818424117111a00027c84021a000b5dde030104d901028183098201581c121fe11487216297c47278f3546bd519ff1d3b0147ea696cf4e79b978201581cf50b216230348692ef604e01d30cf017a6e13cef9835460eac3e438a05a3581df01e976e628603b69c146e942ed143e2eedca268ba24ca4741a42904181a000b2a6b581de141610c3fd1456b7a03a3f7eb8ec9594ac6dc23f1a5df6827dd50f97c1a0004bb1f581de16587e4cd115602b11ede50b409afe3e39dae8de713b846e4871c50751a00050011080109a1581c467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22a1540f702f3ccfe3a7ce285aa848bd00da7ed91e2e051b2eaf95eb8e0f68090b58203fb6b0095211913ed47472f187129b33d8b5743ffda10b5d63ceca607e5ab4f20758204053ee43328f385e21834956ee7aaeb7833cba77678608170135cbc183c0bcfa0f0013a38200581c35ba05c660532144e0dfd2d459bfba2039ef42ae5b689b455e13a7faa58258201455ac3eaa25a75c2ca4a1cd8ba622ff6ad75c53822029efec5b355bf310b27808820282781e68747470733a2f2f74546e727256336956565144354c48466c552e636f6d58205aaa7dcf66584aa72f539cc2f84c13d9880a62727bd94aa477c719eb5e8852af82582073f8804908f0837dbdec1f07e9ec37490cce7214166da606386ef60b2f6d37f1018200f6825820a94f95718f4c305fc2d53b5915a5fb60bd5c378b9b44295d541a5e2d983c383e07820082782468747470733a2f2f5846696c44666f593036764f4d58484230683248433545352e636f6d582044c353ba1ff2c7ee2d499673961142f424026bf4867e845dcc80a3ab81d4e843825820ba02ade06a67215ea78102346e28090b6a3c05f8a012f1bd995c19da453eab5d018202f6825820e2acdac8fdef8b26f94bdbb8ddd05925e9ecf38edccbcd965d2293179fb72aa904820282782b68747470733a2f2f73784d647763777a34556a445569447735625062424a6c7235436450454a302e636f6d5820bfdfc27c947796a30db33b10d68c41a6ea30ca7cea8c77f3c1a11ca4f26159338200581cd8595b04ee7166a3e1be3bbfd058eeee3ccaf04c31d26a49f1b9f9f4a282582024524be5cdacc41a583553a848d609bbf16790d5c8aa127f6759eaab38e36eb201820182783168747470733a2f2f4c57496f7a344a6b662d5369465a6562385434497264666558383646734a6d6370656877792e636f6d582079886a1db39d44b6d53fe2aef7d0d6ee52a37b919db46410a20021125f06c26e8258206127b2d05759128fa713cdfcab6e0438f95cc55a17d9108025329db913af26b2048202f68203581cc55ae7f8171e50ecd3b3cc6b724312b984b49f8a7d144b6b704f9110a38258208e04a0ac47b2b8f2fd4e109b5a57accb45028bb7d6190b0222ec97eb27fb60e6008201826f68747470733a2f2f615a302e636f6d58204cb6e4c9adfc1963a765a59a3dec7063919f6d5f84e5b2cb3169bc19196679ab825820b7f477f99000da33d75ff8ac56ac9a3462dd75108c013bedc0eb70c86de0851a04820282783368747470733a2f2f78336c5a4f33476575736f6c52383653664e6a566e44726f6c2d39374843584f386979625959792e636f6d5820bb8448610b08b1e8d674d17fa8e6e43771b39e9a8d461f933544ab93d0fc0d4a825820ea047580a3fef88836bf58e0a2c5c939ca99215857063fc6d8abc4c5963ec97805820182784068747470733a2f2f774e2d7952676d6473363146736d6f6439397278515a3954434b59773430512e4b7850536f43593973316a614942375a7a5150442e636f6d5820bd1e035175dd89d1daef7abf45398613656e19c6edd5be4d02b4a730fe5e100a14d9010281841a000b0d73581df16d4c594260c810e6af6449a1dac3c84a5732a53026cd4eac44bc1e2c8400f6b7001a000e4f640119f7d8030804010619329307010ad81e821b00001f04b5b6d57d1b00002d79883d20000bd81e821b000003e1cf24df271b0000470de4df8200111a0005d6c61382d81e821b380a189657a9d4211b00005af3107a4000d81e821b19363b823af748d51a017d784014821b69b99a1739a4f65d1b5b40d792b0b494e515821b1e8e69e594358a121b1bd52134da8dc4a71605181800181985d81e8218271903e8d81e821b0754974c1760915f1b0de0b6b3a7640000d81e821b0000000944500bab1b000000174876e800d81e821b0001815a2a7cadfd1b0001c6bf52634000d81e821a000b9eff1a00989680181a8ad81e821b00000003f945c1cf1b00000004a817c800d81e820001d81e821b00003775be0ae07f1b0001c6bf52634000d81e821b0090c6c7a269aad51b03782dace9d90000d81e821b00000006d963ea171b0000000ba43b7400d81e821902091907d0d81e821a000730831a000f4240d81e8218181819d81e821a0001bfeb1a000f4240d81e821b0001d56dae97f79f1b00038d7ea4c68000181b05181c02181d08181e1a000d3fb9181f1a00032d721820021821d81e821b5bf9bde328fd6c071b000000174876e800581c0d4cf4caa625beac94698273f46009fae7507f09aa4dab3c4b8cef6e82783468747470733a2f2f67523231397a7a32584235386261316a304b30585175377059687a6d714865574c6b6c476c554b342e636f6d58200e00ab14ca8c0b3e41c5fbfce1e2a5b4fd3fd382b502003188b41772b1d7f855151a000a0d65161a000e1454a400d901028682582079962c74fd258058b349d58eb79e6faaab881a79661fb51c3bd7624254dd36c5584048c8c76451ee89c91712996e49ad588bde89c534f80d891531a9878349c0f8b2f80d852efe8322f319fb3372efce1678205ed97df03252ef900f877b6d8af0e0825820d3650ba47e6d5317babe0093d56010d8b83ed245a6da930d0f236d442995eac358404305c0ca9978b9a8e76cd0d3e3d956afc148806653ed310da4096cc4064947ddb7fc07eacb9c7b2b61da6614372997cad9d3ddc44c29fb26f07e789cf08947e9825820821773a0ec2d42f114bf12e901e9b8b1a07be196f79177ce5217241ddab1421f5840b1483afb90025baeb52334b3c414650639df7f1aec1f47be0be94925ddebad949e15c64fd602d4244a66faa7369df933f2a3730b7c9a685f59d978235dd01e098258208d0667a46e6c445c9392f004053989c2b19463a600f189a0a9bf126995ffcf065840e4202cdedf632e114b5c43c4e701e6455432b5abac051e3bd2feb24d698714b99002c2898162f60535d27b3dd6400d5622cfdbe279950f8b595e42c22d95f5938258202bf933dd6cbae264a68bec8869547c6f829b8bafa070645bbce61f2c4a3067615840eb4d948de2906211032982e749d7b05f0cf195e269f9f458ddd04117edfd8c3861192ef8de11fa8c902b2552a5091be5e1cd103cf9a4f91a455b8123a617aa7982582083630417f533be201d91deea72e3556f28f60de5ed64488b492539fd54e625ca5840bd9f7627307b31157557fdc8e0efaab0dba045cac5402f3454d9a8d86b6bf2004eaf27e6aef8f57489594db7e79b211fc6fc20cf2f898190c3edd78f0e2a276a02d901028184582069e00293207117ee7b00e43d946aeb4deb34a22615278ab6d555fd773527616c58403d3f914484d82ea1c1ed5a4c7e7b43a2dbf3e8a7ddd5eabf7ccf2d0188a3bcb1411426ef2f6166925e5994a71655bdffb1bba407386978ca8be5ba77a71f7401453ba75abed842675301d90102828202808201838200581c59a94485df08a0ae95b0f423e54e0fd3b191610ddd8a1f62df908faf8200581c909a83bcd39764acb99ff56dd0911102cdb6abc5322958fd5a21fee5830301818200581c278eb475b4917717d0f2940347aa7871803b6a7935fda9cdd0643b0205a68201008280821b3df0c05ec826c0bf1b4747686add4acf3c82010482d87c9f20a443f3689fa12304a4012440220241e3435ffc2a41c7a140432ae40a41f043d38fc84472c3231e2100a0ff821b2991382c0abf1fbb1b1dd232fb438325c682020782d87e9f40ff821b1eb1bef49eaae42c1b34ce5ef9314af04b8203048280821b7d54f7e2a8e14a0b1b7d45c631a89d52bc820308824209cb821b6a80314e0e84ee851b0a78727da83e953b82040382a2442c12183bd87d80d8798000821b6b32229ae3ea3d2d1b69a2fc108bc346faf4d90103a10381484701000022200101",
+                        "cborHex": "84b000d901028282582026bf831a8b9bb8f84d48c0084b52c06304a5da084e8c21cf9255e2b2d8efc02d0582582032e57a839fe74b3560b27414293de3f03041e0d78366ec3c763b99fac0f8e234000dd901028282582089c14782ada5593d9d4ac76584ef291f0683a5da1ac2af9bda00a1a1d0cb7e8007825820e2e0758b6d389552775b5d7f63306f22ca35af9fb825dc57c92b6bf04dd2d2880612d901028282582004ca90e55d2843c3eff7b3099915d0e76df284f4a98832d27bd9b8c96cc1dc070382582087cfbb38314e54df7d4990c6ef2a2fb3a699b75c660485583c09ca01ca31787b050182a400583920d397631c07accc8f621ac575dbad4a762c34aa988122508683c55a2efde8452089a0794310a29ad2902b6b3bfd4cf896ec4baf7c3082c5b701821b267488fdb66a506ea1581c2d725128406dc832eb74c4709aca0512499b3c7b17e00d7cb2e6d1b1a1413301028201d818439f40ff03d818458200820280a400583930e0047b06244c25be09cb988e5df22015e23c65df5f57c3a01313933353049d084435b137a34ae9ed6b4d3fafbff6c590eeb5e5af94b6e60f018200a1581c2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2a14eb814b0e9459b39d14b0fed7cf6f8010282005820b4afdc6b601d91c8852bc498f92756d554dad19acf5648a7722278a2179abf0c03d818582282008200581c004ca693c5950c5e8b920c7197252fc2cd34dcc09d8f3dc31d61b9d1111a00079600021a000675b8030104d90102868304581c93e4fdee1a870c687326c94bc1e1ff26215886b98198477f9afbcf720e8304581cf75d7ed5ec1fba6cd38166022606f9598b852917b28183f7082c328b0e83078201581c19df0b356d015ac612a0b84f56c4d18d21c0ef5f6acf7086bd738c661a0006233c850d8200581ce0ee91b7afb0e25ad7201bc81684802023bd2b3d45218d18764b59dc581c69848a73976f50d8f9cf198f4bf35a1738463350b65ef2a98412574d81031a000d057582008200581c857384332c8912f32557068c0b4b7a210564d3d6d561b6587e6d56eb830e8200581ccd3d58b90f9ffde237ab419282a73d7906fef08549c9ee78805557f18201581cab8b91d34ce238c91cf902bb0c7612dca9e5cb33854c1c677fa25e9e05a6581df00dd642f41b0db65574239885144375130fb00f6ed2a68014b17088751a000c3a28581df0385889849d17b938563eb96bd881722824cb0ecf749fc4eb54a4a76a1a000e4204581de0b6fead2be11af6bbc11660a4ba1acd86849027c24aa9727670b2bda01a00030d3c581df1997cf03c8ba347193f903f92b8a8480ce6330f4f2d82ca650bcff9d71984cb581df1e3bafbebe412aa0d3218e91ac7d08af71ac09bfbc90bb872affb0ae61a00028a99581de113b3d6250e8a347e319663891161a5c7edffd5d1a8402c339f630fda1a00039a0508020ed9010284581c3b35e27b509ba0fef05e786c238237b09fd785c706a518f71781eb75581ca7139bcc952cce97b797d7af9b2cbc4da4ec729e8eb597eec4224069581cf36525e631614885ce5e62a8f671d89a67bffa9a4a066205bf0666f9581cf940cae49c07d5b3b13c4d2db03c85442fed14dde9aa1dfef3fce20209a1581c2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56a1581bc9c4f8cd3d4d8b390621f253225ec8c548e3b39082787b1b0135281b4c313e15d60260e4075820a4681261cac76d9536762d192e00ee7736db18205f27549f8723298cfac4ace00f0113a28203581c94fe6d4b7772e874d42bb83d56b1cb9c73cf47743904bb298f4d17cba38258200e0507220328d501533d8873c24c22203903d42c81e87f32bce6177d11bfd165018200f682582060ce9aaf0130cef82593008b9f188670c0ec14335060ce4967f9f42db3a7960d01820182783d68747470733a2f2f6e2e766e4846336a5137496b525362585751564d3872454632543565474e2d7835504d78314c74516a63463676624e6b592e636f6d58203e98a181abb1b74d1a8e04c56473803899f019417ed5e70265c443de72238ba88258208426f7df83574ddbfc61a6567b5bd4e4a5160c1489b79c6f1deffed8f3ed0e6703820282783d68747470733a2f2f4c65375151446d3950776d3659392d5951646f41366e444f576141524d43476777497369747a454276444a63636f61616a2e636f6d5820f7415485c2a18e6e37640550d93c1b1ed4f451db05c0345d7d73b4617930fe008203581cc3eb2d2da786ec91c48e1a2a048a2b716c7df39e85f4a478805009f3a48258205df292a604f0c451192bdcc3280a05b34998521c3feb133c75fa61c90835e68b07820082783c68747470733a2f2f78454a637559316a4539472d474738374c6c6b6144616c46566d4d6575737247497851746c3954746f4b65765543717a2e636f6d5820fb26ea913e0596e28e8494b778641e2b9c6f74466050ae652abe9219412f7c80825820639617529ffa838b8675b2f599338443aee6326ba8e737d75e6344b26c4df0d3008201827268747470733a2f2f6f62675174492e636f6d5820a406213d2f34cc6822cafc7da4dec640a97ac259760da49be49216333425f40a825820652c2f0551117156de9c5a40e14fb41d566d2adfff2e8819fd86af6ba3cb624f03820282782c68747470733a2f2f4a784d6b79766364424450513653705a76542d7472716544784841484c4266352e636f6d5820253db7d554ef623bc5878f33a14ff53fc7379ee6a4eae6f3873f429db993a97e825820b28a384b1f4eb0e095824ca72e26d1c8b1614a924f58b7d894bc0884d7fe9904038202f6161a000d6123a400d901028682582034c10f8097479f34dece551d3efb0617e0e2255b9002567637fa2422e564dba45840591a648b68c26e4a5d897ae14f4c7a7c7c3d0a2ba71ff79b271e30fb3dc6f806dfb9913478fb64492b9d26362a902e524461eef45b061b59dfabc2ab8026b9eb825820078c66850a00d08173cf5356ace00dc8e90c4537561adf800f491a70df686ef35840efaf49458ee30275b89b1b94b1e4abaafea0724d37677f0da0d1f636494dd7e16237b4b5a8f06b29e5039af264e3a5d17185f9563ede41eff3d67178c95c0cfa8258204b700514e775953dd78dbc6d75fe9be634db4341e9f746e6fc10b32fc92cfa3e5840ce98475e66f3864ba7aefc57cec8aa0103972dc7067fa79c5a2e5f0569862d465d2f85222679af791f814bd8bdc8c21a0585ddf8d123d7406119d89dc8361fc38258209e41c132aae1ecd9e2480498e305bafc423e19de61a8ab1f0cb32653d80b39c758409625aa03b38b8e032a5e96d708fd4fda690ae5180e4fe21829f1c3f718b6e2c5f9f65e15969a523f1a5eb5b08433df160900bfa0359e96fdad4530c3c8dabb7a82582046da834b4bd9d671445805cb18821267a946129639b2413c515b726f705d95f05840a6f078ae457b4d4ab1eb3be72391f6446b8bae5bb04953d0ee8aeef5b3b82a40a2594fbeb3a7085fe79153794ae5ce05a8e4cf9a5a5df3872a2d89eaf3da0b728258200a5ba5c81404bbbe8236d240b2e3df18b0842f1ca47c094ea86b8abbf5043ddd58403069febf62a0ea3934ce1b4fd7b706feab51c6a0fbdd78a23c51835fd060028201ce2d8e548937b0f0afdb13471db7a0f628943aa6ad889f3d0858d11545811002d9010285845820393ee34c1c44fbbfd96a630afacc518fb86cc1d3bcaf213a2d086eeeb3ed56b5584075c9904238fb497182c741398955242f7e3ecf83bc92ad689134bbc8086a947d3eb95fd2ce8fb63009974733f13912719d665ac7a96ff506826727804e5b638345a6ae22709242e7fe845820cb2a53702c5947f47fd933ef2dc4c766bf433d4f3d875928eb9f9c7764caacba5840b3f9c8e07bcb20f31f537c8b42eec3d566de251e1ed2982a96084fe2c05d16a3646f9722d8f8bba3251f8893a88d8fc6c637fe6bb17c4bf4090c94c9631200154224b641478458204edd79604ddca3ab3ab3f628231d7f223c0fe9efa881691c26f56d5610aa755a58404c8329c3bb8d5804be21277f8f438884d3bedca50d28d1877d9fe0acf8c395b248a04316cd12dbe35176db5299a0d95dd63c6669a505717233b41fb1a8b44b7743d2cad94153845820f07f90ae70184f397d12f763dee8cc0f80bbcf16c145bff4b199c362a56727135840c356ff7baced04716042e3095a05355051f3f3dae0579611f9b1cded2248396cdfb44d32a42d2cea7a4bae963778ed550f4db5ce6d81643c0ccae38034080627425d2f43aac7dd845820b2922a0ea4ae3efcaaaebdf64ed574f79db39cfd8437434162a85cab3a7198a05840573a5680056307954457e3ffa2b91706efdd83e8e8b1a0f887e42a6e03393701a7583bd300414a1b110386f13d81573ff7363634a8817fecf4ae62bed7737cc544ee4ef35d44d0d1e14401d901028282050e82050304d90102864375f564a1a1d87d9f4171447b3f46460124418dffa3204021449775c3cd2041be9fd8799f24434683a343e90b5843fab0c204ffffd87e9fa440a50342ce4022232120437cc9c94040409f41af42d5db05433c8fd5ff4107d87a9f244338febb42469043c902cf4480761301ff436eb98dd87e9f40ffa105050344c08ba4e3a422d87c9f21010443f411f9ffd8799f2441f8ff05d87d9f0422ffa140229f43dfca140443d51ba0ff02ff9f9fa520422e2f0500030223020205ffffa1a580a141ba448677af6721a103209f21052442de18ffd87d9f43aaa7bfffa4024304387d00402003437e87922021a09f42ca9b2221ffa003f5d90103a200a30442d71f0b615e10600181820502",
                         "description": "",
-                        "txId": "0439d1c4fa905197e34cf28a85f2f7206517ebabb6b655bf917a3bc0da15246c",
+                        "txId": "4800d865642d0297c4b0503f759fe642ed4eda88dedbb189757b4e40afc67b7e",
                         "type": "Tx ConwayEra"
+                    },
+                    "depositChainStateAcks": {
+                        "0215f1bf0f486081f5e93e2c592b8b35b07a8509ef6e7cd80dd5186aaa1c307f": 3,
+                        "13a4b37ed4145ee74dee37f3c4efdbaaf935e4b763041c28ff299c2df41890c6": 3,
+                        "2ab86e54e85c7e7e514ced9fdb51fc2c19aba4392a3889dcf1d724092dea134b": null,
+                        "4c2ee7d31d83a5c2e1f63bc58e0e4a90265d51507e62bbdd4077da5c39a8e147": 3,
+                        "827fa93f85aff480ff7a975d389a3895905f0bd3e512bb140d4272d2e6dae428": 1
                     },
                     "localTxs": [
                         {
-                            "cborHex": "84ae00d9010283825820196ba9949e9306379081b1acea0d4564ee11d093349016195f73fe5bb637ec0f058258203dfea73f0f18b6c16a75a8589a5dc9606769117bfda7a78341a85b1aada69a7e04825820a75cc5685e903f7f398a38588ff7ce28f952c49cb1476542ebf46485c955a51c0512d9010283825820227850c56522f09b117c211877575ba7136d1adc74bc74894294f009591e3fe203825820808c1c4095bf927c2f7d9188551f5b4d43d67573318eb3324d3d719586e5669401825820eeabc6c4f3c94f86933d3a4e0718f8cafb9eb23d551b5823d4a16baf8b44660703018010a300583920da83b55add9d6d2812de0f7ae33110428e130eadfeeee79699e3d3a669124b69506540995bc6a68b797a179cfad426b2ff7aaf31e9ae4165018200a1581c2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2a14e801df6667c99864e37cb62c4d38f1b1ac85d2e1e1a1dba028201d8184140021a0008bb9a04d90102848a03581c49e6c5764e5258b548fd21bc23a4f2cf953380fac8a2f6b93174d86d5820c2af75296ef39a234b52f5fb6bdbc627a9d7d10eef696675a502ba6e88daa7141a000796611a000de3e8d81e821b01618ceac974c67f1b01bc16d674ec8000581de0cdc5fc248ee2472d2c9c1338fefbbe3875f324436e0a34da33c8f88dd901028083840003440000000550040000000200000000000000010000008202676639572e636f6d8400054400000003f6f68304581ca5dcfb29486df3810121d5106ac4fbca8251fb867273875eeb24c8620d82008201581cfa4871c4ab8ddfa6e3e55e81242a4d6b277ff6a90a7ff4dee00c5bef830e8201581c4f6940c0c3a24299d5b4a49394132b5efc832d9ec68794374aca86498201581cfb4802d55aaeca23807020614321edcd084747f592cde9e0d4ac471b05a6581df0bc5793f2aee853012e12bd2c3fe512801e2fdc9cdbb294bd761cf7011a000a59b8581de0e5d91b9b774eece323b19d2ac84b0a55f96976e73f27a6091c3eeda51a00034978581de0e7c4d45942558525db51a3ce7553f068aefdc0414b40235a141e6cc61959da581df1d73c4dd7033fcf581acacab6842fc59615df6d78ee24ce6b9ce02f261a00082b95581de117512fa90960e2cc39779e2a6e55f9f1c038843fa37f894f7b3a6b431a00035395581de16efee7c53549ce3d13c41a0f0623477fe2168abb97774df5ed17765d1a0004125008010ed9010285581c5a20d1a159a88c9f9cccc3e67a6647b903e91c39f0d098b5c6c68926581c5c236eb87b7715a3bc68d19d4a246c1d17ec14bbb37288bd10ce24ca581c7587fc2c2fecbf7f0ed838db1014effaeae542b21edd2e0ed1757b4c581cdf3536942252dba1841aa885a694337c77083d6b26631e818d51e09b581ce558aa60e00d87be9a5c80becd8a637166353700e388c309b38b381309a1581c007ff8c1cf3f8f3db37f6c9491ebb2d2181ee72e82fa939bca6086f1a147a1f94ff7a558611b4debc029bf40a76e07582017306cac4f3b09e43cb4b3d656da06cae052aba728ee94911c258fc17249fcf70f0115196a3d161a0008971ea500d90102858258201bae19151846f8355a5b9c8d5bdb1df3e95ff5f3aeacb0c1f49af1495b3f7fb9584071230d3ae7f92aca58dff0846798e32be4bef216f7fbfd66c0be61a1516c896f8ba930b678a8b173af941462085677a5160ab167f658a162ba19ab27fb8c564a825820277fa1f451fa32b60d042de1138168572ff2c40d552dece5412659cbe95ce73c5840ccb8d106f1f13e31324c30a5729872f6920720c2b569a45044bc363942ebe5d8748ab76dfef802da7433c846532b7496e05e8fa6f1a60d1017ca6478d351dc3d825820448f7a8fa63a0af21f58f524ab014d234a6df63ac3d734fb7b1c79ff3304ded25840128c45b33ccf741d949cc4f32555561419f66b73f99aa6a23a4791e44eefeaf3e870b9f2007923d11eee22cdb0f70caba34cfa83d71b564bad905a51fa95d746825820e81607484f4b6a4712e2d998f0ef1d27738580e78b3f7a1f156b9b7f2c502bd25840bba9b84b6e5f815434a4f336ec00104c49416afc97b480c64681f5ec1908c77409dd252b1ebd4a0821b232641db7ce1fe02bc04a470222211b1410fc0a12672c82582044920a993361e9c1fde4d3761f141799ba487ed8c0fc1be1ed617b5d33157b135840b0b779b8425660bd645ccd653c94abe14d41190c05f393cee4dfd3dc0ac9ceac6a2afc98960997c7bfbc318d6a3e5ba072aff496ebac965a9a7069181462fc0902d9010286845820bf7bd932af5105e9e1e79aadac8ca79a8beae1733000dd5cd964c95e4589df7b5840991f280e664988f44f66ad7e79de90877aafa6248f470d575025d15a955b90e1ba164d8bd2e369278f63028d542764c5884d6f47b508c862af3762524bd4584b41f14084582046f8921a563e05453e1f11ed2d3f3c3e6a6bf062710541863b450b80088022595840ddefbe8106e10820d5be66e8d10e7b1b855afdae1915995f859e00e6b4fa039b8efe6b4658237bd2da163c6d20c848bd8fe6b81bc911321fd2df72d0d2f177e6449a38709344b9efc5478458204606f6ba77e7d9a592335c141eb315ee1865f38ff9232f9385809b8df1c01ede58409f14f3d99a5ee8beea42288e4729bc3adb047c0aee2baa2ee0f6daf1981ecc7fe149e35511e0fbdd0ed8b0e404ec8d3353e978505feb87237b8e36198649a9e145f36e6a63234550d1e69b8d84582065862a7ea8f029f23b4624692b8759400ac1701a5cd21ce003158b320daa3637584085ca8c189ff0ecc35765ff2db224030b1c81bc6f4da5f3399304a1dc33dd44d1edce20a7e3ddb5bdfd71f659d24145859524b90cde25680ee7f4d08e1798d66544460b054042ff008458205df7c454f767ccd5357e5289c46600ea8d52114b49657087e21253e88be361335840678c8aee15411e0cb9e0dc6ba87ace5b06937450291692b95cc80fa1f337b6457d891477189ed48ebe1b7026a00862a165748141004fce96e90ca9fb7d5e496141e443a09006845820c083a018d2a1927593e57cfcea4dab1c6fd066e8b28205e6a9d0f9415d8c8bed58401b14226f29de0d9a3bc8455bb223f67cbb8c3ed7d840bb087f11c5a5f37b2a8ef7fed424e8a5f218962e4b2f465a3ce275c968ad6274baf4b74e646c3dfe951842bff8449a297e6601d9010282820282830302848200581c9af7d4cddb922639e7d71f1357d1cc5caae5dcc14bdee2e31763d1488200581c908a706f2f13367bed7a73bdc1859ec2402b162d749d27bb2aff1df78200581c0510eaa0c1c50577f7ac0aa0734f3bf64c4baaaaedf828e7d85e09ba8202838200581cd36ab370a58ab00ffc1a08cc16b1153b90a5a00dfe20df8a9a5293b18200581c372f254526d3ca9ed4196e02b0e1e348c0fd0f1ddb0f59f4489209758200581c51be6d5d45161ec64d064023ae1114684ec50613c11e5377d332df0e82018082040606d90102814645010000260105a382020382446268946e821b2b8b62555cc4222d1b0d5f0584dc9d1300820208829f03a2a4441f2522264107200203004420f335da23a3412f2102449ed559b241e04043ed9993a1244309c1119fd87e9f0202ffd87b9f00428df72342c11bffffff821b6e2be54266ea1da11b1091bfc81b80f08b82030482d87b9f41c200a2809f4000000542571effa32124204044cb4b2f5444cfd1d187d87c9f440ff8882e443c9a5ed5ffff821b6213e49e3f9c80231b6bb631090ba11c44f5d90103a200a20181020d42c43801818202838200581c78947974be9f1a912600d1b3767d392b5a43333c9af64616ac7131b18202848201828200581c2ad464ffc162821f6d2191409e21a6aab82febd89303bd961e9c8fda8200581c4253bdffa25c130385f41012426c6a3ef20e41c8772e300138f7a9718202838200581c62589818f7cdac4907d3c27f65285d48bf2bbd6d1543e8c4a84d16818200581ce9e5adb7ff58b92c486cd6a2805842bea353af5703beb7d7f2d525e28200581c208cabd54d0e9f2635f777700ce0cca7ad18acd105734a018ee352da8201808201848200581cfb91022759fc3f557fc8e18aa032f783d874d8a4b6bac69c4a0ce3418200581c40509bd2ea1046b6f9c0f4500b0acf5136681e46959c16c64bacd58e8200581cc1db99e76bf45dc8bfa0a7759e9b305d1369bcf26af96c3af8d42fde8200581ceba17b8a1e206e0a5b1059b9325d375d7e3be3f134fe71ee91122c478200581c239ff92b0d7e9fcfbd0ff5214cd9ecf548d76fc39f60914da5f4ef2f",
+                            "cborHex": "84b200d9010283825820d42f865ab177e192e76faec13cd9ae79255d0f9b6b83a592208d1f92b5067f5208825820e70e5903289859fe4875367a2d870ff9449c853b01d9f4665fbe30bd2dd22cd906825820f783affc2c6d4110fbf1b812ea90bdd73518b09643d70907661c2b284acab72e050dd901028382582013b600b48d7f732236fec816a364740cb66f63931f4250e8b47909bf9d08e8d0068258206c69a101968155c27ec2e4767dc11735d5e722343aaf5c5628698baa3459b8630782582080ec18242ed68eb4ce07800591fcfebb5118bf1b9e9707c0df4678f6d30aa9790512d9010281825820380ed9b8821448cae34164382eac8e86d7fb93ec2a5fda7a7857a2d8adab7107000182a300583930c7869e62f141ee3e1de77a52ccec369bea125ce77c3cf47f819946f0f2261adbecd9197188b0027656d1b42ee5e4d28be316aac3a93c4077018200a1581c467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22a149145fddfba4f591c9ff1b4a834585519efd5503d818458200820403a300582050754d84bb5dabf4715e952ca01db911a6d7630dc6407e1fd7bd438caa03080601821b239de148938b7c22a1581c2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2a141361b0c06c040b1e61d8f03d81858d8820082018183030184830300848200581c348303d4652bf2c26d4c49ca091f2aac1e3e5c8fe6d051d8d5fcadea8200581ce0d19eec6585a4341e1f6d9d22054a658ac94969972cc173339c7bb38200581c4a76e9a363326df4326a73ebad906d7da725f985d46fc25c4faf122a8200581c44a5a78e4bb22c2bed4f2ee65216daab41f6887c5265662a046e1e1c830300808202818200581c453c73d519d37bacfde46fda108ea24c95beebe1e3546dbba632a256830300818200581c73e3466c28b875469e54c2388149b9bc93ab158f7f287a5d80a8045610a4005839115d0a992aebb65f3d2e6a2b48fe2cd7c72afbd3c13f15882a92c5a50e2ab64990dcfbd3d99dc09230b241ecf8462eb449776b18ffac1f43c0018200a1581c2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56a1413801028200582020ad9a327105fe03914e83beb1d6e0c6146ebc6bd2c9f4ccbd0de1bed585df8403d81849820246450100002601111a000bca3a021a000cf07a030104d901028483078200581c40d355037c0066a3e25d2f2285bd7153efcc86a3f1254738a0e959c01a0006accf830f8200581c261614b87e567aa9638a21212e6f40b79a7dbad7a5c257f97c2a0056f683118201581c50312766b39f8945255a3a63c2aff8237896d44577496954917ea24c1a00057bb182008201581cbcf91657b344f865e2c62db595dace1c157ae5cd2bbdaeee7259023b05a1581de01b89bad8dae10906cdc75339b94059eb74a854ac2acffb5971b1e3b01a0001884708010ed9010282581ccd9ea8cf9e2bcc76a5a4c04975b1dcb62429b6faffcdf8204f687ae3581cfec88af5fe0f69aa62de5d1d2008ebd7931ca4180e68508caafe893409a1581c245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abaea150a041370c5734e079e34c2a15c57342743b75e7e86d0131be730b5820e7a540c16d6233f92350dd4656fc9dc786ca36232d8279d9369f18810479714d0f0013a38200581c59eeecb592b920490b9b0ce90c2d8430fa97e66fbd032e63b6303572a18258207c3a163f035ad05c079a12054d5c8166548e3fa3f90170a988eb1aee9a0811b4088201f68204581c263e38efd1d8f4d7dd5b839881289cccbd3ff86074288a59ca9e3321a382582018f0acc31972a67fc6d85dcc886186e0a3543a98341a68fab2320608e8f1beb8038200f68258203cea3ad3ac4e38307abe4fec3d23de415f0fc404c623de696e38f1162bd04aa6088201827668747470733a2f2f485931376847417263542e636f6d5820515b84caf70305c3ca8cef9551608f6be7683a1f785bce02cdea52a6f4a3921f825820f0303560f1f3e24e75507405d82a5388cc89efe6e914eac1388036b4711650ac02820182782268747470733a2f2f6a7055344e6a7174413973694261486f424e7968555a2e636f6d5820774b70c68cb5ebfa320c96e28d14ea717451d0a8b791dd23a95c5b61527535f78204581cd276fea2060c7eb1e3735884af1b31e1330db280f9b84fa6940c63caa2825820b384be1e967fed193c09c9bf9cd1abc100670f7cae5df10269bf6b6557ce5d1402820282783c68747470733a2f2f4d6b6259426f37512e66722d5641305a46497a546256667575304251714654785048594b58756e57477036326c4151672e636f6d5820601a24945fe66f75d1a49e40a7de79a875284d81dcb061412027ad41afab914f825820ba05ecf84a38ab299cdec5e6d21815c0311377c7349c3b31597f7437ad9046b4038201826d68747470733a2f2f522e636f6d58209ce7b8d1ad0c2a469f64e5c07e7bfee7f96430d2aec83e3727292a300e08d3b114d9010282841a00097f47581de00d5791a774a47828ce36ca032606661e0cca2c4076e1381623238d288504825820eb41f16e73128e064dbc7c2386e49f0eb90f86b59924132974e9620001901b7b07d90102818200581c3713130b2d16fe508e0118398bbb7dfb79fe541b33f967ad0f5d8024a38201581ccaa791418f5f96afa0c34ea1f5dbf287e93188c8f185a495adbf0e770e8200581c737c0035168a96d12efacde24a0d5773122c06d7a39879528b7f3d2b028200581cacf09d45f22d84e765d93a54ef523e8196aa17e6b4c631783ed4d49610d81e821a000ac89d1a000f4240827668747470733a2f2f31424d38356153502d722e636f6d5820048e3f10f4de47de8a04ea0f63bb47dc9907d56633b9ebb79cb426715a366a93841a000bf1a8581de01f854d87ff6f277036677f2c9e882cf4e2d7806aafee196fd93d4a5385048258203602d376f5403f64cc0096317399937d40b4bbfc9e66bfb3b959c23d019b363401d90102818201581cd1c59555efbf3461c8a3b8594c379147a4ccec3160a1b70af73d3d5ca58201581c03ff894d1551b59bb25d66c61f711d0db5de9329f7676a359aae0105058201581cd7301559afd414090344cdc17c99e78cba63e5fa2965ad4913dc8f810f8201581cf5ed9f0d21372ad5bb94de112de66cd36f5a7829eef702c3f9ed9f5f0d8200581c335bce3ae832cd6bd94a6f7da395e90387931a7380d16e0193b69185048200581c8caa929978a65f7938069e7a6dd2cd43907b254348ed566e47742eaf08d81e821b001f1f53cf55c0d11b002386f26fc1000082783b68747470733a2f2f634e36616d6d465572433872424658666e48385a773937486472346c5759386e6e527a67727139727a5065637157632e636f6d58207b48cdb3698b7e797513dfa1e1a1f3854c19e8f053a7005ed1d213cd9a817c0b161a0006b46ea600d9010282825820f9d59c0d3bc6ab0bce4120e6951fca412fbad32ddc7e5d4e1c3980e5f8f70bad5840da8545ec6c5f2064337e9c9120ce588e30c147cb5d50b728f649738cd28e891ab319d5ee60f394897fb40605cf2a7ff38ca798ee45d2c042d4942cde2380adec825820436d2f36f0e0293ac9f98dd3a4f09bb2f407c95b6e9e49bbd2a6e64c4ff391665840c24d94fba570bf3ed56755b7f5b313e1a0978f424f4f6e38f8ad850f223c4dc19a00c73d2fcbefe6a7f338551bda26a8f5e34c8a44cb4ab8674e8a9d5647e2fc02d9010283845820143e7a763ab69abe683f0ae66a6fdb6cfc2dfeb7b168ab5f4b301f44c1ead6b9584014d7f74a47877d8e5aa41004e71d5ca1fec0ad7420ce23488becb8e5b41f23fc1e932eae9132870e6ca2c179f67d7d2e975c0c706b59b11d1f17c7a5bf42d90f41e6427f78845820845b818d27ac646073fb3c52ff815aaab7c648fece55a4ae0259dd2265a480d85840e5c27e720e5a19f1837451587d6d5cfb6f38d3c7db5b5fc8368e79527a7ea84cffa3ac60973b3da4915b6e0467add56943d5eae54e9c7a1ccd8e7e617ea4108e412041c4845820edc6555c1d87fdba012dd6b693f03eec13a4f3b459b3ab9c96c6f376945027625840c27a548f54d4634caa129c5352a26a42873c449880a8ba0b6662089d1d29026dba13a1d3fc573a7b73ce627d375d6399a63724e5e77689d8f38fffd8ea53eaff452a88762cb944b0f94ec101d9010285830301828200581cd8c2934ecaa375f10c79656d28b7996f745d0c48bd4c6f8d463fefce8201818201838200581cdacce96dd42d61a1db62a699d974f97c4b9faec23a963d023cf890638200581cadab6819befb747cdfef53336ba4bec84bb53aec5df630f2c70e8f2a8200581c9e06c7ce6109acd6b907609fbcc542c1cbcf3bbd66e5f7c7cde3d2898201828200581c8c31f22a33189f5d74333e090155745b691ec60a10b480a493a140f7820280830300838200581c3b88dc3a96513f5a62bc8993ced49fa6618a388a228e759495c0ebec8201808201828200581cb1f68197d51bc810c7601ea8ae118288216560e18b866bee03df8d958200581c36b0422731297c793eac13d2500a7973b50ce0dc6441585470a262338200581c17758c7f0afe64600652777cdcf9ba30cf1b228700f191d0ab0f568a830302838200581cfd334c9979d19f31f2d968c5641d796c884a8753d39e8b4944ab7aa1830303838201838200581c5629c80b5f771d20b8131a020e072354697efba8e08bd59c7dd7a42a8200581cf53d614b752f282861d948d1111b4999254456fb16f8434a1c0084458200581c2ab11ef61f7f3a92880dbaa8b4d77a81649c575803c14f58de8fe6278202848200581c8199150cbe6e85483da7ca8138ec31a3f5490d2edacca7b4c60e8e1a8200581c6d5ca39cc6eda9dec74e2af24b725f5e07ed48bcde8235c0664c04298200581cbc0e345197c180e403b6f056d67cc80c22b3ea30038050bce87d8bf38200581c5fcd4617e6ae30c157d7c184d576a7b6ccb7b9a1f169575ad744ca138200581c7b392609b5f8b20a29f857145a4752dc5234603c5b56583eef78f7bb8201838200581c6d37c17281c265adbdef3b83c912a644963c6f0b6277b19118b5cdba8201848200581cd746358b44493b9398f7c08f63ad0004fd5f69c7b7882b3fa6a04d868200581c9e17b3bd5c5d6140b9f31971b3b9a8f2575825e0b790b6fe5a80ed358200581c9eb8ed74dfaca59e944548f0d05f2cfb93c89ddaf1293b5f288c500b8200581cc139263592f87e79dcc53458199c37f1885e3d406522ac52e69a1d848201848200581c80817ee6df0a268c3b0558fce69571c38c44a1060fecd672988204a98200581cf91e22e4938f3339b5809746bbdbb21971748e9e6012b628812a7ede8200581ca39e13910b4158bc8debf782aff84bf35b88fbd1a1c5ae60b65363af8200581c5d03920d0821258532bb1441f88de5219677314b55697da75c9c210706d901028148470100002222001104d9010284a3d87980809f4043a09ac19f42b1cf40ff00ff229fa1222000d87e9f40220023ffff40a32205a0432d63be9fd87a9f2020ff9f03402320ffffd87b9f24a40240214487165fd2421e1541490201404020ffa5442f7b56b84044d828f03ed87a9fd87e80a5439984ff40040441602342c1e205010023ffa144b18bdaa8a32241c50024414b038044403f2048d87a9f40ffd8799fd87c9f415d202120ffd87d9f402343a3572244e6f4c1faffd87a9f40ffd87e9f05ffffa1d87e9f2141364193ff9f00ff44f0c8355205a38200038280821b42b3e45b4cf131081b03d9f96e29d221e58201048224821b78a7a301205c01631b3734ffcd867234c582010782a0821b03ab29a00d5eb7991b72728f3c22ae06f2f5d90103a300a503a005a123854041c569f3b19ebcf3b5baa3532340060008220ea26158431a865a054001838200581c33176590816282852c3fabef70d339e35cb6f160e3280a65d5803ceb8204068204090481484701000022220011",
                             "description": "",
-                            "txId": "cf67a89a45c8ab559e4c56dcd1ea29ab7f6b3a8ff2dcd9a434c22cf41fc7d38c",
+                            "txId": "cb7418fd620a6ffe975c15ccab3098fb87a8b6d9cbfecc789670b1fc280c3e28",
                             "type": "Tx ConwayEra"
                         },
                         {
-                            "cborHex": "84b100d90102858258204ba0ae1d21c7001b7a33842c562898148ecff82e0ce06fdc99541d2c92e7717c03825820650461ed4ff780730851429d731ac0bd10c412b40c892522ca3eb1f39db89c970682582085375be2f0513a71d03e6158455354f5716c63e8196f7d6a580bf0b6d48964df07825820a5f6f727957f943b375e0892341b8026b4acfa35c03827da10d622e4fbfe6cc901825820e0f061fb3d49c7db26fd2231e5c464661c142717d591a512fbff70956488809d000dd90102848258200ba649b90201df761d6134115e189c792e09a1e9a4007732a167da35b4db4c2305825820437371161a7d6eb41d3619adfc494202859427b83a0c20785a4530d0275c9af801825820cfb21af8681340bf46368b1fe8729a758e4b27b47601d76bcc613ac8e900f36405825820d3fec2d1120f17219ce17b21505f8f4abd8e7cae802b69bb533c9dc0cfb58e720412d901028182582024c4da523270a95797bb812809fe6e045a449887337fddbc34626211da96c34c0301848358390097063916e0f67caf8d2d7dbc29e24f76023cadd3f69bc634cd48195de562d98f0fa7aec4f41d4a240a74a32f1646baf2c8a9922259c912d28200a1581c245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abaea14bd2288753a2ebbb02ddebaa0158205ce3ad788a51444a8454297411dc2db29cf82b71d98c8d2643468303ec78088182583920aaf68a9ae12e7c651472b96cf8d11f2ab59378e4115fb2ab2cae1b5e84bedf52a901717aeb43459dba3dbe23c2ce752856f8cfcb2fe6feb98200a1581c4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888da1581e4aa3ade1a72223472906366c15c2cc06bcdd2bccdcf73372350848f058d21b665833dde1ee175fa30058390098ac354d72dddafff5c4cddfdf2f6f1e3b2e8dde2db9fd54a726a03217409768491d4d4e82ab19883a8b19406d1d6bc9f0074ececd2ce505018200a1581c4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebea14e758935558ce26653e9ca3e814dc21b2df404641d85305e03d8184a82034746010000222601a300583921b00c167b7b85316328842754d08065d459e2720dba668905a97064603c4f8eed8a5b53c5373d50dfa7a998132c76c2e1aea80ff6e7dcc6fb01821b1133b97ac06ad030a1581c6928d7141a4f9cfeffd64cbd8d4bd7a84d58a7e01fa504b4514bb2c8a15292c0ff0207dc0f8482649fbc9663bee9edfe01028201d8184443f96fbe1082585082d818584683581c8f7987ba282270144bcce48587b2eee96aa2719b75d43c7d3d64719da101582258207a637a71746c736e626d717873736a65697079617a72796b696666677268666a001a07643683821b4a34adfc1b7b6e8da1581c126fd35af87595b837f88a11592cfbd64798e6b8f605dc9ead687d4aa1413501111a000eb337021a0004f6f005a5581df03d6d1e78faead8d8c82eba9819d484bd80b46dc740483abdeb7ca3cc1a0004b62f581df096f7f7efaacdb7305e67ff32dc72404570f09183463f8d506147e3951a00093216581de0986dfd0a1e00160032ddc7b88edc006d920743ca7e4ef34536334cd51a0001bf04581de0def1800afa75b938979fb994a63d327960fbde63af73f505b5adee141a0008f808581df1e374062f9d89280762bab3c1c940e2e667c7166a9ffc1c4d6b4e04dc1a0009fc8d08010ed9010283581c3805c3129a197f6de632464ed4bb5f1d075cea493951ad16720bb4bb581c571f000be95dbcbb88a4864473f3b00aefb87c2b0b2a36cad3cff430581cf8ed077554db6e456ab6160c5b8a7d56544075806523fa75636c8f7809a1581c9c48f43a84ea2bb6c75281f95d63db6d2920dde77a29afa045717a1ca141373b4de3406734565f130b58207618edf63363dbae5a27e866e8710f17dd2a30263e7e707db9f0941e9d4959690f0113a68201581c646f89991144237ab548ee13ebc245d541ded1520849b4146811cd20a282582068102ecf368cd7b81b6aa17b4aaf93177c919e39372011480ffc70c7aab4ca67008202827368747470733a2f2f6562706c6f4a432e636f6d582003be94331c2159dc2411726def9a3b99f99384c13dd0cc07d026514d504f0b0c825820c663e845fc527490ca80426e1452f3147e35718069c2bdd75354dff40042e3a1008202f68203581cb8eda3055e1c1997a115bb8e6136ec6cf2e64974d30abb48e818d142a28258201372e3e4ba5b7470daa65fe510fbeffb92b388f39b366cb60b7bfe066f325fd107820082783668747470733a2f2f346f41774d654f3674366a6b7a753572565557666f504e716f344350526d47454c2e44433169552e6c2e2e636f6d5820da4477a6d61b6f380424a36a2b34705f7c8684bf4377b06acf0b0882f293a3e18258204be45bfce768a5e098ec8a541710e9bc80aa6c41ca5d568341c3566c1fa8927406820182783468747470733a2f2f6f6c666171474e56676d642e3256444770696e2e776d437879725739616f38683171643979595a332e636f6d582067023aca21cd5256326d98734c289b1665620f17a883e0b656d3b914b5e3f12b8204581c4a4a34757631549a487b01b950956af22581b7b894cf42c75c119321a38258202bfbf74fbfd4932a2b8e4e7009a07c968a0e1e7e695c899f9d9f82db56cd15f3078200f68258206f1eabebe30bd8825a3186617b787c2261a33f902f2da993067493d7a68b396308820282783b68747470733a2f2f5848513576524664526c50705135463744455278624b304636726578524a506a5353374654367258625a70724b65532e636f6d5820a5f6cb5a1259ddcb225d8c3f73d32f311541c768976b7c8689d7883b5f305abe8258209480eeb2f9ddab31e8a98caecb15fdc3e0c5dbe6dffe475754af17f16c543d1c038202f68204581c9e7c03cf8529557d1ec14767dbf01d4e3dfcb81a77c3189eb87e8290a482582031ce5939c9a4eb1f2128dbb216f4911e72339603681aee8d2e23db8aab5b8720058200f68258205fb1f9abbb855db88d6834ea106d02b3d23d97fa82623d694334b70d2442641601820082782268747470733a2f2f7a5064454d6f7570666f5470314b3256534851384a532e636f6d5820dc3e7d5ff2f589e5969cdf502c1acd6e88c5aee196ece8745fc7782f6293452b82582085bae92324bf7a2a1f847ed2003a43ad5b53270efb1ae0e2d050ce0b9473e51a008202f6825820e143632dcd6c3d489d18111c02b39d0312539d3fbab70e104f9022dc7ea1b06500820282782c68747470733a2f2f61566f667743347837364247416d71786a63704d6544503263547969413974672e636f6d582086ba444147e5abb3cc8833632bc4606c79720406ce6073f3811e48ed1dd1a18a8204581cb4b6ac8d72c0c367a2bd3532162ce61c87942ffb95426131edccc256a382582070e4daf06ca5d3c7367ea0545a836a39ba7ce5e45829aeb3544829fae86dd831008200f6825820733e071d1118113ee7a1f9d432b8f2d118f199e1c5d5e23e0593e31cb38f7e05058200827668747470733a2f2f487a4c694838762e4d722e636f6d582007198bd0026638869d5f1e9f3deab3628944a296edf439b523e85ba45499e9d0825820b9b5b04a45f2b77bd51f68bb2fe0d321e100cb40d5b88d1e73067faa605a66f700820282782068747470733a2f2f334d574232653942473535314e58384270794b4d2e636f6d5820129534411766464c516630b3f2a80011bb8cd134b79047c137a8e0ae9c7218228204581cdba4f021785e70da6b2d6368d4f0cf625fbe17c370627ecc92dac365a58258206e730ca96050282b24c0caa998b20c6b83debd37df062fa250a816d2d8f4badf088201827068747470733a2f2f4145394c2e636f6d5820ebb6b39c1ebb3b96f6efed342b2efe97711d3df888e67dfbf5170f5250a5519a8258206ff27a35d8c5c8dda819139879a7e2ec63710a43259be59e7b8db1f1249a0dd600820082783468747470733a2f2f473670367a594f536b44513170554f4143376730754865495754766677704a4c706f4b6d304b30572e636f6d58204c33392f586e81550a8fe162c919a69627ac58447aeb7983e1fd2dea793f3b2a825820772ae7277d4f817b6c3f76eba4bf8abf4407e6d5eaf7186411f63a8455a6308308820082781968747470733a2f2f3150686c4f7466303253626e4d2e636f6d582066bc37b91cd906010274c5d5452ae43447bf56a2662e4975707b219deb0bfd98825820d3f9889d512507351c59f527610bd837fd42c22f6c31721307201d8c33a4e609018200827168747470733a2f2f2e585944352e636f6d5820b875ec83b2c28473042b75213a276293066a418aa4242aab444f238cf0a54f6e825820de0d7381465fd3923a84ad63a675072e81dcd0ba6ebad918294ab631e80ce2a0018202826d68747470733a2f2f542e636f6d5820b5fc6444927de85e6fc27f3f44f1e4de42c40b116ad09123582fedbe239d1f0b14d9010284841931aa581df1a288f6dab196b2c6b543ad40378610916afd92b6c529d2e9f151c6cd83058258209d1dde4743c32c5c2ac4a3d178beee72af43d777219427699d4363d493926e910382827368747470733a2f2f7855394b7555792e636f6d5820aa8602b7be5da609d309979d5027dd2a7ef6f51c94b9dfa3395930568ff9e3fb581c09a1fdce4fe4a684b9b2013ab78f6bbf17bd26e38ba672ff5616d4ea82783868747470733a2f2f456e64686662515a796d316c4645634b59353735443044525977302e65674333454b732d6a46796a647554482e636f6d582063251ab8d6d369b4b54073dcd4b975f4e0d9f745bc8c3c478e95fb990e621ead841a000aae7c581df167bf67eaa07ef39833d837552efbfd1a3e3110356390bbc9638272de8302a0581c05eec3b41fec5ffc4f5b6fc11e1259945e75874ae2732b504bde38be82783768747470733a2f2f64616b6a4651394f416c30385573765851595470776c415a37664271574e57304e325a364f4c696d43506f2e636f6d58200e6fa001b0484c3b8242cc4b97a8ef8b28c7ec5dd7a4d7b2d6e40125d03b2569841a000432bc581de0cc74057923f7ecbf82bb75bd8bb027f80aaa2ec32271708d59eb42858203f682781868747470733a2f2f4e73764e4e663066763131312e636f6d5820639ac29f27778bc4e68a39a2ba663854e4975285060317fe6e24c24454b469fd841a0009bb78581de1ceed18a7a9a94880f2b951618a2cfa88f20320435dfa44786cf6d0748504f6d90102838200581c480c8a1a66bee4ba252501e2441ef20b0785bcce340b013b23b50b1b8200581c64bd0512343fcaccc0aa4d5e1140a31400556782d70f248f88577ad88200581ca3757552658e3c311c0bd52ef6626e9b9996e649b33525c629ab0930a68201581c2422fd6eebec1bfe30e88d689e629e22da9a5c30aa0d16a43b3d18a1038201581c2ab70a04c2b15a1a97c614bf622c53670a6c3735ec2bed2b823c65a2018201581c54fcbebe3384b00d80147dea238f09a60f8f2b25b384e630cab51d420d8201581c6266601fc3d02c7d96e9afb02ca1f661715c15835f7923948a669462088200581c33d6cdf92b139844f9d5b8e8653d7a1e8d31c3030382e67abd9246de098200581c553abe03f7e7de80a44bf855db4530a3d500d2d2d9a462e3cbbb74aa06d81e821b00139aa7ea387da71b002386f26fc1000082783a68747470733a2f2f726e7a45782d354a4d4e475a786d6c5939366d56423854586834424a67736c696b626961724d776a786f66595a352e636f6d582087eaf9da6fe66aeafcaa99c0a71cbb434f2dd9205511e41ace38f98a2389022e151a000a7d61161a000db25ba500d9010282825820f45f4e9b1d558f291b225178f9df7addea193a38beffeaf8a6197ebe0a1bfde85840f9a0a5cc88e06aad3536fc21777d2305f3d74a8321399a30e8fb635c6972339efd2ccb8c0370521d14392ee43beb2bc931f09cf6765e81c6913167f1310131b5825820c32a65c62bf36c4de713a85dd68418f219b1adb38234e0250ad164d5bafbd7e05840434fa9266bd2e5409a58a29ca7eb7c2efb5162f103f2d6c81e231dd1e026c125d59b58999f1c58a68d6fa265617f7c6353ab777b14b263fe9ad87ef5f89135c602d90102858458208dc03cb496b1e014241ece9ea2796b81590bb0c9c13f5f07f6beadc301be60475840f73046ee5b862c955038e3cae3d4453506383add0ec7967ecfbf931368d04ecb323a4e7ec65698e7b7811dffeb0e16977edb54077a542387e618bdfc0e692612453970373356443b41e9498458205969e40d76087855f336101be2cecdd469e1541efc1bc9a4a42e5c3f0ee190ce5840c109b6f1023609419819188f205e1af792e6ca6c6ffccb4239937ba01d7984a0b7c2dc3349e45681a1d5ece2036328383d18df0f55196e1ec4fa9677c1db72e4453bc158ea0c411b845820f7a105915c64cd40d29c880f31a25968916302e11500b131d87aa1110f078a065840d17a90144876ea625f157537a504ece9ca94eaf5b8ba9e7beebe4bd60faa2195355e0d0681946b3da6c74af06a973078106ff3688d2b2ff6c549da0a0976ef7a414f41ed8458202c83730a28507f8ab57e9ceed4c69b098a284cc04ad031bc6c5ecf3390c3ca1858406e6ee9a5c18d35b301224b75d0acff8d055828ff88aeeae14ccece7a68a20133007d33a01620a039991f505a0ab62fb0bfeb2523912dca6faa143bc671194500414741ab8458202dc89c2f10b72d52537e803b882ba375d692f32682413c78d3502136e9a71db658404c9e1dc3076c5018b952b249cf60e0f5f778ef26ea5df6552ff020c0a7a05639ec56005c385988d554c00cd251d3ca9dcd6467772b666d1668a2d250ade7730d45f34719b3db45f4086dd35f01d9010282820183830300828201818200581c4dc555f731521f94184fce4cfca0da938f4859679975ab2f627633528201828200581cd85222d06ae9a6e7214b189b410bd030b43bcfc5088a8c1ddc9df5d28200581c5e6228b756bd37c86b9c19b4a44f2f63cce4b71f2aad455520415aa38200581c9b01b2c3390927e82decbb428e09ad90259f3aedf591d9f0bfebef80830304848202808200581c888ca5e547db5712aafbef24f06b59819b91f758754011cc915e45f88200581ca20f5b0d1ff4757103a9aaf527d7e69f23ded4ec21d64da6ddeacad18201848200581c33dd0a514a279c3d404a6e26b14462d05bdc47603c5d1b15d251f9c08200581cd32fa12fd4d7d31f435fb26dc389f838d15e91771aab7c36ab53fc998200581c83f30f44695656f1a381e96b625d78b8ea5ad75c758b4e82f015af408200581cff47ceeba521070b9b2f6dfe9d414f1efffb20a1a2e6da9970f5e8ce8200581c4ecbfefd976ddaa3c0762e0cc76bdc0889864821f16fd13d13a61a0804d90102844080d87d8042889205a482000482a1a5d87b9f0041234234070140ffd87b9f44b65902a64412076f9b42e8f120ff9f44120bdc6b21ff9f03ff23a124049f445b197c9b2441cfff05039f0200428b3c4381ff4eff01821b6391bf4e1453bc8b1b0ca44dc6fe8817b582030782d87e9f9fa441a6232000020143a74f1b05d87a9f44f00de99243e1d4034040ff80ff029fd87c80ff04ff821b2188e7d8b71e4ca71b0a2ef1edd9538c7182040282d87b9fd8799fa09f0403ff4485dbae359f42e90405032141c6ffffff821b14632f33441168e81b16ff09f8cdf8c3648204058280821b32ec4b19592e7d2b1b674d444125c5beeff5f6",
+                            "cborHex": "84b000d9010284825820842c40eccc084776150c623decfa77e300e6973e878e62684161bb413cc8ea4703825820b8a4118d9aab869b006a76c78e6b74cbb8ea3ad43fcf39c7270059d1b865a82c00825820d85ecce17257e0323033cb91d1f8706c66e8dbea37ef69f1a1f76896e6a5655f08825820f498cbe3202932c95e7432ca81d4c93d17d1d162173a4453cfb4bdd6e5e96431060dd901028482582001c053c44b6a22cf9f02f1ca22eec1eb43b1f70ac527e461da9423fc67d9ccca068258200ee098a6228e10ea4430b29b78189d90108f8187dec2df4de8bdef06bfab167d0682582076a92ea06c802748c44a7310579cb1e3142b19d8dfb43c6b971dadeec45d2cd701825820f2c9dc2476e995c9f06e5d3c2c9a41c07ee9a7a79ca3199d11019411aee04f190212d901028182582088473b9965f6919a2dd0bd35caa5379853fcd1690e90c44c9cce374ff699984f040183a400583911857c8a54b65b007e4a98914e270ed548181cb6b11388e51e2afe3bb04244102206030f37cdbaede74581fe80d260672dfb35da094262ecfc01821b78a9e9e00ea28f5ea1581c800c5bd9fd8af62ab4302a315c37d7ff7dfb0e5066d7bc7029ed28f9a1535074bf95c177559a9f245a9875743caaff6a4c1b4ec99488b978246c028201d818410303d818582282008200581c3991bb7e34db5f2f6ca18138436dd1f968f075b7ca5e57c8fef78a88a400583901129b77cd751e01f9eb4437748faed5e19ec00567829ee304a04474e8ec1fc8906f6c92c7a7d353cd189104890f480fcdc6ae94ee07ff813701821b587bff5d4f43c187a1581c4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888da141341b2901780bb525e98302820058204a894ea16fc63105fff9f534c36165d1ddfba8aecd39c6812dd567766cc72c6303d818458200820509a4005839314b1522483d5833736a791002a3e8cf9cbe5dd912990e89e72c7dab94f7addbbf25a4f6a9151bf964e82fff8f3e5454ef8aa833c151f0a98701821b302e8b11cb2972a0a1581c245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abaea148e0ce37e52403892f1b2bf1b98341fe5e3f0282005820f04453a030fc61fe5e738b29263bd1a945da8d5b80cb010608dee4b80c2d141a03d8184a8202474601000022260110a3005839317e324569b5ec21b6b51c4ebb9b5f7b06a1cefac3ed3c8991fcc6f6b5872fb7760d1dadbc1169bb0de0c8421987e9a10369e92495656749ae018200a1581cd39f09dbc94680ba4d75da54ab36e581db1b6879fdfb4e6dca258bb3a141390103d8184982014645010000260111199163021a00011cee030104d901028383078201581cded079709b9cbfb2b422e9b0935e029f3e85e175af33fa3b638e662e1a000ed3a583098201581c6cf16ca8ebd6f59cf04db47cb61c4632098cdafbd2bd7fe3acf5e0b281038304581c42c191559da9638b2c7fbcf07562efe9cc31411615244d59375f3dc1070ed9010283581c2d11cb270395a17c57f91f7f4a4987512e486d08b04ae857836e2527581c63e0c6cc0c4a5e53da0ab32e6e034c1080622c0f4bdc207c2a3eb461581ce850fbc42273c25070338a00305ffdb5224a1e4ec0f4d166d8baa40109a1581c5e4df632b05c70ec460e7def01a5f6e946abe741e58239af17959ba0a148ec7745b5f83511083b2e5e6fe3a332bf5107582070a3a00125f2eccea248ee092cbfd44fea4b6a19a7eefc70d829c2f7346b76ed0f0114d9010284841a000bfdff581df1e23a7009cb6a9467b9e22785cc771df446552ed07815291e1eee7028850482582061a404b2c1ce1a037901d7a497e3fc2a7744bbcd7772341b23ca6d3989f2051a01d90102858201581c670b1261edd603560fb1ee81c45ac39c738439753561e2c0bf0d9f098201581ccc655823d253b267e7f3ce0f06138e5bdd033f1ff5d42bc26f67ef3f8201581ce3cb73a06da95eae78858e46836c90b042e0311c7f3eb711427ab9548200581c3134f56f3b807a9de4e13a5bf5e9768f932cb1e9152e9c1a258d85b68200581c3794544616dd07a35d42994d0b164e17134adfe95fe1b5405099a0b2a48201581c6acc78f9589e14057d32902cb06699e549c8897fc5b33f14041f639a078200581c96f39df067e16e65b33aecfe2b6067ac08213a4b7f2f161d92e81e1e018200581caf6e9c541c7c0bcdf91ac662bdc6b87139b1384ccca6564cfd037d3d0e8200581cd3e529cf926c2f8884eeb27de1b262b70690335f221fcde00544854e08d81e821921f1192710827168747470733a2f2f7257724a702e636f6d5820da0e71b7fbeffee35c1d0582eb676a1faed1c047d093dbff73e20e24da64cb4e841a000a2fe6581df0acaf65f794938ec3b47e7a7ff3d11622aa00798320c772bf8fafe8f0840082582049b26032794e5acb3ff3304c346737e4e1ff3f11f403f86dabe0d920c463c58e01b1001a00021e32011a0006751203000401061a00048fc8070209d81e821b0436d73e442b13131a002faf08101a00062e481382d81e821b11aa17af8a41b2371819d81e821b301d8acb252199a31b00038d7ea4c6800014821b3b3a099ea9a2ec4e1b19e7d1cbd446c99415821b2cfd2413d43e3a001b76effd8c39ee293a16081705181985d81e82021819d81e82131819d81e821a012e95151a017d7840d81e821a000e840d1a000f4240d81e8219623f1a000186a0181a8ad81e821b00031e69335feb611b00038d7ea4c68000d81e821b159442a7c9ce77911b1bc16d674ec80000d81e821b00003462b8fbea311b00005af3107a4000d81e820305d81e8219976919c350d81e821b00002d0273bf76471b000048c273950000d81e82191881192710d81e821a246a30e31a3b9aca00d81e8219b19d1a000186a0d81e821a151e8c051a17d784001820011821d81e821b6e7522a71565e0c31b016345785d8a0000f682783168747470733a2f2f7739485557424a6570742d4e456d6e4e4c363930366f4b73534a365666426b7739587259762e636f6d5820aa1e251dc5d2a138cca5f5363659a0837901ae7fd6c391f3338c22482518ef39841a000253ff581de076e002bd98bfb4d7da3fcfca97dcde4ceabf9a641deabf085d506fa08504825820f009ae809dee0c55dbe3a6eaf30521de47bc0cdb251e700b047aeeb9f23a125b02d90102828201581c71fcbd3096d8033ee1921106ff5743755ac49fe3912d7ab2680d7b658200581cbb99863badf8f0f54df1f1d83278a8aeba6855d4d3281ddaacb0444ba0d81e821a04007d631a0ee6b28082782668747470733a2f2f706a6e5661786768446e654d7165734344633777513478346b702e636f6d5820d1c14ad21e987181920f546ccb8ffe33fd8747f5f966ee176a6eb312e3caaee6841a00036946581df1b880c3e89b8f669486f6012210498cad53ceb12006ad77fb856dd4338400825820263d109dde6769e21b73d3f234ea48b61a51158dcbb806ce3a4e4626b0279cfa04b818001a000544dc020003060407061a000bb6660700080709d81e821b5f229114e6c3dd9d1927100ad81e8201010bd81e8219015b1903e8101a000258c11382d81e821b1c8b479ce7397f031b0008e1bc9bf04000d81e821b627a45f5ab06ebe91b8ac7230489e8000014821b40805d384ce6f6d61b31b98874fe0ead1a15821b510c96887a4a4d041b42479dccc8d50ae716041704181801181a8ad81e821b001e2a4602d437c51b002386f26fc10000d81e821b000000052b205b1f1b0000000746a52880d81e821b00003b435d37da9b1b00005af3107a4000d81e8218991a0001e848d81e821b0000123b806a5b751b00001c6bf5263400d81e82190323192710d81e821a0013e26b1a01312d00d81e821b00aa406a24310ddd1b00de0b6b3a764000d81e8219bdc519c350d81e821b000000a50123074f1b000000e8d4a51000181c08181d07181e1a00034d9d181f1a0009ed5b1820001821d81e821b2cf1fb819dcf69991b000000012a05f200581ca6122d16e4a90d0214c867eb7a0d8794352b038f444f970aa249709b827768747470733a2f2f30694d634e30362e494b4d2e636f6d5820d28a89ec1eef37c52878412bbdd056014eaa473aa7b62453fbaca7f9721927ed151a0003295d161a000ad93da602d901028184582039f61d73445ca022267f4aa9406de5c979f5a85b2e224a5be79c53c2ba92a844584069a4fd96395d544815f8161f7af056f02276ea8d120753df8bae3655335051334fbf891e5328c5fa2cd61113d70b6102b23054b81cfd421ecda0ed1644aafa9e426ed441ec01d901028182018003d9010281474601000022001106d9010281474601000022001104d90102819fa59f0541d141ebffa5010043bc7ee421415e40040442197441f6400001a0428612d87d80d87d9f02402023ffd87a80a39f4041e121ffd87d9f0444f4355e5f42b02aff809f22204221cc04449524fc2fffa0d8799f425b6c20ffff05a38201048203821b6dc8b74d7e0f8c411b276a3dc12b45fb2d820308829f4308f239a4443ca3166d4002d87d9f40ff9f412b4241dfff447fd0e65d43c97073404169ff821b3ea904851ea144951b75581d89e2fed703820401829fa5a3436f9176433738a3445215aba80344357475e84117a10201a244e6b5785c050501d87c9f44b65479dd04ff21a3422f2f2405402200239f42dff642c6b84002ffd8799f05ffa3435bba9124443973b5f824040244535e1becd87e9fd8799f2005400022ffd87d9f0024441fcd87dfff9f427c20404318fb510420ff9f42287a44177881bf425124ff04ffd8799f409f44e400044921ffffa0ff821b13afd0ea38c0b9381b77df6348ab36af25f4d90103a100a600a4836df0a1a29ce997a1f0b1a59c3b4e626f172360626d21832424004286cba0a08341e76041920263eeab96060208682ff0b0b2aa7e205409800e05",
                             "description": "",
-                            "txId": "f91676e962adfa6f59f5d14b44f5d1a83ff3c64f01582c689e0412bada2d0a77",
-                            "type": "Tx ConwayEra"
-                        },
-                        {
-                            "cborHex": "84b400d9010281825820d3d91990cfd975649546e827c96c282f7a0424610377efa76215ef39c7556a1a070dd9010282825820aeec652212349a449f64f97e58b0aaeaa124ac860a098ef6333bb63588c840c203825820c6163ce9136c1ef0052255b9e75aa7363af642b40da864cc0aeb75738cd2a4c90612d901028282582047e277124fdd7cf5a3fdd50bd66054799236679ea0fa81f3a1ba5f1e42a3190c0582582098e1db832922de3169bec1d3bbdf889ba4f0016ad72db1780e6c4e58bd78abc4060183a400583900fd416a10ca645eebd00746902868949f40bd8513c4e60be4f5c63c9757717d991d0872f93303f98d107c3f805ca713e1151a76ab037d355e01821b4ffa12a9a559d294a1581cbe3b384cc054c802c1a26fc3246fcb16b84f961392a0cde0b357b969a155305db7542dddd2369ce81c4aa080f9e2b7c726efcf01028201d8184aa1a22343ba8ca202000203d8184b8201484701000022220011a300581d71460b78cb85b6b85c0eb2dd123bdbcf1c35ed9987342e46ebeeaec4cd01821b6259c0e0236b59e5a1581c2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2a14276680103d818582282008200581cb59982bb4477cdd51822a406ee7190edfa383d4e159303e6f8e47db4a300583930a2b485bdcadeb73cbdcecc29d13208e9a6e288b05944d5e2c8c00ce8f8afde4c1404f0844231f7993c6f5cafee9f98a2c6373f393ff3a856018200a1581cb0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165a141351b598e16c80f2c814a028201d818583cd87e9fd87e9f22a342931f400141144040a441b92144fc5fb48321437c5d38436f558c44e67e52af4201a1249f2242951f0100ffff41629f8002ffff10a400585082d818584683581c1c34f20e59e59a19570c0d0a6822a6c1092f02faa5694761d7a8c1e4a10158225820696f637a716b7564787076766f646e64657679647368677071757069666f6e78021a7354569601821b23a8789a015230c6a1581c467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22a154e7f282b83d421ef1272b445b5c0046a374d9a43f1b4a9d43caeb3f23c302820058200e20b57ad21b491faeb8eb2991e418546ab118305cdb8511280f9cc06407afb003d81858b3820082018283030183830301838200581cc0f6995fc9a6fb792cebdccc6a906ad7701839afd3e4c63a0b600d508200581c922a66ba55e86b41b5d12663471b20a10ede7a8f3bd09ad4021078f88200581c60407aa07aacbfc165faf8c367159b0311609a38d5da8881cb2085208200581ccae1df641a87f20adb7ebd726dc3564524557f9413feee312f055d948202818200581c75371adc39b34a9e2a5772e5eb61e409e663147a5fb986791bf7bec2820180111a000e9faf021a000cbe13030104d9010281840b8200581c3703bfe572ac272fc42570fa6d4235d2b84ff7daab6e362ecfd44422581c755247e585bdda4fa5b042191fcd03835ff2b99e4aa5eded110a2fba1a0006c7b505a2581df1e6c3f53e95ed2754caeec1ba7eeb15d1d3b22a970f2d16089865ca9f1a000a0926581df1f13311d29aee54ea2917d852edc73a771caedaf21a54e9379103fccb1a0006dbb708010ed9010282581c0678bcbf5b1a3b210a6e23518b0d82b0b2dd39594d94befb32421035581c0ec97fd889d8e0afbe5cef4700f8855c55d25b3aed22e8c3fe3b8bb109a1581cb539051ac23ec76e659772d461fb3ce33b0f3a18828b1d465aa8fed9a14270911b343b6b8c20c0d3880b5820f7e55425cb935b51c454a5726eb770ad991043093e5babda1c0c05a8a738c89b0758209644288e720e10d3532710d9874b8aacddc40f6fc0900b9ef75b8306aecd58d60f0113a48200581c08bed4c479e953e12c53b9edcd3965b7c4c1805dd0a45cacf342ff84a58258202c1f8403d2a3902d5e1937073bf63036920439a33ceb7584e0112a838155c621038202f682582034e847a51652da4318c3d929850654c8e6c0be04fc08e0d3f80259f93b3bc6c2048201827468747470733a2f2f46395175527665522e636f6d5820ac1b9c0d6526ecb8f1c8902cb1527ce3e20ad5793be1f18ee9e677bf3e789411825820dba3d744548509ccaf004374b8cfeb2476e97c10466f53f05c11257210f8379208820082783068747470733a2f2f4d4e37702e384f544f756b6878494979676a5952786a2d6a304f3462624349687942374e2e636f6d58209cdaeea85df3aa9186693b1ed10ff17db9afaf4c3efd57218d4ea8ec2a184972825820e20ad26bd032c41b989174b75a178d143e5ab76fc0f74dc91dce44f97d0285c003820282782868747470733a2f2f42494933373763456b5854364559702e7644346e6d73723544326a692e636f6d582026061d2e430cb4c4b402131037e03ebc25ec9cd9683e7b6953f942a11f281a82825820fcd731534177eb823b7ffbb668dbd9f970137d3649d5f6ce9eb10d3216a16fc406820182781a68747470733a2f2f3468306b707552334932527246462e636f6d58206507c0c90ae4abd0b00a24ba7cbfc7ab49c634847df3a8cac202e10c866843298203581c213e95e7a7eb4863640abd87afdbc80ae5831003cc008229ac939d54a68258201a1573e0c92186952d32aac1ea2421bae68a76cc3f87fcab8049097e1c00be49058202f6825820220f2db272b9c7ca85cb11789a0f76cb01c7d392fe3b8cbf1e08506a5897e2d002820082782168747470733a2f2f63746e756f57663346562d44474875446e707734732e636f6d58208ce1e228b2800ed20595f8cae0897bab69cf2c09bea6ce759392ac70ad1ee575825820485f2101465bc640dfb2ec6574f1c846d80a502e7bf9f6bdc251761d5b64dcf306820282782368747470733a2f2f3372373537722e6f52487a49776171555472356d7557722e636f6d5820034f59cfe2e1f18ab1a604b71b95e9d635be67bf269cdf80ce5dab1d6bcfba4d8258206947bb9b2fdc8e65cea884fb373bd14be3de9ddc951f59bc65ea5fcc413bdfb9048202f68258209bbcfabc042d5414cb49757cc1e301ee02df504873ba6d03c10a8b310f7b0cab088200f6825820b9c5e3ae8fffcc76d8c04ee268e6c9c0c93803707424f9604e8c235f3a081bd804820182781b68747470733a2f2f723044716c35646c4b463142714f572e636f6d5820c560d604e977a6f767c3d25a875f1864d230dd6c6014356d118b199da9754a1e8203581c5fc6a6e802bf8982be7402393b61db7da667bc87d507e5233fbe5684a282582018f9706a2b30cc66c20d86a2a40bbdf37cd2bb7abfc6687a9ddcfed52cec57ac018201f682582067dd2828814c21452c677315ff8fcee124e005d2622db6f508684353b25762c0048202f68202581c2d423cabf04553a5a9ac6e6bbadfb0a6426cfbd9fb4712fa7334bd50a4825820086754ce7bbe57a8a8c54a436a2fe60315e916fffc8911282e5f63fa05ea1a1d01820282783368747470733a2f2f6162656c7836354b6b6b74716c52616d6f716f596d5a394576526144704434444c4759447052672e636f6d5820e83487e3d4c5533b43b4fb0d86f9ce547eb620cc8a0217b04fcc4727bbe089c782582036ece70cea2b2bbd50406ef57f26b5f8751d2ce3125ded80ab843c2404fb57e700820082781f68747470733a2f2f702e50536f71646444655567337253627054542e636f6d582036fd98e229d275c771d891b7c88d155a3c6067bb942d357dd0fabce025cba978825820c5fcbb3264dc1b2a8c42efaa959c5d59e10f49f5003fff5fcf1a617ae187ba4103820082782c68747470733a2f2f564e4761496a4564754f5a74526871432e5353697a55595551377836786558462e636f6d5820ad27cfe31530a4eb749a21d16027ceb216fbffcc804f082eb5ebfe5466bf7743825820d623086176ade1157084135bb8eee40c21f36e91d9e7d8eb64fcd4566a29505004820182782668747470733a2f2f4c726a51366b366e656e30764c6563377258745765617548646a2e636f6d5820a559dd89cfa08ff474d40748e52067a8c5ec11ef7addebce67359a3a3716504614d9010283841a00016f18581de16680bccf1ee5e297e30a03b46f06bdb3f25a603d53b5d9fa52724a858504f6d90102828200581c67c5f76218a4a21e27ff8d0f0314697e2935daf71c7c52974ad5b98e8200581c7df814a862f52d2601cb279f155547d1bbaf401f5784b6308dcb60baa58201581ca3e640f823a0a296544ce8d17f6fddc0e2105a6966a6eead0fd75530088200581c4560add6585c2ea021f1c1b77f7454d201ac9d9b85f287210df1b642038200581c6ba76fef17822dc46428300baff81f1b866cffcfd1a9f854639d11a4008200581c99e16be9f912eb5a4024e0e5842250178c81819c338734edd2f9c17a0b8200581ccc923afef49c2cd20c4974def5ca63d45c55dabcbe476e116870541105d81e821a000441b71a000f424082782968747470733a2f2f38726449396b377231354764772d44727548374b4550567134705351322e636f6d58200b91fbd70c3c91bc09cf8aa4182f5bd20ea6962ef1ecabf0677ab9c0f9b56040841a000ef5b8581de1e17dd3791e94aa2f61e40508bd02ea728ba5f8fd7294f66e6f1c7ff88504f6d90102838201581c0cb5cce01b384d7ac4e321a840420b6cc513c8063e40709f32baf57c8200581c80154e8fd4e6055cea303d1065c693306d56287e26e2e5f0d0b3ccee8200581c92b2ec13f3f1523754a85b2127fe7abaf7b05385d9b19d90cbfd0857a68201581c94ceb433b7412bc3f33bc76c0e77337ccd16f4d52b273e5a019b93e30f8200581c21859cd10f92444d72f343b35c67f85f1ae5385b4a117ae16c970851108200581c224c9d2b9ae8ed4bf668ab91dc4d7760cdd271acfef014ddac567dbd0b8200581c27da8ded18343b1b752daeda89ab894660cee8c85aa8eed9f448ccf2038200581cab03324e9e6015243545d611024d3583dccc58dd4f12f995d6bdec55078200581ce46d1640e3d98dc0fa78ecc0ed137e9e6e3dac06dd0fe306060bf87507d81e821a004475031a0098968082782d68747470733a2f2f4538546f51436b6b583850734d475331636f515963532d35344d6f36342e2e53552e636f6d58201b5c088df6486968e935ae9fd4b9f6fa75c1b8b7f60b8c9d59831a65d34988e0841a00018540581df1be02a8bfc4b0b1da52afc67e7463976667e4f898c97cbfd7740d0803810682781868747470733a2f2f6d4c354542393372464135682e636f6d5820e1951f30ceb801cb8ceb318266ace3aa3a3505a0388ea607cacc10bacb2a5756151a000efca8161a000545cca400d9010281825820866e8417c26a3152c2681e1323a61af888899d2705499a6908141c01eb6c61a15840257edff797513d88b56675f6ea4ecc26d2c82306d192dfb03613653ce840fbc2cab1271f967e56b83c1646bd2a061dae3bc5038dfbc257ef02fe0885abbb037c02d9010281845820b5c2b0920002b65ecf1bae93486c464fb7d516fbf48ebefd0a4d11d31044e28e584018d76db93bee76ff47796edc262cdcc3c69120cc0b3bdb47de08b070631a7369e7bfc725db7d64cc159c0f5f76a0e7d940b1d3d916149c95e06064f0b9744ecc4585fdd479ea45cf7bb5f5cd01d901028182050404d9010283a2a19f2001ff9f4042760cffa0449ccad2a280229f9fa202425d2924424cc69f0020ff210544407bc61bfffff4d90103a200a3032109200ea30168f4889190f0979b960520a344200b89e063172b724044d2bca78c0066f4868b9d2f3aa00181820280",
-                            "description": "",
-                            "txId": "dcce394fd4f6ad2b7fd349e03bbc5e6f8923cc1e706226a9df8aef408315e605",
-                            "type": "Tx ConwayEra"
-                        },
-                        {
-                            "cborHex": "84b000d90102868258200c69419dc3ec6c6b664d81143e20318141fd526dc7c2a292981b471b786ef2440182582064374c031797a008b96e4bbe52d75a2f1ceb8f2474ed7d2e447825b3c84693de058258206794ce837251d38add04f77990ac520e594256d54adfd86d8359066ef7ff3d8e02825820c3e3da9eac245a21dbb4d0915bef18b2f775d57ae0dc9379be9484994298cdcb03825820dd48c54633e80952096cfc07373e37bbd8f1d7b8cd89420a474deb57b4add5db06825820f48647a6fa55e8e774ceab5975d2882a8474515fef44d8116002e0852b39a5430012d901028182582014cbfb2ebd4e59575d7a85ef67f118271925bb84e75ac9b94410fa6d083506510801801083585082d818584683581cde116dea9ae27d89f6bb30eb50b5311b443fc6c1816119e27ca024bea10158225820e73b03280ec1f9d2e288556a0e8e7c191b7831879b466d874f81cf54f4b96854021a59bbc28a821b56971e6af86b0ce0a1581ceb6508f7ca9be62e405788b873f0a0ff9052ae8ad8e0ab9b2c38d3d2a143dada221b610dbb716677d0eb582035785ef4a9ea4bae5b46c927a4ae83d55c998f96e629fa70dc306d58b29794ef111a000bc677021a000716cd04d90102848a03581cc9fe150621f7d802cfb13c11e28f78aac9758744a6937e296da7754d58204c0957b4aa597b24f162914da29122d841e641425fdb78365f0bdbd3f27eb32b1a0002bc941a000ca781d81e821a003a29ed1a05f5e100581de120c83570e9806bd8cf5b0018e9fdd8b1c2c7f248fc9972d473f01959d9010282581c36767e09ad6d08e0881750381dad966273884ac6e4ca9135df332680581c4c1fe847fff4416716dd543fe65e80b218a6c5e6ceb350e5c4058a3c8082781968747470733a2f2f694d38455749636c554a4248452e636f6d40830e8201581cc059b41ad7aa2eedb27d9b34885a627a510be74f04686400dfe020688200581ca10692386188cceba8d445848ba166839277a8562af7e68a4ebbcb708304581c261f2b2ca1e5799a0e283003b399ea7561d5d550efbd2c65ebbc00c40d83118201581cf8890fb35ffe8f1c39645b4ebcc0e36046b6ee3d1cf5e56abe6958681a000919ea05a4581df00bd9c3ebfa7a6ea3a06ad5e71f96681a9195b9cbdcdd517f724906d41a000b43cf581df02081f538fc385f84e0689b4c6a8b55aa3af3e868b289da8f61f0a7291a000176e3581df17cdd23b842bcd6d0658f47d2991a2bd317daa0731961d9a8665f7a191a00086450581df1df31222ac19f7ea5303d273b58a770e1ff87a825e88daf1e464370c91a000a7a0a08010ed9010284581c70a923024688874fc37ae4fd1c9d0a01791951d99aaf31b1f0c2493b581cace022b08183aaeecbbb4019fd9760e64a845ce7c95c2423719cbc65581cbaa66bc82da994d4da38e7137d94828f67aaaabd7af213d9d551ec20581cbb9cefee418ae7f96eb3de590f90eea7c0c348e4eb125e836bac748e09a1581c2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56a14f9a6dc27ee3140389daf55e16b3b77a3b00f4d67e60d9c849075820866bf165eb2a6f71371f994e99e290c4126bd13692d845624ed415664137840b13a68201581ce2696d500f85bac1f9a0887713bdd64503e6b81eecf750f0bf45f730a38258200af92494f7c825ca9ca23deb83df6c97263ae0626168e60398dc218f0d8b3293048202827468747470733a2f2f624d684d4f4f506a2e636f6d5820a41c65787bfc187102c16bb0d145fe8abef9d9a1c115c50243ecde38645053c882582065ba5a18a0441cfbce252c0fe797e969e8130c57a0dd7ff00ff2770c219eb6c508820282781a68747470733a2f2f5a74533845532e58726f6f326e4a2e636f6d5820c8b78218ef29362671453a62d618ff0f41144428705a7b6f12757a7a924d14638258206d87fd75e3b5e4de3329ebca2258e6d6decc1f703c08a3de3b0f344d2afd40f100820182782268747470733a2f2f514a446f39636a6968306243316833565178744374392e636f6d5820807cf6274e307265bdb4751665dc70cb6c4cd1c38b404c7b189a657404b4d0b88202581c24da419a3990b9885718e4172c82b7489b8ab52c332924b616c36d3ba18258204aed83ce3ff37de7f1790ffa933bb8f6dc0fc494aa0925aaa2e23ea53546d40a06820182782868747470733a2f2f4d7474696c6c57456d30454763745a37797846315662504a33622e6f2e636f6d5820576b47f1a6e9407611790b644c3521fa4fea2b76bf0d2f8546f5228515b978978202581c255f6799ad926525a3265640cdb6cf2998d411c1bd25914ae4f2bc28a582582023821140c88a701f277bc345c60bc586a610e174b9bd8e53ce7d19bd9961d61902820182782e68747470733a2f2f574744573653656f687a4177514530313953597379493450546147677766334368422e636f6d582051d54bc3de4db9d450719e4227f59d1d16ff3a5b57b6b4ac2c37f6c2170aa2428258202b67c2d5fa7bb9dbdfa7dc14bb93c86acd0dd172c31d371de4bf4b552995038103820182783968747470733a2f2f465747534b2d306657446f675730595649496f74445370573877534b6843574f635965724655676b5135694c6c2e636f6d5820dbb2afa771b11e1df709444840a9ec75389203d55fd510e5c5320aa6ee911d508258205b16dc0e8cec2ddc156157fda3e2b807a5031755132640d437c4a0fb87df2a2102820282782268747470733a2f2f58494f786b4567696c4177643935623479587255344a2e636f6d5820c889a635778b828dc5c65e9ac791df8f877a9161cd100554930d9c8a1647f5c4825820a91de24e9a2490e2a8bea14564b11d6b790f85573580410cd99d4cef629cf36b00820282783a68747470733a2f2f4470484466484b3255356654677848346a37574777694551546b6f766a456c59686851417043795a302e555839762e636f6d582055ff9695ccca60c41015f00451a05187651374f07c6b5f7b877f5dfb15343c2a825820fb0629f053c267661975c1e1ce34abc66aa113187266d46ebf7ee0a809f8a5e005820282782b68747470733a2f2f46785452706267524b655152434b6557543649764f714438386b306f6253642e636f6d58200b4bfc623616c6406f3aa78348fcf4f352ad4aedecba3e9537ee6896374abdca8204581c82d81731a897bade42d095e3b3df19713cd4e9d70e9a252f8b845543a58258209a2802c8ddc1096788278d8d3f386d45ae968af69a4c9113a789a4d68139729207820082782168747470733a2f2f592e62364e5a66546a6b61775a73414b53742e2d622e636f6d58208fe72710729ba268201ecc7c31359d4bdc6e7141e3efe7d4d8843c8ce9c5d482825820c49768d351c326de0bb42218a86cff3463620d5ecd13f23e07e23cb00be5207e048202826f68747470733a2f2f3456542e636f6d582073683d56f2c9ea72bfe87f90803a95543e5b77d4224c78c898ad8b6822326c80825820d4d71d84c5093f3604fea935393116d8f73f25fd05e4f911ca7041cc82d727a1008202f6825820f4601679a565555a1abfd9a94905764fcb7fca0da4088438179e8d1372812e1d07820082782468747470733a2f2f47654a7368354933627837654d6e6345475a6a77505342742e636f6d5820520b3265613b5f0aa266d8f6faa946286826b4b631d5df74cc9b3372566a17d3825820fec905527934ba826adc091fae6520894554627a2031cb41c8a68f20c8d5e9ff04820082783c68747470733a2f2f30497875596555446b6c62764b4b57554c594b2d646c665038523877547035596852526a7a71512d64587a562d50376a2e636f6d5820ad37e773e5ef4893920aee27eaf195110b5252f797d17ed3b176ca0f211c28748204581c9f1de97b68f44eb5d81b1cd70969da369c8f61d68362ea8a0e309599a48258201417ae92de754a3b873cfc4833dd67ffd5d651c353ce200fcfdc3df21089e01a008202827568747470733a2f2f674b574a38783458392e636f6d58200765a4d7799b79644fb99187a442ff6f9754baeb2b6f7601b474c060eef29fa1825820cd4a011fc15ce7a10c30fd2360efc16df21d5a39866674fff419080bfbefbbc900820182783d68747470733a2f2f554e4e4943486536724d54364f78575769466e745467564c30786d413641333655784c442d474579476e36632e63432d6f2e636f6d582072543bdcac2f6f86cef3842f95e2c039e71c27a2c26a1f98d89faded70192012825820f27792a7ce33fe566192348b5906e7854a1571c6712c9806988b4fcd9d92017206820082782868747470733a2f2f647a2d51543548534739654f74476c41476661474c634272666361792e636f6d58203b0483f80fd521c91bfe3da712b633e5f349c0be38a5fcb3434e03d5aba4f04c825820f8c9e173f36f8c8faf1bb841e143efd4e6c1d7302beea208a0259b463f8ce0bf08820282783268747470733a2f2f6a342e726f516256665466593135526c7467377a4d7253475949794a505a564b522d536775712e636f6d582064ce4e8d3e6441e94a7aa1bfe87869a60ca56240948e0c950e83b263950072bc8204581cb4e4ed4fecb3d0c824c802897323e5e66c1d0dd54a70f4be11434f88a582582018696e739b962e86d566ad338715d78de0679a148d6034543558946e63cf6a0007820282781d68747470733a2f2f51324e427a4c6b337271736f666f364c722e636f6d5820150ee1c549aa99b52daebe6c01f6ad099ce722898a340b54b06413f6f48dce7582582027263d3ae2ac02508956aad6152d25846f87b3cf05045299f38f21fbce57d98502820082781f68747470733a2f2f45424d57574f554c4c56482d6765346f4b48332e636f6d582003965bf09e0824579e6b194f58e1c19f37f2c04e2f1e7f891714bb813f8d64dc825820a039135bdf991e6aa139c85281e640da29156e11e896e8403f759d3031f67c0b04820082782a68747470733a2f2f70506641496331515338357478473445536f4a4152646e676e3036466b422e636f6d5820eead9a404fe40b0f347cd21ac80a350c5c6845151d0b21b1ba7c14e2dc1016ac825820c28bc5f25e784d20974587e643243dded29879fcc0c35adccd47c7bbc1c3e27e04820282782568747470733a2f2f70417931514e435533774d67627165565a79517653354248412e636f6d5820f21ab5e567fbc489be5f85667203e338565ac048ebfd5e929796312d033c897b825820c7f6968c57c0d8c71c3870eec5aa5da264e8d8c3d0ff999c032557e90cc4fc4707820082782168747470733a2f2f6555796f54533051546355545079532d6a7a574e502e636f6d582044b84f883da2fefd5ce328efa296e8eb6a03c5227642c892dca43643f030c08314d9010284841a000cc3ca581de19bf40a0a72d45e3f2cd309d04284fd07ecf8afdd35745348363f25f883018258202447bf44ca87824c3c08fe63a62532dfe06a7161a106c2343254f4dbe52c26990682090682782968747470733a2f2f3570414f694b4d4f2e314763464f467944734d457674704a44564369772e636f6d5820cc9665d8c69bc0334278477d480455fa734eb4e9847f941c7ad866b5bc12edaf841a0009a5ac581df02a50e3fe64d3424e55b956c5e289b176ce6fcf6becad9b68191a1b04850482582014db0674addef59dead481fba407483527a09da31cc9471fb2c8b4237e7c719c06d90102858201581c00d96cf9c97b96a2db01b1b517bce25153128c6c3b88e1c0e6e198f18201581c02de9390ee61ba068a90555d9932ffea7d210c5933fe10040b761bde8201581c1b621915bbfca6a8536ab510ae56015e6c50d478594a5b67c129fe568201581caaa07272db6efc21f8ef3bc5a2325b2fab1d449e50daa12afe27dafe8200581c9aa8e3853693233988441c2182e13ebc553c0598d62c6234209a5a43a0d81e821a040672771a1dcd6500827068747470733a2f2f314e31372e636f6d58205e9b17ef0c4b0b4304b2580377856e6ad08da862271fa30b11c04c2c29ab8416841a000257d8581de122a8e9061792652a058dd864444351b204f879a01ce7ac3d62338c808203825820871c73762c36b8130376965909a3a7de1b7f8003cd1b981d8286740c8286ffef03827568747470733a2f2f48346a3270354869352e636f6d582031456acb7b445808662b37939a107391969f0c8cd27ac24a5c0c021682bf73fe841a000a6700581df186f0c4816d3751ed23a431b300de1eb21e5b31343a443ccf4e8e3717810682782568747470733a2f2f34383158515470574f7771325473326a335565654b4f5779792e636f6d58200f2092b73267cb9b83a10a067728997c606ae7790cec2b5c8c9c0cfbcdb45c23151a00030574161a00033899a600d90102818258204f5b7463e753f1072ff6b2943249bb98387bb4f8d9bc3301744a00cc5c9ca9c15840ac1c89f85c2e43aec38ea6ea7353527cf2799ba01770af4b392dae19868c1c2dbcfd601260aac1c61bf6ab5a3061aa0f970316d05a21945edb8cfe6f47d26ccf02d9010281845820068acfb822814587ae563d64a66ef7c260a596fe63e3486e72cc82efbdff03f058409fa82b0bb32e3dd4b0f1b28d883e8657475532023b78b38c88e34b78af68148328c90b18cf53b72155f9aafb8ffbc46b6c486f5ffda732d2c890b9d4176dcb7444dda226284001d90102818303008006d901028148470100002220010104d901028600a52224411b04028042e0b0a104d87b9f24ff434aef5dd8799fa0a323022403204405f11a849f4044f40b9f4e020222ff41f79f05ffffa1d87d9fa2435393c8052223a44042a2b04042085c22425983410a40d8799f00ffa240000143b7449a42e405ffa3d87a802042a63fa1200344a9903caa43714228d87c80a29f9f40230023ffa50540230343b6c1e3202342604d2243c4588c24ff9f42069e43312feaff43cf97519f01a120448127c788ff41bc05a582000482d87e9f9f80d87a9f44df0e5d7a4004ffd87d9f24419105431de088ffff9f9f41dd442cb53ec1ffd87a9f44c5fc5108ff9f010544db46175fffd87c809f44031937b043df47f02242033542b66cffffd87d9f41e9a002410bffa19f43edcaf90224204410dff349ff03410bff821b69512b3ea453a40e1b15f5a2a07730cf478200058223821b3bdbf0e7c8439ed71b4a670eac7745d8f0820007829fd87a9f422e7ca04044c2f63b09ff03ff821b5b1af7f0115419aa1b74cc9328206005ed820200829f03d87c9fd87a9f428ee22141c1ffa103214171a0ff9f00ffa240a0a003ff821b506dc4a81d81e5c81b507da319ad662426820401824172821b7feb5586ff737cda1b1a59d68a4e2998f9f4d90103a20185830303848202838201848200581c759ebe37e3814a4e7866f575ec76e200b6d2e14f36e4be40bca27ddd8200581c137cc67d45c0f2714d613838665148843ecba67820523ce0d6c1eda18200581c9ef6c96fdde03894affc2eb09008667be0d6e107e34253f5894a3a2f8200581c03ede12d9229ca7b3ed7cbb2599df58f02cd067a31db25a813a5a47b8201828200581c0103f5f729e192cf9dbb58e1e8dda2a672392406972ae7d2b41b5e868200581c6ff01a26165a31309f929a0a4ae4997acc34b7060d427054ae9020fd8200581cb0ba0bd72befcefd32c0e78fe3ec102735268f12a5f0b012c6be2bb78202808202808201828202838200581ce76b811041e5186f03fb4850024a82a5abd899e464508e69f1df72688200581c9b3b5ca5665f006a3c106c7994cf0088039ccf614580944f0cc1a8e48200581cf75185008a3aba58756ca23659892b6357968c7621b162fffdbd312c8200581cd3d3082cc295339267ab65cc7836356effaf5fc7a4633438f83a0ff98200581ca9fed0bcb6e14d4cadd4284bb4422fb991113c76791273869ec912598201828200581c7b55dfb74c274a58de60dc13be8b8cc2ccff6ee2c316735cd2ee2ddc8303008083030081830300808201800281484701000022220011",
-                            "description": "",
-                            "txId": "c936da4c2270a10719e87dd92137ffb1d770d5dfa5703c8967ce7c521663f8e3",
-                            "type": "Tx ConwayEra"
-                        },
-                        {
-                            "cborHex": "84b100d90102838258200673c5e96029b3dab917ab12fc5426a2bdbed523834b80b893269ccf005b1bd9008258207d7148367a5046dd888bc21cd23fd6b3eceadc496aea7856a6f84ec1a6beff1f07825820df67714ad7ea464d2ea6a063a312299847a57d43221c9806a957ea225388fde2050dd90102848258202114e569aaa3da13e2306b5a2c151f6dfda145a42d9a04da3d934e7268d491650782582029f47f99a7d56348c5c52e1ab2bd2fd442d008b1d41ca5e943342ff2cd597c6504825820864167c2a79ed5ff566c0945109dc4fe33bdde1d23ef3be2beb41cab2f613fed04825820dd263d75d5024703c6f9f73e694489b62e8732a1eadaf9afeab1c5f92d1d96660212d9010281825820eb5068e50f6d161ef52d68b21e632872dd0af48ff66f85dc24d3b08c881b826804018010a300581d7100047215ff49374ca8d00919564f74dadf6af60e2ee07b5705cd101f01821b400bac47dc28f28aa1581ced76f2014e2b01f50d871a661852979336a7823e0c81eb9e47af3f7ca141350103d818458200820180111a0009bcd8021a00075aa4030104d90102828304581cd26959fc1e7b17a8b089f62594c8c9b182603ded0ff79d5d45ce511a0c830f8200581c943d72c1e2155348aec36f8ea0b9dee51a89f8b7225ceb2b5eb0708982783068747470733a2f2f704a66396952696b5a395258583044624f574a324457575366727a33716a37567039416f2e636f6d58201fb7f6a8cd339595117cde0703f8d5c0fcd5e1d5d3351c493abfbccb21c08b0005a4581df05fbe1cdc3a4b642de9efb47d4e7acfb86b4903ebdd0418d5d87f36ef1a000bfdb9581df0953465824002540608e7303c7260d8db8fbde9f502ac459c827a49931a000da8c1581df1d7dcc73e1e50ce09793ffa17ac06820279ee49abff1657d57f23bc761a0007a648581de197ed0070ac9e72a62b4c9b79bf394fa0da15c716a933582908ec929f1a000deba70ed9010283581c6c549256274f86b84442ee4335cc4c7c9553dbce92be6a06a6d25014581c72ffd5632584440db97a6ade64606250fb1523dc2b211b42c3e5a47c581c87e07bdb99f41d6eb3b3852d17f14fcd7449e7f76dc39d4ff99ecfee09a1581cc047f40ed2ea15094b61aa9af834ce3557dfec47f48c9ada37199e7ea1581da38c27c3727cf8fe1e6c85d88a6759f4dd69fcc7f984e38c6fb961712c3b31c4ad5efac7a1b70b58208e8f5dd677f512b121420887f1be617b9c759d64b4743c30c5e21e1cb39e0ea10f0013a68200581c6d8120ddddd806f6cca73304a280a3e51b446aae94587438998dc97ba68258202d98f65364b63c9961fd5f492c97fefb6a7d6d6629590913d3c9282bc871e820008200f68258205536ed1ab126d543dd23ada8c84bc5c75d8288ddcc6df9dcb7c2620a6f761aae068201f682582095274cdb12b9740d21b90e29fd1cd67bb9b799dfa5b3b774f18044db0a463a6101820082781d68747470733a2f2f414c4c736567346b6b75747a65472d75432e636f6d58208adad813134a8879f76ae52a1a7c457814b55947f5940b4fd9b426d53218f575825820a700ed133575b111d7c2698dffd542c4965c76bb34360bf08290b849abe30e06028202827768747470733a2f2f746a356e72666a614651582e636f6d5820219c7dbcc0e02340b1c64fab21f3fa89eeb0d8f3ce056cfc800c202c971a11e3825820d041c683b6fb1d38b644a43331b164b22d2086f8406e09943fab2ef0748d331c05820182781868747470733a2f2f375a57755374646a5345344f2e636f6d5820a9675860201e5dd6e138fe155b030b464332482a3056fb74533b45207c0e5e01825820fa3f02239cd13a8e92dfbc57ce9cce955bd4717947996eaef086cacdcb18740f028202f68200581caa1ad18566cac623152a7f6686c19b90213ce1e49964888a5446004da38258205c2c8ff18511cc1ac13f9cf514b8e5dadbcc00fcf526db3f445a4711bd93b12d028201f682582073a5df8660985cd45f869451afb42685b49d442e248fd25ab726a5a4e30c50b1058202826e68747470733a2f2f59482e636f6d582048e6609c786f56edb15474b9adc667300d07c81d87c8f4002d987d5779152777825820c860892e41f58baf102475e768baf806a2a9edb7fd8b41e2e99a3edd05fa5d6f04820182782668747470733a2f2f754366706553596d34576e767745323878777749496b523165692e636f6d5820c94502efb88e4cf0c0c8eaaa245aaf26ebd3d2eb1b62c6dd9988d293c5c4512f8200581cb37fd2805c9119947946d897b492577ae99c8ca926d3ac6d169a0fd6a18258202b68dcbea4128add821dcd70fdea82352ea7082237df2c1437edb2f2acc5281f088200f68203581c24056b1bbb487c55882192cb31768daedbc2925839f16663dfd4064fa482582001e73100a3d29bb8c4540d18896acd30fe4b2fd5b0c2e28c9122a27606fa559904820082782368747470733a2f2f4a43786a79367a526436417161344d6f6a6652584132612e636f6d5820a1649de8491960b5129cca9695c7f10973127023784bcc1a9ff99a18d30d70068258202dea53e3f5ea560132571fca38ab63fd50d20409735170a756bfec686b7651f906820082783468747470733a2f2f344546513166325a41773069704836537539327556554161464e736861444869596f7a566955686f2e636f6d582015f8b73e06eb80f4ebd066398981c301d610c09a46e1982ac3a928bdee2dfa4f8258208142ffb1443336784837faa39c88eea7b925947c10e1ac561aa8f856ab4366bd04820182782068747470733a2f2f5330473147582e745247754c7466622d533050342e636f6d5820cd5c5abba65ccf6406d1a7bf1b20fef903776aa2d87b6a3b2f1bc1d0895ad6a7825820be45d774723806b4b40247c80e0f5c1e91af05d747eaee25675a071b3ad132f900820082782868747470733a2f2f3265636a735261457471576848655a76622d6c394a707571424b47692e636f6d58205e510ff4fbbda886ad06cc9303dd0689e1ed3e3395fcedae40bafbec4be390108202581c5db25dc97deef571fbcb14c9be9885811a6974ab5c45d01463725885a18258208d6a528604ed31b324d6839054edfe320f84572670c759d0ae9006738ee17794058202f68202581ce77a4b28d3a9b10240c76c2c849b8c9a4f6f9f6fe7e690507202f02ba1825820e123467331b88eaa99c08a75515ffac196fd7d457cecc15d3ee33cfd7b9a277f018201826d68747470733a2f2f6a2e636f6d5820607bab48ba3d9fdf23ee4bd1d93f1abbeed7b618624180f2305007b26330d05a151a00072d20161a000d2987a600d9010286825820bd237358b9e63ec6c1660b7707137b12702b6f9fce1ad02da10b7446370fecc8584029a58b0e71b0c25d8bf101bdb7e51d05ab5a40f6669a6c62402e3122b9a884599c544561ad20f8c2cb9cea7f839953e7db31a000f4866e46360f2d6c5fe27617825820a3b7aba6b5fb6cb466a274518a94f2e994c593023a634a4f5d33ff68d26937e35840a738a09591c7c484f84e8492105f8d34f31fb4f751650f21d766f036564dd79eb9e7c3f17daf49071da14a8fd8fc86998872cf133387f84eaa4977c96089f88c8258203841c7c12f794390a6f854b3d79062cf8a2470df0654c1ccb2519bf960acad5e5840c7dbf5eec36cf9c3e062ff4419a7c344b27a95df4ec34985cab9432d69581739210df73f876823fdf6bcafbea8f58d4600b50325745861bcd080b1b1de751770825820bd6333c8c4ab577fd1be114a1232b29d6d66604dacd6b9953a856471b4c65c9c5840811d5a821fdab3aca714fb35fb916d8a1485d3fe77b8b7bf398f8ca1865ed154826fcd4f48d255691359982a0f0d3c9993cf13eb1ed00171b46899f55e91e9d082582080dd43dc170788c814f3babfaf5806ed4a916082935f62f9e27a4476c18917cc584078805d8b64d974658e5420c188dc7d1cf5e49def2473fffafea86138c7285ffb1b2c360cf5537178582840fa5106c3e4689ab79ab187247a1a7e78156b84e4e18258204d609aa82703fcb508d1f601bb8cd1c77406c6588c8483c403073359489c0ef45840b7b5e7b249777a899a90cb28d467152101b95e3cf3217579860407a242b8f4d38135dee8887a1bab57c54f1c041de674385fb162fcbb8a6f287bce83024a3da802d9010281845820df4d7700f7700cac0a36d7149f5d38b52cfe28e5d6e5d05f2c801fb43de257725840057d7ffd6c63bbbb1f6c198c0fc6e3e4b8cd61a86410d5fb3f8b5ff46d9af91a9a03c34dc05c0d05ba30703daed0e9949cd2d75f04ef3248a74a5d70f07b1eea435d2f3543d02a9d01d90102838201838202838201848200581c047444ece73b308966a2d935d8afc736148e3899933ccb0658cf28978200581c5a0f97c2fe750f1d1f06e22debd2d61d013abd5de595a91deeabdefa8200581c3a04d978d310b2e79585798507f662e9310d246bf241542b706971c78200581c7e66e48a0ffb37f49063ed293a0512edca37f40fcfaaac54740d790d8201828200581c5c6453c98554ad4db8abbf638e2f6f7f32058743cdd28a7c9bde24248200581c6af1824d14b7f709bd57662b166cacedd09a42ac7c473023768f0cdd8200581cf3e305decdd93449262b7eac3e8a23757c4ec142368731f997e0c84e8202848201838200581cd09a7a301aea3167431cef8b5d2c96e8b6f968139ca7f22f504744638200581c1d08d7bc9f81f81a568d2ecd4e87f2307c76159602948fddfc5f04318200581c0960a5b2eafa41ac1ea2982d5d1b09df75965ece90e1966eca6d0bee830300848200581ce5e53c92b76b9ced14892b8252f653f341b8940145de32d1c8c7c4a98200581cadc34a45f56812e2fdd08b2abf512a4f0ef6d39ae39f20a98b71de398200581cb8f7655b3c690efef9d4f94bfff82a3ec715251ff09d30af9cd3d0eb8200581c4b61b2b6e95ae78550d97aca5f63d4408715879be5d4177d62dc6d278202818200581c0630b69da4fbb226ce76a2e2ab28f5950fe7501d8258f8d61b7bb6418202848200581c5265f5f886f9d916c5b34bcce0ec076c30b8205cbb040b45dcbe802a8200581cfadbd3540a7aecccf94434908df35697168beb75fd74630ba0d92cd08200581cfb5598aa3af1ad1a150b5c34e41978a4d040a6d0ea42f19c17ee013d8200581c28ece0b810c0035c0c8b694ab553cd80b9a01049ce6814773a2af8938200581c57a08cf4b9007c7e8e8fb80850c0d3c1cfc3e1a0aba6b7350b73f5598201818200581cf2d833a70bce598986f60b2e881e7d08132fb2af9baca87225ad837882018006d901028148470100002222001104d901028240a544d2bf688623a3d87b9f21414542f73dff23a1002200a240400441ead8799f415a412c04ffa080422d5fa2a14000d87d9f05050421ffa000445c335f16040505a4820002829fa240409f4330ac3c422e8424ff80d87d9fd87d9f40413affd87980ffd87e9fa24304b34a40431b712344007cad9e42825ca02040ffd87e9f23446f401472a40443a4e09440004452568ba621024291feffff821b78b8456d2312fc4d1b0755cd71b7e4ec3582000782d87d80821b35270fe35f09c7581b59de543b66b7487382020182423be5821b0962ca22e0d740a91b40227859cb6ab97782030382437a845b821b4a5037925158b2eb1b375ce2123ea7db73f4d90103a10181820282830301818202818200581c1e9f70bc91553a4799018be7ad35a20877d5d37d4837a33ecae0af9b8201828201838200581cd32719004f3e543ab4c31a8e612b1f218b0f6e5edb3b87e3a880db258200581c0587b4c1accbf50bd2a9a8f3f2232432eb24167e4d09cd44ae08e80c8200581c60546356ce58045f91cdb6fd972cd7b5b5b00f8ad740a95b1199c55b820180",
-                            "description": "",
-                            "txId": "6fa026fc6471d543eee2112c626fc34cd3a0b3817b23fc0f90761636c79eb4c3",
-                            "type": "Tx ConwayEra"
-                        },
-                        {
-                            "cborHex": "84af00d90102868258205609d6285727c2448f13a1c8ffccbb026a271fe06c254efe1295b1b5d6e8a0de0782582079bb6b65b744e1c8880fd0db5da43e1ffc0cbb1687a6878381e8f5aff338016a088258207ac91f8171e9c4e0374e6a781c147bd93d359d9eeb56da7ad2ca999d78dfe0ea008258209bc602dfc798fb3cd79f2421342f0a9588b786cd302a3ef6ab343c1386e9439402825820bfe2d11b5f3e19e1d45d15ed1ee8576e83bd2aa322276425f5fc9c5b8fe024da00825820e55cb4d335307288ab978ef41ee49a6d27980f56d95d111870330d054794a3ca050dd901028182582059b6d4804b22789c35c2719ae00683d9918368a76528edfa11681eb3fab19589080185a400581d7058f7fd3d069d9dfb3255ffb12a354d5f8f852e8d5bc97a2f027eb335018200a1581c2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56a141381b278c4172379126840282005820b05c7a80fc425d7455814595802bd982a7d5fc32e6ea8a70958907227aa9e60603d8184a82034746010000220011a300583930503824c9635a9aa9b06d5a38d404f4bcbbec0330085050dada94198e91a4fdeb0d4ea687e1d6cb79e07fedb4a88c1daced053d65b3a59a8d018200a1581cb0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165a141380103d818582282008200581c7b4693f882c5544f2de6717ce51a5744e3aec30ab4f3225906cb6333a300581d60e832b454994a3a2aebde5a045103aff2796d0a1c2d7cf3e1bad1655c018200a1581c2d725128406dc832eb74c4709aca0512499b3c7b17e00d7cb2e6d1b1a1581eac3e84234d781c9c33df346f64a176c724059d9311d6dca97c101dc449f30103d8184582008204018258393002192457f6c7b0a9492e584ef9a0e34d1712d6b33f5f6cb9a949570b43dcd940e3368aeee2f2ba2cedb283327c95638d95537ff7565927dd8200a1581c8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3a1488cddbacee6a8638e1b6c9516ecddf73363a4005839014cedccf6e009542fcf18e7513cfb75978f02bfa304fd9895022b4908fdaaa395d970cc84d965f51122bd36f3caab5d7162c99948b32708af01821b4e5beb2d624c06d4a1581c4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebea1581a0c0f2e26de24bba2ea0369f7cd015b069e894223a323bb525fbe1b79ec4ae9cbc838d002820058209b0f106785bde831fe984a805293d0f15471d36b707b07608de4b15e869e917603d8184582008204021083581d60985d8ff8031cedfbb61235f01a1d1ce095c54d4d1b4c00cb506727058200a1581cab25622f2d131445bda7927aee3b9938290bebb0e315953deb1f628fa141331b5c6f421fbe49ffc7582016030ce9b5f6497f1a2c9697d0e842512c4aec960c2c1ce83ce38e96e3944b0e111a000173dd021a0005a248030104d9010281830e8200581c9feeecd4a5c2744d1074725f7121ea5a954e586766491dcf8d40e3888201581c602557b42e6ff157495104bc4a7d196d30e8bf2b2bccaad0312e2c5305a1581df1da2fdd648aec4527d2b6470ddca19b9f46f65fff732b9367dbc18b1f1a0007d5cd08020ed9010285581c324cfe54dfe2058ba833baedd0e998e9243b38ba7e4812ce71e959c4581c74b9bd90cd38fac4e56b5ebe3c796008ae0afaafc023ee8754400693581cbd3774de5a96481c0bc7c15d73c971f93cbc716a7ae7896e346f9d22581ce9cfd03fec5704fc9fbfc09f22368d8e6eeca83d38f37f94ccf26035581cee7e0635672c464407fbe9b66eee74eb3ebddca97d2af0a5af507c6c09a1581c8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3a14802230f766f887f193b528905846dc7237a0758206d001ca2fe1f775bac32f23a723e2e01d44b7a23c35940730484acb9088caf570f01161a000e7737a500d9010285825820bc7f7c687016ded9513847a21a123698a98b845c054392723a90ac82bbac51675840ea373ebe45e5043d755ba7c06a073b42f575c4df3645f4d348f6a6304b1e0f841ba56cdaabe374781013fd0e1a4b8da989c4f112fe3475d1b1f2e9795a4e6f58825820f817c9fe39084ff856be3db86a6c4638a8eb75960733e7e448cf28348433ae555840c8168a092a6196fe21f3f19962827e5a0e59019e0523bd938bc2e6b773e7eb7d0b31dd1cd275eae7c50a3815aa7e6e3d87b800b163c90a845bf9224ab5ae39b8825820932df62382c05cdcf9b6ebcf885b2c5a20e86ea5f2347328cfb51ef388d1a0685840813714643f96541400cfbb61aa444f00fe4a0adfbd2de6ccbb39554ba0854ff6f24eac6fc6f8c0789e2e17757b165273acc9e1fce14e16493fd93a7cd1d6d80f8258206cbd431ce0ab399c7997a489d635ef3ca5c40a48e0e1616e1ecf9a75442a77f158404305ae7a30be63c6c1fc77c81875e15ff79c1964de2449bf1a7b8aa4df28be6a46bd81fb5e3bb7e0f2a05aa004ca62ce6d8f7bc0788069116687aa05ce600e288258204217e25cc523698fb47ab257b9b79d62f58d375426e157ee297731ce5cb21d195840fef868b2cb89c89221af8908ff2bb2c049d0ae158bbff363613d5b754a37420056aa5c233b9b7c54c144f3ad9539e3f801445c8e0482a26b030395230ab6d3ae01d901028282050c82050903d901028148470100002222001104d901028240d87c8005a6820104829f9f9f05234043b4fc9aff80a14324fed103ff24a1439c51cdd87b9f012303054239b7ff20ff821b39513ecfdc3c10e11b11bc82edd3922ea882010682d87e80821b04b50f88b6dc54111b408b808ec472e0828203038201821b4f76a959a11a9a481b77dff377b76b978482030782d87b9f4379215ed87c9f44605b901b0001ffff821b633d7f308418c50c1b47cf7bd75dd14afe82040382a0821b3f14de88f2f0e8141b6101efac99838c0b82050782a39f9f441135ece104044022ffff2180a040d87b9fd87a9f014362b8a944e012ffbe40ff2244e97690dba0ff821b5f732937e35733791b17ccdd9d0fa8a9caf4f6",
-                            "description": "",
-                            "txId": "8fa83c89f612a52458d8cbb2804b4fbfaeca5884c9bc48d213d172ebfb7167b9",
+                            "txId": "5dbd12079334f6a95cdfdaac4e0f3b0657a9dfef8dd0b7c1a2c991755547b460",
                             "type": "Tx ConwayEra"
                         }
                     ],
                     "localUTxO": {
-                        "0006080302080400060607080306050108050703070106040100060602040602#32": {
-                            "address": "addr_test1qr6a33ezyk78t4qpnzxs4rxwtjmuwpzlkngd8rhkkqqfhccl5sfkxl0srnd3zj5qmdcq9ydkncwhcg8mdcvrnnfpdftspmldn8",
-                            "datum": null,
-                            "inlineDatum": {
-                                "list": [
-                                    {
-                                        "int": 4
-                                    },
-                                    {
-                                        "int": -3
-                                    },
-                                    {
-                                        "bytes": ""
-                                    },
-                                    {
-                                        "bytes": "4330"
-                                    }
-                                ]
-                            },
-                            "inlineDatumRaw": "9f042240424330ff",
-                            "inlineDatumhash": "709ce74930320b7ff5457794c1ce119dcd9c1c40e3811bc39316cd9c61348272",
-                            "referenceScript": null,
-                            "value": {
-                                "af0c44c018e28c01b5adb082ebad634894c7d24a43533ea056b14384": {
-                                    "ff1cd5b143c34e0942625573f97a359f83d7873e55e6779a6eb28f08a775": 2
-                                },
-                                "lovelace": 1323170
-                            }
-                        },
-                        "0202010501070100000207020205080205030808050700010503060005040101#62": {
-                            "address": "addr_test1xqvelgsp7d3wcnf0k7d575ztmet4kf6nsamqe7kneguz8yns4wn6msrv6rplxc2kdne5qnln8es7m4nhlsaeeajxxj5q2cekq5",
-                            "datum": null,
-                            "datumhash": "609b1196325824d8620e0364f8769a010c2315b36031644b47573a05327afa9e",
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "9f37533a36941fcc4afc8d6b43a8455489cf401ce871b7b9e9c41c12": {
-                                    "ca5d964054888c72b28113": 7993436474890105447
-                                },
-                                "lovelace": 1349030
-                            }
-                        },
-                        "0300010001040606080707030407010206060501050307050803070601050800#10": {
-                            "address": "addr_test1yzux8z689yl6spdfswyffgrvy49ukq3k95l7spkmx3l25nkz3aew9epf79w2274gclulnhdazsr9g3frn9lq8wvqxxushgxy4f",
-                            "datum": null,
-                            "datumhash": "cbc5ef225f0cbe249a3bce489bc6d49cb3421d8887e8dfae7b7f29616c491cf0",
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 1116290
-                            }
-                        },
-                        "0301050304040503080404010500060503010702030107000807080202050401#92": {
-                            "address": "addr_test1zzlp2d764zhq8p8nxug433xpdy4rj0gvdpcshg8nfhaft5gq57klayf2t3xgxm82rlelqhr4au7mvc9h5wdaweqdt8pqgjc6mt",
-                            "datum": null,
-                            "inlineDatum": {
-                                "int": 5
-                            },
-                            "inlineDatumRaw": "05",
-                            "inlineDatumhash": "fb3d635c7cb573d1b9e9bff4a64ab4f25190d29b6fd8db94c605a218a23fa9ad",
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 1008540
-                            }
-                        },
-                        "0401020201080100050607040705000003020207060802000208010800050605#81": {
-                            "address": "addr_test1ypeqxyzsg8qm0d5dpdhduxz6kk205r2gv78c4vs5tf5pe3j8z7g0ck74dyme6n8wzpngxl032kfrxg7dtz6e2v54ch0sl4t2uc",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "b0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165": {
-                                    "37": 1
-                                },
-                                "lovelace": 1124910
-                            }
-                        },
-                        "0508020607010805010508050305070200030205030006080405050305010208#75": {
-                            "address": "addr_test1zps8953dzvgxlcqqe55pu7kwjq3tjf20q4hxmfkq3cxu2dmmczfzhm8pwy4jn6cek74d40xkslg9ghfjnk2ughqfesxszjqwpp",
+                        "0002000101030404060507000206020608000107040303070105020204030008#53": {
+                            "address": "addr_test1qqpl9ff4gk6vtr3436kxkucnnelxwmqmlj8un0t45gawdyawphd3gqey0nc5nm2m2094rsggj0ds2mtpts7j8sss57gqjekt2n",
                             "datum": null,
                             "datumhash": null,
                             "inlineDatum": null,
@@ -3458,28 +3632,100 @@
                             "value": {
                                 "lovelace": 969750
                             }
+                        },
+                        "0207000104080306070504000100030106040608020804060001010805000704#21": {
+                            "address": "addr_test1xrjvwt9sqtkw26k963vzacyyqvzmwcla9c28a2xhqhz6ylnr2rhvzvq52mrlxd9w0t0cjuj2d8xznhfcaqqc4n7vjrsqsrppq5",
+                            "datum": null,
+                            "datumhash": "e801640f83fe660d75c817676e13f56fb9c3e36411a1fb9ade5511a2de0377c4",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0306000603060401020705000300060600000000000502080305030600070100#82": {
+                            "address": "addr_test1zzjekv562d7ewutt47fllwds9fyyzhy5ue5xyxnnz0l542wzfmc0q6ljymh6d3ndkncxp3dtmgx32emsl530cta24tuscrucr6",
+                            "datum": null,
+                            "inlineDatum": {
+                                "list": []
+                            },
+                            "inlineDatumRaw": "80",
+                            "inlineDatumhash": "45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0",
+                            "referenceScript": null,
+                            "value": {
+                                "37ccf30ea76099f734009de254301da2c38508f66dc445a2b8113847": {
+                                    "39": 1
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0404080603060200040605020605010702030705010802010307040200010007#24": {
+                            "address": "addr_test1vpkr50jjt7c3wdyz7wd8p8v5ze8u6kac0f48anp9yws6krsg84q5k",
+                            "datum": null,
+                            "datumhash": "5046e9be9be461bd3b3da982c3e54b163c4683d1bff5ab940dc679cd31739d0a",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0601060706080605050805070306000200050404040205080008080304030000#37": {
+                            "address": "addr_test1wpzp2n3rpy34shucxkhauycz08smmx7qex07a8rq5j5zttqa4tcjk",
+                            "datum": null,
+                            "datumhash": "8fe3021bd830aafa2eb9894badb2ccd9f6c6ccb787276d372e9e7504a0df4184",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "5b010357fb56a1bcc48b297864aaf1b68595644cfbc58ab786c3b718": {
+                                    "44cb63bc29e7ed5db168f81fb5fb5d3530e267": 8048609301154382719
+                                },
+                                "lovelace": 1262830
+                            }
+                        },
+                        "0806050207050001040000070305030803080605000007030208040805050508#99": {
+                            "address": "addr_test1qrpzeueaxu390mwcsrdzegrecfrqskxcjd5nfa7ekusuf0kjc97vleqpn0zquzjp92w8g33jv8tdasa7ggla7n6sw2uq3wx8ae",
+                            "datum": null,
+                            "datumhash": "2d0f82a33cfcb03f6291a30d093201e92fe4b282bc0c924df7958a737aeeddcc",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "f97612029241e9d747f3c087d93a48aed78d2401388984b4c2192a8c": {
+                                    "1c4e5e92ff": 2402645547593240968
+                                },
+                                "lovelace": 7500000000000000
+                            }
                         }
                     },
+                    "pendingDecommitVersion": 4,
+                    "pendingDepositVersion": 5,
                     "seenSnapshot": {
-                        "lastSeen": 1,
-                        "requested": 3,
-                        "tag": "RequestedSnapshot"
+                        "tag": "NoSeenSnapshot"
                     },
-                    "version": 4
+                    "version": 3
                 },
-                "headId": "08010805060703000503060200020400",
+                "headId": "01030205080108030506010006000407",
                 "headSeed": "06070108050501010706050403040108",
                 "parameters": {
-                    "contestationPeriod": 31536000,
+                    "contestationPeriod": 2588,
                     "parties": [
                         {
-                            "vkey": "6441fda816004ff871073b77d32707ee5467a341eabcba57eaffea82e32306fc"
+                            "vkey": "109fd03e4235d2712f32af382c7c46723d38fd696dc7ca567df4cd8f41c08765"
                         },
                         {
-                            "vkey": "560e93da5c7cd475982b1b5a27ec3ca2047ad52685d64aaa0086fd6e2a46634a"
+                            "vkey": "ef97a6feb10baf3e18d840a2fe9cafa905c5e8be28179b01b6285be977da3811"
                         },
                         {
-                            "vkey": "e766c9c854fb8c1498df4d7238053af9736b0decd7743b84ed80235e82a7ceaf"
+                            "vkey": "5194ed94f63644bf0d81993668a9dc8dee49066fc183152fe1aab375e19bc345"
+                        },
+                        {
+                            "vkey": "b5ec1e4bb2821a0bd01e6b5a3affb1d2d3ef434ccd27ee6ff5793d3a272de5bd"
+                        },
+                        {
+                            "vkey": "0427f962d76696da474d162003127a2bf169323747647d24c44816df89442276"
                         }
                     ]
                 }
@@ -3490,8 +3736,8 @@
             "contents": {
                 "chainState": {
                     "recordedAt": {
-                        "blockHash": "0001040603000203070803060506060102020407050400050501010506010002",
-                        "slot": 3,
+                        "blockHash": "0707080108050104070800020800010005020301040204050106030602080105",
+                        "slot": 5,
                         "tag": "ChainPoint"
                     },
                     "spendableUTxO": {

--- a/hydra-node/golden/ReasonablySized (NodeState (Tx ConwayEra)).json
+++ b/hydra-node/golden/ReasonablySized (NodeState (Tx ConwayEra)).json
@@ -748,6 +748,8 @@
                             }
                         ]
                     },
+                    "pendingDecommitVersion": null,
+                    "pendingDepositVersion": null,
                     "readyToFanoutSent": false,
                     "version": 0
                 },
@@ -2702,6 +2704,8 @@
                             }
                         ]
                     },
+                    "pendingDecommitVersion": null,
+                    "pendingDepositVersion": null,
                     "readyToFanoutSent": true,
                     "version": 3
                 },

--- a/hydra-node/golden/StateChanged/Checkpoint.json
+++ b/hydra-node/golden/StateChanged/Checkpoint.json
@@ -103,6 +103,8 @@
                                 }
                             ]
                         },
+                        "pendingDecommitVersion": null,
+                        "pendingDepositVersion": null,
                         "readyToFanoutSent": true,
                         "version": 0
                     },

--- a/hydra-node/golden/StateChanged/PartySignedSnapshot.json
+++ b/hydra-node/golden/StateChanged/PartySignedSnapshot.json
@@ -2,66 +2,62 @@
     "samples": [
         {
             "party": {
-                "vkey": "43672c4cbd485b4c49791f96d1388afd6f6e361a9abdb1d75b6856b4e6701177"
+                "vkey": "1c70a023c07abc2a6af5bd07a94df24247c5176d2a0027c23867767d1406f463"
             },
-            "signature": "93ccf23947af949af75057b04327c6214c1e729d4d29a1215f65774cf07d7b93d962ef626e5a0e2c3e7f8bbf1b3ffcb679389857b2876352be68d97f5f188a05",
+            "pendingDecommitVersion": null,
+            "pendingDepositVersion": null,
+            "signature": "8b59f4add659bb4ecc17bf035f6219d58445b6f42b49fdbcb8d5cd013786b8d7866c493784546bb537ad55b44c8d6f93bfee0480b9359c04b5a8c545dac27008",
             "snapshot": {
-                "confirmed": [
-                    {
-                        "cborHex": "84af00d90102818258208e4e6204c37ee053257f95f68407395e86a855e20131c06145c9080ac8ed2f270012d90102818258201cb935b6c4e68013b70afbc3d82f9add5472cada0fc9cc839b59c8831835ac0900018010a400585782d818584d83581ca9a5276a03a7bede26c4986b6d9a5172b51ee842a4780db274626d2da201582258206c6f6e616f717474766d6d6e6c6a756874697669696f6b767a6d61626b78746802451a0ff7b078021adcff009101821b4ccc0f5e4dfb74d4a1581c106395182bb236642c157aa055cac946709bac865cc2f5e6b1187680a15818076d2121aa245e96ad9aa45dd7b6a124709dd08d364c8be21b23959a263f92d79e028201d818587dd87a9f9f809f0041dcffa4224323cbde2044e65c69a02002418b41639f0142f3b620ff02ff4103a49f42949b42650aff4024d8799f02ffa30042aa01240040009f447a7b1e6c0244fbce389843b70f2840ff9f0505ffa42404040040050440a2d87e9f417a244021ffa043ddf094d8799f4042cc0f20447dd047d3ffff03d818458200820280111a0006858e021a00087ee3030104d901028184108200581c51f46c4976d38e61a59597f8427bb072f2c47a5b541c1b1538d0734f1a000df78682783168747470733a2f2f646a79367a6a3941686b745267446972666768466f6a6636656344566d6c562d59554d58632e636f6d5820e194cf9b862518ba6787c64cb0c1e05678cef49c8d9f859b141765707c66b6f409a1581cc266b6c604fb3ff4804572f46789a9294fbf937ae63872cae7d9f8cda1582038cc5443fc7cb5bba4189350f76ea5af620fdd5c49362e9138d7b5445de6fdab1b29c9f2ab118e78540b582039515fab92cba992e33b1e89b159debd4e95c78a3eac721f167eec13edca01d207582021da6807edece5f5885cea79ede78f57c39764279be37e4943ebccb9bb1475bf0f0014d9010281841a00076e02581df1c2c70c55ec86db9d3b2fce97c5209ac0bf4d5cfa48d4c699cc2d7adf830582582054eb27f3fb55a850807ec3dfabfc67b0b7beb89a3dce2b72071bb33b3343679f0082826f68747470733a2f2f35622d2e636f6d58204134f8663a093c10fe1cbaea2d23066ebfbf93ad775ba04dc1bbc612870feb12f682782e68747470733a2f2f572d332e327857536c5142764137765030476847416e4167566e63576a73667241412e636f6d582071c00088ec440874a48d44f38d8015b89b2318968359ab9c6d76d3a1eeebf8f0151a00015d2016193051a201d90102818200581c4404bee063242102a35f331ca5f31f5cce670fd9d2bc535d384a49b204d9010281d87e9f42e73e04a2a09f41c7422219234384e8adff9f4435a7427924030521ff02a1a22342b54e41ef0242be5404fff5d90103a100a10040",
-                        "description": "",
-                        "txId": "cf45e25c0b3e407c3b4f291b07def6d2046a123de7924351c85e9661d72dd629",
-                        "type": "Tx ConwayEra"
-                    }
-                ],
-                "headId": "00000100010100000100010101000001",
+                "confirmed": [],
+                "headId": "00000101010001000000000001000000",
                 "number": 1,
                 "utxo": {
-                    "0001010001010001010100000101000100010101000000000001010001010000#27": {
-                        "address": "addr_test1yp2ufplh0h247qqk6kruuynph790eta4x8agw6uxlxztnv65g2z68ghst8jjycnhkzjph4djduywr2vl2uk7k86dwvtsff9ahx",
+                    "0001000001010100010101010000010001000001010001000000000001000100#91": {
+                        "address": "addr_test1qppyrm3ghsy492r98wpt74xlcl5e3yv9wmc8jqxkpx22pgw9uhu2p8f7euc8l2x6ejz5dzqwv8ja7zj3q42p4kfcwa5ss0lrtk",
                         "datum": null,
-                        "datumhash": "37fbbc0340e6af08f309e21fd6f0a0b472454b761433abb9c8fa87502554ec17",
+                        "datumhash": "40870cf61e7729d0386ed4a52fbf4a1d54d0b28f0354d502543a425bfbb9fd06",
                         "inlineDatum": null,
                         "inlineDatumRaw": null,
-                        "referenceScript": {
-                            "script": {
-                                "cborHex": "820401",
-                                "description": "",
-                                "type": "SimpleScript"
-                            },
-                            "scriptLanguage": "SimpleScriptLanguage"
-                        },
+                        "referenceScript": null,
                         "value": {
-                            "4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebe": {
-                                "32": 9037098053186049560
+                            "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
+                                "6d84bd92f79302e1d3dbb25a": 1
                             },
-                            "lovelace": 5978688693063840705
+                            "lovelace": 1318860
                         }
                     }
                 },
                 "utxoToCommit": {
-                    "0001000000010101000001010100000101000001000100010000010000000100#14": {
-                        "address": "addr1wxyphs9a4m93pr02wrntuzw9vpx9md8jczkw035juvw3afga5d53e",
+                    "0000010101000000000000010100000101000100000100010001010101010101#52": {
+                        "address": "addr_test1zp56qa50dlu4e4y5vh08jg6nvttj98gjm4f5y6al60qh4pdrer2tre0vgfsus75ss33605xadmv0xlfnutt6dkhdtz3qw4rfz0",
                         "datum": null,
-                        "datumhash": "37e675669f575b5aa09b4a4e8a82d62c2a19c86ffb356d820196073536dc9442",
+                        "datumhash": null,
                         "inlineDatum": null,
                         "inlineDatumRaw": null,
-                        "referenceScript": {
-                            "script": {
-                                "cborHex": "820501",
-                                "description": "",
-                                "type": "SimpleScript"
-                            },
-                            "scriptLanguage": "SimpleScriptLanguage"
-                        },
+                        "referenceScript": null,
                         "value": {
-                            "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
-                                "d2703122b81040ffcad60474bc2bf1f1635bd0c9a4fdc6a242": 1
-                            }
+                            "2d725128406dc832eb74c4709aca0512499b3c7b17e00d7cb2e6d1b1": {
+                                "3eae7ee37fcacfbdc5f8f4009ecec8dd3feb": 7732993800565299715
+                            },
+                            "lovelace": 1232660
                         }
                     }
                 },
-                "utxoToDecommit": null,
+                "utxoToDecommit": {
+                    "0000000001000000010000010001010101000101010101000101010101000000#20": {
+                        "address": "addr_test1yzymhc8gctx92n865u6w29fz428j0cgcdz8fmqv52udcwtcjlq7lj7gsmwzrlckqh326stvyvnjcj03vfls7v2lxuzzsh40jcw",
+                        "datum": null,
+                        "inlineDatum": {
+                            "list": []
+                        },
+                        "inlineDatumRaw": "80",
+                        "inlineDatumhash": "45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0",
+                        "referenceScript": null,
+                        "value": {
+                            "lovelace": 45000000000000000
+                        }
+                    }
+                },
                 "version": 0
             },
             "tag": "PartySignedSnapshot"

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -38,7 +38,6 @@ common project-config
     PatternSynonyms
     TypeFamilies
     ViewPatterns
-    StrictData
 
   ghc-options:
     -Wall -Wcompat -Widentities -Wincomplete-record-updates

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -38,6 +38,7 @@ common project-config
     PatternSynonyms
     TypeFamilies
     ViewPatterns
+    StrictData
 
   ghc-options:
     -Wall -Wcompat -Widentities -Wincomplete-record-updates

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -3733,6 +3733,14 @@ components:
           $ref: "api.yaml#/components/schemas/HeadSeed"
         version:
           $ref: "api.yaml#/components/schemas/SnapshotVersion"
+        pendingDepositVersion:
+          oneOf:
+            - type: "null"
+            - $ref: "api.yaml#/components/schemas/SnapshotVersion"
+        pendingDecommitVersion:
+          oneOf:
+            - type: "null"
+            - $ref: "api.yaml#/components/schemas/SnapshotVersion"
 
     CoordinatedHeadState:
       type: object
@@ -3773,6 +3781,18 @@ components:
             - $ref: "api.yaml#/components/schemas/Transaction"
         version:
           $ref: "api.yaml#/components/schemas/SnapshotVersion"
+        pendingDepositVersion:
+          oneOf:
+            - type: "null"
+            - $ref: "api.yaml#/components/schemas/SnapshotVersion"
+        pendingDecommitVersion:
+          oneOf:
+            - type: "null"
+            - $ref: "api.yaml#/components/schemas/SnapshotVersion"
+        depositChainStateAcks:
+          type: object
+        decommitChainStateAcks:
+          type: object
 
     Deposit:
       type: object

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -908,7 +908,9 @@ onOpenNetworkReqDec env ledger ttl currentSlot openState decommitTx =
 
   Ledger{applyTransactions} = ledger
 
-  nextSn = seenSnapshotNumber seenSnapshot + 1
+  Snapshot{number = confirmedSn} = getSnapshot confirmedSnapshot
+
+  nextSn = confirmedSn + 1
 
   snapshotInFlight = case seenSnapshot of
     NoSeenSnapshot -> False
@@ -918,6 +920,7 @@ onOpenNetworkReqDec env ledger ttl currentSlot openState decommitTx =
 
   CoordinatedHeadState
     { decommitTx = mExistingDecommitTx
+    , confirmedSnapshot
     , localTxs
     , localUTxO
     , version

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -22,7 +22,7 @@ module Hydra.HeadLogic (
 
 import Hydra.Prelude
 
-import Data.List (elemIndex, minimumBy)
+import Data.List (elemIndex, maximum, minimumBy)
 import Data.Map.Strict qualified as Map
 import Data.Set ((\\))
 import Data.Set qualified as Set
@@ -337,12 +337,14 @@ onOpenNetworkReqTx env ledger currentSlot st ttl pendingDeposits tx =
             -- Skip decommit/deposit if already posted in previous snapshot
             decommitToInclude = skipPostedDecommit previousSnapshot decommitTx
             depositToInclude = skipPostedDeposit pendingDeposits currentDepositTxId previousSnapshot.utxoToCommit
+            -- Use pending version if available (deferred version update)
+            effectiveVersion = fromMaybe version (pendingDepositVersion <|> pendingDecommitVersion)
          in outcome
               -- XXX: This state update has no equivalence in the
               -- spec. Do we really need to store that we have
               -- requested a snapshot? If yes, should update spec.
               <> newState SnapshotRequestDecided{snapshotNumber = nextSn}
-              <> cause (NetworkEffect $ ReqSn version nextSn (txId <$> take maxTxsPerSnapshot localTxs') decommitToInclude (setExistingDeposit pendingDeposits depositToInclude))
+              <> cause (NetworkEffect $ ReqSn effectiveVersion nextSn (txId <$> take maxTxsPerSnapshot localTxs') decommitToInclude (setExistingDeposit pendingDeposits depositToInclude))
       else outcome
 
   Environment{party} = env
@@ -357,6 +359,8 @@ onOpenNetworkReqTx env ledger currentSlot st ttl pendingDeposits tx =
     , decommitTx
     , version
     , currentDepositTxId
+    , pendingDepositVersion
+    , pendingDecommitVersion
     } = coordinatedHeadState
 
   Snapshot{number = confirmedSn} = getSnapshot confirmedSnapshot
@@ -380,7 +384,7 @@ onOpenNetworkReqTx env ledger currentSlot st ttl pendingDeposits tx =
 --
 -- __Transition__: 'OpenState' → 'OpenState'
 onOpenNetworkReqSn ::
-  IsTx tx =>
+  IsChainState tx =>
   Environment ->
   Ledger tx ->
   PendingDeposits tx ->
@@ -423,7 +427,7 @@ onOpenNetworkReqSn env ledger pendingDeposits currentSlot st otherParty sv sn re
                 let nextSnapshot =
                       Snapshot
                         { headId
-                        , version = version
+                        , version = sv -- Use the requested version (current or pending)
                         , number = sn
                         , confirmed = requestedTxs
                         , utxo = snapshotUTxO
@@ -437,7 +441,7 @@ onOpenNetworkReqSn env ledger pendingDeposits currentSlot st otherParty sv sn re
                 --       σᵢ ← MS-Sign(kₕˢⁱᵍ, (cid‖v‖ŝ‖η‖η𝛼‖ηω))
                 let snapshotSignature = sign signingKey nextSnapshot
                 -- Spec: multicast (ackSn, ŝ, σᵢ)
-                (cause (NetworkEffect $ AckSn snapshotSignature sn) <>) $ do
+                (cause (NetworkEffect $ AckSn snapshotSignature sn pendingDepositVersion pendingDecommitVersion) <>) $ do
                   -- Spec: ̂Σ ← ∅
                   --       L̂ ← 𝑈
                   --       𝑋 ← T
@@ -456,8 +460,12 @@ onOpenNetworkReqSn env ledger pendingDeposits currentSlot st otherParty sv sn re
                       }
  where
   requireReqSn continue
-    | sv /= version =
-        Error $ RequireFailed $ ReqSvNumberInvalid{requestedSv = sv, lastSeenSv = version}
+    | sv /= version && Just sv /= pendingDepositVersion && Just sv /= pendingDecommitVersion =
+        -- If sv is one step ahead and a commit/decommit is pending settlement, the
+        -- CommitFinalized/DecommitFinalized chain event may not have arrived yet — wait.
+        if sv == version + 1 && (isJust confUTxOToCommit || isJust confUTxOToDecommit)
+          then wait $ WaitOnSnapshotVersion sv
+          else Error $ RequireFailed $ ReqSvNumberInvalid{requestedSv = sv, lastSeenSv = version}
     | sn /= seenSn + 1 =
         Error $ RequireFailed $ ReqSnNumberInvalid{requestedSn = sn, lastSeenSn = seenSn}
     | not (isLeader parameters otherParty sn) =
@@ -472,7 +480,7 @@ onOpenNetworkReqSn env ledger pendingDeposits currentSlot st otherParty sv sn re
         wait $ WaitOnSnapshotNumber seenSn
 
   waitOnSnapshotVersion continue
-    | version == sv =
+    | version == sv || Just sv == pendingDepositVersion || Just sv == pendingDecommitVersion =
         continue
     | otherwise =
         wait $ WaitOnSnapshotVersion sv
@@ -573,7 +581,7 @@ onOpenNetworkReqSn env ledger pendingDeposits currentSlot st otherParty sv sn re
     InitialSnapshot{initialUTxO} -> initialUTxO
     ConfirmedSnapshot{snapshot = Snapshot{utxo, utxoToCommit}} -> utxo <> fromMaybe mempty utxoToCommit
 
-  CoordinatedHeadState{confirmedSnapshot, seenSnapshot, allTxs, localTxs, version} = coordinatedHeadState
+  CoordinatedHeadState{confirmedSnapshot, seenSnapshot, allTxs, localTxs, version, pendingDepositVersion, pendingDecommitVersion} = coordinatedHeadState
 
   OpenState{parameters, coordinatedHeadState, headId} = st
 
@@ -601,8 +609,12 @@ onOpenNetworkAckSn ::
   Signature (Snapshot tx) ->
   -- | Snapshot number of this AckSn.
   SnapshotNumber ->
+  -- | Pending deposit version the sender has observed.
+  Maybe SnapshotVersion ->
+  -- | Pending decommit version the sender has observed.
+  Maybe SnapshotVersion ->
   Outcome tx
-onOpenNetworkAckSn Environment{party} pendingDeposits openState otherParty snapshotSignature sn =
+onOpenNetworkAckSn Environment{party} pendingDeposits openState otherParty snapshotSignature sn senderPendingDepositVersion senderPendingDecommitVersion =
   -- Spec: require s ∈ {ŝ, ŝ + 1}
   requireValidAckSn $ do
     -- Spec: wait ŝ = s
@@ -610,7 +622,7 @@ onOpenNetworkAckSn Environment{party} pendingDeposits openState otherParty snaps
       -- Spec: require (j,⋅) ∉ ̂Σ
       requireNotSignedYet sigs $ do
         -- Spec: ̂Σ[j] ← σⱼ
-        (newState PartySignedSnapshot{snapshot, party = otherParty, signature = snapshotSignature} <>) $
+        (newState PartySignedSnapshot{snapshot, party = otherParty, signature = snapshotSignature, pendingDepositVersion = senderPendingDepositVersion, pendingDecommitVersion = senderPendingDecommitVersion} <>) $
           --       if ∀k ∈ [1..n] : (k,·) ∈ ̂Σ
           ifAllMembersHaveSigned snapshot sigs $ \sigs' -> do
             -- Spec: σ̃ ← MS-ASig(kₕˢᵉᵗᵘᵖ,̂Σ)
@@ -668,6 +680,8 @@ onOpenNetworkAckSn Environment{party} pendingDeposits openState otherParty snaps
                 { snapshot
                 , party = otherParty
                 , signature = snapshotSignature
+                , pendingDepositVersion = senderPendingDepositVersion
+                , pendingDecommitVersion = senderPendingDecommitVersion
                 }
 
   requireVerifiedMultisignature multisig msg cont =
@@ -686,16 +700,28 @@ onOpenNetworkAckSn Environment{party} pendingDeposits openState otherParty snaps
     let nextSn = previous.number + 1
         -- Skip decommit/deposit if already posted in previous snapshot
         decommitToInclude = skipPostedDecommit previous decommitTx
-        depositToInclude = skipPostedDeposit pendingDeposits currentDepositTxId previous.utxoToCommit
+        -- Use pending version if available (deferred version update)
+        effectiveVersion = fromMaybe version (pendingDepositVersion <|> pendingDecommitVersion)
+        -- Only include a new deposit if the previous commit is settled on chain.
+        -- If effectiveVersion == previous.version and a commit is still pending,
+        -- the receiver would reject with ReqSnCommitNotSettled. Wait for CommitFinalized
+        -- to arrive (which sets pendingDepositVersion) before requesting the next deposit.
+        commitSettled = effectiveVersion > previous.version || isNothing previous.utxoToCommit
+        depositToInclude =
+          if commitSettled
+            then findNextActiveDeposit pendingDeposits previous.utxoToCommit
+            else Nothing
+        -- Check if there's anything to snapshot: L2 txs, deposit, or decommit
+        hasWork = not (null localTxs) || isJust depositToInclude || isJust decommitToInclude
     -- NB: No snapshotInFlight check needed here because we KNOW the previous snapshot
     -- just confirmed (we're inside ifAllMembersHaveSigned). After aggregation, seenSnapshot
     -- will be LastSeenSnapshot{lastSeen = previous.number}, so nextSn is safe to request.
     -- The snapshotInFlight check in onOpenNetworkReqTx handles the ReqTx case.
-    if isLeader parameters party nextSn && not (null localTxs)
+    if isLeader parameters party nextSn && hasWork
       then
         outcome
           <> newState SnapshotRequestDecided{snapshotNumber = nextSn}
-          <> cause (NetworkEffect $ ReqSn version nextSn (txId <$> take maxTxsPerSnapshot localTxs) decommitToInclude (setExistingDeposit pendingDeposits depositToInclude))
+          <> cause (NetworkEffect $ ReqSn effectiveVersion nextSn (txId <$> take maxTxsPerSnapshot localTxs) decommitToInclude (setExistingDeposit pendingDeposits depositToInclude))
       else outcome
 
   maybePostIncrementTx snapshot@Snapshot{utxoToCommit} signatures outcome =
@@ -745,7 +771,7 @@ onOpenNetworkAckSn Environment{party} pendingDeposits openState otherParty snaps
     , headId
     } = openState
 
-  CoordinatedHeadState{seenSnapshot, localTxs, decommitTx, currentDepositTxId, version} = coordinatedHeadState
+  CoordinatedHeadState{seenSnapshot, localTxs, decommitTx, version, pendingDepositVersion, pendingDecommitVersion} = coordinatedHeadState
 
 -- | Client request to recover deposited UTxO.
 --
@@ -891,7 +917,9 @@ onOpenNetworkReqDec env ledger ttl currentSlot openState decommitTx =
 
   maybeRequestSnapshot =
     if not (snapshotInFlight seenSnapshot nextSn) && isLeader parameters party nextSn
-      then cause (NetworkEffect (ReqSn version nextSn (txId <$> take maxTxsPerSnapshot localTxs) (Just decommitTx) Nothing))
+      then
+        let effectiveVersion = fromMaybe version (pendingDepositVersion <|> pendingDecommitVersion)
+         in cause (NetworkEffect (ReqSn effectiveVersion nextSn (txId <$> take maxTxsPerSnapshot localTxs) (Just decommitTx) Nothing))
       else noop
 
   Environment{party} = env
@@ -909,6 +937,8 @@ onOpenNetworkReqDec env ledger ttl currentSlot openState decommitTx =
     , localUTxO
     , version
     , seenSnapshot
+    , pendingDepositVersion
+    , pendingDecommitVersion
     } = coordinatedHeadState
 
   OpenState
@@ -977,20 +1007,30 @@ onOpenChainTick env chainTime pendingDeposits st =
       withNextActive (newActive <> newExpired <> pendingDeposits) $ \depositTxId ->
         -- REVIEW: this is not really a wait, but discard?
         -- TODO: Spec: wait tx𝜔 = ⊥ ∧ 𝑈𝛼 = ∅
-        if isNothing decommitTx
-          && isNothing currentDepositTxId
-          && not (snapshotInFlight seenSnapshot nextSn)
-          && isLeader parameters party nextSn
-          then
-            -- XXX: This state update has no equivalence in the
-            -- spec. Do we really need to store that we have
-            -- requested a snapshot? If yes, should update spec.
-            newState SnapshotRequestDecided{snapshotNumber = nextSn}
-              -- Spec: multicast (reqSn,̂ 𝑣,̄ 𝒮.𝑠 + 1,̂ 𝒯, 𝑈𝛼, ⊥)
-              <> cause (NetworkEffect $ ReqSn version nextSn (txId <$> take maxTxsPerSnapshot localTxs) Nothing (Just depositTxId))
-          else
-            noop
+        -- Check if this deposit is new (not already being processed)
+        let isNewDeposit = currentDepositTxId /= Just depositTxId
+            -- Only include a deposit if the previous commit is settled on chain.
+            -- If depositVersion == confVersion and a commit is still pending, the
+            -- receiver would reject with ReqSnCommitNotSettled. CommitFinalized will
+            -- set pendingDepositVersion (> confVersion) once the chain confirms.
+            commitSettled = depositVersion > confVersion || isNothing confUTxOToCommit
+         in if isNothing decommitTx
+              && (isNothing currentDepositTxId || isNewDeposit)
+              && not (snapshotInFlight seenSnapshot nextSn)
+              && isLeader parameters party nextSn
+              && commitSettled
+              then
+                -- XXX: This state update has no equivalence in the
+                -- spec. Do we really need to store that we have
+                -- requested a snapshot? If yes, should update spec.
+                newState SnapshotRequestDecided{snapshotNumber = nextSn}
+                  -- Spec: multicast (reqSn,̂ 𝑣,̄ 𝒮.𝑠 + 1,̂ 𝒯, 𝑈𝛼, ⊥)
+                  -- Use pending version if available (deferred version update)
+                  <> cause (NetworkEffect $ ReqSn depositVersion nextSn (txId <$> take maxTxsPerSnapshot localTxs) Nothing (Just depositTxId))
+              else
+                noop
  where
+  depositVersion = fromMaybe version (pendingDepositVersion <|> pendingDecommitVersion)
   -- Pending active deposits are selected in arrival order (FIFO).
   withNextActive :: forall tx. (Eq (UTxOType tx), Monoid (UTxOType tx)) => Map (TxIdType tx) (Deposit tx) -> (TxIdType tx -> Outcome tx) -> Outcome tx
   withNextActive deposits cont = do
@@ -1012,9 +1052,11 @@ onOpenChainTick env chainTime pendingDeposits st =
     , version
     , decommitTx
     , currentDepositTxId
+    , pendingDepositVersion
+    , pendingDecommitVersion
     } = coordinatedHeadState
 
-  Snapshot{number = confirmedSn} = getSnapshot confirmedSnapshot
+  Snapshot{number = confirmedSn, version = confVersion, utxoToCommit = confUTxOToCommit} = getSnapshot confirmedSnapshot
 
   OpenState{coordinatedHeadState, parameters} = st
 
@@ -1167,12 +1209,16 @@ onOpenClientClose st =
           CloseTx
             { headId
             , headParameters = parameters
-            , openVersion = version
+            , openVersion = effectiveVersion
             , closingSnapshot = confirmedSnapshot
             }
       }
  where
-  CoordinatedHeadState{confirmedSnapshot, version} = coordinatedHeadState
+  CoordinatedHeadState{confirmedSnapshot, version, pendingDepositVersion, pendingDecommitVersion} = coordinatedHeadState
+
+  -- Use the effective version that the chain expects, which includes any
+  -- pending version updates that have already been finalized on-chain
+  effectiveVersion = maximum (version : catMaybes [pendingDepositVersion, pendingDecommitVersion])
 
   OpenState{coordinatedHeadState, headId, parameters} = st
 
@@ -1213,13 +1259,17 @@ onOpenChainCloseTx openState newChainState closedSnapshotNumber contestationDead
                   ContestTx
                     { headId
                     , headParameters
-                    , openVersion = version
+                    , openVersion = effectiveVersion
                     , contestingSnapshot = confirmedSnapshot
                     }
               }
       else outcome
 
-  CoordinatedHeadState{confirmedSnapshot, version} = coordinatedHeadState
+  CoordinatedHeadState{confirmedSnapshot, version, pendingDepositVersion, pendingDecommitVersion} = coordinatedHeadState
+
+  -- Use the effective version that the chain expects, which includes any
+  -- pending version updates that have already been finalized on-chain
+  effectiveVersion = maximum (version : catMaybes [pendingDepositVersion, pendingDecommitVersion])
 
   OpenState{parameters = headParameters, headId, coordinatedHeadState} = openState
 
@@ -1336,7 +1386,7 @@ onClosedChainContestTx closedState newChainState snapshotNumber contestationDead
                   ContestTx
                     { headId
                     , headParameters
-                    , openVersion = version
+                    , openVersion = effectiveVersion
                     , contestingSnapshot = confirmedSnapshot
                     }
               }
@@ -1347,7 +1397,11 @@ onClosedChainContestTx closedState newChainState snapshotNumber contestationDead
     | otherwise ->
         newState HeadContested{headId, chainState = newChainState, contestationDeadline, snapshotNumber}
  where
-  ClosedState{parameters = headParameters, confirmedSnapshot, headId, version} = closedState
+  ClosedState{parameters = headParameters, confirmedSnapshot, headId, version, pendingDepositVersion, pendingDecommitVersion} = closedState
+
+  -- Use the effective version that the chain expects, which includes any
+  -- pending version updates that have already been finalized on-chain
+  effectiveVersion = maximum (version : catMaybes [pendingDepositVersion, pendingDecommitVersion])
 
 -- | Client request to fanout leads to a fanout transaction on chain using the
 -- latest confirmed snapshot from 'ClosedState'.
@@ -1369,12 +1423,12 @@ onClosedClientFanout closedState =
               -- are the same, the utxoToCommit has not been used on chain yet
               -- so we disregard, so we must not fan it out.
               utxoToCommit =
-                if snapshotVersion == version
+                if snapshotVersion == effectiveVersion
                   then Nothing
                   else utxoToCommit
             , -- For decommit, if it hasn't happened, we _must_ fan it out.
               utxoToDecommit =
-                if snapshotVersion == version
+                if snapshotVersion == effectiveVersion
                   then utxoToDecommit
                   else Nothing
             , headSeed
@@ -1384,7 +1438,11 @@ onClosedClientFanout closedState =
  where
   Snapshot{utxo, utxoToCommit, utxoToDecommit, version = snapshotVersion} = getSnapshot confirmedSnapshot
 
-  ClosedState{headSeed, confirmedSnapshot, contestationDeadline, version} = closedState
+  ClosedState{headSeed, confirmedSnapshot, contestationDeadline, version, pendingDepositVersion, pendingDecommitVersion} = closedState
+
+  -- Use the effective version that the chain expects, which includes any
+  -- pending version updates that have already been finalized on-chain
+  effectiveVersion = maximum (version : catMaybes [pendingDepositVersion, pendingDecommitVersion])
 
 -- | Observe a fanout transaction by finalize the head state and notifying
 -- clients about it.
@@ -1473,7 +1531,7 @@ skipPostedDecommit :: IsTx tx => Snapshot tx -> Maybe tx -> Maybe tx
 skipPostedDecommit previousSnapshot decommit =
   case (decommit, previousSnapshot.utxoToDecommit) of
     (Just tx, Just prevUtxo)
-      | resolveInputsUTxO previousSnapshot.utxo tx == prevUtxo -> Nothing -- Already posted
+      | utxoFromTx tx == prevUtxo -> Nothing -- Already posted
     _ -> decommit -- Keep it
 
 -- | Skip a deposit if it was already posted in a previous snapshot.
@@ -1487,6 +1545,15 @@ skipPostedDeposit pendingDeposits depositTxId previousUtxoToCommit =
           | deposited == prevUtxo -> Nothing -- Already posted
         _ -> depositTxId -- Keep it
     _ -> depositTxId -- Keep it
+
+-- | Find the next active deposit that hasn't been posted yet.
+-- Looks through all pending deposits to find an Active one that wasn't in the previous snapshot.
+findNextActiveDeposit :: IsTx tx => PendingDeposits tx -> Maybe (UTxOType tx) -> Maybe (TxIdType tx)
+findNextActiveDeposit pendingDeposits previousUtxoToCommit =
+  fst <$> find isActiveAndNotPosted (Map.toList pendingDeposits)
+ where
+  isActiveAndNotPosted (_, Deposit{status, deposited}) =
+    status == Active && Just deposited /= previousUtxoToCommit
 
 -- | Handles inputs and converts them into 'StateChanged' events along with
 -- 'Effect's, in case it is processed successfully. Later, the Node will
@@ -1692,8 +1759,8 @@ handleNetworkInput env ledger ChainPointTime{currentSlot} pendingDeposits st ev 
     onOpenNetworkReqTx env ledger currentSlot openState ttl pendingDeposits tx
   (Open openState@OpenState{headId = ourHeadId}, NetworkInput _ (ReceivedMessage{sender, msg = ReqSn sv sn txIds decommitTx depositTxId})) ->
     onOpenNetworkReqSn env ledger (depositsForHead ourHeadId pendingDeposits) currentSlot openState sender sv sn txIds decommitTx depositTxId
-  (Open openState@OpenState{headId = ourHeadId}, NetworkInput _ (ReceivedMessage{sender, msg = AckSn snapshotSignature sn})) ->
-    onOpenNetworkAckSn env (depositsForHead ourHeadId pendingDeposits) openState sender snapshotSignature sn
+  (Open openState@OpenState{headId = ourHeadId}, NetworkInput _ (ReceivedMessage{sender, msg = AckSn snapshotSignature sn pendingDepositVersion pendingDecommitVersion})) ->
+    onOpenNetworkAckSn env (depositsForHead ourHeadId pendingDeposits) openState sender snapshotSignature sn pendingDepositVersion pendingDecommitVersion
   (Open openState, NetworkInput ttl (ReceivedMessage{msg = ReqDec{transaction}})) ->
     onOpenNetworkReqDec env ledger ttl currentSlot openState transaction
   _ ->
@@ -1815,27 +1882,46 @@ aggregateNodeState nodeState sc =
           case st of
             Open
               os@OpenState{coordinatedHeadState} ->
-                let deposit = Map.lookup depositTxId currentPendingDeposits
-                    newUTxO = maybe mempty (\Deposit{deposited} -> deposited) deposit
-                 in nodeState
-                      { headState =
-                          Open
-                            os
-                              { chainState
-                              , coordinatedHeadState =
-                                  coordinatedHeadState
-                                    { version = newVersion
-                                    , -- NOTE: This must correspond to the just finalized
-                                      -- depositTxId, but we should not verify this here.
-                                      currentDepositTxId = Nothing
-                                    , localUTxO = localUTxO <> newUTxO
-                                    , seenSnapshot = toLastSeenSnapshot (seenSnapshot coordinatedHeadState)
-                                    }
-                              }
-                      , pendingDeposits = Map.delete depositTxId currentPendingDeposits
-                      }
+                let
+                  -- Apply ALL previous pending versions immediately
+                  -- When a new CommitFinalized arrives, we know the chain has progressed
+                  -- past any previous pending versions, so apply them now
+                  chsWithDepositApplied = case pendingDepositVersion of
+                    Just prevVersion ->
+                      coordinatedHeadState
+                        { version = prevVersion
+                        , pendingDepositVersion = Nothing
+                        , depositChainStateAcks = mempty
+                        }
+                    Nothing -> coordinatedHeadState
+                  chsWithPreviousApplied = case pendingDecommitVersion of
+                    Just prevVersion ->
+                      chsWithDepositApplied
+                        { version = prevVersion
+                        , pendingDecommitVersion = Nothing
+                        , decommitChainStateAcks = mempty
+                        }
+                    Nothing -> chsWithDepositApplied
+                 in
+                  nodeState
+                    { headState =
+                        Open
+                          os
+                            { chainState
+                            , coordinatedHeadState =
+                                chsWithPreviousApplied
+                                  { pendingDepositVersion = Just newVersion
+                                  , -- Clear currentDepositTxId - let onOpenChainTick pick up next deposit
+                                    currentDepositTxId = Nothing
+                                  , -- Keep seenSnapshot unchanged - let snapshot protocol proceed naturally
+                                    -- Clear deposit chain state acks to start collecting for new version
+                                    depositChainStateAcks = mempty
+                                  }
+                            }
+                    , pendingDeposits = Map.delete depositTxId currentPendingDeposits
+                    }
                where
-                CoordinatedHeadState{localUTxO} = coordinatedHeadState
+                CoordinatedHeadState{pendingDepositVersion, pendingDecommitVersion} = coordinatedHeadState
             _otherState ->
               nodeState
                 { headState = st
@@ -1854,24 +1940,70 @@ aggregateNodeState nodeState sc =
 
 -- * HeadState aggregate
 
--- | Convert any SeenSnapshot to LastSeenSnapshot, preserving the correct snapshot number.
--- Used by CommitFinalized and DecommitFinalized to handle race conditions where
--- on-chain transaction confirmation happens before AckSn messages arrive.
-toLastSeenSnapshot :: SeenSnapshot tx -> SeenSnapshot tx
-toLastSeenSnapshot = \case
-  NoSeenSnapshot ->
-    LastSeenSnapshot{lastSeen = 0}
-  LastSeenSnapshot{lastSeen} ->
-    LastSeenSnapshot{lastSeen}
-  -- NB: Use 'requested' not 'lastSeen' to prevent infinite AckSn loop.
-  -- When leader requests snapshot N with commit/decommit and the on-chain transaction
-  -- is observed before AckSn messages arrive, the transaction is part of snapshot N
-  -- (requested), not snapshot N-1 (lastSeen). Using lastSeen would cause AckSn(N)
-  -- messages to fail the guard check and be requeued infinitely.
-  RequestedSnapshot{requested} ->
-    LastSeenSnapshot{lastSeen = requested}
-  SeenSnapshot{snapshot = Snapshot{number}} ->
-    LastSeenSnapshot{lastSeen = number}
+-- | Apply pending version update if all parties have acknowledged it.
+-- This is used to synchronize version bumps across all parties after observing
+-- DecommitFinalized or CommitFinalized chain events, avoiding ReqSvNumberInvalid
+-- rejections due to asynchronous chain observations.
+maybeApplyVersionBump :: [Party] -> CoordinatedHeadState tx -> CoordinatedHeadState tx
+maybeApplyVersionBump allParties chs@CoordinatedHeadState{pendingDepositVersion, pendingDecommitVersion, depositChainStateAcks, decommitChainStateAcks} =
+  let allPartiesSet = Set.fromList allParties
+
+      -- Check if deposit version has consensus
+      depositReady = case pendingDepositVersion of
+        Nothing -> Nothing
+        Just newDepositVersion ->
+          let depositAckedParties = Map.keysSet depositChainStateAcks
+              allDepositAcked = allPartiesSet == depositAckedParties
+              allAckedSameDepositVersion = all (== Just newDepositVersion) (Map.elems depositChainStateAcks)
+           in if allDepositAcked && allAckedSameDepositVersion
+                then Just newDepositVersion
+                else Nothing
+
+      -- Check if decommit version has consensus
+      decommitReady = case pendingDecommitVersion of
+        Nothing -> Nothing
+        Just newDecommitVersion ->
+          let decommitAckedParties = Map.keysSet decommitChainStateAcks
+              allDecommitAcked = allPartiesSet == decommitAckedParties
+              allAckedSameDecommitVersion = all (== Just newDecommitVersion) (Map.elems decommitChainStateAcks)
+           in if allDecommitAcked && allAckedSameDecommitVersion
+                then Just newDecommitVersion
+                else Nothing
+
+      -- Apply chronologically (lower version number first)
+      applyDeposit chsState =
+        case depositReady of
+          Nothing -> chsState
+          Just newDepositVersion ->
+            chsState
+              { version = newDepositVersion
+              , pendingDepositVersion = Nothing
+              , depositChainStateAcks = mempty
+              }
+
+      applyDecommit chsState =
+        case decommitReady of
+          Nothing -> chsState
+          Just newDecommitVersion ->
+            chsState
+              { version = newDecommitVersion
+              , pendingDecommitVersion = Nothing
+              , decommitChainStateAcks = mempty
+              }
+   in case (depositReady, decommitReady) of
+        (Just depositVersion, Just decommitVersion) ->
+          -- Both ready: apply BOTH version bumps in chronological order.
+          -- Since both applyDeposit and applyDecommit write to the same `version` field,
+          -- we must apply lower version first (via inner function), then higher version
+          -- (via outer function), so the final `version` value is the maximum.
+          -- Example: if depositVersion=1, decommitVersion=2, we do:
+          --   applyDeposit: version = 0 → 1, then applyDecommit: version = 1 → 2
+          if depositVersion <= decommitVersion
+            then applyDecommit (applyDeposit chs)
+            else applyDeposit (applyDecommit chs)
+        (Just _, Nothing) -> applyDeposit chs
+        (Nothing, Just _) -> applyDecommit chs
+        (Nothing, Nothing) -> chs -- Still waiting
 
 -- | Reflect 'StateChanged' events onto the 'HeadState' aggregate.
 aggregate :: IsChainState tx => HeadState tx -> StateChanged tx -> HeadState tx
@@ -1929,6 +2061,10 @@ aggregate st = \case
                   , currentDepositTxId = Nothing
                   , decommitTx = Nothing
                   , version = 0
+                  , pendingDepositVersion = Nothing
+                  , pendingDecommitVersion = Nothing
+                  , depositChainStateAcks = mempty
+                  , decommitChainStateAcks = mempty
                   }
             , chainState
             , headId
@@ -1998,7 +2134,7 @@ aggregate st = \case
        where
         CoordinatedHeadState{allTxs} = coordinatedHeadState
       _otherState -> st
-  PartySignedSnapshot{party, signature} ->
+  PartySignedSnapshot{party, signature, pendingDepositVersion, pendingDecommitVersion} ->
     case st of
       Open
         os@OpenState
@@ -2015,24 +2151,35 @@ aggregate st = \case
                         ss
                           { signatories = Map.insert party signature signatories
                           }
+                    , -- Only insert into acks maps when party is acknowledging a specific version (Just x)
+                      -- Don't track Nothing values - they provide no useful information
+                      depositChainStateAcks = case pendingDepositVersion of
+                        Just v -> Map.insert party (Just v) (depositChainStateAcks chs)
+                        Nothing -> depositChainStateAcks chs
+                    , decommitChainStateAcks = case pendingDecommitVersion of
+                        Just v -> Map.insert party (Just v) (decommitChainStateAcks chs)
+                        Nothing -> decommitChainStateAcks chs
                     }
               }
       _otherState -> st
   SnapshotConfirmed{snapshot, signatures} ->
     case st of
-      Open os@OpenState{coordinatedHeadState} ->
-        Open
-          os
-            { coordinatedHeadState =
-                coordinatedHeadState
-                  { confirmedSnapshot =
-                      ConfirmedSnapshot
-                        { snapshot
-                        , signatures
-                        }
-                  , seenSnapshot = LastSeenSnapshot number
-                  }
-            }
+      Open os@OpenState{coordinatedHeadState, parameters = HeadParameters{parties}} ->
+        let updatedChs =
+              coordinatedHeadState
+                { confirmedSnapshot =
+                    ConfirmedSnapshot
+                      { snapshot
+                      , signatures
+                      }
+                , seenSnapshot = LastSeenSnapshot number
+                }
+            -- Check if all parties have acknowledged pending version and apply it
+            chsWithVersionBump = maybeApplyVersionBump parties updatedChs
+         in Open
+              os
+                { coordinatedHeadState = chsWithVersionBump
+                }
        where
         Snapshot{number} = snapshot
       _otherState -> st
@@ -2085,16 +2232,41 @@ aggregate st = \case
     case st of
       Open
         os@OpenState{coordinatedHeadState} ->
-          Open
-            os
-              { chainState
-              , coordinatedHeadState =
-                  coordinatedHeadState
-                    { decommitTx = Nothing
-                    , version = newVersion
-                    , seenSnapshot = toLastSeenSnapshot (seenSnapshot coordinatedHeadState)
-                    }
-              }
+          let
+            -- Apply ALL previous pending versions immediately
+            -- When a new DecommitFinalized arrives, we know the chain has progressed
+            -- past any previous pending versions, so apply them now
+            chsWithDecommitApplied = case pendingDecommitVersion of
+              Just prevVersion ->
+                coordinatedHeadState
+                  { version = prevVersion
+                  , pendingDecommitVersion = Nothing
+                  , decommitChainStateAcks = mempty
+                  }
+              Nothing -> coordinatedHeadState
+            chsWithPreviousApplied = case pendingDepositVersion of
+              Just prevVersion ->
+                chsWithDecommitApplied
+                  { version = prevVersion
+                  , pendingDepositVersion = Nothing
+                  , depositChainStateAcks = mempty
+                  }
+              Nothing -> chsWithDecommitApplied
+           in
+            Open
+              os
+                { chainState
+                , coordinatedHeadState =
+                    chsWithPreviousApplied
+                      { decommitTx = Nothing
+                      , pendingDecommitVersion = Just newVersion
+                      , -- Keep seenSnapshot unchanged - let snapshot protocol proceed naturally
+                        -- Clear decommit chain state acks to start collecting for new version
+                        decommitChainStateAcks = mempty
+                      }
+                }
+         where
+          CoordinatedHeadState{pendingDecommitVersion, pendingDepositVersion} = coordinatedHeadState
       _otherState -> st
   HeadClosed{chainState, contestationDeadline} ->
     case st of
@@ -2105,6 +2277,8 @@ aggregate st = \case
             CoordinatedHeadState
               { confirmedSnapshot
               , version
+              , pendingDepositVersion
+              , pendingDecommitVersion
               }
           , headId
           , headSeed
@@ -2119,11 +2293,13 @@ aggregate st = \case
               , headId
               , headSeed
               , version
+              , pendingDepositVersion
+              , pendingDecommitVersion
               }
       _otherState -> st
   HeadContested{chainState, contestationDeadline} ->
     case st of
-      Closed ClosedState{parameters, confirmedSnapshot, readyToFanoutSent, headId, headSeed, version} ->
+      Closed ClosedState{parameters, confirmedSnapshot, readyToFanoutSent, headId, headSeed, version, pendingDepositVersion, pendingDecommitVersion} ->
         Closed
           ClosedState
             { parameters
@@ -2134,6 +2310,8 @@ aggregate st = \case
             , headId
             , headSeed
             , version
+            , pendingDepositVersion
+            , pendingDecommitVersion
             }
       _otherState -> st
   HeadFannedOut{chainState} ->
@@ -2149,7 +2327,22 @@ aggregate st = \case
       Closed cst -> Closed cst{readyToFanoutSent = True}
       _otherState -> st
   ChainRolledBack{chainState} ->
-    setChainState chainState st
+    case st of
+      Open os@OpenState{coordinatedHeadState} ->
+        -- On rollback, clear pending versions and chainStateAcks since the
+        -- IncrementTx/DecrementTx that triggered them may have been rolled back
+        Open
+          os
+            { chainState
+            , coordinatedHeadState =
+                coordinatedHeadState
+                  { pendingDepositVersion = Nothing
+                  , pendingDecommitVersion = Nothing
+                  , depositChainStateAcks = mempty
+                  , decommitChainStateAcks = mempty
+                  }
+            }
+      _otherState -> setChainState chainState st
   TickObserved{} -> st
   IgnoredHeadInitializing{} -> st
   TxInvalid{transaction} -> case st of

--- a/hydra-node/src/Hydra/HeadLogic/Outcome.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Outcome.hs
@@ -93,7 +93,13 @@ data StateChanged tx
       , newLocalTxs :: [tx]
       , newCurrentDepositTxId :: Maybe (TxIdType tx)
       }
-  | PartySignedSnapshot {snapshot :: Snapshot tx, party :: Party, signature :: Signature (Snapshot tx)}
+  | PartySignedSnapshot
+      { snapshot :: Snapshot tx
+      , party :: Party
+      , signature :: Signature (Snapshot tx)
+      , pendingDepositVersion :: Maybe SnapshotVersion
+      , pendingDecommitVersion :: Maybe SnapshotVersion
+      }
   | SnapshotConfirmed {headId :: HeadId, snapshot :: Snapshot tx, signatures :: MultiSignature (Snapshot tx)}
   | DepositRecorded
       { chainState :: ChainStateType tx

--- a/hydra-node/src/Hydra/HeadLogic/State.hs
+++ b/hydra-node/src/Hydra/HeadLogic/State.hs
@@ -43,10 +43,10 @@ data HeadState tx
   | Closed (ClosedState tx)
   deriving stock (Generic)
 
-deriving stock instance (IsTx tx, Eq (ChainStateType tx)) => Eq (HeadState tx)
-deriving stock instance (IsTx tx, Show (ChainStateType tx)) => Show (HeadState tx)
-deriving anyclass instance (IsTx tx, ToJSON (ChainStateType tx)) => ToJSON (HeadState tx)
-deriving anyclass instance (IsTx tx, FromJSON (ChainStateType tx)) => FromJSON (HeadState tx)
+deriving stock instance (IsTx tx, Eq (ChainStateType tx), Eq (ChainPointType tx)) => Eq (HeadState tx)
+deriving stock instance (IsTx tx, Show (ChainStateType tx), Show (ChainPointType tx)) => Show (HeadState tx)
+deriving anyclass instance (IsTx tx, ToJSON (ChainStateType tx), ToJSON (ChainPointType tx)) => ToJSON (HeadState tx)
+deriving anyclass instance (IsTx tx, FromJSON (ChainStateType tx), FromJSON (ChainPointType tx)) => FromJSON (HeadState tx)
 
 -- | Update the chain state in any 'HeadState'.
 setChainState :: ChainStateType tx -> HeadState tx -> HeadState tx
@@ -126,10 +126,10 @@ data OpenState tx = OpenState
   }
   deriving stock (Generic)
 
-deriving stock instance (IsTx tx, Eq (ChainStateType tx)) => Eq (OpenState tx)
-deriving stock instance (IsTx tx, Show (ChainStateType tx)) => Show (OpenState tx)
-deriving anyclass instance (IsTx tx, ToJSON (ChainStateType tx)) => ToJSON (OpenState tx)
-deriving anyclass instance (IsTx tx, FromJSON (ChainStateType tx)) => FromJSON (OpenState tx)
+deriving stock instance (IsTx tx, Eq (ChainStateType tx), Eq (ChainPointType tx)) => Eq (OpenState tx)
+deriving stock instance (IsTx tx, Show (ChainStateType tx), Show (ChainPointType tx)) => Show (OpenState tx)
+deriving anyclass instance (IsTx tx, ToJSON (ChainStateType tx), ToJSON (ChainPointType tx)) => ToJSON (OpenState tx)
+deriving anyclass instance (IsTx tx, FromJSON (ChainStateType tx), FromJSON (ChainPointType tx)) => FromJSON (OpenState tx)
 
 -- | Off-chain state of the Coordinated Head protocol.
 data CoordinatedHeadState tx = CoordinatedHeadState
@@ -154,13 +154,23 @@ data CoordinatedHeadState tx = CoordinatedHeadState
   -- ^ Pending decommit transaction. Spec: txω
   , version :: SnapshotVersion
   -- ^ Last open state version as observed on chain. Spec: ̂v
+  , pendingDepositVersion :: Maybe SnapshotVersion
+  -- ^ Pending version update from CommitFinalized (deposit).
+  -- Applied when all parties acknowledge via AckSn.
+  , pendingDecommitVersion :: Maybe SnapshotVersion
+  -- ^ Pending version update from DecommitFinalized (decommit).
+  -- Applied when all parties acknowledge via AckSn.
+  , depositChainStateAcks :: Map Party (Maybe SnapshotVersion)
+  -- ^ Acknowledgments for pending deposit version from each party.
+  , decommitChainStateAcks :: Map Party (Maybe SnapshotVersion)
+  -- ^ Acknowledgments for pending decommit version from each party.
   }
   deriving stock (Generic)
 
-deriving stock instance IsTx tx => Eq (CoordinatedHeadState tx)
-deriving stock instance IsTx tx => Show (CoordinatedHeadState tx)
-deriving anyclass instance IsTx tx => ToJSON (CoordinatedHeadState tx)
-deriving anyclass instance IsTx tx => FromJSON (CoordinatedHeadState tx)
+deriving stock instance (IsTx tx, Eq (ChainPointType tx)) => Eq (CoordinatedHeadState tx)
+deriving stock instance (IsTx tx, Show (ChainPointType tx)) => Show (CoordinatedHeadState tx)
+deriving anyclass instance (IsTx tx, ToJSON (ChainPointType tx)) => ToJSON (CoordinatedHeadState tx)
+deriving anyclass instance (IsTx tx, FromJSON (ChainPointType tx)) => FromJSON (CoordinatedHeadState tx)
 
 -- | Data structure to help in tracking whether we have seen or requested a
 -- ReqSn already and if seen, the signatures we collected already.
@@ -210,6 +220,8 @@ data ClosedState tx = ClosedState
   , headId :: HeadId
   , headSeed :: HeadSeed
   , version :: SnapshotVersion
+  , pendingDepositVersion :: Maybe SnapshotVersion
+  , pendingDecommitVersion :: Maybe SnapshotVersion
   }
   deriving stock (Generic)
 

--- a/hydra-node/src/Hydra/Ledger/Simple.hs
+++ b/hydra-node/src/Hydra/Ledger/Simple.hs
@@ -85,6 +85,7 @@ instance IsTx SimpleTx where
   balance = Set.size
   hashUTxO = toStrict . foldMap (serialise . unSimpleTxOut)
   utxoFromTx = txOutputs
+  resolveInputsUTxO _utxo = txInputs
   outputsOfUTxO = toList
   withoutUTxO = Set.difference
 

--- a/hydra-node/src/Hydra/Network/Message.hs
+++ b/hydra-node/src/Hydra/Network/Message.hs
@@ -6,6 +6,7 @@ import Hydra.Prelude
 
 import Cardano.Binary (serialize')
 import Cardano.Crypto.Util (SignableRepresentation, getSignableRepresentation)
+import Hydra.Chain.ChainState (ChainPointType, IsChainState)
 import Hydra.Network (Connectivity)
 import Hydra.Tx (
   IsTx (TxIdType),
@@ -35,30 +36,32 @@ data Message tx
   | AckSn
       { signed :: Signature (Snapshot tx)
       , snapshotNumber :: SnapshotNumber
+      , pendingDepositVersion :: Maybe SnapshotVersion
+      , pendingDecommitVersion :: Maybe SnapshotVersion
       }
   | ReqDec {transaction :: tx}
   deriving stock (Generic)
 
-deriving stock instance IsTx tx => Eq (Message tx)
-deriving stock instance IsTx tx => Show (Message tx)
-deriving anyclass instance IsTx tx => ToJSON (Message tx)
-deriving anyclass instance IsTx tx => FromJSON (Message tx)
+deriving stock instance (IsTx tx, Eq (ChainPointType tx)) => Eq (Message tx)
+deriving stock instance (IsTx tx, Show (ChainPointType tx)) => Show (Message tx)
+deriving anyclass instance (IsTx tx, ToJSON (ChainPointType tx)) => ToJSON (Message tx)
+deriving anyclass instance (IsTx tx, FromJSON (ChainPointType tx)) => FromJSON (Message tx)
 
-instance (ToCBOR tx, ToCBOR (UTxOType tx), ToCBOR (TxIdType tx)) => ToCBOR (Message tx) where
+instance (IsChainState tx, ToCBOR tx, ToCBOR (UTxOType tx), ToCBOR (TxIdType tx), ToCBOR (ChainPointType tx)) => ToCBOR (Message tx) where
   toCBOR = \case
     ReqTx tx -> toCBOR ("ReqTx" :: Text) <> toCBOR tx
     ReqSn sv sn txs decommitTx incrementUTxO -> toCBOR ("ReqSn" :: Text) <> toCBOR sv <> toCBOR sn <> toCBOR txs <> toCBOR decommitTx <> toCBOR incrementUTxO
-    AckSn sig sn -> toCBOR ("AckSn" :: Text) <> toCBOR sig <> toCBOR sn
+    AckSn sig sn pdv pddv -> toCBOR ("AckSn" :: Text) <> toCBOR sig <> toCBOR sn <> toCBOR pdv <> toCBOR pddv
     ReqDec utxo -> toCBOR ("ReqDec" :: Text) <> toCBOR utxo
 
-instance (FromCBOR tx, FromCBOR (UTxOType tx), FromCBOR (TxIdType tx)) => FromCBOR (Message tx) where
+instance (IsChainState tx, FromCBOR tx, FromCBOR (UTxOType tx), FromCBOR (TxIdType tx), FromCBOR (ChainPointType tx)) => FromCBOR (Message tx) where
   fromCBOR =
     fromCBOR >>= \case
       ("ReqTx" :: Text) -> ReqTx <$> fromCBOR
       "ReqSn" -> ReqSn <$> fromCBOR <*> fromCBOR <*> fromCBOR <*> fromCBOR <*> fromCBOR
-      "AckSn" -> AckSn <$> fromCBOR <*> fromCBOR
+      "AckSn" -> AckSn <$> fromCBOR <*> fromCBOR <*> fromCBOR <*> fromCBOR
       "ReqDec" -> ReqDec <$> fromCBOR
       msg -> fail $ show msg <> " is not a proper CBOR-encoded Message"
 
-instance IsTx tx => SignableRepresentation (Message tx) where
+instance (IsChainState tx, ToCBOR tx, ToCBOR (UTxOType tx), ToCBOR (TxIdType tx), ToCBOR (ChainPointType tx)) => SignableRepresentation (Message tx) where
   getSignableRepresentation = serialize'

--- a/hydra-node/src/Hydra/Node/Network.hs
+++ b/hydra-node/src/Hydra/Node/Network.hs
@@ -45,16 +45,16 @@ module Hydra.Node.Network (
 import Hydra.Prelude hiding (fromList, replicate)
 
 import Control.Tracer (Tracer)
+import Hydra.Chain.ChainState (ChainPointType, IsChainState)
 import Hydra.Network (NetworkComponent, NetworkConfiguration (..), ProtocolVersion (..))
 import Hydra.Network.Authenticate (AuthLog, Authenticated, withAuthentication)
 import Hydra.Network.Etcd (EtcdLog, withEtcdNetwork)
 import Hydra.Network.Message (Message)
-import Hydra.Tx (IsTx)
 
 -- | Starts the network layer of a node, passing configured `Network` to its continuation.
 withNetwork ::
   forall tx.
-  IsTx tx =>
+  (IsChainState tx, ToCBOR (ChainPointType tx), FromCBOR (ChainPointType tx)) =>
   -- | Tracer to use for logging messages.
   Tracer IO NetworkLog ->
   -- | The network configuration

--- a/hydra-node/src/Hydra/Node/State.hs
+++ b/hydra-node/src/Hydra/Node/State.hs
@@ -49,10 +49,10 @@ data NodeState tx
       }
   deriving stock (Generic)
 
-deriving stock instance (IsTx tx, Eq (ChainStateType tx)) => Eq (NodeState tx)
-deriving stock instance (IsTx tx, Show (ChainStateType tx)) => Show (NodeState tx)
-deriving anyclass instance (IsTx tx, ToJSON (ChainStateType tx)) => ToJSON (NodeState tx)
-deriving anyclass instance (IsTx tx, FromJSON (ChainStateType tx)) => FromJSON (NodeState tx)
+deriving stock instance (IsTx tx, Eq (ChainStateType tx), Eq (ChainPointType tx)) => Eq (NodeState tx)
+deriving stock instance (IsTx tx, Show (ChainStateType tx), Show (ChainPointType tx)) => Show (NodeState tx)
+deriving anyclass instance (IsTx tx, ToJSON (ChainStateType tx), ToJSON (ChainPointType tx)) => ToJSON (NodeState tx)
+deriving anyclass instance (IsTx tx, FromJSON (ChainStateType tx), FromJSON (ChainPointType tx)) => FromJSON (NodeState tx)
 
 initNodeState :: IsChainState tx => ChainStateType tx -> NodeState tx
 initNodeState chainState =

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -15,7 +15,7 @@ import Control.Concurrent.Class.MonadSTM (
   writeTQueue,
   writeTVar,
  )
-import Control.Monad.Class.MonadAsync (cancel, forConcurrently)
+import Control.Monad.Class.MonadAsync (cancel, concurrently_, forConcurrently)
 import Control.Monad.IOSim (IOSim, runSimTrace, selectTraceEventsDynamic)
 import Data.List ((!!))
 import Data.List qualified as List
@@ -75,6 +75,8 @@ import Test.Hydra.Tx.Fixture (
   aliceSk,
   bob,
   bobSk,
+  carol,
+  carolSk,
   deriveOnChainId,
   testHeadId,
   testHeadSeed,
@@ -902,6 +904,69 @@ spec = parallel $ do
                 HeadIsContested{snapshotNumber} -> guard $ snapshotNumber == 1
                 _ -> Nothing
 
+  describe "Three participant Head" $ do
+    it "processes L2 transactions together with de/commits" $
+      shouldRunInSim $ do
+        withSimulatedChainAndNetwork $ \chain ->
+          withHydraNode aliceSk [bob, carol] chain $ \n1 ->
+            withHydraNode bobSk [alice, carol] chain $ \n2 ->
+              withHydraNode carolSk [alice, bob] chain $ \n3 -> do
+                openHead3 chain n1 n2 n3
+
+                let numTxs = 25 :: Int
+                let aliceTxs =
+                      [ SimpleTx
+                          (fromIntegral txid)
+                          (if txid == 100 then utxoRef 1 else utxoRef (fromIntegral (txid - 1)))
+                          (utxoRef (fromIntegral txid))
+                      | txid <- [100 .. 100 + numTxs - 1]
+                      ]
+
+                -- Run L2 tx spam concurrently with deposits + decommits
+                concurrently_
+                  -- Thread 1: Alice spams 25 chained L2 txs
+                  (forM_ aliceTxs $ \tx -> send n1 (NewTx tx) >> threadDelay 0)
+                  -- Thread 2: two deposits, then two sequential decommits
+                  ( do
+                      deadline1 <- newDeadlineFarEnoughFromNow
+                      dep1 <- simulateDeposit chain testHeadId (utxoRefs [200]) deadline1
+                      waitUntil [n1, n2, n3] $ CommitFinalized{headId = testHeadId, depositTxId = dep1}
+                      threadDelay 0
+                      deadline2 <- newDeadlineFarEnoughFromNow
+                      dep2 <- simulateDeposit chain testHeadId (utxoRefs [201]) deadline2
+                      waitUntil [n1, n2, n3] $ CommitFinalized{headId = testHeadId, depositTxId = dep2}
+                      threadDelay 0
+                      -- First decommit: Carol removes utxoRef 3
+                      send n3 (Decommit $ SimpleTx 300 (utxoRef 3) (utxoRef 300))
+                      threadDelay 0
+                      waitUntilMatch [n1, n2, n3] $ \case
+                        DecommitFinalized{} -> Just ()
+                        _ -> Nothing
+                      -- Second decommit: Bob removes utxoRef 2
+                      send n2 (Decommit $ SimpleTx 400 (utxoRef 2) (utxoRef 400))
+                  )
+
+                waitUntilMatch [n1, n2, n3] $ \case
+                  DecommitFinalized{} -> Just ()
+                  _ -> Nothing
+
+                -- Verify final state: L2 txs landed, both deposits added, both decommits removed
+                headUTxO <- getHeadUTxO . headState <$> queryState n1
+                fromMaybe mempty headUTxO `shouldSatisfy` member 124 -- Last L2 tx output
+                fromMaybe mempty headUTxO `shouldSatisfy` member 200 -- Deposit 1 added
+                fromMaybe mempty headUTxO `shouldSatisfy` member 201 -- Deposit 2 added
+                fromMaybe mempty headUTxO `shouldSatisfy` (not . member 1) -- Alice's UTXO spent by L2 txs
+                fromMaybe mempty headUTxO `shouldSatisfy` (not . member 2) -- Bob's UTXO decommitted
+                fromMaybe mempty headUTxO `shouldSatisfy` (not . member 3) -- Carol's UTXO decommitted
+
+                send n1 Close
+                waitUntil [n1, n2, n3] $ ReadyToFanout{headId = testHeadId}
+                send n2 Fanout
+                waitUntilMatch [n1, n2, n3] $ \case
+                  HeadIsFinalized{} -> Just ()
+                  _ -> Nothing
+
+
   describe "Hydra Node Logging" $ do
     it "traces processing of events" $ do
       let result = runSimTrace $ do
@@ -1413,6 +1478,23 @@ openHead2 chain n1 n2 = do
   simulateCommit chain testHeadId bob (utxoRef 2)
   waitUntil [n1, n2] $ Committed testHeadId bob (utxoRef 2)
   waitUntil [n1, n2] $ HeadIsOpen{headId = testHeadId, utxo = utxoRefs [1, 2]}
+
+openHead3 ::
+  SimulatedChainNetwork SimpleTx (IOSim s) ->
+  TestHydraClient SimpleTx (IOSim s) ->
+  TestHydraClient SimpleTx (IOSim s) ->
+  TestHydraClient SimpleTx (IOSim s) ->
+  IOSim s ()
+openHead3 chain n1 n2 n3 = do
+  send n1 Init
+  waitUntil [n1, n2, n3] $ HeadIsInitializing testHeadId (fromList [alice, bob, carol])
+  simulateCommit chain testHeadId alice (utxoRef 1)
+  waitUntil [n1, n2, n3] $ Committed testHeadId alice (utxoRef 1)
+  simulateCommit chain testHeadId bob (utxoRef 2)
+  waitUntil [n1, n2, n3] $ Committed testHeadId bob (utxoRef 2)
+  simulateCommit chain testHeadId carol (utxoRef 3)
+  waitUntil [n1, n2, n3] $ Committed testHeadId carol (utxoRef 3)
+  waitUntil [n1, n2, n3] $ HeadIsOpen{headId = testHeadId, utxo = utxoRefs [1, 2, 3]}
 
 assertHeadIsClosed :: (HasCallStack, MonadThrow m) => ServerOutput tx -> m ()
 assertHeadIsClosed = \case

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -916,9 +916,9 @@ spec = parallel $ do
                 let numTxs = 25 :: Int
                 let aliceTxs =
                       [ SimpleTx
-                          (fromIntegral txid)
-                          (if txid == 100 then utxoRef 1 else utxoRef (fromIntegral (txid - 1)))
-                          (utxoRef (fromIntegral txid))
+                        (fromIntegral txid)
+                        (if txid == 100 then utxoRef 1 else utxoRef (fromIntegral (txid - 1)))
+                        (utxoRef (fromIntegral txid))
                       | txid <- [100 .. 100 + numTxs - 1]
                       ]
 
@@ -958,14 +958,12 @@ spec = parallel $ do
                 fromMaybe mempty headUTxO `shouldSatisfy` (not . member 1) -- Alice's UTXO spent by L2 txs
                 fromMaybe mempty headUTxO `shouldSatisfy` (not . member 2) -- Bob's UTXO decommitted
                 fromMaybe mempty headUTxO `shouldSatisfy` (not . member 3) -- Carol's UTXO decommitted
-
                 send n1 Close
                 waitUntil [n1, n2, n3] $ ReadyToFanout{headId = testHeadId}
                 send n2 Fanout
                 waitUntilMatch [n1, n2, n3] $ \case
                   HeadIsFinalized{} -> Just ()
                   _ -> Nothing
-
 
   describe "Hydra Node Logging" $ do
     it "traces processing of events" $ do

--- a/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
@@ -62,6 +62,10 @@ spec = do
             , currentDepositTxId = Nothing
             , decommitTx = Nothing
             , version = 0
+            , pendingDepositVersion = Nothing
+            , pendingDecommitVersion = Nothing
+            , depositChainStateAcks = mempty
+            , decommitChainStateAcks = mempty
             }
     let sendReqSn :: Effect tx -> Bool
         sendReqSn = \case
@@ -69,7 +73,7 @@ spec = do
           _ -> False
     let snapshot1 = Snapshot testHeadId 0 1 [] mempty Nothing Nothing
 
-    let ackFrom sk vk = receiveMessageFrom vk $ AckSn (sign sk snapshot1) 1
+    let ackFrom sk vk = receiveMessageFrom vk $ AckSn (sign sk snapshot1) 1 Nothing Nothing
 
     describe "Generic Snapshot property" $ do
       prop "there's always a leader for every snapshot number" prop_thereIsAlwaysALeader
@@ -218,6 +222,10 @@ prop_singleMemberHeadAlwaysSnapshotOnReqTx sn = monadicIO $ do
         , currentDepositTxId = Nothing
         , decommitTx = Nothing
         , version
+        , pendingDepositVersion = Nothing
+        , pendingDecommitVersion = Nothing
+        , depositChainStateAcks = mempty
+        , decommitChainStateAcks = mempty
         }
     s0 = inOpenState' [alice] st
   now <- run $ nowFromSlot (currentSlot . chainPointTime $ s0)

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -544,7 +544,8 @@ spec =
         it "does not request same decommit twice across snapshots" $ do
           let localUTxO = utxoRefs [1, 2, 3]
               decommitTx' = SimpleTx 10 (utxoRefs [3]) (utxoRef 99)
-              utxoToDecommit' = utxoFromTx decommitTx'
+              -- utxoToDecommit should be the INPUTS of the decommit tx (what's removed from the Head)
+              utxoToDecommit' = txInputs decommitTx'
 
               -- Snapshot 0: initial snapshot
               snapshot0 = testSnapshot 0 0 [] localUTxO

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -114,6 +114,10 @@ spec =
               , currentDepositTxId = Nothing
               , decommitTx = Nothing
               , version = 0
+              , pendingDepositVersion = Nothing
+              , pendingDecommitVersion = Nothing
+              , depositChainStateAcks = mempty
+              , decommitChainStateAcks = mempty
               }
 
       it "reports if a requested tx is expired" $ do
@@ -141,7 +145,7 @@ spec =
         let reqSn :: Input tx
             reqSn = receiveMessage $ ReqSn 0 1 [] Nothing Nothing
             snapshot1 = Snapshot testHeadId 0 1 [] mempty Nothing Nothing
-            ackFrom sk vk = receiveMessageFrom vk $ AckSn (sign sk snapshot1) 1
+            ackFrom sk vk = receiveMessageFrom vk $ AckSn (sign sk snapshot1) 1 Nothing Nothing
         snapshotInProgress <- runHeadLogic bobEnv ledger (inOpenState threeParties) $ do
           step reqSn
           step (ackFrom carolSk carol)
@@ -378,24 +382,26 @@ spec =
           let decommitFinalizedOutcome = update aliceEnv ledger now s0 decrementObservation
           let s1 = aggregateState s0 decommitFinalizedOutcome
 
-          -- Verify seenSnapshot was reset (not stuck as RequestedSnapshot)
-          -- After DecommitFinalized, lastSeen should be the snapshot number that
-          -- included the decommit (snapshot 1), not the previously confirmed snapshot (0).
-          -- This prevents incoming AckSn messages for snapshot 1 from being requeued infinitely.
+          -- Verify seenSnapshot is unchanged (still RequestedSnapshot)
+          -- After DecommitFinalized, the snapshot protocol continues naturally.
+          -- The leader needs to receive their own ReqSn and collect AckSn messages.
           case s1 of
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
-              chs.version `shouldBe` 4
-              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 1}
+              chs.version `shouldBe` 3 -- Version NOT bumped immediately (deferred update)
+              chs.pendingDecommitVersion `shouldBe` Just 4 -- Decommit version stored as pending
+              chs.seenSnapshot `shouldBe` RequestedSnapshot{lastSeen = 0, requested = 1} -- Unchanged!
               chs.decommitTx `shouldBe` Nothing
             _ -> fail "expected Open state"
 
-          -- 2. The stale ReqSn(v=3) arrives and is rejected (version mismatch)
-          let staleReqSn :: Input SimpleTx
-              staleReqSn = receiveMessageFrom alice $ ReqSn 3 1 [] Nothing Nothing
+          -- 2. The ReqSn(v=3) arrives and is ACCEPTED (version still 3, not bumped yet)
+          -- This is the FIX: with deferred version update, incoming ReqSn is not rejected
+          let reqSn :: Input SimpleTx
+              reqSn = receiveMessageFrom alice $ ReqSn 3 1 [] Nothing Nothing
           now' <- nowFromSlot s1.chainPointTime.currentSlot
-          update aliceEnv ledger now' s1 staleReqSn `shouldSatisfy` \case
-            Error (RequireFailed ReqSvNumberInvalid{}) -> True
-            _ -> False
+          update aliceEnv ledger now' s1 reqSn `shouldSatisfy` \case
+            Error{} -> False
+            Wait{} -> False
+            Continue{} -> True
 
           -- 3. A new ReqTx arrives — bob (leader for sn=2) can request a new
           -- snapshot because snapshotInFlight is now False after the reset
@@ -414,20 +420,18 @@ spec =
                 _ -> False
             _ -> fail "expected Open state"
 
-        it "DecommitFinalized race: calculates correct snapshot number when seenSnapshot ahead of confirmedSnapshot" $ do
-          -- This test reproduces the bug where DecommitFinalized arrives before AckSn completes,
-          -- causing seenSnapshot to get ahead of confirmedSnapshot, which then causes wrong
-          -- snapshot number calculation on the next ReqTx.
+        it "DecommitFinalized race: ReqTx waits while snapshot still in-flight" $ do
+          -- This test verifies correct behavior when DecommitFinalized arrives before AckSn completes.
+          -- The snapshot protocol should continue naturally - we don't force premature state transitions.
           --
-          -- Bug scenario:
+          -- Correct behavior:
           -- 1. Snapshot 1 requested with decommit (RequestedSnapshot{lastSeen=0, requested=1})
           -- 2. DecrementTx posted to chain
           -- 3. DecommitFinalized observed BEFORE AckSn messages complete
-          -- 4. toLastSeenSnapshot converts RequestedSnapshot{requested=1} → LastSeenSnapshot{lastSeen=1}
-          -- 5. Now: confirmedSnapshot.number=0 but seenSnapshot.lastSeen=1 (seenSnapshot is ahead!)
-          -- 6. New L2 tx arrives
-          -- 7. BUGGY: nextSn = confirmedSn + 1 = 0 + 1 = 1 (wrong! snapshot 1 is already "seen")
-          -- 8. FIXED: nextSn = max(confirmedSn, seenSn) + 1 = max(0, 1) + 1 = 2 (correct!)
+          -- 4. seenSnapshot stays RequestedSnapshot (snapshot 1 still in-flight)
+          -- 5. New L2 tx arrives
+          -- 6. ReqTx does NOT create new snapshot request (snapshot 1 still in-flight)
+          -- 7. Transaction is accepted into localTxs and will be included in next snapshot after snapshot 1 confirms
 
           let localUTxO = utxoRefs [1]
               -- Snapshot 0 is confirmed (initial state)
@@ -455,11 +459,12 @@ spec =
           let decommitFinalizedOutcome = update aliceEnv ledger now s0 decrementObservation
           let s1 = aggregateState s0 decommitFinalizedOutcome
 
-          -- Verify seenSnapshot is now ahead of confirmedSnapshot
+          -- Verify seenSnapshot is unchanged after DecommitFinalized
           case s1 of
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
-              chs.version `shouldBe` 1
-              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 1} -- seenSnapshot updated
+              chs.version `shouldBe` 0 -- Version NOT bumped immediately (deferred update)
+              chs.pendingDecommitVersion `shouldBe` Just 1 -- Decommit version stored as pending
+              chs.seenSnapshot `shouldBe` RequestedSnapshot{lastSeen = 0, requested = 1} -- Unchanged!
               chs.confirmedSnapshot.snapshot.number `shouldBe` 0 -- confirmedSnapshot still at 0!
               chs.decommitTx `shouldBe` Nothing -- decommit cleared
             _ -> fail "expected Open state"
@@ -468,9 +473,12 @@ spec =
           let newTx = aValidTx 42
           let reqTxOutcome = update bobEnv ledger now s1 $ receiveMessage $ ReqTx newTx
 
-          -- Verify it requests snapshot 2 (not snapshot 1)
-          -- Note: Bob is leader for snapshot 2
-          reqTxOutcome `hasEffect` NetworkEffect (ReqSn 1 2 [txId newTx] Nothing Nothing)
+          -- Verify transaction is accepted but NO snapshot requested (snapshot 1 still in-flight)
+          let isReqSnEffect (NetworkEffect ReqSn{}) = True
+              isReqSnEffect _ = False
+           in reqTxOutcome `shouldSatisfy` \case
+                Continue{effects} -> not $ any isReqSnEffect effects
+                _ -> False
 
         it "AckSn for decommit snapshot is noop after DecommitFinalized" $ do
           let localUTxO = utxoRefs [1]
@@ -492,7 +500,7 @@ spec =
                     }
 
           -- AckSn for snapshot 1 arrives late
-          let ackSn = AckSn (sign aliceSk snapshot1) 1
+          let ackSn = AckSn (sign aliceSk snapshot1) 1 Nothing Nothing
               input = receiveMessageFrom alice ackSn
           now <- nowFromSlot s0.chainPointTime.currentSlot
 
@@ -527,12 +535,13 @@ spec =
           let decommitFinalizedOutcome = update bobEnv ledger now s0 decrementObservation
           let s1 = aggregateState s0 decommitFinalizedOutcome
 
-          -- Verify DecommitFinalized correctly extracted snapshot number from SeenSnapshot
+          -- Verify DecommitFinalized keeps seenSnapshot unchanged
           case s1 of
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
-              chs.version `shouldBe` 4
+              chs.version `shouldBe` 3 -- Version NOT bumped immediately (deferred update)
+              chs.pendingDecommitVersion `shouldBe` Just 4 -- Decommit version stored as pending
               chs.decommitTx `shouldBe` Nothing
-              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 1}
+              chs.seenSnapshot `shouldBe` SeenSnapshot{snapshot = snapshot1, signatories = mempty} -- Unchanged!
             _ -> fail "expected Open state"
 
         it "CommitFinalized with RequestedSnapshot should use requested number not lastSeen" $ do
@@ -562,19 +571,20 @@ spec =
 
           case s1 of
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
-              chs.version `shouldBe` 4
+              chs.version `shouldBe` 3 -- Version NOT bumped immediately (deferred update)
+              chs.pendingDepositVersion `shouldBe` Just 4 -- Deposit version stored as pending
               chs.currentDepositTxId `shouldBe` Nothing
-              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 1}
+              chs.seenSnapshot `shouldBe` RequestedSnapshot{lastSeen = 0, requested = 1} -- Unchanged!
             _ -> fail "expected Open state"
 
-        it "version race: ReqSn with old version is rejected after DecommitFinalized bumps version" $ do
-          -- This test exposes the version race bug:
+        it "version race: ReqSn with old version is ACCEPTED after DecommitFinalized (pending version)" $ do
+          -- This test verifies the fix for the version race bug:
           -- 1. Snapshot 0 confirmed with decommit at version 0
           -- 2. Leader sends ReqSn(version=0, number=1) to network
-          -- 3. DecommitFinalized arrives at follower's node, bumping version to 1
-          -- 4. Follower receives stale ReqSn(version=0, number=1) but now expects version=1
-          -- 5. Follower rejects with ReqSvNumberInvalid
-          -- 6. System is stuck: snapshot 1 never completes, later snapshots wait forever
+          -- 3. DecommitFinalized arrives at follower's node, storing pendingDecommitVersion=1 (version stays 0)
+          -- 4. Follower receives ReqSn(version=0, number=1) and accepts it (version still 0)
+          -- 5. Snapshot proceeds normally
+          -- 6. Version bump applied after all parties acknowledge via AckSn
 
           let localUTxO = utxoRefs [1, 2, 3]
               decommitTx' = SimpleTx 10 (utxoRefs [3]) (utxoRef 99)
@@ -621,16 +631,18 @@ spec =
           let staleReqSn = ReqSn{snapshotVersion = 0, snapshotNumber = 1, transactionIds = [], decommitTx = Nothing, depositTxId = Nothing}
               reqSnInput = receiveMessageFrom alice staleReqSn
 
-          -- Follower rejects with ReqSvNumberInvalid (version mismatch)
+          -- Follower ACCEPTS the ReqSn (version still 0, pending update stored)
           update bobEnv ledger now bobAfterFinalized reqSnInput `shouldSatisfy` \case
-            Error (RequireFailed ReqSvNumberInvalid{requestedSv = 0, lastSeenSv = 1}) -> True
+            Continue{} -> True
             _ -> False
 
         it "does not request same decommit twice across snapshots" $ do
           let localUTxO = utxoRefs [1, 2, 3]
               decommitTx' = SimpleTx 10 (utxoRefs [3]) (utxoRef 99)
-              -- utxoToDecommit should be the INPUTS of the decommit tx (what's removed from the Head)
-              utxoToDecommit' = txInputs decommitTx'
+              -- utxoToDecommit stores the OUTPUTS of the decommit tx (what gets placed on L1).
+              -- requireApplicableDecommitTx sets this via utxoFromTx and uses withoutUTxO to
+              -- remove them from the active L2 UTxO.
+              utxoToDecommit' = utxoFromTx decommitTx'
 
               -- Snapshot 0: initial snapshot
               snapshot0 = testSnapshot 0 0 [] localUTxO
@@ -733,9 +745,9 @@ spec =
           s1 <- runHeadLogic bobEnv ledger s0 $ do
             -- First confirm snapshot 1
             step $ receiveMessage $ ReqSn 0 1 [] Nothing Nothing
-            step $ receiveMessageFrom carol $ AckSn (sign carolSk snapshot1) 1
-            step $ receiveMessageFrom alice $ AckSn (sign aliceSk snapshot1) 1
-            step $ receiveMessageFrom bob $ AckSn (sign bobSk snapshot1) 1
+            step $ receiveMessageFrom carol $ AckSn (sign carolSk snapshot1) 1 Nothing Nothing
+            step $ receiveMessageFrom alice $ AckSn (sign aliceSk snapshot1) 1 Nothing Nothing
+            step $ receiveMessageFrom bob $ AckSn (sign bobSk snapshot1) 1 Nothing Nothing
             getState
 
           -- At this point seenSnapshot = LastSeenSnapshot{lastSeen=1}
@@ -751,6 +763,141 @@ spec =
                 RequestedSnapshot{lastSeen, requested} -> requested == 2 && lastSeen == 1
                 _ -> False
             _ -> fail "expected Open state"
+
+        it "applies both deposit and decommit versions chronologically when both ready" $ do
+          -- Simplified test: Both CommitFinalized and DecommitFinalized arrive,
+          -- then a snapshot confirms with all parties acknowledging both pending versions
+          let localUTxO = utxoRefs [1, 2, 3]
+              depositTxId = 42
+              decommitTx' = SimpleTx 10 (utxoRefs [3]) (utxoRef 88)
+
+              snapshot0 = testSnapshot 0 0 [] localUTxO
+              confirmedSn0 = ConfirmedSnapshot{snapshot = snapshot0, signatures = Crypto.aggregate []}
+
+              -- Initial state with both deposit and decommit pending
+              s0 =
+                inOpenState' threeParties $
+                  coordinatedHeadState
+                    { localUTxO
+                    , version = 0
+                    , confirmedSnapshot = confirmedSn0
+                    , seenSnapshot = LastSeenSnapshot{lastSeen = 0}
+                    , currentDepositTxId = Just depositTxId
+                    , decommitTx = Just decommitTx'
+                    }
+
+          currentTime <- nowFromSlot s0.chainPointTime.currentSlot
+
+          -- 1. CommitFinalized arrives (v=1)
+          let incrementObservation = observeTx $ OnIncrementTx{headId = testHeadId, newVersion = 1, depositTxId}
+          let s1 = aggregateState s0 $ update aliceEnv ledger currentTime s0 incrementObservation
+
+          -- 2. DecommitFinalized arrives (v=2)
+          let utxoToDecommit' = txInputs decommitTx'
+              decrementObservation = observeTx $ OnDecrementTx{headId = testHeadId, newVersion = 2, distributedUTxO = utxoToDecommit'}
+          let s2 = aggregateState s1 $ update aliceEnv ledger currentTime s1 decrementObservation
+
+          -- Verify first pending version is applied immediately, second is pending
+          -- When DecommitFinalized arrives, it applies pendingDepositVersion immediately
+          case s2 of
+            NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
+              chs.version `shouldBe` 1 -- First version applied immediately!
+              chs.pendingDepositVersion `shouldBe` Nothing -- Already applied
+              chs.pendingDecommitVersion `shouldBe` Just 2 -- Still pending
+            _ -> fail "expected Open state"
+
+          -- 3. Snapshot 1 confirms with all parties acknowledging decommit version only
+          -- (deposit version was already applied immediately)
+          let snapshot1 = testSnapshot 1 1 [] localUTxO -- version is now 1
+          s3 <- runHeadLogic aliceEnv ledger s2 $ do
+            step $ receiveMessage $ ReqSn 1 1 [] Nothing Nothing -- version 1
+            step $ receiveMessageFrom bob $ AckSn (sign bobSk snapshot1) 1 Nothing (Just 2)
+            step $ receiveMessageFrom carol $ AckSn (sign carolSk snapshot1) 1 Nothing (Just 2)
+            step $ receiveMessageFrom alice $ AckSn (sign aliceSk snapshot1) 1 Nothing (Just 2)
+            getState
+
+          -- Verify final version: deposit was applied immediately (1), decommit via consensus (2)
+          case s3 of
+            NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
+              chs.version `shouldBe` 2 -- Final version after both applied!
+              chs.pendingDepositVersion `shouldBe` Nothing
+              chs.pendingDecommitVersion `shouldBe` Nothing
+              chs.depositChainStateAcks `shouldBe` mempty
+              chs.decommitChainStateAcks `shouldBe` mempty
+            _ -> fail "expected Open state after version bump"
+
+        it "clears pending versions on chain rollback" $ do
+          -- This test verifies that when a chain rollback happens, we clear
+          -- the pending versions and chainStateAcks to avoid applying version
+          -- updates for transactions that have been rolled back.
+          --
+          -- Scenario:
+          -- 1. CommitFinalized arrives → pendingDepositVersion=1
+          -- 2. Chain rollback occurs (e.g., IncrementTx rolled back)
+          -- 3. Pending versions and chainStateAcks should be cleared
+
+          let localUTxO = utxoRefs [1, 2, 3]
+              depositTxId = 42
+
+              snapshot0 = testSnapshot 0 0 [] localUTxO
+              confirmedSn0 =
+                ConfirmedSnapshot
+                  { snapshot = snapshot0
+                  , signatures = Crypto.aggregate []
+                  }
+
+              s0 =
+                inOpenState' threeParties $
+                  coordinatedHeadState
+                    { localUTxO
+                    , version = 0
+                    , confirmedSnapshot = confirmedSn0
+                    , seenSnapshot = LastSeenSnapshot{lastSeen = 0}
+                    }
+
+          -- 1. CommitFinalized arrives setting pendingDepositVersion
+          let incrementObservation = observeTx $ OnIncrementTx{headId = testHeadId, newVersion = 1, depositTxId}
+          currentTime <- nowFromSlot s0.chainPointTime.currentSlot
+          let commitFinalizedOutcome = update aliceEnv ledger currentTime s0 incrementObservation
+          let s1 = aggregateState s0 commitFinalizedOutcome
+
+          -- Verify pendingDepositVersion is set
+          case s1 of
+            NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
+              chs.pendingDepositVersion `shouldBe` Just 1
+              chs.depositChainStateAcks `shouldBe` mempty
+            _ -> fail "expected Open state after CommitFinalized"
+
+          -- 2. Some parties send AckSn, partially filling chainStateAcks
+          s2 <- runHeadLogic aliceEnv ledger s1 $ do
+            step $ receiveMessage $ ReqSn 0 1 [] Nothing Nothing
+            step $ receiveMessageFrom alice $ AckSn (sign aliceSk snapshot0) 1 (Just 1) Nothing
+            step $ receiveMessageFrom bob $ AckSn (sign bobSk snapshot0) 1 (Just 1) Nothing
+            -- Carol hasn't acked yet, so version not applied
+            getState
+
+          -- Verify chainStateAcks partially filled
+          case s2 of
+            NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
+              chs.pendingDepositVersion `shouldBe` Just 1
+              chs.version `shouldBe` 0 -- Not yet applied
+              Map.size chs.depositChainStateAcks `shouldBe` 2 -- Alice and Bob
+            _ -> fail "expected Open state with partial acks"
+
+          -- 3. Chain rollback occurs
+          let rollbackObservation = ChainInput Rollback{chainTime = currentTime, rolledBackChainState = SimpleChainState 0}
+          let rollbackOutcome = update aliceEnv ledger currentTime s2 rollbackObservation
+          let s3 = aggregateState s2 rollbackOutcome
+
+          -- Verify pending versions and chainStateAcks are cleared
+          case s3 of
+            NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
+              chs.version `shouldBe` 0 -- Still at 0
+              chs.pendingDepositVersion `shouldBe` Nothing -- Cleared!
+              chs.pendingDecommitVersion `shouldBe` Nothing -- Cleared!
+              chs.depositChainStateAcks `shouldBe` mempty -- Cleared!
+              chs.decommitChainStateAcks `shouldBe` mempty -- Cleared!
+            _ -> fail "expected Open state after rollback"
 
       describe "Tracks Transaction Ids" $ do
         it "keeps transactions in allTxs given it receives a ReqTx" $ do
@@ -784,7 +931,7 @@ spec =
               pendingTransaction = SimpleTx 2 mempty (utxoRef 2)
               reqSn = receiveMessage $ ReqSn 0 1 [1] Nothing Nothing
               snapshot1 = testSnapshot 1 0 [t1] (utxoRefs [1])
-              ackFrom sk vk = receiveMessageFrom vk $ AckSn (sign sk snapshot1) 1
+              ackFrom sk vk = receiveMessageFrom vk $ AckSn (sign sk snapshot1) 1 Nothing Nothing
 
           sa <- runHeadLogic bobEnv ledger (inOpenState threeParties) $ do
             step $ receiveMessage $ ReqTx t1
@@ -806,8 +953,8 @@ spec =
             reqSn = receiveMessage $ ReqSn 0 1 [] Nothing Nothing
             snapshot = testSnapshot 1 0 [] mempty
             snapshot' = testSnapshot 2 0 [] mempty
-            ackFrom sk vk = receiveMessageFrom vk $ AckSn (sign sk snapshot) 1
-            invalidAckFrom sk vk = receiveMessageFrom vk $ AckSn (sign sk snapshot') 1
+            ackFrom sk vk = receiveMessageFrom vk $ AckSn (sign sk snapshot) 1 Nothing Nothing
+            invalidAckFrom sk vk = receiveMessageFrom vk $ AckSn (sign sk snapshot') 1 Nothing Nothing
         waitingForLastAck <-
           runHeadLogic bobEnv ledger (inOpenState threeParties) $ do
             step reqSn
@@ -825,7 +972,7 @@ spec =
         let reqSn :: Input tx
             reqSn = receiveMessage $ ReqSn 0 1 [] Nothing Nothing
             snapshot = testSnapshot 1 0 [] mempty
-            ackFrom sk vk = receiveMessageFrom vk $ AckSn (sign sk snapshot) 1
+            ackFrom sk vk = receiveMessageFrom vk $ AckSn (sign sk snapshot) 1 Nothing Nothing
         waitingForLastAck <-
           runHeadLogic bobEnv ledger (inOpenState threeParties) $ do
             step reqSn
@@ -844,11 +991,11 @@ spec =
             reqSn = receiveMessage $ ReqSn 0 1 [] Nothing Nothing
             snapshot1 = testSnapshot 1 0 [] mempty
             ackFrom :: Crypto.SigningKey Crypto.HydraKey -> Party -> Input SimpleTx
-            ackFrom sk vk = receiveMessageFrom vk $ AckSn (sign sk snapshot1) 1
+            ackFrom sk vk = receiveMessageFrom vk $ AckSn (sign sk snapshot1) 1 Nothing Nothing
             invalidAckFrom :: Crypto.SigningKey Crypto.HydraKey -> Party -> Input SimpleTx
             invalidAckFrom sk vk =
               receiveMessageFrom vk $
-                AckSn (coerce $ sign sk ("foo" :: ByteString)) 1
+                AckSn (coerce $ sign sk ("foo" :: ByteString)) 1 Nothing Nothing
         waitingForLastAck <-
           runHeadLogic bobEnv ledger (inOpenState threeParties) $ do
             step reqSn
@@ -866,7 +1013,7 @@ spec =
         let reqSn :: Input tx
             reqSn = receiveMessage $ ReqSn 0 1 [] Nothing Nothing
             snapshot1 = testSnapshot 1 0 [] mempty
-            ackFrom sk vk = receiveMessageFrom vk $ AckSn (sign sk snapshot1) 1
+            ackFrom sk vk = receiveMessageFrom vk $ AckSn (sign sk snapshot1) 1 Nothing Nothing
         waitingForAck <-
           runHeadLogic bobEnv ledger (inOpenState threeParties) $ do
             step reqSn
@@ -883,7 +1030,7 @@ spec =
         let reqSn :: Input tx
             reqSn = receiveMessage $ ReqSn 0 1 [] Nothing Nothing
             snapshot1 = Snapshot testHeadId 0 1 [] mempty Nothing Nothing
-            ackFrom sk = receiveMessageFrom (deriveParty sk) $ AckSn (sign sk snapshot1) 1
+            ackFrom sk = receiveMessageFrom (deriveParty sk) $ AckSn (sign sk snapshot1) 1 Nothing Nothing
 
         s0 <- runHeadLogic bobEnv ledger (inOpenState threeParties) $ do
           step reqSn
@@ -920,7 +1067,7 @@ spec =
 
       it "waits if we receive an AckSn for an unseen snapshot" $ do
         let snapshot = testSnapshot 1 0 [] mempty
-            input = receiveMessage $ AckSn (sign aliceSk snapshot) 1
+            input = receiveMessage $ AckSn (sign aliceSk snapshot) 1 Nothing Nothing
             s0 = inOpenState threeParties
         now <- nowFromSlot s0.chainPointTime.currentSlot
         update bobEnv ledger now s0 input
@@ -957,7 +1104,7 @@ spec =
             input = receiveMessageFrom leader $ ReqSn 0 (number snapshot) [] Nothing Nothing
             sig = sign bobSk snapshot
             st = inOpenState threeParties
-            ack = AckSn sig (number snapshot)
+            ack = AckSn sig (number snapshot) Nothing Nothing
         now <- nowFromSlot st.chainPointTime.currentSlot
         update bobEnv ledger now st input `hasEffect` NetworkEffect ack
 
@@ -1140,7 +1287,7 @@ spec =
                   , utxoToCommit = Just depositedUtxo
                   , utxoToDecommit = Nothing
                   }
-              ackSn = receiveMessage $ AckSn (sign aliceSk snapshot1) 1
+              ackSn = receiveMessage $ AckSn (sign aliceSk snapshot1) 1 Nothing Nothing
           s4 <- runHeadLogic aliceEnv' ledger s3 $ do
             step ackSn
             getState
@@ -1261,7 +1408,7 @@ spec =
                   , utxoToCommit = Just depositedUtxo
                   , utxoToDecommit = Nothing
                   }
-              ackSn = receiveMessage $ AckSn (sign aliceSk snapshot1) 1
+              ackSn = receiveMessage $ AckSn (sign aliceSk snapshot1) 1 Nothing Nothing
           s4 <- runHeadLogic aliceEnv' ledger s3 $ do
             step ackSn
             getState
@@ -1344,7 +1491,7 @@ spec =
                   , utxoToCommit = Nothing
                   , utxoToDecommit = Just (utxoRef 3) -- outputs of decommit tx
                   }
-              ackSn = receiveMessage $ AckSn (sign aliceSk snapshot1) 1
+              ackSn = receiveMessage $ AckSn (sign aliceSk snapshot1) 1 Nothing Nothing
           s3 <- runHeadLogic aliceEnv' ledger s2 $ do
             step ackSn
             getState
@@ -1847,6 +1994,10 @@ spec =
                           , currentDepositTxId = Nothing
                           , decommitTx = Nothing
                           , version = 0
+                          , pendingDepositVersion = Nothing
+                          , pendingDecommitVersion = Nothing
+                          , depositChainStateAcks = mempty
+                          , decommitChainStateAcks = mempty
                           }
                     , chainState = ChainStateAt{spendableUTxO = mempty, recordedAt = Nothing}
                     , headId = testHeadId
@@ -1942,6 +2093,10 @@ spec =
                               , currentDepositTxId = Nothing
                               , decommitTx = Nothing
                               , version = 0
+                              , pendingDepositVersion = Nothing
+                              , pendingDecommitVersion = Nothing
+                              , depositChainStateAcks = mempty
+                              , decommitChainStateAcks = mempty
                               }
                         , chainState = ChainStateAt{spendableUTxO = mempty, recordedAt = Nothing}
                         , headId = testHeadId
@@ -1989,6 +2144,10 @@ spec =
                             , currentDepositTxId = Nothing
                             , decommitTx = Nothing
                             , version = 0
+                            , pendingDepositVersion = Nothing
+                            , pendingDecommitVersion = Nothing
+                            , depositChainStateAcks = mempty
+                            , decommitChainStateAcks = mempty
                             }
                       , chainState = ChainStateAt{spendableUTxO = mempty, recordedAt = Nothing}
                       , headId = testHeadId
@@ -2162,6 +2321,10 @@ inOpenState parties =
       , currentDepositTxId = Nothing
       , decommitTx = Nothing
       , version = 0
+      , pendingDepositVersion = Nothing
+      , pendingDecommitVersion = Nothing
+      , depositChainStateAcks = mempty
+      , decommitChainStateAcks = mempty
       }
  where
   u0 = mempty
@@ -2204,6 +2367,8 @@ inClosedState' parties confirmedSnapshot =
         , headId = testHeadId
         , headSeed = testHeadSeed
         , version = 0
+        , pendingDepositVersion = Nothing
+        , pendingDecommitVersion = Nothing
         }
  where
   parameters = HeadParameters defaultContestationPeriod parties

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -211,9 +211,11 @@ instance StateModel WorldState where
         , (1, genRollbackAndForward)
         ]
           -- XXX: if using > 0 we could run into a new tx not having utxo available situation?
-          <> [(10, genNewTx) | length confirmedUTxO > 1]
-          <> [(2, genDecommit) | length confirmedUTxO > 1]
+          <> [(10, genNewTx) | hasSpendableUTxO]
+          <> [(2, genDecommit) | hasSpendableUTxO]
           <> [(2, genDeposit headIdVar) | not $ null availableToDeposit]
+     where
+      hasSpendableUTxO = not (all (null . toList . snd) confirmedUTxO)
 
     genDeposit headIdVar = do
       sk <- snd <$> elements hydraParties

--- a/hydra-node/test/Hydra/Model/Payment.hs
+++ b/hydra-node/test/Hydra/Model/Payment.hs
@@ -87,6 +87,8 @@ instance IsTx Payment where
     [(from, value)] -> Payment{from, to = from, value}
     _ -> error "cant spend from multiple utxo in one payment"
   utxoFromTx Payment{to, value} = [(to, value)]
+  resolveInputsUTxO utxo Payment{from, value} =
+    filter (\(key, val) -> key == from && val == value) utxo
   outputsOfUTxO = id
   withoutUTxO a b =
     let as = second toList <$> a

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -6,12 +6,14 @@ module Hydra.NetworkSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Codec.CBOR.Read (deserialiseFromBytes)
 import Codec.CBOR.Write (toLazyByteString)
 import Control.Concurrent.Class.MonadSTM (
   readTQueue,
   writeTQueue,
  )
+import Hydra.Chain.ChainState (ChainSlot (..))
 import Hydra.Ledger.Simple (SimpleTx (..))
 import Hydra.Logging (showLogsOnFailure)
 import Hydra.Network (
@@ -36,6 +38,13 @@ import Test.Network.Ports (randomUnusedTCPPorts, withFreePort)
 import Test.QuickCheck (Property, (===))
 import Test.QuickCheck.Instances.ByteString ()
 import Test.Util (noopCallback, waitEq, waitMatch)
+
+-- Orphan instances for ChainSlot CBOR serialization (used by SimpleTx)
+instance ToCBOR ChainSlot where
+  toCBOR (ChainSlot n) = toCBOR n
+
+instance FromCBOR ChainSlot where
+  fromCBOR = ChainSlot <$> fromCBOR
 
 spec :: Spec
 spec = do

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -226,9 +226,9 @@ spec = parallel $ do
             inputs =
               inputsToOpenHead
                 <> [ receiveMessage ReqSn{snapshotVersion = 0, snapshotNumber = 1, transactionIds = mempty, depositTxId = Nothing, decommitTx = Nothing}
-                   , receiveMessageFrom alice $ AckSn (sign aliceSk sn1) 1
-                   , receiveMessageFrom bob $ AckSn (sign bobSk sn1) 1
-                   , receiveMessageFrom carol $ AckSn (sign carolSk sn1) 1
+                   , receiveMessageFrom alice $ AckSn (sign aliceSk sn1) 1 Nothing Nothing
+                   , receiveMessageFrom bob $ AckSn (sign bobSk sn1) 1 Nothing Nothing
+                   , receiveMessageFrom carol $ AckSn (sign carolSk sn1) 1 Nothing Nothing
                    , receiveMessage ReqTx{transaction = tx1}
                    ]
 
@@ -237,7 +237,7 @@ spec = parallel $ do
             >>= recordNetwork
         runToCompletion node
 
-        getNetworkEvents `shouldReturn` [AckSn (sign bobSk sn1) 1, ReqSn 0 2 [1] Nothing Nothing]
+        getNetworkEvents `shouldReturn` [AckSn (sign bobSk sn1) 1 Nothing Nothing, ReqSn 0 2 [1] Nothing Nothing]
 
     it "processes out-of-order AckSn" $
       showLogsOnFailure "NodeSpec" $ \tracer -> do
@@ -246,14 +246,14 @@ spec = parallel $ do
             sigAlice = sign aliceSk snapshot
             inputs =
               inputsToOpenHead
-                <> [ receiveMessageFrom bob AckSn{signed = sigBob, snapshotNumber = 1}
+                <> [ receiveMessageFrom bob AckSn{signed = sigBob, snapshotNumber = 1, pendingDepositVersion = Nothing, pendingDecommitVersion = Nothing}
                    , receiveMessage ReqSn{snapshotVersion = 0, snapshotNumber = 1, transactionIds = [], decommitTx = Nothing, depositTxId = Nothing}
                    ]
         (node, getNetworkEvents) <-
           testHydraNode tracer aliceSk [bob, carol] cperiod inputs
             >>= recordNetwork
         runToCompletion node
-        getNetworkEvents `shouldReturn` [AckSn{signed = sigAlice, snapshotNumber = 1}]
+        getNetworkEvents `shouldReturn` [AckSn{signed = sigAlice, snapshotNumber = 1, pendingDepositVersion = Nothing, pendingDecommitVersion = Nothing}]
 
     it "notifies client when postTx throws PostTxError" $
       showLogsOnFailure "NodeSpec" $ \tracer -> do
@@ -292,7 +292,7 @@ spec = parallel $ do
             testHydraNode tracer bobSk [alice, carol] cperiod inputs
               >>= recordNetwork
           runToCompletion node
-          getNetworkEvents `shouldReturn` [AckSn{signed = sigBob, snapshotNumber = 1}]
+          getNetworkEvents `shouldReturn` [AckSn{signed = sigBob, snapshotNumber = 1, pendingDepositVersion = Nothing, pendingDecommitVersion = Nothing}]
 
   describe "checkHeadState" $ do
     let defaultEnv =

--- a/hydra-node/testlib/Test/Hydra/API/ServerOutput.hs
+++ b/hydra-node/testlib/Test/Hydra/API/ServerOutput.hs
@@ -6,7 +6,7 @@ module Test.Hydra.API.ServerOutput where
 import Hydra.API.ClientInput (ClientInput)
 import Hydra.API.ServerOutput (ClientMessage, DecommitInvalidReason, Greetings, HeadStatus, NetworkInfo, ServerOutput (..), TimedServerOutput)
 import Hydra.Chain (PostChainTx)
-import Hydra.Chain.ChainState (ChainStateType, IsChainState)
+import Hydra.Chain.ChainState (ChainPointType, ChainStateType, IsChainState)
 import Hydra.HeadLogic.Error (SideLoadRequirementFailure)
 import Test.Hydra.Chain ()
 import Test.Hydra.Ledger ()
@@ -27,7 +27,7 @@ instance ArbitraryIsTx tx => Arbitrary (DecommitInvalidReason tx) where
 instance ArbitraryIsTx tx => Arbitrary (SideLoadRequirementFailure tx) where
   arbitrary = genericArbitrary
 
-instance (IsChainState tx, Arbitrary (ChainStateType tx), Arbitrary (ClientInput tx), Arbitrary (PostChainTx tx), ArbitraryIsTx tx) => Arbitrary (ClientMessage tx) where
+instance (IsChainState tx, Arbitrary (ChainStateType tx), Arbitrary (ChainPointType tx), Arbitrary (ClientInput tx), Arbitrary (PostChainTx tx), ArbitraryIsTx tx) => Arbitrary (ClientMessage tx) where
   arbitrary = genericArbitrary
 
 instance ArbitraryIsTx tx => Arbitrary (Greetings tx) where
@@ -37,11 +37,11 @@ instance (ArbitraryIsTx tx, IsChainState tx) => ToADTArbitrary (Greetings tx)
 
 data InvalidInput = InvalidInput
 
-instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (ServerOutput tx) where
+instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx), Arbitrary (ChainPointType tx)) => Arbitrary (ServerOutput tx) where
   arbitrary = genericArbitrary
   shrink = recursivelyShrink
 
-instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx), IsChainState tx) => ToADTArbitrary (ServerOutput tx)
+instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx), Arbitrary (ChainPointType tx), IsChainState tx) => ToADTArbitrary (ServerOutput tx)
 
 instance Arbitrary HeadStatus where
   arbitrary = genericArbitrary

--- a/hydra-node/testlib/Test/Hydra/HeadLogic/Outcome.hs
+++ b/hydra-node/testlib/Test/Hydra/HeadLogic/Outcome.hs
@@ -6,7 +6,7 @@ module Test.Hydra.HeadLogic.Outcome where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import Hydra.Chain.ChainState (ChainStateType (..), IsChainState)
+import Hydra.Chain.ChainState (ChainPointType, ChainStateType (..), IsChainState)
 import Hydra.HeadLogic.Outcome (StateChanged (..))
 import Hydra.Node.Environment (Environment (..), mkHeadParameters)
 import Test.Hydra.API.ServerOutput ()
@@ -45,7 +45,7 @@ genStateChanged env =
     , TransactionAppliedToLocalUTxO <$> arbitrary <*> arbitrary <*> arbitrary
     , SnapshotRequestDecided <$> arbitrary
     , SnapshotRequested <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
-    , PartySignedSnapshot <$> arbitrary <*> arbitrary <*> arbitrary
+    , PartySignedSnapshot <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
     , SnapshotConfirmed <$> arbitrary <*> arbitrary <*> arbitrary
     , DepositRecorded <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
     , DepositActivated <$> arbitrary <*> arbitrary <*> arbitrary

--- a/hydra-node/testlib/Test/Hydra/HeadLogic/State.hs
+++ b/hydra-node/testlib/Test/Hydra/HeadLogic/State.hs
@@ -6,11 +6,11 @@ module Test.Hydra.HeadLogic.State where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import Hydra.Chain.ChainState (IsChainState (..))
+import Hydra.Chain.ChainState (ChainPointType, IsChainState (..))
 import Hydra.HeadLogic.State (ClosedState (..), CoordinatedHeadState (..), HeadState (..), IdleState (..), InitialState (..), OpenState (..), SeenSnapshot (..))
 import Test.Hydra.Tx.Gen (ArbitraryIsTx)
 
-instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (HeadState tx) where
+instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx), Arbitrary (ChainPointType tx)) => Arbitrary (HeadState tx) where
   arbitrary = genericArbitrary
 
 instance Arbitrary (ChainStateType tx) => Arbitrary (IdleState tx) where
@@ -26,7 +26,7 @@ instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (Initial
       <*> arbitrary
       <*> arbitrary
 
-instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (OpenState tx) where
+instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx), Arbitrary (ChainPointType tx)) => Arbitrary (OpenState tx) where
   arbitrary =
     OpenState
       <$> arbitrary
@@ -35,7 +35,7 @@ instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (OpenSta
       <*> arbitrary
       <*> arbitrary
 
-instance ArbitraryIsTx tx => Arbitrary (CoordinatedHeadState tx) where
+instance (ArbitraryIsTx tx, Arbitrary (ChainPointType tx)) => Arbitrary (CoordinatedHeadState tx) where
   arbitrary = genericArbitrary
 
 instance ArbitraryIsTx tx => Arbitrary (SeenSnapshot tx) where
@@ -45,6 +45,8 @@ instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (ClosedS
   arbitrary =
     ClosedState
       <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary

--- a/hydra-node/testlib/Test/Hydra/Network/Message.hs
+++ b/hydra-node/testlib/Test/Hydra/Network/Message.hs
@@ -5,6 +5,7 @@ module Test.Hydra.Network.Message where
 
 import Test.Hydra.Prelude
 
+import Hydra.Chain.ChainState (ChainPointType)
 import Hydra.Network.Message (Message, NetworkEvent)
 import Test.Hydra.Network ()
 import Test.Hydra.Tx.Gen (ArbitraryIsTx)
@@ -13,7 +14,7 @@ import Test.QuickCheck.Arbitrary.ADT (ToADTArbitrary)
 instance Arbitrary msg => Arbitrary (NetworkEvent msg) where
   arbitrary = genericArbitrary
 
-instance ArbitraryIsTx tx => Arbitrary (Message tx) where
+instance (ArbitraryIsTx tx, Arbitrary (ChainPointType tx)) => Arbitrary (Message tx) where
   arbitrary = genericArbitrary
 
-instance ArbitraryIsTx tx => ToADTArbitrary (Message tx)
+instance (ArbitraryIsTx tx, Arbitrary (ChainPointType tx)) => ToADTArbitrary (Message tx)

--- a/hydra-node/testlib/Test/Hydra/Node/State.hs
+++ b/hydra-node/testlib/Test/Hydra/Node/State.hs
@@ -5,13 +5,13 @@ module Test.Hydra.Node.State where
 
 import Test.Hydra.Prelude
 
-import Hydra.Chain.ChainState (IsChainState (..))
+import Hydra.Chain.ChainState (ChainPointType, IsChainState (..))
 import Hydra.Node.State (ChainPointTime, Deposit, DepositStatus, NodeState, SyncedStatus)
 import Test.Hydra.HeadLogic.State ()
 import Test.Hydra.Tx.Gen (ArbitraryIsTx)
 import Test.QuickCheck (recursivelyShrink)
 
-instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (NodeState tx) where
+instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx), Arbitrary (ChainPointType tx)) => Arbitrary (NodeState tx) where
   arbitrary = genericArbitrary
 
 instance Arbitrary ChainPointTime where

--- a/hydra-tx/src/Hydra/Tx/IsTx.hs
+++ b/hydra-tx/src/Hydra/Tx/IsTx.hs
@@ -90,6 +90,10 @@ class
   -- | Get the UTxO produced by given transaction.
   utxoFromTx :: tx -> UTxOType tx
 
+  -- | Resolve transaction inputs against a UTxO set.
+  -- Returns the subset of the UTxO that the transaction consumes.
+  resolveInputsUTxO :: UTxOType tx -> tx -> UTxOType tx
+
   -- | Get only the outputs in given UTxO.
   outputsOfUTxO :: UTxOType tx -> [TxOutType tx]
 
@@ -160,6 +164,8 @@ instance IsTx Tx where
   txSpendingUTxO = Api.txSpendingUTxO
 
   utxoFromTx = Api.utxoFromTx
+
+  resolveInputsUTxO = Api.resolveInputsUTxO
 
   outputsOfUTxO = UTxO.txOutputs
 


### PR DESCRIPTION
  1. Duplicate Deposits/Decommits Across Snapshots
  - When snapshots overlapped (snapshot N confirms and posts to chain, snapshot N+1 requested before DecommitFinalized/CommitFinalized observed), the same deposit/decommit would be included in multiple snapshot requests
  - Fix: Skip deposits/decommits already posted in previous snapshots by comparing with utxoToCommit/utxoToDecommit
                                                                                       
  2. Distributed Consensus Race: Wrong Snapshot Numbers After Chain Events
  - Scenario (3-party head: Alice, Bob, Carol):
    a. Snapshot 1 with decommit - all parties send AckSn
    b. Alice & Bob receive all signatures → SnapshotConfirmed → post DecrementTx to chain
    c. Carol's network delayed → still in SeenSnapshot{number=1} waiting for final AckSn
    d. Carol observes DecommitFinalized on chain (from Alice/Bob's post) → seenSnapshot becomes LastSeenSnapshot{lastSeen=1}
    e. Bug: confirmedSnapshot.number = 0 (not updated by chain events), but seenSnapshot.lastSeen = 1
    f. New L2 tx arrives → calculates nextSn = confirmedSn + 1 = 1
    g. Validation fails: ReqSnNumberInvalid{requestedSn=1, lastSeenSn=1}
  - Fix: Use max(confirmedSn, latestSeenSnapshotNumber(seenSnapshot)) + 1 for next snapshot number to account for parties observing chain events at different times

  3. State Transition Bug in Chain Event Handlers
  - DecommitFinalized/CommitFinalized handlers used incorrect helper to convert RequestedSnapshot state
  - Fix: toLastSeenSnapshot helper properly uses requested field (not lastSeen) when converting RequestedSnapshot to LastSeenSnapshot

  4. Test Correctness
  - Decommit test was green for the wrong reason (not properly validating decommit inputs)
  - Fix: Proper comparison of decommit inputs against utxoToDecommit

  TL;DR: Fixed distributed consensus race conditions where parties observe chain events (DecommitFinalized/CommitFinalized) at different times relative to their local off-chain consensus completion, and duplicate inclusion bugs under high L2 load.


---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
