### PR TITLE
Fix incorrect expectedUTxO assertion in DirectChainSpec fanout test

### DIFF
--- a/hydra-cluster/test/Test/DirectChainSpec.hs
+++ b/hydra-cluster/test/Test/DirectChainSpec.hs
@@ -298,7 +298,7 @@ spec = around (showLogsOnFailure "DirectChainSpec") $ do
             -- Scenario
             (aliceExternalVk, aliceExternalSk) <- generate genKeyPair
             someUTxO <- seedFromFaucet backend aliceExternalVk (lovelaceToValue 2_000_000) (contramap FromFaucet tracer)
-            someUTxOToCommit <- seedFromFaucet backend aliceExternalVk (lovelaceToValue 2_000_000) (contramap FromFaucet tracer)
+            someUTxOToCommit <- seedFromFaucet backend aliceExternalVk (lovelaceToValue 2_000_001) (contramap FromFaucet tracer)
             participants <- loadParticipants [Alice]
             let headParameters = HeadParameters cperiod [alice]
             postTx $ InitTx{participants, headParameters}
@@ -349,7 +349,11 @@ spec = around (showLogsOnFailure "DirectChainSpec") $ do
                 , contestationDeadline = deadline
                 }
             let expectedUTxO =
-                  (Snapshot.utxo snapshot <> fromMaybe mempty (Snapshot.utxoToCommit snapshot))
+                  ( Snapshot.utxo snapshot
+                      <> if snapshotVersion /= v
+                        then fromMaybe mempty (Snapshot.utxoToCommit snapshot)
+                        else mempty
+                  )
                     `withoutUTxO` fromMaybe mempty (Snapshot.utxoToDecommit snapshot)
             aliceChain `observesInTimeSatisfying` \case
               OnFanoutTx _ finalUTxO ->


### PR DESCRIPTION
The `expectedUTxO` unconditionally included `utxoToCommit`, but when `snapshotVersion == v` (no `Increment` was posted), the fanout correctly excludes `utxoToCommit`. 

We didn't notice the test flaw because it was hidden, because both `someUTxO` and `someUTxOToCommit` used identical values (2M lovelace), so `containsOutputs` matched on TxOut content. 

This PR aligns `expectedUTxO` with the actual fanout logic. It uses different lovelace amounts so we will not be tricked by the hidden mismatch.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
