### PR TITLE
Improve bench-e2e 

### DIFF
--- a/hydra-cluster/bench/Bench/Summary.hs
+++ b/hydra-cluster/bench/Bench/Summary.hs
@@ -106,7 +106,7 @@ markdownReport now summaries =
     ]
 
   formattedSummary :: (Summary, SystemStats) -> [Text]
-  formattedSummary (Summary{clusterSize, numberOfTxs, averageConfirmationTime, quantiles, summaryTitle, summaryDescription, numberOfInvalidTxs}, systemStats) =
+  formattedSummary (Summary{clusterSize, numberOfTxs, averageConfirmationTime, quantiles, summaryTitle, summaryDescription, numberOfInvalidTxs, numberOfFanoutOutputs}, systemStats) =
     [ ""
     , "## " <> summaryTitle
     , ""
@@ -126,6 +126,8 @@ markdownReport now summaries =
             else []
          )
       ++ [ "| _Number of Invalid txs_ | " <> show numberOfInvalidTxs <> " |"
+         ]
+      ++ [ "| _Fanout outputs_        | " <> show numberOfFanoutOutputs <> " |"
          ]
       ++ ["      "]
       ++ if null systemStats then [] else "\n### Memory data \n" : [unlines systemStats]


### PR DESCRIPTION
- Don't fail benches on fanout failure and print number of fanout outputs.
- In order to measure off-chain snapshot signing performance I made sure we don't stop on fanout failure (in case we just cannot  fanout specific number of outputs) and added the number of fanout/head outputs in the final md file.


---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
