### PR TITLE
Don't smother exception when submiting tx

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -11,9 +11,7 @@ on:
         - preview
         - preprod
         - mainnet
-        - sanchonet
         - blockfrost-preview
-
 
       hydra-scripts-tx-id:
         description: "TxId of already published scripts (leave empty to publish)"
@@ -69,11 +67,3 @@ jobs:
           echo "::warning file=blockfrost-project.txt,title=BLOCKFROST::Missing blockfrost project file."
         fi
         nix develop .#exes --command bash -c "hydra-cluster --${{inputs.network}} --state-directory ${state_dir} ${HYDRA_SCRIPTS_ARG} ${USE_MITHRIL_ARG}"
-
-    - name: 💾 Upload logs
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: hydra-cluster-logs
-        path: ${state_dir}/logs/**/*
-        if-no-files-found: ignore

--- a/hydra-cluster/src/Hydra/Cluster/Faucet.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Faucet.hs
@@ -108,12 +108,9 @@ seedFromFaucetWithMinting backend receivingVerificationKey val tracer mintingScr
 findFaucetUTxO :: ChainBackend backend => NetworkId -> backend -> Coin -> IO UTxO
 findFaucetUTxO networkId backend lovelace = do
   (faucetVk, _) <- keysFor Faucet
-  faucetUTxO <- Backend.queryUTxO backend [buildAddress faucetVk networkId]
-  let foundUTxO = UTxO.filter (\o -> (selectLovelace . txOutValue) o >= lovelace) faucetUTxO
-  when (UTxO.null foundUTxO) $
-    throwIO $
-      FaucetHasNotEnoughFunds{faucetUTxO}
-  pure foundUTxO
+  let address = buildAddress faucetVk networkId
+  faucetUTxO <- Backend.queryUTxO backend [address]
+  findUTxO faucetUTxO lovelace
 
 seedFromFaucetBlockfrost ::
   BlockfrostOptions ->
@@ -144,7 +141,8 @@ seedFromFaucetBlockfrost options receivingVerificationKey lovelace = do
   let stakePools = Set.fromList (Blockfrost.toCardanoPoolId <$> stakePools')
   let systemStart = SystemStart $ posixSecondsToUTCTime systemStart'
   eraHistory <- Blockfrost.queryEraHistory
-  foundUTxO <- findUTxO options networkId changeAddress lovelace
+  faucetUTxO <- Blockfrost.queryUTxO options networkId [changeAddress]
+  foundUTxO <- findUTxO faucetUTxO lovelace
   case buildTransactionWithPParams' pparams systemStart eraHistory stakePools (mkVkAddress networkId faucetVk) foundUTxO [] [theOutput] Nothing of
     Left e -> liftIO $ throwIO $ FaucetFailedToBuildTx{reason = e}
     Right tx -> do
@@ -155,15 +153,15 @@ seedFromFaucetBlockfrost options receivingVerificationKey lovelace = do
         Right _ -> do
           void $ Blockfrost.awaitUTxO networkId [changeAddress] (Hydra.Tx.txId signedTx) options
           Blockfrost.awaitUTxO networkId [receivingAddress] (Hydra.Tx.txId signedTx) options
- where
-  findUTxO opts networkId address lovelace' = do
-    faucetUTxO <- Blockfrost.queryUTxO opts networkId [address]
-    let foundUTxO = UTxO.find (\o -> (selectLovelace . txOutValue) o >= lovelace') faucetUTxO
-    when (isNothing foundUTxO) $
-      liftIO $
-        throwIO $
-          FaucetHasNotEnoughFunds{faucetUTxO}
-    pure $ maybe mempty (uncurry UTxO.singleton) foundUTxO
+
+findUTxO :: MonadIO m => UTxO.UTxO Era -> Lovelace -> m (UTxO.UTxO Era)
+findUTxO utxo lovelace' = do
+  let foundUTxO = UTxO.find (\o -> (selectLovelace . txOutValue) o >= lovelace') utxo
+  when (isNothing foundUTxO) $
+    liftIO $
+      throwIO $
+        FaucetHasNotEnoughFunds{faucetUTxO = utxo}
+  pure $ maybe mempty (uncurry UTxO.singleton) foundUTxO
 
 -- | Like 'seedFromFaucet', but without returning the seeded 'UTxO'.
 seedFromFaucet_ ::

--- a/hydra-cluster/src/Hydra/Cluster/Faucet.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Faucet.hs
@@ -42,6 +42,7 @@ instance Exception FaucetException
 data FaucetLog
   = TraceResourceExhaustedHandled Text
   | ReturnedFunds {returnAmount :: Coin}
+  | SubmitTxError Text
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON)
 
@@ -251,8 +252,11 @@ createOutputAtAddress networkId backend atAddress datum val = do
 retryOnExceptions :: (MonadCatch m, MonadDelay m, ChainBackend backend) => Tracer m FaucetLog -> backend -> m a -> m a
 retryOnExceptions tracer backend action =
   action
-    `catches` [ Handler $ \(_ :: SubmitTransactionException) -> do
+    `catches` [ Handler $ \(ex :: SubmitTransactionException) -> do
                   delayBF backend
+                  traceWith tracer $
+                    SubmitTxError $
+                      show ex
                   retryOnExceptions tracer backend action
               , Handler $ \(ex :: IOException) -> do
                   unless (isResourceExhausted ex) $


### PR DESCRIPTION
A couple of tidyups that came out of the smoketests:

1. Don't upload logs; just go on to the runner to get them instead. This is because the logs are cummulative; for example the cardano mainnet logs are 100meg. No reason to be uploading all those artifacts every time.

1. Select only a _single_ UTxO that matches the criteria; not all of them. This fixes a bug where we are putting them all in the collateral:  <img width="712" height="236" alt="image" src="https://github.com/user-attachments/assets/7ae7b264-5eda-44b7-9514-08646a5ccab0" /> We actually should just conditionally do this based on whether or not we're spending from a script ( cc @v0d1ch ).

1. Expose an error that was otherwise surpressed.