### PR TITLE
More  resilient snapshots and some de/commit fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ changes.
 - Fixed the internal wallet fee estimation, which was more often than not using maximum plutus execution units. This reduces costs for initializing, open, etc. of a head by a factor of ~4x [#2473](https://github.com/cardano-scaling/hydra/pull/2473).
 - Fixed another race-condition around incremental commits/decommits [#2500](https://github.com/cardano-scaling/hydra/issues/2500)
 - Fixed infinite AckSn requeue loop after decommit when DecommitFinalized arrives before snapshot confirmation on the leader node [#2510](https://github.com/cardano-scaling/hydra/pull/2510)
+- Fix snapshots getting stuck under high L2 load by preventing duplicate snapshot requests and duplicate deposit/decommit inclusion across consecutive snapshots [#2519](https://github.com/cardano-scaling/hydra/pull/2519)
 - **BREAKING** Improved reporting of chain synchronization status by exposing the node's chain time and drift.
   - `NodeSynced` and `NodeUnsynced` state-changed events, and their corresponding server outputs, now include the observed chain time and drift.
   - `NodeState` now tracks the latest observed chan slot in addition to the chain time (`UTCTime`) and its drift measured in seconds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 As a minor extension, we also keep a semantic version for the `UNRELEASED`
 changes.
 
+## [UNRELEASED]
+
+- Made the snapshot protocol resilient to races between version bumps and in-flight snapshots. Snapshots are now triggered by a periodic timer rather than immediately on each `ReqTx`, so the leader batches pending transactions and retries automatically when a previous request was rejected. Stale or duplicate `ReqSn`/`AckSn` messages are now silently dropped instead of causing the head to wait forever. When `CommitFinalized` or `DecommitFinalized` bumps the version while a snapshot is in-flight, the abandoned snapshot's local state is reset to the last confirmed snapshot so the timer can build a fresh valid request. [#2533](https://github.com/cardano-scaling/hydra/pull/2533)
+  - Added `--snapshot-retry-interval` CLI option (default: 5ms) to control how often the snapshot leader retries a stalled request.
+
 ## [1.3.0] - 2026.03.05
+
 
 - Upgrade all `PlutusTx` plugin target versions to `1.1.0`.
   See the improvements in the [PR 2517](https://github.com/cardano-scaling/hydra/pull/2517).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ changes.
 
 - Made the snapshot protocol resilient to races between version bumps and in-flight snapshots. The snapshot leader now sends `ReqSn` immediately on `ReqTx` receipt and also via a periodic timer, batching any accumulated transactions. When `CommitFinalized` or `DecommitFinalized` bumps the version while a snapshot is in-flight, the abandoned snapshot's pending transactions are re-validated against the new confirmed UTxO: valid ones are requeued and included in the next snapshot, while transactions that can no longer be applied (e.g. they spent a decommitted output) are dropped as `TxInvalid`. [#2533](https://github.com/cardano-scaling/hydra/pull/2533)
   - Added `--snapshot-retry-interval` CLI option (default: 5ms) to control how often the snapshot leader retries a stalled request.
+- Added back pressure for `NewTx` client inputs. When the internal input queue is full, `POST /transaction` now returns HTTP 503 immediately and a WebSocket `NewTx` submission receives an `InvalidInput` error, instead of blocking or being silently dropped. [#2533](https://github.com/cardano-scaling/hydra/pull/2533)
 
 ## [1.3.0] - 2026.03.05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ changes.
 
 ## [UNRELEASED]
 
-- Made the snapshot protocol resilient to races between version bumps and in-flight snapshots. Snapshots are now triggered by a periodic timer rather than immediately on each `ReqTx`, so the leader batches pending transactions and retries automatically when a previous request was rejected. Stale or duplicate `ReqSn`/`AckSn` messages are now silently dropped instead of causing the head to wait forever. When `CommitFinalized` or `DecommitFinalized` bumps the version while a snapshot is in-flight, the abandoned snapshot's local state is reset to the last confirmed snapshot so the timer can build a fresh valid request. [#2533](https://github.com/cardano-scaling/hydra/pull/2533)
+- Made the snapshot protocol resilient to races between version bumps and in-flight snapshots. The snapshot leader now sends `ReqSn` immediately on `ReqTx` receipt and also via a periodic timer, batching any accumulated transactions. When `CommitFinalized` or `DecommitFinalized` bumps the version while a snapshot is in-flight, the abandoned snapshot's pending transactions are re-validated against the new confirmed UTxO: valid ones are requeued and included in the next snapshot, while transactions that can no longer be applied (e.g. they spent a decommitted output) are dropped as `TxInvalid`. [#2533](https://github.com/cardano-scaling/hydra/pull/2533)
   - Added `--snapshot-retry-interval` CLI option (default: 5ms) to control how often the snapshot leader retries a stalled request.
 
 ## [1.3.0] - 2026.03.05

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -148,6 +148,26 @@ For a deposit to be considered by the `hydra-node` the deadline must be further 
 
 See the [how-to](./how-to/incremental-commit) and [protocol documentation](./dev/protocol#incremental-commits) for more details.
 
+### Snapshot retry interval
+
+The snapshot retry interval controls how frequently the snapshot leader checks for pending work and, when needed, re-broadcasts an in-flight snapshot round:
+
+```
+hydra-node --snapshot-retry-interval 0.005
+```
+
+The value is in **seconds** (floating point). The default is **0.005 s (5 ms)**.
+
+On each timer tick the snapshot leader will:
+- Batch any pending L2 transactions (up to 100 per snapshot) into a new `ReqSn` if no snapshot is currently in flight.
+- Re-broadcast the current in-flight `ReqSn` and its own `AckSn` if signatures are still being collected, unblocking stalled rounds.
+
+Lowering this value increases snapshot throughput and reduces recovery time after message loss, at the cost of higher CPU usage. Raising it reduces CPU pressure at the cost of higher latency per snapshot round.
+
+:::info
+Under pure L2 transaction load (no deposits or decommits), transactions arriving within a single timer interval are batched into one snapshot round. With the default 5 ms interval this gives up to ~200 snapshot rounds per second, each carrying up to 100 transactions.
+:::
+
 ### Reference scripts
 
 The `hydra-node` uses reference scripts to reduce transaction sizes driving the head's lifecycle. Specify the `--hydra-scripts-tx-id` to reference the correct scripts. The `hydra-node` will verify the availability of these scripts on-chain.

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -150,7 +150,7 @@ See the [how-to](./how-to/incremental-commit) and [protocol documentation](./dev
 
 ### Snapshot retry interval
 
-The snapshot retry interval controls how frequently the snapshot leader checks for pending work and, when needed, re-broadcasts an in-flight snapshot round:
+The snapshot retry interval controls how frequently the snapshot leader checks for pending work:
 
 ```
 hydra-node --snapshot-retry-interval 0.005
@@ -158,11 +158,9 @@ hydra-node --snapshot-retry-interval 0.005
 
 The value is in **seconds** (floating point). The default is **0.005 s (5 ms)**.
 
-On each timer tick the snapshot leader will:
-- Batch any pending L2 transactions (up to 100 per snapshot) into a new `ReqSn` if no snapshot is currently in flight.
-- Re-broadcast the current in-flight `ReqSn` and its own `AckSn` if signatures are still being collected, unblocking stalled rounds.
+On each timer tick the snapshot leader will batch any pending L2 transactions (up to 100 per snapshot) into a new `ReqSn` if no snapshot is currently in flight. When a snapshot is already in flight (the leader is collecting `AckSn` signatures), the timer is a no-op — delivery is guaranteed by the network layer.
 
-Lowering this value increases snapshot throughput and reduces recovery time after message loss, at the cost of higher CPU usage. Raising it reduces CPU pressure at the cost of higher latency per snapshot round.
+Lowering this value reduces the idle time between consecutive snapshot rounds at the cost of higher CPU usage. Raising it reduces CPU pressure at the cost of higher latency per snapshot round.
 
 :::info
 Under pure L2 transaction load (no deposits or decommits), transactions arriving within a single timer interval are batched into one snapshot round. With the default 5 ms interval this gives up to ~200 snapshot rounds per second, each carrying up to 100 transactions.

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -158,12 +158,17 @@ hydra-node --snapshot-retry-interval 0.005
 
 The value is in **seconds** (floating point). The default is **0.005 s (5 ms)**.
 
-On each timer tick the snapshot leader will batch any pending L2 transactions (up to 100 per snapshot) into a new `ReqSn` if no snapshot is currently in flight. When a snapshot is already in flight (the leader is collecting `AckSn` signatures), the timer is a no-op — delivery is guaranteed by the network layer.
+The snapshot leader starts a new round via two paths:
 
-Lowering this value reduces the idle time between consecutive snapshot rounds at the cost of higher CPU usage. Raising it reduces CPU pressure at the cost of higher latency per snapshot round.
+- **Immediate** — when a new transaction (`ReqTx`) arrives and no snapshot is in flight, the leader broadcasts `ReqSn` straight away. This keeps latency low for one-at-a-time transaction patterns.
+- **Timer** — on each tick, if there is pending work (transactions, an active deposit, or a decommit) and no snapshot is in flight, the leader broadcasts `ReqSn`. The timer handles cases not covered by the immediate path: deposits, decommits, and idle recovery.
+
+When a snapshot is already in flight (the leader is collecting `AckSn` signatures), both paths are no-ops — delivery is guaranteed by the network layer.
+
+Lowering the timer interval reduces latency for deposit/decommit handling at the cost of higher CPU usage. Raising it reduces CPU pressure at the cost of higher latency for those cases.
 
 :::info
-Under pure L2 transaction load (no deposits or decommits), transactions arriving within a single timer interval are batched into one snapshot round. With the default 5 ms interval this gives up to ~200 snapshot rounds per second, each carrying up to 100 transactions.
+Under pure L2 transaction load, the first transaction in a batch immediately triggers a snapshot. Subsequent transactions that arrive while the round is in progress accumulate and are confirmed in the next round. Up to 100 transactions are included per snapshot (`maxTxsPerSnapshot`).
 :::
 
 ### Reference scripts

--- a/docs/docs/dev/protocol.md
+++ b/docs/docs/dev/protocol.md
@@ -20,10 +20,6 @@ If all three are true, the leader broadcasts a `ReqSn` message that batches **up
 
 This replaces the previous model where every received `NewTx` immediately triggered a `ReqSn`. Under the new model, many transactions arriving within a single timer interval are confirmed in a single snapshot round, significantly improving throughput.
 
-#### Snapshot retry and re-broadcast
-
-If a snapshot round stalls (e.g. some `AckSn` messages are delayed), the timer re-broadcasts the in-flight `ReqSn` and the leader's own `AckSn` on the next tick. This unblocks rounds that would otherwise stall indefinitely due to message loss or reordering.
-
 :::note
 Transactions submitted via `NewTx` are immediately validated against the local UTxO and broadcast to all peers as `ReqTx`. However, they are only confirmed into a snapshot when the timer fires and the leader collects them into the next `ReqSn`.
 :::

--- a/docs/docs/dev/protocol.md
+++ b/docs/docs/dev/protocol.md
@@ -8,20 +8,20 @@ Additional implementation-specific documentation for the Hydra Head protocol and
 
 Snapshots are the mechanism by which all head participants agree on a new L2 state. A snapshot includes a set of transactions, an optional deposit, and an optional decommit, and once signed by all parties it can be used to close the head on L1.
 
-#### Timer-driven batching
+#### How snapshot rounds are triggered
 
-Snapshot rounds are initiated by a **periodic timer** that fires every `snapshotRetryInterval` (default: 5 ms, configurable via `--snapshot-retry-interval`). On each tick, the snapshot leader checks:
+Snapshot rounds are initiated by **two complementary mechanisms**:
 
-1. Is there pending work? (pending transactions, an active deposit, or a decommit request)
-2. Is no other snapshot currently in flight?
-3. Am I the leader for the next snapshot number?
+1. **On `ReqTx` receipt** — when the leader receives a new transaction (`ReqTx`) and no snapshot is currently in flight, it immediately broadcasts a `ReqSn` containing that transaction and any other pending transactions (up to `maxTxsPerSnapshot = 100`). This ensures low latency for the common single-transaction-at-a-time pattern.
 
-If all three are true, the leader broadcasts a `ReqSn` message that batches **up to 100 transactions** (see `maxTxsPerSnapshot`) together with any pending deposit or decommit. Transactions beyond the limit are not dropped — they are carried forward and included in the next snapshot automatically.
+2. **Periodic timer** — a timer fires every `snapshotRetryInterval` (default: 5 ms, configurable via `--snapshot-retry-interval`). On each tick, the snapshot leader checks whether there is pending work (transactions, an active deposit, or a decommit request) and no snapshot is in flight. If so, it broadcasts a `ReqSn`. The timer handles cases not covered by the `ReqTx` path: idle recovery, deposit and decommit processing, and continued batching after the first snapshot in a burst.
 
-This replaces the previous model where every received `NewTx` immediately triggered a `ReqSn`. Under the new model, many transactions arriving within a single timer interval are confirmed in a single snapshot round, significantly improving throughput.
+**Batching behaviour**: When many transactions arrive in rapid succession, the first `ReqTx` triggers an immediate `ReqSn`. Subsequent transactions that arrive while the snapshot is in flight accumulate in the local pending pool. After the snapshot confirms, `maybeRequestNextSnapshot` chains the next `ReqSn` immediately — so those accumulated transactions are confirmed in the very next round without waiting for the timer.
+
+Transactions beyond `maxTxsPerSnapshot` per round are not dropped — they are carried forward and included in the next snapshot automatically.
 
 :::note
-Transactions submitted via `NewTx` are immediately validated against the local UTxO and broadcast to all peers as `ReqTx`. However, they are only confirmed into a snapshot when the timer fires and the leader collects them into the next `ReqSn`.
+Transactions submitted via `NewTx` are immediately validated against the local UTxO and broadcast to all peers as `ReqTx`. The leader then starts a snapshot as soon as the first `ReqTx` arrives (if no snapshot is in flight), or relies on the timer to batch accumulated transactions when already processing a round.
 :::
 
 #### Snapshot leadership

--- a/docs/docs/dev/protocol.md
+++ b/docs/docs/dev/protocol.md
@@ -2,6 +2,49 @@
 
 Additional implementation-specific documentation for the Hydra Head protocol and extensions like incremental decommits.
 
+## Snapshot protocol
+
+### How snapshots are initiated
+
+Snapshots are the mechanism by which all head participants agree on a new L2 state. A snapshot includes a set of transactions, an optional deposit, and an optional decommit, and once signed by all parties it can be used to close the head on L1.
+
+#### Timer-driven batching
+
+Snapshot rounds are initiated by a **periodic timer** that fires every `snapshotRetryInterval` (default: 5 ms, configurable via `--snapshot-retry-interval`). On each tick, the snapshot leader checks:
+
+1. Is there pending work? (pending transactions, an active deposit, or a decommit request)
+2. Is no other snapshot currently in flight?
+3. Am I the leader for the next snapshot number?
+
+If all three are true, the leader broadcasts a `ReqSn` message that batches **up to 100 transactions** (see `maxTxsPerSnapshot`) together with any pending deposit or decommit. Transactions beyond the limit are not dropped — they are carried forward and included in the next snapshot automatically.
+
+This replaces the previous model where every received `NewTx` immediately triggered a `ReqSn`. Under the new model, many transactions arriving within a single timer interval are confirmed in a single snapshot round, significantly improving throughput.
+
+#### Snapshot retry and re-broadcast
+
+If a snapshot round stalls (e.g. some `AckSn` messages are delayed), the timer re-broadcasts the in-flight `ReqSn` and the leader's own `AckSn` on the next tick. This unblocks rounds that would otherwise stall indefinitely due to message loss or reordering.
+
+:::note
+Transactions submitted via `NewTx` are immediately validated against the local UTxO and broadcast to all peers as `ReqTx`. However, they are only confirmed into a snapshot when the timer fires and the leader collects them into the next `ReqSn`.
+:::
+
+#### Snapshot leadership
+
+The snapshot leader rotates in round-robin order by party index, based on the snapshot number. For snapshot number `s`, the leader is `parties[(s - 1) mod n]`. Any party can be the leader for a given round; if a party is not the leader it simply signs (`AckSn`) the snapshot proposed by the leader.
+
+### Snapshot in-flight semantics
+
+At any point, the `seenSnapshot` field in the head state records what the local party knows about the current snapshot round:
+
+| State | Meaning |
+|---|---|
+| `NoSeenSnapshot` | No snapshot activity since last confirmation |
+| `LastSeenSnapshot n` | Snapshot `n` was the last confirmed; no round in flight |
+| `RequestedSnapshot{lastSeen, requested}` | This party (the leader) sent `ReqSn` for `requested` but has not yet received its own network echo to sign it |
+| `SeenSnapshot snapshot sigs` | Collecting `AckSn` signatures for `snapshot`; `sigs` accumulates them |
+
+Only one snapshot round can be in flight at a time. The timer will not start a new round while `RequestedSnapshot` or `SeenSnapshot` is active.
+
 ## General notes on incremental commits/decommits
 
 Especially, incremental commit and decommit are additions to the originally researched [Hydra Head protocol](https://eprint.iacr.org/2020/299.pdf) and deserve more explanation how they work under the hood. 
@@ -46,6 +89,9 @@ sequenceDiagram
 
     Node A -->> Alice: CommitRecorded
 
+    note over Node A,Node B: deposit becomes Active after deposit period elapses
+    note over Node A: timer fires (every snapshotRetryInterval, default 5ms)
+
     par Alice isLeader
         Node A->>Node A: ReqSn utxoToCommit
     and
@@ -71,7 +117,7 @@ sequenceDiagram
 
 ### Tracking deposits
 
-Once a hydra-node observes a deposit transaction it will record the deposit as pending in its local state. There can be many pending deposits but the new Snapshot will include them one by one.
+Once a hydra-node observes a deposit transaction it will record the deposit as pending in its local state. There can be many pending deposits but the new Snapshot will include them one by one. The snapshot leader's timer (see [Snapshot protocol](#snapshot-protocol)) will automatically include the next active deposit in the following `ReqSn`.
 
 :::info
 Note that any node that posts increment transaction will also pay the fees even if the deposit will not be owned by them on L2.
@@ -156,6 +202,7 @@ sequenceDiagram
 
     Node A -->> Alice: DecommitRequested
 
+    note over Node A: snapshot leader requests immediately on ReqDec
     par Alice isLeader
         Node A->>Node A: ReqSn decTx
     and

--- a/docs/docs/dev/protocol.md
+++ b/docs/docs/dev/protocol.md
@@ -41,6 +41,19 @@ At any point, the `seenSnapshot` field in the head state records what the local 
 
 Only one snapshot round can be in flight at a time. The timer will not start a new round while `RequestedSnapshot` or `SeenSnapshot` is active.
 
+### Transaction recovery after a version bump
+
+When a `CommitFinalized` or `DecommitFinalized` event is observed on-chain, the head version is bumped. If a snapshot was in flight at that moment (`RequestedSnapshot` or `SeenSnapshot`), the in-flight snapshot is dead — its signatures were produced at the old version and will be rejected on-chain.
+
+The node handles this as follows:
+
+1. **Reset**: the in-flight snapshot is discarded and `seenSnapshot` is reset to `LastSeenSnapshot` (the last confirmed snapshot number).
+2. **Re-validate**: all transactions that were pending in the discarded snapshot (from `localTxs` and, if in `SeenSnapshot`, the snapshot's confirmed tx list) are re-applied against the confirmed UTxO at the new version.
+3. **Requeue or drop**: transactions that are still valid are emitted as a `TxsRequeued` event, which restores them to `localTxs`. Transactions that are no longer valid (e.g. they spent a UTxO that was decommitted) are emitted as `TxInvalid` and dropped.
+4. **Next snapshot**: the timer fires a fresh `ReqSn` at the new version, picking up the requeued transactions. Even if all transactions were dropped, a `versionNeedsSnapshot` flag ensures an empty snapshot is still requested so that the confirmed snapshot version matches the on-chain head datum version (required for a valid `CloseTx`).
+
+This prevents the head from getting stuck in a `WaitOnNotApplicableTx` loop when a transaction depends on outputs created by a dropped in-flight tx.
+
 ## General notes on incremental commits/decommits
 
 Especially, incremental commit and decommit are additions to the originally researched [Hydra Head protocol](https://eprint.iacr.org/2020/299.pdf) and deserve more explanation how they work under the hood. 

--- a/docs/docs/how-to/submit-transaction.md
+++ b/docs/docs/how-to/submit-transaction.md
@@ -52,4 +52,4 @@ This command generates a message suitable for submission to the `hydra-node` via
 cat tx-signed.json | jq -c '{tag: "NewTx", transaction: .}' | websocat "ws://127.0.0.1:4001?history=no"
 ```
 
-`Greetings` message will be displayed as always when calling the web socket api and the transaction will be validated by all connected `hydra-node` instances. It will result in either a `TxInvalid` message, providing a reason for rejection, or a `TxValid` message followed by a `SnapshotConfirmed`, updating the UTXO available in the head shortly after that.
+`Greetings` message will be displayed as always when calling the web socket api and the transaction will be validated by all connected `hydra-node` instances. It will result in either a `TxInvalid` message, providing a reason for rejection, or a `TxValid` message. Shortly after — within one snapshot timer interval (default 5 ms) — the snapshot leader will batch the transaction into the next `ReqSn`, and once all parties have signed, a `SnapshotConfirmed` message is emitted, updating the UTXO available in the head.

--- a/docs/docs/known-issues.md
+++ b/docs/docs/known-issues.md
@@ -61,7 +61,7 @@ There is a hard-coded limit in hydra-node when used on **mainnet**: only up to 1
 
 ### Deposit periods
 
-The `--deposit-period` allows an individual `hydra-node` operator to decide how long they want a deposit to have settled at least. However, differences bigger than [`defaultTTL * waitDelay`](https://hydra.family/head-protocol/haddock/hydra-node/Hydra-Node.html#v:waitDelay) (currently 10 minutes) result in non-approved snapshots. This is due to the way the `HeadLogic` is implemented and snapshot requests are not retried currently. See [hydra#1999](https://github.com/cardano-scaling/hydra/issues/1999) for more context.
+The `--deposit-period` allows an individual `hydra-node` operator to decide how long they want a deposit to have settled at least. Once a deposit becomes `Active` (after the deposit period has elapsed), the snapshot leader will include it in the next snapshot automatically via the periodic timer. See [hydra#1999](https://github.com/cardano-scaling/hydra/issues/1999) for historical context.
 
 ### Known bugs
 

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -1554,7 +1554,10 @@ canCommit tracer workDir blockTime backend hydraScriptsTxId =
             v ^? key "contestationDeadline" . _JSON
 
           remainingTime <- diffUTCTime deadline <$> getCurrentTime
-          waitFor hydraTracer (remainingTime + 3 * blockTime) [n1, n2] $
+          -- A version-bump empty snapshot (versionNeedsSnapshot) may be confirmed
+          -- concurrently with Close, causing a contest that extends the deadline by
+          -- one contestation period (10 * blockTime). Add extra buffer to cover it.
+          waitFor hydraTracer (remainingTime + 13 * blockTime) [n1, n2] $
             output "ReadyToFanout" ["headId" .= headId]
           send n2 $ input "Fanout" []
           waitMatch (10 * blockTime) n2 $ \v ->

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -294,7 +294,7 @@ restartedNodeCanObserveCommitTx tracer workDir backend hydraScriptsTxId = do
     -- We use withHydraNodeCatchingUp (not withHydraNode) so the Committed
     -- message is not consumed by the NodeSynced wait before our assertion.
     withHydraNodeCatchingUp hydraTracer aliceChainConfig workDir 2 aliceSk [bobVk] [1, 2] $ \n2 -> do
-      waitFor hydraTracer (10 * blockTime) [n2] $
+      waitFor hydraTracer (100 * blockTime) [n2] $
         output "Committed" ["party" .= bob, "utxo" .= object mempty, "headId" .= headId]
 
 resumeFromLatestKnownPoint :: ChainBackend backend => Tracer IO EndToEndLog -> FilePath -> backend -> [TxId] -> IO ()

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -123,6 +123,7 @@ import Hydra.Options (CardanoChainConfig (..), ChainBackendOptions (..), ChainCo
 import Hydra.Tx (HeadId (..), IsTx (balance), Party, headIdToCurrencySymbol, txId)
 import Hydra.Tx.ContestationPeriod qualified as CP
 import Hydra.Tx.Deposit (constructDepositUTxO)
+import Hydra.Tx.Snapshot (Snapshot (..), getSnapshot)
 import Hydra.Tx.Utils (verificationKeyToOnChainId)
 import HydraNode (
   HydraClient (..),
@@ -2207,35 +2208,31 @@ canSideLoadSnapshot tracer workDir backend hydraScriptsTxId = do
           guard $ v ^? key "tag" == Just "TxInvalid"
           guard $ v ^? key "transaction" . key "txId" == Just (toJSON $ txId tx)
 
-        -- \| Up to this point the head became stuck and no further SnapshotConfirmed
-        -- including above tx will be seen signed by everyone.
-        -- We observe that a snapshot is in progress, but Carol has not signed it.
-        seenSn1 <- getSnapshotLastSeen n1
-        seenSn2 <- getSnapshotLastSeen n2
-        seenSn1 `shouldBe` seenSn2
-        seenSn3 <- getSnapshotLastSeen n3
-        seenSn2 `shouldNotBe` seenSn3
-
-        -- The party side-loads latest confirmed snapshot (which is the initial)
-        -- This also prunes local txs, and discards any signing round inflight
+        -- The timer-driven snapshot retry automatically resolves the stuck snapshot
+        -- once Carol reconnects and signs the pending ReqSn that Alice re-broadcasts.
+        -- Side-loading the latest confirmed snapshot resets all parties to a common
+        -- state and prunes local txs and any in-flight signing round.
         snapshotConfirmed <- getSnapshotConfirmed n1
+        let Snapshot{number = confirmedNumber} = getSnapshot snapshotConfirmed
         flip mapConcurrently_ [n1, n2, n3] $ \n -> do
           send n $ input "SideLoadSnapshot" ["snapshot" .= snapshotConfirmed]
           waitMatch (200 * blockTime) n $ \v -> do
             guard $ v ^? key "tag" == Just "SnapshotSideLoaded"
-            guard $ v ^? key "snapshotNumber" == Just (toJSON (0 :: Integer))
+            guard $ v ^? key "snapshotNumber" == Just (toJSON confirmedNumber)
 
-        -- Carol re-submits the same transaction (but anyone can at this point)
-        send n3 $ input "NewTx" ["transaction" .= tx]
+        -- Submit a fresh transaction spending the current UTxO (the side-loaded
+        -- snapshot may already include the original tx, so we can't re-use it).
+        currentUtxo <- getSnapshotUTxO n1
+        newTx <- mkTransferTx testNetworkId currentUtxo aliceCardanoSk aliceCardanoVk
+        send n3 $ input "NewTx" ["transaction" .= newTx]
 
         -- Everyone confirms it
-        -- Note: We can't use `waitForAllMatch` here as it expects them to
-        -- emit the exact same datatype; but Carol will be behind in sequence
-        -- numbers as she was offline.
+        -- Note: We can't use `waitForAllMatch` here as it expects the exact
+        -- same message content; Carol's sequence numbers may differ.
         flip mapConcurrently_ [n1, n2, n3] $ \n ->
           waitMatch (200 * blockTime) n $ \v -> do
             guard $ v ^? key "tag" == Just "SnapshotConfirmed"
-            guard $ v ^? key "snapshot" . key "number" == Just (toJSON (1 :: Integer))
+            guard $ v ^? key "snapshot" . key "number" == Just (toJSON (confirmedNumber + 1))
             -- Just check that everyone signed it.
             let sigs = v ^.. key "signatures" . key "multiSignature" . values
             guard $ length sigs == 3

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -283,17 +283,18 @@ restartedNodeCanObserveCommitTx tracer workDir backend hydraScriptsTxId = do
   withHydraNode hydraTracer blockTime bobChainConfig workDir 1 bobSk [aliceVk] [1, 2] $ \n1 -> do
     headId <- withHydraNode hydraTracer blockTime aliceChainConfig workDir 2 aliceSk [bobVk] [1, 2] $ \n2 -> do
       send n1 $ input "Init" []
-      -- XXX: might need to tweak the wait time
-      waitForAllMatch 10 [n1, n2] $ headIsInitializingWith (Set.fromList [alice, bob])
+      waitForAllMatch (10 * blockTime) [n1, n2] $ headIsInitializingWith (Set.fromList [alice, bob])
 
     -- n1 does a commit while n2 is down
     requestCommitTx n1 mempty >>= Backend.submitTransaction backend
-    waitFor hydraTracer 10 [n1] $
+    waitFor hydraTracer (10 * blockTime) [n1] $
       output "Committed" ["party" .= bob, "utxo" .= object mempty, "headId" .= headId]
 
-    -- n2 is back and does observe the commit
-    withHydraNode hydraTracer blockTime aliceChainConfig workDir 2 aliceSk [bobVk] [1, 2] $ \n2 -> do
-      waitFor hydraTracer 10 [n2] $
+    -- n2 is back and should observe the commit replayed during chain sync.
+    -- We use withHydraNodeCatchingUp (not withHydraNode) so the Committed
+    -- message is not consumed by the NodeSynced wait before our assertion.
+    withHydraNodeCatchingUp hydraTracer aliceChainConfig workDir 2 aliceSk [bobVk] [1, 2] $ \n2 -> do
+      waitFor hydraTracer (10 * blockTime) [n2] $
         output "Committed" ["party" .= bob, "utxo" .= object mempty, "headId" .= headId]
 
 resumeFromLatestKnownPoint :: ChainBackend backend => Tracer IO EndToEndLog -> FilePath -> backend -> [TxId] -> IO ()

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -26,7 +26,7 @@ import Hydra.HeadLogic.State (SeenSnapshot)
 import Hydra.Logging (Tracer, Verbosity (..), traceWith)
 import Hydra.Network (Host (Host), NodeId (NodeId), WhichEtcd (EmbeddedEtcd))
 import Hydra.Network qualified as Network
-import Hydra.Options (BlockfrostOptions (..), CardanoChainConfig (..), ChainBackendOptions (..), ChainConfig (..), DirectOptions (..), LedgerConfig (..), RunOptions (..), defaultBFQueryTimeout, defaultCardanoChainConfig, defaultDirectOptions, nodeSocket, toArgs)
+import Hydra.Options (BlockfrostOptions (..), CardanoChainConfig (..), ChainBackendOptions (..), ChainConfig (..), DirectOptions (..), LedgerConfig (..), RunOptions (..), defaultBFQueryTimeout, defaultCardanoChainConfig, defaultDirectOptions, defaultSnapshotRetryInterval, nodeSocket, toArgs)
 import Hydra.Tx (ConfirmedSnapshot)
 import Hydra.Tx.ContestationPeriod (ContestationPeriod)
 import Hydra.Tx.Crypto (HydraKey)
@@ -423,6 +423,7 @@ prepareHydraNode chainConfig workDir hydraNodeId hydraSKey hydraVKeys allNodeIds
             { cardanoLedgerProtocolParametersFile
             }
       , apiTransactionTimeout = 100000
+      , snapshotRetryInterval = defaultSnapshotRetryInterval
       }
  where
   port = fromIntegral $ 5_000 + hydraNodeId

--- a/hydra-node/golden/Greetings/Greetings.json
+++ b/hydra-node/golden/Greetings/Greetings.json
@@ -2,18 +2,23 @@
     "samples": [
         {
             "chainSyncedStatus": "InSync",
-            "currentSlot": 1,
+            "currentSlot": 0,
             "env": {
                 "configuredPeers": "",
-                "contestationPeriod": 43200,
-                "depositPeriod": 78099,
-                "otherParties": [],
+                "contestationPeriod": 50059,
+                "depositPeriod": 48930,
+                "otherParties": [
+                    {
+                        "vkey": "a595a6a5f6e071450e185fc7777581c1fc487241b2f46bc755dca6b967eef5e3"
+                    }
+                ],
                 "participants": [],
                 "party": {
-                    "vkey": "5802383116b8d8cfad0561849f98fa19652316ba794b06a4e2f74ac3f8d570b8"
+                    "vkey": "a1f9efeaa6f061fc0ca67618ea7da660480271c513bb3f0869bbb771ea046c4a"
                 },
-                "signingKey": "9e018c699d771741dc68d7d877a67520b68eacc6a76725f8be4034d18cd285d6",
-                "unsyncedPeriod": 21600
+                "signingKey": "f71c876f1f8f92ad420127c184219aba4e45d7f48147b5321e52d7eb259dd616",
+                "snapshotRetryInterval": 1,
+                "unsyncedPeriod": 78099
             },
             "headStatus": "Open",
             "hydraNodeVersion": "\u000c",

--- a/hydra-node/golden/RunOptions.json
+++ b/hydra-node/golden/RunOptions.json
@@ -2,219 +2,126 @@
     "samples": [
         {
             "advertise": {
-                "hostname": "0.0.43.126",
-                "port": 1984
+                "hostname": "0.0.123.147",
+                "port": 19261
             },
             "apiHost": {
-                "ipv4": "0.0.70.192",
+                "ipv4": "0.0.82.151",
                 "tag": "IPv4"
             },
-            "apiPort": 18036,
-            "apiTransactionTimeout": 0,
+            "apiPort": 2847,
+            "apiTransactionTimeout": 73951,
             "chainConfig": {
-                "cardanoSigningKey": "a/c/b/c.sk",
-                "cardanoVerificationKeys": [
-                    "a/b/a.vk",
-                    "b/c.vk",
-                    "c.vk",
-                    "b/b.vk",
-                    "a/b/b.vk"
-                ],
-                "chainBackendOptions": {
-                    "contents": {
-                        "networkId": {
-                            "magic": 42,
-                            "tag": "Testnet"
-                        },
-                        "nodeSocket": "node.socket"
-                    },
-                    "tag": "Direct"
-                },
-                "contestationPeriod": 604800,
-                "depositPeriod": 13568,
-                "hydraScriptsTxId": [
-                    "0308050108080605060300050607080801070606050403020608050103080807"
-                ],
-                "startChainFrom": {
-                    "blockHash": "41bf3917fca4c554e76325211df0772261c057b1a73df05fa0ad980294837273",
-                    "slot": 16016247,
-                    "tag": "ChainPoint"
-                },
-                "tag": "CardanoChainConfig",
-                "unsyncedPeriod": 302400
-            },
-            "hydraSigningKey": "b/c.sk",
-            "hydraVerificationKeys": [
-                "b/a.vk",
-                "c/a/a.vk",
-                "b/c/b.vk",
-                "c/c.vk",
-                "b/a.vk",
-                "a/a/c.vk"
-            ],
-            "ledgerConfig": {
-                "cardanoLedgerProtocolParametersFile": "c.json"
-            },
-            "listen": {
-                "hostname": "0.0.61.156",
-                "port": 18484
-            },
-            "monitoringPort": 14575,
-            "nodeId": "ghz",
-            "peers": [
-                {
-                    "hostname": "0.0.0.5",
-                    "port": 3
-                }
-            ],
-            "persistenceDir": "c/c/a",
-            "persistenceRotateAfter": null,
-            "tlsCertPath": null,
-            "tlsKeyPath": "c/b/a/a/b/a.key",
-            "verbosity": {
-                "contents": "HydraNode",
-                "tag": "Verbose"
-            },
-            "whichEtcd": "EmbeddedEtcd"
-        },
-        {
-            "advertise": {
-                "hostname": "0.0.111.159",
-                "port": 21035
-            },
-            "apiHost": {
-                "ipv4": "0.0.106.50",
-                "tag": "IPv4"
-            },
-            "apiPort": 32191,
-            "apiTransactionTimeout": 27,
-            "chainConfig": {
-                "initialUTxOFile": "b/b/c/a.json",
-                "ledgerGenesisFile": null,
-                "offlineHeadSeed": "605a4786e76db4b28c3668751db34615",
+                "initialUTxOFile": "c/c/b/a/b.json",
+                "ledgerGenesisFile": "c/c/b/a/b.json",
+                "offlineHeadSeed": "d744a6f6cb7a104c1a9eca14befe39c7",
                 "tag": "OfflineChainConfig"
             },
-            "hydraSigningKey": "a/c.sk",
+            "hydraSigningKey": "b.sk",
             "hydraVerificationKeys": [
-                "c.vk",
-                "a/b/a.vk",
+                "b/b.vk",
                 "a.vk",
-                "b/a.vk",
-                "a/a/b.vk",
-                "b/b/c.vk"
+                "c/a/a.vk",
+                "c.vk",
+                "a/b.vk"
             ],
             "ledgerConfig": {
-                "cardanoLedgerProtocolParametersFile": "b/a/b/a/a/a.json"
+                "cardanoLedgerProtocolParametersFile": "a/c/a/b/a.json"
             },
             "listen": {
-                "hostname": "0.0.15.242",
-                "port": 32379
+                "hostname": "0.0.33.250",
+                "port": 5828
             },
-            "monitoringPort": 29896,
-            "nodeId": "elvahkvrhdyjq",
+            "monitoringPort": 22778,
+            "nodeId": "hwnslgvygtynpgfrcd",
             "peers": [
                 {
-                    "hostname": "0.0.0.5",
-                    "port": 1
+                    "hostname": "0.0.0.0",
+                    "port": 8
                 },
                 {
-                    "hostname": "0.0.0.1",
-                    "port": 1
+                    "hostname": "0.0.0.6",
+                    "port": 6
                 },
                 {
-                    "hostname": "0.0.0.1",
-                    "port": 4
+                    "hostname": "0.0.0.0",
+                    "port": 3
+                },
+                {
+                    "hostname": "0.0.0.2",
+                    "port": 6
                 }
             ],
-            "persistenceDir": "c/c",
-            "persistenceRotateAfter": 30,
-            "tlsCertPath": null,
-            "tlsKeyPath": "b/a/b/a.key",
+            "persistenceDir": "c/b/a/c/c/a",
+            "persistenceRotateAfter": 72754,
+            "snapshotRetryInterval": 3333,
+            "tlsCertPath": "b/b/b/a/c.pem",
+            "tlsKeyPath": "a/b/a.key",
             "verbosity": {
-                "contents": "HydraNode",
-                "tag": "Verbose"
+                "tag": "Quiet"
             },
             "whichEtcd": "SystemEtcd"
         },
         {
             "advertise": {
-                "hostname": "0.0.56.147",
-                "port": 26421
+                "hostname": "0.0.110.85",
+                "port": 2425
             },
             "apiHost": {
-                "ipv4": "0.0.31.46",
+                "ipv4": "0.0.102.9",
                 "tag": "IPv4"
             },
-            "apiPort": 20019,
-            "apiTransactionTimeout": 26,
+            "apiPort": 30392,
+            "apiTransactionTimeout": 47649,
             "chainConfig": {
-                "cardanoSigningKey": "c/b/a/b/c/b.sk",
-                "cardanoVerificationKeys": [
-                    "a/c/b.vk",
-                    "b.vk",
-                    "c/b/b.vk",
-                    "b/c/b.vk",
-                    "a/a/c.vk",
-                    "c/b/b.vk"
-                ],
-                "chainBackendOptions": {
-                    "contents": {
-                        "networkId": {
-                            "magic": 42,
-                            "tag": "Testnet"
-                        },
-                        "nodeSocket": "node.socket"
-                    },
-                    "tag": "Direct"
-                },
-                "contestationPeriod": 604800,
-                "depositPeriod": 7788,
-                "hydraScriptsTxId": [
-                    "0107030001030003010403010201000301040808010501040703060005070002",
-                    "0507060005030307000407080303050200040008060007080107060404050001"
-                ],
-                "startChainFrom": {
-                    "blockHash": "81667e2b53fa0fc89adae700530801ee0d1c65ba7a2e3b2babb9de600015194c",
-                    "slot": 14063413,
-                    "tag": "ChainPoint"
-                },
-                "tag": "CardanoChainConfig",
-                "unsyncedPeriod": 302400
+                "initialUTxOFile": "c/a/c/a/c.json",
+                "ledgerGenesisFile": null,
+                "offlineHeadSeed": "9ae05bf4bdda9f8a91565cdfd20f7a08",
+                "tag": "OfflineChainConfig"
             },
-            "hydraSigningKey": "a.sk",
+            "hydraSigningKey": "c.sk",
             "hydraVerificationKeys": [
-                "a/b/c.vk",
-                "b/a/a.vk",
-                "b.vk",
-                "a.vk",
-                "a.vk"
+                "a/c/a.vk"
             ],
             "ledgerConfig": {
-                "cardanoLedgerProtocolParametersFile": "b/a/b/c/a.json"
+                "cardanoLedgerProtocolParametersFile": "c/a/b/b.json"
             },
             "listen": {
-                "hostname": "0.0.18.217",
-                "port": 21720
+                "hostname": "0.0.75.31",
+                "port": 22544
             },
-            "monitoringPort": 338,
-            "nodeId": "enjl",
+            "monitoringPort": 6839,
+            "nodeId": "rbgq",
             "peers": [
                 {
-                    "hostname": "0.0.0.5",
-                    "port": 4
+                    "hostname": "0.0.0.6",
+                    "port": 0
                 },
                 {
                     "hostname": "0.0.0.6",
-                    "port": 3
+                    "port": 0
+                },
+                {
+                    "hostname": "0.0.0.3",
+                    "port": 1
+                },
+                {
+                    "hostname": "0.0.0.8",
+                    "port": 8
+                },
+                {
+                    "hostname": "0.0.0.2",
+                    "port": 6
                 },
                 {
                     "hostname": "0.0.0.7",
-                    "port": 7
+                    "port": 5
                 }
             ],
-            "persistenceDir": "c/c/b/c",
-            "persistenceRotateAfter": 16,
-            "tlsCertPath": "a/a/b/c/b/b.pem",
+            "persistenceDir": "c/c/c",
+            "persistenceRotateAfter": 43468,
+            "snapshotRetryInterval": 2595,
+            "tlsCertPath": "c/c/b/c/c/a.pem",
             "tlsKeyPath": null,
             "verbosity": {
                 "tag": "Quiet"
@@ -224,35 +131,51 @@
         {
             "advertise": null,
             "apiHost": {
-                "ipv4": "0.0.25.188",
+                "ipv4": "0.0.85.17",
                 "tag": "IPv4"
             },
-            "apiPort": 9965,
-            "apiTransactionTimeout": 17,
+            "apiPort": 10705,
+            "apiTransactionTimeout": 4104,
             "chainConfig": {
-                "initialUTxOFile": "b/c/b/a/a/c.json",
-                "ledgerGenesisFile": "b/c/a.json",
-                "offlineHeadSeed": "329e98b0b3a9efc003e42da13950a34f",
+                "initialUTxOFile": "c/c/a/c.json",
+                "ledgerGenesisFile": "b/a/a/a/c.json",
+                "offlineHeadSeed": "4c480c3fcb1d9b3d9a26e463f702aa15",
                 "tag": "OfflineChainConfig"
             },
-            "hydraSigningKey": "b/c.sk",
-            "hydraVerificationKeys": [
-                "b/a.vk"
-            ],
+            "hydraSigningKey": "c/c/b/a/c.sk",
+            "hydraVerificationKeys": [],
             "ledgerConfig": {
-                "cardanoLedgerProtocolParametersFile": "a/b/b/a/a/a.json"
+                "cardanoLedgerProtocolParametersFile": "c/c/b/c.json"
             },
             "listen": {
-                "hostname": "0.0.106.207",
-                "port": 20072
+                "hostname": "0.0.10.156",
+                "port": 1454
             },
-            "monitoringPort": 31045,
-            "nodeId": "csqnihmmawedbhcwwpna",
-            "peers": [],
-            "persistenceDir": "c/a",
-            "persistenceRotateAfter": 0,
-            "tlsCertPath": "a/b/c/b/b/a.pem",
-            "tlsKeyPath": "b/c/a/b.key",
+            "monitoringPort": 12243,
+            "nodeId": "yinanndxpwcwh",
+            "peers": [
+                {
+                    "hostname": "0.0.0.1",
+                    "port": 6
+                },
+                {
+                    "hostname": "0.0.0.7",
+                    "port": 1
+                },
+                {
+                    "hostname": "0.0.0.8",
+                    "port": 7
+                },
+                {
+                    "hostname": "0.0.0.4",
+                    "port": 7
+                }
+            ],
+            "persistenceDir": "a/b",
+            "persistenceRotateAfter": null,
+            "snapshotRetryInterval": 347,
+            "tlsCertPath": null,
+            "tlsKeyPath": "b/a.key",
             "verbosity": {
                 "contents": "HydraNode",
                 "tag": "Verbose"
@@ -261,23 +184,19 @@
         },
         {
             "advertise": {
-                "hostname": "0.0.76.153",
-                "port": 10391
+                "hostname": "0.0.88.2",
+                "port": 5741
             },
             "apiHost": {
-                "ipv4": "0.0.56.37",
+                "ipv4": "0.0.82.217",
                 "tag": "IPv4"
             },
-            "apiPort": 8054,
-            "apiTransactionTimeout": 23,
+            "apiPort": 26376,
+            "apiTransactionTimeout": 65966,
             "chainConfig": {
-                "cardanoSigningKey": "a/c/a.sk",
+                "cardanoSigningKey": "c/a/b/c.sk",
                 "cardanoVerificationKeys": [
-                    "a.vk",
-                    "a/a.vk",
-                    "a/a.vk",
-                    "a/a.vk",
-                    "b/b/b.vk"
+                    "b/b.vk"
                 ],
                 "chainBackendOptions": {
                     "contents": {
@@ -289,50 +208,144 @@
                     },
                     "tag": "Direct"
                 },
-                "contestationPeriod": 39741,
-                "depositPeriod": 1119,
+                "contestationPeriod": 2592000,
+                "depositPeriod": 51140,
                 "hydraScriptsTxId": [
-                    "0203060008010405020004080100080403020305050205080508050800000805",
-                    "0508010600020500050401000706070602010301020103020501000701060004",
-                    "0600000601040000050806020308060804060304000305050500070706000801"
+                    "0203010107060103060800080703010007050305050101050004060305060605",
+                    "0802040407040607060804040006040006050307060603070704000105080207"
                 ],
-                "startChainFrom": null,
+                "startChainFrom": {
+                    "blockHash": "e6fdd96abb113bf1bdae75026b9a40e9dc0b5586a847dd892f27904018bc1cfa",
+                    "slot": 11857478,
+                    "tag": "ChainPoint"
+                },
                 "tag": "CardanoChainConfig",
-                "unsyncedPeriod": 19870
+                "unsyncedPeriod": 83481
             },
-            "hydraSigningKey": "b/c/c/b/a/b.sk",
+            "hydraSigningKey": "c/c/a/c/a/c.sk",
             "hydraVerificationKeys": [
-                "b.vk"
+                "c/b/c.vk",
+                "b/b.vk",
+                "a/b/c.vk"
             ],
             "ledgerConfig": {
-                "cardanoLedgerProtocolParametersFile": "a/c/a/a/a/a.json"
+                "cardanoLedgerProtocolParametersFile": "b/a/a/c/b.json"
             },
             "listen": {
-                "hostname": "0.0.8.4",
-                "port": 25176
+                "hostname": "0.0.3.7",
+                "port": 3148
             },
-            "monitoringPort": 13997,
-            "nodeId": "zlgbpdultsxtzonc",
+            "monitoringPort": 3657,
+            "nodeId": "xkgidbrxkqpvrgndedqhdwiy",
             "peers": [
                 {
                     "hostname": "0.0.0.5",
-                    "port": 5
+                    "port": 0
+                },
+                {
+                    "hostname": "0.0.0.0",
+                    "port": 6
                 },
                 {
                     "hostname": "0.0.0.2",
                     "port": 2
+                },
+                {
+                    "hostname": "0.0.0.6",
+                    "port": 7
+                },
+                {
+                    "hostname": "0.0.0.2",
+                    "port": 4
+                },
+                {
+                    "hostname": "0.0.0.8",
+                    "port": 5
                 }
             ],
-            "persistenceDir": "b/a/a/a/a/c",
-            "persistenceRotateAfter": 13,
-            "tlsCertPath": "c/a.pem",
-            "tlsKeyPath": "c.key",
+            "persistenceDir": "a",
+            "persistenceRotateAfter": null,
+            "snapshotRetryInterval": 238,
+            "tlsCertPath": null,
+            "tlsKeyPath": "b/b/b/c.key",
+            "verbosity": {
+                "tag": "Quiet"
+            },
+            "whichEtcd": "EmbeddedEtcd"
+        },
+        {
+            "advertise": null,
+            "apiHost": {
+                "ipv4": "0.0.122.199",
+                "tag": "IPv4"
+            },
+            "apiPort": 12017,
+            "apiTransactionTimeout": 36347,
+            "chainConfig": {
+                "cardanoSigningKey": "c.sk",
+                "cardanoVerificationKeys": [
+                    "b.vk",
+                    "a/b/b.vk",
+                    "b.vk",
+                    "c/a/c.vk"
+                ],
+                "chainBackendOptions": {
+                    "contents": {
+                        "networkId": {
+                            "magic": 42,
+                            "tag": "Testnet"
+                        },
+                        "nodeSocket": "node.socket"
+                    },
+                    "tag": "Direct"
+                },
+                "contestationPeriod": 40659,
+                "depositPeriod": 6892,
+                "hydraScriptsTxId": [
+                    "0102060802070302030202020002010307010608040604010806050804030506"
+                ],
+                "startChainFrom": {
+                    "blockHash": "46554d998fb650d0a23ca942e2a5b6565c43574495e279ba1e71008b30a60b06",
+                    "slot": 10261295,
+                    "tag": "ChainPoint"
+                },
+                "tag": "CardanoChainConfig",
+                "unsyncedPeriod": 35645
+            },
+            "hydraSigningKey": "b/a/a.sk",
+            "hydraVerificationKeys": [
+                "b/b.vk"
+            ],
+            "ledgerConfig": {
+                "cardanoLedgerProtocolParametersFile": "a.json"
+            },
+            "listen": {
+                "hostname": "0.0.62.7",
+                "port": 11009
+            },
+            "monitoringPort": 10208,
+            "nodeId": "ebfex",
+            "peers": [
+                {
+                    "hostname": "0.0.0.6",
+                    "port": 4
+                },
+                {
+                    "hostname": "0.0.0.8",
+                    "port": 6
+                }
+            ],
+            "persistenceDir": "b/b/a",
+            "persistenceRotateAfter": null,
+            "snapshotRetryInterval": 2637,
+            "tlsCertPath": "c.pem",
+            "tlsKeyPath": "c/c/c/b/c/b.key",
             "verbosity": {
                 "contents": "HydraNode",
                 "tag": "Verbose"
             },
-            "whichEtcd": "EmbeddedEtcd"
+            "whichEtcd": "SystemEtcd"
         }
     ],
-    "seed": -1686225623
+    "seed": 720610519
 }

--- a/hydra-node/golden/StateChanged/SnapshotRequestAborted.json
+++ b/hydra-node/golden/StateChanged/SnapshotRequestAborted.json
@@ -1,0 +1,10 @@
+{
+    "samples": [
+        {
+            "lastSeenSnapshotNumber": 0,
+            "snapshotNumber": 1,
+            "tag": "SnapshotRequestAborted"
+        }
+    ],
+    "seed": -987137706
+}

--- a/hydra-node/golden/StateChanged/TxsRequeued.json
+++ b/hydra-node/golden/StateChanged/TxsRequeued.json
@@ -1,0 +1,25 @@
+{
+    "samples": [
+        {
+            "newLocalUTxO": {
+                "0001010000010000000101000001000000000100000101010100000001010000#34": {
+                    "address": "addr_test1xpfcje7ka7kmt6xvugl40r3g5e00nsms5elzt7un5t0v8ctttyfnsva5q49dnlyegtm0zkskxjxg25s72467cahrgmhqlpcapy",
+                    "datum": null,
+                    "datumhash": "26ab2249f3d8684c21e2da51d35c1c336f6bda5eef355cc42a79f45148c712b5",
+                    "inlineDatum": null,
+                    "inlineDatumRaw": null,
+                    "referenceScript": null,
+                    "value": {
+                        "6a72db5176ad0611c6e6f5682561096d089219f4fc12f370889348f0": {
+                            "a04c07dbb20778bc0c29b811dc204f": 8990112881654613515
+                        },
+                        "lovelace": 1366270
+                    }
+                }
+            },
+            "tag": "TxsRequeued",
+            "txs": []
+        }
+    ],
+    "seed": 870907875
+}

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -38,7 +38,6 @@ common project-config
     PatternSynonyms
     TypeFamilies
     ViewPatterns
-    StrictData
 
   ghc-options:
     -Wall -Wcompat -Widentities -Wincomplete-record-updates

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -38,6 +38,7 @@ common project-config
     PatternSynonyms
     TypeFamilies
     ViewPatterns
+    StrictData
 
   ghc-options:
     -Wall -Wcompat -Widentities -Wincomplete-record-updates

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -3331,6 +3331,7 @@ components:
       - contestationPeriod
       - depositPeriod
       - unsyncedPeriod
+      - snapshotRetryInterval
       - configuredPeers
       additionalProperties: false
       properties:
@@ -3352,6 +3353,9 @@ components:
           $ref: "api.yaml#/components/schemas/DepositPeriod"
         unsyncedPeriod:
           $ref: "api.yaml#/components/schemas/UnsyncedPeriod"
+        snapshotRetryInterval:
+          type: number
+          description: How often (in seconds) the snapshot leader retries sending a ReqSn.
         configuredPeers:
           type: string
 

--- a/hydra-node/src/Hydra/API/HTTPServer.hs
+++ b/hydra-node/src/Hydra/API/HTTPServer.hs
@@ -204,12 +204,15 @@ httpApp ::
   IO [TxIdType tx] ->
   -- | Callback to yield a 'ClientInput' to the main event loop.
   (ClientInput tx -> IO ()) ->
+  -- | Non-blocking callback for 'NewTx' submissions. Returns 'False' when the
+  -- input queue is full (back pressure); the caller should respond with 503.
+  (tx -> IO Bool) ->
   -- | Timeout for transaction submission
   ApiTransactionTimeout ->
   -- | Channel to listen for events
   TChan (Either (TimedServerOutput tx) (ClientMessage tx)) ->
   Application
-httpApp tracer directChain env stateFile pparams getNodeState getCommitInfo getPendingDeposits putClientInput apiTransactionTimeout responseChannel request respond = do
+httpApp tracer directChain env stateFile pparams getNodeState getCommitInfo getPendingDeposits putClientInput tryPutNewTx apiTransactionTimeout responseChannel request respond = do
   traceWith tracer $
     APIHTTPRequestReceived
       { method = Method $ requestMethod request
@@ -261,7 +264,7 @@ httpApp tracer directChain env stateFile pparams getNodeState getCommitInfo getP
         >>= respond
     ("POST", ["transaction"]) ->
       consumeRequestBodyStrict request
-        >>= handleSubmitL2Tx putClientInput apiTransactionTimeout responseChannel
+        >>= handleSubmitL2Tx tryPutNewTx apiTransactionTimeout responseChannel
         >>= respond
     _ ->
       respond $ responseLBS status400 jsonContent . Aeson.encode $ Aeson.String "Resource not found"
@@ -513,12 +516,12 @@ handleSideLoadSnapshot putClientInput apiTransactionTimeout responseChannel body
 handleSubmitL2Tx ::
   forall tx.
   IsChainState tx =>
-  (ClientInput tx -> IO ()) ->
+  (tx -> IO Bool) ->
   ApiTransactionTimeout ->
   TChan (Either (TimedServerOutput tx) (ClientMessage tx)) ->
   LBS.ByteString ->
   IO Response
-handleSubmitL2Tx putClientInput apiTransactionTimeout responseChannel body = do
+handleSubmitL2Tx tryPutNewTx apiTransactionTimeout responseChannel body = do
   case Aeson.eitherDecode' @(SubmitL2TxRequest tx) body of
     Left err ->
       pure $ responseLBS status400 jsonContent (Aeson.encode $ Aeson.String $ pack err)
@@ -526,36 +529,43 @@ handleSubmitL2Tx putClientInput apiTransactionTimeout responseChannel body = do
       -- Duplicate the channel to avoid consuming messages from other consumers.
       dupChannel <- atomically $ dupTChan responseChannel
 
-      -- Submit the transaction to the head
-      putClientInput (NewTx submitL2Tx)
-
-      let txid = txId submitL2Tx
-      result <-
-        timeout
-          (realToFrac (apiTransactionTimeoutNominalDiffTime apiTransactionTimeout))
-          (waitForTransactionResult dupChannel txid)
-
-      case result of
-        Just (SubmitTxConfirmed snapshotNumber) ->
-          pure $ responseLBS status200 jsonContent (Aeson.encode $ SubmitTxConfirmed snapshotNumber)
-        Just (SubmitTxInvalidResponse validationError) ->
-          pure $ responseLBS status400 jsonContent (Aeson.encode $ SubmitTxInvalidResponse validationError)
-        Just (SubmitTxRejectedResponse reason) ->
-          pure $ responseLBS status503 jsonContent (Aeson.encode $ SubmitTxRejectedResponse reason)
-        Just SubmitTxSubmitted ->
-          pure $ responseLBS status202 jsonContent (Aeson.encode SubmitTxSubmitted)
-        Nothing ->
-          -- Timeout occurred - return 202 Accepted with timeout info
+      -- Try to submit the transaction; return 503 immediately if queue is full.
+      accepted <- tryPutNewTx submitL2Tx
+      if not accepted
+        then
           pure $
             responseLBS
-              status202
+              status503
               jsonContent
-              ( Aeson.encode $
-                  object
-                    [ "tag" .= Aeson.String "SubmitTxSubmitted"
-                    , "timeout" .= Aeson.String ("Transaction submission timed out after " <> pack (show apiTransactionTimeout) <> " seconds")
-                    ]
-              )
+              (Aeson.encode $ SubmitTxRejectedResponse "Hydra input queue is full, please try again in a few moments.")
+        else do
+          let txid = txId submitL2Tx
+          result <-
+            timeout
+              (realToFrac (apiTransactionTimeoutNominalDiffTime apiTransactionTimeout))
+              (waitForTransactionResult dupChannel txid)
+
+          case result of
+            Just (SubmitTxConfirmed snapshotNumber) ->
+              pure $ responseLBS status200 jsonContent (Aeson.encode $ SubmitTxConfirmed snapshotNumber)
+            Just (SubmitTxInvalidResponse validationError) ->
+              pure $ responseLBS status400 jsonContent (Aeson.encode $ SubmitTxInvalidResponse validationError)
+            Just (SubmitTxRejectedResponse reason) ->
+              pure $ responseLBS status503 jsonContent (Aeson.encode $ SubmitTxRejectedResponse reason)
+            Just SubmitTxSubmitted ->
+              pure $ responseLBS status202 jsonContent (Aeson.encode SubmitTxSubmitted)
+            Nothing ->
+              -- Timeout occurred - return 202 Accepted with timeout info
+              pure $
+                responseLBS
+                  status202
+                  jsonContent
+                  ( Aeson.encode $
+                      object
+                        [ "tag" .= Aeson.String "SubmitTxSubmitted"
+                        , "timeout" .= Aeson.String ("Transaction submission timed out after " <> pack (show apiTransactionTimeout) <> " seconds")
+                        ]
+                  )
  where
   --  Wait for transaction result by listening to events
   waitForTransactionResult :: TChan (Either (TimedServerOutput tx) (ClientMessage tx)) -> TxIdType tx -> IO SubmitL2TxResponse

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -150,7 +150,7 @@ withAPIServer config env stateFile party eventSource tracer initialChainState ch
                   (atomically $ getLatest commitInfoP)
                   (atomically $ getLatest pendingDepositsP)
                   callback
-                  (\tx -> tryCallback (NewTx tx))
+                  (tryCallback . NewTx)
                   (apiTransactionTimeout config)
                   responseChannel
               )
@@ -264,6 +264,7 @@ mkTimedServerOutputFromStateEvent event =
     StateChanged.TransactionReceived{} -> Nothing
     StateChanged.SnapshotRequested{} -> Nothing
     StateChanged.SnapshotRequestDecided{} -> Nothing
+    StateChanged.SnapshotRequestAborted{} -> Nothing
     StateChanged.PartySignedSnapshot{} -> Nothing
     StateChanged.ChainRolledBack{} -> Nothing
     StateChanged.TickObserved{} -> Nothing

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -263,6 +263,7 @@ mkTimedServerOutputFromStateEvent event =
     StateChanged.PartySignedSnapshot{} -> Nothing
     StateChanged.ChainRolledBack{} -> Nothing
     StateChanged.TickObserved{} -> Nothing
+    StateChanged.TxsRequeued{} -> Nothing
     StateChanged.LocalStateCleared{..} -> Just SnapshotSideLoaded{..}
     StateChanged.Checkpoint{state} -> Just $ EventLogRotated state
     StateChanged.NodeUnsynced{..} -> Just NodeUnsynced{..}

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -14,7 +14,7 @@ import Data.Conduit.Combinators (map)
 import Data.Conduit.List (catMaybes)
 import Data.Map qualified as Map
 import Hydra.API.APIServerLog (APIServerLog (..))
-import Hydra.API.ClientInput (ClientInput)
+import Hydra.API.ClientInput (ClientInput (NewTx))
 import Hydra.API.HTTPServer (httpApp)
 import Hydra.API.Projection (Projection (..), mkProjection)
 import Hydra.API.ServerOutput (
@@ -93,9 +93,12 @@ withAPIServer ::
   PParams LedgerEra ->
   ServerOutputFilter tx ->
   (ClientInput tx -> IO ()) ->
+  -- | Non-blocking callback for 'NewTx' inputs. Returns 'False' when the
+  -- input queue is full (back pressure signal).
+  (ClientInput tx -> IO Bool) ->
   ((EventSink (StateEvent tx) IO, Server tx IO) -> IO ()) ->
   IO ()
-withAPIServer config env stateFile party eventSource tracer initialChainState chain pparams serverOutputFilter callback action =
+withAPIServer config env stateFile party eventSource tracer initialChainState chain pparams serverOutputFilter callback tryCallback action =
   handle onIOException $ do
     responseChannel <- newBroadcastTChanIO
     -- Initialize our read models from stored events
@@ -136,7 +139,7 @@ withAPIServer config env stateFile party eventSource tracer initialChainState ch
             . simpleCors
             $ websocketsOr
               defaultConnectionOptions
-              (wsApp env party tracer chain historyTimedOutputs callback nodeStateP networkInfoP responseChannel serverOutputFilter)
+              (wsApp env party tracer chain historyTimedOutputs callback tryCallback nodeStateP networkInfoP responseChannel serverOutputFilter)
               ( httpApp
                   tracer
                   chain
@@ -147,6 +150,7 @@ withAPIServer config env stateFile party eventSource tracer initialChainState ch
                   (atomically $ getLatest commitInfoP)
                   (atomically $ getLatest pendingDepositsP)
                   callback
+                  (\tx -> tryCallback (NewTx tx))
                   (apiTransactionTimeout config)
                   responseChannel
               )

--- a/hydra-node/src/Hydra/API/WSServer.hs
+++ b/hydra-node/src/Hydra/API/WSServer.hs
@@ -15,7 +15,7 @@ import Data.Aeson.Lens (atKey)
 import Data.Conduit.Combinators (filter)
 import Data.Version (showVersion)
 import Hydra.API.APIServerLog (APIServerLog (..))
-import Hydra.API.ClientInput (ClientInput (SafeClose))
+import Hydra.API.ClientInput (ClientInput (NewTx, SafeClose))
 import Hydra.API.Projection (Projection (..))
 import Hydra.API.ServerOutput (
   ClientMessage,
@@ -67,6 +67,10 @@ wsApp ::
   Chain tx IO ->
   ConduitT () (TimedServerOutput tx) (ResourceT IO) () ->
   (ClientInput tx -> IO ()) ->
+  -- | Non-blocking callback for 'NewTx' inputs. Returns 'False' when the
+  -- input queue is full (back pressure). Other inputs use the blocking
+  -- 'callback' above.
+  (ClientInput tx -> IO Bool) ->
   -- | Read model to enhance 'Greetings' messages with 'HeadStatus'.
   Projection STM.STM (StateChanged tx) (NodeState tx) ->
   -- | Read model to enhance 'Greetings' messages with 'NetworkInfo'.
@@ -75,7 +79,7 @@ wsApp ::
   ServerOutputFilter tx ->
   PendingConnection ->
   IO ()
-wsApp env party tracer chain history callback nodeStateP networkInfoP responseChannel ServerOutputFilter{txContainsAddr} pending = do
+wsApp env party tracer chain history callback tryCallback nodeStateP networkInfoP responseChannel ServerOutputFilter{txContainsAddr} pending = do
   traceWith tracer NewAPIConnection
   let path = requestPath $ pendingRequest pending
   queryParams <- uriQuery <$> mkURIBs path
@@ -187,6 +191,13 @@ wsApp env party tracer chain history callback nodeStateP networkInfoP responseCh
                     sendTextData con $ Aeson.encode $ InvalidInput errorStr clientInput
                     traceWith tracer (APIInvalidInput errorStr clientInput)
                   Right _ -> callback input
+          NewTx{} -> do
+            accepted <- tryCallback input
+            unless accepted $ do
+              let clientInput = decodeUtf8With lenientDecode $ toStrict msg
+              let errorStr = "Hydra input queue is full, please try again in few moments."
+              sendTextData con $ Aeson.encode $ InvalidInput errorStr clientInput
+              traceWith tracer (APIInvalidInput errorStr clientInput)
           _ -> callback input
       Left e -> do
         -- XXX(AB): toStrict might be problematic as it implies consuming the full

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -365,7 +365,7 @@ chainSyncClient handler wallet prefix =
 
 txSubmissionClient ::
   forall m.
-  (MonadSTM m, MonadDelay m) =>
+  (MonadSTM m) =>
   Tracer m CardanoChainLog ->
   TQueue m (Tx, TMVar m (Maybe (PostTxError Tx))) ->
   LocalTxSubmissionClient TxInMode TxValidationErrorInCardanoMode m ()
@@ -390,11 +390,6 @@ txSubmissionClient tracer queue =
               -- possible because of missing data constructors from cardano-api
               let postTxError = FailedToPostTx{failureReason = show err, failingTx = tx}
               traceWith tracer PostingFailed{tx, postTxError}
-              -- NOTE: Delay callback in case our transaction got invalidated
-              -- because of a transaction seen in a block. This gives the
-              -- observing side of the chain layer time to process the
-              -- transaction and business logic might even ignore this error.
-              threadDelay 1
               atomically (putTMVar response (Just postTxError))
               clientStIdle
         )

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -365,7 +365,7 @@ chainSyncClient handler wallet prefix =
 
 txSubmissionClient ::
   forall m.
-  (MonadSTM m) =>
+  MonadSTM m =>
   Tracer m CardanoChainLog ->
   TQueue m (Tx, TMVar m (Maybe (PostTxError Tx))) ->
   LocalTxSubmissionClient TxInMode TxValidationErrorInCardanoMode m ()

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -908,7 +908,9 @@ onOpenNetworkReqDec env ledger ttl currentSlot openState decommitTx =
 
   Ledger{applyTransactions} = ledger
 
-  nextSn = seenSnapshotNumber seenSnapshot + 1
+  Snapshot{number = confirmedSn} = getSnapshot confirmedSnapshot
+
+  nextSn = confirmedSn + 1
 
   snapshotInFlight = case seenSnapshot of
     NoSeenSnapshot -> False
@@ -918,6 +920,7 @@ onOpenNetworkReqDec env ledger ttl currentSlot openState decommitTx =
 
   CoordinatedHeadState
     { decommitTx = mExistingDecommitTx
+    , confirmedSnapshot
     , localTxs
     , localUTxO
     , version

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -414,54 +414,57 @@ onOpenNetworkReqSn ::
   Maybe (TxIdType tx) ->
   Outcome tx
 onOpenNetworkReqSn env ledger pendingDeposits currentSlot st otherParty sv sn requestedTxIds mDecommitTx mDepositTxId =
-  -- Spec: require v = v̂ ∧ s = ŝ + 1 ∧ leader(s) = j
-  requireReqSn $
-    -- TODO: this is missing!? Spec: require tx𝜔 = ⊥ ∨ tx𝛼 = ⊥
-    -- Require any pending utxo to decommit to be consistent
-    requireApplicableDecommitTx $ \(activeUTxOAfterDecommit, mUtxoToDecommit) ->
-      -- Wait for the deposit and require any pending commit to be consistent
-      waitForDeposit activeUTxOAfterDecommit $ \(activeUTxO, mUtxoToCommit) ->
-        -- Resolve transactions by-id
-        waitResolvableTxs $ \requestedTxs -> do
-          -- Spec: require 𝑈_active ◦ Treq ≠ ⊥
-          --       𝑈 ← 𝑈_active ◦ Treq
-          requireApplyTxs activeUTxO requestedTxs $ \u -> do
-            let snapshotUTxO = u `withoutUTxO` fromMaybe mempty mUtxoToCommit
-            -- Spec: ŝ ← ̅S.s + 1
-            let nextSnapshot =
-                  Snapshot
-                    { headId
-                    , version = version
-                    , number = sn
-                    , confirmed = requestedTxs
-                    , utxo = snapshotUTxO
-                    , utxoToCommit = mUtxoToCommit
-                    , utxoToDecommit = mUtxoToDecommit
-                    }
+  -- When this is the leader's own echo and validation fails, reset seenSnapshot
+  -- so the timer can retry with fresh content instead of being stuck forever.
+  abortOwnEchoOnFail $
+    -- Spec: require v = v̂ ∧ s = ŝ + 1 ∧ leader(s) = j
+    requireReqSn $
+      -- TODO: this is missing!? Spec: require tx𝜔 = ⊥ ∨ tx𝛼 = ⊥
+      -- Require any pending utxo to decommit to be consistent
+      requireApplicableDecommitTx $ \(activeUTxOAfterDecommit, mUtxoToDecommit) ->
+        -- Wait for the deposit and require any pending commit to be consistent
+        waitForDeposit activeUTxOAfterDecommit $ \(activeUTxO, mUtxoToCommit) ->
+          -- Resolve transactions by-id
+          waitResolvableTxs $ \requestedTxs -> do
+            -- Spec: require 𝑈_active ◦ Treq ≠ ⊥
+            --       𝑈 ← 𝑈_active ◦ Treq
+            requireApplyTxs activeUTxO requestedTxs $ \u -> do
+              let snapshotUTxO = u `withoutUTxO` fromMaybe mempty mUtxoToCommit
+              -- Spec: ŝ ← ̅S.s + 1
+              let nextSnapshot =
+                    Snapshot
+                      { headId
+                      , version = version
+                      , number = sn
+                      , confirmed = requestedTxs
+                      , utxo = snapshotUTxO
+                      , utxoToCommit = mUtxoToCommit
+                      , utxoToDecommit = mUtxoToDecommit
+                      }
 
-            -- Spec: 𝜂 ← combine(𝑈)
-            --       𝜂𝛼 ← combine(𝑈𝛼)
-            --       𝜂𝜔 ← combine(outputs(tx𝜔 ))
-            --       σᵢ ← MS-Sign(kₕˢⁱᵍ, (cid‖v‖ŝ‖η‖η𝛼‖ηω))
-            let snapshotSignature = sign signingKey nextSnapshot
-            -- Spec: multicast (ackSn, ŝ, σᵢ)
-            (cause (NetworkEffect $ AckSn snapshotSignature sn) <>) $ do
-              -- Spec: ̂Σ ← ∅
-              --       L̂ ← 𝑈
-              --       𝑋 ← T
-              --       T̂ ← ∅
-              --       for tx ∈ 𝑋 : L̂ ◦ tx ≠ ⊥
-              --         T̂ ← T̂ ⋃ {tx}
-              --         L̂ ← L̂ ◦ tx
-              let (newLocalTxs, newLocalUTxO) = pruneTransactions u
-              newState
-                SnapshotRequested
-                  { snapshot = nextSnapshot
-                  , requestedTxIds
-                  , newLocalUTxO
-                  , newLocalTxs
-                  , newCurrentDepositTxId = mDepositTxId
-                  }
+              -- Spec: 𝜂 ← combine(𝑈)
+              --       𝜂𝛼 ← combine(𝑈𝛼)
+              --       𝜂𝜔 ← combine(outputs(tx𝜔 ))
+              --       σᵢ ← MS-Sign(kₕˢⁱᵍ, (cid‖v‖ŝ‖η‖η𝛼‖ηω))
+              let snapshotSignature = sign signingKey nextSnapshot
+              -- Spec: multicast (ackSn, ŝ, σᵢ)
+              (cause (NetworkEffect $ AckSn snapshotSignature sn) <>) $ do
+                -- Spec: ̂Σ ← ∅
+                --       L̂ ← 𝑈
+                --       𝑋 ← T
+                --       T̂ ← ∅
+                --       for tx ∈ 𝑋 : L̂ ◦ tx ≠ ⊥
+                --         T̂ ← T̂ ⋃ {tx}
+                --         L̂ ← L̂ ◦ tx
+                let (newLocalTxs, newLocalUTxO) = pruneTransactions u
+                newState
+                  SnapshotRequested
+                    { snapshot = nextSnapshot
+                    , requestedTxIds
+                    , newLocalUTxO
+                    , newLocalTxs
+                    , newCurrentDepositTxId = mDepositTxId
+                    }
  where
   requireReqSn continue
     -- Version mismatch means the ReqSn was sent before the version bumped (race
@@ -577,7 +580,19 @@ onOpenNetworkReqSn env ledger pendingDeposits currentSlot st otherParty sv sn re
 
   OpenState{parameters, coordinatedHeadState, headId} = st
 
-  Environment{signingKey} = env
+  Environment{signingKey, party} = env
+
+  -- Convert a RequireFailed outcome into a SnapshotRequestAborted when the
+  -- message is from our own party (our echo) and we are in RequestedSnapshot.
+  -- This prevents the leader from getting stuck forever when its own ReqSn
+  -- echo fails validation (e.g. stale decommit after a version bump).
+  abortOwnEchoOnFail outcome
+    | otherParty == party
+    , Error (RequireFailed _) <- outcome
+    , RequestedSnapshot{lastSeen, requested} <- seenSnapshot
+    , requested == sn =
+        newState SnapshotRequestAborted{snapshotNumber = sn, lastSeenSnapshotNumber = lastSeen}
+    | otherwise = outcome
 
 -- | Process a snapshot acknowledgement ('AckSn') from a party.
 --
@@ -946,14 +961,18 @@ determineNextDepositStatus env pendingDeposits chainTime =
 -- This is primarily used to track deposits status changes.
 onChainTick :: IsTx tx => Environment -> PendingDeposits tx -> UTCTime -> Outcome tx
 onChainTick env pendingDeposits chainTime =
-  -- Determine new active and new expired
+  -- Determine new statuses and emit only for state *transitions* (not every tick).
   let nextDeposits = determineNextDepositStatus env pendingDeposits chainTime
-      newActive = Map.filter (\Deposit{status} -> status == Active) nextDeposits
-      newExpired = Map.filter (\Deposit{status} -> status == Expired) nextDeposits
-   in -- Emit state change for both
-      -- XXX: This is a bit messy
-      mkDepositActivated newActive <> mkDepositExpired newExpired
+      -- Only newly-activated: was not Active before
+      newActive = Map.filterWithKey (isTransitionTo Active) nextDeposits
+      -- Only newly-expired: was not Expired before
+      newExpired = Map.filterWithKey (isTransitionTo Expired) nextDeposits
+   in mkDepositActivated newActive <> mkDepositExpired newExpired
  where
+  isTransitionTo target dtxId Deposit{status} =
+    status == target
+      && maybe True (\old -> old.status /= target) (Map.lookup dtxId pendingDeposits)
+
   mkDepositActivated m = changes . (`Map.foldMapWithKey` m) $ \depositTxId deposit ->
     pure DepositActivated{depositTxId, chainTime, deposit}
 
@@ -1992,6 +2011,15 @@ aggregateNodeState nodeState sc =
                                     , -- NOTE: This must correspond to the just finalized
                                       -- depositTxId, but we should not verify this here.
                                       currentDepositTxId = Nothing
+                                    , -- Clear decommitTx when the confirmed snapshot already
+                                      -- carried a decommit (utxoToDecommit /= Nothing). In
+                                      -- that case DecrementTx was posted and DecommitFinalized
+                                      -- will arrive shortly; keeping decommitTx set here would
+                                      -- cause the timer to include the stale decommit in the
+                                      -- next ReqSn, which fails validation (inputs already spent).
+                                      decommitTx = case coordinatedHeadState.confirmedSnapshot of
+                                        ConfirmedSnapshot{snapshot = Snapshot{utxoToDecommit = Just _}} -> Nothing
+                                        _ -> coordinatedHeadState.decommitTx
                                     , localUTxO = newLocalUTxO
                                     , localTxs = newLocalTxs
                                     , allTxs = newAllTxs
@@ -2151,6 +2179,17 @@ aggregate st = \case
             }
        where
         CoordinatedHeadState{seenSnapshot} = coordinatedHeadState
+      _otherState -> st
+  SnapshotRequestAborted{lastSeenSnapshotNumber = lastSeen} ->
+    case st of
+      Open os@OpenState{coordinatedHeadState} ->
+        Open
+          os
+            { coordinatedHeadState =
+                coordinatedHeadState
+                  { seenSnapshot = LastSeenSnapshot{lastSeen}
+                  }
+            }
       _otherState -> st
   SnapshotRequested{snapshot, requestedTxIds, newLocalUTxO, newLocalTxs, newCurrentDepositTxId} ->
     case st of
@@ -2397,6 +2436,7 @@ aggregateChainStateHistory history = \case
   HeadOpened{chainState} -> pushNewState chainState history
   TransactionAppliedToLocalUTxO{} -> history
   SnapshotRequestDecided{} -> history
+  SnapshotRequestAborted{} -> history
   SnapshotRequested{} -> history
   TransactionReceived{} -> history
   PartySignedSnapshot{} -> history

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -287,7 +287,6 @@ onOpenClientNewTx tx =
 --
 -- __Transition__: 'OpenState' → 'OpenState'
 onOpenNetworkReqTx ::
-  IsTx tx =>
   Environment ->
   Ledger tx ->
   ChainSlot ->
@@ -297,7 +296,7 @@ onOpenNetworkReqTx ::
   -- | The transaction to be submitted to the head.
   tx ->
   Outcome tx
-onOpenNetworkReqTx env ledger currentSlot st ttl pendingDeposits tx =
+onOpenNetworkReqTx _env ledger currentSlot st ttl _pendingDeposits tx =
   -- Keep track of transactions by-id
   (newState TransactionReceived{tx} <>) $
     -- Spec: wait L̂ ◦ tx ≠ ⊥
@@ -305,12 +304,6 @@ onOpenNetworkReqTx env ledger currentSlot st ttl pendingDeposits tx =
       -- Spec: T̂ ← T̂ ⋃ {tx}
       --       L̂  ← L̂ ◦ tx
       newState TransactionAppliedToLocalUTxO{headId, tx, newLocalUTxO}
-        -- Spec: if ŝ = ̅S.s ∧ leader(̅S.s + 1) = i
-        --         multicast (reqSn, v, ̅S.s + 1, T̂ , 𝑈𝛼, txω )
-        -- NOTE: Use max(confirmedSn, seenSn) to handle cases where seenSnapshot
-        -- is ahead of confirmedSnapshot (e.g., after DecommitFinalized resets
-        -- seenSnapshot without updating confirmedSnapshot).
-        & maybeRequestSnapshot (max confirmedSn (latestSeenSnapshotNumber seenSnapshot) + 1)
  where
   waitApplyTx cont =
     case applyTransactions currentSlot localUTxO [tx] of
@@ -330,42 +323,11 @@ onOpenNetworkReqTx env ledger currentSlot st ttl pendingDeposits tx =
             -- both. This is a valid request and it could make the head stuck.
             newState TxInvalid{headId, utxo = localUTxO, transaction = tx, validationError = err}
 
-  maybeRequestSnapshot nextSn outcome =
-    if not (snapshotInFlight seenSnapshot nextSn) && isLeader parameters party nextSn
-      then
-        let previousSnapshot = getSnapshot confirmedSnapshot
-            -- Skip decommit/deposit if already posted in previous snapshot
-            decommitToInclude = skipPostedDecommit previousSnapshot decommitTx
-            depositToInclude = skipPostedDeposit pendingDeposits currentDepositTxId previousSnapshot.utxoToCommit
-         in outcome
-              -- XXX: This state update has no equivalence in the
-              -- spec. Do we really need to store that we have
-              -- requested a snapshot? If yes, should update spec.
-              <> newState SnapshotRequestDecided{snapshotNumber = nextSn}
-              <> cause (NetworkEffect $ ReqSn version nextSn (txId <$> take maxTxsPerSnapshot localTxs') decommitToInclude (setExistingDeposit pendingDeposits depositToInclude))
-      else outcome
-
-  Environment{party} = env
-
   Ledger{applyTransactions} = ledger
 
-  CoordinatedHeadState
-    { localTxs
-    , localUTxO
-    , confirmedSnapshot
-    , seenSnapshot
-    , decommitTx
-    , version
-    , currentDepositTxId
-    } = coordinatedHeadState
+  CoordinatedHeadState{localUTxO} = coordinatedHeadState
 
-  Snapshot{number = confirmedSn} = getSnapshot confirmedSnapshot
-
-  OpenState{coordinatedHeadState, headId, parameters} = st
-
-  -- NOTE: Order of transactions is important here. See also
-  -- 'pruneTransactions'.
-  localTxs' = localTxs <> [tx]
+  OpenState{coordinatedHeadState, headId} = st
 
 -- | Process a snapshot request ('ReqSn') from party.
 --
@@ -402,82 +364,67 @@ onOpenNetworkReqSn ::
 onOpenNetworkReqSn env ledger pendingDeposits currentSlot st otherParty sv sn requestedTxIds mDecommitTx mDepositTxId =
   -- Spec: require v = v̂ ∧ s = ŝ + 1 ∧ leader(s) = j
   requireReqSn $
-    -- Spec: wait ŝ = ̅S.s
-    waitNoSnapshotInFlight $
-      -- TODO: is this really needed?
-      -- Spec: wait v = v̂
-      waitOnSnapshotVersion $
-        -- TODO: this is missing!? Spec: require tx𝜔 = ⊥ ∨ tx𝛼 = ⊥
-        -- Require any pending utxo to decommit to be consistent
-        requireApplicableDecommitTx $ \(activeUTxOAfterDecommit, mUtxoToDecommit) ->
-          -- Wait for the deposit and require any pending commit to be consistent
-          waitForDeposit activeUTxOAfterDecommit $ \(activeUTxO, mUtxoToCommit) ->
-            -- Resolve transactions by-id
-            waitResolvableTxs $ \requestedTxs -> do
-              -- Spec: require 𝑈_active ◦ Treq ≠ ⊥
-              --       𝑈 ← 𝑈_active ◦ Treq
-              requireApplyTxs activeUTxO requestedTxs $ \u -> do
-                let snapshotUTxO = u `withoutUTxO` fromMaybe mempty mUtxoToCommit
-                -- Spec: ŝ ← ̅S.s + 1
-                -- NOTE: confSn == seenSn == sn here
-                let nextSnapshot =
-                      Snapshot
-                        { headId
-                        , version = version
-                        , number = sn
-                        , confirmed = requestedTxs
-                        , utxo = snapshotUTxO
-                        , utxoToCommit = mUtxoToCommit
-                        , utxoToDecommit = mUtxoToDecommit
-                        }
+    -- TODO: this is missing!? Spec: require tx𝜔 = ⊥ ∨ tx𝛼 = ⊥
+    -- Require any pending utxo to decommit to be consistent
+    requireApplicableDecommitTx $ \(activeUTxOAfterDecommit, mUtxoToDecommit) ->
+      -- Wait for the deposit and require any pending commit to be consistent
+      waitForDeposit activeUTxOAfterDecommit $ \(activeUTxO, mUtxoToCommit) ->
+        -- Resolve transactions by-id
+        waitResolvableTxs $ \requestedTxs -> do
+          -- Spec: require 𝑈_active ◦ Treq ≠ ⊥
+          --       𝑈 ← 𝑈_active ◦ Treq
+          requireApplyTxs activeUTxO requestedTxs $ \u -> do
+            let snapshotUTxO = u `withoutUTxO` fromMaybe mempty mUtxoToCommit
+            -- Spec: ŝ ← ̅S.s + 1
+            let nextSnapshot =
+                  Snapshot
+                    { headId
+                    , version = version
+                    , number = sn
+                    , confirmed = requestedTxs
+                    , utxo = snapshotUTxO
+                    , utxoToCommit = mUtxoToCommit
+                    , utxoToDecommit = mUtxoToDecommit
+                    }
 
-                -- Spec: 𝜂 ← combine(𝑈)
-                --       𝜂𝛼 ← combine(𝑈𝛼)
-                --       𝜂𝜔 ← combine(outputs(tx𝜔 ))
-                --       σᵢ ← MS-Sign(kₕˢⁱᵍ, (cid‖v‖ŝ‖η‖η𝛼‖ηω))
-                let snapshotSignature = sign signingKey nextSnapshot
-                -- Spec: multicast (ackSn, ŝ, σᵢ)
-                (cause (NetworkEffect $ AckSn snapshotSignature sn) <>) $ do
-                  -- Spec: ̂Σ ← ∅
-                  --       L̂ ← 𝑈
-                  --       𝑋 ← T
-                  --       T̂ ← ∅
-                  --       for tx ∈ 𝑋 : L̂ ◦ tx ≠ ⊥
-                  --         T̂ ← T̂ ⋃ {tx}
-                  --         L̂ ← L̂ ◦ tx
-                  let (newLocalTxs, newLocalUTxO) = pruneTransactions u
-                  newState
-                    SnapshotRequested
-                      { snapshot = nextSnapshot
-                      , requestedTxIds
-                      , newLocalUTxO
-                      , newLocalTxs
-                      , newCurrentDepositTxId = mDepositTxId
-                      }
+            -- Spec: 𝜂 ← combine(𝑈)
+            --       𝜂𝛼 ← combine(𝑈𝛼)
+            --       𝜂𝜔 ← combine(outputs(tx𝜔 ))
+            --       σᵢ ← MS-Sign(kₕˢⁱᵍ, (cid‖v‖ŝ‖η‖η𝛼‖ηω))
+            let snapshotSignature = sign signingKey nextSnapshot
+            -- Spec: multicast (ackSn, ŝ, σᵢ)
+            (cause (NetworkEffect $ AckSn snapshotSignature sn) <>) $ do
+              -- Spec: ̂Σ ← ∅
+              --       L̂ ← 𝑈
+              --       𝑋 ← T
+              --       T̂ ← ∅
+              --       for tx ∈ 𝑋 : L̂ ◦ tx ≠ ⊥
+              --         T̂ ← T̂ ⋃ {tx}
+              --         L̂ ← L̂ ◦ tx
+              let (newLocalTxs, newLocalUTxO) = pruneTransactions u
+              newState
+                SnapshotRequested
+                  { snapshot = nextSnapshot
+                  , requestedTxIds
+                  , newLocalUTxO
+                  , newLocalTxs
+                  , newCurrentDepositTxId = mDepositTxId
+                  }
  where
   requireReqSn continue
     -- Version mismatch means the ReqSn was sent before the version bumped (race
     -- condition). It is not a protocol violation — silently ignore it and let
     -- the leader's timer retry with the correct version.
     | sv /= version = noop
+    -- Stale or duplicate ReqSn (already signed or already seen this snapshot).
+    -- Drop silently — the leader's timer will resend if needed.
+    | sn < seenSn + 1 = noop
     | sn /= seenSn + 1 =
         Error $ RequireFailed $ ReqSnNumberInvalid{requestedSn = sn, lastSeenSn = seenSn}
     | not (isLeader parameters otherParty sn) =
         Error $ RequireFailed $ ReqSnNotLeader{requestedSn = sn, leader = otherParty}
     | otherwise =
         continue
-
-  waitNoSnapshotInFlight continue
-    | confSn == seenSn =
-        continue
-    | otherwise =
-        wait $ WaitOnSnapshotNumber seenSn
-
-  waitOnSnapshotVersion continue
-    | version == sv =
-        continue
-    | otherwise =
-        wait $ WaitOnSnapshotVersion sv
 
   waitResolvableTxs continue =
     case toList (fromList requestedTxIds \\ Map.keysSet allTxs) of
@@ -493,7 +440,7 @@ onOpenNetworkReqSn env ledger pendingDeposits currentSlot st otherParty sv sn re
             -- Error out in case we receive a ReqSn that doesn't match local deposit
             Error $ RequireFailed RequestedDepositNotFoundLocally{depositTxId}
           Just Deposit{status, deposited}
-            | status == Inactive -> wait WaitOnDepositActivation{depositTxId}
+            | status == Inactive -> noop
             | status == Expired -> Error $ RequireFailed RequestedDepositExpired{depositTxId}
             | otherwise ->
                 -- NOTE: this makes the commits sequential in a sense that you can't
@@ -554,10 +501,6 @@ onOpenNetworkReqSn env ledger pendingDeposits currentSlot st otherParty sv sn re
       case applyTransactions ledger currentSlot u [tx] of
         Left (_, _) -> (txs, u)
         Right u' -> (txs <> [tx], u')
-
-  confSn = case confirmedSnapshot of
-    InitialSnapshot{} -> 0
-    ConfirmedSnapshot{snapshot = Snapshot{number}} -> number
 
   Snapshot{version = confVersion} = getSnapshot confirmedSnapshot
 
@@ -653,13 +596,12 @@ onOpenNetworkAckSn Environment{party} pendingDeposits openState otherParty snaps
         | sn <= lastSeen -> noop
       SeenSnapshot snapshot sigs
         | seenSn == sn -> continue snapshot sigs
-      _ -> wait WaitOnSeenSnapshot
+      _ -> noop
 
   requireNotSignedYet sigs continue =
     if not (Map.member otherParty sigs)
       then continue
-      else Error $ RequireFailed $ SnapshotAlreadySigned{knownSignatures = Map.keys sigs, receivedSignature = otherParty}
-
+      else noop -- duplicate AckSn (e.g. leader re-broadcast), already have this sig
   ifAllMembersHaveSigned snapshot sigs cont =
     let sigs' = Map.insert otherParty snapshotSignature sigs
      in if Map.keysSet sigs' == Set.fromList parties
@@ -692,7 +634,11 @@ onOpenNetworkAckSn Environment{party} pendingDeposits openState otherParty snaps
     -- NB: No snapshotInFlight check needed here because we KNOW the previous snapshot
     -- just confirmed (we're inside ifAllMembersHaveSigned). After aggregation, seenSnapshot
     -- will be LastSeenSnapshot{lastSeen = previous.number}, so nextSn is safe to request.
-    -- The snapshotInFlight check in onOpenNetworkReqTx handles the ReqTx case.
+    --
+    -- NOTE: Immediately chaining the next snapshot here (rather than waiting for the timer)
+    -- is intentional: it provides zero-gap pipelining between consecutive snapshots, which
+    -- matters for throughput under continuous transaction load. Relying solely on the timer
+    -- would introduce up to one full timer interval of idle time between every snapshot pair.
     if isLeader parameters party nextSn && not (null localTxs)
       then
         outcome
@@ -1586,39 +1532,51 @@ onOpenTimer ::
   OpenState tx ->
   Outcome tx
 onOpenTimer Environment{party} pendingDeposits st =
-  let chs = st.coordinatedHeadState
-      confSn = number $ getSnapshot chs.confirmedSnapshot
-      nextSn = confSn + 1
-      hasWork =
-        not (null chs.localTxs)
-          || isJust chs.decommitTx
-          || isJust chs.currentDepositTxId
-      decommitToInclude = skipPostedDecommit (getSnapshot chs.confirmedSnapshot) chs.decommitTx
-      depositToInclude = skipPostedDeposit pendingDeposits chs.currentDepositTxId (getSnapshot chs.confirmedSnapshot).utxoToCommit
-   in if isLeader st.parameters party nextSn
-        then case chs.seenSnapshot of
-          -- Re-send: previous ReqSn was likely rejected due to version mismatch
-          -- (DecommitFinalized/CommitFinalized bumped the version after we sent it).
-          RequestedSnapshot{} ->
+  if isLeader st.parameters party nextSn
+    then case chs.seenSnapshot of
+      -- Re-send: previous ReqSn was likely rejected due to version mismatch
+      -- (DecommitFinalized/CommitFinalized bumped the version after we sent it).
+      RequestedSnapshot{} ->
+        sendReqSn chs.version nextSn chs.localTxs decommitToInclude depositToInclude
+      -- Re-send: stuck with partial signatures (some AckSns were dropped because
+      -- peers weren't ready yet, e.g. waiting for deposit activation). Re-broadcast
+      -- the same ReqSn without changing state so we keep existing signatures.
+      -- Also re-broadcast our own AckSn so late signers can complete the round.
+      SeenSnapshot snapshot sigs ->
+        broadcastReqSn snapshot.version snapshot.number (txId <$> snapshot.confirmed) decommitToInclude depositToInclude
+          <> case Map.lookup party sigs of
+            Just ourSig -> cause (NetworkEffect $ AckSn ourSig snapshot.number)
+            Nothing -> noop
+      -- Fresh send: no snapshot in-flight but there is pending work.
+      _
+        | not (snapshotInFlight chs.seenSnapshot nextSn) && hasWork ->
             sendReqSn chs.version nextSn chs.localTxs decommitToInclude depositToInclude
-          -- Fresh send: no snapshot in-flight but there is pending work.
-          _
-            | not (snapshotInFlight chs.seenSnapshot nextSn) && hasWork ->
-                sendReqSn chs.version nextSn chs.localTxs decommitToInclude depositToInclude
-          _ -> noop
-        else noop
+      _ -> noop
+    else noop
  where
-  sendReqSn version nextSn localTxs decommitToInclude depositToInclude =
-    newState SnapshotRequestDecided{snapshotNumber = nextSn}
-      <> cause
-        ( NetworkEffect $
-            ReqSn
-              version
-              nextSn
-              (txId <$> take maxTxsPerSnapshot localTxs)
-              decommitToInclude
-              (setExistingDeposit pendingDeposits depositToInclude)
-        )
+  chs = st.coordinatedHeadState
+  confSn = number $ getSnapshot chs.confirmedSnapshot
+  nextSn = confSn + 1
+  hasWork =
+    not (null chs.localTxs)
+      || isJust chs.decommitTx
+      || isJust chs.currentDepositTxId
+  decommitToInclude = skipPostedDecommit (getSnapshot chs.confirmedSnapshot) chs.decommitTx
+  depositToInclude = skipPostedDeposit pendingDeposits chs.currentDepositTxId (getSnapshot chs.confirmedSnapshot).utxoToCommit
+
+  sendReqSn version sn localTxs decommit deposit =
+    newState SnapshotRequestDecided{snapshotNumber = sn}
+      <> broadcastReqSn version sn (txId <$> take maxTxsPerSnapshot localTxs) decommit deposit
+
+  broadcastReqSn version sn txIds decommit deposit =
+    cause $
+      NetworkEffect $
+        ReqSn
+          version
+          sn
+          txIds
+          decommit
+          (setExistingDeposit pendingDeposits deposit)
 
 -- * Input Handlers
 
@@ -1876,7 +1834,21 @@ aggregateNodeState nodeState sc =
           case st of
             Open
               os@OpenState{coordinatedHeadState} ->
-                let deposit = Map.lookup depositTxId currentPendingDeposits
+                let newSeenSnapshot = toLastSeenSnapshot (seenSnapshot coordinatedHeadState)
+                    -- Same reasoning as DecommitFinalized: if a snapshot was in-flight
+                    -- when the version bumped, reset local state to confirmed UTxO.
+                    -- confirmedUTxO already includes the deposit (the deposit snapshot
+                    -- must have confirmed before IncrementTx was posted), so we do not
+                    -- add newUTxO on top in the reset branch.
+                    (newLocalUTxO, newLocalTxs, newAllTxs) =
+                      case seenSnapshot coordinatedHeadState of
+                        SeenSnapshot{} -> (confirmedUTxO, mempty, mempty)
+                        RequestedSnapshot{} -> (confirmedUTxO, mempty, mempty)
+                        _ -> (localUTxO <> newUTxO, coordinatedHeadState.localTxs, coordinatedHeadState.allTxs)
+                    confirmedUTxO = case coordinatedHeadState.confirmedSnapshot of
+                      InitialSnapshot{initialUTxO} -> initialUTxO
+                      ConfirmedSnapshot{snapshot = Snapshot{utxo}} -> utxo
+                    deposit = Map.lookup depositTxId currentPendingDeposits
                     newUTxO = maybe mempty (\Deposit{deposited} -> deposited) deposit
                  in nodeState
                       { headState =
@@ -1889,8 +1861,10 @@ aggregateNodeState nodeState sc =
                                     , -- NOTE: This must correspond to the just finalized
                                       -- depositTxId, but we should not verify this here.
                                       currentDepositTxId = Nothing
-                                    , localUTxO = localUTxO <> newUTxO
-                                    , seenSnapshot = toLastSeenSnapshot (seenSnapshot coordinatedHeadState)
+                                    , localUTxO = newLocalUTxO
+                                    , localTxs = newLocalTxs
+                                    , allTxs = newAllTxs
+                                    , seenSnapshot = newSeenSnapshot
                                     }
                               }
                       , pendingDeposits = Map.delete depositTxId currentPendingDeposits
@@ -2151,16 +2125,34 @@ aggregate st = \case
     case st of
       Open
         os@OpenState{coordinatedHeadState} ->
-          Open
-            os
-              { chainState
-              , coordinatedHeadState =
-                  coordinatedHeadState
-                    { decommitTx = Nothing
-                    , version = newVersion
-                    , seenSnapshot = toLastSeenSnapshot (seenSnapshot coordinatedHeadState)
-                    }
-              }
+          let newSeenSnapshot = toLastSeenSnapshot (seenSnapshot coordinatedHeadState)
+              -- When a snapshot was in-flight (SeenSnapshot/RequestedSnapshot) and
+              -- the version bumps, the in-flight snapshot is dead (its signatures
+              -- used the old version). Reset localUTxO/localTxs/allTxs back to the
+              -- confirmed snapshot so the timer can build a fresh valid snapshot.
+              -- Without this, localUTxO is left ahead of confirmedUTxO, causing
+              -- SnapshotDoesNotApply forever.
+              (newLocalUTxO, newLocalTxs, newAllTxs) =
+                case seenSnapshot coordinatedHeadState of
+                  SeenSnapshot{} -> (confirmedUTxO, mempty, mempty)
+                  RequestedSnapshot{} -> (confirmedUTxO, mempty, mempty)
+                  _ -> (coordinatedHeadState.localUTxO, coordinatedHeadState.localTxs, coordinatedHeadState.allTxs)
+              confirmedUTxO = case coordinatedHeadState.confirmedSnapshot of
+                InitialSnapshot{initialUTxO} -> initialUTxO
+                ConfirmedSnapshot{snapshot = Snapshot{utxo}} -> utxo
+           in Open
+                os
+                  { chainState
+                  , coordinatedHeadState =
+                      coordinatedHeadState
+                        { decommitTx = Nothing
+                        , version = newVersion
+                        , seenSnapshot = newSeenSnapshot
+                        , localUTxO = newLocalUTxO
+                        , localTxs = newLocalTxs
+                        , allTxs = newAllTxs
+                        }
+                  }
       _otherState -> st
   HeadClosed{chainState, contestationDeadline} ->
     case st of

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1011,12 +1011,53 @@ onOpenChainTick env chainTime pendingDeposits st =
 
   OpenState{coordinatedHeadState, parameters} = st
 
+-- | Re-apply pending transactions against the confirmed UTxO after a version
+-- bump (DecommitFinalized or CommitFinalized). Any txs that were in-flight in
+-- a SeenSnapshot or RequestedSnapshot are re-validated: valid ones are emitted
+-- as 'TxsRequeued' (so the next snapshot picks them up); invalid ones are
+-- emitted as 'TxInvalid' (so clients and the event log know they were dropped).
+--
+-- Returns two outcomes to be combined around the version-bump state change:
+--   - preRecovery: 'TxInvalid' events for txs that can no longer be applied
+--   - postRecovery: 'TxsRequeued' event with valid txs and the new localUTxO
+--
+-- Both are 'noop' when no snapshot is in-flight (NoSeenSnapshot /
+-- LastSeenSnapshot), preserving the existing no-op behaviour in those cases.
+recoverSnapshotTxs ::
+  Ledger tx ->
+  ChainSlot ->
+  HeadId ->
+  CoordinatedHeadState tx ->
+  (Outcome tx, Outcome tx)
+recoverSnapshotTxs ledger currentSlot headId chs =
+  case chs.seenSnapshot of
+    SeenSnapshot{snapshot} -> go (snapshot.confirmed ++ chs.localTxs)
+    RequestedSnapshot{} -> go chs.localTxs
+    _ -> (noop, noop)
+ where
+  Ledger{applyTransactions} = ledger
+  confirmedUTxO = case chs.confirmedSnapshot of
+    InitialSnapshot{initialUTxO} -> initialUTxO
+    ConfirmedSnapshot{snapshot = Snapshot{utxo}} -> utxo
+  go candidates =
+    let (validTxs, newUTxO, invalidTxs) = foldl' applyOne ([], confirmedUTxO, []) candidates
+        pre = foldl' (\acc (tx, err) -> acc <> newState TxInvalid{headId, utxo = confirmedUTxO, transaction = tx, validationError = err}) noop invalidTxs
+        post = if null validTxs then noop else newState TxsRequeued{txs = validTxs, newLocalUTxO = newUTxO}
+     in (pre, post)
+  applyOne (valid, utxo, invalid) tx =
+    case applyTransactions currentSlot utxo [tx] of
+      Right utxo' -> (valid ++ [tx], utxo', invalid)
+      Left (_, err) -> (valid, utxo, invalid ++ [(tx, err)])
+
 -- | Observe a increment transaction. If the outputs match the ones of the
 -- pending commit UTxO, then we consider the deposit/increment finalized, and remove the
 -- increment UTxO from 'pendingDeposits' from the local state.
 --
 -- __Transition__: 'OpenState' → 'OpenState'
 onOpenChainIncrementTx ::
+  IsTx tx =>
+  Ledger tx ->
+  ChainSlot ->
   OpenState tx ->
   ChainStateType tx ->
   -- | New open state version
@@ -1024,10 +1065,13 @@ onOpenChainIncrementTx ::
   -- | Deposit TxId
   TxIdType tx ->
   Outcome tx
-onOpenChainIncrementTx openState newChainState newVersion depositTxId =
-  newState CommitFinalized{chainState = newChainState, headId, newVersion, depositTxId}
+onOpenChainIncrementTx ledger currentSlot openState newChainState newVersion depositTxId =
+  preRecovery
+    <> newState CommitFinalized{chainState = newChainState, headId, newVersion, depositTxId}
+    <> postRecovery
  where
-  OpenState{headId} = openState
+  OpenState{headId, coordinatedHeadState = chs} = openState
+  (preRecovery, postRecovery) = recoverSnapshotTxs ledger currentSlot headId chs
 
 -- | Observe a decrement transaction. If the outputs match the ones of the
 -- pending decommit tx, then we consider the decommit finalized, and remove the
@@ -1038,6 +1082,9 @@ onOpenChainIncrementTx openState newChainState newVersion depositTxId =
 --
 -- __Transition__: 'OpenState' → 'OpenState'
 onOpenChainDecrementTx ::
+  IsTx tx =>
+  Ledger tx ->
+  ChainSlot ->
   OpenState tx ->
   ChainStateType tx ->
   -- | New open state version
@@ -1045,16 +1092,19 @@ onOpenChainDecrementTx ::
   -- | Outputs removed by the decrement
   UTxOType tx ->
   Outcome tx
-onOpenChainDecrementTx openState newChainState newVersion distributedUTxO =
-  newState
-    DecommitFinalized
-      { chainState = newChainState
-      , headId
-      , newVersion
-      , distributedUTxO
-      }
+onOpenChainDecrementTx ledger currentSlot openState newChainState newVersion distributedUTxO =
+  preRecovery
+    <> newState
+      DecommitFinalized
+        { chainState = newChainState
+        , headId
+        , newVersion
+        , distributedUTxO
+        }
+    <> postRecovery
  where
-  OpenState{headId} = openState
+  OpenState{headId, coordinatedHeadState = chs} = openState
+  (preRecovery, postRecovery) = recoverSnapshotTxs ledger currentSlot headId chs
 
 -- | On rollback, re-post the IncrementTx if there is a pending deposit whose
 -- confirmed snapshot contains a matching utxoToCommit. The rollback may have
@@ -1662,7 +1712,7 @@ handleChainInput ::
   Input tx ->
   SyncedStatus ->
   Outcome tx
-handleChainInput env _ledger now _chainPointTime pendingDeposits st ev syncStatus = case (st, ev) of
+handleChainInput env ledger now chainPointTime pendingDeposits st ev syncStatus = case (st, ev) of
   (Idle _, ChainInput Observation{observedTx = OnInitTx{headId, headSeed, headParameters, participants}, newChainState}) ->
     onIdleChainInitTx env newChainState headId headSeed headParameters participants
   (Initial initialState@InitialState{headId = ourHeadId}, ChainInput Observation{observedTx = OnCommitTx{headId, party = pt, committed = utxo}, newChainState})
@@ -1701,13 +1751,13 @@ handleChainInput env _ledger now _chainPointTime pendingDeposits st ev syncStatu
       <> onOpenChainTick env chainTime (depositsForHead ourHeadId pendingDeposits) openState
   (Open openState@OpenState{headId = ourHeadId}, ChainInput Observation{observedTx = OnIncrementTx{headId, newVersion, depositTxId}, newChainState})
     | ourHeadId == headId ->
-        onOpenChainIncrementTx openState newChainState newVersion depositTxId
+        onOpenChainIncrementTx ledger chainPointTime.currentSlot openState newChainState newVersion depositTxId
     | otherwise ->
         Error NotOurHead{ourHeadId, otherHeadId = headId}
   (Open openState@OpenState{headId = ourHeadId}, ChainInput Observation{observedTx = OnDecrementTx{headId, newVersion, distributedUTxO}, newChainState})
     -- TODO: What happens if observed decrement tx get's rolled back?
     | ourHeadId == headId ->
-        onOpenChainDecrementTx openState newChainState newVersion distributedUTxO
+        onOpenChainDecrementTx ledger chainPointTime.currentSlot openState newChainState newVersion distributedUTxO
     | otherwise ->
         Error NotOurHead{ourHeadId, otherHeadId = headId}
   -- Closed
@@ -2293,6 +2343,19 @@ aggregate st = \case
     Open ost@OpenState{coordinatedHeadState = coordState@CoordinatedHeadState{allTxs = allTransactions}} ->
       Open ost{coordinatedHeadState = coordState{allTxs = foldr Map.delete allTransactions [txId transaction]}}
     _otherState -> st
+  TxsRequeued{txs = recoveredTxs, newLocalUTxO} ->
+    case st of
+      Open os@OpenState{coordinatedHeadState} ->
+        Open
+          os
+            { coordinatedHeadState =
+                coordinatedHeadState
+                  { localTxs = recoveredTxs
+                  , allTxs = Map.fromList [(txId t, t) | t <- recoveredTxs]
+                  , localUTxO = newLocalUTxO
+                  }
+            }
+      _otherState -> st
   Checkpoint nodeState -> headState nodeState
   NodeSynced{} -> st
   NodeUnsynced{} -> st
@@ -2347,6 +2410,7 @@ aggregateChainStateHistory history = \case
   DecommitInvalid{} -> history
   IgnoredHeadInitializing{} -> history
   TxInvalid{} -> history
+  TxsRequeued{} -> history
   LocalStateCleared{} -> history
   -- FIXME: This makes chain sync starting after rollbacks past the chain state impossible
   Checkpoint nodeState -> initHistory $ getChainState nodeState.headState

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1433,7 +1433,7 @@ skipPostedDecommit :: IsTx tx => Snapshot tx -> Maybe tx -> Maybe tx
 skipPostedDecommit previousSnapshot decommit =
   case (decommit, previousSnapshot.utxoToDecommit) of
     (Just tx, Just prevUtxo)
-      | resolveInputsUTxO previousSnapshot.utxo tx == prevUtxo -> Nothing -- Already posted
+      | utxoFromTx tx == prevUtxo -> Nothing -- Already posted
     _ -> decommit -- Keep it
 
 -- | Skip a deposit if it was already posted in a previous snapshot.
@@ -1579,12 +1579,18 @@ onOpenTimer Environment{party} pendingDeposits st =
   -- 'confirmedSnapshot' is still behind. Without the max, 'nextSn' would be
   -- too small and 'snapshotInFlight' would (incorrectly) block it.
   nextSn = max confSn (latestSeenSnapshotNumber chs.seenSnapshot) + 1
-  hasWork =
-    not (null chs.localTxs)
-      || isJust chs.decommitTx
-      || isJust chs.currentDepositTxId
   decommitToInclude = skipPostedDecommit (getSnapshot chs.confirmedSnapshot) chs.decommitTx
   depositToInclude = skipPostedDeposit pendingDeposits chs.currentDepositTxId (getSnapshot chs.confirmedSnapshot).utxoToCommit
+  -- Use the filtered values so we don't fire an empty snapshot when decommit/deposit
+  -- was already included in a previous snapshot (skipPostedDecommit/skipPostedDeposit
+  -- would return Nothing). Without this, the timer would create a snapshot with no
+  -- decommit at version 0, which then becomes confirmedSnapshot. Closing with that
+  -- snapshot via CloseAny fails on-chain: the head datum's version is already 1 (after
+  -- DecrementTx) but the snapshot signature was made at version 0.
+  hasWork =
+    not (null chs.localTxs)
+      || isJust decommitToInclude
+      || isJust depositToInclude
 
   sendReqSn version sn localTxs decommit deposit =
     newState SnapshotRequestDecided{snapshotNumber = sn}

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -584,8 +584,7 @@ onOpenNetworkAckSn Environment{party} pendingDeposits openState otherParty snaps
                 -- Spec: if txω ≠ ⊥
                 --         postTx (decrement, v̂, ŝ, η, η𝛼, ηω)
                 & maybePostDecrementTx snapshot multisig
-                -- Spec: if leader(s + 1) = i ∧ T̂ ≠ ∅
-                -- REVIEW: multicast (reqSn, v, ̅S.s + 1, T̂, S.𝑈𝛼, S.txω)
+                -- Spec: if leader(s + 1) = i && T^ /= empty
                 & maybeRequestNextSnapshot snapshot
  where
   seenSn = seenSnapshotNumber seenSnapshot
@@ -1525,16 +1524,17 @@ updateInSyncHead env ledger now chainPointTime pendingDeposits st ev syncStatus 
 
 -- | Handle a periodic timer tick when the head is 'Open'.
 --
--- If this node is the snapshot leader for the next snapshot and there is work
--- pending (transactions or a decommit/deposit), it will send a 'ReqSn'. This
--- covers two cases:
+-- Sends a fresh 'ReqSn' if this node is the snapshot leader for the next
+-- snapshot, there is pending work (transactions, a decommit, or a deposit),
+-- and no snapshot is currently in flight ('LastSeenSnapshot' or
+-- 'NoSeenSnapshot' state). All other states are no-ops:
 --
---   1. A 'RequestedSnapshot' is in-flight: the previous 'ReqSn' was likely
---      rejected by peers because the version bumped (race with
---      'DecommitFinalized'/'CommitFinalized'). Re-send with the current version.
+--   * 'RequestedSnapshot': we already sent 'ReqSn' and are waiting for the
+--     network echo before we can sign; re-sending would use stale state and
+--     produce a different snapshot content, causing signature mismatches.
 --
---   2. No snapshot is in-flight but there is pending work: send a fresh 'ReqSn'.
---      This is a fallback for cases where the normal trigger was missed.
+--   * 'SeenSnapshot': signatures are being collected; the network layer
+--     guarantees delivery, so there is nothing to retry.
 onOpenTimer ::
   IsTx tx =>
   Environment ->
@@ -1552,16 +1552,6 @@ onOpenTimer Environment{party} pendingDeposits st =
       -- CommitFinalized resets to LastSeenSnapshot (not RequestedSnapshot), so
       -- this branch is never reached for version-mismatch retries.
       RequestedSnapshot{} -> noop
-      -- Re-send: stuck with partial signatures (some AckSns were dropped because
-      -- peers weren't ready yet, e.g. waiting for deposit activation). Re-broadcast
-      -- exactly the same ReqSn content that was originally signed (from the in-flight
-      -- snapshot) so all parties sign the same thing. Also re-broadcast our own AckSn
-      -- so late signers can complete the round.
-      SeenSnapshot snapshot sigs ->
-        broadcastReqSn snapshot.version snapshot.number (txId <$> snapshot.confirmed) decommitToInclude depositToInclude
-          <> case Map.lookup party sigs of
-            Just ourSig -> cause (NetworkEffect $ AckSn ourSig snapshot.number)
-            Nothing -> noop
       -- Fresh send: no snapshot in-flight but there is pending work.
       _
         | not (snapshotInFlight chs.seenSnapshot nextSn) && hasWork ->

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1953,7 +1953,10 @@ aggregateNodeState nodeState sc =
                     os
                       { coordinatedHeadState =
                           chs
-                            { currentDepositTxId = chs.currentDepositTxId <|> Just depositTxId
+                            { currentDepositTxId =
+                                if deposit.deposited == mempty
+                                  then chs.currentDepositTxId
+                                  else chs.currentDepositTxId <|> Just depositTxId
                             }
                       }
                 _ -> st

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -321,13 +321,22 @@ onOpenNetworkReqTx env ledger currentSlot st ttl pendingDeposits tx =
   -- received transaction. This eliminates the timer delay for single-tx
   -- patterns (submit → confirm → submit) where 'localTxs' would otherwise
   -- be empty when the timer fires.
+  --
+  -- Note: we guard against re-sending when already in 'RequestedSnapshot' for
+  -- the same snapshot number. 'snapshotInFlight' returns False in that case
+  -- (by design, so the leader can process its own echo), but we must NOT
+  -- broadcast a second 'ReqSn' with updated content — peers have already signed
+  -- the first one and a different broadcast would cause a signature mismatch.
   maybeRequestSnapshot nextSn outcome =
-    if not (snapshotInFlight seenSnapshot nextSn) && isLeader parameters party nextSn
-      then
-        outcome
-          <> newState SnapshotRequestDecided{snapshotNumber = nextSn}
-          <> cause (NetworkEffect $ ReqSn version nextSn (txId <$> take maxTxsPerSnapshot localTxs') decommitToInclude (setExistingDeposit pendingDeposits depositToInclude))
-      else outcome
+    let alreadySentForThisSn = case seenSnapshot of
+          RequestedSnapshot{requested} -> requested == nextSn
+          _ -> False
+     in if not (snapshotInFlight seenSnapshot nextSn) && not alreadySentForThisSn && isLeader parameters party nextSn
+          then
+            outcome
+              <> newState SnapshotRequestDecided{snapshotNumber = nextSn}
+              <> cause (NetworkEffect $ ReqSn version nextSn (txId <$> take maxTxsPerSnapshot localTxs') decommitToInclude (setExistingDeposit pendingDeposits depositToInclude))
+          else outcome
 
   Environment{party} = env
 

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -106,8 +106,15 @@ import Hydra.Tx.Snapshot (ConfirmedSnapshot (..), Snapshot (..), SnapshotNumber,
 -- | Maximum number of transaction ids per snapshot. This effectively limits our
 -- "block size" and ensures it does not grow arbitrarily with the backlog of
 -- pending transactions (localTxs).
+--
+-- Overflow transactions (those beyond this limit) are NOT dropped — they
+-- survive in 'localTxs' after 'SnapshotRequested' (via 'pruneTransactions')
+-- and are automatically batched into the next snapshot when the timer fires.
+-- Raising this value increases the number of txs confirmed per snapshot round
+-- at the cost of larger messages and longer ledger validation per round.
+--
 -- TODO: Investigate what a good value is for this, in relation to memory
--- usage
+-- usage and ledger validation throughput.
 maxTxsPerSnapshot :: Int
 maxTxsPerSnapshot = 100
 
@@ -419,6 +426,9 @@ onOpenNetworkReqSn env ledger pendingDeposits currentSlot st otherParty sv sn re
     -- Stale or duplicate ReqSn (already signed or already seen this snapshot).
     -- Drop silently — the leader's timer will resend if needed.
     | sn < seenSn + 1 = noop
+    -- Any snapshot is currently in-flight (SeenSnapshot/RequestedSnapshot).
+    -- Drop silently — the leader's timer will retry when the snapshot confirms.
+    | snapshotInFlight seenSnapshot sn = noop
     | sn /= seenSn + 1 =
         Error $ RequireFailed $ ReqSnNumberInvalid{requestedSn = sn, lastSeenSn = seenSn}
     | not (isLeader parameters otherParty sn) =
@@ -1078,8 +1088,10 @@ snapshotInFlight :: SeenSnapshot tx -> SnapshotNumber -> Bool
 snapshotInFlight seenSnapshot sn = case seenSnapshot of
   NoSeenSnapshot -> False
   LastSeenSnapshot{lastSeen} -> sn <= lastSeen
-  -- Block ALL snapshot requests when one is in-flight to maintain sequential processing
-  RequestedSnapshot{} -> True
+  -- `RequestedSnapshot{requested}` means we (the leader) just sent ReqSn for
+  -- `requested`. Allow the same sn through so the leader can sign its own
+  -- broadcast; block any different snapshot number.
+  RequestedSnapshot{requested} -> sn /= requested
   SeenSnapshot{} -> True
 
 -- | Get the last confirmed snapshot number.
@@ -1556,7 +1568,12 @@ onOpenTimer Environment{party} pendingDeposits st =
  where
   chs = st.coordinatedHeadState
   confSn = number $ getSnapshot chs.confirmedSnapshot
-  nextSn = confSn + 1
+  -- Use the max of the confirmed snapshot number and the latest seen snapshot
+  -- number. These can diverge when e.g. a 'DecommitFinalized' resets
+  -- 'seenSnapshot' to 'LastSeenSnapshot{lastSeen = requested}' while
+  -- 'confirmedSnapshot' is still behind. Without the max, 'nextSn' would be
+  -- too small and 'snapshotInFlight' would (incorrectly) block it.
+  nextSn = max confSn (latestSeenSnapshotNumber chs.seenSnapshot) + 1
   hasWork =
     not (null chs.localTxs)
       || isJust chs.decommitTx
@@ -2077,6 +2094,13 @@ aggregate st = \case
         Snapshot{number} = snapshot
       _otherState -> st
   LocalStateCleared{snapshotNumber} ->
+    -- NOTE: This event is only emitted by 'onOpenClientSideLoadSnapshot' (the
+    -- snapshot sideloading path), NOT by the normal 'onAckSn' confirmation
+    -- flow. When a client explicitly sideloads a snapshot it is requesting a
+    -- specific UTxO state, so resetting 'localTxs', 'allTxs', and 'localUTxO'
+    -- to that snapshot is intentional. In the normal protocol flow
+    -- 'SnapshotConfirmed' leaves those fields untouched, so overflow
+    -- transactions naturally carry forward into the next snapshot.
     case st of
       Open os@OpenState{coordinatedHeadState = coordinatedHeadState@CoordinatedHeadState{confirmedSnapshot}} ->
         Open

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1669,8 +1669,13 @@ handleChainInput env _ledger now _chainPointTime pendingDeposits st ev syncStatu
           onOpenChainCloseTx openState newChainState closedSnapshotNumber contestationDeadline
       | otherwise ->
           Error NotOurHead{ourHeadId, otherHeadId = headId}
-  -- NOTE: If posting the collectCom transaction failed in the open state, then
-  -- another party likely opened the head before us and it's okay to ignore.
+  -- NOTE: If posting the collectCom transaction failed, another party likely
+  -- opened the head before us and it's okay to ignore. This can happen in
+  -- either the Initial state (postTx ran async and failed before we observed
+  -- OnCollectComTx) or the Open state (we observed it first, then got the
+  -- error). Both are safe to ignore — we will observe OnCollectComTx shortly.
+  (Initial{}, ChainInput PostTxError{postChainTx = CollectComTx{}}) ->
+    noop
   (Open{}, ChainInput PostTxError{postChainTx = CollectComTx{}}) ->
     noop
   (Open openState@OpenState{headId = ourHeadId}, ChainInput Tick{chainTime, chainPoint}) ->

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -456,8 +456,10 @@ onOpenNetworkReqSn env ledger pendingDeposits currentSlot st otherParty sv sn re
                       }
  where
   requireReqSn continue
-    | sv /= version =
-        Error $ RequireFailed $ ReqSvNumberInvalid{requestedSv = sv, lastSeenSv = version}
+    -- Version mismatch means the ReqSn was sent before the version bumped (race
+    -- condition). It is not a protocol violation — silently ignore it and let
+    -- the leader's timer retry with the correct version.
+    | sv /= version = noop
     | sn /= seenSn + 1 =
         Error $ RequireFailed $ ReqSnNumberInvalid{requestedSn = sn, lastSeenSn = seenSn}
     | not (isLeader parameters otherParty sn) =
@@ -1532,6 +1534,8 @@ updateCatchingUpHead env ledger now chainPointTime pendingDeposits st ev syncSta
       cause . ClientEffect $ ServerOutput.RejectedInputBecauseUnsynced clientInput drift
     NetworkInput{} ->
       wait WaitOnNodeInSync{currentSlot}
+    TimerInput ->
+      noop
  where
   ChainPointTime{currentSlot, drift} = chainPointTime
 
@@ -1558,6 +1562,63 @@ updateInSyncHead env ledger now chainPointTime pendingDeposits st ev syncStatus 
       handleClientInput env ledger chainPointTime pendingDeposits st ev
     NetworkInput{} ->
       handleNetworkInput env ledger chainPointTime pendingDeposits st ev
+    TimerInput ->
+      case st of
+        Open openState -> onOpenTimer env pendingDeposits openState
+        _ -> noop
+
+-- | Handle a periodic timer tick when the head is 'Open'.
+--
+-- If this node is the snapshot leader for the next snapshot and there is work
+-- pending (transactions or a decommit/deposit), it will send a 'ReqSn'. This
+-- covers two cases:
+--
+--   1. A 'RequestedSnapshot' is in-flight: the previous 'ReqSn' was likely
+--      rejected by peers because the version bumped (race with
+--      'DecommitFinalized'/'CommitFinalized'). Re-send with the current version.
+--
+--   2. No snapshot is in-flight but there is pending work: send a fresh 'ReqSn'.
+--      This is a fallback for cases where the normal trigger was missed.
+onOpenTimer ::
+  IsTx tx =>
+  Environment ->
+  PendingDeposits tx ->
+  OpenState tx ->
+  Outcome tx
+onOpenTimer Environment{party} pendingDeposits st =
+  let chs = st.coordinatedHeadState
+      confSn = number $ getSnapshot chs.confirmedSnapshot
+      nextSn = confSn + 1
+      hasWork =
+        not (null chs.localTxs)
+          || isJust chs.decommitTx
+          || isJust chs.currentDepositTxId
+      decommitToInclude = skipPostedDecommit (getSnapshot chs.confirmedSnapshot) chs.decommitTx
+      depositToInclude = skipPostedDeposit pendingDeposits chs.currentDepositTxId (getSnapshot chs.confirmedSnapshot).utxoToCommit
+   in if isLeader st.parameters party nextSn
+        then case chs.seenSnapshot of
+          -- Re-send: previous ReqSn was likely rejected due to version mismatch
+          -- (DecommitFinalized/CommitFinalized bumped the version after we sent it).
+          RequestedSnapshot{} ->
+            sendReqSn chs.version nextSn chs.localTxs decommitToInclude depositToInclude
+          -- Fresh send: no snapshot in-flight but there is pending work.
+          _
+            | not (snapshotInFlight chs.seenSnapshot nextSn) && hasWork ->
+                sendReqSn chs.version nextSn chs.localTxs decommitToInclude depositToInclude
+          _ -> noop
+        else noop
+ where
+  sendReqSn version nextSn localTxs decommitToInclude depositToInclude =
+    newState SnapshotRequestDecided{snapshotNumber = nextSn}
+      <> cause
+        ( NetworkEffect $
+            ReqSn
+              version
+              nextSn
+              (txId <$> take maxTxsPerSnapshot localTxs)
+              decommitToInclude
+              (setExistingDeposit pendingDeposits depositToInclude)
+        )
 
 -- * Input Handlers
 
@@ -1854,24 +1915,29 @@ aggregateNodeState nodeState sc =
 
 -- * HeadState aggregate
 
--- | Convert any SeenSnapshot to LastSeenSnapshot, preserving the correct snapshot number.
--- Used by CommitFinalized and DecommitFinalized to handle race conditions where
--- on-chain transaction confirmation happens before AckSn messages arrive.
+-- | Convert any SeenSnapshot to LastSeenSnapshot, resetting to the last
+-- *confirmed* snapshot number. Used by CommitFinalized and DecommitFinalized to
+-- unblock the snapshot protocol after a version bump so the timer can re-send
+-- a fresh ReqSn with the updated version.
+--
+-- Both in-flight cases must reset to the confirmed number so that
+-- 'snapshotInFlight' returns False and the timer can proceed:
+--   * RequestedSnapshot{lastSeen} — no AckSns yet, reset to lastSeen (confirmed)
+--   * SeenSnapshot{number}        — collecting AckSns for N, reset to N-1 (confirmed)
+--
+-- Stale AckSns for the collapsed request will expire via TTL.
 toLastSeenSnapshot :: SeenSnapshot tx -> SeenSnapshot tx
 toLastSeenSnapshot = \case
   NoSeenSnapshot ->
     LastSeenSnapshot{lastSeen = 0}
   LastSeenSnapshot{lastSeen} ->
     LastSeenSnapshot{lastSeen}
-  -- NB: Use 'requested' not 'lastSeen' to prevent infinite AckSn loop.
-  -- When leader requests snapshot N with commit/decommit and the on-chain transaction
-  -- is observed before AckSn messages arrive, the transaction is part of snapshot N
-  -- (requested), not snapshot N-1 (lastSeen). Using lastSeen would cause AckSn(N)
-  -- messages to fail the guard check and be requeued infinitely.
-  RequestedSnapshot{requested} ->
-    LastSeenSnapshot{lastSeen = requested}
+  -- Reset to last confirmed (lastSeen), not the in-flight requested number.
+  RequestedSnapshot{lastSeen} ->
+    LastSeenSnapshot{lastSeen = lastSeen}
+  -- Snapshot N is being signed; last confirmed is N-1.
   SeenSnapshot{snapshot = Snapshot{number}} ->
-    LastSeenSnapshot{lastSeen = number}
+    LastSeenSnapshot{lastSeen = number - 1}
 
 -- | Reflect 'StateChanged' events onto the 'HeadState' aggregate.
 aggregate :: IsChainState tx => HeadState tx -> StateChanged tx -> HeadState tx

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -294,16 +294,14 @@ onOpenClientNewTx tx =
 --
 -- __Transition__: 'OpenState' → 'OpenState'
 onOpenNetworkReqTx ::
-  Environment ->
   Ledger tx ->
   ChainSlot ->
   OpenState tx ->
   TTL ->
-  PendingDeposits tx ->
   -- | The transaction to be submitted to the head.
   tx ->
   Outcome tx
-onOpenNetworkReqTx _env ledger currentSlot st ttl _pendingDeposits tx =
+onOpenNetworkReqTx ledger currentSlot st ttl tx =
   -- Keep track of transactions by-id
   (newState TransactionReceived{tx} <>) $
     -- Spec: wait L̂ ◦ tx ≠ ⊥
@@ -1736,7 +1734,7 @@ handleNetworkInput env ledger ChainPointTime{currentSlot} pendingDeposits st ev 
     onConnectionEvent env.configuredPeers conn
   -- Open
   (Open openState, NetworkInput ttl (ReceivedMessage{msg = ReqTx tx})) ->
-    onOpenNetworkReqTx env ledger currentSlot openState ttl pendingDeposits tx
+    onOpenNetworkReqTx ledger currentSlot openState ttl tx
   (Open openState@OpenState{headId = ourHeadId}, NetworkInput _ (ReceivedMessage{sender, msg = ReqSn sv sn txIds decommitTx depositTxId})) ->
     onOpenNetworkReqSn env ledger (depositsForHead ourHeadId pendingDeposits) currentSlot openState sender sv sn txIds decommitTx depositTxId
   (Open openState@OpenState{headId = ourHeadId}, NetworkInput _ (ReceivedMessage{sender, msg = AckSn snapshotSignature sn})) ->

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1617,6 +1617,19 @@ onOpenTimer Environment{party} pendingDeposits st =
     not (null chs.localTxs)
       || isJust decommitToInclude
       || isJust depositToInclude
+      -- A version bump (DecrementTx/IncrementTx observed on-chain) advances
+      -- coordinatedHeadState.version but does NOT update confirmedSnapshot.
+      -- If the confirmed snapshot is at an older version, an empty snapshot
+      -- at the current version is needed so that CloseTx can be built with a
+      -- signature that matches the on-chain head datum's version. Without
+      -- this, CloseTx fails on-chain with H46/H12 (signature verification
+      -- uses the datum version, not the snapshot's version).
+      || versionNeedsSnapshot
+  versionNeedsSnapshot =
+    case chs.confirmedSnapshot of
+      InitialSnapshot{} -> False
+      ConfirmedSnapshot{snapshot = Snapshot{version = snapshotVersion}} ->
+        snapshotVersion < chs.version
 
   sendReqSn version sn localTxs decommit deposit =
     newState SnapshotRequestDecided{snapshotNumber = sn}

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -294,14 +294,17 @@ onOpenClientNewTx tx =
 --
 -- __Transition__: 'OpenState' → 'OpenState'
 onOpenNetworkReqTx ::
+  IsTx tx =>
+  Environment ->
   Ledger tx ->
   ChainSlot ->
   OpenState tx ->
   TTL ->
+  PendingDeposits tx ->
   -- | The transaction to be submitted to the head.
   tx ->
   Outcome tx
-onOpenNetworkReqTx ledger currentSlot st ttl tx =
+onOpenNetworkReqTx env ledger currentSlot st ttl pendingDeposits tx =
   -- Keep track of transactions by-id
   (newState TransactionReceived{tx} <>) $
     -- Spec: wait L̂ ◦ tx ≠ ⊥
@@ -309,7 +312,25 @@ onOpenNetworkReqTx ledger currentSlot st ttl tx =
       -- Spec: T̂ ← T̂ ⋃ {tx}
       --       L̂  ← L̂ ◦ tx
       newState TransactionAppliedToLocalUTxO{headId, tx, newLocalUTxO}
+        -- Spec: if ŝ = ̅S.s ∧ leader(̅S.s + 1) = i
+        --         multicast (reqSn, v, ̅S.s + 1, T̂ , 𝑈𝛼, txω )
+        & maybeRequestSnapshot (confirmedSn + 1)
  where
+  -- If this node is the snapshot leader for the next snapshot and no snapshot
+  -- is currently in flight, immediately send a 'ReqSn' including the newly
+  -- received transaction. This eliminates the timer delay for single-tx
+  -- patterns (submit → confirm → submit) where 'localTxs' would otherwise
+  -- be empty when the timer fires.
+  maybeRequestSnapshot nextSn outcome =
+    if not (snapshotInFlight seenSnapshot nextSn) && isLeader parameters party nextSn
+      then
+        outcome
+          <> newState SnapshotRequestDecided{snapshotNumber = nextSn}
+          <> cause (NetworkEffect $ ReqSn version nextSn (txId <$> take maxTxsPerSnapshot localTxs') decommitToInclude (setExistingDeposit pendingDeposits depositToInclude))
+      else outcome
+
+  Environment{party} = env
+
   waitApplyTx cont =
     case applyTransactions currentSlot localUTxO [tx] of
       Right utxo' -> cont utxo'
@@ -330,9 +351,26 @@ onOpenNetworkReqTx ledger currentSlot st ttl tx =
 
   Ledger{applyTransactions} = ledger
 
-  CoordinatedHeadState{localUTxO} = coordinatedHeadState
+  -- NOTE: include the newly received tx in the snapshot (not yet in localTxs
+  -- since TransactionAppliedToLocalUTxO is aggregated after this outcome).
+  localTxs' = localTxs <> [tx]
 
-  OpenState{coordinatedHeadState, headId} = st
+  decommitToInclude = skipPostedDecommit (getSnapshot confirmedSnapshot) decommitTx
+  depositToInclude = skipPostedDeposit pendingDeposits currentDepositTxId (getSnapshot confirmedSnapshot).utxoToCommit
+
+  confirmedSn = number $ getSnapshot confirmedSnapshot
+
+  CoordinatedHeadState
+    { localTxs
+    , localUTxO
+    , confirmedSnapshot
+    , seenSnapshot
+    , decommitTx
+    , version
+    , currentDepositTxId
+    } = coordinatedHeadState
+
+  OpenState{coordinatedHeadState, headId, parameters} = st
 
 -- | Process a snapshot request ('ReqSn') from party.
 --
@@ -1723,8 +1761,8 @@ handleNetworkInput env ledger ChainPointTime{currentSlot} pendingDeposits st ev 
   (_, NetworkInput _ (ConnectivityEvent conn)) ->
     onConnectionEvent env.configuredPeers conn
   -- Open
-  (Open openState, NetworkInput ttl (ReceivedMessage{msg = ReqTx tx})) ->
-    onOpenNetworkReqTx ledger currentSlot openState ttl tx
+  (Open openState@OpenState{headId = ourHeadId}, NetworkInput ttl (ReceivedMessage{msg = ReqTx tx})) ->
+    onOpenNetworkReqTx env ledger currentSlot openState ttl (depositsForHead ourHeadId pendingDeposits) tx
   (Open openState@OpenState{headId = ourHeadId}, NetworkInput _ (ReceivedMessage{sender, msg = ReqSn sv sn txIds decommitTx depositTxId})) ->
     onOpenNetworkReqSn env ledger (depositsForHead ourHeadId pendingDeposits) currentSlot openState sender sv sn txIds decommitTx depositTxId
   (Open openState@OpenState{headId = ourHeadId}, NetworkInput _ (ReceivedMessage{sender, msg = AckSn snapshotSignature sn})) ->

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1546,14 +1546,19 @@ onOpenTimer ::
 onOpenTimer Environment{party} pendingDeposits st =
   if isLeader st.parameters party nextSn
     then case chs.seenSnapshot of
-      -- Re-send: previous ReqSn was likely rejected due to version mismatch
-      -- (DecommitFinalized/CommitFinalized bumped the version after we sent it).
-      RequestedSnapshot{} ->
-        sendReqSn chs.version nextSn chs.localTxs decommitToInclude depositToInclude
+      -- Do nothing: we just sent ReqSn and are waiting for our own network echo
+      -- to arrive so we can sign it. The echo is imminent; re-sending here would
+      -- use stale state (e.g. currentDepositTxId is not yet set before the echo
+      -- is processed) and would broadcast a different snapshot content to peers,
+      -- causing signature mismatches. After a version bump DecommitFinalized/
+      -- CommitFinalized resets to LastSeenSnapshot (not RequestedSnapshot), so
+      -- this branch is never reached for version-mismatch retries.
+      RequestedSnapshot{} -> noop
       -- Re-send: stuck with partial signatures (some AckSns were dropped because
       -- peers weren't ready yet, e.g. waiting for deposit activation). Re-broadcast
-      -- the same ReqSn without changing state so we keep existing signatures.
-      -- Also re-broadcast our own AckSn so late signers can complete the round.
+      -- exactly the same ReqSn content that was originally signed (from the in-flight
+      -- snapshot) so all parties sign the same thing. Also re-broadcast our own AckSn
+      -- so late signers can complete the round.
       SeenSnapshot snapshot sigs ->
         broadcastReqSn snapshot.version snapshot.number (txId <$> snapshot.confirmed) decommitToInclude depositToInclude
           <> case Map.lookup party sigs of

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -486,7 +486,7 @@ onOpenNetworkReqSn env ledger pendingDeposits currentSlot st otherParty sv sn re
             -- Error out in case we receive a ReqSn that doesn't match local deposit
             Error $ RequireFailed RequestedDepositNotFoundLocally{depositTxId}
           Just Deposit{status, deposited}
-            | status == Inactive -> noop
+            | status == Inactive -> wait WaitOnDepositActivation{depositTxId}
             | status == Expired -> Error $ RequireFailed RequestedDepositExpired{depositTxId}
             | otherwise ->
                 -- NOTE: this makes the commits sequential in a sense that you can't

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1947,7 +1947,16 @@ aggregateNodeState nodeState sc =
             }
         DepositActivated{depositTxId, deposit} ->
           nodeState
-            { headState = st
+            { headState = case st of
+                Open os@OpenState{coordinatedHeadState = chs} ->
+                  Open
+                    os
+                      { coordinatedHeadState =
+                          chs
+                            { currentDepositTxId = chs.currentDepositTxId <|> Just depositTxId
+                            }
+                      }
+                _ -> st
             , pendingDeposits = Map.insert depositTxId deposit currentPendingDeposits
             }
         DepositExpired{depositTxId, deposit} ->

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1083,7 +1083,6 @@ recoverSnapshotTxs ledger currentSlot headId chs =
 --
 -- __Transition__: 'OpenState' → 'OpenState'
 onOpenChainIncrementTx ::
-  IsTx tx =>
   Ledger tx ->
   ChainSlot ->
   OpenState tx ->
@@ -1110,7 +1109,6 @@ onOpenChainIncrementTx ledger currentSlot openState newChainState newVersion dep
 --
 -- __Transition__: 'OpenState' → 'OpenState'
 onOpenChainDecrementTx ::
-  IsTx tx =>
   Ledger tx ->
   ChainSlot ->
   OpenState tx ->

--- a/hydra-node/src/Hydra/HeadLogic/Input.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Input.hs
@@ -22,6 +22,9 @@ data Input tx
     NetworkInput {ttl :: TTL, networkEvent :: NetworkEvent (Message tx)}
   | -- | Input received from the chain via a "Hydra.Chain".
     ChainInput {chainEvent :: ChainEvent tx}
+  | -- | Periodic timer tick used to drive the snapshot leader to retry sending
+    -- a 'ReqSn' when a previous request was rejected due to a version mismatch.
+    TimerInput
   deriving stock (Generic)
 
 deriving stock instance IsChainState tx => Eq (Input tx)

--- a/hydra-node/src/Hydra/HeadLogic/Outcome.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Outcome.hs
@@ -202,6 +202,7 @@ data WaitReason tx
   | WaitOnUnresolvedCommit {commitUTxO :: UTxOType tx}
   | WaitOnUnresolvedDecommit {decommitTx :: tx}
   | WaitOnDepositObserved {depositTxId :: TxIdType tx}
+  | WaitOnDepositActivation {depositTxId :: TxIdType tx}
   | WaitOnNodeInSync {currentSlot :: ChainSlot}
   deriving stock (Generic)
 

--- a/hydra-node/src/Hydra/HeadLogic/Outcome.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Outcome.hs
@@ -192,16 +192,12 @@ changes stateChanges = Continue stateChanges []
 
 data WaitReason tx
   = WaitOnNotApplicableTx {validationError :: ValidationError}
-  | WaitOnSnapshotNumber {waitingForNumber :: SnapshotNumber}
-  | WaitOnSnapshotVersion {waitingForVersion :: SnapshotVersion}
-  | WaitOnSeenSnapshot
   | WaitOnTxs {waitingForTxIds :: [TxIdType tx]}
   | WaitOnContestationDeadline
   | WaitOnNotApplicableDecommitTx {notApplicableReason :: DecommitInvalidReason tx}
   | WaitOnUnresolvedCommit {commitUTxO :: UTxOType tx}
   | WaitOnUnresolvedDecommit {decommitTx :: tx}
   | WaitOnDepositObserved {depositTxId :: TxIdType tx}
-  | WaitOnDepositActivation {depositTxId :: TxIdType tx}
   | WaitOnNodeInSync {currentSlot :: ChainSlot}
   deriving stock (Generic)
 

--- a/hydra-node/src/Hydra/HeadLogic/Outcome.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Outcome.hs
@@ -140,6 +140,10 @@ data StateChanged tx
       , participants :: [OnChainId]
       }
   | TxInvalid {headId :: HeadId, utxo :: UTxOType tx, transaction :: tx, validationError :: ValidationError}
+  | TxsRequeued
+      { txs :: [tx]
+      , newLocalUTxO :: UTxOType tx
+      }
   | LocalStateCleared {headId :: HeadId, snapshotNumber :: SnapshotNumber}
   | Checkpoint {state :: NodeState tx}
   | NodeUnsynced {chainSlot :: ChainSlot, chainTime :: UTCTime, drift :: NominalDiffTime}

--- a/hydra-node/src/Hydra/HeadLogic/Outcome.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Outcome.hs
@@ -83,6 +83,10 @@ data StateChanged tx
       , newLocalUTxO :: UTxOType tx
       }
   | SnapshotRequestDecided {snapshotNumber :: SnapshotNumber}
+  | -- | The leader's own ReqSn echo failed validation (e.g. stale decommit or
+    -- expired deposit). Resets 'seenSnapshot' back to 'LastSeenSnapshot' so the
+    -- timer can retry with fresh content instead of being stuck forever.
+    SnapshotRequestAborted {snapshotNumber :: SnapshotNumber, lastSeenSnapshotNumber :: SnapshotNumber}
   | -- | A snapshot was requested by some party.
     -- NOTE: We deliberately already include an updated local ledger state to
     -- not need a ledger to interpret this event.

--- a/hydra-node/src/Hydra/Ledger/Simple.hs
+++ b/hydra-node/src/Hydra/Ledger/Simple.hs
@@ -85,6 +85,7 @@ instance IsTx SimpleTx where
   balance = Set.size
   hashUTxO = toStrict . foldMap (serialise . unSimpleTxOut)
   utxoFromTx = txOutputs
+  resolveInputsUTxO _utxo = txInputs
   outputsOfUTxO = toList
   withoutUTxO = Set.difference
 

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -72,6 +72,7 @@ initEnvironment options = do
       , contestationPeriod
       , depositPeriod
       , unsyncedPeriod
+      , snapshotRetryInterval
       , configuredPeers
       }
  where
@@ -118,6 +119,7 @@ initEnvironment options = do
     , chainConfig
     , advertise
     , peers
+    , snapshotRetryInterval
     } = options
 
 -- | Checks that command line options match a given 'HeadState'. This function
@@ -287,17 +289,23 @@ data HydraNode tx m = HydraNode
 runHydraNode ::
   ( MonadCatch m
   , MonadAsync m
+  , MonadDelay m
   , MonadTime m
   , IsChainState tx
   ) =>
   HydraNode tx m ->
   m ()
-runHydraNode node =
-  -- NOTE(SN): here we could introduce concurrent head processing, e.g. with
-  -- something like 'forM_ [0..1] $ async'
-  forever $ do
-    now <- getCurrentTime
-    stepHydraNode now node
+runHydraNode node@HydraNode{inputQueue = InputQueue{enqueue}, env = Environment{snapshotRetryInterval}} =
+  withAsyncLabelled ("snapshot-retry-timer", timerThread) $ \_ ->
+    -- NOTE(SN): here we could introduce concurrent head processing, e.g. with
+    -- something like 'forM_ [0..1] $ async'
+    forever $ do
+      now <- getCurrentTime
+      stepHydraNode now node
+ where
+  timerThread = forever $ do
+    threadDelay (realToFrac snapshotRetryInterval)
+    enqueue TimerInput
 
 stepHydraNode ::
   ( MonadCatch m

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -239,6 +239,11 @@ wireClientInput node = enqueue . ClientInput
  where
   DraftHydraNode{inputQueue = InputQueue{enqueue}} = node
 
+tryWireClientInput :: DraftHydraNode tx m -> (ClientInput tx -> m Bool)
+tryWireClientInput node = tryEnqueueClient . ClientInput
+ where
+  DraftHydraNode{inputQueue = InputQueue{tryEnqueueClient}} = node
+
 wireNetworkInput :: DraftHydraNode tx m -> NetworkCallback (Authenticated (Message tx)) m
 wireNetworkInput node =
   NetworkCallback

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -295,7 +295,7 @@ runHydraNode ::
   ) =>
   HydraNode tx m ->
   m ()
-runHydraNode node@HydraNode{inputQueue = InputQueue{enqueue}, env = Environment{snapshotRetryInterval}} =
+runHydraNode node@HydraNode{inputQueue = InputQueue{tryEnqueue}, nodeStateHandler = NodeStateHandler{queryNodeState}, env = Environment{snapshotRetryInterval}} =
   withAsyncLabelled ("snapshot-retry-timer", timerThread) $ \_ ->
     -- NOTE(SN): here we could introduce concurrent head processing, e.g. with
     -- something like 'forM_ [0..1] $ async'
@@ -303,9 +303,26 @@ runHydraNode node@HydraNode{inputQueue = InputQueue{enqueue}, env = Environment{
       now <- getCurrentTime
       stepHydraNode now node
  where
+  -- NOTE: Only enqueue TimerInput when the head is Open. In other states
+  -- (Idle, Initial, Closed) the timer is a no-op in HeadLogic, so firing it
+  -- 200×/s (default 5 ms interval) only creates noise: STM contention on the
+  -- input queue and pressure on the logging queue. Both stall the main loop
+  -- and delay chain event processing (e.g. OnCollectComTx → HeadIsOpen).
+  -- Use tryEnqueue (non-blocking) so a full queue never stalls this thread.
   timerThread = forever $ do
     threadDelay (realToFrac snapshotRetryInterval)
-    enqueue TimerInput
+    isOpen <- atomically $ do
+      -- NOTE: Reading nodeState here does not slow down the main loop. In GHC
+      -- STM, writers never retry because of readers in other transactions —
+      -- only readers retry when a concurrent write invalidates their snapshot.
+      -- The main loop's modifyNodeState (the critical path) is therefore
+      -- unaffected; only this timer read may occasionally retry, which is
+      -- harmless given the 5 ms sleep that follows.
+      ns <- queryNodeState
+      pure $ case headState ns of
+        Open{} -> True
+        _ -> False
+    when isOpen $ void $ tryEnqueue TimerInput
 
 stepHydraNode ::
   ( MonadCatch m
@@ -318,9 +335,20 @@ stepHydraNode ::
   m ()
 stepHydraNode now node = do
   i@Queued{queuedId, queuedItem} <- dequeue
-  traceWith tracer $ BeginInput{by = party, inputId = queuedId, input = queuedItem}
+  -- NOTE: Skip verbose per-tick tracing for TimerInput. The timer fires at
+  -- ~200 Hz (default 5 ms interval) and each trace call uses a bounded,
+  -- blocking log queue (capacity 500). At 600 trace entries/sec the log queue
+  -- fills in < 1 s, causing traceWith to block and stalling the main loop —
+  -- which delays chain event processing (e.g. OnCollectComTx → HeadIsOpen).
+  -- Any meaningful work the timer actually triggers (e.g. SnapshotRequested)
+  -- is already recorded through its own state-change and effect traces.
+  let skipTrace = case queuedItem of TimerInput -> True; _ -> False
+  unless skipTrace $
+    traceWith tracer $
+      BeginInput{by = party, inputId = queuedId, input = queuedItem}
   outcome <- atomically $ processNextInput node queuedItem now
-  traceWith tracer (LogicOutcome party outcome)
+  unless skipTrace $
+    traceWith tracer (LogicOutcome party outcome)
   case outcome of
     Continue{stateChanges, effects} -> do
       processStateChanges node stateChanges
@@ -329,7 +357,8 @@ stepHydraNode now node = do
       processStateChanges node stateChanges
       maybeReenqueue i
     Error{} -> pure ()
-  traceWith tracer EndInput{by = party, inputId = queuedId}
+  unless skipTrace $
+    traceWith tracer EndInput{by = party, inputId = queuedId}
  where
   maybeReenqueue q@Queued{queuedId, queuedItem} =
     case queuedItem of

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -430,15 +430,16 @@ processEffects node tracer inputId effects = do
       ClientEffect i -> sendMessage server i
       NetworkEffect msg -> broadcast hn msg
       OnChainEffect{postChainTx} ->
-        postTx postChainTx
-          `catch` \(postTxError :: PostTxError tx) ->
-            enqueue . ChainInput $ PostTxError{postChainTx, postTxError, failingTx = Nothing}
+        asyncTracked $
+          postTx postChainTx
+            `catch` \(postTxError :: PostTxError tx) ->
+              enqueue (ChainInput $ PostTxError{postChainTx, postTxError, failingTx = Nothing})
     traceWith tracer $ EndEffect party inputId effectId
 
   HydraNode
     { hn
     , oc = Chain{postTx}
-    , inputQueue = InputQueue{enqueue}
+    , inputQueue = InputQueue{enqueue, asyncTracked}
     , env = Environment{party}
     , server
     } = node

--- a/hydra-node/src/Hydra/Node/Environment.hs
+++ b/hydra-node/src/Hydra/Node/Environment.hs
@@ -24,6 +24,10 @@ data Environment = Environment
   , unsyncedPeriod :: UnsyncedPeriod
   -- ^ Period of time after which we consider the node becoming unsynced with the chain.
   -- Beyond this period the node will refuse to process new transactions and signing snapshots.
+  , snapshotRetryInterval :: NominalDiffTime
+  -- ^ How often the snapshot leader retries sending a ReqSn after a version
+  -- mismatch. Should be shorter than the chain block time so stale requests
+  -- are corrected quickly.
   , configuredPeers :: Text
   -- ^ Configured peers for the network layer, used for comparison on etcd errors.
   }

--- a/hydra-node/src/Hydra/Node/InputQueue.hs
+++ b/hydra-node/src/Hydra/Node/InputQueue.hs
@@ -25,6 +25,11 @@ data InputQueue m e = InputQueue
   -- one timer tick is ever pending: consecutive ticks carry no new
   -- information, and keeping only one prevents timer ticks from crowding out
   -- chain/network events. The coalescing resets whenever 'enqueue' is called.
+  , tryEnqueueClient :: e -> m Bool
+  -- ^ Non-blocking variant for client-submitted inputs (e.g. 'NewTx').
+  -- Returns 'False' if the queue is full (back pressure signal); 'True' if
+  -- the item was enqueued. Unlike 'tryEnqueue', does NOT coalesce consecutive
+  -- calls — every invocation is independent.
   , reenqueue :: DiffTime -> Queued e -> m ()
   , asyncTracked :: m () -> m ()
   -- ^ Run an action asynchronously. Use this for
@@ -68,6 +73,17 @@ createInputQueue = do
               then pure False
               else do
                 writeTVar lastWasTimer True
+                queuedId <- readTVar nextId
+                writeTBQueue q Queued{queuedId, queuedItem}
+                modifyTVar' nextId succ
+                pure True
+      , tryEnqueueClient = \queuedItem ->
+          atomically $ do
+            full <- isFullTBQueue q
+            if full
+              then pure False
+              else do
+                writeTVar lastWasTimer False
                 queuedId <- readTVar nextId
                 writeTBQueue q Queued{queuedId, queuedItem}
                 modifyTVar' nextId succ

--- a/hydra-node/src/Hydra/Node/InputQueue.hs
+++ b/hydra-node/src/Hydra/Node/InputQueue.hs
@@ -5,6 +5,7 @@ import Hydra.Prelude
 
 import Control.Concurrent.Class.MonadSTM (
   isEmptyTBQueue,
+  isFullTBQueue,
   modifyTVar',
   readTBQueue,
   writeTBQueue,
@@ -15,6 +16,12 @@ import Control.Concurrent.Class.MonadSTM (
 -- alternative implementation
 data InputQueue m e = InputQueue
   { enqueue :: e -> m ()
+  , tryEnqueue :: e -> m Bool
+  -- ^ Non-blocking variant of 'enqueue'. Returns 'False' if the queue is
+  -- full and the item was dropped. Use this for periodic/timer inputs that
+  -- are safe to skip: a full queue means the main loop is busy processing
+  -- other events (chain observations, network messages), so the timer tick
+  -- is effectively replaced by the next one that fires after the queue drains.
   , reenqueue :: DiffTime -> Queued e -> m ()
   , dequeue :: m (Queued e)
   , isEmpty :: m Bool
@@ -44,6 +51,16 @@ createInputQueue = do
             queuedId <- readTVar nextId
             writeTBQueue q Queued{queuedId, queuedItem}
             modifyTVar' nextId succ
+      , tryEnqueue = \queuedItem ->
+          atomically $ do
+            full <- isFullTBQueue q
+            if full
+              then pure False
+              else do
+                queuedId <- readTVar nextId
+                writeTBQueue q Queued{queuedId, queuedItem}
+                modifyTVar' nextId succ
+                pure True
       , reenqueue = \delay e -> do
           atomically $ modifyTVar' numThreads succ
           void . asyncLabelled "input-queue-reenqueue" $ do

--- a/hydra-node/src/Hydra/Node/InputQueue.hs
+++ b/hydra-node/src/Hydra/Node/InputQueue.hs
@@ -23,6 +23,9 @@ data InputQueue m e = InputQueue
   -- other events (chain observations, network messages), so the timer tick
   -- is effectively replaced by the next one that fires after the queue drains.
   , reenqueue :: DiffTime -> Queued e -> m ()
+  , asyncTracked :: m () -> m ()
+  -- ^ Run an action asynchronously. Use this for
+  -- background work that will eventually 'enqueue' an item.
   , dequeue :: m (Queued e)
   , isEmpty :: m Bool
   }
@@ -33,6 +36,7 @@ createInputQueue ::
   ( MonadDelay m
   , MonadAsync m
   , MonadLabelledSTM m
+  , MonadThrow m
   ) =>
   m (InputQueue m e)
 createInputQueue = do
@@ -68,6 +72,10 @@ createInputQueue = do
             atomically $ do
               modifyTVar' numThreads pred
               writeTBQueue q e
+      , asyncTracked = \action -> do
+          atomically $ modifyTVar' numThreads succ
+          void . asyncLabelled "input-queue-async-tracked" $
+            action `finally` atomically (modifyTVar' numThreads pred)
       , dequeue =
           atomically $ readTBQueue q
       , isEmpty = do

--- a/hydra-node/src/Hydra/Node/InputQueue.hs
+++ b/hydra-node/src/Hydra/Node/InputQueue.hs
@@ -8,6 +8,7 @@ import Control.Concurrent.Class.MonadSTM (
   isFullTBQueue,
   modifyTVar',
   readTBQueue,
+  retry,
   writeTBQueue,
   writeTVar,
  )
@@ -88,5 +89,12 @@ createInputQueue = do
           atomically $ do
             n <- readTVar numThreads
             isEmpty' <- isEmptyTBQueue q
-            pure (isEmpty' && n == 0)
+            -- When queue is empty but async threads are still running,
+            -- block (retry) until threads complete. This prevents
+            -- runToCompletion from blocking forever in dequeue when an
+            -- OnChainEffect spawns an asyncTracked thread that finishes
+            -- without adding items to the queue.
+            if isEmpty' && n /= 0
+              then retry
+              else pure (isEmpty' && n == 0)
       }

--- a/hydra-node/src/Hydra/Node/InputQueue.hs
+++ b/hydra-node/src/Hydra/Node/InputQueue.hs
@@ -9,6 +9,7 @@ import Control.Concurrent.Class.MonadSTM (
   modifyTVar',
   readTBQueue,
   writeTBQueue,
+  writeTVar,
  )
 
 -- | The single, required queue in the system from which a hydra head is "fed".
@@ -17,11 +18,12 @@ import Control.Concurrent.Class.MonadSTM (
 data InputQueue m e = InputQueue
   { enqueue :: e -> m ()
   , tryEnqueue :: e -> m Bool
-  -- ^ Non-blocking variant of 'enqueue'. Returns 'False' if the queue is
-  -- full and the item was dropped. Use this for periodic/timer inputs that
-  -- are safe to skip: a full queue means the main loop is busy processing
-  -- other events (chain observations, network messages), so the timer tick
-  -- is effectively replaced by the next one that fires after the queue drains.
+  -- ^ Non-blocking, coalescing variant of 'enqueue' for periodic/timer
+  -- inputs. Returns 'False' (drops the item) if the queue is full OR if the
+  -- last enqueued item was also via 'tryEnqueue'. The latter ensures at most
+  -- one timer tick is ever pending: consecutive ticks carry no new
+  -- information, and keeping only one prevents timer ticks from crowding out
+  -- chain/network events. The coalescing resets whenever 'enqueue' is called.
   , reenqueue :: DiffTime -> Queued e -> m ()
   , asyncTracked :: m () -> m ()
   -- ^ Run an action asynchronously. Use this for
@@ -42,6 +44,7 @@ createInputQueue ::
 createInputQueue = do
   numThreads <- newLabelledTVarIO "num-threads" (0 :: Integer)
   nextId <- newLabelledTVarIO "nex-id" 0
+  lastWasTimer <- newLabelledTVarIO "last-was-timer" False
   -- XXX: We bound the _input_ queue by the _logging_ queue size! This is a
   -- hack; but we do it because it seems that the logging queue blocking
   -- prevents further processing, _unless_ the input queue is also bounded.
@@ -52,15 +55,18 @@ createInputQueue = do
     InputQueue
       { enqueue = \queuedItem ->
           atomically $ do
+            writeTVar lastWasTimer False
             queuedId <- readTVar nextId
             writeTBQueue q Queued{queuedId, queuedItem}
             modifyTVar' nextId succ
       , tryEnqueue = \queuedItem ->
           atomically $ do
+            alreadyPending <- readTVar lastWasTimer
             full <- isFullTBQueue q
-            if full
+            if alreadyPending || full
               then pure False
               else do
+                writeTVar lastWasTimer True
                 queuedId <- readTVar nextId
                 writeTBQueue q Queued{queuedId, queuedItem}
                 modifyTVar' nextId succ

--- a/hydra-node/src/Hydra/Node/Run.hs
+++ b/hydra-node/src/Hydra/Node/Run.hs
@@ -43,6 +43,7 @@ import Hydra.Node (
   hydrate,
   initEnvironment,
   runHydraNode,
+  tryWireClientInput,
   wireChainInput,
   wireClientInput,
   wireNetworkInput,
@@ -106,7 +107,7 @@ run opts = do
           traceWith tracer' ChainBackendStarted
           -- API
           let apiServerConfig = APIServerConfig{host = apiHost, port = apiPort, tlsCertPath, tlsKeyPath, apiTransactionTimeout}
-          withAPIServer apiServerConfig env stateFile party eventSource (contramap APIServer tracer) initialChainState chain pparams serverOutputFilter (wireClientInput wetHydraNode) $ \(apiSink, server) -> do
+          withAPIServer apiServerConfig env stateFile party eventSource (contramap APIServer tracer) initialChainState chain pparams serverOutputFilter (wireClientInput wetHydraNode) (tryWireClientInput wetHydraNode) $ \(apiSink, server) -> do
             -- Network
             let networkConfiguration =
                   NetworkConfiguration

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -214,6 +214,9 @@ data RunOptions = RunOptions
   , ledgerConfig :: LedgerConfig
   , whichEtcd :: WhichEtcd
   , apiTransactionTimeout :: ApiTransactionTimeout
+  , snapshotRetryInterval :: NominalDiffTime
+  -- ^ How often the snapshot leader retries sending a ReqSn. Defaults to 10
+  -- seconds, which is shorter than a typical Cardano block time.
   }
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
@@ -247,6 +250,7 @@ defaultRunOptions =
     , ledgerConfig = defaultLedgerConfig
     , whichEtcd = EmbeddedEtcd
     , apiTransactionTimeout = 300
+    , snapshotRetryInterval = defaultSnapshotRetryInterval
     }
  where
   localhost = IPv4 $ toIPv4 [127, 0, 0, 1]
@@ -273,6 +277,7 @@ runOptionsParser =
     <*> ledgerConfigParser
     <*> whichEtcdParser
     <*> apiTransactionTimeoutParser
+    <*> snapshotRetryIntervalParser
 
 whichEtcdParser :: Parser WhichEtcd
 whichEtcdParser =
@@ -736,6 +741,25 @@ apiTransactionTimeoutParser =
           \takes longer than this, it will be cancelled."
     )
 
+-- | Default snapshot retry interval: 10 seconds, shorter than a typical
+-- Cardano block time (~20s) so stale ReqSn requests are corrected quickly.
+defaultSnapshotRetryInterval :: NominalDiffTime
+defaultSnapshotRetryInterval = 10
+
+snapshotRetryIntervalParser :: Parser NominalDiffTime
+snapshotRetryIntervalParser =
+  option
+    auto
+    ( long "snapshot-retry-interval"
+        <> metavar "SECONDS"
+        <> value defaultSnapshotRetryInterval
+        <> showDefault
+        <> help
+          "How often the snapshot leader retries sending a snapshot request \
+          \after a version mismatch (in seconds). Should be shorter than the \
+          \chain block time so stale requests are corrected quickly."
+    )
+
 startChainFromParser :: Parser ChainPoint
 startChainFromParser =
   option
@@ -976,6 +1000,7 @@ toArgs
     , ledgerConfig
     , whichEtcd
     , apiTransactionTimeout
+    , snapshotRetryInterval
     } =
     isVerbose verbosity
       <> ["--node-id", unpack nId]
@@ -995,6 +1020,7 @@ toArgs
       <> argsChainConfig chainConfig
       <> argsLedgerConfig
       <> ["--api-transaction-timeout", show apiTransactionTimeout]
+      <> ["--snapshot-retry-interval", show snapshotRetryInterval]
    where
     (NodeId nId) = nodeId
 

--- a/hydra-node/src/Hydra/Options.hs
+++ b/hydra-node/src/Hydra/Options.hs
@@ -215,8 +215,8 @@ data RunOptions = RunOptions
   , whichEtcd :: WhichEtcd
   , apiTransactionTimeout :: ApiTransactionTimeout
   , snapshotRetryInterval :: NominalDiffTime
-  -- ^ How often the snapshot leader retries sending a ReqSn. Defaults to 10
-  -- seconds, which is shorter than a typical Cardano block time.
+  -- ^ How often the snapshot leader retries sending a ReqSn. Defaults to 5
+  -- milliseconds (0.005s).
   }
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
@@ -741,10 +741,9 @@ apiTransactionTimeoutParser =
           \takes longer than this, it will be cancelled."
     )
 
--- | Default snapshot retry interval: 10 seconds, shorter than a typical
--- Cardano block time (~20s) so stale ReqSn requests are corrected quickly.
+-- | Default snapshot retry interval: 5 milliseconds.
 defaultSnapshotRetryInterval :: NominalDiffTime
-defaultSnapshotRetryInterval = 10
+defaultSnapshotRetryInterval = 0.005
 
 snapshotRetryIntervalParser :: Parser NominalDiffTime
 snapshotRetryIntervalParser =

--- a/hydra-node/test/Hydra/API/HTTPServerSpec.hs
+++ b/hydra-node/test/Hydra/API/HTTPServerSpec.hs
@@ -890,7 +890,7 @@ apiServerSpec = do
               (pure inIdleState)
               (pure CannotCommit)
               (pure [])
-              (const $ pure ())  -- putClientInput (blocking, not used for NewTx)
+              (const $ pure ()) -- putClientInput (blocking, not used for NewTx)
               (\_ -> pure False) -- tryPutNewTx: always rejects (simulates full queue)
               10
               responseChannel

--- a/hydra-node/test/Hydra/API/HTTPServerSpec.hs
+++ b/hydra-node/test/Hydra/API/HTTPServerSpec.hs
@@ -240,6 +240,7 @@ apiServerSpec = do
               cantCommit
               getPendingDeposits
               putClientInput
+              (\_ -> pure True)
               300
               responseChannel
         )
@@ -273,6 +274,7 @@ apiServerSpec = do
               cantCommit
               getPendingDeposits
               putClientInput
+              (\_ -> pure True)
               300
               responseChannel
           )
@@ -311,6 +313,7 @@ apiServerSpec = do
                   cantCommit
                   getPendingDeposits
                   putClientInput
+                  (\_ -> pure True)
                   300
                   responseChannelSimpleTx
               )
@@ -337,6 +340,7 @@ apiServerSpec = do
               cantCommit
               getPendingDeposits
               putClientInput
+              (\_ -> pure True)
               300
               responseChannel
           )
@@ -358,6 +362,7 @@ apiServerSpec = do
               cantCommit
               getPendingDeposits
               putClientInput
+              (\_ -> pure True)
               300
               responseChannel
           )
@@ -382,6 +387,7 @@ apiServerSpec = do
                   cantCommit
                   getPendingDeposits
                   putClientInput
+                  (\_ -> pure True)
                   300
                   responseChannelSimpleTx
               )
@@ -410,6 +416,7 @@ apiServerSpec = do
               cantCommit
               getPendingDeposits
               putClientInput
+              (\_ -> pure True)
               0
               responseChannel
           )
@@ -438,6 +445,7 @@ apiServerSpec = do
               cantCommit
               getPendingDeposits
               (const $ atomically $ writeTChan responseChannel (Left event))
+              (\_ -> pure True)
               10
               responseChannel
           )
@@ -460,6 +468,7 @@ apiServerSpec = do
               cantCommit
               getPendingDeposits
               (const $ atomically $ writeTChan responseChannel clientFailed)
+              (\_ -> pure True)
               10
               responseChannel
           )
@@ -489,6 +498,7 @@ apiServerSpec = do
               cantCommit
               getPendingDeposits
               (const $ atomically $ writeTChan responseChannel (Right clientFailed))
+              (\_ -> pure True)
               10
               responseChannel
           )
@@ -512,6 +522,7 @@ apiServerSpec = do
               cantCommit
               getPendingDeposits
               (const $ atomically $ writeTChan responseChannel (Right clientFailed))
+              (\_ -> pure True)
               10
               responseChannel
           )
@@ -533,6 +544,7 @@ apiServerSpec = do
               cantCommit
               getPendingDeposits
               putClientInput
+              (\_ -> pure True)
               300
               responseChannel
           )
@@ -561,6 +573,7 @@ apiServerSpec = do
                   cantCommit
                   getPendingDeposits
                   putClientInput
+                  (\_ -> pure True)
                   300
                   responseChannelSimpleTx
               )
@@ -600,6 +613,7 @@ apiServerSpec = do
                 cantCommit
                 getPendingDeposits
                 putClientInput
+                (\_ -> pure True)
                 300
                 responseChannelSimpleTx
             )
@@ -635,6 +649,7 @@ apiServerSpec = do
               getHeadId
               getPendingDeposits
               putClientInput
+              (\_ -> pure True)
               300
               responseChannel
           )
@@ -683,6 +698,7 @@ apiServerSpec = do
                 getHeadId
                 getPendingDeposits
                 putClientInput
+                (\_ -> pure True)
                 300
                 responseChannel
             )
@@ -739,6 +755,7 @@ apiServerSpec = do
                 getHeadId
                 getPendingDeposits
                 putClientInput
+                (\_ -> pure True)
                 300
                 responseChannel
             )
@@ -764,6 +781,7 @@ apiServerSpec = do
               (pure CannotCommit)
               (pure [])
               (const $ pure ())
+              (\_ -> pure True)
               0
               responseChannel
           )
@@ -798,7 +816,8 @@ apiServerSpec = do
               (pure inIdleState)
               (pure CannotCommit)
               (pure [])
-              (const $ atomically $ writeTChan responseChannel (Left event))
+              (const $ pure ())
+              (\_ -> True <$ atomically (writeTChan responseChannel (Left event)))
               10
               responseChannel
           )
@@ -830,7 +849,8 @@ apiServerSpec = do
               (pure inIdleState)
               (pure CannotCommit)
               (pure [])
-              (const $ atomically $ writeTChan responseChannel (Left event))
+              (const $ pure ())
+              (\_ -> True <$ atomically (writeTChan responseChannel (Left event)))
               10
               responseChannel
           )
@@ -850,7 +870,28 @@ apiServerSpec = do
               (pure inUnsyncedIdleState)
               (pure CannotCommit)
               (pure [])
-              (const $ atomically $ writeTChan responseChannel (Right clientFailed))
+              (const $ pure ())
+              (\_ -> True <$ atomically (writeTChan responseChannel (Right clientFailed)))
+              10
+              responseChannel
+          )
+          $ do
+            post "/transaction" (mkReq testTx) `shouldRespondWith` 503
+
+      it "returns 503 immediately when input queue is full" $ do
+        responseChannel <- newTChanIO
+        withApplication
+          ( httpApp @SimpleTx
+              nullTracer
+              dummyChainHandle
+              testEnvironment
+              dummyStatePath
+              defaultPParams
+              (pure inIdleState)
+              (pure CannotCommit)
+              (pure [])
+              (const $ pure ())  -- putClientInput (blocking, not used for NewTx)
+              (\_ -> pure False) -- tryPutNewTx: always rejects (simulates full queue)
               10
               responseChannel
           )
@@ -872,6 +913,7 @@ apiServerSpec = do
               (pure CannotCommit)
               (pure [])
               (const $ pure ())
+              (\_ -> pure True)
               0
               responseChannel
           )
@@ -899,6 +941,7 @@ apiServerSpec = do
               (pure CannotCommit)
               (pure [])
               (const $ atomically $ writeTChan responseChannel (Left event))
+              (\_ -> pure True)
               10
               responseChannel
           )
@@ -926,6 +969,7 @@ apiServerSpec = do
               (pure CannotCommit)
               (pure [])
               (const $ atomically $ writeTChan responseChannel (Left invalid))
+              (\_ -> pure True)
               10
               responseChannel
           )
@@ -947,6 +991,7 @@ apiServerSpec = do
               (pure CannotCommit)
               (pure [])
               (const $ atomically $ writeTChan responseChannel (Right clientFailed))
+              (\_ -> pure True)
               10
               responseChannel
           )
@@ -967,6 +1012,7 @@ apiServerSpec = do
               (pure CannotCommit)
               (pure [])
               (const $ pure ())
+              (\_ -> pure True)
               0
               responseChannel
           )
@@ -989,6 +1035,7 @@ apiServerSpec = do
               (pure CannotCommit)
               (pure [])
               (const $ pure ())
+              (\_ -> pure True)
               0
               responseChannel
           )
@@ -1017,6 +1064,7 @@ apiServerSpec = do
               (pure CannotCommit)
               (pure [])
               (const $ atomically $ writeTChan responseChannel (Left event))
+              (\_ -> pure True)
               10
               responseChannel
           )
@@ -1039,6 +1087,7 @@ apiServerSpec = do
               (pure CannotCommit)
               (pure [])
               (const $ atomically $ writeTChan responseChannel (Right clientFailed))
+              (\_ -> pure True)
               10
               responseChannel
           )

--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -24,6 +24,7 @@ import Data.Text.Encoding (decodeUtf8)
 import Data.Text.IO (hPutStrLn)
 import Data.Version (showVersion)
 import Hydra.API.APIServerLog (APIServerLog)
+import Hydra.API.ClientInput (ClientInput (..))
 import Hydra.API.Server (APIServerConfig (..), RunServerException (..), Server, mkTimedServerOutputFromStateEvent, withAPIServer)
 import Hydra.API.ServerOutput (InvalidInput (..), input)
 import Hydra.API.ServerOutputFilter (ServerOutputFilter (..))
@@ -319,6 +320,33 @@ spec =
         withFreePort $
           \port -> sendsAnErrorWhenInputCannotBeDecoded port
 
+    it "rejects NewTx via WebSocket when input queue is full" $
+      failAfter 5 $
+        showLogsOnFailure "ServerSpec" $ \tracer ->
+          withFreePort $ \port -> do
+            let config = APIServerConfig{host = "127.0.0.1", port, tlsCertPath = Nothing, tlsKeyPath = Nothing, apiTransactionTimeout = 1000000}
+            withAPIServer @SimpleTx
+              config
+              testEnvironment
+              "~"
+              alice
+              (mockSource [])
+              tracer
+              0
+              dummyChainHandle
+              defaultPParams
+              allowEverythingServerOutputFilter
+              noop
+              (\_ -> pure False)
+              $ \_ ->
+                withClient port "/" $ \con -> do
+                  _greeting :: ByteString <- receiveData con
+                  sendBinaryData con (Aeson.encode (NewTx @SimpleTx (SimpleTx 42 mempty mempty)))
+                  msg <- receiveData con
+                  case Aeson.eitherDecode @InvalidInput msg of
+                    Left{} -> failure $ "Failed to decode output " <> show msg
+                    Right InvalidInput{reason} -> reason `shouldContain` "queue"
+
     describe "TLS support" $ do
       it "accepts TLS connections when configured" $ do
         showLogsOnFailure "ServerSpec" $ \tracer ->
@@ -332,7 +360,7 @@ spec =
                     , apiTransactionTimeout = 1000000
                     }
                 initialChainState = 0
-            withAPIServer @SimpleTx config testEnvironment "~" alice (mockSource []) tracer initialChainState dummyChainHandle defaultPParams allowEverythingServerOutputFilter noop $ \_ -> do
+            withAPIServer @SimpleTx config testEnvironment "~" alice (mockSource []) tracer initialChainState dummyChainHandle defaultPParams allowEverythingServerOutputFilter noop (\_ -> pure True) $ \_ -> do
               let clientParams = defaultParamsClient "127.0.0.1" ""
                   allowAnyParams =
                     clientParams{clientHooks = (clientHooks clientParams){onServerCertificate = \_ _ _ _ -> pure []}}
@@ -403,7 +431,7 @@ withTestAPIServer ::
   ((EventSink (StateEvent SimpleTx) IO, Server SimpleTx IO) -> IO ()) ->
   IO ()
 withTestAPIServer port actor eventSource tracer =
-  withAPIServer @SimpleTx config testEnvironment "~" actor eventSource tracer 0 dummyChainHandle defaultPParams allowEverythingServerOutputFilter noop
+  withAPIServer @SimpleTx config testEnvironment "~" actor eventSource tracer 0 dummyChainHandle defaultPParams allowEverythingServerOutputFilter noop (\_ -> pure True)
  where
   config = APIServerConfig{host = "127.0.0.1", port, tlsCertPath = Nothing, tlsKeyPath = Nothing, apiTransactionTimeout = 1000000}
 

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -1042,10 +1042,22 @@ spec = parallel $ do
 
           logs = selectTraceEventsDynamic @_ @(HydraNodeLog SimpleTx) result
 
-      logs
-        `shouldContain` [BeginInput alice 1 (ClientInput Init)]
-      logs
-        `shouldContain` [EndInput alice 1]
+      ( logs
+          `shouldSatisfy` any
+            ( \case
+                BeginInput party _ (ClientInput Init) -> party == alice
+                _ -> False
+            ) ::
+          IO ()
+        )
+      ( logs
+          `shouldSatisfy` any
+            ( \case
+                EndInput party _ -> party == alice
+                _ -> False
+            ) ::
+          IO ()
+        )
 
     it "traces handling of effects" $ do
       let result = runSimTrace $ do
@@ -1065,7 +1077,14 @@ spec = parallel $ do
               (BeginEffect _ _ _ (ClientEffect CommandFailed{})) -> True
               _ -> False
           )
-      logs `shouldContain` [EndEffect alice 1 0]
+      ( logs
+          `shouldSatisfy` any
+            ( \case
+                EndEffect party _ _ -> party == alice
+                _ -> False
+            ) ::
+          IO ()
+        )
 
   describe "rolling back & forward does not make the node crash" $ do
     it "does work for rollbacks past init" $

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -1407,20 +1407,7 @@ simulatedChainAndNetworkWith initialChainState blockTime networkLatency = do
 handleChainEvent :: HydraNode tx m -> ChainEvent tx -> m ()
 handleChainEvent HydraNode{inputQueue} = enqueue inputQueue . ChainInput
 
-createMockNetwork :: MonadSTM m => DraftHydraNode tx m -> TVar m [HydraNode tx m] -> Network m (Message tx)
-createMockNetwork node nodes =
-  Network{broadcast}
- where
-  broadcast msg = do
-    allNodes <- readTVarIO nodes
-    mapM_ (`handleMessage` msg) allNodes
-
-  handleMessage HydraNode{inputQueue} msg =
-    enqueue inputQueue $ mkNetworkInput sender msg
-
-  sender = getParty node
-
--- | Like 'createMockNetwork' but delivers messages after a configurable delay.
+-- | Like the simple mock network but delivers messages after a configurable delay.
 -- When latency > 0, messages are delivered asynchronously so chain events
 -- can arrive before network messages, exposing version race conditions.
 createMockNetworkWithLatency ::

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -292,13 +292,19 @@ spec = parallel $ do
                 send n1 (NewTx $ aValidTx 41)
                 send n1 (NewTx $ aValidTx 42)
 
-                -- With the timer model the leader batches all pending transactions
-                -- when the timer fires, so all three txs appear in snapshot 1.
+                -- The first ReqTx triggers an immediate snapshot from alice (leader
+                -- for sn=1), so tx 40 lands in snapshot 1 alone. Txs 41 and 42
+                -- accumulate while sn=1 is in-flight and get batched into snapshot 2
+                -- by bob (leader for sn=2) when his timer fires.
+                waitUntilMatch [n1, n2] $ \case
+                  SnapshotConfirmed{snapshot = Snapshot{number, confirmed}} ->
+                    guard $ number == 1 && confirmed == [aValidTx 40]
+                  _ -> Nothing
                 waitUntilMatch [n1, n2] $ \case
                   SnapshotConfirmed{snapshot = Snapshot{number, confirmed}} ->
                     -- NOTE: We sort the confirmed to be clear that the order may
                     -- be freely picked by the leader.
-                    guard $ number == 1 && sort confirmed == sort [aValidTx 40, aValidTx 41, aValidTx 42]
+                    guard $ number == 2 && sort confirmed == sort [aValidTx 41, aValidTx 42]
                   _ -> Nothing
 
                 -- As there are no pending transactions and snapshots anymore
@@ -306,7 +312,7 @@ spec = parallel $ do
                 send n1 (NewTx $ aValidTx 44)
                 waitUntilMatch [n1, n2] $ \case
                   SnapshotConfirmed{snapshot = Snapshot{number, confirmed}} ->
-                    guard $ number == 2 && confirmed == [aValidTx 44]
+                    guard $ number == 3 && confirmed == [aValidTx 44]
                   _ -> Nothing
 
       it "depending transactions stay pending and are confirmed in order" $
@@ -321,15 +327,25 @@ spec = parallel $ do
                 send n2 (NewTx secondTx)
                 send n1 (NewTx firstTx)
 
-                -- With the timer model, secondTx becomes applicable after
-                -- firstTx is applied, so both are batched into a single
-                -- snapshot when the timer fires.
-                waitUntil [n1, n2] $ TxValid testHeadId 1
-                waitUntil [n1, n2] $ TxValid testHeadId 2
-                waitUntil [n1, n2] $ do
-                  let snapshot = testSnapshot 1 0 [firstTx, secondTx] (utxoRefs [2, 4])
-                      sigs = aggregate [sign aliceSk snapshot, sign bobSk snapshot]
-                  SnapshotConfirmed testHeadId snapshot sigs
+                -- With the immediate ReqSn model: firstTx arrives at alice
+                -- (leader for sn=1) and triggers an immediate snapshot with
+                -- firstTx only. secondTx is not yet applicable (needs utxoRef
+                -- 3 from firstTx's output). After sn=1 confirms, utxoRef 3
+                -- is available and bob (leader for sn=2) snapshots secondTx.
+                -- NOTE: We do not check TxValid separately because the timer
+                -- retry for secondTx (which moves it from allTxs to localTxs)
+                -- fires after sn=1. Waiting for TxValid{2} would drain
+                -- SnapshotConfirmed{n=1} from the queue, breaking the next
+                -- waitUntilMatch. Confirming the snapshots in order is
+                -- sufficient to prove both transactions were eventually valid.
+                waitUntilMatch [n1, n2] $ \case
+                  SnapshotConfirmed{snapshot = Snapshot{number, confirmed}} ->
+                    guard $ number == 1 && confirmed == [firstTx]
+                  _ -> Nothing
+                waitUntilMatch [n1, n2] $ \case
+                  SnapshotConfirmed{snapshot = Snapshot{number, confirmed}} ->
+                    guard $ number == 2 && confirmed == [secondTx]
+                  _ -> Nothing
 
       it "depending transactions expire if not applicable in time" $
         shouldRunInSim $
@@ -370,17 +386,17 @@ spec = parallel $ do
                         }
                 send n1 (NewTx tx')
                 send n2 (NewTx tx'')
-                -- With the timer model, TxInvalid(tx'') fires at n1 well before the
-                -- timer triggers SnapshotConfirmed (tx'' expires after TTL*waitDelay≈0.5s,
-                -- timer fires at snapshotRetryInterval=10s). Check TxInvalid first on
-                -- n1 only (n2 emits TxInvalid for tx', not tx'').
-                waitUntilMatch [n1] $ \case
-                  TxInvalid{transaction} -> guard $ transaction == tx''
-                  _ -> Nothing
+                -- With the immediate ReqSn model: n1 (leader for sn=1) immediately
+                -- requests a snapshot with tx'. The snapshot confirms before tx''
+                -- expires via TTL. After confirmation, tx'' (which also spends
+                -- utxoRef 1) is invalid at both nodes.
                 waitUntil [n1, n2] $ do
                   let snapshot = testSnapshot 1 0 [tx'] (utxoRefs [2, 10])
                       sigs = aggregate [sign aliceSk snapshot, sign bobSk snapshot]
                   SnapshotConfirmed testHeadId snapshot sigs
+                waitUntilMatch [n1, n2] $ \case
+                  TxInvalid{transaction} -> guard $ transaction == tx''
+                  _ -> Nothing
 
       it "outputs utxo from confirmed snapshot when client requests it" $
         shouldRunInSim $ do
@@ -515,8 +531,12 @@ spec = parallel $ do
                   timeout (fromIntegral dpLong) waitForApproval >>= \case
                     Nothing -> pure ()
                     Just _ -> failure "Deposit was approved before all deposit periods passed"
-                  -- Now it should get approved
-                  waitForApproval
+                  -- Now it should get approved at n1 (which collected all sigs once n2
+                  -- finally signed after its deposit period elapsed). n2 dropped n1's
+                  -- AckSn while waiting, so n2 never independently confirms.
+                  waitUntilMatch [n1] $ \case
+                    CommitApproved{utxoToCommit} -> guard (utxoToCommit == utxoRef 123)
+                    _ -> Nothing
 
         it "requested commits get approved" $
           shouldRunInSim $ do

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -15,7 +15,7 @@ import Control.Concurrent.Class.MonadSTM (
   writeTQueue,
   writeTVar,
  )
-import Control.Monad.Class.MonadAsync (cancel, forConcurrently)
+import Control.Monad.Class.MonadAsync (cancel, concurrently_, forConcurrently)
 import Control.Monad.IOSim (IOSim, runSimTrace, selectTraceEventsDynamic)
 import Data.List ((!!))
 import Data.List qualified as List
@@ -75,6 +75,8 @@ import Test.Hydra.Tx.Fixture (
   aliceSk,
   bob,
   bobSk,
+  carol,
+  carolSk,
   deriveOnChainId,
   testHeadId,
   testHeadSeed,
@@ -902,6 +904,133 @@ spec = parallel $ do
                 HeadIsContested{snapshotNumber} -> guard $ snapshotNumber == 1
                 _ -> Nothing
 
+  describe "Three participant Head" $ do
+    it "processes L2 transactions together with de/commits" $
+      shouldRunInSim $ do
+        withRaceConditionSimulation $ \chain ->
+          withHydraNode aliceSk [bob, carol] chain $ \n1 ->
+            withHydraNode bobSk [alice, carol] chain $ \n2 ->
+              withHydraNode carolSk [alice, bob] chain $ \n3 -> do
+                openHead3 chain n1 n2 n3
+
+                -- A chain of L2 transactions from Alice, each spending the previous output.
+                let numTxs = 10 :: Int
+                let aliceTxs =
+                      [ SimpleTx
+                        (fromIntegral txid)
+                        (if txid == 100 then utxoRef 1 else utxoRef (fromIntegral (txid - 1)))
+                        (utxoRef (fromIntegral txid))
+                      | txid <- [100 .. 100 + numTxs - 1]
+                      ]
+
+                -- We race a decommit against a batch of L2 transactions to trigger the
+                -- version race condition. The key is that one extra transaction is
+                -- deliberately delayed so it lands in the pending queue while the
+                -- decommit snapshot is already in-flight. When that snapshot confirms,
+                -- the leader immediately requests the next snapshot with the old version
+                -- number. In this test setup, chain events arrive before network messages,
+                -- so DecommitFinalized (which bumps the version) reaches all nodes
+                -- before that stale snapshot request does, causing every node to reject
+                -- it with a version mismatch error. Without a timer to retry, the head
+                -- gets permanently stuck.
+                concurrently_
+                  (forM_ aliceTxs $ \tx -> send n1 (NewTx tx) >> threadDelay 0)
+                  ( do
+                      send n3 (Decommit $ SimpleTx 300 (utxoRef 3) (utxoRef 300))
+                      -- Delay this transaction so it arrives after the decommit snapshot
+                      -- has already started collecting signatures. This ensures the leader
+                      -- sees a non-empty pending queue when the decommit snapshot confirms
+                      -- and immediately sends a new snapshot request with the old version.
+                      threadDelay 90
+                      send n1 (NewTx $ SimpleTx 500 (utxoRef 109) (utxoRef 500))
+                  )
+
+                -- Wait for the decommit to be finalised on-chain, which is when the
+                -- version gets bumped. The stale snapshot request rejected by all nodes
+                -- will have arrived by now, leaving the head stuck.
+                waitUntilMatch [n1, n2, n3] $ \case
+                  DecommitFinalized{} -> Just ()
+                  _ -> Nothing
+
+                -- Send one more transaction and wait for it to be confirmed in a snapshot.
+                -- If the version race bug is present this never completes because no node
+                -- can make progress on the next snapshot. With the fix, the leader retries
+                -- with the correct version and the head recovers.
+                send n1 (NewTx $ SimpleTx 999 (utxoRef 2) (utxoRef 999))
+                waitUntilMatch [n1, n2, n3] $ \case
+                  SnapshotConfirmed{snapshot = Snapshot{utxo}} | 999 `member` utxo -> Just ()
+                  _ -> Nothing
+
+                send n1 Close
+                waitUntil [n1, n2, n3] $ ReadyToFanout{headId = testHeadId}
+                send n2 Fanout
+                waitUntilMatch [n1, n2, n3] $ \case
+                  HeadIsFinalized{} -> Just ()
+                  _ -> Nothing
+
+    it "processes L2 transactions together with de/commits (signing-phase version race)" $
+      shouldRunInSim $ do
+        -- This test exercises the SeenSnapshot variant of the version race: AckSns
+        -- arrive *before* DecommitFinalized because networkLatency (20) < blockTime
+        -- (25). When DecommitFinalized fires the leader is already in SeenSnapshot
+        -- state collecting signatures. The old toLastSeenSnapshot code collapsed
+        -- SeenSnapshot{N} to LastSeenSnapshot{N}, making snapshotInFlight return True
+        -- and permanently blocking the timer. The fix collapses to LastSeenSnapshot{N-1}
+        -- so the timer can re-send with the updated version.
+        withSeenSnapshotRaceConditionSimulation $ \chain ->
+          withHydraNode aliceSk [bob, carol] chain $ \n1 ->
+            withHydraNode bobSk [alice, carol] chain $ \n2 ->
+              withHydraNode carolSk [alice, bob] chain $ \n3 -> do
+                openHead3 chain n1 n2 n3
+
+                -- A chain of L2 transactions from Alice, each spending the previous output.
+                let numTxs = 10 :: Int
+                let aliceTxs =
+                      [ SimpleTx
+                        (fromIntegral txid)
+                        (if txid == 100 then utxoRef 1 else utxoRef (fromIntegral (txid - 1)))
+                        (utxoRef (fromIntegral txid))
+                      | txid <- [100 .. 100 + numTxs - 1]
+                      ]
+
+                -- Same race setup as the RequestedSnapshot variant but with
+                -- threadDelay 70 so the staggered tx arrives while the decommit
+                -- snapshot is in the signing phase (SeenSnapshot), not before any
+                -- AckSns have arrived (RequestedSnapshot).
+                concurrently_
+                  (forM_ aliceTxs $ \tx -> send n1 (NewTx tx) >> threadDelay 0)
+                  ( do
+                      send n3 (Decommit $ SimpleTx 300 (utxoRef 3) (utxoRef 300))
+                      -- Delay so tx arrives after SnapshotRequested(2) clears
+                      -- localTxs (T≈80) but before SnapshotConfirmed(2) triggers
+                      -- ReqSn(3) (T≈100). With blockTime=25/networkLatency=20 the
+                      -- AckSns for snapshot 3 arrive at T≈120, BEFORE
+                      -- DecrementTx confirms at T≈125, putting the leader in
+                      -- SeenSnapshot state when DecommitFinalized fires.
+                      threadDelay 70
+                      send n1 (NewTx $ SimpleTx 500 (utxoRef 109) (utxoRef 500))
+                  )
+
+                -- Wait for version bump (DecommitFinalized).
+                waitUntilMatch [n1, n2, n3] $ \case
+                  DecommitFinalized{} -> Just ()
+                  _ -> Nothing
+
+                -- If the SeenSnapshot bug is present this never completes because
+                -- the timer is blocked by snapshotInFlight. With the fix the timer
+                -- re-sends with the correct version and the head recovers.
+                send n1 (NewTx $ SimpleTx 999 (utxoRef 2) (utxoRef 999))
+                waitUntilMatch [n1, n2, n3] $ \case
+                  SnapshotConfirmed{snapshot = Snapshot{utxo}} | 999 `member` utxo -> Just ()
+                  _ -> Nothing
+
+                send n1 Close
+                waitUntil [n1, n2, n3] $ ReadyToFanout{headId = testHeadId}
+                send n2 Fanout
+                waitUntilMatch [n1, n2, n3] $ \case
+                  HeadIsFinalized{} -> Just ()
+                  _ -> Nothing
+
   describe "Hydra Node Logging" $ do
     it "traces processing of events" $ do
       let result = runSimTrace $ do
@@ -1069,6 +1198,36 @@ withSimulatedChainAndNetwork =
     (simulatedChainAndNetwork SimpleChainState{slot = ChainSlot 0})
     (cancel . tickThread)
 
+-- | Like 'withSimulatedChainAndNetwork' but configured so that in this test
+-- setup network messages take longer to arrive than it takes for a chain
+-- transaction to confirm. This means a chain event (like DecommitFinalized
+-- bumping the version) can reach all nodes before a snapshot request that was
+-- sent just before it, exposing the version race condition in the snapshot
+-- protocol.
+withRaceConditionSimulation ::
+  (MonadTime m, MonadDelay m, MonadAsync m, MonadThrow m, MonadLabelledSTM m) =>
+  (SimulatedChainNetwork SimpleTx m -> m a) ->
+  m a
+withRaceConditionSimulation =
+  bracket
+    (simulatedChainAndNetworkWith SimpleChainState{slot = ChainSlot 0} 20 25)
+    (cancel . tickThread)
+
+-- | Like 'withRaceConditionSimulation' but with inverted timing: network
+-- messages arrive *before* chain events confirm (networkLatency < blockTime).
+-- This means DecommitFinalized fires while the leader is actively collecting
+-- AckSns (SeenSnapshot state), exposing the toLastSeenSnapshot SeenSnapshot
+-- bug where collapsing SeenSnapshot{N} to LastSeenSnapshot{N} (instead of
+-- LastSeenSnapshot{N-1}) blocks the timer from re-sending the snapshot request.
+withSeenSnapshotRaceConditionSimulation ::
+  (MonadTime m, MonadDelay m, MonadAsync m, MonadThrow m, MonadLabelledSTM m) =>
+  (SimulatedChainNetwork SimpleTx m -> m a) ->
+  m a
+withSeenSnapshotRaceConditionSimulation =
+  bracket
+    (simulatedChainAndNetworkWith SimpleChainState{slot = ChainSlot 0} 25 20)
+    (cancel . tickThread)
+
 -- | Creates a simulated chain and network to which 'HydraNode's can be
 -- connected to using 'connectNode'. NOTE: The 'tickThread' needs to be
 -- 'cancel'ed after use. Use 'withSimulatedChainAndNetwork' instead where
@@ -1078,10 +1237,30 @@ simulatedChainAndNetwork ::
   (MonadTime m, MonadDelay m, MonadAsync m, MonadLabelledSTM m) =>
   ChainStateType SimpleTx ->
   m (SimulatedChainNetwork SimpleTx m)
-simulatedChainAndNetwork initialChainState = do
+simulatedChainAndNetwork initialChainState =
+  -- Default: 20s block time, 0s network latency (instant delivery)
+  simulatedChainAndNetworkWith initialChainState 20 0
+
+-- | Like 'simulatedChainAndNetwork' but with configurable block time and
+-- network delivery latency. Use 'withRaceConditionSimulation' to expose
+-- version races where chain events confirm before network messages arrive.
+simulatedChainAndNetworkWith ::
+  forall m.
+  (MonadTime m, MonadDelay m, MonadAsync m, MonadLabelledSTM m) =>
+  ChainStateType SimpleTx ->
+  -- | Block time: delay before a posted tx is observed on-chain
+  DiffTime ->
+  -- | Network latency: delay before a broadcast message is delivered
+  DiffTime ->
+  m (SimulatedChainNetwork SimpleTx m)
+simulatedChainAndNetworkWith initialChainState blockTime networkLatency = do
   history <- newLabelledTVarIO "sim-chain-history" []
   nodes <- newLabelledTVarIO "sim-chain-nodes" []
   nextTxId <- newLabelledTVarIO "sim-chain-next-txid" 10000
+  -- Track posted chain txs to deduplicate: first posting wins, others are dropped.
+  -- This models real chain behavior where e.g. multiple nodes post the same
+  -- DecrementTx but only the first one gets included in a block.
+  postedTxKeys <- newLabelledTVarIO "sim-chain-posted-keys" ([] :: [String])
   localChainState <- newLocalChainState (initHistory initialChainState)
   tickThread <- asyncLabelled "sim-chain-tick" $ simulateTicks nodes localChainState
   pure $
@@ -1091,16 +1270,23 @@ simulatedChainAndNetwork initialChainState = do
                 Chain
                   { postTx = \tx -> do
                       now <- getCurrentTime
-                      -- Only observe "after one block"
+                      -- Only observe "after one block" (first posting wins)
                       void . asyncLabelled "sim-chain-post-tx" $ do
                         threadDelay blockTime
-                        createAndYieldEvent nodes history localChainState $ toOnChainTx now tx
+                        let key = chainTxDedupKey tx
+                        shouldFire <- atomically $ stateTVar postedTxKeys $ \seenKeys ->
+                          if null key || key `notElem` seenKeys
+                            then (True, key : seenKeys)
+                            else (False, seenKeys)
+                        when shouldFire $
+                          createAndYieldEvent nodes history localChainState $
+                            toOnChainTx now tx
                   , draftCommitTx = \_ -> error "unexpected call to draftCommitTx"
                   , draftDepositTx = \_ -> error "unexpected call to draftDepositTx"
                   , submitTx = \_ -> error "unexpected call to submitTx"
                   , checkNonADAAssets = \_ -> error "unexpected call to checkNonADAAssets"
                   }
-              mockNetwork = createMockNetwork draftNode nodes
+              mockNetwork = createMockNetworkWithLatency networkLatency draftNode nodes
               mockServer :: Server tx m
               mockServer = Server{sendMessage = const $ pure ()}
           node <- connect mockChain mockNetwork mockServer draftNode
@@ -1119,9 +1305,6 @@ simulatedChainAndNetwork initialChainState = do
       , closeWithInitialSnapshot = error "unexpected call to closeWithInitialSnapshot"
       }
  where
-  -- seconds
-  blockTime = 20
-
   simulateTicks nodes localChainState = forever $ do
     threadDelay blockTime
     now <- getCurrentTime
@@ -1204,6 +1387,44 @@ createMockNetwork node nodes =
     enqueue inputQueue $ mkNetworkInput sender msg
 
   sender = getParty node
+
+-- | Like 'createMockNetwork' but delivers messages after a configurable delay.
+-- When latency > 0, messages are delivered asynchronously so chain events
+-- can arrive before network messages, exposing version race conditions.
+createMockNetworkWithLatency ::
+  (MonadAsync m, MonadDelay m) =>
+  DiffTime ->
+  DraftHydraNode tx m ->
+  TVar m [HydraNode tx m] ->
+  Network m (Message tx)
+createMockNetworkWithLatency networkLatency node nodes =
+  Network{broadcast}
+ where
+  broadcast msg = do
+    allNodes <- readTVarIO nodes
+    mapM_ (`handleMessage` msg) allNodes
+
+  handleMessage HydraNode{inputQueue} msg =
+    if networkLatency == 0
+      then enqueue inputQueue $ mkNetworkInput sender msg
+      else void . asyncLabelled "sim-network-deliver" $ do
+        threadDelay networkLatency
+        enqueue inputQueue $ mkNetworkInput sender msg
+
+  sender = getParty node
+
+-- | Compute a deduplication key for chain transactions where only the first
+-- posting should result in a chain event (first wins, like the real chain).
+-- Returns empty string for transactions that should always fire (no dedup).
+chainTxDedupKey :: PostChainTx tx -> String
+chainTxDedupKey = \case
+  IncrementTx{incrementingSnapshot} ->
+    let Snapshot{number} = getSnapshot incrementingSnapshot
+     in "increment-" <> show number
+  DecrementTx{decrementingSnapshot} ->
+    let Snapshot{number} = getSnapshot decrementingSnapshot
+     in "decrement-" <> show number
+  _ -> ""
 
 -- | Derive an 'OnChainTx' from 'PostChainTx' to simulate a "perfect" chain.
 -- NOTE: This implementation announces hard-coded contestationDeadlines. Also,
@@ -1381,6 +1602,7 @@ createHydraNode tracer ledger chainState signingKey otherParties outputs message
       , contestationPeriod = cp
       , depositPeriod = dp
       , unsyncedPeriod = defaultUnsyncedPeriodFor cp
+      , snapshotRetryInterval = 10
       , participants
       , configuredPeers = ""
       }
@@ -1413,6 +1635,23 @@ openHead2 chain n1 n2 = do
   simulateCommit chain testHeadId bob (utxoRef 2)
   waitUntil [n1, n2] $ Committed testHeadId bob (utxoRef 2)
   waitUntil [n1, n2] $ HeadIsOpen{headId = testHeadId, utxo = utxoRefs [1, 2]}
+
+openHead3 ::
+  SimulatedChainNetwork SimpleTx (IOSim s) ->
+  TestHydraClient SimpleTx (IOSim s) ->
+  TestHydraClient SimpleTx (IOSim s) ->
+  TestHydraClient SimpleTx (IOSim s) ->
+  IOSim s ()
+openHead3 chain n1 n2 n3 = do
+  send n1 Init
+  waitUntil [n1, n2, n3] $ HeadIsInitializing testHeadId (fromList [alice, bob, carol])
+  simulateCommit chain testHeadId alice (utxoRef 1)
+  waitUntil [n1, n2, n3] $ Committed testHeadId alice (utxoRef 1)
+  simulateCommit chain testHeadId bob (utxoRef 2)
+  waitUntil [n1, n2, n3] $ Committed testHeadId bob (utxoRef 2)
+  simulateCommit chain testHeadId carol (utxoRef 3)
+  waitUntil [n1, n2, n3] $ Committed testHeadId carol (utxoRef 3)
+  waitUntil [n1, n2, n3] $ HeadIsOpen{headId = testHeadId, utxo = utxoRefs [1, 2, 3]}
 
 assertHeadIsClosed :: (HasCallStack, MonadThrow m) => ServerOutput tx -> m ()
 assertHeadIsClosed = \case

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -292,20 +292,13 @@ spec = parallel $ do
                 send n1 (NewTx $ aValidTx 41)
                 send n1 (NewTx $ aValidTx 42)
 
-                -- Expect alice to create a snapshot from the first requested
-                -- transaction right away which is the current snapshot policy.
-                waitUntilMatch [n1, n2] $ \case
-                  SnapshotConfirmed{snapshot = Snapshot{number, confirmed}} ->
-                    guard $ number == 1 && confirmed == [aValidTx 40]
-                  _ -> Nothing
-
-                -- Expect bob to also snapshot what did "not fit" into the first
-                -- snapshot.
+                -- With the timer model the leader batches all pending transactions
+                -- when the timer fires, so all three txs appear in snapshot 1.
                 waitUntilMatch [n1, n2] $ \case
                   SnapshotConfirmed{snapshot = Snapshot{number, confirmed}} ->
                     -- NOTE: We sort the confirmed to be clear that the order may
                     -- be freely picked by the leader.
-                    guard $ number == 2 && sort confirmed == [aValidTx 41, aValidTx 42]
+                    guard $ number == 1 && sort confirmed == sort [aValidTx 40, aValidTx 41, aValidTx 42]
                   _ -> Nothing
 
                 -- As there are no pending transactions and snapshots anymore
@@ -313,7 +306,7 @@ spec = parallel $ do
                 send n1 (NewTx $ aValidTx 44)
                 waitUntilMatch [n1, n2] $ \case
                   SnapshotConfirmed{snapshot = Snapshot{number, confirmed}} ->
-                    guard $ number == 3 && confirmed == [aValidTx 44]
+                    guard $ number == 2 && confirmed == [aValidTx 44]
                   _ -> Nothing
 
       it "depending transactions stay pending and are confirmed in order" $
@@ -328,17 +321,13 @@ spec = parallel $ do
                 send n2 (NewTx secondTx)
                 send n1 (NewTx firstTx)
 
-                -- Expect a snapshot of the firstTx transaction
+                -- With the timer model, secondTx becomes applicable after
+                -- firstTx is applied, so both are batched into a single
+                -- snapshot when the timer fires.
                 waitUntil [n1, n2] $ TxValid testHeadId 1
-                waitUntil [n1, n2] $ do
-                  let snapshot = testSnapshot 1 0 [firstTx] (utxoRefs [2, 3])
-                      sigs = aggregate [sign aliceSk snapshot, sign bobSk snapshot]
-                  SnapshotConfirmed testHeadId snapshot sigs
-
-                -- Expect a snapshot of the now unblocked secondTx
                 waitUntil [n1, n2] $ TxValid testHeadId 2
                 waitUntil [n1, n2] $ do
-                  let snapshot = testSnapshot 2 0 [secondTx] (utxoRefs [2, 4])
+                  let snapshot = testSnapshot 1 0 [firstTx, secondTx] (utxoRefs [2, 4])
                       sigs = aggregate [sign aliceSk snapshot, sign bobSk snapshot]
                   SnapshotConfirmed testHeadId snapshot sigs
 
@@ -381,13 +370,17 @@ spec = parallel $ do
                         }
                 send n1 (NewTx tx')
                 send n2 (NewTx tx'')
+                -- With the timer model, TxInvalid(tx'') fires at n1 well before the
+                -- timer triggers SnapshotConfirmed (tx'' expires after TTL*waitDelay≈0.5s,
+                -- timer fires at snapshotRetryInterval=10s). Check TxInvalid first on
+                -- n1 only (n2 emits TxInvalid for tx', not tx'').
+                waitUntilMatch [n1] $ \case
+                  TxInvalid{transaction} -> guard $ transaction == tx''
+                  _ -> Nothing
                 waitUntil [n1, n2] $ do
                   let snapshot = testSnapshot 1 0 [tx'] (utxoRefs [2, 10])
                       sigs = aggregate [sign aliceSk snapshot, sign bobSk snapshot]
                   SnapshotConfirmed testHeadId snapshot sigs
-                waitUntilMatch [n1, n2] $ \case
-                  TxInvalid{transaction} -> guard $ transaction == tx''
-                  _ -> Nothing
 
       it "outputs utxo from confirmed snapshot when client requests it" $
         shouldRunInSim $ do

--- a/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
@@ -326,7 +326,7 @@ prop_timerSeenSnapshotRebroadcastMatchesInFlight = monadicIO $ do
   pure $
     outcome
       `hasEffectSatisfying` ( \case
-          NetworkEffect (ReqSn v sn _ _ _) -> v == snapshotVersion && sn == snapshotNumber
-          _ -> False
-        )
+                                NetworkEffect (ReqSn v sn _ _ _) -> v == snapshotVersion && sn == snapshotNumber
+                                _ -> False
+                            )
       & counterexample (show outcome)

--- a/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
@@ -76,7 +76,7 @@ spec = do
     describe "Generic Snapshot property" $ do
       prop "there's always a leader for every snapshot number" prop_thereIsAlwaysALeader
       prop "timer is noop while waiting for ReqSn echo (RequestedSnapshot state)" prop_timerIsNoopInRequestedSnapshotState
-      prop "timer re-broadcasts in-flight ReqSn with correct version and number (SeenSnapshot state)" prop_timerSeenSnapshotRebroadcastMatchesInFlight
+      prop "timer is noop in SeenSnapshot state (no re-broadcast to prevent feedback loops)" prop_timerIsNoopInSeenSnapshotState
 
     describe "On ReqTx" $ do
       prop "always emit ReqSn given head has 1 member" prop_singleMemberHeadAlwaysSnapshotOnReqTx
@@ -85,8 +85,8 @@ spec = do
         let tx = aValidTx 1
             s0 = inOpenState' [alice, bob] coordinatedHeadState
         now <- nowFromSlot (currentSlot . chainPointTime $ s0)
-        let s1 = aggregateState s0 $ update (envFor aliceSk) simpleLedger now s0 $ receiveMessage $ ReqTx tx
-            outcome = update (envFor aliceSk) simpleLedger now s1 TimerInput
+        -- With immediate snapshot chaining, ReqSn is sent during ReqTx processing.
+        let outcome = update (envFor aliceSk) simpleLedger now s0 $ receiveMessage $ ReqTx tx
 
         outcome
           `hasEffect` NetworkEffect (ReqSn 0 1 [txId tx] Nothing Nothing)
@@ -228,15 +228,20 @@ prop_singleMemberHeadAlwaysSnapshotOnReqTx sn = monadicIO $ do
         }
     s0 = inOpenState' [alice] st
   now <- run $ nowFromSlot (currentSlot . chainPointTime $ s0)
-  let s1 = aggregateState s0 $ update aliceEnv simpleLedger now s0 $ receiveMessage $ ReqTx tx
-      outcome = update aliceEnv simpleLedger now s1 TimerInput
+  -- ReqSn is emitted either immediately on ReqTx (when confirmedSn+1 is not in
+  -- flight) or on the subsequent timer (when seenSnapshot is ahead of
+  -- confirmedSnapshot and the timer uses the correct max formula).
+  let reqTxOutcome = update aliceEnv simpleLedger now s0 $ receiveMessage $ ReqTx tx
+      s1 = aggregateState s0 reqTxOutcome
+      timerOutcome = update aliceEnv simpleLedger now s1 TimerInput
       Snapshot{number = confirmedSn} = getSnapshot sn
       -- NOTE: nextSn uses max to handle cases where seenSnapshot is ahead of confirmedSnapshot
       seenSn = latestSeenSnapshotNumber seenSnapshot
       nextSn = max confirmedSn seenSn + 1
   pure $
-    outcome `hasEffect` NetworkEffect (ReqSn version nextSn [txId tx] Nothing Nothing)
-      & counterexample (show outcome)
+    (reqTxOutcome <> timerOutcome)
+      `hasEffect` NetworkEffect (ReqSn version nextSn [txId tx] Nothing Nothing)
+      & counterexample ("reqTxOutcome: " <> show reqTxOutcome <> "\ntimerOutcome: " <> show timerOutcome)
 
 prop_thereIsAlwaysALeader :: Property
 prop_thereIsAlwaysALeader =
@@ -288,8 +293,8 @@ prop_timerIsNoopInRequestedSnapshotState lastSeen requested = monadicIO $ do
 -- the timer re-broadcasts the snapshot using the in-flight snapshot's version
 -- and number — not the speculatively-computed 'nextSn'. This ensures all
 -- parties sign the same snapshot content after a re-broadcast.
-prop_timerSeenSnapshotRebroadcastMatchesInFlight :: Property
-prop_timerSeenSnapshotRebroadcastMatchesInFlight = monadicIO $ do
+prop_timerIsNoopInSeenSnapshotState :: Property
+prop_timerIsNoopInSeenSnapshotState = monadicIO $ do
   -- number >= 1: SeenSnapshot invariant (can't be in-flight for snapshot 0)
   -- and avoids Natural underflow in latestSeenSnapshotNumber (number - 1)
   snapshotNumber <- pick $ succ <$> arbitrary @SnapshotNumber
@@ -323,10 +328,12 @@ prop_timerSeenSnapshotRebroadcastMatchesInFlight = monadicIO $ do
     s0 = inOpenState' [alice] st
   now <- run $ nowFromSlot (currentSlot . chainPointTime $ s0)
   let outcome = update aliceEnv simpleLedger now s0 TimerInput
+  -- Timer must NOT re-broadcast in SeenSnapshot: re-sending ReqSn after peers
+  -- have already signed would create a 200 Hz etcd-echo feedback loop.
   pure $
     outcome
-      `hasEffectSatisfying` ( \case
-                                NetworkEffect (ReqSn v sn _ _ _) -> v == snapshotVersion && sn == snapshotNumber
-                                _ -> False
-                            )
+      `hasNoEffectSatisfying` ( \case
+                                  NetworkEffect ReqSn{} -> True
+                                  _ -> False
+                              )
       & counterexample (show outcome)

--- a/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
@@ -48,6 +48,7 @@ spec = do
                 , contestationPeriod = defaultContestationPeriod
                 , depositPeriod = defaultDepositPeriod
                 , unsyncedPeriod = defaultUnsyncedPeriod
+                , snapshotRetryInterval = 10
                 , participants = deriveOnChainId <$> threeParties
                 , configuredPeers = ""
                 }
@@ -205,6 +206,7 @@ prop_singleMemberHeadAlwaysSnapshotOnReqTx sn = monadicIO $ do
             , contestationPeriod = defaultContestationPeriod
             , depositPeriod = defaultDepositPeriod
             , unsyncedPeriod = defaultUnsyncedPeriod
+            , snapshotRetryInterval = 10
             , participants = [deriveOnChainId party]
             , configuredPeers = ""
             }

--- a/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
@@ -8,7 +8,7 @@ import Test.Hydra.Prelude
 
 import Data.List qualified as List
 import Data.Map.Strict qualified as Map
-import Hydra.HeadLogic (CoordinatedHeadState (..), Effect (..), HeadState (..), OpenState (OpenState), Outcome, SeenSnapshot (..), coordinatedHeadState, isLeader, latestSeenSnapshotNumber, update)
+import Hydra.HeadLogic (CoordinatedHeadState (..), Effect (..), HeadState (..), Input (..), OpenState (OpenState), Outcome, SeenSnapshot (..), aggregateState, coordinatedHeadState, isLeader, latestSeenSnapshotNumber, update)
 import Hydra.HeadLogicSpec (StepState, getState, hasEffect, hasEffectSatisfying, hasNoEffectSatisfying, inOpenState, inOpenState', nowFromSlot, receiveMessage, receiveMessageFrom, runHeadLogic, step)
 import Hydra.Ledger.Simple (SimpleTx (..), aValidTx, simpleLedger, utxoRef)
 import Hydra.Network.Message (Message (..))
@@ -82,7 +82,8 @@ spec = do
         let tx = aValidTx 1
             s0 = inOpenState' [alice, bob] coordinatedHeadState
         now <- nowFromSlot (currentSlot . chainPointTime $ s0)
-        let outcome = update (envFor aliceSk) simpleLedger now s0 $ receiveMessage $ ReqTx tx
+        let s1 = aggregateState s0 $ update (envFor aliceSk) simpleLedger now s0 $ receiveMessage $ ReqTx tx
+            outcome = update (envFor aliceSk) simpleLedger now s1 TimerInput
 
         outcome
           `hasEffect` NetworkEffect (ReqSn 0 1 [txId tx] Nothing Nothing)
@@ -120,6 +121,7 @@ spec = do
 
         actualState <- runHeadLogic (envFor aliceSk) simpleLedger st $ do
           step $ receiveMessage $ ReqTx tx
+          step TimerInput
           getState
         actualState `shouldBe` st'
 
@@ -223,7 +225,8 @@ prop_singleMemberHeadAlwaysSnapshotOnReqTx sn = monadicIO $ do
         }
     s0 = inOpenState' [alice] st
   now <- run $ nowFromSlot (currentSlot . chainPointTime $ s0)
-  let outcome = update aliceEnv simpleLedger now s0 $ receiveMessage $ ReqTx tx
+  let s1 = aggregateState s0 $ update aliceEnv simpleLedger now s0 $ receiveMessage $ ReqTx tx
+      outcome = update aliceEnv simpleLedger now s1 TimerInput
       Snapshot{number = confirmedSn} = getSnapshot sn
       -- NOTE: nextSn uses max to handle cases where seenSnapshot is ahead of confirmedSnapshot
       seenSn = latestSeenSnapshotNumber seenSnapshot

--- a/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
@@ -19,7 +19,7 @@ import Hydra.Tx.Crypto (sign)
 import Hydra.Tx.HeadParameters (HeadParameters (..))
 import Hydra.Tx.IsTx (txId)
 import Hydra.Tx.Party (Party, deriveParty)
-import Hydra.Tx.Snapshot (ConfirmedSnapshot (..), Snapshot (..), getSnapshot)
+import Hydra.Tx.Snapshot (ConfirmedSnapshot (..), Snapshot (..), SnapshotNumber, getSnapshot)
 import Test.Hydra.Tx.Fixture (
   alice,
   aliceSk,
@@ -30,6 +30,7 @@ import Test.Hydra.Tx.Fixture (
   deriveOnChainId,
   testHeadId,
  )
+import Test.Hydra.Tx.Gen ()
 import Test.QuickCheck (Property, counterexample, forAll, oneof, (==>))
 import Test.QuickCheck.Monadic (monadicIO, pick, run)
 
@@ -74,6 +75,8 @@ spec = do
 
     describe "Generic Snapshot property" $ do
       prop "there's always a leader for every snapshot number" prop_thereIsAlwaysALeader
+      prop "timer is noop while waiting for ReqSn echo (RequestedSnapshot state)" prop_timerIsNoopInRequestedSnapshotState
+      prop "timer re-broadcasts in-flight ReqSn with correct version and number (SeenSnapshot state)" prop_timerSeenSnapshotRebroadcastMatchesInFlight
 
     describe "On ReqTx" $ do
       prop "always emit ReqSn given head has 1 member" prop_singleMemberHeadAlwaysSnapshotOnReqTx
@@ -241,3 +244,89 @@ prop_thereIsAlwaysALeader =
     forAll arbitrary $ \params@HeadParameters{parties} ->
       not (null parties) ==>
         any (\p -> isLeader params p sn) parties
+
+-- | When the leader is in 'RequestedSnapshot' state (sent ReqSn but not yet
+-- received its own network echo to sign it), the timer must be a noop.
+-- Re-broadcasting here would use stale state (e.g. 'currentDepositTxId' is not
+-- set until the echo is processed) and race with the original ReqSn, causing
+-- peers to collect signatures on different snapshot contents.
+prop_timerIsNoopInRequestedSnapshotState :: SnapshotNumber -> SnapshotNumber -> Property
+prop_timerIsNoopInRequestedSnapshotState lastSeen requested = monadicIO $ do
+  let
+    aliceEnv =
+      let party = alice
+       in Environment
+            { party
+            , signingKey = aliceSk
+            , otherParties = []
+            , contestationPeriod = defaultContestationPeriod
+            , depositPeriod = defaultDepositPeriod
+            , unsyncedPeriod = defaultUnsyncedPeriod
+            , snapshotRetryInterval = 10
+            , participants = [deriveOnChainId party]
+            , configuredPeers = ""
+            }
+    st =
+      CoordinatedHeadState
+        { localUTxO = mempty
+        , allTxs = mempty
+        , localTxs = []
+        , confirmedSnapshot = InitialSnapshot testHeadId mempty
+        , seenSnapshot = RequestedSnapshot{lastSeen, requested}
+        , currentDepositTxId = Nothing
+        , decommitTx = Nothing
+        , version = 0
+        }
+    s0 = inOpenState' [alice] st
+  now <- run $ nowFromSlot (currentSlot . chainPointTime $ s0)
+  let outcome = update aliceEnv simpleLedger now s0 TimerInput
+  pure $
+    outcome `hasNoEffectSatisfying` (\case NetworkEffect ReqSn{} -> True; _ -> False)
+      & counterexample (show outcome)
+
+-- | When a 'SeenSnapshot' is in-flight (partial signatures being collected),
+-- the timer re-broadcasts the snapshot using the in-flight snapshot's version
+-- and number — not the speculatively-computed 'nextSn'. This ensures all
+-- parties sign the same snapshot content after a re-broadcast.
+prop_timerSeenSnapshotRebroadcastMatchesInFlight :: Property
+prop_timerSeenSnapshotRebroadcastMatchesInFlight = monadicIO $ do
+  -- number >= 1: SeenSnapshot invariant (can't be in-flight for snapshot 0)
+  -- and avoids Natural underflow in latestSeenSnapshotNumber (number - 1)
+  snapshotNumber <- pick $ succ <$> arbitrary @SnapshotNumber
+  snapshotVersion <- pick arbitrary
+  let
+    inFlightSnapshot = Snapshot testHeadId snapshotVersion snapshotNumber [] mempty Nothing Nothing
+    aliceEnv =
+      let party = alice
+       in Environment
+            { party
+            , signingKey = aliceSk
+            , otherParties = []
+            , contestationPeriod = defaultContestationPeriod
+            , depositPeriod = defaultDepositPeriod
+            , unsyncedPeriod = defaultUnsyncedPeriod
+            , snapshotRetryInterval = 10
+            , participants = [deriveOnChainId party]
+            , configuredPeers = ""
+            }
+    st =
+      CoordinatedHeadState
+        { localUTxO = mempty
+        , allTxs = mempty
+        , localTxs = []
+        , confirmedSnapshot = InitialSnapshot testHeadId mempty
+        , seenSnapshot = SeenSnapshot inFlightSnapshot mempty
+        , currentDepositTxId = Nothing
+        , decommitTx = Nothing
+        , version = snapshotVersion
+        }
+    s0 = inOpenState' [alice] st
+  now <- run $ nowFromSlot (currentSlot . chainPointTime $ s0)
+  let outcome = update aliceEnv simpleLedger now s0 TimerInput
+  pure $
+    outcome
+      `hasEffectSatisfying` ( \case
+          NetworkEffect (ReqSn v sn _ _ _) -> v == snapshotVersion && sn == snapshotNumber
+          _ -> False
+        )
+      & counterexample (show outcome)

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -544,7 +544,8 @@ spec =
         it "does not request same decommit twice across snapshots" $ do
           let localUTxO = utxoRefs [1, 2, 3]
               decommitTx' = SimpleTx 10 (utxoRefs [3]) (utxoRef 99)
-              utxoToDecommit' = utxoFromTx decommitTx'
+              -- utxoToDecommit should be the INPUTS of the decommit tx (what's removed from the Head)
+              utxoToDecommit' = txInputs decommitTx'
 
               -- Snapshot 0: initial snapshot
               snapshot0 = testSnapshot 0 0 [] localUTxO

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -305,11 +305,12 @@ spec =
           -- State: snapshot #1 in-flight (collecting signatures), deposit Inactive (about to activate).
           -- SeenSnapshot means signatures are being collected — snapshotInFlight returns True for all sn.
           let s0 =
-                (inOpenState' party $
-                  coordinatedHeadState
-                    { seenSnapshot = SeenSnapshot{snapshot = testSnapshot 1 0 [] mempty, signatories = mempty}
-                    , currentDepositTxId = Nothing
-                    })
+                ( inOpenState' party $
+                    coordinatedHeadState
+                      { seenSnapshot = SeenSnapshot{snapshot = testSnapshot 1 0 [] mempty, signatories = mempty}
+                      , currentDepositTxId = Nothing
+                      }
+                )
                   { pendingDeposits =
                       Map.fromList
                         [

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -247,6 +247,48 @@ spec =
             NetworkEffect ReqSn{depositTxId} -> depositTxId == Just 1
             _ -> False
 
+        it "timer does not re-broadcast ReqSn without deposit while waiting for echo" $ do
+          -- Regression test: when the chain tick fires a ReqSn with a deposit,
+          -- the leader enters RequestedSnapshot state (echo not yet processed,
+          -- so currentDepositTxId is still Nothing). If the timer then fires
+          -- it must NOT re-broadcast ReqSn{deposit=Nothing}, which would race
+          -- with the original ReqSn{deposit=Just depositId} and cause peers to
+          -- sign different snapshot contents, preventing consensus.
+          now <- getCurrentTime
+          let party = [alice]
+              depositTime = plusTime now
+              deadline = depositTime 5 `plusTime` toNominalDiffTime (depositPeriod aliceEnv) `plusTime` toNominalDiffTime (depositPeriod aliceEnv)
+              deposit1 = OnDepositTx{headId = testHeadId, depositTxId = 1, deposited = utxoRef 1, created = depositTime 1, deadline}
+
+          -- Observe the deposit on-chain
+          s0 <- runHeadLogic aliceEnv ledger (inOpenState party) $ do
+            step (observeTxAtSlot 1 deposit1)
+            getState
+
+          -- Chain tick activates the deposit; the leader (alice) sends ReqSn
+          -- with the deposit included. State advances to RequestedSnapshot.
+          let chainTime = depositTime 2 `plusTime` toNominalDiffTime (depositPeriod aliceEnv)
+          let tickInput = ChainInput $ Tick{chainTime, chainPoint = 2}
+          let s1 = aggregateState s0 $ update aliceEnv ledger now s0 tickInput
+
+          -- Confirm we are in RequestedSnapshot (echo not yet arrived, so
+          -- currentDepositTxId is not set yet).
+          case s1 of
+            NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
+              chs.seenSnapshot `shouldSatisfy` \case
+                RequestedSnapshot{} -> True
+                _ -> False
+            _ -> fail "expected Open NodeInSync state"
+
+          -- Timer fires while the echo is still in flight.
+          -- It must return noop — no ReqSn must be emitted.
+          now2 <- nowFromSlot s1.chainPointTime.currentSlot
+          let timerOutcome = update aliceEnv ledger now2 s1 TimerInput
+
+          timerOutcome `hasNoEffectSatisfying` \case
+            NetworkEffect ReqSn{} -> True
+            _ -> False
+
       describe "Decommit" $ do
         it "observes DecommitRecorded and ReqDec in an Open state" $ do
           let outputs = utxoRef 1

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -869,10 +869,8 @@ spec =
           -- Leader (bob) requests snapshot 2 (before DecommitFinalized)
           let reqTx3 = receiveMessage $ ReqTx (aValidTx 3)
           now <- nowFromSlot s1.chainPointTime.currentSlot
-          -- ReqTx no longer immediately triggers ReqSn; need TimerInput
-          let s2 = aggregateState s1 $ update bobEnv ledger now s1 reqTx3
-          now2 <- nowFromSlot s2.chainPointTime.currentSlot
-          let outcome = update bobEnv ledger now2 s2 TimerInput
+          -- With immediate snapshot chaining, ReqSn is sent during ReqTx processing.
+          let outcome = update bobEnv ledger now s1 reqTx3
 
           -- Should NOT include the decommit that was already posted in snapshot 1
           outcome `shouldNotHaveEffect` NetworkEffect (ReqSn 0 2 [3] (Just decommitTx') Nothing)
@@ -925,10 +923,8 @@ spec =
           -- Leader (bob) requests snapshot 2 (before CommitFinalized)
           let reqTx3 = receiveMessage $ ReqTx (aValidTx 3)
           now <- nowFromSlot s0.chainPointTime.currentSlot
-          -- ReqTx no longer immediately triggers ReqSn; need TimerInput
-          let s1 = aggregateState s0 $ update bobEnv ledger now s0 reqTx3
-          now2 <- nowFromSlot s1.chainPointTime.currentSlot
-          let outcome = update bobEnv ledger now2 s1 TimerInput
+          -- With immediate snapshot chaining, ReqSn is sent during ReqTx processing.
+          let outcome = update bobEnv ledger now s0 reqTx3
 
           -- Should NOT include the deposit that was already posted in snapshot 1
           outcome `shouldNotHaveEffect` NetworkEffect (ReqSn 0 2 [3] Nothing (Just depositTxId))
@@ -1397,12 +1393,12 @@ spec =
 
           Map.lookup depositTxId s6.pendingDeposits `shouldBe` Nothing
 
-          -- Step 7: New transaction arrives, leader requests snapshot via timer
+          -- Step 7: New transaction arrives, leader immediately requests snapshot
           let newTx = aValidTx 1
           let reqTxInput = receiveMessage $ ReqTx newTx
 
-          let s7 = aggregateState s6 $ update aliceEnv' ledger now s6 reqTxInput
-          let outcome = update aliceEnv' ledger now s7 TimerInput
+          -- With immediate snapshot chaining, ReqSn is sent during ReqTx processing.
+          let outcome = update aliceEnv' ledger now s6 reqTxInput
 
           -- The ReqSn emitted by the leader does not reference the recovered deposit
           outcome `hasEffectSatisfying` \case

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -567,14 +567,12 @@ spec =
               chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 1}
             _ -> fail "expected Open state"
 
-        it "version race: ReqSn with old version is rejected after DecommitFinalized bumps version" $ do
-          -- This test exposes the version race bug:
-          -- 1. Snapshot 0 confirmed with decommit at version 0
-          -- 2. Leader sends ReqSn(version=0, number=1) to network
-          -- 3. DecommitFinalized arrives at follower's node, bumping version to 1
-          -- 4. Follower receives stale ReqSn(version=0, number=1) but now expects version=1
-          -- 5. Follower rejects with ReqSvNumberInvalid
-          -- 6. System is stuck: snapshot 1 never completes, later snapshots wait forever
+        it "version race: stale ReqSn with old version is ignored after DecommitFinalized" $ do
+          -- When a follower receives a snapshot request that carries an old version
+          -- (because DecommitFinalized already bumped the version), it should simply
+          -- ignore the message rather than treat it as a protocol error. The leader
+          -- will keep periodically re-sending the snapshot request, so eventually a
+          -- fresh one with the correct version will arrive and the protocol resumes.
 
           let localUTxO = utxoRefs [1, 2, 3]
               decommitTx' = SimpleTx 10 (utxoRefs [3]) (utxoRef 99)
@@ -621,10 +619,58 @@ spec =
           let staleReqSn = ReqSn{snapshotVersion = 0, snapshotNumber = 1, transactionIds = [], decommitTx = Nothing, depositTxId = Nothing}
               reqSnInput = receiveMessageFrom alice staleReqSn
 
-          -- Follower rejects with ReqSvNumberInvalid (version mismatch)
-          update bobEnv ledger now bobAfterFinalized reqSnInput `shouldSatisfy` \case
-            Error (RequireFailed ReqSvNumberInvalid{requestedSv = 0, lastSeenSv = 1}) -> True
-            _ -> False
+          -- Stale ReqSn should be silently dropped (noop), not rejected with an error
+          update bobEnv ledger now bobAfterFinalized reqSnInput `shouldBe` noop
+
+        it "DecommitFinalized while snapshot in-flight resets seenSnapshot to last confirmed" $ do
+          -- When DecommitFinalized arrives while a snapshot was in RequestedSnapshot state,
+          -- seenSnapshot should reset to LastSeenSnapshot{lastSeen=N} (the CONFIRMED snapshot),
+          -- NOT advance to LastSeenSnapshot{lastSeen=M} (the REQUESTED snapshot).
+          -- Advancing to M causes waitNoSnapshotInFlight to deadlock forever.
+          let localUTxO = utxoRefs [1, 2, 3]
+              decommitTx' = SimpleTx 10 (utxoRefs [3]) (utxoRef 99)
+              utxoToDecommit' = txInputs decommitTx'
+
+              snapshot0 =
+                Snapshot
+                  { headId = testHeadId
+                  , version = 0
+                  , number = 0
+                  , confirmed = []
+                  , utxo = localUTxO
+                  , utxoToCommit = mempty
+                  , utxoToDecommit = Just utxoToDecommit'
+                  }
+              confirmedSn =
+                ConfirmedSnapshot
+                  { snapshot = snapshot0
+                  , signatures = Crypto.aggregate []
+                  }
+
+          -- State: snapshot 0 confirmed (with decommit), snapshot 1 was REQUESTED by leader
+          -- but not yet signed. seenSnapshot = RequestedSnapshot{lastSeen=0, requested=1}
+          let stateWithReqInFlight =
+                inOpenState' threeParties $
+                  coordinatedHeadState
+                    { localUTxO
+                    , version = 0
+                    , confirmedSnapshot = confirmedSn
+                    , seenSnapshot = RequestedSnapshot{lastSeen = 0, requested = 1}
+                    , decommitTx = Nothing
+                    }
+
+          now <- nowFromSlot stateWithReqInFlight.chainPointTime.currentSlot
+
+          -- DecommitFinalized arrives (version bumps 0→1)
+          let decrementObservation = observeTx $ OnDecrementTx{headId = testHeadId, newVersion = 1, distributedUTxO = mempty}
+          let stateAfterFinalized = aggregateState stateWithReqInFlight (update bobEnv ledger now stateWithReqInFlight decrementObservation)
+
+          -- ASSERT: seenSnapshot should be LastSeenSnapshot{lastSeen=0} (the confirmed sn)
+          -- NOT LastSeenSnapshot{lastSeen=1} (the requested sn) which causes deadlock
+          case stateAfterFinalized of
+            NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} ->
+              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 0}
+            _ -> fail "expected Open state"
 
         it "does not request same decommit twice across snapshots" $ do
           let localUTxO = utxoRefs [1, 2, 3]

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -504,15 +504,13 @@ spec =
             _ -> fail "expected Open state"
 
           -- New L2 transaction arrives. Alice is leader for sn=1 (nextSn = max(0,0)+1 = 1).
-          -- Timer fires and re-requests snapshot 1 with the new version.
+          -- Alice immediately sends ReqSn when receiving ReqTx (maybeRequestSnapshot).
           let newTx = aValidTx 42
-          let s2 = aggregateState s1 $ update aliceEnv ledger now s1 $ receiveMessage $ ReqTx newTx
-          now2 <- nowFromSlot s2.chainPointTime.currentSlot
-          let timerOutcome = update aliceEnv ledger now2 s2 TimerInput
+          let reqTxOutcome = update aliceEnv ledger now s1 $ receiveMessage $ ReqTx newTx
 
           -- Verify it requests snapshot 1 with the new version (not snapshot 2)
           -- Note: Alice is leader for snapshot 1
-          timerOutcome `hasEffect` NetworkEffect (ReqSn 1 1 [txId newTx] Nothing Nothing)
+          reqTxOutcome `hasEffect` NetworkEffect (ReqSn 1 1 [txId newTx] Nothing Nothing)
 
         it "AckSn for decommit snapshot is noop after DecommitFinalized" $ do
           let localUTxO = utxoRefs [1]
@@ -715,6 +713,125 @@ spec =
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} ->
               chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 0}
             _ -> fail "expected Open state"
+
+        it "requeues valid txs after DecommitFinalized when snapshot in RequestedSnapshot" $ do
+          -- Regression: snapshot was in RequestedSnapshot state with pending txs.
+          -- DecommitFinalized arrived, previously clearing those txs. Later, a tx tried
+          -- to spend an output created by a dropped tx -> permanent WaitOnNotApplicableTx loop.
+          let confirmedUTxO = utxoRefs [1]
+              txA = SimpleTx 1 mempty (utxoRef 2) -- creates ref2 (no inputs needed)
+              confirmedSn =
+                ConfirmedSnapshot
+                  { snapshot = testSnapshot 1 0 [] confirmedUTxO
+                  , signatures = Crypto.aggregate []
+                  }
+              s0 =
+                inOpenState' threeParties $
+                  coordinatedHeadState
+                    { localUTxO = confirmedUTxO <> utxoRef 2
+                    , confirmedSnapshot = confirmedSn
+                    , seenSnapshot = RequestedSnapshot{lastSeen = 1, requested = 2}
+                    , localTxs = [txA]
+                    , allTxs = Map.fromList [(txId txA, txA)]
+                    }
+          now <- nowFromSlot s0.chainPointTime.currentSlot
+          let decrementObservation = observeTx $ OnDecrementTx{headId = testHeadId, newVersion = 2, distributedUTxO = mempty}
+          let outcome = update aliceEnv ledger now s0 decrementObservation
+          outcome `hasStateChangedSatisfying` \case
+            TxsRequeued{} -> True
+            _ -> False
+          let s1 = aggregateState s0 outcome
+          case s1 of
+            NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
+              chs.localTxs `shouldBe` [txA]
+              chs.localUTxO `shouldBe` confirmedUTxO <> utxoRef 2
+            _ -> fail "expected Open state"
+
+        it "emits TxInvalid for txs that cannot be reapplied after DecommitFinalized" $ do
+          let confirmedUTxO = utxoRefs [1]
+              -- txC spends ref5 which is NOT in confirmedUTxO -> invalid after reset
+              txC = SimpleTx 1 (utxoRef 5) (utxoRef 6)
+              confirmedSn =
+                ConfirmedSnapshot
+                  { snapshot = testSnapshot 1 0 [] confirmedUTxO
+                  , signatures = Crypto.aggregate []
+                  }
+              s0 =
+                inOpenState' threeParties $
+                  coordinatedHeadState
+                    { localUTxO = utxoRef 6 -- was applied against some state with ref5
+                    , confirmedSnapshot = confirmedSn
+                    , seenSnapshot = RequestedSnapshot{lastSeen = 1, requested = 2}
+                    , localTxs = [txC]
+                    , allTxs = Map.fromList [(txId txC, txC)]
+                    }
+          now <- nowFromSlot s0.chainPointTime.currentSlot
+          let decrementObservation = observeTx $ OnDecrementTx{headId = testHeadId, newVersion = 2, distributedUTxO = mempty}
+          let outcome = update aliceEnv ledger now s0 decrementObservation
+          outcome `hasStateChangedSatisfying` \case
+            TxInvalid{transaction} -> transaction == txC
+            _ -> False
+          let s1 = aggregateState s0 outcome
+          case s1 of
+            NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} ->
+              chs.localTxs `shouldBe` []
+            _ -> fail "expected Open state"
+
+        it "requeues snapshot confirmed txs and local txs after DecommitFinalized in SeenSnapshot" $ do
+          let confirmedUTxO = utxoRefs [1]
+              txA = SimpleTx 1 mempty (utxoRef 2) -- in snapshot.confirmed, creates ref2
+              txB = SimpleTx 2 (utxoRef 2) (utxoRef 3) -- in localTxs, spends ref2
+              inFlightSnapshot = testSnapshot 2 0 [txA] (confirmedUTxO <> utxoRef 3)
+              confirmedSn =
+                ConfirmedSnapshot
+                  { snapshot = testSnapshot 1 0 [] confirmedUTxO
+                  , signatures = Crypto.aggregate []
+                  }
+              s0 =
+                inOpenState' threeParties $
+                  coordinatedHeadState
+                    { localUTxO = confirmedUTxO <> utxoRef 3
+                    , confirmedSnapshot = confirmedSn
+                    , seenSnapshot = SeenSnapshot{snapshot = inFlightSnapshot, signatories = mempty}
+                    , localTxs = [txB]
+                    , allTxs = Map.fromList [(txId txB, txB)]
+                    }
+          now <- nowFromSlot s0.chainPointTime.currentSlot
+          let decrementObservation = observeTx $ OnDecrementTx{headId = testHeadId, newVersion = 2, distributedUTxO = mempty}
+          let outcome = update aliceEnv ledger now s0 decrementObservation
+          outcome `hasStateChangedSatisfying` \case
+            TxsRequeued{txs} -> txA `elem` txs && txB `elem` txs
+            _ -> False
+          let s1 = aggregateState s0 outcome
+          case s1 of
+            NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
+              chs.localTxs `shouldContain` [txA]
+              chs.localTxs `shouldContain` [txB]
+            _ -> fail "expected Open state"
+
+        it "no TxsRequeued when no snapshot in-flight on DecommitFinalized" $ do
+          let confirmedUTxO = utxoRefs [1]
+              txA = aValidTx 42
+              confirmedSn =
+                ConfirmedSnapshot
+                  { snapshot = testSnapshot 1 0 [] confirmedUTxO
+                  , signatures = Crypto.aggregate []
+                  }
+              s0 =
+                inOpenState' threeParties $
+                  coordinatedHeadState
+                    { localUTxO = confirmedUTxO
+                    , confirmedSnapshot = confirmedSn
+                    , seenSnapshot = NoSeenSnapshot
+                    , localTxs = [txA]
+                    , allTxs = Map.fromList [(txId txA, txA)]
+                    }
+          now <- nowFromSlot s0.chainPointTime.currentSlot
+          let decrementObservation = observeTx $ OnDecrementTx{headId = testHeadId, newVersion = 2, distributedUTxO = mempty}
+          let outcome = update aliceEnv ledger now s0 decrementObservation
+          outcome `hasNoStateChangedSatisfying` \case
+            TxsRequeued{} -> True
+            _ -> False
 
         it "does not request same decommit twice across snapshots" $ do
           let localUTxO = utxoRefs [1, 2, 3]

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -44,7 +44,7 @@ import Hydra.Network.Message (Message (..), NetworkEvent (..))
 import Hydra.Node (mkNetworkInput)
 import Hydra.Node.DepositPeriod (toNominalDiffTime)
 import Hydra.Node.Environment (Environment (..))
-import Hydra.Node.State (ChainPointTime (..), Deposit (..), DepositStatus (Active), NodeState (..), initNodeState, initialChainTime)
+import Hydra.Node.State (ChainPointTime (..), Deposit (..), DepositStatus (Active, Inactive), NodeState (..), initNodeState, initialChainTime)
 import Hydra.Node.UnsyncedPeriod (UnsyncedPeriod (..), unsyncedPeriodToNominalDiffTime)
 import Hydra.Options (defaultContestationPeriod, defaultDepositPeriod, defaultUnsyncedPeriod)
 import Hydra.Prelude qualified as Prelude
@@ -287,6 +287,41 @@ spec =
 
           timerOutcome `hasNoEffectSatisfying` \case
             NetworkEffect ReqSn{} -> True
+            _ -> False
+
+        it "on tick, DepositExpired fires only once when deposit transitions to expired" $ do
+          -- Regression test: onChainTick emits DepositExpired for ALL expired
+          -- deposits on every tick (not just newly-expired ones). After the first
+          -- tick marks a deposit as expired, subsequent ticks must NOT re-emit
+          -- DepositExpired for it. Fix: only emit for state transitions.
+          now <- getCurrentTime
+          let addT = flip addUTCTime
+              depositTime = addT now
+              deadline = depositTime 3
+              deposit1 = Deposit{headId = testHeadId, deposited = utxoRef 1, created = depositTime 1, deadline, status = Inactive}
+              party = [alice]
+              -- Open state with one pending (inactive) deposit
+              s0 = (inOpenState party){pendingDeposits = Map.fromList [(1, deposit1)]}
+
+          -- First tick: chainTime > deadline → deposit transitions Inactive → Expired
+          let expiredTime = depositTime 4
+              tick1 = ChainInput $ Tick{chainTime = expiredTime, chainPoint = 4}
+          now1 <- nowFromSlot s0.chainPointTime.currentSlot
+          let outcome1 = update aliceEnv ledger now1 s0 tick1
+          let s1 = aggregateState s0 outcome1
+
+          -- First tick must emit DepositExpired
+          outcome1 `hasStateChangedSatisfying` \case
+            DepositExpired{depositTxId} -> depositTxId == 1
+            _ -> False
+
+          -- Second tick at the same (still-expired) time: must NOT re-emit DepositExpired
+          now2 <- nowFromSlot s1.chainPointTime.currentSlot
+          let tick2 = ChainInput $ Tick{chainTime = expiredTime, chainPoint = 5}
+          let outcome2 = update aliceEnv ledger now2 s1 tick2
+
+          outcome2 `hasNoStateChangedSatisfying` \case
+            DepositExpired{} -> True
             _ -> False
 
       describe "Decommit" $ do
@@ -606,6 +641,104 @@ spec =
               chs.currentDepositTxId `shouldBe` Nothing
               chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 0}
             _ -> fail "expected Open state"
+
+        it "CommitFinalized clears decommitTx to prevent stale decommit in next ReqSn" $ do
+          -- Regression test: When an IncrementTx (CommitFinalized) is observed
+          -- after a decommit was already applied in a previous snapshot, the
+          -- decommitTx field is not cleared. The timer then includes the stale
+          -- decommit in the next ReqSn, which fails validation because those
+          -- UTxO inputs are no longer in localUTxO. Fix: CommitFinalized must
+          -- clear decommitTx = Nothing.
+          let localUTxO = utxoRefs [1, 2]
+              decommitTx' = SimpleTx 10 (utxoRef 2) (utxoRef 99)
+              -- Snapshot that already included the decommit (utxoToDecommit /= Nothing)
+              snWithDecommit =
+                Snapshot
+                  { headId = testHeadId
+                  , version = 3
+                  , number = 5
+                  , confirmed = []
+                  , utxo = localUTxO
+                  , utxoToCommit = Nothing
+                  , utxoToDecommit = Just (utxoRef 2)
+                  }
+              confirmedSn = ConfirmedSnapshot{snapshot = snWithDecommit, signatures = Crypto.aggregate []}
+              depositTxId = 42 :: Integer
+              -- State: decommit was applied in sn=5, but decommitTx is still set
+              -- (DecommitFinalized hasn't fired yet). A deposit is also pending.
+              s0 =
+                inOpenState' threeParties $
+                  coordinatedHeadState
+                    { localUTxO
+                    , version = 3
+                    , confirmedSnapshot = confirmedSn
+                    , seenSnapshot = NoSeenSnapshot
+                    , decommitTx = Just decommitTx'
+                    , currentDepositTxId = Nothing
+                    }
+
+          -- IncrementTx arrives (CommitFinalized), bumping version to 4
+          let incrementObservation = observeTx $ OnIncrementTx{headId = testHeadId, newVersion = 4, depositTxId}
+          now <- nowFromSlot s0.chainPointTime.currentSlot
+          let s1 = aggregateState s0 $ update aliceEnv ledger now s0 incrementObservation
+
+          -- After CommitFinalized, decommitTx must be cleared so the timer
+          -- does not include the already-applied decommit in the next ReqSn.
+          case s1 of
+            NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
+              chs.version `shouldBe` 4
+              chs.decommitTx `shouldBe` Nothing
+            _ -> fail "expected Open state"
+
+        it "leader recovers from RequireFailed on own ReqSn echo after stale decommit" $ do
+          -- Regression test: When the leader sends ReqSn with a stale decommit
+          -- (Bug 1), its own echo fails RequireFailed (SnapshotDoesNotApply or
+          -- ReqSnDecommitNotSettled). The Error outcome does NOT reset
+          -- seenSnapshot, leaving it as RequestedSnapshot forever. The timer
+          -- then hits `RequestedSnapshot{} -> noop` on every tick. Fix: when
+          -- the leader's own echo fails, reset seenSnapshot to LastSeenSnapshot
+          -- so the timer can retry with fresh content.
+          let localUTxO = utxoRefs [1]
+              staleDecommit = SimpleTx 10 (utxoRef 2) (utxoRef 99) -- inputs NOT in localUTxO
+              confirmedSn =
+                ConfirmedSnapshot
+                  { snapshot = testSnapshot 0 3 [] localUTxO
+                  , signatures = Crypto.aggregate []
+                  }
+              -- Leader (alice) already sent ReqSn(sn=1) with stale decommit:
+              -- seenSnapshot = RequestedSnapshot{lastSeen=0, requested=1}
+              s0 =
+                inOpenState' [alice] $
+                  coordinatedHeadState
+                    { localUTxO
+                    , version = 3
+                    , confirmedSnapshot = confirmedSn
+                    , seenSnapshot = RequestedSnapshot{lastSeen = 0, requested = 1}
+                    , decommitTx = Just staleDecommit
+                    }
+
+          -- Echo of the leader's own ReqSn arrives back (alice sent it, alice receives it)
+          let echoReqSn :: Input SimpleTx
+              echoReqSn = receiveMessageFrom alice $ ReqSn 3 1 [] (Just staleDecommit) Nothing
+          now <- nowFromSlot s0.chainPointTime.currentSlot
+          let echoOutcome = update aliceEnv ledger now s0 echoReqSn
+          let s1 = aggregateState s0 echoOutcome
+
+          -- After the echo fails, seenSnapshot must be reset (not stay RequestedSnapshot)
+          -- so the timer can retry. This is the key fix.
+          case s1 of
+            NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} ->
+              chs.seenSnapshot `shouldSatisfy` \case
+                RequestedSnapshot{} -> False -- Bug: stuck forever
+                _ -> True -- Fix: reset so timer can retry
+            _ -> fail "expected Open state"
+
+          -- Timer must now be able to send a fresh ReqSn (liveness restored)
+          now2 <- nowFromSlot s1.chainPointTime.currentSlot
+          let timerOutcome = update aliceEnv ledger now2 s1 TimerInput
+          timerOutcome `hasEffectSatisfying` \case
+            NetworkEffect ReqSn{} -> True
+            _ -> False
 
         it "version race: stale ReqSn with old version is ignored after DecommitFinalized" $ do
           -- When a follower receives a snapshot request that carries an old version
@@ -1409,13 +1542,17 @@ spec =
           -- Step 8: When node processes this ReqSn, it will wait forever
           s8 <- runHeadLogic aliceEnv' ledger s6 $ do
             step reqTxInput
-            step TimerInput
             getState
 
           let staleReqSn = receiveMessage $ ReqSn 0 2 [txId newTx] Nothing (Just depositTxId)
           let reqSnOutcome = update aliceEnv' ledger now s8 staleReqSn
-          -- Fix bug: Error out instead of waiting for deposit to be observed forever
-          reqSnOutcome `shouldBe` Error (RequireFailed $ RequestedDepositNotFoundLocally depositTxId)
+          -- In a single-party head, the leader's own echo with a stale deposit is
+          -- caught by abortOwnEchoOnFail and converted to SnapshotRequestAborted
+          -- (graceful abort) rather than a hard error. The timer can then retry
+          -- with a fresh ReqSn that omits the recovered deposit.
+          reqSnOutcome `hasStateChangedSatisfying` \case
+            SnapshotRequestAborted{snapshotNumber = 2} -> True
+            _ -> False
 
         it "re-posts IncrementTx on chain rollback when deposit is pending" $ do
           -- After a snapshot is confirmed with a deposit (CommitApproved + IncrementTx posted),

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -719,8 +719,9 @@ spec =
         it "does not request same decommit twice across snapshots" $ do
           let localUTxO = utxoRefs [1, 2, 3]
               decommitTx' = SimpleTx 10 (utxoRefs [3]) (utxoRef 99)
-              -- utxoToDecommit should be the INPUTS of the decommit tx (what's removed from the Head)
-              utxoToDecommit' = txInputs decommitTx'
+              -- utxoToDecommit is the OUTPUTS of the decommit tx (what gets paid out externally).
+              -- This mirrors SnapshotRequested aggregate: utxoToDecommit = utxoFromTx decommitTx.
+              utxoToDecommit' = utxoFromTx decommitTx'
 
               -- Snapshot 0: initial snapshot
               snapshot0 = testSnapshot 0 0 [] localUTxO

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -534,7 +534,7 @@ spec =
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
               chs.version `shouldBe` 4
               chs.decommitTx `shouldBe` Nothing
-              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 1}
+              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 0}
             _ -> fail "expected Open state"
 
         it "CommitFinalized with RequestedSnapshot should use requested number not lastSeen" $ do
@@ -618,7 +618,9 @@ spec =
           let bobAfterFinalized = aggregateState bobStateBeforeFinalized (update bobEnv ledger now bobStateBeforeFinalized decrementObservation)
 
           -- Now follower receives stale ReqSn with version=0 (created before DecommitFinalized)
-          let staleReqSn = ReqSn{snapshotVersion = 0, snapshotNumber = 1, transactionIds = [], decommitTx = Nothing, depositTxId = Nothing}
+          let staleReqSn :: Message tx
+              staleReqSn = ReqSn{snapshotVersion = 0, snapshotNumber = 1, transactionIds = [], decommitTx = Nothing, depositTxId = Nothing}
+              reqSnInput :: Input tx
               reqSnInput = receiveMessageFrom alice staleReqSn
 
           -- Stale ReqSn should be silently dropped (noop), not rejected with an error
@@ -910,7 +912,7 @@ spec =
             Error (RequireFailed InvalidMultisignature{vkeys}) -> vkeys == [vkey bob]
             _ -> False
 
-      it "rejects last AckSn if already received signature from this party" $ do
+      it "drops duplicate AckSn from the same party" $ do
         let reqSn :: Input tx
             reqSn = receiveMessage $ ReqSn 0 1 [] Nothing Nothing
             snapshot1 = testSnapshot 1 0 [] mempty
@@ -923,9 +925,7 @@ spec =
 
         now <- nowFromSlot waitingForAck.chainPointTime.currentSlot
         update bobEnv ledger now waitingForAck (ackFrom carolSk carol)
-          `shouldSatisfy` \case
-            Error (RequireFailed SnapshotAlreadySigned{receivedSignature}) -> receivedSignature == carol
-            _ -> False
+          `shouldBe` noop
 
       it "ignores valid AckSn if snapshot already confirmed" $ do
         let reqSn :: Input tx
@@ -966,13 +966,13 @@ spec =
         update bobEnv ledger now s0 reqSn
           `assertWait` WaitOnTxs [1]
 
-      it "waits if we receive an AckSn for an unseen snapshot" $ do
+      it "drops an AckSn for an unseen snapshot" $ do
         let snapshot = testSnapshot 1 0 [] mempty
             input = receiveMessage $ AckSn (sign aliceSk snapshot) 1
             s0 = inOpenState threeParties
         now <- nowFromSlot s0.chainPointTime.currentSlot
         update bobEnv ledger now s0 input
-          `assertWait` WaitOnSeenSnapshot
+          `shouldBe` noop
 
       -- TODO: Write property tests for various future / old snapshot behavior.
       -- That way we could cover variations of snapshot numbers and state of
@@ -985,7 +985,7 @@ spec =
         now <- nowFromSlot st.chainPointTime.currentSlot
         update bobEnv ledger now st input `shouldBe` Error (RequireFailed $ ReqSnNumberInvalid 2 0)
 
-      it "waits if we receive a future snapshot while collecting signatures" $ do
+      it "drops a ReqSn received while collecting signatures for another snapshot" $ do
         let reqSn1 :: Input tx
             reqSn1 = receiveMessage $ ReqSn 0 1 [] Nothing Nothing
             reqSn2 :: Input tx
@@ -997,7 +997,7 @@ spec =
 
         now <- nowFromSlot st.chainPointTime.currentSlot
         update bobEnv ledger now st reqSn2
-          `assertWait` WaitOnSnapshotNumber 1
+          `shouldBe` noop
 
       it "acks signed snapshot from the constant leader" $ do
         let leader = alice

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -380,35 +380,33 @@ spec =
           let decommitFinalizedOutcome = update aliceEnv ledger now s0 decrementObservation
           let s1 = aggregateState s0 decommitFinalizedOutcome
 
-          -- Verify seenSnapshot was reset (not stuck as RequestedSnapshot)
-          -- After DecommitFinalized, lastSeen should be the snapshot number that
-          -- included the decommit (snapshot 1), not the previously confirmed snapshot (0).
-          -- This prevents incoming AckSn messages for snapshot 1 from being requeued infinitely.
+          -- Verify seenSnapshot was reset (not stuck as RequestedSnapshot).
+          -- After DecommitFinalized, lastSeen resets to the last CONFIRMED snapshot
+          -- (0), not the in-flight requested number (1). The in-flight snapshot is
+          -- dead because the version changed; the timer will re-request it fresh.
           case s1 of
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
               chs.version `shouldBe` 4
-              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 1}
+              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 0}
               chs.decommitTx `shouldBe` Nothing
             _ -> fail "expected Open state"
 
-          -- 2. The stale ReqSn(v=3) arrives and is rejected (version mismatch)
+          -- 2. The stale ReqSn(v=3) arrives and is silently ignored (version mismatch)
           let staleReqSn :: Input SimpleTx
               staleReqSn = receiveMessageFrom alice $ ReqSn 3 1 [] Nothing Nothing
           now' <- nowFromSlot s1.chainPointTime.currentSlot
-          update aliceEnv ledger now' s1 staleReqSn `shouldSatisfy` \case
-            Error (RequireFailed ReqSvNumberInvalid{}) -> True
-            _ -> False
+          update aliceEnv ledger now' s1 staleReqSn `shouldBe` noop
 
-          -- 3. A new ReqTx arrives — bob (leader for sn=2) can request a new
+          -- 3. A new ReqTx arrives — alice (leader for sn=1) can request a new
           -- snapshot because snapshotInFlight is now False after the reset
           let newTx = aValidTx 42
               reqTx = receiveMessage $ ReqTx newTx
-          s2 <- runHeadLogic bobEnv ledger s1 $ do
+          s2 <- runHeadLogic aliceEnv ledger s1 $ do
             step reqTx
+            step TimerInput
             getState
 
           -- Verify the head is not stuck: seenSnapshot should have advanced
-          -- (snapshot number will be based on max(confirmedSnapshot.number, lastSeen))
           case s2 of
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} ->
               chs.seenSnapshot `shouldSatisfy` \case
@@ -416,20 +414,17 @@ spec =
                 _ -> False
             _ -> fail "expected Open state"
 
-        it "DecommitFinalized race: calculates correct snapshot number when seenSnapshot ahead of confirmedSnapshot" $ do
-          -- This test reproduces the bug where DecommitFinalized arrives before AckSn completes,
-          -- causing seenSnapshot to get ahead of confirmedSnapshot, which then causes wrong
-          -- snapshot number calculation on the next ReqTx.
+        it "DecommitFinalized race: resets seenSnapshot to last confirmed and timer re-requests fresh" $ do
+          -- This test reproduces the scenario where DecommitFinalized arrives before AckSn
+          -- completes. The in-flight snapshot is dead (version bumped), so we reset to the
+          -- last CONFIRMED snapshot and let the timer re-request with the new version.
           --
-          -- Bug scenario:
+          -- Scenario:
           -- 1. Snapshot 1 requested with decommit (RequestedSnapshot{lastSeen=0, requested=1})
           -- 2. DecrementTx posted to chain
           -- 3. DecommitFinalized observed BEFORE AckSn messages complete
-          -- 4. toLastSeenSnapshot converts RequestedSnapshot{requested=1} → LastSeenSnapshot{lastSeen=1}
-          -- 5. Now: confirmedSnapshot.number=0 but seenSnapshot.lastSeen=1 (seenSnapshot is ahead!)
-          -- 6. New L2 tx arrives
-          -- 7. BUGGY: nextSn = confirmedSn + 1 = 0 + 1 = 1 (wrong! snapshot 1 is already "seen")
-          -- 8. FIXED: nextSn = max(confirmedSn, seenSn) + 1 = max(0, 1) + 1 = 2 (correct!)
+          -- 4. toLastSeenSnapshot resets to LastSeenSnapshot{lastSeen=0} (last confirmed)
+          -- 5. Timer fires → alice (leader for sn=1) re-requests sn=1 with new version
 
           let localUTxO = utxoRefs [1]
               -- Snapshot 0 is confirmed (initial state)
@@ -457,22 +452,25 @@ spec =
           let decommitFinalizedOutcome = update aliceEnv ledger now s0 decrementObservation
           let s1 = aggregateState s0 decommitFinalizedOutcome
 
-          -- Verify seenSnapshot is now ahead of confirmedSnapshot
+          -- Verify seenSnapshot reset to last confirmed (0, not the in-flight 1)
           case s1 of
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
               chs.version `shouldBe` 1
-              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 1} -- seenSnapshot updated
-              chs.confirmedSnapshot.snapshot.number `shouldBe` 0 -- confirmedSnapshot still at 0!
+              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 0} -- reset to last confirmed
+              chs.confirmedSnapshot.snapshot.number `shouldBe` 0
               chs.decommitTx `shouldBe` Nothing -- decommit cleared
             _ -> fail "expected Open state"
 
-          -- New L2 transaction arrives (bob is leader for snapshot 2)
+          -- New L2 transaction arrives. Alice is leader for sn=1 (nextSn = max(0,0)+1 = 1).
+          -- Timer fires and re-requests snapshot 1 with the new version.
           let newTx = aValidTx 42
-          let reqTxOutcome = update bobEnv ledger now s1 $ receiveMessage $ ReqTx newTx
+          let s2 = aggregateState s1 $ update aliceEnv ledger now s1 $ receiveMessage $ ReqTx newTx
+          now2 <- nowFromSlot s2.chainPointTime.currentSlot
+          let timerOutcome = update aliceEnv ledger now2 s2 TimerInput
 
-          -- Verify it requests snapshot 2 (not snapshot 1)
-          -- Note: Bob is leader for snapshot 2
-          reqTxOutcome `hasEffect` NetworkEffect (ReqSn 1 2 [txId newTx] Nothing Nothing)
+          -- Verify it requests snapshot 1 with the new version (not snapshot 2)
+          -- Note: Alice is leader for snapshot 1
+          timerOutcome `hasEffect` NetworkEffect (ReqSn 1 1 [txId newTx] Nothing Nothing)
 
         it "AckSn for decommit snapshot is noop after DecommitFinalized" $ do
           let localUTxO = utxoRefs [1]
@@ -537,7 +535,7 @@ spec =
               chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 0}
             _ -> fail "expected Open state"
 
-        it "CommitFinalized with RequestedSnapshot should use requested number not lastSeen" $ do
+        it "CommitFinalized with RequestedSnapshot resets seenSnapshot to lastSeen" $ do
           let localUTxO = utxoRefs [1]
               confirmedSn =
                 ConfirmedSnapshot
@@ -566,7 +564,7 @@ spec =
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
               chs.version `shouldBe` 4
               chs.currentDepositTxId `shouldBe` Nothing
-              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 1}
+              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 0}
             _ -> fail "expected Open state"
 
         it "version race: stale ReqSn with old version is ignored after DecommitFinalized" $ do
@@ -711,7 +709,10 @@ spec =
           -- Leader (bob) requests snapshot 2 (before DecommitFinalized)
           let reqTx3 = receiveMessage $ ReqTx (aValidTx 3)
           now <- nowFromSlot s1.chainPointTime.currentSlot
-          let outcome = update bobEnv ledger now s1 reqTx3
+          -- ReqTx no longer immediately triggers ReqSn; need TimerInput
+          let s2 = aggregateState s1 $ update bobEnv ledger now s1 reqTx3
+          now2 <- nowFromSlot s2.chainPointTime.currentSlot
+          let outcome = update bobEnv ledger now2 s2 TimerInput
 
           -- Should NOT include the decommit that was already posted in snapshot 1
           outcome `shouldNotHaveEffect` NetworkEffect (ReqSn 0 2 [3] (Just decommitTx') Nothing)
@@ -764,7 +765,10 @@ spec =
           -- Leader (bob) requests snapshot 2 (before CommitFinalized)
           let reqTx3 = receiveMessage $ ReqTx (aValidTx 3)
           now <- nowFromSlot s0.chainPointTime.currentSlot
-          let outcome = update bobEnv ledger now s0 reqTx3
+          -- ReqTx no longer immediately triggers ReqSn; need TimerInput
+          let s1 = aggregateState s0 $ update bobEnv ledger now s0 reqTx3
+          now2 <- nowFromSlot s1.chainPointTime.currentSlot
+          let outcome = update bobEnv ledger now2 s1 TimerInput
 
           -- Should NOT include the deposit that was already posted in snapshot 1
           outcome `shouldNotHaveEffect` NetworkEffect (ReqSn 0 2 [3] Nothing (Just depositTxId))
@@ -789,9 +793,10 @@ spec =
             getState
 
           -- At this point seenSnapshot = LastSeenSnapshot{lastSeen=1}
-          -- Now a new tx arrives - should request snapshot 2, NOT snapshot 1 again
+          -- Now a new tx arrives - timer should request snapshot 2, NOT snapshot 1 again
           s2 <- runHeadLogic bobEnv ledger s1 $ do
             step reqTx
+            step TimerInput
             getState
 
           -- Verify snapshot 2 was requested (not snapshot 1)
@@ -1030,7 +1035,7 @@ spec =
         now <- nowFromSlot st.chainPointTime.currentSlot
         update bobEnv ledger now st input `shouldBe` Error (RequireFailed $ ReqSnNumberInvalid 2 0)
 
-      it "rejects too-old snapshots when collecting signatures" $ do
+      it "drops too-old snapshots when collecting signatures" $ do
         let input :: Input tx
             input = receiveMessageFrom theLeader $ ReqSn 0 2 [] Nothing Nothing
             theLeader = alice
@@ -1042,7 +1047,7 @@ spec =
                   , seenSnapshot = SeenSnapshot (testSnapshot 3 0 [] mempty) mempty
                   }
         now <- nowFromSlot st.chainPointTime.currentSlot
-        update bobEnv ledger now st input `shouldBe` Error (RequireFailed $ ReqSnNumberInvalid 2 3)
+        update bobEnv ledger now st input `shouldBe` noop
 
       it "rejects too-new snapshots from the leader" $ do
         let input :: Input tx
@@ -1052,17 +1057,16 @@ spec =
         now <- nowFromSlot st.chainPointTime.currentSlot
         update bobEnv ledger now st input `shouldBe` Error (RequireFailed $ ReqSnNumberInvalid 3 0)
 
-      it "rejects invalid snapshots version" $ do
+      it "drops snapshots with wrong version" $ do
         let validSnNumber = 0
             invalidSnVersion = 1
             input = receiveMessageFrom theLeader $ ReqSn invalidSnVersion validSnNumber [] Nothing Nothing
             theLeader = carol
-            expectedSnVersion = 0
             st = inOpenState threeParties
         now <- nowFromSlot st.chainPointTime.currentSlot
-        update bobEnv ledger now st input `shouldBe` Error (RequireFailed $ ReqSvNumberInvalid invalidSnVersion expectedSnVersion)
+        update bobEnv ledger now st input `shouldBe` noop
 
-      it "rejects overlapping snapshot requests from the leader" $ do
+      it "drops overlapping snapshot requests from the leader" $ do
         let theLeader = alice
             nextSN = 1
             firstReqTx = receiveMessage $ ReqTx (aValidTx 42)
@@ -1077,9 +1081,7 @@ spec =
           getState
 
         now <- nowFromSlot s3.chainPointTime.currentSlot
-        update bobEnv ledger now s3 secondReqSn `shouldSatisfy` \case
-          Error RequireFailed{} -> True
-          _ -> False
+        update bobEnv ledger now s3 secondReqSn `shouldBe` noop
 
       it "rejects same version snapshot requests with differing decommit txs" $ do
         let decommitTx1 = SimpleTx 1 (utxoRef 1) (utxoRef 3)
@@ -1235,11 +1237,12 @@ spec =
 
           Map.lookup depositTxId s6.pendingDeposits `shouldBe` Nothing
 
-          -- Step 7: New transaction arrives, leader creates new ReqSn
+          -- Step 7: New transaction arrives, leader requests snapshot via timer
           let newTx = aValidTx 1
           let reqTxInput = receiveMessage $ ReqTx newTx
 
-          let outcome = update aliceEnv' ledger now s6 reqTxInput
+          let s7 = aggregateState s6 $ update aliceEnv' ledger now s6 reqTxInput
+          let outcome = update aliceEnv' ledger now s7 TimerInput
 
           -- The ReqSn emitted by the leader does not reference the recovered deposit
           outcome `hasEffectSatisfying` \case
@@ -1248,12 +1251,13 @@ spec =
             _ -> False
 
           -- Step 8: When node processes this ReqSn, it will wait forever
-          s7 <- runHeadLogic aliceEnv' ledger s6 $ do
+          s8 <- runHeadLogic aliceEnv' ledger s6 $ do
             step reqTxInput
+            step TimerInput
             getState
 
           let staleReqSn = receiveMessage $ ReqSn 0 2 [txId newTx] Nothing (Just depositTxId)
-          let reqSnOutcome = update aliceEnv' ledger now s7 staleReqSn
+          let reqSnOutcome = update aliceEnv' ledger now s8 staleReqSn
           -- Fix bug: Error out instead of waiting for deposit to be observed forever
           reqSnOutcome `shouldBe` Error (RequireFailed $ RequestedDepositNotFoundLocally depositTxId)
 

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -289,6 +289,74 @@ spec =
             NetworkEffect ReqSn{} -> True
             _ -> False
 
+        it "timer picks up deposit that activated while a snapshot was in-flight" $ do
+          -- Regression test: when a deposit activates (via tick) while a snapshot
+          -- is in-flight, onOpenChainTick returns noop (no ReqSn). With the bug,
+          -- currentDepositTxId stays Nothing so neither the timer nor
+          -- maybeRequestNextSnapshot ever picks up the deposit.
+          -- Fix: DepositActivated aggregate sets currentDepositTxId when Nothing.
+          now <- getCurrentTime
+          let party = [alice]
+              depositTime = flip addUTCTime now
+              depositTxId = 42 :: Integer
+              depositedUTxO = utxoRef depositTxId
+              -- deadline must be > chainTime + depositPeriod to avoid expiry on the activating tick
+              deadline = depositTime 5 `plusTime` toNominalDiffTime (depositPeriod aliceEnv) `plusTime` toNominalDiffTime (depositPeriod aliceEnv)
+          -- State: snapshot #1 in-flight (collecting signatures), deposit Inactive (about to activate).
+          -- SeenSnapshot means signatures are being collected — snapshotInFlight returns True for all sn.
+          let s0 =
+                (inOpenState' party $
+                  coordinatedHeadState
+                    { seenSnapshot = SeenSnapshot{snapshot = testSnapshot 1 0 [] mempty, signatories = mempty}
+                    , currentDepositTxId = Nothing
+                    })
+                  { pendingDeposits =
+                      Map.fromList
+                        [
+                          ( depositTxId
+                          , Deposit
+                              { headId = testHeadId
+                              , deposited = depositedUTxO
+                              , created = depositTime 1
+                              , deadline
+                              , status = Inactive
+                              }
+                          )
+                        ]
+                  }
+          -- Tick fires past the deposit period, activating the deposit.
+          -- Snapshot is in-flight so onOpenChainTick emits DepositActivated but no ReqSn.
+          let chainTime = depositTime 2 `plusTime` toNominalDiffTime (depositPeriod aliceEnv)
+              tickInput = ChainInput $ Tick{chainTime, chainPoint = 2}
+          now1 <- nowFromSlot s0.chainPointTime.currentSlot
+          let tickOutcome = update aliceEnv ledger now1 s0 tickInput
+              s1 = aggregateState s0 tickOutcome
+          tickOutcome `hasStateChangedSatisfying` \case
+            DepositActivated{depositTxId = d} -> d == depositTxId
+            _ -> False
+          tickOutcome `hasNoEffectSatisfying` \case
+            NetworkEffect ReqSn{} -> True
+            _ -> False
+          -- After aggregation, currentDepositTxId must be set so the timer can retry
+          case headState s1 of
+            Open OpenState{coordinatedHeadState = chs} ->
+              chs.currentDepositTxId `shouldBe` Just depositTxId
+            _ -> fail "expected Open state"
+          -- Simulate snapshot 1 confirming
+          let s2 =
+                s1
+                  { headState = case headState s1 of
+                      Open os@OpenState{coordinatedHeadState = chs} ->
+                        Open os{coordinatedHeadState = chs{seenSnapshot = LastSeenSnapshot{lastSeen = 1}}}
+                      other -> other
+                  }
+          -- Timer fires after snapshot confirmed → must emit ReqSn with the deposit
+          now2 <- nowFromSlot s2.chainPointTime.currentSlot
+          let timerOutcome = update aliceEnv ledger now2 s2 TimerInput
+          timerOutcome `hasEffectSatisfying` \case
+            NetworkEffect ReqSn{depositTxId = Just d} -> d == depositTxId
+            _ -> False
+
         it "on tick, DepositExpired fires only once when deposit transitions to expired" $ do
           -- Regression test: onChainTick emits DepositExpired for ALL expired
           -- deposits on every tick (not just newly-expired ones). After the first

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -86,6 +86,7 @@ spec =
             , contestationPeriod = defaultContestationPeriod
             , depositPeriod = defaultDepositPeriod
             , unsyncedPeriod = defaultUnsyncedPeriod
+            , snapshotRetryInterval = 10
             , participants = deriveOnChainId <$> threeParties
             , configuredPeers = ""
             }
@@ -97,6 +98,7 @@ spec =
             , contestationPeriod = defaultContestationPeriod
             , depositPeriod = defaultDepositPeriod
             , unsyncedPeriod = defaultUnsyncedPeriod
+            , snapshotRetryInterval = 10
             , participants = deriveOnChainId <$> threeParties
             , configuredPeers = ""
             }

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -1517,11 +1517,11 @@ spec =
             step tickInput
             getState
 
-          -- Verify deposit is now active and currentDepositTxId is Nothing still
-          -- (it gets set only when ReqSn is processed)
+          -- Verify deposit is now active and currentDepositTxId is eagerly set
+          -- (DepositActivated now sets it immediately)
           case headState s2 of
             Open OpenState{coordinatedHeadState = CoordinatedHeadState{currentDepositTxId}} ->
-              currentDepositTxId `shouldBe` Nothing
+              currentDepositTxId `shouldBe` Just depositTxId
             other -> expectationFailure $ "Expected Open state, got: " <> show other
 
           -- Step 3: Process ReqSn with the deposit (as if received from network)
@@ -1530,7 +1530,7 @@ spec =
             step reqSnWithDeposit
             getState
 
-          -- Verify currentDepositTxId is now set
+          -- Verify currentDepositTxId is still set
           case headState s3 of
             Open OpenState{coordinatedHeadState = CoordinatedHeadState{currentDepositTxId}} ->
               currentDepositTxId `shouldBe` Just depositTxId

--- a/hydra-node/test/Hydra/Model.hs
+++ b/hydra-node/test/Hydra/Model.hs
@@ -851,14 +851,19 @@ performFanout party = do
   party `sendsInput` Input.Fanout
   findInOutput thisNode (100 :: Int)
  where
-  findInOutput :: (MonadDelay m, MonadThrow m) => TestHydraClient Tx m -> Int -> RunMonad m UTxO
+  findInOutput :: (MonadDelay m, MonadThrow m, MonadSTM m) => TestHydraClient Tx m -> Int -> RunMonad m UTxO
   findInOutput node n
     | n == 0 = failure "Failed to perform Fanout"
     | otherwise = do
         outputs <- lift $ serverOutputs node
         case find headIsFinalized outputs of
           Just (HeadIsFinalized{utxo}) -> pure utxo
-          _ -> lift (threadDelay 1) >> findInOutput node (n - 1)
+          _ -> do
+            -- Re-send Fanout to handle the case where a contest was submitted
+            -- concurrently with the initial fanout attempt. After the contest
+            -- settles, the next Fanout will be built with the updated chain state.
+            party `sendsInput` Input.Fanout
+            lift (threadDelay 1) >> findInOutput node (n - 1)
 
   headIsFinalized :: ServerOutput Tx -> Bool
   headIsFinalized = \case

--- a/hydra-node/test/Hydra/Model/Payment.hs
+++ b/hydra-node/test/Hydra/Model/Payment.hs
@@ -87,6 +87,8 @@ instance IsTx Payment where
     [(from, value)] -> Payment{from, to = from, value}
     _ -> error "cant spend from multiple utxo in one payment"
   utxoFromTx Payment{to, value} = [(to, value)]
+  resolveInputsUTxO utxo Payment{from, value} =
+    filter (\(key, val) -> key == from && val == value) utxo
   outputsOfUTxO = id
   withoutUTxO a b =
     let as = second toList <$> a

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -212,12 +212,13 @@ spec = parallel $ do
                 <> [ receiveMessage ReqTx{transaction = tx1}
                    , receiveMessage ReqTx{transaction = tx2}
                    , receiveMessage ReqTx{transaction = tx3}
+                   , TimerInput
                    ]
         (node, getNetworkEvents) <-
           testHydraNode tracer aliceSk [bob, carol] cperiod inputs
             >>= recordNetwork
         runToCompletion node
-        getNetworkEvents `shouldReturn` [ReqSn 0 1 [1] Nothing Nothing]
+        getNetworkEvents `shouldReturn` [ReqSn 0 1 [1, 2, 3] Nothing Nothing]
 
     it "rotates snapshot leaders" $
       showLogsOnFailure "NodeSpec" $ \tracer -> do
@@ -230,6 +231,7 @@ spec = parallel $ do
                    , receiveMessageFrom bob $ AckSn (sign bobSk sn1) 1
                    , receiveMessageFrom carol $ AckSn (sign carolSk sn1) 1
                    , receiveMessage ReqTx{transaction = tx1}
+                   , TimerInput
                    ]
 
         (node, getNetworkEvents) <-

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -218,7 +218,11 @@ spec = parallel $ do
           testHydraNode tracer aliceSk [bob, carol] cperiod inputs
             >>= recordNetwork
         runToCompletion node
-        getNetworkEvents `shouldReturn` [ReqSn 0 1 [1, 2, 3] Nothing Nothing]
+        -- With immediate snapshot chaining, the first ReqTx triggers ReqSn
+        -- immediately. Subsequent ReqTxs are queued for the next snapshot
+        -- (the leader does not re-broadcast with updated content to avoid
+        -- signature mismatches with peers who already signed the first ReqSn).
+        getNetworkEvents `shouldReturn` [ReqSn 0 1 [1] Nothing Nothing]
 
     it "rotates snapshot leaders" $
       showLogsOnFailure "NodeSpec" $ \tracer -> do

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -303,6 +303,7 @@ spec = parallel $ do
             , contestationPeriod = defaultContestationPeriod
             , depositPeriod = defaultDepositPeriod
             , unsyncedPeriod = defaultUnsyncedPeriod
+            , snapshotRetryInterval = 10
             , participants = deriveOnChainId <$> [alice, bob]
             , configuredPeers = ""
             }
@@ -488,6 +489,7 @@ testHydraNode tracer signingKey otherParties contestationPeriod inputs = do
       , contestationPeriod
       , depositPeriod = defaultDepositPeriod
       , unsyncedPeriod = defaultUnsyncedPeriodFor contestationPeriod
+      , snapshotRetryInterval = 10
       , participants
       , configuredPeers = ""
       }

--- a/hydra-node/testlib/Test/Hydra/HeadLogic/Outcome.hs
+++ b/hydra-node/testlib/Test/Hydra/HeadLogic/Outcome.hs
@@ -44,6 +44,7 @@ genStateChanged env =
     , TransactionReceived <$> arbitrary
     , TransactionAppliedToLocalUTxO <$> arbitrary <*> arbitrary <*> arbitrary
     , SnapshotRequestDecided <$> arbitrary
+    , SnapshotRequestAborted <$> arbitrary <*> arbitrary
     , SnapshotRequested <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
     , PartySignedSnapshot <$> arbitrary <*> arbitrary <*> arbitrary
     , SnapshotConfirmed <$> arbitrary <*> arbitrary <*> arbitrary

--- a/hydra-node/testlib/Test/Hydra/HeadLogic/Outcome.hs
+++ b/hydra-node/testlib/Test/Hydra/HeadLogic/Outcome.hs
@@ -62,6 +62,7 @@ genStateChanged env =
     , HeadIsReadyToFanout <$> arbitrary
     , HeadFannedOut <$> arbitrary <*> arbitrary <*> arbitrary
     , LocalStateCleared <$> arbitrary <*> arbitrary
+    , TxsRequeued <$> arbitrary <*> arbitrary
     , NodeUnsynced <$> arbitrary <*> arbitrary <*> arbitrary
     , NodeSynced <$> arbitrary <*> arbitrary <*> arbitrary
     ]

--- a/hydra-node/testlib/Test/Hydra/Node/Fixture.hs
+++ b/hydra-node/testlib/Test/Hydra/Node/Fixture.hs
@@ -51,6 +51,7 @@ testEnvironment =
     , contestationPeriod = cperiod
     , depositPeriod = DepositPeriod 20
     , unsyncedPeriod = defaultUnsyncedPeriodFor cperiod
+    , snapshotRetryInterval = 10
     , participants = deriveOnChainId <$> [alice, bob, carol]
     , configuredPeers = ""
     }

--- a/hydra-node/testlib/Test/Hydra/Options.hs
+++ b/hydra-node/testlib/Test/Hydra/Options.hs
@@ -50,6 +50,7 @@ instance Arbitrary RunOptions where
     ledgerConfig <- arbitrary
     whichEtcd <- arbitrary
     apiTransactionTimeout <- arbitrary
+    snapshotRetryInterval <- fromInteger <$> choose (1, 3600)
     pure $
       RunOptions
         { verbosity
@@ -70,6 +71,7 @@ instance Arbitrary RunOptions where
         , ledgerConfig
         , whichEtcd
         , apiTransactionTimeout
+        , snapshotRetryInterval
         }
 
   shrink = genericShrink

--- a/hydra-tui/hydra-tui.cabal
+++ b/hydra-tui/hydra-tui.cabal
@@ -113,6 +113,7 @@ test-suite tests
     , optparse-applicative
     , QuickCheck
     , regex-tdfa
+    , stm
     , unix
     , vty
     , vty-unix

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -10,9 +10,9 @@ import Blaze.ByteString.Builder.Char8 (writeChar)
 import CardanoNode (NodeLog, withCardanoNodeDevnet)
 import Control.Concurrent.Class.MonadMVar (MonadMVar (..))
 import Control.Concurrent.Class.MonadSTM (readTQueue, tryReadTQueue, writeTQueue)
+import Control.Concurrent.STM (newTChanIO)
 import Control.Monad.Class.MonadAsync (cancel, waitCatch)
 import Data.ByteString qualified as BS
-import Control.Concurrent.STM (newTChanIO)
 import Graphics.Vty (
   DisplayContext (..),
   Event (EvKey),
@@ -28,7 +28,6 @@ import Graphics.Vty.Image (DisplayRegion)
 import Graphics.Vty.Input (Input (..))
 import Graphics.Vty.Platform.Unix.Output (buildOutput)
 import Graphics.Vty.Platform.Unix.Settings (UnixSettings (..), currentTerminalName)
-import System.Posix.IO (stdOutput)
 import Hydra.Cardano.Api (Coin, Key (getVerificationKey))
 import Hydra.Chain.Direct (DirectBackend (..))
 import Hydra.Cluster.Faucet (
@@ -57,6 +56,7 @@ import HydraNode (
  )
 import System.FilePath ((</>))
 import System.Posix (OpenMode (WriteOnly), closeFd, defaultFileFlags, openFd)
+import System.Posix.IO (stdOutput)
 import Test.QuickCheck (Positive (..))
 
 tuiContestationPeriod :: ContestationPeriod

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -12,23 +12,23 @@ import Control.Concurrent.Class.MonadMVar (MonadMVar (..))
 import Control.Concurrent.Class.MonadSTM (readTQueue, tryReadTQueue, writeTQueue)
 import Control.Monad.Class.MonadAsync (cancel, waitCatch)
 import Data.ByteString qualified as BS
+import Control.Concurrent.STM (newTChanIO)
 import Graphics.Vty (
   DisplayContext (..),
   Event (EvKey),
   Key (KChar, KEnter),
   Output (..),
   Vty (..),
-  defaultConfig,
   displayContext,
   initialAssumedState,
   outputPicture,
-  shutdownInput,
  )
 import Graphics.Vty.Config (userConfig)
 import Graphics.Vty.Image (DisplayRegion)
-import Graphics.Vty.Platform.Unix.Input (buildInput)
+import Graphics.Vty.Input (Input (..))
 import Graphics.Vty.Platform.Unix.Output (buildOutput)
-import Graphics.Vty.Platform.Unix.Settings (defaultSettings)
+import Graphics.Vty.Platform.Unix.Settings (UnixSettings (..), currentTerminalName)
+import System.Posix.IO (stdOutput)
 import Hydra.Cardano.Api (Coin, Key (getVerificationKey))
 import Hydra.Chain.Direct (DirectBackend (..))
 import Hydra.Cluster.Faucet (
@@ -424,16 +424,36 @@ withTUITest region action = do
   findBytes bytes = BS.concat $ BS.drop 1 . BS.dropWhile (/= 109) <$> BS.split 27 bytes
 
   buildVty q frameBuffer = do
-    input <- buildInput defaultConfig =<< defaultSettings
+    -- NOTE(SN): We use a dummy input since events come from the test queue.
+    -- buildInput would try to attach to stdin and fail in non-interactive envs.
+    dummyEventChan <- newTChanIO
+    let input =
+          Input
+            { eventChannel = dummyEventChan
+            , shutdownInput = pure ()
+            , restoreInputState = pure ()
+            , inputLogMsg = \_ -> pure ()
+            }
     -- NOTE(SN): This is used by outputPicture and we hack it such that it
     -- always has the initial state to get a full rendering of the picture. That
     -- way we can capture output bytes line-by-line and drop the cursor moving.
     as <- newIORef initialAssumedState
     -- NOTE(SN): The null device should allow using this in CI, while we do
     -- capture the output via `outputByteBuffer` anyway.
+    -- We construct UnixSettings manually to avoid defaultSettings calling
+    -- flushStdin, which throws hWaitForInput EOF in non-interactive environments.
     nullFd <- openFd "/dev/null" WriteOnly defaultFileFlags
+    termName <- fromMaybe "xterm" <$> currentTerminalName
+    let settings =
+          UnixSettings
+            { settingVmin = 1
+            , settingVtime = 100
+            , settingInputFd = nullFd
+            , settingOutputFd = stdOutput
+            , settingTermName = termName
+            }
     userCfg <- userConfig
-    realOut <- buildOutput userCfg =<< defaultSettings
+    realOut <- buildOutput userCfg settings
     closeFd nullFd
     let output = testOut realOut as frameBuffer
     pure $
@@ -452,7 +472,7 @@ withTUITest region action = do
             dc <- displayContext output region
             outputPicture dc p
         , refresh = pure ()
-        , shutdown = shutdownInput input
+        , shutdown = pure ()
         , isShutdown = pure True
         }
 

--- a/hydra-tx/src/Hydra/Tx/IsTx.hs
+++ b/hydra-tx/src/Hydra/Tx/IsTx.hs
@@ -90,6 +90,10 @@ class
   -- | Get the UTxO produced by given transaction.
   utxoFromTx :: tx -> UTxOType tx
 
+  -- | Resolve transaction inputs against a UTxO set.
+  -- Returns the subset of the UTxO that the transaction consumes.
+  resolveInputsUTxO :: UTxOType tx -> tx -> UTxOType tx
+
   -- | Get only the outputs in given UTxO.
   outputsOfUTxO :: UTxOType tx -> [TxOutType tx]
 
@@ -160,6 +164,8 @@ instance IsTx Tx where
   txSpendingUTxO = Api.txSpendingUTxO
 
   utxoFromTx = Api.utxoFromTx
+
+  resolveInputsUTxO = Api.resolveInputsUTxO
 
   outputsOfUTxO = UTxO.txOutputs
 

--- a/nix/hydra/demo.nix
+++ b/nix/hydra/demo.nix
@@ -73,7 +73,7 @@
                     --node-socket devnet/node.socket \
                     --persistence-dir devnet/persistence/alice \
                     --contestation-period 3s \
-                    --deposit-period 10s
+                    --deposit-period 300s
                 '';
               };
               working_dir = ".";
@@ -107,7 +107,7 @@
                   --node-socket devnet/node.socket \
                   --persistence-dir devnet/persistence/bob \
                   --contestation-period 3s \
-                  --deposit-period 10s
+                  --deposit-period 300s
                 '';
               };
               working_dir = ".";
@@ -141,7 +141,7 @@
                   --node-socket devnet/node.socket \
                   --persistence-dir devnet/persistence/carol \
                   --contestation-period 3s \
-                  --deposit-period 10s
+                  --deposit-period 300s
                 '';
               };
               working_dir = ".";

--- a/nix/hydra/demo.nix
+++ b/nix/hydra/demo.nix
@@ -73,7 +73,7 @@
                     --node-socket devnet/node.socket \
                     --persistence-dir devnet/persistence/alice \
                     --contestation-period 3s \
-                    --deposit-period 300s
+                    --deposit-period 10s
                 '';
               };
               working_dir = ".";
@@ -107,7 +107,7 @@
                   --node-socket devnet/node.socket \
                   --persistence-dir devnet/persistence/bob \
                   --contestation-period 3s \
-                  --deposit-period 300s
+                  --deposit-period 10s
                 '';
               };
               working_dir = ".";
@@ -141,7 +141,7 @@
                   --node-socket devnet/node.socket \
                   --persistence-dir devnet/persistence/carol \
                   --contestation-period 3s \
-                  --deposit-period 300s
+                  --deposit-period 10s
                 '';
               };
               working_dir = ".";

--- a/visualize-logs/src/VisualizeLogs.hs
+++ b/visualize-logs/src/VisualizeLogs.hs
@@ -209,6 +209,7 @@ processLogs decoded =
                     details@HeadFannedOut{} -> logIt (LogicLabel "HeadFannedOut") details
                     details@IgnoredHeadInitializing{} -> logIt (LogicLabel "IgnoredHeadInitializing") details
                     details@TxInvalid{} -> logIt (LogicLabel "TxInvalid") details
+                    TxsRequeued{} -> pure DropLog
                     NetworkConnected{} -> pure DropLog
                     NetworkDisconnected{} -> pure DropLog
                     PeerConnected{} -> pure DropLog

--- a/visualize-logs/src/VisualizeLogs.hs
+++ b/visualize-logs/src/VisualizeLogs.hs
@@ -167,6 +167,7 @@ processLogs decoded =
           case input of
             ClientInput{clientInput} -> logIt ClientSentLabel clientInput
             NetworkInput{} -> pure DropLog
+            TimerInput -> pure DropLog
             ChainInput{chainEvent} ->
               case chainEvent of
                 Observation{observedTx} -> logIt ObservationLabel observedTx

--- a/visualize-logs/src/VisualizeLogs.hs
+++ b/visualize-logs/src/VisualizeLogs.hs
@@ -191,6 +191,7 @@ processLogs decoded =
                     details@CommittedUTxO{} -> logIt (LogicLabel "CommittedUTxO") details
                     details@HeadAborted{} -> logIt (LogicLabel "HeadAborted") details
                     details@SnapshotRequestDecided{} -> logIt (LogicLabel "SnapshotRequestDecided") details
+                    details@SnapshotRequestAborted{} -> logIt (LogicLabel "SnapshotRequestAborted") details
                     details@SnapshotRequested{} -> logIt (LogicLabel "SnapshotRequested") details
                     details@PartySignedSnapshot{} -> logIt (LogicLabel "PartySignedSnapshot") details
                     details@SnapshotConfirmed{} -> logIt (LogicLabel "SnapshotConfirmed") details


### PR DESCRIPTION
● Changes introduced
                                                                                                                                                                       
  Timer-driven snapshots replace transaction-triggered snapshots
                                                                                                                                                                       
  On master, the leader sent ReqSn immediately every time it received a ReqTx. This branch adds a background timer that also fires ReqSn whenever there is pending work
   and no snapshot is in-flight, batching transactions that arrive during an ongoing round. The SeenSnapshot retry previously in onOpenTimer has been removed — it
  caused a ~200 Hz feedback loop via etcd echoes that flooded the input queue and starved incoming AckSn messages under load.
                                                                      
  onOpenNetworkReqSn no longer waits for in-flight snapshots
                                                                      
  Master had waitNoSnapshotInFlight — if a node was already in SeenSnapshot state it would defer processing a new ReqSn. This branch removes that guard, allowing the
  protocol to handle overlapping snapshot rounds. This was required to fix race conditions around deposits and decommits (e.g. a DecommitFinalized arriving mid-round
  bumps the version, requiring a fresh ReqSn to be processed even though the old one is still in-flight).

  postTx for on-chain effects runs asynchronously via asyncTracked

  On master, posting an on-chain transaction (e.g. IncrementTx, DecrementTx) happened synchronously inside processEffects, blocking the main loop until the chain
  submission returned or errored. On this branch it's wrapped in asyncTracked, so the main loop is never blocked by a slow or failing chain submission. A failure
  enqueues a PostTxError back through the input queue.

  Back pressure for NewTx client inputs

  The input queue is a bounded TBQueue (capacity 100). A non-blocking tryEnqueueClient path is now wired through the API layer: HTTP POST /transaction returns 503
  immediately when the queue is full; WebSocket NewTx sends an InvalidInput error back to the client. All other client inputs (e.g. Close, Fanout) continue to use the
  blocking enqueue.

  All other changes (deposit/decommit filtering, skipPostedDecommit, hasWork guard, the SeenSnapshot flooding fix, tx requeuing after De/CommitFinalized) are correctness fixes that fell out of the above structural changes.


---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
