### PR TITLE
Fix the linux binary name produced by CI

### DIFF
--- a/.github/workflows/binaries.yaml
+++ b/.github/workflows/binaries.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os:
           - name: ubuntu-latest
-            arch: x86_linux
+            arch: x86_64-linux
           - name: ubuntu-24.04-arm
             arch: aarch64-linux
     steps:


### PR DESCRIPTION
I got the architecture name wrong; which resulted in a bad name for the binaries, which broke the tutorial.