### PR TITLE
Fix Plutus script evaluation on L2 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 As a minor extension, we also keep a semantic version for the `UNRELEASED`
 changes.
 
+## [UNRELEASED]
+
+- Fix Plutus script evaluation on mainnet/testnet: L2 ledger `Globals` now uses era-aware `EpochInfo` (queried from chain) instead of `fixedEpochInfo`, ensuring correct `POSIXTime` values in Plutus `ScriptContext` for time-sensitive scripts on multi-era chains. Offline/devnet mode is unaffected.
+
 ## [1.3.0] - 2026.03.05
 
 - Upgrade all `PlutusTx` plugin target versions to `1.1.0`.

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -449,6 +449,8 @@ test-suite tests
     , lens-aeson
     , network-simple-wss
     , network-udp
+    , ouroboros-consensus
+    , ouroboros-consensus-cardano
     , plutus-ledger-api               >=1.1.1.0
     , plutus-tx
     , QuickCheck
@@ -458,6 +460,7 @@ test-suite tests
     , req
     , resourcet
     , silently
+    , sop-extras
     , stm
     , temporary
     , text

--- a/hydra-node/src/Hydra/Node/Run.hs
+++ b/hydra-node/src/Hydra/Node/Run.hs
@@ -4,24 +4,17 @@ import Hydra.Prelude hiding (fromList)
 
 import Cardano.Ledger.BaseTypes (Globals (..), boundRational, mkActiveSlotCoeff, unNonZero)
 import Cardano.Ledger.Shelley.API (computeRandomnessStabilisationWindow, computeStabilityWindow)
-import Cardano.Slotting.EpochInfo (fixedEpochInfo)
+import Cardano.Slotting.EpochInfo (fixedEpochInfo, hoistEpochInfo)
 import Cardano.Slotting.Time (mkSlotLength)
+import Control.Monad.Trans.Except (runExcept)
 import Hydra.API.Server (APIServerConfig (..), withAPIServer)
 import Hydra.API.ServerOutputFilter (serverOutputFilter)
-import Hydra.Cardano.Api (
-  GenesisParameters (..),
-  LedgerEra,
-  PParams,
-  ProtocolParametersConversionError,
-  ShelleyEra,
-  SystemStart (..),
-  Tx,
-  toShelleyNetwork,
- )
+import Hydra.Cardano.Api (EraHistory (EraHistory), GenesisParameters (..), LedgerEra, PParams, ProtocolParametersConversionError, ShelleyEra, SystemStart (..), Tx, toShelleyNetwork)
 import Hydra.Chain (ChainComponent, ChainStateHistory, maximumNumberOfParties)
-import Hydra.Chain.Backend (ChainBackend (queryGenesisParameters))
+import Hydra.Chain.Backend (ChainBackend (queryEraHistory, queryGenesisParameters))
 import Hydra.Chain.Blockfrost (BlockfrostBackend (..))
 import Hydra.Chain.Cardano (withCardanoChain)
+import Hydra.Chain.CardanoClient (QueryPoint (..))
 import Hydra.Chain.ChainState (IsChainState (..))
 import Hydra.Chain.Direct (DirectBackend (..))
 import Hydra.Chain.Direct.State (initialChainState)
@@ -62,6 +55,7 @@ import Hydra.Options (
  )
 import Hydra.Persistence (createPersistenceIncremental)
 import Hydra.Utils (readJsonFileThrow)
+import Ouroboros.Consensus.HardFork.History qualified as Consensus
 import System.FilePath ((</>))
 
 data ConfigurationException
@@ -182,13 +176,21 @@ run opts = do
 getGlobalsForChain :: ChainConfig -> IO Globals
 getGlobalsForChain = \case
   Offline OfflineChainConfig{ledgerGenesisFile} ->
+    -- Offline/devnet: single era, fixedEpochInfo is correct
     loadGenesisFile ledgerGenesisFile
       >>= newGlobals
   Cardano CardanoChainConfig{chainBackendOptions} ->
+    -- Online mode: query era history from the chain for correct
+    -- slot-to-time conversions in Plutus script evaluation.
     case chainBackendOptions of
-      Direct directOptions -> queryGenesisParameters (DirectBackend directOptions)
-      Blockfrost blockfrostOptions -> queryGenesisParameters (BlockfrostBackend blockfrostOptions)
-      >>= newGlobals
+      Direct directOptions -> globalsFromBackend (DirectBackend directOptions)
+      Blockfrost blockfrostOptions -> globalsFromBackend (BlockfrostBackend blockfrostOptions)
+ where
+  globalsFromBackend :: ChainBackend b => b -> IO Globals
+  globalsFromBackend b = do
+    genesis <- queryGenesisParameters b
+    eraHistory <- queryEraHistory b QueryTip
+    newGlobalsWithEraHistory genesis eraHistory
 
 data GlobalsTranslationException = GlobalsTranslationException
   deriving stock (Eq, Show)
@@ -231,6 +233,46 @@ newGlobals genesisParameters = do
     , protocolParamEpochLength
     , protocolParamSlotLength
     } = genesisParameters
-  -- NOTE: uses fixed epoch info for our L2 ledger
+  -- NOTE: uses fixed epoch info for our L2 ledger (only correct for devnet/offline)
   epochInfo = fixedEpochInfo protocolParamEpochLength slotLength
   slotLength = mkSlotLength protocolParamSlotLength
+
+-- | Create new L2 ledger 'Globals' using a proper 'EraHistory' for era-aware
+-- slot-to-time conversions. This ensures Plutus scripts receive correct
+-- POSIXTime values in their ScriptContext on multi-era chains (mainnet/testnet).
+--
+-- Throws at least 'GlobalsTranslationException'
+newGlobalsWithEraHistory :: MonadThrow m => GenesisParameters ShelleyEra -> EraHistory -> m Globals
+newGlobalsWithEraHistory genesisParameters (EraHistory interpreter) = do
+  case mkActiveSlotCoeff <$> boundRational protocolParamActiveSlotsCoefficient of
+    Nothing -> throwIO GlobalsTranslationException
+    Just slotCoeff -> do
+      let k = unNonZero protocolParamSecurity
+      pure $
+        Globals
+          { activeSlotCoeff = slotCoeff
+          , epochInfo = eraAwareEpochInfo
+          , maxKESEvo = fromIntegral protocolParamMaxKESEvolutions
+          , maxLovelaceSupply = fromIntegral protocolParamMaxLovelaceSupply
+          , networkId = toShelleyNetwork protocolParamNetworkId
+          , quorum = fromIntegral protocolParamUpdateQuorum
+          , randomnessStabilisationWindow = computeRandomnessStabilisationWindow k slotCoeff
+          , securityParameter = protocolParamSecurity
+          , slotsPerKESPeriod = fromIntegral protocolParamSlotsPerKESPeriod
+          , stabilityWindow = computeStabilityWindow k slotCoeff
+          , systemStart = SystemStart protocolParamSystemStart
+          }
+ where
+  GenesisParameters
+    { protocolParamSlotsPerKESPeriod
+    , protocolParamUpdateQuorum
+    , protocolParamMaxLovelaceSupply
+    , protocolParamSecurity
+    , protocolParamActiveSlotsCoefficient
+    , protocolParamSystemStart
+    , protocolParamNetworkId
+    , protocolParamMaxKESEvolutions
+    } = genesisParameters
+  eraAwareEpochInfo =
+    hoistEpochInfo (first show . runExcept) $
+      Consensus.interpreterToEpochInfo interpreter

--- a/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
+++ b/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
@@ -8,9 +8,12 @@ import Test.Hydra.Prelude
 
 import Cardano.Ledger.Api (ensureMinCoinTxOut)
 import Cardano.Ledger.Credential (Credential (..))
+import Cardano.Slotting.EpochInfo (EpochInfo, epochInfoSlotToRelativeTime, fixedEpochInfo, hoistEpochInfo)
+import Cardano.Slotting.Time (RelativeTime (..), mkSlotLength)
 import Data.Aeson (eitherDecode, encode)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Lens (key)
+import Data.SOP.NonEmpty (NonEmpty (NonEmptyCons, NonEmptyOne))
 import Data.Text (unpack)
 import GHC.IsList (IsList (..))
 import Hydra.Cardano.Api.Pretty (renderTx)
@@ -18,6 +21,20 @@ import Hydra.Chain.ChainState (ChainSlot (ChainSlot))
 import Hydra.JSONSchema (prop_validateJSONSchema)
 import Hydra.Ledger (applyTransactions)
 import Hydra.Ledger.Cardano (cardanoLedger)
+import Ouroboros.Consensus.Block (GenesisWindow (..))
+import Ouroboros.Consensus.Cardano.Block (CardanoEras)
+import Ouroboros.Consensus.HardFork.History (
+  Bound (..),
+  EraEnd (..),
+  EraParams (..),
+  EraSummary (..),
+  SafeZone (..),
+  Summary (Summary),
+  initBound,
+  mkInterpreter,
+ )
+import Ouroboros.Consensus.HardFork.History qualified as Consensus
+import Ouroboros.Consensus.Shelley.Crypto (StandardCrypto)
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
 import Test.Cardano.Ledger.Babbage.Arbitrary ()
 import Test.Gen.Cardano.Api.Typed (genChainPoint)
@@ -42,6 +59,76 @@ spec :: Spec
 spec =
   parallel $ do
     roundtripAndGoldenSpecs (Proxy @AssetName)
+
+    describe "EpochInfo" $ do
+      it "fixedEpochInfo gives wrong slot-to-time for multi-era chains" $ do
+        -- On a real chain (mainnet/testnet), Byron era has 20s slots and
+        -- Shelley+ has 1s slots. fixedEpochInfo uses a single slot length,
+        -- which produces wrong POSIXTime conversions for Plutus scripts.
+        let
+          -- Byron era: 21600 slots per epoch, 20s per slot, runs for 208 epochs
+          byronSlots = 21600 * 208 -- 4,492,800 slots
+          byronSecondsPerSlot = 20
+          byronDuration = byronSlots * byronSecondsPerSlot -- seconds
+          -- A slot well into the Shelley era (1s slots)
+          testSlot = SlotNo (byronSlots + 1000)
+          -- Expected time: byron duration + 1000 seconds (1s per Shelley slot)
+          expectedRelativeTime = byronDuration + 1000
+
+          -- What fixedEpochInfo computes (assumes 1s slots from genesis):
+          fixedRelativeTime = unSlotNo testSlot -- 4,493,800 seconds
+
+        -- The multi-era EpochInfo should give a different (correct) time
+        -- than fixedEpochInfo. fixedEpochInfo assumes all slots are 1s,
+        -- but the Byron slots were actually 20s each.
+        expectedRelativeTime `shouldNotBe` fixedRelativeTime
+
+        -- The actual time via era-aware interpreter
+        let eraHistory = multiEraHistory
+            EraHistory interpreter = eraHistory
+        case Consensus.interpretQuery interpreter (Consensus.slotToWallclock testSlot) of
+          Left err -> expectationFailure $ "Failed to query era history: " <> show err
+          Right (relTime, _slotLen) -> do
+            -- Era-aware gives the correct time (byron duration + 1000s)
+            relTime `shouldBe` RelativeTime (fromIntegral expectedRelativeTime)
+            -- This differs from what fixedEpochInfo would compute
+            relTime `shouldNotBe` RelativeTime (fromIntegral fixedRelativeTime)
+
+      it "fixedEpochInfo causes wrong Globals for L2 Plutus evaluation on mainnet" $ do
+        -- This test demonstrates the actual bug: Globals constructed with
+        -- fixedEpochInfo (as in newGlobals) will have a different epochInfo
+        -- than Globals constructed with the correct era-aware EpochInfo.
+        -- When Ledger.applyTx evaluates Plutus scripts, it uses
+        -- Globals.epochInfo to convert slot numbers to POSIXTime in the
+        -- ScriptContext. With the wrong epochInfo, time-sensitive Plutus
+        -- scripts (like Close, Contest, Fanout) receive incorrect time values.
+        let shelleySlotLength = mkSlotLength 1
+            shelleyEpochSize = EpochSize 432000
+            -- This is what newGlobals currently does (wrong for multi-era):
+            fixedEI = fixedEpochInfo shelleyEpochSize shelleySlotLength
+            -- This is what it should do (correct for multi-era):
+            EraHistory interpreter = multiEraHistory
+            eraAwareEI :: EpochInfo (Either Text)
+            eraAwareEI =
+              hoistEpochInfo (first show . runExcept) $
+                Consensus.interpreterToEpochInfo interpreter
+            -- A slot in the Shelley era
+            testSlot = SlotNo 5000000
+
+        -- The two Globals will produce different results when the ledger
+        -- converts slots to POSIXTime for Plutus script evaluation.
+        -- We verify the epochInfos disagree on the time for the test slot.
+        let fixedResult = epochInfoSlotToRelativeTime fixedEI testSlot :: Either Text RelativeTime
+            eraAwareResult = epochInfoSlotToRelativeTime eraAwareEI testSlot :: Either Text RelativeTime
+        case (fixedResult, eraAwareResult) of
+          (Left err, _) -> expectationFailure $ "Fixed epochInfo failed: " <> show err
+          (_, Left err) -> expectationFailure $ "Era-aware epochInfo failed: " <> show err
+          (Right fixedTime, Right eraTime) -> do
+            -- fixedEpochInfo says: slot 5000000 * 1s = 5000000s from system start
+            fixedTime `shouldBe` RelativeTime 5000000
+            -- Era-aware says: byron(4492800 slots * 20s) + shelley(507200 slots * 1s)
+            --               = 89856000 + 507200 = 90363200s
+            eraTime `shouldNotBe` fixedTime
 
     -- XXX: Move API conformance tests to API specs and add any missing ones
     describe "UTxO" $ do
@@ -196,3 +283,63 @@ propGeneratesGoodTxOut txOut =
       case cred of
         KeyHashObj{} -> False
         ScriptHashObj{} -> True
+
+-- | A realistic multi-era 'EraHistory' mimicking mainnet/testnet where:
+-- - Byron era: 21600 slots/epoch, 20s/slot, runs for 208 epochs (4,492,800 slots)
+-- - Shelley+ era: 432000 slots/epoch, 1s/slot, open-ended
+--
+-- This causes slot-to-time conversions to differ from a simple fixedEpochInfo
+-- because Byron slots are 20x longer than Shelley slots.
+multiEraHistory :: EraHistory
+multiEraHistory =
+  EraHistory (mkInterpreter summary)
+ where
+  byronSlotsPerEpoch = 21600
+  byronEpochs = 208
+  byronSlots = byronSlotsPerEpoch * byronEpochs -- 4,492,800
+  byronSlotLength = mkSlotLength 20
+  byronDurationSeconds = fromIntegral byronSlots * 20 -- 89,856,000 seconds
+  summary :: Summary (CardanoEras StandardCrypto)
+  summary =
+    Summary $
+      NonEmptyCons
+        byronEra
+        ( NonEmptyOne shelleyEra
+        )
+
+  byronEra =
+    EraSummary
+      { eraStart = initBound
+      , eraEnd =
+          EraEnd
+            Bound
+              { boundTime = RelativeTime byronDurationSeconds
+              , boundSlot = SlotNo byronSlots
+              , boundEpoch = EpochNo byronEpochs
+              }
+      , eraParams =
+          EraParams
+            { eraEpochSize = EpochSize byronSlotsPerEpoch
+            , eraSlotLength = byronSlotLength
+            , eraSafeZone = StandardSafeZone (2 * byronSlotsPerEpoch)
+            , eraGenesisWin = GenesisWindow (2 * byronSlotsPerEpoch)
+            }
+      }
+
+  shelleyEra =
+    EraSummary
+      { eraStart =
+          Bound
+            { boundTime = RelativeTime byronDurationSeconds
+            , boundSlot = SlotNo byronSlots
+            , boundEpoch = EpochNo byronEpochs
+            }
+      , eraEnd = EraUnbounded
+      , eraParams =
+          EraParams
+            { eraEpochSize = EpochSize 432000
+            , eraSlotLength = mkSlotLength 1
+            , eraSafeZone = UnsafeIndefiniteSafeZone
+            , eraGenesisWin = GenesisWindow 432000
+            }
+      }

--- a/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
+++ b/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
@@ -78,11 +78,6 @@ spec =
           -- What fixedEpochInfo computes (assumes 1s slots from genesis):
           fixedRelativeTime = unSlotNo testSlot -- 4,493,800 seconds
 
-        -- The multi-era EpochInfo should give a different (correct) time
-        -- than fixedEpochInfo. fixedEpochInfo assumes all slots are 1s,
-        -- but the Byron slots were actually 20s each.
-        expectedRelativeTime `shouldNotBe` fixedRelativeTime
-
         -- The actual time via era-aware interpreter
         let eraHistory = multiEraHistory
             EraHistory interpreter = eraHistory
@@ -101,12 +96,13 @@ spec =
         -- When Ledger.applyTx evaluates Plutus scripts, it uses
         -- Globals.epochInfo to convert slot numbers to POSIXTime in the
         -- ScriptContext. With the wrong epochInfo, time-sensitive Plutus
-        -- scripts (like Close, Contest, Fanout) receive incorrect time values.
+        -- scripts receive incorrect time values.
         let shelleySlotLength = mkSlotLength 1
             shelleyEpochSize = EpochSize 432000
-            -- This is what newGlobals currently does (wrong for multi-era):
+            -- Fixed epoch info
+            fixedEI :: EpochInfo (Either Text)
             fixedEI = fixedEpochInfo shelleyEpochSize shelleySlotLength
-            -- This is what it should do (correct for multi-era):
+            -- Correct for multi-era
             EraHistory interpreter = multiEraHistory
             eraAwareEI :: EpochInfo (Either Text)
             eraAwareEI =
@@ -115,20 +111,11 @@ spec =
             -- A slot in the Shelley era
             testSlot = SlotNo 5000000
 
-        -- The two Globals will produce different results when the ledger
-        -- converts slots to POSIXTime for Plutus script evaluation.
-        -- We verify the epochInfos disagree on the time for the test slot.
-        let fixedResult = epochInfoSlotToRelativeTime fixedEI testSlot :: Either Text RelativeTime
-            eraAwareResult = epochInfoSlotToRelativeTime eraAwareEI testSlot :: Either Text RelativeTime
-        case (fixedResult, eraAwareResult) of
-          (Left err, _) -> expectationFailure $ "Fixed epochInfo failed: " <> show err
-          (_, Left err) -> expectationFailure $ "Era-aware epochInfo failed: " <> show err
-          (Right fixedTime, Right eraTime) -> do
-            -- fixedEpochInfo says: slot 5000000 * 1s = 5000000s from system start
-            fixedTime `shouldBe` RelativeTime 5000000
-            -- Era-aware says: byron(4492800 slots * 20s) + shelley(507200 slots * 1s)
-            --               = 89856000 + 507200 = 90363200s
-            eraTime `shouldNotBe` fixedTime
+        -- fixedEpochInfo says: slot 5000000 * 1s = 5000000s from system start
+        -- Era-aware says: byron(4492800 slots * 20s) + shelley(507200 slots * 1s)
+        --               = 89856000 + 507200 = 90363200s
+        epochInfoSlotToRelativeTime fixedEI testSlot `shouldBe` Right (RelativeTime 5000000)
+        epochInfoSlotToRelativeTime eraAwareEI testSlot `shouldBe` Right (RelativeTime 90363200)
 
     -- XXX: Move API conformance tests to API specs and add any missing ones
     describe "UTxO" $ do


### PR DESCRIPTION
fix https://github.com/cardano-scaling/hydra/issues/2554

Fix Plutus script evaluation on L2 using era-aware EpochInfo for public networks

  On multi-era chains, Byron slots are 20s each while Shelley+ slots are 1s.
  Using fixedEpochInfo for L2 Globals produces wrong POSIXTime values in the
  Plutus ScriptContext, which can cause time-sensitive scripts to fail. 
  For online (Cardano) mode, query the chain's EraHistory and
  use it to build an era-aware EpochInfo via newGlobalsWithEraHistory. Offline
  mode keeps fixedEpochInfo since it runs a single-era devnet.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
