### PR TITLE
More resilient snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 As a minor extension, we also keep a semantic version for the `UNRELEASED`
 changes.
 
+[UNRELEASED]
+
+- Fix head getting permanently stuck after CommitFinalized or DecommitFinalized bumps the snapshot version before a pending ReqSn echo returns, causing stale-version rejection with no re-trigger.
+
 ## [1.3.0] - 2026.03.05
 
 - Upgrade all `PlutusTx` plugin target versions to `1.1.0`.

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -336,7 +336,20 @@ onOpenNetworkReqTx env ledger currentSlot st ttl pendingDeposits tx =
           -- spec. Do we really need to store that we have
           -- requested a snapshot? If yes, should update spec.
           <> newState SnapshotRequestDecided{snapshotNumber = nextSn}
-          <> cause (NetworkEffect $ ReqSn version nextSn (txId <$> take maxTxsPerSnapshot localTxs') decommitTx (setExistingDeposit pendingDeposits currentDepositTxId))
+          <> cause
+            ( NetworkEffect $
+                ReqSn
+                  version
+                  nextSn
+                  (txId <$> take maxTxsPerSnapshot localTxs')
+                  decommitTx
+                  ( selectNextDeposit
+                      pendingDeposits
+                      currentDepositTxId
+                      decommitTx
+                      ((.utxoToCommit) (getSnapshot confirmedSnapshot))
+                  )
+            )
       else outcome
 
   Environment{party} = env
@@ -356,7 +369,6 @@ onOpenNetworkReqTx env ledger currentSlot st ttl pendingDeposits tx =
   Snapshot{number = confirmedSn} = getSnapshot confirmedSnapshot
 
   OpenState{coordinatedHeadState, headId, parameters} = st
-
 
   -- NOTE: Order of transactions is important here. See also
   -- 'pruneTransactions'.
@@ -679,11 +691,12 @@ onOpenNetworkAckSn Environment{party} pendingDeposits openState otherParty snaps
 
   maybeRequestNextSnapshot previous outcome = do
     let nextSn = previous.number + 1
+        nextDeposit = selectNextDeposit pendingDeposits currentDepositTxId decommitTx previous.utxoToCommit
     if isLeader parameters party nextSn && not (null localTxs)
       then
         outcome
           <> newState SnapshotRequestDecided{snapshotNumber = nextSn}
-          <> cause (NetworkEffect $ ReqSn version nextSn (txId <$> take maxTxsPerSnapshot localTxs) decommitTx (setExistingDeposit pendingDeposits currentDepositTxId))
+          <> cause (NetworkEffect $ ReqSn version nextSn (txId <$> take maxTxsPerSnapshot localTxs) decommitTx nextDeposit)
       else outcome
 
   maybePostIncrementTx snapshot@Snapshot{utxoToCommit} signatures outcome =
@@ -890,7 +903,6 @@ onOpenNetworkReqDec env ledger ttl currentSlot openState decommitTx =
 
   nextSn = number + 1
 
-
   CoordinatedHeadState
     { decommitTx = mExistingDecommitTx
     , confirmedSnapshot
@@ -1007,7 +1019,6 @@ onOpenChainTick env chainTime pendingDeposits st =
 
   OpenState{coordinatedHeadState, parameters} = st
 
-
 -- | Observe a increment transaction. If the outputs match the ones of the
 -- pending commit UTxO, then we consider the deposit/increment finalized, and remove the
 -- increment UTxO from 'pendingDeposits' from the local state.
@@ -1039,7 +1050,6 @@ onOpenChainIncrementTx env openState newChainState newVersion depositTxId =
   Environment{party} = env
 
   nextSn = confirmedSn + 1
-
 
   -- Only request a new snapshot when no snapshot is already in-flight.
   -- If we are in SeenSnapshot, all parties have already processed the ReqSn
@@ -1095,7 +1105,6 @@ onOpenChainDecrementTx env pendingDeposits openState newChainState newVersion di
   Environment{party} = env
 
   nextSn = confirmedSn + 1
-
 
   -- Only request a new snapshot when no snapshot is already in-flight.
   -- If we are in SeenSnapshot, all parties have already processed the ReqSn
@@ -1491,6 +1500,37 @@ setExistingDeposit pendingDeposits currentDeposit = do
       case Map.lookup depositTxId pendingDeposits of
         Nothing -> Nothing
         Just _ -> currentDeposit
+
+-- | Find the oldest non-empty active deposit, if any. Deposits are selected
+-- in FIFO order by their 'created' timestamp. This mirrors the selection
+-- logic in 'withNextActive' used by 'onOpenChainTick'.
+nextActiveDepositId :: IsTx tx => PendingDeposits tx -> Maybe (TxIdType tx)
+nextActiveDepositId deposits =
+  case filter (\(_, Deposit{deposited, status}) -> deposited /= mempty && status == Active) (Map.toList deposits) of
+    [] -> Nothing
+    xs -> Just (fst (minimumBy (comparing ((.created) . snd)) xs))
+
+-- | Select the deposit to include in the next snapshot.
+--
+-- Prefers a deposit already tracked in 'currentDepositTxId' (if still pending).
+-- Falls back to the oldest active deposit from 'pendingDeposits', but only
+-- when neither a decommit is pending nor the last confirmed snapshot already
+-- included a deposit (to avoid double-posting 'IncrementTx' before
+-- 'CommitFinalized' removes the deposit).
+selectNextDeposit ::
+  IsTx tx =>
+  PendingDeposits tx ->
+  Maybe (TxIdType tx) ->
+  -- | Pending decommit tx
+  Maybe tx ->
+  -- | utxoToCommit of the last relevant confirmed snapshot
+  Maybe (UTxOType tx) ->
+  Maybe (TxIdType tx)
+selectNextDeposit pendingDeposits currentDepositTxId mDecommitTx mConfirmedUtxoToCommit =
+  setExistingDeposit pendingDeposits currentDepositTxId
+    <|> case (mDecommitTx, mConfirmedUtxoToCommit) of
+      (Nothing, Nothing) -> nextActiveDepositId pendingDeposits
+      _ -> Nothing
 
 -- | Handles inputs and converts them into 'StateChanged' events along with
 -- 'Effect's, in case it is processed successfully. Later, the Node will
@@ -2055,7 +2095,15 @@ aggregate st = \case
             }
       _otherState -> st
   DepositRecorded{} -> st
-  DepositActivated{} -> st
+  DepositActivated{depositTxId} -> case st of
+    Open os@OpenState{coordinatedHeadState = chs} ->
+      -- Spec: txω = ⊥ ∨ txα = ⊥ — deposit and decommit are mutually exclusive.
+      -- Only queue the deposit when no decommit is pending; otherwise the tick
+      -- will pick it up once the decommit completes.
+      case chs.decommitTx of
+        Just _ -> st
+        Nothing -> Open os{coordinatedHeadState = chs{currentDepositTxId = chs.currentDepositTxId <|> Just depositTxId}}
+    _ -> st
   DepositExpired{} -> st
   CommitApproved{} -> st
   DepositRecovered{} -> st

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -71,6 +71,7 @@ import Hydra.HeadLogic.State (
   getChainState,
   seenSnapshotNumber,
   setChainState,
+  snapshotInFlight,
  )
 import Hydra.Ledger (Ledger (..), applyTransactions)
 import Hydra.Network qualified as Network
@@ -328,7 +329,7 @@ onOpenNetworkReqTx env ledger currentSlot st ttl pendingDeposits tx =
             newState TxInvalid{headId, utxo = localUTxO, transaction = tx, validationError = err}
 
   maybeRequestSnapshot nextSn outcome =
-    if not snapshotInFlight && isLeader parameters party nextSn
+    if not (snapshotInFlight seenSnapshot) && isLeader parameters party nextSn
       then
         outcome
           -- XXX: This state update has no equivalence in the
@@ -356,11 +357,6 @@ onOpenNetworkReqTx env ledger currentSlot st ttl pendingDeposits tx =
 
   OpenState{coordinatedHeadState, headId, parameters} = st
 
-  snapshotInFlight = case seenSnapshot of
-    NoSeenSnapshot -> False
-    LastSeenSnapshot{} -> False
-    RequestedSnapshot{} -> True
-    SeenSnapshot{} -> True
 
   -- NOTE: Order of transactions is important here. See also
   -- 'pruneTransactions'.
@@ -882,7 +878,7 @@ onOpenNetworkReqDec env ledger ttl currentSlot openState decommitTx =
                 }
 
   maybeRequestSnapshot =
-    if not snapshotInFlight && isLeader parameters party nextSn
+    if not (snapshotInFlight seenSnapshot) && isLeader parameters party nextSn
       then cause (NetworkEffect (ReqSn version nextSn (txId <$> take maxTxsPerSnapshot localTxs) (Just decommitTx) Nothing))
       else noop
 
@@ -894,11 +890,6 @@ onOpenNetworkReqDec env ledger ttl currentSlot openState decommitTx =
 
   nextSn = number + 1
 
-  snapshotInFlight = case seenSnapshot of
-    NoSeenSnapshot -> False
-    LastSeenSnapshot{} -> False
-    RequestedSnapshot{} -> True
-    SeenSnapshot{} -> True
 
   CoordinatedHeadState
     { decommitTx = mExistingDecommitTx
@@ -977,7 +968,7 @@ onOpenChainTick env chainTime pendingDeposits st =
         -- TODO: Spec: wait tx𝜔 = ⊥ ∧ 𝑈𝛼 = ∅
         if isNothing decommitTx
           && isNothing currentDepositTxId
-          && not snapshotInFlight
+          && not (snapshotInFlight seenSnapshot)
           && isLeader parameters party nextSn
           then
             -- XXX: This state update has no equivalence in the
@@ -1016,11 +1007,6 @@ onOpenChainTick env chainTime pendingDeposits st =
 
   OpenState{coordinatedHeadState, parameters} = st
 
-  snapshotInFlight = case seenSnapshot of
-    NoSeenSnapshot -> False
-    LastSeenSnapshot{} -> False
-    RequestedSnapshot{} -> True
-    SeenSnapshot{} -> True
 
 -- | Observe a increment transaction. If the outputs match the ones of the
 -- pending commit UTxO, then we consider the deposit/increment finalized, and remove the
@@ -1046,7 +1032,7 @@ onOpenChainIncrementTx env openState newChainState newVersion depositTxId =
  where
   OpenState{headId, parameters, coordinatedHeadState} = openState
 
-  CoordinatedHeadState{localTxs, confirmedSnapshot, version} = coordinatedHeadState
+  CoordinatedHeadState{localTxs, confirmedSnapshot, version, seenSnapshot} = coordinatedHeadState
 
   Snapshot{number = confirmedSn} = getSnapshot confirmedSnapshot
 
@@ -1054,16 +1040,18 @@ onOpenChainIncrementTx env openState newChainState newVersion depositTxId =
 
   nextSn = confirmedSn + 1
 
-  -- After CommitFinalized is aggregated, seenSnapshot becomes
-  -- LastSeenSnapshot{confirmedSn}, so snapshotInFlight will be False and we
-  -- can immediately request the next snapshot for any pending work using newVersion.
+
+  -- Only request a new snapshot when no snapshot is already in-flight.
+  -- If we are in SeenSnapshot, all parties have already processed the ReqSn
+  -- and sent their AckSns — that snapshot will complete and maybeRequestNextSnapshot
+  -- will chain the next one using the bumped version. Firing here with stale
+  -- localTxs (pruned against the in-flight snapshot's UTxO) would cause
+  -- BadInputsUTxO on the receiving parties.
   -- Guard on version /= newVersion prevents a duplicate SnapshotRequestDecided when
   -- multiple parties post IncrementTx for the same deposit and each posting fires a
-  -- separate CommitFinalized observation. The second observation finds version already
-  -- bumped and must not re-advance seenSnapshot to RequestedSnapshot, which would
-  -- permanently block the leader's echo via waitNoSnapshotInFlight.
+  -- separate CommitFinalized observation.
   maybeRequestSnapshotAfterCommit =
-    if isLeader parameters party nextSn && not (null localTxs) && version /= newVersion
+    if isLeader parameters party nextSn && not (null localTxs) && version /= newVersion && not (snapshotInFlight seenSnapshot)
       then
         newState SnapshotRequestDecided{snapshotNumber = nextSn}
           <> cause (NetworkEffect $ ReqSn newVersion nextSn (txId <$> take maxTxsPerSnapshot localTxs) Nothing Nothing)
@@ -1100,7 +1088,7 @@ onOpenChainDecrementTx env pendingDeposits openState newChainState newVersion di
  where
   OpenState{headId, parameters, coordinatedHeadState} = openState
 
-  CoordinatedHeadState{localTxs, confirmedSnapshot, currentDepositTxId, version} = coordinatedHeadState
+  CoordinatedHeadState{localTxs, confirmedSnapshot, currentDepositTxId, version, seenSnapshot} = coordinatedHeadState
 
   Snapshot{number = confirmedSn} = getSnapshot confirmedSnapshot
 
@@ -1108,14 +1096,18 @@ onOpenChainDecrementTx env pendingDeposits openState newChainState newVersion di
 
   nextSn = confirmedSn + 1
 
-  -- After DecommitFinalized is aggregated, seenSnapshot becomes
-  -- LastSeenSnapshot so snapshotInFlight will be False and we can immediately
-  -- request the next snapshot for any pending work using newVersion. Guard on
-  -- version /= newVersion mirrors the CommitFinalized guard: prevents a
+
+  -- Only request a new snapshot when no snapshot is already in-flight.
+  -- If we are in SeenSnapshot, all parties have already processed the ReqSn
+  -- and sent their AckSns — that snapshot will complete and maybeRequestNextSnapshot
+  -- will chain the next one using the bumped version. Firing here with stale
+  -- localTxs (pruned against the in-flight snapshot's UTxO) would cause
+  -- BadInputsUTxO on the receiving parties.
+  -- Guard on version /= newVersion mirrors the CommitFinalized guard: prevents a
   -- duplicate SnapshotRequestDecided when multiple DecrementTx postings fire
   -- separate DecommitFinalized observations for the same decommit.
   maybeRequestSnapshotAfterDecommit =
-    if isLeader parameters party nextSn && not (null localTxs) && version /= newVersion
+    if isLeader parameters party nextSn && not (null localTxs) && version /= newVersion && not (snapshotInFlight seenSnapshot)
       then
         newState SnapshotRequestDecided{snapshotNumber = nextSn}
           <> cause (NetworkEffect $ ReqSn newVersion nextSn (txId <$> take maxTxsPerSnapshot localTxs) Nothing (setExistingDeposit pendingDeposits currentDepositTxId))
@@ -1841,13 +1833,20 @@ aggregateNodeState nodeState sc =
                                       -- depositTxId, but we should not verify this here.
                                       currentDepositTxId = Nothing
                                     , localUTxO = localUTxO <> newUTxO
-                                    , seenSnapshot = LastSeenSnapshot{lastSeen = confirmedSn}
+                                    , -- If a snapshot is already in SeenSnapshot, all parties
+                                      -- have processed the ReqSn and sent AckSns — preserve it
+                                      -- so that snapshot can still complete and chain the next
+                                      -- one with the bumped version. Only reset when nothing
+                                      -- is in-flight.
+                                      seenSnapshot = case seenSnapshot of
+                                        SeenSnapshot{} -> seenSnapshot
+                                        _ -> LastSeenSnapshot{lastSeen = confirmedSn}
                                     }
                               }
                       , pendingDeposits = Map.delete depositTxId currentPendingDeposits
                       }
                where
-                CoordinatedHeadState{localUTxO, confirmedSnapshot} = coordinatedHeadState
+                CoordinatedHeadState{localUTxO, confirmedSnapshot, seenSnapshot} = coordinatedHeadState
                 Snapshot{number = confirmedSn} = getSnapshot confirmedSnapshot
             _otherState ->
               nodeState
@@ -2078,7 +2077,7 @@ aggregate st = \case
   DecommitFinalized{chainState, newVersion} ->
     case st of
       Open
-        os@OpenState{coordinatedHeadState = coordinatedHeadState@CoordinatedHeadState{confirmedSnapshot}} ->
+        os@OpenState{coordinatedHeadState = coordinatedHeadState@CoordinatedHeadState{confirmedSnapshot, seenSnapshot}} ->
           let Snapshot{number = confirmedSn} = getSnapshot confirmedSnapshot
            in Open
                 os
@@ -2087,7 +2086,13 @@ aggregate st = \case
                       coordinatedHeadState
                         { decommitTx = Nothing
                         , version = newVersion
-                        , seenSnapshot = LastSeenSnapshot{lastSeen = confirmedSn}
+                        , -- If a snapshot is already in SeenSnapshot, all parties have
+                          -- processed the ReqSn and sent AckSns — preserve it so that
+                          -- snapshot can still complete and chain the next one with the
+                          -- bumped version. Only reset when nothing is in-flight.
+                          seenSnapshot = case seenSnapshot of
+                            SeenSnapshot{} -> seenSnapshot
+                            _ -> LastSeenSnapshot{lastSeen = confirmedSn}
                         }
                   }
       _otherState -> st

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1046,7 +1046,7 @@ onOpenChainIncrementTx env openState newChainState newVersion depositTxId =
  where
   OpenState{headId, parameters, coordinatedHeadState} = openState
 
-  CoordinatedHeadState{localTxs, confirmedSnapshot} = coordinatedHeadState
+  CoordinatedHeadState{localTxs, confirmedSnapshot, version} = coordinatedHeadState
 
   Snapshot{number = confirmedSn} = getSnapshot confirmedSnapshot
 
@@ -1057,8 +1057,13 @@ onOpenChainIncrementTx env openState newChainState newVersion depositTxId =
   -- After CommitFinalized is aggregated, seenSnapshot becomes
   -- LastSeenSnapshot{confirmedSn}, so snapshotInFlight will be False and we
   -- can immediately request the next snapshot for any pending work using newVersion.
+  -- Guard on version /= newVersion prevents a duplicate SnapshotRequestDecided when
+  -- multiple parties post IncrementTx for the same deposit and each posting fires a
+  -- separate CommitFinalized observation. The second observation finds version already
+  -- bumped and must not re-advance seenSnapshot to RequestedSnapshot, which would
+  -- permanently block the leader's echo via waitNoSnapshotInFlight.
   maybeRequestSnapshotAfterCommit =
-    if isLeader parameters party nextSn && not (null localTxs)
+    if isLeader parameters party nextSn && not (null localTxs) && version /= newVersion
       then
         newState SnapshotRequestDecided{snapshotNumber = nextSn}
           <> cause (NetworkEffect $ ReqSn newVersion nextSn (txId <$> take maxTxsPerSnapshot localTxs) Nothing Nothing)
@@ -1095,7 +1100,7 @@ onOpenChainDecrementTx env pendingDeposits openState newChainState newVersion di
  where
   OpenState{headId, parameters, coordinatedHeadState} = openState
 
-  CoordinatedHeadState{localTxs, confirmedSnapshot, currentDepositTxId} = coordinatedHeadState
+  CoordinatedHeadState{localTxs, confirmedSnapshot, currentDepositTxId, version} = coordinatedHeadState
 
   Snapshot{number = confirmedSn} = getSnapshot confirmedSnapshot
 
@@ -1106,8 +1111,11 @@ onOpenChainDecrementTx env pendingDeposits openState newChainState newVersion di
   -- After DecommitFinalized is aggregated, seenSnapshot becomes
   -- LastSeenSnapshot{confirmedSn}, so snapshotInFlight will be False and we
   -- can immediately request the next snapshot for any pending work using newVersion.
+  -- Guard on version /= newVersion mirrors the CommitFinalized guard: prevents a
+  -- duplicate SnapshotRequestDecided when multiple DecrementTx postings fire
+  -- separate DecommitFinalized observations for the same decommit.
   maybeRequestSnapshotAfterDecommit =
-    if isLeader parameters party nextSn && not (null localTxs)
+    if isLeader parameters party nextSn && not (null localTxs) && version /= newVersion
       then
         newState SnapshotRequestDecided{snapshotNumber = nextSn}
           <> cause (NetworkEffect $ ReqSn newVersion nextSn (txId <$> take maxTxsPerSnapshot localTxs) Nothing (setExistingDeposit pendingDeposits currentDepositTxId))

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1049,6 +1049,9 @@ onOpenChainIncrementTx openState newChainState newVersion depositTxId =
 --
 -- __Transition__: 'OpenState' → 'OpenState'
 onOpenChainDecrementTx ::
+  IsTx tx =>
+  Environment ->
+  PendingDeposits tx ->
   OpenState tx ->
   ChainStateType tx ->
   -- | New open state version
@@ -1056,7 +1059,7 @@ onOpenChainDecrementTx ::
   -- | Outputs removed by the decrement
   UTxOType tx ->
   Outcome tx
-onOpenChainDecrementTx openState newChainState newVersion distributedUTxO =
+onOpenChainDecrementTx env pendingDeposits openState newChainState newVersion distributedUTxO =
   newState
     DecommitFinalized
       { chainState = newChainState
@@ -1064,8 +1067,27 @@ onOpenChainDecrementTx openState newChainState newVersion distributedUTxO =
       , newVersion
       , distributedUTxO
       }
+    <> maybeRequestSnapshotAfterDecommit
  where
-  OpenState{headId} = openState
+  OpenState{headId, parameters, coordinatedHeadState} = openState
+
+  CoordinatedHeadState{localTxs, confirmedSnapshot, currentDepositTxId} = coordinatedHeadState
+
+  Snapshot{number = confirmedSn} = getSnapshot confirmedSnapshot
+
+  Environment{party} = env
+
+  nextSn = confirmedSn + 1
+
+  -- After DecommitFinalized is aggregated, seenSnapshot becomes
+  -- LastSeenSnapshot{confirmedSn}, so snapshotInFlight will be False and we
+  -- can immediately request the next snapshot for any pending work using newVersion.
+  maybeRequestSnapshotAfterDecommit =
+    if isLeader parameters party nextSn && not (null localTxs)
+      then
+        newState SnapshotRequestDecided{snapshotNumber = nextSn}
+          <> cause (NetworkEffect $ ReqSn newVersion nextSn (txId <$> take maxTxsPerSnapshot localTxs) Nothing (setExistingDeposit pendingDeposits currentDepositTxId))
+      else noop
 
 -- | On rollback, re-post the IncrementTx if there is a pending deposit whose
 -- confirmed snapshot contains a matching utxoToCommit. The rollback may have
@@ -1574,7 +1596,7 @@ handleChainInput env _ledger now _chainPointTime pendingDeposits st ev syncStatu
   (Open openState@OpenState{headId = ourHeadId}, ChainInput Observation{observedTx = OnDecrementTx{headId, newVersion, distributedUTxO}, newChainState})
     -- TODO: What happens if observed decrement tx get's rolled back?
     | ourHeadId == headId ->
-        onOpenChainDecrementTx openState newChainState newVersion distributedUTxO
+        onOpenChainDecrementTx env pendingDeposits openState newChainState newVersion distributedUTxO
     | otherwise ->
         Error NotOurHead{ourHeadId, otherHeadId = headId}
   -- Closed
@@ -2042,17 +2064,18 @@ aggregate st = \case
   DecommitFinalized{chainState, newVersion} ->
     case st of
       Open
-        os@OpenState{coordinatedHeadState} ->
-          Open
-            os
-              { chainState
-              , coordinatedHeadState =
-                  coordinatedHeadState
-                    { decommitTx = Nothing
-                    , version = newVersion
-                    , seenSnapshot = toLastSeenSnapshot (seenSnapshot coordinatedHeadState)
-                    }
-              }
+        os@OpenState{coordinatedHeadState = coordinatedHeadState@CoordinatedHeadState{confirmedSnapshot}} ->
+          let Snapshot{number = confirmedSn} = getSnapshot confirmedSnapshot
+           in Open
+                os
+                  { chainState
+                  , coordinatedHeadState =
+                      coordinatedHeadState
+                        { decommitTx = Nothing
+                        , version = newVersion
+                        , seenSnapshot = LastSeenSnapshot{lastSeen = confirmedSn}
+                        }
+                  }
       _otherState -> st
   HeadClosed{chainState, contestationDeadline} ->
     case st of

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1026,8 +1026,13 @@ onOpenChainTick env chainTime pendingDeposits st =
 -- pending commit UTxO, then we consider the deposit/increment finalized, and remove the
 -- increment UTxO from 'pendingDeposits' from the local state.
 --
+-- Finally, if the client observing happens to be the leader, then a new ReqSn
+-- is broadcasted.
+--
 -- __Transition__: 'OpenState' → 'OpenState'
 onOpenChainIncrementTx ::
+  IsTx tx =>
+  Environment ->
   OpenState tx ->
   ChainStateType tx ->
   -- | New open state version
@@ -1035,10 +1040,29 @@ onOpenChainIncrementTx ::
   -- | Deposit TxId
   TxIdType tx ->
   Outcome tx
-onOpenChainIncrementTx openState newChainState newVersion depositTxId =
+onOpenChainIncrementTx env openState newChainState newVersion depositTxId =
   newState CommitFinalized{chainState = newChainState, headId, newVersion, depositTxId}
+    <> maybeRequestSnapshotAfterCommit
  where
-  OpenState{headId} = openState
+  OpenState{headId, parameters, coordinatedHeadState} = openState
+
+  CoordinatedHeadState{localTxs, confirmedSnapshot} = coordinatedHeadState
+
+  Snapshot{number = confirmedSn} = getSnapshot confirmedSnapshot
+
+  Environment{party} = env
+
+  nextSn = confirmedSn + 1
+
+  -- After CommitFinalized is aggregated, seenSnapshot becomes
+  -- LastSeenSnapshot{confirmedSn}, so snapshotInFlight will be False and we
+  -- can immediately request the next snapshot for any pending work using newVersion.
+  maybeRequestSnapshotAfterCommit =
+    if isLeader parameters party nextSn && not (null localTxs)
+      then
+        newState SnapshotRequestDecided{snapshotNumber = nextSn}
+          <> cause (NetworkEffect $ ReqSn newVersion nextSn (txId <$> take maxTxsPerSnapshot localTxs) Nothing Nothing)
+      else noop
 
 -- | Observe a decrement transaction. If the outputs match the ones of the
 -- pending decommit tx, then we consider the decommit finalized, and remove the
@@ -1590,7 +1614,7 @@ handleChainInput env _ledger now _chainPointTime pendingDeposits st ev syncStatu
       <> onOpenChainTick env chainTime (depositsForHead ourHeadId pendingDeposits) openState
   (Open openState@OpenState{headId = ourHeadId}, ChainInput Observation{observedTx = OnIncrementTx{headId, newVersion, depositTxId}, newChainState})
     | ourHeadId == headId ->
-        onOpenChainIncrementTx openState newChainState newVersion depositTxId
+        onOpenChainIncrementTx env openState newChainState newVersion depositTxId
     | otherwise ->
         Error NotOurHead{ourHeadId, otherHeadId = headId}
   (Open openState@OpenState{headId = ourHeadId}, ChainInput Observation{observedTx = OnDecrementTx{headId, newVersion, distributedUTxO}, newChainState})
@@ -1809,13 +1833,14 @@ aggregateNodeState nodeState sc =
                                       -- depositTxId, but we should not verify this here.
                                       currentDepositTxId = Nothing
                                     , localUTxO = localUTxO <> newUTxO
-                                    , seenSnapshot = toLastSeenSnapshot (seenSnapshot coordinatedHeadState)
+                                    , seenSnapshot = LastSeenSnapshot{lastSeen = confirmedSn}
                                     }
                               }
                       , pendingDeposits = Map.delete depositTxId currentPendingDeposits
                       }
                where
-                CoordinatedHeadState{localUTxO} = coordinatedHeadState
+                CoordinatedHeadState{localUTxO, confirmedSnapshot} = coordinatedHeadState
+                Snapshot{number = confirmedSn} = getSnapshot confirmedSnapshot
             _otherState ->
               nodeState
                 { headState = st

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -69,6 +69,7 @@ import Hydra.HeadLogic.State (
   PendingCommits,
   SeenSnapshot (..),
   getChainState,
+  isCollectingAcks,
   seenSnapshotNumber,
   setChainState,
   snapshotInFlight,
@@ -1051,17 +1052,18 @@ onOpenChainIncrementTx env openState newChainState newVersion depositTxId =
 
   nextSn = confirmedSn + 1
 
-  -- Only request a new snapshot when no snapshot is already in-flight.
-  -- If we are in SeenSnapshot, all parties have already processed the ReqSn
-  -- and sent their AckSns — that snapshot will complete and maybeRequestNextSnapshot
-  -- will chain the next one using the bumped version. Firing here with stale
-  -- localTxs (pruned against the in-flight snapshot's UTxO) would cause
+  -- Do not re-request if AckSns are already being collected (SeenSnapshot): that
+  -- snapshot will complete and maybeRequestNextSnapshot will chain the next one
+  -- using the bumped version. Firing here with stale localTxs would cause
   -- BadInputsUTxO on the receiving parties.
+  -- RequestedSnapshot is allowed: the in-flight ReqSn carries the old version and
+  -- will be rejected with ReqSvNumberInvalid, so we must re-request immediately
+  -- with the new version to avoid a permanently stuck head.
   -- Guard on version /= newVersion prevents a duplicate SnapshotRequestDecided when
   -- multiple parties post IncrementTx for the same deposit and each posting fires a
   -- separate CommitFinalized observation.
   maybeRequestSnapshotAfterCommit =
-    if isLeader parameters party nextSn && not (null localTxs) && version /= newVersion && not (snapshotInFlight seenSnapshot)
+    if isLeader parameters party nextSn && not (null localTxs) && version /= newVersion && not (isCollectingAcks seenSnapshot)
       then
         newState SnapshotRequestDecided{snapshotNumber = nextSn}
           <> cause (NetworkEffect $ ReqSn newVersion nextSn (txId <$> take maxTxsPerSnapshot localTxs) Nothing Nothing)
@@ -1106,17 +1108,18 @@ onOpenChainDecrementTx env pendingDeposits openState newChainState newVersion di
 
   nextSn = confirmedSn + 1
 
-  -- Only request a new snapshot when no snapshot is already in-flight.
-  -- If we are in SeenSnapshot, all parties have already processed the ReqSn
-  -- and sent their AckSns — that snapshot will complete and maybeRequestNextSnapshot
-  -- will chain the next one using the bumped version. Firing here with stale
-  -- localTxs (pruned against the in-flight snapshot's UTxO) would cause
+  -- Do not re-request if AckSns are already being collected (SeenSnapshot): that
+  -- snapshot will complete and maybeRequestNextSnapshot will chain the next one
+  -- using the bumped version. Firing here with stale localTxs would cause
   -- BadInputsUTxO on the receiving parties.
+  -- RequestedSnapshot is allowed: the in-flight ReqSn carries the old version and
+  -- will be rejected with ReqSvNumberInvalid, so we must re-request immediately
+  -- with the new version to avoid a permanently stuck head.
   -- Guard on version /= newVersion mirrors the CommitFinalized guard: prevents a
   -- duplicate SnapshotRequestDecided when multiple DecrementTx postings fire
   -- separate DecommitFinalized observations for the same decommit.
   maybeRequestSnapshotAfterDecommit =
-    if isLeader parameters party nextSn && not (null localTxs) && version /= newVersion && not (snapshotInFlight seenSnapshot)
+    if isLeader parameters party nextSn && not (null localTxs) && version /= newVersion && not (isCollectingAcks seenSnapshot)
       then
         newState SnapshotRequestDecided{snapshotNumber = nextSn}
           <> cause (NetworkEffect $ ReqSn newVersion nextSn (txId <$> take maxTxsPerSnapshot localTxs) Nothing (setExistingDeposit pendingDeposits currentDepositTxId))

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1109,9 +1109,9 @@ onOpenChainDecrementTx env pendingDeposits openState newChainState newVersion di
   nextSn = confirmedSn + 1
 
   -- After DecommitFinalized is aggregated, seenSnapshot becomes
-  -- LastSeenSnapshot (via toLastSeenSnapshot), so snapshotInFlight will be False
-  -- and we can immediately request the next snapshot for any pending work using newVersion.
-  -- Guard on version /= newVersion mirrors the CommitFinalized guard: prevents a
+  -- LastSeenSnapshot so snapshotInFlight will be False and we can immediately
+  -- request the next snapshot for any pending work using newVersion. Guard on
+  -- version /= newVersion mirrors the CommitFinalized guard: prevents a
   -- duplicate SnapshotRequestDecided when multiple DecrementTx postings fire
   -- separate DecommitFinalized observations for the same decommit.
   maybeRequestSnapshotAfterDecommit =
@@ -1866,25 +1866,6 @@ aggregateNodeState nodeState sc =
           nodeState{headState = st}
 
 -- * HeadState aggregate
-
--- | Convert any SeenSnapshot to LastSeenSnapshot, preserving the correct snapshot number.
--- Used by CommitFinalized and DecommitFinalized to handle race conditions where
--- on-chain transaction confirmation happens before AckSn messages arrive.
-toLastSeenSnapshot :: SeenSnapshot tx -> SeenSnapshot tx
-toLastSeenSnapshot = \case
-  NoSeenSnapshot ->
-    LastSeenSnapshot{lastSeen = 0}
-  LastSeenSnapshot{lastSeen} ->
-    LastSeenSnapshot{lastSeen}
-  -- NB: Use 'requested' not 'lastSeen' to prevent infinite AckSn loop.
-  -- When leader requests snapshot N with commit/decommit and the on-chain transaction
-  -- is observed before AckSn messages arrive, the transaction is part of snapshot N
-  -- (requested), not snapshot N-1 (lastSeen). Using lastSeen would cause AckSn(N)
-  -- messages to fail the guard check and be requeued infinitely.
-  RequestedSnapshot{requested} ->
-    LastSeenSnapshot{lastSeen = requested}
-  SeenSnapshot{snapshot = Snapshot{number}} ->
-    LastSeenSnapshot{lastSeen = number}
 
 -- | Reflect 'StateChanged' events onto the 'HeadState' aggregate.
 aggregate :: IsChainState tx => HeadState tx -> StateChanged tx -> HeadState tx

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1109,8 +1109,8 @@ onOpenChainDecrementTx env pendingDeposits openState newChainState newVersion di
   nextSn = confirmedSn + 1
 
   -- After DecommitFinalized is aggregated, seenSnapshot becomes
-  -- LastSeenSnapshot{confirmedSn}, so snapshotInFlight will be False and we
-  -- can immediately request the next snapshot for any pending work using newVersion.
+  -- LastSeenSnapshot (via toLastSeenSnapshot), so snapshotInFlight will be False
+  -- and we can immediately request the next snapshot for any pending work using newVersion.
   -- Guard on version /= newVersion mirrors the CommitFinalized guard: prevents a
   -- duplicate SnapshotRequestDecided when multiple DecrementTx postings fire
   -- separate DecommitFinalized observations for the same decommit.

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1663,7 +1663,7 @@ handleChainInput env _ledger now _chainPointTime pendingDeposits st ev syncStatu
   (Open openState@OpenState{headId = ourHeadId}, ChainInput Observation{observedTx = OnDecrementTx{headId, newVersion, distributedUTxO}, newChainState})
     -- TODO: What happens if observed decrement tx get's rolled back?
     | ourHeadId == headId ->
-        onOpenChainDecrementTx env pendingDeposits openState newChainState newVersion distributedUTxO
+        onOpenChainDecrementTx env (depositsForHead ourHeadId pendingDeposits) openState newChainState newVersion distributedUTxO
     | otherwise ->
         Error NotOurHead{ourHeadId, otherHeadId = headId}
   -- Closed
@@ -1704,7 +1704,7 @@ handleChainInput env _ledger now _chainPointTime pendingDeposits st ev syncStatu
     ) ->
       newState ChainRolledBack{chainState = rolledBackChainState}
         <> handleOutOfSync env now (chainStatePoint rolledBackChainState) chainTime syncStatus
-        <> maybeRepostIncrementTx headId parameters pendingDeposits currentDepositTxId confirmedSnapshot
+        <> maybeRepostIncrementTx headId parameters (depositsForHead headId pendingDeposits) currentDepositTxId confirmedSnapshot
         <> maybeRepostDecrementTx headId parameters decommitTx confirmedSnapshot
   -- General
   (_, ChainInput Rollback{rolledBackChainState, chainTime}) ->
@@ -1735,8 +1735,8 @@ handleNetworkInput env ledger ChainPointTime{currentSlot} pendingDeposits st ev 
   (_, NetworkInput _ (ConnectivityEvent conn)) ->
     onConnectionEvent env.configuredPeers conn
   -- Open
-  (Open openState, NetworkInput ttl (ReceivedMessage{msg = ReqTx tx})) ->
-    onOpenNetworkReqTx env ledger currentSlot openState ttl pendingDeposits tx
+  (Open openState@OpenState{headId = ourHeadId}, NetworkInput ttl (ReceivedMessage{msg = ReqTx tx})) ->
+    onOpenNetworkReqTx env ledger currentSlot openState ttl (depositsForHead ourHeadId pendingDeposits) tx
   (Open openState@OpenState{headId = ourHeadId}, NetworkInput _ (ReceivedMessage{sender, msg = ReqSn sv sn txIds decommitTx depositTxId})) ->
     onOpenNetworkReqSn env ledger (depositsForHead ourHeadId pendingDeposits) currentSlot openState sender sv sn txIds decommitTx depositTxId
   (Open openState@OpenState{headId = ourHeadId}, NetworkInput _ (ReceivedMessage{sender, msg = AckSn snapshotSignature sn})) ->

--- a/hydra-node/src/Hydra/HeadLogic/State.hs
+++ b/hydra-node/src/Hydra/HeadLogic/State.hs
@@ -195,6 +195,14 @@ seenSnapshotNumber = \case
   RequestedSnapshot{lastSeen} -> lastSeen
   SeenSnapshot{snapshot = Snapshot{number}} -> number
 
+-- | Whether a snapshot is currently in-flight (requested or being signed).
+snapshotInFlight :: SeenSnapshot tx -> Bool
+snapshotInFlight = \case
+  NoSeenSnapshot -> False
+  LastSeenSnapshot{} -> False
+  RequestedSnapshot{} -> True
+  SeenSnapshot{} -> True
+
 -- ** Closed
 
 -- | An 'Closed' head with an current candidate 'ConfirmedSnapshot', which may

--- a/hydra-node/src/Hydra/HeadLogic/State.hs
+++ b/hydra-node/src/Hydra/HeadLogic/State.hs
@@ -203,6 +203,15 @@ snapshotInFlight = \case
   RequestedSnapshot{} -> True
   SeenSnapshot{} -> True
 
+-- | Whether AckSns are currently being collected for a snapshot.
+-- Unlike 'snapshotInFlight', returns False for 'RequestedSnapshot' — a
+-- snapshot sent but not yet echoed is stale once the version bumps and should
+-- not block a fresh request with the new version.
+isCollectingAcks :: SeenSnapshot tx -> Bool
+isCollectingAcks = \case
+  SeenSnapshot{} -> True
+  _ -> False
+
 -- ** Closed
 
 -- | An 'Closed' head with an current candidate 'ConfirmedSnapshot', which may

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -15,7 +15,7 @@ import Control.Concurrent.Class.MonadSTM (
   writeTQueue,
   writeTVar,
  )
-import Control.Monad.Class.MonadAsync (cancel, forConcurrently)
+import Control.Monad.Class.MonadAsync (async, cancel, forConcurrently)
 import Control.Monad.IOSim (IOSim, runSimTrace, selectTraceEventsDynamic)
 import Data.List ((!!))
 import Data.List qualified as List
@@ -235,6 +235,41 @@ spec = parallel $ do
               waitUntil [n2] $ Committed testHeadId alice (utxoRef 1)
               headUTxO <- getHeadUTxO . headState <$> queryState n1
               fromMaybe mempty headUTxO `shouldBe` utxoRefs [1]
+
+    -- Reproduces the version-race using a slow network.
+    -- DecommitFinalized arrives at ALL nodes BEFORE the ReqSn
+    -- echo. When the stale ReqSn(ver=0) echo arrives, both
+    -- nodes already have version=1 → ReqSvNumberInvalid → snapshot stuck.
+    it "snapshot does not get stuck on version race with slow network" $
+      shouldRunInSim $
+        withSimulatedChainAndSlowNetwork 25 0 $ \chain ->
+          withHydraNode aliceSk [bob] chain $ \n1 ->
+            withHydraNode bobSk [alice] chain $ \n2 -> do
+              openHead2 chain n1 n2
+              deadline <- newDeadlineFarEnoughFromNow
+              depositId <- simulateDeposit chain testHeadId (utxoRef 500) deadline
+              waitUntilMatch [n1, n2] $ \case
+                CommitFinalized{depositTxId} | depositTxId == depositId -> Just ()
+                _ -> Nothing
+              -- Send a decommit and an L2 tx so there is pending work that
+              -- triggers ReqSn(ver=0) immediately after the decommit snapshot
+              -- confirms. With networkDelay=25s, DecommitFinalized arrives
+              -- 5 seconds before the ReqSn echo — reproducing the race.
+              send n1 (Decommit (SimpleTx 300 (utxoRef 500) (utxoRef 5000)))
+              send n1 (NewTx (aValidTx 999))
+              -- Wait for decommit snapshot to confirm
+              waitUntilMatch [n1, n2] $ \case
+                SnapshotConfirmed{snapshot = Snapshot{utxoToDecommit = Just _}} -> Just ()
+                _ -> Nothing
+
+              send n1 (NewTx (aValidTx 8888))
+              -- The next snapshot must confirm with version=2 (deposit bumped
+              -- 0→1, decommit bumps 1→2). Without the fix the head is
+              -- permanently stuck: the stale ReqSn(ver=1) is rejected and
+              -- the leader stays in RequestedSnapshot, blocking retries.
+              waitUntilMatch [n1, n2] $ \case
+                SnapshotConfirmed{snapshot = Snapshot{version = 2}} -> Just ()
+                _ -> Nothing
 
     describe "in an open head" $ do
       it "sees the head closed by other nodes" $

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -271,6 +271,37 @@ spec = parallel $ do
                 SnapshotConfirmed{snapshot = Snapshot{version = 2}} -> Just ()
                 _ -> Nothing
 
+    -- Reproduces the version-race for CommitFinalized using a slow network.
+    -- After the deposit snapshot confirms (ver=0), maybeRequestNextSnapshot
+    -- fires ReqSn(ver=0, sn=2) immediately for pending L2 txs. Then
+    -- CommitFinalized bumps version to 1 before the echo returns (25s).
+    -- The stale ReqSn(ver=0) is rejected with ReqSvNumberInvalid and nobody
+    -- re-triggers ReqSn(ver=1) → head permanently stuck without the fix.
+    it "snapshot does not get stuck on CommitFinalized version race with slow network" $
+      shouldRunInSim $
+        withSimulatedChainAndSlowNetwork 25 0 $ \chain ->
+          withHydraNode aliceSk [bob] chain $ \n1 ->
+            withHydraNode bobSk [alice] chain $ \n2 -> do
+              openHead2 chain n1 n2
+              deadline <- newDeadlineFarEnoughFromNow
+              -- Submit a deposit and a pending L2 tx so there is pending work
+              -- when the deposit snapshot confirms (triggering immediate ReqSn).
+              void $ simulateDeposit chain testHeadId (utxoRef 500) deadline
+              send n1 (NewTx (aValidTx 999))
+              -- Wait for the deposit snapshot to confirm (version still 0 at
+              -- this point — CommitFinalized fires after posting to chain).
+              waitUntilMatch [n1, n2] $ \case
+                SnapshotConfirmed{snapshot = Snapshot{utxoToCommit = Just _}} -> Just ()
+                _ -> Nothing
+              -- After the deposit snapshot confirms, the leader sends
+              -- ReqSn(ver=0, sn=2) for tx 999. CommitFinalized then arrives
+              -- and bumps version to 1. The stale ReqSn(ver=0) echo is
+              -- rejected. Without the fix the head gets permanently stuck
+              -- as nobody re-triggers ReqSn(ver=1).
+              waitUntilMatch [n1, n2] $ \case
+                SnapshotConfirmed{snapshot = Snapshot{version = 1}} -> Just ()
+                _ -> Nothing
+
     describe "in an open head" $ do
       it "sees the head closed by other nodes" $
         shouldRunInSim $ do

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -1154,17 +1154,6 @@ withSimulatedChainAndSlowNetwork networkDelay chainDelay =
  where
   initialChainState = SimpleChainState{slot = ChainSlot 0}
 
--- | Creates a simulated chain and network to which 'HydraNode's can be
--- connected to using 'connectNode'. NOTE: The 'tickThread' needs to be
--- 'cancel'ed after use. Use 'withSimulatedChainAndNetwork' instead where
--- possible.
-simulatedChainAndNetwork ::
-  forall m.
-  (MonadTime m, MonadDelay m, MonadAsync m, MonadLabelledSTM m) =>
-  ChainStateType SimpleTx ->
-  m (SimulatedChainNetwork SimpleTx m)
-simulatedChainAndNetwork = simulatedChainAndNetworkUsing createMockNetwork 0
-
 -- | Like 'simulatedChainAndNetwork' but accepts a custom network factory and
 -- an optional chain observation delay. When 'chainDelay' > 0, each chain event
 -- is delivered to nodes asynchronously after that delay, allowing tests to
@@ -1292,20 +1281,7 @@ simulatedChainAndNetworkUsing networkCallback chainDelay initialChainState = do
 handleChainEvent :: HydraNode tx m -> ChainEvent tx -> m ()
 handleChainEvent HydraNode{inputQueue} = enqueue inputQueue . ChainInput
 
-createMockNetwork :: MonadSTM m => DraftHydraNode tx m -> TVar m [HydraNode tx m] -> Network m (Message tx)
-createMockNetwork node nodes =
-  Network{broadcast}
- where
-  broadcast msg = do
-    allNodes <- readTVarIO nodes
-    mapM_ (`handleMessage` msg) allNodes
-
-  handleMessage HydraNode{inputQueue} msg =
-    enqueue inputQueue $ mkNetworkInput sender msg
-
-  sender = getParty node
-
--- | Like 'createMockNetwork' but delivers messages asynchronously after a
+-- | Delivers messages asynchronously after a
 -- configurable delay. When the delay exceeds the chain's block time (20s),
 -- on-chain events arrive at nodes before network echoes, reproducing
 -- version-race conditions seen in production.

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -1132,6 +1132,24 @@ withSimulatedChainAndNetwork ::
   m a
 withSimulatedChainAndNetwork = withSimulatedChainAndSlowNetwork 0 0
 
+-- | Simulated chain and network where the network and/or chain observations
+-- can be delivered with a configurable delay. Handy to reproduce race
+-- conditions related to message ordering.
+withSimulatedChainAndSlowNetwork ::
+  (MonadTime m, MonadDelay m, MonadAsync m, MonadThrow m, MonadLabelledSTM m) =>
+  -- | Network message delay
+  DiffTime ->
+  -- | Chain observation delay
+  DiffTime ->
+  (SimulatedChainNetwork SimpleTx m -> m a) ->
+  m a
+withSimulatedChainAndSlowNetwork networkDelay chainDelay =
+  bracket
+    (simulatedChainAndNetworkUsing (createMockNetworkWithDelay networkDelay) chainDelay initialChainState)
+    (cancel . tickThread)
+ where
+  initialChainState = SimpleChainState{slot = ChainSlot 0}
+
 -- | Creates a simulated chain and network to which 'HydraNode's can be
 -- connected to using 'connectNode'. NOTE: The 'tickThread' needs to be
 -- 'cancel'ed after use. Use 'withSimulatedChainAndNetwork' instead where
@@ -1304,24 +1322,6 @@ createMockNetworkWithDelay networkDelay node nodes =
         enqueue inputQueue $ mkNetworkInput sender msg
 
   sender = getParty node
-
--- | Simulated chain and network where the network and/or chain observations
--- can be delivered with a configurable delay. Handy to reproduce race
--- conditions related to message ordering.
-withSimulatedChainAndSlowNetwork ::
-  (MonadTime m, MonadDelay m, MonadAsync m, MonadThrow m, MonadLabelledSTM m) =>
-  -- | Network message delay
-  DiffTime ->
-  -- | Chain observation delay
-  DiffTime ->
-  (SimulatedChainNetwork SimpleTx m -> m a) ->
-  m a
-withSimulatedChainAndSlowNetwork networkDelay chainDelay =
-  bracket
-    (simulatedChainAndNetworkUsing (createMockNetworkWithDelay networkDelay) chainDelay initialChainState)
-    (cancel . tickThread)
- where
-  initialChainState = SimpleChainState{slot = ChainSlot 0}
 
 -- | Derive an 'OnChainTx' from 'PostChainTx' to simulate a "perfect" chain.
 -- NOTE: This implementation announces hard-coded contestationDeadlines. Also,

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -1099,10 +1099,7 @@ withSimulatedChainAndNetwork ::
   (MonadTime m, MonadDelay m, MonadAsync m, MonadThrow m, MonadLabelledSTM m) =>
   (SimulatedChainNetwork SimpleTx m -> m a) ->
   m a
-withSimulatedChainAndNetwork =
-  bracket
-    (simulatedChainAndNetwork SimpleChainState{slot = ChainSlot 0})
-    (cancel . tickThread)
+withSimulatedChainAndNetwork = withSimulatedChainAndSlowNetwork 0 0
 
 -- | Creates a simulated chain and network to which 'HydraNode's can be
 -- connected to using 'connectNode'. NOTE: The 'tickThread' needs to be
@@ -1113,7 +1110,20 @@ simulatedChainAndNetwork ::
   (MonadTime m, MonadDelay m, MonadAsync m, MonadLabelledSTM m) =>
   ChainStateType SimpleTx ->
   m (SimulatedChainNetwork SimpleTx m)
-simulatedChainAndNetwork initialChainState = do
+simulatedChainAndNetwork = simulatedChainAndNetworkUsing createMockNetwork 0
+
+-- | Like 'simulatedChainAndNetwork' but accepts a custom network factory and
+-- an optional chain observation delay. When 'chainDelay' > 0, each chain event
+-- is delivered to nodes asynchronously after that delay, allowing tests to
+-- reproduce races where nodes observe the same on-chain event at different times.
+simulatedChainAndNetworkUsing ::
+  forall m.
+  (MonadTime m, MonadDelay m, MonadAsync m, MonadLabelledSTM m) =>
+  (DraftHydraNode SimpleTx m -> TVar m [HydraNode SimpleTx m] -> Network m (Message SimpleTx)) ->
+  DiffTime ->
+  ChainStateType SimpleTx ->
+  m (SimulatedChainNetwork SimpleTx m)
+simulatedChainAndNetworkUsing networkCallback chainDelay initialChainState = do
   history <- newLabelledTVarIO "sim-chain-history" []
   nodes <- newLabelledTVarIO "sim-chain-nodes" []
   nextTxId <- newLabelledTVarIO "sim-chain-next-txid" 10000
@@ -1135,7 +1145,7 @@ simulatedChainAndNetwork initialChainState = do
                   , submitTx = \_ -> error "unexpected call to submitTx"
                   , checkNonADAAssets = \_ -> error "unexpected call to checkNonADAAssets"
                   }
-              mockNetwork = createMockNetwork draftNode nodes
+              mockNetwork = networkCallback draftNode nodes
               mockServer :: Server tx m
               mockServer = Server{sendMessage = const $ pure ()}
           node <- connect mockChain mockNetwork mockServer draftNode
@@ -1190,7 +1200,9 @@ simulatedChainAndNetwork initialChainState = do
       modifyTVar' history (chainEvent :)
       readTVar nodes
     forM_ ns $ \n ->
-      handleChainEvent n chainEvent
+      void . asyncLabelled "sim-chain-event" $ do
+        threadDelay chainDelay
+        handleChainEvent n chainEvent
 
   rollbackAndForward ::
     IsChainState tx =>
@@ -1239,6 +1251,46 @@ createMockNetwork node nodes =
     enqueue inputQueue $ mkNetworkInput sender msg
 
   sender = getParty node
+
+-- | Like 'createMockNetwork' but delivers messages asynchronously after a
+-- configurable delay. When the delay exceeds the chain's block time (20s),
+-- on-chain events arrive at nodes before network echoes, reproducing
+-- version-race conditions seen in production.
+createMockNetworkWithDelay ::
+  (MonadAsync m, MonadDelay m) =>
+  DiffTime ->
+  DraftHydraNode tx m ->
+  TVar m [HydraNode tx m] ->
+  Network m (Message tx)
+createMockNetworkWithDelay networkDelay node nodes =
+  Network{broadcast}
+ where
+  broadcast msg = do
+    allNodes <- readTVarIO nodes
+    forM_ allNodes $ \HydraNode{inputQueue} ->
+      void . async $ do
+        threadDelay networkDelay
+        enqueue inputQueue $ mkNetworkInput sender msg
+
+  sender = getParty node
+
+-- | Simulated chain and network where the network and/or chain observations
+-- can be delivered with a configurable delay. Handy to reproduce race
+-- conditions related to message ordering.
+withSimulatedChainAndSlowNetwork ::
+  (MonadTime m, MonadDelay m, MonadAsync m, MonadThrow m, MonadLabelledSTM m) =>
+  -- | Network message delay
+  DiffTime ->
+  -- | Chain observation delay
+  DiffTime ->
+  (SimulatedChainNetwork SimpleTx m -> m a) ->
+  m a
+withSimulatedChainAndSlowNetwork networkDelay chainDelay =
+  bracket
+    (simulatedChainAndNetworkUsing (createMockNetworkWithDelay networkDelay) chainDelay initialChainState)
+    (cancel . tickThread)
+ where
+  initialChainState = SimpleChainState{slot = ChainSlot 0}
 
 -- | Derive an 'OnChainTx' from 'PostChainTx' to simulate a "perfect" chain.
 -- NOTE: This implementation announces hard-coded contestationDeadlines. Also,

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -280,8 +280,12 @@ spec = parallel $ do
     it "snapshot does not get stuck on CommitFinalized version race with slow network" $
       shouldRunInSim $
         withSimulatedChainAndSlowNetwork 25 0 $ \chain ->
-          withHydraNode aliceSk [bob] chain $ \n1 ->
-            withHydraNode bobSk [alice] chain $ \n2 -> do
+          -- Use a short depositPeriod (1s) so the deposit activates on the
+          -- first chain tick (blockTime=20s), before tx 999 is snapshotted
+          -- (ReqTx echo arrives at networkDelay=25s). This ensures tx 999 is
+          -- still pending in localTxs when the deposit snapshot confirms.
+          withHydraNode' (DepositPeriod 1) aliceSk [bob] chain $ \n1 ->
+            withHydraNode' (DepositPeriod 1) bobSk [alice] chain $ \n2 -> do
               openHead2 chain n1 n2
               deadline <- newDeadlineFarEnoughFromNow
               -- Submit a deposit and a pending L2 tx so there is pending work

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -379,13 +379,14 @@ spec =
           let s1 = aggregateState s0 decommitFinalizedOutcome
 
           -- Verify seenSnapshot was reset (not stuck as RequestedSnapshot)
-          -- After DecommitFinalized, lastSeen should be the snapshot number that
-          -- included the decommit (snapshot 1), not the previously confirmed snapshot (0).
-          -- This prevents incoming AckSn messages for snapshot 1 from being requeued infinitely.
+          -- After DecommitFinalized, seenSnapshot resets to LastSeenSnapshot{lastSeen=confirmedSn}.
+          -- This allows maybeRequestSnapshotAfterDecommit to fire a fresh ReqSn immediately.
+          -- NOTE: localUTxO is already correct at this point — DecommitRecorded removed the
+          -- decommit outputs from localUTxO when ReqDec was first processed, before ReqSn was sent.
           case s1 of
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
               chs.version `shouldBe` 4
-              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 1}
+              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 0}
               chs.decommitTx `shouldBe` Nothing
             _ -> fail "expected Open state"
 
@@ -414,7 +415,7 @@ spec =
                 _ -> False
             _ -> fail "expected Open state"
 
-        it "DecommitFinalized with RequestedSnapshot uses requested number not lastSeen" $ do
+        it "DecommitFinalized with RequestedSnapshot resets seenSnapshot to confirmedSn" $ do
           let localUTxO = utxoRefs [1]
               confirmedSn =
                 ConfirmedSnapshot
@@ -438,11 +439,11 @@ spec =
           let decommitFinalizedOutcome = update aliceEnv ledger now s0 decrementObservation
           let s1 = aggregateState s0 decommitFinalizedOutcome
 
-          -- Verify seenSnapshot uses requested (1), not lastSeen (0)
+          -- Verify seenSnapshot resets to confirmedSn (0), regardless of requested (1)
           case s1 of
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
               chs.version `shouldBe` 4
-              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 1}
+              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 0}
               chs.decommitTx `shouldBe` Nothing
             _ -> fail "expected Open state"
 
@@ -501,15 +502,15 @@ spec =
           let decommitFinalizedOutcome = update bobEnv ledger now s0 decrementObservation
           let s1 = aggregateState s0 decommitFinalizedOutcome
 
-          -- Verify DecommitFinalized correctly extracted snapshot number from SeenSnapshot
+          -- Verify DecommitFinalized resets seenSnapshot to confirmedSn (0)
           case s1 of
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
               chs.version `shouldBe` 4
               chs.decommitTx `shouldBe` Nothing
-              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 1}
+              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 0}
             _ -> fail "expected Open state"
 
-        it "CommitFinalized with RequestedSnapshot should use requested number not lastSeen" $ do
+        it "CommitFinalized with RequestedSnapshot resets seenSnapshot to confirmedSn" $ do
           let localUTxO = utxoRefs [1]
               confirmedSn =
                 ConfirmedSnapshot
@@ -534,11 +535,12 @@ spec =
           let commitFinalizedOutcome = update aliceEnv ledger now s0 incrementObservation
           let s1 = aggregateState s0 commitFinalizedOutcome
 
+          -- seenSnapshot resets to confirmedSn (0), not requested (1)
           case s1 of
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
               chs.version `shouldBe` 4
               chs.currentDepositTxId `shouldBe` Nothing
-              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 1}
+              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 0}
             _ -> fail "expected Open state"
 
       describe "Tracks Transaction Ids" $ do

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -283,7 +283,8 @@ spec =
                     , currentDepositTxId = Nothing
                     }
               )
-                { pendingDeposits = Map.singleton depositId deposit }
+                { pendingDeposits = Map.singleton depositId deposit
+                }
 
           -- Alice's AckSn confirms sn=1; maybeRequestNextSnapshot fires for sn=2.
           now' <- nowFromSlot s0.chainPointTime.currentSlot

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -510,6 +510,76 @@ spec =
               chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 0}
             _ -> fail "expected Open state"
 
+        it "DecommitFinalized with SeenSnapshot does not re-request snapshot already in-flight" $ do
+          let localUTxO = utxoRefs [1]
+              decommitTx = SimpleTx 10 mempty (utxoRef 99)
+              snapshot1 = testSnapshot 0 3 [] localUTxO & \s -> s{number = 1}
+              confirmedSn =
+                ConfirmedSnapshot
+                  { snapshot = testSnapshot 0 3 [] localUTxO
+                  , signatures = Crypto.aggregate []
+                  }
+              s0 =
+                inOpenState' threeParties $
+                  coordinatedHeadState
+                    { localUTxO
+                    , version = 3
+                    , confirmedSnapshot = confirmedSn
+                    , seenSnapshot = SeenSnapshot{snapshot = snapshot1, signatories = mempty}
+                    , decommitTx = Just decommitTx
+                    }
+
+          let decrementObservation = observeTx $ OnDecrementTx{headId = testHeadId, newVersion = 4, distributedUTxO = mempty}
+          now <- nowFromSlot s0.chainPointTime.currentSlot
+          let outcome = update aliceEnv ledger now s0 decrementObservation
+
+          -- No new snapshot should be requested: the one in SeenSnapshot will complete
+          outcome `hasNoStateChangedSatisfying` \case
+            SnapshotRequestDecided{} -> True
+            _ -> False
+
+          -- seenSnapshot must be preserved so AckSns can still be collected
+          let s1 = aggregateState s0 outcome
+          case s1 of
+            NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} ->
+              chs.seenSnapshot `shouldBe` SeenSnapshot{snapshot = snapshot1, signatories = mempty}
+            _ -> fail "expected Open state"
+
+        it "CommitFinalized with SeenSnapshot does not re-request snapshot already in-flight" $ do
+          let localUTxO = utxoRefs [1]
+              snapshot1 = testSnapshot 0 3 [] localUTxO & \s -> s{number = 1}
+              confirmedSn =
+                ConfirmedSnapshot
+                  { snapshot = testSnapshot 0 3 [] localUTxO
+                  , signatures = Crypto.aggregate []
+                  }
+              depositTxId = 42
+              s0 =
+                inOpenState' threeParties $
+                  coordinatedHeadState
+                    { localUTxO
+                    , version = 3
+                    , confirmedSnapshot = confirmedSn
+                    , seenSnapshot = SeenSnapshot{snapshot = snapshot1, signatories = mempty}
+                    , currentDepositTxId = Just depositTxId
+                    }
+
+          let incrementObservation = observeTx $ OnIncrementTx{headId = testHeadId, newVersion = 4, depositTxId}
+          now <- nowFromSlot s0.chainPointTime.currentSlot
+          let outcome = update aliceEnv ledger now s0 incrementObservation
+
+          -- No new snapshot should be requested: the one in SeenSnapshot will complete
+          outcome `hasNoStateChangedSatisfying` \case
+            SnapshotRequestDecided{} -> True
+            _ -> False
+
+          -- seenSnapshot must be preserved so AckSns can still be collected
+          let s1 = aggregateState s0 outcome
+          case s1 of
+            NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} ->
+              chs.seenSnapshot `shouldBe` SeenSnapshot{snapshot = snapshot1, signatories = mempty}
+            _ -> fail "expected Open state"
+
         it "CommitFinalized with RequestedSnapshot resets seenSnapshot to confirmedSn" $ do
           let localUTxO = utxoRefs [1]
               confirmedSn =

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -245,6 +245,56 @@ spec =
             NetworkEffect ReqSn{depositTxId} -> depositTxId == Just 1
             _ -> False
 
+        it "deposit activated while snapshot in-flight is picked up by next chained snapshot" $ do
+          -- Regression: a deposit that becomes Active while a snapshot is in-flight
+          -- (so the tick cannot request a snapshot for it) must be included in the
+          -- next chained ReqSn once the in-flight snapshot confirms.
+          --
+          -- After DepositActivated is aggregated the deposit sits in pendingDeposits
+          -- with status=Active, but currentDepositTxId stays Nothing (the bug).
+          -- When maybeRequestNextSnapshot fires it calls
+          --   setExistingDeposit pendingDeposits Nothing = Nothing
+          -- so the deposit is silently dropped from every subsequent ReqSn.
+          now <- getCurrentTime
+          let
+            depositId = 999
+            deposit =
+              Deposit
+                { headId = testHeadId
+                , deposited = utxoRef 50
+                , created = now
+                , deadline = addUTCTime 3600 now
+                , status = Active
+                }
+            -- Single-party head: alice is always leader, so maybeRequestNextSnapshot
+            -- fires for sn=2 when she receives her own AckSn for sn=1.
+            singleParty = [alice]
+            -- sn=1 in SeenSnapshot — no deposit was included (activated too late).
+            snapshot1 = testSnapshot 1 0 [] mempty
+            -- Pending L2 tx ensures not (null localTxs) → maybeRequestNextSnapshot fires.
+            tx2 = aValidTx 2
+            -- State as it would be after DepositActivated was processed:
+            -- pendingDeposits has the Active deposit, currentDepositTxId is still Nothing.
+            s0 =
+              ( inOpenState' singleParty $
+                  coordinatedHeadState
+                    { seenSnapshot = SeenSnapshot{snapshot = snapshot1, signatories = Map.empty}
+                    , localTxs = [tx2]
+                    , currentDepositTxId = Nothing
+                    }
+              )
+                { pendingDeposits = Map.singleton depositId deposit }
+
+          -- Alice's AckSn confirms sn=1; maybeRequestNextSnapshot fires for sn=2.
+          now' <- nowFromSlot s0.chainPointTime.currentSlot
+          let ackSn = receiveMessageFrom alice $ AckSn (sign aliceSk snapshot1) 1
+          let outcome = update aliceEnv ledger now' s0 ackSn
+
+          -- The chained ReqSn for sn=2 must include the active deposit.
+          outcome `hasEffectSatisfying` \case
+            NetworkEffect ReqSn{depositTxId} -> depositTxId == Just depositId
+            _ -> False
+
       describe "Decommit" $ do
         it "observes DecommitRecorded and ReqDec in an Open state" $ do
           let outputs = utxoRef 1

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -527,7 +527,7 @@ spec =
             Continue{} -> True
             Error{} -> True
             Wait{} -> False -- Must NOT Wait (infinite AckSn requeue)
-        it "DecommitFinalized with SeenSnapshot state extracts correct snapshot number" $ do
+        it "DecommitFinalized with SeenSnapshot preserves seenSnapshot so AckSns can still be collected" $ do
           let localUTxO = utxoRefs [1]
               decommitTx = SimpleTx 10 mempty (utxoRef 99)
               snapshot1 = testSnapshot 0 3 [] localUTxO & \s -> s{number = 1}
@@ -553,12 +553,13 @@ spec =
           let decommitFinalizedOutcome = update bobEnv ledger now s0 decrementObservation
           let s1 = aggregateState s0 decommitFinalizedOutcome
 
-          -- Verify DecommitFinalized resets seenSnapshot to confirmedSn (0)
+          -- DecommitFinalized preserves SeenSnapshot so AckSns can still be collected.
+          -- seenSnapshot stays as SeenSnapshot (not reset to LastSeenSnapshot).
           case s1 of
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
               chs.version `shouldBe` 4
               chs.decommitTx `shouldBe` Nothing
-              chs.seenSnapshot `shouldBe` LastSeenSnapshot{lastSeen = 0}
+              chs.seenSnapshot `shouldBe` SeenSnapshot{snapshot = snapshot1, signatories = mempty}
             _ -> fail "expected Open state"
 
         it "DecommitFinalized with SeenSnapshot does not re-request snapshot already in-flight" $ do
@@ -1022,11 +1023,11 @@ spec =
             step tickInput
             getState
 
-          -- Verify deposit is now active and currentDepositTxId is Nothing still
-          -- (it gets set only when ReqSn is processed)
+          -- Verify deposit is now active. DepositActivated queues the deposit
+          -- immediately into currentDepositTxId (via <|> in the aggregate).
           case headState s2 of
             Open OpenState{coordinatedHeadState = CoordinatedHeadState{currentDepositTxId}} ->
-              currentDepositTxId `shouldBe` Nothing
+              currentDepositTxId `shouldBe` Just depositTxId
             other -> expectationFailure $ "Expected Open state, got: " <> show other
 
           -- Step 3: Process ReqSn with the deposit (as if received from network)

--- a/hydra-node/test/Test/Util.hs
+++ b/hydra-node/test/Test/Util.hs
@@ -6,7 +6,6 @@ import Hydra.Prelude
 import Test.Hydra.Prelude hiding (shouldBe)
 
 import Control.Concurrent.Class.MonadSTM (modifyTVar', readTVarIO)
-import Control.Monad.Class.MonadSay (say)
 import Control.Monad.IOSim (
   Failure (FailureException),
   IOSim,
@@ -20,6 +19,7 @@ import Control.Tracer (Tracer (Tracer))
 import Data.Aeson (encode)
 import Data.Aeson qualified as Aeson
 import Data.Text qualified as Text
+import System.IO.Temp (writeSystemTempFile)
 import Hydra.Ledger.Simple (SimpleTx)
 import Hydra.Logging (Envelope (..), traceInTVar)
 import Hydra.Network (NetworkCallback (..))
@@ -49,7 +49,9 @@ shouldRunInSim action =
       throwIO ex
  where
   tr = runSimTrace action
-  dumpTrace = say (toString $ printTrace (Proxy :: Proxy (HydraNodeLog SimpleTx)) tr)
+  dumpTrace = do
+    fp <- writeSystemTempFile "io-sim-trace" $ toString $ printTrace (Proxy :: Proxy (HydraNodeLog SimpleTx)) tr
+    putStrLn $ "IOSim trace written to: " <> fp
 
 -- | Utility function to dump logs given a `SimTrace`.
 printTrace :: forall log a. (Typeable log, ToJSON log) => Proxy log -> SimTrace a -> Text

--- a/hydra-node/test/Test/Util.hs
+++ b/hydra-node/test/Test/Util.hs
@@ -19,11 +19,11 @@ import Control.Tracer (Tracer (Tracer))
 import Data.Aeson (encode)
 import Data.Aeson qualified as Aeson
 import Data.Text qualified as Text
-import System.IO.Temp (writeSystemTempFile)
 import Hydra.Ledger.Simple (SimpleTx)
 import Hydra.Logging (Envelope (..), traceInTVar)
 import Hydra.Network (NetworkCallback (..))
 import Hydra.Node (HydraNodeLog)
+import System.IO.Temp (writeSystemTempFile)
 import Test.HUnit.Lang (FailureReason (ExpectedButGot))
 import Test.QuickCheck (forAll, withMaxSuccess)
 


### PR DESCRIPTION
● This branch fixes several scenarios where a Hydra Head gets permanently stuck after a deposit or withdrawal.

  The root cause is a version race. When a deposit or withdrawal completes on-chain, the Head bumps its internal version number. If the leader has already sent a snapshot request (ReqSn) with the old version number, and the chain confirmation arrives before the echo comes back, that snapshot gets rejected as stale (ReqSvNumberInvalid).
   Nothing was retrying, so the Head froze.

  DecommitFinalized race: After a withdrawal snapshot confirms, the leader fires a new ReqSn immediately for any pending transactions. If DecommitFinalized arrives before the echo returns, the version is already bumped and the stale ReqSn gets rejected. The fix distinguishes two cases. If the leader is in RequestedSnapshot state (ReqSn
   sent, echo not yet back), the stale echo will fail, so DecommitFinalized immediately fires a fresh ReqSn with the new version. If the leader is in SeenSnapshot state (all parties have signed, AckSns being collected), that snapshot will complete naturally and the next one chains with the correct version — no re-request needed.
  Previously the guard blocked both cases equally, leaving the head stuck in the RequestedSnapshot case.

  CommitFinalized race: Identical race but for deposits. Same fix pattern — re-request immediately on CommitFinalized when in RequestedSnapshot, preserve SeenSnapshot and let it complete. An additional guard prevents firing ReqSn twice when multiple parties observe the same CommitFinalized event.

  Missed deposit in chained snapshots: If a deposit becomes active while a snapshot is already in-flight, it can't be included in that snapshot. After the snapshot confirms, the deposit tracking variable gets cleared — so the deposit was never picked up and would eventually expire. Fix: scan pendingDeposits for the oldest active
  deposit as a fallback when the tracking variable is unset.

  Write IOSim trace to file instead of stdout on test failure: The old dumpTrace used say which in IO context dumps the entire IOSim trace (potentially thousands of JSON lines) to stdout on test failure. With slow-network tests generating much larger traces, this was very noisy. Now the trace is written to a temp file and only the path
   is printed.

Related spec PR: https://github.com/cardano-scaling/hydra-formal-specification/pull/25

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
