### PR TITLE
Filter pending deposits by HeadId when processing ReqTx

### DIFF
--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1663,7 +1663,7 @@ handleChainInput env _ledger now _chainPointTime pendingDeposits st ev syncStatu
   (Open openState@OpenState{headId = ourHeadId}, ChainInput Observation{observedTx = OnDecrementTx{headId, newVersion, distributedUTxO}, newChainState})
     -- TODO: What happens if observed decrement tx get's rolled back?
     | ourHeadId == headId ->
-        onOpenChainDecrementTx env pendingDeposits openState newChainState newVersion distributedUTxO
+        onOpenChainDecrementTx env (depositsForHead ourHeadId pendingDeposits) openState newChainState newVersion distributedUTxO
     | otherwise ->
         Error NotOurHead{ourHeadId, otherHeadId = headId}
   -- Closed
@@ -1704,7 +1704,7 @@ handleChainInput env _ledger now _chainPointTime pendingDeposits st ev syncStatu
     ) ->
       newState ChainRolledBack{chainState = rolledBackChainState}
         <> handleOutOfSync env now (chainStatePoint rolledBackChainState) chainTime syncStatus
-        <> maybeRepostIncrementTx headId parameters pendingDeposits currentDepositTxId confirmedSnapshot
+        <> maybeRepostIncrementTx headId parameters (depositsForHead headId pendingDeposits) currentDepositTxId confirmedSnapshot
         <> maybeRepostDecrementTx headId parameters decommitTx confirmedSnapshot
   -- General
   (_, ChainInput Rollback{rolledBackChainState, chainTime}) ->
@@ -1735,8 +1735,8 @@ handleNetworkInput env ledger ChainPointTime{currentSlot} pendingDeposits st ev 
   (_, NetworkInput _ (ConnectivityEvent conn)) ->
     onConnectionEvent env.configuredPeers conn
   -- Open
-  (Open openState, NetworkInput ttl (ReceivedMessage{msg = ReqTx tx})) ->
-    onOpenNetworkReqTx env ledger currentSlot openState ttl pendingDeposits tx
+  (Open openState@OpenState{headId = ourHeadId}, NetworkInput ttl (ReceivedMessage{msg = ReqTx tx})) ->
+    onOpenNetworkReqTx env ledger currentSlot openState ttl (depositsForHead ourHeadId pendingDeposits) tx
   (Open openState@OpenState{headId = ourHeadId}, NetworkInput _ (ReceivedMessage{sender, msg = ReqSn sv sn txIds decommitTx depositTxId})) ->
     onOpenNetworkReqSn env ledger (depositsForHead ourHeadId pendingDeposits) currentSlot openState sender sv sn txIds decommitTx depositTxId
   (Open openState@OpenState{headId = ourHeadId}, NetworkInput _ (ReceivedMessage{sender, msg = AckSn snapshotSignature sn})) ->


### PR DESCRIPTION
## Summary
- Fix `RequestedDepositNotFoundLocally` error when submitting L2 transactions while deposits from other heads exist
- Apply `depositsForHead` filter to `pendingDeposits` in ReqTx handler, consistent with ReqSn and AckSn handlers
- Prevents `selectNextDeposit` from picking deposits belonging to other heads

## Problem
When processing a `ReqTx` (new L2 transaction), `onOpenNetworkReqTx` received unfiltered `pendingDeposits`. This allowed `selectNextDeposit` to
pick a deposit from another head, include it in the `ReqSn`, and cause `RequestedDepositNotFoundLocally` errors when peers couldn't find the
deposit in their filtered list.

## Test plan
- [ ] Verify existing deposit-related tests pass                                                                                                     
- [ ] Test L2 transaction submission while deposits from other heads are observed on chain