### PR TITLE
Cache signible bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 As a minor extension, we also keep a semantic version for the `UNRELEASED`
 changes.
 
+## [UNRELEASED]
+
+  - Reduce snapshot confirmation latency by ~7% (avg) by caching the pre-computed signable bytes of a snapshot in `SeenSnapshot`, avoiding repeated UTxO serialization and hashing on every `AckSn` verification during a signing round.
+
 ## [2.0.0] - 2026.04.05
 
 - **BREAKING** Directly open heads [#2536](https://github.com/cardano-scaling/hydra/pull/2536)

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -92,8 +92,10 @@ import Hydra.Tx.Crypto (
   Signature,
   Verified (..),
   aggregateInOrder,
+  getSignableRepresentation,
   sign,
   verifyMultiSignature,
+  verifyMultiSignatureBytes,
  )
 import Hydra.Tx.HeadParameters (HeadParameters (..))
 import Hydra.Tx.OnChainId (OnChainId)
@@ -519,7 +521,7 @@ onOpenNetworkAckSn Environment{party} pendingDeposits openState otherParty snaps
   -- Spec: require s ∈ {ŝ, ŝ + 1}
   requireValidAckSn $ do
     -- Spec: wait ŝ = s
-    waitOnSeenSnapshot $ \snapshot sigs -> do
+    waitOnSeenSnapshot $ \snapshot sigs snapshotBytes -> do
       -- Spec: require (j,⋅) ∉ ̂Σ
       requireNotSignedYet sigs $ do
         -- Spec: ̂Σ[j] ← σⱼ
@@ -533,7 +535,7 @@ onOpenNetworkAckSn Environment{party} pendingDeposits openState otherParty snaps
             --       𝑈𝜔 ← outputs(tx𝜔 )
             --       ηω ← combine(𝑈𝜔)
             --       require MS-Verify(k ̃H, (cid‖v̂‖ŝ‖η‖η𝛼‖ηω), σ̃)
-            requireVerifiedMultisignature multisig snapshot $
+            requireVerifiedMultisignature multisig snapshotBytes $
               do
                 -- Spec: ̅S ← snObj(v̂, ŝ, Û, T̂, 𝑈𝛼, 𝑈𝜔)
                 --       ̅S.σ ← ̃σ
@@ -562,8 +564,8 @@ onOpenNetworkAckSn Environment{party} pendingDeposits openState otherParty snaps
       -- instances of hydra-node using the same keys.
       LastSeenSnapshot{lastSeen}
         | sn <= lastSeen -> noop
-      SeenSnapshot snapshot sigs
-        | seenSn == sn -> continue snapshot sigs
+      SeenSnapshot{snapshot, signatories = sigs, signableBytes}
+        | seenSn == sn -> continue snapshot sigs signableBytes
       _ -> wait WaitOnSeenSnapshot
 
   requireNotSignedYet sigs continue =
@@ -584,7 +586,7 @@ onOpenNetworkAckSn Environment{party} pendingDeposits openState otherParty snaps
                 }
 
   requireVerifiedMultisignature multisig msg cont =
-    case verifyMultiSignature vkeys multisig msg of
+    case verifyMultiSignatureBytes vkeys multisig msg of
       Verified -> cont
       FailedKeys failures ->
         Error $
@@ -1903,7 +1905,12 @@ aggregate st = \case
           os
             { coordinatedHeadState =
                 coordinatedHeadState
-                  { seenSnapshot = SeenSnapshot snapshot mempty
+                  { seenSnapshot =
+                      SeenSnapshot
+                        { snapshot
+                        , signatories = mempty
+                        , signableBytes = getSignableRepresentation snapshot
+                        }
                   , localTxs = newLocalTxs
                   , localUTxO = newLocalUTxO
                   , allTxs = foldr Map.delete allTxs requestedTxIds

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -67,6 +67,7 @@ import Hydra.HeadLogic.State (
   SeenSnapshot (..),
   getChainState,
   isCollectingAcks,
+  mkSeenSnapshot,
   seenSnapshotNumber,
   setChainState,
   snapshotInFlight,
@@ -92,7 +93,6 @@ import Hydra.Tx.Crypto (
   Signature,
   Verified (..),
   aggregateInOrder,
-  getSignableRepresentation,
   sign,
   verifyMultiSignature,
   verifyMultiSignatureBytes,
@@ -1905,12 +1905,7 @@ aggregate st = \case
           os
             { coordinatedHeadState =
                 coordinatedHeadState
-                  { seenSnapshot =
-                      SeenSnapshot
-                        { snapshot
-                        , signatories = mempty
-                        , signableBytes = getSignableRepresentation snapshot
-                        }
+                  { seenSnapshot = mkSeenSnapshot snapshot mempty
                   , localTxs = newLocalTxs
                   , localUTxO = newLocalUTxO
                   , allTxs = foldr Map.delete allTxs requestedTxIds

--- a/hydra-node/src/Hydra/HeadLogic/State.hs
+++ b/hydra-node/src/Hydra/HeadLogic/State.hs
@@ -6,6 +6,7 @@ module Hydra.HeadLogic.State where
 
 import Hydra.Prelude
 
+import Data.Aeson (object, withObject, (.:), (.=))
 import Data.Map qualified as Map
 import Hydra.Chain.ChainState (IsChainState (..))
 import Hydra.Tx (
@@ -15,7 +16,7 @@ import Hydra.Tx (
   IsTx (..),
   Party,
  )
-import Hydra.Tx.Crypto (Signature)
+import Hydra.Tx.Crypto (Signature, getSignableRepresentation)
 import Hydra.Tx.Snapshot (
   ConfirmedSnapshot,
   Snapshot (..),
@@ -151,14 +152,52 @@ data SeenSnapshot tx
     SeenSnapshot
       { snapshot :: Snapshot tx
       , signatories :: Map Party (Signature (Snapshot tx))
-      -- ^ Collected signatures and so far.
+      -- ^ Collected signatures so far.
+      , signableBytes :: ByteString
+      -- ^ Pre-computed result of 'getSignableRepresentation snapshot', cached
+      -- to avoid recomputing the expensive UTxO hash on every AckSn verification.
       }
   deriving stock (Generic)
 
 deriving stock instance IsTx tx => Eq (SeenSnapshot tx)
 deriving stock instance IsTx tx => Show (SeenSnapshot tx)
-deriving anyclass instance IsTx tx => ToJSON (SeenSnapshot tx)
-deriving anyclass instance IsTx tx => FromJSON (SeenSnapshot tx)
+
+-- Manual instances that exclude 'signableBytes' from JSON (it is derived from
+-- 'snapshot' and recomputed on deserialisation).
+instance IsTx tx => ToJSON (SeenSnapshot tx) where
+  toJSON = \case
+    NoSeenSnapshot ->
+      object ["tag" .= ("NoSeenSnapshot" :: Text)]
+    LastSeenSnapshot{lastSeen} ->
+      object ["tag" .= ("LastSeenSnapshot" :: Text), "lastSeen" .= lastSeen]
+    RequestedSnapshot{lastSeen, requested} ->
+      object
+        [ "tag" .= ("RequestedSnapshot" :: Text)
+        , "lastSeen" .= lastSeen
+        , "requested" .= requested
+        ]
+    SeenSnapshot{snapshot, signatories} ->
+      object
+        [ "tag" .= ("SeenSnapshot" :: Text)
+        , "snapshot" .= snapshot
+        , "signatories" .= signatories
+        ]
+
+instance IsTx tx => FromJSON (SeenSnapshot tx) where
+  parseJSON = withObject "SeenSnapshot" $ \obj -> do
+    tag :: Text <- obj .: "tag"
+    case tag of
+      "NoSeenSnapshot" -> pure NoSeenSnapshot
+      "LastSeenSnapshot" -> LastSeenSnapshot <$> obj .: "lastSeen"
+      "RequestedSnapshot" ->
+        RequestedSnapshot
+          <$> obj .: "lastSeen"
+          <*> obj .: "requested"
+      "SeenSnapshot" -> do
+        snapshot <- obj .: "snapshot"
+        signatories <- obj .: "signatories"
+        pure SeenSnapshot{snapshot, signatories, signableBytes = getSignableRepresentation snapshot}
+      other -> fail $ "unknown SeenSnapshot tag: " <> toString other
 
 -- | Get the last seen snapshot number given a 'SeenSnapshot'.
 seenSnapshotNumber :: SeenSnapshot tx -> SnapshotNumber

--- a/hydra-node/src/Hydra/HeadLogic/State.hs
+++ b/hydra-node/src/Hydra/HeadLogic/State.hs
@@ -196,8 +196,18 @@ instance IsTx tx => FromJSON (SeenSnapshot tx) where
       "SeenSnapshot" -> do
         snapshot <- obj .: "snapshot"
         signatories <- obj .: "signatories"
-        pure SeenSnapshot{snapshot, signatories, signableBytes = getSignableRepresentation snapshot}
+        pure $ mkSeenSnapshot snapshot signatories
       other -> fail $ "unknown SeenSnapshot tag: " <> toString other
+
+-- | Smart constructor for 'SeenSnapshot' that computes and caches
+-- 'signableBytes' from 'snapshot', enforcing the invariant that they stay in sync.
+mkSeenSnapshot ::
+  IsTx tx =>
+  Snapshot tx ->
+  Map Party (Signature (Snapshot tx)) ->
+  SeenSnapshot tx
+mkSeenSnapshot snapshot signatories =
+  SeenSnapshot{snapshot, signatories, signableBytes = getSignableRepresentation snapshot}
 
 -- | Get the last seen snapshot number given a 'SeenSnapshot'.
 seenSnapshotNumber :: SeenSnapshot tx -> SnapshotNumber

--- a/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
@@ -15,7 +15,7 @@ import Hydra.Network.Message (Message (..))
 import Hydra.Node.Environment (Environment (..))
 import Hydra.Node.State (ChainPointTime (..), NodeState (..))
 import Hydra.Options (defaultContestationPeriod, defaultDepositPeriod, defaultUnsyncedPeriod)
-import Hydra.Tx.Crypto (sign)
+import Hydra.Tx.Crypto (getSignableRepresentation, sign)
 import Hydra.Tx.HeadParameters (HeadParameters (..))
 import Hydra.Tx.IsTx (txId)
 import Hydra.Tx.Party (Party, deriveParty)
@@ -98,7 +98,7 @@ spec = do
       it "does NOT send ReqSn when we are the leader but snapshot in flight" $ do
         let tx = aValidTx 1
             sn1 = Snapshot testHeadId 1 1 [] u0 Nothing Nothing :: Snapshot SimpleTx
-            st = coordinatedHeadState{seenSnapshot = SeenSnapshot sn1 mempty}
+            st = coordinatedHeadState{seenSnapshot = SeenSnapshot{snapshot = sn1, signatories = mempty, signableBytes = getSignableRepresentation sn1}}
             s0 = inOpenState' [alice, bob] st
         now <- nowFromSlot (currentSlot . chainPointTime $ s0)
         let outcome = update (envFor aliceSk) simpleLedger now s0 $ receiveMessage $ ReqTx tx

--- a/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
@@ -8,14 +8,14 @@ import Test.Hydra.Prelude
 
 import Data.List qualified as List
 import Data.Map.Strict qualified as Map
-import Hydra.HeadLogic (CoordinatedHeadState (..), Effect (..), HeadState (..), OpenState (OpenState), Outcome, SeenSnapshot (..), coordinatedHeadState, isLeader, update)
+import Hydra.HeadLogic (CoordinatedHeadState (..), Effect (..), HeadState (..), OpenState (OpenState), Outcome, SeenSnapshot (..), coordinatedHeadState, isLeader, mkSeenSnapshot, update)
 import Hydra.HeadLogicSpec (StepState, getState, hasEffect, hasEffectSatisfying, hasNoEffectSatisfying, inOpenState, inOpenState', nowFromSlot, receiveMessage, receiveMessageFrom, runHeadLogic, step)
 import Hydra.Ledger.Simple (SimpleTx (..), aValidTx, simpleLedger, utxoRef)
 import Hydra.Network.Message (Message (..))
 import Hydra.Node.Environment (Environment (..))
 import Hydra.Node.State (ChainPointTime (..), NodeState (..))
 import Hydra.Options (defaultContestationPeriod, defaultDepositPeriod, defaultUnsyncedPeriod)
-import Hydra.Tx.Crypto (getSignableRepresentation, sign)
+import Hydra.Tx.Crypto (sign)
 import Hydra.Tx.HeadParameters (HeadParameters (..))
 import Hydra.Tx.IsTx (txId)
 import Hydra.Tx.Party (Party, deriveParty)
@@ -98,7 +98,7 @@ spec = do
       it "does NOT send ReqSn when we are the leader but snapshot in flight" $ do
         let tx = aValidTx 1
             sn1 = Snapshot testHeadId 1 1 [] u0 Nothing Nothing :: Snapshot SimpleTx
-            st = coordinatedHeadState{seenSnapshot = SeenSnapshot{snapshot = sn1, signatories = mempty, signableBytes = getSignableRepresentation sn1}}
+            st = coordinatedHeadState{seenSnapshot = mkSeenSnapshot sn1 mempty}
             s0 = inOpenState' [alice, bob] st
         now <- nowFromSlot (currentSlot . chainPointTime $ s0)
         let outcome = update (envFor aliceSk) simpleLedger now s0 $ receiveMessage $ ReqTx tx

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -49,7 +49,7 @@ import Hydra.Options (defaultContestationPeriod, defaultDepositPeriod, defaultUn
 import Hydra.Prelude qualified as Prelude
 import Hydra.Tx (HeadId)
 import Hydra.Tx.ContestationPeriod qualified as CP
-import Hydra.Tx.Crypto (aggregate, generateSigningKey, sign)
+import Hydra.Tx.Crypto (aggregate, generateSigningKey, getSignableRepresentation, sign)
 import Hydra.Tx.Crypto qualified as Crypto
 import Hydra.Tx.HeadParameters (HeadParameters (..))
 import Hydra.Tx.IsTx (IsTx (..))
@@ -277,7 +277,7 @@ spec =
             s0 =
               ( inOpenState' singleParty $
                   coordinatedHeadState
-                    { seenSnapshot = SeenSnapshot{snapshot = snapshot1, signatories = Map.empty}
+                    { seenSnapshot = SeenSnapshot{snapshot = snapshot1, signatories = Map.empty, signableBytes = getSignableRepresentation snapshot1}
                     , localTxs = [tx2]
                     , currentDepositTxId = Nothing
                     }
@@ -599,7 +599,7 @@ spec =
                     { localUTxO
                     , version = 3
                     , confirmedSnapshot = confirmedSn
-                    , seenSnapshot = SeenSnapshot{snapshot = snapshot1, signatories = mempty}
+                    , seenSnapshot = SeenSnapshot{snapshot = snapshot1, signatories = mempty, signableBytes = getSignableRepresentation snapshot1}
                     , decommitTx = Just decommitTx
                     }
 
@@ -615,7 +615,7 @@ spec =
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
               chs.version `shouldBe` 4
               chs.decommitTx `shouldBe` Nothing
-              chs.seenSnapshot `shouldBe` SeenSnapshot{snapshot = snapshot1, signatories = mempty}
+              chs.seenSnapshot `shouldBe` SeenSnapshot{snapshot = snapshot1, signatories = mempty, signableBytes = getSignableRepresentation snapshot1}
             _ -> fail "expected Open state"
 
         it "DecommitFinalized with SeenSnapshot does not re-request snapshot already in-flight" $ do
@@ -633,7 +633,7 @@ spec =
                     { localUTxO
                     , version = 3
                     , confirmedSnapshot = confirmedSn
-                    , seenSnapshot = SeenSnapshot{snapshot = snapshot1, signatories = mempty}
+                    , seenSnapshot = SeenSnapshot{snapshot = snapshot1, signatories = mempty, signableBytes = getSignableRepresentation snapshot1}
                     , decommitTx = Just decommitTx
                     }
 
@@ -650,7 +650,7 @@ spec =
           let s1 = aggregateState s0 outcome
           case s1 of
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} ->
-              chs.seenSnapshot `shouldBe` SeenSnapshot{snapshot = snapshot1, signatories = mempty}
+              chs.seenSnapshot `shouldBe` SeenSnapshot{snapshot = snapshot1, signatories = mempty, signableBytes = getSignableRepresentation snapshot1}
             _ -> fail "expected Open state"
 
         it "CommitFinalized with SeenSnapshot does not re-request snapshot already in-flight" $ do
@@ -668,7 +668,7 @@ spec =
                     { localUTxO
                     , version = 3
                     , confirmedSnapshot = confirmedSn
-                    , seenSnapshot = SeenSnapshot{snapshot = snapshot1, signatories = mempty}
+                    , seenSnapshot = SeenSnapshot{snapshot = snapshot1, signatories = mempty, signableBytes = getSignableRepresentation snapshot1}
                     , currentDepositTxId = Just depositTxId
                     }
 
@@ -685,7 +685,7 @@ spec =
           let s1 = aggregateState s0 outcome
           case s1 of
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} ->
-              chs.seenSnapshot `shouldBe` SeenSnapshot{snapshot = snapshot1, signatories = mempty}
+              chs.seenSnapshot `shouldBe` SeenSnapshot{snapshot = snapshot1, signatories = mempty, signableBytes = getSignableRepresentation snapshot1}
             _ -> fail "expected Open state"
 
         it "CommitFinalized with RequestedSnapshot resets seenSnapshot to confirmedSn" $ do
@@ -960,7 +960,7 @@ spec =
               inOpenState' threeParties $
                 coordinatedHeadState
                   { confirmedSnapshot = ConfirmedSnapshot snapshot (Crypto.aggregate [])
-                  , seenSnapshot = SeenSnapshot (testSnapshot 3 0 [] mempty) mempty
+                  , seenSnapshot = let sn = testSnapshot 3 0 [] mempty in SeenSnapshot{snapshot = sn, signatories = mempty, signableBytes = getSignableRepresentation sn}
                   }
         now <- nowFromSlot st.chainPointTime.currentSlot
         update bobEnv ledger now st input `shouldBe` Error (RequireFailed $ ReqSnNumberInvalid 2 3)

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -33,7 +33,7 @@ import Hydra.Chain.ChainState (ChainSlot (..), IsChainState)
 import Hydra.Chain.Direct.State (ChainStateAt (..))
 import Hydra.Chain.Direct.TimeHandle (TimeHandle, mkTimeHandle, safeZone, slotToUTCTime)
 import Hydra.HeadLogic (ClosedState (..), CoordinatedHeadState (..), Effect (..), HeadState (..), Input (..), LogicError (..), OpenState (..), Outcome (..), RequirementFailure (..), SideLoadRequirementFailure (..), StateChanged (..), TTL, WaitReason (..), aggregateState, cause, noop, update)
-import Hydra.HeadLogic.State (IdleState (..), SeenSnapshot (..), getHeadParameters)
+import Hydra.HeadLogic.State (IdleState (..), SeenSnapshot (..), getHeadParameters, mkSeenSnapshot)
 import Hydra.Ledger (Ledger (..), ValidationError (..))
 import Hydra.Ledger.Cardano (cardanoLedger, mkRangedTx, mkSimpleTx)
 import Hydra.Ledger.Cardano.TimeSpec (genUTCTime)
@@ -49,7 +49,7 @@ import Hydra.Options (defaultContestationPeriod, defaultDepositPeriod, defaultUn
 import Hydra.Prelude qualified as Prelude
 import Hydra.Tx (HeadId)
 import Hydra.Tx.ContestationPeriod qualified as CP
-import Hydra.Tx.Crypto (aggregate, generateSigningKey, getSignableRepresentation, sign)
+import Hydra.Tx.Crypto (aggregate, generateSigningKey, sign)
 import Hydra.Tx.Crypto qualified as Crypto
 import Hydra.Tx.HeadParameters (HeadParameters (..))
 import Hydra.Tx.IsTx (IsTx (..))
@@ -277,7 +277,7 @@ spec =
             s0 =
               ( inOpenState' singleParty $
                   coordinatedHeadState
-                    { seenSnapshot = SeenSnapshot{snapshot = snapshot1, signatories = Map.empty, signableBytes = getSignableRepresentation snapshot1}
+                    { seenSnapshot = mkSeenSnapshot snapshot1 Map.empty
                     , localTxs = [tx2]
                     , currentDepositTxId = Nothing
                     }
@@ -599,7 +599,7 @@ spec =
                     { localUTxO
                     , version = 3
                     , confirmedSnapshot = confirmedSn
-                    , seenSnapshot = SeenSnapshot{snapshot = snapshot1, signatories = mempty, signableBytes = getSignableRepresentation snapshot1}
+                    , seenSnapshot = mkSeenSnapshot snapshot1 mempty
                     , decommitTx = Just decommitTx
                     }
 
@@ -615,7 +615,7 @@ spec =
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} -> do
               chs.version `shouldBe` 4
               chs.decommitTx `shouldBe` Nothing
-              chs.seenSnapshot `shouldBe` SeenSnapshot{snapshot = snapshot1, signatories = mempty, signableBytes = getSignableRepresentation snapshot1}
+              chs.seenSnapshot `shouldBe` mkSeenSnapshot snapshot1 mempty
             _ -> fail "expected Open state"
 
         it "DecommitFinalized with SeenSnapshot does not re-request snapshot already in-flight" $ do
@@ -633,7 +633,7 @@ spec =
                     { localUTxO
                     , version = 3
                     , confirmedSnapshot = confirmedSn
-                    , seenSnapshot = SeenSnapshot{snapshot = snapshot1, signatories = mempty, signableBytes = getSignableRepresentation snapshot1}
+                    , seenSnapshot = mkSeenSnapshot snapshot1 mempty
                     , decommitTx = Just decommitTx
                     }
 
@@ -650,7 +650,7 @@ spec =
           let s1 = aggregateState s0 outcome
           case s1 of
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} ->
-              chs.seenSnapshot `shouldBe` SeenSnapshot{snapshot = snapshot1, signatories = mempty, signableBytes = getSignableRepresentation snapshot1}
+              chs.seenSnapshot `shouldBe` mkSeenSnapshot snapshot1 mempty
             _ -> fail "expected Open state"
 
         it "CommitFinalized with SeenSnapshot does not re-request snapshot already in-flight" $ do
@@ -668,7 +668,7 @@ spec =
                     { localUTxO
                     , version = 3
                     , confirmedSnapshot = confirmedSn
-                    , seenSnapshot = SeenSnapshot{snapshot = snapshot1, signatories = mempty, signableBytes = getSignableRepresentation snapshot1}
+                    , seenSnapshot = mkSeenSnapshot snapshot1 mempty
                     , currentDepositTxId = Just depositTxId
                     }
 
@@ -685,7 +685,7 @@ spec =
           let s1 = aggregateState s0 outcome
           case s1 of
             NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} ->
-              chs.seenSnapshot `shouldBe` SeenSnapshot{snapshot = snapshot1, signatories = mempty, signableBytes = getSignableRepresentation snapshot1}
+              chs.seenSnapshot `shouldBe` mkSeenSnapshot snapshot1 mempty
             _ -> fail "expected Open state"
 
         it "CommitFinalized with RequestedSnapshot resets seenSnapshot to confirmedSn" $ do
@@ -960,7 +960,7 @@ spec =
               inOpenState' threeParties $
                 coordinatedHeadState
                   { confirmedSnapshot = ConfirmedSnapshot snapshot (Crypto.aggregate [])
-                  , seenSnapshot = let sn = testSnapshot 3 0 [] mempty in SeenSnapshot{snapshot = sn, signatories = mempty, signableBytes = getSignableRepresentation sn}
+                  , seenSnapshot = mkSeenSnapshot (testSnapshot 3 0 [] mempty) mempty
                   }
         now <- nowFromSlot st.chainPointTime.currentSlot
         update bobEnv ledger now st input `shouldBe` Error (RequireFailed $ ReqSnNumberInvalid 2 3)

--- a/hydra-node/testlib/Test/Hydra/HeadLogic/State.hs
+++ b/hydra-node/testlib/Test/Hydra/HeadLogic/State.hs
@@ -15,7 +15,9 @@ import Hydra.HeadLogic.State (
   OpenState (..),
   SeenSnapshot (..),
  )
+import Hydra.Tx.Crypto (getSignableRepresentation)
 import Test.Hydra.Tx.Gen (ArbitraryIsTx)
+import Test.QuickCheck (oneof)
 
 instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (HeadState tx) where
   arbitrary = genericArbitrary
@@ -36,7 +38,16 @@ instance ArbitraryIsTx tx => Arbitrary (CoordinatedHeadState tx) where
   arbitrary = genericArbitrary
 
 instance ArbitraryIsTx tx => Arbitrary (SeenSnapshot tx) where
-  arbitrary = genericArbitrary
+  arbitrary =
+    oneof
+      [ pure NoSeenSnapshot
+      , LastSeenSnapshot <$> arbitrary
+      , RequestedSnapshot <$> arbitrary <*> arbitrary
+      , do
+          snapshot <- arbitrary
+          signatories <- arbitrary
+          pure SeenSnapshot{snapshot, signatories, signableBytes = getSignableRepresentation snapshot}
+      ]
 
 instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (ClosedState tx) where
   arbitrary =

--- a/hydra-node/testlib/Test/Hydra/HeadLogic/State.hs
+++ b/hydra-node/testlib/Test/Hydra/HeadLogic/State.hs
@@ -14,8 +14,8 @@ import Hydra.HeadLogic.State (
   IdleState (..),
   OpenState (..),
   SeenSnapshot (..),
+  mkSeenSnapshot,
  )
-import Hydra.Tx.Crypto (getSignableRepresentation)
 import Test.Hydra.Tx.Gen (ArbitraryIsTx)
 import Test.QuickCheck (oneof)
 
@@ -43,10 +43,7 @@ instance ArbitraryIsTx tx => Arbitrary (SeenSnapshot tx) where
       [ pure NoSeenSnapshot
       , LastSeenSnapshot <$> arbitrary
       , RequestedSnapshot <$> arbitrary <*> arbitrary
-      , do
-          snapshot <- arbitrary
-          signatories <- arbitrary
-          pure SeenSnapshot{snapshot, signatories, signableBytes = getSignableRepresentation snapshot}
+      , mkSeenSnapshot <$> arbitrary <*> arbitrary
       ]
 
 instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (ClosedState tx) where

--- a/hydra-tx/src/Hydra/Tx/Crypto.hs
+++ b/hydra-tx/src/Hydra/Tx/Crypto.hs
@@ -22,6 +22,9 @@ module Hydra.Tx.Crypto (
   SigningKey (HydraSigningKey),
   VerificationKey (HydraVerificationKey),
   module Hydra.Tx.Crypto,
+
+  -- * Re-exports
+  getSignableRepresentation,
 ) where
 
 import Hydra.Prelude hiding (Key, show)
@@ -50,7 +53,7 @@ import Cardano.Crypto.Hash (Blake2b_256, SHA256, castHash, hashFromBytes, hashTo
 import Cardano.Crypto.Hash qualified as Crypto
 import Cardano.Crypto.Hash.Class (HashAlgorithm (digest))
 import Cardano.Crypto.Seed (getSeedBytes, mkSeedFromBytes)
-import Cardano.Crypto.Util (SignableRepresentation)
+import Cardano.Crypto.Util (SignableRepresentation, getSignableRepresentation)
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Base16 qualified as Base16
 import Data.ByteString.Char8 qualified as BSC
@@ -325,6 +328,30 @@ verifyMultiSignature ::
 verifyMultiSignature vks HydraMultiSignature{multiSignature} a
   | length vks == length multiSignature =
       let verifications = zipWith (\vk s -> (vk, verify vk s a)) vks multiSignature
+          failures = fst <$> filter (not . snd) verifications
+       in if null failures
+            then Verified
+            else FailedKeys failures
+  | otherwise = KeyNumberMismatch
+
+-- | Like 'verifyMultiSignature' but operates on pre-computed signable bytes,
+-- avoiding repeated calls to 'getSignableRepresentation'. Use this when the
+-- same value would be verified multiple times (e.g. per-party in a round).
+verifyMultiSignatureBytes ::
+  [VerificationKey HydraKey] ->
+  MultiSignature a ->
+  ByteString ->
+  Verified
+verifyMultiSignatureBytes vks HydraMultiSignature{multiSignature} bs
+  | length vks == length multiSignature =
+      let ctx = () :: ContextDSIGN Ed25519DSIGN
+          verifications =
+            zipWith
+              ( \(HydraVerificationKey vk) (HydraSignature sig) ->
+                  (HydraVerificationKey vk, case verifyDSIGN ctx vk bs sig of Right () -> True; Left _ -> False)
+              )
+              vks
+              multiSignature
           failures = fst <$> filter (not . snd) verifications
        in if null failures
             then Verified

--- a/hydra-tx/src/Hydra/Tx/Crypto.hs
+++ b/hydra-tx/src/Hydra/Tx/Crypto.hs
@@ -339,14 +339,14 @@ verifyMultiSignatureBytes ::
 verifyMultiSignatureBytes vks HydraMultiSignature{multiSignature} bs
   | length vks == length multiSignature =
       let ctx = () :: ContextDSIGN Ed25519DSIGN
-          verifications =
-            zipWith
-              ( \(HydraVerificationKey vk) (HydraSignature sig) ->
-                  (HydraVerificationKey vk, case verifyDSIGN ctx vk bs sig of Right () -> True; Left _ -> False)
+          failures =
+            mapMaybe
+              ( \(vk@(HydraVerificationKey rawVk), HydraSignature sig) ->
+                  case verifyDSIGN ctx rawVk bs sig of
+                    Right () -> Nothing
+                    Left _ -> Just vk
               )
-              vks
-              multiSignature
-          failures = fst <$> filter (not . snd) verifications
+              (zip vks multiSignature)
        in if null failures
             then Verified
             else FailedKeys failures

--- a/hydra-tx/src/Hydra/Tx/Crypto.hs
+++ b/hydra-tx/src/Hydra/Tx/Crypto.hs
@@ -325,14 +325,8 @@ verifyMultiSignature ::
   MultiSignature a ->
   a ->
   Verified
-verifyMultiSignature vks HydraMultiSignature{multiSignature} a
-  | length vks == length multiSignature =
-      let verifications = zipWith (\vk s -> (vk, verify vk s a)) vks multiSignature
-          failures = fst <$> filter (not . snd) verifications
-       in if null failures
-            then Verified
-            else FailedKeys failures
-  | otherwise = KeyNumberMismatch
+verifyMultiSignature vks multisig a =
+  verifyMultiSignatureBytes vks multisig (getSignableRepresentation a)
 
 -- | Like 'verifyMultiSignature' but operates on pre-computed signable bytes,
 -- avoiding repeated calls to 'getSignableRepresentation'. Use this when the


### PR DESCRIPTION
fix #2570 


  Summary

  During snapshot signing rounds, each incoming AckSn triggers verifyMultiSignature which internally calls getSignableRepresentation on the Snapshot to get the bytes to verify against. This serializes and hashes the entire UTxO set. In a cluster of N parties, the same expensive computation was repeated N times per snapshot.

  This PR caches the result as signableBytes :: ByteString inside the SeenSnapshot constructor, computed once when the snapshot is first seen and reused for all subsequent AckSn verifications.

  Changes

  - SeenSnapshot gains a signableBytes field with manual ToJSON/FromJSON instances that exclude it from serialization — it is recomputed from snapshot on deserialization, so persistence and state recovery are unaffected
  - verifyMultiSignatureBytes added to Crypto — like verifyMultiSignature but takes pre-computed bytes; verifyMultiSignature now delegates to it, eliminating code duplication
  - mkSeenSnapshot smart constructor added to enforce the invariant that signableBytes always equals getSignableRepresentation snapshot — direct record construction is replaced at all call sites

  Benchmark Results (3-node cluster with growing UTxO set)

```

| Metric                | master   | fix (cache-signible-bytes) | Delta          |
| --------------------- | -------- | -------------------------- | -------------- |
| Avg confirmation (ms) | 465.8    | **430.2**                  | **-7.6%**      |
| P50                   | 406.7ms  | **384.3ms**                | **-5.5%**      |
| P95                   | 919.8ms  | **864.0ms**                | **-6.1%**      |
| P99                   | 1301.1ms | 1475.4ms                   | +13.4% (noise) |
| Invalid txs           | 0        | 0                          | —              |
| Fanout outputs        | 1503     | 1503                       | —              |
```
---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
