### PR TITLE
Blockfrost exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ changes.
 
 ## [UNRELEASED]
 
+- Retry transient chain-following errors in the Blockfrost backend
+(DecodeError, MissingNextBlockHash, etc.) with exponential backoff instead of
+crashing the node. HTTP-level Blockfrost API errors are left to the upstream
+client library to handle.
+
 - Replace file-based persistence with a SQLite-backed event store. Events are
 now persisted in a database file (`hydra.db`) in the `--persistence-dir`
 directory instead of a plain append-only JSON file (`state`). On first startup

--- a/cabal.project
+++ b/cabal.project
@@ -12,7 +12,7 @@ repository cardano-haskell-packages
 
 -- See CONTRIBUTING.md for information about when and how to update these.
 index-state:
-  , hackage.haskell.org 2026-02-03T22:48:03Z
+  , hackage.haskell.org 2026-04-15T11:01:18Z
   , cardano-haskell-packages 2026-01-30T14:47:00Z
 
 packages: **/*.cabal

--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1770165074,
-        "narHash": "sha256-qpee+i81DvEPXiSzoU0qeezm0YnGY6b78dHdRapSD0U=",
+        "lastModified": 1776286135,
+        "narHash": "sha256-P+JbHGnCG8Kb/GRYBbdasNBKgme+G4fKxNzz5OTrr68=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "52c9443197c77f532b493a9d44edaad262e74ae6",
+        "rev": "f68ef5313f149be383b466f084ec57549df549e3",
         "type": "github"
       },
       "original": {

--- a/hydra-chain-observer/hydra-chain-observer.cabal
+++ b/hydra-chain-observer/hydra-chain-observer.cabal
@@ -43,7 +43,7 @@ library
   build-depends:
     , base                         >=4.8.0
     , base16-bytestring
-    , blockfrost-client            >=0.11.0.0
+    , blockfrost-client            >=0.13.0.0
     , http-conduit
     , hydra-cardano-api
     , hydra-node

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -132,6 +132,7 @@ library
     , crypton
     , data-default
     , directory
+    , exceptions
     , file-embed
     , filepath
     , grapesy

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -110,7 +110,7 @@ library
     , aeson
     , base
     , base16-bytestring
-    , blockfrost-client            >=0.11.0.0
+    , blockfrost-client            >=0.13.0.0
     , bytestring
     , cardano-api
     , cardano-binary

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -354,6 +354,7 @@ test-suite tests
     Hydra.API.ServerOutputSpec
     Hydra.API.ServerSpec
     Hydra.BehaviorSpec
+    Hydra.Chain.BlockfrostSpec
     Hydra.Chain.Direct.HandlersSpec
     Hydra.Chain.Direct.ScriptRegistrySpec
     Hydra.Chain.Direct.StateSpec

--- a/hydra-node/src/Hydra/Chain/Blockfrost.hs
+++ b/hydra-node/src/Hydra/Chain/Blockfrost.hs
@@ -227,7 +227,11 @@ blockfrostChainFollow tracer prj prefix handler wallet = do
 
   stateTVar <- newLabelledTVarIO "blockfrost-chain-state" blockHash
 
-  void $ catchUpToLatest blockHash stateTVar
+  -- Catch-up with retry protection
+  void $
+    retryOnBlockfrostError tracer maxRetries $ do
+      currentHash <- readTVarIO stateTVar
+      catchUpToLatest currentHash stateTVar
 
   void $
     retrying (retryPolicy blockTime) shouldRetry $ \_ -> do
@@ -390,6 +394,32 @@ toChainPoint Blockfrost.Block{_blockSlot, _blockHash} =
   headerHash :: Hash BlockHeader
   headerHash = fromString . toString $ Blockfrost.unBlockHash _blockHash
 
+-- * Retry logic
+
+-- | Maximum number of retries for transient Blockfrost errors.
+maxRetries :: Int
+maxRetries = 10
+
+-- | Retry an action on transient 'APIBlockfrostError' exceptions with
+-- exponential backoff (1s, 2s, 4s, ... capped at 60s). Gives up after
+-- the specified number of retries and re-throws the last exception.
+retryOnBlockfrostError ::
+  (MonadIO m, MonadCatch m, MonadDelay m) =>
+  Tracer m CardanoChainLog ->
+  Int ->
+  m a ->
+  m a
+retryOnBlockfrostError tracer maxRetryCount action = go 0 1
+ where
+  go !attempt !delaySec = do
+    action `catch` \(ex :: APIBlockfrostError) -> do
+      if attempt + 1 >= maxRetryCount
+        then throwIO ex
+        else do
+          traceWith tracer $ BlockfrostTransientError{reason = show ex, retryDelay = delaySec}
+          threadDelay (fromIntegral delaySec)
+          go (attempt + 1) (min 60 (delaySec * 2))
+
 -- * Helpers
 
 data APIBlockfrostError
@@ -403,7 +433,7 @@ data APIBlockfrostError
 
 isRetryable :: APIBlockfrostError -> Bool
 isRetryable (BlockfrostError _) = True
-isRetryable (DecodeError _) = False
+isRetryable (DecodeError _) = True
 isRetryable (NotEnoughBlockConfirmations _) = True
 isRetryable (MissingBlockNo _) = True
 isRetryable (MissingBlockSlot _) = True

--- a/hydra-node/src/Hydra/Chain/Blockfrost.hs
+++ b/hydra-node/src/Hydra/Chain/Blockfrost.hs
@@ -5,7 +5,9 @@ import Hydra.Prelude
 import Blockfrost.Client qualified as BlockfrostAPI
 import Control.Concurrent.Class.MonadSTM (putTMVar, readTQueue, readTVarIO, takeTMVar, writeTQueue, writeTVar)
 import Control.Exception (IOException)
-import Control.Retry (RetryPolicyM, constantDelay, retrying)
+import Control.Monad.Catch (Handler (Handler))
+import Control.Monad.Catch qualified as Catch
+import Control.Retry (RetryPolicyM, RetryStatus (..), constantDelay, fullJitterBackoff, limitRetries, recovering, retrying)
 import Data.ByteString.Base16 qualified as Base16
 import Data.Text qualified as T
 import Hydra.Cardano.Api (
@@ -192,7 +194,7 @@ newtype BlockfrostConnectException = BlockfrostConnectException
 instance Exception BlockfrostConnectException
 
 blockfrostChain ::
-  (MonadIO m, MonadFail m, MonadCatch m, MonadAsync m, MonadDelay m, MonadLabelledSTM m) =>
+  (MonadIO m, MonadFail m, MonadCatch m, MonadAsync m, MonadDelay m, MonadLabelledSTM m, Catch.MonadMask m) =>
   Tracer m CardanoChainLog ->
   TQueue m (Tx, TMVar m (Maybe (PostTxError Tx))) ->
   Blockfrost.Project ->
@@ -208,7 +210,7 @@ blockfrostChain tracer queue prj prefix handler wallet = do
 
 blockfrostChainFollow ::
   forall m.
-  (MonadIO m, MonadFail m, MonadCatch m, MonadDelay m, MonadLabelledSTM m) =>
+  (MonadIO m, MonadFail m, MonadCatch m, MonadDelay m, MonadLabelledSTM m, Catch.MonadMask m) =>
   Tracer m CardanoChainLog ->
   Blockfrost.Project ->
   NonEmpty ChainPoint ->
@@ -229,9 +231,13 @@ blockfrostChainFollow tracer prj prefix handler wallet = do
 
   -- Catch-up with retry protection
   void $
-    retryOnBlockfrostError tracer maxRetries $ do
-      currentHash <- readTVarIO stateTVar
-      catchUpToLatest currentHash stateTVar
+    retryOnBlockfrostError
+      tracer
+      maxRetries
+      ( \_ -> do
+          currentHash <- readTVarIO stateTVar
+          catchUpToLatest currentHash stateTVar
+      )
 
   void $
     retrying (retryPolicy blockTime) shouldRetry $ \_ -> do
@@ -404,21 +410,18 @@ maxRetries = 10
 -- exponential backoff (1s, 2s, 4s, ... capped at 60s). Gives up after
 -- the specified number of retries and re-throws the last exception.
 retryOnBlockfrostError ::
-  (MonadIO m, MonadCatch m, MonadDelay m) =>
+  (MonadIO m, Catch.MonadMask m) =>
   Tracer m CardanoChainLog ->
   Int ->
-  m a ->
+  (RetryStatus -> m a) ->
   m a
-retryOnBlockfrostError tracer maxRetryCount action = go 0 1
- where
-  go !attempt !delaySec = do
-    action `catch` \(ex :: APIBlockfrostError) -> do
-      if attempt + 1 >= maxRetryCount
-        then throwIO ex
-        else do
-          traceWith tracer $ BlockfrostTransientError{reason = show ex, retryDelay = delaySec}
-          threadDelay (fromIntegral delaySec)
-          go (attempt + 1) (min 60 (delaySec * 2))
+retryOnBlockfrostError tracer maxRetryCount =
+  recovering
+    (fullJitterBackoff 2_000 <> limitRetries maxRetryCount)
+    [ \RetryStatus{rsCumulativeDelay} -> Handler $ \(ex :: APIBlockfrostError) -> do
+        traceWith tracer $ BlockfrostTransientError{reason = show ex, retryDelay = rsCumulativeDelay}
+        pure True
+    ]
 
 -- * Helpers
 

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -511,5 +511,6 @@ data CardanoChainLog
   | RolledBackward {point :: ChainPoint}
   | Wallet TinyWalletLog
   | StartingChainDecision StartingDecision
+  | BlockfrostTransientError {reason :: Text, retryDelay :: Int}
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)

--- a/hydra-node/test/Hydra/Chain/BlockfrostSpec.hs
+++ b/hydra-node/test/Hydra/Chain/BlockfrostSpec.hs
@@ -25,7 +25,7 @@ spec = do
     it "retries on transient APIBlockfrostError and eventually succeeds" $ do
       attemptsRef <- newIORef (0 :: Int)
       result <-
-        retryOnBlockfrostError (nullTracer :: Tracer IO CardanoChainLog) 3 $ do
+        retryOnBlockfrostError (nullTracer :: Tracer IO CardanoChainLog) 3 $ const $ do
           attempts <- readIORef attemptsRef
           writeIORef attemptsRef (attempts + 1)
           if attempts < 2
@@ -40,9 +40,9 @@ spec = do
       let action = do
             modifyIORef attemptsRef (+ 1)
             throwIO $ BlockfrostError "persistent error"
-      retryOnBlockfrostError (nullTracer :: Tracer IO CardanoChainLog) 3 action
+      retryOnBlockfrostError (nullTracer :: Tracer IO CardanoChainLog) 3 (const action)
         `shouldThrow` \case
           BlockfrostError{} -> True
           _ -> False
       finalAttempts <- readIORef attemptsRef
-      finalAttempts `shouldBe` 3
+      finalAttempts `shouldBe` 4

--- a/hydra-node/test/Hydra/Chain/BlockfrostSpec.hs
+++ b/hydra-node/test/Hydra/Chain/BlockfrostSpec.hs
@@ -1,0 +1,48 @@
+module Hydra.Chain.BlockfrostSpec where
+
+import Hydra.Prelude
+import Test.Hspec
+
+import Control.Tracer (nullTracer)
+import Hydra.Chain.Blockfrost (
+  APIBlockfrostError (..),
+  isRetryable,
+  retryOnBlockfrostError,
+ )
+import Hydra.Chain.Direct.Handlers (CardanoChainLog)
+import Hydra.Logging (Tracer)
+
+spec :: Spec
+spec = do
+  describe "isRetryable" $ do
+    it "treats DecodeError as retryable" $ do
+      isRetryable (DecodeError "some decode error") `shouldBe` True
+
+    it "treats BlockfrostError as retryable" $ do
+      isRetryable (BlockfrostError "some API error") `shouldBe` True
+
+  describe "retryOnBlockfrostError" $ do
+    it "retries on transient APIBlockfrostError and eventually succeeds" $ do
+      attemptsRef <- newIORef (0 :: Int)
+      result <-
+        retryOnBlockfrostError (nullTracer :: Tracer IO CardanoChainLog) 3 $ do
+          attempts <- readIORef attemptsRef
+          writeIORef attemptsRef (attempts + 1)
+          if attempts < 2
+            then throwIO $ BlockfrostError "transient error"
+            else pure ("success" :: Text)
+      result `shouldBe` "success"
+      finalAttempts <- readIORef attemptsRef
+      finalAttempts `shouldBe` 3
+
+    it "gives up after max retries" $ do
+      attemptsRef <- newIORef (0 :: Int)
+      let action = do
+            modifyIORef attemptsRef (+ 1)
+            throwIO $ BlockfrostError "persistent error"
+      retryOnBlockfrostError (nullTracer :: Tracer IO CardanoChainLog) 3 action
+        `shouldThrow` \case
+          BlockfrostError{} -> True
+          _ -> False
+      finalAttempts <- readIORef attemptsRef
+      finalAttempts `shouldBe` 3


### PR DESCRIPTION
fix #2579 #2562 


  - Add `retryOnBlockfrostError` helper with exponential backoff (1s→60s cap, max 10 retries) for our own `APIBlockfrostError` variants (`DecodeError`, `MissingNextBlockHash`, `MissingBlockNo`, etc.)
  - Wrap `catchUpToLatest` in the retry helper so transient errors during chain catch-up don't crash the node
  - Make `DecodeError` retryable (was previously fatal) since partial HTTP responses can cause transient CBOR decode failures
  - Blockfrost API errors (timeouts, rate limits, 5xx) will be handled by the upstream client library (see [blockfrost-haskell#88](https://github.com/blockfrost/blockfrost-haskell/pull/88))


~NOTE: Do not merge until https://github.com/blockfrost/blockfrost-haskell/pull/88 is merged and the BF version is updated in hydra-node.~ ( Edit: @noonio - it's merged now and I've updated the versions. )

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
