### PR TITLE
Pumba command emded in the Haskell now; for more control over when to…

### DIFF
--- a/.github/workflows/network-test.yaml
+++ b/.github/workflows/network-test.yaml
@@ -104,7 +104,7 @@ jobs:
           --hydra-client=localhost:4001 \
           --hydra-client=localhost:4002 \
           --hydra-client=localhost:4003 \
-          --pumba-command="pumba -l info --random --interval 20s netem --duration 15s loss --percent ${percent} re2:hydra-node"
+          --pumba-command="pumba -l info --random --interval 20s netem --duration 5s loss --percent ${percent} re2:hydra-node"
 
     - name: Acquire logs
       if: always()

--- a/.github/workflows/network-test.yaml
+++ b/.github/workflows/network-test.yaml
@@ -74,7 +74,6 @@ jobs:
     - name: Build required nix and docker derivations
       run: |
         nix build .#legacyPackages.x86_64-linux.hydra-cluster.components.benchmarks.bench-e2e
-        nix build github:noonio/pumba/noon/add-flake
 
     # Use tmate to get a shell onto the runner to do some temporary hacking
     #
@@ -88,22 +87,12 @@ jobs:
 
     - name: Run pumba and the benchmarks
       run: |
-        # Extract inputs with defaults for non-workflow_dispatch events
-        # TODO: which defaults?
         percent="${{ matrix.netem_loss }}"
         scaling_factor="${{ matrix.scaling_factor }}"
 
-        # Package loss on random nodes every 20s for 5s. This should make the
-        # benchmark progress reasonably, but under stress
-        nix run github:noonio/pumba/noon/add-flake -- -l info \
-          --random \
-          --interval 20s \
-          netem \
-          --duration 5s \
-          loss --percent ${percent} \
-          "re2:hydra-node" &
-
-        # Run benchmark on demo
+        # Pumba is launched by the benchmark itself after the Head is open and
+        # deposits are finalized, so that network faults only apply during the
+        # transaction-submission phase and cannot cause deposit expiry.
         mkdir -p benchmarks
         nix run .#legacyPackages.x86_64-linux.hydra-cluster.components.benchmarks.bench-e2e -- \
           demo \
@@ -114,7 +103,8 @@ jobs:
           --node-socket=demo/devnet/node.socket \
           --hydra-client=localhost:4001 \
           --hydra-client=localhost:4002 \
-          --hydra-client=localhost:4003
+          --hydra-client=localhost:4003 \
+          --pumba-command="pumba -l info --random --interval 20s netem --duration 15s loss --percent ${percent} re2:hydra-node"
 
     - name: Acquire logs
       if: always()

--- a/flake.lock
+++ b/flake.lock
@@ -729,6 +729,42 @@
         "type": "github"
       }
     },
+    "flake-utils_6": {
+      "inputs": {
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_7": {
+      "inputs": {
+        "systems": "systems_5"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "formal-ledger": {
       "flake": false,
       "locked": {
@@ -791,6 +827,28 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gomod2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_6",
+        "nixpkgs": [
+          "pumba",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1721902146,
+        "narHash": "sha256-zIycVdlCezEPqbbznII1VSC+gR4W2woG8EEEwz7Zjy0=",
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "rev": "7b8ef0d5fdc09b3a7acb27f1e6c168888947f364",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "gomod2nix",
         "type": "github"
       }
     },
@@ -2517,6 +2575,38 @@
     },
     "nixpkgs_22": {
       "locked": {
+        "lastModified": 1717179513,
+        "narHash": "sha256-vboIEwIQojofItm2xGCdZCzW96U85l9nDW3ifMuAIdM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "63dacb46bf939521bdc93981b4cbb7ecb58427a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_23": {
+      "locked": {
+        "lastModified": 1720957393,
+        "narHash": "sha256-oedh2RwpjEa+TNxhg5Je9Ch6d3W1NKi7DbRO1ziHemA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "693bc46d169f5af9c992095736e82c3488bf7dbb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_24": {
+      "locked": {
         "lastModified": 1726436956,
         "narHash": "sha256-a3rP7uafX/qBFX0y4CGS8vvTPvxsLl9eZQ85DkIn3DI=",
         "owner": "NixOS",
@@ -2731,6 +2821,28 @@
         "type": "github"
       }
     },
+    "pumba": {
+      "inputs": {
+        "flake-utils": "flake-utils_5",
+        "gomod2nix": "gomod2nix",
+        "nixpkgs": "nixpkgs_22",
+        "treefmt-nix": "treefmt-nix_7"
+      },
+      "locked": {
+        "lastModified": 1722352209,
+        "narHash": "sha256-Ti9zRXSOL95dPuv4/XyafLVysL46TwnOGoRufI2gN/Y=",
+        "owner": "noonio",
+        "repo": "pumba",
+        "rev": "e3067b88c55055fcffa13e77f5dc21dccbdf8ea9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "noonio",
+        "ref": "noon/add-flake",
+        "repo": "pumba",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "CHaP": "CHaP",
@@ -2751,15 +2863,16 @@
         ],
         "nixpkgs-2411": "nixpkgs-2411_3",
         "process-compose-flake": "process-compose-flake",
+        "pumba": "pumba",
         "rust-accumulator": "rust-accumulator"
       }
     },
     "rust-accumulator": {
       "inputs": {
         "fenix": "fenix",
-        "flake-utils": "flake-utils_5",
+        "flake-utils": "flake-utils_7",
         "naersk": "naersk",
-        "nixpkgs": "nixpkgs_22"
+        "nixpkgs": "nixpkgs_24"
       },
       "locked": {
         "lastModified": 1730459213,
@@ -2955,6 +3068,36 @@
         "type": "github"
       }
     },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_5": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": "nixpkgs_4"
@@ -3061,6 +3204,24 @@
         "owner": "numtide",
         "repo": "treefmt-nix",
         "rev": "71b125cd05fbfd78cab3e070b73544abe24c5016",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_7": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_23"
+      },
+      "locked": {
+        "lastModified": 1722330636,
+        "narHash": "sha256-uru7JzOa33YlSRwf9sfXpJG+UAV+bnBEYMjrzKrQZFw=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "768acdb06968e53aa1ee8de207fd955335c754b7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
     process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
     rust-accumulator.url = "github:cardano-scaling/rust-accumulator";
     nix-fast-build.url = "github:Mic92/nix-fast-build";
+    pumba.url = "github:noonio/pumba/noon/add-flake";
   };
 
   outputs = inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } (inputs.import-tree ./nix);

--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -59,6 +59,7 @@ import HydraNode (
   withHydraCluster,
  )
 import System.FilePath ((</>))
+import System.Process.Typed (shell, withProcessTerm)
 import Test.HUnit.Lang (formatFailureReason)
 import Text.Printf (printf)
 
@@ -86,7 +87,7 @@ bench startingNodeId timeoutSeconds workDir dataset = do
           putStrLn $ "Timing: " <> show timing
           withHydraCluster hydraTracer timing workDir nodeSocket' startingNodeId cardanoKeys hydraKeys hydraScriptsTxId $ \clients -> do
             waitForNodesConnected hydraTracer 20 clients
-            scenario hydraTracer timing opts workDir dataset clients
+            scenario hydraTracer timing opts workDir dataset clients Nothing
         systemStats <- readTVarIO statsTvar
         pure (scenarioData, systemStats)
 
@@ -95,10 +96,11 @@ benchDemo ::
   SocketPath ->
   NominalDiffTime ->
   [Host] ->
+  Maybe String ->
   FilePath ->
   Dataset ->
   IO (Summary, SystemStats)
-benchDemo networkId nodeSocket timeoutSeconds hydraClients workDir dataset@Dataset{clientDatasets} = do
+benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand workDir dataset@Dataset{clientDatasets} = do
   putStrLn $ "Test logs available in: " <> (workDir </> "test.log")
   withFile (workDir </> "test.log") ReadWriteMode $ \hdl ->
     withTracerOutputTo (BlockBuffering (Just 64000)) hdl "Test" $ \tracer ->
@@ -120,7 +122,7 @@ benchDemo networkId nodeSocket timeoutSeconds hydraClients workDir dataset@Datas
               withHydraClientConnections hydraTracer (hydraClients `zip` [1 ..]) [] $ \case
                 [] -> error "no hydra clients provided"
                 (leader : followers) ->
-                  (,[]) <$> scenario hydraTracer timing opts workDir dataset (leader :| followers)
+                  (,[]) <$> scenario hydraTracer timing opts workDir dataset (leader :| followers) pumbaCommand
  where
   withHydraClientConnections ::
     Tracer IO HydraNodeLog ->
@@ -151,8 +153,9 @@ scenario ::
   FilePath ->
   Dataset ->
   NonEmpty HydraClient ->
+  Maybe String ->
   IO Summary
-scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, description} nonEmptyClients = do
+scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, description} nonEmptyClients pumbaCommand = do
   let clusterSize = fromIntegral $ length clientDatasets
   let leader = head nonEmptyClients
       clients = toList nonEmptyClients
@@ -179,12 +182,16 @@ scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, descript
   Set.fromList deposits `shouldBe` Set.fromList (txId <$> depositTxs)
 
   putTextLn "HeadIsOpen with deposits finalized"
-  processedTransactions <- processTransactions clients clientDatasets
+
+  -- Note: We only run Pumba during normal transaction processing; this is
+  -- acceptable because otherwise we do not retry the particular actions that
+  -- may or may not be dropped.
+  processedTransactions <- withPumba pumbaCommand $ processTransactions clients clientDatasets
 
   putTextLn "Closing the Head"
   send leader $ input "Close" []
 
-  deadline <- waitMatch (5 * blockTime) leader $ \v -> do
+  deadline <- waitMatch (20 * blockTime) leader $ \v -> do
     guard $ v ^? key "tag" == Just "HeadIsClosed"
     guard $ v ^? key "headId" == Just (toJSON headId)
     v ^? key "contestationDeadline" . _JSON
@@ -240,6 +247,12 @@ scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, descript
       }
  where
   Timing{blockTime} = timing
+
+  withPumba :: Maybe String -> IO a -> IO a
+  withPumba Nothing action = action
+  withPumba (Just cmd) action = do
+    putTextLn $ "Starting pumba: " <> toText cmd
+    withProcessTerm (shell cmd) $ const action
 
 defaultDescription :: Text
 defaultDescription = ""

--- a/hydra-cluster/bench/Bench/Options.hs
+++ b/hydra-cluster/bench/Bench/Options.hs
@@ -192,7 +192,7 @@ pumbaCommandParser =
         <> help
           "Shell command to run as a network fault injector (e.g. pumba) once the \
           \Head is open and deposits are finalized. The process is started just before \
-          \transaction submission begins and is terminated when the Head closes."
+          \transaction submission begins and is terminated before the Head is closed."
     )
 
 hydraClientsParser :: Parser Host

--- a/hydra-cluster/bench/Bench/Options.hs
+++ b/hydra-cluster/bench/Bench/Options.hs
@@ -53,6 +53,7 @@ data Options
       , networkId :: NetworkId
       , nodeSocket :: SocketPath
       , hydraClients :: [Host]
+      , pumbaCommand :: Maybe String
       }
 
 benchOptionsParser :: ParserInfo Options
@@ -181,6 +182,18 @@ demoOptionsParser =
     <*> networkIdParser
     <*> nodeSocketParser
     <*> many hydraClientsParser
+    <*> optional pumbaCommandParser
+
+pumbaCommandParser :: Parser String
+pumbaCommandParser =
+  strOption
+    ( long "pumba-command"
+        <> metavar "CMD"
+        <> help
+          "Shell command to run as a network fault injector (e.g. pumba) once the \
+          \Head is open and deposits are finalized. The process is started just before \
+          \transaction submission begins and is terminated when the Head closes."
+    )
 
 hydraClientsParser :: Parser Host
 hydraClientsParser =

--- a/hydra-cluster/bench/Main.hs
+++ b/hydra-cluster/bench/Main.hs
@@ -32,13 +32,13 @@ main = do
           threadDelay 10
           runSingle dataset dir action
       summarizeResults outputDirectory results
-    DemoOptions{outputDirectory, numberOfTxs, timeoutSeconds, networkId, nodeSocket, hydraClients} -> do
+    DemoOptions{outputDirectory, numberOfTxs, timeoutSeconds, networkId, nodeSocket, hydraClients, pumbaCommand} -> do
       (_, faucetSk) <- keysFor Faucet
       dataset <- generateDemoUTxODataset networkId nodeSocket faucetSk (length hydraClients) numberOfTxs
       workDir <- maybe (createTempDir "bench-demo") checkEmpty outputDirectory
       results <-
         runSingle dataset workDir $
-          benchDemo networkId nodeSocket timeoutSeconds hydraClients
+          benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand
       summarizeResults outputDirectory [results]
       removeDirectoryRecursive workDir
     DatasetOptions{outputDirectory, timeoutSeconds, datasetUTxO, numberOfTxs, clusterSize, startingNodeId} -> do

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -232,6 +232,7 @@ benchmark bench-e2e
     , statistics
     , text
     , time
+    , typed-process
     , vector
 
   build-tool-depends: hydra-node:hydra-node

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -134,6 +134,7 @@
           run-tmux
           pkgs.cardano-node
           pkgs.cardano-cli
+          pkgs.pumba
         ];
       };
 

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -39,6 +39,7 @@
             inherit (inputs.cardano-node.packages.${system}) cardano-cli;
             inherit (inputs.cardano-node.packages.${system}) cardano-node;
             inherit (inputs.mithril.packages.${system}) mithril-client-cli;
+            pumba = inputs.pumba.packages.${system}.default;
           })
         ];
       };


### PR DESCRIPTION
Trying to fix the consistent CI failures we're seeing.

I think it's because the pumba command was hiding the close tx, as well as resulting in lost deposits.

This change just moves the pumba stuff to _only_ surround the tx processing as per normal. It's kind of obvious if we lose a deposit then it just expires; and we don't attempt to close if we didn't see it; so neither of those were testing anything interesting.