### PR TITLE
Skip long-running network stress test on NIGHTLY CI

### DIFF
--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -68,7 +68,7 @@ spec = do
       -- important to keep around. Successfully completion of this test looks
       -- like either a "mvcc database size exceeded" error; or no error at
       -- all. Failures looks like complete blocking
-      around_ onlyNightly $ it "broadcasts 100KiB messages 1M times @nightly" $ \tracer ->
+      around_ onlyLocal $ it "broadcasts 100KiB messages 1M times" $ \tracer ->
         withTempDir "test-etcd" $ \tmp -> do
           putStrLn $ "Folder " ++ show tmp
           PeerConfig2{aliceConfig, bobConfig} <- setup2Peers tmp

--- a/hydra-test-utils/src/Test/Hydra/Prelude.hs
+++ b/hydra-test-utils/src/Test/Hydra/Prelude.hs
@@ -15,6 +15,7 @@ module Test.Hydra.Prelude (
   checkProcessHasNotDied,
   exceptionContaining,
   withClearedPATH,
+  onlyLocal,
   onlyNightly,
   Gen,
   Arbitrary (..),
@@ -237,6 +238,14 @@ onlyNightly action = do
   lookupEnv "CI_NIGHTLY" >>= \case
     Nothing -> pendingWith "Only runs nightly"
     Just _ -> action
+
+-- | Only run this test locally, i.e. when no CI environment variable is set.
+-- Useful for long-running stress tests that would kill CI runners.
+onlyLocal :: IO () -> IO ()
+onlyLocal action = do
+  lookupEnv "CI" >>= \case
+    Nothing -> action
+    Just _ -> pendingWith "Only runs locally (skipped on CI)"
 
 data HydraTestnet
   = LocalDevnet


### PR DESCRIPTION
fix #2556 

Skipping this huge test yields green CI https://github.com/cardano-scaling/hydra/actions/runs/24712867310

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
