### PR TITLE
Make selfCI Linux-only in build

### DIFF
--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -44,7 +44,6 @@
         pkgs.yarn
         pkgs.yq
         pkgs.nix-fast-build
-        pkgs.selfci
         pkgs.just
       ];
 
@@ -66,6 +65,7 @@
       ++
       pkgs.lib.optionals pkgs.stdenv.isLinux [
         pkgs.systemd
+        pkgs.selfci
       ];
 
       haskellNixShell = (hsPkgs.shellFor {


### PR DESCRIPTION
`selfci` uses `libc::SYS_pidfd_open` (Linux-only syscall)

I moved `pkgs.selfci` out of the unconditional `buildInputs` and into the existing Linux-only block

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
