### PR TITLE
Add claude skills and md file

### DIFF
--- a/.claude/skills/cardano-haskell-developer/SKILL.md
+++ b/.claude/skills/cardano-haskell-developer/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: cardano-haskell-developer
+description: Specialized in Hydra Head Protocol development, Cardano blockchain Haskell codebases, log analysis, state machine debugging, CBOR/Plutus decoding, and test generation. Activate when working on hydra-node, cardano-ledger, plutus, or any Cardano Haskell project.
+tools: Read, Glob, Grep, Bash, Edit, Write
+---
+
+# Cardano Haskell Developer
+
+Expert assistant for Hydra Head Protocol and Cardano blockchain development in Haskell.
+
+## Development Philosophy
+
+**Act as a senior software developer/architect with these core principles:**
+
+1. **Simplicity First**: Always choose the simplest solution that solves the problem
+   - Prefer straightforward fixes over clever abstractions
+   - Add complexity only when absolutely necessary
+   - Refactor existing code rather than creating new patterns
+   - Question whether a feature is needed before implementing it
+
+2. **Test-Driven Validation**: Every fix must be backed by thorough testing
+   - Write unit tests that verify the fix solves the specific issue
+   - Ensure existing tests still pass (regression prevention)
+   - Add tests for edge cases and error conditions
+   - Use property-based testing for invariants when appropriate
+   - Run the full test suite before considering work complete
+
+3. **Architectural Thinking**: Consider the broader impact
+   - Understand the system's state machine and event flow before coding
+   - Trace through the full lifecycle: Input → Effect → StateChanged → aggregate
+   - Check rollback scenarios and error paths
+   - Verify that the fix doesn't introduce new edge cases
+   - Document assumptions and constraints
+   - **CRITICAL - Think Decentralized**: Always consider out-of-order message scenarios
+     - Hydra is a distributed protocol where parties may observe events at different times
+     - Chain events (DecommitFinalized, CommitFinalized) can arrive before off-chain snapshot completion
+     - Ask: "What if Party A sees event X but Party B doesn't see it yet?"
+     - Test whether parties can diverge in their snapshot number calculations
+     - Ensure protocol validation (requireReqSn checks) aligns with request logic
+     - Remember: fixes that work in isolated tests may fail in decentralized scenarios with message delays
+
+4. **Evidence-Based Debugging**: Let data guide decisions
+   - Analyze logs thoroughly before proposing fixes
+   - Trace the exact sequence of events that led to the bug
+   - Verify hypotheses with concrete test cases
+   - Use the type system to prevent entire classes of bugs
+
+## Core Competencies
+
+### 1. Hydra State Machine Analysis
+The Hydra Head protocol is an **event-sourced state machine** with states: `Idle -> Initial -> Open -> Closed -> Idle`.
+
+When debugging state machine issues:
+- Always trace the full event chain: `Input -> Effect -> StateChanged -> aggregate`
+- Check rollback handling: `ChainRolledBack` must undo **all** side effects of the rolled-back state changes
+- Check `LocalStateCleared` for completeness: it must reset **all** transient state (e.g., `currentDepositTxId`, `decommitTx`)
+- Look for stale references: when a transaction is rolled back, any state referencing that tx becomes invalid
+- Verify snapshot progression: `ReqSn` -> `AckSn` -> `SnapshotConfirmed` must not get stuck in loops
+
+**Key code locations:**
+- State machine core: `hydra-node/src/Hydra/HeadLogic.hs`
+- State types: `hydra-node/src/Hydra/HeadLogic/State.hs`
+- Outcomes/Effects: `hydra-node/src/Hydra/HeadLogic/Outcome.hs`
+- Errors: `hydra-node/src/Hydra/HeadLogic/Error.hs`
+- Input types: `hydra-node/src/Hydra/HeadLogic/Input.hs`
+- Chain interaction: `hydra-node/src/Hydra/Chain/Direct/`
+
+### 2. Log File Analysis
+When analyzing hydra-node logs:
+- Logs are JSON-structured, one object per line
+- Key fields: `timestamp`, `tag`, `node` (party identifier)
+- Look for event sequences by correlating `tag` values across nodes
+- Common patterns to search for:
+  - `ReqSn` followed by `AckSn` (or lack thereof) to detect stuck snapshots
+  - `RolledBack` events and what state changes they undo
+  - `PostTxOnChainFailed` for chain submission errors
+  - `WaitOnDepositObserved` / `WaitOnNotPendingDeposit` for deposit issues
+- Use `jq` for structured queries: `jq 'select(.tag == "ReqSn")' logfile`
+- Correlate timestamps across multiple node logs to understand message ordering
+
+### 3. CBOR and Transaction Decoding
+When working with Cardano transactions and serialization:
+- CBOR (Concise Binary Object Representation) is the wire format for Cardano
+- Use `cardano-cli transaction view` to inspect transaction bodies
+- Plutus scripts are CBOR-encoded; decode with appropriate deserializers
+- Hash algorithms: Blake2b-256 for transaction IDs, Blake2b-224 for key/script hashes
+- Address structure: header byte + payment credential + stake credential
+- Bech32 encoding for human-readable addresses (addr1..., stake1...)
+- When decoding hex data, check if it's double-CBOR-wrapped (common in script datums)
+
+### 4. Plutus Script Analysis
+When examining Hydra's on-chain validators:
+- Hydra validators are in `hydra-plutus/` and `hydra-plutus-extras/`
+- Scripts enforce the Head protocol's on-chain state transitions
+- Key scripts: Head validator, Commit validator, Deposit validator
+- Check datum/redeemer structures match expected formats
+- Verify minting policy logic for participation tokens
+- Script size matters: check against Cardano's execution unit limits
+
+### 5. Test Generation
+When writing tests for Hydra:
+- **Unit tests**: Pure property tests for `HeadLogic` state transitions
+  - Use QuickCheck generators for arbitrary states and inputs
+  - Test both happy paths and error conditions
+  - Verify `aggregate` correctly applies `StateChanged` events
+- **Model-based tests**: Check in `hydra-node/test/` for model-based testing patterns
+- **End-to-end tests**: `hydra-cluster/test/Test/EndToEndSpec.hs`
+  - These spin up actual cardano-node and hydra-node processes
+  - Use `withCluster` helpers for test setup
+- Always check for rollback scenarios in tests
+- Test invariants: UTxO conservation, snapshot number monotonicity, signature validity
+
+**IMPORTANT - Testing Requirements for Every Fix:**
+- Write a failing test FIRST that demonstrates the bug
+- Ensure the test passes after applying the fix
+- Run the FULL test suite before considering work complete
+- Verify no regressions were introduced
+- Test edge cases and error conditions thoroughly
+
+## Workflow: Debugging a Stuck Snapshot
+
+1. **Identify the symptom**: grep logs for repeated `ReqSn` without matching `SnapshotConfirmed`
+2. **Find the snapshot number**: what `snapshotNumber` is being requested?
+3. **Check prerequisites**: does the snapshot reference a deposit/decommit that was rolled back?
+4. **Trace the state**: what is `confirmedSnapshot`, `currentDepositTxId`, `pendingDeposits`?
+5. **Check rollback handling**: did a `ChainRolledBack` event occur? Did it clean up all references?
+6. **Verify waiters**: is there a `wait` condition that can never be satisfied?
+7. **Propose fix**: identify which `StateChanged` or `aggregate` case is incomplete
+
+## Workflow: Analyzing a Chain Rollback Bug
+
+1. **Find the rollback**: grep for `ChainRolledBack` or `Rollback` in logs
+2. **Identify rolled-back events**: what `StateChanged` events were undone by `rollbackOpenState`?
+3. **Check state consistency**: after rollback, is there any state that references rolled-back transactions?
+4. **Verify pending operations**: are `pendingDeposits`, `currentDepositTxId`, `decommitTx` consistent?
+5. **Check recovery**: does the node correctly re-observe the transactions if they reappear on chain?
+
+## Workflow: Adding a New Chain Event
+
+1. Define the on-chain event type in `Hydra.Chain`
+2. Add handling in `HeadLogic.hs` for the appropriate state
+3. Create `StateChanged` constructors for state transitions
+4. Implement `aggregate` case for the new state changes
+5. Add chain observation logic in `Hydra.Chain.Direct`
+6. Write unit tests covering the new event in all relevant states
+7. Write integration test if it involves chain interaction
+
+## Haskell-Specific Guidance
+
+- This project uses GHC with common extensions (OverloadedStrings, TypeApplications, etc.)
+- Build with `cabal build` or via nix (`nix develop` then `cabal build`)
+- Run tests: `cabal test hydra-node` or specific test with `-p "pattern"`
+- The codebase uses `aeson` for JSON, `cardano-api` for Cardano types
+- Lenses are used sparingly; pattern matching is preferred
+- Error handling uses custom sum types (not exceptions) in pure code
+- IO errors use `MonadThrow` / `MonadCatch` from `unliftio`
+- Formatting: use `nix fmt` to format all files in the project
+- Always use Haskell best practises
+
+## Code Quality Standards
+
+**CRITICAL**: All code changes must meet these quality requirements:
+
+1. **Zero Compilation Warnings**
+   - Code must compile without ANY warnings
+   - Check with: `cabal build hydra-cluster` (or relevant package)
+   - Common warning types to fix:
+     - `-Wunused-matches`: Unused lambda parameters (use `_` for intentionally unused params)
+     - `-Wunused-imports`: Remove unused imports or unnecessary re-exports
+     - `-Wname-shadowing`: Rename shadowing variables
+   - Use `--ghc-options=-Wall` or `--ghc-options=-Werror` to surface all warnings
+
+2. **Consistent Formatting**
+   - Always run `nix fmt` after making changes (formats entire project)
+   - Can also format specific files: `nix fmt path/to/file.hs`
+   - The formatter is configured in the project's flake.nix
+   - Never commit unformatted code
+
+3. **Build Verification**
+   - After fixes, always rebuild to verify no warnings: `cabal build all`
+   - Check specific components if working on them: `cabal build exe:hydra-cluster`
+   - Verify formatting didn't introduce errors: build after formatting
+
+4. **Pattern: Getting blockTime from Backend**
+   - DON'T pass `blockTime` as a parameter from `withHydraScriptsAndBackendRunning`
+   - DO fetch it inside the test: `blockTime <- Backend.getBlockTime backend`
+   - Use `\_ backend hydraScriptsTxId ->` in lambdas (underscore for unused blockTime param)
+   - This keeps the API uniform and reduces parameter passing
+
+## Work Completion Protocol
+
+**MANDATORY: Before declaring ANY code work complete, execute these steps IN ORDER:**
+
+1. **Format Code**
+   - Run: `nix fmt`
+   - This formats the entire project
+   - NEVER skip this step
+
+2. **Verify Build**
+   - Run: `cabal build all`
+   - Ensure ZERO warnings
+   - Fix any warnings before proceeding
+
+3. **Run Tests**
+   - Run full test suite: `cabal test all`
+   - For specific tests: `cabal test hydra-node --test-options='--match "pattern"'`
+   - All tests must pass
+
+4. **Review Changes**
+   - Run: `git status` and `git diff`
+   - Verify only intended files are modified
+   - Check that changes align with the fix
+
+5. **Final Checklist**
+   - [ ] Did I consider decentralized scenarios?
+   - [ ] Are all tests passing?
+   - [ ] Is the code formatted?
+   - [ ] Are there zero build warnings?
+   - [ ] Did I update MEMORY.md if this was a significant fix/learning?
+
+**Only after completing ALL steps above, declare the work complete.**
+
+## Common Pitfalls
+
+- **Double CBOR wrapping**: Script datums are often CBOR-within-CBOR; always check encoding layers
+- **Rollback incompleteness**: When adding new state, always ask "what happens if this is rolled back?"
+- **Snapshot version conflicts**: Ensure snapshot numbers are monotonically increasing across all parties
+- **Pending deposit state**: `pendingDeposits` map must be kept in sync with chain observations and rollbacks
+- **Test flakiness**: E2E tests depend on timing; use retry/wait helpers rather than fixed delays
+- **Out-of-order messages in distributed systems**: ALWAYS consider scenarios where:
+  - Chain events arrive at different times for different parties
+  - One party has `LastSeenSnapshot{lastSeen=1}` while another has `RequestedSnapshot{lastSeen=0, requested=1}`
+  - State calculations use unconfirmed snapshots (e.g., using `requested` instead of `lastSeen`)
+  - Protocol validation checks don't align with request logic
+  - Example: DecommitFinalized may arrive before all AckSn messages, causing parties to calculate different nextSn values
+  - Solution: Use only confirmed snapshot numbers for calculations, block all requests when any snapshot is in-flight

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of this plan until
+we reach a shared understanding. Walk down each branch of the design
+tree resolving dependencies between decisions one by one.
+
+If a question can be answered by exploring the codebase, explore
+the codebase instead.
+
+For each question, provide your recommended answer.

--- a/.claude/skills/hydra-log-analysis/SKILL.md
+++ b/.claude/skills/hydra-log-analysis/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: hydra-log-analysis
+description: Diagnose hydra-node JSON log files when something has gone wrong on a running Head — most commonly "why did snapshots stop confirming?" Builds a chronological timeline of state changes, network effects, and chain events leading up to the problem, then matches the timeline against known Hydra failure patterns (etcd ReqSn feedback loops, leader stuck in RequestedSnapshot, stale decommit/deposit, version race, deposit activation race). Supports single-node analysis or multi-node Head analysis (correlates leader vs peers, AckSn coverage, state divergence) and accepts native hydra JSON, journalctl-json, and journalctl text formats. Use this skill when the user provides a path to a hydra-node log and asks why a Head stalled, why a transaction wasn't confirmed, why a snapshot wasn't acknowledged, or any similar protocol-stall diagnostic question. Also use it when investigating bench-e2e or devnet runs that produced unexpected throughput or hangs.
+---
+
+# Hydra Log Analysis
+
+## Overview
+
+Hydra-node emits structured JSON-lines logs where each entry contains an `input`, an `outcome` with `stateChanges` and `effects`, plus chain and network events. When a Head misbehaves — snapshots stop confirming, a leader gets stuck, a deposit never activates — the answer is usually reconstructable from the log, but only if the right fields are correlated in chronological order.
+
+This skill provides a repeatable workflow: locate the boundary where things went wrong, walk forward emitting a timeline, match the timeline against the catalog of known failure patterns, and **only report a finding when the timeline conclusively proves it**.
+
+## Two non-negotiable rules
+
+These override convenience. Read them before doing anything else.
+
+### 1. Read `hydra-node/src/Hydra/HeadLogic.hs` first
+
+`HeadLogic.hs` is the source of truth for off-chain protocol behavior. It dictates which inputs produce which state changes and effects, what the preconditions of every transition are, and what the timer does in each `seenSnapshot` state. Log analysis without that context is guesswork.
+
+Before opening any log file, read `hydra-node/src/Hydra/HeadLogic.hs` (and the associated `HeadLogic/State.hs`, `HeadLogic/Outcome.hs`, `HeadLogic/Error.hs` as needed). If the user has explicitly told you to skip this step for a particular task, only then skip it.
+
+### 2. Be confident before reporting; "no problem found" is a valid answer
+
+If the timeline does not conclusively support a diagnosis, **report that**. Do not speculate, do not pick the closest-looking pattern, do not invent a story to explain ambiguous evidence. A correct "I cannot tell from this log what is wrong" is far more useful than a confident wrong answer.
+
+The bar: every reported finding must be backed by specific timeline rows that prove it. If you can't produce that evidence, you don't have the finding.
+
+## When to use
+
+Trigger on requests like:
+
+- "Why did snapshots stop confirming in this run?"
+- "Why is the Head stuck?"
+- "Why didn't this transaction get into a snapshot?"
+- "Analyze this hydra-node log."
+- "What went wrong here?" (with a log path)
+- "The bench run regressed — find out where."
+
+Skip this skill for code-only questions that do not involve a concrete log file.
+
+## Required inputs
+
+Paths to one or more hydra-node log files, supplied by the user. Do not search the filesystem for log files.
+
+When the user provides multiple files (a Head has 2+ nodes), **ask whose log each one is** — leader, peer-A, alice, etc. Use the labels they give you when invoking `merge_timelines.sh` and `cluster_diagnose.sh`. Do not auto-derive labels from filenames; node identity matters and is the user's to assert.
+
+Logs may be in any of three formats — `normalize.sh` handles all transparently:
+1. Native hydra-node JSON (one JSON object per line)
+2. `journalctl --output=json` (`.MESSAGE` field wraps the original)
+3. `journalctl` default/short text format (`Mar 12 ... prog[pid]: {json}`)
+
+If `jq` is not installed, stop and tell the user.
+
+## Workflow
+
+### Step 0 — Read `HeadLogic.hs`
+
+See rule 1. Skip only if the user has already explicitly waived this for the current task.
+
+### Step 1 — Establish the boundary (single log)
+
+```bash
+scripts/find_boundary.sh <logfile>
+```
+
+Output: row index, timestamp, snapshot number, signature count of the last `SnapshotConfirmed`. Everything after this row is the "problem window."
+
+The `row` index refers to the **normalized** stream (Nth valid hydra log entry, ignoring journalctl prefix noise). It is the value to pass to `--since-row` downstream.
+
+### Step 2 — Build the timeline
+
+**Single log:**
+
+```bash
+scripts/timeline.sh <logfile> [--since-row N] [--tail N]
+```
+
+**Multi-log (one Head, several nodes):**
+
+```bash
+scripts/merge_timelines.sh leader:<log1> peer-A:<log2> peer-B:<log3> [--sn N] [--since-ts T]
+```
+
+Output: TSV with `node | row | timestamp | kind | tag | summary`, sorted chronologically. Every later report cites rows from this output.
+
+### Step 3 — Run the diagnostic battery
+
+**Single log:**
+
+```bash
+scripts/snapshot_diagnose.sh <logfile>
+```
+
+Detects: REQSN_FLOOD, LEADER_STUCK, NO_ACKSN / ACKSN_COVERAGE, STALE_DECOMMIT, DEPOSIT_NOT_ACTIVATED, REPEATED_CHAIN_TICK, REQUIREFAILED_SUMMARY, REQTX_DROUGHT.
+
+**Multi-log:**
+
+```bash
+scripts/cluster_diagnose.sh leader:<log1> peer-A:<log2> peer-B:<log3>
+```
+
+Detects: ACKSN_GAP_CLUSTER, REQSN_NOT_DELIVERED, STATE_DIVERGENCE, CHAIN_SKEW. Each finding is followed by an inline `EVIDENCE` block of merged-timeline rows — that is the proof.
+
+### Step 4 — Interpret against known patterns
+
+Match findings from Step 3 against `references/failure_patterns.md` (single-node) and `references/multi_node.md` (cluster). Each catalog entry documents signature, mechanism, fix history (commit/PR), and the code paths in `HeadLogic.hs` to verify against.
+
+For cluster findings, **re-read** the relevant `HeadLogic.hs` code path before concluding. Verify the diagnosis against the actual transition logic; do not rely on the catalog entry alone.
+
+If no pattern matches, fall back to `references/log_format.md` and `references/jq_recipes.md` for ad-hoc queries.
+
+### Step 5 — Write the verdict
+
+Produce a short report:
+
+1. **Timeline** — relevant rows from Step 2, verbatim. Use literal tag names (`SnapshotRequested`, not "snapshot was requested").
+2. **Diagnosis** — pattern name from the catalog, OR "no known pattern matches; insufficient evidence to identify root cause." For each finding, cite specific timeline rows that prove it. No row, no finding.
+3. **Next steps** — what to inspect in `HeadLogic.hs`, what additional logs would disambiguate, or which experiment would confirm.
+
+Keep it tight. Bullets beat paragraphs. The user reads this to decide where to look in code.
+
+## Key references
+
+- `references/log_format.md` — JSON paths, tag taxonomy, field semantics, format detection
+- `references/failure_patterns.md` — single-node failure catalog
+- `references/multi_node.md` — cluster-level failure catalog
+- `references/jq_recipes.md` — ad-hoc one-liners
+
+## Anti-patterns
+
+- Do not skip Step 0. `HeadLogic.hs` first, always.
+- Do not invent failure patterns. If nothing matches, say so.
+- Do not summarize log lines into prose. Timeline rows are the evidence; show them.
+- Do not paraphrase tags. The literal tag is what matches the code.
+- Do not auto-label nodes from filenames. Ask the user.
+- Do not run the full bench or replay the run. Logs only.
+- Do not modify the log file. Read-only analysis.

--- a/.claude/skills/hydra-log-analysis/references/failure_patterns.md
+++ b/.claude/skills/hydra-log-analysis/references/failure_patterns.md
@@ -1,0 +1,148 @@
+# Hydra Failure Patterns — Diagnostic Catalog
+
+Each entry: **signature** (what to grep for), **mechanism** (why it happens), **fix history** (commit/PR if known), **code paths** (where to look).
+
+When `snapshot_diagnose.sh` reports a finding tagged `[PATTERN_NAME]`, look up that anchor here.
+
+---
+
+## REQSN_FLOOD — etcd ReqSn feedback loop {#reqsn-flood}
+
+**Signature**: same `snapshotNumber` appears in `effects[].message.tag == "ReqSn"` more than ~10 times. Often hundreds.
+
+**Mechanism**: prior to the fix, `onOpenTimer` re-broadcast `ReqSn`+`AckSn` in the `SeenSnapshot` case while waiting for the remaining AckSns. Each broadcast went through etcd, which echoed it back as a `NetworkInput`, resetting the input queue's `lastWasTimer=False`, allowing the next timer tick to fire — creating a 200Hz feedback loop that flooded etcd's `PersistentQueue` (capacity 100), back-pressuring `processEffects` and delaying real AckSn delivery.
+
+**Fix history**: removed `SeenSnapshot` case from `onOpenTimer`; timer in `SeenSnapshot` is now a noop. Branch `resilient-snapshots`, around 2026-03-10.
+
+**Code paths**:
+- `hydra-node/src/Hydra/HeadLogic.hs` — `onOpenTimer`
+- `hydra-node/src/Hydra/Node/InputQueue.hs` — `lastWasTimer` coalescing
+
+**Disambiguation**: if ReqSn flood is present **without** repeated SnapshotRequested entries, it may be a different bug (peer re-broadcasting). Check whether the flood is on this node's effects or in its inputs.
+
+---
+
+## LEADER_STUCK — leader stuck in RequestedSnapshot {#leader-stuck}
+
+**Signature**: a `SnapshotRequested(sn=N)` event with **no** matching `SnapshotConfirmed(sn=N)`, and one or more `RequireFailed` outcomes between them. Often the failing input is the leader's own echoed ReqSn.
+
+**Mechanism**: `snapshotInFlight RequestedSnapshot{requested=sn} sn = False` lets the leader process its own echo, but if the echo fails validation (e.g. signature mismatch from a stale tx set), the leader stays in `RequestedSnapshot` forever — no further timer or ReqTx will reset it.
+
+**Fix history**: introduced `SnapshotRequestAborted` StateChanged + `abortOwnEchoOnFail` wrapper in `onOpenNetworkReqSn`. Branch `resilient-snapshots`, 2026-03-12.
+
+**Code paths**:
+- `hydra-node/src/Hydra/HeadLogic.hs` — `onOpenNetworkReqSn`, `abortOwnEchoOnFail`
+- `hydra-node/golden/StateChanged/SnapshotRequestAborted.json`
+
+**Disambiguation**: combined with REQSN_FLOOD it usually means the flood **caused** the stuck state (echoes interleave with stale ReqTx). Solo, it suggests a logic bug in own-echo validation.
+
+---
+
+## NO_ACKSN / ACKSN_COVERAGE — missing peer acknowledgements {#missing-acksn}
+
+**Signature**: `SnapshotRequested(sn=N)` followed by zero or fewer-than-quorum `AckSn(sn=N)` inputs from peers.
+
+**Mechanism**: peer never received the ReqSn, peer rejected it (peer's RequireFailed visible only in peer's log), or AckSn was lost in transit.
+
+**Diagnosis**: requires peer logs. Run `find_boundary.sh` and `timeline.sh` on each peer's log; locate ReqSn input with the same `sn` and check what came after.
+
+**Code paths**:
+- `hydra-node/src/Hydra/HeadLogic.hs` — `onOpenNetworkReqSn` (peer side)
+
+---
+
+## STALE_DECOMMIT — CommitFinalized leaves stale decommitTx {#stale-decommit}
+
+**Signature**: `SnapshotRequested` where `decommitTx != null` follows a `CommitFinalized` event in which `confirmedSnapshot.utxoToDecommit != null`.
+
+**Mechanism**: prior to fix, `aggregateNodeState` for `CommitFinalized` did not clear `decommitTx`, so the next snapshot still tried to decommit utxo that was already part of the just-finalized commit, causing signature/utxo mismatches.
+
+**Fix history**: `aggregateNodeState` CommitFinalized case now clears `decommitTx` when `confirmedSnapshot.utxoToDecommit = Just _`. Branch `resilient-snapshots`, 2026-03-12.
+
+**Code paths**:
+- `hydra-node/src/Hydra/HeadLogic.hs` — `aggregateNodeState`, CommitFinalized case
+
+---
+
+## DEPOSIT_NOT_ACTIVATED — deposit activation race {#deposit-activation-race}
+
+**Signature**: `DepositRecorded(txId=X)` exists, but no `DepositActivated(txId=X)` despite the deposit deadline having passed (compare `chainTime` against deposit deadline).
+
+**Mechanism**: `DepositActivated` aggregate set `currentDepositTxId = Just depositTxId` unconditionally, but a concurrent state path could clear it back to `Nothing` before the timer picked it up.
+
+**Fix history**: `DepositActivated` aggregate now uses `currentDepositTxId = currentDepositTxId <|> Just depositTxId` so timer reliably picks it up. See project memory `project_deposit_bug.md`.
+
+**Code paths**:
+- `hydra-node/src/Hydra/HeadLogic.hs` — `aggregateNodeState`, DepositActivated case
+
+---
+
+## REPEATED_CHAIN_TICK — duplicate DepositExpired/DepositActivated {#repeated-chain-tick}
+
+**Signature**: same `(tag, depositTxId)` tuple appears in the log on multiple ticks — `DepositExpired tx=abc` fired 5 times, etc.
+
+**Mechanism**: `onChainTick` re-emitted the transition event on every tick where the predicate held, instead of only on the tick where the status actually changed.
+
+**Fix history**: `onChainTick` now uses `isTransitionTo` filter — only emits the event when status flips. Branch `resilient-snapshots`, 2026-03-12.
+
+**Code paths**:
+- `hydra-node/src/Hydra/HeadLogic.hs` — `onChainTick`
+
+---
+
+## VERSION_RACE — version mismatch after CommitFinalized/DecommitFinalized {#version-race}
+
+**Signature**: `RequireFailed` with reason involving `version` mismatch, often after a `CommitFinalized` or `DecommitFinalized`. Snapshots stop confirming until all parties agree on the new version.
+
+**Mechanism**: version was previously updated immediately on the version-bump event, but peers' AckSns for the in-flight snapshot still carried the old version. Solution: defer version update until all parties acknowledge.
+
+**Fix history**: deferred version update with chain-state consensus via AckSn. 2026-02-27.
+
+**Code paths**:
+- `hydra-node/src/Hydra/HeadLogic.hs` — version update logic
+
+---
+
+## REQUIREFAILED_SUMMARY — generic precondition violations {#requirefailed}
+
+Not a single pattern but a fingerprint. The top reasons typically are:
+
+- `ReqSvNumberInvalid` / `ReqSnNumberInvalid` — leader proposed wrong snapshot number
+- `SnapshotAlreadySigned` — duplicate AckSn from same party
+- `SnapshotDoesNotApply` — UTxO state mismatch (often points to a STALE_DECOMMIT or stale localUTxO)
+- `InvalidMultisignature` — signature didn't verify (often from version mismatch)
+- `RequireFailed` with `ReqVersionInvalid` — see VERSION_RACE
+
+Cross-reference with `hydra-node/src/Hydra/HeadLogic/Error.hs` for the full taxonomy.
+
+---
+
+## REQTX_DROUGHT — no new ReqTx broadcast {#reqtx-drought}
+
+**Signature**: gap of >1000 log lines since the last ReqTx effect.
+
+**Mechanism**: usually benign (no client load) but can indicate input queue starvation if `lastWasTimer` was stuck `True` (rarer post-fix).
+
+**Disambiguation**: if accompanied by REQSN_FLOOD, the queue was flooded with ReqSn echoes and starved real ReqTx. If solo, usually means the workload simply stopped.
+
+---
+
+## SNAPSHOT_NEVER_CONFIRMED — generic stall {#snapshot-never-confirmed}
+
+**Signature**: `SnapshotRequested(sn=N)` at the end of the log with no following `SnapshotConfirmed(sn=N)` and no `RequireFailed`.
+
+**Mechanism**: catch-all for stalls without an explicit error. Almost always reduces to NO_ACKSN once peer logs are inspected.
+
+**Diagnosis**: requires peer logs.
+
+---
+
+## Pattern not in this file?
+
+If `snapshot_diagnose.sh` returned no findings or the timeline shows something unfamiliar, fall back to:
+
+1. `references/jq_recipes.md` for ad-hoc queries
+2. `hydra-node/src/Hydra/HeadLogic.hs` source — search for the failing tag
+3. The user's memory at `~/.claude/projects/-home-v0d1ch-code-hydra/memory/MEMORY.md` for recent project context
+
+When a novel failure is fully diagnosed, propose adding it to this file.

--- a/.claude/skills/hydra-log-analysis/references/jq_recipes.md
+++ b/.claude/skills/hydra-log-analysis/references/jq_recipes.md
@@ -1,0 +1,135 @@
+# jq Recipes for hydra-node Logs
+
+Copy-paste recipes for ad-hoc questions when the canned scripts don't cover what is needed. Each recipe assumes `LOG=path/to/hydra-node.log` and that the log is JSON-lines.
+
+## Counts and tallies
+
+### Count every state-change tag
+```bash
+jq -r '.message.node.outcome.stateChanges // [] | .[].tag' "$LOG" \
+  | sort | uniq -c | sort -rn
+```
+
+### Count every effect tag
+```bash
+jq -r '.message.node.outcome.effects // [] | .[] | (.message.tag // .tag)' "$LOG" \
+  | sort | uniq -c | sort -rn
+```
+
+### Count input tags
+```bash
+jq -r '.message.node.input // empty | .tag' "$LOG" \
+  | sort | uniq -c | sort -rn
+```
+
+### ReqSn broadcasts per snapshot number (flood detector)
+```bash
+jq -r '.message.node.outcome.effects // [] | .[]
+       | select((.message.tag // .tag) == "ReqSn")
+       | .message.snapshotNumber' "$LOG" \
+  | sort -n | uniq -c | sort -rn | head
+```
+
+### AckSn distinct parties per snapshot number
+```bash
+jq -r '.message.node.input // empty
+       | select(.tag == "NetworkInput")
+       | .message
+       | select(.tag == "AckSn")
+       | "\(.snapshotNumber)\t\(.party.vkey)"' "$LOG" \
+  | sort -u \
+  | awk '{c[$1]++} END {for (k in c) printf "sn=%s\t%d distinct parties\n", k, c[k]}' \
+  | sort -k1.4n
+```
+
+## Timing and gaps
+
+### Gap (in seconds) between consecutive SnapshotConfirmed events
+```bash
+jq -r 'select((.. | objects | .tag? // "") | test("SnapshotConfirmed"))
+       | .timestamp' "$LOG" \
+  | awk 'NR>1 {
+      cmd = "date -u -d \"" $0 "\" +%s.%N";
+      cmd | getline t; close(cmd);
+      if (prev) printf "%.3f s\n", t - prev;
+      prev = t;
+      next
+    }
+    { cmd = "date -u -d \"" $0 "\" +%s.%N"; cmd | getline prev; close(cmd) }'
+```
+
+### Time between SnapshotRequested(N) and SnapshotConfirmed(N)
+```bash
+jq -r 'select(.. | objects | (.tag? == "SnapshotRequested" or .tag? == "SnapshotConfirmed"))
+       | [.timestamp, (.. | objects | select(.tag? == "SnapshotRequested" or .tag? == "SnapshotConfirmed") | "\(.tag) sn=\(.snapshot.number // .snapshotNumber)")] | @tsv' "$LOG"
+# Then pair adjacent rows for matching sn.
+```
+
+## Per-tag extraction
+
+### Pull every SnapshotRequested with its decommit/deposit fields
+```bash
+jq -r '.message.node.outcome.stateChanges // [] | .[]
+       | select(.tag == "SnapshotRequested")
+       | [.timestamp, (.snapshot.number // .snapshotNumber),
+          (.decommitTx // "null"),
+          (.depositTxId // "null")] | @tsv' "$LOG"
+```
+
+### Show every RequireFailed with reason
+```bash
+jq -r '..|objects|select(.tag? == "RequireFailed")
+       | "\(.reason.tag // .reason // "unknown")"' "$LOG" \
+  | sort | uniq -c | sort -rn
+```
+
+### Plutus validation failures with debug traces
+```bash
+grep -n '"Plutus validation failed"' "$LOG" \
+  | head -n 5
+# Then on a hit:
+sed -n '${LINE}p' "$LOG" | jq '..|.DebugFailure? | select(.)'
+```
+
+## Multi-node correlation
+
+### Find where node1 and node2 first diverge in stateChange tags
+```bash
+diff \
+  <(jq -r '.message.node.outcome.stateChanges // [] | .[].tag' node1.log) \
+  <(jq -r '.message.node.outcome.stateChanges // [] | .[].tag' node2.log) \
+  | head -n 40
+```
+
+### All AckSns received from a specific peer
+```bash
+jq -r --arg pk "abcdef0123" '
+  .message.node.input // empty
+  | select(.tag == "NetworkInput")
+  | .message
+  | select(.tag == "AckSn" and (.party.vkey | startswith($pk)))
+  | "\(.snapshotNumber)"' "$LOG" \
+  | sort -n | uniq
+```
+
+## Ad-hoc filters by line range
+
+### View lines 1000–1100 as pretty JSON
+```bash
+sed -n '1000,1100p' "$LOG" | jq -C
+```
+
+### Last N significant events before EOF
+```bash
+tail -n 5000 "$LOG" \
+  | jq -r 'select(.message.node.outcome.stateChanges // [] | length > 0)
+           | [.timestamp, (.message.node.outcome.stateChanges[].tag)] | @tsv' \
+  | tail -n 30
+```
+
+## Performance tips
+
+- Always pre-filter with `grep -n` when looking for a known string — `grep` is 10–100× faster than `jq` over a multi-GB log.
+- Use `--stream` mode for huge logs if you only need shallow fields.
+- `jq -c` (compact) output is faster than pretty-printing.
+- Avoid recursive descent (`..`) on large logs unless you need it; explicit paths are much faster.

--- a/.claude/skills/hydra-log-analysis/references/log_format.md
+++ b/.claude/skills/hydra-log-analysis/references/log_format.md
@@ -1,0 +1,125 @@
+# hydra-node Log Format Reference
+
+Hydra-node emits **JSON Lines** (one JSON object per line). Every line is independently parseable.
+
+## Top-level object shape
+
+```jsonc
+{
+  "timestamp": "2026-03-12T14:23:45.123Z",     // ISO 8601 UTC
+  "threadId": "ThreadId 42",
+  "namespace": "...",
+  "message": {
+    "node": {                                   // present on every protocol log line
+      "input":  { ... },                        // what triggered processing (optional)
+      "outcome": {                              // what came out of HeadLogic.update
+        "stateChanges": [ ... ],                // array of StateChanged events
+        "effects":      [ ... ],                // array of Effects (network/chain/client)
+        "error":        { ... }                 // present only on Left outcomes
+      }
+    }
+  }
+}
+```
+
+Other top-level message shapes exist (chain follower, network layer, etc.) but the **HeadLogic** lines under `message.node` are the load-bearing ones for protocol diagnosis.
+
+## Key JSON paths
+
+| Purpose | Path |
+|---|---|
+| Wall-clock timestamp | `.timestamp` |
+| Triggering input tag | `.message.node.input.tag` |
+| State change list | `.message.node.outcome.stateChanges[]` |
+| State change tag | `.message.node.outcome.stateChanges[].tag` |
+| Effect list | `.message.node.outcome.effects[]` |
+| Network message tag inside effect | `.message.node.outcome.effects[].message.tag` |
+| Outcome error | `.message.node.outcome.error` |
+| Snapshot number (state) | `.snapshot.number` (newer) or `.snapshotNumber` (older) |
+| Snapshot number (effect) | `.message.snapshotNumber` |
+| Party identity | `.party.vkey` (hex string) |
+
+Recursive descent (`.. | objects | select(.tag? == "X")`) is the safest way to find a tag if its exact path varies between hydra-node versions or codepaths.
+
+## State-change tags (significant subset)
+
+Found at `.message.node.outcome.stateChanges[].tag`.
+
+### Snapshot lifecycle
+- `SnapshotRequested` — leader emitted ReqSn; carries `snapshot.number`, optional `decommitTx`, optional `depositTxId`
+- `SnapshotConfirmed` — quorum of AckSns gathered; carries `snapshot` and `signatures` map keyed by party
+- `SnapshotRequestAborted` — leader's own ReqSn echo failed validation; cleanly resets to NoSeenSnapshot (added recently — see project memory `project_deposit_bug.md`)
+
+### Transactions
+- `TransactionAppliedToLocalUTxO` — tx applied locally; carries `newLocalUTxO`
+- `TransactionReceived` — tx received over network from a peer
+
+### Commits / decommits / deposits
+- `PartyCommitted` — collectCom UTxO contribution observed on chain
+- `CommitFinalized` — chain confirmed an incremental commit; clears pending deposit
+- `DecommitFinalized` — chain confirmed an incremental decommit; clears `decommitTx`
+- `DepositRecorded` — chain saw a deposit tx; records `depositTxId` and `chainTime`
+- `DepositActivated` — deposit deadline reached and tx is in scope; sets `currentDepositTxId`
+- `DepositExpired` — deposit deadline passed without inclusion
+
+### Head lifecycle
+- `HeadInitialized` / `HeadOpened` / `HeadClosed` / `HeadIsContested` / `HeadIsFinalized`
+
+### Chain
+- `TickObserved` — chain follower advanced to a new slot/time
+
+## Effect tags (network)
+
+Found at `.message.node.outcome.effects[].message.tag` (network effects wrap a `Message` ADT).
+
+- `ReqTx` — broadcast a new transaction to peers
+- `ReqSn` — leader requesting a snapshot; carries `snapshotNumber`, `transactionIds`, optional `decommitTx`, `depositTxId`
+- `AckSn` — non-leader acknowledging a snapshot; carries `snapshotNumber`, `signed` signature, `party`
+- `ConfTx` — confirm transaction (rare)
+- `ReqDec` — request a decommit (legacy)
+
+There is also a `ToParty` effect-shape variant when sending point-to-point — look for `.toParty.vkey`.
+
+## Input tags
+
+Found at `.message.node.input.tag`.
+
+- `NetworkInput` — wraps a `Message` from a peer; inner tag at `.message.tag`
+- `ChainInput` — observed chain event (commit, deposit, tick, close)
+- `ClientInput` — request from the API client (`NewTx`, `Decommit`, `Recover`, `Close`...)
+
+## Error / failure shapes
+
+When HeadLogic rejects an input, `outcome` contains:
+
+```jsonc
+{
+  "tag": "Error",                  // sometimes
+  "error": {
+    "tag": "RequireFailed",        // typical wrapper
+    "reason": {
+      "tag": "ReqSvNumberInvalid", // or similar — see HeadLogic/Error.hs
+      ...
+    }
+  }
+}
+```
+
+Grep heuristics:
+- `"RequireFailed"` — HeadLogic precondition violation
+- `"Plutus validation failed"` — on-chain script rejected a tx (Aiken `expect` failure produces a `DebugFailure` array)
+- `"Invalid"` — generic validation error
+
+## Time fields
+
+- `.timestamp` — wall clock, ISO 8601, **always UTC**
+- `.chainTime` (inside chain events / DepositRecorded) — POSIX time **in milliseconds**
+- Tx validity bounds — POSIX **milliseconds** since epoch
+
+## Multi-node correlation
+
+Each node's log is independent. To correlate:
+- Match on `snapshotNumber` for snapshot-related events
+- Match on `txId` (inside `transaction.txId` or as bytes in `transactionIds[]`) for tx events
+- Match on `depositTxId` for deposit lifecycle
+- Match on `chainTime` to align on the chain timeline (timestamps will differ slightly per node)

--- a/.claude/skills/hydra-log-analysis/references/multi_node.md
+++ b/.claude/skills/hydra-log-analysis/references/multi_node.md
@@ -1,0 +1,82 @@
+# Multi-Node (Cluster) Failure Patterns
+
+Patterns that are only diagnosable with logs from two or more nodes of the same Head. Use after running `scripts/cluster_diagnose.sh`. For each pattern, **re-read the relevant code in `hydra-node/src/Hydra/HeadLogic.hs` before concluding** — the catalog is a starting hypothesis, not a verdict.
+
+---
+
+## ACKSN_GAP_CLUSTER — quorum AckSn not reached cluster-wide {#acksn-gap-cluster}
+
+**Signature**: `SnapshotRequested(sn=N)` appears at one or more nodes, but the merged timeline shows fewer than `n_nodes` distinct nodes emitting `AckSn(sn=N)`, and no node ever emits `SnapshotConfirmed(sn=N)`.
+
+**Mechanism candidates** (verify each by code inspection):
+- A peer received `ReqSn(N)` but `RequireFailed` rejected it locally — check that peer's outcome.error in the same window
+- The peer never received `ReqSn(N)` — see REQSN_NOT_DELIVERED
+- Network partition: peer received but its `AckSn` effect never reached the leader — check leader's input stream for AckSn from that peer
+- Peer crashed or was paused — its log will simply end before AckSn
+
+**Code paths to verify**:
+- `onOpenNetworkReqSn` in `hydra-node/src/Hydra/HeadLogic.hs` — peer's ReqSn handling
+- `onOpenNetworkAckSn` — leader's AckSn aggregation
+- The quorum check (look for the function that checks `length signatures == length parties`)
+
+**Confidence rule**: do not conclude "peer X is at fault" unless the merged timeline shows either (a) peer X's log emits a RequireFailed for sn=N, or (b) peer X's log shows no NetworkInput for ReqSn(N) at all, or (c) peer X's log ends before sn=N. Anything else is speculation.
+
+---
+
+## REQSN_NOT_DELIVERED — leader broadcast ReqSn but peers didn't receive it {#reqsn-not-delivered}
+
+**Signature**: leader emits `ReqSn(sn=N)` as an effect, but one or more peers' logs show no `NetworkInput { message = ReqSn(N) }` within a reasonable window (seconds, not minutes).
+
+**Mechanism candidates**:
+- etcd / network layer dropped the message
+- Peer was offline at the time of broadcast (its log will reflect this — gap in input stream)
+- Receiver-side filter rejected it before logging (rare; check `Hydra/Network/...`)
+
+**Code paths to verify**:
+- `Hydra/Network/Etcd.hs` — broadcast and delivery
+- `Hydra/Node/InputQueue.hs` — input queue ingestion (could it have been coalesced?)
+
+**Confidence rule**: a peer not logging a NetworkInput for ReqSn within ~5 seconds of the leader's effect is strong evidence. Within 5 seconds is ambiguous (timestamps across nodes can drift slightly).
+
+---
+
+## STATE_DIVERGENCE — node state-change streams diverge {#state-divergence}
+
+**Signature**: each node's `stateChanges[].tag` stream, taken in order, is identical up to some index — then differs at index K. Diagnostic output names the index and per-node tag at that position.
+
+**Mechanism candidates**:
+- One node missed an input the others received (combine with REQSN_NOT_DELIVERED check)
+- One node observed a chain event the others did not (chain-follower lag — combine with CHAIN_SKEW)
+- A bug in `aggregateNodeState` produced inconsistent state from the same input — this is the *most serious* possibility, and worth opening an issue for
+
+**Code paths to verify**:
+- `aggregateNodeState` in `hydra-node/src/Hydra/HeadLogic.hs` — must be deterministic given the same inputs
+- The specific event tags at the divergence point — look for nondeterminism in their handlers
+
+**Confidence rule**: divergence does not by itself indicate a bug. Verify that the divergent nodes received the *same* inputs. If inputs differ, the state divergence is a downstream symptom, not the cause.
+
+---
+
+## CHAIN_SKEW — same chain event observed at very different times {#chain-skew}
+
+**Signature**: the same chain-derived event (e.g. `DepositRecorded(txId=X)`, `CommitFinalized`, `DecommitFinalized`) appears in multiple nodes' logs but with timestamps differing by more than ~5 seconds.
+
+**Mechanism candidates**:
+- One node's chain follower is lagging (cardano-node sync issue, network slow)
+- The nodes are connected to different cardano-nodes (acceptable in some setups)
+- Clock skew between hosts (rare in containerized setups; check `chronyd`/`ntp` if suspected)
+
+**Code paths to verify**: not in `HeadLogic.hs` — this is a chain layer concern. Look at `Hydra/Chain/Direct/...` if needed.
+
+**Confidence rule**: chain skew alone does not cause snapshot failures unless one node is *so* far behind that it hasn't seen a deposit-activation event the others are acting on. Cross-reference with the snapshot timeline before flagging this as a root cause.
+
+---
+
+## When the cluster diagnose returns no findings
+
+This is a real and useful outcome. Possible explanations:
+1. The Head is operating normally; the user's hypothesis of "snapshots stopped" may be incorrect — check `find_boundary.sh` against current expected sn.
+2. The failure is single-node only — fall back to `snapshot_diagnose.sh` per node and `failure_patterns.md`.
+3. The failure is in a layer this skill does not analyze (chain, network transport, persistence) — say so explicitly.
+
+**Do not** synthesize a finding by combining weak signals from multiple checks. If each check individually returned no firm result, the report is "no firm cluster-level diagnosis."

--- a/.claude/skills/hydra-log-analysis/scripts/cluster_diagnose.sh
+++ b/.claude/skills/hydra-log-analysis/scripts/cluster_diagnose.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# Cross-node diagnostic battery for a Hydra Head — runs over multiple
+# node logs and identifies failures only visible cluster-wide.
+#
+# Each finding is followed by an EVIDENCE block: rows from the merged
+# timeline that prove the finding. This is the "timeline that proves
+# the error you are reporting is truthful" requirement.
+#
+# Usage:
+#   cluster_diagnose.sh <label1>:<log1> <label2>:<log2> [<label3>:<log3> ...]
+#
+# Findings emitted:
+#   ACKSN_GAP_CLUSTER  — leader's snapshot N has < quorum AckSn cluster-wide
+#   REQSN_NOT_DELIVERED — leader sent ReqSn(N) but ≥1 peer never received it
+#   STATE_DIVERGENCE   — first index where state-change tag streams differ
+#   CHAIN_SKEW         — same chain event observed at very different times
+#                        across nodes (>5s skew)
+
+set -euo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <label1>:<log1> <label2>:<log2> [<label3>:<log3> ...]" >&2
+  exit 2
+fi
+
+specs=("$@")
+
+# Build the merged timeline once.
+merged=$(mktemp)
+trap 'rm -f "$merged"' EXIT
+"$HERE/merge_timelines.sh" "${specs[@]}" > "$merged"
+
+findings=0
+
+emit_finding() {
+  local pattern="$1" headline="$2"
+  printf "\n[%s] %s\n" "$pattern" "$headline"
+  findings=$((findings+1))
+}
+
+emit_evidence_sn() {
+  local sn="$1"
+  echo "  EVIDENCE (timeline rows for sn=$sn):"
+  awk -F'\t' -v sn="$sn" '
+    NR == 1 { next }                              # skip header
+    $6 ~ ("sn=" sn "([^0-9]|$)") || $5 ~ ("sn=" sn "$") {
+      printf "    %s\n", $0
+    }
+  ' "$merged"
+}
+
+# ---------------------------------------------------------------------------
+# Set 1: per-snapshot AckSn coverage across the cluster.
+# For each snapshot number with a SnapshotRequested anywhere, count how many
+# distinct nodes emitted an AckSn effect for that sn.
+# ---------------------------------------------------------------------------
+
+# Collect (sn, kind, node) triples from the merged stream.
+# kind = req | ack | conf
+sn_events=$(awk -F'\t' '
+  NR == 1 { next }
+  $5 == "SnapshotRequested" {
+    if (match($6, /sn=[0-9]+/)) {
+      sn = substr($6, RSTART+3, RLENGTH-3)
+      print sn "\treq\t" $1
+    }
+  }
+  $5 == "AckSn" {
+    if (match($6, /sn=[0-9]+/)) {
+      sn = substr($6, RSTART+3, RLENGTH-3)
+      print sn "\tack\t" $1
+    }
+  }
+  $5 == "SnapshotConfirmed" {
+    if (match($6, /sn=[0-9]+/)) {
+      sn = substr($6, RSTART+3, RLENGTH-3)
+      print sn "\tconf\t" $1
+    }
+  }
+' "$merged" | sort -u)
+
+n_nodes="${#specs[@]}"
+quorum=$n_nodes  # Hydra requires unanimous acknowledgement
+
+# For each (sn, kind), count distinct nodes.
+echo "$sn_events" | awk -F'\t' '
+  { key = $1 "\t" $2; nodes[key] = nodes[key] " " $3 }
+  END {
+    for (k in nodes) {
+      n = split(nodes[k], a, " "); seen = ""
+      count = 0
+      for (i = 1; i <= n; i++) {
+        if (a[i] == "") continue
+        if (seen !~ ("(^| )" a[i] "( |$)")) { seen = seen " " a[i]; count++ }
+      }
+      print k "\t" count "\t" seen
+    }
+  }
+' | sort -k1,1n -k2,2 > "$merged.cov"
+
+# Find requested snapshots that never reached quorum AckSn.
+while IFS=$'\t' read -r sn kind count nodes; do
+  [[ "$kind" != "req" ]] && continue
+  # AckSn count for same sn
+  ack_count=$(awk -F'\t' -v sn="$sn" '$1==sn && $2=="ack" {print $3}' "$merged.cov")
+  ack_count=${ack_count:-0}
+  conf_count=$(awk -F'\t' -v sn="$sn" '$1==sn && $2=="conf" {print $3}' "$merged.cov")
+  conf_count=${conf_count:-0}
+  if [[ "$conf_count" -ge 1 ]]; then continue; fi   # snapshot succeeded somewhere; skip
+  if [[ "$ack_count" -lt "$quorum" ]]; then
+    emit_finding "ACKSN_GAP_CLUSTER" \
+      "sn=$sn requested but only $ack_count/$quorum nodes emitted AckSn (no node confirmed)"
+    emit_evidence_sn "$sn"
+  fi
+done < "$merged.cov"
+rm -f "$merged.cov"
+
+# ---------------------------------------------------------------------------
+# Set 2: ReqSn delivery — for each ReqSn effect, did all peers receive it
+# (visible as their own NetworkInput on that sn)?
+# ---------------------------------------------------------------------------
+
+# ReqSn effects per sn → set of leaders.
+# NetworkInput msg=ReqSn per sn → set of receivers.
+delivery=$(awk -F'\t' '
+  NR == 1 { next }
+  $5 == "ReqSn" && $4 == "effect" {
+    if (match($6, /sn=[0-9]+/)) {
+      sn = substr($6, RSTART+3, RLENGTH-3)
+      print sn "\tsent\t" $1
+    }
+  }
+  $4 == "input" && $5 == "NetworkInput" && $6 ~ /msg=ReqSn/ {
+    if (match($6, /sn=[0-9]+/)) {
+      sn = substr($6, RSTART+3, RLENGTH-3)
+      print sn "\trecv\t" $1
+    }
+  }
+' "$merged" | sort -u)
+
+# Build per-sn sets and compare.
+echo "$delivery" | awk -F'\t' -v all_nodes="${specs[*]%%:*}" -v n_nodes="$n_nodes" '
+  { rec[$1 "\t" $2] = rec[$1 "\t" $2] " " $3 }
+  END {
+    # Determine all sns that had any ReqSn at all.
+    for (k in rec) {
+      split(k, p, "\t"); sns[p[1]] = 1
+    }
+    for (sn in sns) {
+      sent = rec[sn "\tsent"]
+      recv = rec[sn "\trecv"]
+      # n_recv should equal n_nodes - 1 (everyone except the leader).
+      n = split(recv, a, " "); seen = ""; rcount = 0
+      for (i = 1; i <= n; i++) {
+        if (a[i] == "") continue
+        if (seen !~ ("(^| )" a[i] "( |$)")) { seen = seen " " a[i]; rcount++ }
+      }
+      if (sent != "" && rcount < n_nodes - 1) {
+        printf "%s\t%d\t%s\n", sn, rcount, recv
+      }
+    }
+  }
+' | sort -n > "$merged.deliv"
+
+while IFS=$'\t' read -r sn rcount recv; do
+  emit_finding "REQSN_NOT_DELIVERED" \
+    "sn=$sn — leader sent ReqSn but only $rcount peer(s) saw it as NetworkInput (expected $((n_nodes-1)))"
+  emit_evidence_sn "$sn"
+done < "$merged.deliv"
+rm -f "$merged.deliv"
+
+# ---------------------------------------------------------------------------
+# Set 3: state divergence — first index where stateChange tag stream differs.
+# We compare the per-node state-change tag stream (in their own row order),
+# zipped on stream index.
+# ---------------------------------------------------------------------------
+
+state_streams_dir=$(mktemp -d)
+trap 'rm -rf "$merged" "$state_streams_dir"' EXIT
+
+for spec in "${specs[@]}"; do
+  label="${spec%%:*}"
+  awk -F'\t' -v l="$label" '$1==l && $4=="state" {print $5}' "$merged" \
+    > "$state_streams_dir/$label"
+done
+
+# Zip the tag streams. Find first index where any node disagrees.
+labels=( )
+for spec in "${specs[@]}"; do labels+=("${spec%%:*}"); done
+
+paste "${labels[@]/#/$state_streams_dir/}" \
+  | awk -F'\t' -v labels="${labels[*]}" '
+    BEGIN { split(labels, lbl, " ") }
+    {
+      n = NF
+      same = 1
+      first = $1
+      for (i = 2; i <= n; i++) if ($i != "" && $i != first && first != "") { same = 0; break }
+      if (!same) {
+        printf "  index %d: ", NR
+        for (i = 1; i <= n; i++) printf "%s=%s ", lbl[i], ($i ? $i : "(none)")
+        print ""
+        exit
+      }
+    }
+  ' > "$state_streams_dir/divergence"
+
+if [[ -s "$state_streams_dir/divergence" ]]; then
+  emit_finding "STATE_DIVERGENCE" "node state-change streams diverge at:"
+  cat "$state_streams_dir/divergence"
+fi
+
+# ---------------------------------------------------------------------------
+# Set 4: chain skew — same chain-observed event seen at different timestamps
+# across nodes (>5s skew = potentially serious, indicates one node lagging).
+# ---------------------------------------------------------------------------
+
+# Chain events keyed by their depositTxId or chainTime (already in summary).
+# For each chain-related state-change tag, find earliest and latest timestamp.
+awk -F'\t' '
+  NR == 1 { next }
+  $5 == "DepositRecorded" || $5 == "DepositActivated" || $5 == "DepositExpired" \
+    || $5 == "CommitFinalized" || $5 == "DecommitFinalized" {
+    key = $5 "\t" $6
+    if (!(key in first_ts)) { first_ts[key] = $3; first_node[key] = $1 }
+    last_ts[key] = $3; last_node[key] = $1
+  }
+  END {
+    for (k in first_ts) print k "\t" first_node[k] "\t" first_ts[k] "\t" last_node[k] "\t" last_ts[k]
+  }
+' "$merged" \
+  | while IFS=$'\t' read -r tag summary first_n first_t last_n last_t; do
+      [[ "$first_n" == "$last_n" ]] && continue
+      # Skew calculation in seconds (POSIX). Best-effort with `date -d`.
+      if first_secs=$(date -d "$first_t" +%s 2>/dev/null) \
+         && last_secs=$(date -d "$last_t" +%s 2>/dev/null); then
+        skew=$((last_secs - first_secs))
+        if [[ "$skew" -gt 5 ]]; then
+          emit_finding "CHAIN_SKEW" \
+            "$tag ($summary) seen by $first_n at $first_t but $last_n at $last_t (~${skew}s later)"
+        fi
+      fi
+    done
+
+# ---------------------------------------------------------------------------
+
+echo ""
+if [[ "$findings" -eq 0 ]]; then
+  echo "No cluster-level patterns matched. The merged timeline is in this run's tmpdir; for ad-hoc inspection:"
+  echo "  scripts/merge_timelines.sh ${specs[*]} | less"
+  exit 1
+else
+  echo "$findings cross-node finding(s). Cross-reference with references/multi_node.md."
+  exit 0
+fi

--- a/.claude/skills/hydra-log-analysis/scripts/find_boundary.sh
+++ b/.claude/skills/hydra-log-analysis/scripts/find_boundary.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Find the last SnapshotConfirmed event in a hydra-node JSON log.
+# Output (TSV): row<TAB>timestamp<TAB>snapshot<TAB>signatures
+#
+# `row` is the index in the normalized stream (i.e. the Nth valid hydra log
+# entry, ignoring journalctl prefix noise). This is what timeline.sh's
+# --since-line expects.
+#
+# This is the boundary for downstream analysis: everything after this row
+# is the "problem window" when investigating a stall.
+#
+# Accepts native hydra JSON, journalctl-json (.MESSAGE wrapper), and
+# journalctl text format — see normalize.sh.
+#
+# Usage: find_boundary.sh <logfile>
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <logfile>" >&2
+  exit 2
+fi
+
+logfile="$1"
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+if [[ ! -r "$logfile" ]]; then
+  echo "error: cannot read $logfile" >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq not installed" >&2
+  exit 1
+fi
+
+# Single jq pass over the normalized stream. SnapshotConfirmed appears in
+# message.node.outcome.stateChanges[].tag — match anywhere via recursive descent.
+# Emit every match with row number; tail picks the last one.
+result=$("$HERE/normalize.sh" "$logfile" \
+  | jq -r '
+      input_line_number as $row
+      | (.timestamp // "?") as $ts
+      | (.. | objects | select(.tag? == "SnapshotConfirmed")) as $sc
+      | [
+          $row, $ts,
+          (($sc.snapshot.number // $sc.snapshotNumber // "?") | tostring),
+          (($sc.signatures // {}) | length | tostring)
+        ] | @tsv
+    ' 2>/dev/null | tail -n 1)
+
+if [[ -z "$result" ]]; then
+  echo "no SnapshotConfirmed event found in $logfile" >&2
+  exit 3
+fi
+
+printf "row\ttimestamp\tsnapshot\tsignatures\n"
+printf "%s\n" "$result"

--- a/.claude/skills/hydra-log-analysis/scripts/merge_timelines.sh
+++ b/.claude/skills/hydra-log-analysis/scripts/merge_timelines.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Merge timelines from multiple hydra-node logs (one per node in a Head)
+# into a single chronological TSV stream — your evidence ledger.
+#
+# Output (TSV): node<TAB>row<TAB>timestamp<TAB>kind<TAB>tag<TAB>summary
+# Sorted by timestamp ascending. Stable when timestamps tie (preserves per-node row order).
+#
+# Each input is "label:path" — the label is whatever you tell the user
+# (e.g. "leader", "peer-A", "alice"). Pick labels at the conversation
+# level by asking the user whose log each file is.
+#
+# Inputs may be native hydra JSON, journalctl-json, or journalctl text —
+# normalize.sh handles all three transparently.
+#
+# Usage:
+#   merge_timelines.sh <label1>:<log1> <label2>:<log2> [<label3>:<log3> ...]
+#                      [--all-tags] [--sn N] [--since-ts ISO8601]
+#
+#   --all-tags        emit every event, not just significant ones
+#   --sn N            filter to events touching snapshot N (in summary or tag)
+#   --since-ts T      filter to events at or after T (ISO 8601)
+
+set -euo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# Parse args
+specs=()
+extra_args=()
+sn_filter=""
+since_ts=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --all-tags) extra_args+=(--all-tags); shift;;
+    --sn) sn_filter="$2"; shift 2;;
+    --since-ts) since_ts="$2"; shift 2;;
+    -h|--help)
+      sed -n '2,30p' "$0"
+      exit 0;;
+    *)
+      if [[ "$1" != *:* ]]; then
+        echo "error: arg '$1' is not in label:path form" >&2
+        exit 2
+      fi
+      specs+=("$1"); shift;;
+  esac
+done
+
+if [[ "${#specs[@]}" -lt 2 ]]; then
+  echo "usage: $0 <label1>:<log1> <label2>:<log2> [<label3>:<log3> ...] [--all-tags] [--sn N] [--since-ts T]" >&2
+  exit 2
+fi
+
+# Per-spec, run timeline.sh and prefix every output row with the label.
+# Skip the header row from each timeline.sh output.
+combined=$(mktemp)
+trap 'rm -f "$combined"' EXIT
+
+for spec in "${specs[@]}"; do
+  label="${spec%%:*}"
+  path="${spec#*:}"
+  if [[ ! -r "$path" ]]; then
+    echo "error: cannot read '$path'" >&2
+    exit 1
+  fi
+  "$HERE/timeline.sh" "$path" "${extra_args[@]}" \
+    | tail -n +2 \
+    | awk -v l="$label" 'BEGIN{FS=OFS="\t"} {print l, $0}' \
+    >> "$combined"
+done
+
+# Header
+printf "node\trow\ttimestamp\tkind\ttag\tsummary\n"
+
+# Sort by timestamp (column 3), stable. Apply optional filters.
+sort -s -t $'\t' -k3,3 "$combined" \
+| { if [[ -n "$since_ts" ]]; then awk -F'\t' -v t="$since_ts" '$3 >= t'; else cat; fi; } \
+| { if [[ -n "$sn_filter" ]]; then
+      # Match "sn=N" anywhere in the summary, or N alone in summary, or in tag.
+      awk -F'\t' -v sn="$sn_filter" '
+        $6 ~ ("sn=" sn "([^0-9]|$)") || $5 ~ ("^.*sn=" sn "$") {print}
+      '
+    else cat; fi; }

--- a/.claude/skills/hydra-log-analysis/scripts/normalize.sh
+++ b/.claude/skills/hydra-log-analysis/scripts/normalize.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Normalize a hydra-node log to plain JSON-lines on stdout.
+#
+# Handles three input formats transparently:
+#   1. Native hydra-node JSON (one JSON object per line)
+#   2. journalctl --output=json     (top-level object with a .MESSAGE field
+#                                    containing the original hydra JSON)
+#   3. journalctl default/short     ("Mar 12 14:23:45 host prog[pid]: {json}")
+#
+# Lines that cannot be coerced to a hydra log object are silently dropped,
+# so this script is safe to chain in front of any downstream jq pipeline.
+#
+# Usage: normalize.sh <logfile>
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <logfile>" >&2
+  exit 2
+fi
+
+logfile="$1"
+
+if [[ ! -r "$logfile" ]]; then
+  echo "error: cannot read $logfile" >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq not installed" >&2
+  exit 1
+fi
+
+# -R: read raw lines (don't try to parse as JSON ourselves)
+# -c: compact output
+# Strategy per line:
+#   - try parsing as JSON
+#       - if it has .MESSAGE that looks like JSON, that's journalctl-json — unwrap
+#       - else use the parsed object as-is
+#   - if it didn't parse, try regex-stripping a "<...>: {json}" prefix
+#   - finally, only emit lines that look like a hydra log (.timestamp + .message)
+jq -R -c '
+  def is_hydra: (.timestamp? != null) and (.message? != null);
+
+  . as $line
+  | (try fromjson catch null) as $j
+  | (
+      if $j == null then
+        # journalctl short format: "<date> <host> <prog>[<pid>]: {json}"
+        ($line | capture("\\]:\\s+(?<inner>\\{.*\\})\\s*$"; "x")? // null)
+        | if . == null then null
+          else (.inner | try fromjson catch null)
+          end
+      elif ($j | type) == "object"
+           and ($j.MESSAGE? != null)
+           and (($j.MESSAGE | type) == "string")
+           and ($j.MESSAGE | ltrimstr(" ") | startswith("{")) then
+        ($j.MESSAGE | try fromjson catch null)
+      else
+        $j
+      end
+    )
+  | select(. != null and (type == "object") and is_hydra)
+' "$logfile"

--- a/.claude/skills/hydra-log-analysis/scripts/snapshot_diagnose.sh
+++ b/.claude/skills/hydra-log-analysis/scripts/snapshot_diagnose.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Diagnostic battery for hydra-node logs — answers "why did snapshots stop confirming?"
+#
+# Runs canned checks against the failure patterns documented in
+# references/failure_patterns.md. Each check that fires emits one finding line:
+#   [PATTERN] short description (evidence)
+#
+# Exit code: 0 if any pattern matched, 1 if no patterns matched, 2 on bad input.
+#
+# Usage: snapshot_diagnose.sh <logfile> [--since-line N]
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <logfile> [--since-row N]" >&2
+  exit 2
+fi
+
+logfile="$1"; shift
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+since_row=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --since-row|--since-line) since_row="$2"; shift 2;;
+    *) echo "unknown arg: $1" >&2; exit 2;;
+  esac
+done
+
+if [[ ! -r "$logfile" ]]; then
+  echo "error: cannot read $logfile" >&2
+  exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq not installed" >&2
+  exit 2
+fi
+
+# Normalize once into a tmpfile (handles journalctl), then slice.
+# Subsequent jq passes read the slice without re-normalizing.
+slice=$(mktemp)
+trap 'rm -f "$slice"' EXIT
+"$HERE/normalize.sh" "$logfile" | awk -v start="$since_row" 'NR>=start' > "$slice"
+
+findings=0
+
+emit() {
+  printf "[%s] %s\n" "$1" "$2"
+  findings=$((findings+1))
+}
+
+# ---------------------------------------------------------------------------
+# Check 1: ReqSn flood / etcd feedback loop
+# Pattern: ReqSn for the same snapshot number broadcast many times.
+# Reference: references/failure_patterns.md#reqsn-flood
+# ---------------------------------------------------------------------------
+reqsn_counts=$(jq -r '
+  .message.node.outcome.effects // []
+  | .[]?
+  | select((.message.tag // .tag) == "ReqSn")
+  | .message.snapshotNumber // empty
+' "$slice" | sort | uniq -c | sort -rn)
+
+if [[ -n "$reqsn_counts" ]]; then
+  worst_count=$(echo "$reqsn_counts" | awk 'NR==1 {print $1}')
+  worst_sn=$(echo "$reqsn_counts" | awk 'NR==1 {print $2}')
+  if [[ "$worst_count" -gt 10 ]]; then
+    emit "REQSN_FLOOD" "snapshot $worst_sn had $worst_count ReqSn broadcasts (>10 indicates feedback loop)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Check 2: Leader stuck in RequestedSnapshot — own-echo RequireFailed
+# Pattern: SnapshotRequested with no following SnapshotConfirmed for same sn,
+#          plus a RequireFailed event in between.
+# Reference: references/failure_patterns.md#leader-stuck
+# ---------------------------------------------------------------------------
+last_requested=$(jq -r '
+  .message.node.outcome.stateChanges // []
+  | .[]?
+  | select(.tag == "SnapshotRequested")
+  | (.snapshot.number // .snapshotNumber // empty)
+' "$slice" | tail -n 1)
+
+last_confirmed=$(jq -r '
+  .message.node.outcome.stateChanges // []
+  | .[]?
+  | select(.tag == "SnapshotConfirmed")
+  | (.snapshot.number // .snapshotNumber // empty)
+' "$slice" | tail -n 1)
+
+if [[ -n "$last_requested" && "$last_requested" != "$last_confirmed" ]]; then
+  rf_count=$(jq -r '
+    [.. | objects | select(.tag? == "RequireFailed" or (.error? // "" | tostring | test("RequireFailed")))]
+    | length
+  ' "$slice" | awk '{s+=$1} END{print s+0}')
+  if [[ "$rf_count" -gt 0 ]]; then
+    emit "LEADER_STUCK" "SnapshotRequested(sn=$last_requested) never confirmed; $rf_count RequireFailed events in window"
+  else
+    emit "SNAPSHOT_NEVER_CONFIRMED" "SnapshotRequested(sn=$last_requested) never confirmed; no explicit RequireFailed (check AckSn coverage)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Check 3: AckSn coverage — for last requested snapshot, which parties acked?
+# Reference: references/failure_patterns.md#missing-acksn
+# ---------------------------------------------------------------------------
+if [[ -n "$last_requested" ]]; then
+  ack_parties=$(jq -r --arg sn "$last_requested" '
+    .message.node.input // empty
+    | select(.tag == "NetworkInput")
+    | .message
+    | select(.tag == "AckSn" and ((.snapshotNumber // -1) | tostring) == $sn)
+    | .party.vkey // empty
+  ' "$slice" | sort -u)
+  ack_count=$(echo "$ack_parties" | grep -c . || true)
+  if [[ "$ack_count" -gt 0 ]]; then
+    emit "ACKSN_COVERAGE" "sn=$last_requested received AckSn from $ack_count distinct party(ies): $(echo "$ack_parties" | tr '\n' ' ' | head -c 80)..."
+  else
+    emit "NO_ACKSN" "sn=$last_requested received zero AckSn — peers never acknowledged"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Check 4: Stale decommit — CommitFinalized followed by SnapshotRequested still
+#          carrying decommitTx
+# Reference: references/failure_patterns.md#stale-decommit
+# ---------------------------------------------------------------------------
+stale_decommit=$(jq -r '
+  .message.node.outcome.stateChanges // []
+  | .[]?
+  | select(.tag == "SnapshotRequested" and .decommitTx != null)
+  | "\(.snapshot.number // .snapshotNumber)"
+' "$slice" | tail -n 1)
+
+# Only flag if there was a CommitFinalized recently (cheap heuristic).
+if [[ -n "$stale_decommit" ]]; then
+  has_commit_finalized=$(jq -r '
+    .. | objects | select(.tag? == "CommitFinalized") | "x"
+  ' "$slice" | head -n 1)
+  if [[ -n "$has_commit_finalized" ]]; then
+    emit "STALE_DECOMMIT" "SnapshotRequested(sn=$stale_decommit) carries decommitTx after CommitFinalized — possible stale state"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Check 5: Deposit activation gap — DepositRecorded without DepositActivated
+# Reference: references/failure_patterns.md#deposit-activation-race
+# ---------------------------------------------------------------------------
+recorded=$(jq -r '
+  .. | objects | select(.tag? == "DepositRecorded") | .depositTxId // empty
+' "$slice" | sort -u)
+activated=$(jq -r '
+  .. | objects | select(.tag? == "DepositActivated") | .depositTxId // empty
+' "$slice" | sort -u)
+if [[ -n "$recorded" ]]; then
+  unactivated=$(comm -23 <(echo "$recorded") <(echo "$activated") || true)
+  if [[ -n "$unactivated" ]]; then
+    n=$(echo "$unactivated" | grep -c . || true)
+    emit "DEPOSIT_NOT_ACTIVATED" "$n deposit(s) recorded but never activated: $(echo "$unactivated" | head -n 1 | cut -c1-12)..."
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Check 6: Repeated chain-tick — same DepositExpired/DepositActivated emitted
+#          on multiple ticks for the same deposit (pre-fix bug pattern)
+# Reference: references/failure_patterns.md#repeated-chain-tick
+# ---------------------------------------------------------------------------
+dup_ticks=$(jq -r '
+  .. | objects
+  | select(.tag? == "DepositExpired" or .tag? == "DepositActivated")
+  | "\(.tag) \(.depositTxId // "?")"
+' "$slice" | sort | uniq -c | awk '$1 > 1 {print}')
+if [[ -n "$dup_ticks" ]]; then
+  worst=$(echo "$dup_ticks" | sort -rn | head -n 1)
+  emit "REPEATED_CHAIN_TICK" "duplicate deposit transition events: $worst"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 7: RequireFailed counts by reason
+# Reference: references/failure_patterns.md#requirefailed
+# ---------------------------------------------------------------------------
+rf_by_reason=$(jq -r '
+  .. | objects
+  | select(.tag? == "RequireFailed")
+  | (.reason.tag // .reason // "unknown")
+' "$slice" | sort | uniq -c | sort -rn | head -n 5)
+if [[ -n "$rf_by_reason" ]]; then
+  emit "REQUIREFAILED_SUMMARY" "top RequireFailed reasons: $(echo "$rf_by_reason" | tr '\n' ';' | head -c 200)"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 8: No new ReqTx but pending localTxs — input queue starved?
+# Cheap heuristic only — full diagnosis requires queue depth telemetry.
+# ---------------------------------------------------------------------------
+last_reqtx_line=$(jq -r '
+  input_line_number as $ln
+  | (.message.node.outcome.effects // []) | .[]?
+  | select((.message.tag // .tag) == "ReqTx")
+  | $ln
+' "$slice" | tail -n 1)
+total_lines=$(wc -l < "$slice")
+if [[ -n "$last_reqtx_line" && "$total_lines" -gt 0 ]]; then
+  gap=$((total_lines - last_reqtx_line))
+  if [[ "$gap" -gt 1000 ]]; then
+    emit "REQTX_DROUGHT" "no ReqTx broadcast in last $gap log lines — possible queue starvation or no work"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+if [[ "$findings" -eq 0 ]]; then
+  echo "No known patterns matched. Use timeline.sh and references/jq_recipes.md for ad-hoc analysis."
+  exit 1
+else
+  echo "$findings finding(s). Cross-reference with references/failure_patterns.md."
+  exit 0
+fi

--- a/.claude/skills/hydra-log-analysis/scripts/timeline.sh
+++ b/.claude/skills/hydra-log-analysis/scripts/timeline.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Build a chronological timeline of significant events from a hydra-node log.
+#
+# Output (TSV): row<TAB>timestamp<TAB>kind<TAB>tag<TAB>summary
+#   row is the index in the normalized stream (Nth hydra log entry)
+#   kind ∈ {state, effect, input, error}
+#   tag is the literal tag from the log (e.g. SnapshotRequested, ReqSn, RequireFailed)
+#   summary is a short human-readable detail (snapshot number, party, txid prefix...)
+#
+# Pipe through `column -t -s $'\t'` for aligned display.
+#
+# Accepts native hydra JSON, journalctl-json, and journalctl text format —
+# see normalize.sh.
+#
+# Usage: timeline.sh <logfile> [--since-row N] [--head N] [--tail N] [--all-tags]
+#
+# By default only "significant" tags are emitted. Use --all-tags to dump every
+# stateChange/effect/input regardless of tag.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  cat >&2 <<EOF
+usage: $0 <logfile> [--since-row N] [--head N] [--tail N] [--all-tags]
+  --since-row N    start at row N (e.g. boundary from find_boundary.sh)
+  --head N         show only first N timeline rows after filtering
+  --tail N         show only last N timeline rows after filtering
+  --all-tags       emit every event, not just significant ones
+EOF
+  exit 2
+fi
+
+logfile="$1"; shift
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+since_row=1
+head_n=""
+tail_n=""
+all_tags=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --since-row|--since-line) since_row="$2"; shift 2;;
+    --head) head_n="$2"; shift 2;;
+    --tail) tail_n="$2"; shift 2;;
+    --all-tags) all_tags=1; shift;;
+    *) echo "unknown arg: $1" >&2; exit 2;;
+  esac
+done
+
+if [[ ! -r "$logfile" ]]; then
+  echo "error: cannot read $logfile" >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq not installed" >&2
+  exit 1
+fi
+
+# Significant tags — see references/log_format.md for the full taxonomy.
+SIG_STATE='SnapshotRequested|SnapshotConfirmed|SnapshotRequestAborted|TransactionAppliedToLocalUTxO|CommitFinalized|DecommitFinalized|DepositActivated|DepositExpired|DepositRecorded|HeadOpened|HeadClosed|HeadIsContested|TickObserved|PartyCommitted|HeadInitialized|TransactionReceived'
+SIG_EFFECT='ReqSn|AckSn|ReqTx|ReqDec|ConfTx'
+SIG_INPUT='NetworkInput|ChainInput|ClientInput'
+
+printf "row\ttimestamp\tkind\ttag\tsummary\n"
+
+# Single-pass approach: normalize then awk to slice by row, then one jq invocation.
+# jq's input_line_number reflects position in the sliced stream, so we add the offset back.
+"$HERE/normalize.sh" "$logfile" \
+| awk -v start="$since_row" 'NR>=start' \
+| jq -r \
+    --arg sigState "$SIG_STATE" \
+    --arg sigEffect "$SIG_EFFECT" \
+    --arg sigInput "$SIG_INPUT" \
+    --argjson allTags "$all_tags" \
+    --argjson offset "$since_row" '
+
+  def short(s): if s == null then "" else (s|tostring)[0:12] end;
+  def keep(t; sig): $allTags == 1 or (t|tostring|test("^(" + sig + ")$"));
+
+  (input_line_number + $offset - 1) as $row
+  | (.timestamp // "?") as $ts
+  | (
+      # State changes
+      (.message.node.outcome.stateChanges // [])
+      | .[]?
+      | (.tag // "?") as $tag
+      | select(keep($tag; $sigState))
+      | [
+          $row, $ts, "state", $tag,
+          ([
+            (if (.snapshot.number // .snapshotNumber) != null
+              then "sn=\(.snapshot.number // .snapshotNumber)"
+              else empty end),
+            (if .party.vkey then "party=\(short(.party.vkey))" else empty end),
+            (if .depositTxId then "deposit=\(short(.depositTxId))" else empty end),
+            (if .chainTime then "ct=\(.chainTime)" else empty end),
+            (if .newLocalUTxO then "utxoΔ" else empty end)
+          ] | map(select(. != "")) | join(" "))
+        ]
+    ),
+
+    (
+      # Network/chain effects
+      (.message.node.outcome.effects // [])
+      | .[]?
+      | (.message.tag // .tag // "?") as $tag
+      | select(keep($tag; $sigEffect))
+      | [
+          $row, $ts, "effect", $tag,
+          ([
+            (if .message.snapshotNumber != null then "sn=\(.message.snapshotNumber)" else empty end),
+            (if .message.transactionIds then "txs=\(.message.transactionIds|length)" else empty end),
+            (if .message.transaction.txId then "tx=\(short(.message.transaction.txId))" else empty end),
+            (if .toParty.vkey then "→\(short(.toParty.vkey))" else empty end)
+          ] | map(select(. != "")) | join(" "))
+        ]
+    ),
+
+    (
+      # Inputs
+      .message.node.input // empty
+      | (.tag // "?") as $tag
+      | select(keep($tag; $sigInput))
+      | [
+          $row, $ts, "input", $tag,
+          ([
+            (if .message.tag then "msg=\(.message.tag)" else empty end),
+            (if .message.snapshotNumber != null then "sn=\(.message.snapshotNumber)" else empty end),
+            (if .party.vkey then "from=\(short(.party.vkey))" else empty end)
+          ] | map(select(. != "")) | join(" "))
+        ]
+    ),
+
+    (
+      # Errors / failures
+      ((.message.node.outcome.error // .message.node.outcome.tag // empty) | tostring) as $err
+      | select($err != "" and ($err | test("Error|Failed|Invalid"; "i")))
+      | [$row, $ts, "error", $err, ""]
+    )
+  | @tsv
+' \
+| { if [[ -n "$head_n" ]]; then head -n "$head_n"; \
+    elif [[ -n "$tail_n" ]]; then tail -n "$tail_n"; \
+    else cat; fi; }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# Hydra Development Guidelines
+
+Hydra is a Nix-based Haskell project. Activate the dev shell with `nix develop` (or set up `direnv` with `direnv allow`) before running any `cabal` command.
+
+## Build verification
+
+Always build with warnings as errors:
+
+```
+cabal build all --ghc-options="-Werror"
+```
+
+## Formatting
+
+Run `nix fmt` after any code changes, before committing.
+
+## Testing
+
+- **TDD**: write a failing test before implementing. Align on approach (or enter plan mode, if your AI tool supports it) before writing code.
+- **Running tests with an AI assistant**: the assistant should ask whether to run the test suite itself or stop at the build step and let the contributor run tests. Different contributors prefer different defaults — confirm before assuming.
+
+## Project orientation
+
+- `hydra-node/src/Hydra/HeadLogic.hs` — off-chain protocol source of truth (pure event-sourced state machine)
+- State / events / errors / inputs: `HeadLogic/State.hs`, `HeadLogic/Outcome.hs`, `HeadLogic/Error.hs`, `HeadLogic/Input.hs`
+- Head lifecycle: Idle → Initial → Open → Closed → Idle
+
+## Contributing — AI assistant usage
+
+This repo ships project-level Claude Code skills under `.claude/skills/`. They load automatically when their triggers match.
+
+- **`hydra-log-analysis`** — diagnose hydra-node logs ("why did snapshots stop confirming?", multi-node correlation, journalctl-formatted docker logs)
+- **`cardano-haskell-developer`** — auto-activates for Cardano/Hydra Haskell work; covers state-machine debugging, log analysis, CBOR/Plutus decoding
+- **`grill-me`** — interactive design Q&A; useful for stress-testing a plan before implementing
+
+To inspect a skill, read `.claude/skills/<name>/SKILL.md`. To trigger one explicitly, mention it by name to your AI assistant.
+
+If you add a new skill that benefits the team, put it under `.claude/skills/` so others pick it up automatically.


### PR DESCRIPTION
This PR introduces global `CLAUDE.md` file as well as three skills:

- `/cardano-haskell-developer`
- `/hydra-log-analysis`
- `/grill-me` 

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
