### PR TITLE
Seq instead of list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ after upgrading, existing `state` files are automatically migrated into
 
   - Reduce snapshot confirmation latency by ~7% (avg) by caching the pre-computed signable bytes of a snapshot in `SeenSnapshot`, avoiding repeated UTxO serialization and hashing on every `AckSn` verification during a signing round.
 
+- Replace 'list' with `Seq` type to speed up transaction processing in some
+  instances [#2597](https://github.com/cardano-scaling/hydra/pull/2597).
+
 
 ## [2.0.0] - 2026.04.05
 

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -24,6 +24,7 @@ import Hydra.Prelude
 
 import Data.List (elemIndex, minimumBy)
 import Data.Map.Strict qualified as Map
+import Data.Sequence qualified as Seq
 import Data.Set ((\\))
 import Data.Set qualified as Set
 import Hydra.API.ClientInput (ClientInput (..))
@@ -249,7 +250,7 @@ onOpenNetworkReqTx env ledger currentSlot st ttl pendingDeposits tx =
                 ReqSn
                   version
                   nextSn
-                  (txId <$> take maxTxsPerSnapshot localTxs')
+                  (toList $ txId <$> Seq.take maxTxsPerSnapshot localTxs')
                   decommitTx
                   ( selectNextDeposit
                       pendingDeposits
@@ -280,7 +281,7 @@ onOpenNetworkReqTx env ledger currentSlot st ttl pendingDeposits tx =
 
   -- NOTE: Order of transactions is important here. See also
   -- 'pruneTransactions'.
-  localTxs' = localTxs <> [tx]
+  localTxs' = localTxs Seq.|> tx
 
 -- | Process a snapshot request ('ReqSn') from party.
 --
@@ -456,7 +457,7 @@ onOpenNetworkReqSn env ledger pendingDeposits currentSlot st otherParty sv sn re
     -- order. That is, left-associative as new transactions are first validated
     -- and then appended to `localTxs` (when aggregating
     -- 'TransactionAppliedToLocalUTxO').
-    foldl' go ([], utxo) localTxs
+    foldl' go (mempty, utxo) localTxs
    where
     go (txs, u) tx =
       -- XXX: We prune transactions on any error, while only some of them are
@@ -465,7 +466,7 @@ onOpenNetworkReqSn env ledger pendingDeposits currentSlot st otherParty sv sn re
       -- here when a tx becomes invalid.
       case applyTransactions ledger currentSlot u [tx] of
         Left (_, _) -> (txs, u)
-        Right u' -> (txs <> [tx], u')
+        Right u' -> (txs Seq.|> tx, u')
 
   confSn = case confirmedSnapshot of
     InitialSnapshot{} -> 0
@@ -603,7 +604,7 @@ onOpenNetworkAckSn Environment{party} pendingDeposits openState otherParty snaps
       then
         outcome
           <> newState SnapshotRequestDecided{snapshotNumber = nextSn}
-          <> cause (NetworkEffect $ ReqSn version nextSn (txId <$> take maxTxsPerSnapshot localTxs) decommitTx nextDeposit)
+          <> cause (NetworkEffect $ ReqSn version nextSn (toList $ txId <$> Seq.take maxTxsPerSnapshot localTxs) decommitTx nextDeposit)
       else outcome
 
   maybePostIncrementTx snapshot@Snapshot{utxoToCommit} signatures outcome =
@@ -802,7 +803,7 @@ onOpenNetworkReqDec env ledger ttl currentSlot openState decommitTx =
 
   maybeRequestSnapshot =
     if not (snapshotInFlight seenSnapshot) && isLeader parameters party nextSn
-      then cause (NetworkEffect (ReqSn version nextSn (txId <$> take maxTxsPerSnapshot localTxs) (Just decommitTx) Nothing))
+      then cause (NetworkEffect (ReqSn version nextSn (toList $ txId <$> Seq.take maxTxsPerSnapshot localTxs) (Just decommitTx) Nothing))
       else noop
 
   Environment{party} = env
@@ -907,7 +908,7 @@ onOpenChainTick env chainTime pendingDeposits st =
             -- requested a snapshot? If yes, should update spec.
             newState SnapshotRequestDecided{snapshotNumber = nextSn}
               -- Spec: multicast (reqSn,̂ 𝑣,̄ 𝒮.𝑠 + 1,̂ 𝒯, 𝑈𝛼, ⊥)
-              <> cause (NetworkEffect $ ReqSn version nextSn (txId <$> take maxTxsPerSnapshot localTxs) Nothing (Just depositTxId))
+              <> cause (NetworkEffect $ ReqSn version nextSn (toList $ txId <$> Seq.take maxTxsPerSnapshot localTxs) Nothing (Just depositTxId))
           else
             noop
  where
@@ -962,7 +963,7 @@ maybeRequestSnapshotAfterVersionBump ::
   HeadParameters ->
   Party ->
   SnapshotNumber ->
-  [tx] ->
+  Seq tx ->
   SnapshotVersion ->
   SnapshotVersion ->
   SeenSnapshot tx ->
@@ -972,7 +973,7 @@ maybeRequestSnapshotAfterVersionBump parameters party nextSn localTxs version ne
   if isLeader parameters party nextSn && not (null localTxs) && version /= newVersion && not (isCollectingAcks seenSnapshot)
     then
       newState SnapshotRequestDecided{snapshotNumber = nextSn}
-        <> cause (NetworkEffect $ ReqSn newVersion nextSn (txId <$> take maxTxsPerSnapshot localTxs) Nothing depositTxId)
+        <> cause (NetworkEffect $ ReqSn newVersion nextSn (toList $ txId <$> Seq.take maxTxsPerSnapshot localTxs) Nothing depositTxId)
     else noop
 
 -- | Observe a increment transaction. If the outputs match the ones of the
@@ -1874,7 +1875,7 @@ aggregate st = \case
                   { localUTxO = newLocalUTxO
                   , -- NOTE: Order of transactions is important here. See also
                     -- 'pruneTransactions'.
-                    localTxs = localTxs <> [tx]
+                    localTxs = localTxs Seq.|> tx
                   }
             }
        where

--- a/hydra-node/src/Hydra/HeadLogic/Outcome.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Outcome.hs
@@ -81,7 +81,7 @@ data StateChanged tx
     SnapshotRequested
       { requestedSnapshot :: Snapshot tx
       , newLocalUTxO :: UTxOType tx
-      , newLocalTxs :: [tx]
+      , newLocalTxs :: Seq tx
       , newCurrentDepositTxId :: Maybe (TxIdType tx)
       }
   | PartySignedSnapshot {snapshotNumber :: SnapshotNumber, party :: Party, signature :: Signature (Snapshot tx)}

--- a/hydra-node/src/Hydra/HeadLogic/State.hs
+++ b/hydra-node/src/Hydra/HeadLogic/State.hs
@@ -110,9 +110,9 @@ data CoordinatedHeadState tx = CoordinatedHeadState
   { localUTxO :: UTxOType tx
   -- ^ The latest UTxO resulting from applying 'localTxs' to
   -- 'confirmedSnapshot'. Spec: L̂
-  , localTxs :: [tx]
-  -- ^ List of transactions applied locally and pending inclusion in a snapshot.
-  -- Ordering in this list is important as transactions are added in order of
+  , localTxs :: Seq tx
+  -- ^ Sequence of transactions applied locally and pending inclusion in a
+  -- snapshot. Ordering is important as transactions are added in order of
   -- application. Spec: T̂
   , allTxs :: !(Map.Map (TxIdType tx) tx)
   -- ^ Map containing all the transactions ever seen by this node and not yet

--- a/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
@@ -88,7 +88,7 @@ spec = do
 
       it "does NOT send ReqSn when we are NOT the leader even if no snapshot in flight" $ do
         let tx = aValidTx 1
-            st = coordinatedHeadState{localTxs = [tx]}
+            st = coordinatedHeadState{localTxs = pure tx}
             s0 = inOpenState' [alice, bob] st
         now <- nowFromSlot (currentSlot . chainPointTime $ s0)
         let outcome = update (envFor bobSk) simpleLedger now s0 $ receiveMessageFrom bob $ ReqTx tx
@@ -111,7 +111,7 @@ spec = do
             st' =
               inOpenState' threeParties $
                 coordinatedHeadState
-                  { localTxs = [tx]
+                  { localTxs = pure tx
                   , allTxs = Map.singleton (txId tx) tx
                   , localUTxO = u0 <> utxoRef (txId tx)
                   , seenSnapshot = RequestedSnapshot{lastSeen = 0, requested = 1}
@@ -212,7 +212,7 @@ prop_singleMemberHeadAlwaysSnapshotOnReqTx sn = monadicIO $ do
       CoordinatedHeadState
         { localUTxO = mempty
         , allTxs = mempty
-        , localTxs = []
+        , localTxs = mempty
         , confirmedSnapshot = sn
         , seenSnapshot
         , currentDepositTxId = Nothing

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -20,6 +20,7 @@ import Control.Monad (foldM)
 import Data.List qualified as List
 import Data.Map (notMember)
 import Data.Map qualified as Map
+import Data.Sequence qualified as Seq
 import Hydra.API.ClientInput (ClientInput (SideLoadSnapshot))
 import Hydra.API.ServerOutput (ClientMessage (..), DecommitInvalidReason (..))
 import Hydra.Cardano.Api (ChainPoint (..), SlotNo (..), fromLedgerTx, mkVkAddress, toLedgerTx, txOutValue, unSlotNo, pattern TxValidityUpperBound)
@@ -174,7 +175,7 @@ spec =
 
           case headState s of
             Open OpenState{coordinatedHeadState = CoordinatedHeadState{localTxs}} -> do
-              localTxs `shouldBe` [tx2, tx3]
+              localTxs `shouldBe` Seq.fromList [tx2, tx3]
             _ -> fail "expected Open state"
 
       describe "Deposit" $ do
@@ -278,7 +279,7 @@ spec =
               ( inOpenState' singleParty $
                   coordinatedHeadState
                     { seenSnapshot = mkSeenSnapshot snapshot1 Map.empty
-                    , localTxs = [tx2]
+                    , localTxs = pure tx2
                     , currentDepositTxId = Nothing
                     }
               )
@@ -1601,7 +1602,7 @@ spec =
                 coordinatedHeadState
                   { localUTxO = utxoRef 4
                   , allTxs = Map.fromList [(txId tx2, tx2), (txId tx3, tx3)]
-                  , localTxs = [tx2, tx3]
+                  , localTxs = Seq.fromList [tx2, tx3]
                   , confirmedSnapshot = ConfirmedSnapshot snapshot1 multisig1
                   , seenSnapshot = RequestedSnapshot{lastSeen = 1, requested = 2}
                   }
@@ -1736,7 +1737,7 @@ spec =
                         CoordinatedHeadState
                           { localUTxO = mempty
                           , allTxs = mempty
-                          , localTxs = []
+                          , localTxs = mempty
                           , confirmedSnapshot = InitialSnapshot testHeadId
                           , seenSnapshot = NoSeenSnapshot
                           , currentDepositTxId = Nothing
@@ -1831,7 +1832,7 @@ spec =
                             CoordinatedHeadState
                               { localUTxO = uncurry UTxO.singleton utxo
                               , allTxs = mempty
-                              , localTxs = [expiringTransaction]
+                              , localTxs = pure expiringTransaction
                               , confirmedSnapshot = InitialSnapshot testHeadId
                               , seenSnapshot = NoSeenSnapshot
                               , currentDepositTxId = Nothing
@@ -1878,7 +1879,7 @@ spec =
                           CoordinatedHeadState
                             { localUTxO = mempty
                             , allTxs = mempty
-                            , localTxs = []
+                            , localTxs = mempty
                             , confirmedSnapshot = InitialSnapshot testHeadId
                             , seenSnapshot = NoSeenSnapshot
                             , currentDepositTxId = Nothing


### PR DESCRIPTION
Uses the `Seq` type instead of a `list`, which makes it a little faster, on my computer, in some circumstances:

### Scenario 1

Before (`--number-of-txs 300`):

```
> cabal run bench-e2e -- datasets --number-of-txs 300 --output-directory /tmp/bench-before-300
Average confirmation time (ms): 17.457022511
P99: 29.295330019999994ms
P95: 22.807852549999993ms
P50: 16.398083ms
```
41s clock time as measured by my terminal.

After (`--number-of-txs 300`):

```
> cabal run bench-e2e -- datasets --number-of-txs 300 --output-directory /tmp/bench-after-300
Average confirmation time (ms): 17.389314338
P99: 27.240633599999995ms
P95: 22.911740449999996ms
P50: 16.474119ms
```

40s clock time.

_Conclusion_: Almost no difference.

### Scenario 2

Before (`--number-of-txs 3000`):

```
> cabal run bench-e2e -- datasets --number-of-txs 3000 --output-directory /tmp/bench-before-3000
Average confirmation time (ms): 40.479327468
P99: 57.356654989999996ms
P95: 52.25816309999999ms
P50: 40.995065ms
```

2min 37s clock time.

After (`--number-of-txs 3000`):

```
> cabal run bench-e2e -- datasets --number-of-txs 3000 --output-directory /tmp/bench-after-3000
Average confirmation time (ms): 17.389314338
P99: 27.240633599999995ms
P95: 22.911740449999996ms
P50: 16.474119ms
```

1min 25s clock time.

_Conclusion_: Roughly twice as fast!

-- Edit:

<img width="1200" height="900" alt="image" src="https://github.com/user-attachments/assets/c8f88948-acee-4f90-9fa3-4f46515f6119" />
