### PR TITLE
Fall back to mithril package when mithril-client-cli is unavailable

### DIFF
--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -39,7 +39,7 @@
             weeder = pkgs.haskell-nix.tool compiler "weeder" "2.9.0";
             inherit (inputs.cardano-node.packages.${system}) cardano-cli;
             inherit (inputs.cardano-node.packages.${system}) cardano-node;
-            mithril-client-cli = inputs.mithril.packages.${system}.mithril-client-cli or inputs.mithril.packages.${system}.mithril;
+            mithril-client-cli = inputs.mithril.packages.${system}.mithril-client-cli or inputs.mithril.packages.${system}.mithril; # Todo: revert when https://github.com/input-output-hk/mithril/pull/3224 is released
             pumba = inputs.pumba.packages.${system}.default;
           })
         ];

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -39,7 +39,7 @@
             weeder = pkgs.haskell-nix.tool compiler "weeder" "2.9.0";
             inherit (inputs.cardano-node.packages.${system}) cardano-cli;
             inherit (inputs.cardano-node.packages.${system}) cardano-node;
-            inherit (inputs.mithril.packages.${system}) mithril-client-cli;
+            mithril-client-cli = inputs.mithril.packages.${system}.mithril-client-cli or inputs.mithril.packages.${system}.mithril;
             pumba = inputs.pumba.packages.${system}.default;
           })
         ];


### PR DESCRIPTION
The `mithri`l `2617.0` release switched all nodes to static musl builds. As a side effect, mithril-client-cli is no longer exposed as a standalone Nix package for non-Linux platforms. It only exists under `packages.x86_64-linux`. This broke nix develop on `aarch64-darwin`.


The one real downside of current solution is that the fallback pulls in the entire mithril package (aggregator, signer, end-to-end tooling, etc.) just to get `mithril-client`.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
