### PR TITLE
Set utxoCostPerByte to zero as well; then we can do 1-lovelace NewTx's.

### DIFF
--- a/demo/seed-devnet.sh
+++ b/demo/seed-devnet.sh
@@ -105,10 +105,10 @@ function queryPParams() {
   echo >&2 "Query Protocol parameters"
   if [[ -x ${CCLI_CMD} ]]; then
      ccli query protocol-parameters --socket-path ${DEVNET_DIR}/node.socket  --out-file /dev/stdout \
-      | jq ".txFeeFixed = 0 | .txFeePerByte = 0 | .executionUnitPrices.priceMemory = 0 | .executionUnitPrices.priceSteps = 0" > devnet/protocol-parameters.json
+      | jq ".txFeeFixed = 0 | .txFeePerByte = 0 | .executionUnitPrices.priceMemory = 0 | .executionUnitPrices.priceSteps = 0 | .utxoCostPerByte = 0" > devnet/protocol-parameters.json
    else
      docker exec demo-cardano-node-1 cardano-cli query protocol-parameters --testnet-magic ${NETWORK_ID} --socket-path ${DEVNET_DIR}/node.socket --out-file /dev/stdout \
-      | jq ".txFeeFixed = 0 | .txFeePerByte = 0 | .executionUnitPrices.priceMemory = 0 | .executionUnitPrices.priceSteps = 0" > devnet/protocol-parameters.json
+      | jq ".txFeeFixed = 0 | .txFeePerByte = 0 | .executionUnitPrices.priceMemory = 0 | .executionUnitPrices.priceSteps = 0 | .utxoCostPerByte = 0" > devnet/protocol-parameters.json
   fi
   echo >&2 "Saved in protocol-parameters.json"
 }

--- a/docs/docs/tutorial/index.md
+++ b/docs/docs/tutorial/index.md
@@ -392,7 +392,7 @@ The next step involves configuring the protocol parameters for the ledger within
 
 ```
 cardano-cli query protocol-parameters \
-  | jq '.txFeeFixed = 0 |.txFeePerByte = 0 | .executionUnitPrices.priceMemory = 0 | .executionUnitPrices.priceSteps = 0' \
+  | jq '.txFeeFixed = 0 |.txFeePerByte = 0 | .executionUnitPrices.priceMemory = 0 | .executionUnitPrices.priceSteps = 0 | .utxoCostPerByte = 0' \
   > protocol-parameters.json
 ```
 

--- a/sample-node-config/nixos/README.md
+++ b/sample-node-config/nixos/README.md
@@ -46,7 +46,7 @@ container accordingly.
 Lastly, the `hydra-node` requires some `protocol-parameters.json` to configure the ledger in the `/data/hydra-node` directory. Use the ones from the e2e tests `hydra-cluster/config/protocol-parameters.json` or the L1 ones via the `cardano-cli` on the target host as basis:
 
 ``` sh
-ssh example "CARDANO_NODE_SOCKET_PATH=/data/cardano-node/node.socket cardano-cli query protocol-parameters --testnet-magic 2 | 's/"txFeeFixed.*/"txFeeFixed": 0,/;s/"txFeePerByte.*/"txFeePerByte": 0,/' > /data/hydra-node/protocol-parameters.json"
+ssh example "CARDANO_NODE_SOCKET_PATH=/data/cardano-node/node.socket cardano-cli query protocol-parameters --testnet-magic 2 | 's/"txFeeFixed.*/"txFeeFixed": 0,/;s/"txFeePerByte.*/"txFeePerByte": 0,/;s/"utxoCostPerByte.*/"utxoCostPerByte": 0,/' > /data/hydra-node/protocol-parameters.json"
 ```
 
 IMPORTANT: The `hydraw` application requires **0 fees**! So ensure `"txFeeFixed": 0` and `"txFeePerByte": 0`.


### PR DESCRIPTION
We weren't setting this field to zero, which was resulting in `BabbageOutputTooSmallUTxO`, when this should not be a problem on L2 with the right protocol parameters.