### PR TITLE
Validate headId in aggregate to prevent cross-head event contamination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ distribute in a single partial fanout step, replacing a hardcoded limit.
 preferred transaction first, falling back to progressively smaller chunks until
 one fits within the script
 
+- Fix a bug where replaying persisted events from a previous head could corrupt
+the state of a newly opened head.
+
 ## [2.1.0] - 2026.05.13
 
 - Improved security for deposits

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -6,12 +6,12 @@
 --
 -- More specifically, the 'update' will handle 'Input's (or rather "commands" in
 -- event sourcing speak) and convert that into a list of side-'Effect's and
--- 'StateChanged' events, which in turn are 'aggregate'd into a single
--- 'HeadState'.
+-- 'StateChanged' events, which in turn are applied via 'aggregateNodeState' into
+-- a single 'NodeState'.
 --
 -- As the specification is using a more imperative way of specifying the protocol
 -- behavior, one would find the decision logic in 'update' while state updates
--- can be found in the corresponding 'aggregate' branch.
+-- can be found in the corresponding 'applyEvent' branch.
 module Hydra.HeadLogic (
   module Hydra.HeadLogic,
   module Hydra.HeadLogic.Input,
@@ -1593,7 +1593,7 @@ selectNextDeposit pendingDeposits currentDepositTxId mDecommitTx mConfirmedUtxoT
 
 -- | Handles inputs and converts them into 'StateChanged' events along with
 -- 'Effect's, in case it is processed successfully. Later, the Node will
--- 'aggregate' the events, resulting in a new 'HeadState'.
+-- apply the events via 'aggregateNodeState', resulting in a new 'NodeState'.
 update ::
   IsChainState tx =>
   Environment ->
@@ -1859,38 +1859,43 @@ handleClientInput env ledger ChainPointTime{currentSlot} pendingDeposits st ev =
 -- * NodeState aggregate
 
 -- | Reflect 'StateChanged' events onto the 'NodeState' aggregateNodeState.
+-- Events carrying a 'HeadId' that does not match the current state are silently
+-- ignored, preventing cross-head state contamination during event replay.
+-- Events without a 'HeadId' are always applied.
 aggregateNodeState :: IsChainState tx => NodeState tx -> StateChanged tx -> NodeState tx
 aggregateNodeState nodeState sc =
-  let currentPendingDeposits = pendingDeposits nodeState
-      st = aggregate (headState nodeState) sc
-      chainPointTimeState = chainPointTime nodeState
-   in case sc of
-        HeadOpened{chainState} ->
-          nodeState
-            { headState = st
-            , chainPointTime = chainPointTimeState{currentSlot = chainStateSlot chainState}
-            }
-        DepositRecorded{headId, depositTxId, deposited, created, deadline} ->
-          nodeState
-            { headState = st
-            , pendingDeposits = Map.insert depositTxId Deposit{headId, deposited, created, deadline, status = Inactive} currentPendingDeposits
-            }
-        DepositActivated{depositTxId, deposit} ->
-          nodeState
-            { headState = st
-            , pendingDeposits = Map.insert depositTxId deposit currentPendingDeposits
-            }
-        DepositExpired{depositTxId, deposit} ->
-          nodeState
-            { headState = st
-            , -- NB: We keep expired deposits in a map since we actually need it when Recovering.
-              -- There is a corresponding error RequestedDepositExpired which gives users context on stale ReqSn.
-              pendingDeposits = Map.insert depositTxId deposit currentPendingDeposits
-            }
-        DepositRecovered{headId, depositTxId} ->
-          case st of
-            Open os@OpenState{headId = ourHeadId, coordinatedHeadState}
-              | headId == ourHeadId ->
+  case (headIdOf (headState nodeState), eventHeadId sc) of
+    (Just sid, Just eid) | sid /= eid -> nodeState
+    _ ->
+      let currentPendingDeposits = pendingDeposits nodeState
+          st = applyEvent (headState nodeState) sc
+          chainPointTimeState = chainPointTime nodeState
+       in case sc of
+            HeadOpened{chainState} ->
+              nodeState
+                { headState = st
+                , chainPointTime = chainPointTimeState{currentSlot = chainStateSlot chainState}
+                }
+            DepositRecorded{headId, depositTxId, deposited, created, deadline} ->
+              nodeState
+                { headState = st
+                , pendingDeposits = Map.insert depositTxId Deposit{headId, deposited, created, deadline, status = Inactive} currentPendingDeposits
+                }
+            DepositActivated{depositTxId, deposit} ->
+              nodeState
+                { headState = st
+                , pendingDeposits = Map.insert depositTxId deposit currentPendingDeposits
+                }
+            DepositExpired{depositTxId, deposit} ->
+              nodeState
+                { headState = st
+                , -- NB: We keep expired deposits in a map since we actually need it when Recovering.
+                  -- There is a corresponding error RequestedDepositExpired which gives users context on stale ReqSn.
+                  pendingDeposits = Map.insert depositTxId deposit currentPendingDeposits
+                }
+            DepositRecovered{depositTxId} ->
+              case st of
+                Open os@OpenState{coordinatedHeadState} ->
                   nodeState
                     { headState =
                         Open
@@ -1905,15 +1910,14 @@ aggregateNodeState nodeState sc =
                             }
                     , pendingDeposits = Map.delete depositTxId currentPendingDeposits
                     }
-            _ ->
-              nodeState
-                { headState = st
-                , pendingDeposits = Map.delete depositTxId currentPendingDeposits
-                }
-        CommitFinalized{chainState, headId, newVersion, depositTxId} ->
-          case st of
-            Open os@OpenState{headId = ourHeadId, coordinatedHeadState}
-              | headId == ourHeadId ->
+                _ ->
+                  nodeState
+                    { headState = st
+                    , pendingDeposits = Map.delete depositTxId currentPendingDeposits
+                    }
+            CommitFinalized{chainState, newVersion, depositTxId} ->
+              case st of
+                Open os@OpenState{coordinatedHeadState} ->
                   let deposit = Map.lookup depositTxId currentPendingDeposits
                       newUTxO = maybe mempty (\Deposit{deposited} -> deposited) deposit
                    in nodeState
@@ -1940,36 +1944,42 @@ aggregateNodeState nodeState sc =
                                 }
                         , pendingDeposits = Map.delete depositTxId currentPendingDeposits
                         }
-             where
-              CoordinatedHeadState{localUTxO, confirmedSnapshot, seenSnapshot} = coordinatedHeadState
-              Snapshot{number = confirmedSn} = getSnapshot confirmedSnapshot
+                 where
+                  CoordinatedHeadState{localUTxO, confirmedSnapshot, seenSnapshot} = coordinatedHeadState
+                  Snapshot{number = confirmedSn} = getSnapshot confirmedSnapshot
+                _ ->
+                  nodeState
+                    { headState = st
+                    , pendingDeposits = Map.delete depositTxId currentPendingDeposits
+                    }
+            TickObserved{chainPoint} ->
+              nodeState{headState = st, chainPointTime = chainPointTimeState{currentSlot = chainPointSlot chainPoint}}
+            ChainRolledBack{chainState} ->
+              nodeState{headState = st, chainPointTime = chainPointTimeState{currentSlot = chainStateSlot chainState}}
+            NodeUnsynced{chainSlot, chainTime, drift} ->
+              NodeCatchingUp{headState = st, pendingDeposits = currentPendingDeposits, chainPointTime = ChainPointTime chainSlot chainTime drift}
+            NodeSynced{chainSlot, chainTime, drift} ->
+              NodeInSync{headState = st, pendingDeposits = currentPendingDeposits, chainPointTime = ChainPointTime chainSlot chainTime drift}
             _ ->
-              nodeState
-                { headState = st
-                , pendingDeposits = Map.delete depositTxId currentPendingDeposits
-                }
-        TickObserved{chainPoint} ->
-          nodeState{headState = st, chainPointTime = chainPointTimeState{currentSlot = chainPointSlot chainPoint}}
-        ChainRolledBack{chainState} ->
-          nodeState{headState = st, chainPointTime = chainPointTimeState{currentSlot = chainStateSlot chainState}}
-        NodeUnsynced{chainSlot, chainTime, drift} ->
-          NodeCatchingUp{headState = st, pendingDeposits = currentPendingDeposits, chainPointTime = ChainPointTime chainSlot chainTime drift}
-        NodeSynced{chainSlot, chainTime, drift} ->
-          NodeInSync{headState = st, pendingDeposits = currentPendingDeposits, chainPointTime = ChainPointTime chainSlot chainTime drift}
-        _ ->
-          nodeState{headState = st}
+              nodeState{headState = st}
 
--- * HeadState aggregate
+-- * HeadState aggregate helpers
 
 -- | Extract the 'HeadId' from a 'StateChanged' event, if the event carries one.
--- Events that do not carry a 'HeadId' always pass through 'aggregate' unchanged.
+-- Events that do not carry a 'HeadId' always pass through 'aggregateNodeState' unchanged.
 eventHeadId :: StateChanged tx -> Maybe HeadId
 eventHeadId = \case
   HeadOpened{headId} -> Just headId
   TransactionAppliedToLocalUTxO{headId} -> Just headId
   SnapshotConfirmed{headId} -> Just headId
   LocalStateCleared{headId} -> Just headId
+  DepositRecorded{headId} -> Just headId
+  DepositRecovered{headId} -> Just headId
+  CommitApproved{headId} -> Just headId
+  CommitFinalized{headId} -> Just headId
   DecommitRecorded{headId} -> Just headId
+  DecommitApproved{headId} -> Just headId
+  DecommitInvalid{headId} -> Just headId
   DecommitFinalized{headId} -> Just headId
   HeadIsReadyToFanout{headId} -> Just headId
   HeadClosed{headId} -> Just headId
@@ -1977,21 +1987,17 @@ eventHeadId = \case
   HeadFannedOut{headId} -> Just headId
   TxInvalid{headId} -> Just headId
   HeadPartialFannedOut{headId} -> Just headId
+  -- The headId in IgnoredHeadInitializing is the OTHER head's id (not ours),
+  -- so it must not be used to filter against the current head state.
+  IgnoredHeadInitializing{} -> Nothing
   TransactionReceived{} -> Nothing
   SnapshotRequestDecided{} -> Nothing
   SnapshotRequested{} -> Nothing
   PartySignedSnapshot{} -> Nothing
-  DepositRecorded{} -> Nothing
-  DepositExpired{} -> Nothing
   DepositActivated{} -> Nothing
-  DepositRecovered{} -> Nothing
-  CommitApproved{} -> Nothing
-  CommitFinalized{} -> Nothing
-  DecommitApproved{} -> Nothing
-  DecommitInvalid{} -> Nothing
+  DepositExpired{} -> Nothing
   ChainRolledBack{} -> Nothing
   TickObserved{} -> Nothing
-  IgnoredHeadInitializing{} -> Nothing
   NetworkDisconnected -> Nothing
   NetworkConnected -> Nothing
   PeerConnected{} -> Nothing
@@ -2008,15 +2014,6 @@ headIdOf = \case
   Idle _ -> Nothing
   Open OpenState{headId} -> Just headId
   Closed ClosedState{headId} -> Just headId
-
--- | Reflect 'StateChanged' events onto the 'HeadState' aggregate.
--- Events carrying a 'HeadId' that does not match the current state are silently
--- ignored, preventing cross-head state contamination during event replay.
--- Events without a 'HeadId' are always applied.
-aggregate :: IsChainState tx => HeadState tx -> StateChanged tx -> HeadState tx
-aggregate st sc = case (headIdOf st, eventHeadId sc) of
-  (Just sid, Just eid) | sid /= eid -> st
-  _ -> applyEvent st sc
 
 applyEvent :: IsChainState tx => HeadState tx -> StateChanged tx -> HeadState tx
 applyEvent st = \case
@@ -2152,7 +2149,7 @@ applyEvent st = \case
                       , seenSnapshot = LastSeenSnapshot snapshot.number
                       }
                 }
-          Nothing -> Hydra.Prelude.error "aggregate: SnapshotConfirmed but no snapshot in event or seenSnapshot"
+          Nothing -> Hydra.Prelude.error "applyEvent: SnapshotConfirmed but no snapshot in event or seenSnapshot"
       _otherState -> st
    where
     snapshotFromSeen :: SeenSnapshot tx -> Maybe (Snapshot tx)

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1976,7 +1976,31 @@ eventHeadId = \case
   HeadContested{headId} -> Just headId
   HeadFannedOut{headId} -> Just headId
   TxInvalid{headId} -> Just headId
-  _ -> Nothing
+  HeadPartialFannedOut{headId} -> Just headId
+  TransactionReceived{} -> Nothing
+  SnapshotRequestDecided{} -> Nothing
+  SnapshotRequested{} -> Nothing
+  PartySignedSnapshot{} -> Nothing
+  DepositRecorded{} -> Nothing
+  DepositExpired{} -> Nothing
+  DepositActivated{} -> Nothing
+  DepositRecovered{} -> Nothing
+  CommitApproved{} -> Nothing
+  CommitFinalized{} -> Nothing
+  DecommitApproved{} -> Nothing
+  DecommitInvalid{} -> Nothing
+  ChainRolledBack{} -> Nothing
+  TickObserved{} -> Nothing
+  IgnoredHeadInitializing{} -> Nothing
+  NetworkDisconnected -> Nothing
+  NetworkConnected -> Nothing
+  PeerConnected{} -> Nothing
+  PeerDisconnected{} -> Nothing
+  NetworkVersionMismatch{} -> Nothing
+  NetworkClusterIDMismatch{} -> Nothing
+  Checkpoint{} -> Nothing
+  NodeUnsynced{} -> Nothing
+  NodeSynced{} -> Nothing
 
 -- | Extract the 'HeadId' from the current 'HeadState', if any.
 headIdOf :: HeadState tx -> Maybe HeadId
@@ -1990,12 +2014,9 @@ headIdOf = \case
 -- ignored, preventing cross-head state contamination during event replay.
 -- Events without a 'HeadId' are always applied.
 aggregate :: IsChainState tx => HeadState tx -> StateChanged tx -> HeadState tx
-aggregate st sc
-  | Just eid <- eventHeadId sc
-  , Just sid <- headIdOf st
-  , eid /= sid =
-      st
-  | otherwise = applyEvent st sc
+aggregate st sc = case (headIdOf st, eventHeadId sc) of
+  (Just sid, Just eid) | sid /= eid -> st
+  _ -> applyEvent st sc
 
 applyEvent :: IsChainState tx => HeadState tx -> StateChanged tx -> HeadState tx
 applyEvent st = \case

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1961,9 +1961,44 @@ aggregateNodeState nodeState sc =
 
 -- * HeadState aggregate
 
+-- | Extract the 'HeadId' from a 'StateChanged' event, if the event carries one.
+-- Events that do not carry a 'HeadId' always pass through 'aggregate' unchanged.
+eventHeadId :: StateChanged tx -> Maybe HeadId
+eventHeadId = \case
+  HeadOpened{headId} -> Just headId
+  TransactionAppliedToLocalUTxO{headId} -> Just headId
+  SnapshotConfirmed{headId} -> Just headId
+  LocalStateCleared{headId} -> Just headId
+  DecommitRecorded{headId} -> Just headId
+  DecommitFinalized{headId} -> Just headId
+  HeadIsReadyToFanout{headId} -> Just headId
+  HeadClosed{headId} -> Just headId
+  HeadContested{headId} -> Just headId
+  HeadFannedOut{headId} -> Just headId
+  TxInvalid{headId} -> Just headId
+  _ -> Nothing
+
+-- | Extract the 'HeadId' from the current 'HeadState', if any.
+headIdOf :: HeadState tx -> Maybe HeadId
+headIdOf = \case
+  Idle _ -> Nothing
+  Open OpenState{headId} -> Just headId
+  Closed ClosedState{headId} -> Just headId
+
 -- | Reflect 'StateChanged' events onto the 'HeadState' aggregate.
+-- Events carrying a 'HeadId' that does not match the current state are silently
+-- ignored, preventing cross-head state contamination during event replay.
+-- Events without a 'HeadId' are always applied.
 aggregate :: IsChainState tx => HeadState tx -> StateChanged tx -> HeadState tx
-aggregate st = \case
+aggregate st sc
+  | Just eid <- eventHeadId sc
+  , Just sid <- headIdOf st
+  , eid /= sid =
+      st
+  | otherwise = applyEvent st sc
+
+applyEvent :: IsChainState tx => HeadState tx -> StateChanged tx -> HeadState tx
+applyEvent st = \case
   NetworkConnected -> st
   NetworkDisconnected -> st
   NetworkVersionMismatch{} -> st

--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -240,7 +240,7 @@ spec =
       showLogsOnFailure "ServerSpec" $ \tracer ->
         withFreePort $ \port -> do
           -- Use a single headId throughout so the headId validation in
-          -- 'aggregate' does not drop events from a mismatched head.
+          -- 'aggregateNodeState' does not drop events from a mismatched head.
           headId <- generate arbitrary
 
           -- Prime some relevant server outputs already into event source to

--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -239,37 +239,32 @@ spec =
     it "displays correctly headStatus and snapshotUtxo in a Greeting message" $
       showLogsOnFailure "ServerSpec" $ \tracer ->
         withFreePort $ \port -> do
+          -- Use a single headId throughout so the headId validation in
+          -- 'aggregate' does not drop events from a mismatched head.
+          headId <- generate arbitrary
+
           -- Prime some relevant server outputs already into event source to
           -- check whether the latest headStatus is loaded correctly.
           existingStateChanges <-
             generate $
               mapM
                 (>>= genStateEvent)
-                [ Outcome.HeadOpened <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
-                , Outcome.HeadFannedOut <$> arbitrary <*> arbitrary <*> arbitrary
+                [ Outcome.HeadOpened <$> arbitrary <*> arbitrary <*> pure headId <*> arbitrary <*> arbitrary
                 ]
           let eventSource = mockSource existingStateChanges
 
           withTestAPIServer port alice eventSource tracer $ \(EventSink{putEvent}, _) -> do
             let generateSnapshot =
-                  Outcome.SnapshotConfirmed <$> arbitrary <*> (Just <$> arbitrary) <*> arbitrary
+                  (Outcome.SnapshotConfirmed headId . Just <$> arbitrary) <*> arbitrary
 
             waitForValue port $ \v -> do
               guard $ v ^? key "headStatus" == Just (Aeson.String "Open")
               guard $ v ^? key "snapshotUtxo" == Just (Aeson.Array mempty)
 
-            (headId, headIsOpenMsg) <- generate $ do
-              headId <- arbitrary
-              output <-
-                genStateEvent
-                  =<< ( Outcome.HeadOpened <$> arbitrary <*> arbitrary <*> pure headId <*> arbitrary <*> arbitrary
-                      )
-              pure (headId, output)
-
             snapShotConfirmedMsg@StateEvent{stateChanged = Outcome.SnapshotConfirmed{snapshot = Just Snapshot{utxo, utxoToCommit}}} <-
               generate $ genStateEvent =<< generateSnapshot
 
-            mapM_ putEvent [headIsOpenMsg, snapShotConfirmedMsg]
+            putEvent snapShotConfirmedMsg
             waitForValue port $ \v -> do
               guard $ v ^? key "headStatus" == Just (Aeson.String "Open")
               guard $ v ^? key "snapshotUtxo" == Just (toJSON $ utxo <> fromMaybe mempty utxoToCommit)
@@ -279,10 +274,11 @@ spec =
                 Outcome.SnapshotConfirmed{snapshot = Just Snapshot{utxo = utxo', utxoToCommit = utxoToCommit'}}
               } <-
               generate $ genStateEvent =<< generateSnapshot
-            headClosedMsg <- generate $ do
-              genStateEvent
-                =<< ( Outcome.HeadClosed headId <$> arbitrary <*> arbitrary <*> arbitrary
-                    )
+            headClosedMsg <-
+              generate $
+                genStateEvent
+                  =<< ( Outcome.HeadClosed headId <$> arbitrary <*> arbitrary <*> arbitrary
+                      )
             readyToFanoutMsg <- generate $ genStateEvent Outcome.HeadIsReadyToFanout{headId}
 
             mapM_ putEvent [snapShotConfirmedMsg', headClosedMsg, readyToFanoutMsg]
@@ -293,9 +289,9 @@ spec =
     it "greets with correct head status and snapshot utxo after restart" $
       showLogsOnFailure "ServerSpec" $ \tracer ->
         withFreePort $ \port -> do
-          headIsOpenMsg <- generate $ Outcome.HeadOpened <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+          headIsOpenMsg@Outcome.HeadOpened{headId = openedHeadId} <- generate $ Outcome.HeadOpened <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 
-          let generateSnapshot = generate $ Outcome.SnapshotConfirmed <$> arbitrary <*> (Just <$> arbitrary) <*> arbitrary
+          let generateSnapshot = generate $ (Outcome.SnapshotConfirmed openedHeadId . Just <$> arbitrary) <*> arbitrary
           snapShotConfirmedMsg@Outcome.SnapshotConfirmed{snapshot = Just Snapshot{utxo, utxoToCommit}} <- generateSnapshot
 
           stateEvents :: [StateEvent SimpleTx] <- generate $ mapM genStateEvent [headIsOpenMsg, snapShotConfirmedMsg]

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -357,6 +357,35 @@ spec =
               chs.localUTxO `shouldBe` ownUTxO
             _ -> fail "expected Open state"
 
+        it "HeadClosed from another head does not transition Open to Closed during replay" $ do
+          otherHeadId :: HeadId <- generate arbitrary
+          let s0 = inOpenState threeParties
+              closedEvent =
+                HeadClosed
+                  { headId = otherHeadId
+                  , snapshotNumber = 0
+                  , chainState = 0
+                  , contestationDeadline = arbitrary `generateWith` 42
+                  }
+          let s1 = aggregateState s0 $ Continue [closedEvent] []
+          case s1 of
+            NodeInSync{headState = Open _} -> pure ()
+            other -> fail $ "expected Open state, got: " <> show other
+
+        it "HeadFannedOut from another head does not transition Closed to Idle during replay" $ do
+          otherHeadId :: HeadId <- generate arbitrary
+          let s0 = inClosedState threeParties
+              fanoutEvent =
+                HeadFannedOut
+                  { headId = otherHeadId
+                  , utxo = mempty
+                  , chainState = 0
+                  }
+          let s1 = aggregateState s0 $ Continue [fanoutEvent] []
+          case s1 of
+            NodeInSync{headState = Closed _} -> pure ()
+            other -> fail $ "expected Closed state, got: " <> show other
+
       describe "Decommit" $ do
         it "observes DecommitRecorded and ReqDec in an Open state" $ do
           let outputs = utxoRef 1

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -378,7 +378,7 @@ spec =
               fanoutEvent =
                 HeadFannedOut
                   { headId = otherHeadId
-                  , utxo = mempty
+                  , finalizedOutputs = mempty
                   , chainState = 0
                   }
           let s1 = aggregateState s0 $ Continue [fanoutEvent] []


### PR DESCRIPTION
 fix #2605 
 
  The SQLite event store accumulates events from all head lifecycles without
  rotation. On restart, `aggregate` replays every persisted StateChanged event
  but unlike the live `handleChainInput` path, never checked that an event's
  headId matched the current state — so a HeadClosed or HeadFannedOut event
  from a previous head could silently drive an unrelated Open/Closed head into
  the wrong state.

  

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
