### PR TITLE
Switch to tasty for tests

### DIFF
--- a/.github/actions/publish-test-report/action.yml
+++ b/.github/actions/publish-test-report/action.yml
@@ -1,0 +1,38 @@
+name: Publish test report
+description: |
+  Publish a JUnit XML test report as a PR check summary and upload the raw
+  XML as a workflow artifact. Both steps run with `if: always()` so failed
+  test suites still produce a report.
+
+inputs:
+  report-path:
+    description: Path to the JUnit XML to publish.
+    required: true
+  check-name:
+    description: Name used for the published check / summary.
+    required: true
+  artifact-name:
+    description: Name used for the uploaded JUnit XML artifact.
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - name: 📊 Publish test report
+      if: always()
+      uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
+      with:
+        report_paths: ${{ inputs.report-path }}
+        check_name: ${{ inputs.check-name }}
+        detailed_summary: true
+        include_passed: false
+        require_tests: false
+
+    - name: 💾 Upload JUnit XML
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.report-path }}
+        if-no-files-found: warn

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -79,23 +79,13 @@ jobs:
         mkdir -p test-reports
         nix develop .#${{ matrix.package }}-tests --command tests --xml=test-reports/junit.xml
 
-    - name: 📊 Publish test report
+    - name: 📊 Publish test report & upload JUnit XML
       if: always()
-      uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
+      uses: ./.github/actions/publish-test-report
       with:
-        report_paths: '${{ matrix.package }}/test-reports/junit.xml'
-        check_name: 'tests / ${{ matrix.package }} (${{ matrix.os }})'
-        detailed_summary: true
-        include_passed: false
-        require_tests: false
-
-    - name: 💾 Upload JUnit XML
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: junit-${{ matrix.package }}-${{ matrix.os }}
-        path: ${{ matrix.package }}/test-reports/junit.xml
-        if-no-files-found: warn
+        report-path: ${{ matrix.package }}/test-reports/junit.xml
+        check-name: tests / ${{ matrix.package }} (${{ matrix.os }})
+        artifact-name: junit-${{ matrix.package }}-${{ matrix.os }}
 
     # NOTE: This depends on the path used in hydra-cluster e2e tests
     - name: 💾 Upload logs

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -54,7 +54,16 @@ jobs:
       run: |
         cd ${{ matrix.package }} # To ensure the `./golden` files are available.
         mkdir -p test-reports
-        nix develop .#${{ matrix.package }}-tests --command tests --xml=test-reports/junit.xml
+        # hydra-node's NetworkSpec spins etcd subprocesses; under tasty's
+        # default parallelism it wedges on these small CI runners (etcd
+        # loses quorum after the manual lease revoke and the suite hangs).
+        # Force the suite single-threaded here; other packages keep tasty's
+        # default parallelism, which they handle fine.
+        threads_flag=""
+        if [ "${{ matrix.package }}" = "hydra-node" ]; then
+          threads_flag="--num-threads=1"
+        fi
+        nix develop .#${{ matrix.package }}-tests --command tests --xml=test-reports/junit.xml $threads_flag
 
     # This one is special, as it requires a tty.
     - name: ❓ Test (TUI)

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -53,7 +53,8 @@ jobs:
       if: ${{ matrix.package != 'hydra-tui' }}
       run: |
         cd ${{ matrix.package }} # To ensure the `./golden` files are available.
-        nix develop .#${{ matrix.package }}-tests --command tests
+        mkdir -p test-reports
+        nix develop .#${{ matrix.package }}-tests --command tests --xml=test-reports/junit.xml
 
     # This one is special, as it requires a tty.
     - name: ❓ Test (TUI)
@@ -66,7 +67,26 @@ jobs:
         TERM: "xterm"
       run: |
         cd ${{ matrix.package  }}
-        nix develop .#${{ matrix.package }}-tests --command tests
+        mkdir -p test-reports
+        nix develop .#${{ matrix.package }}-tests --command tests --xml=test-reports/junit.xml
+
+    - name: 📊 Publish test report
+      if: always()
+      uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
+      with:
+        report_paths: '${{ matrix.package }}/test-reports/junit.xml'
+        check_name: 'tests / ${{ matrix.package }} (${{ matrix.os }})'
+        detailed_summary: true
+        include_passed: false
+        require_tests: false
+
+    - name: 💾 Upload JUnit XML
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: junit-${{ matrix.package }}-${{ matrix.os }}
+        path: ${{ matrix.package }}/test-reports/junit.xml
+        if-no-files-found: warn
 
     # NOTE: This depends on the path used in hydra-cluster e2e tests
     - name: 💾 Upload logs

--- a/.github/workflows/nightly-ci.yaml
+++ b/.github/workflows/nightly-ci.yaml
@@ -39,10 +39,29 @@ jobs:
         if [[ "${{secrets.blockfrost_token}}" != '' ]]; then
           cd ${{ matrix.package }}
           echo "${{secrets.blockfrost_token}}" > blockfrost-project.txt
-          nix develop .#${{ matrix.package }}-tests --command tests -m "@requiresBlockfrost"
+          mkdir -p test-reports
+          nix develop .#${{ matrix.package }}-tests --command tests -p "/@requiresBlockfrost/" --xml=test-reports/junit.xml
         else
           echo "::warning file=blockfrost-project.txt,title=BLOCKFROST::Missing blockfrost project file."
         fi
+
+    - name: 📊 Publish test report
+      if: always()
+      uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
+      with:
+        report_paths: '${{ matrix.package }}/test-reports/junit.xml'
+        check_name: 'nightly blockfrost / ${{ matrix.package }}'
+        detailed_summary: true
+        include_passed: false
+        require_tests: false
+
+    - name: 💾 Upload JUnit XML
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: junit-nightly-blockfrost-${{ matrix.package }}
+        path: ${{ matrix.package }}/test-reports/junit.xml
+        if-no-files-found: warn
 
 
   other-nightly-tests:
@@ -71,4 +90,23 @@ jobs:
     - name: Run tests
       run: |
         cd ${{ matrix.package }}
-        nix develop .#${{ matrix.package }}-tests --command tests -m "@nightly"
+        mkdir -p test-reports
+        nix develop .#${{ matrix.package }}-tests --command tests -p "/@nightly/" --xml=test-reports/junit.xml
+
+    - name: 📊 Publish test report
+      if: always()
+      uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
+      with:
+        report_paths: '${{ matrix.package }}/test-reports/junit.xml'
+        check_name: 'nightly / ${{ matrix.package }}'
+        detailed_summary: true
+        include_passed: false
+        require_tests: false
+
+    - name: 💾 Upload JUnit XML
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: junit-nightly-${{ matrix.package }}
+        path: ${{ matrix.package }}/test-reports/junit.xml
+        if-no-files-found: warn

--- a/.github/workflows/nightly-ci.yaml
+++ b/.github/workflows/nightly-ci.yaml
@@ -45,23 +45,13 @@ jobs:
           echo "::warning file=blockfrost-project.txt,title=BLOCKFROST::Missing blockfrost project file."
         fi
 
-    - name: 📊 Publish test report
+    - name: 📊 Publish test report & upload JUnit XML
       if: always()
-      uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
+      uses: ./.github/actions/publish-test-report
       with:
-        report_paths: '${{ matrix.package }}/test-reports/junit.xml'
-        check_name: 'nightly blockfrost / ${{ matrix.package }}'
-        detailed_summary: true
-        include_passed: false
-        require_tests: false
-
-    - name: 💾 Upload JUnit XML
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: junit-nightly-blockfrost-${{ matrix.package }}
-        path: ${{ matrix.package }}/test-reports/junit.xml
-        if-no-files-found: warn
+        report-path: ${{ matrix.package }}/test-reports/junit.xml
+        check-name: nightly blockfrost / ${{ matrix.package }}
+        artifact-name: junit-nightly-blockfrost-${{ matrix.package }}
 
 
   other-nightly-tests:
@@ -93,20 +83,10 @@ jobs:
         mkdir -p test-reports
         nix develop .#${{ matrix.package }}-tests --command tests -p "/@nightly/" --xml=test-reports/junit.xml
 
-    - name: 📊 Publish test report
+    - name: 📊 Publish test report & upload JUnit XML
       if: always()
-      uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
+      uses: ./.github/actions/publish-test-report
       with:
-        report_paths: '${{ matrix.package }}/test-reports/junit.xml'
-        check_name: 'nightly / ${{ matrix.package }}'
-        detailed_summary: true
-        include_passed: false
-        require_tests: false
-
-    - name: 💾 Upload JUnit XML
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: junit-nightly-${{ matrix.package }}
-        path: ${{ matrix.package }}/test-reports/junit.xml
-        if-no-files-found: warn
+        report-path: ${{ matrix.package }}/test-reports/junit.xml
+        check-name: nightly / ${{ matrix.package }}
+        artifact-name: junit-nightly-${{ matrix.package }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,12 @@
 *.hp
 *.prof
 .hspec-failures
+.tasty-rerun-log
+/test-reports/
+# stray hspec-golden-aeson output when `cabal test PKG` is run from the
+# repo root instead of from inside the package directory; the canonical
+# golden files live at e.g. hydra-node/golden/, hydra-tx/golden/, etc.
+/golden/
 
 # Nix
 result*

--- a/hydra-chain-observer/hydra-chain-observer.cabal
+++ b/hydra-chain-observer/hydra-chain-observer.cabal
@@ -72,13 +72,12 @@ executable hydra-chain-observer
     , hydra-prelude
 
 test-suite tests
-  import:             project-config
-  ghc-options:        -threaded -rtsopts -with-rtsopts=-N
-  hs-source-dirs:     test
-  main-is:            Main.hs
-  type:               exitcode-stdio-1.0
+  import:         project-config
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
+  hs-source-dirs: test
+  main-is:        Main.hs
+  type:           exitcode-stdio-1.0
   build-depends:
-    , hspec
     , hspec-golden-aeson
     , hydra-cardano-api
     , hydra-chain-observer
@@ -90,8 +89,4 @@ test-suite tests
     , hydra-tx:testlib
     , QuickCheck
 
-  other-modules:
-    Hydra.ChainObserverSpec
-    Spec
-
-  build-tool-depends: hspec-discover:hspec-discover
+  other-modules:  Hydra.ChainObserverSpec

--- a/hydra-chain-observer/test/Main.hs
+++ b/hydra-chain-observer/test/Main.hs
@@ -1,8 +1,13 @@
 module Main where
 
 import Hydra.Prelude
-import Spec qualified
-import Test.Hspec.Runner
+
+import Hydra.ChainObserverSpec qualified
+import Test.Hydra.TastyMain (defaultMainHydra, testSpec)
 
 main :: IO ()
-main = hspec Spec.spec
+main =
+  defaultMainHydra
+    "hydra-chain-observer"
+    [ testSpec "ChainObserver" Hydra.ChainObserverSpec.spec
+    ]

--- a/hydra-chain-observer/test/Spec.hs
+++ b/hydra-chain-observer/test/Spec.hs
@@ -1,1 +1,0 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}

--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -134,7 +134,7 @@ benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand workDir 
     case apiHosts of
       [] -> action connections
       ((apiHost, peerId) : rest) -> do
-        withConnectionToNodeHost tracer peerId apiHost (Just "/?history=no") $ \con -> do
+        withConnectionToNodeHost tracer peerId apiHost Nothing (Just "/?history=no") $ \con -> do
           withHydraClientConnections tracer rest (con : connections) action
 
   returnFaucetFunds tracer opts = do

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -149,7 +149,6 @@ test-suite tests
   type:               exitcode-stdio-1.0
   other-modules:
     Paths_hydra_cluster
-    Spec
     Test.BlockfrostChainSpec
     Test.CardanoClientSpec
     Test.CardanoNodeSpec
@@ -173,7 +172,6 @@ test-suite tests
     , containers
     , directory
     , filepath
-    , hspec
     , hspec-golden-aeson
     , http-conduit
     , hydra-cardano-api
@@ -191,11 +189,11 @@ test-suite tests
     , QuickCheck
     , split
     , stm
+    , tasty
     , text
     , time
 
   build-tool-depends:
-    , hspec-discover:hspec-discover
     , hydra-chain-observer:hydra-chain-observer
     , hydra-node:hydra-node
 

--- a/hydra-cluster/src/CardanoNode.hs
+++ b/hydra-cluster/src/CardanoNode.hs
@@ -4,6 +4,8 @@ module CardanoNode where
 
 import Hydra.Prelude
 
+import Test.Network.Ports qualified as Ports
+
 import Cardano.Slotting.Time (diffRelativeTime, getRelativeTime, toRelativeTime)
 import CardanoClient (QueryPoint (QueryTip))
 import Control.Lens ((?~), (^?!))
@@ -211,7 +213,11 @@ withCardanoNodeDevnet ::
   IO a
 withCardanoNodeDevnet tracer stateDirectory action = do
   args <- setupCardanoDevnet stateDirectory
-  withCardanoNode tracer stateDirectory args action
+  -- Allocate a free port for the cardano-node P2P listener so concurrent
+  -- devnets don't all try to bind 3001 (the cardano-node default).
+  [p] <- Ports.randomUnusedTCPPorts 1
+  let args' = args{nodePort = Just p}
+  withCardanoNode tracer stateDirectory args' action
 
 withBlockfrostBackend ::
   Tracer IO EndToEndLog ->

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -113,6 +113,7 @@ import Hydra.Cluster.Util (Timing (..), chainConfigFor, chainConfigFor', deposit
 import Hydra.Contract.Dummy (dummyRewardingScript, dummyValidatorScript)
 import Hydra.Ledger.Cardano (mkSimpleTx, mkTransferTx, unsafeBuildTransaction)
 import Hydra.Logging (Tracer, traceWith)
+import Hydra.Network qualified as Network
 import Hydra.Node.State (SyncedStatus (..))
 import Hydra.Node.UnsyncedPeriod (defaultUnsyncedPeriodFor, unsyncedPeriodToNominalDiffTime)
 import Hydra.Options (CardanoChainConfig (..), ChainBackendOptions (..), ChainConfig (..), DirectOptions (..), RunOptions (..), startChainFrom)
@@ -122,6 +123,8 @@ import Hydra.Tx.Deposit (constructDepositUTxO)
 import Hydra.Tx.Utils (verificationKeyToOnChainId)
 import HydraNode (
   HydraClient (..),
+  HydraNodePorts (..),
+  allocateHydraNodePortsFor,
   getProtocolParameters,
   getSnapshotConfirmed,
   getSnapshotUTxO,
@@ -141,13 +144,17 @@ import HydraNode (
   withHydraNode,
   withHydraNodeCatchingUp,
   withPreparedHydraNode,
+  withSoloHydraNode,
+  withSoloHydraNodeCatchingUp,
   withUnsyncedHydraNode,
+  withUnsyncedSoloHydraNode,
  )
 import Network.HTTP.Conduit (parseUrlThrow)
 import Network.HTTP.Conduit qualified as L
 import Network.HTTP.Req (
   HttpException (VanillaHttpException),
   JsonResponse,
+  Option,
   POST (POST),
   ReqBodyJson (ReqBodyJson),
   defaultHttpConfig,
@@ -188,10 +195,11 @@ oneOfThreeNodesStopsForAWhile tracer workDir opts hydraScriptsTxId = do
   carolChainConfig <-
     chainConfigFor Carol workDir opts hydraScriptsTxId [Alice, Bob] timing
       <&> setNetworkId networkId
-  withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk, carolVk] [1, 2, 3] $ \n1 -> do
+  nodePorts <- allocateHydraNodePortsFor [1, 2, 3]
+  withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk, carolVk] nodePorts $ \n1 -> do
     aliceUTxO <- seedFromFaucet opts aliceCardanoVk (lovelaceToValue 2_000_000) (contramap FromFaucet tracer)
-    withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk, carolVk] [1, 2, 3] $ \n2 -> do
-      withHydraNode hydraTracer blockTime carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] $ \n3 -> do
+    withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk, carolVk] nodePorts $ \n2 -> do
+      withHydraNode hydraTracer blockTime carolChainConfig workDir 3 carolSk [aliceVk, bobVk] nodePorts $ \n3 -> do
         -- Init & open head
         send n1 $ input "Init" []
         headId <- waitForAllMatch (10 * blockTime) [n1, n2, n3] $ headIsOpenWith (Set.fromList [alice, bob, carol])
@@ -222,7 +230,7 @@ oneOfThreeNodesStopsForAWhile tracer workDir opts hydraScriptsTxId = do
       send n1 $ input "NewTx" ["transaction" .= tx]
 
       -- Carol reconnects, and then the snapshot can be confirmed
-      withHydraNode hydraTracer blockTime carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] $ \n3 -> do
+      withHydraNode hydraTracer blockTime carolChainConfig workDir 3 carolSk [aliceVk, bobVk] nodePorts $ \n3 -> do
         -- Note: We can't use `waitForAlMatch` here as it expects them to
         -- emit the exact same datatype; but Carol will be behind in sequence
         -- numbers as she was offline.
@@ -255,8 +263,9 @@ restartedNodeCanObserveCommitTx tracer workDir opts hydraScriptsTxId = do
       <&> setNetworkId networkId
 
   let hydraTracer = contramap FromHydraNode tracer
-  withHydraNode hydraTracer blockTime bobChainConfig workDir 1 bobSk [aliceVk] [1, 2] $ \n1 -> do
-    headId <- withHydraNode hydraTracer blockTime aliceChainConfig workDir 2 aliceSk [bobVk] [1, 2] $ \n2 -> do
+  nodePorts <- allocateHydraNodePortsFor [1, 2]
+  withHydraNode hydraTracer blockTime bobChainConfig workDir 1 bobSk [aliceVk] nodePorts $ \n1 -> do
+    headId <- withHydraNode hydraTracer blockTime aliceChainConfig workDir 2 aliceSk [bobVk] nodePorts $ \n2 -> do
       send n1 $ input "Init" []
       -- XXX: might need to tweak the wait time
       waitForAllMatch 10 [n1, n2] $ headIsOpenWith (Set.fromList [alice, bob])
@@ -271,7 +280,7 @@ restartedNodeCanObserveCommitTx tracer workDir opts hydraScriptsTxId = do
       guard $ v ^? key "utxoToCommit" == Just (toJSON depositUTxO)
 
     -- n2 is back and does observe the deposit
-    withUnsyncedHydraNode hydraTracer aliceChainConfig workDir 2 aliceSk [bobVk] [1, 2] $ \n2 -> do
+    withUnsyncedHydraNode hydraTracer aliceChainConfig workDir 2 aliceSk [bobVk] nodePorts $ \n2 -> do
       waitMatch (10 * blockTime) n2 $ \v -> do
         guard $ v ^? key "tag" == Just "CommitRecorded"
         guard $ v ^? key "headId" == Just (toJSON headId)
@@ -287,7 +296,7 @@ resumeFromLatestKnownPoint tracer workDir opts hydraScriptsTxId = do
       <&> setNetworkId networkId
 
   chainSlot :: ChainSlot <-
-    withHydraNodeCatchingUp hydraTracer aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+    withSoloHydraNodeCatchingUp hydraTracer aliceChainConfig workDir 1 aliceSk [] $ \n1 -> do
       chainSlot <- waitMatch 20 n1 $ \v -> do
         guard $ v ^? key "tag" == Just "Greetings"
         guard $ v ^? key "headStatus" == Just (toJSON Idle)
@@ -299,7 +308,7 @@ resumeFromLatestKnownPoint tracer workDir opts hydraScriptsTxId = do
       pure chainSlot
 
   chainSlot' <-
-    withHydraNodeCatchingUp hydraTracer aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+    withSoloHydraNodeCatchingUp hydraTracer aliceChainConfig workDir 1 aliceSk [] $ \n1 -> do
       waitMatch 20 n1 $ \v -> do
         guard $ v ^? key "tag" == Just "Greetings"
         guard $ v ^? key "headStatus" == Just (toJSON Idle)
@@ -322,11 +331,11 @@ restartedNodeCanClose tracer workDir opts hydraScriptsTxId = do
       <&> modifyConfig (\config -> config{startChainFrom = Nothing})
 
   let hydraTracer = contramap FromHydraNode tracer
-  headId1 <- withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+  headId1 <- withSoloHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] $ \n1 -> do
     send n1 $ input "Init" []
     waitMatch (10 * blockTime) n1 $ headIsOpenWith (Set.fromList [alice])
 
-  withUnsyncedHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+  withUnsyncedSoloHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [] $ \n1 -> do
     -- Also expect to see past server outputs replayed
     headId2 <- waitMatch (20 * blockTime * 10) n1 $ headIsOpenWith (Set.fromList [alice])
     headId1 `shouldBe` headId2
@@ -335,7 +344,7 @@ restartedNodeCanClose tracer workDir opts hydraScriptsTxId = do
     waitMatch 20 n1 $ \v -> do
       guard $ v ^? key "tag" == Just "HeadIsClosed"
       guard $ v ^? key "headId" == Just (toJSON headId2)
-  withUnsyncedHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+  withUnsyncedSoloHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [] $ \n1 -> do
     waitMatch (20 * blockTime * 10) n1 $ \v -> do
       guard $ v ^? key "tag" == Just "Greetings"
       guard $ v ^? key "headStatus" == Just "Closed"
@@ -366,8 +375,9 @@ nodeReObservesOnChainTxs tracer workDir opts hydraScriptsTxId = do
 
   let hydraTracer = contramap FromHydraNode tracer
 
-  withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk] [2] $ \n1 -> do
-    (headId', decrementOuts) <- withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk] [1] $ \n2 -> do
+  nodePorts <- allocateHydraNodePortsFor [1, 2]
+  withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk] nodePorts $ \n1 -> do
+    (headId', decrementOuts) <- withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk] nodePorts $ \n2 -> do
       send n1 $ input "Init" []
 
       headId <- waitMatch (20 * blockTime) n1 $ headIsOpenWith (Set.fromList [alice, bob])
@@ -432,7 +442,7 @@ nodeReObservesOnChainTxs tracer workDir opts hydraScriptsTxId = do
       callProcess "cp" ["-r", workDir </> "state-2", tmpDir]
       callProcess "rm" ["-rf", tmpDir </> "state-2" </> "state*"]
       callProcess "rm" ["-rf", tmpDir </> "state-2" </> "last-known-revision"]
-      withUnsyncedHydraNode hydraTracer bobChainConfigFromTip tmpDir 2 bobSk [aliceVk] [1] $ \n2 -> do
+      withUnsyncedHydraNode hydraTracer bobChainConfigFromTip tmpDir 2 bobSk [aliceVk] nodePorts $ \n2 -> do
         -- Also expect to see past server outputs replayed
         headId2 <- waitMatch (10 * blockTime * 10) n2 $ headIsOpenWith (Set.fromList [alice, bob])
         headId2 `shouldBe` headId'
@@ -503,14 +513,14 @@ singlePartyHeadFullLifeCycle tracer workDir opts hydraScriptsTxId =
             , "changeAddress" .= changeAddress
             ]
 
-    withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+    withSoloHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] $ \n1 -> do
       -- Open head
       send n1 $ input "Init" []
       headId <- waitMatch (30 * blockTime) n1 $ headIsOpenWith (Set.fromList [alice])
       -- Deposit UTxO
       res <-
         runReq defaultHttpConfig $
-          req POST (http "127.0.0.1" /: "commit") (ReqBodyJson clientPayload) (Proxy :: Proxy (JsonResponse Tx)) (port $ 4000 + 1)
+          req POST (http "127.0.0.1" /: "commit") (ReqBodyJson clientPayload) (Proxy :: Proxy (JsonResponse Tx)) (hydraApiPort n1)
 
       let tx = signTx walletSk $ responseBody res
       runBackend opts $ submitTransaction tx
@@ -597,7 +607,8 @@ singlePartyOpenAHead tracer workDir opts hydraScriptsTxId persistenceRotateAfter
     utxoToDeposit <- seedFromFaucet opts walletVk (lovelaceToValue 100_000_000) (contramap FromFaucet tracer)
 
     let hydraTracer = contramap FromHydraNode tracer
-    options <- prepareHydraNode aliceChainConfig workDir 1 aliceSk [] [] id
+    nodePorts <- allocateHydraNodePortsFor [1]
+    options <- prepareHydraNode aliceChainConfig workDir 1 aliceSk [] nodePorts id
     let options' = options{persistenceRotateAfter}
     withPreparedHydraNode hydraTracer workDir 1 options' $ \n1 -> do
       void $ waitForNodesSynced (5 * blockTime) [n1]
@@ -632,7 +643,7 @@ canDeposit tracer workDir opts hydraScriptsTxId =
       aliceChainConfig <- chainConfigFor Alice workDir opts hydraScriptsTxId [] timing
       let hydraNodeId = 1
       let hydraTracer = contramap FromHydraNode tracer
-      withHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
+      withSoloHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] $ \n1 -> do
         send n1 $ input "Init" []
         headId <- waitMatch (10 * blockTime) n1 $ headIsOpenWith (Set.fromList [alice])
 
@@ -646,7 +657,7 @@ canDeposit tracer workDir opts hydraScriptsTxId =
               (http "127.0.0.1" /: "commit")
               (ReqBodyJson utxoToDeposit)
               (Proxy :: Proxy (JsonResponse (DraftCommitTxResponse Tx)))
-              (port $ 4000 + hydraNodeId)
+              (hydraApiPort n1)
 
         let DraftCommitTxResponse{commitTx} = responseBody res
         let depositTx = signTx walletSk commitTx
@@ -675,7 +686,7 @@ singlePartyUsesScriptOnL2 tracer workDir opts hydraScriptsTxId =
       aliceChainConfig <- chainConfigFor Alice workDir opts hydraScriptsTxId [] timing
       let hydraNodeId = 1
       let hydraTracer = contramap FromHydraNode tracer
-      withHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
+      withSoloHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] $ \n1 -> do
         send n1 $ input "Init" []
         headId <- waitMatch (10 * blockTime) n1 $ headIsOpenWith (Set.fromList [alice])
 
@@ -798,7 +809,7 @@ singlePartyUsesWithdrawZeroTrick tracer workDir opts hydraScriptsTxId =
         let hydraNodeId = 1
         let hydraTracer = contramap FromHydraNode tracer
         networkId <- runBackend opts queryNetworkId
-        withHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
+        withSoloHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] $ \n1 -> do
           send n1 $ input "Init" []
           headId <- waitMatch (10 * blockTime) n1 $ headIsOpenWith (Set.fromList [alice])
           -- Deposit funds into head
@@ -870,7 +881,7 @@ canDepositScriptBlueprint tracer workDir opts hydraScriptsTxId =
       chainConfigFor Alice workDir opts hydraScriptsTxId [] timing
     let hydraNodeId = 1
     let hydraTracer = contramap FromHydraNode tracer
-    withHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
+    withSoloHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] $ \n1 -> do
       send n1 $ input "Init" []
       headId <- waitMatch (10 * blockTime) n1 $ headIsOpenWith (Set.fromList [alice])
       (clientPayload, blueprint) <- prepareScriptPayload 7_000_000
@@ -878,7 +889,7 @@ canDepositScriptBlueprint tracer workDir opts hydraScriptsTxId =
       commitTx <-
         fmap responseBody $
           runReq defaultHttpConfig $
-            req POST (http "127.0.0.1" /: "commit") (ReqBodyJson clientPayload) (Proxy :: Proxy (JsonResponse Tx)) (port $ 4000 + hydraNodeId)
+            req POST (http "127.0.0.1" /: "commit") (ReqBodyJson clientPayload) (Proxy :: Proxy (JsonResponse Tx)) (hydraApiPort n1)
       runBackend opts $ submitTransaction commitTx
 
       -- The deposited UTxO in the head is keyed by the blueprint tx's outputs.
@@ -922,10 +933,10 @@ persistenceCanLoadWithNothingCommitted tracer workDir opts hydraScriptsTxId =
     aliceChainConfig <- chainConfigFor Alice workDir opts hydraScriptsTxId [] timing
     let hydraNodeId = 1
     let hydraTracer = contramap FromHydraNode tracer
-    headId <- withHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
+    headId <- withSoloHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] $ \n1 -> do
       send n1 $ input "Init" []
       waitMatch (10 * blockTime) n1 $ headIsOpenWith (Set.fromList [alice])
-    withUnsyncedHydraNode hydraTracer aliceChainConfig workDir hydraNodeId aliceSk [] [1] $ \n1 -> do
+    withUnsyncedSoloHydraNode hydraTracer aliceChainConfig workDir hydraNodeId aliceSk [] $ \n1 -> do
       headId' <- waitMatch (20 * blockTime) n1 $ headIsOpenWith (Set.fromList [alice])
       headId' `shouldBe` headId
 
@@ -951,7 +962,7 @@ canCloseWithLongContestationPeriod tracer workDir opts hydraScriptsTxId = do
     chainConfigFor' Alice workDir opts hydraScriptsTxId [] oneWeek defaultDepositPeriod
       <&> modifyConfig (\config -> config{startChainFrom = Just tip})
   let hydraTracer = contramap FromHydraNode tracer
-  withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+  withSoloHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] $ \n1 -> do
     -- Initialize & open head
     send n1 $ input "Init" []
     _headId <- waitMatch (10 * blockTime) n1 $ headIsOpenWith (Set.fromList [alice])
@@ -981,7 +992,7 @@ canSubmitTransactionThroughAPI tracer workDir opts hydraScriptsTxId =
     aliceChainConfig <- chainConfigFor Alice workDir opts hydraScriptsTxId [] timing
     let hydraNodeId = 1
     let hydraTracer = contramap FromHydraNode tracer
-    withHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] [hydraNodeId] $ \_ -> do
+    withSoloHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] $ \n1 -> do
       -- let's prepare a _user_ transaction from Bob to Carol
       (cardanoBobVk, cardanoBobSk) <- keysFor Bob
       (cardanoCarolVk, _) <- keysFor Carol
@@ -1002,23 +1013,23 @@ canSubmitTransactionThroughAPI tracer workDir opts hydraScriptsTxId =
         Right tx -> do
           let unsignedTx = makeSignedTransaction [] $ getTxBody tx
           let unsignedRequest = toJSON unsignedTx
-          sendRequest hydraNodeId unsignedRequest
+          sendRequest n1 unsignedRequest
             `shouldThrow` expectErrorStatus 400 (Just "MissingVKeyWitnessesUTXOW")
 
           let signedTx = signTx cardanoBobSk unsignedTx
           let signedRequest = toJSON signedTx
-          (sendRequest hydraNodeId signedRequest <&> responseBody)
+          (sendRequest n1 signedRequest <&> responseBody)
             `shouldReturn` TransactionSubmitted
  where
-  sendRequest :: (MonadIO m, ToJSON tx) => Int -> tx -> m (JsonResponse TransactionSubmitted)
-  sendRequest hydraNodeId tx =
+  sendRequest :: (MonadIO m, ToJSON tx) => HydraClient -> tx -> m (JsonResponse TransactionSubmitted)
+  sendRequest client tx =
     runReq defaultHttpConfig $
       req
         POST
         (http "127.0.0.1" /: "cardano-transaction")
         (ReqBodyJson tx)
         (Proxy :: Proxy (JsonResponse TransactionSubmitted))
-        (port $ 4000 + hydraNodeId)
+        (hydraApiPort client)
 
 -- | Three hydra nodes open a head and we assert that none of them sees errors.
 -- This was particularly misleading when everyone tries to post the collect
@@ -1088,9 +1099,12 @@ nodeCanSupportMultipleEtcdClusters tracer workDir opts hydraScriptsTxId = do
 
   let hydraTracer = contramap FromHydraNode tracer
 
-  withUnsyncedHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [bobVk, carolVk] [1, 2, 3] $ \n1 -> do
-    withUnsyncedHydraNode hydraTracer bobChainConfig workDir 2 bobSk [aliceVk, carolVk] [1, 2, 3] $ \n2 -> do
-      withUnsyncedHydraNode hydraTracer carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] $ \n3 -> do
+  nodePorts <- allocateHydraNodePortsFor [1, 2, 3]
+  let subClusterPorts = Map.restrictKeys nodePorts (Set.fromList [2, 3])
+
+  withUnsyncedHydraNode hydraTracer aliceChainConfig workDir 1 aliceSk [bobVk, carolVk] nodePorts $ \n1 -> do
+    withUnsyncedHydraNode hydraTracer bobChainConfig workDir 2 bobSk [aliceVk, carolVk] nodePorts $ \n2 -> do
+      withUnsyncedHydraNode hydraTracer carolChainConfig workDir 3 carolSk [aliceVk, bobVk] nodePorts $ \n3 -> do
         waitForNodesConnected hydraTracer 30 $ n1 :| [n2, n3]
 
     bobChainConfig' <-
@@ -1102,12 +1116,12 @@ nodeCanSupportMultipleEtcdClusters tracer workDir opts hydraScriptsTxId = do
 
     waitForNodesDisconnected hydraTracer 60 $ n1 :| []
 
-    withUnsyncedHydraNode hydraTracer bobChainConfig' workDir 2 bobSk [carolVk] [2, 3] $ \n2 -> do
-      withUnsyncedHydraNode hydraTracer carolChainConfig' workDir 3 carolSk [bobVk] [2, 3] $ \n3 -> do
+    withUnsyncedHydraNode hydraTracer bobChainConfig' workDir 2 bobSk [carolVk] subClusterPorts $ \n2 -> do
+      withUnsyncedHydraNode hydraTracer carolChainConfig' workDir 3 carolSk [bobVk] subClusterPorts $ \n3 -> do
         waitForNodesConnected hydraTracer 30 $ n2 :| [n3]
 
-    withUnsyncedHydraNode hydraTracer bobChainConfig workDir 2 bobSk [aliceVk, carolVk] [1, 2, 3] $ \n2 -> do
-      withUnsyncedHydraNode hydraTracer carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] $ \n3 -> do
+    withUnsyncedHydraNode hydraTracer bobChainConfig workDir 2 bobSk [aliceVk, carolVk] nodePorts $ \n2 -> do
+      withUnsyncedHydraNode hydraTracer carolChainConfig workDir 3 carolSk [aliceVk, bobVk] nodePorts $ \n3 -> do
         waitForNodesConnected hydraTracer 30 $ n1 :| [n2, n3]
 
 -- | Two hydra node setup where Alice is wrongly configured to use Carol's
@@ -1124,8 +1138,9 @@ initWithWrongKeys workDir tracer opts hydraScriptsTxId = do
   bobChainConfig <- chainConfigFor Bob workDir opts hydraScriptsTxId [Alice] timing
 
   let hydraTracer = contramap FromHydraNode tracer
-  withHydraNode hydraTracer blockTime aliceChainConfig workDir 3 aliceSk [bobVk] [3, 4] $ \n1 -> do
-    withHydraNode hydraTracer blockTime bobChainConfig workDir 4 bobSk [aliceVk] [3, 4] $ \n2 -> do
+  nodePorts <- allocateHydraNodePortsFor [3, 4]
+  withHydraNode hydraTracer blockTime aliceChainConfig workDir 3 aliceSk [bobVk] nodePorts $ \n1 -> do
+    withHydraNode hydraTracer blockTime bobChainConfig workDir 4 bobSk [aliceVk] nodePorts $ \n2 -> do
       seedFromFaucet_ opts aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
       send n1 $ input "Init" []
       headId <-
@@ -1155,9 +1170,11 @@ startWithWrongPeers workDir tracer opts hydraScriptsTxId = do
   bobChainConfig <- chainConfigFor Bob workDir opts hydraScriptsTxId [Alice] timing
 
   let hydraTracer = contramap FromHydraNode tracer
-  withHydraNode hydraTracer blockTime aliceChainConfig workDir 3 aliceSk [bobVk] [3, 4] $ \n1 -> do
+  nodePorts <- allocateHydraNodePortsFor [3, 4]
+  let bobAlonePorts = Map.restrictKeys nodePorts (Set.singleton 4)
+  withHydraNode hydraTracer blockTime aliceChainConfig workDir 3 aliceSk [bobVk] nodePorts $ \n1 -> do
     -- NOTE: here we deliberately use the wrong peer list for Bob
-    withHydraNode hydraTracer blockTime bobChainConfig workDir 4 bobSk [aliceVk] [4] $ \_ -> do
+    withHydraNode hydraTracer blockTime bobChainConfig workDir 4 bobSk [aliceVk] bobAlonePorts $ \_ -> do
       seedFromFaucet_ opts aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
 
       (clusterPeers, configuredPeers) <- waitMatch (20 * blockTime) n1 $ \v -> do
@@ -1168,8 +1185,12 @@ startWithWrongPeers workDir tracer opts hydraScriptsTxId = do
 
       when (clusterPeers == configuredPeers) $
         failure "Expected clusterPeers and configuredPeers to be different"
-      clusterPeers `shouldBe` "0.0.0.0:5003=http://0.0.0.0:5003,0.0.0.0:5004=http://0.0.0.0:5004"
-      configuredPeers `shouldBe` "0.0.0.0:5004=http://0.0.0.0:5004"
+      let alicePort = listenPort (nodePorts Map.! 3)
+          bobPort = listenPort (nodePorts Map.! 4)
+          peerEntry :: Network.PortNumber -> Text
+          peerEntry p = "0.0.0.0:" <> show p <> "=http://0.0.0.0:" <> show p
+      clusterPeers `shouldBe` peerEntry alicePort <> "," <> peerEntry bobPort
+      configuredPeers `shouldBe` peerEntry bobPort
 
 -- | Open a a two participant head, deposit funds to it and distribute them on fanout.
 canDepositConcurrently :: Tracer IO EndToEndLog -> FilePath -> ChainBackendOptions -> [TxId] -> IO ()
@@ -1188,8 +1209,9 @@ canDepositConcurrently tracer workDir opts hydraScriptsTxId =
       bobChainConfig <-
         chainConfigFor Bob workDir opts hydraScriptsTxId [Alice] timing
           <&> setNetworkId networkId
-      withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk] [2] $ \n1 -> do
-        withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk] [1] $ \n2 -> do
+      nodePorts <- allocateHydraNodePortsFor [1, 2]
+      withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk] nodePorts $ \n1 -> do
+        withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk] nodePorts $ \n2 -> do
           send n1 $ input "Init" []
           headId <- waitForAllMatch (10 * blockTime) [n1, n2] $ headIsOpenWith (Set.fromList [alice, bob])
 
@@ -1261,7 +1283,8 @@ rejectDeposit tracer workDir opts hydraScriptsTxId =
         <&> setNetworkId networkId
 
     let pparamsDecorator = atKey "utxoCostPerByte" ?~ toJSON (Aeson.Number 4310)
-    optionsWithUTxOCostPerByte <- prepareHydraNode aliceChainConfig workDir 1 aliceSk [] [] pparamsDecorator
+    nodePorts <- allocateHydraNodePortsFor [1]
+    optionsWithUTxOCostPerByte <- prepareHydraNode aliceChainConfig workDir 1 aliceSk [] nodePorts pparamsDecorator
     withPreparedHydraNode hydraTracer workDir 1 optionsWithUTxOCostPerByte $ \n1 -> do
       void $ waitForNodesSynced (10 * blockTime) [n1]
       send n1 $ input "Init" []
@@ -1302,7 +1325,7 @@ canDepositPartially tracer workDir opts hydraScriptsTxId =
       chainConfigFor Alice workDir opts hydraScriptsTxId [] timing
         <&> setNetworkId networkId
     let hydraTracer = contramap FromHydraNode tracer
-    withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+    withSoloHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] $ \n1 -> do
       send n1 $ input "Init" []
       headId <- waitMatch (10 * blockTime) n1 $ headIsOpenWith (Set.fromList [alice])
 
@@ -1331,7 +1354,7 @@ canDepositPartially tracer workDir opts hydraScriptsTxId =
 
       res <-
         runReq defaultHttpConfig $
-          req POST (http "127.0.0.1" /: "commit") (ReqBodyJson clientPayload) (Proxy :: Proxy (JsonResponse Tx)) (port $ 4000 + 1)
+          req POST (http "127.0.0.1" /: "commit") (ReqBodyJson clientPayload) (Proxy :: Proxy (JsonResponse Tx)) (hydraApiPort n1)
 
       let tx = signTx walletSk $ responseBody res
       runBackend opts $ submitTransaction tx
@@ -1361,8 +1384,9 @@ canRecoverDeposit tracer workDir opts hydraScriptsTxId =
       bobChainConfig <-
         chainConfigFor Bob workDir opts hydraScriptsTxId [Alice] timing
           <&> setNetworkId networkId
-      withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk] [2] $ \n1 -> do
-        headId <- withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk] [1] $ \n2 -> do
+      nodePorts <- allocateHydraNodePortsFor [1, 2]
+      withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk] nodePorts $ \n1 -> do
+        headId <- withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk] nodePorts $ \n2 -> do
           send n1 $ input "Init" []
           waitForAllMatch (10 * blockTime) [n1, n2] $ headIsOpenWith (Set.fromList [alice, bob])
         -- stop the second node here
@@ -1441,7 +1465,7 @@ canRecoverDepositInAnyState tracer workDir opts hydraScriptsTxId =
     aliceChainConfig <-
       chainConfigFor Alice workDir opts hydraScriptsTxId [] timing
         <&> setNetworkId networkId
-    withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+    withSoloHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] $ \n1 -> do
       -- Init the head
       send n1 $ input "Init" []
       headId <- waitMatch (10 * blockTime) n1 $ headIsOpenWith (Set.fromList [alice])
@@ -1554,8 +1578,9 @@ canSeePendingDeposits tracer workDir opts hydraScriptsTxId =
       bobChainConfig <-
         chainConfigFor Bob workDir opts hydraScriptsTxId [Alice] timing
           <&> setNetworkId networkId
-      withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk] [2] $ \n1 -> do
-        _ <- withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk] [1] $ \n2 -> do
+      nodePorts <- allocateHydraNodePortsFor [1, 2]
+      withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk] nodePorts $ \n1 -> do
+        _ <- withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk] nodePorts $ \n2 -> do
           send n1 $ input "Init" []
           _ <- waitForAllMatch (10 * blockTime) [n1, n2] $ headIsOpenWith (Set.fromList [alice, bob])
           -- Stop Bob here so deposits stay pending (can't reach CommitFinalized without both nodes).
@@ -1600,7 +1625,7 @@ canDecommit tracer workDir opts hydraScriptsTxId =
     aliceChainConfig <-
       chainConfigFor Alice workDir opts hydraScriptsTxId [] timing
         <&> setNetworkId networkId
-    withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+    withSoloHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] $ \n1 -> do
       -- Initialize & open head
       send n1 $ input "Init" []
       headId <- waitMatch (10 * blockTime) n1 $ headIsOpenWith (Set.fromList [alice])
@@ -1703,7 +1728,7 @@ canSideLoadSnapshot tracer workDir opts hydraScriptsTxId = do
     chainConfigFor Alice workDir opts hydraScriptsTxId [] timing
       <&> setNetworkId networkId
 
-  withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+  withSoloHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] $ \n1 -> do
     aliceUTxO <- seedFromFaucet opts aliceCardanoVk (lovelaceToValue 2_000_000) (contramap FromFaucet tracer)
 
     send n1 $ input "Init" []
@@ -1748,11 +1773,12 @@ canResumeOnMemberAlreadyBootstrapped tracer workDir opts hydraScriptsTxId = do
   bobChainConfig <-
     chainConfigFor Bob workDir opts hydraScriptsTxId [Alice] timing
       <&> setNetworkId networkId
-  withHydraNodeCatchingUp hydraTracer aliceChainConfig workDir 1 aliceSk [bobVk] [1, 2] $ \n1 -> do
+  nodePorts <- allocateHydraNodePortsFor [1, 2]
+  withHydraNodeCatchingUp hydraTracer aliceChainConfig workDir 1 aliceSk [bobVk] nodePorts $ \n1 -> do
     waitMatch (20 * blockTime) n1 $ \v -> do
       guard $ v ^? key "tag" == Just "Greetings"
       guard $ v ^? key "headStatus" == Just (toJSON Idle)
-    withHydraNodeCatchingUp hydraTracer bobChainConfig workDir 2 bobSk [aliceVk] [1, 2] $ \n2 -> do
+    withHydraNodeCatchingUp hydraTracer bobChainConfig workDir 2 bobSk [aliceVk] nodePorts $ \n2 -> do
       waitMatch (20 * blockTime) n2 $ \v -> do
         guard $ v ^? key "tag" == Just "Greetings"
         guard $ v ^? key "headStatus" == Just (toJSON Idle)
@@ -1761,13 +1787,13 @@ canResumeOnMemberAlreadyBootstrapped tracer workDir opts hydraScriptsTxId = do
     callProcess "rm" ["-rf", workDir </> "state-2"]
     threadDelay 1
 
-    withHydraNodeCatchingUp hydraTracer bobChainConfig workDir 2 bobSk [aliceVk] [1, 2] (const $ threadDelay 1)
+    withHydraNodeCatchingUp hydraTracer bobChainConfig workDir 2 bobSk [aliceVk] nodePorts (const $ threadDelay 1)
       `shouldThrow` \(e :: SomeException) ->
         "hydra-node" `isInfixOf` show e
           && "etcd" `isInfixOf` show e
 
     setEnv "ETCD_INITIAL_CLUSTER_STATE" "existing"
-    withHydraNodeCatchingUp hydraTracer bobChainConfig workDir 2 bobSk [aliceVk] [1, 2] (const $ pure ())
+    withHydraNodeCatchingUp hydraTracer bobChainConfig workDir 2 bobSk [aliceVk] nodePorts (const $ pure ())
     unsetEnv "ETCD_INITIAL_CLUSTER_STATE"
  where
   hydraTracer = contramap FromHydraNode tracer
@@ -1794,10 +1820,11 @@ waitsForChainInSyncAndSecure tracer workDir opts hydraScriptsTxId = do
     chainConfigFor Carol workDir opts hydraScriptsTxId [Alice, Bob] timing
       <&> setNetworkId networkId
 
-  withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk, carolVk] [1, 2, 3] $ \n1 -> do
-    withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk, carolVk] [1, 2, 3] $ \n2 -> do
+  nodePorts <- allocateHydraNodePortsFor [1, 2, 3]
+  withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk, carolVk] nodePorts $ \n1 -> do
+    withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk, carolVk] nodePorts $ \n2 -> do
       -- Open a head while Carol online
-      headId <- withHydraNode hydraTracer blockTime carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] $ \n3 -> do
+      headId <- withHydraNode hydraTracer blockTime carolChainConfig workDir 3 carolSk [aliceVk, bobVk] nodePorts $ \n3 -> do
         send n1 $ input "Init" []
         headId <- waitForAllMatch (10 * blockTime) [n1, n2, n3] $ headIsOpenWith (Set.fromList [alice, bob, carol])
 
@@ -1827,7 +1854,7 @@ waitsForChainInSyncAndSecure tracer workDir opts hydraScriptsTxId = do
         guard $ v ^? key "headId" == Just (toJSON headId)
 
       -- Carol restarts
-      withHydraNodeCatchingUp hydraTracer carolChainConfig workDir 3 carolSk [aliceVk, bobVk] [1, 2, 3] $ \n3 -> do
+      withHydraNodeCatchingUp hydraTracer carolChainConfig workDir 3 carolSk [aliceVk, bobVk] nodePorts $ \n3 -> do
         -- The node reports that it is in the Open state when restarting.
         -- NOTE: chainSyncedStatus in Greetings reflects the persisted sync status
         -- (InSync from last session), not the current one. The node may not have
@@ -1884,11 +1911,11 @@ threeNodesWithMirrorParty tracer workDir opts hydraScriptsTxId = do
       <&> setNetworkId networkId
 
   let hydraTracer = contramap FromHydraNode tracer
-  let allNodeIds = [1, 2, 3]
-  withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk] allNodeIds $ \n1 -> do
-    withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk] allNodeIds $ \n2 -> do
+  nodePorts <- allocateHydraNodePortsFor [1, 2, 3]
+  withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [bobVk] nodePorts $ \n1 -> do
+    withHydraNode hydraTracer blockTime bobChainConfig workDir 2 bobSk [aliceVk] nodePorts $ \n2 -> do
       -- One party will participate using same hydra credentials
-      withHydraNode hydraTracer blockTime aliceChainConfig workDir 3 aliceSk [bobVk] allNodeIds $ \n3 -> do
+      withHydraNode hydraTracer blockTime aliceChainConfig workDir 3 aliceSk [bobVk] nodePorts $ \n3 -> do
         let clients = [n1, n2, n3]
         send n1 $ input "Init" []
         headId <- waitForAllMatch (10 * blockTime) clients $ headIsOpenWith (Set.fromList [alice, bob])
@@ -2044,6 +2071,14 @@ expectErrorStatus
     assertBodyContains Nothing _ = False
 expectErrorStatus _ _ _ = False
 
--- | Get the base URL for HTTP API calls to a hydra-node.
+-- | Get the base URL for HTTP API calls to a hydra-node, using the actual
+-- API port the node was started on (allocated dynamically by
+-- 'allocateHydraNodePorts').
 hydraNodeBaseUrl :: HydraClient -> String
-hydraNodeBaseUrl HydraClient{hydraNodeId} = "http://127.0.0.1:" <> show (4000 + hydraNodeId)
+hydraNodeBaseUrl HydraClient{apiHost} =
+  "http://127.0.0.1:" <> show (Network.port apiHost)
+
+-- | An 'Option' carrying a hydra-node's actual API port. Use to set
+-- the port in a 'Network.HTTP.Req.req' call.
+hydraApiPort :: HydraClient -> Option scheme
+hydraApiPort HydraClient{apiHost} = port (fromIntegral (Network.port apiHost))

--- a/hydra-cluster/src/Hydra/Cluster/SecurityScenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/SecurityScenarios.hs
@@ -106,7 +106,7 @@ import HydraNode (
   requestCommitTx,
   send,
   waitMatch,
-  withHydraNode,
+  withSoloHydraNode,
  )
 import PlutusLedgerApi.V3 (toBuiltin)
 import Test.Hydra.Tx.Gen (genKeyPair)
@@ -134,7 +134,7 @@ cannotStealDepositWithoutHeadInput tracer workDir opts hydraScriptsTxId =
       chainConfigFor Alice workDir opts hydraScriptsTxId [] timing
         <&> setNetworkId networkId
     let hydraTracer = contramap FromHydraNode tracer
-    withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+    withSoloHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] $ \n1 -> do
       send n1 $ input "Init" []
       _headId <- waitMatch (10 * blockTime) n1 $ headIsOpenWith (Set.fromList [alice])
 
@@ -196,7 +196,7 @@ cannotStealDepositWithCounterfeitHeadToken tracer workDir opts hydraScriptsTxId 
       chainConfigFor Alice workDir opts hydraScriptsTxId [] timing
         <&> setNetworkId networkId
     let hydraTracer = contramap FromHydraNode tracer
-    withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+    withSoloHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] $ \n1 -> do
       send n1 $ input "Init" []
       _headId <- waitMatch (10 * blockTime) n1 $ headIsOpenWith (Set.fromList [alice])
 
@@ -404,7 +404,7 @@ cannotRedirectExtraDepositDuringIncrement tracer workDir opts hydraScriptsTxId =
     -- get a chance to submit its own honest Increment that would race the
     -- redirection.
     (headId, victim1Vk, deposit1TxId, victim2Vk, deposit2TxId) <-
-      withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+      withSoloHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] $ \n1 -> do
         send n1 $ input "Init" []
         hid <- waitMatch (10 * blockTime) n1 $ headIsOpenWith (Set.fromList [alice])
         (vVk1, dTxId1) <- placeVictimDepositNoWait tracer opts n1 5_000_000
@@ -655,7 +655,7 @@ cannotAbsorbDepositDuringClose tracer workDir opts hydraScriptsTxId =
     -- Bootstrap the head and craft the deposit tx; exit before the node
     -- can auto-Increment.
     (headId, victimVk, depositTxId') <-
-      withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+      withSoloHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] $ \n1 -> do
         send n1 $ input "Init" []
         hid <- waitMatch (10 * blockTime) n1 $ headIsOpenWith (Set.fromList [alice])
         (vVk, dTxId) <- placeVictimDepositNoWait tracer opts n1 5_000_000
@@ -802,7 +802,7 @@ cannotStealLargerDepositDuringOwnIncrement tracer workDir opts hydraScriptsTxId 
     -- over. The "victim" deposit is much larger (20 ADA) and is what the
     -- leader will redirect.
     (headId, leaderDepositorVk, leaderDepositTxId, victimVk, victimDepositTxId) <-
-      withHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] [1] $ \n1 -> do
+      withSoloHydraNode hydraTracer blockTime aliceChainConfig workDir 1 aliceSk [] $ \n1 -> do
         send n1 $ input "Init" []
         hid <- waitMatch (10 * blockTime) n1 $ headIsOpenWith (Set.fromList [alice])
         (lVk, lTxId) <- placeVictimDepositNoWait tracer opts n1 3_000_000

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -359,20 +359,37 @@ data HydraNodePorts = HydraNodePorts
 -- | Allocate three unused TCP ports from the OS for a single hydra-node.
 allocateHydraNodePorts :: IO HydraNodePorts
 allocateHydraNodePorts = do
-  [a, l, m] <- randomUnusedTCPPorts 3
-  pure
-    HydraNodePorts
-      { apiPort = fromIntegral a
-      , listenPort = fromIntegral l
-      , monitoringPort = fromIntegral m
-      }
+  m <- allocateHydraNodePortsFor [0]
+  case Map.lookup 0 m of
+    Just ports -> pure ports
+    Nothing -> Prelude.error "allocateHydraNodePorts: empty allocation"
 
 -- | Allocate ports for every node in a cluster up front. The returned map
 -- must be passed to every 'prepareHydraNode' / 'withHydraNode' call for
 -- nodes in this cluster so peers can be addressed correctly.
+--
+-- All @3 * length nodeIds@ ports are requested in a single
+-- 'randomUnusedTCPPorts' call so they're mutually unique. A per-node loop
+-- would close each batch's sockets between calls, letting the kernel hand
+-- back a just-released port to a later node — which is exactly how
+-- @--listen@ for one node ended up equal to @--monitoring-port@ for another
+-- and crashed etcd with @EADDRINUSE@ in the 'two heads on the same network'
+-- test.
 allocateHydraNodePortsFor :: [Int] -> IO (Map Int HydraNodePorts)
-allocateHydraNodePortsFor nodeIds =
-  Map.fromList <$> traverse (\i -> (i,) <$> allocateHydraNodePorts) nodeIds
+allocateHydraNodePortsFor nodeIds = do
+  ports <- randomUnusedTCPPorts (3 * length nodeIds)
+  pure $ Map.fromList $ zip nodeIds (chunk3 ports)
+ where
+  chunk3 :: [Int] -> [HydraNodePorts]
+  chunk3 = \case
+    a : l : m : rest ->
+      HydraNodePorts
+        { apiPort = fromIntegral a
+        , listenPort = fromIntegral l
+        , monitoringPort = fromIntegral m
+        }
+        : chunk3 rest
+    _ -> []
 
 -- | Process-global cache mapping each @(workDir, nodeId)@ to its allocated
 -- ports. The cache exists because restart-style tests (re-running

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -409,7 +409,8 @@ soloHydraNodePortsFor workDir nodeId = do
     Just ports -> pure ports
     Nothing -> do
       ports <- allocateHydraNodePorts
-      atomicModifyIORef' soloHydraNodePortsCache (Map.insert (workDir, nodeId) ports)
+      atomicModifyIORef' soloHydraNodePortsCache $ \m ->
+        (Map.insert (workDir, nodeId) ports m, ())
       pure ports
 
 -- | Prepare protocol-parameters to run a hydra-node with given 'ChainConfig' and using the config from

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -409,7 +409,7 @@ soloHydraNodePortsFor workDir nodeId = do
     Just ports -> pure ports
     Nothing -> do
       ports <- allocateHydraNodePorts
-      modifyIORef' soloHydraNodePortsCache (Map.insert (workDir, nodeId) ports)
+      atomicModifyIORef' soloHydraNodePortsCache (Map.insert (workDir, nodeId) ports)
       pure ports
 
 -- | Prepare protocol-parameters to run a hydra-node with given 'ChainConfig' and using the config from

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -21,12 +21,13 @@ import Data.Aeson.Lens (atKey, key, _String)
 import Data.Aeson.Types (Pair)
 import Data.ByteString (hGetContents)
 import Data.List qualified as List
+import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 import Hydra.API.HTTPServer (DraftCommitTxRequest (..), DraftCommitTxResponse (..))
 import Hydra.Chain.Blockfrost.Client qualified as Blockfrost
 import Hydra.Cluster.Util (Timing (..), readConfigFile)
 import Hydra.Logging (Tracer, Verbosity (..), traceWith)
-import Hydra.Network (Host (Host), NodeId (NodeId), WhichEtcd (EmbeddedEtcd))
+import Hydra.Network (Host (Host), NodeId (NodeId), WhichEtcd (SystemEtcd))
 import Hydra.Network qualified as Network
 import Hydra.Options (BlockfrostOptions (..), CardanoChainConfig (..), ChainBackendOptions (..), ChainConfig (..), DirectOptions (..), LedgerConfig (..), RunOptions (..), defaultBFQueryTimeout, defaultCardanoChainConfig, defaultDirectOptions, nodeSocket, toArgs)
 import Hydra.Tx (ConfirmedSnapshot)
@@ -38,6 +39,7 @@ import Network.HTTP.Simple (getResponseBody, httpJSON, httpLbs, setRequestBodyJS
 import Network.WebSockets (Connection, ConnectionException, HandshakeException, receiveData, runClient, sendClose, sendTextData)
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath ((<.>), (</>))
+import System.IO.Unsafe (unsafePerformIO)
 import System.Info (os)
 import System.Process.Typed (
   ExitCode (..),
@@ -52,6 +54,7 @@ import System.Process.Typed (
  )
 import Test.Hydra.Prelude (failure)
 import Test.Hydra.Prelude qualified as Prelude
+import Test.Network.Ports (randomUnusedTCPPorts)
 import Prelude qualified
 
 -- * Client to interact with a hydra-node
@@ -59,6 +62,8 @@ import Prelude qualified
 data HydraClient = HydraClient
   { hydraNodeId :: Int
   , apiHost :: Host
+  , monitoringPort :: Maybe Network.PortNumber
+  -- ^ Port the hydra-node exposes Prometheus metrics on, if enabled.
   , connection :: Connection
   , tracer :: Tracer IO HydraNodeLog
   }
@@ -249,19 +254,22 @@ getSnapshotConfirmed HydraClient{apiHost = Host{hostname, port}} =
       (Req.port (fromInteger . toInteger $ port))
 
 getMetrics :: HasCallStack => HydraClient -> IO ByteString
-getMetrics HydraClient{hydraNodeId, apiHost = Host{hostname}} = do
+getMetrics HydraClient{hydraNodeId, apiHost = Host{hostname}, monitoringPort} = do
+  metricsPort <- case monitoringPort of
+    Just p -> pure p
+    Nothing -> failure $ "Cannot fetch metrics: hydra-node " <> show hydraNodeId <> " has no monitoringPort configured."
   Prelude.failAfter 3 $
-    try (runReq defaultHttpConfig request) >>= \case
+    try (runReq defaultHttpConfig (request metricsPort)) >>= \case
       Left (e :: HttpException) -> failure $ "Request for hydra-node metrics failed: " <> show e
       Right body -> pure $ Req.responseBody body
  where
-  request =
+  request metricsPort =
     Req.req
       GET
       (Req.http hostname /: "metrics")
       NoReqBody
       Req.bsResponse
-      (Req.port $ 6_000 + hydraNodeId)
+      (Req.port (fromIntegral metricsPort))
 
 -- * Start / connect to a cluster of nodes
 
@@ -294,13 +302,14 @@ withHydraCluster tracer timing workDir nodeSocket firstNodeId allKeys hydraKeys 
     let skFile = File $ workDir </> show ix <.> "sk"
     void $ writeFileTextEnvelope vkFile Nothing vk
     void $ writeFileTextEnvelope skFile Nothing sk
-  startNodes [] allNodeIds
+  nodePorts <- allocateHydraNodePortsFor allNodeIds
+  startNodes nodePorts [] allNodeIds
  where
   clusterSize = length allKeys
 
   allNodeIds = [firstNodeId .. firstNodeId + clusterSize - 1]
 
-  startNodes clients = \case
+  startNodes nodePorts clients = \case
     [] -> action (fromList $ reverse clients)
     (nodeId : rest) -> do
       let hydraSigningKey = hydraKeys Prelude.!! (nodeId - firstNodeId)
@@ -329,12 +338,62 @@ withHydraCluster tracer timing workDir nodeSocket firstNodeId allKeys hydraKeys 
         nodeId
         hydraSigningKey
         hydraVerificationKeys
-        allNodeIds
-        (\c -> startNodes (c : clients) rest)
+        nodePorts
+        (\c -> startNodes nodePorts (c : clients) rest)
 
   Timing{blockTime, contestationPeriod, depositPeriod} = timing
 
 -- * Start / connect to a hydra-node
+
+-- | The three ports a hydra-node binds: API, peer-to-peer listen, and the
+-- optional Prometheus monitoring endpoint. Callers allocate these via
+-- 'allocateHydraNodePorts' (or pre-allocate a full cluster) and thread them
+-- through 'prepareHydraNode' / 'withHydraNode'.
+data HydraNodePorts = HydraNodePorts
+  { apiPort :: Network.PortNumber
+  , listenPort :: Network.PortNumber
+  , monitoringPort :: Network.PortNumber
+  }
+  deriving stock (Show, Eq)
+
+-- | Allocate three unused TCP ports from the OS for a single hydra-node.
+allocateHydraNodePorts :: IO HydraNodePorts
+allocateHydraNodePorts = do
+  [a, l, m] <- randomUnusedTCPPorts 3
+  pure
+    HydraNodePorts
+      { apiPort = fromIntegral a
+      , listenPort = fromIntegral l
+      , monitoringPort = fromIntegral m
+      }
+
+-- | Allocate ports for every node in a cluster up front. The returned map
+-- must be passed to every 'prepareHydraNode' / 'withHydraNode' call for
+-- nodes in this cluster so peers can be addressed correctly.
+allocateHydraNodePortsFor :: [Int] -> IO (Map Int HydraNodePorts)
+allocateHydraNodePortsFor nodeIds =
+  Map.fromList <$> traverse (\i -> (i,) <$> allocateHydraNodePorts) nodeIds
+
+-- | Process-global cache mapping each @(workDir, nodeId)@ to its allocated
+-- ports. The cache exists because restart-style tests (re-running
+-- 'withSoloHydraNode' or similar against the same @workDir@) depend on
+-- etcd's persistent cluster state, which is keyed by the listen URL. If a
+-- restart picked fresh ports, etcd would refuse to start.
+{-# NOINLINE soloHydraNodePortsCache #-}
+soloHydraNodePortsCache :: IORef (Map (FilePath, Int) HydraNodePorts)
+soloHydraNodePortsCache = unsafePerformIO (newIORef mempty)
+
+-- | Allocate ports for a single hydra-node, memoizing the result for the
+-- given @(workDir, nodeId)@ so that subsequent calls reuse the same ports.
+soloHydraNodePortsFor :: FilePath -> Int -> IO HydraNodePorts
+soloHydraNodePortsFor workDir nodeId = do
+  cache <- readIORef soloHydraNodePortsCache
+  case Map.lookup (workDir, nodeId) cache of
+    Just ports -> pure ports
+    Nothing -> do
+      ports <- allocateHydraNodePorts
+      modifyIORef' soloHydraNodePortsCache (Map.insert (workDir, nodeId) ports)
+      pure ports
 
 -- | Prepare protocol-parameters to run a hydra-node with given 'ChainConfig' and using the config from
 -- config/.
@@ -371,6 +430,11 @@ preparePParams chainConfig stateDir paramsDecorator = do
 
 -- | Prepare 'RunOptions' to run a hydra-node with given 'ChainConfig' and using the config from
 -- config/.
+--
+-- The @nodePorts@ map must contain an entry for this @hydraNodeId@ and for
+-- every peer this node should connect to. Use 'allocateHydraNodePortsFor' to
+-- build it for a cluster, or 'allocateHydraNodePorts' + a singleton map for a
+-- standalone node.
 prepareHydraNode ::
   HasCallStack =>
   ChainConfig ->
@@ -378,12 +442,17 @@ prepareHydraNode ::
   Int ->
   SigningKey HydraKey ->
   [VerificationKey HydraKey] ->
-  [Int] ->
+  Map Int HydraNodePorts ->
   (Aeson.Value -> Aeson.Value) ->
   IO RunOptions
-prepareHydraNode chainConfig workDir hydraNodeId hydraSKey hydraVKeys allNodeIds paramsDecorator = do
+prepareHydraNode chainConfig workDir hydraNodeId hydraSKey hydraVKeys nodePorts paramsDecorator = do
+  HydraNodePorts{apiPort, listenPort, monitoringPort} <-
+    maybe
+      (failure $ "prepareHydraNode: no port allocation for node " <> show hydraNodeId)
+      pure
+      (Map.lookup hydraNodeId nodePorts)
   -- NOTE: AirPlay on MacOS uses 5000 and we must avoid it.
-  when (os == "darwin") $ port `Prelude.shouldNotBe` (5_000 :: Network.PortNumber)
+  when (os == "darwin") $ listenPort `Prelude.shouldNotBe` (5_000 :: Network.PortNumber)
   let stateDir = workDir </> "state-" <> show hydraNodeId
   createDirectoryIfMissing True stateDir
   cardanoLedgerProtocolParametersFile <- preparePParams chainConfig stateDir paramsDecorator
@@ -396,20 +465,24 @@ prepareHydraNode chainConfig workDir hydraNodeId hydraSKey hydraVKeys allNodeIds
     RunOptions
       { verbosity = Verbose "HydraNode"
       , nodeId = NodeId $ show hydraNodeId
-      , listen = Host "0.0.0.0" (fromIntegral $ 5_000 + hydraNodeId)
+      , listen = Host "0.0.0.0" listenPort
       , advertise = Nothing
-      , peers
+      , peers = peersFromMap
       , apiHost = "0.0.0.0"
-      , apiPort = fromIntegral $ 4_000 + hydraNodeId
+      , apiPort
       , tlsCertPath = Nothing
       , tlsKeyPath = Nothing
-      , monitoringPort = Just $ fromIntegral $ 6_000 + hydraNodeId
+      , monitoringPort = Just monitoringPort
       , hydraSigningKey
       , hydraVerificationKeys
       , persistenceDir = stateDir
       , persistenceRotateAfter = Nothing
       , chainConfig
-      , whichEtcd = EmbeddedEtcd
+      , -- NOTE: Use the system etcd to avoid ETXTBSY races where multiple
+        -- parallel tests extract the embedded etcd binary into their own
+        -- tempdirs and execve while another thread still holds the
+        -- write-fd. The dev-shell and CI both provide etcd in $PATH.
+        whichEtcd = SystemEtcd
       , ledgerConfig =
           CardanoLedgerConfig
             { cardanoLedgerProtocolParametersFile
@@ -417,14 +490,10 @@ prepareHydraNode chainConfig workDir hydraNodeId hydraSKey hydraVKeys allNodeIds
       , apiTransactionTimeout = 100000
       }
  where
-  port = fromIntegral $ 5_000 + hydraNodeId
   -- NOTE: See comment above about 0.0.0.0 vs 127.0.0.1
-  peers =
-    [ Host
-      { Network.hostname = "0.0.0.0"
-      , Network.port = fromIntegral $ 5_000 + i
-      }
-    | i <- allNodeIds
+  peersFromMap =
+    [ Host{Network.hostname = "0.0.0.0", Network.port = listenPort p}
+    | (i, p) <- Map.toList nodePorts
     , i /= hydraNodeId
     ]
 
@@ -450,9 +519,17 @@ withPreparedHydraNode tracer workDir hydraNodeId runOptions action =
       -- NOTE: exit code thread gets cancelled if 'action' terminates first
       raceLabelled
         ("collect-check-process-exit-code", collectAndCheckExitCode p)
-        ("with-connection-to-node", withConnectionToNode tracer hydraNodeId action)
+        ("with-connection-to-node", withConnectionToNode tracer hydraNodeId apiAddress monPort action)
         <&> either absurd id
  where
+  apiAddress =
+    case runOptions of
+      RunOptions{apiPort = p} ->
+        Host{Network.hostname = "127.0.0.1", Network.port = p}
+
+  monPort = case runOptions of
+    RunOptions{monitoringPort = mp} -> mp
+
   collectAndCheckExitCode p = do
     let h = getStderr p
     waitExitCode p >>= \case
@@ -467,10 +544,62 @@ withPreparedHydraNode tracer workDir hydraNodeId runOptions action =
 
   logFilePath = workDir </> "logs" </> "hydra-node-" <> show hydraNodeId <.> "log"
 
+-- | Convenience: run a single hydra-node with no peers and freshly
+-- allocated dynamic ports. Equivalent to 'withHydraNode' with a singleton
+-- port map.
+withSoloHydraNode ::
+  HasCallStack =>
+  Tracer IO HydraNodeLog ->
+  NominalDiffTime ->
+  ChainConfig ->
+  FilePath ->
+  Int ->
+  SigningKey HydraKey ->
+  [VerificationKey HydraKey] ->
+  (HydraClient -> IO a) ->
+  IO a
+withSoloHydraNode tracer blockTime chainConfig workDir hydraNodeId hydraSKey hydraVKeys action = do
+  ports <- soloHydraNodePortsFor workDir hydraNodeId
+  withHydraNode tracer blockTime chainConfig workDir hydraNodeId hydraSKey hydraVKeys (Map.singleton hydraNodeId ports) action
+
+-- | Convenience: 'withUnsyncedHydraNode' for a single node with freshly
+-- allocated dynamic ports.
+withUnsyncedSoloHydraNode ::
+  HasCallStack =>
+  Tracer IO HydraNodeLog ->
+  ChainConfig ->
+  FilePath ->
+  Int ->
+  SigningKey HydraKey ->
+  [VerificationKey HydraKey] ->
+  (HydraClient -> IO a) ->
+  IO a
+withUnsyncedSoloHydraNode tracer chainConfig workDir hydraNodeId hydraSKey hydraVKeys action = do
+  ports <- soloHydraNodePortsFor workDir hydraNodeId
+  withUnsyncedHydraNode tracer chainConfig workDir hydraNodeId hydraSKey hydraVKeys (Map.singleton hydraNodeId ports) action
+
+-- | Convenience: 'withHydraNodeCatchingUp' for a single node with freshly
+-- allocated dynamic ports.
+withSoloHydraNodeCatchingUp ::
+  HasCallStack =>
+  Tracer IO HydraNodeLog ->
+  ChainConfig ->
+  FilePath ->
+  Int ->
+  SigningKey HydraKey ->
+  [VerificationKey HydraKey] ->
+  (HydraClient -> IO a) ->
+  IO a
+withSoloHydraNodeCatchingUp tracer chainConfig workDir hydraNodeId hydraSKey hydraVKeys action = do
+  ports <- soloHydraNodePortsFor workDir hydraNodeId
+  withHydraNodeCatchingUp tracer chainConfig workDir hydraNodeId hydraSKey hydraVKeys (Map.singleton hydraNodeId ports) action
+
 -- | Run a hydra-node just like `withHydraNode`; but before running any
 -- action, observe a `Greetings` message with the node in sync first. NOTE
 -- that importantly, any messages seen BEFORE we observe this will be lost;
 -- i.e. unobservable by subsequent `waitFor`s.
+--
+-- See 'prepareHydraNode' for how to build the port map.
 withHydraNode ::
   HasCallStack =>
   Tracer IO HydraNodeLog ->
@@ -480,11 +609,11 @@ withHydraNode ::
   Int ->
   SigningKey HydraKey ->
   [VerificationKey HydraKey] ->
-  [Int] ->
+  Map Int HydraNodePorts ->
   (HydraClient -> IO a) ->
   IO a
-withHydraNode tracer blockTime chainConfig workDir hydraNodeId hydraSKey hydraVKeys allNodeIds action = do
-  opts <- prepareHydraNode chainConfig workDir hydraNodeId hydraSKey hydraVKeys allNodeIds id
+withHydraNode tracer blockTime chainConfig workDir hydraNodeId hydraSKey hydraVKeys nodePorts action = do
+  opts <- prepareHydraNode chainConfig workDir hydraNodeId hydraSKey hydraVKeys nodePorts id
   withPreparedHydraNode tracer workDir hydraNodeId opts action'
  where
   waitTime = blockTime * 5
@@ -502,11 +631,11 @@ withUnsyncedHydraNode ::
   Int ->
   SigningKey HydraKey ->
   [VerificationKey HydraKey] ->
-  [Int] ->
+  Map Int HydraNodePorts ->
   (HydraClient -> IO a) ->
   IO a
-withUnsyncedHydraNode tracer chainConfig workDir hydraNodeId hydraSKey hydraVKeys allNodeIds action = do
-  opts <- prepareHydraNode chainConfig workDir hydraNodeId hydraSKey hydraVKeys allNodeIds id
+withUnsyncedHydraNode tracer chainConfig workDir hydraNodeId hydraSKey hydraVKeys nodePorts action = do
+  opts <- prepareHydraNode chainConfig workDir hydraNodeId hydraSKey hydraVKeys nodePorts id
   withPreparedHydraNode tracer workDir hydraNodeId opts action
 
 -- | Run a hydra-node with given 'ChainConfig' and using the config from
@@ -519,22 +648,19 @@ withHydraNodeCatchingUp ::
   Int ->
   SigningKey HydraKey ->
   [VerificationKey HydraKey] ->
-  [Int] ->
+  Map Int HydraNodePorts ->
   (HydraClient -> IO a) ->
   IO a
-withHydraNodeCatchingUp tracer chainConfig workDir hydraNodeId hydraSKey hydraVKeys allNodeIds action = do
-  opts <- prepareHydraNode chainConfig workDir hydraNodeId hydraSKey hydraVKeys allNodeIds id
+withHydraNodeCatchingUp tracer chainConfig workDir hydraNodeId hydraSKey hydraVKeys nodePorts action = do
+  opts <- prepareHydraNode chainConfig workDir hydraNodeId hydraSKey hydraVKeys nodePorts id
   withPreparedHydraNode tracer workDir hydraNodeId opts action
 
-withConnectionToNode :: forall a. Tracer IO HydraNodeLog -> Int -> (HydraClient -> IO a) -> IO a
-withConnectionToNode tracer hydraNodeId =
-  withConnectionToNodeHost tracer hydraNodeId Host{hostname, port} (Just "/?history=yes")
- where
-  hostname = "127.0.0.1"
-  port = fromInteger $ 4_000 + toInteger hydraNodeId
+withConnectionToNode :: forall a. Tracer IO HydraNodeLog -> Int -> Host -> Maybe Network.PortNumber -> (HydraClient -> IO a) -> IO a
+withConnectionToNode tracer hydraNodeId apiHost monitoringPort =
+  withConnectionToNodeHost tracer hydraNodeId apiHost monitoringPort (Just "/?history=yes")
 
-withConnectionToNodeHost :: forall a. Tracer IO HydraNodeLog -> Int -> Host -> Maybe String -> (HydraClient -> IO a) -> IO a
-withConnectionToNodeHost tracer hydraNodeId apiHost@Host{hostname, port} mQueryParams action = do
+withConnectionToNodeHost :: forall a. Tracer IO HydraNodeLog -> Int -> Host -> Maybe Network.PortNumber -> Maybe String -> (HydraClient -> IO a) -> IO a
+withConnectionToNodeHost tracer hydraNodeId apiHost@Host{hostname, port} monitoringPort mQueryParams action = do
   connectedOnce <- newIORef False
   (retries, delay) <-
     Prelude.getHydraNetwork >>= \case
@@ -563,7 +689,7 @@ withConnectionToNodeHost tracer hydraNodeId apiHost@Host{hostname, port} mQueryP
     \connection -> do
       atomicWriteIORef connectedOnce True
       traceWith tracer (NodeStarted hydraNodeId)
-      res <- action $ HydraClient{hydraNodeId, apiHost, connection, tracer}
+      res <- action $ HydraClient{hydraNodeId, apiHost, monitoringPort, connection, tracer}
       sendClose connection ("Bye" :: Text)
       pure res
 

--- a/hydra-cluster/test/Main.hs
+++ b/hydra-cluster/test/Main.hs
@@ -1,8 +1,53 @@
 module Main where
 
 import Hydra.Prelude
-import Spec qualified
-import Test.Hspec.Runner
 
+import Test.BlockfrostChainSpec qualified
+import Test.CardanoClientSpec qualified
+import Test.CardanoNodeSpec qualified
+import Test.ChainObserverSpec qualified
+import Test.DirectChainSpec qualified
+import Test.EndToEndSpec qualified
+import Test.GeneratorSpec qualified
+import Test.Hydra.Cluster.CardanoCliSpec qualified
+import Test.Hydra.Cluster.FaucetSpec qualified
+import Test.Hydra.Cluster.HydraClientSpec qualified
+import Test.Hydra.Cluster.MithrilSpec qualified
+import Test.Hydra.TastyMain (hydraTestTree, runHydraTests, testSpec)
+import Test.OfflineChainSpec qualified
+import Test.Tasty (localOption)
+import Test.Tasty.Runners (NumThreads (..))
+
+-- Most tests in this suite each spawn a cardano-node devnet plus 3-6
+-- hydra-nodes. Running two such tests concurrently oversubscribes the CPU
+-- and breaks any test whose @waitMatch@ / @waitForAllMatch@ budget is
+-- expressed in @blockTime@ units (often @10 * blockTime ≈ 1.5s@, which is
+-- fine when one cardano-node has the box to itself but not when it has to
+-- share). At NumThreads >= 2, ~1-3% of tests flake on each run with errors
+-- like "waitMatch did not match within 1.5s" while the trace shows the
+-- node still @CatchingUp@ with 10s of drift. Until those budgets are
+-- loosened or the tests are refactored to share a single cardano-node, we
+-- default to NumThreads 1.
+--
+-- Users on beefy machines can override via @--num-threads N@ on the
+-- command line — tasty's @applyTopLevelPlusTestOptions@ layers CLI args
+-- over the in-tree default, so the CLI value wins.
 main :: IO ()
-main = hspec Spec.spec
+main = do
+  tree <-
+    hydraTestTree
+      "hydra-cluster"
+      [ testSpec "BlockfrostChain" Test.BlockfrostChainSpec.spec
+      , testSpec "CardanoClient" Test.CardanoClientSpec.spec
+      , testSpec "CardanoNode" Test.CardanoNodeSpec.spec
+      , testSpec "ChainObserver" Test.ChainObserverSpec.spec
+      , testSpec "DirectChain" Test.DirectChainSpec.spec
+      , testSpec "EndToEnd" Test.EndToEndSpec.spec
+      , testSpec "Generator" Test.GeneratorSpec.spec
+      , testSpec "Hydra.Cluster.CardanoCli" Test.Hydra.Cluster.CardanoCliSpec.spec
+      , testSpec "Hydra.Cluster.Faucet" Test.Hydra.Cluster.FaucetSpec.spec
+      , testSpec "Hydra.Cluster.HydraClient" Test.Hydra.Cluster.HydraClientSpec.spec
+      , testSpec "Hydra.Cluster.Mithril" Test.Hydra.Cluster.MithrilSpec.spec
+      , testSpec "OfflineChain" Test.OfflineChainSpec.spec
+      ]
+  runHydraTests "hydra-cluster" (localOption (NumThreads 1) tree)

--- a/hydra-cluster/test/Spec.hs
+++ b/hydra-cluster/test/Spec.hs
@@ -1,1 +1,0 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}

--- a/hydra-cluster/test/Test/ChainObserverSpec.hs
+++ b/hydra-cluster/test/Test/ChainObserverSpec.hs
@@ -22,7 +22,7 @@ import Hydra.Cluster.Fixture (Actor (..))
 import Hydra.Cluster.Util (chainConfigFor, keysFor, mkTestTiming)
 import Hydra.Logging (showLogsOnFailure)
 import Hydra.Options (ChainBackendOptions (..), DirectOptions (..))
-import HydraNode (input, output, send, waitFor, waitMatch, withHydraNode)
+import HydraNode (allocateHydraNodePortsFor, input, output, send, waitFor, waitMatch, withHydraNode)
 import System.IO.Error (isEOFError, isIllegalOperation)
 import System.Process (CreateProcess (std_out), StdStream (..), proc, withCreateProcess)
 import Test.Hydra.Tx.Fixture (aliceSk)
@@ -41,7 +41,8 @@ spec = do
             (aliceCardanoVk, _) <- keysFor Alice
             let timing = mkTestTiming blockTime
             aliceChainConfig <- chainConfigFor Alice tmpDir (Direct directOpts) hydraScriptsTxId [] timing
-            withHydraNode hydraTracer blockTime aliceChainConfig tmpDir 1 aliceSk [] [1] $ \hydraNode -> do
+            nodePorts <- allocateHydraNodePortsFor [1]
+            withHydraNode hydraTracer blockTime aliceChainConfig tmpDir 1 aliceSk [] nodePorts $ \hydraNode -> do
               withChainObserver directOpts $ \observer -> do
                 seedFromFaucet_ (Direct directOpts) aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
 

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -89,7 +89,7 @@ import Hydra.Ledger.Cardano (mkRangedTx, mkSimpleTx)
 import Hydra.Logging (Tracer, showLogsOnFailure)
 import Hydra.Options
 import Hydra.Tx.IsTx (txId)
-import HydraNode (getMetrics, getSnapshotUTxO, input, output, prepareHydraNode, requestCommitTx, send, waitFor, waitForAllMatch, waitForNodesConnected, waitForNodesSynced, waitMatch, withHydraCluster, withHydraNode, withPreparedHydraNode, withUnsyncedHydraNode)
+import HydraNode (allocateHydraNodePortsFor, getMetrics, getSnapshotUTxO, input, output, prepareHydraNode, requestCommitTx, send, waitFor, waitForAllMatch, waitForNodesConnected, waitForNodesSynced, waitMatch, withHydraCluster, withHydraNode, withPreparedHydraNode, withSoloHydraNode, withUnsyncedSoloHydraNode)
 import Network.HTTP.Conduit (parseUrlThrow)
 import Network.HTTP.Simple (getResponseBody, httpJSON)
 import System.Directory (removeDirectoryRecursive)
@@ -131,7 +131,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
                   }
         let blockTime = 5
         -- Start a hydra-node in offline mode and submit a transaction from alice to bob
-        aliceToBob <- withHydraNode (contramap FromHydraNode tracer) blockTime offlineConfig tmpDir 1 aliceSk [] [1] $ \node -> do
+        aliceToBob <- withSoloHydraNode (contramap FromHydraNode tracer) blockTime offlineConfig tmpDir 1 aliceSk [] $ \node -> do
           let Just (aliceSeedTxIn, aliceSeedTxOut) = UTxO.find (isVkTxOut aliceCardanoVk) initialUTxO
           let Right aliceToBob =
                 mkSimpleTx
@@ -144,7 +144,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
           pure aliceToBob
 
         -- Restart a hydra-node in offline mode expect we can reverse the transaction (it retains state)
-        withUnsyncedHydraNode (contramap FromHydraNode tracer) offlineConfig tmpDir 1 aliceSk [] [1] $ \node -> do
+        withUnsyncedSoloHydraNode (contramap FromHydraNode tracer) offlineConfig tmpDir 1 aliceSk [] $ \node -> do
           let
             bobTxOut = toCtxUTxOTxOut $ List.head (txOuts' aliceToBob)
             Right bobToAlice =
@@ -169,8 +169,13 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
                   , ledgerGenesisFile = Nothing
                   }
         let blockTime = 5
+        -- Share one port allocation across all three restarts so the
+        -- on-disk etcd state stays consistent (etcd cluster members are
+        -- identified by listen URL; if ports change between restarts etcd
+        -- refuses to start with the existing data dir).
+        nodePorts <- allocateHydraNodePortsFor [1]
         -- Start a hydra-node in offline mode and submit several self-txs
-        withHydraNode (contramap FromHydraNode tracer) blockTime offlineConfig tmpDir 1 aliceSk [] [] $ \node -> do
+        withHydraNode (contramap FromHydraNode tracer) blockTime offlineConfig tmpDir 1 aliceSk [] nodePorts $ \node -> do
           -- Offline mode needs to confirm deposit of initialUTxO first.
           waitMatch 20 node $ \v -> do
             guard $ v ^? key "tag" == Just "SnapshotConfirmed"
@@ -178,13 +183,13 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
 
         -- Measure restart time
         t0 <- getCurrentTime
-        diff1 <- withHydraNode (contramap FromHydraNode tracer) blockTime offlineConfig tmpDir 1 aliceSk [] [] $ \_ -> do
+        diff1 <- withHydraNode (contramap FromHydraNode tracer) blockTime offlineConfig tmpDir 1 aliceSk [] nodePorts $ \_ -> do
           t1 <- getCurrentTime
           let diff = diffUTCTime t1 t0
           pure diff
 
         -- Measure restart after rotation
-        options <- prepareHydraNode offlineConfig tmpDir 1 aliceSk [] [] id
+        options <- prepareHydraNode offlineConfig tmpDir 1 aliceSk [] nodePorts id
         let options' = options{persistenceRotateAfter = Just (Positive 10)}
         t1 <- getCurrentTime
         diff2 <- withPreparedHydraNode (contramap FromHydraNode tracer) tmpDir 1 options' $ \n -> do
@@ -215,9 +220,10 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
                   }
         let tr = contramap FromHydraNode tracer
         let blockTime = 5
+        nodePorts <- allocateHydraNodePortsFor [1, 2]
         -- Start two hydra-nodes in offline mode and submit a transaction from alice to bob
-        withHydraNode tr blockTime offlineConfig tmpDir 1 aliceSk [bobVk] [1, 2] $ \aliceNode -> do
-          withHydraNode tr blockTime offlineConfig tmpDir 2 bobSk [aliceVk] [1, 2] $ \bobNode -> do
+        withHydraNode tr blockTime offlineConfig tmpDir 1 aliceSk [bobVk] nodePorts $ \aliceNode -> do
+          withHydraNode tr blockTime offlineConfig tmpDir 2 bobSk [aliceVk] nodePorts $ \bobNode -> do
             waitForNodesConnected tr 20 $ aliceNode :| [bobNode]
             let Just (aliceSeedTxIn, aliceSeedTxOut) = UTxO.find (isVkTxOut aliceCardanoVk) initialUTxO
             let Right aliceToBob =
@@ -561,7 +567,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
             aliceChainConfig <- chainConfigFor Alice tmp opts hydraScriptsTxId [] timing
             let nodeId = 1
             let hydraTracer = contramap FromHydraNode tracer
-            (tip, aliceHeadId) <- withHydraNode hydraTracer blockTime aliceChainConfig tmp nodeId aliceSk [] [1] $ \n1 -> do
+            (tip, aliceHeadId) <- withSoloHydraNode hydraTracer blockTime aliceChainConfig tmp nodeId aliceSk [] $ \n1 -> do
               seedFromFaucet_ opts aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
               tip <- runBackend opts queryTip
               send n1 $ input "Init" []
@@ -576,7 +582,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
             removeDirectoryRecursive $ tmp </> "state-" <> show nodeId
 
             let aliceChainConfig' = aliceChainConfig & modifyConfig (\cfg -> cfg{startChainFrom = Just tip})
-            withUnsyncedHydraNode hydraTracer aliceChainConfig' tmp 1 aliceSk [] [1] $ \n1 -> do
+            withUnsyncedSoloHydraNode hydraTracer aliceChainConfig' tmp 1 aliceSk [] $ \n1 -> do
               headId' <- waitForAllMatch (10 * blockTime * 10) [n1] $ headIsOpenWith (Set.fromList [alice])
               headId' `shouldBe` aliceHeadId
 
@@ -629,8 +635,9 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
               aliceChainConfig <- chainConfigFor Alice tmpDir opts hydraScriptsTxId [] timing
               bobChainConfig <- chainConfigFor Bob tmpDir opts hydraScriptsTxId [Alice] timing
               let hydraTracer = contramap FromHydraNode tracer
-              withHydraNode hydraTracer blockTime aliceChainConfig tmpDir 1 aliceSk [] allNodeIds $ \n1 ->
-                withHydraNode hydraTracer blockTime bobChainConfig tmpDir 2 bobSk [aliceVk] allNodeIds $ \n2 -> do
+              nodePorts <- allocateHydraNodePortsFor allNodeIds
+              withHydraNode hydraTracer blockTime aliceChainConfig tmpDir 1 aliceSk [] nodePorts $ \n1 ->
+                withHydraNode hydraTracer blockTime bobChainConfig tmpDir 2 bobSk [aliceVk] nodePorts $ \n2 -> do
                   -- Funds to be used as fuel by Hydra protocol transactions
                   seedFromFaucet_ opts aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
                   seedFromFaucet_ opts bobCardanoVk 100_000_000 (contramap FromFaucet tracer)
@@ -665,10 +672,11 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
             aliceChainConfig <- chainConfigFor Alice tmpDir opts hydraScriptsTxId [Bob, Carol] timing
             bobChainConfig <- chainConfigFor Bob tmpDir opts hydraScriptsTxId [Alice, Carol] timing
             carolChainConfig <- chainConfigFor Carol tmpDir opts hydraScriptsTxId [Alice, Bob] timing
+            nodePorts <- allocateHydraNodePortsFor allNodeIds
             failAfter 20 $
-              withHydraNode hydraTracer blockTime aliceChainConfig tmpDir 1 aliceSk [bobVk, carolVk] allNodeIds $ \n1 ->
-                withHydraNode hydraTracer blockTime bobChainConfig tmpDir 2 bobSk [aliceVk, carolVk] allNodeIds $ \n2 ->
-                  withHydraNode hydraTracer blockTime carolChainConfig tmpDir 3 carolSk [aliceVk, bobVk] allNodeIds $ \n3 -> do
+              withHydraNode hydraTracer blockTime aliceChainConfig tmpDir 1 aliceSk [bobVk, carolVk] nodePorts $ \n1 ->
+                withHydraNode hydraTracer blockTime bobChainConfig tmpDir 2 bobSk [aliceVk, carolVk] nodePorts $ \n2 ->
+                  withHydraNode hydraTracer blockTime carolChainConfig tmpDir 3 carolSk [aliceVk, bobVk] nodePorts $ \n3 -> do
                     -- Funds to be used as fuel by Hydra protocol transactions
                     seedFromFaucet_ opts aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
                     waitForNodesConnected hydraTracer 20 $ n1 :| [n2, n3]
@@ -697,7 +705,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
                               , nodeSocket = nodeSocket'
                               }
                       }
-            withHydraNode (contramap FromHydraNode tracer) blockTime chainConfig dir 1 aliceSk [] [1] (const $ pure ())
+            withSoloHydraNode (contramap FromHydraNode tracer) blockTime chainConfig dir 1 aliceSk [] (const $ pure ())
               `shouldThrow` \(e :: SomeException) ->
                 "hydra-node" `isInfixOf` show e
                   && "not-existing.sk" `isInfixOf` show e
@@ -711,7 +719,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
             aliceChainConfig <- chainConfigFor Alice dir opts hydraScriptsTxId [] timing
 
             -- XXX: Need to do something in 'action' otherwise always green?
-            withHydraNode hydraTracer blockTime aliceChainConfig dir 1 aliceSk [] [1] $ \_ -> do
+            withSoloHydraNode hydraTracer blockTime aliceChainConfig dir 1 aliceSk [] $ \_ -> do
               threadDelay 0.1
 
       it "can be restarted" $ \tracer -> do
@@ -724,10 +732,10 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
 
             -- XXX: Need to do something in 'action' otherwise always green?
             failAfter 10 $
-              withHydraNode hydraTracer blockTime aliceChainConfig dir 1 aliceSk [] [1] $ \_ -> do
+              withSoloHydraNode hydraTracer blockTime aliceChainConfig dir 1 aliceSk [] $ \_ -> do
                 threadDelay 0.1
             failAfter 10 $
-              withHydraNode hydraTracer blockTime aliceChainConfig dir 1 aliceSk [] [1] $ \_ -> do
+              withSoloHydraNode hydraTracer blockTime aliceChainConfig dir 1 aliceSk [] $ \_ -> do
                 threadDelay 0.1
 
       it "logs to a logfile" $ \tracer -> do
@@ -738,7 +746,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
             refuelIfNeeded tracer opts Alice 100_000_000
             let timing = mkTestTiming blockTime
             aliceChainConfig <- chainConfigFor Alice dir opts hydraScriptsTxId [] timing
-            withHydraNode hydraTracer blockTime aliceChainConfig dir 1 aliceSk [] [1] $ \n1 -> do
+            withSoloHydraNode hydraTracer blockTime aliceChainConfig dir 1 aliceSk [] $ \n1 -> do
               send n1 $ input "Init" []
 
             let logFilePath = dir </> "logs" </> "hydra-node-1.log"
@@ -753,7 +761,7 @@ timedTx tmpDir tracer opts hydraScriptsTxId = do
   let timing = mkTestTiming blockTime
   aliceChainConfig <- chainConfigFor Alice tmpDir opts hydraScriptsTxId [] timing
   let hydraTracer = contramap FromHydraNode tracer
-  withHydraNode hydraTracer blockTime aliceChainConfig tmpDir 1 aliceSk [] [1] $ \n1 -> do
+  withSoloHydraNode hydraTracer blockTime aliceChainConfig tmpDir 1 aliceSk [] $ \n1 -> do
     let lovelaceBalanceValue = 100_000_000
 
     -- Funds to be used as fuel by Hydra protocol transactions

--- a/hydra-cluster/test/Test/Hydra/Cluster/HydraClientSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/HydraClientSpec.hs
@@ -234,6 +234,7 @@ runScenario hydraTracer hnode addr action = do
     hydraTracer
     (HydraNode.hydraNodeId hnode)
     (HydraNode.apiHost hnode)
+    (HydraNode.monitoringPort hnode)
     (Just $ Text.unpack (queryAddress addr))
     action
 

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -345,9 +345,9 @@ benchmark logging
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N4
 
 test-suite tests
-  import:             project-config
-  ghc-options:        -threaded -rtsopts -with-rtsopts=-N
-  hs-source-dirs:     test
+  import:         project-config
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
+  hs-source-dirs: test
   other-modules:
     Hydra.API.ClientInputSpec
     Hydra.API.HTTPServerSpec
@@ -392,11 +392,10 @@ test-suite tests
     Hydra.PersistentQueueSpec
     Hydra.UtilsSpec
     Paths_hydra_node
-    Spec
     Test.Util
 
-  main-is:            Main.hs
-  type:               exitcode-stdio-1.0
+  main-is:        Main.hs
+  type:           exitcode-stdio-1.0
   build-depends:
     , aeson
     , amazonka
@@ -465,5 +464,4 @@ test-suite tests
     , typed-process
     , websockets
 
-  build-tool-depends: hspec-discover:hspec-discover
-  ghc-options:        -threaded -rtsopts
+  ghc-options:    -threaded -rtsopts

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -100,7 +100,7 @@ import Network.Socket (PortNumber)
 import System.Directory (createDirectoryIfMissing, listDirectory, removeFile)
 import System.Environment.Blank (getEnvironment)
 import System.FilePath ((</>))
-import System.IO.Error (isDoesNotExistError)
+import System.IO.Error (isDoesNotExistError, isEOFError)
 import System.Process (interruptProcessGroupOf)
 import System.Process.Typed (
   Process,
@@ -172,19 +172,33 @@ withEtcdNetwork tracer protocolVersion config callback action = do
  where
   clientHost = Host{hostname = "127.0.0.1", port = getClientPort config}
   traceStderr p NetworkCallback{onConnectivity} =
-    forever $ do
-      bs <- BS.hGetLine (getStderr p)
-      case Aeson.eitherDecodeStrict bs of
-        Left err -> traceWith tracer FailedToDecodeLog{log = decodeUtf8 bs, reason = show err}
-        Right v -> do
-          let expectedClusterMismatch = do
-                level' <- bs ^? Aeson.key "level" . Aeson.nonNull
-                msg' <- bs ^? Aeson.key "msg" . Aeson.nonNull
-                pure (level', msg')
-          case expectedClusterMismatch of
-            Just (Aeson.String "error", Aeson.String "request sent was ignored due to cluster ID mismatch") ->
-              onConnectivity ClusterIDMismatch{clusterPeers = T.pack clusterPeers}
-            _ -> traceWith tracer $ EtcdLog{etcd = v}
+    let loop = do
+          bs <- BS.hGetLine (getStderr p)
+          case Aeson.eitherDecodeStrict bs of
+            Left err -> traceWith tracer FailedToDecodeLog{log = decodeUtf8 bs, reason = show err}
+            Right v -> do
+              let expectedClusterMismatch = do
+                    level' <- bs ^? Aeson.key "level" . Aeson.nonNull
+                    msg' <- bs ^? Aeson.key "msg" . Aeson.nonNull
+                    pure (level', msg')
+              case expectedClusterMismatch of
+                Just (Aeson.String "error", Aeson.String "request sent was ignored due to cluster ID mismatch") ->
+                  onConnectivity ClusterIDMismatch{clusterPeers = T.pack clusterPeers}
+                _ -> traceWith tracer $ EtcdLog{etcd = v}
+          loop
+     in -- When etcd's stderr pipe closes (because the etcd subprocess exited),
+        -- 'BS.hGetLine' raises 'hGetLine: end of file'. We don't want that
+        -- naked IOException racing the descriptive "Sub-process etcd exited
+        -- with: ExitFailure N" from 'etcd-waitExitCode' below — on slower
+        -- machines the EOF often wins, and the IOException then gets caught
+        -- by 'withAPIServer's IOException handler and re-thrown as
+        -- 'RunServerException', stripping every mention of etcd from the
+        -- final error. Block on EOF instead so 'etcd-waitExitCode' is always
+        -- the one that fires.
+        loop `catch` \e ->
+          if isEOFError e
+            then forever (threadDelay 60)
+            else throwIO e
 
   -- XXX: Could use TLS to secure peer connections
   -- XXX: Could use discovery to simplify configuration

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -197,7 +197,7 @@ withEtcdNetwork tracer protocolVersion config callback action = do
         -- the one that fires.
         loop `catch` \e ->
           if isEOFError e
-            then pure ()
+            then forever (threadDelay 60)
             else throwIO e
 
   -- XXX: Could use TLS to secure peer connections

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -276,7 +276,16 @@ grpcServer config =
 -- the listen address is offset by the default port 5001. This will result in
 -- the default client port 2379 be used by default still.
 getClientPort :: NetworkConfiguration -> PortNumber
-getClientPort NetworkConfiguration{listen} = 2379 + port listen - 5001
+getClientPort NetworkConfiguration{listen} = peerPortToClientPort (port listen)
+
+-- | Derive the etcd client port from a configured peer (listen) port.
+--
+-- Exposed separately from 'getClientPort' so test fixtures can pre-allocate
+-- both the peer and the derived client port without constructing a full
+-- 'NetworkConfiguration'. Keep this and 'getClientPort' in lockstep — any
+-- change to the offset must happen here, in one place.
+peerPortToClientPort :: PortNumber -> PortNumber
+peerPortToClientPort listenPort = 2379 + listenPort - 5001
 
 -- | Check and write version on etcd cluster. This will retry until we are on a
 -- majority cluster and succeed. If the version does not match a corresponding

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -197,7 +197,7 @@ withEtcdNetwork tracer protocolVersion config callback action = do
         -- the one that fires.
         loop `catch` \e ->
           if isEOFError e
-            then forever (threadDelay 60)
+            then pure ()
             else throwIO e
 
   -- XXX: Could use TLS to secure peer connections

--- a/hydra-node/src/Hydra/Node/State.hs
+++ b/hydra-node/src/Hydra/Node/State.hs
@@ -74,7 +74,8 @@ initialChainTime :: UTCTime
 initialChainTime = posixSecondsToUTCTime 0
 
 data SyncedStatus = InSync | CatchingUp
-  deriving (Generic, Eq, Show, ToJSON, FromJSON)
+  deriving stock (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
 
 syncedStatus :: NodeState tx -> SyncedStatus
 syncedStatus NodeInSync{} = InSync
@@ -89,7 +90,7 @@ data Deposit tx = Deposit
   , deadline :: UTCTime
   , status :: DepositStatus
   }
-  deriving (Generic)
+  deriving stock (Generic)
 
 deriving stock instance IsTx tx => Eq (Deposit tx)
 deriving stock instance IsTx tx => Show (Deposit tx)
@@ -97,7 +98,8 @@ deriving anyclass instance IsTx tx => ToJSON (Deposit tx)
 deriving anyclass instance IsTx tx => FromJSON (Deposit tx)
 
 data DepositStatus = Inactive | Active | Expired
-  deriving (Generic, Eq, Show, ToJSON, FromJSON)
+  deriving stock (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
 
 depositsForHead :: HeadId -> PendingDeposits tx -> PendingDeposits tx
 depositsForHead targetHeadId =

--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -178,8 +178,13 @@ spec =
                 mapM_ putEvent history
                 -- start client that doesn't want to see the history
                 withClient port "/?history=yes" $ \conn -> do
-                  -- wait on the greeting message
-                  waitMatch 5 conn $ guard . matchGreetings
+                  -- Wait on the greeting message. The longer-than-typical
+                  -- budget here is because this is a property test running
+                  -- ~100 iterations; each iteration spins up a full WS
+                  -- server, and the per-iteration 5s default was racing
+                  -- with CPU contention when the full hydra-node test
+                  -- suite runs in parallel.
+                  waitMatch 20 conn $ guard . matchGreetings
 
                   notHistoryMessage :: StateEvent SimpleTx <- generate genStateEventForApi
                   putEvent notHistoryMessage
@@ -218,7 +223,11 @@ spec =
       forAllShrink (listOf genStateEventForApi) shrink $ \events -> do
         monadicIO $ do
           run $
-            showLogsOnFailure "ServerSpec" $ \tracer -> failAfter 5 $
+            -- NOTE: 20s, matching the similar property test above, so the
+            -- timeout doesn't fire just because the full tasty suite is
+            -- running many of these in parallel and starving each server's
+            -- WS read of CPU.
+            showLogsOnFailure "ServerSpec" $ \tracer -> failAfter 20 $
               withFreePort $ \port ->
                 withTestAPIServer port alice (mockSource events) tracer $ \_ -> do
                   withClient port "/?history=yes" $ \conn -> do

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -45,7 +45,7 @@ spec = do
       let v1 = ProtocolVersion 1
 
       it "broadcasts to self" $ \tracer -> do
-        failAfter 5 $
+        failAfter 30 $
           withTempDir "test-etcd" $ \tmp -> do
             withFreePort $ \port -> do
               let config =
@@ -57,7 +57,7 @@ spec = do
                       , peers = []
                       , nodeId = "alice"
                       , persistenceDir = tmp </> "alice"
-                      , whichEtcd = EmbeddedEtcd
+                      , whichEtcd = SystemEtcd
                       }
               (recordingCallback, waitNext, _) <- newRecordingCallback
               withEtcdNetwork tracer v1 config recordingCallback $ \n -> do
@@ -88,7 +88,7 @@ spec = do
 
       it "broadcasts messages to single connected peer" $ \tracer -> do
         withTempDir "test-etcd" $ \tmp -> do
-          failAfter 5 $ do
+          failAfter 30 $ do
             PeerConfig2{aliceConfig, bobConfig} <- setup2Peers tmp
             withEtcdNetwork @Int tracer v1 aliceConfig noopCallback $ \n1 -> do
               (recordReceived, waitNext, _) <- newRecordingCallback
@@ -189,7 +189,7 @@ spec = do
 
       it "checks protocol version" $ \tracer -> do
         withTempDir "test-etcd" $ \tmp -> do
-          failAfter 10 $ do
+          failAfter 30 $ do
             PeerConfig2{aliceConfig, bobConfig} <- setup2Peers tmp
             let v2 = ProtocolVersion 2
             (recordAlice, _, waitAlice) <- newRecordingCallback
@@ -206,7 +206,9 @@ spec = do
 
       it "resends messages" $ \tracer -> do
         withTempDir "test-etcd" $ \tmp -> do
-          failAfter 20 $ do
+          -- Sends 1000 messages through a 3-node etcd cluster; the
+          -- 20s budget was too tight under parallel CI load.
+          failAfter 60 $ do
             PeerConfig3{aliceConfig, bobConfig, carolConfig} <- setup3Peers tmp
             (recordBob, waitBob, _) <- newRecordingCallback
             (recordCarol, waitCarol, _) <- newRecordingCallback
@@ -283,7 +285,7 @@ spec = do
 
       it "emits cluster id mismatch" $ \tracer -> do
         withTempDir "test-etcd" $ \tmp -> do
-          failAfter 10 $ do
+          failAfter 30 $ do
             PeerConfig2{aliceConfig, bobConfig} <- setup2Peers tmp
             let v2 = ProtocolVersion 2
             (recordAlice, _, waitAlice) <- newRecordingCallback
@@ -326,7 +328,7 @@ setup2Peers tmp = do
             , peers = [bobHost]
             , nodeId = "alice"
             , persistenceDir = tmp </> "alice"
-            , whichEtcd = EmbeddedEtcd
+            , whichEtcd = SystemEtcd
             }
       , bobConfig =
           NetworkConfiguration
@@ -337,7 +339,7 @@ setup2Peers tmp = do
             , peers = [aliceHost]
             , nodeId = "bob"
             , persistenceDir = tmp </> "bob"
-            , whichEtcd = EmbeddedEtcd
+            , whichEtcd = SystemEtcd
             }
       }
 
@@ -364,7 +366,7 @@ setup3Peers tmp = do
             , peers = [bobHost, carolHost]
             , nodeId = "alice"
             , persistenceDir = tmp </> "alice"
-            , whichEtcd = EmbeddedEtcd
+            , whichEtcd = SystemEtcd
             }
       , bobConfig =
           NetworkConfiguration
@@ -375,7 +377,7 @@ setup3Peers tmp = do
             , peers = [aliceHost, carolHost]
             , nodeId = "bob"
             , persistenceDir = tmp </> "bob"
-            , whichEtcd = EmbeddedEtcd
+            , whichEtcd = SystemEtcd
             }
       , carolConfig =
           NetworkConfiguration
@@ -386,7 +388,7 @@ setup3Peers tmp = do
             , peers = [aliceHost, bobHost]
             , nodeId = "carol"
             , persistenceDir = tmp </> "carol"
-            , whichEtcd = EmbeddedEtcd
+            , whichEtcd = SystemEtcd
             }
       }
 

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -32,7 +32,7 @@ import Test.Aeson.GenericSpecs (Settings (..), defaultSettings, roundtripAndGold
 import Test.Hydra.Ledger.Simple ()
 import Test.Hydra.Network.Message ()
 import Test.Hydra.Node.Fixture (alice, aliceSk, bob, bobSk, carol, carolSk)
-import Test.Network.Ports (randomUnusedTCPPorts, withFreePort)
+import Test.Network.Ports (randomUnusedTCPPortsWithDerived, withFreePort)
 import Test.QuickCheck (Property, (===))
 import Test.QuickCheck.Instances.ByteString ()
 import Test.Util (noopCallback, waitEq, waitMatch)
@@ -179,7 +179,12 @@ spec = do
                 -- Expire all leases manually to simulate a keepAlive coming too
                 -- late. Note that we do not distinguish which is which so
                 -- alice's lease will also be killed, but does not matter here.
-                let endpoints = "--endpoints=" <> show (listen aliceConfig)
+                -- NOTE: etcdctl talks to the etcd /client/ port, not the peer
+                -- port. Using @listen aliceConfig@ here used to work on etcd
+                -- 3.5 (whose peer listener happened to answer client RPCs too)
+                -- but hangs on etcd 3.6, where the peer port no longer serves
+                -- the lease API.
+                let endpoints = "--endpoints=127.0.0.1:" <> show (getClientPort aliceConfig)
                 output <- readProcessStdout_ . shell $ "etcdctl lease list " <> endpoints
                 let leases = drop 1 $ lines $ decodeUtf8 output
                 forM_ leases $ \lease ->
@@ -314,7 +319,10 @@ data PeerConfig2 = PeerConfig2
 
 setup2Peers :: FilePath -> IO PeerConfig2
 setup2Peers tmp = do
-  [port1, port2] <- fmap fromIntegral <$> randomUnusedTCPPorts 2
+  -- Allocate peer ports whose derived etcd client ports (peer - 2622) are
+  -- also free at allocation time — otherwise etcd dies on startup with
+  -- "bind: address already in use" for the client port. See 'getClientPort'.
+  [port1, port2] <- fmap fromIntegral <$> randomUnusedTCPPortsWithDerived (\p -> p - 2622) 2
   let aliceHost = Host lo port1
   let bobHost = Host lo port2
   pure
@@ -351,7 +359,8 @@ data PeerConfig3 = PeerConfig3
 
 setup3Peers :: FilePath -> IO PeerConfig3
 setup3Peers tmp = do
-  [port1, port2, port3] <- fmap fromIntegral <$> randomUnusedTCPPorts 3
+  -- See note in 'setup2Peers' about the derived client port.
+  [port1, port2, port3] <- fmap fromIntegral <$> randomUnusedTCPPortsWithDerived (\p -> p - 2622) 3
   let aliceHost = Host lo port1
   let bobHost = Host lo port2
   let carolHost = Host lo port3

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -22,7 +22,7 @@ import Hydra.Network (
   ProtocolVersion (..),
   WhichEtcd (..),
  )
-import Hydra.Network.Etcd (getClientPort, withEtcdNetwork)
+import Hydra.Network.Etcd (getClientPort, peerPortToClientPort, withEtcdNetwork)
 import Hydra.Network.Message (Message (..))
 import Hydra.Node.Network (NetworkConfiguration (..))
 import System.Directory (removeFile)
@@ -319,10 +319,10 @@ data PeerConfig2 = PeerConfig2
 
 setup2Peers :: FilePath -> IO PeerConfig2
 setup2Peers tmp = do
-  -- Allocate peer ports whose derived etcd client ports (peer - 2622) are
-  -- also free at allocation time — otherwise etcd dies on startup with
-  -- "bind: address already in use" for the client port. See 'getClientPort'.
-  [port1, port2] <- fmap fromIntegral <$> randomUnusedTCPPortsWithDerived (\p -> p - 2622) 2
+  -- Allocate peer ports whose derived etcd client ports are also free at
+  -- allocation time — otherwise etcd dies on startup with "bind: address
+  -- already in use" for the client port. See 'peerPortToClientPort'.
+  [port1, port2] <- fmap fromIntegral <$> randomUnusedTCPPortsWithDerived peerPortToClientPort 2
   let aliceHost = Host lo port1
   let bobHost = Host lo port2
   pure
@@ -360,7 +360,7 @@ data PeerConfig3 = PeerConfig3
 setup3Peers :: FilePath -> IO PeerConfig3
 setup3Peers tmp = do
   -- See note in 'setup2Peers' about the derived client port.
-  [port1, port2, port3] <- fmap fromIntegral <$> randomUnusedTCPPortsWithDerived (\p -> p - 2622) 3
+  [port1, port2, port3] <- fmap fromIntegral <$> randomUnusedTCPPortsWithDerived peerPortToClientPort 3
   let aliceHost = Host lo port1
   let bobHost = Host lo port2
   let carolHost = Host lo port3

--- a/hydra-node/test/Hydra/PersistentQueueSpec.hs
+++ b/hydra-node/test/Hydra/PersistentQueueSpec.hs
@@ -31,7 +31,9 @@ spec = do
 
 shouldNotBlock :: HasCallStack => IO a -> IO a
 shouldNotBlock action = do
-  timeout 0.1 action >>= \case
+  -- Generous enough to survive heavy parallel load on CI; the goal is to
+  -- detect a hung action, not benchmark responsiveness.
+  timeout 5 action >>= \case
     Nothing -> failure "blocked unexpectedly"
     Just a -> pure a
 

--- a/hydra-node/test/Main.hs
+++ b/hydra-node/test/Main.hs
@@ -41,7 +41,7 @@ import Hydra.OptionsSpec qualified
 import Hydra.PartySpec qualified
 import Hydra.PersistentQueueSpec qualified
 import Hydra.UtilsSpec qualified
-import Test.Hydra.TastyMain (defaultMainHydra, testSpec)
+import Test.Hydra.TastyMain (defaultMainHydra, serializeOnCI, testSpec)
 
 main :: IO ()
 main =
@@ -77,7 +77,10 @@ main =
     , testSpec "Model.MockChain" Hydra.Model.MockChainSpec.spec
     , testSpec "Model" Hydra.ModelSpec.spec
     , testSpec "Network.Authenticate" Hydra.Network.AuthenticateSpec.spec
-    , testSpec "Network" Hydra.NetworkSpec.spec
+    , -- NetworkSpec spins 2–3 etcd subprocesses per test; running its cases
+      -- in parallel starves etcd on small CI runners and deadlocks the suite.
+      -- Serialize only there (CI=…); dev machines stay fully parallel.
+      serializeOnCI (testSpec "Network" Hydra.NetworkSpec.spec)
     , testSpec "NetworkVersions" Hydra.NetworkVersionsSpec.spec
     , testSpec "Node.InputQueue" Hydra.Node.InputQueueSpec.spec
     , testSpec "Node.Run" Hydra.Node.RunSpec.spec

--- a/hydra-node/test/Main.hs
+++ b/hydra-node/test/Main.hs
@@ -41,7 +41,7 @@ import Hydra.OptionsSpec qualified
 import Hydra.PartySpec qualified
 import Hydra.PersistentQueueSpec qualified
 import Hydra.UtilsSpec qualified
-import Test.Hydra.TastyMain (defaultMainHydra, serializeOnCI, testSpec)
+import Test.Hydra.TastyMain (defaultMainHydra, testSpec)
 
 main :: IO ()
 main =
@@ -77,10 +77,7 @@ main =
     , testSpec "Model.MockChain" Hydra.Model.MockChainSpec.spec
     , testSpec "Model" Hydra.ModelSpec.spec
     , testSpec "Network.Authenticate" Hydra.Network.AuthenticateSpec.spec
-    , -- NetworkSpec spins 2–3 etcd subprocesses per test; running its cases
-      -- in parallel starves etcd on small CI runners and deadlocks the suite.
-      -- Serialize only there (CI=…); dev machines stay fully parallel.
-      serializeOnCI (testSpec "Network" Hydra.NetworkSpec.spec)
+    , testSpec "Network" Hydra.NetworkSpec.spec
     , testSpec "NetworkVersions" Hydra.NetworkVersionsSpec.spec
     , testSpec "Node.InputQueue" Hydra.Node.InputQueueSpec.spec
     , testSpec "Node.Run" Hydra.Node.RunSpec.spec

--- a/hydra-node/test/Main.hs
+++ b/hydra-node/test/Main.hs
@@ -1,8 +1,89 @@
 module Main where
 
 import Hydra.Prelude
-import Spec qualified
-import Test.Hspec.Runner
+
+import Hydra.API.ClientInputSpec qualified
+import Hydra.API.HTTPServerSpec qualified
+import Hydra.API.ServerOutputSpec qualified
+import Hydra.API.ServerSpec qualified
+import Hydra.BehaviorSpec qualified
+import Hydra.Chain.BlockfrostSpec qualified
+import Hydra.Chain.Direct.HandlersSpec qualified
+import Hydra.Chain.Direct.ScriptRegistrySpec qualified
+import Hydra.Chain.Direct.StateSpec qualified
+import Hydra.Chain.Direct.TimeHandleSpec qualified
+import Hydra.Chain.Direct.TxSpec qualified
+import Hydra.Chain.Direct.TxTraceSpec qualified
+import Hydra.Chain.Direct.WalletSpec qualified
+import Hydra.Chain.ScriptRegistrySpec qualified
+import Hydra.CryptoSpec qualified
+import Hydra.Events.RotationSpec qualified
+import Hydra.Events.S3Spec qualified
+import Hydra.Events.SQLiteBasedSpec qualified
+import Hydra.Events.UDPSpec qualified
+import Hydra.HeadLogicSnapshotSpec qualified
+import Hydra.HeadLogicSpec qualified
+import Hydra.JSONSchemaSpec qualified
+import Hydra.Ledger.Cardano.TimeSpec qualified
+import Hydra.Ledger.CardanoSpec qualified
+import Hydra.Ledger.SimpleSpec qualified
+import Hydra.Logging.MonitoringSpec qualified
+import Hydra.LoggingSpec qualified
+import Hydra.Model.MockChainSpec qualified
+import Hydra.ModelSpec qualified
+import Hydra.Network.AuthenticateSpec qualified
+import Hydra.NetworkSpec qualified
+import Hydra.NetworkVersionsSpec qualified
+import Hydra.Node.InputQueueSpec qualified
+import Hydra.Node.RunSpec qualified
+import Hydra.NodeSpec qualified
+import Hydra.OptionsSpec qualified
+import Hydra.PartySpec qualified
+import Hydra.PersistentQueueSpec qualified
+import Hydra.UtilsSpec qualified
+import Test.Hydra.TastyMain (defaultMainHydra, testSpec)
 
 main :: IO ()
-main = hspec Spec.spec
+main =
+  defaultMainHydra
+    "hydra-node"
+    [ testSpec "API.ClientInput" Hydra.API.ClientInputSpec.spec
+    , testSpec "API.HTTPServer" Hydra.API.HTTPServerSpec.spec
+    , testSpec "API.ServerOutput" Hydra.API.ServerOutputSpec.spec
+    , testSpec "API.Server" Hydra.API.ServerSpec.spec
+    , testSpec "Behavior" Hydra.BehaviorSpec.spec
+    , testSpec "Chain.Blockfrost" Hydra.Chain.BlockfrostSpec.spec
+    , testSpec "Chain.Direct.Handlers" Hydra.Chain.Direct.HandlersSpec.spec
+    , testSpec "Chain.Direct.ScriptRegistry" Hydra.Chain.Direct.ScriptRegistrySpec.spec
+    , testSpec "Chain.Direct.State" Hydra.Chain.Direct.StateSpec.spec
+    , testSpec "Chain.Direct.TimeHandle" Hydra.Chain.Direct.TimeHandleSpec.spec
+    , testSpec "Chain.Direct.Tx" Hydra.Chain.Direct.TxSpec.spec
+    , testSpec "Chain.Direct.TxTrace" Hydra.Chain.Direct.TxTraceSpec.spec
+    , testSpec "Chain.Direct.Wallet" Hydra.Chain.Direct.WalletSpec.spec
+    , testSpec "Chain.ScriptRegistry" Hydra.Chain.ScriptRegistrySpec.spec
+    , testSpec "Crypto" Hydra.CryptoSpec.spec
+    , testSpec "Events.Rotation" Hydra.Events.RotationSpec.spec
+    , testSpec "Events.S3" Hydra.Events.S3Spec.spec
+    , testSpec "Events.SQLiteBased" Hydra.Events.SQLiteBasedSpec.spec
+    , testSpec "Events.UDP" Hydra.Events.UDPSpec.spec
+    , testSpec "HeadLogicSnapshot" Hydra.HeadLogicSnapshotSpec.spec
+    , testSpec "HeadLogic" Hydra.HeadLogicSpec.spec
+    , testSpec "JSONSchema" Hydra.JSONSchemaSpec.spec
+    , testSpec "Ledger.Cardano" Hydra.Ledger.CardanoSpec.spec
+    , testSpec "Ledger.Cardano.Time" Hydra.Ledger.Cardano.TimeSpec.spec
+    , testSpec "Ledger.Simple" Hydra.Ledger.SimpleSpec.spec
+    , testSpec "Logging.Monitoring" Hydra.Logging.MonitoringSpec.spec
+    , testSpec "Logging" Hydra.LoggingSpec.spec
+    , testSpec "Model.MockChain" Hydra.Model.MockChainSpec.spec
+    , testSpec "Model" Hydra.ModelSpec.spec
+    , testSpec "Network.Authenticate" Hydra.Network.AuthenticateSpec.spec
+    , testSpec "Network" Hydra.NetworkSpec.spec
+    , testSpec "NetworkVersions" Hydra.NetworkVersionsSpec.spec
+    , testSpec "Node.InputQueue" Hydra.Node.InputQueueSpec.spec
+    , testSpec "Node.Run" Hydra.Node.RunSpec.spec
+    , testSpec "Node" Hydra.NodeSpec.spec
+    , testSpec "Options" Hydra.OptionsSpec.spec
+    , testSpec "Party" Hydra.PartySpec.spec
+    , testSpec "PersistentQueue" Hydra.PersistentQueueSpec.spec
+    , testSpec "Utils" Hydra.UtilsSpec.spec
+    ]

--- a/hydra-node/test/Spec.hs
+++ b/hydra-node/test/Spec.hs
@@ -1,1 +1,0 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}

--- a/hydra-plutus-extras/hydra-plutus-extras.cabal
+++ b/hydra-plutus-extras/hydra-plutus-extras.cabal
@@ -58,21 +58,17 @@ library
     , time
 
 test-suite tests
-  import:             project-config
-  ghc-options:        -threaded -rtsopts -with-rtsopts=-N
-  hs-source-dirs:     test
-  main-is:            Main.hs
-  type:               exitcode-stdio-1.0
-  other-modules:
-    Hydra.Plutus.Extras.TimeSpec
-    Spec
-
+  import:         project-config
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
+  hs-source-dirs: test
+  main-is:        Main.hs
+  type:           exitcode-stdio-1.0
+  other-modules:  Hydra.Plutus.Extras.TimeSpec
   build-depends:
     , base
     , hspec
     , hydra-plutus-extras
     , hydra-prelude
+    , hydra-test-utils
     , QuickCheck
     , time
-
-  build-tool-depends: hspec-discover:hspec-discover

--- a/hydra-plutus-extras/test/Main.hs
+++ b/hydra-plutus-extras/test/Main.hs
@@ -1,9 +1,13 @@
 module Main where
 
-import Prelude
+import Hydra.Prelude
 
-import Spec qualified
-import Test.Hspec (hspec)
+import Hydra.Plutus.Extras.TimeSpec qualified
+import Test.Hydra.TastyMain (defaultMainHydra, testSpec)
 
 main :: IO ()
-main = hspec Spec.spec
+main =
+  defaultMainHydra
+    "hydra-plutus-extras"
+    [ testSpec "Plutus.Extras.Time" Hydra.Plutus.Extras.TimeSpec.spec
+    ]

--- a/hydra-plutus-extras/test/Spec.hs
+++ b/hydra-plutus-extras/test/Spec.hs
@@ -1,1 +1,0 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -66,20 +66,17 @@ library
     , base
     , base16-bytestring
     , bytestring
-    , cardano-crypto-class
     , file-embed
-    , haskell-accumulator
     , hydra-cardano-api
     , hydra-plutus-extras
     , hydra-prelude
     , lens
     , lens-aeson
     , plutus-accumulator
-    , plutus-core           >=1.55
-    , plutus-ledger-api     >=1.55
-    , plutus-tx             >=1.53
-    , plutus-tx-plugin      >=1.53
-    , QuickCheck
+    , plutus-core          >=1.55
+    , plutus-ledger-api    >=1.55
+    , plutus-tx            >=1.53
+    , plutus-tx-plugin     >=1.53
     , serialise
     , template-haskell
     , time

--- a/hydra-plutus/hydra-plutus.cabal
+++ b/hydra-plutus/hydra-plutus.cabal
@@ -96,19 +96,17 @@ library testlib
     , QuickCheck
 
 test-suite tests
-  import:             project-config
-  ghc-options:        -threaded -rtsopts -with-rtsopts=-N
-  hs-source-dirs:     test
-  main-is:            Main.hs
-  type:               exitcode-stdio-1.0
+  import:         project-config
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
+  hs-source-dirs: test
+  main-is:        Main.hs
+  type:           exitcode-stdio-1.0
   other-modules:
     Hydra.Data.ContestationPeriodSpec
     Hydra.Plutus.GoldenSpec
-    Spec
 
   build-depends:
     , hspec
-    , hspec-golden
     , hydra-cardano-api
     , hydra-plutus
     , hydra-plutus:testlib
@@ -116,9 +114,10 @@ test-suite tests
     , hydra-test-utils
     , plutus-ledger-api
     , QuickCheck
+    , tasty
+    , tasty-golden
+    , tasty-hunit
     , typed-process
-
-  build-tool-depends: hspec-discover:hspec-discover
 
 executable inspect-script
   import:         project-config

--- a/hydra-plutus/test/Hydra/Plutus/GoldenSpec.hs
+++ b/hydra-plutus/test/Hydra/Plutus/GoldenSpec.hs
@@ -11,7 +11,6 @@
 module Hydra.Plutus.GoldenSpec where
 
 import Hydra.Prelude
-import Test.Hydra.Prelude
 
 import Hydra.Cardano.Api (
   File (..),
@@ -29,51 +28,75 @@ import Hydra.Contract.HeadTokens qualified as HeadTokens
 import Hydra.Version (gitDescribe)
 import PlutusLedgerApi.V3 (serialiseCompiledCode)
 import System.Process.Typed (runProcess_, shell)
-import Test.Hspec.Golden (Golden (..))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Golden.Advanced (goldenTest)
+import Test.Tasty.HUnit (assertFailure, testCase)
 
 aikenBuildCommand :: String
 aikenBuildCommand = "aiken build -t compact"
 
-spec :: Spec
-spec = do
-  it "Plutus blueprint is up-to-date" $ do
-    -- Running aiken -t compact should not change plutus.json
-    existing <- readFileBS "plutus.json"
-    runProcess_ $ shell aikenBuildCommand
-    actual <- readFileBS "plutus.json"
-    -- Undo any changes made by aiken
-    writeFileBS "plutus.json" existing
-    when (actual /= existing) $ do
-      putTextLn $ "Plutus blueprint in plutus.json is not up-to-date. Run " <> show aikenBuildCommand <> " to update it."
-    actual `shouldBe` existing
-
-  it "Head validator script" $
-    goldenScript "vHead" Head.validatorScript
-  it "Head minting policy script" $
-    goldenScript "mHead" (PlutusScriptSerialised $ serialiseCompiledCode HeadTokens.unappliedMintingPolicy)
-  it "CRS script" $
-    goldenScript "vCRS" CRS.validatorScript
+tests :: TestTree
+tests =
+  testGroup
+    "Hydra.Plutus.Golden"
+    [ testCase "Plutus blueprint is up-to-date" $ do
+        -- Running aiken -t compact should not change plutus.json
+        existing <- readFileBS "plutus.json"
+        runProcess_ $ shell aikenBuildCommand
+        actual <- readFileBS "plutus.json"
+        -- Undo any changes made by aiken
+        writeFileBS "plutus.json" existing
+        when (actual /= existing) $
+          assertFailure $
+            "Plutus blueprint in plutus.json is not up-to-date. Run "
+              <> show aikenBuildCommand
+              <> " to update it."
+    , goldenScript "Head validator script" "vHead" Head.validatorScript
+    , goldenScript
+        "Head minting policy script"
+        "mHead"
+        (PlutusScriptSerialised $ serialiseCompiledCode HeadTokens.unappliedMintingPolicy)
+    , goldenScript "CRS script" "vCRS" CRS.validatorScript
+    ]
 
 -- | Write a golden script on first run and ensure it stays the same on
--- subsequent runs.
-goldenScript :: String -> PlutusScript -> Golden Script
-goldenScript name plutusScript =
-  Golden
-    { output = PlutusScript plutusScript
-    , encodePretty = show . hashScript
-    , writeToFile
-    , readFromFile
-    , goldenFile = "scripts/" <> name <> ".plutus"
-    , actualFile = Nothing
-    , failFirstTime = False
-    }
+-- subsequent runs. The on-disk representation is cardano-api's text-envelope
+-- JSON; comparison is by 'Script' equality (ignoring the description metadata,
+-- which embeds a git describe and would otherwise be unstable).
+goldenScript :: String -> String -> PlutusScript -> TestTree
+goldenScript testName name plutusScript =
+  goldenTest
+    testName
+    readGolden
+    (pure expected)
+    compareScripts
+    writeGolden
  where
+  expected :: Script
+  expected = PlutusScript plutusScript
+
+  goldenFile :: FilePath
+  goldenFile = "scripts/" <> name <> ".plutus"
+
+  fullScriptName :: String
   fullScriptName = "hydra-" <> name <> maybe "" ("-" <>) gitDescribe
 
-  writeToFile fp script =
-    void $ writeFileTextEnvelope (File fp) (Just $ fromString fullScriptName) script
+  readGolden :: IO Script
+  readGolden =
+    readFileTextEnvelope (File goldenFile)
+      >>= either (fail . show) pure
 
-  readFromFile :: FilePath -> IO Script
-  readFromFile fp =
-    either (die . show) pure
-      =<< readFileTextEnvelope (File fp)
+  writeGolden :: Script -> IO ()
+  writeGolden script =
+    writeFileTextEnvelope (File goldenFile) (Just $ fromString fullScriptName) script
+      >>= either (fail . show) pure
+
+  compareScripts :: Script -> Script -> IO (Maybe String)
+  compareScripts golden actual
+    | golden == actual = pure Nothing
+    | otherwise =
+        pure . Just $
+          "script hash mismatch:\n  golden: "
+            <> show (hashScript golden)
+            <> "\n  actual: "
+            <> show (hashScript actual)

--- a/hydra-plutus/test/Main.hs
+++ b/hydra-plutus/test/Main.hs
@@ -2,9 +2,14 @@ module Main where
 
 import Hydra.Prelude
 
-import Test.Hspec.Runner (hspec)
-
-import Spec qualified
+import Hydra.Data.ContestationPeriodSpec qualified
+import Hydra.Plutus.GoldenSpec qualified
+import Test.Hydra.TastyMain (defaultMainHydra, testSpec)
 
 main :: IO ()
-main = hspec Spec.spec
+main =
+  defaultMainHydra
+    "hydra-plutus"
+    [ testSpec "Data.ContestationPeriod" Hydra.Data.ContestationPeriodSpec.spec
+    , pure Hydra.Plutus.GoldenSpec.tests
+    ]

--- a/hydra-plutus/test/Spec.hs
+++ b/hydra-plutus/test/Spec.hs
@@ -1,1 +1,0 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}

--- a/hydra-test-utils/hydra-test-utils.cabal
+++ b/hydra-test-utils/hydra-test-utils.cabal
@@ -34,6 +34,7 @@ library
   hs-source-dirs:  src
   exposed-modules:
     Test.Hydra.Prelude
+    Test.Hydra.TastyMain
     Test.Network.Ports
 
   build-depends:
@@ -50,4 +51,9 @@ library
     , QuickCheck
     , quickcheck-arbitrary-adt
     , relude
+    , tasty
+    , tasty-ant-xml
+    , tasty-hspec
+    , tasty-html
+    , tasty-rerun
     , temporary

--- a/hydra-test-utils/hydra-test-utils.cabal
+++ b/hydra-test-utils/hydra-test-utils.cabal
@@ -46,7 +46,6 @@ library
     , HUnit
     , hydra-prelude
     , network
-    , port-utils
     , process
     , QuickCheck
     , quickcheck-arbitrary-adt

--- a/hydra-test-utils/src/Test/Hydra/TastyMain.hs
+++ b/hydra-test-utils/src/Test/Hydra/TastyMain.hs
@@ -14,7 +14,6 @@ module Test.Hydra.TastyMain (
   hydraTestTree,
   hydraIngredients,
   testSpec,
-  serializeOnCI,
 ) where
 
 import Hydra.Prelude
@@ -24,19 +23,9 @@ import Test.Tasty (TestName, TestTree, defaultMainWithIngredients, localOption, 
 import Test.Tasty.Hspec (TreatPendingAs (TreatPendingAsSuccess), testSpec)
 import Test.Tasty.Ingredients (Ingredient, composeReporters)
 import Test.Tasty.Ingredients.Rerun (rerunningTests)
-import Test.Tasty.Runners (NumThreads (..), consoleTestReporter, listingTests)
+import Test.Tasty.Runners (consoleTestReporter, listingTests)
 import Test.Tasty.Runners.AntXML (antXMLRunner)
 import Test.Tasty.Runners.Html (htmlRunner)
-
--- | Force the given 'TestTree' to run one test at a time, but only when the
--- @CI@ env var is set. Keeps full parallelism on developer machines (which
--- have spare cores) while serializing resource-sensitive groups on the small
--- CI runners where parallel execution might otherwise starve them out.
-serializeOnCI :: IO TestTree -> IO TestTree
-serializeOnCI mtree = do
-  tree <- mtree
-  onCI <- isJust <$> lookupEnv "CI"
-  pure $ if onCI then localOption (NumThreads 1) tree else tree
 
 -- | Resolve a list of @IO TestTree@ into one Hydra-style 'TestTree' wrapped in
 -- the project-wide options. Suitable for further wrapping with 'localOption'

--- a/hydra-test-utils/src/Test/Hydra/TastyMain.hs
+++ b/hydra-test-utils/src/Test/Hydra/TastyMain.hs
@@ -14,6 +14,7 @@ module Test.Hydra.TastyMain (
   hydraTestTree,
   hydraIngredients,
   testSpec,
+  serializeOnCI,
 ) where
 
 import Hydra.Prelude
@@ -23,9 +24,19 @@ import Test.Tasty (TestName, TestTree, defaultMainWithIngredients, localOption, 
 import Test.Tasty.Hspec (TreatPendingAs (TreatPendingAsSuccess), testSpec)
 import Test.Tasty.Ingredients (Ingredient, composeReporters)
 import Test.Tasty.Ingredients.Rerun (rerunningTests)
-import Test.Tasty.Runners (consoleTestReporter, listingTests)
+import Test.Tasty.Runners (NumThreads (..), consoleTestReporter, listingTests)
 import Test.Tasty.Runners.AntXML (antXMLRunner)
 import Test.Tasty.Runners.Html (htmlRunner)
+
+-- | Force the given 'TestTree' to run one test at a time, but only when the
+-- @CI@ env var is set. Keeps full parallelism on developer machines (which
+-- have spare cores) while serializing resource-sensitive groups on the small
+-- CI runners where parallel execution might otherwise starve them out.
+serializeOnCI :: IO TestTree -> IO TestTree
+serializeOnCI mtree = do
+  tree <- mtree
+  onCI <- isJust <$> lookupEnv "CI"
+  pure $ if onCI then localOption (NumThreads 1) tree else tree
 
 -- | Resolve a list of @IO TestTree@ into one Hydra-style 'TestTree' wrapped in
 -- the project-wide options. Suitable for further wrapping with 'localOption'

--- a/hydra-test-utils/src/Test/Hydra/TastyMain.hs
+++ b/hydra-test-utils/src/Test/Hydra/TastyMain.hs
@@ -1,0 +1,86 @@
+-- | Shared test driver for Hydra test-suites. Each package's @test/Main.hs@
+-- builds a list of 'TestTree's and hands them to 'defaultMainHydra', which
+-- wraps everything in the project-wide options.
+--
+-- For Hspec specs use the re-exported 'testSpec'; for native tasty test trees
+-- use 'pure tree'.
+--
+-- Use 'hydraTestTree' if you need to wrap the tree in extra
+-- 'localOption' / 'adjustOption' layers (e.g. forcing 'NumThreads 1' for an
+-- integration suite) before handing it to 'Test.Tasty.defaultMain'.
+module Test.Hydra.TastyMain (
+  defaultMainHydra,
+  runHydraTests,
+  hydraTestTree,
+  hydraIngredients,
+  testSpec,
+) where
+
+import Hydra.Prelude
+
+import System.Environment qualified as Env
+import Test.Tasty (TestName, TestTree, defaultMainWithIngredients, localOption, testGroup)
+import Test.Tasty.Hspec (TreatPendingAs (TreatPendingAsSuccess), testSpec)
+import Test.Tasty.Ingredients (Ingredient, composeReporters)
+import Test.Tasty.Ingredients.Rerun (rerunningTests)
+import Test.Tasty.Runners (consoleTestReporter, listingTests)
+import Test.Tasty.Runners.AntXML (antXMLRunner)
+import Test.Tasty.Runners.Html (htmlRunner)
+
+-- | Resolve a list of @IO TestTree@ into one Hydra-style 'TestTree' wrapped in
+-- the project-wide options. Suitable for further wrapping with 'localOption'
+-- before handing to 'Test.Tasty.defaultMain'.
+hydraTestTree :: TestName -> [IO TestTree] -> IO TestTree
+hydraTestTree groupName trees = do
+  resolved <- sequence trees
+  pure $ localOption TreatPendingAsSuccess (testGroup groupName resolved)
+
+-- | The tasty ingredients used by every Hydra test-suite. Bundles
+-- @tasty-rerun@ (pass @--rerun@ to re-run only the previously-failed
+-- tests), @tasty-html@ (pass @--html=PATH@ to also write an HTML
+-- report) and @tasty-ant-xml@ (pass @--xml=PATH@ to write a JUnit-style
+-- XML report, which CI consumes to surface per-test failures in the
+-- GitHub UI) on top of the default console runner.
+--
+-- The XML / HTML / console reporters are composed with 'composeReporters'
+-- so they all run together: passing @--xml=…@ or @--html=…@ still prints
+-- the per-test pass\/fail list to stdout, rather than suppressing it.
+hydraIngredients :: [Ingredient]
+hydraIngredients =
+  [ rerunningTests
+      [ listingTests
+      , antXMLRunner `composeReporters` htmlRunner `composeReporters` consoleTestReporter
+      ]
+  ]
+
+-- | Run a tasty 'TestTree' with 'hydraIngredients'. Before tasty parses the
+-- command line, any literal @{suite}@ in argv is replaced with the given
+-- suite name. This lets a single @cabal test all
+-- --test-options=\"--html=test-reports\/{suite}.html\"@ write one report
+-- per package (e.g. @test-reports\/hydra-node.html@,
+-- @test-reports\/hydra-tx.html@, ...) instead of every suite overwriting
+-- the same file. Args without @{suite}@ pass through unchanged.
+runHydraTests :: TestName -> TestTree -> IO ()
+runHydraTests suite tree = do
+  args <- map (substituteSuite suite) <$> Env.getArgs
+  Env.withArgs args $ defaultMainWithIngredients hydraIngredients tree
+
+substituteSuite :: TestName -> String -> String
+substituteSuite suite = go
+ where
+  placeholder = "{suite}"
+  plen = length placeholder
+  go [] = []
+  go xs@(c : cs)
+    | placeholder `isPrefixOf` xs = suite <> go (drop plen xs)
+    | otherwise = c : go cs
+
+-- | Build a tasty test runner from a list of @IO TestTree@. Pending hspec
+-- tests (e.g. those guarded by 'onlyNightly' / 'onlyLocal') are treated as
+-- successes by default to match the project's hspec-era behaviour.
+--
+-- Substitutes the @{suite}@ placeholder in argv (see 'runHydraTests') and
+-- runs with 'hydraIngredients'.
+defaultMainHydra :: TestName -> [IO TestTree] -> IO ()
+defaultMainHydra groupName trees =
+  hydraTestTree groupName trees >>= runHydraTests groupName

--- a/hydra-test-utils/src/Test/Network/Ports.hs
+++ b/hydra-test-utils/src/Test/Network/Ports.hs
@@ -55,3 +55,57 @@ bindFreshLoopback = do
   s <- socket AF_INET Stream defaultProtocol
   bind s (SockAddrInet 0 (tupleToHostAddress (127, 0, 0, 1)))
   pure s
+
+-- | Find @count@ free TCPv4 ports such that for each returned port @p@, the
+-- /derived/ port @derive p@ is also free at allocation time.
+--
+-- This is needed for tests that drive a subprocess which itself opens a
+-- companion port computed from the configured one — e.g. etcd, whose client
+-- port is @listen - 2622@ in this codebase. A vanilla 'randomUnusedTCPPorts'
+-- guarantees the @count@ primary ports are mutually unique but says nothing
+-- about the derived companions, which can be in use by anything on the host
+-- (other processes, other test fixtures, TIME_WAIT, etc.). The result is a
+-- flaky 'bind: address already in use' the moment the subprocess starts.
+--
+-- We acquire the primary port from the OS, then try to bind its companion to
+-- prove it's free; if the companion bind fails we drop the primary and
+-- retry, up to a generous bound (collisions on the companion are rare in
+-- the ephemeral range, so we should converge quickly).
+--
+-- NOTE: There's still a small race between releasing the bound sockets and
+-- the subprocess binding them, but it's the same race 'randomUnusedTCPPorts'
+-- already has, and not the root cause of the etcd flakes.
+randomUnusedTCPPortsWithDerived ::
+  (PortNumber -> PortNumber) ->
+  Int ->
+  IO [Int]
+randomUnusedTCPPortsWithDerived derive count =
+  bracket (acquire count [] (count * 20)) release (pure . map (\(p, _, _) -> fromIntegral p))
+ where
+  acquire :: Int -> [(PortNumber, Socket, Socket)] -> Int -> IO [(PortNumber, Socket, Socket)]
+  acquire 0 acc _ = pure acc
+  acquire _ _ 0 =
+    fail $
+      "randomUnusedTCPPortsWithDerived: ran out of retries trying to pair "
+        <> show count
+        <> " primary ports with free derived ports."
+  acquire k acc budget = do
+    peerSock <- bindFreshLoopback
+    peerPortNum <- socketPort peerSock
+    let companion = derive peerPortNum
+    eClient <- try $ bindSpecificLoopback companion
+    case eClient of
+      Left (_ :: SomeException) -> do
+        close peerSock
+        acquire k acc (budget - 1)
+      Right clientSock ->
+        acquire (k - 1) ((peerPortNum, peerSock, clientSock) : acc) (budget - 1)
+
+  release :: [(PortNumber, Socket, Socket)] -> IO ()
+  release = mapM_ (\(_, ps, cs) -> close ps `finally` close cs)
+
+bindSpecificLoopback :: PortNumber -> IO Socket
+bindSpecificLoopback portNumber = do
+  s <- socket AF_INET Stream defaultProtocol
+  bind s (SockAddrInet portNumber (tupleToHostAddress (127, 0, 0, 1)))
+  pure s

--- a/hydra-test-utils/src/Test/Network/Ports.hs
+++ b/hydra-test-utils/src/Test/Network/Ports.hs
@@ -4,9 +4,18 @@ module Test.Network.Ports where
 import Hydra.Prelude
 
 import Network.Socket (
+  Family (AF_INET),
   PortNumber,
+  SockAddr (SockAddrInet),
+  Socket,
+  SocketType (Stream),
+  bind,
+  close,
+  defaultProtocol,
+  socket,
+  socketPort,
+  tupleToHostAddress,
  )
-import Network.Socket.Free (getFreePort)
 
 -- | Find a TCPv4 port which is likely to be free for listening on
 -- @localhost@. This binds a socket, receives an OS-assigned port, then closes
@@ -17,8 +26,7 @@ import Network.Socket.Free (getFreePort)
 --
 -- Do not use this unless you have no other option.
 getRandomPort :: IO PortNumber
-getRandomPort = do
-  fromIntegral <$> getFreePort
+getRandomPort = bracket bindFreshLoopback close socketPort
 
 -- | Find a free TCPv4 port and pass it to the given 'action'.
 --
@@ -28,8 +36,22 @@ withFreePort action = getRandomPort >>= action
 
 -- | Find the specified number of free ports.
 --
+-- The returned ports are guaranteed mutually unique: we bind all @count@
+-- sockets at once and only read their OS-assigned ports while every socket is
+-- still bound, then release them in one go. A naive sequential bind-close-read
+-- loop can hand back the same just-released ephemeral port twice on busy CI
+-- runners, which then explodes downstream as @EADDRINUSE@.
+--
 -- NOTE: Should be used only for testing, see 'getRandomPort' for limitations.
 randomUnusedTCPPorts :: Int -> IO [Int]
 randomUnusedTCPPorts count =
-  fmap fromIntegral
-    <$> replicateM count (withFreePort return)
+  bracket
+    (replicateM count bindFreshLoopback)
+    (mapM_ close)
+    (fmap (fmap fromIntegral) . mapM socketPort)
+
+bindFreshLoopback :: IO Socket
+bindFreshLoopback = do
+  s <- socket AF_INET Stream defaultProtocol
+  bind s (SockAddrInet 0 (tupleToHostAddress (127, 0, 0, 1)))
+  pure s

--- a/hydra-tui/hydra-tui.cabal
+++ b/hydra-tui/hydra-tui.cabal
@@ -93,7 +93,6 @@ test-suite tests
   other-modules:
     Hydra.TUI.OptionsSpec
     Hydra.TUISpec
-    Spec
 
   main-is:            Main.hs
   type:               exitcode-stdio-1.0
@@ -101,7 +100,6 @@ test-suite tests
     , blaze-builder
     , bytestring
     , filepath
-    , hspec
     , hydra-cardano-api
     , hydra-cluster
     , hydra-node
@@ -117,8 +115,5 @@ test-suite tests
     , vty
     , vty-unix
 
-  build-tool-depends:
-    , hspec-discover:hspec-discover
-    , hydra-node:hydra-node
-
+  build-tool-depends: hydra-node:hydra-node
   ghc-options:        -threaded -rtsopts

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -9,7 +9,7 @@ import Test.Hydra.Prelude
 import Blaze.ByteString.Builder.Char8 (writeChar)
 import CardanoNode (NodeLog, withCardanoNodeDevnet)
 import Control.Concurrent.Class.MonadMVar (MonadMVar (..))
-import Control.Concurrent.Class.MonadSTM (readTQueue, tryReadTQueue, writeTQueue)
+import Control.Concurrent.Class.MonadSTM (tryReadTQueue, writeTQueue)
 import Control.Monad.Class.MonadAsync (cancel, waitCatch)
 import Data.ByteString qualified as BS
 import Graphics.Vty (
@@ -363,14 +363,32 @@ withTUITest region action = do
       , sendInputEvent = atomically . writeTQueue q
       , getPicture
       , shouldRender = \expected -> do
-          bytes <- getPicture
-          let unescaped = findBytes bytes
-          unless (expected `BS.isInfixOf` unescaped) $
-            failure $
-              "Expected bytes not found in frame: "
-                <> decodeUtf8 expected
-                <> "\n"
-                <> decodeUtf8 unescaped
+          -- Poll the frame buffer until @expected@ appears or the budget runs
+          -- out. The TUI updates asynchronously (vty render + WebSocket event
+          -- stream), so a single point check after a fixed 'threadDelay' is
+          -- racy under CI load — especially after 'restartNode', where the
+          -- ~700 ms hydra-node KZG warm-up eats most of the post-restart
+          -- budget before the head state is even pushed to the TUI.
+          let budget = 5 :: NominalDiffTime
+          deadline <- addUTCTime budget <$> getCurrentTime
+          let loop = do
+                bytes <- getPicture
+                let unescaped = findBytes bytes
+                if expected `BS.isInfixOf` unescaped
+                  then pure ()
+                  else do
+                    now <- getCurrentTime
+                    if now >= deadline
+                      then
+                        failure $
+                          "Expected bytes not found in frame within "
+                            <> show budget
+                            <> ": "
+                            <> decodeUtf8 expected
+                            <> "\n"
+                            <> decodeUtf8 unescaped
+                      else threadDelay 0.05 >> loop
+          loop
       , shouldNotRender = \expected -> do
           bytes <- getPicture
           let unescaped = findBytes bytes
@@ -398,10 +416,23 @@ withTUITest region action = do
     realOut <- buildOutput userCfg =<< defaultSettings
     closeFd nullFd
     let output = testOut realOut as frameBuffer
+    -- Poll the test event queue instead of STM-blocking on it. A blocking
+    -- 'readTQueue q' makes GHC raise 'BlockedIndefinitelyOnSTM' against the
+    -- brick thread the moment the test action returns: that's when its
+    -- 'sendInputEvent' closure (the only writer reference to @q@) is GC'd,
+    -- and the RTS notices the brick reader has no possible writers. The
+    -- 'raceLabelled_' below cancels the brick thread immediately after, so
+    -- the deadlock is purely transient — but the RTS still prints the
+    -- exception to stderr before the cancel arrives, which makes the test
+    -- output look broken even though it passes.
+    let pollNextEvent =
+          atomically (tryReadTQueue q) >>= \case
+            Just e -> pure e
+            Nothing -> threadDelay 0.01 >> pollNextEvent
     pure $
       Vty
         { inputIface = input -- TODO(SN): this is not used
-        , nextEvent = atomically $ readTQueue q
+        , nextEvent = pollNextEvent
         , nextEventNonblocking = atomically $ tryReadTQueue q
         , outputIface = output
         , update = \p -> do

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -49,8 +49,9 @@ import Hydra.TUI.Drawing (renderTime)
 import Hydra.TUI.Options (Options (..))
 import Hydra.Tx.ContestationPeriod (ContestationPeriod, toNominalDiffTime)
 import HydraNode (
-  HydraClient (HydraClient, hydraNodeId),
+  HydraClient (..),
   HydraNodeLog,
+  allocateHydraNodePortsFor,
   prepareHydraNode,
   withHydraNode,
   withPreparedHydraNode,
@@ -188,7 +189,8 @@ setupRotatedStateTUI action = do
         seedFromFaucet_ backendOpts externalVKey 42_000_000 (contramap FromFaucet tracer)
         (aliceCardanoVk, _) <- keysFor Alice
         seedFromFaucet_ backendOpts aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
-        options <- prepareHydraNode chainConfig tmpDir nodeId aliceSk [] [nodeId] id
+        nodePorts <- allocateHydraNodePortsFor [nodeId]
+        options <- prepareHydraNode chainConfig tmpDir nodeId aliceSk [] nodePorts id
         let options' = options{persistenceRotateAfter = Just (Positive 1)}
         withTUIRotatedTest (contramap FromHydra tracer) tmpDir nodeId blockTime backend externalKeyFilePath options' action
 
@@ -255,7 +257,7 @@ withTUIRotatedTest ::
 withTUIRotatedTest tracer tmpDir nodeId blockTime backend externalKeyFilePath options action =
   withHydraNodeHandle tracer tmpDir nodeId options $ \nodeHandle -> do
     startNode nodeHandle
-    HydraClient{hydraNodeId} <- getClient nodeHandle
+    HydraClient{apiHost = Host{port = apiPort}} <- getClient nodeHandle
     withTUITest (150, 10) $ \brickTest@TUITest{buildVty} -> do
       raceLabelled_
         ( "run-vty"
@@ -266,7 +268,7 @@ withTUIRotatedTest tracer tmpDir nodeId blockTime backend externalKeyFilePath op
                 { hydraNodeHost =
                     Host
                       { hostname = "127.0.0.1"
-                      , port = fromIntegral $ 4000 + hydraNodeId
+                      , port = apiPort
                       }
                 , cardanoConnection =
                     Right nodeSocket
@@ -306,7 +308,8 @@ setupNodeAndTUI' hostname lovelace action =
         -- Some ADA to commit
         seedFromFaucet_ backendOpts externalVKey 42_000_000 (contramap FromFaucet tracer)
         let DirectOptions{nodeSocket, networkId} = backend
-        withHydraNode (contramap FromHydra tracer) blockTime chainConfig tmpDir nodeId aliceSk [] [nodeId] $ \HydraClient{hydraNodeId} -> do
+        nodePorts <- allocateHydraNodePortsFor [nodeId]
+        withHydraNode (contramap FromHydra tracer) blockTime chainConfig tmpDir nodeId aliceSk [] nodePorts $ \HydraClient{apiHost = Host{port = apiPort}} -> do
           seedFromFaucet_ backendOpts aliceCardanoVk lovelace (contramap FromFaucet tracer)
 
           withTUITest (150, 10) $ \brickTest@TUITest{buildVty} -> do
@@ -318,7 +321,7 @@ setupNodeAndTUI' hostname lovelace action =
                     { hydraNodeHost =
                         Host
                           { hostname = hostname
-                          , port = fromIntegral $ 4000 + hydraNodeId
+                          , port = apiPort
                           }
                     , cardanoConnection =
                         Right nodeSocket

--- a/hydra-tui/test/Main.hs
+++ b/hydra-tui/test/Main.hs
@@ -1,8 +1,15 @@
 module Main where
 
 import Hydra.Prelude
-import Spec qualified
-import Test.Hspec.Runner
+
+import Hydra.TUI.OptionsSpec qualified
+import Hydra.TUISpec qualified
+import Test.Hydra.TastyMain (defaultMainHydra, testSpec)
 
 main :: IO ()
-main = hspec Spec.spec
+main =
+  defaultMainHydra
+    "hydra-tui"
+    [ testSpec "TUI" Hydra.TUISpec.spec
+    , testSpec "TUI.Options" Hydra.TUI.OptionsSpec.spec
+    ]

--- a/hydra-tui/test/Spec.hs
+++ b/hydra-tui/test/Spec.hs
@@ -1,1 +1,0 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}

--- a/hydra-tx/hydra-tx.cabal
+++ b/hydra-tx/hydra-tx.cabal
@@ -166,10 +166,10 @@ library testlib
   ghc-options:        -haddock
 
 test-suite tests
-  import:             project-config
-  ghc-options:        -threaded -rtsopts -with-rtsopts=-N
-  hs-source-dirs:     test
-  main-is:            Main.hs
+  import:         project-config
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
+  hs-source-dirs: test
+  main-is:        Main.hs
   other-modules:
     Hydra.Tx.ContestationPeriodSpec
     Hydra.Tx.Contract.Close.CloseInitial
@@ -191,9 +191,8 @@ test-suite tests
     Hydra.Tx.HeadIdSpec
     Hydra.Tx.IsTxSpec
     Hydra.Tx.KZGTrustedSetupSpec
-    Spec
 
-  type:               exitcode-stdio-1.0
+  type:           exitcode-stdio-1.0
   build-depends:
     , aeson
     , base
@@ -225,8 +224,7 @@ test-suite tests
     , quickcheck-instances
     , time
 
-  build-tool-depends: hspec-discover:hspec-discover
-  ghc-options:        -threaded -rtsopts
+  ghc-options:    -threaded -rtsopts
 
 benchmark accumulator-bench
   import:         project-config

--- a/hydra-tx/test/Main.hs
+++ b/hydra-tx/test/Main.hs
@@ -1,8 +1,21 @@
 module Main where
 
 import Hydra.Prelude
-import Spec qualified
-import Test.Hspec.Runner
+
+import Hydra.Tx.ContestationPeriodSpec qualified
+import Hydra.Tx.Contract.ContractSpec qualified
+import Hydra.Tx.HeadIdSpec qualified
+import Hydra.Tx.IsTxSpec qualified
+import Hydra.Tx.KZGTrustedSetupSpec qualified
+import Test.Hydra.TastyMain (defaultMainHydra, testSpec)
 
 main :: IO ()
-main = hspec Spec.spec
+main =
+  defaultMainHydra
+    "hydra-tx"
+    [ testSpec "ContestationPeriod" Hydra.Tx.ContestationPeriodSpec.spec
+    , testSpec "Contract" Hydra.Tx.Contract.ContractSpec.spec
+    , testSpec "HeadId" Hydra.Tx.HeadIdSpec.spec
+    , testSpec "IsTx" Hydra.Tx.IsTxSpec.spec
+    , testSpec "KZGTrustedSetup" Hydra.Tx.KZGTrustedSetupSpec.spec
+    ]

--- a/hydra-tx/test/Spec.hs
+++ b/hydra-tx/test/Spec.hs
@@ -1,1 +1,0 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}

--- a/justfile
+++ b/justfile
@@ -18,7 +18,10 @@ check:
     --flake ".#checks.$(nix eval --impure --raw --expr builtins.currentSystem)" \
     --no-link \
     --skip-cached
-  just check-html
+  # nix-fast-build writes per-suite XML/HTML into each test derivation's nix
+  # store path, not ./test-reports/. Only build a local index if some other
+  # invocation ('just test') has already populated test-reports/.
+  if ls test-reports/*.xml >/dev/null 2>&1; then just test-index; fi
 
 # run cabal tests, optionally with a tasty pattern (see `--pattern`).
 # `--keep-going` so failures in one test-suite don't hide failures in others;

--- a/justfile
+++ b/justfile
@@ -23,19 +23,38 @@ check:
   # invocation ('just test') has already populated test-reports/.
   if ls test-reports/*.xml >/dev/null 2>&1; then just test-index; fi
 
-# run cabal tests, optionally with a tasty pattern (see `--pattern`).
+# run cabal tests, optionally with a tasty `--pattern`.
 # `--keep-going` so failures in one test-suite don't hide failures in others;
 # `{suite}` is substituted with the test-suite name by `runHydraTests`, so a
 # single `just test` produces one HTML+XML report per package and an
 # index.html that links them.
+#
+# The pattern is wrapped in /.../ so tasty matches it as a literal substring
+# of the test path (a bare word like `expired-lease` is otherwise read as
+# the awk expression `expired - lease`, which evaluates to 0 and matches
+# nothing). Hyphens are translated to spaces so a shell-friendly hyphenated
+# token like `expired-lease` matches a test named `expired lease` — handy
+# because tasty matches `/.../` content verbatim (including spaces) rather
+# than as full regex.
+#
+# Example:
+#   just test hydra-node expired-lease       # → --pattern=/expired lease/
 test PKG="all" PATTERN="":
   #!/usr/bin/env bash
   set -euo pipefail
   mkdir -p test-reports
-  cabal test {{PKG}} \
-    --keep-going \
-    --test-options="--html=$(pwd)/test-reports/{suite}.html --xml=$(pwd)/test-reports/{suite}.xml" \
-    {{ if PATTERN == "" { "" } else { "--test-options=--pattern=" + PATTERN } }}
+  args=(
+    --keep-going
+    "--test-options=--html=$(pwd)/test-reports/{suite}.html --xml=$(pwd)/test-reports/{suite}.xml"
+  )
+  if [ -n "{{PATTERN}}" ]; then
+    needle=$(printf %s "{{PATTERN}}" | tr '-' ' ')
+    # --test-option (singular) passes ARG verbatim, while --test-options
+    # (plural) splits on whitespace — so use the singular form for the
+    # pattern, which usually contains spaces after the hyphen rewrite.
+    args+=("--test-option=--pattern=/${needle}/")
+  fi
+  cabal test {{PKG}} "${args[@]}"
   just test-index
 
 # emit ./test-reports/index.html linking to per-suite HTML reports, with

--- a/justfile
+++ b/justfile
@@ -10,16 +10,72 @@ default:
 ci:
   selfci check --print-output
 
-# run "nix-fast-build" to run the nix checks
+# run "nix-fast-build" to run the nix checks, then produce HTML test reports
+# under ./test-reports/ via the tasty-html ingredient wired into every Hydra
+# test-suite. Reports are written per package so they don't overwrite each other.
 check:
   nix-fast-build \
     --flake ".#checks.$(nix eval --impure --raw --expr builtins.currentSystem)" \
     --no-link \
     --skip-cached
+  just check-html
 
-# run cabal tests, optionally with some test selection
-test PKG="all" PATTERN="/":
-  cabal test {{PKG}} --test-options='--match "{{PATTERN}}"'
+# run cabal tests, optionally with a tasty pattern (see `--pattern`).
+# `--keep-going` so failures in one test-suite don't hide failures in others;
+# `{suite}` is substituted with the test-suite name by `runHydraTests`, so a
+# single `just test` produces one HTML+XML report per package and an
+# index.html that links them.
+test PKG="all" PATTERN="":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  mkdir -p test-reports
+  cabal test {{PKG}} \
+    --keep-going \
+    --test-options="--html=$(pwd)/test-reports/{suite}.html --xml=$(pwd)/test-reports/{suite}.xml" \
+    {{ if PATTERN == "" { "" } else { "--test-options=--pattern=" + PATTERN } }}
+  just test-index
+
+# emit ./test-reports/index.html linking to per-suite HTML reports, with
+# pass/fail/error counts pulled from the per-suite JUnit XML.
+test-index:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  cd test-reports
+  shopt -s nullglob
+  xmls=(*.xml)
+  if [ ${#xmls[@]} -eq 0 ]; then
+    echo "no test-reports/*.xml found — run 'just test' first" >&2
+    exit 1
+  fi
+  {
+    echo '<!doctype html><meta charset="utf-8"><title>Hydra test reports</title>'
+    echo '<style>'
+    echo 'body{font-family:system-ui,sans-serif;max-width:50rem;margin:2rem auto;padding:0 1rem;color:#222}'
+    echo 'h1{font-size:1.4rem}table{border-collapse:collapse;width:100%}'
+    echo 'th,td{padding:.4rem .7rem;text-align:left;border-bottom:1px solid #e3e3e3}'
+    echo 'th{font-weight:600;background:#f7f7f7}td.num{text-align:right;font-variant-numeric:tabular-nums}'
+    echo 'tr.fail td:first-child::before{content:"✗ ";color:#b00}'
+    echo 'tr.ok td:first-child::before{content:"✓ ";color:#080}'
+    echo 'a{color:#06c;text-decoration:none}a:hover{text-decoration:underline}'
+    echo '</style>'
+    echo "<h1>Hydra test reports <small style=\"font-weight:normal;color:#777\">— generated $(date '+%Y-%m-%d %H:%M:%S')</small></h1>"
+    echo '<table><thead><tr><th>Suite</th><th class="num">Tests</th><th class="num">Failed</th><th class="num">Errors</th><th>Generated</th></tr></thead><tbody>'
+    for xml in "${xmls[@]}"; do
+      suite="${xml%.xml}"
+      html="${suite}.html"
+      attrs=$(head -c 4096 "$xml" || true)
+      tests=$(printf %s "$attrs" | grep -oE 'tests="[0-9]+"'    | head -1 | grep -oE '[0-9]+' || echo "?")
+      fails=$(printf %s "$attrs" | grep -oE 'failures="[0-9]+"' | head -1 | grep -oE '[0-9]+' || echo "0")
+      errs=$(printf %s  "$attrs" | grep -oE 'errors="[0-9]+"'   | head -1 | grep -oE '[0-9]+' || echo "0")
+      mtime=$(date -r "$xml" '+%Y-%m-%d %H:%M:%S')
+      cls="ok"
+      if [ "${fails:-0}" != "0" ] || [ "${errs:-0}" != "0" ]; then cls="fail"; fi
+      if [ -f "$html" ]; then link="<a href=\"$html\">$suite</a>"; else link="$suite"; fi
+      echo "<tr class=\"$cls\"><td>$link</td><td class=\"num\">$tests</td><td class=\"num\">$fails</td><td class=\"num\">$errs</td><td>$mtime</td></tr>"
+    done
+    echo '</tbody></table>'
+  } > index.html
+  echo "wrote test-reports/index.html (${#xmls[@]} suites)"
 
 # build with -Werror and strict linting flags.
 lint PKG="all":

--- a/nix/hydra/haddocks.nix
+++ b/nix/hydra/haddocks.nix
@@ -4,7 +4,6 @@ _: {
       {
         paths = [
           hsPkgs.hydra-prelude.components.library.doc
-          hsPkgs.hydra-cardano-api.components.library.doc
           hsPkgs.hydra-plutus.components.library.doc
           hsPkgs.hydra-node.components.library.doc
           hsPkgs.hydra-tx.components.library.doc

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -174,6 +174,7 @@
               pkgs.cardano-cli
               pkgs.mithril-client-cli
               pkgs.check-jsonschema
+              pkgs.etcd # hydra-cluster's HydraNode.hs runs hydra-node with SystemEtcd
             ];
         };
         hydra-tui-tests = pkgs.mkShellNoCC {
@@ -184,6 +185,7 @@
               hydra-node
               pkgs.cardano-node
               pkgs.cardano-cli
+              pkgs.etcd # hydra-cluster's HydraNode.hs runs hydra-node with SystemEtcd
             ];
         };
 

--- a/nix/hydra/packages.nix
+++ b/nix/hydra/packages.nix
@@ -204,6 +204,7 @@
               hydra-node
               pkgs.cardano-node
               pkgs.cardano-cli
+              pkgs.etcd # hydra-cluster's HydraNode.hs runs hydra-node with SystemEtcd
             ];
         };
       } // staticPackages;

--- a/nix/hydra/project.nix
+++ b/nix/hydra/project.nix
@@ -99,11 +99,15 @@
           # GHC 9.6.7 has a haddock bug (tyConStupidTheta) that panics on data
           # types declared with the deprecated DatatypeContexts extension.
           # Skip haddocks for the affected upstream packages so `withHoogle`
-          # can still index everything else.
+          # can still index everything else. hydra-cardano-api re-exports
+          # Cardano.Api broadly (module X / module Cardano.Api), which surfaces
+          # the same DatatypeContexts types and panics haddock on our wrapper
+          # package too.
           {
             packages.cardano-diffusion.doHaddock = false;
             packages.cardano-ledger-shelley.doHaddock = false;
             packages.ouroboros-network.doHaddock = false;
+            packages.hydra-cardano-api.doHaddock = false;
           }
         ];
       };

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -25,7 +25,6 @@
         # For plotting results of hydra-cluster benchmarks
         pkgs.gnuplot
         pkgs.haskell-language-server
-        pkgs.haskellPackages.hspec-discover
         # The interactive Glasgow Haskell Compiler as a Daemon
         pkgs.haskellPackages.ghcid
         # Generate a graph of the module dependencies in the "dot" format


### PR DESCRIPTION
Wait for #2324 to merge.

This makes a couple of changes to the tests:

1. Switch from hspec to tasty. Why? Few reasons, but 1 is I want to try [tasty-cache](https://github.com/silky/tasty-cache);
2. We get some nice formatted test output in the PRs now:
  <img width="870" height="1031" alt="image" src="https://github.com/user-attachments/assets/0c660f0e-7103-4d78-a2cd-e1b3c2e0f5a6" />
3. Some more tests are ran in parallel
