### PR TITLE
Simple claude.md ; `just lint` uses separate directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /cabal.project.local
 /cabal.project.old
 /dist-newstyle/
+/dist-newstyle-lint/
 
 # Haskell
 *.eventlog

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ new-headers.txt
 
 # Blockfrost environment
 blockfrost-project.txt
+
+# Claude
+CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# Development workflow
+
+- You can launch `cabal repl <project>` to make quick recompilations in a separate process while working on features
+- Always run `just lint` after finishing code changes
+- Run `just check` as a final step; it's resource-intensive so prefer to do as few times as possible
+- Whenever a code change is complete, make sure any documentation is also updated; you can look in `docs/` to find it
+
+# Testing
+
+- Run `just test <package> "<test name pattern>"`; i.e. `just test hydra-tx "hashing"`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 # Testing
 
-- If making same-package changes, use the `cabal repl <package>:test:tests` to load the test package and run the tests through `:main -p  "<test name>"`
+- If making same-package changes, use the `cabal repl <package>:test:tests` to load the test package and run the tests through `:main -p  "/<test name>/"`
 - If making cross-package changes, you can use `just test <package> "<test name>"`; i.e. `just test hydra-tx "hashing"`
 
 # Finishing code changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,14 @@
 # Development workflow
 
 - You can launch `cabal repl <project>` to make quick recompilations in a separate process while working on features
-- Always run `just lint` after finishing code changes
-- Run `just check` as a final step; it's resource-intensive so prefer to do as few times as possible
-- Whenever a code change is complete, make sure any documentation is also updated; you can look in `docs/` to find it
 
 # Testing
 
-- Run `just test <package> "<test name pattern>"`; i.e. `just test hydra-tx "hashing"`
+- If making same-package changes, use the `cabal repl <package>:test:tests` to load the test package and run the tests through `:main -p  "<test name>"`
+- If making cross-package changes, you can use `just test <package> "<test name>"`; i.e. `just test hydra-tx "hashing"`
+
+# Finishing code changes
+
+- Always run `just lint` and iterate on fixes after finishing code changes
+- Run `just test && just check` as a final step; it's resource-intensive so prefer to do as few times as possible
+- Make sure any documentation is also updated; you can look in `docs/` to find it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,9 @@
 
 # Testing
 
-- If making same-package changes, use the `cabal repl <package>:test:tests` to load the test package and run the tests through `:main -p  "/<test name>/"`
-- If making cross-package changes, you can use `just test <package> "<test name>"`; i.e. `just test hydra-tx "hashing"`
+- If making same-package changes, use `cabal repl <package>:test:tests` to load the test package and run the tests through `:main -p  "/<test name>/"`
+- If making cross-package changes, use `just test <package> "<test name>"`; i.e. `just test hydra-tx "hashing"`
+  - :reload won't pick up dep changes (it silently keeps the old compiled dep) so tests can falsely pass. Restart the repl, or use just test.
 
 # Finishing code changes
 

--- a/hydra-prelude/src/Hydra/Prelude.hs
+++ b/hydra-prelude/src/Hydra/Prelude.hs
@@ -256,25 +256,25 @@ newLabelledTBQueueIO = (atomically .) . newLabelledTBQueue
 
 -- * Helpers for labeling Threads
 
-raceLabelled :: (MonadThread m, MonadAsync m) => (String, m a) -> (String, m b) -> m (Either a b)
+raceLabelled :: MonadAsync m => (String, m a) -> (String, m b) -> m (Either a b)
 raceLabelled (lblA, mA) (lblB, mB) =
   race
     (labelThisThread lblA >> mA)
     (labelThisThread lblB >> mB)
 
-raceLabelled_ :: (MonadThread m, MonadAsync m) => (String, m a) -> (String, m b) -> m ()
+raceLabelled_ :: MonadAsync m => (String, m a) -> (String, m b) -> m ()
 raceLabelled_ = (void .) . raceLabelled
 
 withAsyncLabelled :: MonadAsync m => (String, m a) -> (Async m a -> m b) -> m b
 withAsyncLabelled (lbl, ma) = withAsync (labelThisThread lbl >> ma)
 
-concurrentlyLabelled :: (MonadThread m, MonadAsync m) => (String, m a) -> (String, m b) -> m (a, b)
+concurrentlyLabelled :: MonadAsync m => (String, m a) -> (String, m b) -> m (a, b)
 concurrentlyLabelled (lblA, mA) (lblB, mB) =
   concurrently
     (labelThisThread lblA >> mA)
     (labelThisThread lblB >> mB)
 
-concurrentlyLabelled_ :: (MonadThread m, MonadAsync m) => (String, m a) -> (String, m b) -> m ()
+concurrentlyLabelled_ :: MonadAsync m => (String, m a) -> (String, m b) -> m ()
 concurrentlyLabelled_ = (void .) . concurrentlyLabelled
 
 asyncLabelled :: MonadAsync m => String -> m a -> m (Async m a)

--- a/justfile
+++ b/justfile
@@ -10,18 +10,12 @@ default:
 ci:
   selfci check --print-output
 
-# run "nix-fast-build" to run the nix checks, then produce HTML test reports
-# under ./test-reports/ via the tasty-html ingredient wired into every Hydra
-# test-suite. Reports are written per package so they don't overwrite each other.
+# run "nix-fast-build" to run the nix checks
 check:
   nix-fast-build \
     --flake ".#checks.$(nix eval --impure --raw --expr builtins.currentSystem)" \
     --no-link \
     --skip-cached
-  # nix-fast-build writes per-suite XML/HTML into each test derivation's nix
-  # store path, not ./test-reports/. Only build a local index if some other
-  # invocation ('just test') has already populated test-reports/.
-  if ls test-reports/*.xml >/dev/null 2>&1; then just test-index; fi
 
 # run cabal tests, optionally with a tasty `--pattern`.
 # `--keep-going` so failures in one test-suite don't hide failures in others;

--- a/justfile
+++ b/justfile
@@ -97,11 +97,17 @@ test-index:
   echo "wrote test-reports/index.html (${#xmls[@]} suites)"
 
 # format, and build with -Werror and strict linting flags.
+#
+# Uses a dedicated --builddir so the strict -Werror / extra -W… flags here
+# don't invalidate the regular dist-newstyle artifacts used by 'just test',
+# cabal repl, etc. (cabal keys its build cache on ghc-options, so mixing the
+# two would force a full rebuild on every switch).
 lint PKG="all":
   #!/usr/bin/env bash
   set -euo pipefail
   nix fmt
   cabal build {{PKG}} \
+    --builddir=dist-newstyle-lint \
     --ghc-options="-Werror \
       -Wall \
       -Wcompat \

--- a/justfile
+++ b/justfile
@@ -59,6 +59,9 @@ test PKG="all" PATTERN="":
 
 # emit ./test-reports/index.html linking to per-suite HTML reports, with
 # pass/fail/error counts pulled from the per-suite JUnit XML.
+#
+# Note: This was written with Claude; so don't worry too much about the HTML
+# detail, or changing it.
 test-index:
   #!/usr/bin/env bash
   set -euo pipefail
@@ -99,8 +102,11 @@ test-index:
   } > index.html
   echo "wrote test-reports/index.html (${#xmls[@]} suites)"
 
-# build with -Werror and strict linting flags.
+# format, and build with -Werror and strict linting flags.
 lint PKG="all":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  nix fmt
   cabal build {{PKG}} \
     --ghc-options="-Werror \
       -Wall \


### PR DESCRIPTION
Following https://arps18.github.io/posts/claude-code-mastery/#31-the-real-claudemd-from-the-claude-code-team this adds a very simple CLAUDE.md.

I also add a CLAUDE.local.md; for me I think I will put in that:

```
- Don't ever commit or push; I'll do that manually
```

If you all agree these steps here are an absolute minimum, we can go with it!

One annoying thing about the .local.md files is that you need to put them in every worktree ( cc @v0d1ch ); so maybe it's of dubious value anyway 🤷🏻 .

Note that this also changes the `just lint` step to use a separate directory; so linting and regular building don't overwrite each other.

### Todo

- [x] Show an example of something maybe we'd like in a CLAUDE.local.md file
- [x] Decide if this is really the _minimum_ (I'm happy with it; you can decide by voting against the PR 😂 )
- [x] Check if the advice about the cabal repl is good enough
