### PR TITLE
Resolve pumba-style test failure by more resilient etcd writes

### DIFF
--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -448,6 +448,10 @@ waitForAllConfirmations n1 Registry{processedTxs} allIds = do
             confirmedIds <- mapM (confirmTx processedTxs) txIds
             go $ remainingIds \\ Set.fromList confirmedIds
 
+  -- 60s (was 20s) so the pumba network-loss benchmark
+  -- ('.github/workflows/network-test.yaml', up to 90% packet loss) has
+  -- enough headroom for snapshot confirmation under repeated gRPC
+  -- retries. Tighten only after re-running that workflow.
   waitForSnapshotConfirmation = waitMatch 60 n1 $ \v ->
     maybeTxValid v <|> maybeTxInvalid v <|> maybeSnapshotConfirmed v
 

--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -448,7 +448,7 @@ waitForAllConfirmations n1 Registry{processedTxs} allIds = do
             confirmedIds <- mapM (confirmTx processedTxs) txIds
             go $ remainingIds \\ Set.fromList confirmedIds
 
-  waitForSnapshotConfirmation = waitMatch 20 n1 $ \v ->
+  waitForSnapshotConfirmation = waitMatch 60 n1 $ \v ->
     maybeTxValid v <|> maybeTxInvalid v <|> maybeSnapshotConfirmed v
 
   maybeTxValid :: Value -> Maybe WaitResult

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -55,7 +55,7 @@ import System.Process.Typed (
  )
 import Test.Hydra.Prelude (failure)
 import Test.Hydra.Prelude qualified as Prelude
-import Test.Network.Ports (randomUnusedTCPPorts)
+import Test.Network.Ports (randomUnusedTCPPorts, randomUnusedTCPPortsWithDerived)
 import Prelude qualified
 
 -- * Client to interact with a hydra-node
@@ -369,49 +369,52 @@ allocateHydraNodePorts = do
 -- must be passed to every 'prepareHydraNode' / 'withHydraNode' call for
 -- nodes in this cluster so peers can be addressed correctly.
 --
--- All @3 * length nodeIds@ ports are requested in a single
--- 'randomUnusedTCPPorts' call so they're mutually unique. A per-node loop
--- would close each batch's sockets between calls, letting the kernel hand
--- back a just-released port to a later node — which is exactly how
--- @--listen@ for one node ended up equal to @--monitoring-port@ for another
--- and crashed etcd with @EADDRINUSE@ in the 'two heads on the same network'
--- test.
+-- Listen ports are taken via 'randomUnusedTCPPortsWithDerived' so each
+-- listen port's derived etcd /client/ port — 'peerPortToClientPort' — is
+-- actually held bound at allocation time. That defends against two
+-- failure modes: an unrelated process on the host occupying the derived
+-- port (which a plain 'randomUnusedTCPPorts' would not catch and which
+-- explodes as @EADDRINUSE@ the moment etcd starts), and an unlucky draw
+-- where the derived port lands on top of another node's api/monitoring
+-- port (which used to make the GRPC client talk to Warp instead of
+-- etcd).
 --
--- Additionally, hydra-node derives its etcd client port from the listen
--- port (see 'peerPortToClientPort'), and the derived port is /not/ in the
--- batch we asked the OS for. We retry until the derived ports are also
--- disjoint from every primary; otherwise an unlucky draw makes a node's
--- etcd client port equal its own (or another node's) api/monitoring port,
--- and the GRPC client ends up talking to Warp instead of etcd.
+-- Api and monitoring ports are then acquired in a second batch and
+-- checked to be disjoint from both the listen ports and the derived
+-- client ports; on collision we retry that second batch.
 allocateHydraNodePortsFor :: [Int] -> IO (Map Int HydraNodePorts)
-allocateHydraNodePortsFor nodeIds = go (20 :: Int)
+allocateHydraNodePortsFor nodeIds = do
+  listenPorts <- randomUnusedTCPPortsWithDerived peerPortToClientPort n
+  let derivedClientPorts =
+        [ fromIntegral (peerPortToClientPort (fromIntegral p))
+        | p <- listenPorts
+        ]
+      reserved = listenPorts <> derivedClientPorts
+  apiAndMonPorts <- acquireDisjoint reserved (20 :: Int)
+  let apiPorts = take n apiAndMonPorts
+      monPorts = drop n apiAndMonPorts
+      assigned = Prelude.zipWith3 mkPorts apiPorts listenPorts monPorts
+  pure $ Map.fromList $ zip nodeIds assigned
  where
   n = length nodeIds
-  go 0 =
-    Prelude.error
-      "allocateHydraNodePortsFor: ran out of retries trying to avoid a derived-etcd-client-port collision"
-  go remaining = do
-    ports <- randomUnusedTCPPorts (3 * n)
-    let assigned = chunk3 ports
-        derived =
-          [ fromIntegral (peerPortToClientPort (listenPort hp))
-          | hp <- assigned
-          ]
-        allClaims = ports <> derived
-    if length allClaims == length (List.nub allClaims)
-      then pure $ Map.fromList $ zip nodeIds assigned
-      else go (remaining - 1)
 
-  chunk3 :: [Int] -> [HydraNodePorts]
-  chunk3 = \case
-    a : l : m : rest ->
-      HydraNodePorts
-        { apiPort = fromIntegral a
-        , listenPort = fromIntegral l
-        , monitoringPort = fromIntegral m
-        }
-        : chunk3 rest
-    _ -> []
+  acquireDisjoint :: [Int] -> Int -> IO [Int]
+  acquireDisjoint _ 0 =
+    fail
+      "allocateHydraNodePortsFor: ran out of retries trying to keep the api/monitoring ports disjoint from the derived etcd client ports"
+  acquireDisjoint reserved remaining = do
+    ps <- randomUnusedTCPPorts (2 * n)
+    if null (ps `List.intersect` reserved)
+      then pure ps
+      else acquireDisjoint reserved (remaining - 1)
+
+  mkPorts :: Int -> Int -> Int -> HydraNodePorts
+  mkPorts a l m =
+    HydraNodePorts
+      { apiPort = fromIntegral a
+      , listenPort = fromIntegral l
+      , monitoringPort = fromIntegral m
+      }
 
 -- | Process-global cache mapping each @(workDir, nodeId)@ to its allocated
 -- ports. The cache exists because restart-style tests (re-running

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -29,6 +29,7 @@ import Hydra.Cluster.Util (Timing (..), readConfigFile)
 import Hydra.Logging (Tracer, Verbosity (..), traceWith)
 import Hydra.Network (Host (Host), NodeId (NodeId), WhichEtcd (SystemEtcd))
 import Hydra.Network qualified as Network
+import Hydra.Network.Etcd (peerPortToClientPort)
 import Hydra.Options (BlockfrostOptions (..), CardanoChainConfig (..), ChainBackendOptions (..), ChainConfig (..), DirectOptions (..), LedgerConfig (..), RunOptions (..), defaultBFQueryTimeout, defaultCardanoChainConfig, defaultDirectOptions, nodeSocket, toArgs)
 import Hydra.Tx (ConfirmedSnapshot)
 import Hydra.Tx.Crypto (HydraKey)
@@ -375,11 +376,32 @@ allocateHydraNodePorts = do
 -- @--listen@ for one node ended up equal to @--monitoring-port@ for another
 -- and crashed etcd with @EADDRINUSE@ in the 'two heads on the same network'
 -- test.
+--
+-- Additionally, hydra-node derives its etcd client port from the listen
+-- port (see 'peerPortToClientPort'), and the derived port is /not/ in the
+-- batch we asked the OS for. We retry until the derived ports are also
+-- disjoint from every primary; otherwise an unlucky draw makes a node's
+-- etcd client port equal its own (or another node's) api/monitoring port,
+-- and the GRPC client ends up talking to Warp instead of etcd.
 allocateHydraNodePortsFor :: [Int] -> IO (Map Int HydraNodePorts)
-allocateHydraNodePortsFor nodeIds = do
-  ports <- randomUnusedTCPPorts (3 * length nodeIds)
-  pure $ Map.fromList $ zip nodeIds (chunk3 ports)
+allocateHydraNodePortsFor nodeIds = go (20 :: Int)
  where
+  n = length nodeIds
+  go 0 =
+    Prelude.error
+      "allocateHydraNodePortsFor: ran out of retries trying to avoid a derived-etcd-client-port collision"
+  go remaining = do
+    ports <- randomUnusedTCPPorts (3 * n)
+    let assigned = chunk3 ports
+        derived =
+          [ fromIntegral (peerPortToClientPort (listenPort hp))
+          | hp <- assigned
+          ]
+        allClaims = ports <> derived
+    if length allClaims == length (List.nub allClaims)
+      then pure $ Map.fromList $ zip nodeIds assigned
+      else go (remaining - 1)
+
   chunk3 :: [Int] -> [HydraNodePorts]
   chunk3 = \case
     a : l : m : rest ->

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -46,6 +46,7 @@ import Control.Concurrent.Class.MonadSTM (
   modifyTVar',
   peekTBQueue,
   readTBQueue,
+  readTVarIO,
   swapTVar,
   writeTBQueue,
   writeTVar,
@@ -347,6 +348,16 @@ checkVersion tracer conn ourVersion NetworkCallback{onConnectivity} = do
 --
 -- Retries on failure to 'putMessage' in case we are on a minority cluster or
 -- when the grpc call timeouts.
+--
+-- Idempotent under transient 'GrpcDeadlineExceeded': 'putMessage' uses an
+-- etcd transaction conditioned on the key's current 'mod_revision' matching
+-- the last revision we successfully wrote. If a deadline-exceeded retry
+-- arrives at etcd after the original request already committed, the compare
+-- fails server-side (the mod_revision has advanced), the failure branch's
+-- range tells us what the new revision is, and we move on without writing a
+-- second time. So a retry whose original committed creates zero extra etcd
+-- revisions and the watcher on each peer sees exactly one event per logical
+-- broadcast. Same key namespace as master ('msg-\<host\>'), no disk growth.
 broadcastMessages ::
   (ToCBOR msg, Eq msg) =>
   Tracer IO EtcdLog ->
@@ -355,38 +366,152 @@ broadcastMessages ::
   Host ->
   PersistentQueue IO msg ->
   IO ()
-broadcastMessages tracer config ourHost queue =
+broadcastMessages tracer config ourHost queue = do
+  -- Seed 'lastModRev' from etcd. With this in place the in-memory value
+  -- always matches the server's view of our key when the loop starts:
+  --
+  --   * fresh process + fresh etcd → key absent → @lastModRev = 0@;
+  --     'putMessage' compares against 0 (which etcd treats as "key does
+  --     not exist") and the success branch creates the key.
+  --   * fresh process + persisted etcd (e.g. Carol restart) → key
+  --     present with some non-zero @mod_revision@ → @lastModRev@ starts
+  --     at that revision; 'putMessage' compares against it and the
+  --     success branch advances.
+  --
+  -- The init query removes the ambiguity that the older code had on
+  -- @lastModRev == 0 + compare-fail@: with seeding, any compare-fail is
+  -- unambiguously this peer's own deadline-exceeded retry, so the
+  -- failure branch just adopts the new baseline and pops.
+  initialModRev <- retryInitQuery
+  lastModRevVar <- newLabelledTVarIO "etcd-broadcast-last-mod-rev" initialModRev
   withGrpcContext "broadcastMessages" . forever $ do
     msg <- peekPersistentQueue queue
-    (putMessage tracer config ourHost msg >> popPersistentQueue queue msg)
+    (putMessage tracer config ourHost lastModRevVar msg >> popPersistentQueue queue msg)
       `catch` \case
         GrpcException{grpcError, grpcErrorMessage}
           | grpcError == GrpcUnavailable || grpcError == GrpcDeadlineExceeded -> do
               traceWith tracer $ BroadcastFailed{reason = fromMaybe "unknown" grpcErrorMessage}
               threadDelay 1
         e -> throwIO e
+ where
+  -- Same retry shape as the broadcast loop: keep trying through
+  -- transient connection errors so we can survive an etcd cluster that
+  -- is still electing or that we briefly cannot reach.
+  retryInitQuery =
+    queryInitialModRev tracer config ourHost
+      `catch` \case
+        GrpcException{grpcError, grpcErrorMessage}
+          | grpcError == GrpcUnavailable || grpcError == GrpcDeadlineExceeded -> do
+              traceWith tracer $ BroadcastFailed{reason = fromMaybe "init query failed" grpcErrorMessage}
+              threadDelay 1
+              retryInitQuery
+        e -> throwIO e
+
+-- | Query etcd for the current 'mod_revision' of this peer's broadcast key.
+-- Returns 0 if the key does not yet exist. Used by 'broadcastMessages' to
+-- seed its in-memory baseline so subsequent @compare mod_revision@ checks
+-- match etcd's reality from the very first 'putMessage'.
+queryInitialModRev ::
+  Tracer IO EtcdLog ->
+  NetworkConfiguration ->
+  Host ->
+  IO Int64
+queryInitialModRev tracer config ourHost =
+  withConnection (connParams tracer (Just . Timeout Second $ TimeoutValue 3)) (grpcServer config) $ \conn -> do
+    res <- nonStreaming conn (rpc @(Protobuf KV "range")) req
+    pure $ fromMaybe 0 (res ^? #kvs . traverse . #modRevision)
+ where
+  key = encodeUtf8 @Text $ "msg-" <> show ourHost
+  req = defMessage & #key .~ key
 
 -- | Broadcast a message to the etcd cluster.
+--
+-- Wraps the etcd @put@ in a @Txn@:
+--
+--   * compare: @mod_revision(key) == lastModRev@
+--   * success: @put(key, value)@
+--   * failure: @range(key)@ (so we can learn the actual @mod_revision@ if our
+--     compare failed, e.g. because a previous attempt of ours committed
+--     server-side after returning 'GrpcDeadlineExceeded' to the client)
+--
+-- 'lastModRevVar' is updated in both branches: from the response header on
+-- a successful put, from the range result on a compare failure. Retries of
+-- the same @msg@ after a deadline-exceeded converge to a single effective
+-- revision rather than producing duplicate deliveries. Because
+-- 'broadcastMessages' seeds 'lastModRev' from etcd at startup
+-- ('queryInitialModRev'), a compare failure unambiguously means "this
+-- peer's earlier attempt already wrote a later revision than we have
+-- recorded" — i.e. the message is already delivered and the caller can pop.
 putMessage ::
   ToCBOR msg =>
   Tracer IO EtcdLog ->
   NetworkConfiguration ->
   -- | Used to identify sender.
   Host ->
+  -- | The peer's last observed 'mod_revision' on its own broadcast key.
+  TVar IO Int64 ->
   msg ->
   IO ()
-putMessage tracer config ourHost msg = do
+putMessage tracer config ourHost lastModRevVar msg = do
+  lastModRev <- readTVarIO lastModRevVar
   -- XXX: Here we open a new connection _for every message_! This is
   -- effectively a work-around for https://github.com/cardano-scaling/hydra/issues/2167.
   withConnection (connParams tracer (Just . Timeout Second $ TimeoutValue 3)) (grpcServer config) $ \conn -> do
-    void $ nonStreaming conn (rpc @(Protobuf KV "put")) req
+    res <- nonStreaming conn (rpc @(Protobuf KV "txn")) (txnReq lastModRev)
+    if res ^. #succeeded
+      then
+        -- Our compare matched and the put ran. The new mod_revision on
+        -- our key equals the cluster revision returned in the response
+        -- header.
+        atomically $ writeTVar lastModRevVar (res ^. #header . #revision)
+      else case res ^? #responses . traverse . #responseRange . #kvs . traverse . #modRevision of
+        Just observedModRev -> do
+          -- Compare failed. Since 'broadcastMessages' seeded 'lastModRev'
+          -- from etcd at startup and we are the only writer to our key,
+          -- the only way 'mod_revision' moved past 'lastModRev' is an
+          -- earlier attempt of ours committing server-side despite a
+          -- 'GrpcDeadlineExceeded' to the client. The message has been
+          -- delivered; adopt the new baseline and let the outer loop pop.
+          traceWith tracer BroadcastDeduped{previousModRev = lastModRev, observedModRev}
+          atomically $ writeTVar lastModRevVar observedModRev
+        Nothing ->
+          -- Compare failed AND range came back empty: etcd has no record
+          -- of our key. Unreachable in normal operation (only we write to
+          -- our key; nothing deletes it). If we ever do hit this, the
+          -- safe move is to crash loudly — the surrounding race kills the
+          -- node and a fresh start re-runs 'queryInitialModRev' against
+          -- whatever state etcd actually has.
+          fail $
+            "putMessage: compare against mod_revision "
+              <> show lastModRev
+              <> " failed but our broadcast key has no current value in etcd"
  where
-  req =
-    defMessage
-      & #key .~ key
-      & #value .~ serialize' msg
-
   key = encodeUtf8 @Text $ "msg-" <> show ourHost
+
+  -- Compare: mod_revision(key) == lastModRev
+  modRevMatches lastModRev =
+    defMessage
+      & #result .~ Proto Compare'EQUAL
+      & #target .~ Proto Compare'MOD
+      & #key .~ key
+      & #modRevision .~ lastModRev
+
+  putReqOp =
+    defMessage
+      & #requestPut
+        .~ ( defMessage
+              & #key .~ key
+              & #value .~ serialize' msg
+           )
+
+  rangeReqOp =
+    defMessage & #requestRange .~ (defMessage & #key .~ key)
+
+  txnReq lastModRev =
+    defMessage
+      & #compare .~ [modRevMatches lastModRev]
+      & #success .~ [putReqOp]
+      & #failure .~ [rangeReqOp]
 
 -- | Fetch and wait for messages from the etcd cluster.
 waitMessages ::
@@ -668,5 +793,10 @@ data EtcdLog
   | MatchingProtocolVersion {version :: ProtocolVersion}
   | WatchMessagesStartRevision {startRevision :: Int64}
   | WatchMessagesFallbackTo {compactRevision :: Int64}
+  | -- | The etcd transaction wrapping a broadcast 'put' found that our
+    -- key's @mod_revision@ had moved past what we last recorded — the
+    -- expected outcome when a 'GrpcDeadlineExceeded'-retried put already
+    -- committed server-side. No second put was issued.
+    BroadcastDeduped {previousModRev :: Int64, observedModRev :: Int64}
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -442,6 +442,15 @@ queryInitialModRev tracer config ourHost =
 -- ('queryInitialModRev'), a compare failure unambiguously means "this
 -- peer's earlier attempt already wrote a later revision than we have
 -- recorded" — i.e. the message is already delivered and the caller can pop.
+--
+-- __Cluster-reset behaviour (intentionally fatal):__ if the compare fails
+-- and the @range@ branch returns no kvs, the etcd cluster has lost the
+-- key we wrote against — either the data dir was wiped or the cluster
+-- was replaced underneath us. We do not silently reseed: this is a
+-- node-level event that should surface, not be papered over. 'putMessage'
+-- calls 'fail', which kills the broadcast loop, propagates up to take
+-- down the node, and on restart 'queryInitialModRev' re-seeds
+-- 'lastModRev' from whatever state etcd actually has.
 putMessage ::
   ToCBOR msg =>
   Tracer IO EtcdLog ->

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -40,7 +40,14 @@ import Test.Util (noopCallback, waitEq, waitMatch)
 spec :: Spec
 spec = do
   -- TODO: add tests about advertise being honored
-  describe "Etcd" $
+  --
+  -- Each Etcd test spins up a 2- or 3-node etcd cluster on loopback ports.
+  -- Running these in parallel (tasty's default on developer machines) means
+  -- multiple subprocesses fight for ports and CPU at the same instant, which
+  -- can cause failures. Force sequential execution within this describe;
+  -- CI already pins '--num-threads=1' for the whole hydra-node
+  -- suite, so this only changes behaviour for local runs.
+  describe "Etcd" . sequential $
     around (showLogsOnFailure "NetworkSpec") $ do
       let v1 = ProtocolVersion 1
 
@@ -98,7 +105,7 @@ spec = do
 
       it "handles broadcast to minority" $ \tracer -> do
         withTempDir "test-etcd" $ \tmp -> do
-          failAfter 20 $ do
+          failAfter 60 $ do
             PeerConfig3{aliceConfig, bobConfig, carolConfig} <- setup3Peers tmp
             (recordReceived, waitNext, _) <- newRecordingCallback
             withEtcdNetwork @Int tracer v1 aliceConfig recordReceived $ \n1 -> do
@@ -118,7 +125,7 @@ spec = do
 
       it "handles broadcast to majority" $ \tracer -> do
         withTempDir "test-etcd" $ \tmp -> do
-          failAfter 20 $ do
+          failAfter 60 $ do
             PeerConfig3{aliceConfig, bobConfig, carolConfig} <- setup3Peers tmp
             (recordReceived, waitNext, _) <- newRecordingCallback
             withEtcdNetwork @Int tracer v1 aliceConfig noopCallback $ \n1 ->
@@ -165,7 +172,7 @@ spec = do
 
       it "handles expired lease" $ \tracer -> do
         withTempDir "test-etcd" $ \tmp -> do
-          failAfter 15 $ do
+          failAfter 30 $ do
             PeerConfig2{aliceConfig, bobConfig} <- setup2Peers tmp
             -- Record and assert connectivity events from alice's perspective
             (recordReceived, _, waitConnectivity) <- newRecordingCallback
@@ -194,13 +201,13 @@ spec = do
 
       it "checks protocol version" $ \tracer -> do
         withTempDir "test-etcd" $ \tmp -> do
-          failAfter 30 $ do
+          failAfter 60 $ do
             PeerConfig2{aliceConfig, bobConfig} <- setup2Peers tmp
             let v2 = ProtocolVersion 2
             (recordAlice, _, waitAlice) <- newRecordingCallback
             (recordBob, _, waitBob) <- newRecordingCallback
-            let aliceSees = waitEq waitAlice 5
-                bobSees = waitEq waitBob 5
+            let aliceSees = waitEq waitAlice 30
+                bobSees = waitEq waitBob 30
             withEtcdNetwork @Int tracer v1 aliceConfig recordAlice $ \_ -> do
               withEtcdNetwork @Int tracer v2 bobConfig recordBob $ \_ -> do
                 -- Both will try to write to the cluster at the same time
@@ -235,7 +242,7 @@ spec = do
 
       it "handles compaction and lost local state" $ \tracer -> do
         withTempDir "test-etcd" $ \tmp -> do
-          failAfter 20 $ do
+          failAfter 60 $ do
             PeerConfig3{aliceConfig, bobConfig, carolConfig} <- setup3Peers tmp
             (recordBob, waitBob, _) <- newRecordingCallback
             (recordCarol, waitCarol, _) <- newRecordingCallback
@@ -290,13 +297,13 @@ spec = do
 
       it "emits cluster id mismatch" $ \tracer -> do
         withTempDir "test-etcd" $ \tmp -> do
-          failAfter 30 $ do
+          failAfter 60 $ do
             PeerConfig2{aliceConfig, bobConfig} <- setup2Peers tmp
             let v2 = ProtocolVersion 2
             (recordAlice, _, waitAlice) <- newRecordingCallback
             (recordBob, _, waitBob) <- newRecordingCallback
-            let aliceSees = waitMatch waitAlice 5
-            let bobSees = waitMatch waitBob 5
+            let aliceSees = waitMatch waitAlice 30
+            let bobSees = waitMatch waitBob 30
             let bobConfig' = bobConfig{peers = []}
             withEtcdNetwork @Int tracer v1 aliceConfig recordAlice $ \_ ->
               withEtcdNetwork @Int tracer v2 bobConfig' recordBob $ \_ ->

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -10,10 +10,11 @@ import Codec.CBOR.Read (deserialiseFromBytes)
 import Codec.CBOR.Write (toLazyByteString)
 import Control.Concurrent.Class.MonadSTM (
   readTQueue,
+  readTVarIO,
   writeTQueue,
  )
 import Hydra.Ledger.Simple (SimpleTx (..))
-import Hydra.Logging (showLogsOnFailure)
+import Hydra.Logging (Envelope (message), showLogsOnFailure, traceInTVar)
 import Hydra.Network (
   Connectivity (..),
   Host (..),
@@ -22,7 +23,7 @@ import Hydra.Network (
   ProtocolVersion (..),
   WhichEtcd (..),
  )
-import Hydra.Network.Etcd (getClientPort, peerPortToClientPort, withEtcdNetwork)
+import Hydra.Network.Etcd (EtcdLog (..), getClientPort, peerPortToClientPort, putMessage, withEtcdNetwork)
 import Hydra.Network.Message (Message (..))
 import Hydra.Node.Network (NetworkConfiguration (..))
 import System.Directory (removeFile)
@@ -32,7 +33,7 @@ import Test.Aeson.GenericSpecs (Settings (..), defaultSettings, roundtripAndGold
 import Test.Hydra.Ledger.Simple ()
 import Test.Hydra.Network.Message ()
 import Test.Hydra.Node.Fixture (alice, aliceSk, bob, bobSk, carol, carolSk)
-import Test.Network.Ports (randomUnusedTCPPortsWithDerived, withFreePort)
+import Test.Network.Ports (randomUnusedTCPPortsWithDerived, withFreePortAndDerived)
 import Test.QuickCheck (Property, (===))
 import Test.QuickCheck.Instances.ByteString ()
 import Test.Util (noopCallback, waitEq, waitMatch)
@@ -47,6 +48,13 @@ spec = do
   -- can cause failures. Force sequential execution within this describe;
   -- CI already pins '--num-threads=1' for the whole hydra-node
   -- suite, so this only changes behaviour for local runs.
+  --
+  -- Per-test 'failAfter' budgets in this block are deliberately generous
+  -- (60s). The previous 15–30s budgets fired too eagerly when an etcd
+  -- election or a gRPC reconnect happened to land on the same scheduler
+  -- tick as a CI slowdown. The 'network-test.yaml' workflow (pumba
+  -- packet loss) is the operating point this guards against; tighten
+  -- only if you've confirmed it still passes there.
   describe "Etcd" . sequential $
     around (showLogsOnFailure "NetworkSpec") $ do
       let v1 = ProtocolVersion 1
@@ -54,7 +62,7 @@ spec = do
       it "broadcasts to self" $ \tracer -> do
         failAfter 30 $
           withTempDir "test-etcd" $ \tmp -> do
-            withFreePort $ \port -> do
+            withFreePortAndDerived peerPortToClientPort $ \port -> do
               let config =
                     NetworkConfiguration
                       { listen = Host lo port
@@ -70,6 +78,60 @@ spec = do
               withEtcdNetwork tracer v1 config recordingCallback $ \n -> do
                 broadcast n ("asdf" :: Text)
                 waitNext `shouldReturn` "asdf"
+
+      -- Exercises 'putMessage's compare-failure branch directly. The
+      -- scenario it mimics: a previous 'putMessage' committed
+      -- server-side but the gRPC client returned
+      -- 'GrpcDeadlineExceeded', so the in-memory 'lastModRev' is
+      -- stale on the retry. The Txn's compare(modRev == stale) must
+      -- fail, the range branch must observe the new revision, the
+      -- 'BroadcastDeduped' event must be traced, and most importantly
+      -- /no second write/ should land — so the receiver does not see
+      -- a duplicate.
+      it "putMessage dedups when lastModRev is stale" $ \tracer -> do
+        failAfter 30 $
+          withTempDir "test-etcd" $ \tmp -> do
+            withFreePortAndDerived peerPortToClientPort $ \port -> do
+              let host = Host lo port
+                  config =
+                    NetworkConfiguration
+                      { listen = host
+                      , advertise = host
+                      , signingKey = aliceSk
+                      , otherParties = []
+                      , peers = []
+                      , nodeId = "alice"
+                      , persistenceDir = tmp </> "alice"
+                      , whichEtcd = SystemEtcd
+                      }
+              (recordingCallback, waitNext, _) <- newRecordingCallback
+              withEtcdNetwork @Int tracer v1 config recordingCallback $ \n -> do
+                -- Real broadcast advances msg-<host>'s mod_revision.
+                broadcast n 1
+                waitNext `shouldReturn` 1
+                -- Capture EtcdLog events from a direct putMessage call.
+                traces <- newLabelledTVarIO "putMessage-dedup-traces" []
+                let captureTracer = traceInTVar traces "putMessageDedupSpec"
+                staleVar <- newLabelledTVarIO "stale-last-mod-rev" 0
+                -- Compare against 0 must fail (real modRev > 0); the
+                -- failure branch should adopt the observed revision
+                -- and trace BroadcastDeduped instead of writing.
+                putMessage @Int captureTracer config host staleVar 99
+                captured <- map message <$> readTVarIO traces
+                captured
+                  `shouldSatisfy` any
+                    ( \case
+                        BroadcastDeduped{} -> True
+                        _ -> False
+                    )
+                updatedModRev <- readTVarIO staleVar
+                updatedModRev `shouldSatisfy` (> 0)
+                -- Send a fresh marker. If 99 had actually been
+                -- written by the deduped call, the receiver would
+                -- see it before 2 (etcd revisions are monotonic and
+                -- the watch is in-order).
+                broadcast n 2
+                waitNext `shouldReturn` 2
 
       -- Note: This test is disabled as it takes took long; but it is
       -- important to keep around. Successfully completion of this test looks

--- a/hydra-test-utils/src/Test/Network/Ports.hs
+++ b/hydra-test-utils/src/Test/Network/Ports.hs
@@ -34,6 +34,16 @@ getRandomPort = bracket bindFreshLoopback close socketPort
 withFreePort :: (PortNumber -> IO a) -> IO a
 withFreePort action = getRandomPort >>= action
 
+-- | Like 'withFreePort' but also reserves the derived companion port,
+-- in the same sense as 'randomUnusedTCPPortsWithDerived' — i.e. the
+-- companion is verified free at allocation time. Use this for tests
+-- that spin up a subprocess (such as etcd) which itself binds a port
+-- computed from the configured one.
+withFreePortAndDerived :: (PortNumber -> PortNumber) -> (PortNumber -> IO a) -> IO a
+withFreePortAndDerived derive action = do
+  [p] <- randomUnusedTCPPortsWithDerived derive 1
+  action (fromIntegral p)
+
 -- | Find the specified number of free ports.
 --
 -- The returned ports are guaranteed mutually unique: we bind all @count@


### PR DESCRIPTION
The 90% pumba test was failing because of missed etcd writes.

This fixes the flakiness on the pumba network tests by being more resilient at how it writes keys to ecd. i think it's reasonably uncontroversial; seems like a genuninely useful change, and hopefully means we can trust our tests a little more.