### PR TITLE
Fix publish-docs by copying build/ output into nix derivation result

### DIFF
--- a/nix/hydra/docs.nix
+++ b/nix/hydra/docs.nix
@@ -34,6 +34,12 @@
             cp -rL ${self'.packages.haddocks} static/haddocks
             chmod -R u+w static/haddocks
           '';
+          # yarn pack (used by buildYarnPackage's installPhase) excludes the
+          # build/ directory because it is listed in .gitignore. Copy it
+          # explicitly so the workflow can find result/build/*.
+          postInstall = ''
+            cp -r build "$out/build"
+          '';
         };
 
       docs-unstable = docs.overrideAttrs {


### PR DESCRIPTION
I noticed the Publish Docs workflow has been failing on master lately.

The error is:

```bash
 cp: cannot stat 'result/build/*': No such file or directory
 ```
 The workflow does `nix build .#docs-unstable` and then `cp result/build/* $out -r`. The nix build succeeds but `result/build/` doesn't exist.
 
The workflow gets its output by running `yarn pack` to create tarball, then extracting it to `$out`.
Yarn respects `.gitignore` and `docs/.gitignore` lists exactly our `/build` folder.

This was not an issue before because the derivation was previously served from Cachix. The cache was invalidated by the `docs.nix` refactor in #2609 , which forced a fresh rebuild that exposed the issue.

The fix adds a `postInstall` hook that copies `build/` from the nix build sandbox directly into `$out/build/`.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
