### PR TITLE
Bit more benchmarking information on PRs

### DIFF
--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -104,13 +104,20 @@ jobs:
         include:
           - package: hydra-node
             bench: tx-cost
+            tag: tx-cost
             options: '--output-directory $(pwd)/../benchmarks'
           - package: hydra-node
             bench: micro
+            tag: micro
             options: '-o $(pwd)/../benchmarks/ledger-bench.html'
           - package: hydra-cluster
             bench: bench-e2e
+            tag: e2e
             options: 'single datasets/1-node.json datasets/3-nodes.json --output-directory $(pwd)/../benchmarks --timeout 1000s'
+          - package: hydra-cluster
+            bench: bench-e2e
+            tag: matrix
+            options: 'matrix --output-directory $(pwd)/../benchmarks --number-of-txs 30 --timeout 3600s'
     steps:
     - name: 📥 Checkout repository
       uses: actions/checkout@v4
@@ -130,7 +137,7 @@ jobs:
     - name: 💾 Upload build & test artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: benchmarks-${{matrix.package}}-${{matrix.bench}}
+        name: benchmarks-${{matrix.package}}-${{matrix.tag}}
         path: benchmarks
 
     # NOTE: This depends on the path used in hydra-cluster bench
@@ -159,8 +166,14 @@ jobs:
     - name: ⚙ Prepare comment body
       id: comment-body
       run: |
-        # Drop first 5 header lines and demote headlines one level
-        cat <(cat artifact/transaction-cost.md | sed '1,5d;s/^#/##/') <(cat artifact/end-to-end-benchmarks.md | sed '1,5d;s/^#/##/') | grep -v '^:::' > comment-body.md
+        # Drop first 5 header lines and demote headlines one level. Concatenate
+        # tx costs, the existing single end-to-end run, and the matrix
+        # scenarios so reviewers see every benchmark output in one PR comment.
+        cat \
+          <(cat artifact/transaction-cost.md | sed '1,5d;s/^#/##/') \
+          <(cat artifact/end-to-end-benchmarks.md | sed '1,5d;s/^#/##/') \
+          <(cat artifact/scenarios.md | sed '1,5d;s/^#/##/') \
+          | grep -v '^:::' > comment-body.md
 
     - name: 🔎 Find Comment
       uses: peter-evans/find-comment@v3

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -117,7 +117,10 @@ jobs:
           - package: hydra-cluster
             bench: bench-e2e
             tag: matrix
-            options: 'matrix --output-directory $(pwd)/../benchmarks --number-of-txs 30 --timeout 3600s'
+            # Skip the incremental-ops dimension in CI: per-cycle ~90s adds up
+            # across cells and the cost is known/bounded. Local runs can still
+            # opt in via `--incremental-modes False,True`.
+            options: 'matrix --output-directory $(pwd)/../benchmarks --number-of-txs 30 --timeout 3600s --incremental-modes False'
     steps:
     - name: 📥 Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -193,4 +193,3 @@ jobs:
         edit-mode: replace
         issue-number: ${{ github.event.pull_request.number }}
         body-file: comment-body.md
-        reactions: rocket

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -71,6 +71,12 @@ jobs:
           hydra-cluster/datasets/1-node.json \
           hydra-cluster/datasets/3-nodes.json \
           --output-directory $out/benchmarks
+        nix develop .#hydra-cluster-bench --command -- \
+          bench-e2e \
+          matrix \
+          --output-directory $out/benchmarks \
+          --number-of-txs 30 \
+          --timeout 3600s
 
     - name: 👉 Create redirects
       run: |

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -76,7 +76,8 @@ jobs:
           matrix \
           --output-directory $out/benchmarks \
           --number-of-txs 30 \
-          --timeout 3600s
+          --timeout 3600s \
+          --incremental-modes False
 
     - name: 👉 Create redirects
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ changes.
 
 ## [UNRELEASED]
 
+- Extend the end-to-end benchmark with real-world TPS metrics (end-to-end and
+  per-snapshot quantiles), a new `Mixed` UTxO generator that grows then contracts
+  the head state, an opt-in interleaved incremental commit/decommit cycle
+  (`--incremental-ops`), and a new `matrix` sub-command that iterates over
+  cluster sizes, UTxO shapes, and incremental modes. CI publishes the matrix
+  output as a new
+  [scenario benchmarks](https://hydra.family/head-protocol/benchmarks/scenarios)
+  page.
+
 - Heads with large UTxO sets can now be fanned out in multiple steps using
   `PartialFanoutTx` and `FinalPartialFanoutTx` transactions [#2324](https://github.com/cardano-scaling/hydra/pull/2324).
   Each step distributes as many outputs as fit in a single transaction (determined

--- a/docs/docs/faqs.md
+++ b/docs/docs/faqs.md
@@ -56,8 +56,11 @@ transactions simultaneously without conflicts, especially with good
 networking, which optimizes resource usage. As the project progresses, we're
 constantly evaluating its real-world performance in terms of throughput and
 finality. For more details, read <a
-href="https://iohk.io/en/blog/posts/2021/09/17/hydra-cardano-s-solution-for-ultimate-scalability">this</a> blog post and see the latest
-benchmarking data <a href="../benchmarks">here</a>.
+href="https://iohk.io/en/blog/posts/2021/09/17/hydra-cardano-s-solution-for-ultimate-scalability">this</a> blog post, see the latest
+benchmarking data <a href="../benchmarks">here</a>, and look at the
+<a href="../benchmarks/scenarios">scenario benchmarks</a> for per-snapshot and
+end-to-end TPS across head sizes, UTxO shapes, and incremental commit/decommit
+modes.
 
 </details>
 

--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -5,7 +5,7 @@ module Bench.EndToEnd where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import Bench.Summary (Summary (..), SystemStats, makeQuantiles)
+import Bench.Summary (Summary (..), SystemStats, makeDoubleQuantiles, makeQuantiles)
 import Cardano.Api.UTxO qualified as UTxO
 import CardanoNode (EndToEndLog (..), HydraNodeLog, findRunningCardanoNode', runBackend, withCardanoNodeDevnet)
 import Control.Concurrent.Class.MonadSTM (
@@ -17,7 +17,7 @@ import Control.Concurrent.Class.MonadSTM (
   writeTBQueue,
  )
 import Control.Lens (to, (^..), (^?))
-import Control.Monad.Class.MonadAsync (mapConcurrently)
+import Control.Monad.Class.MonadAsync (concurrently, mapConcurrently)
 import Data.Aeson (Result (Error, Success), Value, encode, fromJSON, (.=))
 import Data.Aeson.Lens (key, values, _JSON, _Number, _String)
 import Data.Aeson.Types (parseMaybe)
@@ -28,12 +28,14 @@ import Data.Scientific (Scientific)
 import Data.Set ((\\))
 import Data.Set qualified as Set
 import Data.Time (UTCTime (UTCTime), utctDayTime)
-import Hydra.Cardano.Api (NetworkId, SocketPath, Tx, TxId, getVerificationKey, lovelaceToValue, signTx)
+import Data.Vector (Vector)
+import Hydra.Cardano.Api (NetworkId, PaymentKey, SigningKey, SocketPath, Tx, TxId, UTxO, getVerificationKey, lovelaceToValue, signTx, txOutAddress, txOutValue)
 import Hydra.Chain.Backend (ChainBackend (..))
 import Hydra.Cluster.Faucet (FaucetLog (..), publishHydraScriptsAs, returnFundsToFaucet', seedFromFaucet)
 import Hydra.Cluster.Fixture (Actor (..))
 import Hydra.Cluster.Util (Timing (..), depositTimeout)
 import Hydra.Generator (ClientDataset (..), Dataset (..))
+import Hydra.Ledger.Cardano (mkSimpleTx)
 import Hydra.Logging (
   Tracer,
   traceWith,
@@ -45,10 +47,12 @@ import Hydra.Tx (HeadId, txId)
 import Hydra.Tx.Crypto (generateSigningKey)
 import HydraNode (
   HydraClient,
+  apiHost,
   getSnapshotUTxO,
   hydraNodeId,
   input,
   output,
+  postDecommit,
   requestCommitTx,
   send,
   waitFor,
@@ -63,8 +67,8 @@ import System.Process.Typed (shell, withProcessTerm)
 import Test.HUnit.Lang (formatFailureReason)
 import Text.Printf (printf)
 
-bench :: Int -> NominalDiffTime -> FilePath -> Dataset -> IO (Summary, SystemStats)
-bench startingNodeId timeoutSeconds workDir dataset = do
+bench :: Int -> NominalDiffTime -> Bool -> FilePath -> Dataset -> IO (Summary, SystemStats)
+bench startingNodeId timeoutSeconds incrementalOpsEnabled workDir dataset = do
   putStrLn $ "Test logs available in: " <> (workDir </> "test.log")
   withFile (workDir </> "test.log") ReadWriteMode $ \hdl ->
     withTracerOutputTo (BlockBuffering (Just 64000)) hdl "Test" $ \tracer ->
@@ -78,7 +82,7 @@ bench startingNodeId timeoutSeconds workDir dataset = do
           let contestationPeriod = truncate $ 10 * blockTime
           let DirectOptions{nodeSocket = nodeSocket'} = directOpts
           putTextLn "Seeding network"
-          seedNetwork opts dataset (contramap FromFaucet tracer)
+          sideUTxOs <- seedNetwork opts dataset incrementalOpsEnabled (contramap FromFaucet tracer)
           putTextLn "Publishing hydra scripts"
           hydraScriptsTxId <- publishHydraScriptsAs opts Faucet
           putStrLn $ "Starting hydra cluster in " <> workDir
@@ -87,7 +91,7 @@ bench startingNodeId timeoutSeconds workDir dataset = do
           putStrLn $ "Timing: " <> show timing
           withHydraCluster hydraTracer timing workDir nodeSocket' startingNodeId cardanoKeys hydraKeys hydraScriptsTxId $ \clients -> do
             waitForNodesConnected hydraTracer 20 clients
-            scenario hydraTracer timing opts workDir dataset clients Nothing
+            scenario hydraTracer timing opts workDir dataset clients Nothing sideUTxOs
         systemStats <- readTVarIO statsTvar
         pure (scenarioData, systemStats)
 
@@ -97,10 +101,11 @@ benchDemo ::
   NominalDiffTime ->
   [Host] ->
   Maybe String ->
+  Bool ->
   FilePath ->
   Dataset ->
   IO (Summary, SystemStats)
-benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand workDir dataset@Dataset{clientDatasets} = do
+benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand incrementalOpsEnabled workDir dataset@Dataset{clientDatasets} = do
   putStrLn $ "Test logs available in: " <> (workDir </> "test.log")
   withFile (workDir </> "test.log") ReadWriteMode $ \hdl ->
     withTracerOutputTo (BlockBuffering (Just 64000)) hdl "Test" $ \tracer ->
@@ -113,7 +118,7 @@ benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand workDir 
           Just (blockTime, directOpts) -> do
             let opts = Direct directOpts
             putTextLn "Seeding network"
-            seedNetwork opts dataset (contramap FromFaucet tracer)
+            sideUTxOs <- seedNetwork opts dataset incrementalOpsEnabled (contramap FromFaucet tracer)
             (`finally` returnFaucetFunds tracer opts) $ do
               putStrLn $ "Connecting to hydra cluster: " <> show hydraClients
               let hydraTracer = contramap FromHydraNode tracer
@@ -122,7 +127,7 @@ benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand workDir 
               withHydraClientConnections hydraTracer (hydraClients `zip` [1 ..]) [] $ \case
                 [] -> error "no hydra clients provided"
                 (leader : followers) ->
-                  (,[]) <$> scenario hydraTracer timing opts workDir dataset (leader :| followers) pumbaCommand
+                  (,[]) <$> scenario hydraTracer timing opts workDir dataset (leader :| followers) pumbaCommand sideUTxOs
  where
   withHydraClientConnections ::
     Tracer IO HydraNodeLog ->
@@ -154,8 +159,11 @@ scenario ::
   Dataset ->
   NonEmpty HydraClient ->
   Maybe String ->
+  -- | Optional pre-seeded side UTxOs, one per client dataset, used for
+  -- interleaved incremental commit/decommit cycles. Empty list disables.
+  [UTxO] ->
   IO Summary
-scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, description} nonEmptyClients pumbaCommand = do
+scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, description} nonEmptyClients pumbaCommand sideUTxOs = do
   let clusterSize = fromIntegral $ length clientDatasets
   let leader = head nonEmptyClients
       clients = toList nonEmptyClients
@@ -186,7 +194,12 @@ scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, descript
   -- Note: We only run Pumba during normal transaction processing; this is
   -- acceptable because otherwise we do not retry the particular actions that
   -- may or may not be dropped.
-  processedTransactions <- withPumba pumbaCommand $ processTransactions clients clientDatasets
+  let incrementalCtx =
+        if null sideUTxOs
+          then Nothing
+          else Just IncrementalContext{ctxBackend = opts, ctxSideUTxOs = sideUTxOs, ctxHeadId = headId, ctxTracer = hydraTracer}
+  (processedTransactions, snapshotsSeen, incrementalCommitTimes, incrementalDecommitTimes) <-
+    withPumba pumbaCommand $ processTransactions clients clientDatasets incrementalCtx
 
   putTextLn "Closing the Head"
   send leader $ input "Close" []
@@ -229,6 +242,8 @@ scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, descript
       quantiles = makeQuantiles confTimes
       summaryTitle = fromMaybe "Baseline Scenario" title
       summaryDescription = fromMaybe defaultDescription description
+      (endToEndTps, snapshotTpsQuantiles, numberOfSnapshots) =
+        computeThroughput processedTransactions snapshotsSeen
 
   pure $
     Summary
@@ -241,6 +256,11 @@ scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, descript
       , summaryDescription
       , numberOfInvalidTxs
       , numberOfFanoutOutputs
+      , endToEndTps
+      , snapshotTpsQuantiles
+      , numberOfSnapshots
+      , incrementalCommitTimes
+      , incrementalDecommitTimes
       }
  where
   Timing{blockTime} = timing
@@ -294,11 +314,20 @@ movingAverage confirmations =
    in map average fiveSeconds
 
 -- | Distribute 100 ADA fuel, starting funds from faucet for each client in the
--- dataset.
-seedNetwork :: ChainBackendOptions -> Dataset -> Tracer IO FaucetLog -> IO ()
-seedNetwork opts Dataset{fundingTransaction, hydraNodeKeys} tracer = do
+-- dataset. When 'incrementalOpsEnabled' is True, additionally seeds a small
+-- side UTxO (10 ADA) per client used later for interleaved incremental
+-- commit/decommit cycles. The returned list is parallel to
+-- 'clientDatasets' (empty when the flag is off).
+seedNetwork :: ChainBackendOptions -> Dataset -> Bool -> Tracer IO FaucetLog -> IO [UTxO]
+seedNetwork opts Dataset{fundingTransaction, hydraNodeKeys, clientDatasets} incrementalOpsEnabled tracer = do
   fundClients hydraNodeKeys
   forM_ hydraNodeKeys fuelWith100Ada
+  if incrementalOpsEnabled
+    then do
+      putTextLn "Funding side UTxOs for incremental ops"
+      forM clientDatasets $ \ClientDataset{paymentKey} ->
+        seedFromFaucet opts (getVerificationKey paymentKey) (lovelaceToValue 10_000_000) tracer
+    else pure []
  where
   fundClients hydraSKeys = do
     putTextLn "Fund scenario from faucet"
@@ -331,18 +360,54 @@ data Event = Event
   }
   deriving stock (Generic, Eq, Show)
 
-processTransactions :: [HydraClient] -> [ClientDataset] -> IO (Map.Map TxId Event)
-processTransactions clients clientDatasets = do
-  let processors = zip (zip clientDatasets (cycle clients)) [1 ..]
-  mconcat <$> mapConcurrently (uncurry clientProcessDataset) processors
+data IncrementalContext = IncrementalContext
+  { ctxBackend :: ChainBackendOptions
+  , ctxSideUTxOs :: [UTxO]
+  , ctxHeadId :: HeadId
+  , ctxTracer :: Tracer IO HydraNodeLog
+  }
+
+processTransactions ::
+  [HydraClient] ->
+  [ClientDataset] ->
+  Maybe IncrementalContext ->
+  IO (Map.Map TxId Event, Map.Map Scientific (UTCTime, Int), [NominalDiffTime], [NominalDiffTime])
+processTransactions clients clientDatasets incrementalCtx = do
+  -- Allocate per-client state up front so the optional incremental ops thread
+  -- can share access to the per-client registries.
+  perClient <- forM (zip clientDatasets (cycle clients)) $ \(cd@ClientDataset{txSequence}, client) -> do
+    let n = length txSequence
+    submissionQ <- newLabelledTBQueueIO "submission" (fromIntegral n)
+    registry <- newRegistry
+    atomically $ forM_ txSequence $ writeTBQueue submissionQ
+    pure (cd, client, submissionQ, registry, n)
+
+  let runIncremental = case incrementalCtx of
+        Nothing -> pure ([], [])
+        Just ctx -> runAllIncrementalOps ctx perClient
+
+  let perClientActions =
+        zipWith
+          ( \clientId (cd, client, submissionQ, registry, n) ->
+              clientProcessDataset cd client clientId submissionQ registry n
+          )
+          [1 ..]
+          perClient
+
+  (clientResults, (commitTimes, decommitTimes)) <-
+    concurrently
+      (mapConcurrently identity perClientActions)
+      runIncremental
+
+  let mergedTxs = Map.unions (map fst clientResults)
+      earlierObservation :: (UTCTime, Int) -> (UTCTime, Int) -> (UTCTime, Int)
+      earlierObservation (t1, c) (t2, _) = (min t1 t2, c)
+      mergedSnapshots = foldr (Map.unionWith earlierObservation . snd) Map.empty clientResults
+  pure (mergedTxs, mergedSnapshots, commitTimes, decommitTimes)
  where
   formatLocation = maybe "" (\loc -> "at " <> prettySrcLoc loc)
 
-  clientProcessDataset (ClientDataset{txSequence}, client) clientId = do
-    let numberOfTxs = length txSequence
-    submissionQ <- newLabelledTBQueueIO "submission" (fromIntegral numberOfTxs)
-    registry <- newRegistry
-    atomically $ forM_ txSequence $ writeTBQueue submissionQ
+  clientProcessDataset ClientDataset{txSequence} client clientId submissionQ registry numberOfTxs = do
     concurrentlyLabelled_
       ("submit-txs", submitTxs client registry submissionQ)
       ( "confirm-txs"
@@ -354,7 +419,81 @@ processTransactions clients clientDatasets = do
         putStrLn ("Something went wrong while waiting for all confirmations: " <> formatLocation sourceLocation <> ": " <> formatFailureReason reason)
           `catch` \(ex :: SomeException) ->
             putStrLn ("Something went wrong while waiting for all confirmations: " <> show ex)
-    readTVarIO (processedTxs registry)
+    (,) <$> readTVarIO (processedTxs registry) <*> readTVarIO (observedSnapshots registry)
+
+  runAllIncrementalOps :: IncrementalContext -> [(ClientDataset, HydraClient, TBQueue IO Tx, Registry Tx, Int)] -> IO ([NominalDiffTime], [NominalDiffTime])
+  runAllIncrementalOps IncrementalContext{ctxBackend, ctxSideUTxOs, ctxTracer} perClient = do
+    let pairs = zip ctxSideUTxOs perClient
+    results <-
+      mapConcurrently
+        ( \(sideUTxO, (ClientDataset{paymentKey}, client, submissionQ, _registry, numberOfTxs)) ->
+            try @_ @SomeException
+              (runOneIncrementalOp ctxTracer ctxBackend client paymentKey sideUTxO numberOfTxs submissionQ)
+        )
+        pairs
+    let collected = rights results
+        commits = mapMaybe fst collected
+        decommits = mapMaybe snd collected
+    forM_ results $ \case
+      Left ex -> putStrLn $ "Incremental op failed: " <> show ex
+      _ -> pure ()
+    pure (commits, decommits)
+
+  -- Opens a fresh API connection so the wait on CommitFinalized/DecommitFinalized
+  -- doesn't compete with the existing waitForAllConfirmations on the same WS.
+  runOneIncrementalOp ::
+    Tracer IO HydraNodeLog ->
+    ChainBackendOptions ->
+    HydraClient ->
+    SigningKey PaymentKey ->
+    UTxO ->
+    Int ->
+    TBQueue IO Tx ->
+    IO (Maybe NominalDiffTime, Maybe NominalDiffTime)
+  runOneIncrementalOp tracer backend client paymentKey sideUTxO numberOfTxs submissionQ = do
+    -- Wait until ~half this client's queue has drained.
+    atomically $ do
+      remaining <- lengthTBQueue submissionQ
+      let drained = fromIntegral numberOfTxs - fromIntegral remaining :: Double
+          target = fromIntegral numberOfTxs / 2 :: Double
+      check (drained >= target)
+
+    withConnectionToNodeHost tracer (hydraNodeId client) (apiHost client) Nothing (Just "/?history=no") $ \obs -> do
+      putTextLn "Incremental: requesting commit"
+      startCommit <- getCurrentTime
+      depositTx <- requestCommitTx client sideUTxO <&> signTx paymentKey
+      let depositTxId = txId depositTx
+      runBackend backend $ submitTransaction depositTx
+      _ <- waitMatch 180 obs $ \v -> do
+        guard (v ^? key "tag" == Just "CommitFinalized")
+        observed <- v ^? key "depositTxId" >>= parseMaybe parseJSON
+        guard (observed == depositTxId)
+        pure ()
+      commitFinalisedAt <- getCurrentTime
+      let commitTime = commitFinalisedAt `diffUTCTime` startCommit
+      putTextLn $ "Incremental: commit finalised in " <> show commitTime
+
+      case UTxO.toList sideUTxO of
+        [] -> pure (Just commitTime, Nothing)
+        ((i, o) : _) ->
+          case mkSimpleTx (i, o) (txOutAddress o, txOutValue o) paymentKey of
+            Left err -> do
+              putStrLn $ "Incremental: decommit tx build failed: " <> show err
+              pure (Just commitTime, Nothing)
+            Right decommitTx -> do
+              putTextLn "Incremental: posting decommit"
+              startDecommit <- getCurrentTime
+              postDecommit client decommitTx
+              let decommitTxId = txId decommitTx
+              _ <- waitMatch 180 obs $ \v -> do
+                guard (v ^? key "tag" == Just "DecommitFinalized")
+                observed <- v ^? key "decommitTxId" >>= parseMaybe parseJSON
+                guard (observed == decommitTxId)
+                pure ()
+              decommitFinalisedAt <- getCurrentTime
+              let decommitTime = decommitFinalisedAt `diffUTCTime` startDecommit
+              putTextLn $ "Incremental: decommit finalised in " <> show decommitTime
+              pure (Just commitTime, Just decommitTime)
 
 progressReport :: Int -> Int -> Int -> TBQueue IO Tx -> IO ()
 progressReport nodeId clientId queueSize queue = do
@@ -396,15 +535,15 @@ data WaitResult
 
 data Registry tx = Registry
   { processedTxs :: TVar IO (Map.Map TxId Event)
-  , latestSnapshot :: TVar IO Scientific
+  , observedSnapshots :: TVar IO (Map.Map Scientific (UTCTime, Int))
   }
 
 newRegistry ::
   IO (Registry Tx)
 newRegistry = do
   processedTxs <- newLabelledTVarIO "registry-processed-txs" mempty
-  latestSnapshot <- newLabelledTVarIO "registry-latest-snapshot" 0
-  pure $ Registry{processedTxs, latestSnapshot}
+  observedSnapshots <- newLabelledTVarIO "registry-observed-snapshots" mempty
+  pure $ Registry{processedTxs, observedSnapshots}
 
 submitTxs ::
   HydraClient ->
@@ -430,7 +569,7 @@ waitForAllConfirmations ::
   Registry Tx ->
   Set TxId ->
   IO ()
-waitForAllConfirmations n1 Registry{processedTxs} allIds = do
+waitForAllConfirmations n1 Registry{processedTxs, observedSnapshots} allIds = do
   go allIds
  where
   go remainingIds
@@ -444,7 +583,11 @@ waitForAllConfirmations n1 Registry{processedTxs} allIds = do
           TxInvalid{transactionId} -> do
             invalidTx processedTxs transactionId
             go $ Set.delete transactionId remainingIds
-          SnapshotConfirmed{txIds} -> do
+          SnapshotConfirmed{txIds, number} -> do
+            now <- getCurrentTime
+            atomically $
+              modifyTVar observedSnapshots $
+                Map.insertWith (\_new old -> old) number (now, length txIds)
             confirmedIds <- mapM (confirmTx processedTxs) txIds
             go $ remainingIds \\ Set.fromList confirmedIds
 
@@ -527,6 +670,46 @@ analyze = \case
   (_, Event{submittedAt, validAt = Just valid, confirmedAt = Just conf}) ->
     Just (submittedAt, valid `diffUTCTime` submittedAt, conf `diffUTCTime` submittedAt)
   _ -> Nothing
+
+-- | End-to-end TPS over the run plus quantiles of per-snapshot TPS.
+--
+-- End-to-end TPS divides the count of confirmed txs by the wall-clock window
+-- from earliest submission to latest confirmation. Per-snapshot TPS is
+-- derived for snapshots that confirmed at least one tx by dividing the tx
+-- count by the gap to the previous observation (or the earliest submission
+-- time for the first snapshot).
+computeThroughput :: Map.Map TxId Event -> Map.Map Scientific (UTCTime, Int) -> (Double, Vector Double, Int)
+computeThroughput txs snapshots =
+  let submitted = mapMaybe submittedAtFor (Map.elems txs)
+      confirmed = mapMaybe confirmedAt (Map.elems txs)
+      numberOfTxs = length confirmed
+      e2eTps = case (submitted, confirmed) of
+        (s : _, _ : _) ->
+          let span_ = realToFrac (List.maximum confirmed `diffUTCTime` List.minimum (s : submitted)) :: Double
+           in if span_ > 0 then fromIntegral numberOfTxs / span_ else 0
+        _ -> 0
+      sortedSnapshots = sortOn fst (Map.toList snapshots)
+      anchor = case submitted of
+        [] -> Nothing
+        _ -> Just (List.minimum submitted)
+      perSnapshotRates = perSnapshotTps anchor sortedSnapshots
+   in (e2eTps, makeDoubleQuantiles perSnapshotRates, length sortedSnapshots)
+ where
+  submittedAtFor Event{submittedAt} = Just submittedAt
+  perSnapshotTps :: Maybe UTCTime -> [(Scientific, (UTCTime, Int))] -> [Double]
+  perSnapshotTps = go
+   where
+    go :: Maybe UTCTime -> [(Scientific, (UTCTime, Int))] -> [Double]
+    go _ [] = []
+    go prev ((_, (t, c)) : rest)
+      | c <= 0 = go (Just t) rest
+      | otherwise =
+          case prev of
+            Just p ->
+              let dt = realToFrac (t `diffUTCTime` p) :: Double
+                  rate = if dt > 0 then fromIntegral c / dt else 0
+               in rate : go (Just t) rest
+            Nothing -> go (Just t) rest
 
 writeResultsCsv :: FilePath -> [(UTCTime, NominalDiffTime, NominalDiffTime, Int)] -> IO ()
 writeResultsCsv fp res = do

--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -69,8 +69,8 @@ import System.Timeout qualified
 import Test.HUnit.Lang (formatFailureReason)
 import Text.Printf (printf)
 
-bench :: Int -> NominalDiffTime -> Bool -> FilePath -> Dataset -> IO (Summary, SystemStats)
-bench startingNodeId timeoutSeconds incrementalOpsEnabled workDir dataset = do
+bench :: Int -> NominalDiffTime -> Bool -> Bool -> FilePath -> Dataset -> IO (Summary, SystemStats)
+bench startingNodeId timeoutSeconds incrementalOpsEnabled waitForTxValidEnabled workDir dataset = do
   putStrLn $ "Test logs available in: " <> (workDir </> "test.log")
   withFile (workDir </> "test.log") ReadWriteMode $ \hdl ->
     withTracerOutputTo (BlockBuffering (Just 64000)) hdl "Test" $ \tracer ->
@@ -93,7 +93,7 @@ bench startingNodeId timeoutSeconds incrementalOpsEnabled workDir dataset = do
           putStrLn $ "Timing: " <> show timing
           withHydraCluster hydraTracer timing workDir nodeSocket' startingNodeId cardanoKeys hydraKeys hydraScriptsTxId $ \clients -> do
             waitForNodesConnected hydraTracer 20 clients
-            scenario hydraTracer timing opts workDir dataset clients Nothing sideUTxOs
+            scenario hydraTracer timing opts workDir dataset clients Nothing sideUTxOs waitForTxValidEnabled
         systemStats <- readTVarIO statsTvar
         pure (scenarioData, systemStats)
 
@@ -104,10 +104,11 @@ benchDemo ::
   [Host] ->
   Maybe String ->
   Bool ->
+  Bool ->
   FilePath ->
   Dataset ->
   IO (Summary, SystemStats)
-benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand incrementalOpsEnabled workDir dataset@Dataset{clientDatasets} = do
+benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand incrementalOpsEnabled waitForTxValidEnabled workDir dataset@Dataset{clientDatasets} = do
   putStrLn $ "Test logs available in: " <> (workDir </> "test.log")
   withFile (workDir </> "test.log") ReadWriteMode $ \hdl ->
     withTracerOutputTo (BlockBuffering (Just 64000)) hdl "Test" $ \tracer ->
@@ -129,7 +130,7 @@ benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand incremen
               withHydraClientConnections hydraTracer (hydraClients `zip` [1 ..]) [] $ \case
                 [] -> error "no hydra clients provided"
                 (leader : followers) ->
-                  (,[]) <$> scenario hydraTracer timing opts workDir dataset (leader :| followers) pumbaCommand sideUTxOs
+                  (,[]) <$> scenario hydraTracer timing opts workDir dataset (leader :| followers) pumbaCommand sideUTxOs waitForTxValidEnabled
  where
   withHydraClientConnections ::
     Tracer IO HydraNodeLog ->
@@ -164,8 +165,12 @@ scenario ::
   -- | Optional pre-seeded side UTxOs, one per client dataset, used for
   -- interleaved incremental commit/decommit cycles. Empty list disables.
   [UTxO] ->
+  -- | When True, the submitter waits for each tx to confirm before posting
+  -- the next (one in-flight tx per client). When False, the submitter fires
+  -- all txs as fast as the queue can be drained.
+  Bool ->
   IO Summary
-scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, description} nonEmptyClients pumbaCommand sideUTxOs = do
+scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, description} nonEmptyClients pumbaCommand sideUTxOs waitForTxValidEnabled = do
   let clusterSize = fromIntegral $ length clientDatasets
   let leader = head nonEmptyClients
       clients = toList nonEmptyClients
@@ -211,7 +216,7 @@ scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, descript
               , ctxDecommitLock = decommitLock
               }
   (processedTransactions, snapshotsSeen, incrementalCommitTimes, incrementalDecommitTimes) <-
-    withPumba pumbaCommand $ processTransactions clients clientDatasets incrementalCtx
+    withPumba pumbaCommand $ processTransactions clients clientDatasets incrementalCtx waitForTxValidEnabled
 
   putTextLn "Closing the Head"
   send leader $ input "Close" []
@@ -388,8 +393,9 @@ processTransactions ::
   [HydraClient] ->
   [ClientDataset] ->
   Maybe IncrementalContext ->
+  Bool ->
   IO (Map.Map TxId Event, Map.Map Scientific (UTCTime, Int), [NominalDiffTime], [NominalDiffTime])
-processTransactions clients clientDatasets incrementalCtx = do
+processTransactions clients clientDatasets incrementalCtx waitForTxValidEnabled = do
   -- Allocate per-client state up front so the optional incremental ops thread
   -- can share access to the per-client registries.
   perClient <- forM (zip clientDatasets (cycle clients)) $ \(cd@ClientDataset{txSequence}, client) -> do
@@ -426,7 +432,7 @@ processTransactions clients clientDatasets incrementalCtx = do
 
   clientProcessDataset ClientDataset{txSequence} client clientId submissionQ registry numberOfTxs = do
     concurrentlyLabelled_
-      ("submit-txs", submitTxs client registry submissionQ)
+      ("submit-txs", submitTxs waitForTxValidEnabled client registry submissionQ)
       ( "confirm-txs"
       , concurrentlyLabelled_
           ("wait-for-all-confirmations", waitForAllConfirmations client registry (Set.fromList $ map txId txSequence))
@@ -625,17 +631,21 @@ newRegistry = do
   pure $ Registry{processedTxs, observedSnapshots}
 
 submitTxs ::
+  -- | When True, wait for each tx to confirm before sending the next; one
+  -- in-flight tx per client. When False, drain the queue as fast as possible
+  -- and rely on 'waitForAllConfirmations' to gate the bench's completion.
+  Bool ->
   HydraClient ->
   Registry Tx ->
   TBQueue IO Tx ->
   IO ()
-submitTxs client registry@Registry{processedTxs} submissionQ = do
+submitTxs waitForTxValidEnabled client registry@Registry{processedTxs} submissionQ = do
   txToSubmit <- atomically $ tryReadTBQueue submissionQ
   case txToSubmit of
     Just tx -> do
       newTx processedTxs client tx
-      waitTxIsConfirmed (txId tx)
-      submitTxs client registry submissionQ
+      when waitForTxValidEnabled $ waitTxIsConfirmed (txId tx)
+      submitTxs waitForTxValidEnabled client registry submissionQ
     Nothing -> pure ()
  where
   waitTxIsConfirmed txid =

--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -69,8 +69,21 @@ import System.Timeout qualified
 import Test.HUnit.Lang (formatFailureReason)
 import Text.Printf (printf)
 
-bench :: Int -> NominalDiffTime -> Bool -> Bool -> FilePath -> Dataset -> IO (Summary, SystemStats)
-bench startingNodeId timeoutSeconds incrementalOpsEnabled waitForTxValidEnabled workDir dataset = do
+-- | Behaviour toggles for a benchmark run, threaded from the CLI down into the
+-- scenario. Bundling these into a record avoids transposing the otherwise
+-- adjacent 'Bool' arguments at the call sites.
+data BenchRunOptions = BenchRunOptions
+  { incrementalOps :: Bool
+  -- ^ Exercise one interleaved incremental commit + decommit per client.
+  , waitForTxValid :: Bool
+  -- ^ Wait for each tx to confirm before posting the next (one in-flight tx
+  -- per client) instead of firing the whole queue as fast as it drains.
+  }
+  deriving stock (Eq, Show)
+
+bench :: Int -> NominalDiffTime -> BenchRunOptions -> FilePath -> Dataset -> IO (Summary, SystemStats)
+bench startingNodeId timeoutSeconds runOptions workDir dataset = do
+  let BenchRunOptions{incrementalOps} = runOptions
   putStrLn $ "Test logs available in: " <> (workDir </> "test.log")
   withFile (workDir </> "test.log") ReadWriteMode $ \hdl ->
     withTracerOutputTo (BlockBuffering (Just 64000)) hdl "Test" $ \tracer ->
@@ -84,7 +97,7 @@ bench startingNodeId timeoutSeconds incrementalOpsEnabled waitForTxValidEnabled 
           let contestationPeriod = truncate $ 10 * blockTime
           let DirectOptions{nodeSocket = nodeSocket'} = directOpts
           putTextLn "Seeding network"
-          sideUTxOs <- seedNetwork opts dataset incrementalOpsEnabled (contramap FromFaucet tracer)
+          sideUTxOs <- seedNetwork opts dataset incrementalOps (contramap FromFaucet tracer)
           putTextLn "Publishing hydra scripts"
           hydraScriptsTxId <- publishHydraScriptsAs opts Faucet
           putStrLn $ "Starting hydra cluster in " <> workDir
@@ -93,7 +106,7 @@ bench startingNodeId timeoutSeconds incrementalOpsEnabled waitForTxValidEnabled 
           putStrLn $ "Timing: " <> show timing
           withHydraCluster hydraTracer timing workDir nodeSocket' startingNodeId cardanoKeys hydraKeys hydraScriptsTxId $ \clients -> do
             waitForNodesConnected hydraTracer 20 clients
-            scenario hydraTracer timing opts workDir dataset clients Nothing sideUTxOs waitForTxValidEnabled
+            scenario hydraTracer timing opts workDir dataset clients Nothing sideUTxOs runOptions
         systemStats <- readTVarIO statsTvar
         pure (scenarioData, systemStats)
 
@@ -103,12 +116,12 @@ benchDemo ::
   NominalDiffTime ->
   [Host] ->
   Maybe String ->
-  Bool ->
-  Bool ->
+  BenchRunOptions ->
   FilePath ->
   Dataset ->
   IO (Summary, SystemStats)
-benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand incrementalOpsEnabled waitForTxValidEnabled workDir dataset@Dataset{clientDatasets} = do
+benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand runOptions workDir dataset@Dataset{clientDatasets} = do
+  let BenchRunOptions{incrementalOps} = runOptions
   putStrLn $ "Test logs available in: " <> (workDir </> "test.log")
   withFile (workDir </> "test.log") ReadWriteMode $ \hdl ->
     withTracerOutputTo (BlockBuffering (Just 64000)) hdl "Test" $ \tracer ->
@@ -121,7 +134,7 @@ benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand incremen
           Just (blockTime, directOpts) -> do
             let opts = Direct directOpts
             putTextLn "Seeding network"
-            sideUTxOs <- seedNetwork opts dataset incrementalOpsEnabled (contramap FromFaucet tracer)
+            sideUTxOs <- seedNetwork opts dataset incrementalOps (contramap FromFaucet tracer)
             (`finally` returnFaucetFunds tracer opts) $ do
               putStrLn $ "Connecting to hydra cluster: " <> show hydraClients
               let hydraTracer = contramap FromHydraNode tracer
@@ -130,7 +143,7 @@ benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand incremen
               withHydraClientConnections hydraTracer (hydraClients `zip` [1 ..]) [] $ \case
                 [] -> error "no hydra clients provided"
                 (leader : followers) ->
-                  (,[]) <$> scenario hydraTracer timing opts workDir dataset (leader :| followers) pumbaCommand sideUTxOs waitForTxValidEnabled
+                  (,[]) <$> scenario hydraTracer timing opts workDir dataset (leader :| followers) pumbaCommand sideUTxOs runOptions
  where
   withHydraClientConnections ::
     Tracer IO HydraNodeLog ->
@@ -165,12 +178,10 @@ scenario ::
   -- | Optional pre-seeded side UTxOs, one per client dataset, used for
   -- interleaved incremental commit/decommit cycles. Empty list disables.
   [UTxO] ->
-  -- | When True, the submitter waits for each tx to confirm before posting
-  -- the next (one in-flight tx per client). When False, the submitter fires
-  -- all txs as fast as the queue can be drained.
-  Bool ->
+  BenchRunOptions ->
   IO Summary
-scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, description} nonEmptyClients pumbaCommand sideUTxOs waitForTxValidEnabled = do
+scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, description} nonEmptyClients pumbaCommand sideUTxOs runOptions = do
+  let BenchRunOptions{waitForTxValid} = runOptions
   let clusterSize = fromIntegral $ length clientDatasets
   let leader = head nonEmptyClients
       clients = toList nonEmptyClients
@@ -216,7 +227,7 @@ scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, descript
               , ctxDecommitLock = decommitLock
               }
   (processedTransactions, snapshotsSeen, incrementalCommitTimes, incrementalDecommitTimes) <-
-    withPumba pumbaCommand $ processTransactions clients clientDatasets incrementalCtx waitForTxValidEnabled
+    withPumba pumbaCommand $ processTransactions clients clientDatasets incrementalCtx waitForTxValid
 
   putTextLn "Closing the Head"
   send leader $ input "Close" []
@@ -259,7 +270,7 @@ scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, descript
       quantiles = makeQuantiles confTimes
       summaryTitle = fromMaybe "Baseline Scenario" title
       summaryDescription = fromMaybe defaultDescription description
-      (endToEndTps, snapshotTpsQuantiles, numberOfSnapshots) =
+      (endToEndTps, runWallClockSeconds, snapshotTpsQuantiles, numberOfSnapshots) =
         computeThroughput processedTransactions snapshotsSeen
 
   pure $
@@ -274,6 +285,7 @@ scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, descript
       , numberOfInvalidTxs
       , numberOfFanoutOutputs
       , endToEndTps
+      , runWallClockSeconds
       , snapshotTpsQuantiles
       , numberOfSnapshots
       , incrementalCommitTimes
@@ -760,31 +772,31 @@ analyze = \case
     Just (submittedAt, valid `diffUTCTime` submittedAt, conf `diffUTCTime` submittedAt)
   _ -> Nothing
 
--- | End-to-end TPS over the run plus quantiles of per-snapshot TPS.
+-- | Measured wall-clock span, end-to-end TPS over the run, and quantiles of
+-- per-snapshot TPS.
 --
--- End-to-end TPS divides the count of confirmed txs by the wall-clock window
--- from earliest submission to latest confirmation. Per-snapshot TPS is
--- derived for snapshots that confirmed at least one tx by dividing the tx
--- count by the gap to the previous observation (or the earliest submission
--- time for the first snapshot).
-computeThroughput :: Map.Map TxId Event -> Map.Map Scientific (UTCTime, Int) -> (Double, Vector Double, Int)
+-- The wall-clock span is the elapsed time from the earliest tx submission to
+-- the latest confirmation; end-to-end TPS is the confirmed tx count divided by
+-- that span. Per-snapshot TPS is derived for snapshots that confirmed at least
+-- one tx by dividing the tx count by the gap to the previous observation (or
+-- the earliest submission time for the first snapshot).
+computeThroughput :: Map.Map TxId Event -> Map.Map Scientific (UTCTime, Int) -> (Double, Double, Vector Double, Int)
 computeThroughput txs snapshots =
-  let submitted = mapMaybe submittedAtFor (Map.elems txs)
+  let submitted = map submittedAtFor (Map.elems txs)
       confirmed = mapMaybe confirmedAt (Map.elems txs)
       numberOfTxs = length confirmed
-      e2eTps = case (submitted, confirmed) of
-        (s : _, _ : _) ->
-          let span_ = realToFrac (List.maximum confirmed `diffUTCTime` List.minimum (s : submitted)) :: Double
-           in if span_ > 0 then fromIntegral numberOfTxs / span_ else 0
+      wallClockSeconds = case (submitted, confirmed) of
+        (_ : _, _ : _) -> realToFrac (List.maximum confirmed `diffUTCTime` List.minimum submitted) :: Double
         _ -> 0
+      e2eTps = if wallClockSeconds > 0 then fromIntegral numberOfTxs / wallClockSeconds else 0
       sortedSnapshots = sortOn fst (Map.toList snapshots)
       anchor = case submitted of
         [] -> Nothing
         _ -> Just (List.minimum submitted)
       perSnapshotRates = perSnapshotTps anchor sortedSnapshots
-   in (e2eTps, makeDoubleQuantiles perSnapshotRates, length sortedSnapshots)
+   in (e2eTps, wallClockSeconds, makeDoubleQuantiles perSnapshotRates, length sortedSnapshots)
  where
-  submittedAtFor Event{submittedAt} = Just submittedAt
+  submittedAtFor Event{submittedAt} = submittedAt
   perSnapshotTps :: Maybe UTCTime -> [(Scientific, (UTCTime, Int))] -> [Double]
   perSnapshotTps = go
    where

--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -16,6 +16,8 @@ import Control.Concurrent.Class.MonadSTM (
   tryReadTBQueue,
   writeTBQueue,
  )
+import Control.Concurrent.MVar (MVar, newMVar, withMVar)
+import Control.Exception (SomeAsyncException)
 import Control.Lens (to, (^..), (^?))
 import Control.Monad.Class.MonadAsync (concurrently, mapConcurrently)
 import Data.Aeson (Result (Error, Success), Value, encode, fromJSON, (.=))
@@ -52,7 +54,6 @@ import HydraNode (
   hydraNodeId,
   input,
   output,
-  postDecommit,
   requestCommitTx,
   send,
   waitFor,
@@ -64,6 +65,7 @@ import HydraNode (
  )
 import System.FilePath ((</>))
 import System.Process.Typed (shell, withProcessTerm)
+import System.Timeout qualified
 import Test.HUnit.Lang (formatFailureReason)
 import Text.Printf (printf)
 
@@ -194,10 +196,20 @@ scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, descript
   -- Note: We only run Pumba during normal transaction processing; this is
   -- acceptable because otherwise we do not retry the particular actions that
   -- may or may not be dropped.
-  let incrementalCtx =
-        if null sideUTxOs
-          then Nothing
-          else Just IncrementalContext{ctxBackend = opts, ctxSideUTxOs = sideUTxOs, ctxHeadId = headId, ctxTracer = hydraTracer}
+  incrementalCtx <-
+    if null sideUTxOs
+      then pure Nothing
+      else do
+        decommitLock <- newMVar ()
+        pure $
+          Just
+            IncrementalContext
+              { ctxBackend = opts
+              , ctxSideUTxOs = sideUTxOs
+              , ctxHeadId = headId
+              , ctxTracer = hydraTracer
+              , ctxDecommitLock = decommitLock
+              }
   (processedTransactions, snapshotsSeen, incrementalCommitTimes, incrementalDecommitTimes) <-
     withPumba pumbaCommand $ processTransactions clients clientDatasets incrementalCtx
 
@@ -365,6 +377,11 @@ data IncrementalContext = IncrementalContext
   , ctxSideUTxOs :: [UTxO]
   , ctxHeadId :: HeadId
   , ctxTracer :: Tracer IO HydraNodeLog
+  , ctxDecommitLock :: MVar ()
+  -- ^ Serialises the post-decommit + wait-for-finalized window across
+  -- clients. The Hydra protocol rejects a decommit with
+  -- 'DecommitAlreadyInFlight' if one is already pending, so cluster-size > 1
+  -- runs would race without this lock.
   }
 
 processTransactions ::
@@ -422,41 +439,69 @@ processTransactions clients clientDatasets incrementalCtx = do
     (,) <$> readTVarIO (processedTxs registry) <*> readTVarIO (observedSnapshots registry)
 
   runAllIncrementalOps :: IncrementalContext -> [(ClientDataset, HydraClient, TBQueue IO Tx, Registry Tx, Int)] -> IO ([NominalDiffTime], [NominalDiffTime])
-  runAllIncrementalOps IncrementalContext{ctxBackend, ctxSideUTxOs, ctxTracer} perClient = do
+  runAllIncrementalOps IncrementalContext{ctxBackend, ctxSideUTxOs, ctxTracer, ctxDecommitLock} perClient = do
     let pairs = zip ctxSideUTxOs perClient
+    -- Run incremental cycles sequentially across clients. Running them
+    -- concurrently causes two head-protocol races: concurrent deposits compete
+    -- for the chain observation window and can be marked DepositExpired with
+    -- cluster size >= 3, and concurrent decommits collide on the single
+    -- "decommit in flight" slot. Sequential keeps the bench measuring per-op
+    -- timings cleanly; client 1's cycle is still interleaved with the regular
+    -- tx flow.
+    -- Cap each cycle at 90s. The actual commit+decommit work has its own
+    -- 180s waits, but withConnectionToNodeHost's sendClose has been observed
+    -- to hang post-decommit on busy nodes. Capture timings into a shared
+    -- IORef written before the hung cleanup so the metrics survive even if
+    -- the timeout fires during connection teardown.
+    let cycleTimeoutMicros = 90 * 1_000_000
     results <-
-      mapConcurrently
-        ( \(sideUTxO, (ClientDataset{paymentKey}, client, submissionQ, _registry, numberOfTxs)) ->
-            try @_ @SomeException
-              (runOneIncrementalOp ctxTracer ctxBackend client paymentKey sideUTxO numberOfTxs submissionQ)
+      mapM
+        ( \(sideUTxO, (ClientDataset{paymentKey}, client, submissionQ, _registry, numberOfTxs)) -> do
+            putTextLn $ "Incremental: mapM dispatching node " <> show (hydraNodeId client)
+            cellRef <- newIORef (Nothing, Nothing)
+            outcome <-
+              System.Timeout.timeout cycleTimeoutMicros $
+                tryNonAsync
+                  (runOneIncrementalOp ctxTracer ctxBackend ctxDecommitLock client paymentKey sideUTxO numberOfTxs submissionQ cellRef)
+            captured <- readIORef cellRef
+            let note :: Text = case outcome of
+                  Nothing -> "cleanup timed out, captured: " <> show captured
+                  Just (Left ex) -> "failed: " <> show ex
+                  Just (Right _) -> "ok"
+            putTextLn $ "Incremental: mapM done with node " <> show (hydraNodeId client) <> " (" <> note <> ")"
+            pure captured
         )
         pairs
-    let collected = rights results
-        commits = mapMaybe fst collected
-        decommits = mapMaybe snd collected
-    forM_ results $ \case
-      Left ex -> putStrLn $ "Incremental op failed: " <> show ex
-      _ -> pure ()
+    let commits = mapMaybe fst results
+        decommits = mapMaybe snd results
     pure (commits, decommits)
 
   -- Opens a fresh API connection so the wait on CommitFinalized/DecommitFinalized
   -- doesn't compete with the existing waitForAllConfirmations on the same WS.
+  -- The decommit + wait window is serialised across clients via the supplied
+  -- lock because the Hydra protocol rejects a decommit if another is in flight.
+  -- Writes finalization times into 'cellRef' as soon as they're observed so
+  -- the caller can recover the measurements even if connection teardown hangs.
   runOneIncrementalOp ::
     Tracer IO HydraNodeLog ->
     ChainBackendOptions ->
+    MVar () ->
     HydraClient ->
     SigningKey PaymentKey ->
     UTxO ->
     Int ->
     TBQueue IO Tx ->
+    IORef (Maybe NominalDiffTime, Maybe NominalDiffTime) ->
     IO (Maybe NominalDiffTime, Maybe NominalDiffTime)
-  runOneIncrementalOp tracer backend client paymentKey sideUTxO numberOfTxs submissionQ = do
+  runOneIncrementalOp tracer backend decommitLock client paymentKey sideUTxO numberOfTxs submissionQ cellRef = do
+    putTextLn $ "Incremental: cycle entered for node " <> show (hydraNodeId client)
     -- Wait until ~half this client's queue has drained.
     atomically $ do
       remaining <- lengthTBQueue submissionQ
       let drained = fromIntegral numberOfTxs - fromIntegral remaining :: Double
           target = fromIntegral numberOfTxs / 2 :: Double
       check (drained >= target)
+    putTextLn $ "Incremental: queue drained, opening obs to node " <> show (hydraNodeId client)
 
     withConnectionToNodeHost tracer (hydraNodeId client) (apiHost client) Nothing (Just "/?history=no") $ \obs -> do
       putTextLn "Incremental: requesting commit"
@@ -471,6 +516,7 @@ processTransactions clients clientDatasets incrementalCtx = do
         pure ()
       commitFinalisedAt <- getCurrentTime
       let commitTime = commitFinalisedAt `diffUTCTime` startCommit
+      atomicWriteIORef cellRef (Just commitTime, Nothing)
       putTextLn $ "Incremental: commit finalised in " <> show commitTime
 
       case UTxO.toList sideUTxO of
@@ -480,20 +526,53 @@ processTransactions clients clientDatasets incrementalCtx = do
             Left err -> do
               putStrLn $ "Incremental: decommit tx build failed: " <> show err
               pure (Just commitTime, Nothing)
-            Right decommitTx -> do
-              putTextLn "Incremental: posting decommit"
-              startDecommit <- getCurrentTime
-              postDecommit client decommitTx
-              let decommitTxId = txId decommitTx
-              _ <- waitMatch 180 obs $ \v -> do
-                guard (v ^? key "tag" == Just "DecommitFinalized")
-                observed <- v ^? key "decommitTxId" >>= parseMaybe parseJSON
-                guard (observed == decommitTxId)
-                pure ()
-              decommitFinalisedAt <- getCurrentTime
-              let decommitTime = decommitFinalisedAt `diffUTCTime` startDecommit
-              putTextLn $ "Incremental: decommit finalised in " <> show decommitTime
-              pure (Just commitTime, Just decommitTime)
+            Right decommitTx ->
+              withMVar decommitLock $ \_ -> do
+                putTextLn "Incremental: posting decommit"
+                startDecommit <- getCurrentTime
+                -- Use the WebSocket Decommit input rather than the /decommit
+                -- HTTP endpoint: the HTTP handler blocks until DecommitFinalized
+                -- (or apiTransactionTimeout) which can exceed the http-client
+                -- default 30s response timeout and propagates as
+                -- ResponseTimeout. WS submission is fire-and-forget; we observe
+                -- the lifecycle events explicitly below.
+                send obs $ input "Decommit" ["decommitTx" .= toJSON decommitTx]
+                let decommitTxId = txId decommitTx
+                -- DecommitApproved carries decommitTxId so we can pick out our
+                -- own. DecommitFinalized has no txid; matching it by tag is
+                -- safe because the lock ensures no other decommit is in flight
+                -- between Approved and Finalized.
+                _ <- waitMatch 180 obs $ \v -> do
+                  guard (v ^? key "tag" == Just "DecommitApproved")
+                  observed <- v ^? key "decommitTxId" >>= parseMaybe parseJSON
+                  guard (observed == decommitTxId)
+                  pure ()
+                _ <- waitMatch 180 obs $ \v ->
+                  guard (v ^? key "tag" == Just "DecommitFinalized")
+                decommitFinalisedAt <- getCurrentTime
+                let decommitTime = decommitFinalisedAt `diffUTCTime` startDecommit
+                atomicWriteIORef cellRef (Just commitTime, Just decommitTime)
+                putTextLn $ "Incremental: decommit finalised in " <> show decommitTime
+                -- We only observed DecommitFinalized on one node's obs. Other
+                -- nodes may not yet have cleared their in-flight decommit state
+                -- after gossip propagation. Hold the lock for a short tail
+                -- before releasing so the next client's WS Decommit input is
+                -- not rejected with DecommitAlreadyInFlight.
+                threadDelay 2_000_000
+                pure (Just commitTime, Just decommitTime)
+
+-- | Like 'try' but rethrows async exceptions instead of swallowing them. Using
+-- a plain 'try @SomeException' around the incremental-ops body breaks the outer
+-- 'failAfter' timeout because 'timeout' delivers its signal via an async
+-- exception that 'try' would otherwise catch and discard.
+tryNonAsync :: IO a -> IO (Either SomeException a)
+tryNonAsync action = do
+  result <- try action
+  case result of
+    Left ex
+      | Just (_ :: SomeAsyncException) <- fromException ex -> throwIO ex
+      | otherwise -> pure (Left ex)
+    Right v -> pure (Right v)
 
 progressReport :: Int -> Int -> Int -> TBQueue IO Tx -> IO ()
 progressReport nodeId clientId queueSize queue = do

--- a/hydra-cluster/bench/Bench/Options.hs
+++ b/hydra-cluster/bench/Bench/Options.hs
@@ -2,6 +2,7 @@ module Bench.Options where
 
 import Hydra.Prelude
 
+import Data.Text (splitOn)
 import Hydra.Cardano.Api (NetworkId, SocketPath)
 import Hydra.Chain (maximumNumberOfParties)
 import Hydra.Network (Host, readHost)
@@ -11,6 +12,7 @@ import Options.Applicative (
   ParserInfo,
   auto,
   command,
+  flag,
   fullDesc,
   header,
   help,
@@ -29,7 +31,7 @@ import Options.Applicative (
  )
 import Options.Applicative.Builder (argument)
 
-data UTxOSize = Constant | Growing deriving stock (Eq, Show, Read)
+data UTxOSize = Constant | Growing | Mixed deriving stock (Eq, Show, Read)
 
 data Options
   = StandaloneOptions
@@ -37,6 +39,7 @@ data Options
       , outputDirectory :: Maybe FilePath
       , timeoutSeconds :: NominalDiffTime
       , startingNodeId :: Int
+      , incrementalOps :: Bool
       }
   | DatasetOptions
       { outputDirectory :: Maybe FilePath
@@ -45,6 +48,7 @@ data Options
       , numberOfTxs :: Int
       , clusterSize :: Word64
       , startingNodeId :: Int
+      , incrementalOps :: Bool
       }
   | DemoOptions
       { outputDirectory :: Maybe FilePath
@@ -55,6 +59,15 @@ data Options
       , hydraClients :: [Host]
       , pumbaCommand :: Maybe String
       }
+  | MatrixOptions
+      { outputDirectory :: Maybe FilePath
+      , timeoutSeconds :: NominalDiffTime
+      , numberOfTxs :: Int
+      , startingNodeId :: Int
+      , clusterSizes :: [Word64]
+      , utxoShapes :: [UTxOSize]
+      , incrementalModes :: [Bool]
+      }
 
 benchOptionsParser :: ParserInfo Options
 benchOptionsParser =
@@ -63,6 +76,7 @@ benchOptionsParser =
         ( command "single" standaloneOptionsInfo
             <> command "datasets" datasetOptionsInfo
             <> command "demo" demoOptionsInfo
+            <> command "matrix" matrixOptionsInfo
         )
         <**> helper
     )
@@ -91,6 +105,7 @@ standaloneOptionsParser =
     <*> optional outputDirectoryParser
     <*> timeoutParser
     <*> startingNodeIdParser
+    <*> incrementalOpsParser
 
 outputDirectoryParser :: Parser FilePath
 outputDirectoryParser =
@@ -157,9 +172,10 @@ utxoSizeParser =
         <> value Constant
         <> metavar "UTxOSize"
         <> help
-          "Generated UTxO size. This can be 'Constant' where UTxO set has constant size \
-          \ depending on the number of generated txs or 'Growing' where each new generated \
-          \ transaction produces one extra output which makes the UTxO in the Head grow."
+          "Generated UTxO shape. 'Constant' keeps the head UTxO at a fixed size by \
+          \ submitting self-transfers. 'Growing' adds one extra output per tx so the \
+          \ head UTxO grows over the run. 'Mixed' grows for the first half of the run \
+          \ then contracts via 2-in 1-out merges for the second half."
     )
 
 demoOptionsInfo :: ParserInfo Options
@@ -226,6 +242,20 @@ datasetOptionsParser =
     <*> numberOfTxsParser
     <*> clusterSizeParser
     <*> startingNodeIdParser
+    <*> incrementalOpsParser
+
+incrementalOpsParser :: Parser Bool
+incrementalOpsParser =
+  flag
+    False
+    True
+    ( long "incremental-ops"
+        <> help
+          "If set, the bench will also exercise one incremental commit and \
+          \ one incremental decommit per client during the main transaction \
+          \ submission window, and report their finalisation times. Off by \
+          \ default."
+    )
 
 filepathParser :: Parser FilePath
 filepathParser =
@@ -234,3 +264,57 @@ filepathParser =
     ( metavar "FILE"
         <> help "Path to a JSON-formatted dataset descriptor file."
     )
+
+matrixOptionsInfo :: ParserInfo Options
+matrixOptionsInfo =
+  info
+    matrixOptionsParser
+    ( progDesc
+        "Run a scenario matrix over cluster sizes, UTxO shapes, and \
+        \ incremental-ops modes. Writes a single 'scenarios.md' to the output \
+        \ directory with a leading comparison table plus one section per cell."
+    )
+
+matrixOptionsParser :: Parser Options
+matrixOptionsParser =
+  MatrixOptions
+    <$> optional outputDirectoryParser
+    <*> timeoutParser
+    <*> numberOfTxsParser
+    <*> startingNodeIdParser
+    <*> clusterSizesParser
+    <*> utxoShapesParser
+    <*> incrementalModesParser
+
+clusterSizesParser :: Parser [Word64]
+clusterSizesParser =
+  option
+    (maybeReader parseListOf)
+    ( long "cluster-sizes"
+        <> value [1, 2, 3]
+        <> metavar "LIST"
+        <> help "Comma-separated cluster sizes to iterate (default: 1,2,3)"
+    )
+
+utxoShapesParser :: Parser [UTxOSize]
+utxoShapesParser =
+  option
+    (maybeReader parseListOf)
+    ( long "shapes"
+        <> value [Constant, Growing, Mixed]
+        <> metavar "LIST"
+        <> help "Comma-separated UTxO shapes to iterate. 'Constant' uses self-transfers so the head UTxO stays flat; 'Growing' adds outputs over time; 'Mixed' grows then contracts. (default: Constant,Growing,Mixed)"
+    )
+
+incrementalModesParser :: Parser [Bool]
+incrementalModesParser =
+  option
+    (maybeReader parseListOf)
+    ( long "incremental-modes"
+        <> value [False, True]
+        <> metavar "LIST"
+        <> help "Comma-separated incremental-ops modes, e.g. False,True (default: False,True)"
+    )
+
+parseListOf :: Read a => String -> Maybe [a]
+parseListOf s = traverse (readMaybe . toString) (splitOn "," (toText s))

--- a/hydra-cluster/bench/Bench/Options.hs
+++ b/hydra-cluster/bench/Bench/Options.hs
@@ -40,6 +40,7 @@ data Options
       , timeoutSeconds :: NominalDiffTime
       , startingNodeId :: Int
       , incrementalOps :: Bool
+      , waitForTxValid :: Bool
       }
   | DatasetOptions
       { outputDirectory :: Maybe FilePath
@@ -49,6 +50,7 @@ data Options
       , clusterSize :: Word64
       , startingNodeId :: Int
       , incrementalOps :: Bool
+      , waitForTxValid :: Bool
       }
   | DemoOptions
       { outputDirectory :: Maybe FilePath
@@ -67,6 +69,7 @@ data Options
       , clusterSizes :: [Word64]
       , utxoShapes :: [UTxOSize]
       , incrementalModes :: [Bool]
+      , waitForTxValidModes :: [Bool]
       }
 
 benchOptionsParser :: ParserInfo Options
@@ -106,6 +109,7 @@ standaloneOptionsParser =
     <*> timeoutParser
     <*> startingNodeIdParser
     <*> incrementalOpsParser
+    <*> waitForTxValidParser
 
 outputDirectoryParser :: Parser FilePath
 outputDirectoryParser =
@@ -243,6 +247,7 @@ datasetOptionsParser =
     <*> clusterSizeParser
     <*> startingNodeIdParser
     <*> incrementalOpsParser
+    <*> waitForTxValidParser
 
 incrementalOpsParser :: Parser Bool
 incrementalOpsParser =
@@ -255,6 +260,19 @@ incrementalOpsParser =
           \ one incremental decommit per client during the main transaction \
           \ submission window, and report their finalisation times. Off by \
           \ default."
+    )
+
+waitForTxValidParser :: Parser Bool
+waitForTxValidParser =
+  flag
+    False
+    True
+    ( long "wait-for-tx-valid"
+        <> help
+          "If set, the submitter waits for each tx's confirmation before \
+          \ posting the next one (one in-flight tx per client). If unset, \
+          \ txs are fired as fast as the queue drains so the head's \
+          \ saturation throughput is exercised. Off by default."
     )
 
 filepathParser :: Parser FilePath
@@ -285,6 +303,7 @@ matrixOptionsParser =
     <*> clusterSizesParser
     <*> utxoShapesParser
     <*> incrementalModesParser
+    <*> waitForTxValidModesParser
 
 clusterSizesParser :: Parser [Word64]
 clusterSizesParser =
@@ -314,6 +333,19 @@ incrementalModesParser =
         <> value [False, True]
         <> metavar "LIST"
         <> help "Comma-separated incremental-ops modes, e.g. False,True (default: False,True)"
+    )
+
+waitForTxValidModesParser :: Parser [Bool]
+waitForTxValidModesParser =
+  option
+    (maybeReader parseListOf)
+    ( long "wait-modes"
+        <> value [False, True]
+        <> metavar "LIST"
+        <> help
+          "Comma-separated wait-for-tx-valid modes. True keeps one in-flight \
+          \ tx per client (round-trip-bound throughput); False fires all txs \
+          \ as fast as possible (saturation throughput). Default: False,True"
     )
 
 parseListOf :: Read a => String -> Maybe [a]

--- a/hydra-cluster/bench/Bench/Summary.hs
+++ b/hydra-cluster/bench/Bench/Summary.hs
@@ -5,6 +5,7 @@ module Bench.Summary where
 import Hydra.Prelude
 
 import Data.Fixed (Nano)
+import Data.List qualified as List
 import Data.Text (pack)
 import Data.Time (nominalDiffTimeToSeconds)
 import Data.Vector (Vector, (!))
@@ -30,6 +31,11 @@ data Summary = Summary
   , summaryDescription :: Text
   , quantiles :: Vector Double
   , numberOfFanoutOutputs :: Int
+  , endToEndTps :: Double
+  , snapshotTpsQuantiles :: Vector Double
+  , numberOfSnapshots :: Int
+  , incrementalCommitTimes :: [NominalDiffTime]
+  , incrementalDecommitTimes :: [NominalDiffTime]
   }
   deriving stock (Generic, Eq, Show)
 
@@ -46,6 +52,11 @@ errorSummary Dataset{title, clientDatasets} (HUnitFailure sourceLocation reason)
         pack $ "Benchmark failed " <> formatLocation sourceLocation <> ": " <> formatFailureReason reason
     , quantiles = mempty
     , numberOfFanoutOutputs = 0
+    , endToEndTps = 0
+    , snapshotTpsQuantiles = mempty
+    , numberOfSnapshots = 0
+    , incrementalCommitTimes = []
+    , incrementalDecommitTimes = []
     }
  where
   formatLocation = maybe "" (\loc -> "at " <> prettySrcLoc loc)
@@ -55,8 +66,13 @@ makeQuantiles :: [NominalDiffTime] -> Vector Double
 makeQuantiles times =
   Statistics.quantilesVec def (fromList [0 .. 99]) 100 (fromList $ map (fromRational . (* 1000) . toRational . nominalDiffTimeToSeconds) times)
 
+makeDoubleQuantiles :: [Double] -> Vector Double
+makeDoubleQuantiles [] = mempty
+makeDoubleQuantiles xs =
+  Statistics.quantilesVec def (fromList [0 .. 99]) 100 (fromList xs)
+
 textReport :: (Summary, SystemStats) -> [Text]
-textReport (Summary{totalTxs, numberOfTxs, averageConfirmationTime, quantiles, numberOfInvalidTxs, numberOfFanoutOutputs}, systemStats) =
+textReport (Summary{totalTxs, numberOfTxs, averageConfirmationTime, quantiles, numberOfInvalidTxs, numberOfFanoutOutputs, endToEndTps, snapshotTpsQuantiles, numberOfSnapshots, incrementalCommitTimes, incrementalDecommitTimes}, systemStats) =
   let frac :: Double
       frac = 100 * fromIntegral numberOfTxs / fromIntegral totalTxs
    in [ pack $ printf "Confirmed txs/Total expected txs: %d/%d (%.2f %%)" numberOfTxs totalTxs frac
@@ -70,9 +86,32 @@ textReport (Summary{totalTxs, numberOfTxs, averageConfirmationTime, quantiles, n
                 ]
               else []
            )
+        ++ [pack $ printf "End-to-end TPS: %.2f tx/s" endToEndTps]
+        ++ [pack $ printf "Snapshots observed: %d" numberOfSnapshots]
+        ++ ( if length snapshotTpsQuantiles == 100
+              then
+                [ pack $ printf "Per-snapshot TPS P50: %.2f tx/s" (snapshotTpsQuantiles ! 50)
+                , pack $ printf "Per-snapshot TPS P95: %.2f tx/s" (snapshotTpsQuantiles ! 95)
+                , pack $ printf "Per-snapshot TPS max: %.2f tx/s" (snapshotTpsQuantiles ! 99)
+                ]
+              else []
+           )
         ++ ["Invalid txs: " <> show numberOfInvalidTxs]
         ++ ["Fanout outputs: " <> show numberOfFanoutOutputs]
+        ++ incrementalLines "Incremental commit" incrementalCommitTimes
+        ++ incrementalLines "Incremental decommit" incrementalDecommitTimes
         ++ if null systemStats then [] else "\n### Memory data \n" : [unlines systemStats]
+ where
+  incrementalLines :: Text -> [NominalDiffTime] -> [Text]
+  incrementalLines lbl = \case
+    [] -> []
+    ts ->
+      let xs = map nominalDiffTimeToMilliseconds ts
+          avg = sum xs / fromIntegral (length xs)
+       in [ lbl <> " count: " <> show (length ts)
+          , lbl <> " avg (ms): " <> show avg
+          , lbl <> " max (ms): " <> show (List.maximum xs)
+          ]
 
 markdownReport :: UTCTime -> [(Summary, SystemStats)] -> [Text]
 markdownReport now summaries =
@@ -105,32 +144,132 @@ markdownReport now summaries =
     , ""
     ]
 
-  formattedSummary :: (Summary, SystemStats) -> [Text]
-  formattedSummary (Summary{clusterSize, numberOfTxs, averageConfirmationTime, quantiles, summaryTitle, summaryDescription, numberOfInvalidTxs, numberOfFanoutOutputs}, systemStats) =
-    [ ""
-    , "## " <> summaryTitle
+formattedSummary :: (Summary, SystemStats) -> [Text]
+formattedSummary (Summary{clusterSize, numberOfTxs, averageConfirmationTime, quantiles, summaryTitle, summaryDescription, numberOfInvalidTxs, numberOfFanoutOutputs, endToEndTps, snapshotTpsQuantiles, numberOfSnapshots, incrementalCommitTimes, incrementalDecommitTimes}, systemStats) =
+  [ ""
+  , "## " <> summaryTitle
+  , ""
+  , summaryDescription
+  , ""
+  , "| Number of nodes |  " <> show clusterSize <> " | "
+  , "| -- | -- |"
+  , "| _Number of txs_ | " <> show numberOfTxs <> " |"
+  , "| _Avg. Confirmation Time (ms)_ | " <> show (nominalDiffTimeToMilliseconds averageConfirmationTime) <> " |"
+  ]
+    ++ ( if length quantiles == 100
+          then
+            [ "| _P99_ | " <> show (quantiles ! 99) <> "ms |"
+            , "| _P95_ | " <> show (quantiles ! 95) <> "ms |"
+            , "| _P50_ | " <> show (quantiles ! 50) <> "ms |"
+            ]
+          else []
+       )
+    ++ [ pack $ printf "| _End-to-end TPS_ | %.2f tx/s |" endToEndTps
+       , "| _Snapshots observed_ | " <> show numberOfSnapshots <> " |"
+       ]
+    ++ ( if length snapshotTpsQuantiles == 100
+          then
+            [ pack $ printf "| _Per-snapshot TPS P50_ | %.2f tx/s |" (snapshotTpsQuantiles ! 50)
+            , pack $ printf "| _Per-snapshot TPS P95_ | %.2f tx/s |" (snapshotTpsQuantiles ! 95)
+            , pack $ printf "| _Per-snapshot TPS max_ | %.2f tx/s |" (snapshotTpsQuantiles ! 99)
+            ]
+          else []
+       )
+    ++ [ "| _Number of Invalid txs_ | " <> show numberOfInvalidTxs <> " |"
+       ]
+    ++ [ "| _Fanout outputs_        | " <> show numberOfFanoutOutputs <> " |"
+       ]
+    ++ markdownIncremental "Incremental commit" incrementalCommitTimes
+    ++ markdownIncremental "Incremental decommit" incrementalDecommitTimes
+    ++ ["      "]
+    ++ if null systemStats then [] else "\n### Memory data \n" : [unlines systemStats]
+ where
+  markdownIncremental :: Text -> [NominalDiffTime] -> [Text]
+  markdownIncremental lbl = \case
+    [] -> []
+    ts ->
+      let xs = map nominalDiffTimeToMilliseconds ts
+          avg = sum xs / fromIntegral (length xs)
+       in [ "| _" <> lbl <> " count_ | " <> show (length ts) <> " |"
+          , "| _" <> lbl <> " avg (ms)_ | " <> show avg <> " |"
+          , "| _" <> lbl <> " max (ms)_ | " <> show (List.maximum xs) <> " |"
+          ]
+
+-- | Markdown report for the matrix runner. Same per-scenario details as
+-- 'markdownReport' but with a 'scenarios.md'-flavoured page header and a
+-- leading comparison table summarising every cell in one view.
+matrixMarkdownReport :: UTCTime -> [(Summary, SystemStats)] -> [Text]
+matrixMarkdownReport now summaries =
+  pageHeader <> comparisonTable summaries <> concatMap formattedSummary summaries
+ where
+  pageHeader :: [Text]
+  pageHeader =
+    [ "--- "
+    , "sidebar_label: 'Scenario benchmarks' "
+    , "sidebar_position: 5 "
+    , "--- "
     , ""
-    , summaryDescription
+    , "# Scenario benchmark results "
     , ""
-    , "| Number of nodes |  " <> show clusterSize <> " | "
-    , "| -- | -- |"
-    , "| _Number of txs_ | " <> show numberOfTxs <> " |"
-    , "| _Avg. Confirmation Time (ms)_ | " <> show (nominalDiffTimeToMilliseconds averageConfirmationTime) <> " |"
+    , "This page collects results from the scenario matrix: every combination \
+      \ of cluster size, UTxO shape, and incremental-ops mode is exercised by \
+      \ CI from the latest `master` code and reported below."
+    , ""
+    , ":::caution"
+    , ""
+    , "Numbers are approximate. They come from cloud VMs rather than \
+      \ controlled hardware, so the useful signal is the relative change \
+      \ between cells and between commits, not the absolute throughput."
+    , ""
+    , ":::"
+    , ""
+    , "_Generated at_  " <> show now
+    , ""
     ]
-      ++ ( if length quantiles == 100
-            then
-              [ "| _P99_ | " <> show (quantiles ! 99) <> "ms |"
-              , "| _P95_ | " <> show (quantiles ! 95) <> "ms |"
-              , "| _P50_ | " <> show (quantiles ! 50) <> "ms |"
-              ]
-            else []
-         )
-      ++ [ "| _Number of Invalid txs_ | " <> show numberOfInvalidTxs <> " |"
-         ]
-      ++ [ "| _Fanout outputs_        | " <> show numberOfFanoutOutputs <> " |"
-         ]
-      ++ ["      "]
-      ++ if null systemStats then [] else "\n### Memory data \n" : [unlines systemStats]
+
+comparisonTable :: [(Summary, SystemStats)] -> [Text]
+comparisonTable summaries =
+  [ ""
+  , "## Summary across cells"
+  , ""
+  , "TPS columns are rates (transactions per second); _Wall clock (s)_ is the \
+    \matching elapsed time, computed as `Txs / End-to-end TPS`, so a row with \
+    \50 txs and 50.58 tx/s ran in about 0.99 s."
+  , ""
+  , "| Scenario | Nodes | Txs | Wall clock (s) | End-to-end TPS (tx/s) | Per-snapshot p50 TPS (tx/s) | Avg conf (ms) | P95 conf (ms) |"
+  , "| -- | -- | -- | -- | -- | -- | -- | -- |"
+  ]
+    <> map row summaries
+    <> [""]
+ where
+  row :: (Summary, SystemStats) -> Text
+  row (Summary{clusterSize, numberOfTxs, summaryTitle, averageConfirmationTime, quantiles, endToEndTps, snapshotTpsQuantiles}, _) =
+    let p95Conf = if length quantiles == 100 then show (quantiles ! 95) else "n/a"
+        p50Tps =
+          if length snapshotTpsQuantiles == 100
+            then pack $ printf "%.2f" (snapshotTpsQuantiles ! 50)
+            else "n/a"
+        wallClock =
+          if endToEndTps > 0
+            then pack $ printf "%.2f" (fromIntegral numberOfTxs / endToEndTps :: Double)
+            else "n/a"
+     in "| "
+          <> summaryTitle
+          <> " | "
+          <> show clusterSize
+          <> " | "
+          <> show numberOfTxs
+          <> " | "
+          <> wallClock
+          <> " | "
+          <> pack (printf "%.2f" endToEndTps)
+          <> " | "
+          <> p50Tps
+          <> " | "
+          <> show (nominalDiffTimeToMilliseconds averageConfirmationTime)
+          <> " | "
+          <> p95Conf
+          <> " |"
 
 nominalDiffTimeToMilliseconds :: NominalDiffTime -> Nano
 nominalDiffTimeToMilliseconds = fromRational . (* 1000) . toRational . nominalDiffTimeToSeconds

--- a/hydra-cluster/bench/Bench/Summary.hs
+++ b/hydra-cluster/bench/Bench/Summary.hs
@@ -33,6 +33,7 @@ data Summary = Summary
   , quantiles :: Vector Double
   , numberOfFanoutOutputs :: Int
   , endToEndTps :: Double
+  , runWallClockSeconds :: Double
   , snapshotTpsQuantiles :: Vector Double
   , numberOfSnapshots :: Int
   , incrementalCommitTimes :: [NominalDiffTime]
@@ -54,6 +55,7 @@ errorSummary Dataset{title, clientDatasets} (HUnitFailure sourceLocation reason)
     , quantiles = mempty
     , numberOfFanoutOutputs = 0
     , endToEndTps = 0
+    , runWallClockSeconds = 0
     , snapshotTpsQuantiles = mempty
     , numberOfSnapshots = 0
     , incrementalCommitTimes = []
@@ -263,8 +265,8 @@ comparisonTable summaries =
   , "## Summary across cells"
   , ""
   , "TPS columns are rates (transactions per second); _Wall clock (s)_ is the \
-    \matching elapsed time, computed as `Txs / End-to-end TPS`, so a row with \
-    \50 txs and 50.58 tx/s ran in about 1.0 s. Times are rounded to one decimal."
+    \measured elapsed time from the first tx submission to the last \
+    \confirmation. Times are rounded to one decimal."
   , ""
   , "| Scenario | Txs | Wall clock (s) | End-to-end TPS (tx/s) | Per-snapshot p50 TPS (tx/s) | Avg conf (ms) | P95 conf (ms) |"
   , "| -- | -- | -- | -- | -- | -- | -- |"
@@ -273,7 +275,7 @@ comparisonTable summaries =
     <> [""]
  where
   row :: (Summary, SystemStats) -> Text
-  row (Summary{numberOfTxs, summaryTitle, averageConfirmationTime, quantiles, endToEndTps, snapshotTpsQuantiles}, _)
+  row (Summary{numberOfTxs, summaryTitle, averageConfirmationTime, quantiles, endToEndTps, runWallClockSeconds, snapshotTpsQuantiles}, _)
     | numberOfTxs == 0 =
         "| "
           <> summaryTitle
@@ -285,8 +287,8 @@ comparisonTable summaries =
                 then pack $ printf "%.2f" (snapshotTpsQuantiles ! 50)
                 else "n/a"
             wallClock =
-              if endToEndTps > 0
-                then oneDec (fromIntegral numberOfTxs / endToEndTps :: Double)
+              if runWallClockSeconds > 0
+                then oneDec runWallClockSeconds
                 else "n/a"
          in "| "
               <> summaryTitle

--- a/hydra-cluster/bench/Bench/Summary.hs
+++ b/hydra-cluster/bench/Bench/Summary.hs
@@ -266,19 +266,17 @@ comparisonTable summaries =
     \matching elapsed time, computed as `Txs / End-to-end TPS`, so a row with \
     \50 txs and 50.58 tx/s ran in about 1.0 s. Times are rounded to one decimal."
   , ""
-  , "| Scenario | Nodes | Txs | Wall clock (s) | End-to-end TPS (tx/s) | Per-snapshot p50 TPS (tx/s) | Avg conf (ms) | P95 conf (ms) |"
-  , "| -- | -- | -- | -- | -- | -- | -- | -- |"
+  , "| Scenario | Txs | Wall clock (s) | End-to-end TPS (tx/s) | Per-snapshot p50 TPS (tx/s) | Avg conf (ms) | P95 conf (ms) |"
+  , "| -- | -- | -- | -- | -- | -- | -- |"
   ]
     <> map row summaries
     <> [""]
  where
   row :: (Summary, SystemStats) -> Text
-  row (Summary{clusterSize, numberOfTxs, summaryTitle, averageConfirmationTime, quantiles, endToEndTps, snapshotTpsQuantiles}, _)
+  row (Summary{numberOfTxs, summaryTitle, averageConfirmationTime, quantiles, endToEndTps, snapshotTpsQuantiles}, _)
     | numberOfTxs == 0 =
         "| "
           <> summaryTitle
-          <> " | "
-          <> show clusterSize
           <> " | 0 | n/a | n/a | n/a | n/a | n/a |"
     | otherwise =
         let p95Conf = if length quantiles == 100 then oneDec (quantiles ! 95) else "n/a"
@@ -292,8 +290,6 @@ comparisonTable summaries =
                 else "n/a"
          in "| "
               <> summaryTitle
-              <> " | "
-              <> show clusterSize
               <> " | "
               <> show numberOfTxs
               <> " | "

--- a/hydra-cluster/bench/Bench/Summary.hs
+++ b/hydra-cluster/bench/Bench/Summary.hs
@@ -82,18 +82,22 @@ makeDoubleQuantiles [] = mempty
 makeDoubleQuantiles xs =
   Statistics.quantilesVec def (fromList [0 .. 99]) 100 (fromList xs)
 
+-- | Render a time value with at most one decimal place.
+oneDec :: Real a => a -> Text
+oneDec x = pack $ printf "%.1f" (realToFrac x :: Double)
+
 textReport :: (Summary, SystemStats) -> [Text]
 textReport (Summary{totalTxs, numberOfTxs, averageConfirmationTime, quantiles, numberOfInvalidTxs, numberOfFanoutOutputs, endToEndTps, snapshotTpsQuantiles, numberOfSnapshots, incrementalCommitTimes, incrementalDecommitTimes}, systemStats) =
   let frac :: Double
       frac = 100 * fromIntegral numberOfTxs / fromIntegral totalTxs
    in [ pack $ printf "Confirmed txs/Total expected txs: %d/%d (%.2f %%)" numberOfTxs totalTxs frac
-      , "Average confirmation time (ms): " <> show (nominalDiffTimeToMilliseconds averageConfirmationTime)
+      , "Average confirmation time (ms): " <> oneDec (nominalDiffTimeToMilliseconds averageConfirmationTime)
       ]
         ++ ( if length quantiles == 100
               then
-                [ "P99: " <> show (quantiles ! 99) <> "ms"
-                , "P95: " <> show (quantiles ! 95) <> "ms"
-                , "P50: " <> show (quantiles ! 50) <> "ms"
+                [ "P99: " <> oneDec (quantiles ! 99) <> "ms"
+                , "P95: " <> oneDec (quantiles ! 95) <> "ms"
+                , "P50: " <> oneDec (quantiles ! 50) <> "ms"
                 ]
               else []
            )
@@ -120,8 +124,8 @@ textReport (Summary{totalTxs, numberOfTxs, averageConfirmationTime, quantiles, n
       let xs = map nominalDiffTimeToMilliseconds ts
           avg = sum xs / fromIntegral (length xs)
        in [ lbl <> " count: " <> show (length ts)
-          , lbl <> " avg (ms): " <> show avg
-          , lbl <> " max (ms): " <> show (List.maximum xs)
+          , lbl <> " avg (ms): " <> oneDec avg
+          , lbl <> " max (ms): " <> oneDec (List.maximum xs)
           ]
 
 markdownReport :: UTCTime -> [(Summary, SystemStats)] -> [Text]
@@ -180,13 +184,13 @@ formattedSummary (Summary{clusterSize, numberOfTxs, averageConfirmationTime, qua
       , "| Number of nodes |  " <> show clusterSize <> " | "
       , "| -- | -- |"
       , "| _Number of txs_ | " <> show numberOfTxs <> " |"
-      , "| _Avg. Confirmation Time (ms)_ | " <> show (nominalDiffTimeToMilliseconds averageConfirmationTime) <> " |"
+      , "| _Avg. Confirmation Time (ms)_ | " <> oneDec (nominalDiffTimeToMilliseconds averageConfirmationTime) <> " |"
       ]
         ++ ( if length quantiles == 100
               then
-                [ "| _P99_ | " <> show (quantiles ! 99) <> "ms |"
-                , "| _P95_ | " <> show (quantiles ! 95) <> "ms |"
-                , "| _P50_ | " <> show (quantiles ! 50) <> "ms |"
+                [ "| _P99_ | " <> oneDec (quantiles ! 99) <> "ms |"
+                , "| _P95_ | " <> oneDec (quantiles ! 95) <> "ms |"
+                , "| _P50_ | " <> oneDec (quantiles ! 50) <> "ms |"
                 ]
               else []
            )
@@ -217,8 +221,8 @@ formattedSummary (Summary{clusterSize, numberOfTxs, averageConfirmationTime, qua
       let xs = map nominalDiffTimeToMilliseconds ts
           avg = sum xs / fromIntegral (length xs)
        in [ "| _" <> lbl <> " count_ | " <> show (length ts) <> " |"
-          , "| _" <> lbl <> " avg (ms)_ | " <> show avg <> " |"
-          , "| _" <> lbl <> " max (ms)_ | " <> show (List.maximum xs) <> " |"
+          , "| _" <> lbl <> " avg (ms)_ | " <> oneDec avg <> " |"
+          , "| _" <> lbl <> " max (ms)_ | " <> oneDec (List.maximum xs) <> " |"
           ]
 
 -- | Markdown report for the matrix runner. Same per-scenario details as
@@ -260,7 +264,7 @@ comparisonTable summaries =
   , ""
   , "TPS columns are rates (transactions per second); _Wall clock (s)_ is the \
     \matching elapsed time, computed as `Txs / End-to-end TPS`, so a row with \
-    \50 txs and 50.58 tx/s ran in about 0.99 s."
+    \50 txs and 50.58 tx/s ran in about 1.0 s. Times are rounded to one decimal."
   , ""
   , "| Scenario | Nodes | Txs | Wall clock (s) | End-to-end TPS (tx/s) | Per-snapshot p50 TPS (tx/s) | Avg conf (ms) | P95 conf (ms) |"
   , "| -- | -- | -- | -- | -- | -- | -- | -- |"
@@ -277,14 +281,14 @@ comparisonTable summaries =
           <> show clusterSize
           <> " | 0 | n/a | n/a | n/a | n/a | n/a |"
     | otherwise =
-        let p95Conf = if length quantiles == 100 then show (quantiles ! 95) else "n/a"
+        let p95Conf = if length quantiles == 100 then oneDec (quantiles ! 95) else "n/a"
             p50Tps =
               if length snapshotTpsQuantiles == 100
                 then pack $ printf "%.2f" (snapshotTpsQuantiles ! 50)
                 else "n/a"
             wallClock =
               if endToEndTps > 0
-                then pack $ printf "%.2f" (fromIntegral numberOfTxs / endToEndTps :: Double)
+                then oneDec (fromIntegral numberOfTxs / endToEndTps :: Double)
                 else "n/a"
          in "| "
               <> summaryTitle
@@ -299,7 +303,7 @@ comparisonTable summaries =
               <> " | "
               <> p50Tps
               <> " | "
-              <> show (nominalDiffTimeToMilliseconds averageConfirmationTime)
+              <> oneDec (nominalDiffTimeToMilliseconds averageConfirmationTime)
               <> " | "
               <> p95Conf
               <> " |"

--- a/hydra-cluster/bench/Bench/Summary.hs
+++ b/hydra-cluster/bench/Bench/Summary.hs
@@ -7,12 +7,13 @@ import Hydra.Prelude
 import Data.Fixed (Nano)
 import Data.List qualified as List
 import Data.Text (pack)
+import Data.Text qualified as T
 import Data.Time (nominalDiffTimeToSeconds)
 import Data.Vector (Vector, (!))
 import Hydra.Generator (ClientDataset (..), Dataset (..))
 import Statistics.Quantile (def)
 import Statistics.Quantile qualified as Statistics
-import Test.HUnit.Lang (formatFailureReason)
+import Test.HUnit.Lang (FailureReason, formatFailureReason)
 import Test.Hydra.Prelude (HUnitFailure (..))
 import Text.Printf (printf)
 
@@ -47,9 +48,9 @@ errorSummary Dataset{title, clientDatasets} (HUnitFailure sourceLocation reason)
     , numberOfTxs = 0
     , numberOfInvalidTxs = 0
     , averageConfirmationTime = 0
-    , summaryTitle = maybe "Error Summary" ("Error Summary " <>) title
+    , summaryTitle = maybe "Failed scenario" (<> " (failed)") title
     , summaryDescription =
-        pack $ "Benchmark failed " <> formatLocation sourceLocation <> ": " <> formatFailureReason reason
+        "Benchmark failed " <> pack (formatLocation sourceLocation) <> ": " <> shortReason reason
     , quantiles = mempty
     , numberOfFanoutOutputs = 0
     , endToEndTps = 0
@@ -60,6 +61,16 @@ errorSummary Dataset{title, clientDatasets} (HUnitFailure sourceLocation reason)
     }
  where
   formatLocation = maybe "" (\loc -> "at " <> prettySrcLoc loc)
+
+  -- Take only the first line of the reason. waitMatch failures dump every
+  -- "seen message" verbatim, which is hundreds of lines of JSON that mangle
+  -- the markdown when this summary lands in a PR comment.
+  shortReason :: FailureReason -> Text
+  shortReason r =
+    let full = pack (formatFailureReason r)
+     in case T.lines full of
+          [] -> "(no reason)"
+          (l : rest) -> l <> if null rest then "" else " (full output omitted)"
 
 makeQuantiles :: [NominalDiffTime] -> Vector Double
 -- makeQuantiles [] = mempty -- No confirmations, no quantiles.
@@ -145,44 +156,59 @@ markdownReport now summaries =
     ]
 
 formattedSummary :: (Summary, SystemStats) -> [Text]
-formattedSummary (Summary{clusterSize, numberOfTxs, averageConfirmationTime, quantiles, summaryTitle, summaryDescription, numberOfInvalidTxs, numberOfFanoutOutputs, endToEndTps, snapshotTpsQuantiles, numberOfSnapshots, incrementalCommitTimes, incrementalDecommitTimes}, systemStats) =
-  [ ""
-  , "## " <> summaryTitle
-  , ""
-  , summaryDescription
-  , ""
-  , "| Number of nodes |  " <> show clusterSize <> " | "
-  , "| -- | -- |"
-  , "| _Number of txs_ | " <> show numberOfTxs <> " |"
-  , "| _Avg. Confirmation Time (ms)_ | " <> show (nominalDiffTimeToMilliseconds averageConfirmationTime) <> " |"
-  ]
-    ++ ( if length quantiles == 100
-          then
-            [ "| _P99_ | " <> show (quantiles ! 99) <> "ms |"
-            , "| _P95_ | " <> show (quantiles ! 95) <> "ms |"
-            , "| _P50_ | " <> show (quantiles ! 50) <> "ms |"
-            ]
-          else []
-       )
-    ++ [ pack $ printf "| _End-to-end TPS_ | %.2f tx/s |" endToEndTps
-       , "| _Snapshots observed_ | " <> show numberOfSnapshots <> " |"
-       ]
-    ++ ( if length snapshotTpsQuantiles == 100
-          then
-            [ pack $ printf "| _Per-snapshot TPS P50_ | %.2f tx/s |" (snapshotTpsQuantiles ! 50)
-            , pack $ printf "| _Per-snapshot TPS P95_ | %.2f tx/s |" (snapshotTpsQuantiles ! 95)
-            , pack $ printf "| _Per-snapshot TPS max_ | %.2f tx/s |" (snapshotTpsQuantiles ! 99)
-            ]
-          else []
-       )
-    ++ [ "| _Number of Invalid txs_ | " <> show numberOfInvalidTxs <> " |"
-       ]
-    ++ [ "| _Fanout outputs_        | " <> show numberOfFanoutOutputs <> " |"
-       ]
-    ++ markdownIncremental "Incremental commit" incrementalCommitTimes
-    ++ markdownIncremental "Incremental decommit" incrementalDecommitTimes
-    ++ ["      "]
-    ++ if null systemStats then [] else "\n### Memory data \n" : [unlines systemStats]
+formattedSummary (Summary{clusterSize, numberOfTxs, averageConfirmationTime, quantiles, summaryTitle, summaryDescription, numberOfInvalidTxs, numberOfFanoutOutputs, endToEndTps, snapshotTpsQuantiles, numberOfSnapshots, incrementalCommitTimes, incrementalDecommitTimes}, systemStats)
+  | numberOfTxs == 0 =
+      -- Failed cell: no confirmations, so all the latency / TPS rows would be
+      -- zeros or empty quantiles. Render a short failure block instead of the
+      -- full table to keep the matrix report readable.
+      [ ""
+      , "## " <> summaryTitle
+      , ""
+      , summaryDescription
+      , ""
+      , "| Number of nodes | " <> show clusterSize <> " |"
+      , "| -- | -- |"
+      , "| _Outcome_ | did not complete, no measurements |"
+      , "      "
+      ]
+  | otherwise =
+      [ ""
+      , "## " <> summaryTitle
+      , ""
+      , summaryDescription
+      , ""
+      , "| Number of nodes |  " <> show clusterSize <> " | "
+      , "| -- | -- |"
+      , "| _Number of txs_ | " <> show numberOfTxs <> " |"
+      , "| _Avg. Confirmation Time (ms)_ | " <> show (nominalDiffTimeToMilliseconds averageConfirmationTime) <> " |"
+      ]
+        ++ ( if length quantiles == 100
+              then
+                [ "| _P99_ | " <> show (quantiles ! 99) <> "ms |"
+                , "| _P95_ | " <> show (quantiles ! 95) <> "ms |"
+                , "| _P50_ | " <> show (quantiles ! 50) <> "ms |"
+                ]
+              else []
+           )
+        ++ [ pack $ printf "| _End-to-end TPS_ | %.2f tx/s |" endToEndTps
+           , "| _Snapshots observed_ | " <> show numberOfSnapshots <> " |"
+           ]
+        ++ ( if length snapshotTpsQuantiles == 100
+              then
+                [ pack $ printf "| _Per-snapshot TPS P50_ | %.2f tx/s |" (snapshotTpsQuantiles ! 50)
+                , pack $ printf "| _Per-snapshot TPS P95_ | %.2f tx/s |" (snapshotTpsQuantiles ! 95)
+                , pack $ printf "| _Per-snapshot TPS max_ | %.2f tx/s |" (snapshotTpsQuantiles ! 99)
+                ]
+              else []
+           )
+        ++ [ "| _Number of Invalid txs_ | " <> show numberOfInvalidTxs <> " |"
+           ]
+        ++ [ "| _Fanout outputs_        | " <> show numberOfFanoutOutputs <> " |"
+           ]
+        ++ markdownIncremental "Incremental commit" incrementalCommitTimes
+        ++ markdownIncremental "Incremental decommit" incrementalDecommitTimes
+        ++ ["      "]
+        ++ if null systemStats then [] else "\n### Memory data \n" : [unlines systemStats]
  where
   markdownIncremental :: Text -> [NominalDiffTime] -> [Text]
   markdownIncremental lbl = \case
@@ -243,33 +269,40 @@ comparisonTable summaries =
     <> [""]
  where
   row :: (Summary, SystemStats) -> Text
-  row (Summary{clusterSize, numberOfTxs, summaryTitle, averageConfirmationTime, quantiles, endToEndTps, snapshotTpsQuantiles}, _) =
-    let p95Conf = if length quantiles == 100 then show (quantiles ! 95) else "n/a"
-        p50Tps =
-          if length snapshotTpsQuantiles == 100
-            then pack $ printf "%.2f" (snapshotTpsQuantiles ! 50)
-            else "n/a"
-        wallClock =
-          if endToEndTps > 0
-            then pack $ printf "%.2f" (fromIntegral numberOfTxs / endToEndTps :: Double)
-            else "n/a"
-     in "| "
+  row (Summary{clusterSize, numberOfTxs, summaryTitle, averageConfirmationTime, quantiles, endToEndTps, snapshotTpsQuantiles}, _)
+    | numberOfTxs == 0 =
+        "| "
           <> summaryTitle
           <> " | "
           <> show clusterSize
-          <> " | "
-          <> show numberOfTxs
-          <> " | "
-          <> wallClock
-          <> " | "
-          <> pack (printf "%.2f" endToEndTps)
-          <> " | "
-          <> p50Tps
-          <> " | "
-          <> show (nominalDiffTimeToMilliseconds averageConfirmationTime)
-          <> " | "
-          <> p95Conf
-          <> " |"
+          <> " | 0 | n/a | n/a | n/a | n/a | n/a |"
+    | otherwise =
+        let p95Conf = if length quantiles == 100 then show (quantiles ! 95) else "n/a"
+            p50Tps =
+              if length snapshotTpsQuantiles == 100
+                then pack $ printf "%.2f" (snapshotTpsQuantiles ! 50)
+                else "n/a"
+            wallClock =
+              if endToEndTps > 0
+                then pack $ printf "%.2f" (fromIntegral numberOfTxs / endToEndTps :: Double)
+                else "n/a"
+         in "| "
+              <> summaryTitle
+              <> " | "
+              <> show clusterSize
+              <> " | "
+              <> show numberOfTxs
+              <> " | "
+              <> wallClock
+              <> " | "
+              <> pack (printf "%.2f" endToEndTps)
+              <> " | "
+              <> p50Tps
+              <> " | "
+              <> show (nominalDiffTimeToMilliseconds averageConfirmationTime)
+              <> " | "
+              <> p95Conf
+              <> " |"
 
 nominalDiffTimeToMilliseconds :: NominalDiffTime -> Nano
 nominalDiffTimeToMilliseconds = fromRational . (* 1000) . toRational . nominalDiffTimeToSeconds

--- a/hydra-cluster/bench/Main.hs
+++ b/hydra-cluster/bench/Main.hs
@@ -7,11 +7,13 @@ import Test.Hydra.Prelude
 
 import Bench.EndToEnd (bench, benchDemo)
 import Bench.Options (Options (..), UTxOSize (..), benchOptionsParser)
-import Bench.Summary (Summary (..), SystemStats, errorSummary, markdownReport, textReport)
+import Bench.Summary (Summary (..), SystemStats, errorSummary, markdownReport, matrixMarkdownReport, textReport)
 import Data.Aeson (eitherDecodeFileStrict', encodeFile)
+import Data.List qualified as List
+import Data.Text qualified as T
 import Hydra.Cluster.Fixture (Actor (..))
 import Hydra.Cluster.Util (keysFor)
-import Hydra.Generator (Dataset (..), generateConstantUTxODataset, generateDemoUTxODataset, generateGrowingUTxODataset)
+import Hydra.Generator (Dataset (..), generateConstantUTxODataset, generateDemoUTxODataset, generateGrowingUTxODataset, generateMixedUTxODataset)
 import Options.Applicative (execParser)
 import System.Directory (createDirectoryIfMissing, listDirectory, removeDirectoryRecursive)
 import System.Environment (withArgs)
@@ -23,10 +25,10 @@ main :: IO ()
 main = do
   hSetBuffering stdout LineBuffering
   execParser benchOptionsParser >>= \case
-    StandaloneOptions{outputDirectory, timeoutSeconds, startingNodeId, datasetFiles} -> do
+    StandaloneOptions{outputDirectory, timeoutSeconds, startingNodeId, datasetFiles, incrementalOps} -> do
       datasets <- forM datasetFiles loadDataset
       putTextLn $ "Running benchmark with datasets: " <> show datasetFiles
-      let action = bench startingNodeId timeoutSeconds
+      let action = bench startingNodeId timeoutSeconds incrementalOps
       results <- forM datasets $ \dataset ->
         withTempDir "bench-dataset" $ \dir -> do
           threadDelay 10
@@ -38,16 +40,17 @@ main = do
       workDir <- maybe (createTempDir "bench-demo") checkEmpty outputDirectory
       results <-
         runSingle dataset workDir $
-          benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand
+          benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand False
       summarizeResults outputDirectory [results]
       removeDirectoryRecursive workDir
-    DatasetOptions{outputDirectory, timeoutSeconds, datasetUTxO, numberOfTxs, clusterSize, startingNodeId} -> do
+    DatasetOptions{outputDirectory, timeoutSeconds, datasetUTxO, numberOfTxs, clusterSize, startingNodeId, incrementalOps} -> do
       (_, faucetSk) <- keysFor Faucet
       workDir <- maybe (createTempDir "bench-e2e") checkEmpty outputDirectory
-      let action = bench startingNodeId timeoutSeconds
+      let action = bench startingNodeId timeoutSeconds incrementalOps
       dataset <- generate $ case datasetUTxO of
         Constant -> generateConstantUTxODataset faucetSk (fromIntegral clusterSize) numberOfTxs
         Growing -> generateGrowingUTxODataset faucetSk (fromIntegral clusterSize) numberOfTxs
+        Mixed -> generateMixedUTxODataset faucetSk (fromIntegral clusterSize) numberOfTxs
       saveDataset (workDir </> "dataset.json") dataset
       putStrLn $ "Saved dataset in: " <> (workDir </> "dataset.json")
       results <- do
@@ -55,7 +58,33 @@ main = do
         threadDelay 10
         runSingle dataset workDir action
       summarizeResults outputDirectory [results]
+    MatrixOptions{outputDirectory, timeoutSeconds, numberOfTxs, startingNodeId, clusterSizes, utxoShapes, incrementalModes} -> do
+      (_, faucetSk) <- keysFor Faucet
+      workDir <- maybe (createTempDir "bench-matrix") checkEmpty outputDirectory
+      let cells = [(cs, sh, im) | cs <- clusterSizes, sh <- utxoShapes, im <- incrementalModes]
+      putStrLn $ "Running matrix with " <> show (length cells) <> " cells"
+      results <- forM (zip [0 :: Int ..] cells) $ \(i, (cs, sh, im)) -> do
+        let cellDir = workDir </> ("cell-" <> show i)
+        createDirectoryIfMissing True cellDir
+        dataset <- generate $ case sh of
+          Constant -> generateConstantUTxODataset faucetSk (fromIntegral cs) numberOfTxs
+          Growing -> generateGrowingUTxODataset faucetSk (fromIntegral cs) numberOfTxs
+          Mixed -> generateMixedUTxODataset faucetSk (fromIntegral cs) numberOfTxs
+        let labelled = dataset{title = Just (matrixCellTitle cs sh im)}
+        saveDataset (cellDir </> "dataset.json") labelled
+        threadDelay 10
+        let nodeIdOffset = startingNodeId + i * fromIntegral (List.maximum clusterSizes)
+        let action = bench nodeIdOffset timeoutSeconds im
+        runSingle labelled cellDir action
+      summarizeMatrixResults outputDirectory results
  where
+  matrixCellTitle :: Word64 -> UTxOSize -> Bool -> Text
+  matrixCellTitle cs sh im =
+    "Cluster "
+      <> T.pack (show cs)
+      <> ", "
+      <> T.pack (show sh)
+      <> (if im then ", incremental ops on" else ", incremental ops off")
   checkEmpty fp = do
     createDirectoryIfMissing True fp
     listDirectory fp >>= \case
@@ -86,6 +115,20 @@ main = do
           writeBenchmarkReport outputDirectory [(summary, [])]
           benchmarkFailedWith dir exc
         exitFailure
+
+  summarizeMatrixResults :: Maybe FilePath -> [Either (Dataset, FilePath, Summary, BenchmarkFailed) (Summary, SystemStats)] -> IO ()
+  summarizeMatrixResults outputDirectory results = do
+    -- For the matrix runner, include failed cells in the report with their
+    -- error summaries so the reader can see which scenarios did not complete.
+    let cells =
+          flip map results $ \case
+            Left (_, _, summary, _) -> (summary, [])
+            Right s -> s
+    writeMatrixReport outputDirectory cells
+    let failures = [exc | Left (_, _, _, exc) <- results]
+    unless (null failures) $ do
+      forM_ (lefts results) $ \(_, dir, _, exc) -> benchmarkFailedWith dir exc
+      exitFailure
 
   loadDataset :: FilePath -> IO Dataset
   loadDataset f = do
@@ -133,5 +176,18 @@ writeBenchmarkReport outputDirectory summaries = do
     putStrLn $ "Writing report to: " <> reportPath
     now <- getCurrentTime
     let report = markdownReport now summaries
+    createDirectoryIfMissing True outputDir
+    writeFileBS reportPath . encodeUtf8 $ unlines report
+
+writeMatrixReport :: Maybe FilePath -> [(Summary, SystemStats)] -> IO ()
+writeMatrixReport outputDirectory summaries = do
+  mapM_ putTextLn (concatMap textReport summaries)
+  whenJust outputDirectory writeReport
+ where
+  writeReport outputDir = do
+    let reportPath = outputDir </> "scenarios.md"
+    putStrLn $ "Writing matrix report to: " <> reportPath
+    now <- getCurrentTime
+    let report = matrixMarkdownReport now summaries
     createDirectoryIfMissing True outputDir
     writeFileBS reportPath . encodeUtf8 $ unlines report

--- a/hydra-cluster/bench/Main.hs
+++ b/hydra-cluster/bench/Main.hs
@@ -25,10 +25,10 @@ main :: IO ()
 main = do
   hSetBuffering stdout LineBuffering
   execParser benchOptionsParser >>= \case
-    StandaloneOptions{outputDirectory, timeoutSeconds, startingNodeId, datasetFiles, incrementalOps} -> do
+    StandaloneOptions{outputDirectory, timeoutSeconds, startingNodeId, datasetFiles, incrementalOps, waitForTxValid} -> do
       datasets <- forM datasetFiles loadDataset
       putTextLn $ "Running benchmark with datasets: " <> show datasetFiles
-      let action = bench startingNodeId timeoutSeconds incrementalOps
+      let action = bench startingNodeId timeoutSeconds incrementalOps waitForTxValid
       results <- forM datasets $ \dataset ->
         withTempDir "bench-dataset" $ \dir -> do
           threadDelay 10
@@ -40,13 +40,13 @@ main = do
       workDir <- maybe (createTempDir "bench-demo") checkEmpty outputDirectory
       results <-
         runSingle dataset workDir $
-          benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand False
+          benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand False False
       summarizeResults outputDirectory [results]
       removeDirectoryRecursive workDir
-    DatasetOptions{outputDirectory, timeoutSeconds, datasetUTxO, numberOfTxs, clusterSize, startingNodeId, incrementalOps} -> do
+    DatasetOptions{outputDirectory, timeoutSeconds, datasetUTxO, numberOfTxs, clusterSize, startingNodeId, incrementalOps, waitForTxValid} -> do
       (_, faucetSk) <- keysFor Faucet
       workDir <- maybe (createTempDir "bench-e2e") checkEmpty outputDirectory
-      let action = bench startingNodeId timeoutSeconds incrementalOps
+      let action = bench startingNodeId timeoutSeconds incrementalOps waitForTxValid
       dataset <- generate $ case datasetUTxO of
         Constant -> generateConstantUTxODataset faucetSk (fromIntegral clusterSize) numberOfTxs
         Growing -> generateGrowingUTxODataset faucetSk (fromIntegral clusterSize) numberOfTxs
@@ -58,33 +58,40 @@ main = do
         threadDelay 10
         runSingle dataset workDir action
       summarizeResults outputDirectory [results]
-    MatrixOptions{outputDirectory, timeoutSeconds, numberOfTxs, startingNodeId, clusterSizes, utxoShapes, incrementalModes} -> do
+    MatrixOptions{outputDirectory, timeoutSeconds, numberOfTxs, startingNodeId, clusterSizes, utxoShapes, incrementalModes, waitForTxValidModes} -> do
       (_, faucetSk) <- keysFor Faucet
       workDir <- maybe (createTempDir "bench-matrix") checkEmpty outputDirectory
-      let cells = [(cs, sh, im) | cs <- clusterSizes, sh <- utxoShapes, im <- incrementalModes]
+      let cells =
+            [ (cs, sh, im, wt)
+            | cs <- clusterSizes
+            , sh <- utxoShapes
+            , im <- incrementalModes
+            , wt <- waitForTxValidModes
+            ]
       putStrLn $ "Running matrix with " <> show (length cells) <> " cells"
-      results <- forM (zip [0 :: Int ..] cells) $ \(i, (cs, sh, im)) -> do
+      results <- forM (zip [0 :: Int ..] cells) $ \(i, (cs, sh, im, wt)) -> do
         let cellDir = workDir </> ("cell-" <> show i)
         createDirectoryIfMissing True cellDir
         dataset <- generate $ case sh of
           Constant -> generateConstantUTxODataset faucetSk (fromIntegral cs) numberOfTxs
           Growing -> generateGrowingUTxODataset faucetSk (fromIntegral cs) numberOfTxs
           Mixed -> generateMixedUTxODataset faucetSk (fromIntegral cs) numberOfTxs
-        let labelled = dataset{title = Just (matrixCellTitle cs sh im)}
+        let labelled = dataset{title = Just (matrixCellTitle cs sh im wt)}
         saveDataset (cellDir </> "dataset.json") labelled
         threadDelay 10
         let nodeIdOffset = startingNodeId + i * fromIntegral (List.maximum clusterSizes)
-        let action = bench nodeIdOffset timeoutSeconds im
+        let action = bench nodeIdOffset timeoutSeconds im wt
         runSingle labelled cellDir action
       summarizeMatrixResults outputDirectory results
  where
-  matrixCellTitle :: Word64 -> UTxOSize -> Bool -> Text
-  matrixCellTitle cs sh im =
+  matrixCellTitle :: Word64 -> UTxOSize -> Bool -> Bool -> Text
+  matrixCellTitle cs sh im wt =
     "Cluster "
       <> T.pack (show cs)
       <> ", "
       <> T.pack (show sh)
       <> (if im then ", incremental ops on" else ", incremental ops off")
+      <> (if wt then ", wait for tx valid" else ", fire and forget")
   checkEmpty fp = do
     createDirectoryIfMissing True fp
     listDirectory fp >>= \case

--- a/hydra-cluster/bench/Main.hs
+++ b/hydra-cluster/bench/Main.hs
@@ -86,7 +86,7 @@ main = do
  where
   matrixCellTitle :: Word64 -> UTxOSize -> Bool -> Bool -> Text
   matrixCellTitle cs sh im wt =
-    "Cluster "
+    "Nodes="
       <> T.pack (show cs)
       <> ", "
       <> T.pack (show sh)

--- a/hydra-cluster/bench/Main.hs
+++ b/hydra-cluster/bench/Main.hs
@@ -5,7 +5,7 @@ module Main where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import Bench.EndToEnd (bench, benchDemo)
+import Bench.EndToEnd (BenchRunOptions (..), bench, benchDemo)
 import Bench.Options (Options (..), UTxOSize (..), benchOptionsParser)
 import Bench.Summary (Summary (..), SystemStats, errorSummary, markdownReport, matrixMarkdownReport, textReport)
 import Data.Aeson (eitherDecodeFileStrict', encodeFile)
@@ -28,7 +28,7 @@ main = do
     StandaloneOptions{outputDirectory, timeoutSeconds, startingNodeId, datasetFiles, incrementalOps, waitForTxValid} -> do
       datasets <- forM datasetFiles loadDataset
       putTextLn $ "Running benchmark with datasets: " <> show datasetFiles
-      let action = bench startingNodeId timeoutSeconds incrementalOps waitForTxValid
+      let action = bench startingNodeId timeoutSeconds BenchRunOptions{incrementalOps, waitForTxValid}
       results <- forM datasets $ \dataset ->
         withTempDir "bench-dataset" $ \dir -> do
           threadDelay 10
@@ -40,13 +40,13 @@ main = do
       workDir <- maybe (createTempDir "bench-demo") checkEmpty outputDirectory
       results <-
         runSingle dataset workDir $
-          benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand False False
+          benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand BenchRunOptions{incrementalOps = False, waitForTxValid = False}
       summarizeResults outputDirectory [results]
       removeDirectoryRecursive workDir
     DatasetOptions{outputDirectory, timeoutSeconds, datasetUTxO, numberOfTxs, clusterSize, startingNodeId, incrementalOps, waitForTxValid} -> do
       (_, faucetSk) <- keysFor Faucet
       workDir <- maybe (createTempDir "bench-e2e") checkEmpty outputDirectory
-      let action = bench startingNodeId timeoutSeconds incrementalOps waitForTxValid
+      let action = bench startingNodeId timeoutSeconds BenchRunOptions{incrementalOps, waitForTxValid}
       dataset <- generate $ case datasetUTxO of
         Constant -> generateConstantUTxODataset faucetSk (fromIntegral clusterSize) numberOfTxs
         Growing -> generateGrowingUTxODataset faucetSk (fromIntegral clusterSize) numberOfTxs
@@ -80,7 +80,7 @@ main = do
         saveDataset (cellDir </> "dataset.json") labelled
         threadDelay 10
         let nodeIdOffset = startingNodeId + i * fromIntegral (List.maximum clusterSizes)
-        let action = bench nodeIdOffset timeoutSeconds im wt
+        let action = bench nodeIdOffset timeoutSeconds BenchRunOptions{incrementalOps = im, waitForTxValid = wt}
         runSingle labelled cellDir action
       summarizeMatrixResults outputDirectory results
  where

--- a/hydra-cluster/bench/Main.hs
+++ b/hydra-cluster/bench/Main.hs
@@ -120,15 +120,18 @@ main = do
   summarizeMatrixResults outputDirectory results = do
     -- For the matrix runner, include failed cells in the report with their
     -- error summaries so the reader can see which scenarios did not complete.
+    -- A single flaky cell is logged but doesn't fail the matrix step; the
+    -- generated scenarios.md keeps the remaining cells' useful data.
     let cells =
           flip map results $ \case
             Left (_, _, summary, _) -> (summary, [])
             Right s -> s
     writeMatrixReport outputDirectory cells
-    let failures = [exc | Left (_, _, _, exc) <- results]
-    unless (null failures) $ do
-      forM_ (lefts results) $ \(_, dir, _, exc) -> benchmarkFailedWith dir exc
-      exitFailure
+    forM_ (lefts results) $ \(_, dir, _, exc) -> benchmarkFailedWith dir exc
+    let okCount = length (rights results)
+        total = length results
+    putStrLn $ "Matrix summary: " <> show okCount <> "/" <> show total <> " cells succeeded"
+    when (okCount == 0) exitFailure
 
   loadDataset :: FilePath -> IO Dataset
   loadDataset f = do

--- a/hydra-cluster/src/Hydra/Generator.hs
+++ b/hydra-cluster/src/Hydra/Generator.hs
@@ -8,6 +8,7 @@ import Cardano.Api.UTxO qualified as UTxO
 import CardanoClient (QueryPoint (QueryTip), localNodeConnectInfo, mkGenesisTx, queryUTxOFor)
 import Control.Monad (foldM)
 import Data.Aeson (object, withObject, (.:), (.=))
+import Data.List qualified as List
 import Hydra.Chain.Backend (buildTransaction)
 import Hydra.Chain.Direct (runDirectBackend)
 import Hydra.Cluster.Faucet (FaucetException (..))
@@ -152,6 +153,141 @@ generateGrowingUTxODataset faucetSk nClients nTxs = do
           Left err ->
             error $ "mkSimpleTx failed: " <> show err
           Right tx -> (utxoFromTx tx, tx : txs)
+
+-- | Generate a 'Dataset' that grows the head's UTxO set for the first half of
+-- the tx sequence and contracts it again for the second half. Phase 1 reuses
+-- the same per-tx pattern as 'generateGrowingUTxODataset' (1-in -> 2-out via
+-- 'mkSimpleTx' with reduced output value). Phase 2 issues 2-in -> 1-out
+-- merges that consume two previously created outputs and produce a single
+-- combined output. End-state has a single UTxO again.
+generateMixedUTxODataset ::
+  -- | Faucet signing key
+  SigningKey PaymentKey ->
+  -- | Number of clients
+  Int ->
+  -- | Number of transactions
+  Int ->
+  Gen Dataset
+generateMixedUTxODataset faucetSk nClients nTxs = do
+  hydraNodeKeys <- replicateM nClients genSigningKey
+  allPaymentKeys <- replicateM nClients genSigningKey
+  clientFunds <- genClientFunds allPaymentKeys availableInitialFunds
+  let fundingTransaction =
+        mkGenesisTx networkId faucetSk (Coin availableInitialFunds) clientFunds
+  clientDatasets <- forM allPaymentKeys (genClientDataset fundingTransaction)
+  pure
+    Dataset
+      { fundingTransaction
+      , hydraNodeKeys
+      , clientDatasets
+      , title = Just "Mixed UTxO Scenario"
+      , description =
+          Just
+            "Each client first grows its UTxO set (1-in to 2-out) for half of \
+            \its tx budget, then contracts it back (2-in to 1-out) for the \
+            \remainder."
+      }
+ where
+  growSteps = nTxs `div` 2
+  contractSteps = nTxs - growSteps
+
+  genClientDataset :: Tx -> SigningKey PaymentKey -> Gen ClientDataset
+  genClientDataset fundingTransaction paymentKey = do
+    let initialUTxO = withInitialUTxO paymentKey fundingTransaction
+    let vk = getVerificationKey paymentKey
+    let (afterGrow, growTxs) =
+          foldl' (genGrowTx paymentKey vk) (initialUTxO, []) [1 .. growSteps]
+    let (_, contractTxs) =
+          foldl' (genContractTx paymentKey vk) (afterGrow, []) [1 .. contractSteps]
+    pure
+      ClientDataset
+        { paymentKey
+        , initialUTxO
+        , txSequence = reverse growTxs ++ reverse contractTxs
+        }
+
+  -- Splits 4 ADA off the largest available UTxO so the change output is large
+  -- enough that subsequent iterations can spend it safely.
+  growChunk :: Coin
+  growChunk = Coin 4_000_000
+
+  -- The grow phase consumes the largest VK-owned UTxO each iteration. Picking
+  -- 'UTxO.find' instead would eventually land on one of the small change
+  -- outputs from earlier iterations, producing a negative-value txout when
+  -- 'growChunk' is subtracted.
+  genGrowTx ::
+    SigningKey PaymentKey ->
+    VerificationKey PaymentKey ->
+    (UTxO.UTxO Era, [Tx]) ->
+    Int ->
+    (UTxO.UTxO Era, [Tx])
+  genGrowTx sk vk (utxo, txs) _ =
+    case largestVkUTxO vk utxo of
+      Nothing -> error "mixed/grow: no utxo left to spend"
+      Just (txIn, txOut)
+        | selectLovelace (txOutValue txOut) <= growChunk ->
+            error $ "mixed/grow: largest VK utxo (" <> show (txOutValue txOut) <> ") is too small to split off " <> show growChunk
+        | otherwise ->
+            let chunkValue = lovelaceToValue growChunk
+             in case mkSimpleTx (txIn, txOut) (mkVkAddress networkId vk, chunkValue) sk of
+                  Left err -> error $ "mixed/grow mkSimpleTx failed: " <> show err
+                  Right tx ->
+                    let remaining = UTxO.difference utxo (UTxO.singleton txIn txOut)
+                     in (remaining <> utxoFromTx tx, tx : txs)
+
+  genContractTx ::
+    SigningKey PaymentKey ->
+    VerificationKey PaymentKey ->
+    (UTxO.UTxO Era, [Tx]) ->
+    Int ->
+    (UTxO.UTxO Era, [Tx])
+  genContractTx sk vk (utxo, txs) _ =
+    case take 2 (UTxO.toList (UTxO.filter (isVkTxOut vk) utxo)) of
+      [(in1, out1), (in2, out2)] ->
+        case mkMergeTx networkId sk (in1, out1) (in2, out2) of
+          Left err -> error $ "mixed/contract mkMergeTx failed: " <> show err
+          Right tx ->
+            let spent = UTxO.fromList [(in1, out1), (in2, out2)]
+                remaining = UTxO.difference utxo spent
+             in (remaining <> utxoFromTx tx, tx : txs)
+      _ -> error "mixed/contract: need at least 2 utxos to merge"
+
+  largestVkUTxO :: VerificationKey PaymentKey -> UTxO.UTxO Era -> Maybe (TxIn, TxOut CtxUTxO)
+  largestVkUTxO vk =
+    let byLovelace :: (TxIn, TxOut CtxUTxO) -> Coin
+        byLovelace (_, o) = selectLovelace (txOutValue o)
+     in fmap (List.maximumBy (comparing byLovelace)) . nonEmpty . UTxO.toList . UTxO.filter (isVkTxOut vk)
+
+-- | Build a zero-fee 2-in 1-out transaction that merges two of a sender's own
+-- outputs into one. Used by the Mixed generator to contract the UTxO set.
+mkMergeTx ::
+  NetworkId ->
+  SigningKey PaymentKey ->
+  (TxIn, TxOut CtxUTxO) ->
+  (TxIn, TxOut CtxUTxO) ->
+  Either TxBodyError Tx
+mkMergeTx network sk (in1, out1) (in2, out2) = do
+  body <- createAndValidateTransactionBody bodyContent
+  let witnesses = [makeShelleyKeyWitness body (WitnessPaymentKey sk)]
+  pure $ makeSignedTransaction witnesses body
+ where
+  vk = getVerificationKey sk
+  combined = txOutValue out1 <> txOutValue out2
+  bodyContent =
+    defaultTxBodyContent
+      { txIns =
+          [ (in1, BuildTxWith $ KeyWitness KeyWitnessForSpending)
+          , (in2, BuildTxWith $ KeyWitness KeyWitnessForSpending)
+          ]
+      , txOuts =
+          [ TxOut @CtxTx
+              (mkVkAddress network vk)
+              combined
+              TxOutDatumNone
+              ReferenceScriptNone
+          ]
+      , txFee = TxFeeExplicit (Coin 0)
+      }
 
 -- | Generate a 'Dataset' from an already running network by querying available
 -- funds of the well-known 'faucet.sk' and assuming the hydra-nodes we connect


### PR DESCRIPTION
Adds some more benchmarking information to the PRs, and in particular a kind of "TPS" count; both in the case where we wait for TxValid, and in the case where we just fire as many txns as possible, then just count how many are in the confirmed snapshots.

### Todo

- [x] Double check TPS is sensible
- [x] Have a scenario where we don't wait for TxValid; but just submit repeatedly
- [x] More scenarios?
- [ ] ~Tracking over time~ (Later)
- [x] ~Perhaps run shorter benchmarks on PR and longer ones nightly?~ Half done; do the other half later