### PR TITLE
Use reapplyTx when processing already validated snapshot transactions

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,1 @@
-if [ -f .env ]; then
-    echo "direnv: loading .env"
-    source .env
-fi
-use flake . --accept-flake-config
+use flake

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,5 @@
-use flake
+if [ -f .env ]; then
+    echo "direnv: loading .env"
+    source .env
+fi
+use flake . --accept-flake-config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 As a minor extension, we also keep a semantic version for the `UNRELEASED`
 changes.
 
+## [UNRELEASED]
+
+- Snapshot processing no longer re-evaluates Plutus scripts for transactions it
+  already validated on receipt.  This removes redundant script execution from the hot
+  path and noticeably increases sustained in-head throughput for script-heavy
+  workloads. [2717](https://github.com/cardano-scaling/hydra/pull/2717)
+
 ## [2.2.0] - 2026.06.12
 
 - Extend the end-to-end benchmark with real-world TPS metrics (end-to-end and

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -74,7 +74,7 @@ import Hydra.HeadLogic.State (
   setChainState,
   snapshotInFlight,
  )
-import Hydra.Ledger (Ledger (..), applyTransactions)
+import Hydra.Ledger (Ledger (..), applyTransactions, reapplyTransactions)
 import Hydra.Network qualified as Network
 import Hydra.Network.Message (Message (..), NetworkEvent (..))
 import Hydra.Node.DepositPeriod (DepositPeriod (..))
@@ -451,10 +451,20 @@ onOpenNetworkReqSn env ledger pendingDeposits currentSlot st otherParty sv sn re
   -- snapshot's UTxO set, eg. it's illegal for a snapshot leader to request a snapshot
   -- containing transactions that do not apply cleanly.
   requireApplyTxs utxo requestedTxs cont =
-    case applyTransactions ledger currentSlot utxo requestedTxs of
+    case reapplyOrApply ledger currentSlot utxo requestedTxs of
       Left (tx, err) ->
         Error $ RequireFailed $ SnapshotDoesNotApply sn (txId tx) err
       Right u -> cont u
+
+  -- The requested transactions were already validated on receipt ('ReqTx'), so
+  -- re-applying them to the confirmed UTxO only needs the state-dependent ledger
+  -- checks (inputs present, value preserved) and can skip the expensive Plutus
+  -- script re-evaluation. When a commit or decommit reshapes the active UTxO we
+  -- conservatively fall back to full application, since the script context may
+  -- then differ from what was validated.
+  reapplyOrApply
+    | isNothing mDecommitTx && isNothing mDepositTxId = reapplyTransactions
+    | otherwise = applyTransactions
 
   requireValidAccumulatorSize :: Accumulator.HydraAccumulator -> Outcome tx -> Outcome tx
   requireValidAccumulatorSize accumulator continue
@@ -479,7 +489,10 @@ onOpenNetworkReqSn env ledger pendingDeposits currentSlot st otherParty sv sn re
       -- actually expected.
       -- For example: `OutsideValidityIntervalUTxO` ledger errors are expected
       -- here when a tx becomes invalid.
-      case applyTransactions ledger currentSlot u [tx] of
+      -- These txs are part of 'localTxs' and were already validated on receipt,
+      -- so we re-apply (skipping Plutus re-evaluation); the state-dependent
+      -- checks still run and prune txs that no longer apply.
+      case reapplyOrApply ledger currentSlot u [tx] of
         Left _ -> go u rest
         Right u' -> tx Seq.<| go u' rest
   confSn = case confirmedSnapshot of

--- a/hydra-node/src/Hydra/Ledger.hs
+++ b/hydra-node/src/Hydra/Ledger.hs
@@ -16,7 +16,7 @@ nextChainSlot (ChainSlot n) = ChainSlot (n + 1)
 -- | An abstract interface for a 'Ledger'. Allows to define mock / simpler
 -- implementation for testing as well as limiting feature-envy from the business
 -- logic by forcing a closed interface.
-newtype Ledger tx = Ledger
+data Ledger tx = Ledger
   { applyTransactions ::
       ChainSlot ->
       UTxOType tx ->
@@ -26,6 +26,20 @@ newtype Ledger tx = Ledger
   -- validation failures returned from the ledger.
   -- TODO: 'ValidationError' should also include the UTxO, which is not
   -- necessarily the same as the given UTxO after some transactions
+  , reapplyTransactions ::
+      ChainSlot ->
+      UTxOType tx ->
+      [tx] ->
+      Either (tx, ValidationError) (UTxOType tx)
+  -- ^ Like 'applyTransactions', but only for transactions that were already
+  -- accepted by 'applyTransactions' earlier (possibly against a different UTxO).
+  -- It skips the expensive *static* checks — Plutus script evaluation and
+  -- witness cryptography — while still running the state-dependent checks
+  -- (inputs present, value preserved), so it fails exactly like
+  -- 'applyTransactions' when a transaction no longer applies.
+  --
+  -- Callers MUST only pass previously-validated transactions; passing an
+  -- unvalidated transaction is unsound (its scripts/signatures are not checked).
   }
 
 -- | Collect applicable transactions and resulting UTxO. In contrast to

--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -31,7 +31,7 @@ import Cardano.Ledger.Conway.Rules (
   ConwayUtxowPredFailure (UtxoFailure),
  )
 import Cardano.Ledger.Conway.State (ConwayAccountState (..))
-import Cardano.Ledger.Plutus (debugPlutus, defaultPlutusDebugOverrides)
+import Cardano.Ledger.Plutus (debugPlutusUnbounded, defaultPlutusDebugOverrides, pdoExUnitsEnforced)
 import Cardano.Ledger.Shelley.API.Mempool qualified as Ledger
 import Cardano.Ledger.Shelley.Genesis qualified as Ledger
 import Cardano.Ledger.Shelley.LedgerState qualified as Ledger
@@ -41,12 +41,9 @@ import Control.Lens ((%~), (.~), (^.))
 import Data.Default (def)
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
-import Data.Text qualified as T
-import Data.Text.Encoding qualified as Text
 import Hydra.Chain.ChainState (ChainSlot (..))
 import Hydra.Ledger (Ledger (..), ValidationError (..))
 import Hydra.Tx (IsTx (..))
-import System.IO.Unsafe (unsafeDupablePerformIO)
 
 -- * Ledger
 
@@ -144,14 +141,11 @@ cardanoLedger globals ledgerEnv =
   toValidationError :: ApplyTxError LedgerEra -> ValidationError
   toValidationError (ConwayApplyTxError (e :| _)) = case e of
     (ConwayUtxowFailure (UtxoFailure (UtxosFailure (ValidationTagMismatch _ (FailedUnexpectedly (PlutusFailure msg ctx :| _)))))) ->
-      ValidationError $
-        "Plutus validation failed: "
-          <> msg
-          <> "Debug info: "
-          -- NOTE: There is not a clear reason why 'debugPlutus' is an IO
-          -- action. It only re-evaluates the script and does not have any
-          -- side-effects.
-          <> show (unsafeDupablePerformIO $ debugPlutus (T.unpack $ Text.decodeUtf8 ctx) maxBound defaultPlutusDebugOverrides)
+        ValidationError $
+          "Plutus validation failed: "
+            <> msg
+            <> "Debug info: "
+            <> show (debugPlutusUnbounded (decodeUtf8 ctx) (defaultPlutusDebugOverrides {pdoExUnitsEnforced = True}))
     _ -> ValidationError $ show e
 
 -- * LedgerEnv

--- a/hydra-node/src/Hydra/Ledger/Cardano.hs
+++ b/hydra-node/src/Hydra/Ledger/Cardano.hs
@@ -53,15 +53,34 @@ import System.IO.Unsafe (unsafeDupablePerformIO)
 -- | Use the cardano-ledger as an in-hydra 'Ledger'.
 cardanoLedger :: Ledger.Globals -> Ledger.LedgerEnv LedgerEra -> Ledger Tx
 cardanoLedger globals ledgerEnv =
-  Ledger{applyTransactions}
+  Ledger{applyTransactions, reapplyTransactions}
  where
   -- NOTE(SN): See full note on 'applyTx' why we only have a single transaction
   -- application here.
-  applyTransactions slot utxo = \case
-    [] -> Right utxo
-    (tx : txs) -> do
-      utxo' <- applyTx slot utxo tx
-      applyTransactions slot utxo' txs
+  applyTransactions = foldTxs applyTx
+
+  -- Re-apply transactions that were already accepted by 'applyTransactions'
+  -- earlier. This skips the static checks (Plutus script evaluation and witness
+  -- cryptography) which dominate the per-tx cost, while still running the
+  -- state-dependent ledger checks so it fails exactly like 'applyTransactions'
+  -- when a transaction no longer applies to the given UTxO.
+  reapplyTransactions = foldTxs reapplyTx
+
+  -- Left-fold a single-transaction step over a list, threading the UTxO forward
+  -- and short-circuiting on the first validation failure.
+  foldTxs ::
+    (ChainSlot -> UTxO -> Tx -> Either (Tx, ValidationError) UTxO) ->
+    ChainSlot ->
+    UTxO ->
+    [Tx] ->
+    Either (Tx, ValidationError) UTxO
+  foldTxs step slot = go
+   where
+    go utxo = \case
+      [] -> Right utxo
+      (tx : txs) -> do
+        utxo' <- step slot utxo tx
+        go utxo' txs
 
   -- TODO(SN): Pre-validate transactions to get less confusing errors on
   -- transactions which are not expected to work on a layer-2
@@ -73,28 +92,30 @@ cardanoLedger globals ledgerEnv =
   -- got confused why a sequence of transactions worked but sequentially applying
   -- single transactions didn't. This was because of this not-keeping the'DPState'
   -- as described above.
-  applyTx (ChainSlot slot) utxo tx =
-    case Ledger.applyTx globals env' memPoolState (toLedgerTx tx) of
-      Left err ->
-        Left (tx, toValidationError err)
-      Right (Ledger.LedgerState{Ledger.lsUTxOState = us}, _validatedTx) ->
-        Right . UTxO.fromShelleyUTxO shelleyBasedEra $ Ledger.utxosUtxo us
-   where
-    -- As we use applyTx we only expect one ledger rule to run and one tx to
-    -- fail validation, hence using the heads of non empty lists is fine.
-    toValidationError :: ApplyTxError LedgerEra -> ValidationError
-    toValidationError (ConwayApplyTxError (e :| _)) = case e of
-      (ConwayUtxowFailure (UtxoFailure (UtxosFailure (ValidationTagMismatch _ (FailedUnexpectedly (PlutusFailure msg ctx :| _)))))) ->
-        ValidationError $
-          "Plutus validation failed: "
-            <> msg
-            <> "Debug info: "
-            -- NOTE: There is not a clear reason why 'debugPlutus' is an IO
-            -- action. It only re-evaluates the script and does not have any
-            -- side-effects.
-            <> show (unsafeDupablePerformIO $ debugPlutus (T.unpack $ Text.decodeUtf8 ctx) maxBound defaultPlutusDebugOverrides)
-      _ -> ValidationError $ show e
+  applyTx slot utxo tx =
+    withLedgerState slot utxo tx $ \env' memPoolState ->
+      case Ledger.applyTx globals env' memPoolState (toLedgerTx tx) of
+        Left err ->
+          Left (tx, toValidationError err)
+        Right (Ledger.LedgerState{Ledger.lsUTxOState = us}, _validatedTx) ->
+          Right . UTxO.fromShelleyUTxO shelleyBasedEra $ Ledger.utxosUtxo us
 
+  -- NOTE: 'unsafeMakeValidated' asserts that the transaction has previously
+  -- passed full validation; this holds because callers only re-apply
+  -- transactions already accepted by 'applyTx'. 'Ledger.reapplyTx' then runs
+  -- every ledger check except the static ones.
+  reapplyTx slot utxo tx =
+    withLedgerState slot utxo tx $ \env' memPoolState ->
+      case Ledger.reapplyTx globals env' memPoolState (Ledger.unsafeMakeValidated (toLedgerTx tx)) of
+        Left err ->
+          Left (tx, toValidationError err)
+        Right Ledger.LedgerState{Ledger.lsUTxOState = us} ->
+          Right . UTxO.fromShelleyUTxO shelleyBasedEra $ Ledger.utxosUtxo us
+
+  -- Build the ledger env and mempool state for a single transaction and hand
+  -- them to the given continuation. Shared by 'applyTx' and 'reapplyTx'.
+  withLedgerState (ChainSlot slot) utxo tx cont = cont env' memPoolState
+   where
     env' = ledgerEnv{Ledger.ledgerSlotNo = fromIntegral slot}
 
     memPoolState =
@@ -117,6 +138,21 @@ cardanoLedger globals ledgerEnv =
         & Map.filter (== Coin 0)
         & Map.keysSet
         & Set.map (unAccountId . aaId)
+
+  -- As we use applyTx we only expect one ledger rule to run and one tx to
+  -- fail validation, hence using the heads of non empty lists is fine.
+  toValidationError :: ApplyTxError LedgerEra -> ValidationError
+  toValidationError (ConwayApplyTxError (e :| _)) = case e of
+    (ConwayUtxowFailure (UtxoFailure (UtxosFailure (ValidationTagMismatch _ (FailedUnexpectedly (PlutusFailure msg ctx :| _)))))) ->
+      ValidationError $
+        "Plutus validation failed: "
+          <> msg
+          <> "Debug info: "
+          -- NOTE: There is not a clear reason why 'debugPlutus' is an IO
+          -- action. It only re-evaluates the script and does not have any
+          -- side-effects.
+          <> show (unsafeDupablePerformIO $ debugPlutus (T.unpack $ Text.decodeUtf8 ctx) maxBound defaultPlutusDebugOverrides)
+    _ -> ValidationError $ show e
 
 -- * LedgerEnv
 

--- a/hydra-node/src/Hydra/Ledger/Simple.hs
+++ b/hydra-node/src/Hydra/Ledger/Simple.hs
@@ -120,7 +120,9 @@ instance IsChainState SimpleTx where
 
 simpleLedger :: Ledger SimpleTx
 simpleLedger =
-  Ledger{applyTransactions}
+  -- NOTE: SimpleTx has no scripts or signatures, so re-application is identical
+  -- to application; there is no static check to skip.
+  Ledger{applyTransactions, reapplyTransactions = applyTransactions}
  where
   -- NOTE: _slot is unused as SimpleTx transactions don't have a notion of time.
   applyTransactions :: Foldable t => p -> Set SimpleTxOut -> t SimpleTx -> Either (SimpleTx, ValidationError) (Set SimpleTxOut)

--- a/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
+++ b/hydra-node/test/Hydra/Ledger/CardanoSpec.hs
@@ -6,6 +6,7 @@ import Hydra.Cardano.Api
 import Hydra.Prelude hiding (toList)
 import Test.Hydra.Prelude
 
+import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Ledger.Api (ensureMinCoinTxOut)
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Slotting.EpochInfo (EpochInfo, epochInfoSlotToRelativeTime, fixedEpochInfo, hoistEpochInfo)
@@ -16,12 +17,14 @@ import Data.Aeson.Lens (key)
 import Data.SOP.NonEmpty (NonEmpty (NonEmptyCons, NonEmptyOne))
 import Data.Text (unpack)
 import GHC.IsList (IsList (..))
+import Hydra.Cardano.Api.Gen (genTxIn)
 import Hydra.Cardano.Api.Pretty (renderTx)
 import Hydra.Chain.ChainState (ChainSlot (ChainSlot))
 import Hydra.JSONSchema (prop_validateJSONSchema)
-import Hydra.Ledger (applyTransactions)
-import Hydra.Ledger.Cardano (cardanoLedger)
+import Hydra.Ledger (applyTransactions, reapplyTransactions)
+import Hydra.Ledger.Cardano (cardanoLedger, mkRangedTx)
 import Hydra.Tx.IsTx (IsTx (..))
+import Hydra.Tx.Secret (mkSecret)
 import Ouroboros.Consensus.Block (GenesisWindow (..))
 import Ouroboros.Consensus.Cardano.Block (CardanoEras)
 import Ouroboros.Consensus.HardFork.History (
@@ -41,8 +44,8 @@ import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
 import Test.Cardano.Ledger.Babbage.Arbitrary ()
 import Test.Gen.Cardano.Api.Typed (genChainPoint)
 import Test.Hydra.Ledger.Cardano (genSequenceOfSimplePaymentTransactions)
-import Test.Hydra.Node.Fixture (defaultGlobals, defaultLedgerEnv, defaultPParams)
-import Test.Hydra.Tx.Gen (genOneUTxOFor, genOutputFor, genTxOut, genUTxOFor, genValue)
+import Test.Hydra.Node.Fixture (defaultGlobals, defaultLedgerEnv, defaultPParams, testNetworkId)
+import Test.Hydra.Tx.Gen (genKeyPair, genOneUTxOFor, genOutputFor, genTxOut, genUTxOFor, genValue)
 import Test.QuickCheck (
   Property,
   checkCoverage,
@@ -145,6 +148,8 @@ spec =
       prop "works with valid transaction" appliesValidTransaction
       prop "works with valid transaction deserialised from JSON" appliesValidTransactionFromJSON
       prop "is equivalent to folding applyTxTo for valid transactions" applyTransactionsEquivalence
+      prop "reapplyTransactions produces same UTxO as applyTransactions for valid transactions" reapplyEquivalence
+      prop "reapplyTransactions still rejects expired transactions" reapplyRejectsExpired
 
     describe "Generators" $ do
       propCollisionResistant "arbitrary @TxIn" (arbitrary @TxIn)
@@ -218,6 +223,35 @@ appliesValidTransactionFromJSON =
           & counterexample ("Result: " <> show result)
           & counterexample ("All txs: " <> unpack (decodeUtf8With lenientDecode $ prettyPrintJSON txs))
           & counterexample ("Initial UTxO: " <> unpack (decodeUtf8With lenientDecode $ prettyPrintJSON utxo))
+
+reapplyEquivalence :: Property
+reapplyEquivalence =
+  forAllBlind genSequenceOfSimplePaymentTransactions $ \(utxo, txs) ->
+    let ledger = cardanoLedger defaultGlobals defaultLedgerEnv
+        slot = ChainSlot 0
+     in applyTransactions ledger slot utxo txs
+          === reapplyTransactions ledger slot utxo txs
+
+reapplyRejectsExpired :: Property
+reapplyRejectsExpired =
+  forAllBlind genExpiringTransaction $ \(utxo, tx) ->
+    let ledger = cardanoLedger defaultGlobals defaultLedgerEnv
+        expiredSlot = ChainSlot 1000
+     in applyTransactions ledger expiredSlot utxo [tx]
+          === reapplyTransactions ledger expiredSlot utxo [tx]
+ where
+  genExpiringTransaction = do
+    (vk, sk) <- genKeyPair
+    txOut <- genOutputFor vk
+    txIn <- genTxIn
+    mkRangedTx
+      (txIn, txOut)
+      (mkVkAddress testNetworkId vk, txOutValue txOut)
+      (mkSecret sk)
+      (Nothing, Just $ TxValidityUpperBound (SlotNo 10))
+      & \case
+        Left _ -> error "cannot generate expiring tx"
+        Right tx -> pure (UTxO.singleton txIn txOut, tx)
 
 -- | A transaction or transaction output can usually only contain a realistic
 -- number of native asset entries. This property checks a realistic order of

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -331,7 +331,9 @@ fixedTimeHandleIndefiniteHorizon = do
 scriptLedger ::
   Ledger Tx
 scriptLedger =
-  Ledger{applyTransactions}
+  -- NOTE: This mock only validates scripts, so re-application reuses the same
+  -- logic.
+  Ledger{applyTransactions, reapplyTransactions = applyTransactions}
  where
   -- XXX: We could easily add 'slot' validation here and this would already
   -- emulate the dropping of outdated transactions from the cardano-node


### PR DESCRIPTION
## Summary

This PR adds a ledger-level `reapplyTransactions` path and uses it while processing snapshot requests for transactions that were already accepted by the node.

For the Cardano ledger backend, `reapplyTransactions` is backed by `cardano-ledger` `reapplyTx`, which skips static checks such as Plutus script evaluation and witness cryptography while still running state-dependent ledger checks.

## Scope

- Re-apply already accepted requested transactions while handling `ReqSn`.
- Re-apply already accepted local transactions while pruning `localTxs` after snapshot construction.
- Fall back to full `applyTransactions` when a commit or decommit changes the active UTxO, because the script context may differ.
- Keep the Simple ledger and mock script ledger behavior unchanged by wiring re-application to normal application there.

## Context

This is intended as a snapshot-side optimization for Plutus-heavy workloads. It does not try to solve the separate `TxValid` throughput ceiling, which likely needs parallel or multi-core script evaluation.

Closes #2716

## Testing

Not run locally in this turn.