### PR TITLE
No delaying on the increment modal

### DIFF
--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -78,6 +78,7 @@ runWithVty buildVty options@Options{hydraNodeHost, cardanoNetworkId, cardanoConn
       , appStartEvent = do
           vty <- getVtyHandle
           liftIO $ setMode (outputIface vty) Mouse True
+          triggerL1Query cardanoClient hydraClient chan
       , appAttrMap = \s -> case s ^. themeL of
           DarkTheme -> darkStyle s
           LightTheme -> lightStyle s

--- a/hydra-tui/src/Hydra/TUI/Drawing.hs
+++ b/hydra-tui/src/Hydra/TUI/Drawing.hs
@@ -70,6 +70,7 @@ modalTabLabel s
   | isJust (s ^. recoveryFormL) = "Recover"
   | otherwise = case s ^? connectedStateL . connectionL . headStateL . activeLinkL . activeHeadStateL . openStateL of
       Just LoadingUTxOForIncrement -> "Increment"
+      Just NoUTxOToIncrement -> "Increment"
       Just (SelectingUTxOToIncrement _) -> "Increment"
       Just (SelectingUTxOToDecommit _) -> "Decommit"
       Just (SelectingUTxO _) -> "New Tx"
@@ -128,7 +129,8 @@ drawActionBar s =
             Just _ -> [("↑↓/Space", " choose"), ("Enter", " recover"), ("Esc/C", " cancel")]
             Nothing -> case activeHeadState of
               Open{openState} -> case openState of
-                SelectingUTxOToIncrement _ -> [("↑↓/Space", " choose"), ("Enter", " select"), ("Esc/C", " cancel")]
+                SelectingUTxOToIncrement _ -> [("↑↓/Space", " choose"), ("Enter", " select"), ("U", " refresh"), ("Esc/C", " cancel")]
+                NoUTxOToIncrement -> [("U", " refresh"), ("Esc/C", " cancel")]
                 SelectingUTxOToDecommit _ -> [("↑↓/Space", " choose"), ("Enter", " decommit"), ("Esc/C", " cancel")]
                 SelectingUTxO _ -> [("↑↓/Space", " choose"), ("Enter", " select"), ("Esc/C", " cancel")]
                 EnteringAmount{} -> [("Enter", " confirm"), ("Esc/C", " cancel")]

--- a/hydra-tui/src/Hydra/TUI/Drawing/FundsTab.hs
+++ b/hydra-tui/src/Hydra/TUI/Drawing/FundsTab.hs
@@ -89,7 +89,9 @@ drawFocusPanelOpen networkId vk utxo pendingUTxOToDecommit pendingIncrements now
       , drawPendingIncrement ownAddress pendingIncrements now
       ]
   LoadingUTxOForIncrement ->
-    padAll 1 $ withAttr neutral $ txt "Querying Cardano node for available UTxO…"
+    padAll 1 $ withAttr neutral $ txt "Refreshing L1 UTxO…"
+  NoUTxOToIncrement ->
+    padAll 1 $ withAttr neutral $ txt "No known L1 funds. Press [U] to refresh."
   SelectingUTxO x -> renderForm x
   SelectingUTxOToDecommit x -> renderForm x
   SelectingUTxOToIncrement x -> renderForm x

--- a/hydra-tui/src/Hydra/TUI/Handlers.hs
+++ b/hydra-tui/src/Hydra/TUI/Handlers.hs
@@ -68,6 +68,10 @@ handleEvent cardanoClient client chan = \case
     syncEventHistoryList
     refreshRecoveryForm
     case e of
+      ClientConnected ->
+        triggerL1Query cardanoClient client chan
+      Update (ApiTimedServerOutput TimedServerOutput{output = API.HeadIsOpen{}}) ->
+        triggerL1Query cardanoClient client chan
       Update (ApiTimedServerOutput TimedServerOutput{output = API.CommitRecorded{}}) ->
         triggerL1Query cardanoClient client chan
       Update (ApiTimedServerOutput TimedServerOutput{output = API.CommitFinalized{}}) ->
@@ -90,17 +94,16 @@ handleEvent cardanoClient client chan = \case
     pendingActionL .= Just "Update complete"
   AppEvent (TxBuildError msg) -> pendingActionL .= Just msg
   AppEvent (UTxOQueryResult utxo) -> do
+    l1UTxOL .= Just utxo
     pendingActionL .= Nothing
     openScreen <- useOpenScreen
     case openScreen of
       Just LoadingUTxOForIncrement -> case utxoRadioField utxo of
         Just form ->
           zoomOpenScreen $ put $ SelectingUTxOToIncrement form
-        Nothing -> do
-          -- Empty or failed query — close modal, return to previous tab, show message
-          zoomOpenScreen $ put OpenHome
-          leaveModal
-          pendingActionL .= Just "No L1 funds available to increment."
+        Nothing ->
+          -- Still no L1 funds; keep the modal open offering another refresh.
+          zoomOpenScreen $ put NoUTxOToIncrement
       Nothing -> do
         -- Head is no longer Open (e.g. it closed mid-query). If we're still
         -- stuck on the loading modal, return the user to their previous tab.
@@ -182,6 +185,24 @@ handleEvent cardanoClient client chan = \case
         setPendingAction e
         zoom (connectedStateL . connectionL . headStateL) $
           handleVtyEventsHeadState cardanoClient client chan e
+      EvKey (KChar 'i') [] | not modalOpen -> do
+        -- Increment reads the cached L1 UTxO ('l1UTxOL') for a snappy modal
+        -- rather than querying the cardano-node. With an empty/unloaded cache
+        -- we show 'NoUTxOToIncrement', which offers a manual refresh. 'i' is
+        -- overloaded: when the head is Idle it inits the head, so delegate any
+        -- non-'OpenHome' state to the per-head handler.
+        screen <- useOpenScreen
+        case screen of
+          Just OpenHome -> do
+            l1 <- use l1UTxOL
+            case l1 >>= \m -> if Map.null m then Nothing else utxoRadioField m of
+              Just form -> zoomOpenScreen $ put $ SelectingUTxOToIncrement form
+              Nothing -> zoomOpenScreen $ put NoUTxOToIncrement
+            enterModal
+          _ -> do
+            setPendingAction e
+            zoom (connectedStateL . connectionL . headStateL) $
+              handleVtyEventsHeadState cardanoClient client chan e
       EvKey (KChar 'r') [] | not modalOpen -> do
         -- Recovery is a single modal flow regardless of head state. The form
         -- is stored in 'recoveryFormL' (not the per-head 'openState') so the
@@ -432,10 +453,8 @@ handleVtyEventsOpen cardanoClient hydraClient chan utxo pendingIncrements e =
           case utxoRadioField utxo' of
             Just form -> put (SelectingUTxOToDecommit form)
             Nothing -> liftIO $ writeBChan chan (TxBuildError "No L2 UTxO available to decommit.")
-        EvKey (KChar 'i') [] -> do
-          put LoadingUTxOForIncrement
-          let myAddr = mkMyAddress cardanoClient hydraClient
-          liftIO $ queryL1UTxOAsync cardanoClient myAddr chan UTxOQueryResult "L1 UTxO query failed"
+        -- 'i' (increment) is handled at the outer event loop so it can read the
+        -- cached L1 UTxO from 'RootState' (see 'EvKey (KChar 'i')' in handleEvent).
         -- 'r' (recover) is handled at the outer event loop as a top-level
         -- modal flow (see 'EvKey (KChar 'r')' in handleEvent), not as an
         -- 'OpenScreen' transition.
@@ -445,6 +464,11 @@ handleVtyEventsOpen cardanoClient hydraClient chan utxo pendingIncrements e =
     LoadingUTxOForIncrement ->
       case e of
         EvKey KEsc [] -> put OpenHome
+        _ -> pure ()
+    NoUTxOToIncrement ->
+      case e of
+        EvKey KEsc [] -> put OpenHome
+        EvKey (KChar 'u') [] -> refreshUTxOForIncrement
         _ -> pure ()
     ConfirmingClose i ->
       case e of
@@ -489,6 +513,7 @@ handleVtyEventsOpen cardanoClient hydraClient chan utxo pendingIncrements e =
           let commitUTxO = uncurry UTxO.singleton utxoSelected
           liftIO $ externalCommitAsync hydraClient chan commitUTxO
           put OpenHome
+        EvKey (KChar 'u') [] -> refreshUTxOForIncrement
         _ -> zoom selectingUTxOToIncrementFormL $ handleFormEvent (VtyEvent e)
     EnteringAmount utxoSelected i ->
       case e of
@@ -564,6 +589,14 @@ handleVtyEventsOpen cardanoClient hydraClient chan utxo pendingIncrements e =
 
   parseAddress =
     fmap ShelleyAddressInEra . deserialiseAddress (AsAddress AsShelleyAddr)
+
+  -- Re-query the L1 UTxO for the increment modal, showing the loading spinner
+  -- meanwhile. The result is delivered as a 'UTxOQueryResult' event, which
+  -- rebuilds the selection form (or 'NoUTxOToIncrement' when still empty).
+  refreshUTxOForIncrement = do
+    put LoadingUTxOForIncrement
+    let myAddr = mkMyAddress cardanoClient hydraClient
+    liftIO $ queryL1UTxOAsync cardanoClient myAddr chan UTxOQueryResult "L1 UTxO query failed"
 
 handleVtyEventsFanoutPossible :: Client Tx IO -> Vty.Event -> EventM Name s ()
 handleVtyEventsFanoutPossible hydraClient e = do
@@ -661,9 +694,8 @@ setPendingAction e = do
         pendingActionL .= Just "Sending Init…"
       (Active (ActiveLink{activeHeadState = FanoutPossible}), EvKey (KChar 'f') []) ->
         pendingActionL .= Just "Sending Fanout…"
-      -- Note: 'i' on Open OpenHome does not set a pending-action message —
-      -- the modal panel itself shows "Querying Cardano node for available
-      -- UTxO…" while LoadingUTxOForIncrement, which is enough.
+      -- Note: 'i' on Open OpenHome is handled at the outer event loop (it reads
+      -- the cached L1 UTxO) and does not flow through here.
       (Active (ActiveLink{activeHeadState = Open{openState}}), EvKey KEnter []) ->
         case openState of
           SelectingUTxOToDecommit _ ->

--- a/hydra-tui/src/Hydra/TUI/Model.hs
+++ b/hydra-tui/src/Hydra/TUI/Model.hs
@@ -90,6 +90,7 @@ type ConfirmingRadioFieldForm e n = Form Bool e n
 data OpenScreen
   = OpenHome
   | LoadingUTxOForIncrement
+  | NoUTxOToIncrement
   | SelectingUTxO {selectingUTxOForm :: UTxORadioFieldForm (HydraEvent Tx) Name}
   | SelectingUTxOToDecommit {selectingUTxOToDecommitForm :: UTxORadioFieldForm (HydraEvent Tx) Name}
   | SelectingUTxOToIncrement {selectingUTxOToIncrementForm :: UTxORadioFieldForm (HydraEvent Tx) Name}

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -141,10 +141,14 @@ spec = do
           sendInputEvent $ EvKey (KChar 'i') []
           threadDelay 1
           shouldRender "Open"
-          -- Start an increment: queries L1 UTxO, opens the increment modal.
+          -- Start an increment: opens the modal from the cached L1 UTxO.
           sendInputEvent $ EvKey (KChar 'i') []
-          threadDelay 3
+          threadDelay 1
           shouldRender "Increment"
+          -- Force a refresh ('u') so the UTxO list is populated regardless of
+          -- whether the background cache warm-up has completed yet.
+          sendInputEvent $ EvKey (KChar 'u') []
+          threadDelay 3
           -- Commit the first available UTxO.
           sendInputEvent $ EvKey KEnter []
           -- Wait for the chain follower to observe the deposit and emit
@@ -220,8 +224,12 @@ spec = do
           shouldRender "Open"
           -- Make a pending deposit so there is something to recover.
           sendInputEvent $ EvKey (KChar 'i') []
-          threadDelay 3
+          threadDelay 1
           shouldRender "Increment"
+          -- Force a refresh ('u') so the UTxO list is populated regardless of
+          -- whether the background cache warm-up has completed yet.
+          sendInputEvent $ EvKey (KChar 'u') []
+          threadDelay 3
           sendInputEvent $ EvKey KEnter []
           threadDelay 8
           shouldRender "Deposit recorded"


### PR DESCRIPTION
Previously, the "Increment" dialog would always re-query the L1 utxo state; this can be quite slow. Now, it just uses the previously-computed value, and allows you a chance to refresh if you wish.