### PR TITLE
Fix Blockfrost error handling so HTTP errors are retried instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ changes.
 - Hydra node can now be configured through a yaml file; easier to spot
   differences in configuration with peers. [#2296](https://github.com/cardano-scaling/hydra/issues/2296).
 
+- Fix Blockfrost chain backend error handling and resilience [#2729](https://github.com/cardano-scaling/hydra/pull/2729)
+
 ## [2.2.0] - 2026.06.12
 
 - Extend the end-to-end benchmark with real-world TPS metrics (end-to-end and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ changes.
 
 - Fix Blockfrost chain backend error handling and resilience [#2729](https://github.com/cardano-scaling/hydra/pull/2729)
 
+- Hydra node can now be configured through a yaml file; easier to spot
+  differences in configuration with peers. [#2296](https://github.com/cardano-scaling/hydra/issues/2296).
+
 ## [2.2.0] - 2026.06.12
 
 - Extend the end-to-end benchmark with real-world TPS metrics (end-to-end and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ changes.
   recovery via the `/commits` endpoint remains available after a head closes,
   in Idle state, and even while a new head is running. [#2743](https://github.com/cardano-scaling/hydra/pull/2743)
 
+- Fix Blockfrost chain backend error handling and resilience [#2729](https://github.com/cardano-scaling/hydra/pull/2729)
+
 ## [2.2.0] - 2026.06.12
 
 - Extend the end-to-end benchmark with real-world TPS metrics (end-to-end and

--- a/hydra-node/src/Hydra/Chain/Blockfrost.hs
+++ b/hydra-node/src/Hydra/Chain/Blockfrost.hs
@@ -24,6 +24,7 @@ import Hydra.Cardano.Api (
  )
 import Hydra.Chain (ChainComponent, ChainStateHistory, PostTxError (..), prefixOf)
 import Hydra.Chain.Backend (ChainBackend (..))
+import Hydra.Chain.Blockfrost.Client (APIBlockfrostError (..), isRetryable)
 import Hydra.Chain.Blockfrost.Client qualified as Blockfrost
 import Hydra.Chain.CardanoClient qualified as CardanoClient
 import Hydra.Chain.Direct.Handlers (
@@ -420,30 +421,9 @@ retryOnBlockfrostError tracer maxRetryCount =
     [ \RetryStatus{rsCumulativeDelay} -> Handler $ \(ex :: APIBlockfrostError) -> do
         traceWith tracer $ BlockfrostTransientError{reason = show ex, retryDelay = rsCumulativeDelay}
         pure True
-    , \RetryStatus{rsCumulativeDelay} -> Handler $ \(ex :: Blockfrost.APIBlockfrostError) -> do
-        traceWith tracer $ BlockfrostTransientError{reason = show ex, retryDelay = rsCumulativeDelay}
-        pure True
     ]
 
 -- * Helpers
-
-data APIBlockfrostError
-  = BlockfrostError Text
-  | DecodeError Text
-  | NotEnoughBlockConfirmations Blockfrost.BlockHash
-  | MissingBlockNo Blockfrost.BlockHash
-  | MissingBlockSlot (Maybe Blockfrost.Slot)
-  | MissingNextBlockHash Blockfrost.BlockHash
-  deriving stock (Show)
-  deriving anyclass (Exception)
-
-isRetryable :: APIBlockfrostError -> Bool
-isRetryable (BlockfrostError _) = True
-isRetryable (DecodeError _) = True
-isRetryable (NotEnoughBlockConfirmations _) = True
-isRetryable (MissingBlockNo _) = True
-isRetryable (MissingBlockSlot _) = True
-isRetryable (MissingNextBlockHash _) = True
 
 toTx :: MonadThrow m => Blockfrost.TransactionCBOR -> m Tx
 toTx (Blockfrost.TransactionCBOR txCbor) =

--- a/hydra-node/src/Hydra/Chain/Blockfrost.hs
+++ b/hydra-node/src/Hydra/Chain/Blockfrost.hs
@@ -420,7 +420,7 @@ retryOnBlockfrostError tracer maxRetryCount =
     (fullJitterBackoff 2_000 <> limitRetries maxRetryCount)
     [ \RetryStatus{rsCumulativeDelay} -> Handler $ \(ex :: APIBlockfrostError) -> do
         traceWith tracer $ BlockfrostTransientError{reason = show ex, retryDelay = rsCumulativeDelay}
-        pure True
+        pure (isRetryable ex)
     ]
 
 -- * Helpers

--- a/hydra-node/src/Hydra/Chain/Blockfrost.hs
+++ b/hydra-node/src/Hydra/Chain/Blockfrost.hs
@@ -220,26 +220,19 @@ blockfrostChainFollow ::
   TinyWallet m ->
   m ()
 blockfrostChainFollow tracer prj prefix handler wallet = do
-  Blockfrost.Genesis{_genesisSlotLength, _genesisActiveSlotsCoefficient} <-
-    Blockfrost.runBlockfrostM prj Blockfrost.getLedgerGenesis
-
-  let blockTime :: Double = realToFrac _genesisSlotLength / realToFrac _genesisActiveSlotsCoefficient
-
-  -- Start from the latest point and fall back to older ones (best effort)
-  -- If none of them can be resolved, we fall back to the tip of the chain.
-  blockHash <- resolvePrefixPoints (toList prefix)
-
-  stateTVar <- newLabelledTVarIO "blockfrost-chain-state" blockHash
-
-  -- Catch-up with retry protection
-  void $
-    retryOnBlockfrostError
-      tracer
-      maxRetries
-      ( \_ -> do
-          currentHash <- readTVarIO stateTVar
-          catchUpToLatest currentHash stateTVar
-      )
+  -- Genesis query and initial catch-up are both wrapped in retry to survive
+  -- transient HTTP errors (e.g. 403 rate limiting, connection resets).
+  (blockTime, stateTVar) <-
+    retryOnBlockfrostError tracer maxRetries $ \_ -> do
+      Blockfrost.Genesis{_genesisSlotLength, _genesisActiveSlotsCoefficient} <-
+        Blockfrost.runBlockfrostM prj Blockfrost.getLedgerGenesis
+      let blockTime :: Double = realToFrac _genesisSlotLength / realToFrac _genesisActiveSlotsCoefficient
+      -- Start from the latest point and fall back to older ones (best effort)
+      -- If none of them can be resolved, we fall back to the tip of the chain.
+      blockHash <- resolvePrefixPoints (toList prefix)
+      stateTVar <- newLabelledTVarIO "blockfrost-chain-state" blockHash
+      void $ catchUpToLatest blockHash stateTVar
+      pure (blockTime, stateTVar)
 
   void $
     retrying (retryPolicy blockTime) shouldRetry $ \_ -> do
@@ -425,6 +418,9 @@ retryOnBlockfrostError tracer maxRetryCount =
   recovering
     (fullJitterBackoff 2_000 <> limitRetries maxRetryCount)
     [ \RetryStatus{rsCumulativeDelay} -> Handler $ \(ex :: APIBlockfrostError) -> do
+        traceWith tracer $ BlockfrostTransientError{reason = show ex, retryDelay = rsCumulativeDelay}
+        pure True
+    , \RetryStatus{rsCumulativeDelay} -> Handler $ \(ex :: Blockfrost.APIBlockfrostError) -> do
         traceWith tracer $ BlockfrostTransientError{reason = show ex, retryDelay = rsCumulativeDelay}
         pure True
     ]

--- a/hydra-node/src/Hydra/Chain/Blockfrost/Client.hs
+++ b/hydra-node/src/Hydra/Chain/Blockfrost/Client.hs
@@ -78,14 +78,29 @@ data BlockfrostException
   | FailedEraHistory
   | AssetNameMissing
   | DeserialiseError Text
-  | DecodeError Text
-  | BlockfrostAPIError Text
   deriving stock (Show)
   deriving anyclass (Exception)
 
-newtype APIBlockfrostError
-  = BlockfrostError BlockfrostException
-  deriving newtype (Show, Exception)
+data APIBlockfrostError
+  = BlockfrostError Text
+  | BlockfrostClientError BlockfrostException
+  | DecodeError Text
+  | NotEnoughBlockConfirmations BlockHash
+  | MissingBlockNo BlockHash
+  | MissingBlockSlot (Maybe Slot)
+  | MissingNextBlockHash BlockHash
+  deriving stock (Show)
+  deriving anyclass (Exception)
+
+isRetryable :: APIBlockfrostError -> Bool
+isRetryable = \case
+  BlockfrostError _ -> True
+  BlockfrostClientError _ -> False
+  DecodeError _ -> True
+  NotEnoughBlockConfirmations _ -> True
+  MissingBlockNo _ -> True
+  MissingBlockSlot _ -> True
+  MissingNextBlockHash _ -> True
 
 runBlockfrostM ::
   (MonadIO m, MonadThrow m) =>
@@ -95,7 +110,7 @@ runBlockfrostM ::
 runBlockfrostM prj action = do
   result <- liftIO $ runBlockfrost prj action
   case result of
-    Left err -> throwIO $ BlockfrostError $ BlockfrostAPIError (show err)
+    Left err -> throwIO $ BlockfrostError (show err)
     Right val -> pure val
 
 -- | Query for 'TxIn's in the search for outputs containing all the reference
@@ -263,7 +278,7 @@ toCardanoTxOut networkId addrTxt val mDatumHash mInlineDatum plutusScript = do
   case plutusScript of
     Nothing -> do
       case toCardanoAddress addrTxt of
-        Nothing -> liftIO $ throwIO $ BlockfrostError $ FailedToDecodeAddress addrTxt
+        Nothing -> liftIO $ throwIO $ BlockfrostClientError $ FailedToDecodeAddress addrTxt
         Just addr -> pure $ TxOut addr val datum ReferenceScriptNone
     Just script -> pure $ TxOut (scriptAddr script) val datum (mkScriptRef script)
  where
@@ -278,13 +293,13 @@ toCardanoPolicyIdAndAssetName :: Text -> BlockfrostClientT IO (PolicyId, AssetNa
 toCardanoPolicyIdAndAssetName pid = do
   Blockfrost.AssetDetails{_assetDetailsPolicyId, _assetDetailsAssetName} <- Blockfrost.getAssetDetails (Blockfrost.mkAssetId pid)
   case deserialiseFromRawBytesHex (encodeUtf8 $ Blockfrost.unPolicyId _assetDetailsPolicyId) of
-    Left err -> liftIO $ throwIO $ BlockfrostError $ DeserialiseError (show err)
+    Left err -> liftIO $ throwIO $ BlockfrostClientError $ DeserialiseError (show err)
     Right p ->
       case _assetDetailsAssetName of
-        Nothing -> liftIO $ throwIO $ BlockfrostError AssetNameMissing
+        Nothing -> liftIO $ throwIO $ BlockfrostClientError AssetNameMissing
         Just assetName ->
           case deserialiseFromRawBytesHex (encodeUtf8 assetName) of
-            Left err -> liftIO $ throwIO $ BlockfrostError $ DeserialiseError (show err)
+            Left err -> liftIO $ throwIO $ BlockfrostClientError $ DeserialiseError (show err)
             Right asset -> pure (p, asset)
 
 toCardanoValue :: [Blockfrost.Amount] -> BlockfrostClientT IO Value
@@ -396,7 +411,7 @@ queryEraHistory = do
   let summary = mkEra <$> eras
   case nonEmptyFromList summary of
     Nothing ->
-      liftIO $ throwIO $ BlockfrostError FailedEraHistory
+      liftIO $ throwIO $ BlockfrostClientError FailedEraHistory
     Just s -> pure $ EraHistory (mkInterpreter $ Summary s)
  where
   mkBound Blockfrost.NetworkEraBound{_boundEpoch, _boundSlot, _boundTime} =
@@ -433,7 +448,7 @@ queryUTxOByTxIn :: BlockfrostOptions -> NetworkId -> [TxIn] -> BlockfrostClientT
 queryUTxOByTxIn BlockfrostOptions{retryTimeout} networkId =
   foldMapM (\(TxIn txid _) -> go retryTimeout (serialiseToRawBytesHexText txid))
  where
-  go 0 txHash = liftIO $ throwIO $ BlockfrostError $ FailedUTxOForHash txHash
+  go 0 txHash = liftIO $ throwIO $ BlockfrostClientError $ FailedUTxOForHash txHash
   go n txHash = do
     res <- Blockfrost.tryError $ Blockfrost.getTxUtxos (Blockfrost.TxHash txHash)
     case res of
@@ -472,7 +487,7 @@ queryUTxO BlockfrostOptions{queryTimeout} networkId addresses = do
     Blockfrost.getAddressUtxos address
       `catchError` \case
         Blockfrost.BlockfrostNotFound err ->
-          liftIO (throwIO (BlockfrostError (BlockfrostAPIError err)))
+          liftIO (throwIO (BlockfrostError err))
         err ->
           throwError err
 
@@ -503,7 +518,7 @@ queryUTxOFor cfg vk = do
     ShelleyAddressInEra addr ->
       queryUTxO cfg networkId [addr]
     ByronAddressInEra{} ->
-      liftIO $ throwIO $ BlockfrostError ByronAddressNotSupported
+      liftIO $ throwIO $ BlockfrostClientError ByronAddressNotSupported
 
 -- | Query the Blockfrost API for 'Genesis'
 queryGenesisParameters :: BlockfrostClientT IO Blockfrost.Genesis
@@ -563,7 +578,7 @@ awaitUTxO ::
 awaitUTxO networkId addresses txid cfg@BlockfrostOptions{retryTimeout} = do
   go retryTimeout
  where
-  go 0 = liftIO $ throwIO $ BlockfrostError (TimeoutOnUTxO txid)
+  go 0 = liftIO $ throwIO $ BlockfrostClientError (TimeoutOnUTxO txid)
   go n = do
     utxo <- Blockfrost.tryError $ queryUTxO cfg networkId addresses
     case utxo of

--- a/hydra-node/src/Hydra/Chain/Blockfrost/Client.hs
+++ b/hydra-node/src/Hydra/Chain/Blockfrost/Client.hs
@@ -486,8 +486,8 @@ queryUTxO BlockfrostOptions{queryTimeout} networkId addresses = do
   utxoWithAddresses <-
     Blockfrost.getAddressUtxos address
       `catchError` \case
-        Blockfrost.BlockfrostNotFound err ->
-          liftIO (throwIO (BlockfrostError err))
+        Blockfrost.BlockfrostNotFound _ ->
+          pure []
         err ->
           throwError err
 

--- a/hydra-node/src/Hydra/Chain/Blockfrost/Client.hs
+++ b/hydra-node/src/Hydra/Chain/Blockfrost/Client.hs
@@ -269,11 +269,11 @@ toCardanoTxOut networkId addrTxt val mDatumHash mInlineDatum plutusScript = do
         -- NOTE: The Blockfrost API returns inline datums as base16 encoded CBOR.
         case decodeBase16 cborDatum :: Either String ByteString of
           Left err ->
-            liftIO $ throwIO $ BlockfrostError $ DeserialiseError $ "Failed to decode inline datum " <> cborDatum <> ": " <> toText err
+            liftIO $ throwIO $ BlockfrostClientError $ DeserialiseError $ "Failed to decode inline datum " <> cborDatum <> ": " <> toText err
           Right rawCborDatum ->
             case deserialiseFromCBOR (proxyToAsType (Proxy @HashableScriptData)) rawCborDatum of
               Left err ->
-                liftIO $ throwIO $ BlockfrostError $ DeserialiseError $ "Failed to deserialise inline datum " <> cborDatum <> ": " <> show err
+                liftIO $ throwIO $ BlockfrostClientError $ DeserialiseError $ "Failed to deserialise inline datum " <> cborDatum <> ": " <> show err
               Right hashableScriptData -> pure $ TxOutDatumInline hashableScriptData
   case plutusScript of
     Nothing -> do

--- a/hydra-node/src/Hydra/Chain/ScriptRegistry.hs
+++ b/hydra-node/src/Hydra/Chain/ScriptRegistry.hs
@@ -93,7 +93,7 @@ publishHydraScripts sk = do
 handleError :: MonadThrow m => SomeException -> m a
 handleError e =
   case fromException e of
-    Just (BlockfrostError (NoUTxOFound addr)) ->
+    Just (BlockfrostClientError (NoUTxOFound addr)) ->
       throwIO $ PublishingFundsMissing (serialiseAddress addr)
     _ ->
       throwIO e

--- a/hydra-node/test/Hydra/Chain/BlockfrostSpec.hs
+++ b/hydra-node/test/Hydra/Chain/BlockfrostSpec.hs
@@ -4,12 +4,8 @@ import Hydra.Prelude
 import Test.Hspec
 
 import Control.Tracer (nullTracer)
-import Hydra.Chain.Blockfrost (
-  APIBlockfrostError (..),
-  isRetryable,
-  retryOnBlockfrostError,
- )
-import Hydra.Chain.Blockfrost.Client qualified as BlockfrostClient
+import Hydra.Chain.Blockfrost (retryOnBlockfrostError)
+import Hydra.Chain.Blockfrost.Client (APIBlockfrostError (..), isRetryable)
 import Hydra.Chain.Direct.Handlers (CardanoChainLog)
 import Hydra.Logging (Tracer)
 
@@ -48,27 +44,27 @@ spec = do
       finalAttempts <- readIORef attemptsRef
       finalAttempts `shouldBe` 4
 
-    it "retries on Client.APIBlockfrostError (HTTP 403) and eventually succeeds" $ do
+    it "retries on HTTP error (BlockfrostError Text) and eventually succeeds" $ do
       attemptsRef <- newIORef (0 :: Int)
       result <-
         retryOnBlockfrostError (nullTracer :: Tracer IO CardanoChainLog) 3 $ const $ do
           attempts <- readIORef attemptsRef
           modifyIORef attemptsRef (+ 1)
           if attempts < 2
-            then throwIO $ BlockfrostClient.BlockfrostError (BlockfrostClient.BlockfrostAPIError "HTTP 403 Forbidden")
+            then throwIO $ BlockfrostError "HTTP 403 Forbidden"
             else pure ("success" :: Text)
       result `shouldBe` "success"
       finalAttempts <- readIORef attemptsRef
       finalAttempts `shouldBe` 3
 
-    it "gives up after max retries on persistent Client.APIBlockfrostError" $ do
+    it "gives up after max retries on persistent HTTP error" $ do
       attemptsRef <- newIORef (0 :: Int)
       let action = do
             modifyIORef attemptsRef (+ 1)
-            throwIO $ BlockfrostClient.BlockfrostError (BlockfrostClient.BlockfrostAPIError "HTTP 403 Forbidden")
+            throwIO $ BlockfrostError "HTTP 403 Forbidden"
       retryOnBlockfrostError (nullTracer :: Tracer IO CardanoChainLog) 3 (const action)
         `shouldThrow` \case
-          BlockfrostClient.BlockfrostError (BlockfrostClient.BlockfrostAPIError _) -> True
+          BlockfrostError _ -> True
           _ -> False
       finalAttempts <- readIORef attemptsRef
       finalAttempts `shouldBe` 4

--- a/hydra-node/test/Hydra/Chain/BlockfrostSpec.hs
+++ b/hydra-node/test/Hydra/Chain/BlockfrostSpec.hs
@@ -68,3 +68,15 @@ spec = do
           _ -> False
       finalAttempts <- readIORef attemptsRef
       finalAttempts `shouldBe` 4
+
+    it "does not retry on BlockfrostClientError" $ do
+      attemptsRef <- newIORef (0 :: Int)
+      let action = do
+            modifyIORef attemptsRef (+ 1)
+            throwIO $ BlockfrostClientError ByronAddressNotSupported
+      retryOnBlockfrostError (nullTracer :: Tracer IO CardanoChainLog) 3 (const action)
+        `shouldThrow` \case
+          BlockfrostClientError{} -> True
+          _ -> False
+      finalAttempts <- readIORef attemptsRef
+      finalAttempts `shouldBe` 1

--- a/hydra-node/test/Hydra/Chain/BlockfrostSpec.hs
+++ b/hydra-node/test/Hydra/Chain/BlockfrostSpec.hs
@@ -9,6 +9,7 @@ import Hydra.Chain.Blockfrost (
   isRetryable,
   retryOnBlockfrostError,
  )
+import Hydra.Chain.Blockfrost.Client qualified as BlockfrostClient
 import Hydra.Chain.Direct.Handlers (CardanoChainLog)
 import Hydra.Logging (Tracer)
 
@@ -43,6 +44,31 @@ spec = do
       retryOnBlockfrostError (nullTracer :: Tracer IO CardanoChainLog) 3 (const action)
         `shouldThrow` \case
           BlockfrostError{} -> True
+          _ -> False
+      finalAttempts <- readIORef attemptsRef
+      finalAttempts `shouldBe` 4
+
+    it "retries on Client.APIBlockfrostError (HTTP 403) and eventually succeeds" $ do
+      attemptsRef <- newIORef (0 :: Int)
+      result <-
+        retryOnBlockfrostError (nullTracer :: Tracer IO CardanoChainLog) 3 $ const $ do
+          attempts <- readIORef attemptsRef
+          modifyIORef attemptsRef (+ 1)
+          if attempts < 2
+            then throwIO $ BlockfrostClient.BlockfrostError (BlockfrostClient.BlockfrostAPIError "HTTP 403 Forbidden")
+            else pure ("success" :: Text)
+      result `shouldBe` "success"
+      finalAttempts <- readIORef attemptsRef
+      finalAttempts `shouldBe` 3
+
+    it "gives up after max retries on persistent Client.APIBlockfrostError" $ do
+      attemptsRef <- newIORef (0 :: Int)
+      let action = do
+            modifyIORef attemptsRef (+ 1)
+            throwIO $ BlockfrostClient.BlockfrostError (BlockfrostClient.BlockfrostAPIError "HTTP 403 Forbidden")
+      retryOnBlockfrostError (nullTracer :: Tracer IO CardanoChainLog) 3 (const action)
+        `shouldThrow` \case
+          BlockfrostClient.BlockfrostError (BlockfrostClient.BlockfrostAPIError _) -> True
           _ -> False
       finalAttempts <- readIORef attemptsRef
       finalAttempts `shouldBe` 4

--- a/hydra-node/test/Hydra/Chain/BlockfrostSpec.hs
+++ b/hydra-node/test/Hydra/Chain/BlockfrostSpec.hs
@@ -5,7 +5,7 @@ import Test.Hspec
 
 import Control.Tracer (nullTracer)
 import Hydra.Chain.Blockfrost (retryOnBlockfrostError)
-import Hydra.Chain.Blockfrost.Client (APIBlockfrostError (..), isRetryable)
+import Hydra.Chain.Blockfrost.Client (APIBlockfrostError (..), BlockfrostException (..), isRetryable)
 import Hydra.Chain.Direct.Handlers (CardanoChainLog)
 import Hydra.Logging (Tracer)
 

--- a/hydra-node/test/Hydra/Chain/ScriptRegistrySpec.hs
+++ b/hydra-node/test/Hydra/Chain/ScriptRegistrySpec.hs
@@ -68,7 +68,7 @@ instance ChainBackend ATestBackend where
   queryUTxOFor _ vk' = ATestBackend $ do
     vk <- ask
     if vk == vk'
-      then throwIO $ BlockfrostError (NoUTxOFound (toAddress vk))
+      then throwIO $ BlockfrostClientError (NoUTxOFound (toAddress vk))
       else failure $ "queryUTxOFor received unexpected VerificationKey: " <> show vk'
 
   -- Other methods are not needed for this test.


### PR DESCRIPTION
fix #2477 

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
