### PR TITLE
Stop benchmark working state from leaking into published docs

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -109,6 +109,14 @@ jobs:
         redirect /tmp/public/head-protocol/monthly/index.html https://cardano-scaling.github.io/website/monthly
         redirect /tmp/public/head-protocol/unstable/monthly/index.html https://cardano-scaling.github.io/website/monthly
 
+    - name: 🧹 Strip benchmark working state
+      run: |
+
+        # Safety net: node working state must never be published. The deploy uses
+        # clean:false, so anything uploaded here lingers on gh-pages forever and
+        # once grew it past the 10GB Pages limit, breaking every deployment.
+        find /tmp/public -type d \( -name etcd -o -name db -o -name logs \) -prune -exec rm -rf {} +
+
     - name: 🚢 Publish Documentation
       uses: JamesIves/github-pages-deploy-action@v4
       with:

--- a/hydra-cluster/bench/Main.hs
+++ b/hydra-cluster/bench/Main.hs
@@ -86,7 +86,11 @@ main = do
         threadDelay 10
         let nodeIdOffset = startingNodeId + i * fromIntegral (List.maximum clusterSizes)
         let action = bench nodeIdOffset timeoutSeconds BenchRunOptions{incrementalOps = im, waitForTxValid = wt}
-        runSingle labelled cellDir action
+        -- Run the cluster in a throwaway dir, not 'cellDir': node working state
+        -- (etcd WAL, cardano-node db, logs) must not reach the published docs.
+        -- Only 'dataset.json' and the aggregated 'scenarios.md' are kept.
+        withTempDir ("bench-matrix-cell-" <> show i) $ \runDir ->
+          runSingle labelled runDir action
       summarizeMatrixResults outputDirectory results
  where
   matrixCellTitle :: Word64 -> UTxOSize -> Bool -> Bool -> Text


### PR DESCRIPTION
The matrix bench ran each cluster directly in `cellDir`, which lives under the published benchmarks/ output. Node working state (etcd WAL segments, `cardano-node` db, logs) was published, and since the docs deploy uses `clean:false` it accumulated on `gh-pages` until the branch exceeded the GitHub Pages 10GB limit, breaking every deployment.

Run each matrix cell in a throwaway temp dir so only dataset.json and the aggregated scenarios.md reach the output. Also strip any etcd/db/logs dirs in the publish workflow as a safety net before deploying.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
