### PR TITLE
Fix PersistentQueue deadlock and add operational visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,11 @@ changes.
 - Hydra node can now be configured through a yaml file; easier to spot
   differences in configuration with peers. [#2296](https://github.com/cardano-scaling/hydra/issues/2296).
 
-- Fix Blockfrost chain backend error handling and resilience [#2729](https://github.com/cardano-scaling/hydra/pull/2729)
+- Fixed a deadlock in the network layer's `PersistentQueue` where a silent
+  no-op in `popPersistentQueue` could leave the broadcast queue permanently stuck
+  at capacity, blocking all outbound messages. Node operators will now see
+  explicit `PersistentQueueFull` and `PersistentQueueLoadFailed` log entries when
+  the queue is under pressure or fails to recover from disk on startup.
 
 ## [2.2.0] - 2026.06.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,10 @@ changes.
   no-op in `popPersistentQueue` could leave the broadcast queue permanently stuck
   at capacity, blocking all outbound messages. Node operators will now see
   explicit `PersistentQueueFull` and `PersistentQueueLoadFailed` log entries when
-  the queue is under pressure or fails to recover from disk on startup.
+  the queue is under pressure or fails to recover from disk on startup. Failing
+  to delete a sent message's backing file no longer crashes the network
+  component; it is logged as `PersistentQueueDeleteFailed` and the message may
+  be re-broadcast after a restart.
 
 ## [2.2.0] - 2026.06.12
 

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -772,14 +772,13 @@ newPersistentQueue tracer path capacity = do
       pure $ List.last idxs
 
 -- | Write a value to the queue, blocking if the queue is full.
-writePersistentQueue :: (ToCBOR a, MonadSTM m, MonadIO m, MonadCatch m) => Tracer IO EtcdLog -> PersistentQueue m a -> a -> m ()
+writePersistentQueue :: (ToCBOR a, MonadSTM m, MonadIO m) => Tracer IO EtcdLog -> PersistentQueue m a -> a -> m ()
 writePersistentQueue tracer PersistentQueue{queue, nextIx, directory} item = do
   next <- atomically $ do
     next <- readTVar nextIx
     modifyTVar' nextIx (+ 1)
     pure next
   writeFileBS (directory </> show next) (serialize' item)
-    `onException` atomically (modifyTVar' nextIx (subtract 1))
   full <- atomically $ isFullTBQueue queue
   when full $ liftIO $ traceWith tracer PersistentQueueFull
   atomically $ writeTBQueue queue (next, item)

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -43,6 +43,7 @@ import Hydra.Prelude
 import Cardano.Binary (decodeFull', serialize')
 import Cardano.Crypto.Hash (SHA256, hashToStringAsHex, hashWithSerialiser)
 import Control.Concurrent.Class.MonadSTM (
+  isFullTBQueue,
   modifyTVar',
   peekTBQueue,
   readTBQueue,
@@ -121,7 +122,7 @@ import System.Process.Typed (
 -- | Concrete network component that broadcasts messages to an etcd cluster and
 -- listens for incoming messages.
 withEtcdNetwork ::
-  (ToCBOR msg, FromCBOR msg, Eq msg) =>
+  (ToCBOR msg, FromCBOR msg) =>
   Tracer IO EtcdLog ->
   ProtocolVersion ->
   -- TODO: check if all of these needed?
@@ -156,14 +157,14 @@ withEtcdNetwork tracer protocolVersion config callback action = do
                         ("etcd-waitMessages", waitMessages tracer conn persistenceDir callback)
                         ( "etcd-callback-4"
                         , do
-                            queue <- newPersistentQueue (persistenceDir </> "pending-broadcast") 100
+                            queue <- newPersistentQueue tracer (persistenceDir </> "pending-broadcast") 100
                             raceLabelled_
                               ("etcd-broadcastMessages", broadcastMessages tracer config advertise queue)
                               ( "etcd-network-component-action"
                               , do
                                   action
                                     Network
-                                      { broadcast = writePersistentQueue queue
+                                      { broadcast = writePersistentQueue tracer queue
                                       }
                               )
                         )
@@ -359,7 +360,7 @@ checkVersion tracer conn ourVersion NetworkCallback{onConnectivity} = do
 -- revisions and the watcher on each peer sees exactly one event per logical
 -- broadcast. Same key namespace as master ('msg-\<host\>'), no disk growth.
 broadcastMessages ::
-  (ToCBOR msg, Eq msg) =>
+  ToCBOR msg =>
   Tracer IO EtcdLog ->
   NetworkConfiguration ->
   -- | Used to identify sender.
@@ -386,7 +387,7 @@ broadcastMessages tracer config ourHost queue = do
   lastModRevVar <- newLabelledTVarIO "etcd-broadcast-last-mod-rev" initialModRev
   withGrpcContext "broadcastMessages" . forever $ do
     msg <- peekPersistentQueue queue
-    (putMessage tracer config ourHost lastModRevVar msg >> popPersistentQueue queue msg)
+    (putMessage tracer config ourHost lastModRevVar msg >> popPersistentQueue queue)
       `catch` \case
         e@GrpcException{grpcError, grpcErrorMessage}
           | isTransientGrpcError grpcError -> do
@@ -738,19 +739,21 @@ data PersistentQueue m a = PersistentQueue
 -- | Create a new persistent queue at file path and given capacity.
 newPersistentQueue ::
   (MonadLabelledSTM m, MonadIO m, FromCBOR a, MonadCatch m, MonadFail m) =>
+  Tracer IO EtcdLog ->
   FilePath ->
   Natural ->
   m (PersistentQueue m a)
-newPersistentQueue path capacity = do
+newPersistentQueue tracer path capacity = do
   paths <- liftIO $ do
     createDirectoryIfMissing True path
     sort . mapMaybe readMaybe <$> listDirectory path
   queue <- newLabelledTBQueueIO "persistent-queue" $ max (fromIntegral $ length paths) capacity
   highestId <-
     try (loadExisting queue paths) >>= \case
-      Left (_ :: IOException) -> do
-        -- XXX: This swallows and not logs the error
-        liftIO $ createDirectoryIfMissing True path
+      Left (e :: IOException) -> do
+        liftIO $ do
+          traceWith tracer PersistentQueueLoadFailed{reason = show e}
+          createDirectoryIfMissing True path
         pure 0
       Right highest -> pure highest
   nextIx <- newLabelledTVarIO "persistent-next-ix" $ highestId + 1
@@ -769,14 +772,16 @@ newPersistentQueue path capacity = do
       pure $ List.last idxs
 
 -- | Write a value to the queue, blocking if the queue is full.
-writePersistentQueue :: (ToCBOR a, MonadSTM m, MonadIO m) => PersistentQueue m a -> a -> m ()
-writePersistentQueue PersistentQueue{queue, nextIx, directory} item = do
+writePersistentQueue :: (ToCBOR a, MonadSTM m, MonadIO m, MonadCatch m) => Tracer IO EtcdLog -> PersistentQueue m a -> a -> m ()
+writePersistentQueue tracer PersistentQueue{queue, nextIx, directory} item = do
   next <- atomically $ do
     next <- readTVar nextIx
     modifyTVar' nextIx (+ 1)
     pure next
-  writeFileBS (directory </> show next) $ serialize' item
-  -- XXX: We should trace when the queue is full
+  writeFileBS (directory </> show next) (serialize' item)
+    `onException` atomically (modifyTVar' nextIx (subtract 1))
+  full <- atomically $ isFullTBQueue queue
+  when full $ liftIO $ traceWith tracer PersistentQueueFull
   atomically $ writeTBQueue queue (next, item)
 
 -- | Get the next value from the queue without removing it, blocking if the
@@ -785,21 +790,13 @@ peekPersistentQueue :: MonadSTM m => PersistentQueue m a -> m a
 peekPersistentQueue PersistentQueue{queue} = do
   snd <$> atomically (peekTBQueue queue)
 
--- | Remove an element from the queue if it matches the given item. Use
--- 'peekPersistentQueue' to wait for next items before popping it.
-popPersistentQueue :: (MonadSTM m, MonadIO m, Eq a) => PersistentQueue m a -> a -> m ()
-popPersistentQueue PersistentQueue{queue, directory} item = do
-  popped <- atomically $ do
-    (ix, next) <- peekTBQueue queue
-    if next == item
-      -- FIXME: why would we not call this? We saw the persistent queue reach
-      -- capacity and writing blocked while nothing seemed to clear it.
-      then readTBQueue queue $> Just ix
-      else pure Nothing
-  case popped of
-    Nothing -> pure ()
-    Just index -> do
-      liftIO . removeFile $ directory </> show index
+-- | Remove the head element from the queue. Must only be called after a
+-- successful 'peekPersistentQueue' by the same (single) consumer thread.
+popPersistentQueue :: (MonadSTM m, MonadIO m) => PersistentQueue m a -> m ()
+popPersistentQueue PersistentQueue{queue, directory} = do
+  (ix, _) <- atomically $ readTBQueue queue
+  liftIO $ removeFile (directory </> show ix)
+    `catch` \e -> unless (isDoesNotExistError e) (throwIO e)
 
 -- * Tracing
 
@@ -820,5 +817,11 @@ data EtcdLog
     -- expected outcome when a 'GrpcDeadlineExceeded'-retried put already
     -- committed server-side. No second put was issued.
     BroadcastDeduped {previousModRev :: Int64, observedModRev :: Int64}
+  | -- | Failed to load persisted queue items from disk on startup. The queue
+    -- starts empty; any in-flight messages from before the crash are lost.
+    PersistentQueueLoadFailed {reason :: Text}
+  | -- | The persistent queue has reached capacity. The calling thread will
+    -- block until the broadcast loop drains at least one item.
+    PersistentQueueFull
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON)

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -387,7 +387,7 @@ broadcastMessages tracer config ourHost queue = do
   lastModRevVar <- newLabelledTVarIO "etcd-broadcast-last-mod-rev" initialModRev
   withGrpcContext "broadcastMessages" . forever $ do
     msg <- peekPersistentQueue queue
-    (putMessage tracer config ourHost lastModRevVar msg >> popPersistentQueue queue)
+    (putMessage tracer config ourHost lastModRevVar msg >> popPersistentQueue tracer queue)
       `catch` \case
         e@GrpcException{grpcError, grpcErrorMessage}
           | isTransientGrpcError grpcError -> do
@@ -791,11 +791,16 @@ peekPersistentQueue PersistentQueue{queue} = do
 
 -- | Remove the head element from the queue. Must only be called after a
 -- successful 'peekPersistentQueue' by the same (single) consumer thread.
-popPersistentQueue :: (MonadSTM m, MonadIO m) => PersistentQueue m a -> m ()
-popPersistentQueue PersistentQueue{queue, directory} = do
+-- Failing to delete the backing file is traced but not fatal: the message was
+-- already broadcast, so a leftover file only means it may be re-broadcast
+-- after a restart (at-least-once delivery, same as the crash-recovery path).
+popPersistentQueue :: (MonadSTM m, MonadIO m) => Tracer IO EtcdLog -> PersistentQueue m a -> m ()
+popPersistentQueue tracer PersistentQueue{queue, directory} = do
   (ix, _) <- atomically $ readTBQueue queue
-  liftIO $ removeFile (directory </> show ix)
-    `catch` \e -> unless (isDoesNotExistError e) (throwIO e)
+  liftIO $
+    removeFile (directory </> show ix) `catch` \e ->
+      unless (isDoesNotExistError e) $
+        traceWith tracer PersistentQueueDeleteFailed{index = ix, reason = show e}
 
 -- * Tracing
 
@@ -822,5 +827,9 @@ data EtcdLog
   | -- | The persistent queue has reached capacity. The calling thread will
     -- block until the broadcast loop drains at least one item.
     PersistentQueueFull
+  | -- | Failed to delete the backing file of an already-broadcast item. The
+    -- queue keeps operating; the leftover file only means the message may be
+    -- re-broadcast after a restart.
+    PersistentQueueDeleteFailed {index :: Natural, reason :: Text}
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON)

--- a/hydra-node/test/Hydra/PersistentQueueSpec.hs
+++ b/hydra-node/test/Hydra/PersistentQueueSpec.hs
@@ -4,6 +4,7 @@ module Hydra.PersistentQueueSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
+import Hydra.Logging (nullTracer)
 import Hydra.Network.Etcd (newPersistentQueue, peekPersistentQueue, writePersistentQueue)
 import Test.QuickCheck (counterexample, generate, ioProperty)
 import Test.QuickCheck.Instances.Natural ()
@@ -13,19 +14,19 @@ spec = do
   it "can be constructed" $ do
     capacity <- generate arbitrary
     withTempDir "persistent-queue" $ \dir -> do
-      void $ newPersistentQueue @_ @Int dir capacity
+      void $ newPersistentQueue @_ @Int nullTracer dir capacity
 
   prop "is persistent with capacity" $ \(items :: [Int]) -> do
     let capacity = fromIntegral $ length items
     counterexample ("capacity: " <> show capacity) $
       ioProperty $
         withTempDir "persistent-queue" $ \dir -> do
-          q <- newPersistentQueue dir capacity
-          shouldNotBlock_ $ mapM (writePersistentQueue q) items
+          q <- newPersistentQueue nullTracer dir capacity
+          shouldNotBlock_ $ mapM (writePersistentQueue nullTracer q) items
           -- This is expected to block as we reached capacity
-          _ <- timeout 0.01 (writePersistentQueue q 123)
+          _ <- timeout 0.01 (writePersistentQueue nullTracer q 123)
           -- A new queue should be initialized with all the elements
-          q2 <- shouldNotBlock $ newPersistentQueue @_ @Int dir capacity
+          q2 <- shouldNotBlock $ newPersistentQueue nullTracer dir capacity
           let expected = maybe 123 head (nonEmpty items)
           peekPersistentQueue q2 `shouldReturn` expected
 

--- a/hydra-node/test/Hydra/PersistentQueueSpec.hs
+++ b/hydra-node/test/Hydra/PersistentQueueSpec.hs
@@ -4,8 +4,12 @@ module Hydra.PersistentQueueSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import Hydra.Logging (nullTracer)
-import Hydra.Network.Etcd (newPersistentQueue, peekPersistentQueue, writePersistentQueue)
+import Control.Concurrent.Class.MonadSTM (check, newTVarIO, readTVarIO)
+import Control.Monad.Class.MonadAsync (concurrently, wait, withAsync)
+import Hydra.Logging (Envelope (message), nullTracer, traceInTVar)
+import Hydra.Network.Etcd (EtcdLog (..), newPersistentQueue, peekPersistentQueue, popPersistentQueue, writePersistentQueue)
+import System.Directory (createDirectory, listDirectory, removeFile)
+import System.FilePath ((</>))
 import Test.QuickCheck (counterexample, generate, ioProperty)
 import Test.QuickCheck.Instances.Natural ()
 
@@ -26,9 +30,101 @@ spec = do
           -- This is expected to block as we reached capacity
           _ <- timeout 0.01 (writePersistentQueue nullTracer q 123)
           -- A new queue should be initialized with all the elements
-          q2 <- shouldNotBlock $ newPersistentQueue nullTracer dir capacity
+          q2 <- shouldNotBlock $ newPersistentQueue @_ @Int nullTracer dir capacity
           let expected = maybe 123 head (nonEmpty items)
           peekPersistentQueue q2 `shouldReturn` expected
+
+  it "pop unblocks a blocked writer when at capacity" $ do
+    withTempDir "persistent-queue" $ \dir -> do
+      traces <- newTVarIO []
+      let tracer = traceInTVar traces "PersistentQueueSpec"
+      q <- newPersistentQueue tracer dir 1
+      writePersistentQueue tracer q (1 :: Int)
+      withAsync (writePersistentQueue tracer q 2) $ \writer -> do
+        -- The writer traces 'PersistentQueueFull' right before blocking on
+        -- the full queue, so this doubles as the signal it reached that point.
+        shouldNotBlock_ . atomically $ do
+          entries <- readTVar traces
+          check $ PersistentQueueFull `elem` (message <$> entries)
+        popPersistentQueue tracer q
+        shouldNotBlock_ $ wait writer
+      peekPersistentQueue q `shouldReturn` 2
+
+  it "does not deadlock when writing beyond capacity with a concurrent consumer" $ do
+    withTempDir "persistent-queue" $ \dir -> do
+      q <- newPersistentQueue nullTracer dir 10
+      let items = [1 .. 100 :: Int]
+      (_, received) <-
+        shouldNotBlock $
+          concurrently
+            (forM_ items $ writePersistentQueue nullTracer q)
+            ( forM items $ \_ -> do
+                item <- peekPersistentQueue q
+                popPersistentQueue nullTracer q
+                pure item
+            )
+      received `shouldBe` items
+      listDirectory dir `shouldReturn` []
+
+  it "pop removes the head item from memory and disk" $ do
+    withTempDir "persistent-queue" $ \dir -> do
+      q <- newPersistentQueue nullTracer dir 10
+      forM_ [1, 2, 3 :: Int] $ writePersistentQueue nullTracer q
+      peekPersistentQueue q `shouldReturn` 1
+      popPersistentQueue nullTracer q
+      peekPersistentQueue q `shouldReturn` 2
+      -- A popped item must not be reloaded on restart (it was already
+      -- broadcast and would be duplicated)
+      q2 <- shouldNotBlock $ newPersistentQueue @_ @Int nullTracer dir 10
+      peekPersistentQueue q2 `shouldReturn` 2
+
+  it "pop tolerates a missing backing file" $ do
+    withTempDir "persistent-queue" $ \dir -> do
+      q <- newPersistentQueue nullTracer dir 10
+      writePersistentQueue nullTracer q (1 :: Int)
+      files <- listDirectory dir
+      forM_ files $ \f -> removeFile (dir </> f)
+      popPersistentQueue nullTracer q
+
+  it "pop survives and traces a failing backing file deletion" $ do
+    withTempDir "persistent-queue" $ \dir -> do
+      traces <- newTVarIO []
+      let tracer = traceInTVar traces "PersistentQueueSpec"
+      q <- newPersistentQueue tracer dir 10
+      writePersistentQueue tracer q (1 :: Int)
+      -- Replace the backing file with a same-named directory so removeFile
+      -- fails with EISDIR instead of ENOENT (works even when running as root)
+      [file] <- listDirectory dir
+      removeFile (dir </> file)
+      createDirectory (dir </> file)
+      writePersistentQueue tracer q 2
+      popPersistentQueue tracer q
+      entries <- readTVarIO traces
+      (message <$> entries) `shouldSatisfy` any isDeleteFailed
+      -- The consumer keeps making progress
+      peekPersistentQueue q `shouldReturn` 2
+
+  it "traces PersistentQueueLoadFailed on corrupt items and starts empty" $ do
+    withTempDir "persistent-queue" $ \dir -> do
+      writeFileBS (dir </> "1") "not-valid-cbor"
+      traces <- newTVarIO []
+      let tracer = traceInTVar traces "PersistentQueueSpec"
+      q <- newPersistentQueue @_ @Int tracer dir 10
+      entries <- readTVarIO traces
+      (message <$> entries) `shouldSatisfy` any isLoadFailed
+      -- The queue starts empty but stays functional
+      writePersistentQueue tracer q 42
+      peekPersistentQueue q `shouldReturn` 42
+
+isDeleteFailed :: EtcdLog -> Bool
+isDeleteFailed = \case
+  PersistentQueueDeleteFailed{} -> True
+  _ -> False
+
+isLoadFailed :: EtcdLog -> Bool
+isLoadFailed = \case
+  PersistentQueueLoadFailed{} -> True
+  _ -> False
 
 shouldNotBlock :: HasCallStack => IO a -> IO a
 shouldNotBlock action = do


### PR DESCRIPTION
  - **Fix FIXME deadlock**: `popPersistentQueue` was using value equality to
    decide whether to remove the head item. A false `Eq` result silently
    no-oped, leaving the head item stuck. With the queue at capacity (100),
    all callers of `broadcast` would block indefinitely with no log output.
    Now pops unconditionally by index — safe because `broadcastMessages` is
    the only consumer.
  - **`removeFile` safety**: catches `isDoesNotExistError` in pop so a missing
    file (e.g. from a prior partial crash) doesn't kill the broadcast loop.
  - **Operational visibility**: emits `PersistentQueueFull` before blocking on
    a full queue, and `PersistentQueueLoadFailed` instead of silently discarding
    a startup load error.
  - **Constraint cleanup**: `Eq msg` dropped from `withEtcdNetwork` and
    `broadcastMessages`.

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
