### PR TITLE
Don't observe unrelated Head deposits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ changes.
   `old-state/hydra-<logId>.db` snapshot before deleting the rotated events,
   restoring the pre-rotation backup behaviour of the old file-based persistence.
 
+- Deposit and recover chain observations are now scoped to the current head:
+  events for unrelated heads are silently ignored in Open and Closed states,
+  preventing foreign deposits from contaminating pending state or chain state
+  history. Deposits from a previous head are never discarded on fanout, so
+  recovery via the `/commits` endpoint remains available after a head closes,
+  in Idle state, and even while a new head is running. [#2743](https://github.com/cardano-scaling/hydra/pull/2743)
+
 ## [2.2.0] - 2026.06.12
 
 - Extend the end-to-end benchmark with real-world TPS metrics (end-to-end and

--- a/docs/docs/how-to/incremental-commit.md
+++ b/docs/docs/how-to/incremental-commit.md
@@ -309,6 +309,15 @@ To recover, we can use the `/commits` endpoint again using the transaction id of
 curl -X DELETE localhost:4001/commits/ab4adce53699015ca8fd112689906338278f435d436516290c68c679921de8a4)
 ```
 
-If we inspect the address funds again we will see that the locked deposit is now recovered. It is important to mention that recovering works even if the Head is closed already.
+If we inspect the address funds again we will see that the locked deposit is now recovered.
+
+Recovery works in all head states:
+
+- **Open** — recover a deposit that the head hasn't ingested yet (e.g. it expired before being picked up).
+- **Closed** — the head is in the closing/contestation period; recovery is still available.
+- **Idle (after fanout)** — deposits that were pending when the head closed are never discarded. The node keeps them in its internal state across the fanout, so you can still recover them after the head is fully settled.
+- **While a new head is running** — if you open a new head, old unrecovered deposits from a previous head remain recoverable. The new head will never accidentally ingest them: it only considers deposits that explicitly target its own head ID.
+
+The on-chain deposit validator enforces two conditions for recovery: the transaction validity lower bound must be after the deposit deadline, and the recovered outputs must match the originals. It does not require the head to be active, so recovery is always possible once the deadline passes regardless of the head lifecycle.
 
 

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1756,10 +1756,30 @@ handleChainInput env _ledger now _chainPointTime pendingDeposits st ev syncStatu
         onClosedChainPartialFanoutTx closedState newChainState distributedOutputs
     | otherwise ->
         Error NotOurHead{ourHeadId, otherHeadId = headId}
-  -- Node-level
-  (_, ChainInput Observation{observedTx = OnDepositTx{headId, depositTxId, deposited, created, deadline}, newChainState}) ->
-    newState DepositRecorded{chainState = newChainState, headId, depositTxId, deposited, created, deadline}
-  (_, ChainInput Observation{observedTx = OnRecoverTx{headId, recoveredTxId, recoveredUTxO}, newChainState}) ->
+  -- Node-level: deposit/recover observations scoped to our head
+  (Open OpenState{headId = ourHeadId}, ChainInput Observation{observedTx = OnDepositTx{headId, depositTxId, deposited, created, deadline}, newChainState})
+    | ourHeadId == headId ->
+        newState DepositRecorded{chainState = newChainState, headId, depositTxId, deposited, created, deadline}
+    | otherwise ->
+        Continue [] []
+  (Closed ClosedState{headId = ourHeadId}, ChainInput Observation{observedTx = OnDepositTx{headId, depositTxId, deposited, created, deadline}, newChainState})
+    | ourHeadId == headId ->
+        newState DepositRecorded{chainState = newChainState, headId, depositTxId, deposited, created, deadline}
+    | otherwise ->
+        Continue [] []
+  (Idle _, ChainInput Observation{observedTx = OnDepositTx{}}) ->
+    Continue [] []
+  (Open OpenState{headId = ourHeadId}, ChainInput Observation{observedTx = OnRecoverTx{headId, recoveredTxId, recoveredUTxO}, newChainState})
+    | ourHeadId == headId ->
+        newState DepositRecovered{chainState = newChainState, headId, depositTxId = recoveredTxId, recovered = recoveredUTxO}
+    | otherwise ->
+        Continue [] []
+  (Closed ClosedState{headId = ourHeadId}, ChainInput Observation{observedTx = OnRecoverTx{headId, recoveredTxId, recoveredUTxO}, newChainState})
+    | ourHeadId == headId ->
+        newState DepositRecovered{chainState = newChainState, headId, depositTxId = recoveredTxId, recovered = recoveredUTxO}
+    | otherwise ->
+        Continue [] []
+  (Idle _, ChainInput Observation{observedTx = OnRecoverTx{headId, recoveredTxId, recoveredUTxO}, newChainState}) ->
     newState DepositRecovered{chainState = newChainState, headId, depositTxId = recoveredTxId, recovered = recoveredUTxO}
   -- Open + Rollback: re-post IncrementTx/DecrementTx if they were in-flight
   ( Open
@@ -1901,11 +1921,18 @@ aggregateNodeState nodeState sc =
                 { headState = st
                 , chainPointTime = chainPointTimeState{currentSlot = chainStateSlot chainState}
                 }
-            DepositRecorded{headId, depositTxId, deposited, created, deadline} ->
-              nodeState
-                { headState = st
-                , pendingDeposits = Map.insert depositTxId Deposit{headId, deposited, created, deadline, status = Inactive} currentPendingDeposits
-                }
+            DepositRecorded{headId = depositHeadId, depositTxId, deposited, created, deadline} ->
+              let ourHeadId = case headState nodeState of
+                    Open OpenState{headId} -> Just headId
+                    Closed ClosedState{headId} -> Just headId
+                    Idle _ -> Nothing
+               in if ourHeadId == Just depositHeadId
+                    then
+                      nodeState
+                        { headState = st
+                        , pendingDeposits = Map.insert depositTxId Deposit{headId = depositHeadId, deposited, created, deadline, status = Inactive} currentPendingDeposits
+                        }
+                    else nodeState{headState = st}
             DepositActivated{depositTxId, deposit} ->
               nodeState
                 { headState = st

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1777,18 +1777,15 @@ handleChainInput env _ledger now _chainPointTime pendingDeposits st ev syncStatu
         Continue [] []
   (Idle _, ChainInput Observation{observedTx = OnDepositTx{}}) ->
     Continue [] []
-  (Open OpenState{headId = ourHeadId}, ChainInput Observation{observedTx = OnRecoverTx{headId, recoveredTxId, recoveredUTxO}, newChainState})
-    | ourHeadId == headId ->
+  -- Deposit recovery is node-level: emit DepositRecovered for any tracked deposit
+  -- regardless of which head is currently active. Previous-head deposits survive
+  -- fanout in 'pendingDeposits', so recovery works even while a new head is Open.
+  -- Unrelated deposits (never in pendingDeposits) are silently ignored.
+  (_, ChainInput Observation{observedTx = OnRecoverTx{headId, recoveredTxId, recoveredUTxO}, newChainState})
+    | Map.member recoveredTxId pendingDeposits ->
         newState DepositRecovered{chainState = newChainState, headId, depositTxId = recoveredTxId, recovered = recoveredUTxO}
     | otherwise ->
         Continue [] []
-  (Closed ClosedState{headId = ourHeadId}, ChainInput Observation{observedTx = OnRecoverTx{headId, recoveredTxId, recoveredUTxO}, newChainState})
-    | ourHeadId == headId ->
-        newState DepositRecovered{chainState = newChainState, headId, depositTxId = recoveredTxId, recovered = recoveredUTxO}
-    | otherwise ->
-        Continue [] []
-  (Idle _, ChainInput Observation{observedTx = OnRecoverTx{headId, recoveredTxId, recoveredUTxO}, newChainState}) ->
-    newState DepositRecovered{chainState = newChainState, headId, depositTxId = recoveredTxId, recovered = recoveredUTxO}
   -- Open + Rollback: re-post IncrementTx/DecrementTx if they were in-flight
   ( Open
       OpenState
@@ -2027,7 +2024,7 @@ eventHeadId = \case
   SnapshotConfirmed{headId} -> Just headId
   LocalStateCleared{headId} -> Just headId
   DepositRecorded{headId} -> Just headId
-  DepositRecovered{headId} -> Just headId
+  DepositRecovered{} -> Nothing
   CommitApproved{headId} -> Just headId
   CommitFinalized{headId} -> Just headId
   DecommitRecorded{headId} -> Just headId

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -696,6 +696,14 @@ onOpenNetworkAckSn Environment{party} pendingDeposits openState otherParty snaps
 -- | Client request to recover deposited UTxO.
 --
 -- __Transition__: 'OpenState' → 'OpenState'
+-- | Client request to recover a deposit by posting a recover transaction on-chain.
+-- Works in any head state (Open, Closed, or Idle after fanout). Deposits from a
+-- previous head are never cleared from 'pendingDeposits' on fanout, so recovery
+-- remains available after a head closes. A new head only sees its own deposits via
+-- 'depositsForHead', so old deposits are never accidentally ingested into L2.
+-- On-chain, the deposit validator only enforces that the deadline has passed and
+-- that the recovered outputs match the originals — it does not require the head to
+-- still be active.
 onClientRecover ::
   IsTx tx =>
   ChainSlot ->

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1929,10 +1929,10 @@ aggregateNodeState nodeState sc =
                 { headState = st
                 , chainPointTime = chainPointTimeState{currentSlot = chainStateSlot chainState}
                 }
-            DepositRecorded{headId = depositHeadId, depositTxId, deposited, created, deadline} ->
+            DepositRecorded{headId, depositTxId, deposited, created, deadline} ->
               nodeState
                 { headState = st
-                , pendingDeposits = Map.insert depositTxId Deposit{headId = depositHeadId, deposited, created, deadline, status = Inactive} currentPendingDeposits
+                , pendingDeposits = Map.insert depositTxId Deposit{headId, deposited, created, deadline, status = Inactive} currentPendingDeposits
                 }
             DepositActivated{depositTxId, deposit} ->
               nodeState

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1930,17 +1930,10 @@ aggregateNodeState nodeState sc =
                 , chainPointTime = chainPointTimeState{currentSlot = chainStateSlot chainState}
                 }
             DepositRecorded{headId = depositHeadId, depositTxId, deposited, created, deadline} ->
-              let ourHeadId = case headState nodeState of
-                    Open OpenState{headId} -> Just headId
-                    Closed ClosedState{headId} -> Just headId
-                    Idle _ -> Nothing
-               in if ourHeadId == Just depositHeadId
-                    then
-                      nodeState
-                        { headState = st
-                        , pendingDeposits = Map.insert depositTxId Deposit{headId = depositHeadId, deposited, created, deadline, status = Inactive} currentPendingDeposits
-                        }
-                    else nodeState{headState = st}
+              nodeState
+                { headState = st
+                , pendingDeposits = Map.insert depositTxId Deposit{headId = depositHeadId, deposited, created, deadline, status = Inactive} currentPendingDeposits
+                }
             DepositActivated{depositTxId, deposit} ->
               nodeState
                 { headState = st

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -696,7 +696,7 @@ onOpenNetworkAckSn Environment{party} pendingDeposits openState otherParty snaps
 -- | Client request to recover deposited UTxO.
 --
 -- __Transition__: 'OpenState' → 'OpenState'
--- | Client request to recover a deposit by posting a recover transaction on-chain.
+-- Client request to recover a deposit by posting a recover transaction on-chain.
 -- Works in any head state (Open, Closed, or Idle after fanout). Deposits from a
 -- previous head are never cleared from 'pendingDeposits' on fanout, so recovery
 -- remains available after a head closes. A new head only sees its own deposits via

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -234,11 +234,12 @@ spec =
 
         it "emits DepositRecorded for own head while Closed" $ do
           let depositTxId' = 1
+              depositedUtxo = utxoRef 1
           let depositOwnHead =
                 observeTx $
                   OnDepositTx
                     { headId = testHeadId
-                    , deposited = mempty
+                    , deposited = depositedUtxo
                     , depositTxId = depositTxId'
                     , created = genUTCTime `generateWith` 41
                     , deadline = genUTCTime `generateWith` 42
@@ -246,16 +247,17 @@ spec =
               s0 = inClosedState threeParties
           now <- nowFromSlot s0.chainPointTime.currentSlot
           update aliceEnv ledger now s0 depositOwnHead `hasStateChangedSatisfying` \case
-            DepositRecorded{depositTxId} -> depositTxId == depositTxId'
+            DepositRecorded{headId, depositTxId, deposited} -> headId == testHeadId && depositTxId == depositTxId' && deposited == depositedUtxo
             _ -> False
 
         it "emits DepositRecovered for own head while Closed" $ do
           now <- getCurrentTime
           let ownDepositId = 1
+              recoveredUtxo = utxoRef 1
               ownDeposit =
                 Deposit
                   { headId = testHeadId
-                  , deposited = utxoRef 1
+                  , deposited = recoveredUtxo
                   , created = now
                   , deadline = addUTCTime 3600 now
                   , status = Active
@@ -266,25 +268,26 @@ spec =
                   OnRecoverTx
                     { headId = testHeadId
                     , recoveredTxId = ownDepositId
-                    , recoveredUTxO = mempty
+                    , recoveredUTxO = recoveredUtxo
                     }
           now' <- nowFromSlot s0.chainPointTime.currentSlot
           update aliceEnv ledger now' s0 recoverOwnDeposit `hasStateChangedSatisfying` \case
-            DepositRecovered{depositTxId} -> depositTxId == ownDepositId
+            DepositRecovered{headId, depositTxId, recovered} -> headId == testHeadId && depositTxId == ownDepositId && recovered == recoveredUtxo
             _ -> False
 
         it "emits DepositRecovered while Idle (post-fanout recovery)" $ do
           let ownDepositId = 1
+              recoveredUtxo = utxoRef 1
               recoverDeposit =
                 observeTx $
                   OnRecoverTx
                     { headId = testHeadId
                     , recoveredTxId = ownDepositId
-                    , recoveredUTxO = mempty
+                    , recoveredUTxO = recoveredUtxo
                     }
           now <- nowFromSlot inIdleState.chainPointTime.currentSlot
           update aliceEnv ledger now inIdleState recoverDeposit `hasStateChangedSatisfying` \case
-            DepositRecovered{depositTxId} -> depositTxId == ownDepositId
+            DepositRecovered{headId, depositTxId, recovered} -> headId == testHeadId && depositTxId == ownDepositId && recovered == recoveredUtxo
             _ -> False
 
         it "allows ClientInput Recover in Idle state for deposit surviving from previous head" $ do
@@ -304,22 +307,23 @@ spec =
           now' <- nowFromSlot s0.chainPointTime.currentSlot
           update aliceEnv ledger now' s0 (ClientInput (Recover depositTxId'))
             `hasEffectSatisfying` \case
-              OnChainEffect{postChainTx = RecoverTx{recoverTxId}} -> recoverTxId == depositTxId'
+              OnChainEffect{postChainTx = RecoverTx{headId, recoverTxId}} -> headId == testHeadId && recoverTxId == depositTxId'
               _ -> False
 
         prop "ignores OnDepositTx while Idle" $ \anyHeadId -> do
-          let depositAnyHead =
+          let depositedUtxo = utxoRef 1
+              depositAnyHead =
                 observeTx $
                   OnDepositTx
                     { headId = anyHeadId
-                    , deposited = mempty
+                    , deposited = depositedUtxo
                     , depositTxId = 1
                     , created = genUTCTime `generateWith` 41
                     , deadline = genUTCTime `generateWith` 42
                     }
           now <- nowFromSlot inIdleState.chainPointTime.currentSlot
           update aliceEnv ledger now inIdleState depositAnyHead `hasNoStateChangedSatisfying` \case
-            DepositRecorded{headId} -> headId == anyHeadId
+            DepositRecorded{headId, deposited} -> headId == anyHeadId && deposited == depositedUtxo
             _ -> False
 
         it "on tick, picks the next active deposit in arrival when in Open state order for ReqSn" $ do

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -471,6 +471,23 @@ spec =
               pendingDeposits `shouldBe` mempty
             _ -> fail "expected Open state"
 
+        it "DepositRecovered while Idle removes deposit from pendingDeposits" $ do
+          now <- getCurrentTime
+          let depositTxId' = 1
+              deposit =
+                Deposit
+                  { headId = testHeadId
+                  , deposited = utxoRef 1
+                  , created = now
+                  , deadline = addUTCTime 3600 now
+                  , status = Active
+                  }
+              s0 = inIdleState{pendingDeposits = Map.singleton depositTxId' deposit}
+          let s1 = aggregateState s0 $ Continue [DepositRecovered{chainState = 0, headId = testHeadId, depositTxId = depositTxId', recovered = utxoRef 1}] []
+          case s1 of
+            NodeInSync{pendingDeposits} -> pendingDeposits `shouldBe` mempty
+            _ -> fail "expected NodeInSync"
+
         it "CommitFinalized from another head does not update version or localUTxO" $ do
           otherHeadId :: HeadId <- generate arbitrary
           let ownUTxO = utxoRefs [1, 2]

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -297,8 +297,18 @@ spec =
             _ -> False
 
         it "emits DepositRecovered while Idle (post-fanout recovery)" $ do
+          now <- getCurrentTime
           let ownDepositId = 1
               recoveredUtxo = utxoRef 1
+              deposit =
+                Deposit
+                  { headId = testHeadId
+                  , deposited = recoveredUtxo
+                  , created = now
+                  , deadline = addUTCTime 3600 now
+                  , status = Active
+                  }
+              s0 = inIdleState{pendingDeposits = Map.singleton ownDepositId deposit}
               recoverDeposit =
                 observeTx $
                   OnRecoverTx
@@ -306,8 +316,8 @@ spec =
                     , recoveredTxId = ownDepositId
                     , recoveredUTxO = recoveredUtxo
                     }
-          now <- nowFromSlot inIdleState.chainPointTime.currentSlot
-          update aliceEnv ledger now inIdleState recoverDeposit `hasStateChangedSatisfying` \case
+          now' <- nowFromSlot s0.chainPointTime.currentSlot
+          update aliceEnv ledger now' s0 recoverDeposit `hasStateChangedSatisfying` \case
             DepositRecovered{headId, depositTxId, recovered} -> headId == testHeadId && depositTxId == ownDepositId && recovered == recoveredUtxo
             _ -> False
 
@@ -482,7 +492,7 @@ spec =
                   , deadline = addUTCTime 3600 now
                   , status = Active
                   }
-              s0 = inIdleState{pendingDeposits = Map.singleton depositTxId' deposit}
+              s0 = (inSync (Idle IdleState{chainState = 0})){pendingDeposits = Map.singleton depositTxId' deposit}
           let s1 = aggregateState s0 $ Continue [DepositRecovered{chainState = 0, headId = testHeadId, depositTxId = depositTxId', recovered = utxoRef 1}] []
           case s1 of
             NodeInSync{pendingDeposits} -> pendingDeposits `shouldBe` mempty

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -23,7 +23,7 @@ import Data.Map.Strict (notMember)
 import Data.Map.Strict qualified as Map
 import Data.Sequence qualified as Seq
 import Data.Set qualified as Set
-import Hydra.API.ClientInput (ClientInput (Fanout, SideLoadSnapshot))
+import Hydra.API.ClientInput (ClientInput (Fanout, Recover, SideLoadSnapshot))
 import Hydra.API.ServerOutput (ClientMessage (..), DecommitInvalidReason (..))
 import Hydra.Cardano.Api (ChainPoint (..), SlotNo (..), fromLedgerTx, mkVkAddress, toLedgerTx, txOutValue, unSlotNo, pattern TxValidityUpperBound)
 import Hydra.Cardano.Api.Gen (genTxIn)
@@ -285,6 +285,26 @@ spec =
           update aliceEnv ledger now inIdleState recoverDeposit `hasStateChangedSatisfying` \case
             DepositRecovered{depositTxId} -> depositTxId == ownDepositId
             _ -> False
+
+        it "allows ClientInput Recover in Idle state for deposit surviving from previous head" $ do
+          now <- getCurrentTime
+          let depositTxId' = 1
+              deposit =
+                Deposit
+                  { headId = testHeadId
+                  , deposited = utxoRef 1
+                  , created = now
+                  , deadline = addUTCTime 3600 now
+                  , status = Active
+                  }
+              -- Deposits from a previous head are never cleared on fanout, so they
+              -- remain in pendingDeposits when the node transitions to Idle.
+              s0 = inIdleState{pendingDeposits = Map.singleton depositTxId' deposit}
+          now' <- nowFromSlot s0.chainPointTime.currentSlot
+          update aliceEnv ledger now' s0 (ClientInput (Recover depositTxId'))
+            `hasEffectSatisfying` \case
+              OnChainEffect{postChainTx = RecoverTx{recoverTxId}} -> recoverTxId == depositTxId'
+              _ -> False
 
         prop "ignores OnDepositTx while Idle" $ \anyHeadId -> do
           let depositAnyHead =

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -202,7 +202,7 @@ spec =
             NetworkEffect ReqSn{depositTxId} -> depositTxId == Just 2
             _ -> False
 
-        prop "tracks depositTx of another head" $ \otherHeadId -> do
+        prop "does not track depositTx of another head" $ \otherHeadId -> do
           let depositOtherHead =
                 observeTx $
                   OnDepositTx
@@ -214,8 +214,91 @@ spec =
                     }
               s0 = inOpenState threeParties
           now <- nowFromSlot s0.chainPointTime.currentSlot
-          update bobEnv ledger now s0 depositOtherHead `hasStateChangedSatisfying` \case
-            DepositRecorded{headId, depositTxId} -> headId == otherHeadId && depositTxId == 1
+          update bobEnv ledger now s0 depositOtherHead `hasNoStateChangedSatisfying` \case
+            DepositRecorded{} -> True
+            _ -> False
+
+        prop "does not emit DepositRecovered for OnRecoverTx of another head while Open" $ \otherHeadId -> do
+          let recoverOtherHead =
+                observeTx $
+                  OnRecoverTx
+                    { headId = otherHeadId
+                    , recoveredTxId = 1
+                    , recoveredUTxO = mempty
+                    }
+              s0 = inOpenState threeParties
+          now <- nowFromSlot s0.chainPointTime.currentSlot
+          update bobEnv ledger now s0 recoverOtherHead `hasNoStateChangedSatisfying` \case
+            DepositRecovered{} -> True
+            _ -> False
+
+        it "emits DepositRecorded for own head while Closed" $ do
+          let depositOwnHead =
+                observeTx $
+                  OnDepositTx
+                    { headId = testHeadId
+                    , deposited = mempty
+                    , depositTxId = 1
+                    , created = genUTCTime `generateWith` 41
+                    , deadline = genUTCTime `generateWith` 42
+                    }
+              s0 = inClosedState threeParties
+          now <- nowFromSlot s0.chainPointTime.currentSlot
+          update aliceEnv ledger now s0 depositOwnHead `hasStateChangedSatisfying` \case
+            DepositRecorded{depositTxId} -> depositTxId == 1
+            _ -> False
+
+        it "emits DepositRecovered for own head while Closed" $ do
+          now <- getCurrentTime
+          let ownDepositId = 1
+              ownDeposit =
+                Deposit
+                  { headId = testHeadId
+                  , deposited = utxoRef 1
+                  , created = now
+                  , deadline = addUTCTime 3600 now
+                  , status = Active
+                  }
+              s0 = (inClosedState threeParties){pendingDeposits = Map.singleton ownDepositId ownDeposit}
+              recoverOwnDeposit =
+                observeTx $
+                  OnRecoverTx
+                    { headId = testHeadId
+                    , recoveredTxId = ownDepositId
+                    , recoveredUTxO = mempty
+                    }
+          now' <- nowFromSlot s0.chainPointTime.currentSlot
+          update aliceEnv ledger now' s0 recoverOwnDeposit `hasStateChangedSatisfying` \case
+            DepositRecovered{depositTxId} -> depositTxId == ownDepositId
+            _ -> False
+
+        it "emits DepositRecovered while Idle (post-fanout recovery)" $ do
+          let ownDepositId = 1
+              recoverDeposit =
+                observeTx $
+                  OnRecoverTx
+                    { headId = testHeadId
+                    , recoveredTxId = ownDepositId
+                    , recoveredUTxO = mempty
+                    }
+          now <- nowFromSlot inIdleState.chainPointTime.currentSlot
+          update aliceEnv ledger now inIdleState recoverDeposit `hasStateChangedSatisfying` \case
+            DepositRecovered{depositTxId} -> depositTxId == ownDepositId
+            _ -> False
+
+        prop "ignores OnDepositTx while Idle" $ \anyHeadId -> do
+          let depositAnyHead =
+                observeTx $
+                  OnDepositTx
+                    { headId = anyHeadId
+                    , deposited = mempty
+                    , depositTxId = 1
+                    , created = genUTCTime `generateWith` 41
+                    , deadline = genUTCTime `generateWith` 42
+                    }
+          now <- nowFromSlot inIdleState.chainPointTime.currentSlot
+          update aliceEnv ledger now inIdleState depositAnyHead `hasNoStateChangedSatisfying` \case
+            DepositRecorded{} -> True
             _ -> False
 
         it "on tick, picks the next active deposit in arrival when in Open state order for ReqSn" $ do

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -299,7 +299,7 @@ spec =
                   }
               -- Deposits from a previous head are never cleared on fanout, so they
               -- remain in pendingDeposits when the node transitions to Idle.
-              s0 = inIdleState{pendingDeposits = Map.singleton depositTxId' deposit}
+              s0 = (inSync (Idle IdleState{chainState = 0})){pendingDeposits = Map.singleton depositTxId' deposit}
           now' <- nowFromSlot s0.chainPointTime.currentSlot
           update aliceEnv ledger now' s0 (ClientInput (Recover depositTxId'))
             `hasEffectSatisfying` \case

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -232,6 +232,27 @@ spec =
             DepositRecovered{headId} -> headId == otherHeadId
             _ -> False
 
+        it "emits DepositRecovered for OnRecoverTx of previous head's deposit while new head is Open" $ do
+          now <- getCurrentTime
+          let depositTxId' = 1
+              depositedUtxo = utxoRef 1
+              deposit =
+                Deposit
+                  { headId = testHeadId
+                  , deposited = depositedUtxo
+                  , created = now
+                  , deadline = addUTCTime 3600 now
+                  , status = Active
+                  }
+              s0 = (inOpenState threeParties){pendingDeposits = Map.singleton depositTxId' deposit}
+              recoverOldHead = observeTx OnRecoverTx{headId = testHeadId, recoveredTxId = depositTxId', recoveredUTxO = depositedUtxo}
+          now' <- nowFromSlot s0.chainPointTime.currentSlot
+          update bobEnv ledger now' s0 recoverOldHead
+            `hasStateChangedSatisfying` \case
+              DepositRecovered{headId, depositTxId, recovered} ->
+                headId == testHeadId && depositTxId == depositTxId' && recovered == depositedUtxo
+              _ -> False
+
         it "emits DepositRecorded for own head while Closed" $ do
           let depositTxId' = 1
               depositedUtxo = utxoRef 1
@@ -445,8 +466,9 @@ spec =
                   }
           let s1 = aggregateState s0 $ Continue [DepositRecovered{chainState = 0, headId = otherHeadId, depositTxId = foreignDepositId, recovered = mempty}] []
           case s1 of
-            NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}} ->
+            NodeInSync{headState = Open OpenState{coordinatedHeadState = chs}, pendingDeposits} -> do
               chs.currentDepositTxId `shouldBe` Just ownDepositId
+              pendingDeposits `shouldBe` mempty
             _ -> fail "expected Open state"
 
         it "CommitFinalized from another head does not update version or localUTxO" $ do

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -215,7 +215,7 @@ spec =
               s0 = inOpenState threeParties
           now <- nowFromSlot s0.chainPointTime.currentSlot
           update bobEnv ledger now s0 depositOtherHead `hasNoStateChangedSatisfying` \case
-            DepositRecorded{} -> True
+            DepositRecorded{headId} -> headId == otherHeadId
             _ -> False
 
         prop "does not emit DepositRecovered for OnRecoverTx of another head while Open" $ \otherHeadId -> do
@@ -229,23 +229,24 @@ spec =
               s0 = inOpenState threeParties
           now <- nowFromSlot s0.chainPointTime.currentSlot
           update bobEnv ledger now s0 recoverOtherHead `hasNoStateChangedSatisfying` \case
-            DepositRecovered{} -> True
+            DepositRecovered{headId} -> headId == otherHeadId
             _ -> False
 
         it "emits DepositRecorded for own head while Closed" $ do
+          let depositTxId' = 1
           let depositOwnHead =
                 observeTx $
                   OnDepositTx
                     { headId = testHeadId
                     , deposited = mempty
-                    , depositTxId = 1
+                    , depositTxId = depositTxId'
                     , created = genUTCTime `generateWith` 41
                     , deadline = genUTCTime `generateWith` 42
                     }
               s0 = inClosedState threeParties
           now <- nowFromSlot s0.chainPointTime.currentSlot
           update aliceEnv ledger now s0 depositOwnHead `hasStateChangedSatisfying` \case
-            DepositRecorded{depositTxId} -> depositTxId == 1
+            DepositRecorded{depositTxId} -> depositTxId == depositTxId'
             _ -> False
 
         it "emits DepositRecovered for own head while Closed" $ do
@@ -318,7 +319,7 @@ spec =
                     }
           now <- nowFromSlot inIdleState.chainPointTime.currentSlot
           update aliceEnv ledger now inIdleState depositAnyHead `hasNoStateChangedSatisfying` \case
-            DepositRecorded{} -> True
+            DepositRecorded{headId} -> headId == anyHeadId
             _ -> False
 
         it "on tick, picks the next active deposit in arrival when in Open state order for ReqSn" $ do


### PR DESCRIPTION
fix #2606 


 This branch scopes deposit chain observations to the current head — Open/Closed states only record `OnDepositTx` events matching **their own headId**, and `Idle` silently drops incoming deposits. 
 
 For recovery, the guard is intentionally different: `OnRecoverTx` is processed for any deposit tracked in `pendingDeposits` regardless of which head is currently active, since deposits from a previous head survive fanout and must remain recoverable. `DepositRecovered` is also exempted from aggregateNodeState's headId filter so the deposit is always cleaned up. The branch adds tests and documentation verifying that recovery works in all states — Open, Closed, Idle post-fanout, and while a new head is running.
                                                                                                                                                                                                                                                                                                                                                 

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter

 