### PR TITLE
Keep pre-rotated databases around, for people that want history.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ changes.
   differences in configuration with peers. [#2296](https://github.com/cardano-scaling/hydra/issues/2296).
 
 - Event log rotation now archives the current database to a numbered
-  `hydra.db-<logId>` snapshot before deleting the rotated events, restoring the
-  pre-rotation backup behaviour of the old file-based persistence.
+  `old-state/hydra-<logId>.db` snapshot before deleting the rotated events,
+  restoring the pre-rotation backup behaviour of the old file-based persistence.
 
 ## [2.2.0] - 2026.06.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ changes.
 - Hydra node can now be configured through a yaml file; easier to spot
   differences in configuration with peers. [#2296](https://github.com/cardano-scaling/hydra/issues/2296).
 
+- Event log rotation now archives the current database to a numbered
+  `hydra.db-<logId>` snapshot before deleting the rotated events, restoring the
+  pre-rotation backup behaviour of the old file-based persistence.
+
 ## [2.2.0] - 2026.06.12
 
 - Extend the end-to-end benchmark with real-world TPS metrics (end-to-end and

--- a/docs/docs/dev/architecture/event-sourcing.md
+++ b/docs/docs/dev/architecture/event-sourcing.md
@@ -88,11 +88,11 @@ Long-living heads may produce a large number of persisted events, which can impa
 
 Event log rotation was introduced to improve recovery times by reducing the number of events that need to be replayed on startup. This is achieved by periodically replacing the current event log with a new one that starts from a checkpoint event, which captures the latest aggregated head state.
 
-Rotation can be enabled via the optional `--persistence-rotate-after` command-line argument, which specifies the number of events after which rotation should occur. When rotation triggers, all events older than the checkpoint are deleted from `hydra.db` and replaced with a single checkpoint event capturing the current aggregated state.
+Rotation can be enabled via the optional `--persistence-rotate-after` command-line argument, which specifies the number of events after which rotation should occur. When rotation triggers, the current database is first archived to a numbered file `hydra.db-<logId>` (a consistent snapshot taken with SQLite's `VACUUM INTO`), and only then are all events older than the checkpoint deleted from `hydra.db` and replaced with a single checkpoint event capturing the current aggregated state. The archive is taken before the delete, so a failure to write it aborts the rotation and leaves the events intact.
 > For example, with `--persistence-rotate-after 100`, a rotation occurs after every 100 new events. The checkpoint event captures the full node state at that point, so on the next restart the node only needs to replay events since the last checkpoint.
 
-Note that a checkpoint event id matches the last persisted event id from the previous rotated log file, preserving the sequential order of event ids across logs.
-This also makes it easier to identify which rotated log file was used to compute the checkpoint, as its event id matches the file name suffix.
+Note that a checkpoint event id matches the last persisted event id from the previous rotated log, preserving the sequential order of event ids across logs.
+This also makes it easier to identify which archived log was used to compute the checkpoint, as its event id matches the `hydra.db-<logId>` file name suffix.
 
 Depending on the rotation configuration used, the current `state` file may already contain more events than the specified threshold, causing a rotation to occur immediately on startup before any new inputs are processed.
 

--- a/docs/docs/dev/architecture/event-sourcing.md
+++ b/docs/docs/dev/architecture/event-sourcing.md
@@ -88,11 +88,11 @@ Long-living heads may produce a large number of persisted events, which can impa
 
 Event log rotation was introduced to improve recovery times by reducing the number of events that need to be replayed on startup. This is achieved by periodically replacing the current event log with a new one that starts from a checkpoint event, which captures the latest aggregated head state.
 
-Rotation can be enabled via the optional `--persistence-rotate-after` command-line argument, which specifies the number of events after which rotation should occur. When rotation triggers, the current database is first archived to a numbered file `hydra.db-<logId>` (a consistent snapshot taken with SQLite's `VACUUM INTO`), and only then are all events older than the checkpoint deleted from `hydra.db` and replaced with a single checkpoint event capturing the current aggregated state. The archive is taken before the delete, so a failure to write it aborts the rotation and leaves the events intact.
+Rotation can be enabled via the optional `--persistence-rotate-after` command-line argument, which specifies the number of events after which rotation should occur. When rotation triggers, the current database is first archived to a numbered file `old-state/hydra-<logId>.db` (a consistent snapshot taken with SQLite's `VACUUM INTO`, in an `old-state` subdirectory of the persistence directory), and only then are all events older than the checkpoint deleted from `hydra.db` and replaced with a single checkpoint event capturing the current aggregated state. The archive is taken before the delete, so a failure to write it aborts the rotation and leaves the events intact.
 > For example, with `--persistence-rotate-after 100`, a rotation occurs after every 100 new events. The checkpoint event captures the full node state at that point, so on the next restart the node only needs to replay events since the last checkpoint.
 
 Note that a checkpoint event id matches the last persisted event id from the previous rotated log, preserving the sequential order of event ids across logs.
-This also makes it easier to identify which archived log was used to compute the checkpoint, as its event id matches the `hydra.db-<logId>` file name suffix.
+This also makes it easier to identify which archived log was used to compute the checkpoint, as its event id appears in the `old-state/hydra-<logId>.db` file name.
 
 Depending on the rotation configuration used, the current `state` file may already contain more events than the specified threshold, causing a rotation to occur immediately on startup before any new inputs are processed.
 

--- a/hydra-node/src/Hydra/Events/SQLiteBased.hs
+++ b/hydra-node/src/Hydra/Events/SQLiteBased.hs
@@ -42,12 +42,12 @@
 --   missed events from chain on restart.
 --
 -- * __Rotation ordering__: 'rotate' flushes the write queue synchronously,
---   archives the current database to @<dbFile>-<logId>@ via @VACUUM INTO@, then
---   performs DELETE + INSERT. This is safe because rotation is only called from
---   the single-threaded event processing loop ('processStateChanges'), so no
---   concurrent enqueues can occur between the flush and the rotation write. The
---   archive is taken before the DELETE, so a backup failure aborts rotation and
---   leaves the events intact.
+--   archives the current database to @old-state/hydra-<logId>.db@ via
+--   @VACUUM INTO@, then performs DELETE + INSERT. This is safe because rotation
+--   is only called from the single-threaded event processing loop
+--   ('processStateChanges'), so no concurrent enqueues can occur between the
+--   flush and the rotation write. The archive is taken before the DELETE, so a
+--   backup failure aborts rotation and leaves the events intact.
 module Hydra.Events.SQLiteBased where
 
 import Hydra.Prelude
@@ -64,7 +64,7 @@ import Hydra.Events (EventSink (..), EventSource (..), HasEventId (..))
 import Hydra.Events.Rotation (EventStore (..))
 import Hydra.Logging (Tracer, traceWith)
 import System.Directory (createDirectoryIfMissing, doesFileExist, removeFile, renameFile)
-import System.FilePath (takeDirectory)
+import System.FilePath (takeBaseName, takeDirectory, takeExtension, (</>))
 
 -- | Exception thrown when a persisted event cannot be decoded.
 data EventDecodingException = EventDecodingException
@@ -383,13 +383,17 @@ deleteAllEvents :: Connection -> IO ()
 deleteAllEvents conn =
   execute_ conn "DELETE FROM events"
 
--- | Archive the current database to @<dbFile>-<logId>@ before rotation removes
--- the events. Uses @VACUUM INTO@ so the snapshot reflects all committed (WAL)
--- data in a single self-contained file, regardless of WAL checkpoint state. The
--- destination is removed first if present (e.g. a re-rotation at the same log
--- id), since @VACUUM INTO@ requires it not to exist.
+-- | Archive the current database before rotation removes the events, into an
+-- @old-state@ subdirectory next to the database, with the log id inserted
+-- before the extension (e.g. @old-state/hydra-42.db@). Uses @VACUUM INTO@ so the
+-- snapshot reflects all committed (WAL) data in a single self-contained file,
+-- regardless of WAL checkpoint state. The destination is removed first if
+-- present (e.g. a re-rotation at the same log id), since @VACUUM INTO@ requires
+-- it not to exist.
 backupDatabase :: Connection -> FilePath -> Word64 -> IO ()
 backupDatabase conn dbFile logId = do
-  let backupPath = dbFile <> "-" <> show logId
+  let backupDir = takeDirectory dbFile </> "old-state"
+      backupPath = backupDir </> (takeBaseName dbFile <> "-" <> show logId <> takeExtension dbFile)
+  createDirectoryIfMissing True backupDir
   whenM (doesFileExist backupPath) $ removeFile backupPath
   execute conn "VACUUM INTO ?" (Only backupPath)

--- a/hydra-node/src/Hydra/Events/SQLiteBased.hs
+++ b/hydra-node/src/Hydra/Events/SQLiteBased.hs
@@ -41,11 +41,13 @@
 --   acceptable because the L1 chain is the source of truth — the node replays
 --   missed events from chain on restart.
 --
--- * __Rotation ordering__: 'rotate' flushes the write queue synchronously
---   before performing DELETE + INSERT. This is safe because
---   rotation is only called from the single-threaded event processing loop
---   ('processStateChanges'), so no concurrent enqueues can occur between the
---   flush and the rotation write.
+-- * __Rotation ordering__: 'rotate' flushes the write queue synchronously,
+--   archives the current database to @<dbFile>-<logId>@ via @VACUUM INTO@, then
+--   performs DELETE + INSERT. This is safe because rotation is only called from
+--   the single-threaded event processing loop ('processStateChanges'), so no
+--   concurrent enqueues can occur between the flush and the rotation write. The
+--   archive is taken before the DELETE, so a backup failure aborts rotation and
+--   leaves the events intact.
 module Hydra.Events.SQLiteBased where
 
 import Hydra.Prelude
@@ -61,7 +63,7 @@ import Database.SQLite.Simple (Connection, Only (..), Statement, close, closeSta
 import Hydra.Events (EventSink (..), EventSource (..), HasEventId (..))
 import Hydra.Events.Rotation (EventStore (..))
 import Hydra.Logging (Tracer, traceWith)
-import System.Directory (createDirectoryIfMissing, doesFileExist, renameFile)
+import System.Directory (createDirectoryIfMissing, doesFileExist, removeFile, renameFile)
 import System.FilePath (takeDirectory)
 
 -- | Exception thrown when a persisted event cannot be decoded.
@@ -193,8 +195,11 @@ mkSQLiteEventStore dbFile = do
             Just ne -> setLastSeenEventId (last ne)
             Nothing -> pure ()
 
-    rotate _ checkpointEvent = do
+    rotate logId checkpointEvent = do
       flushWriteQueue writeQueue
+      -- Archive the current database before removing events, so the
+      -- pre-rotation log is retained (mirrors the old file-based backup).
+      backupDatabase conn dbFile logId
       let evData = toStrict $ Aeson.encode checkpointEvent
       withTransaction conn $ do
         deleteAllEvents conn
@@ -377,3 +382,14 @@ insertEvents conn =
 deleteAllEvents :: Connection -> IO ()
 deleteAllEvents conn =
   execute_ conn "DELETE FROM events"
+
+-- | Archive the current database to @<dbFile>-<logId>@ before rotation removes
+-- the events. Uses @VACUUM INTO@ so the snapshot reflects all committed (WAL)
+-- data in a single self-contained file, regardless of WAL checkpoint state. The
+-- destination is removed first if present (e.g. a re-rotation at the same log
+-- id), since @VACUUM INTO@ requires it not to exist.
+backupDatabase :: Connection -> FilePath -> Word64 -> IO ()
+backupDatabase conn dbFile logId = do
+  let backupPath = dbFile <> "-" <> show logId
+  whenM (doesFileExist backupPath) $ removeFile backupPath
+  execute conn "VACUUM INTO ?" (Only backupPath)

--- a/hydra-node/test/Hydra/Events/SQLiteBasedSpec.hs
+++ b/hydra-node/test/Hydra/Events/SQLiteBasedSpec.hs
@@ -7,6 +7,7 @@ import Test.Hydra.Prelude
 import Data.Aeson qualified as Aeson
 import Data.ByteString qualified as BS
 import Data.List (zipWith3)
+import Data.List qualified as List
 import Database.SQLite.Simple (close, execute, execute_, open)
 import Hydra.Events (EventSink (..), EventSource (..), getEvents, putEvent)
 import Hydra.Events.Rotation (EventStore (..))
@@ -14,10 +15,11 @@ import Hydra.Events.SQLiteBased (EventDecodingException, SQLiteLog (..), getSche
 import Hydra.HeadLogic.StateEvent (StateEvent (..))
 import Hydra.Ledger.Simple (SimpleTx)
 import Hydra.Logging (Envelope (..), nullTracer)
+import System.Directory (doesFileExist)
 import Test.Hydra.Chain.Direct.State ()
 import Test.Hydra.HeadLogic.StateEvent ()
 import Test.Hydra.Ledger.Simple ()
-import Test.QuickCheck (forAllShrink, ioProperty, sublistOf, (===))
+import Test.QuickCheck (forAllShrink, generate, ioProperty, sublistOf, suchThat, (===))
 import Test.QuickCheck.Gen (listOf)
 import Test.Util (captureTracer)
 
@@ -131,6 +133,27 @@ spec = do
                 msgs `shouldSatisfy` elem MigrationComplete{legacyFile}
               pure $
                 loadedEvents === events
+
+    it "keeps a backup of the database before rotating" $ do
+      withTempDir "hydra-sqlite-persistence" $ \tmpDir -> do
+        let dbFile = tmpDir <> "/hydra.db"
+            stateFile = tmpDir <> "/state"
+        events <- generate $ genContinuousEvents `suchThat` (not . null)
+        let lastId = eventId (List.last events)
+            -- content is irrelevant here; we only assert on the archived events
+            checkpointEvent = List.last events
+        withSQLiteEventStore @(StateEvent SimpleTx) nullTracer dbFile stateFile $ \EventStore{eventSink = EventSink{putEvent}, eventSource, rotate} -> do
+          forM_ events putEvent
+          rotate lastId checkpointEvent
+          -- the active store holds only the checkpoint after rotation
+          active <- getEvents eventSource
+          active `shouldBe` [checkpointEvent]
+        -- the pre-rotation events are retained in the numbered backup
+        let backupPath = dbFile <> "-" <> show lastId
+        doesFileExist backupPath `shouldReturn` True
+        withSQLiteEventStore @(StateEvent SimpleTx) nullTracer backupPath stateFile $ \EventStore{eventSource} -> do
+          backedUp <- getEvents eventSource
+          backedUp `shouldBe` events
 
 genContinuousEvents :: Gen [StateEvent SimpleTx]
 genContinuousEvents =

--- a/hydra-node/test/Hydra/Events/SQLiteBasedSpec.hs
+++ b/hydra-node/test/Hydra/Events/SQLiteBasedSpec.hs
@@ -149,7 +149,7 @@ spec = do
           active <- getEvents eventSource
           active `shouldBe` [checkpointEvent]
         -- the pre-rotation events are retained in the numbered backup
-        let backupPath = dbFile <> "-" <> show lastId
+        let backupPath = tmpDir <> "/old-state/hydra-" <> show lastId <> ".db"
         doesFileExist backupPath `shouldReturn` True
         withSQLiteEventStore @(StateEvent SimpleTx) nullTracer backupPath stateFile $ \EventStore{eventSource} -> do
           backedUp <- getEvents eventSource


### PR DESCRIPTION
Fixes https://github.com/cardano-scaling/hydra/issues/2747