### PR TITLE
Implement selective partial fanout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ changes.
 
 ## [2.3.0] - 2026.07.15
 
+- Add **selective partial fanout**: distribute a chosen subset of a closed
+  head's UTxO instead of draining it all at once. Introduces the `PartialFanout`
+  client input, the `HeadPartiallyFannedOut` server output (with a `fanoutMode`
+  telling clients whether the node keeps draining or awaits the next selection),
+  a `FanningOut` head status and a matching TUI selection flow. Keep issuing
+  `PartialFanout` until the head is drained; the final step burns the head
+  tokens. [#2333](https://github.com/cardano-scaling/hydra/issues/2333)
+
 - Fix event log rotation dropping `pendingDeposits` and `chainPointTime` on
   restart. `aggregateNodeState` now restores the full checkpoint snapshot,
   so deposits recorded before a rotation survive a node

--- a/docs/docs/how-to/selective-fanout.md
+++ b/docs/docs/how-to/selective-fanout.md
@@ -68,6 +68,20 @@ initiating node goes offline), driving each step sequentially.
 
 :::
 
+:::caution Driver liveness
+
+Only the node that issued a command advances the fanout. In particular, a plain `Fanout`
+puts the initiating node into an automatic-drain mode where it keeps posting the remaining
+steps by itself; the other nodes only observe and wait. If that node goes offline
+mid-fanout, the remainder is **not** drained automatically — any other party must resume it
+by issuing `PartialFanout` commands (selecting the remaining set) until the head is empty.
+
+If a step is rolled back on chain, the driving node re-posts the next fanout transaction to
+resume. As with all rollback handling, this assumes the rolled-back transactions eventually
+re-appear; a deeply divergent rollback may require re-issuing a `PartialFanout`.
+
+:::
+
 To confirm, query the funds of the wallet on layer 1 from a `cardano-node`:
 
 ```shell

--- a/docs/docs/how-to/selective-fanout.md
+++ b/docs/docs/how-to/selective-fanout.md
@@ -1,0 +1,77 @@
+---
+sidebar_position: 6.5
+---
+
+# Selective fanout
+
+When a head is closed and ready to fan out, the plain `Fanout` command distributes the
+**whole** head at once. With a _selective_ (partial) fanout you instead choose exactly
+which `UTXO` to distribute, and in which order — paying the on-chain cost only for what
+you care about, and leaving the rest in the head to fan out later.
+
+This how-to assumes we are in a similar situation as in the [Getting
+started](../getting-started) or [Testnet tutorial](../tutorial): a head has been
+`Close`d and the node has emitted a `ReadyToFanout` message.
+
+Open a WebSocket session if you haven't already:
+
+```shell
+websocat "ws://127.0.0.1:4001?history=no"
+```
+
+First, find out what is still in the head. The confirmed snapshot UTxO is available over
+HTTP:
+
+```shell
+curl localhost:4001/snapshot/utxo | jq
+```
+
+Pick the subset you want to fan out now and send a `PartialFanout` client input with it
+under `utxoToFanout`. For example, to fan out a single `UTXO`:
+
+```json title="Websocket API"
+{ "tag": "PartialFanout", "utxoToFanout": { "<txin>#<ix>": { /* the matching output */ } } }
+```
+
+The node submits the corresponding layer 1 transaction (automatically splitting it across
+several transactions if the selection is too large to fit in one) and replies with a
+`HeadPartiallyFannedOut` message:
+
+```json title="Example HeadPartiallyFannedOut"
+{
+  "tag": "HeadPartiallyFannedOut",
+  "headId": "...",
+  "distributedUTxO": { /* what this step put back on layer 1 */ },
+  "remainingUTxO": { /* what is still in the head */ }
+}
+```
+
+Use `remainingUTxO` to choose your next selection. Keep issuing `PartialFanout` commands —
+selecting the entire remaining set when you want to finish — until the head is drained. On
+the final step the node automatically submits the transaction that burns the head tokens
+and emits `HeadIsFinalized` with the complete distributed `utxo`.
+
+:::info Selective fanout is sticky
+
+Once you send the first `PartialFanout` for a head, the plain `Fanout` command is no longer
+accepted for it (you will receive a `CommandFailed`). Continue with `PartialFanout`
+commands until the head is empty.
+
+:::
+
+:::tip Multiple parties
+
+Any party can drive the next step. After one party's `PartialFanout` lands, the others
+simply observe it and wait — they will not automatically drain the remainder. So you can
+start a selective fanout on one node and continue selecting from another (useful if the
+initiating node goes offline), driving each step sequentially.
+
+:::
+
+To confirm, query the funds of the wallet on layer 1 from a `cardano-node`:
+
+```shell
+cardano-cli query utxo \
+  --address ${WALLET_ADDR} \
+  --output-json | jq
+```

--- a/docs/docs/how-to/selective-fanout.md
+++ b/docs/docs/how-to/selective-fanout.md
@@ -5,7 +5,7 @@ sidebar_position: 6.5
 # Selective fanout
 
 When a head is closed and ready to fan out, the plain `Fanout` command distributes the
-**whole** head at once. With a _selective_ (partial) fanout you instead choose exactly
+**whole UTxO set** at once. With a _selective_ (partial) fanout you instead choose exactly
 which `UTXO` to distribute, and in which order — paying the on-chain cost only for what
 you care about, and leaving the rest in the head to fan out later.
 
@@ -42,11 +42,15 @@ several transactions if the selection is too large to fit in one) and replies wi
   "tag": "HeadPartiallyFannedOut",
   "headId": "...",
   "distributedUTxO": { /* what this step put back on layer 1 */ },
-  "remainingUTxO": { /* what is still in the head */ }
+  "remainingUTxO": { /* what is still in the head */ },
+  "fanoutMode": "AwaitingFanoutSelection"
 }
 ```
 
-Use `remainingUTxO` to choose your next selection. Keep issuing `PartialFanout` commands —
+`fanoutMode` tells you whether the node is still draining on its own
+(`AutoFanningOut`, e.g. after a plain `Fanout`) or is waiting for your next
+selection (`AwaitingFanoutSelection`) — so a client can show the right prompt
+instead of guessing. Use `remainingUTxO` to choose your next selection. Keep issuing `PartialFanout` commands —
 selecting the entire remaining set when you want to finish — until the head is drained. On
 the final step the node automatically submits the transaction that burns the head tokens
 and emits `HeadIsFinalized` with the complete distributed `utxo`.

--- a/docs/docs/tutorial/index.md
+++ b/docs/docs/tutorial/index.md
@@ -679,6 +679,28 @@ You can do this through the WebSocket API one last time:
 
 This will submit a transaction to layer 1. Once successful, it will be indicated by a `HeadIsFinalized` message that includes the distributed `utxo`.
 
+:::tip Selective fanout
+
+Instead of fanning out the whole head at once, you can choose exactly which UTxOs to
+distribute and in which order, paying the on-chain cost only for what you care about:
+
+```json title="Websocket API"
+{ "tag": "PartialFanout", "utxoToFanout": { /* a subset of the head's UTxO */ } }
+```
+
+Each `PartialFanout` distributes the selected subset (chunked across transactions
+automatically if it is too large for one) and replies with a `HeadPartiallyFannedOut`
+message reporting the `distributedUTxO` and the `remainingUTxO`. Keep issuing
+`PartialFanout` — selecting the entire remaining set when you want to finish — until the
+head is drained, at which point the node automatically submits the final transaction that
+burns the head tokens and emits `HeadIsFinalized`.
+
+Note that selective fanout is sticky: once you send the first `PartialFanout`, the plain
+`Fanout` command is no longer accepted for that head — you continue with `PartialFanout`
+commands until the head is empty.
+
+:::
+
 To confirm, you can query the funds of both `alice` and `bob` on layer 1:
 
 ```shell

--- a/head-state-viewer/src/HydraVis/Compare.hs
+++ b/head-state-viewer/src/HydraVis/Compare.hs
@@ -157,6 +157,9 @@ nodeSummary steps t = case stepAt steps t of
     HS.Closed HS.ClosedState{HS.confirmedSnapshot = cs} ->
       let snap = getSnapshot @tx cs
        in (show (number snap), "-", "-", "closed", balanceText (Snap.utxo snap))
+    HS.FanoutProgress HS.PartialFanoutState{HS.confirmedSnapshot = cs} ->
+      let snap = getSnapshot @tx cs
+       in (show (number snap), "-", "-", "fanning out", balanceText (Snap.utxo snap))
   balanceText u =
     let s = summariseUtxo u
      in if usValued s then lovelaceText (usTotalLovelace s) else "-"

--- a/head-state-viewer/src/HydraVis/UI/Flow.hs
+++ b/head-state-viewer/src/HydraVis/UI/Flow.hs
@@ -38,6 +38,7 @@ stateKindOf n = case headState n of
   HS.Idle{} -> SIdle
   HS.Open{} -> SOpen
   HS.Closed{} -> SClosed
+  HS.FanoutProgress{} -> SFanoutProgress
 
 -- | Counts of transitions and within-state events accumulated by walking the
 -- history in order. We do not have access to the truly-initial 'NodeState'

--- a/head-state-viewer/src/HydraVis/UI/Panels.hs
+++ b/head-state-viewer/src/HydraVis/UI/Panels.hs
@@ -72,6 +72,7 @@ peersBody mctx = \case
     Just c -> fromEnv (ctxEnvironment c)
   HS.Open HS.OpenState{HS.parameters = ps, HS.headId = hid} -> openClosed ps hid
   HS.Closed HS.ClosedState{HS.parameters = ps, HS.headId = hid} -> openClosed ps hid
+  HS.FanoutProgress HS.PartialFanoutState{HS.parameters = ps, HS.headId = hid} -> openClosed ps hid
  where
   me = Env.party . ctxEnvironment <$> mctx
 
@@ -142,6 +143,16 @@ snapshotBody = \case
           , row "confirmed txs" (showT (length (confirmed snap)))
           , row "contestation deadline" (showT deadline)
           , row "ready to fanout" (showT ready)
+          , headBalance snap
+          ]
+  HS.FanoutProgress HS.PartialFanoutState{HS.confirmedSnapshot = cs, HS.contestationDeadline = deadline} ->
+    let snap = getSnapshot @tx cs
+     in div_
+          []
+          [ row "confirmed snapshot #" (showT (number snap))
+          , row "confirmed txs" (showT (length (confirmed snap)))
+          , row "contestation deadline" (showT deadline)
+          , row "fanning out" "in progress"
           , headBalance snap
           ]
  where
@@ -471,6 +482,7 @@ headParties :: HS.HeadState tx -> [Party]
 headParties = \case
   HS.Open HS.OpenState{HS.parameters = ps} -> HP.parties ps
   HS.Closed HS.ClosedState{HS.parameters = ps} -> HP.parties ps
+  HS.FanoutProgress HS.PartialFanoutState{HS.parameters = ps} -> HP.parties ps
   HS.Idle _ -> []
 
 -- | Render the currently-connected peer set as @host:port@, comma separated.

--- a/hydra-node/golden/ClientInput/PartialFanout.json
+++ b/hydra-node/golden/ClientInput/PartialFanout.json
@@ -1,0 +1,24 @@
+{
+    "samples": [
+        {
+            "tag": "PartialFanout",
+            "utxoToFanout": {
+                "0100010001000000000000010000010000000001010100010001010001010100#93": {
+                    "address": "addr_test1zzerh7dxg9mgwwjz0jv3r6v60h67ndelkl5g6djnf3rjn2wyq5ll0jvh5d06frukhwhzud2ywffry7rswpnq79rtw6ysgxfl2u",
+                    "datum": null,
+                    "datumhash": null,
+                    "inlineDatum": null,
+                    "inlineDatumRaw": null,
+                    "referenceScript": null,
+                    "value": {
+                        "245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abae": {
+                            "df2bbe9da2": 1
+                        },
+                        "lovelace": 1142150
+                    }
+                }
+            }
+        }
+    ],
+    "seed": 576953494
+}

--- a/hydra-node/golden/ReasonablySized (NodeState (Tx ConwayEra)).json
+++ b/hydra-node/golden/ReasonablySized (NodeState (Tx ConwayEra)).json
@@ -2,82 +2,161 @@
     "samples": [
         {
             "chainPointTime": {
-                "currentChainTime": "1864-05-12T07:29:52.446515666782Z",
-                "currentSlot": 3,
-                "drift": -1.5
+                "currentChainTime": "1864-05-11T01:24:03.704507600924Z",
+                "currentSlot": 4,
+                "drift": 3.166666666666
             },
             "headState": {
                 "contents": {
                     "chainState": {
                         "recordedAt": {
-                            "blockHash": "0104040403030408010406020303060204030402020802070505080305040100",
-                            "slot": 10,
+                            "blockHash": "0608080305010205070405080208060407070701070406010505050506000700",
+                            "slot": 13,
                             "tag": "ChainPoint"
                         },
                         "spendableUTxO": {
-                            "0001000105060204080803030104000407000700080208030303030803080003#78": {
-                                "address": "addr_test1vpxz8z3wdutkrqew5w2phrsu97jt6hl5zpgh5zz4t37x8ps78rzmt",
+                            "0007040501050504070000040200070108030205010404070102080002030403#85": {
+                                "address": "addr_test1vzhpsrnjgtvjp2jm86sfy78edz3mfkam9es255m9pytwqdgls3me9",
+                                "datum": null,
+                                "datumhash": "9ee702636d03bba44874b18b66dcb50e99088be7e3a3aa9a82b20346d62de781",
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3": {
+                                        "35": 9144914757201160666
+                                    },
+                                    "lovelace": 1185250
+                                }
+                            },
+                            "0007080600020803040800020207040806040608080303080608030006070204#0": {
+                                "address": "addr_test1ypt4x8t97jqu8nmck7a40g2gvvha59m9433t5n5x65eew386zx44n69t5x5jgys5nmll73vud30d0ehf9fxlucs2ndfsju02en",
                                 "datum": null,
                                 "datumhash": null,
                                 "inlineDatum": null,
                                 "inlineDatumRaw": null,
                                 "referenceScript": null,
                                 "value": {
-                                    "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
-                                        "32": 2
+                                    "818b54db5f6bacf4bfa3ac1cbb1f5fcd33dfdec4f8dd24990fe9ae7f": {
+                                        "6659d170ba7c23085cf61b823f": 4570759160093764612
+                                    },
+                                    "lovelace": 1211110
+                                }
+                            },
+                            "0101050000000104060103070007010808050007060806040306070108070601#58": {
+                                "address": "addr_test1ypsgu74ewpsjxtyrugk7zt829agawj3uj3n9k2d27u98dtry7jml3d7euveutxx8pzkfa86zpexcghah9k6m9aw77mws9v98m5",
+                                "datum": null,
+                                "datumhash": null,
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
+                                        "4876": 1
                                     },
                                     "lovelace": 7500000000000000
                                 }
                             },
-                            "0105020508010003060007030303020208080108020505040703030101000606#73": {
-                                "address": "addr_test1xqnvtagk7d0exlp8gd0gkgyl4xs08chxd974uq7w6q9tnelmnz4trutnea8rqlpzt5nmpe96wvh2rfygn6wrvnx0u4fsar0nth",
+                            "0101050100070103020004000602070203030100040004030502070501080800#9": {
+                                "address": "addr_test1wqemkws4yujg2ej5ahz0u6aqafhmyud68rlvwfkxcnjc8egvhdwvx",
                                 "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
+                                "inlineDatum": {
+                                    "constructor": 1,
+                                    "fields": [
+                                        {
+                                            "map": [
+                                                {
+                                                    "k": {
+                                                        "constructor": 2,
+                                                        "fields": [
+                                                            {
+                                                                "int": -5
+                                                            },
+                                                            {
+                                                                "int": 0
+                                                            },
+                                                            {
+                                                                "int": -1
+                                                            },
+                                                            {
+                                                                "bytes": "179c"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "v": {
+                                                        "map": [
+                                                            {
+                                                                "k": {
+                                                                    "int": 0
+                                                                },
+                                                                "v": {
+                                                                    "int": 4
+                                                                }
+                                                            },
+                                                            {
+                                                                "k": {
+                                                                    "bytes": "7f"
+                                                                },
+                                                                "v": {
+                                                                    "int": -2
+                                                                }
+                                                            },
+                                                            {
+                                                                "k": {
+                                                                    "bytes": "90"
+                                                                },
+                                                                "v": {
+                                                                    "int": -5
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "k": {
+                                                        "bytes": "1ee45560"
+                                                    },
+                                                    "v": {
+                                                        "constructor": 0,
+                                                        "fields": []
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "int": 1
+                                        },
+                                        {
+                                            "bytes": "f797"
+                                        }
+                                    ]
+                                },
+                                "inlineDatumRaw": "d87a9fa2d87b9f24002042179cffa30004417f21419024441ee45560d879800142f797ff",
+                                "inlineDatumhash": "e1a265cb5bcc30584de54d8571394c988f867f39988c38c25bdab00f6a27fa11",
                                 "referenceScript": null,
                                 "value": {
-                                    "lovelace": 7500000000000000
-                                }
-                            },
-                            "0604050304050502010507040805010405080405070502050704040108040108#82": {
-                                "address": "addr_test1xzy980ce0ejlzvgs26jrw2y24jykun76t2ahwsm5svwcgjmkxylq28s35adzg94s4p4je6kz2m80706c37ddtvdf6meqluxzsy",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "lovelace": 7500000000000000
-                                }
-                            },
-                            "0701070508070702030305050508050704070403060607010504040808080407#44": {
-                                "address": "addr_test1zzkzy8y39zapktre2g7x2v9x4qhaqkldmqsvqzxv0gl038ck9dvdm04su6x354vs2pufgcena5zpegcv4pgl9fq4q0xq37h90c",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "lovelace": 969750
-                                }
-                            },
-                            "0804050804040500080103040503040700030500040403080106050808020706#36": {
-                                "address": "addr_test1wpwndm40f6sejr4gqdluyvtt4rlpujxcp2gme60dzxnj8jc7suzxq",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "2dd0ef0f275283b1bf1ef27b857a90ed19c3841143c5cf85abf71f1b": {
-                                        "33": 7647518171202614699
+                                    "4a4a4be13a432c7d6c82584920b723884a1bde606e44d7d546a49cfd": {
+                                        "989d25c975": 6634297438983615094
                                     },
                                     "lovelace": 7500000000000000
                                 }
                             },
-                            "0808080800030805070000050004060803010607050805060006070203030707#9": {
-                                "address": "addr_test1zz426thfdg2p9hrt9skftdjul7uhyuz6l9z6fzlm9krnmrf2r8z6akyplxmmlcvdlfj90ykg3wdeghrr3h83chek8zesdq5c60",
+                            "0403010507050202000605020802030305060600000704060505070500060005#68": {
+                                "address": "addr_test1qqxhlmax0zrsemmg328altkpem4yh4jspwxrkydcvqwdnuv37a87r4f4t3f9vqr4v6auy06z8w44lqfnkehcklpah96q0ptew4",
+                                "datum": null,
+                                "datumhash": "95607d61956d6d8e324a1618c482f328d6ec3393f313b91053a6a6793d6c54b1",
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "1a7983b5089de5d0bb850a75e7690b97f2851a279b94c1eb817f6e50": {
+                                        "5da46e9dd9a97a3d57b0d69f5c1ba5c33460b4": 3328374345351551737
+                                    },
+                                    "lovelace": 1383510
+                                }
+                            },
+                            "0503040804070107050000080500060107020207020602050206000802050102#36": {
+                                "address": "addr_test1vp94m927y2x3a92km4u37atxg6wc96t4eervuusmfjzrdusnv9y6n",
                                 "datum": null,
                                 "datumhash": null,
                                 "inlineDatum": null,
@@ -89,241 +168,1676 @@
                             }
                         }
                     },
-                    "coordinatedHeadState": {
-                        "allTxs": {
-                            "0300000508000705040607060702000502060802010707080802000107030807": {
-                                "cborHex": "84b200d9010284825820246be8f4eb6a2aca7aff9c4cbb6c317e7945b7e653c718667a33baef95b6cd9e07825820a27a9aac669f970e637f1b1d3afac2cf10f12781d6d475dfd5035c542281e1bf08825820b0111b6daa2f6f6394d86eb055d1f7b0a84eb2345a8bfabeaeaf5bc6afd8e18502825820e63e9f9673a3ac3c23d164c1eb026e63ad37783f123115c83847285601122825010dd9010281825820a8774830a1fc4baee24d7d35536fb9404966a1b29c8f7323ec78346b7a4a9a870412d901028382582007d105ab6eff16b3f4ecd3c11ce2ab91b41f582939ad6a46914fa6db64174672078258200b38d64229bf12575557e1ffb439a618eed683c317920fe4d9a4c885737f018f018258206248eacc6d49551147a4db8683763798207b4d82fa350a3393d082df69416fb2030182a400583900ca2ba6bcd6ab65ad1bd5a8ae7d9f6c61ca9584d0bcb440b633cea8fd01a81a2c44cdc3de3afbd8b28f99b4586eac35c8b55e9c9d33ea298f018200a1581cb9be4636f90cdbfa6e3319e798ca05ac388377a1b045005f1426f575a141351b29b5247de1f48da80282005820f07b3221419243d503bed13a401ff14acf35022456df9b2e05cb9a6a21ab846803d8184a82034746010000220011a400585082d818584683581cddb9face97aebff487f1354a385df09d03f39eb87a191afea1cec012a1015822582004e05f46c8604adfbc4ff76c2bf8724cc917f88a5c0c83b5830eea0552aef0a0001a3ff73e3a018200a1581c4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebea1413402028201d8184342330f03d8184a820083030181830300801083585082d818584683581cf04de33e25cb190b73612d29da21e905c2590dc4630b7205f5ac2b1ba1015822582077736374676c6273637a746d7477646d71626a667a6b66726e7a7663666b6867001ae9e7adf18200a1581cb0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165a1581e4a63f0c0962aa9b728ec1dae3e9a80f21fe6f0f88eb3ceca93709218cd270258203c9b8156819653acf14f33be8ca70b91cdd35d484a826c10a9976852593cf3cc1104021a0008a088030104d901028482018200581cc8819bd64458e294aa1edb82d5708b4ee107c622606f8f4f410a394984108201581c73209d9e697e0583c21ce75e212129da69a59982438f7d95a8f7d6c11a000d8c6182782d68747470733a2f2f63554e4b5331674d43714a4236707930652d5153544551615578547351433937532e636f6d5820c62037e2160823a9b381d99a324a5a90a178a87fb8a8f41cc2ac32ae298c230983028200581c5f21f29fac454092a9887ea11368b9bdcb0634fe5bb05b25976a44b2581cbf8c9ce792c2bcc56b6e39b57f9a4b4e7a621db8958da3c867028bd183118201581cad50a7ac8de3ee21fe3a13ad84d2a497b8a735574d995621ee20cc190005a1581df1523aa250891d0399272b5ed1be9a09c58e7ab4c58b49cb9fa636d5aa1a000e8c8d08020ed9010282581c35c1e6bc6e071a1e1e7e2a15209edb9a55d1f7297df5f5543cd15680581c705f08d421d2a9d3eeef6d8ba05ded923ec4a0fa4f0fe487c7026ab509a1581c8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3a14db8fcab5973174648056eb083803b25633262355055680b5820916a810466be9dcf659a42585e5fdfd0ca915691e50b63a3d718e32ab937bdc80f0113a28201581c961bb3fc5479a24fb023d05c0e254c8491d118026d5396901506ec8ba382582031fd8fa84d59fde1693fd393be0fdd0825298733498111316661cf1b6868f6dd00820082783068747470733a2f2f5a4d6c4e49504f4d3953306f33386549742d524f6d31616e3166434e58705344324334482e636f6d58201d274e0a50b21663cefdac87837497aa442426e6c6dcd4d238d1b7e99fb98def82582034913f721ec32e55381e7b2373888dbf83705f8265c1ea517d305db37b6f52ea008200f6825820404bbc119442a5e11006c53c6ad1625e10a3c62991ee25a201e9c84ca9bb2ce503820182783c68747470733a2f2f4f3933714239705837357542693972586a6e55427349353455474577456b4350427a4666544c3947454667487746706f2e636f6d5820a249884a680445e540a014aaf1a3029f3fc97ad0718ae3a5a8d12ec243171f4f8204581c5e3cd98c665f7e510381d187f8f1b7b713c9918297be96b578bf1617a2825820281f4b5ec4dfe20c4a54a8b557a43cc83c564c55886c0e739ce7a1165a9f83b801820182782c68747470733a2f2f55366b66586e6e2d56532d4f55646d654557706b4b376a3643306b4a337369682e636f6d5820b14de9cf09cbda6a78f8946b974675ece43ef0aa031afd0399e6021798654ddb825820c5b1ee10e7e39beb9f891f91d3d796ad19f209d33ffae42dbccbb9e17a9dc3c4048200f614d90102828401581de1401116f5ef7a2d884f66272456fa4081be0161c8282649d44ee72da5810682781d68747470733a2f2f67384957693878554c526a3054547830462e636f6d582071b31feb7cf0c2b81d6d9a8aa5f3127829dfcf8fa77c230fe995822ce9fb00c9841a000aa2aa581de0f21cccbbd016c016fc02db88d78fae02f4327aca8e227190ad0dd3178203f682781d68747470733a2f2f6d65414b57547a51445a302d75733247562e636f6d582089b203a668bf5cbcf129e622705b4ae9c6c6eb2296d92b59a6797a543a2f586f1604a600d9010284825820e1291ebd5de0ada21eadd955b3ddc461064cf598f5d4d1a1182b9625dd90f6f8584089f6c5635a0fd2c11b26fa7bed16cbde4f5977303f6d61e36a11ffc8509139c5a0eca0d92cb9904d77e409cd6825021efd8c60e02791650b9c2c7756361d6aa4825820bf3e7edd25ce1b42e199c4b08a0d0d0f806a5d89916ccfb920cf1ddcda3e2d2c584045fb2ad064645f3eb81805e252b40b07a67cc4a4a4bc6572b3030389de9eec620ebf2bdea3d7d3c1845aad08b00a1e141a2979969dfb98885262e9bd27c777b682582019bbd9ee61dbad58715c5e5909db2d4c0ec3d5652c7b6ed77481f12cd0ea30c25840c8b115ed17d90139848cebdd5cc662dc8c6c63125047b9475adba20f6c6d0c7d1cd7b8ca2176091033f48c6788770fa7d8ebbd540e0f40225523cff727347fb58258209abd0bb6d8d179575680c69d68d0a33f7fc58e1b7a8b65576a442a522443052d5840247cda7e4bdc8cfcc2978dceaf9ca2a5a3eb4a127cca4c5887727721d9748f4483c6e299316b03e4e4f69717e62a99c180ed1f07ed1f38ad0cf7f2aabfe7455502d901028384582045e16a761ce5d5c33a3c76f6771e327f861bdbe54e2ce54fda7418828a6f14b0584073151e530dab3476dc1ad7a5088bd79ce6d9b87651e28b040f8a8656c752b148e96f637b0d3490445ab337401c98bbc6167230d05a8a5f2f4e03375586a25905582064194670a46b9bd2f6a89dde95d5ede2a6004ae0f83d1f0d537c226fdfdec67b42a206845820255974de58669ebe80642aff98301c90b9bd7bdc31125cdc808f4efd007fff6d584073b85d4fa2c90bc6028d7748107c9c646fdd74f212cdcd931436984bd5d2f0e805b9c2c9c517d5ea7bb995f53be8473c00c1feca59e3ddc0a49e8ca939ec69e65820280fad6b172067f3656b258225e255334ce819ab94fd883383526644c094647540845820fa9313ffbc0bd34f0dc746aa10fd1f86804e1476829d849d10583d89f7888df75840a40e3162a9e1b75392079a9e026d5b05ef72e8ba901bdbcb268b8312a9b89d86fc5ee9c90d1c5b7148695df5bba8e5bbe46a0cceff9cecd9d81a7dd23a103e8a582028f169c1beaa188ae43f6979c5054e590be60e661c8b17e2d93de5fc255784a3417401d90102838303018483030080830300828201808202828200581c6157910c82710bd54df5effd16f3c8f373d5495bed1d3e47508212d28200581c219983d716fccd1396e3c726e73bf971e59dddf15a3d4f79f8100ce88303008182018083030080820184820180830300818200581ce149a4060fbd003706f8c897d3e7a6e8c6c7c1bbaf7b5ce98ed6af078202828201828200581ce12d72317eb6c81ca331cac5b11314ffafe94702c767b1a75d7968c98200581c5286224552aec7ed35b7d801c1503fe8fa71e54f94469303233bc8d48201838200581c3c8b8011d4c9d73f204df6607a600bb84a5fee0bbffce1db4d675e878200581c47b5105cc9c1954bb9b41dfe3f3e6b7eccd83ebb1a514c2702393c758200581c77c31ce157359b13f8deb346dc6621e37cf4599fa021f3ba2866246c8201828200581c97a435bedd58c5db7c486220a0c317f1c39cc755965b6b8377cee9808200581c935b440185581573c8f4d0e384586ff36f17b6500ae2709e0bc19a7a82050303d901028148470100002220010106d90102814645010000260105a282040882a19fd87a9f415642887642b8ac42ca3e4111ffffa520d8799f044334f9c4ff00d87a800143b6aa122440a243cfdf704478e957f2435532f201d8799f4373763e2003ff821b07fe71f7679ec5dd1b71a565b10a5c384782050682d87c9fd87a9f439f15dc22039f240241c24043de05f8ff4321f574ffff821b130e18251acb861d1b0453882357d11496f5f6",
-                                "description": "",
-                                "txId": "253db3d43cf6c2b13f42c2bcd1a0359ce4f2dbb72f334f85209c951d874f599a",
-                                "type": "Tx ConwayEra"
+                    "confirmedSnapshot": {
+                        "signatures": {
+                            "multiSignature": [
+                                "09b1f270037995261895fdcd8f1d433402f45f9507d597f15e9d8e72bb5c15bb1d69ad6129ddfb7fa2b88a91fd92252020c0419e9f899cd9c11ad5f975939d00",
+                                "465fcf1b29ff2996ebd5ea4de5ddd1ff1fc022c9b2478dfab7b8906d5356fea3488bbca81dc1158b1ec59baf23fea626f0dcf027f43b1027e181cc4cac409e01",
+                                "ffd4bcfdd4cd4576f3dfe21efe1f23b4bd71e947a61101210fc65b62cdb79439d0a5e548180c82f97d101196dffa84ad725c22c83da5845f55943b408bf2b905"
+                            ]
+                        },
+                        "snapshot": {
+                            "accumulator": "14295e7e6ebbaf37128c95a894285ddb0191cf0c729e687553b6e744dbc537f8",
+                            "confirmed": [],
+                            "headId": "06000503020207070806020208030705",
+                            "number": 2,
+                            "utxo": {
+                                "0006010704020507010107050600080007070500000601050603060203030005#76": {
+                                    "address": "addr_test1zptw2jc3xf02f3jw3glwc9rml7m6uxsxmd3gqrrx9jj6w7naw82gldx4r5mv7cxzuqq3qq3d7cnx420fa4vnnxn0gghqqm6rna",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebe": {
+                                            "de0ea671935925d699235a29d6154d774208eacbda58fb98": 3
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0202070002020705050705040602060304070001050203010608080506060200#41": {
+                                    "address": "addr_test1yrvfsycf4s994x5zlskpyku9tudfsqpet69h92rn5wnaxz50zl3dpmkkk5j4tpzjlzc8w0u22g0lff5mv06f3l632eqq42l60y",
+                                    "datum": null,
+                                    "inlineDatum": {
+                                        "constructor": 4,
+                                        "fields": [
+                                            {
+                                                "list": [
+                                                    {
+                                                        "int": -5
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "constructor": 4,
+                                                            "fields": [
+                                                                {
+                                                                    "int": 4
+                                                                },
+                                                                {
+                                                                    "bytes": "4a87aa"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "v": {
+                                                            "list": []
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "list": []
+                                                        },
+                                                        "v": {
+                                                            "bytes": ""
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "constructor": 0,
+                                                            "fields": []
+                                                        },
+                                                        "v": {
+                                                            "list": [
+                                                                {
+                                                                    "int": -5
+                                                                },
+                                                                {
+                                                                    "bytes": "9f"
+                                                                },
+                                                                {
+                                                                    "int": 0
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "list": []
+                                                        },
+                                                        "v": {
+                                                            "map": [
+                                                                {
+                                                                    "k": {
+                                                                        "int": 5
+                                                                    },
+                                                                    "v": {
+                                                                        "int": -4
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "int": 0
+                                                                    },
+                                                                    "v": {
+                                                                        "bytes": "ff0fc0"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "constructor": 0,
+                                                "fields": [
+                                                    {
+                                                        "map": [
+                                                            {
+                                                                "k": {
+                                                                    "int": -1
+                                                                },
+                                                                "v": {
+                                                                    "int": 1
+                                                                }
+                                                            },
+                                                            {
+                                                                "k": {
+                                                                    "int": 0
+                                                                },
+                                                                "v": {
+                                                                    "int": -2
+                                                                }
+                                                            },
+                                                            {
+                                                                "k": {
+                                                                    "int": 2
+                                                                },
+                                                                "v": {
+                                                                    "int": 3
+                                                                }
+                                                            },
+                                                            {
+                                                                "k": {
+                                                                    "bytes": "4afa1288"
+                                                                },
+                                                                "v": {
+                                                                    "int": 4
+                                                                }
+                                                            },
+                                                            {
+                                                                "k": {
+                                                                    "int": 3
+                                                                },
+                                                                "v": {
+                                                                    "int": 5
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "bytes": "4029"
+                                                    },
+                                                    {
+                                                        "map": [
+                                                            {
+                                                                "k": {
+                                                                    "bytes": "d292"
+                                                                },
+                                                                "v": {
+                                                                    "bytes": "28ace9"
+                                                                }
+                                                            },
+                                                            {
+                                                                "k": {
+                                                                    "bytes": "4a"
+                                                                },
+                                                                "v": {
+                                                                    "bytes": "7eebf3"
+                                                                }
+                                                            },
+                                                            {
+                                                                "k": {
+                                                                    "bytes": "23"
+                                                                },
+                                                                "v": {
+                                                                    "int": 2
+                                                                }
+                                                            },
+                                                            {
+                                                                "k": {
+                                                                    "bytes": "7c46fa48"
+                                                                },
+                                                                "v": {
+                                                                    "int": 3
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "inlineDatumRaw": "d87d9f9f24ffa4d87d9f04434a87aaff808040d879809f24419f00ff80a205230043ff0fc0d8799fa5200100210203444afa1288040305424029a442d2924328ace9414a437eebf3412302447c46fa4803ffff",
+                                    "inlineDatumhash": "66e33ebc8d7ea6fe25216b15256264a1f0766324154c732451988b8c67c7e2f1",
+                                    "referenceScript": null,
+                                    "value": {
+                                        "2d725128406dc832eb74c4709aca0512499b3c7b17e00d7cb2e6d1b1": {
+                                            "73e5b2a23ad41df82952a4b8e2a05e77c5788ad090eeefb598dacb0f65b020d4": 1204547626605239581
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0503010304030604000703020506070100050207050605010006020803050102#51": {
+                                    "address": "addr_test1zp3qza3mxjjt8nrx7nuupk852e3u3zwmg36903cvahxqvd4mn5jandtakxc4sja9ldm2wnfdvpdwk0v5r4d5nkp0je9qrhfe5r",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "44d0769108d4ebb2b2d0ef09ee5d51e3950ecc2572e8be69e844ef1e": {
+                                            "170758539d": 2
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0704080605030605060003080801030400060507070304060505000205020400#77": {
+                                    "address": "addr_test1yq49zpsek8zrwfk3ls0luazszcf07v4c3yk7kc877m3x9eeuvphcz77pn3sja73nd5cvstpp6lx38umxy86hqnxz5nkq86ccz3",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0803050802020300010007020705000805000801080200030808040806080205#81": {
+                                    "address": "addr_test1yz3mmfmg4aeja5r0m57yff8rdyxq8qduugxfffaha7aq8l22q5s5ela73cl9q62p7w6zggskarkqw464nve3jhr2tg7q2p8tgr",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0808070506010506050203080802000401020405060607000707040604040201#94": {
+                                    "address": "addr_test1yqz9vejpuftv5rm44smyr3ku7u5r94ffqrda3rzp6ntws8v0c0kknzvrltu0jm537vragfm48mm6xzpad6aqhh5r4kysswea7z",
+                                    "datum": null,
+                                    "inlineDatum": {
+                                        "map": [
+                                            {
+                                                "k": {
+                                                    "int": 2
+                                                },
+                                                "v": {
+                                                    "list": [
+                                                        {
+                                                            "bytes": "a41c2547"
+                                                        },
+                                                        {
+                                                            "constructor": 4,
+                                                            "fields": [
+                                                                {
+                                                                    "int": 1
+                                                                },
+                                                                {
+                                                                    "bytes": "c425"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "list": []
+                                                        },
+                                                        {
+                                                            "bytes": "17"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "int": -1
+                                                },
+                                                "v": {
+                                                    "bytes": "45"
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "int": -1
+                                                },
+                                                "v": {
+                                                    "map": [
+                                                        {
+                                                            "k": {
+                                                                "int": -2
+                                                            },
+                                                            "v": {
+                                                                "int": -3
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "list": [
+                                                                    {
+                                                                        "int": 5
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "constructor": 2,
+                                                                "fields": [
+                                                                    {
+                                                                        "int": -1
+                                                                    },
+                                                                    {
+                                                                        "int": 4
+                                                                    },
+                                                                    {
+                                                                        "bytes": "7431c3"
+                                                                    },
+                                                                    {
+                                                                        "bytes": "6ec3be"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "list": [
+                                                                    {
+                                                                        "bytes": "3ec2"
+                                                                    },
+                                                                    {
+                                                                        "bytes": "c0a971"
+                                                                    },
+                                                                    {
+                                                                        "bytes": "183a"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "list": [
+                                                                    {
+                                                                        "int": -3
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "map": [
+                                                        {
+                                                            "k": {
+                                                                "bytes": "a4cd68"
+                                                            },
+                                                            "v": {
+                                                                "list": [
+                                                                    {
+                                                                        "bytes": "baed95ce"
+                                                                    },
+                                                                    {
+                                                                        "bytes": "98"
+                                                                    },
+                                                                    {
+                                                                        "int": -1
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "bytes": ""
+                                                            },
+                                                            "v": {
+                                                                "int": 3
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "bytes": "0388cd10"
+                                                            },
+                                                            "v": {
+                                                                "int": -3
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "bytes": "c781"
+                                                            },
+                                                            "v": {
+                                                                "constructor": 4,
+                                                                "fields": [
+                                                                    {
+                                                                        "int": 2
+                                                                    },
+                                                                    {
+                                                                        "int": 0
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "map": [
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": ""
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "23"
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "int": -3
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "v": {
+                                                    "map": []
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "constructor": 2,
+                                                    "fields": [
+                                                        {
+                                                            "constructor": 0,
+                                                            "fields": [
+                                                                {
+                                                                    "int": 1
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "constructor": 5,
+                                                            "fields": [
+                                                                {
+                                                                    "bytes": "50e6"
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "v": {
+                                                    "constructor": 2,
+                                                    "fields": [
+                                                        {
+                                                            "int": -4
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "inlineDatumRaw": "a5029f44a41c2547d87d9f0142c425ff804117ff20414520a321229f05ffd87b9f2004437431c3436ec3beff9f423ec243c0a97142183aff9f22ffa543a4cd689f44baed95ce419820ff4003440388cd102242c781d87d9f0200ffa140412322a0d87b9fd8799f01ffd87e9f4250e6ffffd87b9f23ff",
+                                    "inlineDatumhash": "32e487ebaaf7dc1a9e42554a5c04e2abfeb2c58331eed5cc8f095d5a306d7eeb",
+                                    "referenceScript": null,
+                                    "value": {
+                                        "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
+                                            "358ffd2b8d3a9f445958": 7376087447175647294
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                }
+                            },
+                            "utxoToCommit": {
+                                "0401040505070303060705050301020605060802060700000101030207060704#55": {
+                                    "address": "addr_test1zzj2wqxr2k0z7a40qnhwca5quujfkzsvzdsr6p3e8eqqafm06v7mdkzp2jnuwj3w38f8v39lkwkjr24dc7k8qaakv6psak3pdu",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebe": {
+                                            "31": 8774495382857688543
+                                        },
+                                        "lovelace": 1159390
+                                    }
+                                },
+                                "0403040300050605000006050306080001030704020007070107000008070202#7": {
+                                    "address": "addr_test1xruzx6xg0367gxfvq4udmtk4q3su6nfavues8utxm8kh5x7yptxa3knqhvy0cen92v6548sp055se06pq2lq3qly7esqd60d88",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 969750
+                                    }
+                                },
+                                "0403060303030603000707070407000107070608010405050601010704080801#3": {
+                                    "address": "addr_test1wrl4sgh2vvfr0uuvz20qy8xxh2khgadgk4sl0lyutt0vqdcte8cnk",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "2d725128406dc832eb74c4709aca0512499b3c7b17e00d7cb2e6d1b1": {
+                                            "ea23c573f4d6cb263681dcf33e552fafeb0cbb1ef4179727a0": 2476615649994010028
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0502020108040806050004060402000005060702050706070201020504030806#98": {
+                                    "address": "addr_test1xqnf06hnyagmq874nas2d4n8x5hc5p8xfqlm5nrtw03ce29k0svycz5mx9vsskx05fcsmqm926ta79dqswlq43c8v4pqfsusu7",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 969750
+                                    }
+                                },
+                                "0506080107020400040803070208070803060403000801080100060100010708#84": {
+                                    "address": "addr_test1yqp5ppxyhfdlcpln7nv84z27talquyrdysrd2t4g5xk9c4cdnrlake6ykhz6ts9s6nqhk9vfhsxj7d8wy9g35d4rd0asmqkjsh",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 969750
+                                    }
+                                },
+                                "0706060308050806000607080107040503060104030305080503030206050206#64": {
+                                    "address": "addr_test1qrdg2gwumgttpjv4xqamkqyxtwa5gfcz08hdu3vvy4yntxhcfsrrmn0xuza9cf9xg84jwx45nxr3gp6em4ffyycv3c9swv8g2f",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 969750
+                                    }
+                                }
+                            },
+                            "utxoToDecommit": {
+                                "0001020505010403040305080307030308000805050806020603060503070505#63": {
+                                    "address": "addr_test1xpx5p7ypxhxszyrxdrvn8v4d9yh22y6xwh80cuclutyhy7svfwfykd9pkmqa7vn3s432qsxde6yh8z9plpwy7utr9wvqa4cr3f",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 969750
+                                    }
+                                },
+                                "0404010703050604010408050503000503010403020103030804010405050508#32": {
+                                    "address": "addr_test1qr969r2wmajsrgdw5lve4r6g3x2phep89e97tsea5juw2qh897lfflc4thpwekuvvsk0z75l97vtsaln029yaapc9r3sn529g3",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "6fc0e74ca8108215d8fb1e057ae1bff48674b584d32fbfc86f725aa4": {
+                                            "10": 8625980448639294029
+                                        },
+                                        "lovelace": 1159390
+                                    }
+                                },
+                                "0407000504030804020703050601010007060803030001030103080003050105#18": {
+                                    "address": "addr_test1zz7ypd3phqxa9u49lm5gqgdjjcpsmljp2khdpqp9aw43xyac874lkhnv4gzpcxu886d0y7zf6nq0hslhuzzgk5dg9qps2yz75s",
+                                    "datum": null,
+                                    "inlineDatum": {
+                                        "int": -1
+                                    },
+                                    "inlineDatumRaw": "20",
+                                    "inlineDatumhash": "ae85d245a3d00bfde01f59f3c4fe0b4bfae1cb37e9cf91929eadcea4985711de",
+                                    "referenceScript": null,
+                                    "value": {
+                                        "facaf431cc8b307abb78e28b87c3c90ae197e9363b47d434dc42fcec": {
+                                            "8a1a986774": 1
+                                        },
+                                        "lovelace": 1180940
+                                    }
+                                },
+                                "0703050106010704070105070802010806000505040004000704040001070604#59": {
+                                    "address": "addr_test1xzsr2ma2zdcxvclgszmarvrvckj9vm5dwtlyjdg3eexe07sy3pw9z89e6g393p4q5h85e696m5pdje3p2at6rsx2r0wqcf5gn6",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "b5d0485f9fa45ee2f4929e5d28c8824208f93b85604cd056cdba9a6c": {
+                                            "33": 1
+                                        },
+                                        "lovelace": 1124910
+                                    }
+                                },
+                                "0707000308060500020403030202010505070503060401040201050401000104#42": {
+                                    "address": "addr_test1yq78dheueuh4rkue026lseghrcsm6htanusnkq5r4gze66vsqawl5wdgejvkn5kssdqnhvun9655f9zup5y7p7da7phsyya8xf",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 969750
+                                    }
+                                },
+                                "0800060601020706000702000404050800080500060408020208050000080404#27": {
+                                    "address": "addr_test1qq2clf5zx7t4lcumn7ryvgh4eupvl5q6nqujxrwctnhm0wfk0pdecfyzdq3qd9dasegamdacyted9dypc3hgprjwksxs5kf3ze",
+                                    "datum": null,
+                                    "inlineDatum": {
+                                        "int": 5
+                                    },
+                                    "inlineDatumRaw": "05",
+                                    "inlineDatumhash": "fb3d635c7cb573d1b9e9bff4a64ab4f25190d29b6fd8db94c605a218a23fa9ad",
+                                    "referenceScript": null,
+                                    "value": {
+                                        "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
+                                            "f4f5c16f404554658e1b1778cd58f38c989b2312bca88929f9437d9a2db3": 1
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                }
+                            },
+                            "version": 0
+                        },
+                        "tag": "ConfirmedSnapshot"
+                    },
+                    "contestationDeadline": "1864-05-10T14:02:43.550033886698Z",
+                    "headId": "05070801000508070402000706050800",
+                    "headSeed": "06000205050803080402060401020805",
+                    "parameters": {
+                        "contestationPeriod": 83675,
+                        "parties": []
+                    },
+                    "readyToFanoutSent": true,
+                    "version": 4
+                },
+                "tag": "Closed"
+            },
+            "pendingDeposits": {
+                "0300040104030105060603060605070205020705080605030006040404010407": {
+                    "created": "1864-05-06T14:45:57.009466589079Z",
+                    "deadline": "1864-05-15T17:02:23.987912345561Z",
+                    "deposited": {
+                        "0404060804030408070207080708060807080604070203000208030600060402#63": {
+                            "address": "addr_test1yrg3sp78jfwlm7qevprydkwyua90qqz9h9rtssywwwy849df60nc73t2jdfnxaw3np0403a3sx3tqdur72hsd2fy7frskk536u",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 969750
                             }
                         },
-                        "confirmedSnapshot": {
-                            "signatures": {
-                                "multiSignature": [
-                                    "5b5834cd60187ff2acb633fa00b8316bf7fbef10bf9208eca55e1146686376ce7b5cda02469854434c476b1335da10016952088c9d8cb3d32c0249158f2df007",
-                                    "41e8816269ccf37e145ea4150b46675fd390a8dc063f92f7880fa037053907e3dd6afacd3e67963e0cfe8cdbed440a37dc61aa9cd09fedb6a51542ad7734e70a",
-                                    "6b5dfd6292cccae1a26a288c9678d3cfd15272104e338a08fcac37719ed79ea51ce8d8fa29c6054b38f3d178ad1e22bd7e1b82f35a1d1ebc3014be0115d8040d",
-                                    "b8e9540ebd9340cbfbda8b503cbadb3057161a9ed9ed61ed39fa1d0b870732c02b62f45d4204dfa558c4c739c450a12e4fcb15411ef249543f6bca7a196b0001",
-                                    "447dc88d243338511beab17744c95511722b71aec49aabb6f5d8a474cf2fc5406bfdc8958f0cb0f4777c329c42b17fbb3e34548be861fa177f54f5dc7e743706",
-                                    "aeb1fc06b4a0c7c20b89cb7208375bc9225df8c4613cb792afd86bf93025269b969687b9c99b5ee3cad5748dbc6897a97d7043a4ed8e070d8f4c06bd802d1704"
-                                ]
+                        "0502030801040808030800040004080200070802070408050705080605010800#14": {
+                            "address": "addr_test1qqtpyhapne9canftazjzte5jsg5egsga7s0f2z6gptuk3yzfgnr05kql3qz9wwsg89k3thcejjm5ag3tmqeddw5qmpsqj6kk8n",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0600010300050302000108070402010405060108080004060004000404040405#22": {
+                            "address": "addr_test1xpxseewf6hp2ut89386s80wld66dmxzkpmdmmlhz9dt5y33mjkxnws557udy8q65d4d7ckmqvndxtayuhruu834lu7zsmcr50h",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "aa40e664f7b61529fb9e190ca90bb22730362001e5589feceb7d74dc": {
+                                    "30": 6279512167005633772
+                                },
+                                "lovelace": 1159390
+                            }
+                        },
+                        "0701040600050606070501000001070307000504080801000107050604020303#50": {
+                            "address": "addr_test1qqcff8f4d7ds5snsplhqs4qulh6djwcm07yff6jhhs3ahu3a6v8ungzhhh7q6l5994fc0xv9el2zk84rhud8wu9ku0msdlmazu",
+                            "datum": null,
+                            "datumhash": "7e20d78a36385112cb1a910521157e29a6097965567811c18cbca2269772f474",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5": {
+                                    "34": 2512787775054208207
+                                },
+                                "lovelace": 1305930
+                            }
+                        },
+                        "0707010506030604080404080207010703080707080308020108080400000001#78": {
+                            "address": "addr_test1qp6h5mv4lq3tfwaanxpdr6wfnzlnge5j4jp678k8qpgp2ecerups75udsxxc342eudkvh9em6kegsezxvuqkw9xdzfjq0qyhzm",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0707010807010503030600060000030203010400040602060202000405010700#6": {
+                            "address": "addr_test1yqwe6fqnx5zlk6ur29qn4nlzmj6yp7dsmd0u0pv7lqpjg9d8y5gq6rg4ec8q5xuty44cjaxlrkknujkf9zhgmx6vtuxs38lmnt",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56": {
+                                    "35a11cda47f10da0166cb5": 7195818693770454552
+                                },
+                                "lovelace": 1202490
+                            }
+                        }
+                    },
+                    "headId": "05030206060108000508010206080405",
+                    "status": "Inactive"
+                },
+                "0302070005040500020400010505040707000103060003050408050403040205": {
+                    "created": "1864-05-07T06:02:11.99051498956Z",
+                    "deadline": "1864-05-08T13:05:33.011338721749Z",
+                    "deposited": {
+                        "0002010702050401010803070701050004030102030504010205020400040007#55": {
+                            "address": "addr_test1zr6kkx5f5rc34a9geq9w8j0k4cvq9k2l7sj2rfmgresw3znax45aa6avjyv0tgeg96jgjv78gewckg7ecjpztld4zl2s5g9490",
+                            "datum": null,
+                            "inlineDatum": {
+                                "bytes": "6297cccb"
                             },
-                            "snapshot": {
-                                "accumulator": "72d9082e7a61a3b6f1f8a666e2d36e7b2e38d842140a0f88d26b1aea4b2ffd9a",
-                                "confirmed": [],
-                                "headId": "00040303050500010105000102010107",
-                                "number": 3,
-                                "utxo": {
-                                    "0001010503010205060400070205020401060605020703020205050406060401#47": {
-                                        "address": "addr_test1wrf9xj346ztdrzpvyctlfwjwczffjjehty9xnmfsqpkk72qskalhz",
-                                        "datum": null,
-                                        "datumhash": "7a8940039abea00cb534b1f1c3d7d764b4b01af1c686c8f498c079ac9837e75b",
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "2d725128406dc832eb74c4709aca0512499b3c7b17e00d7cb2e6d1b1": {
-                                                "0968c43a306d335376": 6289290525155137373
+                            "inlineDatumRaw": "446297cccb",
+                            "inlineDatumhash": "49424a96a2aa97e0911d36611ef70a8161c76dd8c1d2f1cc886b339750633043",
+                            "referenceScript": null,
+                            "value": {
+                                "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
+                                    "d7b4a5637b5730a5451abea5": 1
+                                },
+                                "lovelace": 1228350
+                            }
+                        },
+                        "0106010503020600050503050701080403030404000201080307040208040001#46": {
+                            "address": "addr_test1qqtd6ruvr8etp6rcv6ura7a9vc5pytja0rtsl9mj4rujd5r7nvyvuquq5f0fly3c4703txc8gfrmdw3at44jdmtelemszpn3e4",
+                            "datum": null,
+                            "datumhash": "108305b501f80c91097553e51851782a7991b9343794291d882a1999e701484a",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "1f4444e1773d837b67827398a6335deee5644475ce251d3df113cea7": {
+                                    "6fa1fb94": 5542558594784149093
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0207080202070803010800080607060104030303020206080301050601020807#27": {
+                            "address": "addr_test1zzjxe097rt6gf5n74hgn2vv48g0kspejqz2jm8e6s02na9fkh2j746ggtxxfzphu4e0z7cze8y6hw0pt8n6zg43s33vqy66x9u",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 969750
+                            }
+                        },
+                        "0503050200060007050801060406080003080808000300010000040702060502#25": {
+                            "address": "addr_test1xqv7qxlange7uusg59lpkvhlst2rxt9w5mr9h5m898u3m9l6hjtxzc2tm9u3anjjnzpp5dpuwruw6gn9ga4753xrahwq5cw945",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 969750
+                            }
+                        },
+                        "0802010402020708000404070101020701080002030500050606020507050404#37": {
+                            "address": "addr_test1yz9u53n3jlqaam4se5xsafh878vu2clgnh4dfyunwyvr2pwnnepgjx2vcwmuwy9a00m0ksxfdejdwcpxd26undmh8avq4pjhla",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "5b1a85fe582d6ccccbcbeced51f03551fabfb03c2a11b62828b8eb2c": {
+                                    "fb9ef1771dc51e6a72593ce462666a147ffa33": 1
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0805060407010000080200030406080405050708080202000700020003070702#70": {
+                            "address": "addr_test1zqaqzwjendxrj8z9n546hy3zdknh6y7dx2ja4prgap90hhrtdfyk69w0pqrkc0mezumeht0aa3lx245g6ecnf4qsxhesrgn0sc",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        }
+                    },
+                    "headId": "08080403050503060004000806080005",
+                    "status": "Expired"
+                },
+                "0504060008070003060708000605030804050308000504040107000707080505": {
+                    "created": "1864-05-04T01:43:45.466657106508Z",
+                    "deadline": "1864-05-07T05:45:22.706889212036Z",
+                    "deposited": {
+                        "0101070701050603070205000500050007080202020600060700000705010103#15": {
+                            "address": "addr_test1qrx4jwr37pjydt3w0jeqqvz9edl4hxrtxm5yhn7fvxykh6vdxx4s4s6kjwfv8tsy6yawn24vrzxqs37r2599xhk9q9vqg6ys0r",
+                            "datum": null,
+                            "datumhash": "9c8fd66a84bd5d68b478e4e8e190689045adc83106c7e18c1a618af65679aec1",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "a9d9a33e7ca4ca0e25da3c8202f440d851f560f80221f4648c0a0f10": {
+                                    "30": 7673719374297616700
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0300030408010506020606080506030404040402060605070300010705080104#14": {
+                            "address": "addr_test1vqcpew0s58v9d7te72q0wdjsu89jymh5ladyna53lareygc3lc8la",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0403030403000703080407070701000001030108070502060600000003030000#45": {
+                            "address": "addr_test1xz5pxatfezs9hmlz09hjtnxmm44zesyep3ef2lsvw57nwf0d8e0kmv8u0vk9gctv9j2nhj05mxxzg3xu8ts9a4xjnqts38khjg",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 969750
+                            }
+                        },
+                        "0507070308010008000507070304000000060608040506070003020008040306#16": {
+                            "address": "addr_test1qzapsseawjflx0w826vs33xp2ps7qffjx977k6fn8ltup3vp4lq7xdc8ddar4e0s0hg2yf4kqwg64l87nlp6uf2nqgtqse60qt",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 969750
+                            }
+                        },
+                        "0705040302050101080304040700070006010802080007070700010502040207#47": {
+                            "address": "addr_test1vr6fm53s2srndc0pfdd20rxhw72l273ly5d3qyak6gm23gsvjd7jr",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "d13356d33e3e41f1d67a7e7800124093f4dc9bf190db816886139dec": {
+                                    "15a50abe56babc24ce9ca8a2": 1
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0806040708000803020308000502010107050006060506010307080802010204#16": {
+                            "address": "addr_test1zrh9pxtgrdysmmjd6zhrmw5wslte0pj344wzxrv7uwcavpud7mrsvzdtxt4dp5p36qk32j4k5p2lngx5pp30fm9656dsp0c0t8",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 969750
+                            }
+                        }
+                    },
+                    "headId": "02060006000307030405060604010607",
+                    "status": "Active"
+                }
+            },
+            "tag": "NodeInSync"
+        },
+        {
+            "chainPointTime": {
+                "currentChainTime": "1864-05-06T08:27:18.24782013665Z",
+                "currentSlot": 3,
+                "drift": 2
+            },
+            "headState": {
+                "contents": {
+                    "chainState": {
+                        "recordedAt": {
+                            "blockHash": "0503050803060702060102040501030404070406040206020408000702030204",
+                            "slot": 6,
+                            "tag": "ChainPoint"
+                        },
+                        "spendableUTxO": {
+                            "0004020100040701020003050304070406020205030208070307060602000504#94": {
+                                "address": "addr_test1zzzr3wlgfxhwrkxh3akwt755rf36yk6ge2cc4z05vdva26wr2s7ug3zmgfrw227unl2kta83z32yga08lgetclj88lesun4swk",
+                                "datum": null,
+                                "inlineDatum": {
+                                    "constructor": 1,
+                                    "fields": [
+                                        {
+                                            "constructor": 4,
+                                            "fields": [
+                                                {
+                                                    "constructor": 3,
+                                                    "fields": [
+                                                        {
+                                                            "int": 2
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "int": 3
+                                                },
+                                                {
+                                                    "map": [
+                                                        {
+                                                            "k": {
+                                                                "bytes": "d373"
+                                                            },
+                                                            "v": {
+                                                                "int": -1
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "int": 1
+                                                            },
+                                                            "v": {
+                                                                "int": 1
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "bytes": ""
+                                                            },
+                                                            "v": {
+                                                                "int": 3
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "int": -1
+                                                            },
+                                                            "v": {
+                                                                "bytes": "89fe3f"
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "int": -3
+                                                            },
+                                                            "v": {
+                                                                "int": -2
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "int": 1
+                                                },
+                                                {
+                                                    "constructor": 4,
+                                                    "fields": [
+                                                        {
+                                                            "int": 1
+                                                        },
+                                                        {
+                                                            "bytes": "91a78128"
+                                                        },
+                                                        {
+                                                            "bytes": "877bf912"
+                                                        },
+                                                        {
+                                                            "bytes": "14"
+                                                        },
+                                                        {
+                                                            "bytes": "f3e43c"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "int": 1
+                                        },
+                                        {
+                                            "int": 2
+                                        },
+                                        {
+                                            "bytes": "d971"
+                                        }
+                                    ]
+                                },
+                                "inlineDatumRaw": "d87a9fd87d9fd87c9f02ff03a542d3732001014003204389fe3f222101d87d9f014491a7812844877bf912411443f3e43cffff010242d971ff",
+                                "inlineDatumhash": "ad687bbf88c61eb8aa2c7ff05c8511e241026a95159bfaba2b096ab90601d951",
+                                "referenceScript": null,
+                                "value": {
+                                    "4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888d": {
+                                        "c7dd4bc90fa7c3b856": 5538856624208307369
+                                    },
+                                    "lovelace": 7500000000000000
+                                }
+                            },
+                            "0405000806070608070204070203010804070507040404010707040802060503#80": {
+                                "address": "addr_test1zpc56m7lssavmnf5lc583qh7yuxqlnwdksk6ty40za5nufchpd4twas6555y5mpm69msmkqv7pkn2j0xmteeel6jgm4svk535x",
+                                "datum": null,
+                                "datumhash": null,
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abae": {
+                                        "34": 1
+                                    },
+                                    "lovelace": 1124910
+                                }
+                            },
+                            "0501060205080807060400020203000500070302060504040401050205050606#13": {
+                                "address": "addr_test1vzrgpvmfdyu39u5r0ja7v7sf4ycdsv9thzajuek2pczk82c69lcwq",
+                                "datum": null,
+                                "datumhash": null,
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "lovelace": 849070
+                                }
+                            },
+                            "0508030103080501060606070802070606060608010300010205060708080206#73": {
+                                "address": "addr_test1zr9rzglv2nsfyx7g4lhqw57dnqqpre0srpefvsxpltpnza7kug3cq3muvxarrshwy6fwcn4wjelagk0fvawtefvy95psa0pyfs",
+                                "datum": null,
+                                "datumhash": null,
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "lovelace": 7500000000000000
+                                }
+                            },
+                            "0701050106050505020808040406030703040601060804020402040802000802#74": {
+                                "address": "addr_test1qq3xn3qe7qerzyd2wqwq8g6z258v22juafxraxams666c5hrs3p0k6d8cvnuce788sh9xzpr72870y3uu73vfrupjsfstyw5v6",
+                                "datum": null,
+                                "datumhash": null,
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "lovelace": 969750
+                                }
+                            },
+                            "0801070201030202050103060708000308040202030406000803020400010303#89": {
+                                "address": "addr_test1wr4la7jery4vw70jy98mnml230rj80pqvxlt6z2j6fjmh9c28haua",
+                                "datum": null,
+                                "datumhash": null,
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "lovelace": 849070
+                                }
+                            }
+                        }
+                    },
+                    "confirmedSnapshot": {
+                        "signatures": {
+                            "multiSignature": [
+                                "38b9a387a971325bc154959f5d1e964767df4de6d9a7acb881d03dbdf436c9a673df098e2325abb851337a4d4280a255b2f126ab1f6d1c8fc1cf8325978d380d"
+                            ]
+                        },
+                        "snapshot": {
+                            "accumulator": "ab9e2d5692c015c654f428bebb749ce70822729188a130344851bc38496dbef4",
+                            "confirmed": [],
+                            "headId": "08010102020503060505020703070505",
+                            "number": 4,
+                            "utxo": {
+                                "0003030300040106060603010802030806070306060204030205080705050200#60": {
+                                    "address": "addr_test1xqj64gw5hl3wp0z525nyu8vcksajmyp5ws4u8p6ejc43ll3samk2n6w9szctf23egjupm2ge3hxsxdscj7w0gzt3ddrssj2m9c",
+                                    "datum": null,
+                                    "inlineDatum": {
+                                        "int": -1
+                                    },
+                                    "inlineDatumRaw": "20",
+                                    "inlineDatumhash": "ae85d245a3d00bfde01f59f3c4fe0b4bfae1cb37e9cf91929eadcea4985711de",
+                                    "referenceScript": null,
+                                    "value": {
+                                        "4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888d": {
+                                            "1ad98d6f8f6f3d1a73c715": 1
+                                        },
+                                        "lovelace": 1206800
+                                    }
+                                },
+                                "0205020101040402030303010200080207030602060002060400040001020700#4": {
+                                    "address": "addr_test1vzpw2qwna45qmtp4mzllvm0r0y6tpkctu8uh7j84s5xs6aqyrxf9n",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 849070
+                                    }
+                                },
+                                "0301060103080803020304070004080800060308010801040206080806050403#13": {
+                                    "address": "addr_test1yqaz7wrreyd2rct6p3xdgy5g5ze8tsu7kr7nkcje5kq3l7hv9llktyylc3mxh48nj0stlttlhh3qgdzdw6ymh2c6ch4qv4et3y",
+                                    "datum": null,
+                                    "datumhash": "a488eff8575c2d22366422366b9429145a0e351b42cd09f8d1591e5c5919044e",
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
+                                            "c5578ede": 2
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0403020304030800070104030507050102030007070300080804070302050503#5": {
+                                    "address": "addr_test1wz9ulrzgp0arm8uqvyxfghxp26fe7u93yjncy09w4wkqctcklc42j",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 849070
+                                    }
+                                },
+                                "0503050401010300070805070301030507000003030208040000000706030705#74": {
+                                    "address": "addr_test1yqgx965smse2jlse89hh759wdg3eqtfwscyc435qakskd85c9487jlqc06udral4dphamx7hajmacep4d43ywynl2ylqflgv8r",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0607080106000303030704040804010605060406040508060604000405010202#94": {
+                                    "address": "addr_test1yrwvsrgvx8570jr5wprrse73d9uxvtqarseldlgspva7efk35kvzezvduu2c8kpdfcvx3m7zv36glquvme76mvzjp7qs460gw5",
+                                    "datum": null,
+                                    "inlineDatum": {
+                                        "bytes": "292cf8"
+                                    },
+                                    "inlineDatumRaw": "43292cf8",
+                                    "inlineDatumhash": "20c1820014cc3aaf1a22ad35ef25925ba515d6a1d63afb60ce1b6dcedd940aaf",
+                                    "referenceScript": null,
+                                    "value": {
+                                        "27a6509c6178657a0668a52357407bb77ded5d1f9bfcbe4071471a6b": {
+                                            "c67c7bc4a0df": 2
+                                        },
+                                        "lovelace": 1198180
+                                    }
+                                }
+                            },
+                            "utxoToCommit": {
+                                "0002010501050401020804040206040800000005050507050706080706010306#9": {
+                                    "address": "addr_test1yqylqwfvu07d6xwj7ga9rz27n60qx2282qpt28y3znwh3e0wxk6q3n7uqvn2tejg06fjtkrjuv3jjvu04a33zfjezpnqqj2j5a",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0103000700040505040603070406020705010708050701060707000306040501#49": {
+                                    "address": "addr_test1xqfusqpqfwtx6d8zqn28pavhnnpvn93daa3t3zy2ja3p0n9x4m92ww08stxwtd330t840k9atk9yka68ve2qrt4708rs3sjqld",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3": {
+                                            "9258b49eb237f28524889bc0cf9a196601ba18422c255f97cc6a36": 1
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0504000201050105030602000601060305070704000606040301080004040706#8": {
+                                    "address": "addr_test1zq286n0t3kfukaapz29vu3wwy5e6ct33wwjhc2sm0ev2glr9kah08c4anwecvam93csvm48lvrek57mpxkwe58fym77s5al0nt",
+                                    "datum": null,
+                                    "datumhash": "28a8dc58b669b8d113ed3232721d52239a5d21652f39b2ddaafb4d6d3ec74d45",
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "d13d536a083370e1130385bc7bf44d72d4c33d9f9b92a9a9bf5a02a7": {
+                                            "651fb2c301": 1
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0602050607040204040601070002060108050402010706050407010605030700#12": {
+                                    "address": "addr_test1qz2pfr2uuyjj2xchr8gzpgvy5ury0hkavjdp30pqaxu7sr7ux4qagnwlk6e80qjg6x9cq68xc60mzt58y2vqyklwcdzqsfd3lg",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 969750
+                                    }
+                                },
+                                "0708060105040000000802020603050204010002030001080402080301010508#46": {
+                                    "address": "addr_test1yz0tjuv2e8x3qdhysu4897qpvrel43p4m3mwn03m7wv6l7hx9k2cfkm0c4a272ggpsuy35erph4mawa2jytd05pyj38s4hf0u7",
+                                    "datum": null,
+                                    "inlineDatum": {
+                                        "map": [
+                                            {
+                                                "k": {
+                                                    "int": -4
+                                                },
+                                                "v": {
+                                                    "bytes": "f0ac5de7"
+                                                }
                                             },
-                                            "lovelace": 1219730
-                                        }
-                                    },
-                                    "0002010607030105060706040002060807010304030803020402040001000307#21": {
-                                        "address": "addr_test1qqnv2u2mstfvdzuwyakhfne0cqw2c69rj0cx3r34kw0kzf3ttv5g9eq39qcrz6ywuhsh8kfctyprrg8nlpsn300kz7rqnkwt0v",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "52d6adf7896fab1fcebcb6664db7083802f37e69fb938dbc5e303e4b": {
-                                                "b6eef37d030c5cefa4ee54594af9a3dd5b4190df2a95be74c06e": 15683481923915117
+                                            {
+                                                "k": {
+                                                    "list": [
+                                                        {
+                                                            "list": [
+                                                                {
+                                                                    "int": 3
+                                                                },
+                                                                {
+                                                                    "bytes": "9c4b64"
+                                                                },
+                                                                {
+                                                                    "bytes": "e3983bee"
+                                                                },
+                                                                {
+                                                                    "bytes": ""
+                                                                },
+                                                                {
+                                                                    "int": 4
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "constructor": 3,
+                                                            "fields": []
+                                                        }
+                                                    ]
+                                                },
+                                                "v": {
+                                                    "int": 5
+                                                }
                                             },
-                                            "lovelace": 7500000000000000
+                                            {
+                                                "k": {
+                                                    "bytes": "e1"
+                                                },
+                                                "v": {
+                                                    "bytes": "92fc4f"
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "int": 2
+                                                },
+                                                "v": {
+                                                    "int": -1
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "list": [
+                                                        {
+                                                            "bytes": "6d95"
+                                                        }
+                                                    ]
+                                                },
+                                                "v": {
+                                                    "map": [
+                                                        {
+                                                            "k": {
+                                                                "bytes": ""
+                                                            },
+                                                            "v": {
+                                                                "constructor": 2,
+                                                                "fields": [
+                                                                    {
+                                                                        "int": -5
+                                                                    },
+                                                                    {
+                                                                        "int": -1
+                                                                    },
+                                                                    {
+                                                                        "int": -4
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "list": [
+                                                                    {
+                                                                        "bytes": "f94d"
+                                                                    },
+                                                                    {
+                                                                        "int": -1
+                                                                    },
+                                                                    {
+                                                                        "bytes": "65"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "map": [
+                                                                    {
+                                                                        "k": {
+                                                                            "int": 4
+                                                                        },
+                                                                        "v": {
+                                                                            "int": 3
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "map": [
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": "987417f0"
+                                                                        },
+                                                                        "v": {
+                                                                            "int": -1
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": "8c"
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "c0a230"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "int": 5
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": ""
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "map": [
+                                                                    {
+                                                                        "k": {
+                                                                            "int": 1
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "d4"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": "d29b59"
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "14"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "int": -4
+                                                                        },
+                                                                        "v": {
+                                                                            "int": 3
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": "13"
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "bbe7"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": ""
+                                                                        },
+                                                                        "v": {
+                                                                            "int": 1
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "int": 1
+                                                            },
+                                                            "v": {
+                                                                "map": [
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": ""
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "3c856034"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": ""
+                                                                        },
+                                                                        "v": {
+                                                                            "int": 5
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "int": 3
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "8da4"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": "95"
+                                                                        },
+                                                                        "v": {
+                                                                            "int": 4
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "list": [
+                                                                    {
+                                                                        "int": -3
+                                                                    },
+                                                                    {
+                                                                        "int": -4
+                                                                    },
+                                                                    {
+                                                                        "int": 5
+                                                                    },
+                                                                    {
+                                                                        "bytes": "6219ab"
+                                                                    },
+                                                                    {
+                                                                        "bytes": "60"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "list": [
+                                                                    {
+                                                                        "int": -5
+                                                                    },
+                                                                    {
+                                                                        "int": 1
+                                                                    },
+                                                                    {
+                                                                        "int": -4
+                                                                    },
+                                                                    {
+                                                                        "int": -4
+                                                                    },
+                                                                    {
+                                                                        "bytes": "bb"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "inlineDatumRaw": "a52344f0ac5de79f9f03439c4b6444e3983bee4004ffd87c80ff0541e14392fc4f02209f426d95ffa540d87b9f242023ff9f42f94d204165ffa10403a344987417f020418c43c0a2300540a50141d443d29b5941142303411342bbe7400101a440443c856034400503428da44195049f222305436219ab4160ff9f2401232341bbff",
+                                    "inlineDatumhash": "4c3f87cb324da0204919bcaa9bae548171766cfbec67beed65cc3568a2bc3205",
+                                    "referenceScript": null,
+                                    "value": {
+                                        "105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5": {
+                                            "33": 7144313582522281637
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0800010507000801000500060206050500010605060106010101020305040405#30": {
+                                    "address": "addr_test1xzv4vpza5zn543uh5wzzxr9mmy7vrqkw93vy64gfltrlar4tq2lxnl578n46r0dxmcey9pxlsz9z6r7ttnd4hfn7j7eqefrerl",
+                                    "datum": null,
+                                    "datumhash": "445af999179e9ab84521e8884e93bf84e021204f994af52892f8e68d09dc3e90",
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56": {
+                                            "507bfe8e76c703c3816f325b887ee6cd711785e447dafb24": 2
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                }
+                            },
+                            "utxoToDecommit": null,
+                            "version": 0
+                        },
+                        "tag": "ConfirmedSnapshot"
+                    },
+                    "contestationDeadline": "1864-05-06T06:35:42.154504885122Z",
+                    "distributedOutputs": {
+                        "0001080305040705030506080300070102010505040707080704040304080803#79": {
+                            "address": "addr_test1yzdg8vc5vf9p64cr2twmr2na9fyymhfk06mtr73f6xuppmcn3q3gw0sq9kdun6wtvs6su5hexd8gc337gue4lj4my7nqgqarg8",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
+                                    "35": 8275907908828705961
+                                },
+                                "lovelace": 1159390
+                            }
+                        },
+                        "0008010404040201020203000100000608050105030803040300060003060102#56": {
+                            "address": "addr_test1qr6ly0dgrtz6cla0h8urnwnlq6kuwdaavlf0sgn7cmmaw42m8evkkzv594evd5s8ymf2vvmcq5kx4y8e6efalcrfumls9278t4",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 969750
+                            }
+                        },
+                        "0207030202060802040407080502060208060107080400070808020704010302#29": {
+                            "address": "addr_test1zq9j8tvfjd3tmwx7wgky589zhp4zwq87fd5jply86va5seerster0j858xjduhxmxslsvfcy26h7ezj53w5x9pc2g3rsckl72a",
+                            "datum": null,
+                            "inlineDatum": {
+                                "map": [
+                                    {
+                                        "k": {
+                                            "int": -5
+                                        },
+                                        "v": {
+                                            "bytes": "3e3aa9"
                                         }
                                     },
-                                    "0100020200030105030104040506020204020304070805070005080401070500#6": {
-                                        "address": "addr_test1qrukwaz5jxpry5nphfyef5h2fpd68m4fcww2qcyd08kn70rsuazuu8llkmsu748sfsamqgcsqs057cn2wus6rt6mtg9s9m3p5u",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 969750
-                                        }
-                                    },
-                                    "0402080006080801040200040305080103060806080100000103010705020305#59": {
-                                        "address": "addr_test1wr5z4h9eqxgxetc749kndw7un4x5e68z3yc9m5zpqztqptcks7t2r",
-                                        "datum": null,
-                                        "inlineDatum": {
+                                    {
+                                        "k": {
+                                            "bytes": "96"
+                                        },
+                                        "v": {
                                             "map": [
                                                 {
                                                     "k": {
-                                                        "bytes": "394b9c74"
+                                                        "bytes": "04e5be"
                                                     },
                                                     "v": {
-                                                        "int": 0
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "bytes": "1ffc71"
-                                                    },
-                                                    "v": {
-                                                        "list": [
+                                                        "constructor": 1,
+                                                        "fields": [
+                                                            {
+                                                                "int": 2
+                                                            },
+                                                            {
+                                                                "int": -3
+                                                            },
+                                                            {
+                                                                "int": -2
+                                                            },
                                                             {
                                                                 "bytes": ""
                                                             }
                                                         ]
                                                     }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "k": {
+                                            "list": [
+                                                {
+                                                    "int": 5
                                                 },
                                                 {
-                                                    "k": {
-                                                        "map": [
-                                                            {
-                                                                "k": {
-                                                                    "int": 1
-                                                                },
-                                                                "v": {
-                                                                    "map": []
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "map": []
-                                                                },
-                                                                "v": {
-                                                                    "list": [
-                                                                        {
-                                                                            "bytes": "2c95"
-                                                                        },
-                                                                        {
-                                                                            "bytes": "40"
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "54"
-                                                                },
-                                                                "v": {
-                                                                    "int": -1
-                                                                }
-                                                            }
-                                                        ]
-                                                    },
-                                                    "v": {
-                                                        "bytes": "a833"
-                                                    }
+                                                    "int": -2
                                                 },
                                                 {
-                                                    "k": {
-                                                        "int": 1
-                                                    },
-                                                    "v": {
-                                                        "int": 3
-                                                    }
+                                                    "bytes": ""
                                                 },
                                                 {
-                                                    "k": {
-                                                        "int": -1
-                                                    },
-                                                    "v": {
-                                                        "constructor": 4,
-                                                        "fields": [
-                                                            {
-                                                                "list": []
-                                                            },
-                                                            {
-                                                                "int": 0
-                                                            },
-                                                            {
-                                                                "constructor": 2,
-                                                                "fields": [
-                                                                    {
-                                                                        "bytes": "8fa4a909"
-                                                                    },
-                                                                    {
-                                                                        "int": -3
-                                                                    },
-                                                                    {
-                                                                        "bytes": "60bd"
-                                                                    }
-                                                                ]
-                                                            },
-                                                            {
-                                                                "bytes": "5c"
-                                                            },
-                                                            {
-                                                                "constructor": 0,
-                                                                "fields": [
-                                                                    {
-                                                                        "bytes": ""
-                                                                    },
-                                                                    {
-                                                                        "bytes": "98"
-                                                                    }
-                                                                ]
-                                                            }
-                                                        ]
-                                                    }
+                                                    "bytes": "33f8ab51"
+                                                },
+                                                {
+                                                    "constructor": 3,
+                                                    "fields": [
+                                                        {
+                                                            "int": -2
+                                                        },
+                                                        {
+                                                            "int": 0
+                                                        },
+                                                        {
+                                                            "bytes": "e1978a"
+                                                        },
+                                                        {
+                                                            "int": 0
+                                                        },
+                                                        {
+                                                            "bytes": "ca189f"
+                                                        }
+                                                    ]
                                                 }
                                             ]
                                         },
-                                        "inlineDatumRaw": "a544394b9c7400431ffc719f40ffa301a0a09f422c954140ff41542042a833010320d87d9f8000d87b9f448fa4a909224260bdff415cd8799f404198ffff",
-                                        "inlineDatumhash": "cafeef0177a4bdf1282e5b4d303e9b8b33425c306a8b1e8c17c3f10c862c44d5",
-                                        "referenceScript": null,
-                                        "value": {
-                                            "5dddcbf9502b3ea7263ec21c2c08c5f633f86fb98d3c8494c1742e27": {
-                                                "357fcd50a379a9c637c67e3e57b166091d407523a08d27527b74b6684da2a360": 7299448678553225121
-                                            },
-                                            "lovelace": 1482640
-                                        }
-                                    },
-                                    "0505070104010704070502040802000003030500080308020000030105070300#12": {
-                                        "address": "addr_test1xprvdeqxt3mf5280x7t8cpz4en5938qjh980la5gex5yeaglaxhyzkx6lh9vmqju7key76guukm5j705augzs86rnjhq89kfmw",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0808040607040101050601010303070206020401000203010803060200050502#85": {
-                                        "address": "addr_test1zqkdy5d3udg54k89v6ksn0gp9k7ls78p338xud4cnmq6zc2z2gmrpel3fkkydl3gdfcsxxxas99nckwafvrpnhzrtrpsuwzzel",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 7500000000000000
-                                        }
-                                    }
-                                },
-                                "utxoToCommit": {
-                                    "0105040104040603020301040704000008020004080608070604080501010507#3": {
-                                        "address": "addr_test1yrwqqmrnmktxurdauj8a76e7mk0ee8fnf0ynsyywcnzva4puq8cstk8k2nat83v02h2scl5yujtyjhd6g9hjktgyvm4qvh92f3",
-                                        "datum": null,
-                                        "inlineDatum": {
-                                            "constructor": 5,
-                                            "fields": [
+                                        "v": {
+                                            "list": [
                                                 {
-                                                    "map": []
-                                                },
-                                                {
-                                                    "bytes": "884d"
-                                                },
-                                                {
-                                                    "constructor": 2,
-                                                    "fields": [
+                                                    "list": [
                                                         {
-                                                            "bytes": "65b0"
+                                                            "bytes": "97f5"
+                                                        },
+                                                        {
+                                                            "int": 5
+                                                        },
+                                                        {
+                                                            "int": 1
+                                                        },
+                                                        {
+                                                            "int": 5
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "list": [
+                                                        {
+                                                            "bytes": ""
+                                                        },
+                                                        {
+                                                            "int": -1
                                                         }
                                                     ]
                                                 },
@@ -331,105 +1845,11 @@
                                                     "map": [
                                                         {
                                                             "k": {
-                                                                "bytes": "17"
+                                                                "bytes": "c2f1"
                                                             },
                                                             "v": {
-                                                                "constructor": 1,
-                                                                "fields": [
-                                                                    {
-                                                                        "bytes": "e9c49c"
-                                                                    },
-                                                                    {
-                                                                        "int": 2
-                                                                    },
-                                                                    {
-                                                                        "bytes": "a03da6"
-                                                                    },
-                                                                    {
-                                                                        "int": -3
-                                                                    }
-                                                                ]
+                                                                "bytes": "dbd0a2"
                                                             }
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "list": [
-                                                        {
-                                                            "list": [
-                                                                {
-                                                                    "int": -3
-                                                                },
-                                                                {
-                                                                    "int": -3
-                                                                },
-                                                                {
-                                                                    "int": 5
-                                                                },
-                                                                {
-                                                                    "bytes": "32903096"
-                                                                }
-                                                            ]
-                                                        },
-                                                        {
-                                                            "constructor": 2,
-                                                            "fields": [
-                                                                {
-                                                                    "int": -5
-                                                                },
-                                                                {
-                                                                    "bytes": ""
-                                                                },
-                                                                {
-                                                                    "int": -2
-                                                                }
-                                                            ]
-                                                        },
-                                                        {
-                                                            "int": 4
-                                                        },
-                                                        {
-                                                            "bytes": "f548"
-                                                        },
-                                                        {
-                                                            "list": [
-                                                                {
-                                                                    "int": -2
-                                                                },
-                                                                {
-                                                                    "bytes": ""
-                                                                }
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        "inlineDatumRaw": "d87e9fa042884dd87b9f4265b0ffa14117d87a9f43e9c49c0243a03da622ff9f9f2222054432903096ffd87b9f244021ff0442f5489f2140ffffff",
-                                        "inlineDatumhash": "6b070750b9012dcdc2312bfd9a9f115639a84ec4e0236327a114e69d28970d8e",
-                                        "referenceScript": null,
-                                        "value": {
-                                            "4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebe": {
-                                                "9c22": 1
-                                            },
-                                            "lovelace": 1422300
-                                        }
-                                    },
-                                    "0202050708030408070406030208030202020005020206080106030207050301#88": {
-                                        "address": "addr_test1qppfv53ye3vv8xgaav73vus7ya4ukv5whzt9y3cy5edjld8t00rf96kr73lurdkm7kzxcxy6s5pqvkv0pa2mymn3thuq0v6gqg",
-                                        "datum": null,
-                                        "inlineDatum": {
-                                            "list": [
-                                                {
-                                                    "map": []
-                                                },
-                                                {
-                                                    "int": -2
-                                                },
-                                                {
-                                                    "list": [
-                                                        {
-                                                            "map": []
                                                         }
                                                     ]
                                                 },
@@ -437,618 +1857,855 @@
                                                     "int": -1
                                                 }
                                             ]
-                                        },
-                                        "inlineDatumRaw": "9fa0219fa0ff20ff",
-                                        "inlineDatumhash": "8104e7b53136170772b3299d7c3c914d6f0abfb5c108d63ea4ea1734b7f51e9e",
-                                        "referenceScript": null,
-                                        "value": {
-                                            "3b7d8de110c390b94cec645604335a28e2b28c2527f35fc314beb22b": {
-                                                "1ae795130b3da0162163a8786c": 591483495980605242
-                                            },
-                                            "lovelace": 7500000000000000
                                         }
-                                    },
-                                    "0206070603060500040500070708010303000006020100080806050402030708#18": {
-                                        "address": "addr_test1zp7s50swmrtry48083cjuk3m4guqtvupcj6qmxs95wl2ht6yuqenk5f964ejrpgchprlglqr49tuqfluyer5shzryshqcgr4px",
-                                        "datum": null,
-                                        "inlineDatum": {
-                                            "int": 4
-                                        },
-                                        "inlineDatumRaw": "04",
-                                        "inlineDatumhash": "642206314f534b29ad297d82440a5f9f210e30ca5ced805a587ca402de927342",
-                                        "referenceScript": null,
-                                        "value": {
-                                            "48511d556f58e0c90f66476267d701e9a9bca02aa1631254915d628e": {
-                                                "f36b61f929905bb3d371c7aaea12f34a8769406fed0fafbabb17c5b580": 7218209109756198128
-                                            },
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0300050407020005030001050205020503060807040606010205070303000608#93": {
-                                        "address": "addr_test1yzqamwwtf8mlxu60085lt3tau4t4rayj0wu3j4he5n8qhcae5euxhxfz9wtw7d22kzgs3n5vd57yx6ggqlnr7w9xzses9fppl5",
-                                        "datum": null,
-                                        "datumhash": "5d7f72c0f292273497d2052a0aea1c5e92e061e88bef49f70c30ca92445273d6",
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "e7e838611338f7aeff9ec09f71e9f436413fb59a3a111af3201d0ade": {
-                                                "8f3b5ab164cd6c167b569736f6ffb52ce2a5433a": 5373489491622056920
-                                            },
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0703010507040803020701070501050306050408000107030607000607010206#82": {
-                                        "address": "addr_test1vqtwjtp4e77caweavms90dja2uwagajqzr8zgv5qcycuk6s7nr09y",
-                                        "datum": null,
-                                        "inlineDatum": {
-                                            "int": 4
-                                        },
-                                        "inlineDatumRaw": "04",
-                                        "inlineDatumhash": "642206314f534b29ad297d82440a5f9f210e30ca5ced805a587ca402de927342",
-                                        "referenceScript": null,
-                                        "value": {
-                                            "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
-                                                "4fdd80d31d7fcfde34fadda61b376cdedc42ab4fdeb6": 8194907741767195066
-                                            },
-                                            "lovelace": 1168010
-                                        }
-                                    },
-                                    "0707040805060707050300040006020506010806010606030700040402040507#74": {
-                                        "address": "addr_test1zzsgqs50tjjyj7m5nggl6g8qaz3zu94j0njl8mjv0l78wn2wa8057zz2mzhavna493q0vulpy4t5uc0qqy7muzcf5emshkvzwd",
-                                        "datum": null,
-                                        "inlineDatum": {
-                                            "bytes": "04dc4e"
-                                        },
-                                        "inlineDatumRaw": "4304dc4e",
-                                        "inlineDatumhash": "33b86ceef8ab0a3c907e6a05a9afbcebde2466b6bd719028493c198b85bd5135",
-                                        "referenceScript": null,
-                                        "value": {
-                                            "111c67357180b955b8ed4be3c7961f9786ac23ef8a1c5e60fca36880": {
-                                                "9465a437bc886fd1612a255a553073": 1
-                                            },
-                                            "lovelace": 1236970
-                                        }
-                                    }
-                                },
-                                "utxoToDecommit": null,
-                                "version": 0
-                            },
-                            "tag": "ConfirmedSnapshot"
-                        },
-                        "currentDepositTxId": "0106030108000408040208060708020706040504070702010805070504070600",
-                        "decommitTx": {
-                            "cborHex": "84b100d90102800dd90102858258201f83f23373462188d9bbb1e4e545e20151a2ff3753c22b656569d552d47c1e3f08825820205fc13780466d8b4580f68f1ed6514cbaa40232f7ba1e3ea9f8fac54b6f987508825820214076185a60230f83aaaecff697a099d4c5a80edb3e259eebbcc2c36170232207825820cd345d7ce623585f3d0dcc83785bd0fd3278b0f4337f5d688ad09c1c2951af8904825820de662ca48f396f8e2e732fe51b64ac4504fdd8b638d33fcc4d1a24d48dae7cbb0812d90102868258200909f56c3e296abdc2f508ef947b038820da83a95f0749813f07ec9206a16f730682582053092e77f539f1bce8c90cee830c3517a4382555bf3e0299f2110578799a3757038258205814aa9d451388bb99b1a9e53a481f24796c11805065c94744797d18d34ff1aa0382582089f544798faaf49d867a66c2641dfc9d30a86d351de9622f717cc65d5a471b0c03825820d552dffa7ba1f7d4e3d826214b97b7c48a03aa9be3ba442962b41bf310b90dbe07825820fa2fb49a7bc215115c5a849534c07702049c5b17360b586cdca26589b2f3d752040181a300581d71a97cb5339fd2ec973afc2f136f42e8d1973fe6f04afbdddb1b857c80018200a1581c077da60a8d3756c467b700ea1c96d7724e2f06f1692b999ac2352ccda15819a8c49e49d6380402feff441a55ba6d2acf7864769aad100f390103d818582282008200581cd43e11ab466f89a9530fbf088ecc9dd0c8effb8fdc1c0a1d6210708110a400583910f74343f74c479aa208132fa9e34a70bcd4697a317d23ff642adf65c5c46c6ff72982bacb396af046a2ad2b293fd5a8fc60c779bf46f0114f01821b1bfd72176d82ce96a1581ceb13380d6acc1df061ed35fc13c4c785ef16dc6e08a4665bdb520020a156fa1f3f26225d9fe167765f56ab53c3b06a746b3b78311b515a8a67cab4e1c40282005820f1790a57cc3c9429670efb65f19b53355c2dce099a85ae0a9d9056a053ba32e403d8184b82034847010000222001010206030104d90102828a03581c47c2dd223799c12af7eed83c2645e76376109b44664b164b5110924c58203782bf503e470f1da999afc3a9cd088585d003978813ca41622161e5db463efb031a0004fadfd81e821a096df9c71a9502f900581df006d23a8a7cfb7cfad0b3464f28539215e37e5a912a4914e10fefc356d9010280818202667a6d2e636f6d82781a68747470733a2f2f2d7249656938576e524179786e6d2e636f6d41068a03581c6fd369fc5b8b50d470a40af9e3d012ee090f902f9ab68a8a2d4b98aa58200616c3ee04980a135742aa405a0bae58c2215bbe47cfbd413b12cd6320016e780005d81e820001581df1457bb9fc2230e0496d515243cb8758ec84079b4291125118428281b3d9010285581c0b5fffa6f355c2e81bb63f49bde6e41c5882b49dead04422eea781b3581c263fe8611449e3b4701fc84d9759956fcb118a18d4c9d495aa59c1ab581c4fed69a3faffd87ff2adfb62f4035df32a71406a490269889e6855fd581ce1799c6d54a0f0e26c9e1eef5146775ad737aff701a3dd105f77fa72581cec409f2e864021da92d2078819f17031822859a091c735e07568ac6786840004f650000000000500000001000000000000008202664f652e636f6d830103782162766c41364a41414d4e52594d4c45553473484448505a79355a6a38332e636f6d8301f67828766b6347467357302d2d374c7a774b342d4d72674741485a59304c79377a346a734844732e636f6d840000f650070000000600000001000000020000008202782a36384b49664c495961596e67384441436f656852322d4334615367734851386e6644304848392e636f6d82782168747470733a2f2f4d7766474b5675426f7a525256474455594a46506d2e636f6d4308010805a6581df07374a3e321508b4db93a2c77899ffc1d270763448e1bc7b121c65fa604581df0ca6a810107316ffe7cb9223a033011e909d23a051b115f43ec95a1d000581de043a1593139f32276ae020c2024638809db18c6755a2567599dd0f9a91a0006b2ff581de0f93be9db6e32bd27a6fde7225c057153461a73d55f6076e96cd924091a00018f87581df1af73aa0cd9802a57be77ce63b767a1f5c078bd62305106f3b7531cdb1a000ef0c5581df1d6f3da9f6f54462eb992b33db5cce2813047ff2012afc77f306de8c319d54d08010ed9010284581c04fffe3c831f5ff9b61318c76a3793e5724150fa403bbb50cc049555581c252f8ea74045da3a4b7e6c338dbb00b0d43aa0a9c06a27fdee155ba1581c6d0e2b584df632f9536db8a0052d8483c3f853abd7a09fe7148b7ddc581cfc7cd755a520dafb85512c139bffbf1f34917bacb1df03fd309743e909a1581cad188ee91ba00d0fc04d477b81fec405730e251fd8b96130f09e8d4fa1486c0dc6e386b8790f1b5413b9710ae79d820b58209c59f994397e683c182703124873c609403d768fb0e63b49bda67b64e998558c0f0113a28201581c7e6c7112fd64a15d492495a5287bf2b2e94218db571fd0bee4f43874a382582034aad29120998758341ca4765119c7d6774ba3b240cfade4d7410902e0d87daa078201f6825820ae95e1574a16f4f440118eda0783ad4baa6e79a0292223ab5b6965bbcd2526fe03820182783968747470733a2f2f7478664a3376596439732e394f303639447063336d38444673434448707135654b667352384f304f3077344b5a2e636f6d58202e987a6f18b816a632e0f9bca33990c1a4ce2bcafdbc0d21e6dc131e8e9fc01d825820c53b9c94ab2d13266396fd1d64e7b99ea9c54d0a6f30c2250058bba94b57b30b058200827568747470733a2f2f51614d474c4139654e2e636f6d5820df8400093d8796d0a2bce5abd917cde4c1ea4919bab4b88ddba023313232a8428200581cf9dc154e3f02f30b4fda9fca6d1057d5618919fb1348c56936659676a3825820115ad681d5f2e9d60ca4ce8442303b1a6eb1e286afc1c7d895bb974659ba86a7028202f68258202c574c2d3cc40071efd4328c43b29cf64029721919cef759cf5e0f73329cae82028200826e68747470733a2f2f41712e636f6d58200861dad6b4500e05560a4717b55df8fecc36ded5492b82dec0ee576dcb8c24fb825820be4abfd7284d61d9eabbf265be26aebe90a1f00c9429b2eec702332d01fa61b604820082781968747470733a2f2f526f5179776c6d4d51387164582e636f6d5820bc2e9894ca00e5c28b5da384be52aa317b72fd33938edd9b34546eedc719529614d9010284841a000b4f0a581de183e58f5fcf73bf95ecc3066c14c9f51997e9075fcb604ded1db2b8868106826f68747470733a2f2f4e52472e636f6d58201618c387809139d61b37097f88d33b07f973114c92b01a88f3830eaf7c0c395c841a00020621581de19f362c12e7886d60fee11108f370fc5d0c2a74a10ee7e3a285dfa6f28203f6827468747470733a2f2f52344a516e6650682e636f6d58202553b1f54395d90245ffd0232d2c276697829d3c03f1be4642a763269bf0c9e7841a000bf1c8581de0097899dd275f1b87be3d4ff9a8db6bd3eac4342fd4681e083d509a268301825820f50df44388dd0cd72a7d7b8045fa7c48619dbe63b8a203c137a315ad4efece6803820903827468747470733a2f2f66793466626335432e636f6d5820025be1ba4021a7ea6134e4964c7040c4e99253c532eb2ac24cd7961b825545908406581de02b61cce5e83c4fb0bef137d57c45c7408ace4a70b3ccd55ba00bd669820382582007492df5d86ade299865b91ba0b00b1baff968e5c7047b5968ff4492299cc6830682783468747470733a2f2f6344717332786f4d716a784c417651554f4275353873465a7448682d3269387452634678613931312e636f6d5820494f47c01c4063afc8029dc92b70cf76e4b9141f8220be75c662dc3a59d64266161a0008bc48a500d9010284825820420d79baafdb3f2b11dfca33b41b282f27204acc5c0f13a89ad6ecd7621339c458406e8633a042185076a89c9a9225ff3a0f70772df5a9f5351fbccde70e48f1639b35553c759f61776db538820184aff702b6a0fd76ca9107ff27c06429963972ce825820f69519b8ebc51dfbe8126c8163fe87073e5779d671f428605069c0e0d59766345840f116a78b2b18e817d34e47f366fd6636b2d02a8f65063386180af78efc0210026c1742b126ec2dd7bd103c0e848cfeddfa1979eaa7117a5bd9b18967070617598258206bdfb611e12f85c4511be46e638ce2e792181cd3f18c29310a130b0f2b715d51584005cfceab2d844943976a32d82f364176ee89f6807193c0661c65d3627901c2ad6c620436a446c29f45e02e4b03480d87b58bc1ad74929fe1860c86fad1bc5132825820057b6f9687887f73e9d921556a6325a02b414e37fe8f68dd41a2a834a03c59a4584059b86087ed374bc84231fbfca69e65b158755f1c5ec7c08ff41812724b2c90d53f82c20355605f9ed0763c564b97658a68234fee4566f1b6b06db7464784868802d90102818458207a09fc31de614ef36923dc6be1622f6486d66ae41fec871465419cf9e0bc27c45840ab32c068559fdccadc8e6b5b6de9290ba79a726f54e4b26b1baef3e9d7e40e6967c2e608fa9d2603ac38b51e4245de15e108d8f8ea01363a80c11c3cf7c9ff0b5820995ffe57f84fa6cec3974edff569eff7c90aec11d68b328f6169489ffe3b1f244431b189d801d90102858200581c97a9d2cacfdb3ccc644f09966f136acf4f48465a840a35b53d703ea88200581cec48c67a2e8d6e8e9197eba82df91b7d498667d0f96b4f3a4977a45d8202818200581ce6ade6b124ff53ff006f23c24ae9e79c553f16ac6a749f1b35a6e29c820183830300838200581c0ca253d5245b087547d65db5ea96b84c4d7f151d2118e91fc9d2e43b8202828200581c671c75fb6268f39b64a34608f0ba03acbaa18c261e2cd55266e1b0928200581c8deb9fc3067136b4c7b910cc2f02d4f175673195f784bc390479be728200581c699cc00fbdac95a9256492e61690e7357e6016071bbdd1eba9eb72b783030184830302828200581c5ff2e1cadb60d0102473c0a82d185d84897fe293d4cb1595d6a5ede48200581c2a57c02610168ae8079aa5cbf61a5530165c0965e2328d1cf94f62468200581c2f94d5dd4d223d7f1515ece5c5b0e5fc760139de697bc42d59b6b1d9830302828200581cea7fd60ee8f844bafdb0739c4d01ff271c09156a124ece63327fd1368200581c08c18f1ce09d68c941bd798908741fa5c3eb97e28a581bcfe5b79c658202838200581c93d7725a8a1a2a1f0d4486ead6793316ecd49cd6d36d9d7db5a430c68200581c3300275576a99f147ece4a068df187a0b747a30ba48c3ee8810627208200581c24430707553e6915bd0e35f87cdba625fc69dbca10be2b115a262f8c8201828200581cc9b01935eddaa3bf8a2b6021d323737101bc1c38d4e1e7d3bc48087f8201838200581c91c72992ca6ef22613afe837608091a92eaf263193241b336d1b7f7b8200581c9bb3f5c31a8384a193d38c143ef2c5f4585388bcf38452929ead58c68200581c1a2f3a3ffbbe04fd0137f1d1388c60149ad6852d2b6ab0ce7ca535ed82040f04d90102812205a482020182d87c9f219f9f0542731701435421e7ff9f0042105e2301ff9f2143bf5c9f004235a0ffa12443905796ffd87980d87a9fa5442d8cabdb42f6294100412c435869232342ad1c43514d3442dbbb01d87b9f42b06720ff9f0222ffffd8799fd87a9f42131841250241cc44f0a06926ff04d87c9f0501ffffff821b1df1fcc77e8cdcec1b7f8ea48e0bc1766d82030182a2d87a9fa242cf2a240201ff41fa22d87b9f40d87a9f418344983c9f07ff44f7280b64d87e80ff821b0dca9c0b9992d58a1b640e41a9f1277f2682030782417a821b0ac86fd3396b69d81b3cb0775319b1190a820504824319ad52821b63aaf72595aa17e31b2cd80f216f932181f4d90103a0",
-                            "description": "",
-                            "txId": "1bd6cb95cfcebc7922edd074c5b61724778af853bcb7246ad22db41cae8217ed",
-                            "type": "Tx ConwayEra"
-                        },
-                        "localTxs": [
-                            {
-                                "cborHex": "84b100d90102858258200643792c908d1a998907fbce2faeb668ae25a64a4d3f4eb19b0f1991c83024a60182582008089c211533869fc2a8cf8d8806797945e44d6b2c092cf0ec8d5e2d305f179a0182582017b9c7a14bf8ffa36ff7f731c66eeb40c602a7343ae83fa0306b9c58a14574490382582084be165bcc84714c6393e23b16fbfafd184c0d5482ccf83d9218eaccb773679005825820e155e9fb18e67332fdcd909d1641f9c50eac60b832d767388a5769d398911cf2050dd9010281825820dade82a517cd742fe82282a7bf1465c059ad300918ccc7e66fdfd01e2804e9d50312d901028182582047a5059f2a1d24170a30b52567586b5ddcf4bd8bae4bee99ff60a01579b4973d050181a400583282d818582883581c7bf5a9778794dbb3828a27b226e5bee172c3e68b415f3171f7d7efa2a102451af3feb1f5021a075dc090018200a1581c4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888da141301b0ba3278d8645e9b1028201d81843421be503d81845820082050910a400585782d818584d83581c9ebed270d5e94c41f537f4ffe1b67b0ec97ab5099533774ac0bef176a20158225820666b716f6f776661657a64726a6d7a6b72766d6b6970767575636172696e6a7a02451a1adae8a6001a0026450401821b5406585e293474eda1581c78c0015aef30f65bb4a8a58a0877582f43328777e0940e6eba3411efa14f47d217e2011e0d25daeaabda90071c01028201d818412103d8184982024645010000226111010202030105a3581df15e605b26c6b6022d284d60150627e9dc7fb9f486a4e7e03d6a9013e304581de101a910c4a2510536d5b7846cf18545143ca492d33609bb399968b1fe05581de13fccfc04eb7ffb7de6a18a613fe4583e511979caca2b32ab3610eacd1a000cd46b0ed9010281581c314b2829d4627754071391adf7c38ca85f98fe11df5bb79c30625b7f09a1581c886ffc92c308bf9e60702fc1e515009d343181b606e54ca270b53bf2a141383b63ebbdab931587e60b582002dd0d76be853f9c0241cf4fdc4185993a7904981b43a551eb1b3d53044e5ca8075820a345281b436c3e4eeb8775f3fcc8bb815931a88a90a233a750c3009ef1f2c86e0f0013a58200581cfa9c2bd9b2d594eb036557373a6f5ff2ea3a985f5454bfefa82423d5a4825820a9a0458959b8d545123608052889b07bed6ba8d2c10725f437b5d1185863912803820282782068747470733a2f2f76637369624d50776732676e714964736a6138342e636f6d58206f18fb08bd4d618728ce1ede68cc507d85cd4d316d647809706452fca471ceac825820bc6075ca19d0b3acded1640b0900a19af276c2663c39bb81735055fa7aa6a86c07820082782368747470733a2f2f65504b496f686f67485443796c59365a2d6f79523049302e636f6d58208c7f84b3c0483144dad85f4cdf3f796486d1cd9298fdfdb0a6602e5d23e94417825820de7d8d5038781d38d75e83c9025a6ddb2250ef4febc4272771d1c2f69f97dc3407820082782568747470733a2f2f6b4d61537a34304959375269557030447344775852305743622e636f6d58205bc53f4b95ce53e6a52f5ca5091d4297f263e2fef02f59760c540690319e4ae7825820eb9ec81378e5ce9bfd760479883a3b9cad1b4fe85d261e1a8adb8ba910144d8a00820082782a68747470733a2f2f72356c4f6b4e623979502d4f33656e4a654f7564434f7a423068306e504e2e636f6d582064e001b15eaae56b8f28fc46bafaf706ee22a6e4195a9912e9c41fdd71f9fff88203581c10fa5bd13f95cc2344894e2939a85c57dab3c64ee7204da71dc31eaea18258208267e80a98d6cfc399d1cfaac7a4dc3fccfa5e2cc8372f2edaa45d345354be2206820182783b68747470733a2f2f77493442386c38582e726f526559442e6e305a7737524a592e6b424a754d7345545271617a397335357a724870656a2e636f6d58205f77dffda0a8b246e0ab9795f05fca15de1b2fc04b9352e5b53dc0309209e7a08204581c31415d24b456ba21b32217b059babafedf32cee8f26386749b4c1129a18258209c553b15aff2b624be51434c1a1a3641c867a89724f9401b2f2377bce967da5005820182784068747470733a2f2f6c414b2e474d566f6f44333961425668376b3872516f476d6362586f594f7962796361684d557079726e336737364663615865392e636f6d5820fd73d350f1487961a9984f04f0d06c0c53979b34a2c7e8983dd2922a2d6ab7ff8204581c803d3ad1cee851f9110cfbde0da8c4aa9409eae2b01c9944d1d5ae6ca58258202ab25dc97673348310534340c4da1ef74c94cfed8642f1cf77562ee4dfd8c8a100820282783668747470733a2f2f346f453671595349706a57545a654f4a514371336a306b4c78432d6d315242392d344a584335594773472e636f6d582012f5bcaf7791771ee99ab76b9277af8a69e4b8c4b55318d42d8c1cf011a237ca8258202c6e6c1367ccd8db20733c7f2939d59faad5211c279cf8ff8d3228268497c6fd04820082783968747470733a2f2f63715a6c664550666a643568723047482d767a7a4a655344595044376d36647a69484764365958714e50662d512e636f6d58208774f9d7556bb01adc2569119350c9f6f403a44d3481eceb089eeaf6ded5477982582036100c439866752e30b71345509b2656336c4dafdf7c47cf7aa907e1c88991dc06820282783168747470733a2f2f744c6b73675456692d7550756b4c52587230647575616a645a504c482d41794132533342462e636f6d58207412c67cb53a6ad29eb6a9971fe35cf07078f4b8207109fd741b4170d96fb78a8258206bb56f9e9fb7bc539b7cd5541abe7f142a7895234c6c819e8a417e26c8f2af3106820182782868747470733a2f2f4d62716c456b2d617637564a7654512e7335736f6b696f65477277542e636f6d5820718932953dc3f704b0c5cc3240eed7b6962724f1730c2e02bf0c8d168fc856b7825820b4207e0b53126d6dbd29f06b017ed699442a0186acfa7e67b86cee5ffad0071c05820182782568747470733a2f2f615136364f334f6936587549685678306836515534474162632e636f6d58205d281937193686174dbba7467c60401eecb9eb55acbb66b6e595bae0c66bad1d8204581cee9bc87a652be66808b2474c910469c58a8954238710a57ad49dd66aa382582006d453616198e51647f3354a6e1a74fae60327995115d41a076197c3d22c2b5f02820182782368747470733a2f2f436c725147384b35427554674c5a2d337a6750466364622e636f6d58200a4510e724bb98c69f43154bec4e74390988b819fb372d5a8084317e99edfef782582020f5d32ad69f8575c69e002f22cfcf8158d6279a39f17c9499184b18a9504dbc04820182782c68747470733a2f2f46673055514e655846424339305663554f4c667862626a72645134467a3762472e636f6d5820f2595ef7f4ffc87065b5e5f06d3b00a1f4efa7a5b3b4f1e64fa712e64f8bf14782582053af48784b55d6d7e11ebebcd32f4e9e0583075a39561362be6ee4384b14bcd8078201826e68747470733a2f2f4c432e636f6d5820ec60a2b149373f8e0e973f58defc1f59c79ed3cd43bd9d9b77bc13420527d4b114d9010285841a0001f6ca581de16156dffdb65b37698f2d58b125d1d5e7bc8a5ad133653fc65f86d4928301825820c1e81a9956900b2c486039be36b278f50089aa0776ff85e0a60e4b6499d0c4e207820a0482783268747470733a2f2f515451544d2d714e536c796f486a445a43625a754d625171506679724555326f3174533641352e636f6d5820da8ea1f492f035ca91b317436b209d8d21a64a3355dd1e0f481b0e57140108ef841a0005c054581de18e7761a2ea975f6cec85f2b2a6724e48180d7bc7557bc481444122038301f6820b00826d68747470733a2f2f732e636f6d5820dbe534abe8fd41097bcb4e39afa12e8c17c594b0ddce3257f4636aac1039278f8404581df0b3446cf72642520377096111308a8be7966ed2d8f53343cfc64677428302a1581de1a32f4cab724f4d4077a7ee6cf4c4251768f0807f2934aea8183a2a991a000effcf581c5bbc617b1b5aa2bc7da7fbae1601840dfdbce0f8ea2df0e17df77e8a826f68747470733a2f2f62335a2e636f6d58200dcace52f306ef0ea06483ffabf283c7ad7030fcbfaeba55c3df6e73e7549e15841a000e7d65581de1e73a2feb2c3c53f66decae698e831f8d64bbf5ad78e7a35f7197f5ea810682783068747470733a2f2f42392d2d3879496c654e75456f427859516a7954736d52723176464867582e50317744382e636f6d58205ec58d97ac9cb747ba51ea4a10c71d4f4957ef37e580f8e09a3fc2999166ea6e84191c23581de07fbdd57e567280b3724c312b353750e095e1e4fe6cb1df5203a773ec8302a1581df0434a81f9822ec934fcc11bb70dfd85740a30ba6dd7f7843cfaff3d8a03581cc0ab2c7ee0910f2d61d060b9a2ed95e7f582c58a544ebbfe8663527b82782668747470733a2f2f6b6659354f4f65456f646234463330797a7768386854433778512e636f6d58207e4cbc1e937bbbf251e31bd79bd634cde6102ed8a9e30c7e603d86f76d47e48e161942e9a600d901028282582014ae122f5de97696122766c7a3d1d65af29ae07cb407693ba606ac58d753010e5840663abbaebdb390543a138d8c22e3d80a535a3342dda3d89774c811081fb29a3500ffac0a11c13879645cadc9dc7779ffdfe650872c457434c7c3563a8d4bc732825820c932777c11216640121a94e982c820004808a00a9265b9e1893de831e89e6d9058406b855e2a599f681488e8a1fef215be9fae2886e6f91e526c1a8b1e3ea5fe6ff04780a6e24228bbd990e480c759a70e0975f7a8661d3e5ba887b3fdfc3596d61b02d9010284845820e017c218b08b1fb72e905027fe57f4ff2ad671185b2985c8ffb44194938ec2345840e6cdb2112eed31615b9ad4a3a0507d3d00864a72a91c84608c82e981eefed1420f8d9377a2a0dc4f71957d9183f2c99e9fbd0e4996e4fa0cff1a74c702c5da295820e58a12a2ade69d1df6a284e46ae13d93ac6005bc030f4d650a74612526b057064084582009f3ed46d7d8892e98516bef2aa7cd4f27461f6f47a3e9a4797d540365d1136a58403f582297b8a2d293ea57d9a84bf63e8b192db5686f654880c8c15f1867b9cd6c849ccb4eff476d11a0c361e5e7f855d037ff9d42beca9bbc4cfce1c5e982c2445820f69a74121056ef9b405d04df2140b3f0d575d17782d9c5237fbbdddf53b3401343d957818458208f47d7061979a4191a0e880860cdf8abddb854a3155e15705b63bebff0b51953584058c236071f734cb2fe2ffeb397520a108c0488818676815fdf578a9bb3003e1cc3208f1b41e774aa2373664baa9ef844e1ec045ab0755ae6aa0a2dab4168d2ad582059e906b2780289e4b9c8c61eccf861bf254b126a05535ccb2c11e9397d8e228944eb27d787845820e3b5c741970878d13aaa11d3a0489a1c8a610d662cd38bd3c63761fe53ba07e95840e59e92c27f2ecdda7c06866fd823ba8280f69704ae1f08fbca7c17af98b251be0535c05cfe8ddbb87578eb7d6defd8b50e01e44004fe6c6c5696817d292a75ca58209227d35f8c01b4c26594754a6dd0717304006007ad8284d3170d8f5fdeb997ed43dd67e401d901028382050782050b820284830300808200581c31192273e69288661db96e81fd0153798781908df715e737241e484682028482028083030080830300818200581ca20f0b4648214b3c2160121baa7a968789d498afe81a5e837a07d6948200581c33949522c64b84d9bc25e74e08124a1576a7711b8ea4a5c6f3e9470b830301838201838200581cbb5a3818850553df6ab09255dbb0b6a529d7f4415e712729321e2aa08200581c3474ad56d5baa2df393979d7c47a8fbf0480306574c744a22407055b8200581cce0c25893ccd008f0710457ec057d9e4cbba1fff67166dd1dc3d22b78201818200581cef7ff392163f0ed3def5b83af55979d0ff76a76205059c74194f62f08202828200581c6715bb102864633cc353415e388dceb8be4eea591a4186a7cd861d598200581c04d79053c1753133a622616399ecab0932d50cda774f83cd0be2f4c303d90102814645010000226104d90102812105a182040382415b821b1017fefb40153cdb1b399fff41394868caf5f6",
-                                "description": "",
-                                "txId": "bb0a968106800f703ab06e03216a25f177f75a987e90b1e4edd921f5310b73d8",
-                                "type": "Tx ConwayEra"
-                            },
-                            {
-                                "cborHex": "84b100d90102818258201cbe2450bc0abfecf236647d3dfe665620fe0680a7edab08ce9bf01cf460fe90030dd90102868258200f6d40c27bbf0555d2a3189aacf09d7c61885b89142bed8d7f819117e59661150582582026ff618d5f14760ef8c5465f656dafe1d7f06564cb25d0b9c77985cb0707c9cf0882582065c5b9bc100fe8dc2bf317eb0f411739a46d71485c4ec6a1d83b34312787647c008258208f557c316f6028d1939c565b75461586e8ca7b93138673266d43a30c0c7d437f08825820b3de6598d586b297efc6fd073227a1a1df2e5a47e0431c38397d1e7981d3ebfc07825820d9213ca58861dddabc441af02c910f9a1526976fd2e94fb4500799149720d8240812d9010284825820407945466869bba302b14d3e4d439782186f744196ac0278449a20b753f27bb10282582060dc9e9f265a948056bc587a28f236d14c7869740e6708e7f73f39feb2fe20790482582064447c6e988bbebabeb7a2a4b1a7a21d717be336ff8ee54496ec755f8dcf7a34048258209212e0645489d0e2f4e3b541535b449c1531fd8252ab09c145d69fa0c00c763a010183835839019c6e52798ded382e6285bd0eda3bd94114d80c2847e76ecd850a2ed83c867712f5fd7267871329791fae4023abe14ef725c3b724e79eb23a8200a1581c245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abaea14c8d29aa8a397e87c6464f7b73015820aeb2d99ad55eeb55fc5a56e54136a2c11a021ed9c903e321d669e6bd5497fd9282585782d818584d83581ce5c49c43f41bc507c438435d6a86bb9da42e767fbda39fc59be95984a2015822582079707a61716a7266726d6b61677679666c776c6d7471697a7a696e666173727202451ac1566dfe021a79d574958200a1581c2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56a1413401a400585782d818584d83581ce34b7b2f735485e1bfa24f3397eaf898076385dce2a52a2217b91717a20158225820d65fca7efb0e39e9b66eaef9a0725e50fd53dcf3f6072f60a1b1e0709ffa0b0702451adb3d4a07021a0995ec5d01821b21e33f3c8a057665a1581c3c0314186409294a3ccb47abfd8c322443d227d0efe4e56c20257660a145a5920f8bde01028201d81843d87a8003d8185901168200820184820182830302848200581ce5a477e8dcd5b8405307f2053470466d668fa921018afb8bd929cb328200581c6a63131f44d20238869560e732f9f1f964a25118842e0c53f3a12aa98200581cf03e127722c8fef47e92488d130cd5175eb098ee95d0c6c7182a0dc48200581c4ac58d4f0ef9739ba4d61980eff7085ba809253da897d8487463a8f48202818200581cc1f43c8574be2ebe4e7df8ca8a785aee90bbc410179b67a9bf2ab8f38202818200581ce33fcb823db999ce47d4c1a39788c77d06e672466d711b44dbc4d6918200581c4844ccb13ce46e81dcacded167f1cfdf9de000e1e57ab6979f67293c830300818200581c3882eff975a758c8ba2505bc6e15ddd803d8642934b0332b9bedc7b010a400583920ca98edecf230942c55c62fd0fd4f55b42dda0ddd2af1bda2a339dde068433d9666bbf2682749d275c6f0f90265639ab29fa38e4d4a548ec2018200a1581c6acf2d35be01597df0cf1079f0a7738e592df3f2d991cba20f001f68a1416401028201d81858519fa1d87b9f24ff049f9f024128010103ff9f4206ba00ffff9f9f24042444f2f917b740ffff9f416a9f024407f6301f2100ffd87b9f4270de04ff80a440020244f7035a97050542c1d523ffd87e9f40ffff03d8184b82034847010000222200111104021a00035a6b030105a3581df1c313ffe622ac72fc84905402a58fb7fc662e6eca295d0f7af6b8df8b05581de1b162304c4f61ba12b5bfc499b353e2982b1caae315c68c8f4b2dfd8d01581de1ba1bd12471d72017ab54dcad413f1e427f488fd44555d7cd685d5c701a0007f03908010ed9010285581c04d1aa3b80422179ea8a0b0096fad0f249b4a64d21dc5a91a5ee6076581c5692c8dea90f1231721fd98ccd6fe9da1c28bfd47ac84681ba68b741581c58e5c8840ece72d674d9a53e45142c8ab8bf18a940a66519329f1e4e581c5c47fd035bb0f7545cd3d88bf1b4f58dd69c35c6280ffd982b705825581c942a236df3bb76a4184674ec93f3136b9c4e01ffbd6b4404f40d76b609a1581cf5544983cab474b3915e42b2009cb61ecb61cccfc94800df2a7a7fbaa14d22ee6a72e05c75ca0d30638af21b78c8c6b9a7b272ea075820ac1cc5440d42ca792e8a2490f3a694026960d639777214154ef8ef037adc54850f0114d9010281841a000d0b10581de06ca75ddec062046bb71be3890debf917f2de15ba6d6ddfccd376244c8504825820e3bc5dc10628c51c318219450fb0057c1a33a85a74b9f6a2040ec3600d072fbb00d90102848201581ca5dbbf9d142d77243c8e64bce6248ebaff513bba24ad6decd8f3f75e8200581c6731619965b46214cccec6ed6f42230a58f1b36838ba4d7d3b305db98200581c67d75bb2b330188394a73d8759700ce91df65834cdf32e99bd2e84f48200581c75c3fe6f82f77cd38dcdeb896113680881da34843abb2089aecadee4a68201581ca3e9d0ee0f90885a7fb6a1577838c0b52dbff3770f623d9df630de34058201581ca41a4086b156b16da265806ea8499ce550dd7fd0e8e5b7b3bbf86392108201581cc87abb8ceb799b61825e2735c85521a45f12fe260825ef3779da3f090d8200581c39827a02b6a02265c60c9b532fefba5417c9d0d46499970926620fb60d8200581ca0754b373c07b889fc45a4024761d2e626f7f6981265598ff09891b3008200581cefda4661ec94e002bf17a11f6a74f2b40f006c79df2d824261ba9ab40ad81e821b00000087dc332c531b000000e8d4a5100082781c68747470733a2f2f77514130707969776158784f4e5061442e636f6d582057fe00f0dec4f09cc30e105bcb9262a63ea8d81e9335ed5f1151feaf40dee46d15061605a502d901028684582075707bbf13909d3caeddb74356b2ea914588e4277b980ed07d086e15c83d6bf05840525ca6cfcfb25363071985aac205d4e22659f174c57397c760188632d45912e4a39a2b368b225f0d3d31f450ed25a8eb10c6cc66621ce9c1bfc54068ccbac72d58202065bea437a22d41bb5655fa8a7e9807b3fb816bac205c1ab5469ba179667d8d43cc91fa84582019d555f0bea30f7d5ce8f3f1b6bab26bbca7a054171ae7516d397724cc97ab0d58402001e47386398838f0bdc66043b1da83d3df5185422329a505fa34e3c54aae747f0f6a90a7ad08021862aab02f0751aa803f744643e4c55a103a7e6f903becf858203c1df5782b86f963444da4328e3201e16b948ff45ef558d8919cdb2e7995909c4427520da2845820034263a8ad131ac7dd342ed4691a10ac9080e269919a95af05f1ca11435825cf5840f91ff70bd0a088e3f729f5c9ccf97572da582503cf56e5a6159df39039c7141bbc7e9c2e5a1e518064124c33248bf0eedd041589afd895a9bb9a715b3e7302ae5820f391a87faabd2f22eaf9741689aa602dea53376ece7574ec1897c498a1528ce441148458205bdcd8919417ffa15e35f191fae24ea0dc23acc63e4c90c998ce2a58e38746ff584059b5babf1113669e128eba605b3963bd9ee3a205458829a689f4241d4a8fbf503c9fbe69759ccc83a9d37bbe92a019f798a40768359140ec83d090611e4ae12258206ca7c05a2b1f58b133a3935f1a819ad537d3b44af8d08fb92465dbccb8e7095a41d78458206be6c9be8b0658491e18054a36686e88ef46cfce8c6902d59c1966832241451b5840f363815002a20ef38fadd5bb8d8553fd38b71567171ead751139a4919073e39cc1803306cb3f7d5e8be55ba2940f3450c4ebfdf101de453bbd8924863c0e00c3582015ed75125ade05e8720c61f5b8479e3b0260a08583e558b0414db44cd5de7c4c4084582033cb5b3211b9fc24d0d492c8b209fe935532a062dfe400dcbc3fbe28d1ef1ff958402474e7e5f02ce7bb862c9a29c1e2f485834b9e477f472036b126ddc5b5df0cd756bd9ffbf33c8bb235aa458230b3257c9b67c179bd2539eacc0aa9f8d8639f985820b96aed77cf3395a6acc17386150b3f9185e7ffa06407aa071def7dbdf42073f845aa3fcb4ebe01d90102818200581c942eae3c25239e2e9ec3bb65974606f0b31a9d2a8e1ac7d12928a68307d90102814645010000260104d9010282d879809f009f4428d12d4e9f02ffffff05a2820003829f224430d0c2b2ff821b1da8ee16a031a3001b39b1dd0db9d9f905820302829f24d87b9f02d87c9f0101ffd87a80d87b9f4040448b98c426ffffa49f412f404436b2562f40ffd87d9f434cbfd6ff441baae6f620a5244272254436589e764243970140432409ca01414a4303f662d87b9f2041ceffa54005202140030340414d23d87e9f2444090c4b94012202ffa5a52143e1eea744da44feeb4465e1cec640020020012144de92f103431276679f2301ffd87b80d87e9f22ff4280e141edd87a9f40202204ff43a83dc7d87a9fa0a3449ec1bffa0121404209b80123433a76404463e1e56fffff821b0974b0cdc6c3a43b1b276aff8331b37aa7f5d90103a300a10d8340615641090181830300818202828201818200581c75b27949dce690a4a42293c5c8dd3953e21cdb85f60f9118b8528540830301848200581ce4cacaee22f2e14fa73f135ed2762b61338523e45af7110af534984e8200581c7f1ee8b08fbe17a9420d9be4a128882a036b2cc8093591e5fc8b1c648200581cd26243785ae7372b1d808734688f32e9c10d3328f117186cda700ddd8200581c3c55f4e6fad9864c7ba38258aef07d8f08762accbe4c29f09516bc23048146450100002601",
-                                "description": "",
-                                "txId": "fb6e988abbfd00660f26587846ecdf54e326ff59331755b1baa2cfa9c8f5a135",
-                                "type": "Tx ConwayEra"
-                            }
-                        ],
-                        "localUTxO": {
-                            "0103070202000801030300070308000708020404070806070702040404060403#23": {
-                                "address": "addr_test1zpnw3vag8aefk42rhnkgwqjemqp06wrmvv8sw7nu3nwdz58723gsu0x4x0cc5c5993kusad9cf43d49uu4y03w30940q70dp25",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "lovelace": 969750
-                                }
-                            },
-                            "0108080607060806000806050802030708050404020002060804070706030008#19": {
-                                "address": "addr_test1xpwnkxy3qyp39uyv8mpumlnz9cn50s209zzzlm76kh6p9j5whx3x63vs7a6kjatdzwc8gk8njmh06s7lh9uujfvqevjswcrjel",
-                                "datum": null,
-                                "inlineDatum": {
-                                    "map": [
-                                        {
-                                            "k": {
-                                                "list": [
-                                                    {
-                                                        "bytes": ""
-                                                    },
-                                                    {
-                                                        "int": -1
-                                                    }
-                                                ]
-                                            },
-                                            "v": {
-                                                "int": -4
-                                            }
-                                        }
-                                    ]
-                                },
-                                "inlineDatumRaw": "a19f4020ff23",
-                                "inlineDatumhash": "8835aa93de8eb374d2e0c9f5529a58a6bb758427e157fec8511ac51acc32e0d5",
-                                "referenceScript": null,
-                                "value": {
-                                    "4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebe": {
-                                        "f09c4dbedbc05f4ceaace7dcc018521aa2fb": 2146037432693688010
-                                    },
-                                    "lovelace": 1293000
-                                }
-                            },
-                            "0402010502080300020603000004000802060607040205080803080006060405#1": {
-                                "address": "addr_test1zrnn50ny95ukegglx2d9rpztv9n9jqm8f28lmmqc84ykhfs3xf4jxtq8r06acptps0pztj4p7sed9mfjmyvdd7e9axzsjnnctg",
-                                "datum": null,
-                                "datumhash": "13207cfc83ef3f234963dcc62f637fe9cb38f74902d5ec687476d32d41ede0f6",
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "733a42c79d238f938df7c676f1878286b15ae00215d218f488f051cf": {
-                                        "4df3e3a8": 585619007632040600
-                                    },
-                                    "lovelace": 7500000000000000
-                                }
-                            },
-                            "0407010601070505040700000606020508050500000206000004000102040404#1": {
-                                "address": "addr_test1yzyltmw92hy26sjzu934dku03cj42f0g7y3qz6m88hcyw5lemnlg7cx7g0qc7avad6p7h9yss6mdmdpfsn2dadjqc4zsfcd88m",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "lovelace": 969750
-                                }
-                            },
-                            "0604000503010808020002050008000603080600030203050304020206000006#80": {
-                                "address": "addr_test1xqr0lvzgfvwzmhgru4k6vj8jgj45wey4nu9tyn5qd722x22vn2n5t5hvs84usunaxqv6fe4a0thsf6zyp9ezlmkxc3rszrf59t",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "lovelace": 969750
-                                }
-                            },
-                            "0703050503050003050307010600040307010006050103000102030802000205#23": {
-                                "address": "addr_test1xz97cg4ew3qlhjpgdn6nc9deu0wgh8w44mkqpz6z6qehsj9n5ec6lsqx84xxnevesmmx4jlsxmkztjl6jjcuql64lmdsukt6ru",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "lovelace": 7500000000000000
-                                }
-                            }
-                        },
-                        "seenSnapshot": {
-                            "signatories": {
-                                "71a4822cac306f8d46e2093d83bf013065d70dbc71ceebb32cd4a527c0c5c942": "a0c0122006682c01b7a27c9744d12fe67257d2f6391c49e9dfcd3d647db7d29f33e17d2942ee11500f069ea5aa659a408f99143e8c7cf5f2c4c6df4d4f1ecf02"
-                            },
-                            "snapshot": {
-                                "accumulator": "da8d12107565650354719dcc3eb8f0ccce993f3953bd9d387be63034f21c86f2",
-                                "confirmed": [
-                                    {
-                                        "cborHex": "84b000d901028282582034ede99d725e567e0d21cf35480b26fa0fe188db7a113d68d55a085363f2b5e3008258203ab4ba47904a58cb45961f97fd687883a0af833d8a6afca02fd23a9d33323668030dd9010285825820203d10db66477a6caf465f1ac09da297c15338fafdfde0616412ca2130d417ea02825820330708328ba706dabab269bfdc709514feb7bf37e0ae6c2e5d24c109a4d534e406825820632da5cee182fa677bc552f8307ff9b281fa05acb6c9b84a657a65e251c2028a02825820c3050311b1db56dfb2e366d61704123af9957e37d152dd6c0bbbff259bc5a6d200825820eace2c7f62df5ceb787e8f1200518f1072a4a55e3679bd7fab262f41b36401f30612d90102858258204705a342b162ae7972a58ed7ffe4bd66a698aaa0f890be8b28906fa690c02452018258205e811de100269a6115cb248481b7c09370042fffebd63e599aeae8aef776c70e038258209c0a198bd9a884d0165b17ac41251fcc5718ec771b1275af7d122439762c3ad600825820aceb86f639cac965bfe43ad632b26d9bc9bb064551d0eaec0602c9981cbea20e01825820b19bdf80c8f8fb62385dc4e1d8ff0366033a7fb208cc082aaf8a9c277f6cea0b030183a3005839318b745bee5973a13a89fd9c9fb8b4d3fe3ea086b3fa59a598d299924b892a4e8d8e739b5ce5f1565e8111d022f4b58b06456e7d0c2f1d0574018200a1581c8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3a14273e61b64187266ca37b34303d81845820082050d825839114f4fe93bbd6396c901b0eb5dd7607e6f67fcd0bd3b1e7f20c9332b3c92b76e5fb5a0def2a97d1cfcd60f418f33a43e8a21f53b97a7d9a2be8200a1581c44fcdae2105495be16455d1c47c05262839ccb5addb4dbfb99fc73aca141351b15a20d2d21e04cd0a400583930cebd14b63bd86bd34bb881cef10c0685db4dba93498484477bb8800c7068058b152c81a5e3d55aa3152fee70a5992a10e42d429c2f833544018200a1581c8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3a1581ebd5073af9fea83aed2ab19f696549e59788e33c61ea1c5fb3c59f9a38a081b755d0ef1367cc63d028201d818414003d8184982014645010000226110a400585782d818584d83581cd4e639e1cf4f352b53f9327ff7c679b43584ab69d931a2a2f659cda3a20158225820707a6773706e61746c6e6274707674726a716e6567657168786a766f6c64646502451ac3db0c47001a7d5b257c01821b6ff8f56bdc1d961da1581c2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2a153a858a33c8d1f3ec4e6317ddf4c28d13518d285010282005820867c2e4595b54f37e5ec56e309af81e6bb41341429953cfc7b8069a8495df22303d8184b8202484701000022220011021a00013d7e04d9010281830e8200581c9545037ec5a8cb0dbb5b113a954cfd715634dbec263a69af784527228200581c6e379a41d873c70dd5d4ab094949201b1dece32b3e49eaf360bc36c008010ed9010281581c544a960a3211d58cbbb3907c5611c7e64900dabd33d153af61c4641909a1581c88243f0e12e56ea4ea9bb6eadd8273a235498e04f0434cf02cd22e23a153680f861062a147836b192ba68438e9ba90f1af3b105d993044c7a4140b582077e22f47927c24c516815dbcb3b5c4505a34a1d39831d8365331f8e7293dfb4f0758202cdf70bf717bb95e8e30a680a7c7363c0227c1c2473a7fda840dda10635fb3100f0113a48200581cd0c795da3f108c0841c22675a978768a7fc213f6b204154ea22735eaa382582025b11e11a97c48e383e05568428474b6853b910d1deb056af4a16ac13a28b12405820182781f68747470733a2f2f5a6f4a7a496f694135767737384376646f442d2e636f6d58206c8eec11ec471bd5ff14b5271b3d1e3160b81ba896774bbd0baa78241a4b4c1f8258203d5d9ac71cb2c94628937d33aa6378559dc2a73763571a034332de5b64134e2f05820182782e68747470733a2f2f75565636525a4e375a716171354975515172576f32522e697661726772626d5878582e636f6d58207a4a27839b7f12a09b8a0e925c0f63501386fe044e1d4dad7f4b6e937da13b6c825820ed171c8aee77c1acfc9b066e6bddf94a71a80ee9e420e6a934f9a01e07d29f8603820082782b68747470733a2f2f3232726a6e6a71624f504b4f4c6b5162345833386e676c445874314f496b6d2e636f6d58200ca5710d814767756ef4a384318eca21b4ea999bea67c5b976af87d5036880f68203581cf55503646476b7be318a9541dba3b79f062edc086a73108c334fb7c3a1825820c85a0894505bec40945c7c1b7e6c579709f76ef57741a6614de93f64607f407d05820082782e68747470733a2f2f557a62737a505471514434712d375a592d463270365a44734e57336b595a397153642e636f6d5820c5106c00aaefc550462a971a1b85586d2c9061f7f4f21141e6eb0c492b0df9698204581c51f97c54f81b12f0e677a60c113d43939c1d981074cd50b924a91a85a482582019ebd900342f8f506f2288590ffa5dbf21c31db514d3668d0896c3a3b69d3ee508820182782868747470733a2f2f4f554f385648746b764139345137466a4456433338446b6a346779332e636f6d58204e54d68f6dfb3117d84014cec70a70ba92aa2523c802a65449a6c55ec8c0885f82582040e2884f46f48ccfcf285c61522a47c1fae5dc2237b34cf6bae975fd72019dac058201f68258207afd2c267dd8435025b60c09c21b12edd5557fb792c2d2339604f2c27b1ef957058202f6825820bc916607c7db9bc8aa05f0eab6f1d00da439a817d5bd933c9c39a84323ad9f1300820282782068747470733a2f2f45314b756b732e62445756326e64466d30394a472e636f6d5820f730f47934e1a33ada9a625cf31da5f84a15ea45fccc1a2c3dfeb1311a38f7db8204581c6de3bc02770e4f7bc81d9d7f6fcb36f7e0ff57f6be1e961391a360caa5825820035ebbe4cf20763d810661b1cb0191ba891ce36eff22370efd541ccb9f514cd0028201f68258203570a922f26538784f74a1b71bc58791df53800b69c3f37a02830f7af311d71f07820282783f68747470733a2f2f754c722d426e4875664430432e6d3930424852545271572e4c654c5461664c48495249566c574270482d4c376253674a4675772e636f6d5820e515f14debe3024a09c0e1acf7afa7d757d5db25a082d16b6a0dec358af06175825820781fa688c216cc2a59c69fd54dfb7f08fa435c734d28675c48f5b0b094c41c6103820082782a68747470733a2f2f36366846457a526a4757796a6d30513461357566586531504a35587354542e636f6d5820767ad30b72e6f33b8bc841c0c48608a6c60ba47847c107769635eed454e9330d82582094bc4f9dbb1419998d645fef1325bbc615d8a503f94c377eeda3a5b5926b1f12058202f6825820a6a2ff9443e493bed5283829e933e7ec38876241001ed139d99bdb395ce4685002820282783c68747470733a2f2f3857535933724c334778476c57734b417453452e646955575167675a646d44627770383651786151464330514e5741512e636f6d5820324070620d75a4086588126442e7acfce9db3dbb3e92ed10356c0a1721b534d5151a0009d7a21605a500d901028282582093756d8ec63654a834b942ae0b1c0f13bbc099ba3be695a4f9d67cf21e7392f5584066b51455f2a9b14918393cee8272b2f327e57a2d9c57e21d70d57324ec13709e4daa41b6284c67b6b3d8ba0d5df55ca9d15b4e4fb552e41869de321f24446b9e825820890bd39d3eca9428b9e00402d21a1daebc234944550e40e6f70ede0a47100d185840453fa1e9aac4b610ea4528e7a784c08386fcae670120f205799ab14711b81b9f009d5777f7d0c7d1c07d332bfd0d1ceecceb462ce5216ddb9fa6e717c8b888a402d90102858458207f6493f07626eca6a094d733a941108287eaf857a74e9da670c41b4efa1d3cba5840279dcc938c13432c1699824e1a97c3dfb6141b96bbaf3c8983f2004f062de41ffee58aa3e93f8f7a1fb118620d1109024c916f3bb247d71951857fae427040375820ac8609c036ed653696728746047bad2b9db21102b11230352bbfff8d8c7211e143341669845820fe1e9ceee61da72b7805cc20858731389210f4fa058013463fde9679b51e40715840de6bf138a6cb2123bd9d9942a58f4ed47f0b20e13e9069ac33dbddbd39b89c1ab6ddaada6d63f986f04004f9586d39517aa0707dfa08491d2388e0b71c14735758208e3a401a75b08abeed6d4dcc2b5419709254874e0a06f1254473895f1996209c447fa304d18458205707399cb032fbe8a5655b554bb5ca0348371970919b95e1ea36532295a0d1cb5840fd236a678556ce33c6df1a1c3f917d490633676cde24b46c85a83dd70f2dbfbb20f394402aba52947bdf19dbbc50467301fc9d7bfe9155306a4c96e09a137a3758200927a22c9a227d4b47826a43f144fd33b90ca12c126e481fbc9b2a0b5640f0da45f26ca6da0a845820efd4de6deeed3d6d192d7c934660acafd156788ed4d1e35162e2f425c6b666aa584068db94e2b526a8a50251ddeed38ffe22ccdd4f6a47f1f7bafc07af599c26c2908eb63d6ccf3c9e28ce4922459a34c7a94d8e43c10f5b1e0a67bac122ea2ece5758206dac5bcb843b5d67c9ec7a3444a93f5a61c85e78c24d29c3b9d2c8b2d68250ab40845820d8ce9ab21161f1a9903d30a3da0dde71ea49a7fd182b74895d5eb61f8ab314935840168b3a030610df1b59896dd59ff7a6278201685c579f69a05bd08b23035c094e98f583b232e27fa5b3dccccc6c4001314cb4e58fbdf0f7208b82aac73a74ba5c58208bc44373bd6d9a3c10bb8af04f1273763143cb73120a7b3ed96ef0e06fce201b42070901d90102818200581c2ec39bd18db68b19c553aeb94bbdb1f17a802021a6d3331e6063c5bf04d901028221a005a682010782a59fd8799f40ff9f01ffd87a9f204320fd520441b14357bd2cff22ff9fd87c9f230240412202ffd87b9f0303ffd87b9f030040ffff04a54080a5443f69c59522224005402342020e20415e80d87d9f4489815029425b99040505ff802404a443eb4efb03435ba0214263f6416a44c74347580244cd04ce2dd87c9f414300024044ae235a2dff0203442b82aab49fa52143ac889f0122232242361a448480c16e41cf427d0cffd8799fd8799f05400341c805ffa0a0ffa1a2030042d378049f42266d436af20b224043073890ff821b42787f9ca25927cf1b41ef24425df9784a82010882d87e9fd8799f21a4419f01442828a5b805244350114041cb03a42143f0553f433a84e40324400442a3f34306117040ffd87a9fd87c9f4348bbac24ffff40a344b08c226821416543288eb29f21ffd87a9f02ff03ff821b5bff16c0b9125e7f1b6daea472260edda482020482d87d9f40a203a441a04474a3b6d6444b4aa97a43f6f5e043d56a6242799022412724a1446ba56fd94153ff821b1bf6d605782722951b03eb15f01c354a8a82030382d8799f80039f443530c1a94446e72e24d87b9f41da419123ffd87d9f43a910f102ff9f0201ffff21ff821b24a32c59636ff50f1b6a1729d67756436f82030882d87d80821b22209b57094b11131b710c8f1ad1f2ee198204008222821b3232d39287200a201b113229300d88915af4d90103a200a508a1697ced91adf3b5a08c5c0009685675f0a2b6997c630a61640ba00c84423a8ba1406112408001828303038482018083030484830301838200581c35eaa5ed5ce1ac9ddba25b6fec119e35f821190a1d38020be5926d4b8200581cb3a6f02db684612e7bf63f3c493815fccf03e8bfe800aeb94c8a09f68200581c44c324c00124ce5defc9747ddf1c8b1c780fb59e4bee309d3d1522438202838200581c371658931392c579b7cb3a5ce436b7193ea1ae3f0e69b43bb14934a98200581c4393562f910c8afcb2dcdef0fb1c9a05a0fb291e158d4c3fb70e1bae8200581caf41d8aaf22787d3bb2242d6639bc4fcf761117c8366f5e7cae457408201808202838200581ccb4f99c54c5404b56bda3e4b3cd0bc11c9c2fb9e347abd67c6285cfd8200581c4fffa4bb7c8ef92df38e438cbe30d592236b762d4c25e4107ad559e98200581c7b8e7b8670af2e32a465f171dc91cf73e5f921eeb8c9f5db0f5030248200581c92344820b5d36060149f5f0a1a35ed5467b597e52a342df4593a766a8201818201818200581cc90e67552a4543ecc3af8e6727ccc1383e1237e1b3740ef9dee31b0e82040e",
-                                        "description": "",
-                                        "txId": "449f2e5b376b65757b70217bf1ca72cab5533742f0d205274dff10b0beda2441",
-                                        "type": "Tx ConwayEra"
                                     },
                                     {
-                                        "cborHex": "84b100d901028282582061833b107ca21e5cb02e4a569d7603ee3e6caccea52acc4e63d2ec2ef432fff908825820a64568b78b5de7af078a0a7b886780a73e0aad80c6dc6f913e3ebd1947304a450112d90102858258205bdc9414e5415670fb1513892641d427209db4ee907933d61fa29dcac1c56a5d0482582079b9b9fa88f866da8f134656bf6178761540d7a0f0cdd76566e347b6f9462f2c088258209e09c84f1fd7006cd23933c70c3bae3efa5e04e4c4e6f3d9d826698c62ef0b1303825820ced30fc3ed13159b04af6575aa15bd7ed89c170cb0889d19b0efbbb3e55975af03825820d9c4a4e6c0cfb273911667429544e85ad731c5a12a1bab8974fa2bd27896092c080186835839100e6a51622479dbc72ec1cbd8df02607e8c5c934cd5b1f5836d56b5ad111102611ac48d447dfe3e4c75d565ea49d8d3f857dd15467b9b393a821b7fecf493d6ebbd70a1581c8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3a143fd038e1b769fbd74fdce2cb85820b2c462e074de4a19dde3d87786e8e5634727c164cade08340613064e87177db5a300583910663a9472408222e93167d8233fbe3a9ce02abd8a53b03973672a6685e086286c2e82a91dd8a89025141636c99da026be335ea86673810c18018200a1581c2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56a141340103d81859012f8200830300828200581cb914bbf2d299f6e0d47c6f927d2fe20c414c492051133683efe1ea0c8202838202848200581c1b77bfd6bc0650ec849943fb9ad67e0ee732d3fa2b5b37fb50a3bcf98200581c33f7c37c215b5afdfe78e1eddc3ee753efb1f430cb014509b4bdfebe8200581cc7677798ba2fc74ec9429fb44dd26f7808eb366a642b52df333c695a8200581c6c5b612c0c5d6dc0bf145843ac2f00935111d11c10c250a4bffd80ff8200581c18aa897e41258e88d63a81e2bd282fdc5189efc32dee6feff9abd7848201838200581cfde549402188579fef0e35dcca910fd2af309dad83a7978213357abf8200581cc15f281e300fe225a82189eec74aa1f4c7247fddb211cc21c4c2511e8200581caa642b76ebdd65875d425df433f4627ddf4a7e34cb5035a890bfa4c6a400583931517944d5f8f38b6668ce741910b58d59a2a4483e0b3d5a8cd6314a9b1e92aaf85972e3f9ff437298e96f647885bb77c87782d98eb8c4526001821b17752999fdf65cf8a1581c4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888da144cbb16ec401028201d818581a9f059fa441d32243f3754f244023415c4258724485c71957ffff03d81846820083030080a30058391104e0f4f30526c8c551520b6d1cbc401e4deed8dc7e811b4e4b90762c0fa583cbf873ef01bbe018c832b5ce56ab06eb4f1c76612cd9b7410001821b64697533249ce92da1581cac8932565e5cfa06f0c00ef2b70c2a9d6277f0060ac2eb0f217a31e2a141360103d8185830820083030081830302828202808202818200581cf4289b67f39d17614e889ad56a70cf8237c005257cd7a0dc1c94fe69a30058392083de655b07b94d8f1506abacd6293a9eb5cc39efaffd47c393dba23f4394d12b357a651f71461fd0ff47bc7f8bb2a3747299d8f2d74509b6018200a1581cc955d3f9b08c781f787c7883387af105b4a6c8513a82f4f8d815a956a141301b619e89647db8087d03d818582282008200581c851ffbc8757989e0b3bc14e800aee403bab99b752e1c5d2d653ed4b482583900941f83164f1592ac2f52ec8ee36d29084416f323de87f2566639eac80ac5cab02054aa4c6da29e39380165503b31f67e5f8a851cffae2de18200a1581c105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5a14a1b4ebe07bded5f476fbb0110a400583911fbb572ec1e4649f0add342faa3f70ba4234fdc24e8ef56608e7683cd5ac2d13a1054f44af39368881231d4623b4571e4e451b7833c11ad9d018200a1581c5e175e17f6e9eab0451ccb21a773d80f4dfba7e9ffc828c452e7ec28a1581ae3826194c2895a52c13850adaf68ae74c3bec29b2ec1b81508ac1b781d0201f5de7aa9028201d818584e9fa4019f02032140ffa0809f42347a41430105ffd87d9f2244e0b392764432fcb406ff8001a2a541012043ab87b90544a097350a42275640054317f91541bd05a143481568439402c0d87c8024ff03d818458200820280021a0001ca0d030104d901028684108201581ce76d4bb164559a16cb8149407436a97df028298952691641d5c4314d0182782b68747470733a2f2f664750725669746b6b61645578474c4939544d3468454d6d32442e354d44552e636f6d5820500a1945d71d66a37509e7a7b48e2bb4101e21f651ffb3053ba2b690d468fe578304581c58227e0677971ed041bca7153d409ab0ad97a8ae076164410c9b728a1084108201581ce6fe2688b9949ee2d37d69e58f27618ad36fbcae482b9283ba9808c304f6830e8201581c401accd166c351331d972ffb888516f602599e01b3d11dabc1c5e2bd8200581caf9e2ca66ae79ca1f6e4b3a57cb181d979c7740993e907fc7a608e1784108200581c123697375c00cd6018c71199404c3b88cb1d72695823092d24a20bae00827668747470733a2f2f324f354c664f624b48652e636f6d5820b922d6b365e962a06b42b867cc1f0ceb266f844c4315dde4aec89edbc3e23ac483078201581ca972bfc4b923232ced53749111c6e707186a49b0269989cc3a46bf6a1a0001c3c905a5581df01a400ac0b6c08e09dd7a035f60d85d741614d0a656a5b171ff5a4de819f325581df099426521534bdb2765873540d05962bfa97f28d56e966064b6f17b0a06581de026f720c354ca5aafc0f9ef1cb384bb2f0bfe640f8e02ecdb11c459011a0008f188581df1810a5dd433c45b629ae3d5ea224cbcd714de1fb2d201a3dd1eea17121a0003448c581df1ea88edffde830a2444cc3592a8cb4800c83fa987b15fe233ef51748c1a0007e1cd08010ed9010284581c61d6532f5a8a33dcca4ab31a05db997c657adb775b776d100e2e3444581c8600a9ebc58ba5927f59046a172df8e73829f83f6aab365a0f70e7c5581c99fd5408a2d675004032da38b1a0407535eab84b8ec1bf6bf8cab84c581cce5726dc2e086eed23d13e9dfe684e58562cb5726f771c91c54ab03f09a1581cd6b90092deeafe72a6eb1d906e0c4c466c290416b9846ae1dc3e3349a14da2761c61e90e5a09974f0e81881b45078946ea30b7ab0b5820064ec828cb3b05aa484595a60c42738c408f116c77d40bd71a3854a5b9772179075820b3729a8e95093eb575c80282c7b25298819fdcab0768e9f5b897092a29ccb5310f0113a58201581c3331d719c8f4a4ffc6b012810cdc85937ab6a6c02f588516ec5213aba58258202c46cc8696d65124e141187537a3913fe3c430292de13df01a398810251ce50b08820182783768747470733a2f2f334a376861316c5564534e6f5246386f6d7a446f4e434b4642334e42632d584a5778584e2e4d333347436b2e636f6d5820c7e1c9fea40211856056fcb38c24aea3ba7903fd614382950f282783627819c4825820a9e8d7590657029dfc7e008e45169c2d8ac8247630396c0677da8e7fb154e8a9038200827268747470733a2f2f3957786862372e636f6d5820f71aafce69112b86554416d0f789e3a3fd40c925bca4115bbfd1ccdf6290274e825820e566221aa1348aea014a833adde7e333a1e1f50e3f2d720bbe5e621113e6203c00820282783068747470733a2f2f4164465531665333633949494d366b4262324a776371435874646a414e46425a6f474e732e636f6d582084e0c59e1e3ba3d854faa5b7bd190f48fedc446f3443033ae2fa6d04378a30cc825820f68a45a3b4050e6c4740d67e8e50b93485cfcc8e425aa278524d2059bc932fb601820182782a68747470733a2f2f4f616d696e4f4256704e4954446f7733674731666461464c326a456c51622e636f6d5820664f7dbf08bf31eb026e3ee4cc368929d8e53dbbb9631453c4fe276b207f7f75825820febaf62b70fb371dc3af8b5166cd741b3bb9a933f57a6f940f8a2d28253bcdf204820282782a68747470733a2f2f6352737a38574b30586a37315256474863443447484b66746650357a63742e636f6d582054a341a650c3e75ed4cfd7916175b0a8297154471eb927c53bd500761e1a851f8200581c6914fd4f6edb5bb6b565f4c71a3ebfdc327ae0aab7ae11021e353946a282582045281db0bada24aeeea77c7dce52b32506925f4d293a9496a3bae4752b197403088202f682582093d649c4b7eaacc94b16ae8caa66d29aa80d821524391014ffda534bcee9b9fd04820282781968747470733a2f2f5376433537483954517237736c2e636f6d58201bea93c7e81c2b10d4ec591f0c98f361f7b11f5a6e1c4539a1aec544a35428708202581c0676d64775ee8132281c8f665365b6f888a0514a144f4c9ceb842f01a282582042d6c17b15bc4606a4c4e227c5922892cf96f2b7132691b1afb8a8cb6399a66005820182782368747470733a2f2f43786c515248492d426944384978665147777652766d342e636f6d5820fa15eee5f6ca83ed171f0addf55a46bdf513815fa8a84e9f801ddb93be202e62825820b346b81e98c337164669ade2c73364709968350de6013b8a4ce5299b1a7bc2a105820282783868747470733a2f2f69746f6938496c757858617358485869464b63794b503364776d315747506a527034764d70757254485271472e636f6d5820ea99db329f64f6e8bd3f969ccdfbe53d99f61ca29dddaceebccc82330d0b4c858202581cb4806ad861a951e7dbbc40dd40f3910ea7bfcb96815211afa3d8f04fa482582013c072ca4596b8c4b13af8e1ed3a8dd46b5674e3ba5d45d694473a545f73ceff078202f682582027935c4f13077821fd031287e0cfb9cc5d3fd20daaac0877a8c627adc920e08404820082782468747470733a2f2f2e76666d31317841794e6f5267373565734a6f453531644a2e636f6d582032983e679a7b25ef221748856859f16ebbd4670e385970f580d18a9727ba6860825820617597c2b37e9cc1ef0230abefd18ed331f628bcc5b29d750e7ecb6dd7bf83db058201f68258208cd8cc3a6f845b9a1d78904c4e81f4bfc5aaca200d69d66256b872878d70dbac018201827168747470733a2f2f714a7933532e636f6d5820c8cc5cb1cd3ba1a75519a6ddd758504340850ff1c1c3f87536a8c127a1841c028204581c7c6688612eb32d3e29ee283cdb24565798ec62305cbafb5d7c35f7e3a48258201abe28ec5770382c16de6e03ed7554e1d16460ba6bd5c156733597e533e03cda008202f68258202f4c2ae1f08db10cd392842996d1e96d921ff6a97f8e9b3b4c957bc33eef2a2505820282782168747470733a2f2f636e554676472d72386d332d72465865666f4f56732e636f6d5820a575a2a388f22fee20e3f4c1b6fb2cf728b59944af40c41c9c5887d2869aef2b8258203c3d3c9b21a0861aae42f2afee52096833a3482b51e95696da2808746e267e0600820082782168747470733a2f2f7948582d35437877745846776c415177366d6e75412e636f6d582055e07d2b526b3e8f19ad24702ac9a696c3dfc33c93dda0ee1b91a7208c359ad08258207c456e330cfb419408f632c270575c62732bf91eef254265b3489d5179017df9018200f614d9010283841a0007519d581de175ceda8ea50ce84b42aab78cc0fc974eda41a060ce28aa8ebb0921f9820382582013c7f6a91e7b5f41c048a163da5ae352ff7ad1a0e999263676ccf64b7fd4cfc705827168747470733a2f2f79317a56322e636f6d5820ef199dacdf067dbc80a273f6ac10ef8ae47b211329a29c1a05af5a7d961498498402581de1c340536630d96322ddaf26fda0d1beb254d642ef14a150773851bb2b840082582024c5b831ab1b683a1614d0d2729a341b2d5080beb01502b25b1bbdef1d9041d604b8180100020603060402051a000499ca060807030ad81e821a05b6843b1a05f5e1000bd81e8219a8151a0007a120101a000748b911021382d81e821b065504d99d83fa131b0de0b6b3a7640000d81e821b0548c4eca62011131b00000009502f900014821b667c262887bfac5f1b32bcf4d16ef05ff715821b3ec2690d58a358aa1b01b424a250efd7621600181807181a8ad81e8219338719c350d81e821a000a29411a000f4240d81e821a00068e5d1a000f4240d81e821aa5c9cb771b000000012a05f200d81e821a0d1e85f51a1dcd6500d81e820001d81e821a04b22d231a07735940d81e821ab1bf82c31b00000002540be400d81e821b00000005fbaf932b1b0000000ba43b7400d81e821b0000001d45006d7f1b000009184e72a000181b07181c01181d00181e1a00028746181f1a000d76441820031821d81e821b25282a2243c540531a00989680581cf1de51a1cae99f1c1f117f5c4948f0c97cdb12c1cc257a64a87adda482781f68747470733a2f2f4141676d4a5143513175487962337568526b7a2e636f6d58203fdc4a6425185715336adf65be323f92bb30a73fcde55ae9afe1aeee46162c5d8406581de073239ff210f128f439bb23a6e4722d0382190238c4b8816217ed1f178203825820847ff5a55ab0e6c85dcdece08bae3af5cdda9318d37a74a8b633481f9fbbd0ee0482782768747470733a2f2f367a6d52545149543863484d642d79586a486f704e4e67634c33512e636f6d5820cd80430f676176031eae04566704c2c31a9596fb15c114d0b7be41420d2170eb1505a300d9010284825820d46a0b2c02dba03225ddafd90ba0875505cee8957a7d0586989792ac465fca5b584069f6bdb41481c1c785889c2a5b28a1cdc0ea78d03b833a686446124f760f5d220f76497152f93ab48c498337fe760117717a8e1874d4551eadaa4dba7eec82b08258208c2bde2adfa868b42c300b1c4dbda0a750bd47015f6d936c77d7dabe885a3ee85840e552088dd90da51093d9ba5848cc67db0d90f5e8fc1553086c5588a0eb1d0f8fb02c1df80b5dd84b78365997c37950cfedc377dbc5cb396622b728bfafb408c58258200791e0050ec92587fab021c71a1917af5fa07791900df3c323ab58c5043962c658406981fbe0799afd7dac4e09a4aa6474ae3fca4e127b35037fc02bf5471597c21a52d3513f369ba06ebf7e3cbd9d350d81d9c390f7ad8ed755d3fadb1c7961cb6e82582099c4e6f80718a8baf1d24398bc66531f2ba59d3cc809354be4e82b841c4dd00058401b4f845cd7952c1a79fd22373ae1e9baea9ef47076bc21c1aa3f71407d51db2f790343b8155bff7f5cd7771d5f65c09254faffd5d77b718c194bd7f7e10dc45302d9010281845820bc55c4af677118a5ae13685df91b932fd09a44983b0fc944b59acde85ced38525840c52050f3859e6d804ffbd34fe91c4470b3a2959eb55013a509b4eb802309fb138e1d2fa2615bcfb2a016db6de9e0be9179d8f4071227f9ad495b52b87a1a901c5820d41ec5aa3c037e532f8a5c71b13993a9bdd9a931b226591f1a80ce1b8695d6284504f3e87ad801d9010281820404f4d90103a300a50181422f900484010567e3aebaf0a2bb9502052209800c0501858200581c0000260f2d702d036f32313d07b0a46def181d5c417ba3a5c93c01e28200581c017f35d708239618886d4f2ca74dbf3d0cdc158bf009b896b4c4d2c78204068205181f8303008004814746010000222601",
-                                        "description": "",
-                                        "txId": "202e9a97afd4651edcf3d75887feb913e325defc8b96241dde029e6c1dc1aa11",
-                                        "type": "Tx ConwayEra"
-                                    },
-                                    {
-                                        "cborHex": "84b100d90102800dd90102858258201a65d2c7346f97cd52a09e84f01736150f986955d8a67df1fd1ff1ca8a12c318088258201b78938f829479e9c1a9ef3483d9ac51c4475b55b5f5800b9e2f05707fd28d3204825820533ec95282add8b340960ec51d7313e0804662c3f5ec1e835a419ce93b582c4201825820c307dd57c8a4a4c48f9b2f641652a4b6d1a3efbc8ba1655a4d88e5f39924b26301825820eb89631f11a74f726fa0e1d0b91ac623a84aa9f32de224bf6a9cd90437b5d3110412d901028382582000c55d42b8643c16db02a3f5e143c401bd968cf2d8c45dfe955200412018f71c078258200f9b8ec13d86bbb39137c0d50a7dcb425a6385732324fc5db9103f1ed9322f8607825820519013b44fa4110e72b5725c023b30d273818d7b58b2e26341983ce70dea7117000181a3005839017669f29d1f68ca92d0d5e829a93cbe12260e43cf836c0c3a54f5e309cffe7c51af35a9c6c4ccc0e011b290f3c1ab392b54eca02975e5457c018200a1581cdc1d2f90d267483538692871ddc7f1b7da0b893b48e4d8a46cd910e4a14a930f6a7908aa8e6b7c081b674ed3a948a3282503d81845820082040710a400583920966e844d8622e9e90e6881ceb85229d3f53eb3102b2f1d357f92e5897e285c08daa9f0b0593ff7fd85db692c56be8f143394d76844ccc764018200a1581c105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5a141301b7785f5a198b87fed0282005820916628ad198d3dd168db43f03ef6073cfc5ea249cc89192f6f248b217516b8f303d8185902668200830302838201848201818200581c685d7b423a742a1a3dddfba016ed92f7acd04c3e4b7f54e8dbcde90b8201818200581c2e105ddae5296ffd205475b70ff4bd0ecd13b5a23a1a1ef6ce2977de8201818200581c90e849c0c1b51da8cf96bd69470cc7f95fed908a2cd874cb1799e549830301848200581c2915ad91200bc8d928d52e0a76d067ab4c2565adb5f164f27e30291b8200581cf53be50627439594f47a11313b987219dd70a74e72e1edc295bfc71c8200581c13b7cbfe73caa9554e88be275b93ec91e11257705729a90211ddc3c48200581cadf254812d681d75ad2b9f7dc25bab63a2f85a22875cfae537e92cd6830300808201848201838200581c48d0cd9fa6381c729fd7ef5df6d88c2025c4b29c765e54bed58582958200581c77aebd3d30d5d3f75d03ee196553ff73cd4021a161368ef47d2baabe8200581c3f21c22133eadc7bd0632678bdecb984a9f3c894f905e972b32ed3908202848200581c51893d0809cc220f29ad85dee3de60e3cc29b42eabcbf41de3bae73d8200581c5958736cf025cb3cc345c7cd980279536298ae415b2e0684ab4c1c9a8200581c1c5e26832e355bb06603085262b196c2b2c7a54017ffc65fa260fd978200581c0f0eaa80321f4f197d5b4c46a2f468ee7bdf8ef8aab88051f908ff0b8200581c31af3bb945376337b051ed491915aebbfbdd1153833d8aa402cb918f8202838200581c2834635c38bcd7f7a432eebbec6c81ad9bf061cb0a345500ee1365158200581c3bfd17add4ba6c44270a84ae72985a314a104c6c1a9bb38699199b548200581ca127c5400572f640c4501d25d95a7cf735ead00047eaea346c8d4af6111a0009d4490202030105a5581df01e043584e3bd97509104c4724d793c884d96933ca26903281ba497ad03581de0161f78376d23ede91fbc9ba3189113279bd81f5fcc1da9ed8ee1e3331a000d025c581de0ffbf2ffd1ea4d1d1e267430dddb42a118611ae7173f06253d87354f300581de1d45049176cc24384475b5e1c65f01f2d98fbb761bede8244321ad2f303581de1e6ac6b968fec14a39e0efc6346718df25c81f1d343d0d7e6bcc1cc451a00074be508010ed9010284581c574a07c6f6c8cc898d0d949a9a969c4093c83e44c2881a362af26ad9581cac17943ee56d5dc300e865ce898c301ae7a42485b6f8e50f13d8196d581cd4248dcfc4913e4e1b8493bccebbe54cc1093fe8adfe04b6f038dac6581ce5607d913dc98dfd49ec7c8e2ecfc6f1bacef49924eb9ea36134053d09a1581ccb0c806cfac659ea703acb578af6f84acea0d2e6d54aaa3410e80cc7a142b3bd3b4d083f85b9a4c1280b58205d533cf52533027deba5e04f57b7fe591295e7af5bb2d984d60a28f9adf8f2400f0113a38200581c3a6c1fc4b546fbcd26259cef1e03dcc61d797965ae09d01e3644b9b9a18258202af1a7ceb3cd55ded368384aa3263009f857f1e353ac7fca2d5abea95fb25da701820082783668747470733a2f2f65456c3171415168423832554368555350753242762e37324f594f4b76577a324d3468357647476545542e636f6d58208af42471c3aa2622a694a7e9d6afd4232bed7396526b5d8ca8ec017072605b8a8203581c5760142f6edca8ba5b911c61fbd5496266e418ac158a1577e8fcf3b1a68258201f808f5e0fa8f0f3330e7f0aef03580e873706f389e4d3dbac6f98caac93c49906820082782068747470733a2f2f434f31504e76714f6c36384a79314b6a486238652e636f6d5820e47472626666c39751e10e96302e45e0e03314942b8b8e1c945fac93146ee242825820787ac8906d2784d176eaa4070397456819fbb4426d215d791b30e998f56761ad08820082782b68747470733a2f2f313066705058674c744a4f7449596c3054506148315a7730544e784234496b2e636f6d58204f5dcb38d6056a305b5af9ccb5afc4823154d65b40e3d89ddc4af6a74fe36d1182582079e7afd2373a1b07987848b3e63e1df72eab81a38436b9131932813f40811d0f02820182782d68747470733a2f2f326f717532766f56326e4c6563434961796a567158624f546452675541724b324d2e636f6d582023b35b3b6c32b24339b3fd9410c65f735c01c868623e089bb8d671539f650b38825820a66436db7f2466e148a460cb96c8f9f94dc11c48bdf8ca0709722723d3745fb904820182782368747470733a2f2f596c377351433267504b775552354a57464e704d475a702e636f6d58207cdcfad66da76d38d06cd635e278d6bd4e14f1ca72d273e2e0575c149f47deb5825820aea5e51278bdade6a1d435fce0fa4a94b3c180434ff6c586b728087b4d1fcf8003820182782068747470733a2f2f4e61505770646d7a436b4465784e504574507a532e636f6d5820995eabe96f952e3d4fd764c50de64cf4d4156d217661016a220d51b31d91f4c3825820c09bd1451f2d794151db4520fa0d0af076c01173a235f4f73a1acf154f2eb85603820282781a68747470733a2f2f614e4936344e743356744f75782d2e636f6d5820e4f39d4186d303a6c1724f8f77e89350e8dbb392f802ad1676b447f28283a0368202581c6b31c5eb85c753fb091936317dc78fcb9822b137519b52346e0a3b0fa38258203d483dac858ad3e88dc7d79f0a241b7f5cbb21902ecc3d1ab47c796da727ac83028200827768747470733a2f2f516949784c7235436854482e636f6d5820b86f51f56da6864cf8fe5735e8560724921a8149c634ccd912901eeeedea268f82582052c768a792b195a377cebbd82b5a4b61f948d6b90e88a6f64cbbbfc3a854123603820082782f68747470733a2f2f31646d4e744c675643552d544a4161567943666871313348756b7963624159753475532e636f6d582092da8fc2fc16229c4c22e44776cb2e005a32d48ee1bf682549c86ca815748aac825820a16ec4165f34e740a4bea881e564ac262724b4eb81502c4479ce61ee328dcb8c01820082783768747470733a2f2f6a3375386a54716875334a6f74364d336d67696546532d4a5257494d6d7a3751557346565944434c63685a2e636f6d5820ad9cc5a0784c9c7ec0394de3225a63f3f147627eaf979e5536f984698d1641f514d90102848401581de1d6739c6c0170b9eef78cae5d234108b76bff20eaa3798fa3e3c3a4f7820382582030f0d5d535806bc7ffc1b37e3e91901e0a0f8d72e38b3ed1f0949f20a2491cf50582783e68747470733a2f2f4f416b6e687a49757871734c7577744357525a66597a504d795945796d4941476a73466a71566b6c6c4f4564342e766747532e636f6d582051b4c58dc79d95f7a3ba4591c30fad5bd65c66dfe70003ba455ea9e3d0396612841a00072d49581df01eceece1dd2e9697624bd0798135c56f189df77a8fce9438d6d613f48302a0f682783168747470733a2f2f565970712e6b34537255612d5658485677413749544e34362d4872647164695374464e6a792e636f6d58206e3f6ceef56af0c7fac102822278230d6806b746a202043b49cba5d5f7747dbf841a00015dea581de04bf62f66204cdc8f4c42bdfce121e7a7327905576a37a8552d5e7564810682783668747470733a2f2f47596944587676334f41662d53724d3965523278423973756261594a653839435a41577545524b4470472e636f6d582037c9698163e3d168f43ed378ac28dbec0cf1c3f56aa6e227fb8c0313c7d99051841a0004093e581de12dfe8cdef1604f876fdd21d4d2e1caee0ef8d53e387e51e8e2da1cc78400f6b7001a000741560119d69e03070408051a000882d0061a000c54fc070709d81e821b0149e2ba1cb274d51b00000002540be4000ad81e821a00049c831a0007a120111012a5009f252304250a07042d0322242e0523060c232a2325220a0f282b2109260d0f0a0f0c0c21242c0a052a2108092c292f28282d0e0b062f102121062d0a23082f00290c2405062a2702080129060c262603020f210d262f220c0d2629020d0c092222240b0c0b050f010a070d0d08002202200921250300212c2e0c2d2e2c2c0f072b2009250e210a032e0c2f0e21270e0e0e272304062d090e0e10100f10100e030e2a05062f280bff019f0c09210f002a022a020a0f002c072d2e2b0d2505022e062c230900020428102d0f2720282404060225242001042d2e0627092328062e0506070d2400262c042f08200c0807282a080e21070e0824202e252624252d23080f052b0a1008072d0c052c21010700012c2c062d2a2b020d0a2f0c2e2e28252c0c2a10280a082b25060a210c06250e0b0f220b2b0f0c092809210e230309251007102610272310200020010f0a20230f0705222e05292324ff0982270a14862e2e0c282f2d1828801382d81e821b5d446d904c89be4d1864d81e821b11cc641a92cf9d331b03782dace9d9000014821b77e9e7a6d900691f1b0bb2c947af5cef4f15821b1ccec093e3b4a1431b2ef8004e67ccc8441705181985d81e821907b51909c4d81e821b00000077c23a2cb51b000000e8d4a51000d81e821a1c0338691a3b9aca00d81e821b0951dd7ab9c829391b1bc16d674ec80000d81e821b0078c4008962d3d91b016345785d8a0000181a8ad81e821a3d673c231a9502f900d81e821b0000000f384185491b000000174876e800d81e821b000004d419cf250b1b0000b1a2bc2ec500d81e8218211832d81e8219459f194e20d81e82021819d81e821b000003bc9af57bab1b00002d79883d2000d81e821b002c48579c4761f71b002c68af0bb14000d81e821a011424411a77359400d81e82191e4d194e20181b07181c08181e1a0008e34d181f1a0002433a1820031821d81e821b027bc4160bc512451b00002d79883d2000581cbec9610cc711e175a8c58f01d474063f3e16b14054fd722da542c339827068747470733a2f2f473254462e636f6d5820ccd251828d557746707af15f8d3c00fa99743cf1e09cb407f57e50c438d7f4db1601a200d90102818258200e7ae8f436882696f2d10a3acdeffb5da709abb372bb932fe822ce463c60f38758403bfce2a0d2512913b7fd5d47c49b5c12189e750813a415ba9a100bce070a7cb15ee6ffb470e932279b0c318aee4d2e63ffe46f95521469b8436156d49dd7651e02d9010285845820d45ef50ed93e211b8c0d2ae8120ddf558fb37d35f88be366520cdda87304318a58404b8f94757cd611c37a549ed6414263e6ee2fd7c54d2a2cc58dbf93beec9785e84a4186b52e126d1eb9841ec322eb60f9b00b015928d60527593cde6892ab312658208a9e96bdbe9cd3b4b366ab1226241d85ecd5d9b2ba4502c76495de9460cb006843e554d784582027507cf11628b37567de0a67169b394d5eed8bda8d3248666b12419aa0eed0d25840f919024b81ef03c92d08a415c9570ef9207c56d98e1525cc3d9b3f9de19c3c65c857a5dbbbb5f6899676fd2c6a6237531aa0554ca8533a14f665c55d8e2daa5f5820980e9eb93382b2958b6707bd041eb8fde6aa0f2e53b185fc62770833db377adc458b08317d4b84582069c26add7d8c5cfe9f2d7f362173a5e9108de3bb9f7ed85f2fb5b13b027ef5b058400fb91647ecb4a5e01d8cc533cb5f45e0f7298f015b0101ab50c67193564e1d8d7f7591857e45747fad6066f8b75127ce5a49ed93be8ae680bba0cf88ebd3dfe45820ada98ba6648a8cde32614fd450752374aee32d9f25fac61a50c8021d415ac39540845820539e5d3dc8d0fbd96f86e5acd601ccc227dbf430f9d5d8307f3567d7af51038758404935f0a274d3db724c3f3a60d8d05160092ff42ee9b7121d13f663671dd8b9890c7a16f52021d145d6262fb0f19bf0f7abf89f3d4fe195452c6488b9d2df0cb658205850edb2c86618e532633ed10d8e45b6083f93fc2f11b57d781531e2dec59adc422f288458208f0801133279a8e54113b4bf6a1183c754d1dfaf11716efe128a5b6eb45866b65840c19d104b7a6f88a23ae59a0dec27e21c61319d88bbf10cf49c2e0ebdc17fdd2c55317faeacdd8b0003f9825169d386b926dec2a216819e4f924c3b41603dd6d258200b32b6d448e50431f66ba2b934f67cb5baadb045df9a955870bf7a3ea132f5ff40f5d90103a300a40063ec8689042409220b42eb5101848200581cba0859dc360469f61c3dc4515058d9b66669482c981d74657e6cb1d58201848201848200581c7f350541af95345fe13c7950918d34e760c0796a34bf0932476f7d17830300848200581c67ddbefc039e75a5b5fb37c33a96abb69958ea9ab4f9cfd94800d9758200581c634b6ebec45407caf41a7a18f89fbb4435d97d6ed2fac97843dd80b98200581c3b0950c151a9e2285b181b237184038ac1d5a7512e3e5eb598e3e3d28200581cbccec5ea742694929eece6c124fe3718cd07252152a552e5c63d88368202848200581c06695e887695ede9c8b1fc720020986e741610992da073f93e971a3a8200581c8eba496ad73f271cdd71bbe56ea4d0c297ffe45bafc0065272534e5e8200581c284cc3c57e40e79c704430b7ee44dc2829d8b9ec34e9c3737b82b23e8200581c4d9ebd101d005fa491ba3da4b756ca51de6d03b658c5d4eae001403a8202828200581cb66810725bc0a870e930ecd0480095740e799f0a8725c9883431618f8200581c066d2d9f19a25527e85efb6cb67b8fa7623e0f770904b8f7ad3349e98200581ce0ef859b3b0723a8a7261321becbef4f76da68b0c225c15cd3f5e650830304848200581c229ec00991cd9b0088e8e2fa95b1c8bcfd35fe865df22631bd14d30a8202848200581c1a63972d81b4885d47214bc0c3a9430caf7c9cbd34d75e787c70fcfa8200581c15252d4b8d9a4c6056d6773db1938bf4f8c63ee28fe868d8466f6a1e8200581c4f3b020bf1023667fce4679abcabbf81de46c031de021f4365f3ad808200581ca2b3b8b18e49ad2ed48019996c651746cfe5acf2ab60068b82208d8b830300808202808200581c3f0901d9c6e09d2dca27161d6aa93772a91119a0223169b8b10dc61d83030384830300808200581cd8077921ee7696469cbedd358e9561ac844735fd0b0089b0de411d6b830300828201838200581ca7cc0a91f4e29db9f3e990b67f62e30819d714257078d353f0bac51b8200581c02272fa5216561163cc8df9004ac6b39b8903b8edd0dd5e33dabc5a28200581c0d0a278f39163fcc0562a5c94fc698f8796a654e725c650b8e41aa758200581cb8532684406c8afa1508af9ebb1a82c3acf4cfcd6eff329d391f49038200581c4c6c8706d2acb2211b9d51a0a1aedeb4b563607228bd04a55c4d830f820283820283830300808201808201828200581cfbfcfe9de44487056495d8b9a0488ed1e41b1f1de7418710242eff368200581c0aaf8baa67e6608e9a96bebbfb68e59cbd127f074581340bb52b63ad8200581c25539ec501ac51d4c3ad4b4903e1b910b0e2850d58c0c1f63a3cab94820183830302828200581c976b3fb3d4d497df44ea2000a410c796a114b8027ad84f14058498118200581cd60c96a556bb0beafcf7e22a0a92c74ac808b7d6320808a41aa510a1830302838200581cb15f860764f2b13e67b8c75f495c0ae25f60ffd41345faa0ca1181268200581c6953f849e4f19e92f33c7255917d1eaa52475ddbdd7594237f3b74228200581c6051b82eaf8da7700087ac5b02a58c27571f9638bfd81612f1be8f4e8202800481484701000022200101",
-                                        "description": "",
-                                        "txId": "839832b2097414c91ac631be5fbaae4e1acf52e74eac6638466e494e5e9fd0df",
-                                        "type": "Tx ConwayEra"
-                                    },
-                                    {
-                                        "cborHex": "84ae00d90102838258204505af3ac7e19950891a3b2d2c22f6643992d5b5f0341c1f988641f18851202f0582582052656b2ff7aaac84843c39c59198bc83152c0443215ba987ecfb6fc38771b067018258209c6d27f83ff84b88313c80bdf3453f362cc76b46b016b55c8e2d46355ba9c89b020dd90102838258208cc21c8262ffca3bf63147863cd9b0ed0eff30fa633656f6cb0d05640bd6dbc107825820be003aef69247fb337395d113e383c34e1d001b8fa6a022b161d2728fd7d76cb04825820f514f79dc0b8d47e3ea3733285f2d581557e4fcaca06a0f8ba3e4ed775b7e98100018010a400585082d818584683581c582c36ad1dc9ceb79e91248c0bfd16eccd785fb2f6912dbb4b95a628a10158225820616c717a6e6e637879636278747379686b64787769637362636f777766767262021ad1724b2801821b4da78d110f2b060fa1581c54ccc7ad3efad2979fdb8858b673aeb21d8de7491ccf30df349b4955a141b2010282005820cf7b2c90c2fb2c4126097f91d078cd20ab24e5ec44baba7c32bb137f49191aab03d81849820246450100002601020405a4581df0067818bdb0ff33cbaa26931d7f4c898d07c952f683dfc3cbd2c3e57203581de0c34f70c8033d7aa6ed871367c83bd2f2b3d50bac7c727ed5adce1d2b1a0001cb34581df1068e44c7aa8805c029aebdbf9dbf7dcf0ed9edaa3fc23d440546093b04581de14fbb6063455d64ac869bd2a62cda86539a6f4085e9f393fe8265af8a1a000ddbc508010ed9010283581c2a0fd8b4da3638ea249c04fb3db52a834f9432637f5a33578fe9f2c9581c937af04b657d9fc25ae5af766d0ff752cd60d80965cd9f744b700dbf581cbb90453f11762e9529f66d3b7df3526c1ed02a613a1e30d61acb0ebf09a1581cffd38d11c16658fc428c7c3a80d1643082956ea30a8abed580c2a5aea141391b76dec16fe2bb1446075820dd7b41263ec0eb7c9b5939c48a78ab860d0c711469bce0cde848e5e1871500cd13a38201581c1f03b9b32e94cdb70fcd70e4a3516fc73385302242f2832115c53cf1a38258201bb1dc8e8bd373fc9ddd46d8b306f1b92a18fac233b05eb354f0e9f591767d9004820182782368747470733a2f2f31794a7a4e654250316e347770724252492e436a7243722e636f6d5820f8a92ff158aff5c0884abf07a8736a3c63cfc07a54783c72727eb4cf555b5ac18258205e91e72c7b5b63348970828c6af89785a4dacea0f9f412ebbc32cc9048064b9a03820182783168747470733a2f2f2e6436766b47566a76616f4d594a727a2d6e66664a6e6d4e65394931775133345871316e592e636f6d5820edb9ce0d628de6fdd3ddc3f0ce9829f675bf2964c2bfc8b9ad5d6e49b0288922825820baf976d5a9c5cf8230581afc26b4e668efa5842ca68bac5996d840302a726ff304820182782668747470733a2f2f44704b5855696a7747487a387830795630586b47483032324d452e636f6d58208cc9c716c7bfa8d4b8d020a9ceeb2ef6913774483951c42e4ea06f7a73abafbd8204581c3b806a29baa8fac58cb4bad98b5acb86ef43508d842aa6164fb10bc1a18258208b4c2fee82b9a383737757bc70863721a286cc4cc527c21572ad9cff31c667d107820282782068747470733a2f2f487734484e64552e544e646d6569646471555a702e636f6d58205c77311a85f43b6664284f67a2b7932c5d199e925fa94eb9b4cd1dbbc3b4c7e78204581ce02e3687f04bec2b79c0c79d6d95164170155e77a20d41e07306234fa3825820478db4dc628bdd897652582cff47de47265b1c86b5aaff80fc46ee70033683ac02820182781868747470733a2f2f556d58724368527869736e582e636f6d58205a5783d70cdc48d6d7db363195d715211c3caa08519f7a19214fb1e2f1c6161182582067cfbf2ac95bacfda30a62f6898104e31f1ccae0038f2e44e764b28f0c02eee606820182783668747470733a2f2f48576d67665377412e756e66336374556a4c7769363342503673342e366843636a6d6f326c462e4144412e636f6d582012b81425f188cf7ccf4fc493ca8748fb7109f79f9ebcc6f1dc499c8787706059825820dd85ae33ff9a1e8daecfd7eb3ae2809bbd1cd570eeb58f08054c3fa2add30d6707820082781868747470733a2f2f646b357a4639656a77724b332e636f6d582066ad878bf572af204cf61d8e2534fa4e1b6f98e7002b7b5f64b4f2ec9b39d27614d90102828402581df04105f09ddcb46df7a515da1fa5b08ea5cdd9229e5df50eb4f33fb0f7850482582037d66b3972bc74ed32d8e4b0df1154e566401117b472614df0329a35fea896a707d9010280a38200581c845a7e0e24cde5b4c84d773d2ec35d064f530e5066fb2d255edf92a8028200581ca15f7ce8f8cf1948d20dda141ef15d802502669b20512c2a80ef969b058200581cfd3091cc26a214f063e7962d9bbb3309ccd9af35ffd90928f131e7e60cd81e8218971903e8826e68747470733a2f2f68772e636f6d582061107b8e79b9ca3921d3bbf64c8ca36f7129a6f3830fcf191b2006a615f87631841a000aa443581df0a12225184c1c664a148e4e577bb7de1d4d9ef0e51731de4f09e658948301825820816a3743740aebee8ea945a1fac94f5f1218fd113753fea6ae22aaaece9b21410282090282781a68747470733a2f2f32582d34384f32544d45374f4d382e636f6d58205f35c656076fcffa62e0e1f82c95f01536b05ceeda258c461638c400dce68522151a000b4860161a000e9246a500d9010282825820e302bb554781573a2cf007627c01aa843393edfb643723bd71b4c08cb33da0fa5840f8411e6701121170f528b5b772c5cb5c5e05189d5f4b51a39f4221c4a693cebc48bed6eb2e9052daf73e458c8177df98aafdee1beb0babd6e9e120434bf7da368258201d0324c8a4c34b808c0d43400e06007b14b529629ad577b0e76ec5c0c462517a58400e2a2643159abb621a0047f5f98139c6b8246b9922fa819145091d9d81e4570331db1ad09ca0f135a54aea52139a8efb0906f04e3db3abc107df8d0f01b8533502d9010282845820a8a10f1c61a1cbfeeac2cd4c7c30e3da54837abec2cb0ae6e4272672a5c5fa185840df7b079a8b6948d8287cb584305cc5882975e93c551f3df5882977d4e83ad53f8e6277c80d766a8af070fe745d649ab6ed08da77018ed256cf9d7b2e3207b3b8582021dee99d2a554844d15532984b9636b745cb47979c791231e74cc5feea09222b4300a04c8458206e661230f8d5a6be9720afe9b95aec468ffffb7d6b4e1ffbcd0b9bca6dccdbbc58409fa98eb7977292b420db78e6833c1ad1cbaee4c280a4c01c9988521f7500d39f4e34d22020ae3fad4fc765ad21cc673a2e897595ee37372ea6eb433c4d1416cb58205ddd22b5a69ca403bbdfa8ff218363c89cd43fadbaaecd5a4526ba78c27ca18e4001d90102828205058200581c114ffeaa2045058daacda8be45ac78cfa1376cde44a5bd9dec0a30ae03d901028148470100002220010105a68200038201821b221bdc9b78df39951b75e3425686b6a73f820205829fa5d87a9f01ff40427059a1415704a1444df181d503019f439c58dd0340ffa52342e7f4002223444efc309b0504200380d87a80ff821b09bfa1ac30652b991b2d08c07a52591744820207829fa4d87d9f42f593ff8000d87c9f230142ac77414b4406e19a56ff437bf34f422b1901a5431649ca425b084043bab0c0010301200140d87c9f20439a26f5a1428d2044d3fceb0a24ff0442aa7b9f9f4043c39c0442d18744af4d1db74282f1ff4322f293ffff821b11591d2d89392c681b71b3cbac15ffb88b8203068242d699821b1d94538756c9f3d41b46020e34510659d48205018200821b3bf88837961458fd1b249c9f1b735aeec68205038240821b695967bf2d9e75e31b5b7c4503149e311cf4d90103a0",
-                                        "description": "",
-                                        "txId": "93f1230fce9ae08b6738954739cde96fa6316f5e55c1a6f66ac3b7fdacac7d9a",
-                                        "type": "Tx ConwayEra"
-                                    }
-                                ],
-                                "headId": "07030101070706050401060506080506",
-                                "number": 4,
-                                "utxo": {
-                                    "0206040407000605060003060301010104010506030508070103050505030308#7": {
-                                        "address": "addr_test1yrssfryryygn7plu9e3tezr02nzs65k7a5mafhgu5w32qlfa7xgz59nx5p7pg6vh88mz3s628nckl004frsnvh0yvwmq3njmyh",
-                                        "datum": null,
-                                        "datumhash": "04297807ac39e85310c9600dcd273b5b218a23f98ad3543e73c8a1a5d81db76e",
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888d": {
-                                                "aebcb9e0cbe7": 1
-                                            },
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0306080500010405040504060804010500000302080003000207030107080304#17": {
-                                        "address": "addr_test1ypyr8hcz8y09nkmfzerfq76x43na36n7hqdu9jwgv75hh2ruzdv92h95d3grrvjc8qnwhel0mned45v0yutjhqy6xggq9vcclk",
-                                        "datum": null,
-                                        "datumhash": "0a9218f193bca85be4e0b2b0d6ee524ceacea7511d19076c2387f9f50ba1304f",
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "566fb66a85b5f4a55cad95b7f94a745d66ee846cbb6ae010eed629aa": {
-                                                "ecac7b309fc712bfee14": 4164995006013027800
-                                            },
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0402000204040304000503050705000508010605040607030404070508010301#50": {
-                                        "address": "addr_test1qz3hj3paa0zfkprn2xp7dj57209x3haqxy4g0ameapljrr0plwx8qexkqwf9jzwlp4y2zs5z97q88wjw8d9g7hx9u2vsznfxpe",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 969750
-                                        }
-                                    },
-                                    "0403050602020802010006030606040603030703080106010200050508020200#55": {
-                                        "address": "addr_test1qq66q4fvn08vrkf9jpwgzluamftv8hmnt9wuvf4dddz2zru6az4ujjal6kd424fpggr32cm2g3kmftla8y2wv7h5hnss0gvvep",
-                                        "datum": null,
-                                        "datumhash": "f48d18e94df6d357fd0f11ba188b2feaf522a4d12227b83886d83afad0a23c2f",
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "d115748cdb69084829fcdbb205e2825a6e6ffec0c9eae6360bc31622": {
-                                                "a4cbc421cc86c797ba796eb0dac1e11517027faa5ce81073324a00eaa27a72": 8529759567623055162
-                                            },
-                                            "lovelace": 1439540
-                                        }
-                                    },
-                                    "0506070706010307010403030503060103070208020800040701020203020105#72": {
-                                        "address": "addr_test1ypc6r09q3wms4f95mj0x5hqmpyt8327yx6exycnvvz8tvpspq3chyuctsjqs7ydswaf08f7y5akxuqzcwpa73gz2a77q3mjtwm",
-                                        "datum": null,
-                                        "inlineDatum": {
-                                            "list": [
-                                                {
-                                                    "constructor": 1,
-                                                    "fields": [
-                                                        {
-                                                            "list": [
-                                                                {
-                                                                    "int": -3
-                                                                },
-                                                                {
-                                                                    "int": 0
-                                                                }
-                                                            ]
-                                                        },
-                                                        {
-                                                            "constructor": 2,
-                                                            "fields": [
-                                                                {
-                                                                    "int": 5
-                                                                },
-                                                                {
-                                                                    "bytes": "10"
-                                                                }
-                                                            ]
-                                                        },
-                                                        {
-                                                            "bytes": ""
-                                                        },
-                                                        {
-                                                            "constructor": 5,
-                                                            "fields": [
-                                                                {
-                                                                    "bytes": ""
-                                                                },
-                                                                {
-                                                                    "int": 0
-                                                                },
-                                                                {
-                                                                    "int": -2
-                                                                },
-                                                                {
-                                                                    "bytes": "308c3a"
-                                                                }
-                                                            ]
-                                                        }
-                                                    ]
-                                                },
+                                        "k": {
+                                            "constructor": 5,
+                                            "fields": [
                                                 {
                                                     "map": [
                                                         {
                                                             "k": {
-                                                                "constructor": 1,
-                                                                "fields": [
-                                                                    {
-                                                                        "bytes": "995dee"
-                                                                    },
-                                                                    {
-                                                                        "bytes": ""
-                                                                    }
-                                                                ]
+                                                                "int": 5
                                                             },
                                                             "v": {
-                                                                "int": 1
-                                                            }
-                                                        },
-                                                        {
-                                                            "k": {
-                                                                "constructor": 0,
-                                                                "fields": [
-                                                                    {
-                                                                        "int": 3
-                                                                    },
-                                                                    {
-                                                                        "bytes": "760e92fd"
-                                                                    },
-                                                                    {
-                                                                        "bytes": ""
-                                                                    },
-                                                                    {
-                                                                        "bytes": "09"
-                                                                    }
-                                                                ]
-                                                            },
-                                                            "v": {
-                                                                "list": [
-                                                                    {
-                                                                        "int": 3
-                                                                    },
-                                                                    {
-                                                                        "int": 1
-                                                                    },
-                                                                    {
-                                                                        "bytes": ""
-                                                                    },
-                                                                    {
-                                                                        "int": -5
-                                                                    }
-                                                                ]
+                                                                "int": 4
                                                             }
                                                         }
                                                     ]
                                                 },
                                                 {
-                                                    "list": []
+                                                    "int": -4
+                                                },
+                                                {
+                                                    "constructor": 1,
+                                                    "fields": [
+                                                        {
+                                                            "int": -1
+                                                        },
+                                                        {
+                                                            "bytes": ""
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "bytes": "53"
                                                 }
                                             ]
                                         },
-                                        "inlineDatumRaw": "9fd87a9f9f2200ffd87b9f054110ff40d87e9f40002143308c3affffa2d87a9f43995dee40ff01d8799f0344760e92fd404109ff9f03014024ff80ff",
-                                        "inlineDatumhash": "dd314dc563a4ed959f90443af20f1f720b1f0f675195bb110bb0e4a9642aec23",
-                                        "referenceScript": null,
-                                        "value": {
-                                            "6fd26f0fd0578ff67dcf49b015c01426fc6709afff1599ef1d59f1f4": {
-                                                "5c43635fd2d92fe35979230c2ce5a0a33b9d09fdcde062047a4d9bc7": 1
-                                            },
-                                            "lovelace": 1542980
+                                        "v": {
+                                            "bytes": ""
                                         }
                                     },
-                                    "0603040003030207080305080202070106010605070700070106010003020304#37": {
-                                        "address": "addr_test1yq2f0y835g2uhfrh5un63say6g92ta7mknu80cdux8l42tgjnjs8hy2jcaa9eekuj88hzv5udz7pcpy3c5s9echtmtrsadzhjh",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 969750
+                                    {
+                                        "k": {
+                                            "constructor": 2,
+                                            "fields": []
+                                        },
+                                        "v": {
+                                            "constructor": 5,
+                                            "fields": [
+                                                {
+                                                    "map": [
+                                                        {
+                                                            "k": {
+                                                                "bytes": "9cc178"
+                                                            },
+                                                            "v": {
+                                                                "bytes": "31c2"
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
                                         }
                                     }
-                                },
-                                "utxoToCommit": {
-                                    "0300000708050800080501040208000500070800010602020608080703080601#67": {
-                                        "address": "addr_test1zpyp0jldesnxcas7uqlehk6kkx7qa94pwg0azk3d30ut5587v7jdctg9t9l57ddteg78sepasasaq8wd6sya8yxusrfs3kpzj3",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 969750
-                                        }
-                                    },
-                                    "0308060407040004000004050008050805060201060604010504040505010105#73": {
-                                        "address": "addr_test1qpdp4qmxka567nhncpvl3uwgtx02lmjddr92ace4a2nv2hku92vewwwnxxng60lk9vv6gz8y988kvs7kcudstx7lcmjqjrnauw",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 969750
-                                        }
-                                    },
-                                    "0405020005010405040008070601010308010700040207020602050208030105#84": {
-                                        "address": "addr_test1zprw6rrz44fche3kvtvx7d355nev6m4xam2pj5f7yfd8yhsne265saxjh5avc4jthyqgn0qznc6q4py5g9y8zpt6hcgszaeudw",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 969750
-                                        }
-                                    },
-                                    "0500060805000603010704070404010106000308060202080708040202050700#73": {
-                                        "address": "addr_test1yqzs7x940a05x6nh5fhll99mnnrl00wuf3ts9y8u7sdsprhqwtuy8x98tw4l05ulrssxap384ya30g2z6vmmep5fm5rqglyeh4",
-                                        "datum": null,
-                                        "datumhash": "c0a69567a6c6198a5fb527f3644eefaa8e0bebd5f4d5e86cfb4c524a14fdbe9b",
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebe": {
-                                                "32": 8450337902095869834
-                                            },
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0503000606000004000106060801080601040203000202040705080708010700#33": {
-                                        "address": "addr_test1yztcqpq9eyt75ndglcwkcms75ra4r84uhn7p9f4x8ca4ncghfg8jxd6revpt7l9hxdexp82t822cg5adnmc2wf0lqk9sgp28d2",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0701080608020002070506040803080501040005000105080307060207020704#72": {
-                                        "address": "addr_test1zz076c9gahhg822yf9n6l4e3f8j7gqms7rncsxq84veftctcdy5ka2av83g473pmqvxeelp8hk44mrllj6lvgv3xuplsrk3cdp",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 969750
-                                        }
-                                    }
-                                },
-                                "utxoToDecommit": {
-                                    "0000060600080206080208040502000106030400040605060100050107070303#10": {
-                                        "address": "addr_test1zzzvuha59hth3qrq5pvdhtd8uydtc6lqtqkr06l5dr48p0xpmdqn8ew7mcwjhlgazjl9emrm69p54gmp2jsj809qlprszfqdlm",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0001080205030100000307000805010705000704060006020408020806070207#16": {
-                                        "address": "addr_test1ypkntncwwm62df9q0f6wrewhgy80hhply3fv3p6dn72t2nmtwhleqezraumj7ftcldptad3pj2az5nltq7522avfvkeswjcz5c",
-                                        "datum": null,
-                                        "datumhash": "cb4916a8270479c0038db6a29792bac32c8142555cfbb7e8e3110ccc60eab047",
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
-                                                "3d14c74ff4e69e04f0a8f7ba504cac2916d9b88ce2bd94": 8312928531760614497
-                                            },
-                                            "lovelace": 1400750
-                                        }
-                                    },
-                                    "0003080604060500080604080600040200050202030703030108070506080205#34": {
-                                        "address": "addr_test1vq9gwlqffev637xtq6l9y0sa0r3cfdv8fygnmxq39rlryackunlny",
-                                        "datum": null,
-                                        "datumhash": "76b63893449605395ac3a9304b356753dceb17e2a10e9a2d9c55e29db78733f0",
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "52749b387028d7166747821e281fa6d825766c66784a8ab5412b2766": {
-                                                "fefdf3ae5be17c3581e36c26f4fa74ea637ad16bbbd71ba14d": 1075415117879538554
-                                            },
-                                            "lovelace": 1293000
-                                        }
-                                    },
-                                    "0203010003070503020703030708010503070605060406070202050807040602#85": {
-                                        "address": "addr_test1xrke66eusr8aw4r3nu0emc9l3gwvfedyadfsuenwktw5wj4d6u4y4aaewu8wlqe83r8zu8q2kpnhsej23q892dzccpmq2qs9ry",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 969750
-                                        }
-                                    },
-                                    "0406080008050304070501060800040502060505010607060207000203000103#79": {
-                                        "address": "addr_test1xqmxms0yz3504l0ytwxsvy0ppxhsdw0fmhqcs5ah80545heq77xz7afrsnz7rtt6vwm9le47q4q794x7ytrgxpw5jvzqnx6vja",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0408040204000501010006030805010607070301010302020308020803080605#55": {
-                                        "address": "addr_test1zqmsjxx4ntxwacpr3u3cuz4e8upedvdg6uh00ckv23zsxjvgu5jmqd2e5knt2eqhvcevnxfjvehdlmd46pj59qrvs8ps82srwf",
-                                        "datum": null,
-                                        "datumhash": "2d2f146b4fe2151eee59eacdc1fed5eb283220d38a28ec099545fc9050ec82ac",
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
-                                                "e0c13a6b38f3": 1
-                                            },
-                                            "lovelace": 7500000000000000
-                                        }
-                                    }
-                                },
-                                "version": 1
+                                ]
                             },
-                            "tag": "SeenSnapshot"
+                            "inlineDatumRaw": "a524433e3aa94196a14304e5bed87a9f02222140ff9f0521404433f8ab51d87c9f210043e1978a0043ca189fffff9f9f4297f5050105ff9f4020ffa142c2f143dbd0a220ffd87e9fa1050423d87a9f2040ff4153ff40d87b80d87e9fa1439cc1784231c2ff",
+                            "inlineDatumhash": "c765f3ff442559d915a02697d6644ef5b93f0524e281125e94428bb26ebd40f4",
+                            "referenceScript": null,
+                            "value": {
+                                "8a9a77d53b4273539d6cba64ea53c8626ad3471dd1e5b37ba7e7a979": {
+                                    "1f58e7950b398e85a22908646601": 1
+                                },
+                                "lovelace": 1655040
+                            }
                         },
-                        "version": 4
+                        "0507050203030601020705040407040804000606040803060203000007070000#28": {
+                            "address": "addr_test1yr7nq0x4tqtp383j2qynk3h5kt3kxv2vql2e0zkchqak4ud2cghkjrplk8362gmdppz8j0khfn2j3ls8zyfrmmuw450s3d6qlj",
+                            "datum": null,
+                            "datumhash": "e6e88c58d571494a7d804a78cbb7eaaf5ad49d5ad14c61246b408468a5a335e0",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
+                                    "2a6fd0069be41812901291e790d998e2ae37aa7779e6c89bdd28f1c781c597": 1
+                                },
+                                "lovelace": 1405060
+                            }
+                        },
+                        "0602050005000508000402070300080101030501010207080002070600020808#57": {
+                            "address": "addr_test1zpw3px3lv83fv9w08u50a5pdck2xptx0zf8a90xmrlp7jyvgkw8th6ruqc986fm496w0szfhvctukw6hlquqxk36ardsnvp4cg",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0800040108040806030603020208010702070106070703010805060607030504#95": {
+                            "address": "addr_test1zzrgud9nsuez53snj8z2cwk8xmeqx5ly5j5sazlq32kcrmfmuakyc0c7khgze9an8cqrj0c6cy7mkmdfad04ndwqc4vssna3xv",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 969750
+                            }
+                        }
                     },
-                    "headId": "05080002030000070403010206030101",
-                    "headSeed": "07070106080402070600050606070305",
+                    "headId": "01030105080607000601070006050802",
+                    "headSeed": "07030201060406050004070502070201",
+                    "mode": {
+                        "tag": "AwaitingSelection"
+                    },
                     "parameters": {
-                        "contestationPeriod": 6039,
+                        "contestationPeriod": 32962,
                         "parties": [
                             {
-                                "vkey": "d9950bf14b5fc1c8a3ed1946736583e164ddfe31f783df5d2b0731254d2d4769"
+                                "vkey": "ce7d2a175e472cb819aba8f1de80b5505ca63989cbdf598c273dc6314db29780"
                             },
                             {
-                                "vkey": "ab547b2e21177882c9a75adbe083f791aa162fd139da0990f68c6a895de06a4b"
+                                "vkey": "b95400fbcc0242b4b195f07b2363c0c859818abf247b3877b65ad12d82ea5a55"
                             },
                             {
-                                "vkey": "7c0070b69166444d5f7682330fa9f47a3f5467dd3970de0aee68cbafbeb090b1"
+                                "vkey": "83d28bb95c2379360245ecccfe9c58224c745a1bbed3cf4635c0eb56fda2bfa1"
                             },
                             {
-                                "vkey": "e06679e73470c7b2d62c21c382adab8d0f973eb633dec35d0814e1b070085318"
+                                "vkey": "b0cb530eb60bd0afbdbc327becef15b8b9c6d8d97ac48c6322a908df6575caaf"
                             },
                             {
-                                "vkey": "5f94993a8ac04b39e9d4a7bd27afec497a4f9a2dae99f44b6a60e0551bed7ebf"
+                                "vkey": "a98987077073385221b7131d97f81e5df4ba2a1d7ce7a3f0cc2d218d5faf23d4"
                             }
                         ]
-                    }
+                    },
+                    "remainingOutputs": {
+                        "0201020802040405010704060504030507010501060501010106000002050404#39": {
+                            "address": "addr_test1xzwmt0n6qtf7hu2p864maq26zp37m7ack32zltha5tvgr8h0uwzdwscselw7eh0p9cpmfrju8gggq4udkdzhyrx4j4dq0rt50s",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abae": {
+                                    "37": 2189173917287918813
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0208050606020407030502030605020303000000010206050001020505010804#43": {
+                            "address": "addr_test1vzwmzyd0stst0lkdz52r4yxksldpcfph5mnrgtvdwy3px4sh303ll",
+                            "datum": null,
+                            "datumhash": "9744b61c8588e32eaddf3705e1af9c9405a38264fd47a644c58174e688058613",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "b4c26ab4eb829be73c67ae8d6ded17738410e35d026ac9e6db79b16b": {
+                                    "087653262fe551": 1
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0508030708000506080502030301050807000401000207080400070501070201#79": {
+                            "address": "addr_test1xz024kzn7rnlapz4qy376cvqkeew0c7yx3uz5345s4txp3rw8vd4300uyu6nfg2ll4d4upuxhd6s9fjyqr0qhdpal85qhkkk5d",
+                            "datum": null,
+                            "datumhash": "b92d83ea53ab6da984c2bfdd4d7ea6619850a5284109a5a303c8766d46e81b82",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "b0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165": {
+                                    "45aa3b00d0b8723748ae7649c528c40ebd382e1f783588bb3a627d4ea1": 1
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0702040506000408070608010008050604020207050103040305050307000005#81": {
+                            "address": "addr_test1zqh9elr52necyx92gsp0fydw8wd40wyds07ashc39pjlddfgxk44822ppsdwugguc59yv3wz50ecp0ufqcx29zzsgl5q056zh9",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0704040800040408060400010507080200060005070006030100010307050500#97": {
+                            "address": "addr_test1qr272ekdxu37jngdeeupajzqn6lfufdejmzv9h76ehecd4xkdagu6nydpt33qtxqk8xvt2lrga6my6jhl6jaw88sjrgshy33e9",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0707050303020106060500010201040100020706050502060604060300040302#95": {
+                            "address": "addr_test1zzksu9y6ty5h7c2d8ah90pdnr4x7sjj46e2hc4qe7mc2ruyyuezjm8hv7km29mfy74usprwcg54pnl7edpfgxqmuef2sgalqcs",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 969750
+                            }
+                        }
+                    },
+                    "version": 1
                 },
-                "tag": "Open"
+                "tag": "FanoutProgress"
             },
-            "pendingDeposits": {},
+            "pendingDeposits": {
+                "0408010000050806020208010306050500050703050503060300000305060508": {
+                    "created": "1864-05-08T10:18:18.305190755992Z",
+                    "deadline": "1864-05-13T12:34:09.62368696717Z",
+                    "deposited": {
+                        "0007000704030100000403060003070307010602080407030302070700030503#60": {
+                            "address": "addr_test1xpyettyzrh44e9as9zcf4zflwkplak3r5esxnjv60dac6t3gjujlf77qq30633t27lneuj0mcq3cntlwfv3e2fz5rlts8rsm6e",
+                            "datum": null,
+                            "datumhash": "477b69be25b2f4defae36cdb1a8f9e20f5af542fed87772cea54dd137b0efd96",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "e5b25313dc796ede363eb1bba5145218762c9749f65cfc8b3d477cd8": {
+                                    "238a85ed6d9387cd": 165160070200392297
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0205080108010204080101070801040700070001070100010004010608040404#52": {
+                            "address": "addr_test1wzhw06ag0rk0azj6nkm69yufanp2q0pmrx4sq7nynvul7qqztzxzn",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0400080807000706070208070804010206010407060708000300030600020007#22": {
+                            "address": "addr_test1yrye2f5dnu5e7t7enmcfv2hked0czszgt8mhx2rt9f7wyrtz3y09x6sph8775fnaduc2nfdp4yz0mkhrkdalj45qra6s8yszfu",
+                            "datum": null,
+                            "inlineDatum": {
+                                "bytes": "2124d8db"
+                            },
+                            "inlineDatumRaw": "442124d8db",
+                            "inlineDatumhash": "4b142a50c68d8485879041e8dbcb2fb3ba92237079adec4b994f090c5019c646",
+                            "referenceScript": null,
+                            "value": {
+                                "b0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165": {
+                                    "5c423a": 1
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0500030204040607020602060504050700060506060404000107060400010501#29": {
+                            "address": "addr_test1vrpg3s3mff0kha7errw40fh5f3c6saqmqmzwphuyydp8h8shxhgwx",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0701000000060001020500030400080702070108050308020807080202000308#34": {
+                            "address": "addr_test1wrttuymk2ujrmq2w9faqyup97wmsl42nzfnryr9n37s5rggj44ffn",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 849070
+                            }
+                        },
+                        "0800080305010105040702030807060705080700000004010801070105040808#63": {
+                            "address": "addr_test1qqmrwf390cgg4e8gtjzg95q3v5dv08cxc30ne966a4fdczdvmn3xdx3g7dc5fg9e7v362lu38p55vzv7lzexxejhny8qxr5sdq",
+                            "datum": null,
+                            "inlineDatum": {
+                                "list": [
+                                    {
+                                        "int": -1
+                                    },
+                                    {
+                                        "int": 3
+                                    },
+                                    {
+                                        "list": [
+                                            {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "bytes": "0c529861"
+                                                        },
+                                                        "v": {
+                                                            "int": -2
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "bytes": ""
+                                                        },
+                                                        "v": {
+                                                            "bytes": "4a"
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "bytes": ""
+                                                        },
+                                                        "v": {
+                                                            "int": -2
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "int": 4
+                                                        },
+                                                        "v": {
+                                                            "int": 4
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "bytes": "8332d8f5"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "list": [
+                                            {
+                                                "constructor": 0,
+                                                "fields": []
+                                            },
+                                            {
+                                                "constructor": 0,
+                                                "fields": [
+                                                    {
+                                                        "int": 1
+                                                    },
+                                                    {
+                                                        "bytes": "a5a5d4"
+                                                    },
+                                                    {
+                                                        "bytes": "9e72c7"
+                                                    },
+                                                    {
+                                                        "int": 0
+                                                    },
+                                                    {
+                                                        "bytes": ""
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "bytes": ""
+                                            },
+                                            {
+                                                "constructor": 3,
+                                                "fields": [
+                                                    {
+                                                        "bytes": "d2f67ac7"
+                                                    },
+                                                    {
+                                                        "int": 1
+                                                    },
+                                                    {
+                                                        "bytes": "bfbe07"
+                                                    },
+                                                    {
+                                                        "int": 1
+                                                    },
+                                                    {
+                                                        "bytes": "30b0"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "int": -3
+                                    }
+                                ]
+                            },
+                            "inlineDatumRaw": "9f20039fa4440c5298612140414a40210404448332d8f5ff9fd87980d8799f0143a5a5d4439e72c70040ff40d87c9f44d2f67ac70143bfbe07014230b0ffff22ff",
+                            "inlineDatumhash": "b706aa7e97b3c2fcffdbb37619823529d89059f68b72518c29623e8df88c4d63",
+                            "referenceScript": null,
+                            "value": {
+                                "ccd3e118a42c182e46b90407f36e6eee2c968a2d1026ae4ca4b3a69a": {
+                                    "acb4d5030060f5885a49c27495b49332da85dd7c4b3fed550f64e6": 4075858703651441835
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        }
+                    },
+                    "headId": "00010608010701010002010206030008",
+                    "status": "Active"
+                }
+            },
             "tag": "NodeCatchingUp"
         },
         {
             "chainPointTime": {
-                "currentChainTime": "1864-05-07T00:23:21.341343475726Z",
-                "currentSlot": 1,
+                "currentChainTime": "1864-05-06T03:10:25.383405255077Z",
+                "currentSlot": 5,
                 "drift": 0
             },
             "headState": {
                 "contents": {
                     "chainState": {
                         "recordedAt": {
-                            "blockHash": "0506080007020605060105030501070801080403070708040007070708050007",
-                            "slot": 6,
+                            "blockHash": "0000020800000505000800080602010703050707050101000602020704000007",
+                            "slot": 7,
                             "tag": "ChainPoint"
                         },
                         "spendableUTxO": {
-                            "0103040703040805080000050802030603070000010802010400070704020200#18": {
-                                "address": "addr_test1qzlw2guqynlq8t32z0fhp0zjjzzvxyu3ky5avyt7vl63xqx78c06s5jxrf398npa04n7xuxle7pnrs5udzfa4tzgh0ksv6e2ky",
+                            "0107080500070108040607070801050505010402080801040600020106080403#35": {
+                                "address": "addr_test1qr4cagxn88m68y5hwa0296m67w7wd6vfd9k8y7knmprj4mahnrncxg5k87l6hqem6m4txdr7swde8pnujw2u7m4tjkesvyg4gh",
+                                "datum": null,
+                                "datumhash": null,
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "dfd7e8aadc27a9cab9b6c19675744a851da1abcb0deb90929582248c": {
+                                        "38": 1
+                                    },
+                                    "lovelace": 7500000000000000
+                                }
+                            },
+                            "0302060201030405010203020703080108030802040802060702010603010507#66": {
+                                "address": "addr_test1vzmyw2nac476ahdt42svqcd04ktqdhws8pm947fhmx4l8hglpn25f",
+                                "datum": null,
+                                "inlineDatum": {
+                                    "map": [
+                                        {
+                                            "k": {
+                                                "int": -3
+                                            },
+                                            "v": {
+                                                "bytes": "70f96d15"
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "list": [
+                                                    {
+                                                        "list": [
+                                                            {
+                                                                "bytes": "e9b730"
+                                                            },
+                                                            {
+                                                                "int": 5
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "list": [
+                                                            {
+                                                                "bytes": "f1c4849c"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "v": {
+                                                "list": [
+                                                    {
+                                                        "int": 2
+                                                    },
+                                                    {
+                                                        "bytes": "dc"
+                                                    },
+                                                    {
+                                                        "bytes": "fd51733e"
+                                                    },
+                                                    {
+                                                        "list": [
+                                                            {
+                                                                "bytes": "a1"
+                                                            },
+                                                            {
+                                                                "bytes": "ee4c"
+                                                            },
+                                                            {
+                                                                "int": 3
+                                                            },
+                                                            {
+                                                                "int": -5
+                                                            },
+                                                            {
+                                                                "bytes": ""
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "map": [
+                                                                {
+                                                                    "k": {
+                                                                        "bytes": "76"
+                                                                    },
+                                                                    "v": {
+                                                                        "int": -1
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "bytes": "fff7fe"
+                                                                    },
+                                                                    "v": {
+                                                                        "int": -4
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "int": -4
+                                                                    },
+                                                                    "v": {
+                                                                        "bytes": "4150405a"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        "v": {
+                                                            "constructor": 3,
+                                                            "fields": []
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "int": -2
+                                                        },
+                                                        "v": {
+                                                            "list": [
+                                                                {
+                                                                    "bytes": "9b"
+                                                                },
+                                                                {
+                                                                    "bytes": "1cf89b60"
+                                                                },
+                                                                {
+                                                                    "bytes": ""
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "constructor": 3,
+                                                            "fields": []
+                                                        },
+                                                        "v": {
+                                                            "bytes": "2ca9"
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "bytes": "868a11"
+                                                        },
+                                                        "v": {
+                                                            "list": [
+                                                                {
+                                                                    "int": -4
+                                                                },
+                                                                {
+                                                                    "int": -1
+                                                                },
+                                                                {
+                                                                    "int": 5
+                                                                },
+                                                                {
+                                                                    "bytes": "946784"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "constructor": 4,
+                                                            "fields": [
+                                                                {
+                                                                    "bytes": "ee"
+                                                                },
+                                                                {
+                                                                    "bytes": "00628581"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "v": {
+                                                            "int": -2
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "v": {
+                                                "constructor": 0,
+                                                "fields": [
+                                                    {
+                                                        "int": 3
+                                                    },
+                                                    {
+                                                        "int": -5
+                                                    },
+                                                    {
+                                                        "int": -2
+                                                    },
+                                                    {
+                                                        "list": [
+                                                            {
+                                                                "int": -3
+                                                            },
+                                                            {
+                                                                "bytes": "c0"
+                                                            },
+                                                            {
+                                                                "int": 5
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "int": 4
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "bytes": "78"
+                                                        },
+                                                        "v": {
+                                                            "list": [
+                                                                {
+                                                                    "int": 3
+                                                                },
+                                                                {
+                                                                    "bytes": "9ef32d"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "constructor": 2,
+                                                            "fields": [
+                                                                {
+                                                                    "int": -3
+                                                                }
+                                                            ]
+                                                        },
+                                                        "v": {
+                                                            "int": 1
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "constructor": 5,
+                                                            "fields": [
+                                                                {
+                                                                    "int": -4
+                                                                },
+                                                                {
+                                                                    "bytes": "9cf619"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "v": {
+                                                            "list": [
+                                                                {
+                                                                    "bytes": ""
+                                                                },
+                                                                {
+                                                                    "bytes": "1414"
+                                                                },
+                                                                {
+                                                                    "int": 1
+                                                                },
+                                                                {
+                                                                    "int": -1
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "int": -4
+                                                        },
+                                                        "v": {
+                                                            "list": [
+                                                                {
+                                                                    "bytes": "da"
+                                                                },
+                                                                {
+                                                                    "int": -1
+                                                                },
+                                                                {
+                                                                    "bytes": ""
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "v": {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "constructor": 2,
+                                                            "fields": []
+                                                        },
+                                                        "v": {
+                                                            "bytes": "a63471cd"
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "constructor": 2,
+                                                            "fields": [
+                                                                {
+                                                                    "int": -2
+                                                                },
+                                                                {
+                                                                    "bytes": "b8c8c1"
+                                                                },
+                                                                {
+                                                                    "int": 0
+                                                                },
+                                                                {
+                                                                    "bytes": "8bb420f1"
+                                                                },
+                                                                {
+                                                                    "bytes": "35"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "v": {
+                                                            "list": [
+                                                                {
+                                                                    "int": 4
+                                                                },
+                                                                {
+                                                                    "bytes": "6e56"
+                                                                },
+                                                                {
+                                                                    "bytes": "ec14196a"
+                                                                },
+                                                                {
+                                                                    "int": 1
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "list": []
+                                                        },
+                                                        "v": {
+                                                            "map": [
+                                                                {
+                                                                    "k": {
+                                                                        "bytes": "bf34"
+                                                                    },
+                                                                    "v": {
+                                                                        "bytes": "f14e"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "bytes": "c9d056"
+                                                        },
+                                                        "v": {
+                                                            "constructor": 5,
+                                                            "fields": [
+                                                                {
+                                                                    "int": -3
+                                                                },
+                                                                {
+                                                                    "bytes": ""
+                                                                },
+                                                                {
+                                                                    "int": -3
+                                                                },
+                                                                {
+                                                                    "bytes": "3253"
+                                                                },
+                                                                {
+                                                                    "bytes": "32"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "int": 4
+                                                        },
+                                                        "v": {
+                                                            "bytes": "246d"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "k": {
+                                                "bytes": "d8"
+                                            },
+                                            "v": {
+                                                "bytes": "b0"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "inlineDatumRaw": "a5224470f96d159f9f43e9b73005ff9f44f1c4849cffff9f0241dc44fd51733e9f41a142ee4c032440ffffa5a341762043fff7fe2323444150405ad87c80219f419b441cf89b6040ffd87c80422ca943868a119f23200543946784ffd87d9f41ee4400628581ff21d8799f0324219f2241c005ff04ffa441789f03439ef32dffd87b9f22ff01d87e9f23439cf619ff9f404214140120ff239f41da2040ffa5d87b8044a63471cdd87b9f2143b8c8c100448bb420f14135ff9f04426e5644ec14196a01ff80a142bf3442f14e43c9d056d87e9f2240224232534132ff0442246d41d841b0",
+                                "inlineDatumhash": "5c8e3bd2ff631c3764e8695a4cfad2672e73f80885fbf4e8a405e18f02b6887b",
+                                "referenceScript": null,
+                                "value": {
+                                    "538a9d089a75f2756f00405aa4bf174c5b6f0ef379ceb1d63ab859b2": {
+                                        "38": 1
+                                    },
+                                    "lovelace": 7500000000000000
+                                }
+                            },
+                            "0702060101070803060303020801060306070804070405060606040601030302#92": {
+                                "address": "addr_test1xr6yp5h5lcn2cfnv2u9jm5ngg722wwclffw8jh7zeqp2qg8t7585c6ar6zmccvdl79lyhmwxe739cuv7e2fjspsu0zzs5xkhss",
                                 "datum": null,
                                 "datumhash": null,
                                 "inlineDatum": null,
@@ -1058,8 +2715,720 @@
                                     "lovelace": 7500000000000000
                                 }
                             },
-                            "0204020707040401040005050503040407070306080007020006050604010802#35": {
-                                "address": "addr_test1ypva9lf7226g6h27trup9qs039glrlft3pkjv8nqnsgfc7n3u4juhczscync0a7vdfgzec3hfggzn77lqmzrqvf0xdmsxee0h4",
+                            "0704000408040405070802010400050700070308040608020108080702040704#62": {
+                                "address": "addr_test1zra46uvt5yqpfksc8hs50vek5zhpq6pe4uq4zclja8cm5fxmyt05mwucac6p99crv3svuua88rzjag6zssx609pc245qras59c",
+                                "datum": null,
+                                "datumhash": null,
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "lovelace": 7500000000000000
+                                }
+                            },
+                            "0804030104030701020706000607080200070308000301060300060208020201#73": {
+                                "address": "addr_test1yqdl204q7qunstmdpl3qsum7h99mprn9asgj2r62hacq6mz7awvtgd4hd5c3q06kusc89lkl4vfdhpplu80aw5m0e0tqak4ehj",
+                                "datum": null,
+                                "datumhash": null,
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "4f367837cf366cb11a24bdd60e8444c4ea17e75312cb69dd683454ff": {
+                                        "30": 1
+                                    },
+                                    "lovelace": 1124910
+                                }
+                            },
+                            "0804030304020000050607020006050400030202050502030208000301030201#78": {
+                                "address": "addr_test1xz3lhy8lhkuytdg4ms60shf4e67lx2dxukh0rk7ee7y6xl9kvv7kskg2h597tflx9a2qglfa89k0yskuf93t6knmxh6qryl2dn",
+                                "datum": null,
+                                "datumhash": null,
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "lovelace": 969750
+                                }
+                            }
+                        }
+                    },
+                    "confirmedSnapshot": {
+                        "signatures": {
+                            "multiSignature": [
+                                "ea49ada66bc69f7b113d5deb6a4b0a27afa4d2fdba7f121ce36f47425a0dfc4a9ba65599c25b52bd7cfc5df902f7b792d21627e0e84ca6eb82eb6ae6ff0f0106",
+                                "a5c55617c67e8001e7eaa95aeb3381e8de1d4c0bedf04f4727743f1860d6285f5a707db8a8a3b01ca7339e5b60e528a1ee37153cec026e49444865ea750bbd03",
+                                "722f131a52ee145b7421742960b8a837fffdedae9278bd9a65e01d439537a3e60da65f1357c05528e2df7af892814bc24192515b91129cb2dc6d84d2c2795008",
+                                "a85757807ffbeb4023baa35a8f2759c07fa396e519b83e622b5d1dbf7aeb27fc05de498150c49531fc88c810439937f491dd3ffad1320ff53ff4ba4384f98208",
+                                "8be878c4c5c5ece03b9d08b91de3c11aecb292c65ed42c43b18c148980f3dc3b7522b83eba4263da9ad0406d5619c8fd65279caff86d7e155c8809f6b147d00f",
+                                "84c0c63d8f9518f5ae5a7eca2a8dd5c3447e0c34da7ff35b51a5ea4d667e6449c80d01f3c888a8e72be5a840a348f91c69fab0e6b86b8a3d527cf87eb6315d0e"
+                            ]
+                        },
+                        "snapshot": {
+                            "accumulator": "1960b30de1f0ead0d40920f9192c77959e254840fa2841690c62e15c6d2f3c05",
+                            "confirmed": [],
+                            "headId": "01030607030007080002010202080103",
+                            "number": 4,
+                            "utxo": {
+                                "0000070603070305020402040108000008000402070305040201050000040007#3": {
+                                    "address": "addr_test1zzhvtj5d9wdk5cagyv72xfuvwcfg4d57dqfh64jm5ry9eqhh909v7wkucrflpzxeh7rcc549ngzkvus6379dslfnaypqwqfdl4",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 969750
+                                    }
+                                },
+                                "0006010301020703060002050205060208040301080307040704080404010501#33": {
+                                    "address": "addr_test1zqfkwg9hmg3993vgks0vhdthg0gk6we0edfnzxl3xuguw4lvl9v8l82erj888a8g2nsk0r926csk6vpqh3cuuekg2spsnm5aug",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0508040400010704070703080300080204080106050700030007060304040206#19": {
+                                    "address": "addr_test1wzujyp2cp80hrute0ajna35azms7zdtaw2xeurgd4fstvnq6hv0zz",
+                                    "datum": null,
+                                    "datumhash": "1c63838c40e5652bc1d3e48f75bf52ff5c45d7d1885d0d7d9ae9d020d3bb2759",
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "217d5f4b9e277895c0198b64bf24567c7dbab0d337971ccd5cde9371": {
+                                            "4317d629b5b8ae99a6ea5ced74f7deebc56e0b037f32c339208af8f9574521": 4500226656224181124
+                                        },
+                                        "lovelace": 1318860
+                                    }
+                                },
+                                "0602030403070201010500060707000601080701060204070407000604040702#1": {
+                                    "address": "addr_test1qqsuyl9dgxk2guw53nthvg0fgchpycr65qch82zu6whfq9gltgd9nnv2a7gql4xnt3e4wdmxz7g9zdnhtahvghaxq3ssyavhpn",
+                                    "datum": null,
+                                    "inlineDatum": {
+                                        "list": [
+                                            {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "list": [
+                                                                {
+                                                                    "int": -5
+                                                                },
+                                                                {
+                                                                    "int": -3
+                                                                }
+                                                            ]
+                                                        },
+                                                        "v": {
+                                                            "constructor": 2,
+                                                            "fields": [
+                                                                {
+                                                                    "int": 4
+                                                                },
+                                                                {
+                                                                    "int": 1
+                                                                },
+                                                                {
+                                                                    "bytes": "7ce52118"
+                                                                },
+                                                                {
+                                                                    "int": -4
+                                                                },
+                                                                {
+                                                                    "bytes": "f11dda"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "int": -2
+                                                        },
+                                                        "v": {
+                                                            "map": []
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "bytes": "200c32"
+                                                        },
+                                                        "v": {
+                                                            "int": 1
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "bytes": "d4"
+                                                        },
+                                                        "v": {
+                                                            "list": []
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "constructor": 3,
+                                                            "fields": [
+                                                                {
+                                                                    "int": 0
+                                                                },
+                                                                {
+                                                                    "int": 0
+                                                                }
+                                                            ]
+                                                        },
+                                                        "v": {
+                                                            "list": [
+                                                                {
+                                                                    "bytes": "6fb7b5"
+                                                                },
+                                                                {
+                                                                    "int": -4
+                                                                },
+                                                                {
+                                                                    "bytes": "5211b0"
+                                                                },
+                                                                {
+                                                                    "int": 2
+                                                                },
+                                                                {
+                                                                    "int": 2
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "int": 2
+                                            },
+                                            {
+                                                "int": -3
+                                            }
+                                        ]
+                                    },
+                                    "inlineDatumRaw": "9fa59f2422ffd87b9f0401447ce521182343f11ddaff21a043200c320141d480d87c9f0000ff9f436fb7b523435211b00202ff0222ff",
+                                    "inlineDatumhash": "bbd647a65ef05f0b8b7d95d5bd01b8193b41e796a235aac0fdd09a1e9fdd8b29",
+                                    "referenceScript": null,
+                                    "value": {
+                                        "245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abae": {
+                                            "cfbcc4": 953845570687439571
+                                        },
+                                        "lovelace": 1439540
+                                    }
+                                },
+                                "0708010608050107060100080100040101000008020706020508010703040104#75": {
+                                    "address": "addr_test1vzt5q4hyry5uggqyh7fw04a2fsckyf2m25um3ynrsw8jfgscgkhq7",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 849070
+                                    }
+                                },
+                                "0808070707080207020706060400040301010101040407030404000500050705#83": {
+                                    "address": "addr_test1qq9538vwngvxe448z5l9xq6y48n2ddydrcdgxvcwte7ngxamggydchhng99cru7x36zdjqkxkmpzkpp7le8u3v0gfmqs5yqyy7",
+                                    "datum": null,
+                                    "datumhash": "4bd2af26ef7ddd431035d6b6cc75a27e4025f6be9474557dde2c1c46d92a0ccb",
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebe": {
+                                            "367ce18fe2a6b56ca1": 1
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                }
+                            },
+                            "utxoToCommit": {
+                                "0101000303020406010104070006030707040604000300000306020504040503#26": {
+                                    "address": "addr_test1qrs290naam725yrd9u688mqh6zzr0vsl3fna85w7q5hmqc7ak0wxusl8d3c4jv0q4r4jjdvdl88lp3y8fvzxtxvn0mfss8qmnq",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 969750
+                                    }
+                                },
+                                "0200060206020301080103030508020302070108020003080801070000020301#90": {
+                                    "address": "addr_test1yqx0mtk7z2ganxzpkwm4dnnzkejdkctpzl6dszaww6lf8eqy2hujc7as6s2llq7svmclahm8rfdya0slwx9fvhnq9f8qpv3gfz",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0208050305050108050208030603000402000607060604020606040005030308#84": {
+                                    "address": "addr_test1ypr35q8e5wv380q3h45fk39z3xccr2dcjzm5vtp6mvqqtcty4ruhwpr6fm2th692e7gemhuj0wnqtk29r592fvsgulwq2t6fkz",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 969750
+                                    }
+                                },
+                                "0406020404030202000007070304050008040006040006000003040007000103#0": {
+                                    "address": "addr_test1ypcw965fjj6ehtdg4lqvhsshfpmy5wzs3s368khc724v70au4rknvdfmxvm936pvz854k3x9jgd3949mvp28j6lgaeyq25styk",
+                                    "datum": null,
+                                    "datumhash": "bd5b087a9fdf5495a4d227983a03feb456cc7a52551856cda7e862f5ceee8b4c",
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebe": {
+                                            "d7f0c5a3b1434cd5631d49f80302d4f85260ef8df2e705aa3441feab2af5d8f7": 778949126149448725
+                                        },
+                                        "lovelace": 1443850
+                                    }
+                                },
+                                "0500040102010007010800080506000207050108040104060505030805030405#66": {
+                                    "address": "addr_test1qzqmsp8v6gtsyptmu3ff7gw2x0nwzk4xxd673wrkpwezm5lmm4kjrt8w07makluef0sn505yuegglea64wzy5vj58fyqzhsqvj",
+                                    "datum": null,
+                                    "inlineDatum": {
+                                        "list": [
+                                            {
+                                                "constructor": 1,
+                                                "fields": []
+                                            },
+                                            {
+                                                "int": -5
+                                            }
+                                        ]
+                                    },
+                                    "inlineDatumRaw": "9fd87a8024ff",
+                                    "inlineDatumhash": "b42683ddefc8e0bf33f26bf505cb4732c9d7e3c553cb4ee5443c5bb4635d9cb0",
+                                    "referenceScript": null,
+                                    "value": {
+                                        "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
+                                            "32": 9104985057986099001
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0704080003050601010606030508050300050703080705030305020103000601#63": {
+                                    "address": "addr_test1xquqfttmtp88h05w3nths4gqm0qmu2g5tyn5lc6e5thjgnd0p08rnh8zm6jfzqh4yv5juwxv8rhampx53zmkl24ppaqqgel8lv",
+                                    "datum": null,
+                                    "inlineDatum": {
+                                        "constructor": 0,
+                                        "fields": [
+                                            {
+                                                "list": [
+                                                    {
+                                                        "bytes": "6d"
+                                                    },
+                                                    {
+                                                        "int": 4
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "bytes": "b7"
+                                            }
+                                        ]
+                                    },
+                                    "inlineDatumRaw": "d8799f9f416d04ff41b7ff",
+                                    "inlineDatumhash": "47e04e0f64845fce21895f983773cce9c12a3e82c00bbefaecdcc83b2a09bd91",
+                                    "referenceScript": null,
+                                    "value": {
+                                        "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
+                                            "db4173c65de1a6824fba606a0ee26775fc66a4": 1
+                                        },
+                                        "lovelace": 1284380
+                                    }
+                                }
+                            },
+                            "utxoToDecommit": {
+                                "0001040004000007000605040104080700050503040202070001050600020503#82": {
+                                    "address": "addr_test1qrfxhgmyfa2n57tt8x5dacrayp0ufasgz25qe3pe2qctw2jdxd7hmacsu0cg75fck7s2a8n0wjul3dqmygdrexnxm8gq66nrxe",
+                                    "datum": null,
+                                    "inlineDatum": {
+                                        "list": [
+                                            {
+                                                "list": []
+                                            },
+                                            {
+                                                "list": [
+                                                    {
+                                                        "map": [
+                                                            {
+                                                                "k": {
+                                                                    "bytes": "b4000d"
+                                                                },
+                                                                "v": {
+                                                                    "bytes": "70"
+                                                                }
+                                                            },
+                                                            {
+                                                                "k": {
+                                                                    "bytes": "b50d"
+                                                                },
+                                                                "v": {
+                                                                    "int": 1
+                                                                }
+                                                            },
+                                                            {
+                                                                "k": {
+                                                                    "int": -3
+                                                                },
+                                                                "v": {
+                                                                    "bytes": "29928676"
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "list": []
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "int": 4
+                                            },
+                                            {
+                                                "int": 1
+                                            }
+                                        ]
+                                    },
+                                    "inlineDatumRaw": "9f809fa343b4000d417042b50d0122442992867680ff0401ff",
+                                    "inlineDatumhash": "5583d45760c264f757e7e52929f6b5cd5d88eb43d077bf5ccb22276a776fd9f8",
+                                    "referenceScript": null,
+                                    "value": {
+                                        "43ac2ed6e6462289369d92872e2dbb09104fda95e547644c08ae332b": {
+                                            "c6353e31e63f61d6ad4240de035dc1ef7831cd42b7948436c479ccd9e78eed": 7978395238781516344
+                                        },
+                                        "lovelace": 1439540
+                                    }
+                                },
+                                "0102070403020200010203070402020700010607010406040701060501010606#16": {
+                                    "address": "addr_test1qzhngl4j3kvmkf9q7l77naaahen6lldwu3ye2827fpyg0yecgma4tag4nnttrk8pmun0autsutaf7qnf9m7mppqsz6uqusrrfz",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 969750
+                                    }
+                                },
+                                "0103030408040307030801060405010007020208050606070508020105020002#9": {
+                                    "address": "addr_test1xqu7yuv5dpglsmeqatyqhgw9xu7njnldgvlv6s3nt0pm43gmnqqcqsep0mv96dzny4tlpe3g855ma99jl63q60q84nlqvuqars",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0408080501070001080302010501060500060108000806080407050708050108#16": {
+                                    "address": "addr_test1xzynqy6nx2ea8a85h4yg85xq5hjaacjrtlf4epnjaughjl75aefasgx7f7mreng07f3hlepdc2u93tqxyqlcy6qzzwxquxt0yt",
+                                    "datum": null,
+                                    "datumhash": "6ac3d1c4cef0206f35e1069cecc3dd8c26362c5e2fb672c7bc08f3687c6fb568",
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3": {
+                                            "37": 1
+                                        },
+                                        "lovelace": 1271450
+                                    }
+                                },
+                                "0702040205000506000306080008040601010008020104010601020700040104#69": {
+                                    "address": "addr_test1yr5xd429sf4tx6p3mlmad9mf3ftqf7kasczkzcdjz3q4anvh7cy8qdn5tcx08qeh7y9qdwsfncp5nm92nec9sfda0zdqs3nejf",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 969750
+                                    }
+                                },
+                                "0808080701080402070400020406020308000208050402030300050108080104#73": {
+                                    "address": "addr_test1zz8hp3yd0fhg8tjmpttx5gt32dl03w9z9gqyx7qsgz6mptk4079k2ca6f4rksed6y06s3ywzp7akc5kuj8yrquf37p8qf4u5f9",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 7500000000000000
+                                    }
+                                }
+                            },
+                            "version": 0
+                        },
+                        "tag": "ConfirmedSnapshot"
+                    },
+                    "contestationDeadline": "1864-05-15T05:35:35.677946604591Z",
+                    "distributedOutputs": {
+                        "0004050200010401050501060607060808030102020201020007070303010508#11": {
+                            "address": "addr_test1wqcs2s33x8d655h6tmtte640qqtpvvcuwzh3xx8flvxwz5qh5dfat",
+                            "datum": null,
+                            "inlineDatum": {
+                                "list": [
+                                    {
+                                        "bytes": ""
+                                    },
+                                    {
+                                        "list": [
+                                            {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "bytes": "e3ee6717"
+                                                        },
+                                                        "v": {
+                                                            "int": -2
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "bytes": "79fb"
+                                                        },
+                                                        "v": {
+                                                            "int": 3
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "bytes": ""
+                                                        },
+                                                        "v": {
+                                                            "int": 2
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "constructor": 5,
+                                                "fields": [
+                                                    {
+                                                        "int": -2
+                                                    },
+                                                    {
+                                                        "bytes": "33ac"
+                                                    },
+                                                    {
+                                                        "int": -4
+                                                    },
+                                                    {
+                                                        "int": 3
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "int": -2
+                                            },
+                                            {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "bytes": "421c6c"
+                                                        },
+                                                        "v": {
+                                                            "int": 1
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "bytes": "dfd2db87"
+                                                        },
+                                                        "v": {
+                                                            "bytes": "909f"
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "bytes": "5079"
+                                                        },
+                                                        "v": {
+                                                            "int": -1
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "int": 5
+                                                        },
+                                                        "v": {
+                                                            "int": -5
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "constructor": 1,
+                                        "fields": [
+                                            {
+                                                "bytes": ""
+                                            },
+                                            {
+                                                "constructor": 0,
+                                                "fields": []
+                                            },
+                                            {
+                                                "list": []
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "inlineDatumRaw": "9f409fa344e3ee6717214279fb034002d87e9f214233ac2303ff21a443421c6c0144dfd2db8742909f425079200524ffd87a9f40d8798080ffff",
+                            "inlineDatumhash": "2a3499c90e83bd85f950913308be5e34c7f5189cd2652d283b2d5cea2b1db961",
+                            "referenceScript": null,
+                            "value": {
+                                "2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56": {
+                                    "fa7ee0c37dfff48c76": 5731366335354882886
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0401050708080706060608050502040600010804000001040300010608050607#86": {
+                            "address": "addr_test1wpmxtrajkpvcmqjz3ve4e00qh4ua40kuvupzjl5yr5ce57gwk45r3",
+                            "datum": null,
+                            "inlineDatum": {
+                                "bytes": "9cc5"
+                            },
+                            "inlineDatumRaw": "429cc5",
+                            "inlineDatumhash": "771caedb97353460a3bbb5f13f33ffe5b3f8c75be99b2d1aefda0c6509122ba5",
+                            "referenceScript": null,
+                            "value": {
+                                "cf637294205a93280393afe4aa5a23f489df9a8b9c19c2a44008f18c": {
+                                    "39": 2446478761806870934
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0707000201040802050308060208070808080404040607050403010206070101#75": {
+                            "address": "addr_test1vqqra3vkwrjvycfg2s7nr4zucar6j6220vm8pxkjkp7hd2qtnm6nh",
+                            "datum": null,
+                            "inlineDatum": {
+                                "int": 5
+                            },
+                            "inlineDatumRaw": "05",
+                            "inlineDatumhash": "fb3d635c7cb573d1b9e9bff4a64ab4f25190d29b6fd8db94c605a218a23fa9ad",
+                            "referenceScript": null,
+                            "value": {
+                                "a8d74ae1b203267b4168abff679f402b8ba6ec3e7031a0723c71561a": {
+                                    "f169c9d7ee0ad0f624651553d7": 1
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0802070801050104050500070006040706010404060106020200050603050205#78": {
+                            "address": "addr_test1xzt7q8su9pdfekx7etwzwz925c8n0yyk74s69hue9nhweuk7jppnuhfqad884jaawj30js2gza42vcr8shnxcnhdlg5q3fz6s2",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0804000104050101060001010408040102050408070602020608060603080107#97": {
+                            "address": "addr_test1zqsajuansal386gqx70tjfjfann87wd24jhk7k9puqzrzz5l0wkedeaajaet2wq0m7kqnn7rjhv2ex9j7yr5m363pnqqu4ehj7",
+                            "datum": null,
+                            "inlineDatum": {
+                                "list": [
+                                    {
+                                        "bytes": "ee"
+                                    }
+                                ]
+                            },
+                            "inlineDatumRaw": "9f41eeff",
+                            "inlineDatumhash": "59a359ba9944af2835674547885757d5ca0457fe81e73b8e997eeb231b7538d3",
+                            "referenceScript": null,
+                            "value": {
+                                "105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5": {
+                                    "36": 2
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0806000500060706030007040005050404040602030605030601070100050403#54": {
+                            "address": "addr_test1zr0j4lf8e47j0xsz2m60k6ra3wemau5thpju2zadgewyrdd3ssux554cgpmvuljqyd76sw5r3d0aenphrmc2nfnej8tq999cqj",
+                            "datum": null,
+                            "datumhash": "afe3058ed5930c2d45012a31397cb6d3976c4cac93b7f6e21de978dcf9c17536",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "6f94ec298ec5f213e0af24e2742bdfc14193d11d00fb35ab88f3172a": {
+                                    "32": 2079147645710915344
+                                },
+                                "lovelace": 1305930
+                            }
+                        }
+                    },
+                    "headId": "03040003000700080605070404070800",
+                    "headSeed": "01050804020708020601070601030504",
+                    "mode": {
+                        "contents": {
+                            "0006010303050605080104010000060400070105040108030104050501000107#42": {
+                                "address": "addr_test1zq9c3rfeyvqhrgy9mssn8smhamfu4rrfw6pum25x2lx0fe084zkv5ptuvk5t54mk0evr7fu6cptudn78up0lkmzxd53qyaqj4n",
+                                "datum": null,
+                                "datumhash": null,
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "lovelace": 7500000000000000
+                                }
+                            },
+                            "0006040605060302020606040100070702050701000406010601040204060103#91": {
+                                "address": "addr_test1yzf7yjkva33t983elpdsxmc9kgvf09t0susexee0w343lzyrlzlpk7ppqn7tjqdxflt70rr8vly5hz5t66fmz009pfcsfsvjz0",
+                                "datum": null,
+                                "datumhash": null,
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "lovelace": 7500000000000000
+                                }
+                            },
+                            "0100080107010007010706050204050800050406050804060006030106040104#9": {
+                                "address": "addr_test1vrpey7cj3r8he5scklusgnumyp6f30ke439y002m3d2r60cdeesq6",
+                                "datum": null,
+                                "datumhash": null,
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "lovelace": 7500000000000000
+                                }
+                            },
+                            "0406030406080603080305030205040503010703000705030807070506030105#30": {
+                                "address": "addr_test1zzrququw2smsahzsdvcjs0xnhwrjsnex4ycwethh6ujpxd60p0vutgajq5xylafduqgxsn6hmtfp5g6xl83zkwwutezsjecvx5",
+                                "datum": null,
+                                "datumhash": null,
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "lovelace": 7500000000000000
+                                }
+                            },
+                            "0703030307070400020008070002060802040308070706040205010603080605#47": {
+                                "address": "addr_test1ypc02ygf8jklkq4hr5zwnr9f0qnrvt35z3uh93rjlezgkv97gkt0yaph09594fxnv9m6rlyvnx2ppva34xqkxdlfra6s5m0dxx",
                                 "datum": null,
                                 "datumhash": null,
                                 "inlineDatum": null,
@@ -1069,161 +3438,634 @@
                                     "lovelace": 969750
                                 }
                             },
-                            "0208020606020507080707010704030401070407010800070302050604040004#82": {
-                                "address": "addr_test1zpa0u2657y39k0ftju9z5yn75l6jxp6n7lkafe6mtlqm5vh60dmdmvv46j6hj0fgzs5qdkxuz7hdu9vqgctgr6v4vx9qwaea38",
-                                "datum": null,
-                                "inlineDatum": {
-                                    "list": [
-                                        {
-                                            "map": [
-                                                {
-                                                    "k": {
-                                                        "int": -1
-                                                    },
-                                                    "v": {
-                                                        "int": -2
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "int": 4
-                                                    },
-                                                    "v": {
-                                                        "list": [
-                                                            {
-                                                                "bytes": "b1a7f0"
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "bytes": "41c9"
-                                                    },
-                                                    "v": {
-                                                        "list": [
-                                                            {
-                                                                "int": 2
-                                                            },
-                                                            {
-                                                                "bytes": ""
-                                                            },
-                                                            {
-                                                                "int": 2
-                                                            },
-                                                            {
-                                                                "int": 1
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "list": [
-                                                            {
-                                                                "int": -1
-                                                            },
-                                                            {
-                                                                "int": 5
-                                                            }
-                                                        ]
-                                                    },
-                                                    "v": {
-                                                        "bytes": ""
-                                                    }
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "int": -2
-                                        },
-                                        {
-                                            "bytes": "2bf1a84b"
-                                        },
-                                        {
-                                            "bytes": "4ed2"
-                                        },
-                                        {
-                                            "list": [
-                                                {
-                                                    "map": []
-                                                },
-                                                {
-                                                    "list": []
-                                                },
-                                                {
-                                                    "int": 3
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                "inlineDatumRaw": "9fa42021049f43b1a7f0ff4241c99f02400201ff9f2005ff4021442bf1a84b424ed29fa08003ffff",
-                                "inlineDatumhash": "44241c0d122f4db060070e7e307c85e15435463d92599a214c376728ffe765b8",
-                                "referenceScript": null,
-                                "value": {
-                                    "9cf3a503b95fa3ffb9404451f83a1dd405a5cc732fd37859331549f9": {
-                                        "9549265af64127644504849d": 3730584702339024407
-                                    },
-                                    "lovelace": 7500000000000000
-                                }
-                            },
-                            "0303040200010204070803030103080403070803040104000100080704000405#57": {
-                                "address": "addr_test1yrnfnzwsd0vnl3sduasdv5lmjwg2wynfp0e5mqxlw5w5us7mjmzt6y00cpymq3g9s4nc93a8phgsq3xr83emuj94fses4nyk7e",
-                                "datum": null,
-                                "inlineDatum": {
-                                    "list": [
-                                        {
-                                            "constructor": 1,
-                                            "fields": [
-                                                {
-                                                    "list": [
-                                                        {
-                                                            "int": -3
-                                                        },
-                                                        {
-                                                            "bytes": "20cc"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                "inlineDatumRaw": "9fd87a9f9f224220ccffffff",
-                                "inlineDatumhash": "cec2505054b06f68b30f329acc24dca77cf5783ac3df5efaf834d48ad788968a",
-                                "referenceScript": null,
-                                "value": {
-                                    "4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebe": {
-                                        "33": 9158161788193446117
-                                    },
-                                    "lovelace": 1245590
-                                }
-                            },
-                            "0402010206050308070601040500020100080201080208050307000407050608#9": {
-                                "address": "addr_test1xzqjfrhv588hd5s6hynj436s35zclzwfy7l9qp5ctq66cyrzqkfgmdlsyn9thuk5uxmeha72e07dadewrnwccghzlrxsr37az4",
-                                "datum": null,
-                                "datumhash": "dbd6b7d5fe56bf7bd0bf729de6cf69f1600366a15deabf1f214afb173a7cca93",
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "0cd55016747d8fb1c5b55128a1046437d5e464af22fda8b84f90ffc5": {
-                                        "dd3424c526a831a019a27425b0b556ba0358199c21d4ae3be038c560a4": 6251745451123030797
-                                    },
-                                    "lovelace": 7500000000000000
-                                }
-                            },
-                            "0504030203060406050506030405030307050302070701020204080504040805#36": {
-                                "address": "addr_test1qp9kqvajj0h04e6tjt9aave04xvxrvax9frawnyuhzrcxqzydh8lgruzynlv3c860xp2s0728w8w7qn4s57hu44zduysjnl4pm",
+                            "0708010008080408010002000206050406020308000105050701060701040007#25": {
+                                "address": "addr_test1vppl40jmqwdz759xcfdnczepxy3cjxrvz3ewqkx68hk67csddas08",
                                 "datum": null,
                                 "datumhash": null,
                                 "inlineDatum": null,
                                 "inlineDatumRaw": null,
                                 "referenceScript": null,
                                 "value": {
-                                    "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
-                                        "d6ac9c81": 2960304561607610563
+                                    "lovelace": 7500000000000000
+                                }
+                            }
+                        },
+                        "tag": "DistributingSelection"
+                    },
+                    "parameters": {
+                        "contestationPeriod": 86400,
+                        "parties": [
+                            {
+                                "vkey": "8102e6970d81c14813c44bfedcb4a98e049429039bbcd239aa0fb1f30612bec5"
+                            },
+                            {
+                                "vkey": "494c54d6d59a7eca1eb774b8141fa2eb625a8a1a6f3bea7b3ba5cb99fb99a731"
+                            },
+                            {
+                                "vkey": "5d05765b69008dbe9ef43787d3188128b692aa3e2f7eb6ed506e2ffcd49c7284"
+                            },
+                            {
+                                "vkey": "3f5a960cbc60864f9957f9d0aadc2805c9b7892f878f946a85ac010362e49a61"
+                            }
+                        ]
+                    },
+                    "remainingOutputs": {
+                        "0107040707000004070407010205020704070002000007070302050204080603#55": {
+                            "address": "addr_test1ypjy6lhjv3y4fu09ltzj50gy2nq7yjn43h7502l6xzksx32sznzyw0dmz67l34wt3jr2h4k7065ge6q0ceck466mladq4ppvlf",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "8d2ad3ac3d25e84cf6478488aa603d3110ae671bae9bf77fa37e1600": {
+                                    "5d68299f311d218f549beb7cce183bb0a8b77b776af4f28c29e03361": 1
+                                },
+                                "lovelace": 1245590
+                            }
+                        },
+                        "0206040803020404060808020206060204000705030705070102000508080500#31": {
+                            "address": "addr_test1xpzcl8k5lv65wrmgh3zjy5zcuqmw0wjgwg0whad489xadt3geucnegpxvq90r9glghytez2mjh9fff6cslyslfwexkxs8v86qv",
+                            "datum": null,
+                            "datumhash": "f1638ee124224464f440c6b3933f1124c0f04194bf86bb02d6d82cda2df3bb22",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "26ac19945bae4add25e0b84b5d2f786ce068ccc5d286f0a63f8a1473": {
+                                    "30": 6228151504416204904
+                                },
+                                "lovelace": 1305930
+                            }
+                        },
+                        "0305040808000206060508030606010703050402060500040207010708040101#36": {
+                            "address": "addr_test1xrx7sns8e5euetecv2hcxxd9ueekk3jvrgpz77g84khlsv3z3qsqce3yy7g7f7s389wc6ptl8rteme5n2uvhet9uv4msf5el2t",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 969750
+                            }
+                        },
+                        "0605020500000307050801010504060507020601080503020300050308060302#11": {
+                            "address": "addr_test1yqwuts2htcjsy35ac9d6zx0tvyjra002m3wxz3qclguu4x03at7jwg6q4l5wtyk7722rtj72xumukas9y50x0ap3m6zqcgkgth",
+                            "datum": null,
+                            "inlineDatum": {
+                                "constructor": 1,
+                                "fields": [
+                                    {
+                                        "constructor": 3,
+                                        "fields": [
+                                            {
+                                                "list": [
+                                                    {
+                                                        "bytes": ""
+                                                    },
+                                                    {
+                                                        "int": 1
+                                                    },
+                                                    {
+                                                        "bytes": "f00cec"
+                                                    },
+                                                    {
+                                                        "int": -3
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "constructor": 3,
+                                                "fields": []
+                                            },
+                                            {
+                                                "int": 0
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "inlineDatumRaw": "d87a9fd87c9f9f400143f00cec22ffd87c8000ffff",
+                            "inlineDatumhash": "0910029ab3593f58fbda2b289557a3ac83e31011dd084acb9961fb4def63036c",
+                            "referenceScript": null,
+                            "value": {
+                                "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
+                                    "0cc22843aa806815": 1993155918163298765
+                                },
+                                "lovelace": 1314550
+                            }
+                        },
+                        "0703020206030006070506070405070402010604000603020803020405080105#50": {
+                            "address": "addr_test1qpl6k8zu8c8cpm3cjhl7h79laaj954g6uhzyq8tf50f4v4qlx7ttkcc9pdxvxeylnzcm9sg90yvqnugggdgxrejajcnsjheh0s",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 969750
+                            }
+                        },
+                        "0801050200050802060005040404020202070306040803050808080108050701#80": {
+                            "address": "addr_test1xpasrm930ewmzy659ngsyzk58fah70nauklmawkfktp4uhm2q24vnf7spn65u8f9mk9gcfj5fhmrvfpdphwphdymfpeq8teg0n",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "4cfc80c8894b38ee1fd1d6cf81cc84dd2b697d758e528df8ef55e903": {
+                                    "355efeacbbdbdaf6a8c43cebeefb0cfe36df1b750ea990b12c35b3b5232cb9": 6347769548460268451
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        }
+                    },
+                    "version": 2
+                },
+                "tag": "FanoutProgress"
+            },
+            "pendingDeposits": {
+                "0003070602070805040201010200040401020308040500030602060306060607": {
+                    "created": "1864-05-07T02:03:28.048521827584Z",
+                    "deadline": "1864-05-07T17:42:42.151958154885Z",
+                    "deposited": {
+                        "0107080507080104060405070603070303000708000005030607010503010406#88": {
+                            "address": "addr_test1xpddj635jwp33cpfk03d3sntq08akcxf4nra6pf96ag6ywe4nv68qxelgymak0c8vqgnr38feefh25z4wv5tug42tsnqy6ws50",
+                            "datum": null,
+                            "datumhash": "0a706d683ffb6ec1e7b31765d95cd6a72e7de0eee3c6b96b23cdbe67b33cc33e",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abae": {
+                                    "39": 1
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0301050602080507010803040101080807000806000806010204080101050701#97": {
+                            "address": "addr_test1zr8cqrexat4dfzeem2chqxgu88qml0tp98k30l3tnw9d87gwgjqfmzhuruf6st7ky2rtkaq9qrwkr8v2ax7hxvl6ulmsflmkcu",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 969750
+                            }
+                        },
+                        "0401060301060202080200080400000806030403060004080703040001020206#99": {
+                            "address": "addr_test1xpnk795jwnnyvx8wev0zxzjgme8pvgwy9wmr60fxpjre6mxv9qees7tle6wzsuvf99d0kxeudjevc6rxgmu2ee3v5suskft49q",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0504060405070705030803080004070701050307010807070105050105030805#31": {
+                            "address": "addr_test1zzr0y0cxvgl5drrh208jhwyu54dasg5hyttfflmkkvk2476jmryu68fgr3zwjz0emvwma08l3waxeqt36t8xyvwcf4ysatk30y",
+                            "datum": null,
+                            "inlineDatum": {
+                                "constructor": 3,
+                                "fields": []
+                            },
+                            "inlineDatumRaw": "d87c80",
+                            "inlineDatumhash": "67d8ed01e13f33438ea9059ac9be2e159f943cffe054283485e0300271e3e9f9",
+                            "referenceScript": null,
+                            "value": {
+                                "414dd4afc6bc5453b8930c1364af8ccb92b017bf953ee2a4018348c7": {
+                                    "9c3e4bcf2650b3764f5647d612b523e0a8e396d268e4": 1
+                                },
+                                "lovelace": 1262830
+                            }
+                        },
+                        "0708060301040800020003060608030208000407040402010706080508030801#72": {
+                            "address": "addr_test1zpdvzdeasf4ujqt2wptcgpcx26jkh9lcyhkj4l8g6434yl4xxvmhq7xczz8xdwu2yznj8wtrvgakmff6v37n6wywrfdsn4743u",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 969750
+                            }
+                        },
+                        "0800040207050507050408060501060408070506070807060107030404040502#5": {
+                            "address": "addr_test1zqmffyt0mh7y7k9fhqwnf78clhx688u4cufaf56zgzlrwzh3j9kmdg5mmykr96e00wmjd8q096de2jdtvzur7m6h7xcsq56knc",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        }
+                    },
+                    "headId": "07070803010700010807020203010000",
+                    "status": "Inactive"
+                },
+                "0204050303000006010407080804000806070304040601020107000604020003": {
+                    "created": "1864-05-14T15:46:09.451079765713Z",
+                    "deadline": "1864-05-05T14:21:42.152617844309Z",
+                    "deposited": {
+                        "0101030604000708040806070305000303000100010108060106000302030507#46": {
+                            "address": "addr_test1xzy45tyewv2nvsse3548hjdr44ze37zww6wgk9m3k5f8uz8zlt0hh9uuefxrvcc3rsl0zvsmdccmem28xqpsa95pp97qwrcaqr",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0108010404070203050700080108030003030307000401050205080006080804#4": {
+                            "address": "addr_test1yqdaprpdkpvze6meadvdu7qk908qtsr7eh765ghjmhmquakumwq5sdps3jsgevuxkjx3khc9s422ehxmm9qe7aywn0ss8708hv",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0205070306010203040101070804000400020300050806020206060807070606#48": {
+                            "address": "addr_test1xzfrxse8taaykyrjrgsc92ph6y3a8p506ftymryaglmvcze8n6uaw47vte4sdcw0n54wvnr0ccez2lmz6uzr0gfxutrqxh63ce",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0300030306030700010001080402050606070203000507080200070606050102#31": {
+                            "address": "addr_test1qr030za6mj58s9n3ejaajamdzpjswq6adethrmqvwywlscwccxeyavg4nlmnpaur3sr6k4f4yhrjvhygk4467nh6yqhq76tsts",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0607020402040407050505050503020308020405030006000001050806050600#71": {
+                            "address": "addr_test1qz7fpju8gnce7y9yv9l55mthx8n5atafmgzg30hqt5ckrk47x4pew3eka7vshskg97ac3nvjtslgwmkgenqmd3kcrxaslt8dpf",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "2e8f7d169825719d9bf59ab067069e54f8be06fc49bd4b6d8d7b0e46": {
+                                    "9a02942e60ed8f7b": 1
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0703030803070602020103080808050204070108020305060700060407060202#93": {
+                            "address": "addr_test1xpfz0mjdfyw7y07anxy4h2uzpanpnvfjy0wzlf67zqmamuxuaa4v22fp6dr60mxyztlknmwy7fc9yy92smhpvt2fnkzsa2muye",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebe": {
+                                    "7e69ee1772523b5f32": 7314520253629974013
+                                },
+                                "lovelace": 1193870
+                            }
+                        }
+                    },
+                    "headId": "08020600070403030606080201070100",
+                    "status": "Active"
+                },
+                "0208030105040307040308070107070407070208070805080702030101040005": {
+                    "created": "1864-05-05T17:43:53.201948778754Z",
+                    "deadline": "1864-05-12T17:29:24.047357605857Z",
+                    "deposited": {
+                        "0008000301030108050501060306060806060100020705010808070202040200#12": {
+                            "address": "addr_test1wpqy9hecmy9af6jvyxec3ahwjen7ykq0twpl4e20k94s4vcujy6tm",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0502010301030005000703060708000104070102030308040400000806060204#17": {
+                            "address": "addr_test1zryqlc7dp07jvv5lsg9p958hjhyr83gu6c44gl9myaj3pw67dwus3l50ynkg542gncj6llpt9zu8ydsjzz3stccaja9sspluq2",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56": {
+                                    "6d6a822ccd4edbd68993cf483bbc4611b7bfabf01e42a4a13da1a0309a3254": 5491146940411827856
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0604000802010705000301040503070800000002010607080406040307010006#20": {
+                            "address": "addr_test1zz92t8yjenqwz6yqk5t8trrwe2je7rdfr8qz5f7ll7y5xmlcx53xxu7j89my2zgmxxqj527q0xnjkzxws2jpnejjnmfsz5epul",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 969750
+                            }
+                        },
+                        "0604070502040503060008000803010603020005030105050107080102070400#44": {
+                            "address": "addr_test1yramp38ms0uwgs03qeexahadusu34299z48xrx7rw8p0628hme03y3hv4lfk7lgkwdhcyprx6hlr52c2sc78vex8tcasg2pw5x",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 969750
+                            }
+                        },
+                        "0606030100040600050806080102030603080307060305010204060007060607#57": {
+                            "address": "addr_test1qqp9xmvna55dj550xszytvhxytyf8kwq4k54wkf8dyw6290z0ldukssujkgaxmwtwu70casawf3wj78dcdx5tg80akzqnhy7cd",
+                            "datum": null,
+                            "inlineDatum": {
+                                "constructor": 0,
+                                "fields": [
+                                    {
+                                        "constructor": 3,
+                                        "fields": [
+                                            {
+                                                "constructor": 0,
+                                                "fields": [
+                                                    {
+                                                        "bytes": "ff2741"
+                                                    },
+                                                    {
+                                                        "bytes": "45f7"
+                                                    },
+                                                    {
+                                                        "bytes": "880515f1"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "bytes": "f4f5dc"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "constructor": 2,
+                                        "fields": [
+                                            {
+                                                "bytes": "bf7abe"
+                                            },
+                                            {
+                                                "bytes": "05561c21"
+                                            },
+                                            {
+                                                "bytes": "f89e9b"
+                                            },
+                                            {
+                                                "constructor": 5,
+                                                "fields": [
+                                                    {
+                                                        "bytes": "3d"
+                                                    },
+                                                    {
+                                                        "int": 3
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "bytes": "a2"
+                                    },
+                                    {
+                                        "int": 5
+                                    },
+                                    {
+                                        "constructor": 3,
+                                        "fields": [
+                                            {
+                                                "constructor": 2,
+                                                "fields": [
+                                                    {
+                                                        "int": -2
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "bytes": "0b33b0"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "inlineDatumRaw": "d8799fd87c9fd8799f43ff27414245f744880515f1ff43f4f5dcffd87b9f43bf7abe4405561c2143f89e9bd87e9f413d03ffff41a205d87c9fd87b9f21ff430b33b0ffff",
+                            "inlineDatumhash": "7b3e0557d5587e317a69a68b04788aec39f48066d91bc68364c4168180c0b186",
+                            "referenceScript": null,
+                            "value": {
+                                "3eaa1e5e7c82e078fdc0f6cf842eccc24a33e67564b1e520290ff8e9": {
+                                    "c6910a632334188d73b161": 4450800880188315664
+                                },
+                                "lovelace": 1534360
+                            }
+                        },
+                        "0807020601020308010103050405010807040003080804010108060803010203#19": {
+                            "address": "addr_test1xpsfak48ru2gzk0pmtcazh2e35pa92wufwjyd4z0c4zrevqkq774pas84nfcrnz4yqz8ecxs04e8l66gvzs0csrlcujs90hdna",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        }
+                    },
+                    "headId": "05030307030503010400020006030505",
+                    "status": "Expired"
+                },
+                "0307020301040301030301020404000707060107050803040201000501030807": {
+                    "created": "1864-05-06T15:34:29.648646792396Z",
+                    "deadline": "1864-05-04T22:55:03.129779720227Z",
+                    "deposited": {
+                        "0201000205040400030400070300030208080707080401030507050403030707#24": {
+                            "address": "addr_test1yphsxfjf5av2tzjw4u25rgu5qcpnyav3clc4c2w27h0hdu7cjgpcera5hjxs3v9zwwj6w7z9llkuaxy9h9wdwhe6psvs5wpchy",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0201060505000700060506010203020803050205060400050401030103000503#80": {
+                            "address": "addr_test1xp8ag8t2rt8p0lvpe9ms95zhtszrrqd03k9ndm8whejqtapwgqec2fgqux8sp5eh6jrfcajw4n77czwjtsxxxcdcsssq5z4hme",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0407050602040706050806070808040207050107050708060603070405080308#94": {
+                            "address": "addr_test1zrchc22wg27yec0nhm20dg5ze39avl4kj622vnu4qycdkagzrpcjgzqslzcpq9gchgdhkhuldjvs0uuneua7qh5jxaysapy842",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0602010502030605030100060507080501070008030608030504000803010200#86": {
+                            "address": "addr_test1yr5d2qtyvf4kqw3zpmtg93xr89u8zxslc8yw8wjk5429a2m5ztjr6f0cfuck8ytnnu6dvx2f950l9xg74332ywwu079qpjmwpw",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0700020001000702040602070601060404060102060502080500000000010308#17": {
+                            "address": "addr_test1wp09eemzea0fdewrmrr8fk0z60ff0vhtj2mmfqkey5tpw6ct3sn5x",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 849070
+                            }
+                        },
+                        "0804030305030102040207000006070606000407020104060203060300030200#81": {
+                            "address": "addr_test1qqwrxn0m24mspxthm88u8wpylqzxxjf2qxqt2cpn54hheky2edk25twvlzkd5d44wr7c0nuqruhadautq4frenlmdd2qa464am",
+                            "datum": null,
+                            "inlineDatum": {
+                                "int": 4
+                            },
+                            "inlineDatumRaw": "04",
+                            "inlineDatumhash": "642206314f534b29ad297d82440a5f9f210e30ca5ced805a587ca402de927342",
+                            "referenceScript": null,
+                            "value": {
+                                "f89403bb75771cb18b7d36cde13ebdcd6bcb1a6cb672e17f313a9649": {
+                                    "1f2431e0": 1
+                                },
+                                "lovelace": 1176630
+                            }
+                        }
+                    },
+                    "headId": "08030702020301080802060001060205",
+                    "status": "Expired"
+                }
+            },
+            "tag": "NodeInSync"
+        },
+        {
+            "chainPointTime": {
+                "currentChainTime": "1864-05-12T03:13:32.163315979287Z",
+                "currentSlot": 1,
+                "drift": -5.333333333334
+            },
+            "headState": {
+                "contents": {
+                    "chainState": {
+                        "recordedAt": null,
+                        "spendableUTxO": {
+                            "0000030306010207080402000007000307050200040802010203060203060407#8": {
+                                "address": "addr_test1qpxc98cqa3zmm2693xl9jz47hp45dcjjc4kglc3qvd28f79v8q52tmk4tn9ydc6qwl5hcz4cprtmfh6hthm5cdgurqwsfxgh83",
+                                "datum": null,
+                                "datumhash": null,
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "lovelace": 969750
+                                }
+                            },
+                            "0103020707000508070304050407050208000602060205040005040407010300#90": {
+                                "address": "addr_test1zqrfuu5dx0ftz08zklkvm37d5aq8tg0uae48eyqzzscc2wkm3swwl0htc8j9qm4306vpgl8254dzjmmtmgrwft5xg90q67cn39",
+                                "datum": null,
+                                "datumhash": null,
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "lovelace": 7500000000000000
+                                }
+                            },
+                            "0505080305070403040806070200050806050203020207050801020202030101#72": {
+                                "address": "addr_test1xrtlw9vaxjmvmkzngtkqj6y2cmf7k779eraswxypxj5u3ss5k2fk6f33k9c5lathmt5y4tu4s3meus0jrsl4yw567v5qvwqc8n",
+                                "datum": null,
+                                "datumhash": null,
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abae": {
+                                        "f89c3b8631b147c405a92f5e995c9bdd112bf240fc1a8d071fdb": 1
+                                    },
+                                    "lovelace": 7500000000000000
+                                }
+                            },
+                            "0703070706080300050106080306050300000807060407020705030600020102#84": {
+                                "address": "addr_test1zzrrd327vs5l2k6s2ejrxs24lm2k0j457gfqdqw8e7fr09sxkgp4hrhem4y3cz2cnptchmlsy9k9q83wfuupmf2arkksrp0h4c",
+                                "datum": null,
+                                "datumhash": null,
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "lovelace": 7500000000000000
+                                }
+                            },
+                            "0705010406080401070607010208080203010106020505020404000601070408#16": {
+                                "address": "addr_test1wrwqr9tf53el8r4pvpzcwpnq36r53nwwxv4cufskd6xh35cfvgks6",
+                                "datum": null,
+                                "datumhash": "1dd7af3c20ad4016c18f501d4a2949e7723df3b5761d9505a586bddbe94f3da8",
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888d": {
+                                        "32": 8459414961853182077
+                                    },
+                                    "lovelace": 7500000000000000
+                                }
+                            },
+                            "0708020805070707050202050104060505020202050105030104060608000106#50": {
+                                "address": "addr_test1xptkpqllpy6988vq0j9qqavgwyvdknswzym7d4e2npvqmk2hf7lkaxkz2qgv8l9g49y60ezrj8htsx0p07msngjvyj5qmej3xr",
+                                "datum": null,
+                                "datumhash": null,
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "9b4c34d1b249f74dc1afa68e93706748c39fc616795d4b92407dd2c1": {
+                                        "36": 1
                                     },
                                     "lovelace": 7500000000000000
                                 }
@@ -1234,55 +4076,40 @@
                 "tag": "Idle"
             },
             "pendingDeposits": {
-                "0700080505080306030701020702010502020408020607040504050301000502": {
-                    "created": "1864-05-06T06:25:05.671554877444Z",
-                    "deadline": "1864-05-14T01:52:53.951593050276Z",
+                "0404080201030802080205080001030400010606060501020108050501010708": {
+                    "created": "1864-05-10T11:26:49.436543115181Z",
+                    "deadline": "1864-05-11T22:12:23.945406143146Z",
                     "deposited": {
-                        "0000030207050501000001050106010606080108010007030002030402020702#92": {
-                            "address": "addr_test1yr56dhnfj8nnyggszfskpcf385ch2qskryrheyamgj4jjkf395tv9cemd4dl5fkl0n24d9k75q0aemgdhtf7rm6wap3qu9mfpj",
+                        "0006030702040704040202050006000306080104080503000503030604030507#76": {
+                            "address": "addr_test1zzm3zm8qu3aj96c5fprush22f04e6mp6zd2k7grsqg9rv37svvtq22m0yh0f68xskyzdcsefmmysmce2wnpp2ppvcpcsjvxmh3",
                             "datum": null,
-                            "datumhash": null,
+                            "datumhash": "ad66d7790ef9a7bba81be81dede6cc35bbc556a225a67b51cc2783c3a9496845",
                             "inlineDatum": null,
                             "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0102070306070303010108030302020201000206080407020404050306010506#84": {
-                            "address": "addr_test1yqf6ta4zwjasx5tdj0hluurmys9k42uv6r7w4adryw8qge7z6zjr5a7d9mh83x64hm7dltyh3002fttv3hghecsrkltqnzxp8t",
-                            "datum": null,
-                            "inlineDatum": {
-                                "int": -3
-                            },
-                            "inlineDatumRaw": "22",
-                            "inlineDatumhash": "95c3003a78585e0db8c9496f6deef4de0ff000994b8534cd66d4fe96bb21ddd3",
                             "referenceScript": null,
                             "value": {
                                 "4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebe": {
-                                    "b503ffb93875e4b1": 2951305275111171708
+                                    "38": 1
                                 },
                                 "lovelace": 7500000000000000
                             }
                         },
-                        "0202070808010404050502010804020506000408060107030005080200030202#11": {
-                            "address": "addr_test1xqdkqvrt4rkshldqu8ctvqg73edx3lr0262kwa4wdw8wqnff3ta9pqcrqx5arlspt52rra5ngmzzlv0az0jfzu4em4xssg2vh9",
+                        "0101050000080400050508020300080701080601080102050704010808060808#16": {
+                            "address": "addr_test1wq0vg9tytxqzzsl0zkah8kwyppd94z8ffnvycffdnhh5m3ql8sdax",
                             "datum": null,
-                            "inlineDatum": {
-                                "int": 5
-                            },
-                            "inlineDatumRaw": "05",
-                            "inlineDatumhash": "fb3d635c7cb573d1b9e9bff4a64ab4f25190d29b6fd8db94c605a218a23fa9ad",
+                            "datumhash": "1eb59369aec7dcad69f14d860a714117bda318c8c9d0e9c768a0594214626d15",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
                             "referenceScript": null,
                             "value": {
-                                "b0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165": {
-                                    "31": 3415762039166708234
+                                "867de070f703e3b281a63b128eea28cc6b1bd752909ee78ff8fdcbe4": {
+                                    "36": 1384999761461562602
                                 },
-                                "lovelace": 7500000000000000
+                                "lovelace": 1185250
                             }
                         },
-                        "0306040306050600070303030000070605060404000506060004000105050106#68": {
-                            "address": "addr_test1qp62p57xf9ruxpwgkzsu57eshmsvm4yex5vk5v4x4jt0uy0q4jtucddfyezcwz8we07xartp6qgg4d538ed9s9tk5uasd273zd",
+                        "0201050606030301020505020804010205070708050500040304050606060702#54": {
+                            "address": "addr_test1zr0v6fkq3purnj0m5sj5tvk5lxksjx672ap9fd96pc45v5jahzd3haq9n9r92pwnrcryd7ut09sau7j20qayamc9l4espyky2v",
                             "datum": null,
                             "datumhash": null,
                             "inlineDatum": null,
@@ -1292,8 +4119,104 @@
                                 "lovelace": 7500000000000000
                             }
                         },
-                        "0307010506010007040504080105030803040700060807060007010301030706#7": {
-                            "address": "addr_test1zqxyk4jllsst8l0yc7chemm2xet4vq3lzjs2szwp5r2q6nwwr8j88temcs8ege8rmx84n6xrnp2dq2cjaav5wk76p8cqnaauex",
+                        "0206070203060800080500020604030105070305000706060404060601030408#92": {
+                            "address": "addr_test1wrqxlv3perya4rat3cfvrmzhhcmacxpla6gftdp0up87zgssmsjkc",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "2d725128406dc832eb74c4709aca0512499b3c7b17e00d7cb2e6d1b1": {
+                                    "ac": 4977889127963808871
+                                },
+                                "lovelace": 1038710
+                            }
+                        },
+                        "0702030801050405010303050303070500070808060600010808070502040802#85": {
+                            "address": "addr_test1zzgwkakusezyl3atxt3nqzgt8cr8jzht6epy3vj8amqwxfmw8keq56asr56yv35zan4f3sp4f499ll92vpttapgf5csqley67s",
+                            "datum": null,
+                            "inlineDatum": {
+                                "list": []
+                            },
+                            "inlineDatumRaw": "80",
+                            "inlineDatumhash": "45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0",
+                            "referenceScript": null,
+                            "value": {
+                                "d9ab31e46afa4cee7cf036856e13500a0d9fe409d9213f6c611e1ef1": {
+                                    "78b5895de90f642206a02d38": 1
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0803000301020201010101050605050208080301020106080202040403010803#92": {
+                            "address": "addr_test1wqaadc0g20dh424qlvyxz69hrhl9r9x3wh5l3lxyd5chhrqcnd2ty",
+                            "datum": null,
+                            "datumhash": "0aee6ad28fee34372e720c5fa3fadc32eaee515a5f6c8473d08d1aae2e890dff",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "77026beb23c41df66893d114649879ef54878796cc73273b54646813": {
+                                    "30": 9120839402326090339
+                                },
+                                "lovelace": 1185250
+                            }
+                        }
+                    },
+                    "headId": "06000503080105050806060103040704",
+                    "status": "Active"
+                },
+                "0503040105050702040707080803010701040608040007070802000601000106": {
+                    "created": "1864-05-11T00:28:02.923230545421Z",
+                    "deadline": "1864-05-04T00:01:48.964059791225Z",
+                    "deposited": {
+                        "0007020601010802060507000105020005060208040303020602070307000600#39": {
+                            "address": "addr_test1qr4llya0ppasrjrl4fjn4tjqh2vkns7af9v5f3pkspyppn8h3pmfct9msczva464ma6s008n054ajutrd2a2sed3294sat3977",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebe": {
+                                    "9c07b7": 156054068552411701
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0007040705050608020607070208020200030502070103010201030703060501#5": {
+                            "address": "addr_test1xrea4gh3xztpuxrum6xvf6qhqvsanl5utk0nveggeqjptvyql9kvpf88z6yg7axg6mrs5y2u5u2peuum2dxluuglf4jqrqa4n2",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "7fa78a9c63a157e4c524067dd65efdc35e8146bda8c4cbd891f77189": {
+                                    "a93fbe": 8812603210302259599
+                                },
+                                "lovelace": 1168010
+                            }
+                        },
+                        "0100070703030403080700010604060002060003030303050104040308050502#16": {
+                            "address": "addr_test1wp2u2ehed72dpvejll907azm642xqa2wjpz29sz70ct685ggaqgtq",
+                            "datum": null,
+                            "inlineDatum": {
+                                "bytes": "6b"
+                            },
+                            "inlineDatumRaw": "416b",
+                            "inlineDatumhash": "52df051d307a34c8a8d1d531ff0e617bf5ef28f2ffe1da1d9c9aeed40c137ed7",
+                            "referenceScript": null,
+                            "value": {
+                                "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
+                                    "925f99bc17496bd77874d9f66f75a9e5178f310ea91a6cce376681f9a25205b2": 820098124620247071
+                                },
+                                "lovelace": 1219730
+                            }
+                        },
+                        "0104050706030701080501060600060406040704080302070000040402060403#0": {
+                            "address": "addr_test1xpz8m024m6043xshjdtas4s7aq3nh5rv9d6wrfwtj83q4tk8gs8s8mrjunq7ncq5dlzrnpe0447pm7ttc7jy6cry647q7fnz3r",
                             "datum": null,
                             "datumhash": null,
                             "inlineDatum": null,
@@ -1303,8 +4226,75 @@
                                 "lovelace": 969750
                             }
                         },
-                        "0408070706060504080400080601040507010200080308010002080704030107#41": {
-                            "address": "addr_test1yz2rrxtgysegxkpq0pf2p34w3yvnpwpqhf9klxucjlla7r22fqwxth43lp0zyr025mjar884vwpafqjd0ew39n09zrdqjqg6xx",
+                        "0108040107080000040401060202070102010305020201060604030208030101#83": {
+                            "address": "addr_test1wzcxr6uytkpjr2qsjvyvsufe3g5k3a5psy3c539an62nv5skapgyz",
+                            "datum": null,
+                            "inlineDatum": {
+                                "constructor": 2,
+                                "fields": [
+                                    {
+                                        "constructor": 3,
+                                        "fields": [
+                                            {
+                                                "bytes": "7523827e"
+                                            },
+                                            {
+                                                "list": []
+                                            },
+                                            {
+                                                "int": 1
+                                            },
+                                            {
+                                                "int": -4
+                                            },
+                                            {
+                                                "bytes": "94"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "bytes": "4e405111"
+                                    },
+                                    {
+                                        "constructor": 5,
+                                        "fields": []
+                                    },
+                                    {
+                                        "int": -3
+                                    }
+                                ]
+                            },
+                            "inlineDatumRaw": "d87b9fd87c9f447523827e8001234194ff444e405111d87e8022ff",
+                            "inlineDatumhash": "5046f769bd9fd9011460ccc1818db900c95ba24313a3c1a6d91a15d49f1dab66",
+                            "referenceScript": null,
+                            "value": {
+                                "0ddf1e45dcd0c710dd604c8af772aa1601918b97590f49f485ed093f": {
+                                    "b739cbb960ecc015b0f323": 9209660078639097539
+                                },
+                                "lovelace": 1236970
+                            }
+                        },
+                        "0600020700020306030408000106060202010305050703060108010207050203#52": {
+                            "address": "addr_test1vqxpktul5hrfs8m9l8zh3dxnwzqy9d6fykcn5nrlm6znk0cr0jlf9",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 849070
+                            }
+                        }
+                    },
+                    "headId": "06070300050202060200010500040107",
+                    "status": "Inactive"
+                },
+                "0508060202080702010202060703080706030502010008010101020207020505": {
+                    "created": "1864-05-10T13:14:33.394043427913Z",
+                    "deadline": "1864-05-13T01:06:04.806875117363Z",
+                    "deposited": {
+                        "0000030801080101050504020108030503010806000802050106070208040302#9": {
+                            "address": "addr_test1vrs37uuwmurqwgsx886ysuawevlcmk46da9clz2kv68708gpn2mxv",
                             "datum": null,
                             "datumhash": null,
                             "inlineDatum": null,
@@ -1313,154 +4303,193 @@
                             "value": {
                                 "lovelace": 7500000000000000
                             }
-                        }
-                    },
-                    "headId": "05010301070708080807080502050108",
-                    "status": "Expired"
-                },
-                "0708040408010800040802010508020503010302010000070308000408030807": {
-                    "created": "1864-05-14T00:45:34.493067256204Z",
-                    "deadline": "1864-05-07T13:15:32.428116575843Z",
-                    "deposited": {
-                        "0005040408050403050308070706020208030702080600020804010302040700#68": {
-                            "address": "addr_test1yz6780ffz5a37heql0td4zqdwc24qzwpgx8fge92ljqagl9r4hq5ehv4u8edejfwvnrksxhhya7p6a0xvj7ngxr0g5nqe8n4te",
+                        },
+                        "0107030402080203050602050703050106040400050704000600020301060708#70": {
+                            "address": "addr_test1xqmn3a4sf2cytthzx5dganmmym6amgh5dx7ksz4elzygklgk2eupt33gerlrh2xwr0dhufzgjndk4dqx6u6cfpn6xwzsdjk05j",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 969750
+                            }
+                        },
+                        "0207050405010506020702050603070606030401040804070307080708010308#29": {
+                            "address": "addr_test1xraqtkl3r5nd6heqsx6fhuqdn7894y25y4aduxzkfnc88srcl2yrpz9q59g9dd07qwa3qqvn2jzws90p9j44vtw7rthsyk62k9",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0304000107000402010508050208010807010105030207060208000500030507#61": {
+                            "address": "addr_test1ypecyqtrgnh8whrvvg49vyyfz2z7d9sv55evmrptgwhnghh3lwge6pus6fm346jv2f7wetqs5egzwslvxd0uay4vt99shagjx4",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0400020407060308070708050606050201080100010403080202060503000502#89": {
+                            "address": "addr_test1ypm8g6zk6nhhxlx6ydk0nt2tu9n7xl50a7ekxh4e5d6tfrrea5vlvvwv5eayk5x8gelae82ccau9s4nqyxdu9f7jp9nqzx4s2n",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "c6908a35a16636a948993a26f87457c39a5f81da429d79b3c2c47a91": {
+                                    "30": 1
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0808000106050305030303020506010400080107050705080404000500010805#32": {
+                            "address": "addr_test1zr6kp3j0cq9g5sgt82xeu8jxawatx67579gtf2csdqutz2h0nxthfys4zy96mkztnkchexm3he6wlfk9z92nwwxnjnwql5upnf",
                             "datum": null,
                             "inlineDatum": {
                                 "list": [
                                     {
                                         "list": [
                                             {
-                                                "constructor": 4,
-                                                "fields": [
+                                                "map": [
                                                     {
-                                                        "int": -4
-                                                    },
-                                                    {
-                                                        "bytes": ""
-                                                    },
-                                                    {
-                                                        "int": -2
+                                                        "k": {
+                                                            "int": 1
+                                                        },
+                                                        "v": {
+                                                            "bytes": ""
+                                                        }
                                                     }
                                                 ]
                                             },
                                             {
-                                                "int": -4
+                                                "bytes": "70"
                                             },
                                             {
-                                                "list": [
-                                                    {
-                                                        "int": -3
-                                                    },
-                                                    {
-                                                        "bytes": "8975471d"
-                                                    },
-                                                    {
-                                                        "bytes": "729fe1"
-                                                    },
-                                                    {
-                                                        "bytes": ""
-                                                    }
-                                                ]
+                                                "int": -3
                                             },
                                             {
-                                                "int": 3
+                                                "list": []
                                             }
                                         ]
                                     },
                                     {
-                                        "constructor": 0,
-                                        "fields": [
-                                            {
-                                                "map": []
-                                            },
-                                            {
-                                                "bytes": ""
-                                            },
-                                            {
-                                                "map": []
-                                            }
-                                        ]
+                                        "int": -3
+                                    },
+                                    {
+                                        "constructor": 5,
+                                        "fields": []
+                                    },
+                                    {
+                                        "int": 5
                                     }
                                 ]
                             },
-                            "inlineDatumRaw": "9f9fd87d9f234021ff239f22448975471d43729fe140ff03ffd8799fa040a0ffff",
-                            "inlineDatumhash": "9ccd9657a5f95082d4b64c2a6eb0cf63f9275a20b439ccab7a49bf4a1ba90280",
+                            "inlineDatumRaw": "9f9fa1014041702280ff22d87e8005ff",
+                            "inlineDatumhash": "e773de2f900e4cc33db0d42d5fe14d334fa8fc5b2461bda45e9de53c5963a08f",
                             "referenceScript": null,
                             "value": {
-                                "07f61b827359451cd01220c554721fb3211dd5cf1cd7066ff1c1b68c": {
-                                    "39": 1
+                                "a0c1584525d20b4606006c254d61dcc5dee5cee8002da53453359e00": {
+                                    "c6e05f9823ee8087664db81839b2bfb76b732a58160120": 1
                                 },
+                                "lovelace": 1323170
+                            }
+                        }
+                    },
+                    "headId": "04040006030102010702020802060005",
+                    "status": "Active"
+                },
+                "0702020607070208050205060800050201050403020102000507070302020004": {
+                    "created": "1864-05-08T03:43:19.251409139478Z",
+                    "deadline": "1864-05-08T02:11:10.206468881447Z",
+                    "deposited": {
+                        "0107000405040706000300020805010803070103070103050604060308080204#4": {
+                            "address": "addr_test1qpus7g9llywh7qrv597zx5mm6xs6gyx8vzs6lkgjw9rx4h7ggc68xwjnyu9ju6feafhcx7ljz2l2unl9kyuzg3xdm4jshaq6xz",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3": {
+                                    "a779661374123b41bc48e9": 1
+                                },
+                                "lovelace": 1168010
+                            }
+                        },
+                        "0304010507020107020506050802020601020108080001070001000306050700#88": {
+                            "address": "addr_test1vq24acgwsknmwgwqswn4jq9gd4kqrk2cgyj22zxxjw57j5sljfvnd",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
                                 "lovelace": 7500000000000000
                             }
                         },
-                        "0504030802060000060601040206000306040004080107020105060300030705#99": {
-                            "address": "addr_test1yz92t864qj7fkecut8tk04wk7svu0kqpqvg2jjey329r49dgxz889ev3p2kfygymmrd225u0m3jtakrpe4lkhra6lp6sge3u83",
+                        "0308030808040404010701010004000103050508000306070505070802040303#63": {
+                            "address": "addr_test1vphnglamxk2l3daa5ulxkamfxetcu3flzp5dr5vq3fw43vsh8avzc",
                             "datum": null,
                             "datumhash": null,
                             "inlineDatum": null,
                             "inlineDatumRaw": null,
                             "referenceScript": null,
                             "value": {
-                                "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
-                                    "74fdc3c5ea4fe28336e86c736c00aa6e216cf502177262b7eea2e4": 1
-                                },
-                                "lovelace": 7500000000000000
+                                "lovelace": 849070
                             }
                         },
-                        "0606010800010204040108030701070702020505080504030305060805060406#17": {
-                            "address": "addr_test1xqhqhg80r2wd6n8wlj68vgv0fxqr3zqzvfhfryj4j4gfxvy99g7klfp586tcc005lltr8qggzzp8f6ve348gkaqadcksjgfrt9",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 969750
-                            }
-                        },
-                        "0606020002060304000808040301080607040804060202010701020007010208#36": {
-                            "address": "addr_test1yq7v6xduyhyjl5shek3z5fnfsssnrl5k6dl2qps9s0flarkkek709yr32wc4r6956ysalp8vd4nctsvrr7xwjadsxumslnv5y5",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 969750
-                            }
-                        },
-                        "0706040405000208060808020802070206070703060701000708020102010102#81": {
-                            "address": "addr_test1qz6g3y7m8srapg5zcssgyxku8lxr37vcnhaa2adh49jkevgpt7zrf7mryr20rzvr5n0923rxrjpgfhk439dq2qg8an2skjf40k",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebe": {
-                                    "6c7213e7": 6708009667591846301
-                                },
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0804020302080001040502050504040408040505010104030006060605030504#64": {
-                            "address": "addr_test1xpfjr3n5dye86ajswmfq48kwpjs09sgtk9f06jc4vnlac6cagvtksys04e62vu0qwnktl6j4wpzw3qmyfk0g0ud0agdqs2zk58",
+                        "0406040704020704070504060703070301000808070401060606000504000503#5": {
+                            "address": "addr_test1yqzz4z2urazxa9gu30tfjzvn25xt9he3sywn60m9q4rf0gtx3uw66fppr3p53e3284p7mg4mzdauqth5xuhjshtedsuqg7pssr",
                             "datum": null,
                             "inlineDatum": {
-                                "int": 5
+                                "bytes": ""
                             },
-                            "inlineDatumRaw": "05",
-                            "inlineDatumhash": "fb3d635c7cb573d1b9e9bff4a64ab4f25190d29b6fd8db94c605a218a23fa9ad",
+                            "inlineDatumRaw": "40",
+                            "inlineDatumhash": "39df024ac52722fe8ae4c1a8740e4c5624a38c3820e504a059aae8728421f8bd",
                             "referenceScript": null,
                             "value": {
-                                "4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888d": {
-                                    "37ddba6f1de9e69aaaff2a27a44f": 2
+                                "e1a1a4eaf21aba37e1626dc97cfd1e9be7712cd9394c77f0d1c5ceed": {
+                                    "db1fb5dd50ba6e": 1
+                                },
+                                "lovelace": 1189560
+                            }
+                        },
+                        "0605020506010502000803020104020404030206020400030303020305060205#48": {
+                            "address": "addr_test1qqjkrnmtua056mq4y2p6zlvlutt9rucyfvh06d2d7ff8gp2fx4sdyptvvvjq4z9aat5p6s6fx7xq4sppyak34fxjhjnswfwu23",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 969750
+                            }
+                        },
+                        "0808040600050007000104070507040506060803040300030401040305080703#31": {
+                            "address": "addr_test1qqlc006eraa8fg9r85e7rnyse497daenhutuwmkkjzvteqwzvwcvtsjk8u9yypkmfg3z39amqqfsp4vjvsh9z276tz7qwmxv5t",
+                            "datum": null,
+                            "datumhash": "8a26c518b599b3bcacfb71f703cb70d7359cce5c6175a74387292885279e3930",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "9b295a84ee5f6de49e440eaddf5862fefc63e740678845b61386f7da": {
+                                    "78efd3fa7c7c52d5249906fc3862e4361c7e3f17d272": 1127999013166925065
                                 },
                                 "lovelace": 7500000000000000
                             }
                         }
                     },
-                    "headId": "07070504080206010201080004080203",
+                    "headId": "00010504060102010400000207050302",
                     "status": "Active"
                 }
             },
@@ -1468,98 +4497,98 @@
         },
         {
             "chainPointTime": {
-                "currentChainTime": "1864-05-08T01:54:06.217367051249Z",
-                "currentSlot": 4,
-                "drift": 4.5
+                "currentChainTime": "1864-05-09T22:50:25.972531600258Z",
+                "currentSlot": 2,
+                "drift": 5
             },
             "headState": {
                 "contents": {
                     "chainState": {
-                        "recordedAt": {
-                            "blockHash": "0002010405070300040507040407050102080002030005060206020407070708",
-                            "slot": 1,
-                            "tag": "ChainPoint"
-                        },
+                        "recordedAt": null,
                         "spendableUTxO": {
-                            "0102020306030105000603070700060407030206020306020202050605040808#15": {
-                                "address": "addr_test1yqnu6564arwsx6ej969tfsg7st9j3xxmmaeh7qfjh8pkxmgulmydqk5qmhuv9l92djvflh9qfq4ycgsm0zts6f5zz8asmv3ess",
+                            "0004010008060707010002050401000300010500060102000803080601080308#20": {
+                                "address": "addr_test1yqeehgy370wlkqnmmreyjnrpxttn2yvmancf37yj8t0efdpd97r9nt3y62e5rxfall0mcq4zq8a43y3zfz67ch4qrqcsyr632m",
                                 "datum": null,
                                 "datumhash": null,
                                 "inlineDatum": null,
                                 "inlineDatumRaw": null,
                                 "referenceScript": null,
                                 "value": {
-                                    "105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5": {
-                                        "38": 1
+                                    "lovelace": 969750
+                                }
+                            },
+                            "0006060006040100060803020304060107060005030705030508040406010206#16": {
+                                "address": "addr_test1zrly8eqsaa94myvkd5h3t88gt0zm23p622pudhnyyrlau67fe82uh3l4n5mea69efxaymdpvtwyhyngw3er5relj095qp7jmvf",
+                                "datum": null,
+                                "datumhash": null,
+                                "inlineDatum": null,
+                                "inlineDatumRaw": null,
+                                "referenceScript": null,
+                                "value": {
+                                    "b56c9b4961f208962e9eb1f23efe2c466a8d5ec457275266edd1de3b": {
+                                        "32": 2
                                     },
                                     "lovelace": 1124910
                                 }
                             },
-                            "0103050202050108070701020608040006000404040106030107040808020407#79": {
-                                "address": "addr_test1qrazkvjmzun5z4yhmtg8fctacck2rnkjvysck925p5jxu2g5epvdd7gxy0ah0s8xu43avmvclyg0d7kpcxd0jhv6hxjsulj078",
+                            "0205080507070602060800070306000601080005010702000204030205030807#97": {
+                                "address": "addr_test1xrd8jxw3kfdnxccgx5zptuv8qt4hwyw8lw6m5la95dh56lh4u9p884n7ljjj0d0qzsnntmy62c8p0cny0js2psa8ne6qy9tn46",
                                 "datum": null,
-                                "datumhash": "76c73fb360a41b9f245d4d0c9acb91893144abd84f5f1d1531d58db658e3ac92",
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
+                                "inlineDatum": {
+                                    "int": -2
+                                },
+                                "inlineDatumRaw": "21",
+                                "inlineDatumhash": "0268be9dbd0446eaa217e1dec8f399249305e551d7fc1437dd84521f74aa621c",
                                 "referenceScript": null,
                                 "value": {
-                                    "0645f552587f8320ae3247f9d19327469a2c08fd3d4c96e7a02f872f": {
+                                    "d0c8eb218ca2ee432f837b1a449aaa265fcb4dd4c3e22e92ee660857": {
                                         "34": 1
                                     },
+                                    "lovelace": 1163700
+                                }
+                            },
+                            "0303010606000205050304060701080104010103030508060803010707000307#49": {
+                                "address": "addr_test1qpwp94p4yu7f65dvuxs73wlvkmcezfmmsu49ejldgappwdljljpwk6fc9terevr4vyag79tqsyu2myvcuz5lc852wfvqnxzjqp",
+                                "datum": null,
+                                "inlineDatum": {
+                                    "bytes": ""
+                                },
+                                "inlineDatumRaw": "40",
+                                "inlineDatumhash": "39df024ac52722fe8ae4c1a8740e4c5624a38c3820e504a059aae8728421f8bd",
+                                "referenceScript": null,
+                                "value": {
+                                    "738717b50f578c71cad322752db31a35c0f2332a5cc5a2c1b3b5f197": {
+                                        "32": 1052112064681146002
+                                    },
                                     "lovelace": 7500000000000000
                                 }
                             },
-                            "0405040104030007050206080003070607070103020805070203000504020106#2": {
-                                "address": "addr_test1xrnx6hupyz5qkvfzfvmtlu68wjxme8thhjxsgvg8xcyvsehfm5e058cl6tznvpenqwparq69z9sg5m6t8v4gjleg6vkqavp8xg",
+                            "0402050702080602050805030500020305000400080608010505010402060503#7": {
+                                "address": "addr_test1ypuu8f0r7s2d59eqqhhp4lksrhg5xehrzlyq9qcr649sdkyh7sqhd70yafxjhet6jy6ave0mr35rt02nkyler9mcy5yqfgte50",
                                 "datum": null,
                                 "datumhash": null,
                                 "inlineDatum": null,
                                 "inlineDatumRaw": null,
                                 "referenceScript": null,
                                 "value": {
-                                    "lovelace": 7500000000000000
-                                }
-                            },
-                            "0406020202010207060708060600030303070106080503000507000505070306#92": {
-                                "address": "addr_test1wqa82w0sxftxe7w3s9x5s2yh9uw2r76naqq35tjtrwytplg4ce0a5",
-                                "datum": null,
-                                "datumhash": "4e8b675fdeb661f2325b10bd9e7da071ca97098315a55a6c4744b4dcb1795f34",
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888d": {
-                                        "99054fe1fb859b0421cb3fcca2a96444e715": 1
+                                    "57b875cb82b489f1ccef52829bf19ad0dad61868fd900bbb07c6f8de": {
+                                        "1b1bc7158f0834b47d3b15772d1b": 1794396770109182401
                                     },
                                     "lovelace": 7500000000000000
                                 }
                             },
-                            "0504020300050308070504060808080407050503070208080707040707050800#93": {
-                                "address": "addr_test1qpyaelm2m5vvqy6qta2t97nel4wy2jesh4mwrc3k35y5szxjgktxvncju66670s58an9rhcwq4uhqe5uqt4f2fwhkxeqkkr3te",
+                            "0503040408030105030000080303080004060000000604070700000807040107#84": {
+                                "address": "addr_test1qqegsplze8dl3kndxzwujvzpkayflh3u8dvzhq943x9dhcrj0c9ywky0hly6l87ndhdn9zyytgtye9720wzkf9u4k0nqxl7q9h",
                                 "datum": null,
-                                "datumhash": "c9d1c7c6f56fe2b4a1cc1daeeec19edc7d71e64067d9e7901e5ecc899dfe5464",
+                                "datumhash": "e4b4f8985fc8e77aa968aadffae0a7364624b4965afd98b809670909a9db027e",
                                 "inlineDatum": null,
                                 "inlineDatumRaw": null,
                                 "referenceScript": null,
                                 "value": {
-                                    "1341c95dd8b25f37b619869cb9b6ea24716abd2b54fbaeb6f74a473c": {
-                                        "39": 1
+                                    "bdef4db3c5efafb4bd1de2799a1b29930d9ea4efa0744c417c1dbfb6": {
+                                        "7b8cd5f8032d351d80aa296caee4c7": 426307098983629257
                                     },
-                                    "lovelace": 7500000000000000
-                                }
-                            },
-                            "0803020403000700030703000505010604080808080203050700030807010701#72": {
-                                "address": "addr_test1vztpg0aaw7uhrv7yeewllrjgw2rudkvwe3fszvvejhu769gxy8d9l",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "2d725128406dc832eb74c4709aca0512499b3c7b17e00d7cb2e6d1b1": {
-                                        "28d436cd60e77a88fb65800b8cbf6e4b797e3378fce301": 1
-                                    },
-                                    "lovelace": 1099050
+                                    "lovelace": 1366270
                                 }
                             }
                         }
@@ -1567,80 +4596,85 @@
                     "confirmedSnapshot": {
                         "signatures": {
                             "multiSignature": [
-                                "5e0ebb49eef7a9513f77cc8d007ddfbcab8ff78e9b56a18b3b1b1deba55bb6beebd02b5264f0670c576d76e091c0966e1ae863326d30ef4b53df9f302f351a00",
-                                "6830b7ff0662d67805015abe169c5da7dcfbd35819e46e9c59722979043aeb4fcdf3186f63212b8a4f7880ccf74699dc57e22f6a66a1e207d78bb18d4949bd02",
-                                "8f8833779470338e4e57df61de3e4356bf782ab09d329c33075fd217878c3b760a9720edfb056d82f8780219eeb18eca6196e7052c824e0f5e5a9fef1b86ec02"
+                                "bdd2aeef3f4b6285aa55f9300be341fa2093518b3ef8a39ed308010cff6b2d52de96fef675e57087a4bfff868a5fb26eddb010dd204533c851611a8389444d02",
+                                "97c8f2a1ea7ad3046565d51fd7704e100312e9e110bcc0c8461fc9170d7ce60c7d5d92e4ff55cf7a5eda748e668846e56e726781e928bfe4b0ce24cf5fe47f04",
+                                "98db44ff0e3e8b6a080fe99ab9393c15bf22f07c943c790fdc7abe9e325b1134adf447cc0d0275992f846135ff8827723fad997580d1133e0c063a0014553d0b",
+                                "e8f9ea52c3a31628bfc4a9a0b672e42ca3387b35d03614867fc063f8142b7ea9acd7ea0e8ed7aa382ff1c44e69caaa930684d0fd80634b5b1e8868aa1b837a0b",
+                                "7b51a40d248b70381fd3f39e0e46b68b6a97992ce2889f6dde8da13aec7524b3263e04526d6f79682be7e6c4d2b8f11a3941f712bb863d6ec62f9f0b572c0206"
                             ]
                         },
                         "snapshot": {
-                            "accumulator": "61e6efd95fc4244176397091ffc3c29f7a2e4559712701296c9978c2a7aed218",
+                            "accumulator": "d039d114997259d9945acc7379b05f8106df61c025bd0050dbe0994d1f055ad8",
                             "confirmed": [],
-                            "headId": "04030308000704040008060402070207",
-                            "number": 6,
+                            "headId": "03030003030008050201080808070501",
+                            "number": 3,
                             "utxo": {
-                                "0003060108070800020204080707050802070504000106000508070800010801#15": {
-                                    "address": "addr_test1xqay04uku2wg2n92z8u70ew8mh8e4438ztzqjp34j62cckfhlcjh0gl6thw9uercg75f3efyw68jan65pr2l9k8t2nrqt58qzt",
+                                "0001030708080803080105000203030807010107080706020708000407060105#77": {
+                                    "address": "addr_test1qzjxfu8jmu64qd4qlxhdsfzn2vk7hmxqdqt3vpss2yl4x9tvc5sqfdujmgw7y6mhk7ak6nft60ha53qjhp2d8ev5vfes3350lj",
                                     "datum": null,
-                                    "datumhash": null,
+                                    "datumhash": "37028fd3d366220336ea43336120fe4c95c4c30ac43c7cb13dd648c1e601ee21",
                                     "inlineDatum": null,
                                     "inlineDatumRaw": null,
                                     "referenceScript": null,
                                     "value": {
-                                        "lovelace": 7500000000000000
-                                    }
-                                },
-                                "0101080603040308080202020600020006060106010401040403010802060601#52": {
-                                    "address": "addr_test1qz4rtu92qrelr062faz9a8eux09l0mk2lje8y7djq4n4lpdudz6tldxpwxtle28mhfx9alada295ccuv98zl4wrr7tqss4t48p",
-                                    "datum": null,
-                                    "datumhash": null,
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "lovelace": 7500000000000000
-                                    }
-                                },
-                                "0101080703030605020707000208080407070704070600080404040801080003#85": {
-                                    "address": "addr_test1vr522qtktfcn6ceyr7r5r2m6uzt22adykx92e08rpyy3p8qpjmdxv",
-                                    "datum": null,
-                                    "datumhash": null,
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
-                                            "35": 1
-                                        },
-                                        "lovelace": 1004230
-                                    }
-                                },
-                                "0303020301000207070303030801070000020600050606010300010506010202#84": {
-                                    "address": "addr_test1zzvfypcjqndehrmjavyw0w97lhs570m4x0nje8700ew6z9a5ffhtznpjzj2yrak60zjftj6f6gzr3futhvzl9yxyemxqxwxkq2",
-                                    "datum": null,
-                                    "datumhash": null,
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888d": {
-                                            "d29fc397f795fe2396091bf77aaf70aeff": 6514413374233014740
+                                        "e88f366a94c20ceb9490ead62469f3be3328d72f96e3bad5dd941682": {
+                                            "32": 1
                                         },
                                         "lovelace": 7500000000000000
                                     }
                                 },
-                                "0407010802030304030506040803010406040308030604030803020704080603#22": {
-                                    "address": "addr_test1wpwgc5npua45wjf70mj90k2crcs4ye27jmuyyr0ahay0pxcvldya7",
+                                "0008010506000506070801060802020303050302070206070304070300060805#52": {
+                                    "address": "addr_test1vzdev5zs2dn5fjng6ln7kdwlcutwux7r3rgsppw39e9jk6gy29yyk",
                                     "datum": null,
                                     "datumhash": null,
                                     "inlineDatum": null,
                                     "inlineDatumRaw": null,
                                     "referenceScript": null,
                                     "value": {
+                                        "lovelace": 849070
+                                    }
+                                },
+                                "0304080702000606000001030407050005030608030008030002060502040202#69": {
+                                    "address": "addr_test1xrsksvupw68hzmhghtpcwktafps544akljas6ffut9kg4r573z36kh6k0lhw49tztndev2eq6yy3jkxlrfk4vw2fm5hshzswr8",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "3f00ce185bc0d4e2f7365063a019832c8ae25fc54d66c867b19d544f": {
+                                            "a5c00cf79de4ba79c7": 7960269002559645056
+                                        },
+                                        "lovelace": 1193870
+                                    }
+                                },
+                                "0400080205060804050102050203060604030608000101000805020701000805#90": {
+                                    "address": "addr_test1zqukyuyynygal5ta0wzjyj2dxcnvtqved3e8zegy83r9ect3x857ygz2h85mdunxe6k26372gg4cq3syv4matndzmlls0un5l8",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 969750
+                                    }
+                                },
+                                "0707080102040804060108000807000101000507070702060803040000070704#5": {
+                                    "address": "addr_test1zpef7f57sdqhnz479gsl9ld0p05wpnp96jegpwrlnll9clpkykjkq6szredwjl0wj6c4fe73s4xuveejypv6ma7quyfq5mgfjh",
+                                    "datum": null,
+                                    "datumhash": "74473f93e6b8d361f26d3e43149304afeb9a3d5fbd7ae9645c7af3b88283676e",
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3": {
+                                            "cd37e5f1a721": 7847621490725413241
+                                        },
                                         "lovelace": 7500000000000000
                                     }
                                 },
-                                "0502050207070307060106000206080200030803000603040506000505010701#41": {
-                                    "address": "addr_test1qp8yv7hrtzf9x3hgmkx720mgtm9uvlq5f2z2wy2tfpg4wzld2m7p34fx93w6g40llje360gyvddmczg8rptahe30w6mschk9e6",
+                                "0800060805030400070603060000010104070207030301010500060800070100#89": {
+                                    "address": "addr_test1qpsqdq09h9y825kjwycfdtmp06dwmr7p5g4d8dd3tauunz3423y2fyxg7gxdg0m5cuh78vum9mh8cged37euye4rrnkstq6zs3",
                                     "datum": null,
                                     "datumhash": null,
                                     "inlineDatum": null,
@@ -1652,2647 +4686,473 @@
                                 }
                             },
                             "utxoToCommit": {
-                                "0001070703020705080205000702070005010401070501060302080503020401#78": {
-                                    "address": "addr_test1xzeyhl2mdwpvuz6mdk6zxwkgxekcqhertfn6hdsjxacyd3slw29m7e6m896u6gjdcu6mply9al4qdp7qjr0qxtwjuurqrf4f5x",
+                                "0001050608010508070505080201050506020707000403050802000702070705#48": {
+                                    "address": "addr_test1yq7exgf55l4ps8cexnmkm4l8a3ykn98t0s4m8sggk25uc287kvmpkr8wxv97nhuk5wvttcwnppmel054eer7hu4v7h8q3mchqu",
                                     "datum": null,
-                                    "datumhash": null,
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
+                                    "inlineDatum": {
+                                        "map": []
+                                    },
+                                    "inlineDatumRaw": "a0",
+                                    "inlineDatumhash": "d36a2619a672494604e11bb447cbcf5231e9f2ba25c2169177edc941bd50ad6c",
                                     "referenceScript": null,
                                     "value": {
-                                        "b0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165": {
-                                            "37": 2938330351294974482
-                                        },
-                                        "lovelace": 1159390
-                                    }
-                                },
-                                "0204060007070102000006040300080706050707060100070601050707000701#82": {
-                                    "address": "addr_test1qpfg62ztla29gmzk0veyrfvj38v3gnhdx7yt5yu42lfs4pcm0dv8r4vhvvvat0xsmsywsnm9glgj6uyrwhu4wclcm6as5y24j8",
-                                    "datum": null,
-                                    "datumhash": null,
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "lovelace": 969750
-                                    }
-                                },
-                                "0408070103060107010507010507000400040205060207020108000802000201#28": {
-                                    "address": "addr_test1zzxlet53h95ccmwp3mlz655x252vhfjclux3tzav8flv6f8grfma55ez8kwqwkcelq5k2kxdw09ztf8z9ngm9d7dwgnsxhpn8k",
-                                    "datum": null,
-                                    "datumhash": null,
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "lovelace": 969750
-                                    }
-                                },
-                                "0608000003080005070002030401060008040208040407070502020006020703#49": {
-                                    "address": "addr_test1xz4m8mfaf7jxkygsahns8v8euk9jtz9j0raqzjm8xwheyerufy9rzpra9qsezkeuekk88e3vgtnjz764tyct2c0gt27qs7sx07",
-                                    "datum": null,
-                                    "datumhash": "adf18faf9d6a7a8b93c9256061027357d1d3d556b0cead26ed09d0e917039893",
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "953af457ec3128f4bbe7faa9d1fe1cf5cbbdf501fc53f0f1054bedd3": {
-                                            "d9e7398edcb0733a": 2
-                                        },
-                                        "lovelace": 1301620
-                                    }
-                                },
-                                "0803020103080300050308070008070007030001070200030205070200070607#27": {
-                                    "address": "addr_test1yz76r4lcrmdeww2xmr8089jdx45fqydhuhaqng340vr09vrl8x2xqh693ury6slh6nukt5mwm8gjn4a5s7ku4kypvx2qa8jalj",
-                                    "datum": null,
-                                    "datumhash": null,
-                                    "inlineDatum": null,
-                                    "inlineDatumRaw": null,
-                                    "referenceScript": null,
-                                    "value": {
-                                        "2c0b1a6eb8af90eee39f86480be2ece84270c4a7cf306bf93a2dcb86": {
-                                            "37": 2163805658492774671
+                                        "f95e420e08e17e402321c01435960266fb8607c39e3d13fd4f45fee5": {
+                                            "31": 2619147590483433683
                                         },
                                         "lovelace": 7500000000000000
                                     }
                                 },
-                                "0804080502010000050500050701070202040800070201020303000306080205#56": {
-                                    "address": "addr_test1qq8jmeac70qhjgypwx2jpnq8h9z2t0zyg5g5shjyr468ahmplqshkjlmdyrar98pmeeuyg70stay3ud40et26ey6v47sqvhu46",
+                                "0006080405060102010100030407070400050506070800060600050602080500#39": {
+                                    "address": "addr_test1ypyuz2kgq7tvapmc6268sjh94qxusz90urz97h2xlxwwxt3u8p2mmkxdhnaq9wte75epsxjyckn3yv7nlzqrrhmh7t8qhv8w0w",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebe": {
+                                            "d2b3a167fe3e7824810ed07e7762b45aa9473207d09d": 7411876114897681116
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0602060103080003000307040103030601050504000308070000040406070404#3": {
+                                    "address": "addr_test1vz5adfcller4jdzc7g7ljr4223766vwtwm5jrq7r74guegcf5f0jd",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 849070
+                                    }
+                                },
+                                "0702030207070303020605020100080803030008050306040805060700030001#85": {
+                                    "address": "addr_test1xqpuf9mqvp32c8ef7xvrglvz4qw4hq802v92yn4exhfhzcypln69pwsjj2rq9wsf0kxsc7ey7340fqy2cqfhqst4p68qfrgz8w",
                                     "datum": null,
                                     "inlineDatum": {
-                                        "constructor": 4,
-                                        "fields": [
+                                        "map": [
                                             {
-                                                "map": []
+                                                "k": {
+                                                    "list": [
+                                                        {
+                                                            "int": -2
+                                                        },
+                                                        {
+                                                            "map": [
+                                                                {
+                                                                    "k": {
+                                                                        "bytes": ""
+                                                                    },
+                                                                    "v": {
+                                                                        "int": -1
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "k": {
+                                                                        "int": -2
+                                                                    },
+                                                                    "v": {
+                                                                        "bytes": ""
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "constructor": 2,
+                                                            "fields": [
+                                                                {
+                                                                    "bytes": "98f6"
+                                                                },
+                                                                {
+                                                                    "int": -2
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "constructor": 1,
+                                                            "fields": [
+                                                                {
+                                                                    "bytes": ""
+                                                                },
+                                                                {
+                                                                    "int": -2
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "v": {
+                                                    "int": -3
+                                                }
                                             }
                                         ]
                                     },
-                                    "inlineDatumRaw": "d87d9fa0ff",
-                                    "inlineDatumhash": "39b5823512db0d794874378f278125864e97a106e3b88de1c73ab0ab94840a65",
+                                    "inlineDatumRaw": "a19f21a240202140d87b9f4298f621ffd87a9f4021ffff22",
+                                    "inlineDatumhash": "2f332973376a20b15368da54a83351dc4fb8961851d0fb7f882a77d17525f49f",
                                     "referenceScript": null,
                                     "value": {
-                                        "fbdc2ee525a9495e192be57de41ab0a58c694c0864145e6205255467": {
-                                            "c38668ab98c5910298": 1
+                                        "1d77f17e278afc13a2ab44d7437eae035473c83242b4bffd33ff0e14": {
+                                            "117bb978b8d6be307669f24d1dcb5d6349124dc2": 376163943241570589
                                         },
-                                        "lovelace": 1215420
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0800070007060601020804000400060503010208010205050102000303040607#90": {
+                                    "address": "addr_test1zz0edf2ryuxxf6suwfs9uhjcwfsmq2qsd5c9eg84ky9c3yjy96ywvwdmw6f8gpzgedar03luheqzxu03l45g93hmzl6scnky8c",
+                                    "datum": null,
+                                    "datumhash": "3a0b7750cc583b31b0b685763c98e16a9209185d8923eddfd1751ceaaf92e87e",
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5": {
+                                            "8b9c6aa784d61b757615b1cff7d34ca65084648f": 1
+                                        },
+                                        "lovelace": 7500000000000000
+                                    }
+                                },
+                                "0805060300060604030401020800030305020504000704030208040207010803#82": {
+                                    "address": "addr_test1zq8g60qu4e4tgpk30tezjnd45uzl47n9cu6sl54s7xz8e36gu227hyk255yfcqg9vces78neeff538en39qjdv8agcvqh76005",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
+                                            "29bbec319a5facca75d2c272d42663997e00ed0112a4": 4001248540661129476
+                                        },
+                                        "lovelace": 1249900
                                     }
                                 }
                             },
-                            "utxoToDecommit": null,
-                            "version": 0
-                        },
-                        "tag": "ConfirmedSnapshot"
-                    },
-                    "contestationDeadline": "1864-05-14T17:10:24.589922062281Z",
-                    "distributedFanoutOutputs": {
-                        "0100060508050708000702020401050803000702010602010005040206060701#23": {
-                            "address": "addr_test1vqnqm9q6emngs8dlcluqjme9dhdjh3f0vfv6jkkzz4sydmcavv969",
-                            "datum": null,
-                            "datumhash": "c0cb76567287dc0e1fc238b7091f52ca890ea504bf9d164166d092252ca7d481",
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5": {
-                                    "833d8ef5997b51d2db4d765eb7": 1
-                                },
-                                "lovelace": 1202490
-                            }
-                        },
-                        "0105060708040200030207070506030701020504040203030805000007060805#53": {
-                            "address": "addr_test1qp9jr7glkqknlug8spawsm2tajldc6edwlgzdyz7f7j78evlleq9lrd7j2ep67wga9rzlcj2nrj88ftf8zfyhyq63h6s2n2y60",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 969750
-                            }
-                        },
-                        "0502010505030402010700020507060308070707060106070005030400030605#98": {
-                            "address": "addr_test1wq9lqjksqwrc85dyk3lqy9jhljqhv5fjfgaanv38pvnggkch2l8sd",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "a4d00ab2e9eb0793a72cbf89822bb6945c9985730c54a7341cc62995": {
-                                    "35": 1
-                                },
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0508020400000305030204030606030802020008050402080301020808070706#42": {
-                            "address": "addr_test1vp03phpr9h08nahjj9emhaqg7dls0zg7zfmaap3slssvhqqzrfurr",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
-                                    "e3f7fcbc0619cb00947fab8acffd5a928ee5a8ccc09fa3": 1
-                                },
-                                "lovelace": 1099050
-                            }
-                        },
-                        "0601080108000301070608010405000607050705070804030404050206000304#99": {
-                            "address": "addr_test1qqgtdhglhknh99helgzcs6z7q5rszzy7nzy4lj0whyywxdhj85vptvekwlczdpyvrrajrtu6n5kqsgypagzazz2cqalq93havp",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "49d5c86184b0be137b53850518580d1b751b5838bf1e8f70bae71bb3": {
-                                    "71fa": 5710560972791983342
-                                },
-                                "lovelace": 1163700
-                            }
-                        },
-                        "0605060604070800070505010508020001000203010404030406020708070102#75": {
-                            "address": "addr_test1zztnvydtt2mvx8ndml3vrfj0faf8adwa686uf3ecd7skg2lc076swr6d9sautthwv5lx9gx3j5p4epw0l00fzkuqn0gszhc4hz",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 969750
-                            }
-                        }
-                    },
-                    "headId": "07080406010607040801030401000608",
-                    "headSeed": "00040607020308020007040408020205",
-                    "parameters": {
-                        "contestationPeriod": 45152,
-                        "parties": [
-                            {
-                                "vkey": "a934792e92aa60eb3432c5bf0e7e7cecef61f9e03e587841e87e1567ed7fd78c"
-                            },
-                            {
-                                "vkey": "54ea6efe3653157738966b94a32b6333c6ff5740eafe45095c19e438f5d28cf7"
-                            },
-                            {
-                                "vkey": "3410aafb27a098120c6524679d75a1ec665a0ffeab2645da683f4568a2575c88"
-                            },
-                            {
-                                "vkey": "dc0e6836b36906a506f5884a04666e75459e589acca7d21aac2f6d81ef5f63c0"
-                            },
-                            {
-                                "vkey": "16dd9e27e91f9a247e546a5135634dff0a2fc9011633cfdbfb1eb0ea15639399"
-                            }
-                        ]
-                    },
-                    "readyToFanoutSent": false,
-                    "remainingFanoutOutputs": {
-                        "0307070703030308030308080405040405000104030200000103000008020303#8": {
-                            "address": "addr_test1zp9ql9u7z6wr8sfwrjkxjd8vce96w8dll8numfy20rcqgwavq9dr7z5tt8r6twc6rymsy549vpqks6uqsmasalhmaxcsexrvlk",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3": {
-                                    "7b50f6695011a77e8fc2925db887fe7bd057ebc0a9d7": 1
-                                },
-                                "lovelace": 1215420
-                            }
-                        },
-                        "0402030804020308020203070707040008010508050105080703010803050805#63": {
-                            "address": "addr_test1xqk6fy9alg42j65tqfh69e68esu9kpp26xrmw24a2mkenhhw6n9fszxstqyzhw8dcvpwpac30j33r8cl239sflt0f2psaknehd",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0404040206070004050502060002010006040002020107020207010807070504#12": {
-                            "address": "addr_test1qqx9ecpec3tcmu2lvzu3qtcr4rtsgc243f8mae7f2mzmftmqr6llchppatg33jjrrmz9ufztcwg4ans9hftk5janvsyqddvavn",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0701060607070407040504020608040107000003030603030804020705070107#24": {
-                            "address": "addr_test1xzpqyycf7gu08yc50zncqcxffs2xm0yelxulejsgvrvhjt3ymklt8af49wqlw0quxqrvr30pcxjr2h0ncxxgf72ufjjqtwumrl",
-                            "datum": null,
-                            "datumhash": "5a476573fe552cef37714c7e81ceef0918f631f5a2c7768897a611f66cf4a11d",
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888d": {
-                                    "a066b8eefb237d": 6761972234044815323
-                                },
-                                "lovelace": 1331790
-                            }
-                        },
-                        "0800030104040603030002030604070006080201080001000301070800070302#24": {
-                            "address": "addr_test1wrcsr8klmdauuwnzq7gk0mgv26kzeyaxe8p4vd0t69k93gce20hrq",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5": {
-                                    "495bd1c245cb5109239f": 1
-                                },
-                                "lovelace": 1043020
-                            }
-                        },
-                        "0803020806060600040807040801030200030203020102040004030707030004#42": {
-                            "address": "addr_test1yqv7arkuruwt4sp0vzlxe3rasqcqs9nk73wu670e97mhng3phxz62rcyrrhtfkqyfsq0jaku5l2jkr3wu4z4v58rj0fsegvu7j",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        }
-                    },
-                    "version": 5
-                },
-                "tag": "Closed"
-            },
-            "pendingDeposits": {
-                "0406000305050403080304080406010300030801060406010807010208050204": {
-                    "created": "1864-05-11T12:30:22.094285616039Z",
-                    "deadline": "1864-05-10T03:16:00.901208391584Z",
-                    "deposited": {
-                        "0304080006000500070804050408020307040400080208080600010305050600#0": {
-                            "address": "addr_test1zpa3gp85vvl575ygxer6q4a0ncxdxt4ffnr50fs7rghzvp3yhxt2a9p4umw997y7ex26fszuu6pyc8fgz6djtv95ahvs07nnqg",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 969750
-                            }
-                        },
-                        "0402080305060600070000060407020102080404080302070703030408000802#24": {
-                            "address": "addr_test1zzawsywp6zjvmkj2sed6t8frck65zzpx2ymcgafu9ajylkq2yyueyr54jfc7xnvrky4xwmcf3ku97xj2z83dlkm4em3qdzxgjz",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 969750
-                            }
-                        },
-                        "0405010104030404060602020408080602010707060100050307060401010001#64": {
-                            "address": "addr_test1yz2rfr0a9xevkmm005leuv02uft7wpnjvsauauv2ate5dgnwcsdz0afrvs3p6us700mxwpcpwlajzwmkk098l7c5dvtq6gm3tk",
-                            "datum": null,
-                            "inlineDatum": {
-                                "map": [
-                                    {
-                                        "k": {
-                                            "map": [
-                                                {
-                                                    "k": {
-                                                        "bytes": "0a08"
-                                                    },
-                                                    "v": {
-                                                        "bytes": "d01ab2"
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "map": [
-                                                            {
-                                                                "k": {
-                                                                    "int": -5
-                                                                },
-                                                                "v": {
-                                                                    "int": -5
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "bcc53d"
-                                                                },
-                                                                "v": {
-                                                                    "bytes": ""
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "int": -1
-                                                                },
-                                                                "v": {
-                                                                    "bytes": "f636bf2d"
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "2f"
-                                                                },
-                                                                "v": {
-                                                                    "int": 0
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "d854a7"
-                                                                },
-                                                                "v": {
-                                                                    "bytes": "9d20dd"
-                                                                }
-                                                            }
-                                                        ]
-                                                    },
-                                                    "v": {
-                                                        "map": [
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "64819b40"
-                                                                },
-                                                                "v": {
-                                                                    "int": 4
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "int": -4
-                                                                },
-                                                                "v": {
-                                                                    "bytes": "0aaaa817"
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "constructor": 0,
+                            "utxoToDecommit": {
+                                "0108050808030803050801080106000502070002020207020505020202010605#50": {
+                                    "address": "addr_test1xpmjvn64er75zmg5mtxu68srl3j3mgj6y085npmav7rhfpj50f6hsq9fje4pngduj8l00jxvadcss9sj05j0k6g2f5nqq60z9t",
+                                    "datum": null,
+                                    "inlineDatum": {
+                                        "list": [
+                                            {
+                                                "constructor": 2,
+                                                "fields": [
+                                                    {
+                                                        "constructor": 2,
                                                         "fields": [
-                                                            {
-                                                                "bytes": "89e6b5"
-                                                            },
-                                                            {
-                                                                "bytes": "1a5865"
-                                                            },
-                                                            {
-                                                                "bytes": "6d36a3"
-                                                            },
-                                                            {
-                                                                "bytes": "6fef1812"
-                                                            },
-                                                            {
-                                                                "bytes": "358b"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "v": {
-                                                        "list": [
                                                             {
                                                                 "int": -4
                                                             },
                                                             {
-                                                                "bytes": "ab8c"
+                                                                "bytes": "bfdea3"
+                                                            },
+                                                            {
+                                                                "bytes": "40e344"
+                                                            },
+                                                            {
+                                                                "int": -2
+                                                            },
+                                                            {
+                                                                "int": -1
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "int": -2
+                                                    },
+                                                    {
+                                                        "bytes": "efbc595d"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "list": [
+                                                    {
+                                                        "list": []
+                                                    },
+                                                    {
+                                                        "list": [
+                                                            {
+                                                                "int": -2
+                                                            },
+                                                            {
+                                                                "bytes": "8a4755ab"
                                                             },
                                                             {
                                                                 "int": 4
                                                             },
                                                             {
-                                                                "bytes": "10"
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "list": [
-                                                            {
                                                                 "int": -5
-                                                            },
-                                                            {
-                                                                "bytes": "e8195dd8"
-                                                            },
-                                                            {
-                                                                "bytes": "9c65"
-                                                            },
-                                                            {
-                                                                "int": -5
-                                                            },
-                                                            {
-                                                                "int": 5
-                                                            }
-                                                        ]
-                                                    },
-                                                    "v": {
-                                                        "map": []
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "constructor": 4,
-                                                        "fields": [
-                                                            {
-                                                                "int": 2
-                                                            }
-                                                        ]
-                                                    },
-                                                    "v": {
-                                                        "constructor": 1,
-                                                        "fields": []
-                                                    }
-                                                }
-                                            ]
-                                        },
-                                        "v": {
-                                            "list": [
-                                                {
-                                                    "list": []
-                                                },
-                                                {
-                                                    "int": 5
-                                                },
-                                                {
-                                                    "bytes": "de840a92"
-                                                },
-                                                {
-                                                    "list": [
-                                                        {
-                                                            "int": 1
-                                                        },
-                                                        {
-                                                            "int": -1
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "k": {
-                                            "constructor": 4,
-                                            "fields": [
-                                                {
-                                                    "map": [
-                                                        {
-                                                            "k": {
-                                                                "bytes": "b0"
-                                                            },
-                                                            "v": {
-                                                                "bytes": ""
-                                                            }
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "map": []
-                                                },
-                                                {
-                                                    "constructor": 3,
-                                                    "fields": []
-                                                }
-                                            ]
-                                        },
-                                        "v": {
-                                            "list": [
-                                                {
-                                                    "bytes": "1a55"
-                                                },
-                                                {
-                                                    "int": -5
-                                                },
-                                                {
-                                                    "bytes": "cc"
-                                                },
-                                                {
-                                                    "map": [
-                                                        {
-                                                            "k": {
-                                                                "int": 0
-                                                            },
-                                                            "v": {
-                                                                "bytes": "c083"
-                                                            }
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "k": {
-                                            "int": 0
-                                        },
-                                        "v": {
-                                            "map": [
-                                                {
-                                                    "k": {
-                                                        "bytes": "84c8f2"
-                                                    },
-                                                    "v": {
-                                                        "constructor": 4,
-                                                        "fields": [
-                                                            {
-                                                                "int": -3
-                                                            },
-                                                            {
-                                                                "bytes": "73c8cd"
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "int": 2
-                                                    },
-                                                    "v": {
-                                                        "bytes": ""
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "constructor": 3,
-                                                        "fields": [
-                                                            {
-                                                                "bytes": ""
-                                                            },
-                                                            {
-                                                                "int": 3
-                                                            }
-                                                        ]
-                                                    },
-                                                    "v": {
-                                                        "map": [
-                                                            {
-                                                                "k": {
-                                                                    "int": 0
-                                                                },
-                                                                "v": {
-                                                                    "bytes": "6c46"
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "int": 2
-                                                                },
-                                                                "v": {
-                                                                    "int": 2
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "int": 5
-                                                                },
-                                                                "v": {
-                                                                    "bytes": "0ace502a"
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "bytes": "99"
-                                                    },
-                                                    "v": {
-                                                        "bytes": "0e699ba1"
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "constructor": 0,
-                                                        "fields": [
-                                                            {
-                                                                "int": -3
-                                                            },
-                                                            {
-                                                                "bytes": "76ec96"
-                                                            },
-                                                            {
-                                                                "int": 5
-                                                            },
-                                                            {
-                                                                "bytes": "26"
-                                                            },
-                                                            {
-                                                                "bytes": ""
-                                                            }
-                                                        ]
-                                                    },
-                                                    "v": {
-                                                        "constructor": 3,
-                                                        "fields": [
-                                                            {
-                                                                "bytes": ""
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "k": {
-                                            "constructor": 2,
-                                            "fields": []
-                                        },
-                                        "v": {
-                                            "constructor": 1,
-                                            "fields": [
-                                                {
-                                                    "int": -2
-                                                },
-                                                {
-                                                    "list": [
-                                                        {
-                                                            "bytes": ""
-                                                        },
-                                                        {
-                                                            "bytes": "84d3"
-                                                        },
-                                                        {
-                                                            "bytes": "bfb2"
-                                                        },
-                                                        {
-                                                            "bytes": "ce"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "list": [
-                                                        {
-                                                            "bytes": ""
-                                                        },
-                                                        {
-                                                            "bytes": ""
-                                                        },
-                                                        {
-                                                            "int": 2
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "k": {
-                                            "bytes": "11"
-                                        },
-                                        "v": {
-                                            "map": [
-                                                {
-                                                    "k": {
-                                                        "list": [
-                                                            {
-                                                                "int": -3
                                                             },
                                                             {
                                                                 "int": 2
                                                             }
                                                         ]
-                                                    },
-                                                    "v": {
-                                                        "map": [
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "44b5"
-                                                                },
-                                                                "v": {
-                                                                    "int": 4
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "int": -4
-                                                    },
-                                                    "v": {
-                                                        "constructor": 3,
-                                                        "fields": [
-                                                            {
-                                                                "int": -5
-                                                            },
-                                                            {
-                                                                "int": -4
-                                                            },
-                                                            {
-                                                                "bytes": "64408e93"
-                                                            },
-                                                            {
-                                                                "int": -3
-                                                            },
-                                                            {
-                                                                "bytes": "19"
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "map": [
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "1ea5"
-                                                                },
-                                                                "v": {
-                                                                    "bytes": "2652ad"
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "b4965de4"
-                                                                },
-                                                                "v": {
-                                                                    "int": 0
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "6e1e9226"
-                                                                },
-                                                                "v": {
-                                                                    "int": -5
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": ""
-                                                                },
-                                                                "v": {
-                                                                    "bytes": "ae"
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "36e2"
-                                                                },
-                                                                "v": {
-                                                                    "int": -2
-                                                                }
-                                                            }
-                                                        ]
-                                                    },
-                                                    "v": {
-                                                        "bytes": "d03a"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "inlineDatumRaw": "a5a5420a0843d01ab2a5242443bcc53d402044f636bf2d412f0043d854a7439d20dda24464819b400423440aaaa817d8799f4389e6b5431a5865436d36a3446fef181242358bff9f2342ab8c044110ff9f2444e8195dd8429c652405ffa0d87d9f02ffd87a809f800544de840a929f0120ffffd87d9fa141b040a0d87c80ff9f421a552441cca10042c083ff00a54384c8f2d87d9f224373c8cdff0240d87c9f4003ffa300426c46020205440ace502a4199440e699ba1d8799f224376ec9605412640ffd87c9f40ffd87b80d87a9f219f404284d342bfb241ceff9f404002ffff4111a39f2202ffa14244b50423d87c9f24234464408e93224119ffa5421ea5432652ad44b4965de400446e1e9226244041ae4236e22142d03a",
-                            "inlineDatumhash": "8c0a33448dcaa60221478f7f7da910d79c6e5f17305adf90e9f096b7f14d3629",
-                            "referenceScript": null,
-                            "value": {
-                                "4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebe": {
-                                    "0c594f6a4b92f4d44f02f08ecd35719dbecf": 4761616018132576266
-                                },
-                                "lovelace": 2491180
-                            }
-                        },
-                        "0508060808060803010106070305060005010606010204070700060201050601#18": {
-                            "address": "addr_test1xqg065q3u85lmyljl5vjsmy7u8erhc2yks5fper5esgk7st4atkhm0n5cgyxugyqygxd2ekrdzwjy8l20f2wyp6zcprq6mhucp",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0601080407020002040105000801020405070802020108010404040108010602#30": {
-                            "address": "addr_test1zqp22satkjp9gnmvdk50saydfl7830967z7zzknqv0jh7klu93j3ccwxumja98y0dehzdjdgkyhcteej6jm2dr5xen3qcx6xda",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 969750
-                            }
-                        },
-                        "0708080201080603000807080107060608060201050500010307030103040308#73": {
-                            "address": "addr_test1qpsqtnsnzz2emvkm928s2nxhp2mkscva0a9lfk890dvdjt03zqnc0qdgwertfcynpjv0ytac587xr8wu2le328p0helsn77j49",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 969750
-                            }
-                        }
-                    },
-                    "headId": "00020306080305070600020300080108",
-                    "status": "Expired"
-                },
-                "0608080108060106060100070408070404050203020801020702080505060301": {
-                    "created": "1864-05-12T20:11:10.495077365703Z",
-                    "deadline": "1864-05-11T04:27:40.514326152317Z",
-                    "deposited": {
-                        "0102050106020205080401020002020708010006040504080702020105000001#70": {
-                            "address": "addr_test1xr35zqgvxghwkvv6phxfj23s5ffe8udqufq0xdfg444nzql6ycn97c5untusu0wez0wu6mwfr32fstszntrhds8hzvgqs4vfdr",
-                            "datum": null,
-                            "datumhash": "5022cdf066873222c0cf2147c4fb2f7a57b56eb5198b4850dd79293389b2c0f8",
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "ffdc103105197d6add1bdcbe670171d00847c9838ef88af93c654334": {
-                                    "7f20": 6107030759058025619
-                                },
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0400070101010403020802050202020405010808000006010800060502020207#51": {
-                            "address": "addr_test1wrrhrt8vxszy4c79gayf3edq93d96ae4m29u2kdr8frjf8chdn9ar",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0604030306010703030403000406010406010102030703010402020002080204#81": {
-                            "address": "addr_test1yrdu35x4kxkkv0j7sthl2u3qhws8f542302uyyryy2358zf7l3f5qq3797ahukffzyy9suvpxeacex2t9d6j9nv7k9rqk5en62",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0604060802040808080107080103050203060203080707060208080502040003#39": {
-                            "address": "addr_test1zz5x69ku0yj9nurdg3c28yxhknppnpnyhsp5qjqmq38x6s2xzhcemwdx4chskhhtznluvawczu4yq7gs54frty8tcrzsuytryy",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 969750
-                            }
-                        },
-                        "0702010100000307040706020100050001060800030606020606000707000107#72": {
-                            "address": "addr_test1zzc3xr76l87chxjjcy4m3py8kf02s4ahlgq8jc8f295506233k53sfrach0f3asd60438un847zyuqw0kkdv0jrj7nuq2tevks",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0800080702020600040807000504030801070106070106040208070600030802#84": {
-                            "address": "addr_test1xpmpme0g6x7s3g7z7dhx3nklykhm8hfzlr5df40xmd0s20wcpelksd5r0t3r2dm5ug34883qllmnve6c79v357kqqakqpjr6vf",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        }
-                    },
-                    "headId": "06030100060204060406030101060007",
-                    "status": "Expired"
-                },
-                "0701060407020108070008010500060303070700060604080701080608030507": {
-                    "created": "1864-05-06T23:57:23.815418966885Z",
-                    "deadline": "1864-05-13T07:44:57.526124775748Z",
-                    "deposited": {
-                        "0000000006050006000208060805020002010307050706020506010700030404#12": {
-                            "address": "addr_test1yr0pvyw4ls5es4pj36nwaa4smlue9cpseqlwkj4lu4a473cxhafyjzvc3hrhdsjwpxr9s70npksraar6uepxt7f4fxaspsr6xt",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0105010307020404070705050805040601030800050106080807000200080507#84": {
-                            "address": "addr_test1qzfzavn63wakldgjkzcyqxq5ylm0c32g8797u7t87tx70uhfz2739kzgywnhctnv5el0za4qn5jw4yj3yeu555j8utqqsw3wqf",
-                            "datum": null,
-                            "inlineDatum": {
-                                "constructor": 3,
-                                "fields": [
-                                    {
-                                        "list": [
-                                            {
-                                                "map": []
-                                            },
-                                            {
-                                                "bytes": "42"
-                                            },
-                                            {
-                                                "int": -1
-                                            },
-                                            {
-                                                "bytes": "aaaf"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "constructor": 2,
-                                        "fields": []
-                                    },
-                                    {
-                                        "bytes": "030b"
-                                    },
-                                    {
-                                        "int": -5
-                                    }
-                                ]
-                            },
-                            "inlineDatumRaw": "d87c9f9fa041422042aaafffd87b8042030b24ff",
-                            "inlineDatumhash": "289c734b0f26bf4bf70eead3865e2ea58ae1a3afe53d3293852ef7791726e551",
-                            "referenceScript": null,
-                            "value": {
-                                "4c89a08a7c9f1edb4c32a8bde9a5067e1a03d76bae8149f53b5c38a9": {
-                                    "e67ac95aa6a8d23c6e0fea": 1242036742644911306
-                                },
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0608040000080402050408060303010100070308060303070306080305070001#61": {
-                            "address": "addr_test1ypew5me775nrg6k7t8yh4s0ae3d95v2dundel6h9pvff9xrmndc203ndt6q73f2zwh7ju6ygs2ppf3e4zsg2c3lhw5nsuwz73v",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0705030306000804010103000101080403040008080208050304040205080704#53": {
-                            "address": "addr_test1xzrqefhdnevtmqd6dc832nw6w5jghtdghnjp2u0hx4gmlh00umcmycftj2z3dnph7zp83std3lc3jl4spesrwztkwqwq3jjqs0",
-                            "datum": null,
-                            "inlineDatum": {
-                                "constructor": 1,
-                                "fields": [
-                                    {
-                                        "bytes": "f5"
-                                    },
-                                    {
-                                        "list": [
-                                            {
-                                                "map": [
-                                                    {
-                                                        "k": {
-                                                            "bytes": "59"
-                                                        },
-                                                        "v": {
-                                                            "bytes": "7b56"
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "int": 3
-                                                        },
-                                                        "v": {
-                                                            "bytes": "90"
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "int": -2
-                                                        },
-                                                        "v": {
-                                                            "int": 4
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "bytes": ""
-                                                        },
-                                                        "v": {
-                                                            "bytes": "ee"
-                                                        }
-                                                    },
-                                                    {
-                                                        "k": {
-                                                            "int": 3
-                                                        },
-                                                        "v": {
-                                                            "int": -1
-                                                        }
                                                     }
                                                 ]
                                             },
                                             {
-                                                "bytes": "69ddfd"
+                                                "constructor": 0,
+                                                "fields": [
+                                                    {
+                                                        "constructor": 1,
+                                                        "fields": [
+                                                            {
+                                                                "bytes": ""
+                                                            },
+                                                            {
+                                                                "bytes": "cf"
+                                                            },
+                                                            {
+                                                                "bytes": "1c72"
+                                                            },
+                                                            {
+                                                                "bytes": ""
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "int": 0
+                                                    }
+                                                ]
                                             }
                                         ]
-                                    }
-                                ]
-                            },
-                            "inlineDatumRaw": "d87a9f41f59fa54159427b5603419021044041ee03204369ddfdffff",
-                            "inlineDatumhash": "e06407c8888084e6f7918f1c719a41b23d03ff41f28f8aa92564ea102d4fb736",
-                            "referenceScript": null,
-                            "value": {
-                                "4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888d": {
-                                    "33": 1
-                                },
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0708040105050602020707060708060103000100040505050701040100080300#59": {
-                            "address": "addr_test1vz3nnw97u8n0kl0j2vs2eu2cc24vn5qcmg5fknnhy7qk62cs5dg45",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0801060303030705010405060708030704000203000006060304060606030604#91": {
-                            "address": "addr_test1xq6fde0nenwndmuvc7l2sy0jjs8elsvz8559h5ukac7f2zp2q8pr3248eajexy6v44n7jnc39wdulcglqyu909n3zxvsf2juha",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        }
-                    },
-                    "headId": "07030002000007010102080103050506",
-                    "status": "Expired"
-                },
-                "0802070002070503080004010005020105020806060305010407060506020300": {
-                    "created": "1864-05-10T11:10:26.871669048094Z",
-                    "deadline": "1864-05-11T23:26:33.491703593419Z",
-                    "deposited": {
-                        "0103060807020002040107070308080306080602080702020801010507060302#33": {
-                            "address": "addr_test1wzyh9jduz0g29dln2t7gh97xkze9jphjp7qtffa4vucy3ugp0c9a0",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0105020405010602060803050204050304030501080408010200000107020502#73": {
-                            "address": "addr_test1xrsakgrrzp7jz44laxs5zdxtw05qgv72krwa0fch86fhsvxzms89rh23q62v9gvnptlu90d5k2kj4g78yaz0e82qrunq59cpgk",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0204030800040003010107070104030202040500070302010001040202060206#26": {
-                            "address": "addr_test1xp36z9zlp5dy23jh43phnasvj0cezqu9s5dhhstyg2lmhsfzedm8888eswf32nndskhf6ecmky5gdjytwp4tju738qsshkdljn",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 969750
-                            }
-                        },
-                        "0303060202000806010504050400040504030004080208070107020807070306#32": {
-                            "address": "addr_test1xzz3dkaafavwm306cvgjhdx8z9klmf003mzzgptk2kn4838hwngjf5nxxsy0s3cp3j087d5wv65pf02z640act8hjtkqkqe29k",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 969750
-                            }
-                        },
-                        "0605080006060301020604010708070307040604050804050105020705020305#97": {
-                            "address": "addr_test1zrgd6xm25eah0retv09nv6am3gxnqje06ss3q5rwqhjuxcq0s3w20chzfjzup4aq9gk7dreragyj4kladpur30cuwufqdjl5vy",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 969750
-                            }
-                        },
-                        "0608010808030001020303000500040800070303030700010303020703040702#47": {
-                            "address": "addr_test1yrpqfcwrq0vx0z7c4smu56ptwr2eryn4y5qglghlcwahsh93xq8p2yh0n6utcymmcdju7ehjaj3uh66gst5f20ngk0wq4fle6p",
-                            "datum": null,
-                            "inlineDatum": {
-                                "int": 2
-                            },
-                            "inlineDatumRaw": "02",
-                            "inlineDatumhash": "bb30a42c1e62f0afda5f0a4e8a562f7a13a24cea00ee81917b86b89e801314aa",
-                            "referenceScript": null,
-                            "value": {
-                                "8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3": {
-                                    "60427857b20b4655d0a79d6456d2d86a0423": 1
-                                },
-                                "lovelace": 1236970
-                            }
-                        }
-                    },
-                    "headId": "07050304080401070208020407040804",
-                    "status": "Active"
-                }
-            },
-            "tag": "NodeCatchingUp"
-        },
-        {
-            "chainPointTime": {
-                "currentChainTime": "1864-05-07T16:38:28.565016211709Z",
-                "currentSlot": 0,
-                "drift": 0
-            },
-            "headState": {
-                "contents": {
-                    "chainState": {
-                        "recordedAt": {
-                            "blockHash": "0702070104080304040308080505060504070701080604010002040600000202",
-                            "slot": 12,
-                            "tag": "ChainPoint"
-                        },
-                        "spendableUTxO": {
-                            "0101040600040807050306010002070602040407050601050600030102080008#84": {
-                                "address": "addr_test1xq0cfv2cdr3dnrr2r5vyxa8l9v6nzh3y9c4wglu9apmszyjxye78ktfsjqquwt0xkkw5tsu5t66nwfu4ndjvyhm08fzqqxgjgf",
-                                "datum": null,
-                                "datumhash": "1c9075222ac497b25e64f37c74a869dada930779b1e0c2c4990b89f3cb804a18",
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888d": {
-                                        "36": 1
                                     },
-                                    "lovelace": 1271450
-                                }
-                            },
-                            "0308050301020107000408010508060803010302080402000304070200060306#43": {
-                                "address": "addr_test1qpje79efdak3avxdn6cq3f9j2lutaduapfprsxsqtyy8wzddkq0yaadmu27a8dapqpz6xwdpq9kdkykpqlky6500z9rskw2dt4",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "lovelace": 7500000000000000
-                                }
-                            },
-                            "0405030207020405010204030601080704060305070605040701070106080801#98": {
-                                "address": "addr_test1qz8stn97mga4w3386g4htrx7zaekqzcjeyfm57u6we4etzpylk0yjczvpzclpl3v6aylrk6a0ctyvs3n5u5hq3vu053q6mc0yr",
-                                "datum": null,
-                                "inlineDatum": {
-                                    "bytes": "e83287ba"
-                                },
-                                "inlineDatumRaw": "44e83287ba",
-                                "inlineDatumhash": "f3a6498b0d86f5d2da0c316b785f01872166a4f3efd976c41cf281f1f61366e1",
-                                "referenceScript": null,
-                                "value": {
-                                    "2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56": {
-                                        "e1f68c5dc0e31577079260f8d54914": 2
-                                    },
-                                    "lovelace": 1241280
-                                }
-                            },
-                            "0501080805000801050607000502050808070306020408020004080502080103#31": {
-                                "address": "addr_test1ypvyg3gxlt3jj6wsrp20e5wv7wxtkk62f2xc2kh4akq0eazk262h98gpcje0uu6qvf4n5pcjq5q2k9gc8txy3dv57kfslrall6",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abae": {
-                                        "f1119c5a2b1ba166071b07f609715148": 5800570517524024752
-                                    },
-                                    "lovelace": 1224040
-                                }
-                            },
-                            "0604080002080600040401010208010106050107030301020005070207000208#44": {
-                                "address": "addr_test1yzkkra08w0n2ujqhzutguvcghz4vp284v0j97ruxjuzclq67f83d5qn3au2m5mxpnsqgyh2k9g5067v9usyvn2y7rm3s8hjcgp",
-                                "datum": null,
-                                "inlineDatum": {
-                                    "bytes": "86"
-                                },
-                                "inlineDatumRaw": "4186",
-                                "inlineDatumhash": "c02e86fc86031431a76c7f02345d28a875ef6659abbe3035a276af4d77b2be62",
-                                "referenceScript": null,
-                                "value": {
-                                    "f9d1bbbe5898dabd73ebc6de12a993a42e8801fa03fc0ab8263d4634": {
-                                        "50fecb6411": 1
-                                    },
-                                    "lovelace": 1185250
-                                }
-                            },
-                            "0708010405040803050108000308080201030305040601050407010008050603#68": {
-                                "address": "addr_test1ypfsl956can23pjtc68zgu28dumj5xl2l08x4fcpwal43j39dts7azeqpr3hzjtaszfw7ha0kj7q6xya5dlvx6hrm5tqqu2k9k",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5": {
-                                        "b2e93431d3f26675ceac07b03708b0c3ea853e1b": 1136655360671488112
-                                    },
-                                    "lovelace": 7500000000000000
-                                }
-                            }
-                        }
-                    },
-                    "coordinatedHeadState": {
-                        "allTxs": {},
-                        "confirmedSnapshot": {
-                            "signatures": {
-                                "multiSignature": [
-                                    "c505cd4d39a5afd510becc72d78cd90dbf4501ef9f41d41f83a1ffa07656ab0fb28d70114527c6ae26509fbcf1fc84fbc6fb612d66c407a1e0d96b83066bd60e"
-                                ]
-                            },
-                            "snapshot": {
-                                "accumulator": "b0243dd070a448f6683b188f846abfa0b624284dc2f4f3de2cac381bc8b5dcfb",
-                                "confirmed": [],
-                                "headId": "04080602050401040100010201020102",
-                                "number": 1,
-                                "utxo": {
-                                    "0102010307010104040304030404080601080704000607070401020808010308#10": {
-                                        "address": "addr_test1yz79sqddrtlxaadh2qta3mr4v0ym2tyhc88q2xtw2uznfv6jl3gngr83ywsk6f5a34yhgcr3tzu8pqw42509fjqswfeqvuyh7c",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 969750
-                                        }
-                                    },
-                                    "0108030704010702080301080301060806030003010700050406030703060602#76": {
-                                        "address": "addr_test1vzcnhx95whsjzqlwwcj29hs354adq8yvrndxm3pq08mac5q2265h8",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0205020505050702000507040001010700070601050408010305050300010206#68": {
-                                        "address": "addr_test1vpj269y7xgspmnyrkk2lug9r4jse8naa3mu39yq0ynqe8tslnzkec",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 849070
-                                        }
-                                    },
-                                    "0308060607020602070206060708020705080701010301050104050805000001#51": {
-                                        "address": "addr_test1qpzc6zm3fcxs5j2lm9v60klc0j8qwc3gw4sweq2k8a7chvq8r6qqe45f73ts4hdqgen3d0x8ydjx7mmy5l0cafcq3f2qjysy9x",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0501040503000006080006000001080004070807030501000505040406020407#54": {
-                                        "address": "addr_test1xrpfal5z8fl0cp837vad9ume6fd6fr0ppn85zkxeux0z7gzz94jy3s6zx06zjhyzsteucyvhuzr6k5tz2f384ud5uqaq4c32jt",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0808030801050000040005070400080707020400010508040303030005060505#88": {
-                                        "address": "addr_test1xryxyjkpcc9j6t44hu4hh9zuj2yfq5kkzwjt25wmt6hmlhszlytl3esa99uxap03lmtqznfsx682wdx5xesw97u4e55s6kf9n0",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "9ba9069384b6cad3260ea556201698c9f4f48d986223d40f0c98b1cf": {
-                                                "37": 4193540598926719044
-                                            },
-                                            "lovelace": 7500000000000000
-                                        }
+                                    "inlineDatumRaw": "9fd87b9fd87b9f2343bfdea34340e3442120ff2144efbc595dff9f809f21448a4755ab042402ffffd8799fd87a9f4041cf421c7240ff00ffff",
+                                    "inlineDatumhash": "c85008e19ffc9ad49042aea472bba7f91678b0803312b04ae0da0ef2d8d4f946",
+                                    "referenceScript": null,
+                                    "value": {
+                                        "245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abae": {
+                                            "33": 1
+                                        },
+                                        "lovelace": 1409370
                                     }
                                 },
-                                "utxoToCommit": {
-                                    "0000010005080103080202040308070203060107050400040607080504080408#92": {
-                                        "address": "addr_test1wzc9gmxzm6drj48g2l7n7l8xxnr4cmcwwl5pjzssr08f3ls6cqsm7",
-                                        "datum": null,
-                                        "datumhash": "9f0dc4f3902faefca651b37ec4ab31e9f91bd858eeea04546b363a75cca19cf1",
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "2d85e3148cfc0471d5900c9cd49be900e944dbbf597dff75e6431673": {
-                                                "b6e6c39511fa050c": 1
-                                            },
-                                            "lovelace": 1180940
-                                        }
-                                    },
-                                    "0007010603020005010706070508030100000203080307020802010007000805#28": {
-                                        "address": "addr_test1qp8gslpaj8llfmxpzp09hwkzmlttmzwg9aqzrce25emdfe0k2p3la5c2wlsp398u5fmp4l44sjzc7lsf5szsfjxspryqacz8yf",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0103020600080005070307050403080607010307060802000505020704010404#14": {
-                                        "address": "addr_test1zp5a8lac3eg03s8ly6asezq9s8emwqet4f0494sv4f836aue2rl8ctlsvjawfrqc8u60g48e9d7c6llemngjfnf67xjq6ph0e3",
-                                        "datum": null,
-                                        "datumhash": "b94638939cee1751fd0f0485c384d67ab9e49fb61fc9463a9ef4f515f7fdf31a",
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "f9519d4adb1f78025683c28a787af1730b86ae05283b7008b3256e4d": {
-                                                "6a0c636bd0": 1
-                                            },
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0500020504060303080601020102070401000500030405020705050804080003#91": {
-                                        "address": "addr_test1zzr6dvqr4kxl9q0nuus7zr97jlv9099kku9k2mstr8mm95etlpw6txp2ay78tcgzf3sru90v5hqy8fh32uw5hvq4vwlsh2dm0e",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0704070402030304010707000004010101080605030004040004060705060707#11": {
-                                        "address": "addr_test1ypse008aw2gwdca50etc2ykjv0j9m2xwh4xl2dcnm397vadknjrm2yy43w4e35fmclnf44lq203fn6pa6cky2mh0ynlq7vljwe",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0805010403060502010501080806010704070507010301070802030106050508#56": {
-                                        "address": "addr_test1qpd63uhm8xvcqc63ey2y9lg46x38jrp0u7q4fr7wel0m56h3mpqr25z4cpq53kvgr6v2a3urpr2qrh3vm9d98jk2899q7347uv",
-                                        "datum": null,
-                                        "datumhash": "0965d46318f3bfe905ac889eda4a392340d7651afae4bb5141bef9bdace77bae",
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5": {
-                                                "e2108db5e761269227932d6eb600045ec470785caf78e3c7202a60a7fd6c": 1
-                                            },
-                                            "lovelace": 1400750
-                                        }
-                                    }
-                                },
-                                "utxoToDecommit": null,
-                                "version": 0
-                            },
-                            "tag": "ConfirmedSnapshot"
-                        },
-                        "currentDepositTxId": "0803000505040402040503020304000000040807000507010806060706020303",
-                        "decommitTx": {
-                            "cborHex": "84b400d90102800dd901028582582001681aebd2b536e965b712dd8d3c6fbd22a3976afa792d9a7733a0a2ca9da4410082582062433feb5f571993d6a967fd4fa6221e5f78a1fb57b0d247e55fc745f8f81231018258208f1102b8594624e7c2ca37f9ff272708c53ac858a7098d174c54eb3914a2adbd03825820aa9871c61e5b23d393fd0b33b8adab9d0ac2c9814550f5e5602b98a702a0fd7400825820acd8f3e07b1ab31df533a1dec106adfc451fda66bf3525d6b31623d5f123fdb80212d901028482582076668c6996540c3774956b332b291ffe2d39c81c1233e2298e4e2b48d1f83d60028258207e042ba2607f9b28b4f4505fcfe05413c67c62de174a7c6d568dc8e60f3cac7d02825820afb97d5276cb44aaa527a5c7e288810a089b4ebcf7da777a4019728eb6332b1406825820fc4f7fb6de80603d6779d58ba2e3c42c8a851228756d54164b1edd1b20169531040184a400583921f4c1a5b21a4ef1f4add97f7f6c931857acd3fc7612611998f2f43979fa502b69198350edc31e59ef4b5b3931039ad1f44053245a24c85a1401821b4e5313052267b516a1581c467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22a141321b5e50a1a1a82adb86028201d818412103d818582282008200581cea13ac401e4201a7660bf45252ecddb0baec20cbc1cdb9ce8976eca7a400581d601662197c221605edb3dec116581c016bdb339c147dfec8ef2a6e040401821b7c14c0a57f2726e7a1581c33a56541e6041432638ea6fd7938a3886c6ee8b014ad231ec94a5979a14130010282005820f04188137c3d2ec9f4fba18550b3714f5a2877d037b21bf8825c27495156e7be03d81849820246450100002601a4005839003e7cd7eaa394a419fe567a2787c0ed8b27ecb19c1f0df62e61ecad4e9c1e499e2b1ec29f952c54f4e9c704e0bb20171979e2d71acb38b099018200a1581c8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3a149a5273ca491749ba5b50202820058203e61530e53bd3df24cf06c9608ff684a9c8c222cc8f2c80a14e022063f7024fe03d81858d182008201838200581c3457045e15d632358b0cf24997616521f46dfcce68dafa54629289ed8201828200581ce01cf5d8cd235349f8474ee56602d6856384a07da6807f629ebb56f18202808202818201848200581cf22c88c311986381621ef4d66b181d292785bd16f6dbaa1f265e247e8200581c94142e97a585fb7ac7b24cbaa92da468edcc700fee1540dcd64713e08200581c032e7fbf4989c215bb1699161dc18fb6fc04a6c602d4665a8ae9baee8200581c6b4ab5f4d5c0beabbb738b315870d22fdeef000fa784d4f6e2aa3f12a3005839106dcbcb4a0c4c4f4b6c9fab63483a5414599dda76e3e1dea0c3b7db4db9bd45385f38f12fb081325e4e6cd5797f28d919f73654326015099c01821b7a550edaf81b4ab8a1581c82fed8b26a2e3808467cc744a349ccd78ca421e4fedf31ba1fe4d269a158180716cf295c6629a697ecf18aab03c1c184d308c31c4ebb9f0203d8184582008202801083583900e96e783d3ff9001aa9d9b36cd23552fca3214a808814e60443fbe3e27f2999cb8a97bea179e024ecb142eca8f4fc274da8fd8f7ad377e919821b359f6b036b38488ea1581cc02a0e461c903f8ffec5fc9eb0fdfe984bb6ae839f2d578650f22e02a141331b5ed25c6fcf4e300b5820236a5810349f8613ab67360de2046deea514c0a62c0ff389f1831d3daa3e77a51104021a00060c16030104d90102828304581c7c96940daf2a24b8240498d53141c4b30af9f444e3ae6a86dfba485f1083088201581c2be5a9cd9b744aac6547b397006ab53f39a3a76ca27a2ab3080b15a40505a6581df0e14692840fac89fd79e9f4f259dfdfadb4c03a36f364dc9dcd3847721a000a56c7581df0ec36c79e740946b04ea8c2325af1ccbeada3a58e8419199816cf3ea219b3ea581df13cb1fc5f750ef5431c2b219723ddc832e4535b4bfdf1a2ec46e3c96c01581df1e6f08806f0098a1af6f1db9072db8e2109420c61f0185f64f6fbdded1a0003e80b581de159c671bfcd713f389fe74e75553fa587e057922d77ddac4edab5c74405581de1ad2175c6eb1274cec64849245076ae1f14aee93c0a6e3be1a90faff61a00090cf808010ed9010285581c08494a4420177d979507a0a9ec12a868065d7bbb048e75c6a17504ea581c44062738ad18f385debcce51f0ca86defdb189557115d28bac2074a5581cb51cdd93cfc134793fe8cb5e78af6084df1d924ffe377e026d7349b0581cc3cbfa0ebbe7095cbf18bbf46ff9b2b00e1ef3d97bdd769e0f4e163a581cc49256c9e04e61f8b9ced9256efc7318bc850c46cd51a1b79eaf45cf09a1581c4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebea1423eff3b7045e2fa3a873e760b5820c7d1ecbdb11ea32e23e7eaa918546778e13cf735fd3a5542013e090f9e51ecaa0758208f678562512f5f45ed383daa9851cfb8cc4db65a24c35e800fd6baeb1686011f0f0013a38200581c188712f9940a9edd04fc14fa617cf2f0f46092bbe89698fb2ee4359ba3825820664884cbf36110f0bc84cc4ae72ffd769e6bd67b4c7565d8b38cb0b8dfaa7d66088200f6825820c2e169b25c957a58ae96a1856c0bd01ed71b04f89ea503ae4c0e95d5530ab6e605820082783b68747470733a2f2f48374b69315a7932596d334a706a686f4b68343663385745326a5065464f3133676e517941704b7372394377312d472e636f6d582062137373ddddc234d355ec05c2c155f94e29d69494a611d7598231a36b3d815d825820fd3536e7fa373ab00bf6f846b67921b1daa77287ae43967d488a96f5c081e86b01820182783068747470733a2f2f4d332e5633424547746c45725a47357a3949587732746b72512e334f756173356551414d2e636f6d5820b153c2e11a00facb41431195d2d91a7fec322d3597ffd4867f5f47b478624be18200581c89371b9045a95abac41d8c954750b1b4c3a578f23253370882454ddca68258200a9ab969453cae860ffd73d4e78a6671150bffa75d61f84bcacde1556eda439e008202827668747470733a2f2f53634c654f456d5333332e636f6d5820293f522198117f1656c44a127f5123ce190c3d60d3b69142929647f3e22a6dc482582028020cabfe5eb82d4317c744013e4bc5e3d7d28b2adcc04c0777fb727a62a7d500820282783a68747470733a2f2f792d3342793663545445734847345a6e614e4b434e61385a464771465541704a5a6339436646496d347457704e702e636f6d58207417ee8740f3cf4cb68507703447763044aa168cc8a06002208a5e7e59afc7fb82582047694ebf5dabb7288e34c6c213c7837136a6c3bcb70896d2d26399d061313636088200f6825820b37bc6177a77e57afc793a62784ce07778df40aef707a2a054f4a9fd89f83e3000820082782068747470733a2f2f5a7a4b6265464e4a30362e4a36547646665950562e636f6d58202bdfac50ab17745316ba391fbabcfb7835051045d0fc3f74ca1987844372fbe7825820c93b88e425c640e8c9175bb7a64f576d0d2fb4dfa91f2606935521d0cab22db6018200827268747470733a2f2f6e505a7530302e636f6d5820298e316c3e2fdfc5c0a4551105b6d99c69edc951b80169a599713b39534f2674825820e81bb28ba7765c7d23bbdf525ae6b9472f4bc1b9153c7198d078c6e4f03991a905820082783768747470733a2f2f71575479676d7a6566436a7a3566334142624b5559697172366571527a3859756b4c3339683253735957332e636f6d5820d9eae11e521149dbcb5e92f9644a3fc5ae41fad8709076af745677fa7aafc0858203581cb61b89dddf39207461db0db87b21124f16f588bd7002a1ffef35540fa4825820575aee749089b1057e6836b0ab47840a997bf693530804291d046c448091a54e058201827568747470733a2f2f72344653472e3864522e636f6d5820955a9b8b8b7e5f734df5daac4ad4410e9df979602541db222205ed19320c37088258206167b5455d9835080f6379665904dd41d233aed5953dc530ff7baaaaeffc657f00820282782268747470733a2f2f4c6c2d6c7a3145576e6c73646a6958377152546c37742e636f6d582020a855ca471c7a6c752449a9228ec954f2eddaf79d9aa471bf26817ac5c44156825820b1960f2edf535bd7a5a8fe783c11f55f2b4ac9c6f494181857ad279ff910c26307820182783768747470733a2f2f67496856752d5850704836766575574852757154427231526a634d4c3667687571444f72356a4a6a506d492e636f6d582040b6d352ef05cb8dde2f1a62fd8e3a632108721b93ca44b27d0d4c839bd7847a825820f3e54de4a167bf04bce535ee12c6189f11a3376a56687b3c2aeab8426dafd67b02820182783568747470733a2f2f473055647834486f78325a5533536c6b725876786d7356366a564f556e4469656e34736875743976492e636f6d58200acf135066ed276a067c6edca3631d59925878d63f8d3de32c8e6ad64361854d14d9010283841a0002d20e581df16883f775fb51a6216de7c39c7cf8928945e8f84c5a5a33765ed27f7d8301825820487f6cc00873e41e42775f2423dd479ed1bdfe17df1b77f1dc0f5510c3b3a05100820b0582781968747470733a2f2f6a574754684b5377426e557a772e636f6d5820c1f08f63d3825632710f325c0dbada3f6d0078bd5706fbba548007edc43a78a58404581df02e5879a5040dda0d3f7ecc53e81a31dd8272370b70c9d6ba4b792ea68203825820ce78bb7b483a4e9ff700d2c22d5068ffcef136f28963976f40c2d3217c49f6880482782768747470733a2f2f594839746d436a302e47557139364c63525661514a37357977456f2e636f6d5820593ecc5954ae7ab2b7809c00732aac29f8656dd44aa50eba212c2751ae58fdce841a000b5220581df079cfd9a1bd9563b6d75739bd92835063da703005eccc4642a38671d78203825820558a6986e37d777202494b2de357f8be564df3ef5f3c19fab6932c92dc9941a40582783468747470733a2f2f38334f2e39556d633062394b474b6d337048447878704775646732412d3542362e567777675169772e636f6d5820b3aebfe7fd94610c13177379f341567ff053e61c4d03e21f0d7370db9ea3f816151a0009c9291605a300d9010286825820cfcd239dcb053d996c9874b1942b881b0c9a0e7b56997d1e043306d66f1b76645840caae502edd3e85d69cc5dcd390e017d7fbc0785c89230878465aab89afdafc1b73d28c31c9e7c6e83d7ea933e75dc4c03fbf39e56f9cfb26598dbaf2ff910bd482582051d3ed35202f55e5029a02d2efa6b5498a1056b0ffdfd02cc95cd6ce38722d4858404ef8e5057e87a75d9808b0b5d4eb91c4a619c4c3b2a5674408b27e465bc93eb26b9d5e6ab200e111468bae6a60d397e6b1d49f0c41b34856e0f292b11b930ff0825820625c0fcf2be4fd33d94ea3d438bc1d93aa919cc5f50f3408605698942b152b655840d2752ac5197142e049e299b352af382e43876dbb5a46ebbe64effb86ede8a951ea272d5fe52f72ddf297beeadb80bf4084b79629911bcf49cda92cd6d8a715c6825820b7264a1dafebdcd3a82598765cb929c65ee9fe3cbd8e150708f5f3f90bc1a612584078768f3b630e28cd95e7a074e4824b08f56261ceac53b5e102c43fb4f401cb968174c3890c7eb6b7f086f90f34edd8a3bcc7dad654ebebd91353a3e6f4d464ab825820fad5b8acb2c5dc97a54bde8b9d0c71db542894e99a0c655d53da2debeae8628658407b5f9468a140b308d339c5ea93225117e2f2b8f200efec2330251e8f19f4081097ce6edf515659273d5d70cca21e28e163457a4df055ec4d2e3cb707f3a81e0a825820bf0461ad37fa379efebc0254c3f555e16afd6ae3469d901e31ef79c472bad10358401f190bb933dd1198a8770c9a7bb8d3a8dc4d7d6585403800701ad2602766ba23d8815333453aa6641203375407369af7dd32f02cc52494daf771124276d034b002d901028384582023c3a6087b7c203fae54b14eeb2919d20297071b8de9e2d2c554fe7f3446e14b5840e268ed334d09a35c153a8a858df707f7cc9eb691be3bb0aaf39a31a9df01f8f2aabda81e7dbe3c4dbec651066922d876320056595139245c93082d3fcff8519b5820e76ff9cef2b90f02088db5048e50c52b1573aff180b3ad22bb928daaea30ae0f4296ef8458202261d3c58e32c33746b4ef8e5fa8b1d129a84d6fe1e0ed40d80691cbddf5e39f584062da17af332298fbd43d221a211a802dfe05bd3dfc0de3b951268cf5f8bb7e4cede62f4b13740cc6e6d507e8a47508458afbacfd4b524cbae0fa70d6d4ed7f765820352c0db15c5176da18d179792012518268528fef493159abb9413b78fcdd2ee2456a5256ceab845820c56229ecaf4b4e294b22c12f9c098fca6c4aa94a9a638b54135a6ecb2ba6fe555840edef1823f72d6f31c1a402c74e3a66e6ed057e10855e9f2758f9e56e742e35b198b42959023381963b9e34e72ef224dcd757536ebc798479016bcbca258779145820cdab68f39fe6ef6e07b82e0aa85757794253a3ae7e9810f1107f7973e3fcbbd043f9f2ee01d90102818200581c09937b927a975c371a56cc5540763fd4594bfd8f7ce5aab3be5a90fbf4f6",
-                            "description": "",
-                            "txId": "8ef2516dddfb54e1ec386393ca16477914e2a6e5a08d960477d741ec737bd952",
-                            "type": "Tx ConwayEra"
-                        },
-                        "localTxs": [
-                            {
-                                "cborHex": "84b100d9010285825820246a75481d18cb68763eae5c2ff6fe099ac52152abb123f29c07b00fe36a167c058258209f9620d94913792be213940091afc74152a6c3895e3d7eeecbfad0b7ca1f266b04825820d08706f6a2f0a45932c5838aa333b49f5fb07eccbbdd3d76b0bd43fd992aeae801825820d84bcceb3f0496a4e1289b4da00d7e2fa83a8f15bacb08e7defe5019e1a495cd07825820f1a6218fe51f90be08496333ad76aca9990ff8e5f4f899cb9be566139581129a070dd90102848258202030be4761bfd83ba18b8823d3a32477b17f252065ec1a3547234fdd04645a4a05825820a8606b135aaa36ef277e966871e99dd2efd55bb6881980d5c062ac93b2a9453b03825820c08086a6f45e4ce84a3c14c62348ea4e0b2b31fd46029c3c2c18184e5653b34902825820e96ecc0c84fbd532b46562dd66ccb58b7dfe5b4d9f20b2f0aa16f33518c003410612d90102858258205a91b63b7389716c13dd99d5fdd0f1f95157036ea7df8f98d2714e53caffb1390482582079817b4e5f8f21f996d077f88aef54d184c2d186d1a4fefea31d27514f3a8e3f06825820baa3bd11c763ffa011f74f1c476f13888fbc5cb35d6804282d415b0b3e8ce80502825820c4436a486d70810a88bf72ee77f8054ece4a9f78642d6d8d7cfe69b2f3174b1b02825820ec0a124ea5c630464e6076b1f7f5fb6d4956eb45952ad2bb5a294eb9d02db5ec050183835839310d6bd05b84d7d93bf7f430279fbd0c4df893ccfbcebcc32b783953016e244be5ce7078a236da79099382d9796870d8c445035fc2f6a08efb8200a1581c245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abaea141311b7e1c7f3e01ce85ee582049d645c1aa3ee49f2a4bbed76038e3e16c42b7a940f1faa693213a18f33fd34aa400581d61da4a414f3307a609ca49000374add2960dea853a96aeaf87cdbda5ca01821b63f72e00834735a5a1581c93cf89f399b53820555c16dc92a4ea9375d3caa231bd84e82295fb0ea1413201028201d81843d87b8003d8185902ae8200830304848201808201838202838200581c243cb083444b19d4b0c8305547c00ef07fe8b3b9d8c80c8a07a6246b8200581cef01e380f24c362abd4a83a5d3ca058fb108a924df1770f5d6eadc858200581cdecb65a14ae34d6767e1ecfe44c3ce07cca6790c5391c26901fb54258201818200581c803e9a43aa800973723d41e2bd39685295602fe5787a406f1b4b72bb8202818200581c93fb45e7c1e407a3c16e05443afc640c7a15264aa3eedf72367b2761820283830301848200581ca3112c9949a8cd67153eb5c3ff64e5447f572fd41f1049dbd07e19718200581c4552b0a5f9dff52fe8bd80cbe46edd70e4dfb3e84155830d68a17dad8200581cebed1f6e459bfd2d7201db5fd9693b9b225da3b1b4e9f8e38714c1d88200581ca632ded71e0bb89d85b11195964e4a5d8701946e3cf60600d42374d2830303848200581c83b9486cc3c56e9f136dd47061dcfb331cd9c3e335052e907994b7e68200581ce6bb66412334579b2096b70d2b1b62f5530938f2679b1f0bcb6d50198200581ca34512eb2625fa496c8ac19f0febb9812d5be8b6a867faca7206185d8200581cf95b924553a406e58df0c564c741b341256335c918f64ff1692301428200581cc333af201d9d2eca5b4651e017e2a07c0d397b86eb5f9f60100f2bfc8202848200581cdf035254dacd134790b5980dca44a3a7805ceca8eceabc3351323b83830301818200581cbede46b160cb0f99fb951b451e7a913f596e2367598aceb08e56cc8a8201848200581ca83417c7bc58f66e61b35bb7accb3fae386a45bd685436bcc8004a6d8200581c4db05a52e3afbc2039b9ab0000abf0780bd29e1c4d1fc1f96979b86c8200581cc26ebc3e0cfda7bba7020daba5fd4e78f9c3286af082480a51ebc40f8200581ca6a34b45457df3c86edadd997840193b6a8d56047bd883ade36d9a8183030080a40058392032349e7e02f242adec94983f4289683347322bfd3683649dce9fc90e35525dd974591fcedf2148f53617bfceda4f7bdc847ffab6a6fdd20101821b369ec2d62cc3db0fa1581c5eab94b65135ec612f313182c5d0bb536e1bf2e3f02868766bc6d35aa15818b440db2fe39f43ecad19909e085e00a21b1e8d4dba591ba01b35b60c9c8ded0e150282005820143f11eaaf66addfae22c1ff2d32f02314ff8102843687cda408862eba2cacf003d81845820082040a10a400583901d5cdb03a1d5a192539f53e76726ce9313f75764bf63007f70d10dd22d0aab4f41b391bfd393be76645828d94f2f40274d6bc96c6538463a401821b35118f8530e34bf5a1581c2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2a1480a329a8a938f3cce1b724806e4906aec730282005820f4b64e795af5f370d78fd609d5d14c692c7d0b1d21a790aab543fb0f0340b9db03d818582282008200581ce154d1e00bf925581ed4c1a8e51b11081422b860338c4b80b79d4f6511030202030104d9010282850d8200581c2a450eb860164f8219f38c51c0c00d53152160c36a5cea1663df12cd581c7f814d9445e9270d5082c2f152951e1db6093fb12f8e7825e8d6c53381021a000af05c830f8200581cd2cf09aa36cbe089ca70dd97ca24cfa13c63db63a45ba3772fa4072682782d68747470733a2f2f366c69625734482d47444d6f777559566c38574744705545734677676b764f47622e636f6d5820992c259959cdfe8a3562f87401eedabf832bc230b0459d20b5a8d88af2aee00005a5581df09895b8cf6701c00f6450c9ba5cac320817a499dcc0c28876d6280e5a1a000a6108581de0a19cf20fa61c2db34c68f4bf0d9728f23c3b8a921151061316379d4d1a0002bc95581de0ba636e61359fd277ff5f690a5d527241cd1abcf50cf0a825550ba7721a000c712e581de1ac447c6701c3c34bb593737ee23fbb59e8d0886703728daf77e33ca81a0008ec25581de1f35ae277faf6685d3aa0db629d9a755a941ae9957dfb89dc43670f950608010ed9010284581ca9c0ecb5ef5f2b10cdacd4e84029e508f775f0909659b9e776706f0d581ccec3cbd266d888dc4aa831d38027bc018890e1997de153f1a8b8dd51581ce80e99685976b713d5337f41919ae83158391a768a0466666ab82c04581cef85ceb6eab771b72a9d9e1c7a2e33433b18660d553f288f83a874c309a1581c4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebea141381b6308980d1d2ab1920f0014d9010285841a00036f6c581df11f4bb74c1de2e6e990405a52af30f2fd7e0f076d19e0563f7751240085048258203e7bda4805084eda0436501a46e18ef0393100148250ea8f03025eac8fbacac306d90102828201581cfaf45b75a6c691df416be9cc93493f734af9cb7637291a5344e387d38200581c01793cfb657969c019eabb7b510c5c18541da2c29ffd1e3f9116b401a58201581cfe1d007d6989b9ce2f24da36da3c14ea7c9c03213546400c098af8f0008200581cb859e7b18de5978707756e97a7d1d7ea840d63a5d721f104f61e1eba108200581cbba1543e570f79a9b61517a62e04773a763cf0f3af0babb3032d03e3098200581cd527eb5545cd5e568e9801eecaeaa554b7914f6086283ca47023bded028200581cda7da245202ad4dd3e82a92280455c654dc745d78932cedaff0cecdd02d81e821b0030b9878788b8d51b00470de4df82000082782968747470733a2f2f3664484d5057533047473751366e56322d4275326a336638527335796c2e636f6d5820615b20ca939c088062214648a29b52ed05281c7888568e691de9baab82c321598406581de00315358e487b8b42e29e4f83f5a88b7ad15e9f12fc7ec9bd9f3bb7248504825820295bba5efea77a7fd4c23c8a18e3755dfa6d0c6b15349b29b4bb97ab7975212202d90102848201581c2d794051fbd4d7b4686a0d77b1612e3c26d489394c3201f92ddc59f48200581c67530d69ea7c922938052f9da9e1ad12675031fd9dae150d3bf9709d8200581cbde6f8d288ac4253598a74795ffde59c8962c6258dde767a08a9be5f8200581cc0972f0d544694c73c8b94573927aec4aa6f17e2620bcd7b633c8ac2a58201581c2a1c34a4ffb427a2fe9ebf67191ed84d8f87e98a3a117f6cdf48f973028201581c63f94009f12f03a0958617145724d25f01bd4682c9d18cd681045d20058201581c7e9cf5f613a4f14635424d619d1a48cdd7dc7ffd73b8616b2d150b88098201581c7edb98147bb6ab00ad2772d0017f732793c2315f287effde0f367412078201581c96e804170a2c97356a524997776df6be30dda1b2993b2444269c2d5b10d81e821a00012c031a000186a082782768747470733a2f2f547936316547754643666e576f3757517042377145674c34496d6a2e636f6d582052e7f6a481c03b6f5295572089160e2903e10689b2fa927c39df4aa938b099508403581df1c8fb07d3fffcdb0af87109e0e6a84c2259d5cae2b4b6e2e1ab52fab182038258205570a403d117c04da5fc15f2ad8cecb609148370aaf9c85342982567a359a6df0382783368747470733a2f2f3449713554304b6645445555376d44556f6e55776c533164366d59445a6d4b54657277534c70362e636f6d582069ede694ddf0975648abfd54c3d16608fc1b9a864bd7cb60c52c44bd35610aea8405581de1e29423fef08083f7268d20965f5c4df47557243190ddd22857c896ee810682783868747470733a2f2f306c66586d4d6a7a5137335867556d50673569767a4338696648623770532e777762676a4a526e766c4570512e636f6d58203e18ce693f7ebe252181258850e8980e7ed883e69074e477d918b1bac1df2a728400581df02513d63469866c2cb67c7a003a4af7cb7f967732810e2567066caeb98302a2581de0dd90d772f0ac757ff4c152df044d8ef13ef2aa77dd7bbf22366eb63d01581df1efcd537cc41520ccd65827a2426158ec424b137aca00578454e648ec1a00040cb6f682782668747470733a2f2f4442443179466f625334754b2e417251534759435a45793844382e636f6d5820d7351b7467510808f4106f6222152a08cad017d3ed577fa0f65f108d340e619015001619d6d3a400d901028382582043bcbf411579c2180c1189858d078249fd572b3bf0809dcda6f3e980341e478a5840928cc52efcc2dd6bfb0d16cc0744d3eb465fcc30f2b52308834e1cdfe3488e1c6c6f3d256fab98ce95d6b2dc89bc8d6e1f69dabb0db1bccfa10209ba82dc105e825820ce90aa7ce5029a399d421e44c36c658364375305be015b0195a276d0c91bc672584021f90a2e1c26137ad7a8f23eabedcb11d717a9bc1250a78d1285dc61c4c08401c594974e5459b1728fa0b3617bdadefe9c2b952fa627ef446dda533240c2f4438258204dbc691418315a116caa8ead8be4ac223a82d807dcd1d7957128b1ceed8aab0158404fbac373f474e7456c2adcf3f3f478a00244531b72fcd51257eda4eaa0bde73b69a4af1df22123b84a5812bff0e3c582522a0aec6d8da2b388e30740ca4ff8fb02d90102858458205950075c38c66ea56f70a638c9d64ab484e364dd9b7d178680bd7d33df20f03c584079b8bd3565c747153c49720132111866636990ece2e6702b805d652b50bc5d19f77cb222e797829839ec1b08276d0e021ab80f5139d8241977c1cdf939a828dd582002c2c38ab2dba8019c45e26a65c50b6c1692001aa8a66536163eb8364fdb7d8a4084582096461d268adc1c4cf903ab3ee1c60a8e15d4c534d0d06ba2d96f6195def181e65840aa4ed7ec5f0e8fd2905176eb2e6f90c46dafb6f3df14cd6c4c4e7c6899e09942708dc05b3f06b3096410e624bdbe45feb3d0d1414ab0482a01224324af1a3e4358206ecd8359afdfcf99768578159058046680c40cca80c3352b204d282bdb0fa32f4553ace33fdb84582068213d4c9602dd272b5c5a2cd21291cb23c11ca8c89fbe4ea6d2ada609f9ea875840677e9ba0c7580d27dae99bad9b74f9c044212930694785b8abaaba9e0bc1f8d4ee50b4c912e66f41b422246c826d200ac705ff82e38e8844b753e4db0dc802de5820f8a7aad3efc68c207688ec816abfb8920ca85391a55e1f48df00ead7186a396e436094b3845820c10471230a8328ab070da299dd8d64db7878d2a490a71ccb87cfe01ab833265658401742c76e8687f7c2f724bdbb68db2977fcc22501b0ccaf5a1a2eb9695a30531f868615ffdb5c6e0d6061c4d03354183c018a8e6de28ec9c203b72b1172b50b72582026e0d0684d2186636b8c9c998b42959c4e91899de08c2524003dedc55487b6b440845820d116da7ce09ed86a7cce795821c3864b695a2e6e8be831e673460aa30a05d7ce5840e94de1f9c2bf14433939a1b4be949a3d38850234fdd2a5b182481a1536be3ae2cb58f22ed83c8b8030b0883ec04c0b1c4a42df7e85ce84b57230cf58a5c7ddf258209e4c777623a96b341546697b7957e871254477c77e31b57ca8109fbd49bd8ed542526604d90102832143307944a443708fdd9f24d87a9f0141c50240ffffa59f020140ffa2022042ef922380a341200224415043f7984a4208699f44dabfd9b6ff43940d34019f402320ff9f44f50f571321002340ffd87c9f43f950342323ff009f9f43c3be050140ffffd87b9f02059f438fb8730043b9d97002428b65ffd87a9f04ff9f04ffff449ecf2f56d87c9fa22042c9ba2122a424242341dc42d1822441ad2400ff05a48200008224821b199eede84649d8691b4f9c8afbee55d3b3820104829fa2d87e9f2344657cdbdaffd87e9f0544b34ea09bff44592bc38a01a0ff821b1279bbb3075e1bda1b1dd71c423e8718758204088221821b6c092a3f8c4c3fea1b4ca7aa4ef831b86082050282d87c80821b29ee6bfcf22793011b6c99e6f38f77dd59f4d90103a200a301a481670a24f480ae941764631e7f0360a0611882046df0a988876ff0ae9ca9f3b0ab938341d3617b662f14f0acba8a8564e88a922e41ac415241be617b0b4415ecf4b00d854300ad0342dc66a0a268e699931ee187ad7a6000611f03018582050482040d82028082050a820509",
-                                "description": "",
-                                "txId": "ac7988686b2b67ed72139c4757dff6e0120e786a7c22da4dcb42f5f1858b1c5a",
-                                "type": "Tx ConwayEra"
-                            },
-                            {
-                                "cborHex": "84b000d901028382582027d93ccddb9598ffa7b355166b247ebc1cc11b2e2101a8769d94af218841c417008258204a481c9c5e444a30766aeb14e57718054028899fc86c600f43442c296e336fae008258205ef4af23062f4f0d5be3c9ca2119753faa057da85dc7399e44a36b8cc2df908e0812d901028382582097afd71fca6714baba145dc9fbd26ca28e013cb223d87c4fde3465b0c623c08503825820b3a7808037329af6e5cf53907581a2eadfb3a1ac61a8e375d98dccc6f9aba56400825820d2b1cbbc7dade494363da153700fbfb19d388a2ef02d8e26f3329d0482d65315060184a40058392028bc01f387461ea7c757ad9f055abc5ecd5ab7b5059999db34dd58ef3d0dd6dc9d25869281d59836d9fd835a188af6600c8754125467c09f018200a1581c2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56a141381b47a4505760fe047f028201d8185831a1a29f03ff40a40343eb78c54243ab4111411c43b7cd9a434f9df844ec30952042d12d9fa1214410e53a939f417840ffff03d81845820082040da400583920dd8fd481141b389a958ce54e637916191d02683ee143c5a2f624f546c2acf9decb6575cbb9f88328670e4f25a4c3cc4ffc778c52ac62a16301821b2529fde999a0396ca1581ca073c4ea29161e1d630da4376504b75dcaa17a57420f6d81c6f3ba62a1452ca4434c401b1ac6ad75359cbc850282005820d3245a8203e8cfd6c4e4367d78bec64a3c92b8a274a9276f63fcbd92c9f1815703d818458200820501a30058392096d376c63f6042cdd619f2aa278ed5581d940789bf8e65b1f76dc5af77f09fa07085215631d76119d2dfdd42dd548af749e5f4ab3ba7d1da018200a1581c4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888da14d2fbfa9e69eba2cbb78c68d71e91b5425740d49c772d203d8184a82024746010000222601a400581d61028b7d0ba1fe276482206cb26df1d0b901734f49cd1f2df38565ce69018200a1581c6168d11ce4e08c55ca99448f541e8c3a925ee7c527fd82e90ad4e166a15820845ac2161b79c2dc41520d529194d5fd566a4b3ed71f6efa8df6f59fe68699061b71144e240a66237b0282005820e1efb5ce367b0d0536637c9d23bd714bdbc0e9a87f7d443758a9d7c7bf9d749a03d81845820082040410a4005839008451be0e722be139a08774f6989f7951dd6b51b455eabae543b4e2b3119a197f5e9258ec27068f19d622d7a41b5fd0f10f364c4f41d0de26018200a1581c6eb360432ca89dc6d8ba473345347c6e259b9140442865b29e71fb32a1581fc7f3cf64fa95806283a3ae022975cfb4bbc5d1c17f45a838e1a067270eb40a01028201d81842414203d8184b82034847010000222200110206030104d90102868a03581c94995b2a396093f6b0a62015a8cc44ddf8e232681c0018b7ea56d7615820b195988c3b91639ae21ce4dab774ef4adc34bb699c5f5399c129bf5b89055592021a0005cbaad81e821a137e43971a1dcd6500581de00aeee391e00914f9d61da2e167725add5e3a47261f6d0dd8aeb4c643d9010284581c1eabaed61e00b331f99efede8963d4dfb29b9f401fc85bb37ee04bb0581c3ddf917dde4c0403492bdf34ab025ceb9764d4450e45b3ba209dc83e581cc08c323816751e03402beafb0fbffc6731f30c8aa3c33809725da9cc581cff885c6fb104b516917800f8b6475e392081674b8f71fe55e4aeb65484830101783d4f65576a6a58312e7637395a56617446332e426c685a56366e5036344e5866736e78522d6f547436655a4f36377a6e71326b7269444d4877492e636f6d84000044000000065006000000000000000000000003000000840000440000000150000000000500000006000000050000008400064400000005500300000004000000050000000600000082783368747470733a2f2f32652d4b36743155634c4856382d30334e67395561494145792d53464a4836474437474a4c6a572e636f6d408304581c110967fd285079844e63fc203ed4f3d43bfce3842f6d7c3f9df879000d84108200581c51ae10206fce97752a06f3454a2cf4d9c79356df87af082eb9390d601a000d212182782d68747470733a2f2f31455a636f4f415442592e3474562d326a6232692d724b336254664962696f476e2e636f6d5820565b8fda507032099ef5f03ac3089f931ce1087c3e7e638b85a3bea0cbf7164682008200581c5d762e502b0c1422f308dca99ae543ecfe61dad2fa8e4b61f683d0128a03581ceab50565ce89844dc0b2f0406d360f194183d4f2c71832552aa86dc65820e1dc5458bf3f06d65c9fc8cb58fdd0e493c5b5baeac45fa47ddfa8463844002c0604d81e821aebbd6c651b0000000174876e80581df179a27db4e79e029c18f56bf78e8e00642d9cb3edf8dd58e92d517494d9010284581cac8967a2989485d3c9bcd7d98a774d6f3eb1d3130fd756687aeb97d0581ccd78c777e26a6a1ca6e8d0bb67d62a05dbd28772ac4861d489869a2f581cfb33499a821ad38234bab20b5a985ef417fa6056d9cbf8b9362571b5581cffd39dd9a07ed5d920d39c5cc9d54a5b5c4abeedb63f14d2a4d8ddaa8582026f55737558454665464968532e636f6d82027833434557304e48616b623335613453535265393665343548374f6e5333626a7a44324362734f474d782e6b61543057632e636f6d830106781e695a475a437777612d797444694c336134625342357a762e54422e636f6d8301006c364a4579742d494b2e636f6d8301057558693065697a4533344e6a6355693675762e636f6d82783668747470733a2f2f51457934672e7041394b57714c384a6a524164694c3051684c2d483434536d6573744d3338443267786b2e636f6d43060008830f8201581c6b31847bed50daed44aacbe1c3730700ab32cfd748eebe964c155fbef608010ed9010282581c56bef85bf3fc0e860ff5061f114a7b1a3f7c63a9ddcc3ff89c0dcc47581c8b0622cdd2e243d859c0f09eaff01831b4cdcc151a6721e8d845c75509a1581c7415200727f43d0f69d0d61e62f227c8f8fa3ed9ec5e7afa52022023a1581f0cbd6c94a2e377959449a774f62841e18df61666466a972447c7024bbb12c51b12468e7b09677bc40b5820de8f26af9deda3b336d6e040d32982dff84ec470cc9934b57b64c7bdeac98e0f07582058229b51697914e0a7ef87f74fea61e243d4fcab59d56da9975590c559eeb15013a18200581c45e33ae422b8b8ccf4e70b8c85718634e5f07fa8b382f619858b6172a48258202aa57b5bc06aa4f6f6c7b7630030aa79f54497e26862a056d9f5296f3807a04b01820082783568747470733a2f2f59362d7446763856642d6c6c4e636644786a686e397a7264795155733561534a6b54356a7a4b7741582e636f6d5820eb4a518b7526d3a1e7a17c9f54af85ec75cc7deac25a77154731896a492075c28258205cd35ebb1d0f286510b313eca2fc9e4a55abca497b47ec68cfd423af085963de04820082783d68747470733a2f2f4e694e4e52732d316c474a4e2e507a2e47786972766c2e57374b4f7a74567431553032325a49496666784f4f4d626852552e636f6d5820d903fadeea1a7777bb0c807f3aab31e52af363e3a9747bbc5d194ea5980799bc8258206d56dde2cfd86622ea0d8274e768dfc0b7f2e6a68072fc2eb4f3c37ac55db828058202f6825820f9ae615520c865faf57bedee4d32dce911bf50cc034b6d5ed5ea402f2a3fed7807820182782968747470733a2f2f586732655a3341533936776c656e557a647752613931487464737239332e636f6d582064ebe324483eb32044b06cf83dbf23ffc2de276f825bfbe232e11975da145e1f14d9010283841a0006e887581de0c5eae6e4f5728352abd6447a2065ed31b4383ce3f89557c57799ebf08301f682090682783168747470733a2f2f68626c42685548537370303949326e4e3042736c6c6472665a2e567347347a396d457744672e636f6d5820ff3592dad1e18f399d7d525032065ecc9bc30279696c4a28b73962e032e61f7f8403581de1987ff1f79bcb1392b0cd12b5b39962cc9394868e6c77d9fcc1d4e0b9810682781868747470733a2f2f476e582d584d6d644443764c2e636f6d582051c5bbfc0f81c1105d093d45ea24fcc03835ae775f4c7884e3da8c84e1afe5998401581de1187706484ecca070c48ac8eeaef97bf3c61a4a32d6f4a9148da582e18400825820f951945260a8f0c715a57d787b15d1f9c46a45ce74764a8f37fd580b649084f705b4010402080308051a00040351060307070ad81e821b0000153f4a73871f1b00002d79883d20000bd81e821b00000009d685de951b000000174876e800100414821b3df9c25ba3395b131b70a862a0ca2bfac315821b29e8dbf750498a681b090a2b3cb5152c2d16071702181808181a8ad81e821b00009d2d8beb98b71b0000e35fa931a000d81e821b000000011287bf771b000000174876e800d81e821b0000000204c738b91b00000002540be400d81e821b000000caad4c0dd11b000000e8d4a51000d81e821912e7192710d81e821b0000000202b2f8b11b000000174876e800d81e821b00000f9a40accf931b000012309ce54000d81e821a0009f8951a000f4240d81e821a014ef4a51a05f5e100d81e821b00000189234e82471b00000246139ca800181b07181d08181e1a000c5e601820061821d81e821b4238ab60c805da091b000000e8d4a51000581c65f290e68cb43a6dc6c2555bec9b06fe52b61b5359b87179d71fb9e282781b68747470733a2f2f5a5342732e6a444347476c67794d512e636f6d5820bb9794693652f55ad2fef2f8efb3d828717d48157cea2c9bf4ee1a7dad331be01505161a00047414a400d90102828258205ad787d68018cc0f565ab3ed531f05bc1466afaf56d92962f95d349bbc7b610d5840946417b7de7e585c427d414cddc826e7583c33c1de65e6ec0933b47c53656bc8fda28c0d4b4c3a36120dfed8882a0c6436ab0cc2b8a917986d06f0d43f82faba8258202bd704a6d4e0bc99fe57e3dacea30d3ccb030b1859a90d6718a6aa725931298d584060b1fa41cf16c0665b42b3b683436edc8d2a061d19b22ad29b2aa063b46962a3e5ce264b34fe3e3dfbcea6b9bffebbf291015d881851a4c41f8546fbd06f114201d90102828202838202818200581c4a1432900c171b9395058f7e3d7df94aebf116ab1b4b3c1c350cf526820282830300808202808200581ca2ebb32ab18138489a17e1f397149e1094d4b0cb8e8c5d4ea8e3663b8200581cf5b09028f5f969ffd2b734f5bdc883617cb7e8b3a2bfef5df809208d07d901028148470100002220010105a482010282d87c9f05a09f20d87e802202ffff821b58aeb06e106668121b46ebac87c7216b6e82020582d87a9fd87c9f2444d1e44348ff21d87c9fd87a9f449b4472030443946db1ffffa0a5a541cf442bd76f5401204042dde6200342b0b14275409f214127ffd87d9f24ffd8799f04ff02a320429b8321222444b2e9ce5cd8799f05ffa20222204178a44041c441e003444ea83e8543d48bfe4232f341d2d87c9f2021423c024117ffff821b40b5073db6830c881b5a2413aca3ee5cb2820308829fa2a2240302239f23439f042f00ffd87e9f24042023ff03ff821b5ae95f41e01d7ae91b5beedaac948a9ce982040182d87a9f9f43414d1201232340ff9f41b1ffd8799f426a44a2004207d041410304ffff821b71fa406e7c9766a31b07ae66e6e53d6ac6f4d90103a200a40b010e610a0fa010a28502421c622369f3a081875ef48b96a24322527aa223692e67efa3acf09284bd613221400101838204048202848202808200581c9a8787b4386c420d263d40df7f5f94d7c6c29f4892ebb646a4d5fd6e8200581cf49f6344c2286e8a57dee9d6641a5a5981a6f82dbf8994d50316529e830300818202818200581c9fa6385bffd1787853ad5108c8bc77880af0dfeda1b136d01f577e348303008183030080",
-                                "description": "",
-                                "txId": "f0d9ff4c2150da6a4db84b64c4a3aef99865150ec352439ae79b5431d07686e9",
-                                "type": "Tx ConwayEra"
-                            },
-                            {
-                                "cborHex": "84b000d9010281825820fd31d1e4d14a59e01be25ca79dca4d13812eaa212e9e3f429c581e63618b5c82070dd9010284825820546643e3b2db71cd7b8f773a9b9c0744579f0d65beae9d4a700b494e73f334620482582077c0d19b76cb6e60b04a3f935a6329f8706d51466f30b52abaeea6793439433d008258208c419b23fad2f444af73aacb7ddee68b37fac3c890be4c8a30640657fcf507a207825820ecf7032a1eb7a6f21ebbfc06ce13d6d212bb44c2ba5a5850edd20dd261f52d800112d90102818258203778cb82c391c07816483a5f779dd0f56de1d215bd5efa3261b4f0950b183b38080181a40058205034ef36af6d6d38aaa6af6dc83cc54ca5b1cf15415f38f18e13718a28010601018200a1581c8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3a14b308a28b88ed8a692c2b22201028201d818410403d818584e82008201818202838201808200581cbb9341353ee3c7138ae2afb6737db13f05286433993a851a5ef7cda98201818200581c87435442620ae0d16713ad1ed1bd31704a24dd00556427ee3ab7cf5a10a30058390093ec29779a9c89eee783ef52a9bd8e8fa1baf90ccca32ef5e4d788e98af3bc8a12f3de9df39af5499ca7eaf2039d04ed14890faaa463b35201821b2e9d8eb113932b5da1581c4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888da142e5d901028201d81858509fd8799fa42001427f1403014299862224ffa204d87a9f4237bf43ddb052ff43ab832804d879809f9f426b010204ff9f4044db1ba50542a66e42c25242935dff00a141fa43e1ba0521ffa1d87d8024ff11060204030405a4581df05b8fee3370558aa3e128a3f34be68f48b1704db3a252ef1daa7b932801581df138d438ea95aca240206ce64f20f6114e0c2b239fd2792a24f3c6061a05581de13d480225bd6ccf23b62be6cc767c53e9f4bda15abbce4c25b78fbc111a00064614581de1d1bcdbe4febfd259370b064106acf6caf19b0609d31ad794f9c855b41a000d22ce09a1581c49b91710b3f4afa89b5f9971c45021e6f714e3e10dab1fec0bf2cc54a1581c2e50f220fe444ea86f51e89a663651b1dcc32f8054fb8624ee7b8d6f1b3e558b401efecea90b58203e2563c6b9f34213138ba7d1e2681eab3f9ddd0b373fae1b7b65e1d5eea5caea075820290004a886652a6c11b4a74a515c3223d6d081ba073f2ceb75ccdbdd4fe226730f0013a28203581c1dfd349c4c0a2d0767e181e3ef678202bf691a0fb58ee69b9333703ea48258203388e25f08e0fb380c7b866ed462beb80bd0a5b9575bb37e2806c148c019ca8702820182782568747470733a2f2f374e5830547a39424b37556f4b6c31737533395264353853582e636f6d5820c6e7e74aed88885363c0540c8ba034fe866e630866455cabccdd20ae0c3bb146825820c17ad814b38ecda3f146609e9586e4a580dd2642758e905791659bae9abcb81d02820082781d68747470733a2f2f3941507172566d5137756e444b677653662e636f6d58201f12fb5bd3b881a42fe7e376e2f1d10d2310ef4aded0e1c762df607a224f0644825820dfa22e1de0a5afef97ec7a03f5e3fec20e1c43f905983af7c739d30b4920aa46028202f6825820e8490e89bf723cdc1f13856b441bb406346710bf209cae4331f67cf7a113fc4f018201f68203581c95c8336308af8d18a3526c921b52b3227ebecc0709ea04535e7c3ff4a482582051e45b0f5ea55f538e4c0170adc5116e71208078bf3c0fc34b4261b9c808c1b4088201f682582058e9dc487b7996e74294cdeaa2702c203582da18b6338a8e899adb1790f6b1d2058202f6825820966ce3c45c77cd792322967bac75974f6655813a4e9dd6c47a6d0d7932b5bd9c03820182783d68747470733a2f2f737453794532415676733355797432615156516559767271714534366f7234316f5156374541424d5a4a7130386154684e2e636f6d58206e7fbef855a3e754df03a1f8003aa6db7ad8657c22ffcc0cd6820a2a06526e63825820b6b61d21c29bbf5161d83279721757ef35fac2d44aea9d858efc57dfab118cfe00820082782368747470733a2f2f765a3564377474737664597075574554594b666147652d2e636f6d58208c9c1a0abe8bd546a41ff30931e68b2f789674136361d229573441b83554dfbc14d9010282841a000b91bb581df079969b437de3ab655f92841ef6a8563ce1eb99c48e69024c417abd018302a1581de0a5a0bfeb807ca9220b179382aeac0678d6987b446fc10c6f14df6a8704581cb80f4877c425f126c35cbe9bbd7484e369d3933c5875d6c9568ba4a882782c68747470733a2f2f6239634c45686e594e694762733946554c766356664e7344474f6243697442452e636f6d5820e9abce34dc37c8d195e2d18470d789d61c7b3678f73686a35e43b3e1f57e21238405581df1d07e81ae3e1441ab4359175c820ed17a7c041b177ecf0e9e08dbdf998400825820699f7b1b6a052cd725cfacad8f768dd6f06aab1cd7be974a674b21a1faf3a2e704b500050105020803020500070708000ad81e82090a0bd81e821b00000001f7063f411b00000002540be400110c1382d81e821b38e846bd942b7d231903e8d81e821b40c4f2376a1315851b000000012a05f20014821b0564a80cc9a955701b39943c4b56fdf1c715821b14da07456a9853651b1f3846d727f08fe41606181807181985d81e82030ad81e8219088f190fa0d81e820001d81e821a012694f51a05f5e100d81e821b001e5016c2d68e891b002386f26fc10000181c02181d08181e1a00034689181f011821d81e821b79d2bd9a995b89831b002386f26fc10000581c990cc55d56e5ae77b953558454b5847e3f40d3825ab5122b2e6f6e2e82782768747470733a2f2f467578757554567a34594e72464b574c615a4b59554e6c385456652e636f6d58200d59b966f1e8b5f747f70ce34878abb6f88dadde0419fc3ca06b6cf5c1d268a61601a500d90102818258206fdd7a1adb4f84c54b09922fb4de9033005c846653da2ef5a8577e374f982e7458409fa65b018e5eb6b12def5251ecb9ba814360acde0e1ee44de03a05ee16140816f0d0e5acac1289eb3924d9020c54911089c5df2d9ad985094edbfb8f5347d1a702d90102848458206b3f9af0e0824142f7279cfa27e8525db3c0e41ec1fb6bd86b05d8a17d5378e85840a3a08e9662f7cb1a177b8a08a20293918f6ce26771f96f4a12afc7b9e26895d34e310de733ce31a646cc2e9d827fe867dce01f653b8d07d2a4a94255e4d84a385820e4a47e7bb61a349f94b2429945491474b0fc0887144756c2cbae875679d9800d45459e9f95a0845820d9440ed33afc0d1a2b1fcd4c1c53f15a2d8315f84d991943a81eab45d23f7ed35840fb36d6f8d1d21b5814e6d8e9903a4a0a7ccabe1c591672cbf7450f54e49750f75c6cebc871c5ca34ab3643becd58b9c0059b087ce6eca6d1027ab2c061c5e8a75820581ac29a9339b71a0b1076938853904b051daca9b64558d7699b67ae56ab284f45b1c07af0e78458204ccfa338c1e6e372e554c2f0f364c6db8961b363d83af96f1942e11cd6ac297e5840bfaacba3a93d741f8ee41dfaae3a702aad3baa3a8db786b1bf196a92175ce700cb299a8bce81d560323599475091be9f0a0fd0424720c1e1041465770878dcaa5820b3da07d6286ddcea10f84ffb3228c9863a3d4e9df4b4727fd55ad1f50b1693bf44bd8372f18458201ccf0104f6f48c0a411893307b23d882493db443b1456ea2a103a8566a0bda055840638bb67e89a8d84b9e3f5050fa9c61f98ede83e852590f51d00b8477ed176a7c199c47f43ce9f03588a395be31a052fbfda4e4c60fde2a632ca80798402ebdf35820e0333f80920703b370f0eb1e4662eba5d123a6947ff10ecd376c6198db0ef773450bb2f395ca01d90102868303008082028082050b820182830302828202818200581c64dd6c51860ea7eea340b4e14e0b84d6ae76e139824debc9aca1533f820280820180820284830300848201818200581cab52ff0aaecac76f0e63de09e8d905746b2a5b8f0394a37fb6d21d05830301838200581c677331c348b78d115d97c4aba20ba1372c739c3b279417463e518cb28200581c81450e5d3472067ae53656164db95da15a1b7b3465b662a8519ddbdb8200581c9db0ea351b830be850248b55eeba2e785fdc2e09fa6cd6e828323f5a8201808200581c314a4eec35cae819a281711c6c880d71e977fea60c4cccb1292bc3ba8201828201808303008083030080830302838200581cf1c789166264935a6707d15d236a0bf8d51a5b8d3bd7c5f4a2a37ec98202808200581c9f5bcd1af58f52fd097ae972902c74cbe1dd89166ec26fa68f2be1e382018004d9010283d87c9f41679fa5427ec6402140200101002005ff21a340a243f659694388a2774004d8799f0442a7d72241f2ff02d87a9f01ff9f0400ffff9fa0a5a3413e4265ba23222141629f402341da05ff40d87c9f20ff9f43b034fa0440427dd2449289b71fff24a4404111054481c9e6e105444e03029b43749c7823809f0401ffa12200a22444a4ebdfb244cb066a6f20d87e9fa3402200410e422fc043e23e50a0ffff2405a382020282d87a80821b2047d1273868cb401b1865f6865c75d879820208829f9f4153029f23413e20ff22ff24ff821b1f315ad1d99a75af1b6ace6415245037128204078224821b21991a56b876b3141b722287afb3bfc17ff5d90103a300a40a250c050d82a0842442d36724677c1c7129e59aa71083617102a14262ca414601838204098202828202838200581c388ff19a5ce15d50757342b1486f49e0e7ecdc7be66d13a0af89e80c830300828200581c0da7e595e05ffbf63e9b5528a26ade00c409929a102191865500f9238200581c997575c19010a07b7c178ecb979dd3e15e096961bd409fd55e892ec9830303838200581cd8dd93914403f8668a1cb6401c522ae3e0e4ba99b9ae5d5b1de011718200581cbe1559ce47337f5d9e01e3ed0da080706b5afc60c1e883b5fcfcb3fe8200581cdf3d936fa732b7801a63ae0821a818046d05c0b1b011eb2834898abe8200581c735264a02846777a221130ace13ce1a04df7bfd3c903d9985711399e82040b04814746010000222601",
-                                "description": "",
-                                "txId": "34d691f922dec19f56a63fc728ca270da1f73c34e2f7425c625eb7c70db643cb",
-                                "type": "Tx ConwayEra"
-                            },
-                            {
-                                "cborHex": "84b200d901028582582018f34d2711998b527bdcc802d88b650694e0c33b0117d3b36b7a493c1689ac9e008258201b45966ac36f6060d8b31ea9b8c088ca59e07142ebc7e6d1f2b54341c667d46203825820745887ca037ce500948e5bc1fd68fcd2d31bd04d186b7dda5c4d1338b455a94e02825820dca78a6b50b6497374ea22ff7e666cbf7dc6b9347ac074f22b31719dcc01c85906825820e5b5e66ad304930ef7654ef0bdaa9840311655edf463dfc0407271faf12f4466000dd9010286825820219cfe0bf5b8863f657b87aab617bfce24ec3bc68e1f46d5d05d5333629d265902825820560c13a154a8d9884669e5bff43101f0e9be48e96b9f46d5efa2cc50ede2e32b078258206988faa1dd0ff0916ce48e339fce8a20f6216290cd8093b6c0fd62dcfa679ce400825820ac6b362966e44eb8dff9f0a562bd65957728571d061e6dc783a64c1bf88862ae05825820da2e0671924f6203ac4b19fa63b21e36cc4c19c541cbf8004a92a82ff6591dcb08825820fcbd1bbbe7073cb9d3cc7f9b7e00a342402b0103a421871ba6180a3caf48eb660412d90102838258207b90a3761668294834d7fd8fd1e0335586f9ae44c586a9ad8178fda71bcc4b0e008258207d6901c4a5591efcd67f8a4a3fd74916ae7386fe70482cff3a8a3f7452b4ee3702825820e736c6b8dd467bf41b0b96328f512f9f298e91fa782828d165a3b834ae670e9b080184a400583901acc45b91f9b160d53b683f01b2d9b95ea5e423b1939eb8bdefa08131cfa61ce0fac0322b9fd3a297ccc390635e9b80c23a4f6641f9c4299001821b7b74463a8efc3da1a1581c2d725128406dc832eb74c4709aca0512499b3c7b17e00d7cb2e6d1b1a14134010282005820b705b468a71b637a188cca1b41f6c676afcb0858d6a14a92de25af0358c9ec4d03d818582282008200581c87cb75cf46e4e2e7840ccf3c1a65b3932967b389d6a04b7b099d4cc2a300583900b533fa10a28c8d20cc1811ca71848fde50519465705d97d89c048ff134382c60401084d710e17e7d6b6955a5daa520383105a97b4c25bbad01821b3f38cb74d33427f5a1581c467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22a14a0a23ef1ba92e6bdab1f61b583232b36de5927803d8184a82034746010000220011a40058392074e2dd527e668f9ad7e4782ee5c16b6b4e4acc25f302b3abfeab5748c0714ced7d2d9f3ceef7e7fac7bc063d639cfce625edbd9679563e4101821b5781d507689294c1a1581c2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56a14b95b32333686fc12a3c3d4e01028201d818583ca2d87e9f9f22ff439939a4ff809fa5404416b7a329402042c2e5050143d9a8990440a20344c887b64b42078a42c5989f43ccf6672041af41feffff2103d818458200820180a4005839119efad13ca93c1fd7c68ab9f2ac5c2504aec50adce1828947d6b40c8a837091852c40600634349d4514d49a3c7602f3a295f6398a36ce3c8c01821b31e760f1e959602da1581c1d5eb24b02d67c048412286bb18d9cf59b983b427b035f26aba15201a14eb37d34e7324fc42b105e4d71fc6c01028200582015be6142517a49bc23893d8751b7e1eac27a3235c5b984d60f53770ec3c78ee903d818586582008201838200581c7d6cf53561a638e76a75d7a33fc61c113d8faa648d02aab1874802da8200581c47bf5355ee3142dc78b41d03bba0c1f98f45315cd867ecf873e2eaaf8200581c15a8c7343ab647958da8c864d38168f7fc6e01b151f7bc925128aeaa11050206030104d90102818a03581c25b9bb8b8e2cf5cf9a14192c88dde473a3a43930861536305d1de27b5820321ea0d2e95b2f2a0c95b5330e9b51a6f8004efb6864fc9526d08d478a96edfa0001d81e821a0d1982f91a1dcd6500581df17ec5f029db88e2c15ccbca79fdeabde0139f12670dc1d27f47c9eef9d90102808183010074496a4c2d46414b746f745674357278662e636f6d82781868747470733a2f2f4f522d556e545336396a35302e636f6d4005a5581de051e516cf9657a135539afb85c8ed5bc8d6a0c75e4d358b74e871a9401a0007c9c4581de0badd2c7e0209271a83fd4af08a97cbe26dd4865edecadc12414a823c1a0002cd85581df1fde91a297c3440bfc3ae65ece87456df98553a4420ee6f3ce4113d3500581de1e7da2bb0f433f477c1d9bb52f5c895e7b88aff27077a73b078c1ee4a1a00069a46581de1fa04b12742ca9a699589db11217352f07b023d4d6fea28d01456a2161a00064c110ed9010281581cefd09577e9354e70cf7aab709faff70bd8fcf19ccd910d355ae0291b09a1581cb0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165a141301b7669e1dd12cb60320b5820e9565cbc122da640202b7032b12f8877fc716ddf222cdc4f773e33a319f30679075820ae9ad79bdb92bea363fda332fb78b8b61386335a95f4a7c1e272899109356d3d0f0113a28201581c15db97ceeb765e214c6ed095d00266885e49ceef0c76dc5966ecade6a5825820204b72d58030f87157fb050b2db372e065b2d34046c333cb5ed48ad1da9257e800820182782468747470733a2f2f747147773668725a4664503976492d516433586c716474672e636f6d5820c2f38c734cf68ca97c5f7ddf0344cbde3ab8b25cde4d062dc4491710cf2d48698258209b0b64d638741c91ac9648e0894940bca7f9f6d34dcebc6581a25cbac434d11603820282783468747470733a2f2f6745496a4770495070586c774e5954476471637834576d486559796c552d314d764b616846696f452e636f6d5820f065bb06b9dd169d0cadf5e05f43f8bb1324b337159d83ba1071bbc40ef002e8825820aa02ff4959c5166d8d63353c45e6a6232a0e049951f6ace4477a767373f516c6068202827368747470733a2f2f4d5963414750752e636f6d5820a9b687d75abb84e019762135a21d628066200f200dd796dd474b632e29720e2f825820be5c789fa205ce2872afc6eb88f48d512e783e2be93a49067499de6ca8aaeb7d06820282782e68747470733a2f2f57492d3672586e5255452e7773753848303273384e7334593175477036376461314f2e636f6d58203c489050886a7b54c2adb255d612b90865a1b8d6f952fd22a87d3da664f4db4a825820e7c8ed728ab6d9e9e8e5e4f353b025c6494528361667d86df92d6cf411954e0e04820082781c68747470733a2f2f343543716659443746476c64706761502e636f6d5820e05158a4f0c49da4469afb2bb53586f975c5e1f3fef960b582be064f0383faf68200581c3ef4316d3ca9995e096392ed6dc2c0e52276999456a0209a63838e3aa48258203bc13c55d3e6ecf827d7d6e123d6eb11ceac3dcfb3c38984d220d3a9d9032d34058201826d68747470733a2f2f392e636f6d5820c74b73572f901679ca5179262dde11935eaac184ccbb439ff3863e84fbbba49982582086069249c9cd35c540029f5387814aa2ceff0b7b2896f374912b8fe03a2e8e8401820082783c68747470733a2f2f2e77324b386135446a7467394d3453376f7348354130334b6c6d5770686b6152525553724e776b6b6e32716d5152466e2e636f6d5820794000ef0e00a5ceb606ca9417a35cfe9923226b0556ddcbf9814e54663822d98258209d220453f1686e6dedf2f0fd065e8dd1bbfdc2c3e14016a13d71f8517503468d04820282781f68747470733a2f2f41763876484b73416230664262414b676971552e636f6d58202d3906554b08ec321cca4e1c3a8f6517abcfb6c1f66c3474c2b106ae96f09201825820f17254dfc2cf67c2ff89645787c8e8266a55c605f0209d2dba002aa67c558c26088200827668747470733a2f2f567a2e536a6b646277792e636f6d5820d1136f0d3b9490b4ced76041ee2fc8345cda71ffdb2a5663c17d4bb0bc5bf11d14d9010286841a000451cf581df09c29223457671e52d2daec3a1077c5849fc7b30f51e6efd7f3dcf9668400825820344a392c2cc1ca4aae373f47bd6289d3d384ae7ba032469c008afb7fe7a76a1401b501030207030504060504061997c508000ad81e821b0040922d714c8b8f1b00b1a2bc2ec500000bd81e821a1c98bdbb1a1dcd6500110d1382d81e821b3a2f85f3f600fde31a000f4240d81e821b40b145c8b8e8cd031b00000002540be40014821b7c642175548b8d921b64fbeabb6edcf7fa15821b52a9d81e903a33141b04ee87aefc1f8be816041703181985d81e821b0000e860fbed57451b0001c6bf52634000d81e821b0003874cbe6c1f5b1b00038d7ea4c68000d81e82190100190271d81e820d1819d81e821b000c9b7ba5d451731b0011c37937e08000181a8ad81e821b33801259890424291b4563918244f40000d81e821b00b1f36cbc61bc2b1b016345785d8a0000d81e821b000000153f0b4fcd1b000000174876e800d81e820101d81e821b27f8846e6665a6b71b4563918244f40000d81e821b003ea232ff133d311b016345785d8a0000d81e821b0000000c196ed7cf1b000000174876e800d81e821a1623154f1a9502f900d81e821a223c0f9f1a3b9aca00d81e821927af19c350181b02181e19d11f181f0f182007581cd1118d6db9b49f5b682a59a9cd503820d88d804869efb88de61182ad82783468747470733a2f2f2e6c35506736345230796c7861647950355132553375334e7037316b61362d6e334f612e5848334d2e636f6d5820b5bc1a39bcdef9405a2382b10393e54fcd3f345ff8c223e1516c5e493da6fe99841a00082af9581df1ada55c745ed93340384093c6b473493ce336bb29b480de0f44d34c878203825820a4efb5f3c0cc7bab4cf5b27eb1719011929f7d2011169d06bbf7a39deb8550d50582783768747470733a2f2f48595a6567714e614d4c3371326b584842377373752d4c75547a2d6a5578672e625435656266726e6979552e636f6d5820630e81a6ce919a4688cc3f050805fff5fd3d65ca4eb97d542ee804bc53ce45fd8402581de0bcd4e26f5ff6910663af26872711a921b2e7b5070f9f35d1cb8778b28203825820f680071b765461715f4f23576d648fa00ace908e40a60ad46b3ef99f55a0e7870082782068747470733a2f2f77687451716f525a317350384d714c6a4b5a58422e636f6d5820a7f1189e001d2f837d88c484c0b33c9190941da1f47799e26abc366597bde83a8406581de1780b9776fb9d1874ef161350bb584b1044400acf90672a7315fef15a8504f6d90102848201581c11a05f1bcc6d6bed80a54b79c2ed6be5190755776a63911a84b463408201581c35f0b915615f29a101f4dc76f65afa452dd6d2414c3884e08c9e29e08201581c43647f8a0283a330e2ef892ea37c74f3aa044a37aa98f97dc453b17b8201581cfa1c32cb97e3338c82f62953445a7dcacfcf5fa92c6e821f504b5774a0d81e821b0000022ea7a6b6791b000005af3107a40082781868747470733a2f2f647747452e693837477472572e636f6d5820911313caeaf5a9281878251016a0865b198ac1f0c31affbb12458e770de4b2938403581df016e146293e6118de5590bdfa8119e33d1ed398e9caa2c1ec1b84a36d8400f6b50102030604000704080809d81e821b38b02685e2ff475d1a000f42400ad81e821b7ea80b33bfa978231b8ac7230489e80000110312a4009f2a20230903022a0110262327092801210e202d0c230d051003090627082523070f0d0a20230f280a20100d09030e090c012c040d262e0b232a01280c2820242e2a0d2010230d2810231000060526030e280e230827050107282a290b1023042906052925082c002e082200270d2601250305220922230104062c0429090a2c2b262d2e030a0b26232e2f0108100f2d0f102e242b102e0521231028080d09250b2b0810090004ff019f0e102b2f2e052b2c102f0e0d0f100e052e022e282c092d272a2228212d270c2a2322092f232b20262c03062221252827200c2a280601022020012b22220510052e0a0e260810062c070a04002a292e102420280a0d2b240e0a24270f0108000f060801290b0c27210523062b0f210c280c2d010d020c0b0c0e0e10012a282b210301232b090b01212b0e23052f030e0d2601002b0e29012c2e2f212b212b2c20090f0c292404080b230d02022a040cff039f0d2927280003062800240b2e0d0d0b0524290e2e210b2b292e2e29040d2e220d222720001007212a0b06242309232e0c2c05252b2e080f012f232e0b2a0d1025062f010a2c2a0d102e0529042e0d0708270107000b242d2803062f24240f0f0b070920272f00240b29020d06282d2b05052828260408070707262826250807072c2f2a050e2800020d0f0621060d28090407200a260c27210c2723220004272c24042921010b242c062b102e200b052328240d250900202e2a0504090427250f0a08012c272d02290c21040a2c250e2825082e2b060e2009012226022a01052a2d2f232f05060b290f240903040a0600002c272c0a2e0e012b0d23ff18d1801382d81e821b025ad1213eeea0071b000071afd498d000d81e821b3aaeb86a25b0e3251b4563918244f4000014821b39abd4778451bffb1b01534511048e0ae815821b4e86d2a8bf5d437b1b6b8ecbebcb2c1d8316041708181800181985d81e821b0000002da5eb1d0d1b000000e8d4a51000d81e8218d11903e8d81e821b00000003de5746971b000000174876e800d81e821919f91961a8d81e821b000000b64b935a911b000000e8d4a51000181a8ad81e821b0000000aa46d4c571b000000174876e800d81e821a013c4cdb1a1dcd6500d81e821b00037c7db0d8387b1b00038d7ea4c68000d81e821a0499f1771a07735940d81e821b00002dc68fbb556f1b0001c6bf52634000d81e820001d81e820101d81e8218491901f4d81e821b0000000205944b791b00000002540be400d81e821b005a1086ec37ed491b016345785d8a0000181b02181e05181f1a000e92651821d81e821b0bae4d000e3d4ca801581c8d50c8ed023175a5024b51c874a1db15da92197dd0452a2a323b2fc282782f68747470733a2f2f3072536a2d376c324a69475946734b6550706838727843706f4265353866544f782e6e2e636f6d5820664abb6f08f4c0c88cfdb9339ca43521d8dc05b70b2f6e3b3ac49d5f995c29f8841a000c349d581df0787223eb212289f10be533483ee3ebb5d042bbb99137cc814d316dd48301f682090182783568747470733a2f2f42646d746f5859537451315865554c666f5361657077632e6f694844796e74414b552d6c38456c59372e636f6d58204ae8e27cda810dd26d411f0ebeae498e46796f85dcd38fddab8d516227a6260e151a0002e2951604a400d9010286825820114cef819354dd2df3df9043a623ae6040be8854dc3239c2e3c33547eeef611358409e9a1242085e4a93307ef52353a6f56493b1da2261246d5c4edefddfcbc526d4570aa66aa8a95500c2843075c5d92883476e9904821cd85568e7b1ea0aad69e18258206d323c7afd1b781909aefbe947c13dc3846bfde985c3b8cf55827a1eb84b295658404c479eca85bf7c9f856ad9b96727db7fc44c1b28b7137fcd453215f1d772e8004cc646ed280cf75260c3a4e89a4f5b6d790b454192336610dc443f01db36e8f1825820410cb89d45468837d9ffab520cbfb2438c19a65fab87cef872932bd88445522d58402bd05cfd1d1801ef53e741a805f9c997e0d6ddf6fc65b90da97b0aac76b4bb45d998facf8166a3e26312494d00f368d4eb44c91edf2438dd5be5b9c08cd7609e825820d5701c91eb7bdde0b69a861136033058b830c6df7bc637b581c766e3a6a7ab5f584009806981360ee3e06eed3e3e080dda45110826579c6f60f29bd902613c2633d1d9d58f0c108b683ef9637851d0265dc1be4823de0a65534a25d3097634daaca88258208216d9d8ff4b6878246f383c573ec5b47aef95ed05da6be1edea618f3ec7b056584066e9d97415d00ba4bd57c3a026a44f9a0ec48b9aca7e0bf443e25dc7cb6e92770b1759cf4eb0d11498c54a358598ad7a5349dbb18ca68c765797c47b3cc85c7f825820ce752b56dff27f3362d0eda7978fc6833727d2460b5ecc9a56ef9a879ef2fef45840927cdbf39e2a773a17f3cdf79a70acbd5324c0bda0d63e0752755ac941b7e6f705b1d1152c2e10627776965a5d10d4e4aafba810a505e480589ef8d2ebc7107a01d90102858200581c55f8ad198bbb94ae232b0455a68e91e9e6c846a02347c6c6a193cf188303008082050c82050982040404d9010286a280d87b9fa2439b62f92201229f43866d9f22402342056affd87e80a3012405434cbe5a400022ff446998f2bba3d87e9f4269fdffa30244ea2813ed42f3600504030121d87b9f44ae0ba47fffa541a6430b5c3b4024425609012341da0244c7be1d26a342d099434750ed9fd87b9f00202244f9e74b8cffa142d2da044297f8ff40004376009dd87d9f809fd87b9f44cd9a0f5b439e33bd414c03ffa3434e8ac9232242602b242280d87b809f40222242f67d22ffffd87a9fd87c9f42d9d742db1d20ff21ff9f9f22ffffff434a7ceea00105a6820206829f05a442697720d87b9f0541fd410a42ad2e04ff43b6663d9f0044f83ab7e521ffa423212441fb20404001a50343a7e0ec0520222340022041bda1446ccfbb47418da221a4428627042042994144fb47c7e321044313ef0b9f212304ff9f43fb556104ffd87c9f4218d42140d87b9f41f902ffffff821b793fb9176025cb641b11f9e1fcc52a23e682020782a524d87a80a443c9046aa2445ecc032620419f43b73ef9d87e9f22200241e820ffd8799f42e4f62041c64244fc04ff410d412420d87b9f212240ff9fd87a9f43ae03cd40ffff2242435f9fd87b9f234222ae240200ff4114d8799f404420dcde574499473ad405ff9f20220522ffffa1020100a122d87b9f4376f92aff821b0ad4d5d194bee1a11b75bf249293691cda82030182d8799f9fa1442f3bf29a41a0a320010002234204b2a22244efe755284003ffd87a9f20a0ff9f0540a5202241924343051a444bc9231d4000413003436b8235ffa5a544dfe4a0d503404190415503042344e53929bb40a0433a6c7bd87a80d87d9f21416244b229a06043a6b877ffd87b9f434adca14467c2daa0448387e18e0444da35b813ffd87e9f022023ff9f44acf99b10050105ff8021ff821b136ae1fb97cef7651b343e671c55927f6382030782a4d87a80a1a202427e064362d6b602d87e9f40ff9fd87c9f404458bc6faf2320ffffd87d9f43929552a440202344f070f31f42a1e304448e0d1337431992b5a4010241e70044c20dcdff22413a40a32444da48cfb723054044228558adffd87d9f9f40ffffd87e9fd87d9f424abb0123ffffa4d8799f4380afd4443f5e93a10023ff9f050541dc24ff05a10500a0a501419043e2a351202140222444e6b1461e421c0621a54395e0a9240323050541064269300540421ff9821b452895dd487b1b471b7429d334859f2cd682050482d87a9fd87e9f22a32121032140429c24ffff821b1a17764f66a515f91b6a4da807227429c68205078201821b32209816fcdb0f1a1b20984492073264d3f4d90103a200a209824260ec82449922a4d9010a83a269f3b9baa2ebb28b06402467211873f0a99e9a42de3b40050481484701000022220011",
-                                "description": "",
-                                "txId": "7e46dcd2d9d62d9de767673e84a91dde7153a45313d5256e8adacf44da6487b2",
-                                "type": "Tx ConwayEra"
-                            },
-                            {
-                                "cborHex": "84b400d901028382582057c08afbbaa0c558fa4012ebac4e48f611f2acf58b5a347f8d5556af8cb0d76507825820aa824a77bb6eccd630979fcd8a54e896af5c40c106f9c07da3118ba8db46422105825820b396cbe674c91c5b0bbb9c8d525c5a6b0a3d4f7cded88b0365fa1013ee004266080dd9010281825820ab21d1c48f55ab4e559ec3a806885616c43eacf3fc24116155b4acb2031ee6cf0612d901028482582009ad7c87179d7beea6adea19db5df90733bf67ac52a3fbbc2dc72797f8983db1088258200d825220c0e4517723c0eae8cdee1ec32efa92dff809f79b846790fc70d5db0901825820693985b99187696e89dc4be486b7f97a5aae75b8c7abd4e381fd3ed1f49b770e06825820c287c0d0d5717092847a4e73839990956c24ce4350b03a7ce45e690417ac50d7020182a400583931d12026eb78a0157733a22c07e0af3b97b2b04e9771358c915b3e481b875b5224ae0f0652b50852c7696611b265ac83a6040845c84102b31c018200a1581ce9cf4bcdec00976ca17884cf3960621f96d326d400a35f42bb8e9ca0a1413201028201d818412403d818458200820409a3005839110da27fd70b0f42d5d530bdf073189256141e6ffb18fd0a8e8d548efdede14d15c539f6fc8465a1b7add41e0d0e140bfd1105c2ca00fb04ba01821b53dc917f0fc51897a1581c858c3a9c9f7ccc8a67af0523a3a73eb52a3ac47480412f3785304668a1581ac3b08a0bb31e641722154c44ce244c18bf0b27a1fa3976aeb4371b58ff4491b5ae7713028201d818588fa5019f049f010040ff23d87d9f430d87f3200123ffd87e9f0202ffffd87b9f43b30128d87a9f4041c442b32d03425e37ffa243f711dc2042445d42b91c0140ffa541c3409f42aa680341c6ffa041020343c1f88a4342f6604184d87b9f05ff24a09f0241dea240429dba2341d09f20439d456b23ff01ff4001d87e9fd87d9f4184ffa403222442640f4188240222ff10a300581d60da1515c5e5086456484890df07cc4919e14e3987b96ba2729855f038018200a1581c2f4ce25c1bdd04f108fd3dde5e45ad6c261efab55d1bc3a535eee9fba155c60cf16fd3f9ddcb5fede4c630ab4ef562ac47d7cb0103d81845820082040b111a000d2b1502198017030104d9010283840a8200581c17c5b8de8edac97bbad630c270a848d1670c41d05d0864bd033d8685581c35898d0d94ba6560e3e67dd25ef6dfe3df8d2d55ed4086f9235de3a9810383088201581c19a8c2eae5adc8086f4197f93c10d6c10e0f432b7ff6b5b2c3ba2f121a000b916283078201581c38b6f1035c73c772dfde6e2246abf61a8717a87d327f7a59dd577c1d1a000b053905a3581de0383e95e82a51bfff7d348755545f27d14099103df21b7128dce9924705581df1939997212bb6f71fce297e2c7daa40150c9bff1e9d8f689396b601ce1a000aa0c1581df1c94ebe341d798666e3b67a97712662e1813748fe03375c39a9b8d0ca0308010ed9010284581c01cc71a7ede5fb701c65515b23991c2a765bbb1ff9785b19c27e642e581c9c8da95932c5f258093e7bd60b80287b0d0e7b5325b805642516ff8d581c9dd725968ec98b1e76cf7ff698294b7616ee46d740f88d823c3e62a4581caf648dfe4f5e5c8df2b7944ff0f90c481e323be5999719f87f6412bc09a1581c2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56a14aeec3a62317ea974e55bf3b1b80616cf11bf2be0b58209c5a50d1aa16c457663b3421c188edbf392eb19da325161c360e022881ffdd35075820d45ea7f53680e27203f2a58f1b3fe346c465aa773fcb148a7ba8373ec496e2550f0113a58200581c16005174b8ad7720bb40701534a8bde1c0ad1bc6a8117cc05f105737a38258206a65f73bde2b3a04ad01d17eaeed4bfdb1e640b831420f49a001d07b0a5f7e2d00820182782e68747470733a2f2f44486e6959685768635967794c78744f7777737561674f594356494d5644695446572e636f6d582059f14499a25485855fadb2738bf00426271c8fae0f83912ecb82ed460ed8f5b28258208d02f2c459660a9bd5f58735349a00098a22de24ca21b2f3b314fd2f79b2051f04820282783968747470733a2f2f39495438756c63657367517857625442654f2d644139686630422e69307a552e734678484559646333697831782e636f6d582030385a3e963564e6c4f0865eb49d8c1da7dd9918ec37dffd4815a10fd91dfd37825820e63828fcd703e49a59763ce5467d2903a5eca7f190670da1019f3a1267b5df98058201f68202581ce3be8b1ecb58fdbb740d5a80826ac91ca1c361c6c94189346a434b13a6825820017f9c35d1e23e749d80f7300f24f45b14b65049e3b60749a8807a3e8620522305820182782368747470733a2f2f526e6a38706153574f306e3754495a617373444b4b62722e636f6d5820139075655f74e9dd70c39cbdc5515888e543131205ef6a4aa62a9ca21b5bc26c82582026d060652ed2989dd4ace6538aee4619cfc09904b8a9a4bb50b6605d376815af04820182781f68747470733a2f2f6d51447934724843505572573958583964344d2e636f6d58208727b3f3198b99a9bf91a0442f9a25c50256f9f75af9be3eee9bffa6eb5409ea82582031910d6d197c8f7b0388fe6c44d7064c8e338e2be94f4088898e92523072a5e402820282783068747470733a2f2f6555592d4d6a6a394462414d396f526274423163575257436f445274684a64765747614b2e636f6d5820cc3b12a073d542a4e15b22b3a7cbfa4e5e096d0a7027bd78809cee92a8880e6a825820d980a23129a2f11dea14320cfa2f9745c51fb869bdbdc0eb3857bcebf199288f03820282782568747470733a2f2f5058516c6348387979564f2d467346374154552d51512e6c5a2e636f6d58206438ad086ad4456e27124c10142a3041a6467daa54ddf9257bf481f7fbee6983825820dbcc71a3989215d20342fa8d65fd3a7adc5f1327e06544668191c7c4ad428b08048201f6825820dcafb31ee9b5d338f2c5a56dd8fca98cd9cfdbbccb26c058698ca88f26a4947805820082783268747470733a2f2f4751664f336e706576754e436d39382e547867684c4e4f7a754849412d6e5a47744a6a5a50472e636f6d5820783b04967ef685de397350777afbe25fc4e39be18a6f233f08b01be53a9936288204581c6b15bd1cdb423f9b63e8a0ebdccf3579578cea744a32462fb99ef9d3a282582059f539f7c8e74d78c84295e08c82e4700d54cade97ea574bacf129e906e31657068200f68258206bd0bc778db5acbfe79f094ef295bbafca480901d6cec90a560b438174c3df2b078202f68204581c7693995159a85613df79c1cb7df7ac415015976531a9aaaf2bea1cf7a48258200ea882e0bf5edc0496cb2b23d2961a6f2d0ce343df9823f7f3c40fa4e897980f04820282781d68747470733a2f2f7349325043474846336176726b2e3973512e636f6d5820393b0fdd3e5fd7604a9378d4979de2d3fb4c527d8bc47221b0cd5c4800facc74825820592be147ef21f0bd8dcb9ade05fac8f5aba8f9ac7967aea9fe0a1bf0f178047507820082782268747470733a2f2f572d666e7972715569456d5544507256596f73624f652e636f6d582008f11d217eccad8f6d0937fb00c7b84b761a301671d637ea820038f3cec31d6a8258208fa7b70aca859f14cad1e3f6fa764ab2dd32337871b7c3174e19da45d46dee53058200826d68747470733a2f2f4b2e636f6d58206e9d77544afceff62aeb4a2ca119b230dfcbb88f6b3541a0d3b544f652a8c197825820a14911619693131f0c61d4287c36505bc8c019522313d17a27ee8ac192382485008202827068747470733a2f2f2e6345552e636f6d58209a21a53cedfe871c23f42dbc9e23a309f9a4ca545f31a0271db550fab3a545e48204581c80165e9b51d4c4d42d30fa2418b931a3812290e1caa77dfd41379150a48258200a74cb14a59d56764e2ae5f9e652d1f63ca884dbccf9d061a9695f55dbee479606820282781c68747470733a2f2f702d317a363836596d766535495a73702e636f6d5820d9c8d988f627a47f53cf71ce5fdc97c748364aa154c8725f615ed2c6a76b4ea7825820152c437083a3a02c28baeca4e6747d83c8431a8a3fb59f08a8853ab5a49f301e00820082782868747470733a2f2f796b58633667676e66794f4265746c38313175484c75697957386e332e636f6d58206ae38edf8e1720106b2e0cf596fa0d2e161765726134ac7bff013c7a9319566e82582054c8b275e6f355192f68c2fa2d514860c6ea34d6e71d288eff0e60212a82580b058200826e68747470733a2f2f59482e636f6d582082bb25550c96b3f9e802efc1a8e48a882e6d826fd765e54ed2e03fa9f7ec629f825820916c1aedbc01c46571ed4104e8f6d82fcd7cf161d5465c54c0752ac84d73b75b02820182783968747470733a2f2f714d574b62565236324c48576778475770454146666f6c584d4c454a6a5378612e4a57364a7251746b72644f372e636f6d5820b5f6cf87b9a0b1859eacf8bacd6930f9763bc4eb47fd0d68a72feb0b39f02c6f14d9010285841a000713fe581de0ecff4cfd89b60e7d53700207eb71af0064c172e7c7bfb9f2d1bbb264830582582068e7b038e3baf2085fe1ed4579d045dc072fd8c514727e33d6b4b0e457b6cd93028282783668747470733a2f2f53754f4547392e5453474e436a47635a49684764355738314d706f55434e564250722e6e3776694e444a2e636f6d58205855521db79df3eb9d0de5f1ea81efa819ef1393d0a01d803e0662d193ba05a9f682782f68747470733a2f2f35466e662d377a6a5445425a38594d3765686c6a7a6f347055304559515531573552502e636f6d58201a78adb5cf4fa147c73d00e7efde83bf110746cccb70769401d39f19a8aba6008403581de076bcaa340d345ee2c8e46c5dfa370e8f96e11cd1e833a130e3861add8305825820f371b52ef27ae3292fe59e0045da690582f9cecda80acfe6212f73f0cdd6883a008282783268747470733a2f2f577739652d45532e3731537467466641424d564b52327a4d447353684b2e64736f64455356702e636f6d58207d9ed3f79aefadf0e65e7bf2d4c35d82c835ab4b44f3ceba4887aa8c10b7d21f581c9f1ef0331c56cc438eff7b40a6bd0ca128641ce7b2cb916660febb9382783668747470733a2f2f36505270642e566b736366712d727179586d41584a73526946774b353970636f46364c515a74414c396c2e636f6d5820a9bcd061a720fcccc492eeb4d5e82fdf8917b622737d7a73ab0037baf21d58f3841a00080681581df1740d1e2b1df9569f0536fab18ada86ac9b77b4895c075f55203d5a5e8302a1581de15d23ff19f08d318d3b045f30334fdd1a7e54428230c2f3021c89ab1701581cf7cad33c701def2f3f13b90878ea08a17ebdc4153157f12f76c86d8982782a68747470733a2f2f4a61416e43334a62336f36646d512d4c47564b6b35704d434862636274302e636f6d582090bd5657a0600924f04d0a392f0c00be2d91bcd50e02a1938ef2fcdd6a1b5dc28419d563581de014e3af9e5eaa64e40ef44f504bd058d1fc7b0afd88e2e9a0746a96e78504825820202b042ad1c709fc278a22266eac4a877181e0b8895324231f1fe28101ddcdd302d90102848200581c499b3827baed60f2899b4dd74a839d2a35c980a4a2e3687410690ac68200581c64614facc8a101cb81fbc0b1951c43bfbc648c89ae216534da10529d8200581c75e8199910745c8c54b804471506fc0c30d483b1b8614fcca9de8b858200581c7a094b8a472a9c3f88ec9ec1c6f48e62e88c6484137c51792edeecd7a38201581cd660ed44b8c68dee75452ba530f8144970c5372a923429b34703136f088201581cec167c74deb818f7f04a902b591b9a227c9bdc9ec5711d821fe16557108200581c43169c6b95567969ec92d168a13a348d8b9d512b4fc0c11dd251c7be08d81e821a007b5cf31a01312d0082782068747470733a2f2f613633584a3648456e78756f2d733876674935452e636f6d58201f3ba14b2561674e17a7d66969a8a8b92e2fe39695e183010804646e7d6f5adf8401581de0b9c151747aba73baf6534f4b416b5d6b7b7b779c653ca732bc9fea7c8305825820c3e9fa1345ec155ab08a3f0615bd7dd500cfdb4792f1dbc434ffa2dc59ea3972028282781868747470733a2f2f6858314355754e6f6b62782d2e636f6d58206cdd780ef80f78337d07105b78e43135350d6e699f1f629af165a382e8984c4a581c826e7e1b2ae22156f95b188b62362ede50702d648aad1fdf1751e04e827368747470733a2f2f4737782d3762392e636f6d582060c5c3f120df5158bc52da308bcb9c75b0a3a99235e5b5799d80d0025ed4712e151a000ce8bf161a0008e595a300d901028182582071bae69b11d14a86995e546ceba648639dbb3ced443354fc61d11b8a127f10a05840e2df3d9f02aebc0bc6a49125fdb259f586bff9b3332181596d26930afb3c464a0bf01d52d8258210cc8453b128879167719545ee2af1beae2f11cd24bfe530e602d901028384582013aa8ecdf31dd9a83cae376b477b90e36ea0d5967fc6b0df906d49cbbb8f28b85840356665053bd47e8307330e3fa09d6e9dd8b842264ed51a6584a1f5b55385362d02aebbb1016eb4b06b29cd73036d7bdd4a0dbdaa6f799054224ad5b46430eb3a58202e2a2c82af77a2ae7bac2c26817af8592979bc7b01fa3d8ad1ca619f75797398454545f76bf6845820f94bf06c46c7057ce09a95bfdb9b9ae4b1ee7f5b9966f9fa19ba3f7ac1e6540958404ff7f01d4c78fcf24a3237a2b7d24b935da8de565f782805ca068963d1c25a2b839a20bb03680207b32afabc2d5882f59fc21f3e8e1c5b00f34687634c2f4ed858205943228a4be44ef7432c4acb8717f2c170eb32ff293267d04d54a7b4433502d040845820846f646f34585cc1e21ff0069c406c58e39a84356997612f214cde53856529ea5840c9514a50f0b418f11e467869ff3510ea955c1dee15fb7702c32c2c7e28ae5438b8d4f7d438c8e1f4c50cb8c6609a8dda4410546cde59aa4bed33bfe10ea05f0f5820136bef03db333b1343735771ac2e27e3ba3d2ab4522fc36d34e44557a7a6a0ab42910404d9010281433a0402f5d90103a200a2058585614143d123600164266e7519240403a0624a530c622e340481484701000022220011",
-                                "description": "",
-                                "txId": "54fece68c0e8333fb08f8a1a65a13820012928a15193dabcf641a1cc1d249a2c",
-                                "type": "Tx ConwayEra"
-                            }
-                        ],
-                        "localUTxO": {
-                            "0100060508080606030804050601030206050107000501000000050504000103#79": {
-                                "address": "addr_test1zquppq9elfvugkvve7m2cpe3d5hq8v6l4xydwfqapd2yezayy0hr3kj3m2rjc35rl93rsta7yj3mpaej2a6s0rknjzhqrtu3ar",
-                                "datum": null,
-                                "inlineDatum": {
-                                    "list": []
-                                },
-                                "inlineDatumRaw": "80",
-                                "inlineDatumhash": "45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0",
-                                "referenceScript": null,
-                                "value": {
-                                    "71af764519452be45e05d6e9002e6a43ea05ea98a4d4c33db4e2832f": {
-                                        "ddf5": 2
-                                    },
-                                    "lovelace": 7500000000000000
-                                }
-                            },
-                            "0107020602070108070701030101070206070406040802060303020502050108#2": {
-                                "address": "addr_test1vz7yfczphfheddcds808kn47jxvu3cm3yxp7veq389tnjpcsxjt6y",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "lovelace": 849070
-                                }
-                            },
-                            "0206070407050508000107020705020408010808030704000601020801050005#20": {
-                                "address": "addr_test1xq3dc79r0jcj6vh432pezzpkv75cwhqv2nzgtxdg8cwpmlth0ak2ky06c2m7csc93uzmft0hxc3uryewnyfasfr365msx7ynrp",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5": {
-                                        "f58ede0ec97043ece48b141d4c93d1edb06e15b750bb40c6": 4333303786957281273
-                                    },
-                                    "lovelace": 1262830
-                                }
-                            },
-                            "0307050301040505000503030304050000060408030705020207020402000108#41": {
-                                "address": "addr_test1zqc6umrxaau5jax50npdz7ww8238kwacdf25jrs6wvvawuhgwprjt04vpj9mwz9z6vl6za6vhnywg5lxqqn8rsfvecvs568muf",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "lovelace": 969750
-                                }
-                            },
-                            "0401010208050503080005020802060406040404000604000204060808010507#20": {
-                                "address": "addr_test1zqd2knwg9lj5d3cpgcf0uujkpzgmjkknalc693gg3d58llsjj046eaujjjg7tasqmyw2wltaw9zd9fz6wjvnwscss54sn8ryvj",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "lovelace": 969750
-                                }
-                            },
-                            "0502030302020208000308000500010706020503000102080807080505050401#7": {
-                                "address": "addr_test1vpaptuwkkzqv5esdsxw9she64hsyuvjyvmhzhjpl854mepcn8x599",
-                                "datum": null,
-                                "inlineDatum": {
-                                    "int": -4
-                                },
-                                "inlineDatumRaw": "23",
-                                "inlineDatumhash": "2208e439244a1d0ef238352e3693098aba9de9dd0154f9056551636c8ed15dc1",
-                                "referenceScript": null,
-                                "value": {
-                                    "26de0b36067e4da42978d5502b586fe80234dfa8e27867e44298cad8": {
-                                        "d10383a933c774e7922b9eeb5548b0ec483d236ed0c2dc7fc9b3f8dff5d1": 4706127827261668191
-                                    },
-                                    "lovelace": 7500000000000000
-                                }
-                            }
-                        },
-                        "seenSnapshot": {
-                            "lastSeen": 1,
-                            "requested": 1,
-                            "tag": "RequestedSnapshot"
-                        },
-                        "version": 1
-                    },
-                    "headId": "04000404030308050205060401060406",
-                    "headSeed": "02050501060705040700010006020500",
-                    "parameters": {
-                        "contestationPeriod": 604800,
-                        "parties": [
-                            {
-                                "vkey": "1407d0fada5b5bd61fd4ccd9a9b70e050f59a01180f523d1f81ed649732c539f"
-                            }
-                        ]
-                    }
-                },
-                "tag": "Open"
-            },
-            "pendingDeposits": {
-                "0103050608080003010508060600070408050804080707070804080704010800": {
-                    "created": "1864-05-06T16:01:44.789464410554Z",
-                    "deadline": "1864-05-12T12:18:17.718833943537Z",
-                    "deposited": {
-                        "0202010004030708010602000503010404060007020604070104030404050805#29": {
-                            "address": "addr_test1yp9xas08u2ye3leua3l5fuaek0mh88vlwgw7sy80j5094vkey3me8fsx77ftecp4urczmj98fkv7lhunjyth8lqmaaqqlk0sgw",
-                            "datum": null,
-                            "datumhash": "ae362942857299bddefa05423d836868574ce5215f5999b2900f2dad21acffa6",
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "628eeeec13ba9ebf8c3d437f4e074891a6b50a5e5540a3f87efa446d": {
-                                    "6529553381": 1
-                                },
-                                "lovelace": 1288690
-                            }
-                        },
-                        "0400050002000602030300010802020402070604070002010106060402070102#87": {
-                            "address": "addr_test1zqq7pd4z6phw9z3xsgp3d7tv3n26sr8rznhq35syfzn597kc4dmptxjzyvz3f8hjgrds0yfj6nquzast4d3hh8erapuqmlz64t",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0505040307060707020404070300060607070000070201010703020001030200#56": {
-                            "address": "addr_test1qp524epvdp420aa7h5njhepkz2vkq42fwnkk5unhfrg0l8z6jfjmd0c4c7u0v4d6luqdxw20g33eumt8dec7cfvu855stp6xfq",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 969750
-                            }
-                        },
-                        "0604060101070103060807000201020502040205040101030704000503020005#94": {
-                            "address": "addr_test1qqhy0hehkhln2qjzkrtq9e82rd70xtvc3y8cczaq5rllfj6fq2hauk0j5g2v43wl4dt8t3yv5kf7c9xc8al8mylxwdjshdqyq8",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0606020303070601070406000602070104020500000105050804070800010003#48": {
-                            "address": "addr_test1qpaj72pmqxz08sj7sjp049fjt66dhug32z4vgq04g7naxj7xt3e24qz3q84jhg4g04hhymp7phlr4uc98hfcf8yjtxwqlf6uwu",
-                            "datum": null,
-                            "inlineDatum": {
-                                "bytes": ""
-                            },
-                            "inlineDatumRaw": "40",
-                            "inlineDatumhash": "39df024ac52722fe8ae4c1a8740e4c5624a38c3820e504a059aae8728421f8bd",
-                            "referenceScript": null,
-                            "value": {
-                                "ca38aa408d5fc9f2da9489d8abbcfaa95bcacffe600fdf7cbb3d38a5": {
-                                    "a8b1a348a643a5b8db8d": 3421622777458417656
-                                },
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0800020608040004050005050308080704070008030508010407070007050500#92": {
-                            "address": "addr_test1qztj98ly8hr6mgy8h0c0aqrjmhpq2ltah8agwktkl5zgjeslhecp78rkp3jkusw7fz0sxmzlrq298davn4vrxmredwcq8dy6pn",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
-                                    "bde6c7631c3cd208": 8272568287728756242
-                                },
-                                "lovelace": 7500000000000000
-                            }
-                        }
-                    },
-                    "headId": "06000101010800000405010401000806",
-                    "status": "Expired"
-                },
-                "0306050106080403030105050104050203000006000607030504060505000604": {
-                    "created": "1864-05-05T20:07:18.134329161228Z",
-                    "deadline": "1864-05-04T22:47:11.07226467524Z",
-                    "deposited": {
-                        "0102030006080200010608020803040602030506060102050304060505030504#16": {
-                            "address": "addr_test1wqhr4xsze07ll2ga5qnyts6efc3qyv8c0vwa7gmq0tasluqcveax8",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 849070
-                            }
-                        },
-                        "0107020800050408060503030104060107040107040707030608000107040603#7": {
-                            "address": "addr_test1yqkw53ttx38jx4kne4m6w8f7s8yeqqy7lmduaelrqr45047a3a0maacgea8csxjgf7paxx9kdskhezy8nz33m5pudx5sp3rcd5",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 969750
-                            }
-                        },
-                        "0107070606050001030207010503080005030706060005030204010301000401#19": {
-                            "address": "addr_test1wz9mjg3h46k4wlfgjwegr7uptrpp9d560z504wafsvcd3fq3fz4lw",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0200060403010306020705030104010308050605060400050404010105060006#52": {
-                            "address": "addr_test1qpjy73qtdqq8j4par0menre9t4ru5pd3cp0e7kssa8j220pwme5epppz374gswkpzqve20vd4qfq2zqw0pg7agtr2c7q64uhh2",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 969750
-                            }
-                        },
-                        "0404000708010406020508000400010205010205020203060104040701080007#5": {
-                            "address": "addr_test1qp5f33kxq54pd4387pcm6tecxfqu3utq3w0kdqctd5ve2dj00vjpkk3qeernwrquq65258yfhkuzrsxeqj44vc7ygacqf48ecq",
-                            "datum": null,
-                            "datumhash": "3caf849a227ab258ef7400089a478c89892aa96ed4d2c89c7aeefa5919924cdf",
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5": {
-                                    "47a290c15443c1d2c26a7f1aa48c0d4d2e9b": 7682511135823535977
-                                },
-                                "lovelace": 1379200
-                            }
-                        },
-                        "0706030301060103030706080205050503030002040504020203020803040407#58": {
-                            "address": "addr_test1wp2c86mdkpjlcfxtnp3h6w2wp03kw759w4q7sn4v6wsfysgyewane",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 849070
-                            }
-                        }
-                    },
-                    "headId": "02000605060201000608000003020000",
-                    "status": "Expired"
-                },
-                "0501080603030702030801020501050702040300000002030407020001050303": {
-                    "created": "1864-05-11T09:53:04.199301607732Z",
-                    "deadline": "1864-05-09T23:04:45.371580073275Z",
-                    "deposited": {
-                        "0005020804060000080105020305040806000004040404010502070800060205#2": {
-                            "address": "addr_test1xzpuw86fvxxkmcf8svxpu6sq30p2pnjv9z9d97sqap9gdhwuyml4hwhckmuuyqgwyumhpkgm6duhkjuxkf7gl5k2d9dq50ykcp",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
-                                    "cfcc902dd1207d0dd3ff691f08b3015766ac63766870bd41506cc6c6": 3917657049884154993
-                                },
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0008010003020308070804000107040100000004060601000505010507040706#20": {
-                            "address": "addr_test1ypfxhp7flupsuwxc7w0t990z0e0y6mp0a98ez073ewxpzsu8ajrxl3rrng7w0lq703903lcs7scwxaungfa76fard4hsphwvpz",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0103010603010207080708080306020004060702010106000708070202040000#93": {
-                            "address": "addr_test1qzndp0jlh6czknmpjlqszet4t4ajpkth6sk08yua3p5grwymn75kusnk5f3fxgaxv6sjhw660e9frxhuajqq5chl3mksk27mqq",
-                            "datum": null,
-                            "inlineDatum": {
-                                "constructor": 5,
-                                "fields": [
-                                    {
+                                "0207010408050108070205060400050503020207060708050700060604040306#83": {
+                                    "address": "addr_test1zppqg76cz94r668qjwnlek94w35fe9ttjvcl7el607qaymhe28sdw2ua8jc905lmhuulfxj7t7p2qqwseh59ynyq90msarxvsy",
+                                    "datum": null,
+                                    "inlineDatum": {
                                         "map": [
                                             {
                                                 "k": {
                                                     "map": [
                                                         {
                                                             "k": {
-                                                                "int": 5
-                                                            },
-                                                            "v": {
-                                                                "int": -3
-                                                            }
-                                                        },
-                                                        {
-                                                            "k": {
-                                                                "bytes": "4d7c"
-                                                            },
-                                                            "v": {
-                                                                "int": 1
-                                                            }
-                                                        },
-                                                        {
-                                                            "k": {
-                                                                "bytes": "bec56ebb"
-                                                            },
-                                                            "v": {
-                                                                "bytes": ""
-                                                            }
-                                                        },
-                                                        {
-                                                            "k": {
-                                                                "int": 2
-                                                            },
-                                                            "v": {
-                                                                "bytes": "a1bf37"
-                                                            }
-                                                        }
-                                                    ]
-                                                },
-                                                "v": {
-                                                    "constructor": 1,
-                                                    "fields": [
-                                                        {
-                                                            "int": 5
-                                                        },
-                                                        {
-                                                            "bytes": "eb44f118"
-                                                        },
-                                                        {
-                                                            "bytes": "c5b2dda8"
-                                                        },
-                                                        {
-                                                            "int": -3
-                                                        }
-                                                    ]
-                                                }
-                                            },
-                                            {
-                                                "k": {
-                                                    "bytes": "5507528f"
-                                                },
-                                                "v": {
-                                                    "int": 0
-                                                }
-                                            },
-                                            {
-                                                "k": {
-                                                    "list": [
-                                                        {
-                                                            "bytes": "1ab3ed"
-                                                        },
-                                                        {
-                                                            "int": -4
-                                                        },
-                                                        {
-                                                            "bytes": "658b"
-                                                        },
-                                                        {
-                                                            "int": 2
-                                                        }
-                                                    ]
-                                                },
-                                                "v": {
-                                                    "int": 0
-                                                }
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            "inlineDatumRaw": "d87e9fa3a40522424d7c0144bec56ebb400243a1bf37d87a9f0544eb44f11844c5b2dda822ff445507528f009f431ab3ed2342658b02ff00ff",
-                            "inlineDatumhash": "4ac26118b5c82093e81dd22ea247e4f82af78dad784632dd9c5dd7c318dd9222",
-                            "referenceScript": null,
-                            "value": {
-                                "8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3": {
-                                    "39": 525200960270043799
-                                },
-                                "lovelace": 1443850
-                            }
-                        },
-                        "0407070806070600050103060301010706020802070107050600060004060101#19": {
-                            "address": "addr_test1wzsh0ruuazcc5klqxakc4t927s8c3ss5jc42l5jt7uq9kjqqz0tw9",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 849070
-                            }
-                        },
-                        "0505010506000703030603040008030706020504060306080801010801050701#43": {
-                            "address": "addr_test1zptxxmla34wdrr4zqhqemx08tgh294kn7jrvgzkyt8sf8rfx7vvtd5ryxv9kwscd8q7hjasc0wpk0r5dzg7k6788dnvq3j84ft",
-                            "datum": null,
-                            "datumhash": "8c7b149f880b8834aa484dc54ae8a7618aa29a67abd1f727e277a7e6666bd2d7",
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "ca799843e54a3a2b925b3fea82c7d49115c08926acd4f52ebed9badc": {
-                                    "a43126df432144d4c3dd8259b579d6": 1
-                                },
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0806000001010703080600000400020304080400020400050501020400070506#43": {
-                            "address": "addr_test1xzz4fec56ftnt4a5njgr66a3jdrumnmy624a7w84cv654kmr3uujaf44vys90j5k4u75zaxsnm7tuzuyqkuxzcvgqjpqaqg2pa",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        }
-                    },
-                    "headId": "05020002080401010103060308060800",
-                    "status": "Active"
-                }
-            },
-            "tag": "NodeInSync"
-        },
-        {
-            "chainPointTime": {
-                "currentChainTime": "1864-05-12T02:20:21.080640231131Z",
-                "currentSlot": 4,
-                "drift": -4
-            },
-            "headState": {
-                "contents": {
-                    "chainState": {
-                        "recordedAt": {
-                            "tag": "ChainPointAtGenesis"
-                        },
-                        "spendableUTxO": {
-                            "0001010404070107070401020206020206050006000607060804060203020708#46": {
-                                "address": "addr_test1yqcy4va39grx53macxn7wtp2euztgvnwve5qf9gdq3swptveu9lyggcpysn2wnu3r2uryd543q5usnrk5jdqj2w35gvsl0qcwv",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "lovelace": 7500000000000000
-                                }
-                            },
-                            "0201030305050303050506040303020801070106070004020602000603000404#29": {
-                                "address": "addr_test1zr0qytca9u34hy3vgvzxm7h5f8wjcpm77tlw0sdtqas2yum496rza8mmuvjwe44xa3fm42sddk54xrn6758w2zt8h7eszrl63y",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abae": {
-                                        "082b448995164ee245857a632b80c6334e4ee2": 1
-                                    },
-                                    "lovelace": 1202490
-                                }
-                            },
-                            "0208080401030207040007040703070608070702020808070701070508080705#63": {
-                                "address": "addr_test1zzsutzk5xf8kakvxgheg5w8rjm7hjxs2fjvy8jxgc6a9atsuvuyh7rr3vkhzd6glh48v33qyla3uv2n9l9qa4xhqsgds7a4yrv",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "lovelace": 969750
-                                }
-                            },
-                            "0302070208050804060300010407010306030405040106080504030701020705#29": {
-                                "address": "addr_test1qq0waddqh9hes0l9sphg2ghnvd3fcst5pa2hqy288ltzjwjk84zw9geg2etfavv5us9n62hqc6f6n3vr5de5ynqq3xds779k4e",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "lovelace": 7500000000000000
-                                }
-                            },
-                            "0501070505070404060303030802040303030203040606030501010604050700#84": {
-                                "address": "addr_test1xptdga7ja6hlwr2yp93vdezrsuwt2x5fwu9w0ygqzttmqf7vyymskuswuclfg9deuatw9ka8gq67susy8cvuutg2gy8qm83k05",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "lovelace": 7500000000000000
-                                }
-                            },
-                            "0804060506060104040104080808030507010606040706060407080508040303#13": {
-                                "address": "addr_test1xrjkgfmx6fy757vdytdq8sc6shkuuu5qr8r2t8hu3h6dwxhh8h8yqjh86a6sql5quhgmrjgdqdevy7m9hdfp6wwkk5hszz4lp5",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "lovelace": 7500000000000000
-                                }
-                            }
-                        }
-                    },
-                    "coordinatedHeadState": {
-                        "allTxs": {
-                            "0508070200030008030401070702050004040402050003020801040408040604": {
-                                "cborHex": "84b000d901028382582015d31678627f8ac61cc48b46fe32fe51bde592d8733d8dd101dd1a0fcd29956b018258205f405db14b8d818bd8690647fa56b4580c8795a87941f0822f4162c5f87f9c9901825820f066231ded52e6864bfcde44841082d69e65d25ae28d875a7c8b0f5c0b47f6f80312d9010281825820404204a324ea566aed341a1671ba74f830fe6b974d39220baa8062ed4dfec2aa020184a4005839101cfa2402d811d18e1a7a5e0078e29986a57c1970f340795cfa90c1da3af8ff26f2bac0e8500cdda215d4fb2c066795c3e3d675f6bba6433d018200a1581c4ca186432a7c5971f5029c05c9e1e558783bbdbb1b9f6140d135c1c4a1581e43c82cf6ca1dbb2221924d51c78ca793441458eb51206ed0469399d317a301028201d81843d87b8003d818582282008200581cf26988a60669534d9edfd04176070d77f69eec4f2edde4c8f818e13583582051e2593092a74dec49fa35241db02e9c9917cc4d06d1091298ad888427030803821b7136338ab7a42e86a1581c105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5a141a61b33f3ed8371177acc5820185046929ba7291a2fff9f386cc16e5344a6337fa2ddfd45853304413a3d9f94a30058392164e31851828fdef1fcb949c37f1f3030060a5af4f6bb4cc70f5e77bfc30c7c48a4060616ae50e9402158ddaa0e17311b08d0600396998b6f01821b2a7d3795f25165faa1581caf11ca1f6380a4acc3ab429f42dc2d738cb94bd8bca5d3b6f12b3c50a141300103d81845820082040aa300583911bd366870691f8a4a32f6369975f1a92fa77f1988c1ce3736ef65c42bea16bf095ac87bc5e7011e622570fa8ac60f7c3f9d111f31fbacb49a01821b59cc60a4700e063aa1581cb6125f2b744b57b68b8d358783524cb1de85c4212365c6291485d531a1581ab4f7854f3a6747473fac6570e9f5982ae2fdfac0fe8dce5bbc701b5c67d39a91badccb03d81845820082050910a400583900515bd86f2c730c6b70241da3520977bb3c447e98a178e94fd57fb923b9127808fc7737ae1897db0e1ef3b2ed71255c51b094e097323fe1b601821b3c44f2aa69e68885a1581c08edf1a49248ed2e1be2e83c99e08ce88130454400c722926c8970d8a14131010282005820677d45a0c8af592c3bb70308b95665b288292c6cd7fcefbfd6046f8128be2d5503d8184b8202484701000022200101111a000a68f00202030104d9010286830f8200581c2430086f04896dceb9d6c8e1cd863d0ca65800feb2917900022e7dcb82782a68747470733a2f2f302d6b6e383339664845494b2e764741567550737247484a7134644959692e636f6d5820aac5c3c59d1d5bbed7a450324fb01c94afdf4f892948a41c57caf2586df260cf82018201581c47eebd51a86a19791b33e7e69d0a8e3294ca240b445e54a1588110d982018200581c1dc84ceebd9b4f30c381053bbbd914046944e90e85b039bf3b8292a0840c8200581cc024f070b2dadceccd147de72a78eb5a1d1016c308acddb5edb902e281021a000bacf88a03581c2f9349868cbfec2cfe06ae9cec5b09563b9cc85db61f9e32056a33ee5820c51a6c46b593b040043310bb2c9c375ddcee83e8c71f0de31ff16e4cfcb10f321a000b4c821a000e4413d81e821b0fc1025b7f4ad2731b4563918244f40000581de0511f81c6a77dec6387808c2e24d8c94d6e5083aae479854c9a60bdaad90102808182027559504b454c503535796949523449495a592e636f6d82782c68747470733a2f2f47707a764c632d4264323961456a7952314b6f444f374d544e457659507a584a2e636f6d4603010207020584108201581c78c3cc3254e602e5b60a793a8c5b4299c59371b8f1a2549772993aa41a0001aecc82782f68747470733a2f2f7954656a52795849506c5a7649667a316f6f344c426b6c44392d4e376c687669306f722e636f6d5820d528134b180619d4e2027904b0ae72b182909e8d5aa2e8b1635512fe0163a77205a1581de14a1cef175f4e0e7356261067e88ad9e23d7be429758c3e74ce363f6f05080109a1581c7a05cdf2483adb1016b34162b18cb3aeb739f344cc3cfa5797b22987a157a0d20bea25431d932776300d6c13f1642d42d5adc38d461b1d0deea521f49fd50b5820154ca9f6620ee7692e12d80df43589c53865aca431d6c1502d14c63e06de1632075820ed7528897b643b72a7cf3a57078d943b91ff6bbbfb3fc05c69c587ff8dea738413a58201581cd372b3db0d5078ffc16e4ab5526a287f17b725e5668ad91ce2d6c1cfa3825820b710ea2e100f0ba56534aba6343b5526b8f77c1f9930efa4c2160ca47070685d01820082783068747470733a2f2f42566341303257686f663051644c35342d694d3966633033626f4e74744d457a617059782e636f6d58207ab9a8930c8af47433f8d0c70edcce8cab4dd545d0fb7e54c23e35933f9663fc825820c42592d733c91375e112e1db569df5658647a84e74f55878df8d288ca22e8d62008202f6825820eb27ba4da973899884e7d73d9e941bdb8fbf1bc6bae7486857ba6d455b769070058200827768747470733a2f2f4a4974476c68414b46435a2e636f6d5820011e9a592b051e8359ebdecd1f2a305ecf590d2e6965b21b576205096c2861248200581cb37120c93a495cef8362757dee9213a83ccbfa3ceb94846349d1bfa5a58258200dc670578216d9e1908831cdddd9c3c6ba5ccafd2bca31329d372a0e6cefb35806820282783268747470733a2f2f7a59596c59734f4c526b516a677934624b6243713256494e6c654b3950664c2e6f68563664582e636f6d58205bfcaf8ddb2ea9e7dd816263cd7faf09f8daae0fc6d854af42a01d9b3a96ec52825820333d3581c014cce584b947a4281f5546660ab6c48ca6b1fc2e2ccbd27265a6b803820282782f68747470733a2f2f556f776e61673636446d71535556634356464758326a73697739416162556d4f3230662e636f6d5820ed84c1025fbfb40e39bdc99f7acc163fd8eaf41b4a61170afa55a8b992417b628258206232886dc2d9d0f3fc82e38da44e26cfc312a32761397fabfe8a9bb2eb19494f00820282784068747470733a2f2f7a7a446168796a7066337175484d4e794d525658314e35357a665172786732425932754d51474b674d354f32344e616f785156302e636f6d5820b54ddbde425afbaa6424f426084e0688c849d90b9d0a65b22fa1f2d4e18fcf5b825820b92e0eeceb80a2ab41675bcb7ba8b3e41a2bd1e1632491900874ada557f0a38c038202f6825820ea30332bfcd7745199cf5a770a8620aba5c9f9044ab950723d77d3e1e45f0ef206820082781a68747470733a2f2f314170325044797177494b4c4f4a2e636f6d5820cab7d0d617e9c62a7f14d1dfe1e53b7a28ec492b11949c0091fabe51664279df8204581c1570e74ec4e89638a8a8e00813ed639f34921c6644fd6d0266268c60a682582012a857f9857c02ac165fa0499b92bc7c72fcd25ee72378b0aa9cc2851c94d86804820182782968747470733a2f2f636a47767431673974737631722e644d7a743557635a552e757971774b2e636f6d5820b664b5e18d2caa9b149935c3356e1f6a78fcc75c3765372e66eb4f1814678ef5825820281d7d36d983977cea87d563b3c1eba1cf8182abb518361b766faa011997d96b04820082783a68747470733a2f2f665a5664627647734c6f2d706d624f306a614e6b2e384733627956644737492e5971444679626f55397a746e6b6e2e636f6d5820fb428fab41bba0b2275eab302add99d1e9278ca69557b3e1d08faec5b100992682582047a94689f8b8fade428cdfbf429479bd0b60cf4bde96e6c005c51decf948f148038202826e68747470733a2f2f53442e636f6d5820bb06355dca700646877d459628f08ff722b22b69843a1de5e44a47f16d76f63a825820634a2714b4996a7465f3a21f2962f7d70f1f4cbd5f96aac989dee820bb096af605820282782268747470733a2f2f3261504b36387979534b786e464a414b6e4a697741502e636f6d5820cea395626cc42e6ab4beaaf815b290db0e0cc16b123e7cb413db2f2cb3ea7a1682582065c55916d4c6d95738ea4fa7f4ba92898afb58214311b4adde628f5457fecc90018200f6825820e0450485a45d055d11c78be52bf08eadb7e23004aa0e3bccf054fa32f02ba00408820082783768747470733a2f2f4f716a3367733763775438773937704b416c573151524a64362e44695073366e433879362d4c573870577a2e636f6d582075ef35b4443a9da3615047161990f4a480f2a680a07f6a3deed4068e51619f048204581ca14111e3cf9e5505fc090762d75ab5d8dae78797c0fd4d9fad753c3ca482582091f7f6be15dc9bdf2397995aea9a10bc595962f751d137acbaf2d97e9e02c52b078201827668747470733a2f2f494630636858583031772e636f6d5820f8a91ebed5bc82153c83f94c892723a74e91de58f7e9bebd4f915f6298137d79825820c3b58c4f9e6eb553b0086ddc704d9cbe4a4a0d0ecaac517cf812e54111d2c5c1038202f6825820e20077168742fc49598bba258fdff08455dacdfee3fe782c456d597c05a9ee61028201f6825820eb534a43804502a4969069c12b07d06e6562d22659911cd3e3b25633014b99d7088201f68204581ca19c47fb4aea0750b40949f615515835b89e9690e9c4a9a595211e9ca582582002500e17efd88ae37bce968652adce6e3c5ff1298530330dd2c06797a56accbb02820182782368747470733a2f2f4e4a53446f55316e6c2d666d44424f7a466b38746f47322e636f6d582091a894eea624a0e71a2debcd3d0fa2acacb24dba3b2b71abacb581fa7f963f1c82582042d21eb3b6122ed61556d65f986045693c8b9a28e1c94e451ee1b4a4bc66bc8f038202826f68747470733a2f2f6751322e636f6d582027057a38d1be397776d2675815c4b5057cc56314f4b46ba303c48b8011ce22088258204e0c18077a218fbb95d84cf222c7fc665b3573ce194e34cfdc628a6f2d67b92608820282783768747470733a2f2f726f79746e4277572d4c76762d74614952474c7651554a58747a734a706c4650364f4d32694a4c367850362e636f6d582041b65ee71ea9436a984a37db18ac1ff195e86d23fb56ce119898593de1bafa41825820b7ec0581707f3dfee45a31eeb905ce17ed52125ad80ae55faffbcc5048320dc7048201f6825820e35089a49651138cd4b467e4275fc358258d73cc84dcd679b85be94b33aa0ae3028201827568747470733a2f2f324b5768784b58366e2e636f6d5820cac920e0dcd7112b1d7d5af6d4121e7efbdc503196e030bc2f90cd26bdba6b4b14d90102858402581de0c2c20f2e18f1a0a624600e43e7d2aea3984c05476690580cb0f0dfdf8301825820e58a44a8905e87b3ade471666aeef22ff77c8529f98b28a06338463a180501ed0182090282782d68747470733a2f2f486f5a787567505a3039357442653349797065386c664446614672786f432e39622e636f6d58202c46649917a8a0d8df24497b8a61d0358b66d8d68b4fef5e5d0d261e3e3ac9c2841a0008c277581df0fd499624fa7b86c847587c3a79b266f94dc50e9d1bbea11f37d057478302a4581de0e2d0c0eb4f4e8cbe0606fdb7bf09da416174441361c271e8ef30446c1a000c7b54581de0fa31c7f093afda4ab67eb1f3e8b4bd6a8870cf0fbc00c104f72808e21a0008b890581df170d93b24cd0054bb3edce4d144ea85ba19458df5c8545a35f2be2d1805581de19d0e4a5d484e9286f7da0aace416545fc0049e7da634a10f86dc2a6603f682783168747470733a2f2f337464797a58476e3736333352654750794f4a524f644b69653537624863562e51452d43442e636f6d5820192c32f0be11d42aea88cb1ad51c2648e1fb481ad21c213d926e9639bd7daf17841a000e093a581de01506145869605153ba2ef3d8e3e92427e1a50ce584ca7dd660d6f18d83018258202a61af3a1b13e3c66a49a3d41c5e86773d34885817dfe943d2e4285bb171200705820c0282781868747470733a2f2f686b4c6955527137454234572e636f6d58201f768bca07913837b934ac2778aa5a92dea40efdcc05f1643755b5cfa7e1fae18403581de0f55cc416eca4f8f29d4488401456c379ec9aba723a52e2b27adf6c64830582582026b6f9695f0c1f9bf6cac71918c321043662656d123dd772799b3aadb37ed2020582827368747470733a2f2f7a54462e4c346c2e636f6d58205925cb0ed4560ab81baf2fd63f85f2db62fba8680e94e235ea6b6407986a8d7d581c647a4e31eeabef929698280b2ee53463ebf725284246216ec45a153b82783868747470733a2f2f416f32352d7866574133754b2e61496c6f4c58562d4c42375a6e336157655a764e3258675674644f3559304e2e636f6d5820460cee08fa53cf87b2f8b07be5eafeec5fe4ace48513b53dd1d158d11e301b938401581df029a752fdbee04da7203dee41a878fad89db18ef94ba3fefeb6a528ae82038258204ad7905ca65c58c1669325d0f119a6163d1582b2b730a2a5a7c5fa6a38fb8a7c0082781d68747470733a2f2f77654774575157306a5761617259764e4e2e636f6d5820a4183894f713ac33fc3fc71c2336a5dc9418fffe471c6857053c79a4c09ca4191606a500d9010286825820bcf90ae9fafdbd15821444c75350681a0161241ce71c4172438870d202b2229b584086e90bf70f686d56c011614cde94d4d91e16968c6193fbe10df20950b3f22a07bbc0689b334c7ba55a7195b1a8954bbd18ea68e5435dc1e40113adebe5d2065a825820fd3d06cc84159b1c6661497a16a8b617a81e4b18c71b778e6921b98f8a09d0185840caa48f33a9e8484328e99c7db23ebe230046af26575da328a47c3c98823dd41640eac156b1dec873999b007ca7962ea5cd1bf774114528d7f531ae3505399d16825820a7f73bf072b89ce5c89f2f034fff1c16b10601bd6836f7fbc92ce62b66764ee358409af4cd5e252e3441b1205c7f343f6ba81e2fd33cc48eded6a8325f1e426b71099f47fcc09cbe4ca99da8d8952cde6f912cedb83a0a65680852dbd894cb1f74f6825820864a2d71f3592d704aa2388bab345aa5618e5ce41ea912c5410b0930812d70df5840bffc88100cb824cea7e417d27ce2f191122558db0e5ee5126678b7b63faaa2171fdebbd4a177c3b92613eeda8f4bb03571922fad21431a4f4505c34cbe09204d825820056f923f53bd8b51f9c982f402b4c7716100a2a9d6fce734f764b33f9feb73e4584069245506da17ccb8346a46e12a671ce151e62c417f42a7cf737879bbbf1fae5294054885fb9d4fcc3ead30b6ea85aab3765e0867751d7805acb728d4a842ef01825820d12779393a28412c30e6adbe5bdcb29825533091249d48172005ec4c4f2ce8da584052922d63e0b58d1e9b01175cfab1072d636407fad6fc290cd1fc78339fab60a3ba02a28c73bf2ac5358f0be2765668b88bdc3fbf1a45adb9cb22a4742cf183a802d90102868458207629bb22126bc7a75300940e532f328b5facec902fa8b464113af2d2d157a6885840e55e57004a1557d3d56537c36d5ef7d2b6d77139463e85bdc1b0a762515c6b3cb838bf2ce2f725e406dbd1cc99cd871c817802cb3d6e26a4293b912be80262c3582007057604edc1998c5164aa9babf4fd7e91b1f94e485dfbd9cb93d704c119c42e408458204a37eed79ea29a65b7ebe603e61abaf5587b20456ce9fb5193d0593b971cf1545840d4417baa0761fe0f33922402cd2e2697b04407ae637ed5274de2b1b5c08ec84fd09917ee5e1efef3727956ff3d878ccc8090a33fe9f0f86d66be79278e00a38e5820a4991d3bbbad9b2768efc3a4cf7b15e01dd268ac6cf4aa858cdd09be6da5d8464084582077e66dcf185d8da1d675971b7c1de29fa09592ce00b2901651911ca38e14872258401013c0dec27c4e23ad257e339f28b87fd9971e89ae09a88f2c0f7ac9b2a63fc5241167ba92ed27e7b2153e02416e2351a7fa1c6a6e78d4dc584ade20bbdda64a5820052ecfc10de929244a89151d78e67142302a1b0c06950cf2df262f3bd04111b94357cb43845820061b657a4aa878657d73b028661d2d80114f8b3b88342fe1cbc49471fc65acad5840623045b7a35d17a1e2f24d48ee44552f7ba4cc7745ccea1e26a405a7b4ac2d49bc7e7ac955f7520a05557f907c0642869e8390f2fda4f5c7597ff0502af84b8f5820751343e86eb289b49dcb8d8a9a37fe189643d5366faab417e0ea0fa0daff022741c28458204eb19889ea772703a12a9dcad9b996defd3b9b232b3e229f35dab1eacdd2c90f5840d65b1851003aeaebdc180ee36c4d61540d949568233da8b3a62789517f2d353d3e4c052ceb723d25b55ede36fcbdcfa231d4583c02bdfe3eaed770c19f7099eb5820e899d60785c61cc653a2507f56daf0d53c0182eec233b650b5646637993c25e245201837cc0c845820ceb2408a42596c17ebe9ec556470d10b1a8cd44a8803e4b289aa0f9d8217c95a5840eb7646761ea40377614e17c186331d84a9de007aed63919c814f4b8b94c58670f43130dc3e2f2d0a8139ca5fc8e9c2edf43c3853ac12e6151a2756f5ef1b4a205820dc61e44fab1f8324f760dbf7e747f304744eedba8735be14bfe1d344f99422a643d2a2af01d90102848200581c4ac8615a643c8c52aa4a10c968eb0927e44a9f540160120acb271fbd82050a820402830300818202848202818200581c580d54db42727e69c924cb7bf37874e139833121641cc82b3af3e6488200581c010fc01d71d35d934751147a586b9ca715cc3287d07c9ff3c9f5a8038200581c20fd0c199f0ab7ebc5187e8767f3647287b7d9d989c5b539763f224b8202818200581c3577f8a81cc32053c0d9c9ffbad5bea29d63db446db2bba2a2c12e7403d90102824847010000222200114645010000226104d90102869fa09f42db4f4469237a0522ffa24324fd4d9f000004ff4215bf0141aaffd87e9fd87d9fa34485e0f12f40417002417141569f212140ffd87b9f4440025888ffa4054443c7e8692422429ae504442fc148b540ffffa520a04485892b75d87c9f42c7b0ff441e674c6c9fd87a9f42b92e23ffffa39f23ff412fd87d9f413fff44b387d6349f02ffd87b9f43d5b328240021ffa14117a0a09fd8799f2043ca88e020ffd87c9f2340ffa00440ff02a0a30280a2219f434c0fa9402400ffd87a9f44edc695b8ff9f4001214179ffa541f323d87b9f4280690241b203ff9f02ffd87d9f434eabd602ff43bfaefc9f4183447659367f43df6ff704ffa101420dbe0144e260a2564475917bb200f5f6",
-                                "description": "",
-                                "txId": "1020bb48756185d8f3e94ef2b85b30f2271fe476b4f87bca5efac1eaec0e42b8",
-                                "type": "Tx ConwayEra"
-                            },
-                            "0605010500070002060700080607010008050006030102040601020801080305": {
-                                "cborHex": "84b200d90102800dd901028282582034e81adce92ac201ccc0e5d2f4bfc04e42ef8a91d12d328055c1b1f4cdcf293902825820cd660f1c771f2de7bb6b91a327bc7cfb3d059c18aedec31850563e805352a7e80112d9010283825820406b7edf897817069684f33e3acc1844a65e9c2eb780175f982136477f07adc001825820634dd1b46714e9cd34556e51bd55388f31bf176d910a0d0bf47e97331f8da56604825820fa484b173011dbeb2f01ff8df2d58c54815cd03cf3e81b8a2a91cfbe4a818018080184a4005839117629b993b08aa73d092915f464aa9fcdfb302115a2fb266e45b79d53b8fecb3512a54ccf6354b55698d2237ada728acdfad012ffad144cb201821b7396402b080c8ca4a1581c245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abaea156ec6f0fa81c7287f6de8f708651abcd625686bc2c3cbd010282005820b026fad4fe0e287235c23e425f30f682b7e879bccf32c3a93485c7e6dde24b3203d818586582008202838200581c58afe53355576e24fd2ba160891e1c1e71d07fd01dd57bcd61a89ff68200581c2b463c398a4c9869fe733017d5768f3af93d75de2257608d7655d0678200581cb05112b7d9b8bb2d18c2d98f957c73f5939f7d6a3edac9f6e67978bea300583930bd8a737335be1f62f11e78ba4974a1dfaf239a8b706a5544ecdcdfd8ca65edaf9551ee8f63cd8f9c7384d3e10745dc18174816731df3d34b01821b4076d07944da5f8da1581c769d4e06a97d3ac1c13e43f721151837aca90ca31fe63dde2e9ccadba15166d788d709ad5716d338cd4a1e1c5475661b2012a0a9241fe09a03d81858f28200820184820183830302848200581cf33c0d74b81746396204b841cddc9cea5d8d785fd9bcdeb6c59506b48200581c38260a6629c02e1fafd7bd797ecd268e03b1a780bc1fbd0d691e15ec8200581c163562f280474b49f21a15c307432e9b31980d5be0dc309f9d45fad78200581c5f3763308b6c032147f3a789c5b9037f23d43efd3295d6464d17801f8200581cfc622e522a6b8aa44b85c132dca1793a9c489d12ba0a501f3f886d008200581c799f064b113d8bff4a0fab79cc790204b7b67b84295dd1158f10f6f48202808200581ceee529d7922e8375d9b6d380d4b98f70bd932ce5a79e0228f4991657820180a400581d610e15eacf2633a133395cd804c5c28f7ebef0114d374a5850b6f605d301821b121801eb7878ccb6a1581c245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abaea1521cbf5cda4b2e1489a51b7fcb2ed51b39d27701028201d818444354243a03d81858d9820083030183830302828200581c54cb488424902b8f5e898722b0154e993d706dacd504019738c083018202808201818202848200581c9749fe24d0172e46f8151593f69cecfd205430386fb259fe70c63d3b8200581c591008be0b7da32e9ece4c9137cb15b4f7de2a800cad77f28c23fe7e8200581c18f5af4c8b0b6190c0aada73fb8565899ce6f6bfca195432e73470868200581cc8c930d1e1f282c4cd63edf5c2acb051a490e69165b5b83dc6f217a98201818201818200581ccd6b9c1ae77d9f74979d9bc500eb742589afe2c7170bc1849d24fa4fa300583911b2bdb372462e0c47ceb3ed6cf3fa54b60c3694f82fd475c7d4f125923086e41ba827f0989d68e71b0d6fecd8249b1658d39df4da7b336fe301821b65a466e764f37564a1581c8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3a141300103d8184b8202484701000022200101111a0008174b0205030104d901028583118200581c45607eebc90b98ea3207ec8f0031315f09874a96bd8404021df83b5c1a0005501783078200581cef41548c7cd23b8cd1e2b7a2dc94cd74a91516c47d93c1c1a83997d61a00043c1c83088201581cfdedc233b67a3daffce72589302175ee1f568305d6fc62614f96025d1a000a6f2883088200581c6bad763db4d321b1003f7c3e4d58a8b595f0c566ec6e9f522a830a6f1a000ce2a283078201581cb85b9355a08decc4db59e8505f78b096ce0b407fd5b47b5bc7049c430205a5581de055acc310cbd8a82abb74949df09c4c3c387400051386b4557e60acc01a00034e6b581de05fc62c18173b5f9ee8bff25a60ca6d22cc523d654071d036523d069819f6a4581de133be7e5c01488392106cdde0bf137b65cb23e80021eacbfd304686d906581de16969f149de4489fbdc03aacc2513471477e3a4952129299ebad5b6be1a000899bb581de1dd76471aeff94af7dcad2c9fb1caca3d01cdb3a46221b3be20abc3421a000eef5608010ed9010282581c6d7dd8b3a8c1d0d44b2b930e1c90f15210abc613ff74135518160cd7581cfac3d9278e1a82b02b5d48f9e8310ea5e28eae04ca31f6c6cd6b98de09a1581c2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2a14856aa6123ee93ab1c1b16efe85ba397ee720b5820e21467a67ce56dbbf165dfb29cf9ebf8673065f1c12ceadbce37f455f48890e1075820feebc31f4406437f66381d7e6ebec3b6fa16ee38c4cb482c9f36ed11f40dd91b0f0013a38200581cb4ea02d89e9bbc15b502e2ea990ac1213b38bacb5350def86b3bc775a68258201ca07ead888f1d9c47966331b07b860e0b2cd0ec0617e892bdcf1f17f2a9524c03820282781868747470733a2f2f717a544d647438436d372e702e636f6d58208ae3aef6cc1e2c3b8ccd27e4670a48467d94e92ad4f3ae318c517f09077a902f8258202847c7835aceaf6894aa188a039995d7846e7bc862b7fd23bc4c04f96f92fcb307820082783f68747470733a2f2f4356475344492e5734636350744d4b483631706870354549657a5465377737523442384b56503234376748454667586336436b2e636f6d58201a7291aa2a4744f9464da4049abf281f2071fd014cadb840001dcadcf0d339268258204b2070648922a093b45286bf9675eb873302bf6e5bae455e4d359da9aeae7a8106820182783868747470733a2f2f4c6250357061384243567970525966704b755233486365537966623936556339663739423765414d2e3173622e636f6d58203e6a2ad7b0cd0fd529dd5dbb3c69a34bf6c48a3d1f8be9e53eba3d9d3a16e9d982582066442b8fa1ab2ce87108a01d68800fa0745dc059e2a2f04910f96b9f30edd61703820082781e68747470733a2f2f456b514c533335656a4f4e5a2d467a6f64352e636f6d582052c1835d1d86de0a4d54132e55c90a0c98010c95b7d28a3ee9fa3a940509f3e7825820839573ee0935fc8d9ec1b3392d35cbfb63bef32812728fc159a1cf0ecd7b822102820082783f68747470733a2f2f7a754146565169617255326d724c4d385469576d4d5164366251702d43513866373070792d304d5370537a374738613149572e2e636f6d5820971c9f0236fb064e7465663e3a81cc38da2156ad2ac61e30cde1f14c21594988825820d427ffecdb382f4db4673f56c8222414cbcda31da8913f0472b9a1501196a68800820182781d68747470733a2f2f395569634a4f62724238425761565278472e636f6d58208418b6d0043fb9cd22c17ac39339dee55752fc7165310d4a9ca82d0702b763e78204581c3199328d8ab7ad26d0aba9283af0c61429f8abaebf60b56781e88303a182582002e14d3d5284e360d365639f552163593237e216bc79b5883765b9f97c725e86068201f68204581c890f52b4a2058753a94c563d13c64e67fb149b76c13a788a5625f127a2825820c5b2f355ed590b83b13ebcf75fa74c7603f52e66dde84f9c148c1eb567ff600d05820282782968747470733a2f2f3841716479726c7a733676582e552e74415a336243693462693765692d2e636f6d58201f3746391ef351ff69a5cf99ae49c664bbfa69347f0273fef4dd528e9af78c95825820f37e7f7017bf58effe5da50f7b3e869c6378c2961fa6dc06e7db0bb92a89cd4f038200826d68747470733a2f2f312e636f6d58209bafca24ef44f53cc76dac9a39a51a583f5f9c6edc7607ad98d6c1cb80db628b151a000ea928161a000b8ca6a402d9010286845820632e72fa59a729253702d75ce657582c5d961c1957fabcf9ddd64f4048a50f355840ed77e12a5178db5f8dd1ef92a4a14a2e6a945c02d0c07305c20ae16bcde97485c37af03603d320749351e81a4416fb62d6178a2a4e75fed9e069fb71c467323b582064f186dfee30dad51c312264dbc74ae58050281dcb3696e8da80b051aa20aebf4517922722df8458205977e5d1c85ab06b7d673c195388adf225e3e242d4d224b3232bea16b38648c85840e82870426f4e501b187230059b5ca25148cc1da433b7be75cd81abd6ab53e7cd7145c419517bf3ef1a435e5668e26b5a7864ef0ccd8a76ef80020f97cfb716ad5820049417060ef0ad0d719e6a522cfbd45210fbb9d661fdf2aa4b282b89e6a5e0cc45c3aa460c27845820a06866a044f5c3a1789ec5a293d2e0a89d26b2099f389968fb52268f0dbc76e258408ff4a354906810ef2bc103d52131ee05a76168d7789b0941e310bd72c6b4b72822b271d45cbde07443b0c91da5a2ca61c909890c528e9f63f957be1f075ce8245820b0d591c74eda942be778d7e94f153e5c4877803d5cdf96302b6fef71824ef78f4147845820e6e689efa862230c8250fa7f64672df226c38a0b5315545ef76763feb086f8e7584096e978385dccc11c2a35590be55d499d215e947cb84ac80be81a993a3e852a63d77c52265519e0d6d1d90adeb5830c9589e195ba4877b3128b60718e91a2eb7b58201303b6d7b99408c29104a99c772c8731a56018b1ec4cbc963d3df0901a55f2d1457f7170b2cf8458204072d163fe2dffa7ccb29a4b500d362aff5af16b1a08e83a2e4d0df6be261a5b584019c22d0b993b7659cb76a2bd82837b937b4940478d5c7b5981d2e2f89458dee066400a96d1a11944eee2827d26b1c46a3ff4c8cc33005d2e72b576abfcecf9ff58208bda3fb7ec063248fc5f19e504c5d71596fd8f61f3bc26552cd270824159496240845820794610e4fd2d40bc10eec061258d6c430fa1a16c3251e8fd0ff72d1788886ca6584060edddfb4c55204ed22bb1edc0dce84c760d608dc8c3dee7878e27cc90886e8eae27b55ab9c30090da8f7e50dc80ca88bd3e75990d2649680029d8ebc6ab827f582070988ac9549496964137f97467ab108d77e0230d5153dbe11942ebbb8e602ef8444b0e265201d90102828205108200581c2ea2526e02c588f50bf9af18a80e954f6075bd7eed77dca4e2b9bc2504d90102840023a5415c03d87a9fd8799f20ff9f0040ffd87e9f0401052020ff4309868fa42101234043bc823b42683c0122ff9f05a5415c402442e1c30123034024425716417c9f2200ff40ffa304809f41014223d320ffd87a80d87c9f022120ff9f23050342df8a413cff9f9f412240ff9f418d44bcc41bb72322ffd87c8023ff2142ccd4d87a9f20d87b9f429b4cff80ff022405a6820006829fd87d9f411d00ff9f00ff419343251af1ff821b61c3ce977bade98d1b34d96fdbbb04ab64820104824164821b58fea088632c90e61b5faf60d4e169063582010582d8799f9fa20005024132a5040102445568763e200240400523ff0543fecb18d87e9fa14042b0f4ffff821b0c02bc7e46cf1c661b0c00c0c7c029d9a682020382d87b9f9f42e3faa0d87e9f418341d5427fa443fb023621ffff009fd87a809f22ffffff821b31514432bc926b531b40b740fcdcaa56168204028280821b28653d2d210d39481b1011bb3dba31634c820502829f05d87b809f40426a49ffff821b4eb275f6b78f92451b186ebf44b639f6bbf4d90103a200a3042109630b013c0d250183830300808201848201828202828200581cb2470ad466623e9989dba9bd4aaa2c565659b38a0cd1e550fb08a6bf8200581c194644f54c5daa214f7a0e4107eff2cd1d657f4e72129d5f2377a44d8200581cdbf0efe49d69c53c1038cb3aad9d85a6b423c999412f17b4259efe408201838202838200581cdfb258283ff6df9062ac8bbff8d615030a8b09445e9ad924c234d3c48200581c30264e1484059812c8761669d7a096f809f57be6242efa8f8f58a08d8200581c4b3b9294d41dbb8d251780cde5c7fbf1205bb412c015d714800486f6830302848200581c99959d2e2fab0e1e79962e3c427344a0f5a536cc146a7815a1696e0e8200581c66f349fb540c7d59ea299d61ce796974f161f355e09b77f6ec33fe7c8200581cee5084327c36896a0c4cfc97a428f6541b191325e00d3d76d5381bf08200581c84e42e7ff0ccceafd3ff8e8aa2b82470aade38c9958b549a8250b6038201848200581c09484ef18abba86b2c4d100612211ad9d4b9f3eeac717a770b5a7c998200581c62574b4572bf4a337be0398a2f41cb1b9bfa5b20a3341300a807cd858200581c2104c0bca3008cb1678ff0359bf9215fc62dccae778bc6c2302119938200581ca5545bdb766f95bb7585aeef3724178d3c4e0018764666c2cc93775e820284830301848200581c08f631e3955a8c20c06165cbbf76b68a680503d92d1bf732b5c0b5f48200581cdb96899570c7bd02c10fa58a1be456e9af0b8a362a68c4cffd3028a48200581c73a9cbd4199426a019a5c7e97f5bf76ca0af1822bebdb6c9865abbe88200581cbb0bba6a6f4efd17d6eccdda93ee94abdab27f75033e9997646702b08202828200581cf1119cc77128db2526cbd3ded8527fcc4134d15d2e8bb00f7ffe867b8200581c4e802266e4e6a3387fe871aa7efb1816e824050e70b5e67b19daa4cd8202848200581c285ec592506fb7929b1d616d6459c9f7511b7be9b4d228a9eb3c8c0f8200581c647b6ed72e1c8132577fd6cd1a7fcbaa3e20c19ff6c492e5d83aa75f8200581c6ab45e1212bb8bbf2c125a644dcca6771f339736e7401aeabbc9b8448200581c9745cdd06ca315f0d21bb17a2ed8a1e1fe7155ff849c31a61b9b9c198201818200581cf838d036901f1a48d5e1d0e30e8d432a95399ebbd84d955bc466d93d8201828201818200581c3701cb34862c524d0b60bbd713cee843147588507c3ad6b1c50600cd82018082040a",
-                                "description": "",
-                                "txId": "383e6289235e796b465ee993f739b8290fdbdb3256e4f60d59287a3736279ffa",
-                                "type": "Tx ConwayEra"
-                            },
-                            "0605040506000508010806080501040106050201050207080700050104050404": {
-                                "cborHex": "84b000d901028282582031359f74645bbd56d69d10cf564f7104307f9154040c5cd07822d63fc5a0844405825820c3815e7898a9e8c932c2db73c0711d1a6fcca4022c2fd48d2dd0aaca0d9a985e080dd901028482582063e5c7521c61cc3248a472a0c205e0466a589eb0051d91b963f0c291d37743e40882582069042e0051d4b12ea7ef02bf556b9e7388b1ed26619a9b263f0939639bbeaab20082582073aabdfcd40e883f57e7ab095ab985f8de09b37bc22d29175ae2f80ab5cdff8106825820b82b6dfbd36a79238ab6da528dc3418af21225a5c9e6123196637d192197b1ce0312d90102828258201d4afd92d0f211f14328c78860eba05a576301b4ff80a095b92461c337274fd0038258209a1d63d0223073ec7ce149c5503895d1381eada393449650aaada2e780bcf0a6050185a300581d7100f19f6525623771f979aea5ad4377a6532f9ab0cb8b3a56729fecca018200a1581c5828406db67b147c88771e09200523685b27f561dba33a217941179fa141380103d818589382008202848200581c148a34835ed8fa706ad787529b9dc8647b9fda934bdceb639e36b24a8201838200581ceeba400a5cfe28672dfda0ddea763f7416833a93417381ee71ab2c168201808200581c5752ef0f4df9aae3dd81e0aea91af494411131702be7c7e6c865d9de83030181830300808200581c3628d165b35f1bb4a667913517015ff9114321a2983148b124667921a400585782d818584d83581ca28a4f200ab9bd2994b103f7298fc4101a5875c6ec1dd12f8d06c43ca20158225820eccd6e8a616bab38a411f63bfac271c1a301f4431d68b6c31a10e4002e871d3002451ad161c366001ad0ac9afc018200a1581c467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22a15129b0cc047fef501f87dd98872950785a8601028201d818412303d8184682008205181ca4005839113828bb5c598834c6bd22682dfe9c1603f613093450da129c9e9331bcd8aa46917476f99286bc5673132b52a0ac27633f23a710f7b2eb475d018200a1581c2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2a141351b1488a63a5e7b38fe02820058206006ae6d47b27b5eb4bc65795616a904c13c54fb6ecde306fb14038c16637f5b03d81858298200830302828200581c4c3333d3e6c4128ff1032d8a230c0489b067a1a049742279256eed3a820180a400583931e190f65fae092fb73cb1e80281046fc7c69042a53afaf5721c6fc18821ff44643c8b07e5c861549db8259f08175c06ee3f8958641cfb4fee01821b5efc217c02159329a1581cdeacb4e082568870938cd94e4739c37d34c21a876c4447737a4b67bca1413501028201d81842419a03d81849820346450100002261a300583901a5e165794eae612ebdd9827c984f4b62d33819376cd44df5ad753635cb98c5df923a3a12922c0923d046673ade199dab02ee62a012ff5c46018200a1581cb25c8bef0ec993cac9314f8f737b63afb88c4f1b6f965e4194ef799da142adf81b63e4e6797be5118103d81845820082040710a400583911548b5b6e06846f2c68632707a637f4538efd15df3ec218ab9d2ee0c9159d2d27b8e435f14b87dddf312f1b3febc227a7e0ed66d7a945274001821b764da9cbe823bae1a1581c5ef4f41b81ec9fb84f5bed07805ec7b6b3282d183b851c3656bdd6fba1581a2236243f6368aa3a7bdbc56f64dbabdc662494248550e11c46db1b4f4f830d3857562c028200582069ab540cc6a857bfbb8914d363fb130135be7a389093b1afe504bd196347919703d81858728200830301828202808202838200581c0fce1959fb813a0eb2dd3238cbf538f600d1cde1beb0718c3ed8b7358202808201828200581ca985a6de45ea8d5f3e2bf47fff4f68a490012f89db4e558f1111b8c48200581cb7e751ac77b12217db6dff08744f8215f3015dae9664845a7f5980cf1103020304d901028284108201581cc23bd013bc9df2a053dc906ed94cb49cb284a60dea403a91c61daed201f683078201581cc8d17b8a67ab6275ed3fe8525da5b0676d23544ddc06384eba41e4101a0004f06a05a2581de00890d57d589c62849f394d8d0bd53d5510bdaf2f60569afc0e8ea8701a000525bc581de152fb43b58b1fc4d24237d05b856e6327a9a13c59f88c8224992a87031a000ee2de08010ed9010285581c19c78de70da1bd32699f7cf30aedd429d87b85a9bdb603c94be27697581c2f6bad47f2a0b97e39f09010a860d26cc888693c10e36363f80a88fe581c9bea0b905b58234511639b56ec4dab482380a14549c7573bc667c769581cb773ed0a650cb465788658db7bfbd9f025cba4f1fdcefe21657665a7581ce81a764a632f4a57f3607fadb06ea0475745fe4f84d3abe42895e62b09a1581cb0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165a14ecc083eaa61dd42f52cb8ab56deb01b41d411374baf0707075820728314f8957191b57df4902443a3ace134672ba31fd4c2c3d034dd468a0279ba13a48201581c2120b349d68ba79cf6af0b1817fedf1fa3a47fbeb546cd5d4ce6b2f0a48258200b8d4e36f0ab5756df905f13e01475f2d776a28d74aa027ba14ad7baced48aeb088200f68258203c7e6d841bc3c9ce35482686a8499f8ce23a38dcff9343f43f94617dbbcf68d408820282783d68747470733a2f2f43705938736335796262534b507069797350727a57344e48644e5132697071666c4e75716c7a767347667765417a73364a2e636f6d5820a3fe0a247b7cedaa83fa0dba53e1d02df6df0945fca534b1d761073cd0297b548258204b79ca7086f934fc4e20a4adafb9bbebd8da5063e4f4c591aed21a1a6893451707820182781a68747470733a2f2f2d5a435a58347845675a305a53792e636f6d582062c10ad9a9fcde9815610e71c583f71ce30c6e81502b7876d7513de2615c7eca825820c10b57aa58c0adeff29f27a0a82f6c01a608e26a86b8462591cdd557bffd63a604820282782d68747470733a2f2f55392e5343674a67414c354d4a48362e6f674e62706c632d4753765346387a36352e636f6d58208b6507fe7e021f19fd3439be3c7cd950292d747e5cc3144ff2882d3c9b2af1dd8201581c3c243c8bf4386f5423bb9c60267283cc5b63d571586cb6a7b4697f1ca182582074a4050594e89003bf994f899d03449cef9cc461f01f88136b1a50ab3b67ce96018200826f68747470733a2f2f6f2e302e636f6d5820b3aabfa61ec4a19b9bc4d7ecf392f0c572a66b8605c13c4d307b261f875151398202581c38a65f1fd4dcee9e2d7aeb6b1fc0d583aef361982297ee4651e9fcaea58258204591070ba731ce88f7e4751f08d0ecd52d02c6257ade5941ae3badb9e774126602820282782668747470733a2f2f4533446f6e6338337151444d31706b66445369576d7433716a692e636f6d58207cdfe2ec009dc9e48193f9545541cb033eb18c8683d91ca4769a22a487b2d166825820680cfce083ec440f629f6c6575aaddee016c6505d2a33d21e84c30965f667fb902820182781d68747470733a2f2f596f7452514b796e7153434750522e38622e636f6d5820dc0fd622beb5f5769485569eaa14f34eb90d83ce8e340f8c0f753b38090233a28258207d5738da090e6a284d281416ef279fe3f665e977a8632b40e92491c50872df4b038200f682582083e490210609f76fa5d4363a93201d78a5a2695974e409d15d627a395521699c03820182781968747470733a2f2f47305643694a3168636d6e64342e636f6d582043aad551911ae19002ef86d13dff82cd44ee7768e17841523dbf914fc336f965825820eab2ef26337b18eb025bb647553074f9523baa3066cca95e85da5412738b6d8405820182782368747470733a2f2f326e56477a346a686d657a6e4c6e2d35624e316561756d2e636f6d582012addb147a9a7cc561ab50735f02ea95f3643b6024f1156ad5a9d9bfc032168f8202581ca5f63796408c4a73acede2662b2f85a779e642da935224f9ad1826e3a58258209caf04c584a6f8d1eea5a26d16f583ae707377f9ded99644c3ba1698819a675304820082783368747470733a2f2f6879352d77554e776373374b53686e47386d49416f6135542d6c76677351493848313654636b392e636f6d5820397d80aedde7f40d99fd38749731c810d1873fed96abd11fecccf99cac6f754b825820af44e665b9eff98f11885e860529803013666135ea0406cf8eb431f8321eca2807820182781968747470733a2f2f316953654a74786271544774302e636f6d5820f479fd46fbc7e44a548dc0ba70f516a973ae88cd0c81522d64169a69ea02e97f825820dccf1df85e1a4ea76092019e74e269b1a63ddbe3e6ac4bb3b27688f259d6cb94078202827568747470733a2f2f49356b6f4b49462e382e636f6d582076f812a8e1d55daeaf45b9ef7e0b38fee4b1250a524b5a8542ee611db4156f54825820edfde056a9cc58650a8fc05250624665788eee62be797f584969a93e39d2df71088200f6825820fb275050fe4418481bd891cb1405f65455c3613740eb8d863b9993ba96d969d901820282783668747470733a2f2f7075784e466b6d44376b4f2e2e7554744642366b767030536c31674b626b5035483750577657716a30372e636f6d58201720a84ceec508ad92519d79c348f612bf543cac90ac5424977f1cfd82c3d75e14d9010285841a000a9c36581de09dbe3204cea66c06b56d152321006df9aa1692d1d0730cc0a1d0493b840082582042d4f2e3a2a4ef40ea72f744f7779d18691423c369ea77cfcc0fc4cce66a2a0302b60000020703040407080209d81e821b0c01907bf55d37d31b002c68af0bb140000ad81e8200010bd81e821b00000458e6b5a0591b000009184e72a000100412a8009f05230b022a292601032e2f06240925100c2d2e29040126222a03092f100e2c212f23090c2028090d0c0a0d212410010f24080a2f2028242600022b2a262d2124252d2f052f2a0d002907060b2100020f22072a0606052907002c000809242828222d052023040a2b0204020e06102f0a090f072c0a0823290e2c020d0b0720222423042e0c25042223002d012100290c2d070f262020040902240c2b0e040221240210102c2cff039f25242f10060a260f222a2305082a090c10032d05062902032b0c2a0309272f062604090a08232e2f0d2206210a0d0200002710102f200008202a00100c04210829010122222c002506012f290e082a2401290b0c05052d26232e0e0a092c0a2f0b0602262e270b2d2f0a072c0f0d0d0d08202d27072e0c05220921240e260b0426242503242e0d2510232c040a08222d052810222d22012d290825080609260f20280f2401072a2a2a2120090c06272b26100a052b232c2e26002204031027272e0a282f25260e022d0b2f0b0203212c0a032702280229072f20212d2a28282b010f07072e250c0302240d240e0b090f200800222a2d0f0a2c2928ff1852830f0908185c862325080c250b1860830f23011861810918da8018f38605020009252e1382d81e821b36bc9cd2a9da830d1b016345785d8a0000d81e821b097ac1fda3ebe9411a05f5e10014821b74ff9e94b9f66f461b17ac789c0da3090a15821b4bf377b718a08ee51b2b9579ac2fbe4db81603181808181985d81e82010ad81e821b068489e640bf1ef11b06f05b59d3b20000d81e821901d31901f4d81e82071832d81e821b097a640d5d77e24f1b0de0b6b3a7640000181a8ad81e821b0000006966656e671b0000012309ce5400d81e821901611901f4d81e821b0000006ede824c3f1b000000746a528800d81e821b00001743592aa1f51b0000b5e620f48000d81e8218631903e8d81e821b00000012fc0340871b000000174876e800d81e821b00000001b269e6411b00000002540be400d81e821b000000146f5827c91b0000003a35294400d81e821a09bb93e91a3b9aca00d81e821b00045bba07ae25c51b0008e1bc9bf04000181b03181d05181e04181f021821d81e821b2bc975002dc413551a0007a120f6826d68747470733a2f2f622e636f6d582056e4cc9cc633a3bcdb530b45855d049cebc63140adea5a3e4f30c376fcaa26728403581de09c4ff5d3426a50af1b42e020dea94de9b1240a9678a3491a698537558203f682783568747470733a2f2f4c4e335357686b516c555a423042306637514c4c44492d5061775647495268477141706767494555662e636f6d582081438409fe403bca173ee494030411e3ca1c4466f4ed0206b6d3b7b642f6ce708403581de15c6cb05d699203822fd3639c4d4670d034e11bd782a0309c027f0ad48302a3581df18b1781aa25c5e5b355162bf94ef0c9480e2daef0f7a916544c58353302581df1d546ddb4cb961af2fddf36bc8d14c14322f8b165895118b689e122c502581de11bc08755dfbdb825bf5ae1b141bba8493bd5ee8b63a3ae3b31eb30d41a0006af21581c05113c5b7ace2fcc073422444412eaee9e789b0fe858f3909a63466e826e68747470733a2f2f414a2e636f6d58208ae6e892a3e83501a039370405280bb76a370cfe907b910fadc69063a0fcabe38404581df121aad82fd2be1a6c73504ba6083d4b0edf1da2552835d944a265e6ee8106827568747470733a2f2f4a5054584e42394e642e636f6d58200aed5bb58e5af578dfe33041699b5436129ffd1a7acb7476faacef69ee9099858402581df059337d07cd8b9a9cdb1a72bd83f6693e9c84584ba20454880f3cc5068106827468747470733a2f2f684776526c7435692e636f6d5820c7838751d6dd85ad49d43453f2eb5af2fefda795593c90084bd0bed70f0c19a21602a400d9010284825820a154a2fce4363b487a2d753a3cab4d9105196d8f467a75b2ecc6fa0378ebc2a25840d9b4ae049805d80306d0eb6e3e55d542cc365da97eee94d2a0cb272ae4c812faeade08416056949c9fc0f30ad202a5c7fb951e612cd5946ee0d0eae16d26dbee825820b2a72ba2faaf8839f9e80803cd32ce48ce92d977144864e2ba4981fb0e3c99ad5840b913dbd107ab4e26ab4e8c74dea4061ef34305ceb3751b669d98ecd170d6d5bf28e98493c782f2425bcb1b9d59ad9ff0ab9932bb47a3438b79dfce5861bb65228258200335269e2443c93d4cc5e543470b97dd387ca3d28bd4726cf674777608e8340f5840149e6d8e222f6c2f53a054f6010ea5aea19853347904f06e08eeb2ba6d0da3e62c3e3d4ea4ffe7fbdc985d961949976c86b8f8fb2f5ebc78d7529cd2e020ab66825820eed040163ec5b5f53bcac0eaaf74baabada1bb504648a783961be99d147e6ba3584055f06c8f7be1650f9d40fb248a6c5fe13bd735e71e34107780d9f16978adc986f5f5ca8f6e21bb836c3b099b564761d01307b758066d92d987e9567c6cc0bf8202d90102858458202e69d24d1bfcbf0997db9c5535faac84e4a5eee32436fa49ce47ab786ccbb7735840658e1815c6959958fb8140b546aa8ce01e6d0e3e4d30db5bb642b75d1cfcad7d246dd1cf05c86c1fa605c21e52766065da36a26b3c148e5ddb047dbee3b387385820231f96ac7267082c0e7dbe1637a52a0c17a82fad134d8b07b5f09d368e05f1b94299cf8458207419f1dd5b0a292169069679a29d6e322b160425f2172b7e5259339da46187075840c7dac7a4434c61a763f62e08e314c47c55530a01541ed1565375d3640a2b31aad12beff63635e527994e7658f5e75d1b1a87883c809a1486cfc70e64596132cd582076833d39f6218889c2589853082b4437f4fbb5deb3ab63eed3a834449e49012b4279e884582003e1d750479b203fe410da5be7b24140d659ef0e68412457fe66000bb2ab436b584055efd24a170012948711103de2ad13e953d378337063243afebe59ba7402e4b059025687e2a4ec7729f8fff0587e375155791f14e519451998290f8ba1db66a658208f1c051b84756aeee64b0734d17b18d2aa7cafbef807e2436777ab037235f9d542b85b845820d518c9e5b988096ec786c2a6b176fc3c8a736cdcf71fbe93163dc122d15d3180584066db7439173a4b54bfb731c234247bbcff469f9da554e28adcab0101dde20a8a5d570bff27abb3ea3b2243ab687c32ecb57687fbb131d551810ec64c30ac7f505820f50077c13db071c009c7730fb152db6da28d44f5c84fd44efd06e62f114b20aa41e884582092f3b28b37499fa0cf9cd6e49efd5cfd03fa7c9b7e2b0b0a25b67826dec599ff5840f41da3d29b6f6136d8cd8e0250fd6ff1b222c17c1384fa5b18f04a3776798c59d7cc10cde990358cecc11145bf1da3d9a6e7df4bcc63a04c6b20c46a075e265a5820507de99ac81a7637a0f2cce3311c3b0ca17955626841c86d1dd700d584bf90d4416404d9010286a3809f447defc843ffa4d87d80d8799f014022432ad184ffa5024396b052032101220440430b008802424a53a504419e42703a43cf0308240343e0df600444b7317547409f436d823e24ff9f20ff2080a59f42eb6b2442417a44be83799124ffd87d9f050400437e51c102ffd87b9f020542be9f404200dcff9f2040002144bfc44fd8ff0240d87c80a143e7c62b40a243f2fc94418f040141c0d87c9f447c415e8d9f2244cc2cbcd3ff9f20ffd87c9f44dcb69a120321ff9f02430369f203ffffa3409f214428627024a405224309e18141b60042d039054135ff43a10e2a9fd87d80ffd87b9fa4004310425323230200415805a14425f8984100d8799f4375c1304041a1426a6141d8ffff4040d87a9f21a022a304d87d9f0522421198ff43f87ba543df9d4b9f0143549a3241d4418340ff0321ffa180a1a24432f77ff1200243dc57590444c8ea041f05a382010782a4d87a9f22d87c9f040000ffd87c9f4022050522ffd87a9f23440bc233fc044133ff9f449bd407d82201ffff0542321ea5809f429f55234002ff21a42120020440010341aca42444edaa284e012322439169d0052202a52042927d2141040243908c4f43fc76be40032401d87e80a0a39f214021ff9f41efff9f41fa42c18a44a9bdcc1a01ff00a09f22232243c194814398583eff9f9f2300240041c8ffa4431d214e41b84413a2e8860304424ce1416040a5400222438c99f843369bba20024127425cd844e65ab3ab4417b4795804ff41c89f8044a5b1865e4190ff821b1e40324ee052fe781b1940808c8e261a46820406829f8022ff821b751dcbc9c49934881b759cfd19360aea4c820504829fd8799f8040d87b9f0343f6554bffa30443dc2b2242b93d432249d303409f443236d2742222204467587c01ffff02a0ff821b252e410482266aad1b38f91479dccb790df4d90103a200a5008008a00b230d600e83406602f48986a200449e0de04e01838205098200581ca18f73afcdcfcf4a56c104691cee6ed5e7da4f08a93e57993423e563820180",
-                                "description": "",
-                                "txId": "13571efe3b5e99ff8e90317daf4a4aee0df18ffbd04d6a12cc9800f15fd5ad73",
-                                "type": "Tx ConwayEra"
-                            }
-                        },
-                        "confirmedSnapshot": {
-                            "signatures": {
-                                "multiSignature": [
-                                    "e39e346a5b07877c469c44b0172420795e9759ccf4a56bf5e2938794bad3d2c26c6f3bc74050e003dab50b7035715821cf73261865a01ed12a118554ee2e7103",
-                                    "8eed0eb67f8188c755ed5fd5cb737316acd19772b25eeb45c3cfaaf4cba5543af195553e982b82614bcb0a55240bb2b60a315109f6e1c908ed8d16881ba4dc09",
-                                    "2a727a148e6f7eeffec29bbd2fded3f167c21c1237d4a0970e52001f3ce22b899cf380a777046e49e5812ed8e89094f72252b7249e577cda04db80b95619fb05",
-                                    "a71c126ae14f339c9925b337d23dad3633df562088f56f1d8b82c3642b43f6080fc9b273cab964a28fb889e7d2059d3e41f804243bc38af0391bc8a0dbe6c808"
-                                ]
-                            },
-                            "snapshot": {
-                                "accumulator": "757b86f6a531d6040597af24c39795b19e62a7ffc757a0ce8d62d9948ab2a658",
-                                "confirmed": [],
-                                "headId": "04010005050600040303040707050702",
-                                "number": 4,
-                                "utxo": {
-                                    "0403060101030305080505010204030705080201010408050208040307050600#25": {
-                                        "address": "addr_test1qqljwuk0vdahuqf58vq7vpjgmn92mku9xtw5xlq9mkfus9jtl2cs3jyhx42st5ppzqzjtlvfn0hmz9347np4akygenrstt4mdn",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 969750
-                                        }
-                                    },
-                                    "0503070702000406040606000803040406000707020704080305060601030506#37": {
-                                        "address": "addr_test1vqrar59qfxh6fr4vpam4avu8jvjv2tkwq99r5nuxmxwtrlqytzlra",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 849070
-                                        }
-                                    },
-                                    "0504070506000104010804080300060400060404040807070406000802030001#98": {
-                                        "address": "addr_test1zq9kd3k47tkkgpy7z5eegj8cmeh0cfpt6lhhvyctsfeg9rhpqfe6wj54gr2qsdlhaxcpwd0wftkyspy6amwtlcer0t0sndgfys",
-                                        "datum": null,
-                                        "inlineDatum": {
-                                            "map": [
-                                                {
-                                                    "k": {
-                                                        "int": 3
-                                                    },
-                                                    "v": {
-                                                        "list": [
-                                                            {
-                                                                "constructor": 5,
+                                                                "constructor": 1,
                                                                 "fields": [
                                                                     {
                                                                         "int": -5
                                                                     },
                                                                     {
-                                                                        "int": -1
+                                                                        "bytes": "2406"
                                                                     },
                                                                     {
-                                                                        "bytes": "479960"
+                                                                        "int": -3
                                                                     },
                                                                     {
-                                                                        "bytes": "14d2"
+                                                                        "int": 0
                                                                     }
                                                                 ]
                                                             },
-                                                            {
-                                                                "list": [
+                                                            "v": {
+                                                                "map": [
                                                                     {
-                                                                        "bytes": "741a"
-                                                                    }
-                                                                ]
-                                                            },
-                                                            {
-                                                                "int": -2
-                                                            },
-                                                            {
-                                                                "list": [
-                                                                    {
-                                                                        "int": -5
+                                                                        "k": {
+                                                                            "int": 3
+                                                                        },
+                                                                        "v": {
+                                                                            "int": -5
+                                                                        }
                                                                     },
                                                                     {
-                                                                        "bytes": "037e5e"
+                                                                        "k": {
+                                                                            "bytes": "04"
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "17596552"
+                                                                        }
                                                                     },
                                                                     {
-                                                                        "bytes": "cf93b995"
-                                                                    },
-                                                                    {
-                                                                        "bytes": "77"
+                                                                        "k": {
+                                                                            "int": 0
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": ""
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "k": {
-                                                        "bytes": "5e3e3c37"
-                                                    },
-                                                    "v": {
-                                                        "int": 0
-                                                    }
-                                                }
-                                            ]
-                                        },
-                                        "inlineDatumRaw": "a2039fd87e9f2420434799604214d2ff9f42741aff219f2443037e5e44cf93b9954177ffff445e3e3c3700",
-                                        "inlineDatumhash": "1f91a2e4f0f6f890a14a92555f085e19a51d77e46d987bc5ace335843e627e95",
-                                        "referenceScript": null,
-                                        "value": {
-                                            "4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888d": {
-                                                "37": 4006066313178900331
-                                            },
-                                            "lovelace": 1383510
-                                        }
-                                    },
-                                    "0601010003000804030202030504020800080601060607040202050802050705#81": {
-                                        "address": "addr_test1zzy633wsq9y0g2cmz0ukp87q3yceg4yyvcm9yp2kv6f3uchrgke6zctnvc5h0zh6pjpew4tfdreqlg0cwevppu2c5asqlsry02",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0707040507020108030702050507080703030407000807050704010101060200#88": {
-                                        "address": "addr_test1qr69eymwlx6grngngac6gypgsd7yqn96h5e65vsgrxejuk3ntjyrzyacfjp57syfuqt74fxsa7xg7qxwcrp0q2gqks4sc4rpc8",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 969750
-                                        }
-                                    },
-                                    "0708010505000705000604070808040501010207050203010408080703030601#15": {
-                                        "address": "addr_test1zr7mdf000mmeuuuehtl7qf9vw8297ul8c6g3mauprqf0awqkvr3s0m0z29fks7qmq458mdmdeyxm6f3anpyxgjrqy4aq8gutum",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 969750
-                                        }
-                                    }
-                                },
-                                "utxoToCommit": {
-                                    "0000080306020500020103010203080401000002020400060501030308040605#31": {
-                                        "address": "addr_test1yzc50amrer26htfngqxxzru67646tdgpl75g9mfefgpkagpjv7m0hwhtx9d69h6lahvhf90h5wsk7ddn9g69nfdvwngqdl8dsh",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0203010307000306040500000406080601040000080605000703000402030307#12": {
-                                        "address": "addr_test1qq3ns3edyc785wls7xlyxv57t4xz8czjk8g9xlk045s8x7y0fac67t3ajdlasygg56vfwg3kpmqukly7ty3jkza9tgmstgjy6z",
-                                        "datum": null,
-                                        "inlineDatum": {
-                                            "list": [
-                                                {
-                                                    "list": [
-                                                        {
-                                                            "list": []
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "bytes": "19"
-                                                },
-                                                {
-                                                    "list": [
-                                                        {
-                                                            "int": -2
                                                         },
                                                         {
-                                                            "list": [
-                                                                {
-                                                                    "bytes": ""
-                                                                },
-                                                                {
-                                                                    "bytes": ""
-                                                                },
-                                                                {
-                                                                    "bytes": "2d73a8"
-                                                                }
-                                                            ]
+                                                            "k": {
+                                                                "bytes": "4c55afcd"
+                                                            },
+                                                            "v": {
+                                                                "int": 5
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "bytes": "5344"
+                                                            },
+                                                            "v": {
+                                                                "map": []
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "v": {
+                                                    "map": [
+                                                        {
+                                                            "k": {
+                                                                "list": [
+                                                                    {
+                                                                        "bytes": "866295"
+                                                                    },
+                                                                    {
+                                                                        "int": 5
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "bytes": "fccadf02"
+                                                            }
+                                                        },
+                                                        {
+                                                            "k": {
+                                                                "map": [
+                                                                    {
+                                                                        "k": {
+                                                                            "int": 4
+                                                                        },
+                                                                        "v": {
+                                                                            "int": 4
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": ""
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "7f241155"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "int": 5
+                                                                        },
+                                                                        "v": {
+                                                                            "bytes": "32914d0e"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "k": {
+                                                                            "bytes": "4727c82e"
+                                                                        },
+                                                                        "v": {
+                                                                            "int": 1
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "v": {
+                                                                "list": []
+                                                            }
                                                         }
                                                     ]
                                                 }
-                                            ]
+                                            }
+                                        ]
+                                    },
+                                    "inlineDatumRaw": "a1a3d87a9f244224062200ffa30324410444175965520040444c55afcd05425344a0a29f4386629505ff44fccadf02a4040440447f241155054432914d0e444727c82e0180",
+                                    "inlineDatumhash": "c1fcdccd2e5bc94a7a25636398bf5b64516c4fe2af0476e3a47bf2edf6db74ee",
+                                    "referenceScript": null,
+                                    "value": {
+                                        "8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3": {
+                                            "2baec64407bc91e3a44ebcba02561480193548e33257186baacd": 1
                                         },
-                                        "inlineDatumRaw": "9f9f80ff41199f219f4040432d73a8ffffff",
-                                        "inlineDatumhash": "a1fd14936ca9651f4efe27d747ee744282f3d56afb78c206a6cb82ed4b244002",
-                                        "referenceScript": null,
-                                        "value": {
-                                            "8f461954fe2f18fee1dca233f358907e643ff839ed1f995e4bf325e3": {
-                                                "17a164df618d6c1957a323d7954393fa": 1
-                                            },
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0402020705010406070008020102070005050601080207060403070607080008#65": {
-                                        "address": "addr_test1xqdj7zqscgttudsx7ts98tqlp69uvcrxztwlu7g6jpc5ktzdswxkfwd0s9gg8xftkfvy3vnnr4x2fsjfgya3nddjvs5sklae0c",
-                                        "datum": null,
-                                        "datumhash": "6b3f0eac833bbef2f2399e59cc7d6e8ea545737b3fdb3d99eb856ac71afd61a0",
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "2c73950550fa924b523737b8ad21d06a21cea0c20320987d835baaef": {
-                                                "33": 2406590807548094167
-                                            },
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0403070508040807080508030001000608070703070306050606030103020408#6": {
-                                        "address": "addr_test1zrrme3hwralmmh8hqsr5km8v3uqjfc27qcy3u02p00s49f5ns888xrx2yfshj7ul27g4wu26ta5z687zcumw3x9utzuqzxcgjr",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0503060101000804060008020306010000050105040208060706070806070001#52": {
-                                        "address": "addr_test1yqtkfgh7yfkx8jmnqqzajrql5g2xse74uhczn66td7ngsjwyv3e8l2rzcen50nmjasf228t6nkc22e5y6e0vrwvxlwxqnakv50",
-                                        "datum": null,
-                                        "inlineDatum": {
-                                            "bytes": "c29fb7"
-                                        },
-                                        "inlineDatumRaw": "43c29fb7",
-                                        "inlineDatumhash": "ee8dc169404002af3121b53f5427167ef94aaadbca46b7b8d6050787a02e5e60",
-                                        "referenceScript": null,
-                                        "value": {
-                                            "299adcc0567d0d6377f9dad287205f4d8132190cdfeabf531800793e": {
-                                                "a9dfd0b35c2c827b98146d64ec1d73e952c827c3": 2
-                                            },
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0608020702060408000506020105060000070607070005070302050102000108#16": {
-                                        "address": "addr_test1zzw8cvg0te20txvls4kpjkcex0g26sv74mpkvn3mt2u0k9kh60q5tyvtek77lvg0hg25e2gt74qcppenk0dhp07awtdsm04jux",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 7500000000000000
-                                        }
+                                        "lovelace": 1573150
                                     }
                                 },
-                                "utxoToDecommit": {
-                                    "0300050101030304020302070602050107060500020104050503020806050704#67": {
-                                        "address": "addr_test1yqlzz23txh3jlesex87ye2pdls82e69yc3r9tq9kjv996zsf6tzv3lx3nca4q4ky9u7h04mm2l3q90twy268kfxr50zq205vc4",
-                                        "datum": null,
-                                        "datumhash": "8700b14ad6e951b37cc008a29c6b92cfd4c2b56a6bc8a4cba9db9b4189613737",
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
-                                                "6f03c7d66e4e85c16f7c3225d9bd": 1
-                                            },
-                                            "lovelace": 1327480
-                                        }
-                                    },
-                                    "0403060404050001050300050101080502070406020502020700060002020705#61": {
-                                        "address": "addr_test1zr3tqqnt5gwpcfstlelzxtvmlc7x670dc30e68tksdnmnnftmy46g0mx9j6puwx7nmwdv3wfu64zc360p8jxmyp72phqq6t5v5",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0404030706040302020408080001000807000104010500040708010106000000#63": {
-                                        "address": "addr_test1zrq47a6mhrxdp5jlxydeq46n90a30yqdahzng20yg7lpql98l8pfptz9l06y0q3g5km3y4vpxeqvsvemp3t5nmsl7pwqvmgm2j",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0606050202040303000806070604040703050205040301000200040305040203#41": {
-                                        "address": "addr_test1yzn80djj5tud0qt2l7atv0vfx0r0vqanenyrzsp3u8dyzn09u2tctrsahh53gs8g59kj0xns8yrn92kcucqfkh3c98zs3lzyde",
-                                        "datum": null,
-                                        "inlineDatum": {
-                                            "bytes": "c7ac"
-                                        },
-                                        "inlineDatumRaw": "42c7ac",
-                                        "inlineDatumhash": "f192ae3426ef0cb94685c6d7d205b780ecb85badd06a3ec33f3cbd4fddd4953a",
-                                        "referenceScript": null,
-                                        "value": {
-                                            "77b5ed177562f34cccadb87c3b8a98ab6d70979f291a38f83e8c5ad9": {
-                                                "36a0686e81abc4b902f0fcaadc309ed115baf6e4883558": 4485110369558259514
-                                            },
-                                            "lovelace": 1301620
-                                        }
-                                    },
-                                    "0705000101080802000808070203060408080602050501020601060707000804#60": {
-                                        "address": "addr_test1zr5y9q7q6u2pfp94x6yj56yugc0gnvz3hd5u89tnshwva902e9l4ms9g39a6vej8td56vptj6qanv8h3fuwzd0gr94cq5tjx42",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 7500000000000000
-                                        }
-                                    },
-                                    "0806000206010802000301050206030702060203050306060805050805050003#3": {
-                                        "address": "addr_test1xrjmxh72nqnwx3fcf0yxwcn3h0fymqgqc3q4uqvel3upwtfz3e8kkkx7wzkgfh5l4yvuwpsm4yjux5v50sx09rkp5umquj5meh",
-                                        "datum": null,
-                                        "datumhash": null,
-                                        "inlineDatum": null,
-                                        "inlineDatumRaw": null,
-                                        "referenceScript": null,
-                                        "value": {
-                                            "lovelace": 969750
-                                        }
+                                "0306060103040206080808080601020405060003080504060707010600070306#2": {
+                                    "address": "addr_test1xzgflhpjn7nrplr6xjdty8de22kgzcm40w5grvl6hy3q4x65k5grdmrv2ux574knt7600n9avs80x0vgj408llpknxuqs8vm8w",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 969750
                                     }
                                 },
-                                "version": 0
-                            },
-                            "tag": "ConfirmedSnapshot"
-                        },
-                        "currentDepositTxId": "0106020705030803060208080203020301080604070703050401050604040103",
-                        "decommitTx": null,
-                        "localTxs": [
-                            {
-                                "cborHex": "84b000d90102838258206f31dcb30809a4e5193d12f4d40b9a1892163b8030a75c7ad93afd7563e671310682582092f4c4083a3ebb1b31761ec194fa891942d00a6f44f8466ff631e48e685285db08825820d9277a61a6bad3db248e33cb4a1039537808934f061b96b1cdfcd4dfa74a796d030dd901028682582041239b70475fc45752de6394ac356ecb806980ef6f155d8b14d8e5ccd876039f038258204f2d55ee24b871321d56a3a759ed3fecf7570d9ce3e94907b769457febdf84ea048258207882f62f914b1ea6029ff4433100491463811dbfbdb8eec71ffbda0e7f0ed375068258209192c5c263774ff2607cc3aad8ef9f53b26f4e95838f3658f6abeceb4946c32404825820d103518748886873c135e1eb12ad98d3b46c780c5d387781e38fadb8e4db35f305825820f1b7f958053759134eb11776605f7faa23da43a159bc3c4b011c7408dbafa8a80612d901028282582035a6410e007e8ce4885bc935b676e056ba1bb011d32d686643d7c7b964b33a6800825820ce9b338d8ca7b113723fc5d143ec8cca587ab8c31c1e6c89aaecffc65b0354420601801105021a00052f9204d901028384108201581c094c9e027602be8696104bdcab7b0d835ccfb45082d2292475ec07230582782768747470733a2f2f3437304844534d5563504970487837565068372e4d3468356877332e636f6d582083139d9f711a388d6843e6b30ef60ee6bbc423b292ffe57f5fd67c047a201dc4840a8200581ceabfc0b11aa9407fc6a1065d1227d65115e907990b3cbeb13f6f0d59581c006417aea0423216dbebe01e45b6e9f2dcd5fc6ca245b10732379372810282018200581c5e6cad36b8eb5706dc67bfb596bd66310dbeddae0575e9f69ace425605a4581df0e0697e311839c2d3ea08d1a2f8af077fa0259267e346261e2bba2c131a000ef3b4581de0361815eac7b56b1a0a47a3d3a69f4929350b2c59736dbc14c5821edb01581de03ddd4656be8d7f1d480f3864a7344f3d2cb1ec8f3e8bc067e3149a541a0004780d581de13838e8291a54d62a86a54b86e2ac9bf47d74e66d6a04d7cdd136eff70108010ed9010282581c875a35e757d2ad9badd0514e2c27e86c05fa4be7236e6a6dcfb3cabc581cbcc9a8b9c43ca04325fe9ebee199d7d5a09d08138c0327bcf484130b09a1581cd29409064fff6dab82ad02799963305288bcf014058e26a1471986c4a141323b4ba54f99a6a347c30758204fb8925215e3c9ce354cecc7966f8e65c5d155e029feb3b6b5d77643c68b565f0f0113a18204581ced031c510016ec01957264fbc3111fedd7ce027fbaeb68306b2e63f0a1825820bfeffba7246fdab30de0c7e03bcb1413bad531259694303efac86d5aff39a48508820082782768747470733a2f2f4b77542d5836572e54505a38476847324a497a733871646f4269562e636f6d582097c82e9d0117d0092e2bd9f2ce1f20de7e992d053badb8c73856b026e719fbbf14d90102858401581de157acb2071a934ae1d0de5c1a57ca1a4e558de54a6b76479757b78bea8106827468747470733a2f2f464c42507a4471742e636f6d5820c212ca1cfc0f7dfb6466fc5711937461c8b68a52546bb23af0804333c5f30b568404581de1c7bb2990fb8feba8228c9ef821f1c7d42178f8a497dc8cdcdb8c82e38301f6820a0482781f68747470733a2f2f784552577438563075454954734a54544939342e636f6d58207f79567186c8279a72056a7143ca93979e65adeb5c042096841fee609ee5ee4d8401581df03e70165b4286f02aa15213b2fd95b878aa125f3f0343a52f34a9efcb8305825820585362f2b61230a59a2a221716abece60da77ec152d62749ffe2bbd27ae988a4088282783f68747470733a2f2f5157316430624f715959544561787a4a34436b3942764e704461544d374d682d512d7a4d595658562d75546e72686f39337a732e636f6d58209a803eb609f51f692908f181b591e7043fa066ad066d0bec5327002bee9cd71ff682783668747470733a2f2f544b6e4764324c31767a636d44366d46594d6f7565372d4a7963354a636b65484c356276426e4f6451512e636f6d5820e73342c9534b73ee62ad691f562837e46e7b58c67ef515b64abec78893c5ccf58401581df07400661019dae1be03812711c999b9517d77f5cffb69685405168cf38301f6820a02827068747470733a2f2f6d4a61362e636f6d5820a7fecf543067f49ae2effe7847459af88586ff267fd0f992552ed785fbc382c5841a0001c44a581de184339bc9fce229f80e76afbcfa133b6c83deae98aa5545101d6a1ded8504825820e37820778d051fa2cd24aab2d28c115822b84248b85c3e85f6eea2f8e6d55e3c08d90102818200581c14e9ce33b8a64b8e1998df6e7f927ac7b6e71a45d9bbb4eb2973c6c8a28201581ca1804ec445be08a31479a9066e5e92a5330a019a8a5f9b7c5c703a00018200581c8347e14f1037e5ff72fb534e4fe29605658df88e50ffeefa7e361f6602d81e82185b186482782c68747470733a2f2f6d3349634a77424368546c3241396d785157415557704335452d2d4e523330582e636f6d58202581a79e763892ade87a188a77090efa13b53b21f985733996225ba7157a740c161a00096302a600d9010285825820402c551b5d9c836a1878dadcfc4b3f13c924295b066e195509d0b1c6f1f1024058406ca5566ceaedc734627f677aaa58e49479be690c8463d1de1c2c7a26ca44a33c892fd5a532fa3c894ee0b7fae88e819397d59cb36eedbada5f589e4559ad0f1e825820333e5f72ee3e3b8455dc259f37bbfdfad8bada9a137eee3b0e3c73f0758df6d75840a2ab3a3ae180a0c74f6b1490738014f84b5181293e77bafeab70c43169c3a353cad3e28ac5b90307a5c3101faf59986f93cc0c35ed4aac83a3142da3f841a7dc8258206e24f2129c08bf03bb56315ca33bf2905229272794f118d4f5d8c8c915a56c475840b1a4f1d1d4eaa965be093c2aada20f5a3ad51f4720b2df613b548ac78f19e4c471db04b04fb4f5521ed45c1be4ab3eadb8f3e06514ea3b3490559f5c8c041e3f825820691087a06c5f277e03745509e8abc9ffeebb7241e35206bef53a3127d77baade5840ffaab7ecba7c1ce40f3f6006b2b8bf7ed133592a9f1400af9e95f2181cb48adf6a5191c67a6bde74dde1db25c9687353a5b2cbb6662f13dc3ad7836069115636825820ff8afdd38ea3e4b25eb9c2a7af41df729006adb26f5e0951222ef37842835d4958403630a689653bf451eb1e65ee80e758f5dcdf743057eea3db3ba5d70789288eb19edd7ba8ad2c177dd4adb8073e6ee5ee9a1f3cc644d56fda4c5ffa27a033a45802d9010281845820f0c09030815bb2a585bce92bbd7d947ecb21e8cd9c6c8093337370ca2429de0658404c07000970e91bcdae7a9bcb21ce867c356382a506ce17105b5bdf818eda842bbb4dc06e328d8b5f9b71bd610d15bf305f8ae18d067809ff8cc5b58fddc3a22658200613c874d0f3aee08c72976957f1bb69686c27527ab0da82571f9f3ef66afd2b4299b601d901028182028006d9010281474601000022001104d9010284d87d9fd87a9f44f5011289a4446ea265a5222402034360a6bd21049f443512a44023ffff009f423bd8029f44425cb8212242fc09443c804426430f6f6aff9f210542fe10424282ff42c83cffd87d9f44bef2b87142e598442511e262a5010520230004445cec94ea21428823429d93ffff41b0a5a4a4413e44681e270d4261ab0003442e822aed042205d87b9f43eaa295ffa222202441a8417aa221427f0820229f220122ffd87d9f232240ffa39f4436cc8f3e0443e394b7ff05a1421e7a00d87a9f41b40544384cb87420ffa0d8799f0244c40fe60b44928d79df0501ff9fd87a9f0223ffd87d9f41440223414f44b32aa1ebff9f43e7996d23032205ff9f434888dfffa305054264b2042302ff409fd87c9f4001ffffd8799f40ff9f9f400443b8101b4002ffd87b9f446153542f447919b8f6004181ffffd87c9fa24228bf00204249e3ff44a51866f99fd8799f0140242440ff809f40ff2142bd84ffa005a38203068280821b0bef9786a37a0e031b6d0a3a2130b6081382040282a1d87b9fd87b9f05441491e18343f9d3efffff9f9f404254bc43110f0a41ccffff821b3d321a27e8fa7a3a1b02c6a22b02eaacb882040682a5a4a3020442e68f40010041ec9f40ffd87c9f00420994ff22d8799f419bffd87b9f042143e2b90a40ff229fa40143e101ec4024030041cb43fe9ae5d87d9f43252e85ffffa2219f2403432fa91a03ff000440d87c8042fa7c4468cf5bb1a19f0142eba7ff43d55b44a4a2050042c69d02a20040240301d87d9f41160244f216368e42e094432acd6cff43c74b15a502412f024439f37e5641d42101012220a0a42302204299cf4101430de6370201d87a9f044337ff1623a2230344d8a5f7094197ff821b06db5e78f2c976091b035e88ef34fa3fb0f5d90103a300a401838541a9246627096de78ab30260a365e4adaa6a6c4023429f51430de101425706a4414841856024226404e79db8440e3a8566600444930c40470d82a242c91b2344c67e144724040e81856112236537124b4f10210001818201828201808200581c3792403718e64bd3a0d948132a83c56be0be03c32cf37557be954d640381484701000022220011",
-                                "description": "",
-                                "txId": "e1f4048bf3340f0ecde3083ab7e1d7bb10adbd00d78879ba1a784fd0f3f59f07",
-                                "type": "Tx ConwayEra"
-                            },
-                            {
-                                "cborHex": "84b100d90102858258200c85807280d15429c24297510d057427ace8ba012824e4264a26bafb5842d08e078258200e55d79bb3963f7e6253552e013348f637bfffd22579e5de72555392e847fd100482582055ede61f2b7f59c11a434793eedc6d3b10988a40dc2b604a36192971a02c232f0282582076540b23625366d0a21b2afe3345ae2819f4b1ff725ab9acaca3f3747db95a3a018258208d036800caf1f428b186ab1b8d4d4c3cbe058f805d9dd130753331cfaba6bcce050dd9010283825820694f934df95120aace5991e2a70f6a2001589b2abf07e62639ee8d7fb92eb500028258208d8e20a1adb36069950bd56e1a6ac944bc969180992e57d9124512ef46cff53203825820cde1a5ff42d7f31803c70238dcac9ff3d3bc110b96721bfff832913a13980ee40612d90102848258203357623866d0f802d60749a510eedff7c730f8ec0a6bdab3d7978d776e18af110782582047ff6d461fd548f9c1e2dd7752a8645b8cfca293d450278b1e2aaf99d0f697f4038258204c6f6c17833cc58840629afe93548c73b96e93662e0bab0ff139b4f4404e131f0282582078c4a1e13ea1cc4c2e0d8485ce8922274b679b01696c68ca933bedb9bee644d3080181a30058391148d9bd99427f54eb8de7616ad003f0f4cc0cc822a30352065efe427161201f58a70f28a919f8b25c6b3717a2396c233dfd1e1ded9c6b66ad01821b0f552debc9fa0c39a1581c2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56a141391b2cbddd3896702e3e028201d818418010a300585082d818584683581cc59067a69505e9358eaa139226f230927af5c3681bbdb9f0ab7d8485a101582258206c69647972636a6a7a796c7378656c68647277666c67637771786a746d6e6e62021aa2a5f25301821b7b9931a7c7a536d6a1581c4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888da141321b5459001f3821c79e028201d8184342f595111a0006efb0021a00067dea04d901028183118200581cf90367743284737b50da40db4c44912767a451c183556b0d87087c790105a6581df04bc262541ccc6dd62a82451d23d3d67ff85a6ecd4775bde167fb1d7005581de0132f2f9df31dd76ef0b77ddebca7ee71f5919090b14ece6daea44b1a1a00034d6e581de049dcefd0f75643b60b1703c76b553534d491124c0dd0801095dca9681a0009041e581de0b07f89a3ef87ddcdaabbdcc987a68ec75feeb158498d590ffdcc39d31a0009eee1581de0d6cfe18018824644de69e01715e6020c55ec791f4f92c0d570cd51371a0004ec37581df1e6a7b5751b63e5af7d716d10b715dc0c30b4e69475092191985bca2c010ed9010286581ca0dbef97189474e82a87b1b3de5ba86590c89f3b9e85970c320d767b581ca7ae61d63473852f78b2c8d63c49d1a73f5cf271909f5d62f75305ae581cadd0cbcaeec0e557b06d9b2dd63c8d7543243d6f966c35b0fa12ce5e581cd1dc59691fcb71e4e8cc44e094fbff86f08513b39951e6be9225e5d3581cdd57d0fec3ee234c4363a0035eea7a82864b11fc09df7bd44f68b9e4581ce808d0b3ddcc3572ab2d877550416168f91919249ef7de14b94ee7ad09a1581cae2d8e6bd62a2a18afb8d26aba9555fa1d85f61d9849b8b3c5ed05afa141301b516042a2275029f20b5820a9807692ad672ec6c26b75ef09d833bc6ee32c4ae62b39bff2085075eca0a00b075820476ac91ba2f0cc869ce3f18365294159e6ef3ce55cff48e470bc072b3b81e85a0f0013a68201581c8c028b8750f6752cfd2f2511a9b94b8633036a24181d67fe53a9d2b1a2825820479c049b4f827813b685923e1b22ef414264c7eb963fa21ba3d353a6437e5e6e05820282783268747470733a2f2f4b74366b645134453674376b6f725035774c314d443445325832636e66454f537468344231352e636f6d5820b1e6dbd385836c1b76e0a89b7340ca7ecf96e3a61928c143777d834325a8005c82582050d081e2138d290fc097a139db7ff64a60f862fc0eba02d89c5272632bed7e8201820182782a68747470733a2f2f683475485842647659666f69336b6176775742746e654b692d2d394243392e636f6d5820266c748b5bc301fab32abd5b148436c1a1ef4be1dee1f3c1e6863bd835d609568201581cdad46c03d673504e96610a22f16ac52a760c37149d7ca337c022f9fca58258202cc0dea42ca8361de64537ea8abc7cf34e345b2ba5eb6f6e38dbc215d5a08701078201827068747470733a2f2f692e75362e636f6d58201c5cbe752cfc1b45cb33f758aad9463a3161eca5550cca6786586459c399f1738258206dec0980d9df2f2538af34b0d14ecddc4e08d9bf0a2cfa7a92d9aa453e4fe08607820182782a68747470733a2f2f7841494f4773794841782e6a305a3558336156476a6d62354a4f4b7832312e636f6d5820c793094988c9f17db1a7a07e7e116074fed5560c4818ddb9becfc163b5536c8c8258207cce2f1d68b8622c02bb62313c0a36f4177591b80dfebc9f093316f5b01a7cdf03820082783568747470733a2f2f6c687743646b494130426c6a52327161477863546a7848466d4c32315a75744944694f6a4344684b442e636f6d582088762b8dea780f1b1b79461f00ac7bd08b1adcd47c08cb67eacd56e5cdb6f4ee825820d39104afb5a7582921b2bf194e5d8d1981e6f359ac8e97e94590ac2ff65707b6018202f6825820d65201ff3ecb1c264b9b0524af445c80a2fc4ea1b30c6d071d598ea8113158ce088200f68203581c0894d0a671deb1290c8e3cfc09db9b590e10db88311cb7d1690a8da9a6825820139f6ade9575dcb06ae7096b2115ffc4347ca7d5cb7abb85ef7fa3ae34b48eb5088202f6825820244300687d2c8b94a07232a983aaa11668d2c3ba79cc68d8ff7a928a5e6e6ec9088202f6825820606c3614c9ef364b798700e7f33c3bc5ef782f86942545338d8c1c1f07c6cc4b06820082783068747470733a2f2f6269716f704a4d524b617356785944317657636b536a474d3150516875636e76786950532e636f6d582090ebd5aa7f2b9c3043501abacac7ed31b5e445ab3695967a7ebcc0e6ab0fcb7f825820771bf5696745e3fd0fd9d151011324a5e6e1947e4efbdf1d412554b959b0fcdc03820282783468747470733a2f2f334c70364b4778474c5a386742326c3955305a4c396b566f64614f7941445973474d6451733466672e636f6d58200256c860c0ff01d30e75d11f7596a43aa8045f9921c89e40a8d04f34c1dd70f4825820bcf31bebdd48501c9efe3f377616ef4d20713bc058622079da70293fcf4a02fe07820082781a68747470733a2f2f5562325952566171392d4b2e48702e636f6d5820cd9f17e2f4c01e215afb30ad57d025a40a380cf6f41054b18830a55b11d8ca6d825820e698cf46cf6e114ac137ef8c5caba5046ea14dd02d444b8dccb31be3bbbc1fec048201827668747470733a2f2f7137754b397a71764d562e636f6d58209c2c27c957d9e530514f6837e50e145105731b909bdd61a550ea0774205ab0228202581c6110f0a4135013c69ff891329c107ba6ef53099e8fe085f47c47a6b0a68258205a8c3aabd309048558dfff299a6395162e761820f9ba2f87e650deb2e17b5e77058202827168747470733a2f2f724a574e762e636f6d5820c60969d5912bcc1ad8eed3978b19b491b60751b738fc5387194c6c70f8eb55a88258207623a7895dd00308df0eb18291e6328a6bf643e3a377031be5079f2143d08d71038202827468747470733a2f2f574c34396e45616a2e636f6d582013b8225aba907ddbf35b5b74059f886551768a2c6b223111ff3bddb17a76ba4082582088e81d4fc13c46f7e73178ca8a8e5cfedee7d276997c4a826f596cf1abe3b5a3008202f68258208bb2388d955fa324c651ebeeee7584c9b54afe290772012bd6481b1be4988b1901820082782568747470733a2f2f37304d6853686f37475857756c5739474648656167693065372e636f6d5820c0ebd4ae39e08dcefd9d8ec3f731088a51290fd9849c746b448577bf37108e87825820e0625fcd5c81b6a5ee7b2e107e67a3658f21005785ac6edd74671bd0699ab14c04820282783368747470733a2f2f6751376f316e3652504244535147664c647856614253326c42427650663176356e4757446d644d2e636f6d5820e08ce29b714dfe611b2f21168fff17c49406e89927b3281938a6f5431645ef30825820e1f90beba55063fd0e72a3e26d00ccc9a6744c8c719d7a881b8d889a6f832fb100820282783868747470733a2f2f65386744746257624955666646766654387863597373692e6a524554757458775a71534e6b37754b4d7644452e636f6d5820479c819a078136d61e40a7c47b5048e3c71c2c0c606870292f98e7529e04ca158204581c1ff05123d48ef6c764df3a8a9e44f7f31130e93b0957dc25e71efeefa48258205ea6a3a4e21e08f52f61c1e66b173bf7c14f3d65cafb0c6aa16f0fd98116b20b00820182781e68747470733a2f2f4f4c2e525544326b333670636742366c57302e636f6d58202a9431f5a2446250928df9612952dd5cafc75924c8fadcdd82c44875c11ada6e825820b97e47da58bdd11144ec50ec9c260119cc5e97a0402ed9e37aaef77578ed0330068201827668747470733a2f2f2d566354534846355a502e636f6d58207a6fa3ce230c49eff47677d9c3e15d110a22b40d8336c8aa3f369cbac413d1a5825820f2c224caa6a3b7e87279bc023f20e204ab6ed1c1631097a27a6e3f317f90dd9908820282783868747470733a2f2f396c79774858664c4f44376e6762663457424e47506f4e7772712d3853476e4b4e71694b7232704e345738512e636f6d582016950619a0b771edf5554567b3e2e961af75ce3e9d00699754cf4002bd3d28e2825820fb68d8378f10be1753e43021ab8ffd9ba8bab40658ac1b8fd7434b94b9a87f0602820282781868747470733a2f2f797042334872366e614d63352e636f6d5820effc6861942304dcd7ba66cb9d873ecbc49949ecab8028b6d4851a67163957e38204581ced79d3ed42ce10c239a61b42db39d86ae242a77a4b6a8f93dc973536a68258202d9f5854dfbba157eebe9fb9612b589d2f701bf11df6463e5d8783643515ddf708820182782868747470733a2f2f65417261553959366c6776364a4e667355695a744b75416a5248364c2e636f6d5820fe5a30ffbbb9285fb2de61d5a55eda80f5bc9f32703ba1ee91e37e2a339adc2c82582067fa8795aa6721f35167110df30a8d12e06deeaea8990922e6e5cf062c045d3f058202826d68747470733a2f2f6c2e636f6d58208b68a8484ce22b6bb6ce8372c5b45e28032afd3115488f79b3c31cd9541db9f38258207362a4c3d1766ab52b5c7c3eeb1a9d3f1dc930e6576966b1430c4c1ffe09f1fe058201827468747470733a2f2f6e544b53324331312e636f6d58202179a098bc6f582ed29786e12e6bf93721e3066605609cdc263a80cb647a815382582099992369c5bb2f181d4cef1a6fcdbe0819d6e7cab79a1e61d9fdfc887032a30b048200f6825820a0be6618c770394d2012733b243e493497ba6cda55cfa8558569d7523c970d3e00820182784068747470733a2f2f7355424f67544c6854755654327970667a68792e574e7266436e4e31396c352e62513666543454795a466d613953654d743467462e636f6d582086fe8ec1891660ea3573e51a574391b95dc2023900da7e3981107ab103498f92825820d84097b5bea4b2eb07552aeb91a5ea9fa9a9161bb4e15717632913335a370064058201f61501161a000263bea500d90102848258204d5f27e5f334242856ca0f03fa96199f5011b02772c04d3b2c11413212e62e0a584058353ac8b6792546e0358b51579121ffc207f5ac269a44a46043873850b8d9bc0243e5b821ecf5f02f526abd8b8ac9d2fc2ac947bd5ae12f52a81bf1c49fda1f825820fc654e9e70f48820aa5f0a7e0db3a4445826ab152bc4a79102ee52fd2d3e7bb55840693bc6571684493f8954fb9a28158561cac8e2905032751ee70c84279193040dbf75a1a24c05da5cc716e84b456a1b5bb400ea613cf75e65b660647b6fac99e9825820ed4a066a3f0f2c083fe69066cb0ec708ff04bd1c5240263e516ee55f587807bd5840c03395605311e630bdfb67535225dcfaca3305c0ba8bcc6d96c07eee7887891df5e85fa2698c9f766b3153d5085063166f34e5dc1e67e22aaa068dbe0111a466825820bc09ec2128e3e93384644c5ad002d286ab378cd765e66b24f6de7e27505a62a35840f24e2d02d46d1ab1d2e7d4bde654602a9af50bb0e2f1499c0db8dc3c329627b429e6efd1e149c9c0f1da7780650aa0381fe8558875614829f1b80ead26347bb401d90102818303008006d901028148470100002222001104d9010286a44381d1039f0500ff412b04d87e9f2343dd69acff9f4220739f24ff8000ffd87e9f9f40ff01d87d9f01ffffd87c9fd87b9f03ff21ff9fa504a42242e4e60001040042149101a342d3c00243dbd4e804416842dc1ea1404298cd00d87c9f4297bd0541f12242366eff44f659637801a10541a7443337fd6d03ff23d879809f40d8799fd87e80d87d9f00ffffffa005a18204038202821b44824e14e9d798ff1b6415ab2ce42a5a31f4f6",
-                                "description": "",
-                                "txId": "1c0e00fa2d1cc4f194f6666027bb404c9b6a609e48e3f82b5ce9a109c6b4eada",
-                                "type": "Tx ConwayEra"
-                            },
-                            {
-                                "cborHex": "84af00d90102848258201ebbaa7ddf37555c27306cc8af13b302a5ff8df60f72bd9a630e559d723f0866068258206ff8d365544c62d024ce5af0d6412a04953e66e65c148e64241c5315991ce02e0782582074f97b219264ac895a3a7140b1de7e9989006ce6937c2671ce704ce255a5b1d900825820b5c06b7deb3685b596fbeeffc2233b59cab7d9d547146439ad625edc8812fe95070dd901028582582005b3575bc37fdcc682e778c63c37772184048a5f3a4421ad2d4713d2c32b3958078258205c305e5eb8335a10fac91256bc84d1eeb42a1f7683a96628c35252e5b753576304825820c40f49c3f14cfa3fd94bc4a680512e260217735c88fe90621bfccceed5c473f604825820e06ad2e913f28cea52a3673a1a2d2a613c174a82b5a14f5f72ef20e6b292464704825820e1ddd9180a5173a0cd234176fa58f09e8980ad4f25bb01703b0f07afb68d0e0d0812d9010285825820024ca38ca0281ab845e9de0a05ee5dfef44b0b0d8d59e24147b2c63d71ec3e670282582047955195f5313dea0bbd161107a910055be42bfcabd3cf8f961618a80127fcb00882582060914d8afdae0e8a1e52426aed888b0c09e6e4355e1525737bf844c581d5e04e068258207073fbf208ec6e0a3e85ab6069900ebea6fbc16ecc2deae3f75420380ae8b12f02825820c47f6c388c08d558d1d9433fbe27e5384cff8755a857cdb8216b4d0466388d44070184a3005839213ca269213fa47fb9c906f13f20a21711f33d2ab516d61391a3bd240fda6ee8d4a3c00cf3d2be1d514ff9970f677cf058e05d08f852f31cde01821b4cfee28a87e12b3aa1581c83e0aefdf4974dbb3e97ae7fe65653fd83ee031d4899f1870b097581a15177d4f97a90a424dc53008705b4a4faaaef1b6b8400e4aecaef5a03d8185901798200820282830301838202808201838200581cfd738b4d6d37f6c88021a5bf8f52af08038a8f01ea39deca1e02f1318200581c5903d60513275745c35955fa2fad31f2ba705e78d28ab775dfe0edd48200581ccd49c97f01a66f34993b4edd111ae82b129ba8282cf5ad2f1fe3e24f8202848200581c0ed27d0b4e6d4e5000be29d0cce2486faa232e393de0b04aae40410c8200581cc0a0a162ea4ea9c459e7022f5b302c1e480040e0ead4add19694140e8200581ce49d275706eee75c01ccc1510b1595542350782ab1b9aa12a8c380fa8200581cf2d3aa3a29aea19dca44416be505871b0f4182a72b95a3a0d5896b1d830302828201838200581c07069b78a3ae4f726326786a78bc528b75b14691e1bf43afc34270438200581cda99eaa715a9a3cb05c8afe25d1850e5cf61e16eacc3c3af0b776c978200581c60561190ad6054ed5db8c9a737b3f623a5eca871b1df394c100fb4598200581c6bec83e10eb32dae7b02cb53c8e5c4ad959c011697e3b80a1bceb03483583920d3762d10a5a2a66b2db845f9483059046599c8e2ab3eba97568f98a097e641635ea2ba06b212af74b31988f2a105700e77ee4d0febcd06a8821b339180d646af3376a1581c9098d79da871f1a065f79ff54277132a3e7a609b5498b0b84c547d85a141311b018e14ef2ae7a87f5820c326a65424aa89b6a127806e1fe7609c5339adf82533fa7a1143218db41a05baa400583930ae4fbec95e98f3b0369ab5e988605fe2df875c7968100491a7e6c434e04e0cbdd8e18a0783106bd3adf69ea821176f3d6d2311bb479a0482018200a1581c4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebea1413101028201d81843d87e8003d8185901178200830303838201818201828200581c01fde722ff05ff0cf49164df0bb1866aa4c374f2eff26e8888757e608200581cb98fc54b35dd742c01017301bf42db40e7b9c9cdf69e69c519b219dd830300838200581c98f1b6529886d727f7d8933306cd1d4c8a5c55de052cf04844355837830300808202848200581ccbab82bb3987faa057dfe4c92776a243522ebe3d432edf364e72b8dc8200581c2a1cf60c139d2603396024c4cc206476cc75ac5db6e9a91b999f86348200581cea49b9cd0498bbb7392aa670774fafdd557cd3c09af8fc719423a4b68200581c47ab68eeee33e945e4df32de0f761015505016f6de11868b1a6204bf8200581ca6b9ee8a46efada5ad1e793502b3c9539749a9edfea16822185d6de982581d61d2b74f3a130bece7d05e8e0a94987d6e4ed3203464639d9b311303ac821b3f400f8f456aa21aa1581c2d725128406dc832eb74c4709aca0512499b3c7b17e00d7cb2e6d1b1a158184fb7ff5c524026d1efb3cc0d951aadec8bb1181bef7cef0301111a000ac1cc021a0006573304d9010285850d8200581cb01a96c16d2164ccdb1767367445642212aae4883dde6e36d12ac865581c70f805f64eed1cb1605736d4a091e813adea61d5e8d85a10810f872681030383088200581c57651db36eded2d075e58ebfc95dd5e6a1ab4cabc5fcfd8983bfc48a1a000805dc83028200581cddf23a684cb0e6e974a75755cc41e6d8168564c1610b2c5d389930f1581c63f1954d5ff41f983d7cf3f264fd3f56cd79433c097967bab3a6898c84108201581cac9c0cbfeca187be4f64b46683754cb9be718ade96b64877768885c51a000776c182783868747470733a2f2f3230577554646957415236424c64536642626473786d6f463238426650656435736f51494d6746655767544d2e636f6d582032f2e2dc8a57354d2877ee0bbc786440b6e7ebe0ea977a72e020debc2e88ff3f83088201581ca478e48e60107c3c3746c4fe9f8f8bfc850a8c1455c069f8729ddd9b020ed9010283581c31a6f43357669feb89d3adb93947b0539d33e506d6c8d3cf94c200f1581c331827054280e797e18af8aff4f0cc06a57a8db02e2db3b28251262a581c7569b60430bfe738d484c070c009d5b7e1f87e70971927e8611516d209a1581c105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5a14829fcf89d2c6534023b7de7456fe606d4560b58200931b41b55ec2a5a5cddb52bb104fd1253d030c64678b32c59975583e2c41bc00f0113a18200581c22e0300e4573c9e1d9f0453a5d5f8caeb4579d3e0b6cdf507fe9c30da4825820135d1af7c1617f4232ae54ccb5f0e969b7067185b54638442395e26baf1534cd068200827068747470733a2f2f754e65442e636f6d5820bd7a7a35c2a19aa92ce08b2bb5274f4c794ab53b1fa5f236bf0e7fc780ef21888258201c51135729c992daf18336f91526e794fa3ba14f07cd81ebeb636e09793cb940068200f682582034815aa23a7f8c029b0d7d4af3d5a0fa1215dddc3397f1dc370f6cee43b835e901820082782468747470733a2f2f303155524567596e426a554f46486a4e3970466f574c51442e636f6d5820822d960ace5a5b0e00263568064157cc2e35c0c6174df551493c5e75a263640582582037430ef9a36903f89f1209eb60548178c5afa87977b5e39297dde14dc8ba3e2403820182782968747470733a2f2f43703741796f464c7979366e5158466b61714b644a5154764d705869642e636f6d582082552ab2349c1b5ef03b37f452e2f582a8e66d8f3a5d77667512f5c726d9495914d90102818400581de0c993a8340b842c9f66ae792f59462856a191607fb9b1ee24cdbcd1658504f6d90102858201581c58ef8fd05bf4537c56dcc7300d5a2c88678ccd3dda6da544a61c06358201581c6b3231101cb17a46055ea5f546b01ac8fc5ea45571e8b412b4c577728201581ca80aa8571763c33625eedba7236ab91e63e25ffd61f98ea9af46db818201581cff712859364760f8d7cc2734c228fd7629772f3237a3799538b699b98200581c5a39952daa7a7ddac66837ef408226605999b13df7924c88583b3a17a68201581c282fc37fd97bb0432b021030d904aae720568322d43dcda92415bbf8088201581c4b0cc44fb60f75f230fa419f26f7a3064b80b825e541b22885e98a26058201581c78efacd5d8b9d9157b9fa10b6dd314693602448edda5356868ee126d108201581c88c064d148b00292a2a318190fb3fcae12c1c44bf3201e1557961c920a8200581c7e41cfb891c82862f1c54180c94b5e337aeed9738319290cc6c98278078200581c96eb67acc2dad7b534be58792ca337a5fa1b3ac9677e75699e83a22002d81e821a0002cfdf1a00030d4082783868747470733a2f2f354f47754b313053674a544a6a6b31664d724e432d4c6f7758676a7230647a4b666e436a507155334c35616c2e636f6d582023b334a84fbc570bb5b80be123616c0d71a641886bdc97a7099891dcdc1d00bc151a0004404e1602a600d90102868258202c0378826b111ac1e30f1102db499bff1d4169c68166c07c0b727578aa1282ee58409e3706643c3fcc6ddcb327678479e70fb4db2b29ab90a7256ee12837317e56f9c1fd74557afdf872e7bcc7dae793626af6b5df502944b3709e5cf146d04281ee825820005e845d2f34ee57a058dcd0d85e8b8830ee5a0f17ef626477182a4d2271069b5840248ac6bc278068ca618af55d34012fe96ebb3a2d7114d9e17b8d86a9301047f56fde2fc85a6647ed73df4ec9a20b3d19c722d74f8d59fa1b8ea2f004877973f58258209fae7a8de7185fc19319dd0aaa73b063725ebc18e0bd9ef3b9512cd69a292cc55840e26c981591c4924721b4e0fad09a49377a34626acc210861c0cdc77752503ba6e0ed49b8611a5bb764915198bbd850189701811efbd7e31de1c2be530da94cd6825820ecf2f5b52532106022abf478d75e5eeaf7c32576087905735cad84a4181bcc0d5840508be0557b1278d6824a4569970761203f1b7478556ca5f91e5b1e519a3fedeffc53bf7a27f49fdb185108c9a4a7cd7bab478d9283d01c530a4bf43590a8ba5d825820390aa75dd46450a499bebccca5190b51c704f2e7f434917c16f23ca0e3d6ffb358400f4fed3b12614887cfe0ac2dedb1d36b8539147c71a10e1184ae260729c5f74ee7c1141b0890e18484451c37357e5846b51c445219ffb4b6ed9f3bab18e544e6825820e1fd346ed25071b4cef1d357aaa8271e3510e7e0021332d82fc736ad9779dd835840cdd822110b10c8349c2eedeff0d7c93e3492f429d944385b935dc7aeb45363e495c24e7afadc15ad1a0031d2a24a43da3c18412604d43998bf8068067c9db47801d90102848205078303018483030082830300828200581c0c89bf16268552717911d28f458e07c7f0ade5b09db387fdfdab5afa8200581c1790300c3387cb898e004aa425b4b728defdc2386102e09db51f43968200581c5597d9776fbff63fb01579431f37dd89b3095d00732db695f8e55b30830300808202838201838200581c750101fcc8e54d0912c173d4f287db76e79de4f9e973af57b13d98598200581c33e730ea67d85cc4b39d3c41b9cff9a3ed1fe91dfb0f13b0f0699ec88200581c7d82b446a3fa65b3335fb147ec738d3c4f17cf4442294c9d72ee33158201808201848200581c021ec69a999f4503aeee7f0808b2db583078bf397761d3f0450792288200581c0f32e736d2c417e242591c3b928cf476f520abec2edded1770c8b91d8200581ce78812f4ab8a827a213b0c7fa8901c9b9645553ac8838a7d15dd37688200581c02fc6036405b3a996fe2086dc503d598dc58609149035682407e02e9830302828200581cbc3755c0e29e1bba24dcb2f01bd9491769c71a7234271c45086eab6a8201818200581c47b4609494f73c664c9c4748ac78acc9beda524eb7fd9be2d3ca95da82040d8201838202838202838200581cfa1b2e14d263594db545c5e00d9ce259b1f7e0bf6b786ef6020f060f8200581cf5a9859f62c557e9e831e2a8a9f8c3c38b038206ed91e5e1eb8399308200581ce75b11eec963d1f9637b365b3054b69b084b17173d71471dbf1caa7e830302828200581c9316a03235e8e4713229f40db9badc6936d7cef8c8e73d2c04d233238200581c6a21020ced8fd543bae9f3b9d5bcd3dc13063db7192efceb75a37a608200581cb795a45bb2a36b8419d37422c2049f0ec602ce5ed54886fc84432a58830300808201828201818200581cfd88b015a2f4e867542a64bf9be9070fad1e9ef8bdeed61edfb4144d82028003d90102814645010000226106d9010281474601000022260104d90102810305a582000382d87a9fd87b9fa544b84d39f72104411d410a0504446fe12886434798d1416ed87b9f22240044aaadd7c5433604cdffd87c9f0001ffffd87a9f9f0303435d3bf8ffd87c9f400242d93202ff44c2d9fe61ffff821b0e39d0223675ecb91b2863e589fc35551a82000582d87e80821b5dccbf67b45938ce1b138b637330338a5782010882a59f9f01ff05ff43f947214264389fa0a240443188e07e2222ff43b535ad414ed87e80409f9f0023ffa342512f41b5200005444020706a9f2043611254ffffa241a821409f020442026e44a8b34d72ff821b283caaaad5e7abb01b68e6043a7327aece820304829f41edff821b6fd51bb87a7f983a1b5d334a9473e2b4638205008222821b70dcf0a1e5f92a051b0c6fa831dfcabbc9f5d90103a300a3050408060c44c2fd849a018483030181830300808303008082050f8200581c7ab50626bc4e7ec5748109f0f674d720e934539f211cd6bf0ab1586b038146450100002601",
-                                "description": "",
-                                "txId": "720691a2cc75df08cdcfb53162af4261b666f2621017ae352002c7886fbb2072",
-                                "type": "Tx ConwayEra"
-                            },
-                            {
-                                "cborHex": "84b200d9010283825820042c16704a5b81a89e73edef24dcada525b42146b055e9cdb0791b6de3c8253408825820825b99fa17fcab5406933913a6ccb7caace7914243438c6ae3c7c9c5827f236903825820b15a5b20a42331f49feca7fd6a291d38c4aa4d565545644b9989f23a19591bae000dd90102858258201b9a9689a02af7959f9125effbb3da47b5f2acaa9ca3cffd176cbe01cc46cfe302825820681368188237e96a6217cdce34c7263bf82113234eea92a1ddeb21fde2544a32018258207a19efed7c15aac1737ae122a13e91d07aef1266f5165500cabd6950dd90ae5e03825820b3c828acdbbc9cb97aad2bd4109571e7b59bf03182deb8fe5f230ef4c5bdc69604825820d4907df195497056cf270c7aee0d3b39213c95ef25090b21ff5f94bc16a2c9be0112d90102818258201a74797fb961da15a53dcdef30add509cd75b28cb200aa517b9eb172a49d749407018582585082d818584683581c95fe65e63a09cea1d48cba205a78acd5bf18fb7fb0f0f8ca40132655a10158225820a8267aad298714d3d4cfea0b078f71cdd7955eda7b9ef45f9ec74a1a345bd588001a325d0ef28200a1581c3bf2c0301dbaa625fd9a5a20e4a69af688d3a37840d67c9f5177ab3ea1581ba98033c8f873e6efa56f48ac8107c94a684943008be77ece11aeb81b45c92b978a0daf12a300581d714f5330ebc39829aa0db154e6b429edf09c7b702e9235bce0051dbcd001821b1bb3f9df039275c0a1581c2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2a141bf1b69606b8b19bff063028201d8184544da12886da4005839311716365858713ce2d7e78d34bea72758c62d8605eec56888a55a182181b4822c9a0fb365590ab637b1808bc64ab2523b08696787e9794c9c018200a1581c105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5a14135010282005820bee15c72ecc08bc7f2d53b264764d4e7345aa17e54b2c14e8930c2e5e6d61df903d818458200820404a4005839304866790111ef863bb844a15930ec05b65c2281cc8658023987fbe2f56a079ce6fcbba11c0a0675b3292143d744bb48bb8fa31ae45a4949ca018200a1581cfc5add0b3be1902acf43bf2b72d806880ecbb825cea60e6de90f3879a141361b6c3b634a7553513102820058206c32f07df821889e46ca2fbd907b8a11e75b1a259b3712a9b161d65f539dc32d03d818458200820407a400585082d818584683581c6040a550a7eeb0bfac484000bddb805d8728399cb109ba8fbcd31c0ba101582258201cfcb06e546ee58d64e67b54a114fbbdce1328935dc3172c48032b386b31f0e3001a6f5fe9cc018200a1581c4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebea1581cd6cec7f0bc4c97c2aeffa6de1ead9da6a8dbfc0918bfb9104ecdb92301028201d818589da3a1a52121404466eae474204042aa392240447ae9787544b5605f209fa403030442279b01439841be0144b9b073cd9f21ffd87e9f014482d6cf1a002240ffff42d60aa442fa15a54002400140413a0102024136d8799f21440961821d447e2ee65900428035ffa343a7c25205054409136d4842143f420c349f02ff4357d51c2304d87a9fd8799f23ff9f034390a45842624a42e93941d5ff04ff41f103d818582282008200581c3c0d52281c2dbf64b54f7deb961b6a016596ba60ce4fbe4738c3ce2710a300585082d818584683581c8004e13a7ee64adc5a7e26bf3745ef5a5b30148fb7530f5cf9afca06a1015822582066676d7063716d6a69667871656c75636166716f787073766b74786171616773001a58813961018200a1581ce97826eb51756d37912720783bffeb1e16fe49faf737c8dd4ba799c0a1581a343dc6ebf865acb0405d27e5eba18a7ce96c60c672f8de9bc3990103d8185901e6820082028383030484830303848200581cfb1943532f3fc6d5ae4bc9c2af624668f69bc8d9a55bebcc9e4b6e0f8200581cc19a399b614c6eecb82d096eac13430e9e7335d865bf1e4ac57d925a8200581cc0176441fdcf97ea17dda10eb8660860bf035681896b08ac269b7b618200581cc671afde464771cb3d5a3c93d6536a61e1360f87b58c2d11bdd172118202828200581c9720e85a9a6cc6332cf51d00601bb6cec7fedd83ac9d3f9218e3e29e8200581c4b2b8131564908682a0aae692240a5d241c52204fb4a23aecf82ac91820280830303848200581cee2197b5543146f6c0b16da7b3988ac7c563c5e0f8715df05e33d4078200581ca8204fa614de963bb00a5c595ae9873fa9aa2519f6b35d3c2f1b29c88200581ce09bb14ab411811a9d35ee9f5bedf0b1b15e751f153310cbece77dea8200581cb456abbbb3699e9ea431ee3f8df948fd2f61810a875e70b9f9f5c033830301828201838200581c5257b82135d7c76b5055757b86c35a55daa1c80ba3ff29fa5db444ae8200581c365f1e6ad647184a63b33cad34d76f4a3067cefe327db859ae69a1bc8200581cfac0e95776b2bf7206e0be3987bbb1d1e75cbb803ab105cea88a9c45830301818200581c042431b48013cd642e7190164f7fd6ca6054fa407ecccd15c8fefc4e83030080111a0006b923021a000ed61f030104d901028582018201581cb501a1b0d34240252e91a4f6256372b66e0068038d7fe2f30dbc972882008200581c47f89b4c2d3c5ef12b0265f0e717bd863a1a1c9ba469c8ca1503b0e3830e8200581cbdd03852d72d2e0a8b7afdfa07d77bad2192b1661e3cdd2c0ea6a0618200581c1fe4b109c0637d22473dd6667fc9e5a51cbf5633c074c172d743a5ab83118201581c9e20403b88d007ef612a2736de27c9e705e749ff5faf543815416f791a0005f6be8304581c517d928477d66ccee004d9b4c0c97b5da2bb7bd73465b19e15c1e1f90705a5581df04364743a9a0df45f5865ca58f556d653d978b85afca2cabe2dba707904581de0d75a4408cd91f90e0f5056fa1b666d36fd85a9654a9a982c7f33457506581df19f168ad00cf1c3655daf59529ffec719c78ae0343a6e336cb77c3a3800581de18c236cc55b27faa0affbfdc2217bb34ada9131e28c0f07cfcba261a81a00052e70581de195508f96bf5c019ce6e3a2117e0080bf7219fa1f78d72008e17901eb030ed9010282581c0f439d4febbc130b33da3bddfa500a45811b9a730ae49af3fa9c4970581c3cbca9326239f3a8592c04b6c1b34921784738a55797253a73c1eb8609a1581c2852240d2d65dda890ced7f04bdb27017f117d3453be7cd75edeb6c5a141331b0bc626e5fe91eb100b582026154c72325c87aefe6a07df1cf40fe88f89020a076cb326c9f82942c93dad30075820fd290d2c17c97426d11760e8729a4fa37680e06d5b0301649203da9ded195b3a0f0014d9010281841a000a41aa581de12da758f1f27b6e29d4f771ffb28dd4d838730a34801bc82a4a50750c830582582040eaca133831e5cd81a5c8854a97fd008d84d388220639fbbe946070df1f9306038282782f68747470733a2f2f32354d484d646234512d7162616a4a6b2d4976624f7465344e62576f4f386f6166476c2e636f6d5820d2c9f082f83cd5970f50cee88a7388c68ee810c7caa80060e6956e5896de9dc7581c9d4463a7ea25a2d51d876379a6162fbfd9a76a05dbf5a19001982a02827068747470733a2f2f416477392e636f6d5820426ea9f7379157ae96d16755c3ec5e5d7c5995f0c132b9d8a39f08cc49b471e51504161a00073c16a500d9010285825820d9c781a60e2c0c7b50e602c289fdd58827056e95844f65efeefe9eb5e0d9a2445840a863059bea140011480587fa3ced4231a1a9c13b81d7647edeea704722655a145d2646812d31785ddc8d53f9680d2acf691c81c4b1759ab564c8c565d7114be98258202ea3b3fe71546daca2fdde5d1bb32276758a4419d1d7208fb2e55c27e7dc649b58409531b6f67836d46bea2784b9bab7a5b82886bb9b994b2a27067135d68425120684d1cbe077aa9f192923ba1a1fae0023312a2dc9c84e887a772d177646b294e7825820dc4feffa3d46e8ac919f4c4c37512752b4cea21d44d1a26c50b77820fe9673fc584099595b2eeafcd45217dded7973325e2a6ef8d19537124f8de9f37e35ef59ad9c87c0ffb9e28ab7d09026e810ff8255ebe17fa41061d5aa47a85ec4004cff55188258201e41ff247e12818f05e72799743bdceb72e1f7e3d1a10a35819069536a0925d45840d62e9afcdc7cfa11cfed9379d058fb217f336905c0fa7a09c0b7444ce969e7562e28b86b4038b6f670264ec832cd85cae65c73f6eb4923e1e266f2e645d550868258206611b1984981cda4c28f5be5325fba58e95d2139fa52a6c9e2eb03ceec43f2865840bb973edf7200676fe1a9177b430477e8a002119722b8eb8aee678e9e4ab9f0f57db61675a09eefb203b445ababadb431a302bca10495aeedef19c0b0b6dc706402d9010285845820b5056814e4323393d39a3b0b44860f55978725dad11d7290b72c2be159d869b85840920263f0e9117af8c46f02513f3750e6dc044ac647af4909fe0315bac41e4c2ae75b240849205b4150c8913b0a910e11ecdb75e6753f8d3b4fb08ab8c108661f582083953fb7ae8ea652ad9af63c8e50c4278feb887763efd17d0f31b1ec7ef3b40c45e37c9f290984582083b63789ed64a0ed8ed9fcac1bed974a3ec7770044342823d75fd0cacd3a2de45840cd10ca22b0996c22593c36451cea0d18187c78eca4f419f992bf4ecfa0e01e48fe4b0e89f47ba1871f068e43e377834e5c590e6b6447dc7591892a30371b22ea58208016cc147c90c01d3c74e3577e4cfa865d048ffd494993e34d02d12989ed599f45b8c8495300845820ab57d4531c15e3bfac371f01512082a12b781bd9a55f977ae9db76c54deb625f5840aab53d083b238b97c6c945f392ac6d12e7aa360cf923bafa979a5f43a571eb041dd89dfd724105c5e081a5abca39c5b69915259198ae380f740fba14671adec458200593e173d1fecd484bd9327f6abcc30216016c2b7aba0fefcddb25ce93bff9ef436a2ce68458207eaf520bcca8e83b551e166312573fb0a13ce8abc228667b7518c1157177f6b6584033d1d91db0d1a4bc5adb34e07e23fbf39bb3c96ab9eda26a4abc56af9ca0c2c93e79650e84b75e2c2fb4b521f737ed81be2e9e0681ef51759b66cecd18ef672558205a37c598f925fd5ec04736b244cfed75c6efcd569901bca91414a6b357c5331f44ce7600e68458204069ee5cd2bbdc5f1375955f9c17066f27ac50c036bcbf133a8f76d751b7000f58400596baabcb40063b5e992568dd09cc0e67ebae9eb6d02a7dbe3396b14748b168cb3bea5001397a9e0aa78c7c186329f676a3f600a72b470047e8d024efe960c158205e40401ed1b8fc5c0344d7ec42a7fbe9ebe2795a2eb8712c842d4b27e9ed9bb142200901d901028183030181830300818200581c215a74091c9addbc4610b3b99f89b9c3311e34e5279d99ddd0d770cb04d90102844236fda5d87c809fa32040410d0141a520a303415e230543f781194346346aff0024d87e80d87d9fa0ff80d87d808041edd87e9f4233fa22239f418cd87a80d8799f23034354b3db404142ffd8799f210240ffff425f79ff422b7105a38201048240821b15c8bd902a20a2781b42e843595b05e7eb82020782d87c80821b247c406d20088fa21b0f6a3214718078238205028242ed6a821b7235237ef6ec85691b44d65e729bedd684f4f6",
-                                "description": "",
-                                "txId": "ab6cef0641e64743d73292bfd1a9975b304b0f8b72004989083c90ce0a8074e6",
-                                "type": "Tx ConwayEra"
-                            },
-                            {
-                                "cborHex": "84ad00d90102800dd90102828258205c022ba1e276d047197feef713f3f5ed6f5252c9388c2cd3ca841c7a4b117e3603825820f941c5a8846aedb554d7944435c7d5ae50a1a8a3ed2b723b89a1c753567ce0df070181a300583920a002471986f660cee6ba4bc66f3ca1b54a46e3f03b62f26b9eda8ab7553ed1265286c1ff1d585c6ca8c076c4a0529c045c9f3ee40272c31301821b53b9bc16d762faaaa1581c4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebea1581a2c409e7f6c6aa12de8f26858d27414e1494c12668e14fcd6a2760103d818582582008201818200581c5ee7d409c1958a11098fccbfe76fd3bac5c29bb0f8d5e8e1a90f546d0202030104d90102838a03581c52386d7f3596bff2fc73aa1ba345ff44f16b8407d692deb7b9546cd058200baea62af411d253cc0064aa74bfb6ab0502d98c93a10bd1dd93a9d53faf940319068802d81e820001581df011cb3b5a088026cab088e25b6890c4d1cb6c365ddd25794281069474d9010286581c43f9ceaa850c25d63b185d22fc120aea4f5bffb5cbd06984193eaa5c581cacdde97d8745b6905fbb44fa3854e3c255800d0b093cd05d8546153e581cd267b76fb6455c78b7dde6d9c563ba7b154e6ef67cfff6c91fe994a3581ce984ee4feeb8eb2c47038e05c41b38146af789d98825a4020ead87c7581cf8deaa7adf266a197086d7f5602c38a8eed343c47730c5a1bdc4c159581cfe5343939e81b0a55fb660c030c67abeab436bf97c559cbcb9863d81848400f6f6f6820278226f6649574d356a3254393749636c46503054504c4c64514772746c374e462e636f6d830105783a62447245716d4241777348706d416e53453167305338626b6d777845584d2e474f515a6677737a583875734e5745315171614f4b6a472e636f6d8202733337366e372e5771344b523556714b2e636f6d82783b68747470733a2f2f4539567036743877465463614e467772492d3477456f49634a5a4b6e3942572d2e524741693777523868375a6257792e636f6d440208080183118200581cd732777c92be15adfd3c2f7868afcfd9727c4fad4002fa4a81c6f6f60384108200581c54a074b19da0b0f17513d17ce27c60b77f18cfc7a40c1c0fc89580271a0009450f82783f68747470733a2f2f32506c496f5371494d584f77514b5a675359343074646f44554e444770506b396e73456e2d2d5557757271762d427844424c452e636f6d5820cb2674f69199c1323ade26767f6be02ebb65e5cdf21529a256637157b8abeb2305a2581de19ad60050ed990025324a4db51a1a2d761a9189359c9f6f613be23e091a000767d9581de1ea6067aa3a523a8f4ec955565796db8b7168aac1b74be0b5763dd8461a0008b52c080109a1581c467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22a1581efda54c0e59cdfda231a3cbd4c9d81662772e0709b5d7ad70a13ba942ea171b6a558ec52be8a6f70b5820fda1c9e6f656029407b378152caad9cf86f2a1ecc9e40d26512ad3faf02d0a1c0f0114d9010286841a000185c6581de0f3cc69ad990ce59bb5b4a7b06a05fc2642ee14abc1e429d0072964708305825820f21daf6f47b54fdb64b8a85feebc3f23c7a061b27c0b71c2106e0b9ac9d29510068282783268747470733a2f2f70556b3173777963384561374f6b566e4c486c4d64586e4f48714864392e76472e45723330702e636f6d582012c09ac70aa1adb56d4f4af2d14184e463f1ef88a07d2a71b0ba6f3c5e89c233581cbb8b35c1bc53d6afec37e522393a87ce5abf2e2258bf8538de951f7f826d68747470733a2f2f742e636f6d582044acf855113e3d60420bb54946855aca56baf6d4a324443c522cb22a8f35a5d0841a00029a12581df0d3001b6d639bf6ab724af77c9cb0768a39e616e4a07fc173c9566e128302a6581de0e2aa01b3162b57d54e9b5c2d17cda597a502a088384337c1cbf3de7e1a000eb283581de0fe15ea59f475cb0ea07c9c9754996da699a94803c6258fe79cb4229204581df16831aee5814459c72269ce4be380b18cb98da2a53a07a952a797b3751a000bf4d3581df17fa4789130bb958963d56c8439bf7c7500ea81b876d391a90d489ea319a822581de114191c7a4594873b99da69e9dfe1c4b7e34bcca0b987197e54c772b401581de1a00b341c05c238bc759dbe51e7add9b94d57ced90361e046b91ca2991a000afc7d581c17949c7f609763b9502973cae75b5bff5f5e528a20edff3eab1ffe3f82782168747470733a2f2f79714a346e6c4f34334b692e744b41462e532d77352e636f6d5820164a0815819ce9499d1b89834d1b386442c0aa3c8f4bcb87b9f870706f255840841a000495ee581de1a8c762c67b6743db934f40015e60b70efd3e0b6960c464248db3f1048305825820ef89412f9a9bf268ffd53f7895c1ec7e840df8844e88487869dfc5f2217b29c7038282783268747470733a2f2f71734c4a345856776949345030355279783473367937486b5132523444724477726f30367a692e636f6d582061f9dd12dbf59109357b17dc60ce919b23803b50801f241e6c696f5e41b6fd2b581c18c7917a79b5e2a6d7165a34cc0f10d9b7a3eddea4c235547eac8efc827568747470733a2f2f5a72706d635765342d2e636f6d58203a62fe7d7cb40e429f0059a54364afeef8abd1a421fcaf18ed6ea578afba2b3b8404581de161364b5d5c06c1594ee753f5349d16e58620f65fb3a4b7eea307b8a483018258207be094e820e07f8f78c873b4e0ecf4e2b15d1dc20f5c17d7ffe87790179c3b0a01820c0282783568747470733a2f2f327436506e34627a54347863627168507651557043707057304e6e6854576c52384f565a50615758712e636f6d58207d1a073c989960f5afcd02150bc00106cee3c58f76ec227d97bd176bee6d48ad8403581df1db09909f14311d6916e5e50d5823b85fe1e9c865e6533479e8e1340e8504f6d90102868201581c0176aabd30b998d3d2c4600d037852bda8ea6172b848474fafb8e7078201581c0d8e2d4f6172946671f31fc3251510b27d263a7a835ee2a23c6894658201581c683dc525ef128ac1e52a224bfe623fc264df627e7193ef06329e17068201581c6b7826eca56f65005aa36aac44f2d555f58a094133a5094078cc32598201581cafbdd371bdc9268f75ed2eb3f00d6fd4e40965480976027729918ff38200581c77d4b681f44a389e780c6397d6064192932ade5153820c1e4bd84e0da38201581c97a24ffec42b975bf0a741a2b5ebb46f5b8e60c1343f447557f5dad9068200581c0c3df6e7a2d95c86b56026a2d02d70388fe392c48e6485eb2d68cff1098200581c1a4dd337c9274128af73911f14838e84d0198b7604495a988b7cc1920fd81e821b0001f0379c00bda11b0011c37937e0800082784068747470733a2f2f574477424653344232396e2d73364e655158542e48384535465657734e7733544859632d7341346a502d62414a47586a725245532e636f6d5820cfab5b6ba486f1a9de4a766317f0d62328b25d1088ae3c0010078bc7c0514290841a0002f524581df0cd0b36220619469f81c703988d49f48c60921ea886cc24bf780e49698504825820906e8f178e137d2959e58a7aa277474bf2533bf2f0a6c43d7e7bd0ef2bd230d608d90102858201581c1d7ea05b35d1c79c7fc17ab184afa8141f242cb4d97683b51a6805068201581c3c99d846a65cad14a7d2a531c1235e70634bd2dbd9f2c825d7c6e4268201581cf90540064d2f01a0262dafd60ea7b902a9fdbb3dfee46ff8d331efa98200581c58b840883e3f9a0e94be5ca8fd819b785112ce8fa4bf574b31c773088200581ccceba763019621bda294bc647c20229573f1cc5e118f721f4eb89b70a68201581c038b3b262b71d5bf9fbb434875495d1ff74e5284fa6268c44676c362098201581c5f4c5b64371bb6bf3126cb11e14b9ba75d5c71014981bf5fc0b0c09d108201581ca60ff93df1cb30bd4cc42570d05e38a17af6c5957149b7b4518eca80098201581cac2fa7708f05e319c3bcff283f30dcf8a4b5e28781da71a0c6560755098200581c9bb0fea592564dfa5b0d26b6e05f5f29baf058a392ae1b9e674d7d33058200581cb48cf8fc228ac9a73f9bfabceb98fa67c7d3b2f845141ff100f7d4490fd81e820101827568747470733a2f2f6c6c6f6a52793056562e636f6d5820597b836d8d9e4a55e5ba1725ad412c778dfc62f4137878cac97640e92f9c5b331602a400d901028182582062edf140ca8fe5ae6906a569f74e1e1337a3bb802c03858b9c78a36e9c04bff45840cedaad031e754d737218cfc7a4aa7599673a36caba1189f4f21f4da6192cc616f0866c32744650bfcd851e023eef083af532363f7b9c87355a7141a60d9c1cfd02d9010283845820767a1dd542cd478cab5709cdcdf8fbb570d99aaf1a52d48aa96f1a818ecf72de5840259dad2f6458e9e5cb8f1dc6146c2094b4b5843cb205be78f32ee6897cccef5715b4629acc5edd056c28b830a9c2ed4cdfd9959c8941675b4f317837ca11167d5820e3bc37dfad6b9740f069b4aad53356059a2013165daf64dcb67d09597e7d0bd54401e81116845820e343c944fdc469c95d1b7e7c533848db61a2e34a25f30363cd253ef3b39ca0d5584088701bcde3da5b7fb71445574b40eb1ece92d42a2b7e9c59f56bc17c3ef99c3548beb7ba03838c8af65c8ffcd56ac88474edf1c408723fb4344051806ac27f5d58205c809cde507d403927757516a5dad1b8b78ce882c638ee73b09aab121c0da09d43aff22d845820adff954c0df6dbc4a979f391782d3ab90a6b1041577e663fbd7d32a0d82880b258407007b89502f6960706601c962a8850ea034c425c47c7019d69b5dc9c840e9b26d4de3569cea084050e234c0bc71db8a4b3169a85016b71265302b61c05966cb45820ac0311952b8e4dac5cc20f40b4051711b8d7244e796ae3c6fe67cb1125bf8c5341b901d9010283820282830300808200581c20e19a36a9d5b3280b0e4a2146d2920ede5e84994df85e0148486cbb82040d82040b05a282000182a205d87b9f42237ed87b9f427e2f012442d29cffd87e9f42646a210542edec22ffd87d8044de920665ff9f44a210876d43eb1f06ffd87d9f0203a1004044178df148ff821b54419df862a1888e1b788ba512cb7923028205008243430f94821b26bd86bf8f9d5fd71b21668d07eee4f8c0f4f6",
-                                "description": "",
-                                "txId": "0f60d64dc23cd9b5edd175e20057cd7522c461f57acb59aeb468b50508faa0e7",
-                                "type": "Tx ConwayEra"
-                            }
-                        ],
-                        "localUTxO": {
-                            "0103030301060700050502060506010800070707020700060605010305010806#36": {
-                                "address": "addr_test1vzlugvf2zruf042tj3ewrj59lj33g4l4mdakgdtppt5yxqcn4a6mm",
-                                "datum": null,
-                                "datumhash": "73b7b2c553506a981e1f240c2442bfa0c6f3e3b6ddd252a637801dfed1d8efdd",
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "ba1d67903b7379bd8c2a8b890d794c33ef29307795b95e3f42c2a20d": {
-                                        "37": 1
-                                    },
-                                    "lovelace": 1150770
-                                }
-                            },
-                            "0400020801050000040107000500030106050402080204050200000605010604#71": {
-                                "address": "addr_test1xr4tvn0r29ld65r0gj2u3h0hp03kxras5fce5vegh7uf0utug4fgw94x0spqyac5ryqddfl6jcnyvf0gsfs3yzmqp0tqhxmfge",
-                                "datum": null,
-                                "inlineDatum": {
-                                    "constructor": 1,
-                                    "fields": [
-                                        {
-                                            "bytes": ""
-                                        }
-                                    ]
+                                "0402050202060400050104050207010608020603010506080101010806020105#95": {
+                                    "address": "addr_test1qpe97asr4uwvh96mjwj3d68ewc3pc5num0yzupt69l8mp9r0mx0nwf65z5hnxehn7hcee83huvgpndz50su3w7ugegequsc5c6",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 969750
+                                    }
                                 },
-                                "inlineDatumRaw": "d87a9f40ff",
-                                "inlineDatumhash": "e5fb11c462e8260367a2f6dba56be077d9c9c1a330b7d96a73a23f581cd3e897",
-                                "referenceScript": null,
-                                "value": {
-                                    "105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5": {
-                                        "39": 8540753368897628881
+                                "0406060805060403030300020301060708050205040008010505030400000404#46": {
+                                    "address": "addr_test1ypeyv8dcqzury7nd79av7rh6ymkfv9wlk0v8wr2klx9l67e52euldt0vz4afkk58sulq284re3trp56mehg6y7fp2c6qtehzs3",
+                                    "datum": null,
+                                    "datumhash": null,
+                                    "inlineDatum": null,
+                                    "inlineDatumRaw": null,
+                                    "referenceScript": null,
+                                    "value": {
+                                        "lovelace": 969750
+                                    }
+                                },
+                                "0507070401040202050103080008030704060703020302030303030800060804#54": {
+                                    "address": "addr_test1zpnur00sje9fhg7xect07t8q5ymfp9qvm4mq0ksnmhryatmxzp7nafkn90nnp3xp79e74ekg7lklgdp4z2t4q35sxp0s626reg",
+                                    "datum": null,
+                                    "inlineDatum": {
+                                        "bytes": ""
                                     },
-                                    "lovelace": 1215420
+                                    "inlineDatumRaw": "40",
+                                    "inlineDatumhash": "39df024ac52722fe8ae4c1a8740e4c5624a38c3820e504a059aae8728421f8bd",
+                                    "referenceScript": null,
+                                    "value": {
+                                        "75e17c5417bcff4c36eecbc086ce9858417f56d4635a1f677a2b4a1d": {
+                                            "761d283b7b80b4fbbd91307610e66205ae1e37e8583f5053eacac9a9ed": 9052191472481260646
+                                        },
+                                        "lovelace": 1323170
+                                    }
                                 }
                             },
-                            "0603060805070301050804010607000103040105040608070100010208030002#37": {
-                                "address": "addr_test1qq4nt5uerafymhjkvtu0phkwae3tetdrrs9amnv6tf9euxf5zts4j87kew0lfacjlqtede0zt8mctflp3v4kw0ccmv3shq79cf",
-                                "datum": null,
-                                "datumhash": "c63238c3daf1f5c2fa81f16f6e3b215e729936d2537ed3aac90ea51d6b566506",
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "41982a11d6ec0ec13e905d637f87f32f33f44fc93aea8a8e023323a6": {
-                                        "9be7cbe26193f9ec4935bb802933": 1
-                                    },
-                                    "lovelace": 1327480
-                                }
-                            },
-                            "0701040106000402070808000501070208000208010003050805070408020503#89": {
-                                "address": "addr_test1zpplvzvprqxfgs3trlzp6efks28mrhyhj56m0yuhjddfaqtptk33qtsf35z6k6p0ny9zdxtmt68mdqprp7u49gf5f52qzt37yv",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "lovelace": 969750
-                                }
-                            },
-                            "0800060605020808020503070107070603050208020705010701060102010101#33": {
-                                "address": "addr_test1xruccxu8yytj4njzvkr9rx35gwuk3ae0ac5d9q3m7qyknw44fx8dmvmwwmxhepfemglgyqptp0z2xar2535uc6vdqkkqwx2t9d",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "5d3752087a8f130bf15d11e69d052e92a247875c85c56b3c53cd4569": {
-                                        "ad25114d": 5183846224652604268
-                                    },
-                                    "lovelace": 7500000000000000
-                                }
-                            },
-                            "0807030102040101080003060606070100060308030307080407040003030505#64": {
-                                "address": "addr_test1qrk5phj53cj8w7pdvr2ryalykdt6gd3hya5g389rtmsd3muqdgm2mk6jh3e38h6p4u7xph2d3zes0kta746ka9yvgr6sa78sy5",
-                                "datum": null,
-                                "datumhash": null,
-                                "inlineDatum": null,
-                                "inlineDatumRaw": null,
-                                "referenceScript": null,
-                                "value": {
-                                    "b0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165": {
-                                        "d57e407c8c26effb116845e1e6f0398f61dc215357744e102f0b7f2a9ba6736e": 7561857207836786549
-                                    },
-                                    "lovelace": 7500000000000000
-                                }
-                            }
+                            "version": 0
                         },
-                        "seenSnapshot": {
-                            "tag": "NoSeenSnapshot"
-                        },
-                        "version": 0
+                        "tag": "ConfirmedSnapshot"
                     },
-                    "headId": "07080103000805050806030706080305",
-                    "headSeed": "06020204020201070806030703060302",
+                    "contestationDeadline": "1864-05-08T13:08:59.758193091336Z",
+                    "headId": "06070707030003010003010605060102",
+                    "headSeed": "04010204060107050802010804000800",
                     "parameters": {
-                        "contestationPeriod": 604800,
+                        "contestationPeriod": 31536000,
                         "parties": [
                             {
-                                "vkey": "f02fe6001fab8272584ced105143b8490081ad934f39244fb6905d5098d02f3f"
+                                "vkey": "4f56fd0a4ced7bae721add7fe3d975ed42f009e639e86533718ee5ed5783e63d"
                             },
                             {
-                                "vkey": "c39240d2e1a83db0c35218927d6d7978da2f86ae98534514d8c15ab36c291c38"
-                            },
-                            {
-                                "vkey": "b1b09640f9b1277f9e1c0580628cbd3727b86df775c7a1fd2056023a13ec357e"
-                            },
-                            {
-                                "vkey": "c1413161f3d49e54a27c75ba8357cb6c906f8c4de9a1c3099ecdf5f8002ee3e7"
+                                "vkey": "5462e4226a515afd12a871448f8f2ac43b42b356e8fb2442e57f16c94d8bb08e"
                             }
                         ]
-                    }
+                    },
+                    "readyToFanoutSent": false,
+                    "version": 4
                 },
-                "tag": "Open"
+                "tag": "Closed"
             },
             "pendingDeposits": {
-                "0008060503000506050502000701000801030807040105040507050501030704": {
-                    "created": "1864-05-05T01:15:54.522188776873Z",
-                    "deadline": "1864-05-13T12:21:53.460798769468Z",
+                "0201000101070308000404060204030408070601040205050004060403010303": {
+                    "created": "1864-05-07T00:03:50.226519868403Z",
+                    "deadline": "1864-05-11T16:34:41.746159419752Z",
                     "deposited": {
-                        "0000030804080508050405020607010504010104030103070308020202010705#65": {
-                            "address": "addr_test1xrjlg86qsa3cg4h4vyg7wh7u34ul8mg87lmuwdjz327s0eap7mtkv6gxqsfw39lqyfd7axpwr389rh2lsxgprxaqx38sq55s6g",
-                            "datum": null,
-                            "inlineDatum": {
-                                "list": []
-                            },
-                            "inlineDatumRaw": "80",
-                            "inlineDatumhash": "45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0",
-                            "referenceScript": null,
-                            "value": {
-                                "4a1c412d8e2b3015a7fb7d382808fb7cb721bf93a56e8bb6661cdebe": {
-                                    "32": 1
-                                },
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0107080100060806050007080301000806070404000301070405040605000605#61": {
-                            "address": "addr_test1yp0c3zvh56gt8lkkwdnpn6nacystp89d5c6mec305amxlfvhtnv7s45eecugdksfapdflujenhc57yrkma5fatqmhthqkxtqjt",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
-                                    "075b1de14917dd0f513300ce9a2cb3fb390daf19c97a1937": 3
-                                },
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0205050206020505080106060407030704070404040703030807000300000702#99": {
-                            "address": "addr_test1qzg3dceg7gx7lcp2duvtgms35vecyqczwm9jttaqtwq0vx5y7ev63l5er860ckx0je40hdgaq62k9a7z3dgrzv5z3pwqxq39u5",
-                            "datum": null,
-                            "datumhash": "23c3259bbaee0be924c5316739724fafa74ab459b0ac90ab61dd3427df51226c",
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "b02a8339380db83d405b887ffed432718d04bd236d11139782e994ca": {
-                                    "8d24a3a44f47aceaba7e77acc643acd6dd8f4751096b7493": 6870124839445405081
-                                },
-                                "lovelace": 1409370
-                            }
-                        },
-                        "0207000805060104040004070505080305000100030704020805020402070203#42": {
-                            "address": "addr_test1xzlwealh4vmzqxwc500vrfrn7lhsww5jmngqw437eag9rpdnen8vmlcrclrgqd98udzlcqe2wuumh4ectxwrdptctc4s83yyqg",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0407050808010600020807050104050004060205040400050604050102010702#34": {
-                            "address": "addr_test1xr6aqmrpq3q6m0296564vnu8a2jy035zn33esqssrp2wgmf2fd797637wqjr2dq2v0cqht3rjz36slnuacfffsnaz6ls0zgnza",
-                            "datum": null,
-                            "datumhash": "6149a981464605f0287bc91bbf37594e2ecc385457614eef53fd7dc91d6eb115",
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "243b1d332ff1539f59dbf6616b4e105d1af20aa838256541ac4b69a2": {
-                                    "9993caf7a5cd8e575bb5494f65": 8011855837295708256
-                                },
-                                "lovelace": 1357650
-                            }
-                        },
-                        "0606020205000701020804020704000004020803000007050404050402010701#88": {
-                            "address": "addr_test1yzq07u3lyvde23e066rcqlyly5hx5hksn6rp5shm45my0wfrtvtlph9stjq9dzh58gsygw48v0vvlevmgzpupgjyak0qm7ms35",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        }
-                    },
-                    "headId": "00040008050006070701080300050806",
-                    "status": "Active"
-                },
-                "0107040505000806000704070804070808080807080404030803060306010402": {
-                    "created": "1864-05-06T07:22:49.189161560607Z",
-                    "deadline": "1864-05-08T14:31:50.806946288583Z",
-                    "deposited": {
-                        "0002000001040302050704020300030006020708020605010003050301070803#21": {
-                            "address": "addr_test1xren83uer7evuptlmt24nxk69xgqwkudz7qygjygjkfj5rhmmv85l7lg2eknl302e2cqueuw25lugly75rj6qcgkphtqsc8pee",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0002010501070300080400020200080001070002020000020402060706040307#80": {
-                            "address": "addr_test1yzz7t55uphxvzj4sg3mw9nayfrq0xk6dzf7sunuqlnmmdk20m65vm2dpwfzzyx97xerzwf05vpqexsvt7ur0m79xdxfqhpf6lf",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "105a8f1bb56444cacc86378c95421aceeb326b0fb7743e493eb82fd5": {
-                                    "ddb0369570c2a27c13bfe2836bd17f0cebc360042d08": 1
-                                },
-                                "lovelace": 1215420
-                            }
-                        },
-                        "0508060108000504080206050104000603050502060208010301060007000201#59": {
-                            "address": "addr_test1qq6050ca3339xsday6lp7pnms92yhkyauw2sjesktptlzjwfgarkc9hm9txd7t064qxfq56hk6ae6qczmqjn62khjpms8rshhs",
+                        "0003060301070701000302070707030701000806030807070704080205070006#21": {
+                            "address": "addr_test1zqa7y8y52gfe2ryf7s2at3h0dmx5r8wdgp7dsvxl9fum3z632p9dathe8pee8l8dakkus7zrqp4n4kujg7mkkmrgytvs0lurhg",
                             "datum": null,
                             "datumhash": null,
                             "inlineDatum": null,
@@ -4302,8 +5162,8 @@
                                 "lovelace": 969750
                             }
                         },
-                        "0703020102080307080500070602060604030503030100010405040600030707#78": {
-                            "address": "addr_test1zrjafj9ye2mkvkfry0l7hvg5w7wp0vzpcu89jwkhagzd4rd4pp4m4d26kavw7tft5y6yek3l4l3taynf25nafltctujsthdhvd",
+                        "0300030802010100060407030800030305050407080500030302040401070806#60": {
+                            "address": "addr_test1zrucxwguw75s6fkx588xpec2spn7anqfkuaw7puezt2f0eym0rjwfsq92t0nlw6s220n8z7ftv5lak9634lxyulwv6nqn8jv8f",
                             "datum": null,
                             "datumhash": null,
                             "inlineDatum": null,
@@ -4313,282 +5173,80 @@
                                 "lovelace": 7500000000000000
                             }
                         },
-                        "0802080407040407080806030204080600080605060203010804020503040506#88": {
-                            "address": "addr_test1xqzvkhmqhy93crkuk3kfwtcp45veejzk45r6krwr0kl8mzgu0zcfvcyx6ej54cyxnas6khh5dkpngud76e9d70w4cwtsx45jzv",
+                        "0400050803070202020306020506020405060505030400000106020203080800#62": {
+                            "address": "addr_test1qqj74rvtnmwms2sh09v8sp6zlfppunvnma6c2eh4m8ut9ddul8ljncmw93gukjutz2jhs8tt0n48qkc8k4ukj6g3vkts96pgnv",
                             "datum": null,
                             "datumhash": null,
                             "inlineDatum": null,
                             "inlineDatumRaw": null,
                             "referenceScript": null,
                             "value": {
-                                "c3b49edfc072382640935c0bd52acdb8b386a04f2c51770612ed7043": {
-                                    "5b80872a88b544a117a13549": 3963027447483040234
-                                },
-                                "lovelace": 1206800
+                                "lovelace": 7500000000000000
                             }
                         },
-                        "0805030506050802000007080803060202040102000008060104010607010803#65": {
-                            "address": "addr_test1xpqxg2uz4tsgg6re4pl5pd7q42udq7ncmpaw9e7zr06u3mtlf6upvn22ulqp4qpxey5rjsr53drnmdpxwttqxgvclr9snafse2",
+                        "0403080805060303070708030300050103040507020106070505000204010107#12": {
+                            "address": "addr_test1xqqgjvmwswqv0zaw8usa8ll0hjpqnav2ja94hveznxkva94kuwjete8m3lz0vrz7wjmk0rhv6el5aa6cyrwvkv8dcgkqangkmf",
                             "datum": null,
                             "datumhash": null,
                             "inlineDatum": null,
                             "inlineDatumRaw": null,
                             "referenceScript": null,
                             "value": {
-                                "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
-                                    "7b09eff0f03a3265": 8941965149198235915
+                                "lovelace": 969750
+                            }
+                        },
+                        "0404070603050106000808000708080803020807050206060100040301010407#51": {
+                            "address": "addr_test1yzx5lmeuevn0fg4fyfads4vyx39v6lq24vq4kjsy9zvlldhcfakqr8zfw4wr9df5lrrahjr0qsfyknz2vjwgk7rlca3qp4dhvr",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 969750
+                            }
+                        },
+                        "0801070600030107030803020306050505010506040501060000040702010506#55": {
+                            "address": "addr_test1xqwpqs4yh0cqcfk56way4p4602ts0vg38wwx8z4dsql8tjd0lzqrxh5u54jvxfx3yvnx6g0zlvz5c7w80vqztjqmghtqel53q7",
+                            "datum": null,
+                            "inlineDatum": {
+                                "list": [
+                                    {
+                                        "bytes": "6379"
+                                    }
+                                ]
+                            },
+                            "inlineDatumRaw": "9f426379ff",
+                            "inlineDatumhash": "8d393c0c0b17911a07220da5e7a64694d91e6a98e23772efdd4d049d3b86043d",
+                            "referenceScript": null,
+                            "value": {
+                                "477afd3ab6094686362ca13f5f64efe947289706d0b02d5acca721eb": {
+                                    "64d6": 1
                                 },
                                 "lovelace": 7500000000000000
                             }
                         }
                     },
-                    "headId": "04010703070000030006050004080301",
-                    "status": "Expired"
+                    "headId": "01020406040707040604070207030003",
+                    "status": "Active"
                 },
-                "0301010804080808050000080307050307040407010507000504060806020808": {
-                    "created": "1864-05-03T22:33:58.454610951186Z",
-                    "deadline": "1864-05-12T23:08:00.412388729193Z",
+                "0203030201070307060500060203070002030806000401050007040506010707": {
+                    "created": "1864-05-06T16:50:17.800619016787Z",
+                    "deadline": "1864-05-12T23:31:01.038379135119Z",
                     "deposited": {
-                        "0206040403070700010104030004010300040207070306010001030608010504#67": {
-                            "address": "addr_test1vphnvllnqpt90w4qv8dht0gysltwq0xglkeukt4ltf5g2hg40ada4",
+                        "0100040805060305060706020105020308040300050100080403080407060805#87": {
+                            "address": "addr_test1xzmyw78uvmm5e7a4ly6c2tzrk93jvpu87rw847lmx29g3t9zg94j2z7k9r6rarlut3emcre9e7dyal2qq9kqfvclrjzsn0rsae",
                             "datum": null,
                             "datumhash": null,
                             "inlineDatum": null,
                             "inlineDatumRaw": null,
                             "referenceScript": null,
                             "value": {
-                                "lovelace": 7500000000000000
+                                "lovelace": 969750
                             }
                         },
-                        "0208000400030505020707030101000702040200010306070503070202060507#12": {
-                            "address": "addr_test1yzgnwxf397c8n0r608a94azgzhf0yakkwkqukx4m3mugmxxs37xn5dy9vr7wyfet3nj9av7rslpy7368lwwq3gdqwwvsd2zsha",
-                            "datum": null,
-                            "inlineDatum": {
-                                "list": []
-                            },
-                            "inlineDatumRaw": "80",
-                            "inlineDatumhash": "45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0",
-                            "referenceScript": null,
-                            "value": {
-                                "245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abae": {
-                                    "36": 8695425275106254809
-                                },
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0301000800040602060701020800080707060407050300050203080607080602#96": {
-                            "address": "addr_test1yz8q5mhyve6clvj8t4atchhjrncjhxxf490s38qw64qcc2pjt6fjjpxe735s6kh799jg8x3crydce2jnsqceexf7xwgqc3f25f",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0601010103010003010502020005080705040005010606070302000700020300#5": {
-                            "address": "addr_test1qqc3z00dh9k5pat9mj8l3mst6gsjxaaty00wf6ccqxl8y8ux73phtmg3n2geknvxygq0t9ev9rg4zjpztxn4g92wa29q6pmv2g",
-                            "datum": null,
-                            "datumhash": "421112266b0a38932415033d55d3c63cf6b46a2fcf36ce67dd5abaa06a467397",
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "4b8456d6355b7f261970c380cc694940a3165451223838aed2a9753e": {
-                                    "f5dea7241da83d7a0dbe55": 1
-                                },
-                                "lovelace": 1314550
-                            }
-                        },
-                        "0705050502070702040106060104010204010803040206060106000302010804#34": {
-                            "address": "addr_test1vp6442pmwelh0x9cjn5ap4su5w6xqrnhtlt2j6ez4zd0dlcscf6yw",
-                            "datum": null,
-                            "inlineDatum": {
-                                "map": [
-                                    {
-                                        "k": {
-                                            "constructor": 1,
-                                            "fields": []
-                                        },
-                                        "v": {
-                                            "map": [
-                                                {
-                                                    "k": {
-                                                        "int": -5
-                                                    },
-                                                    "v": {
-                                                        "map": [
-                                                            {
-                                                                "k": {
-                                                                    "int": 0
-                                                                },
-                                                                "v": {
-                                                                    "int": -5
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "54"
-                                                                },
-                                                                "v": {
-                                                                    "int": -4
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "int": -3
-                                                                },
-                                                                "v": {
-                                                                    "bytes": "e1967b6f"
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "int": -4
-                                                                },
-                                                                "v": {
-                                                                    "int": -1
-                                                                }
-                                                            },
-                                                            {
-                                                                "k": {
-                                                                    "bytes": "943fd97c"
-                                                                },
-                                                                "v": {
-                                                                    "int": 3
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "k": {
-                                            "bytes": "a9"
-                                        },
-                                        "v": {
-                                            "list": [
-                                                {
-                                                    "map": [
-                                                        {
-                                                            "k": {
-                                                                "bytes": "ca"
-                                                            },
-                                                            "v": {
-                                                                "bytes": "12"
-                                                            }
-                                                        },
-                                                        {
-                                                            "k": {
-                                                                "bytes": "596e47"
-                                                            },
-                                                            "v": {
-                                                                "bytes": "0affbdd8"
-                                                            }
-                                                        },
-                                                        {
-                                                            "k": {
-                                                                "int": -1
-                                                            },
-                                                            "v": {
-                                                                "int": -1
-                                                            }
-                                                        },
-                                                        {
-                                                            "k": {
-                                                                "int": 4
-                                                            },
-                                                            "v": {
-                                                                "int": -5
-                                                            }
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "constructor": 1,
-                                                    "fields": [
-                                                        {
-                                                            "int": -5
-                                                        },
-                                                        {
-                                                            "int": -1
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "list": [
-                                                        {
-                                                            "int": -1
-                                                        },
-                                                        {
-                                                            "int": -1
-                                                        },
-                                                        {
-                                                            "int": 1
-                                                        },
-                                                        {
-                                                            "bytes": "f78f2049"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "k": {
-                                            "bytes": "a143"
-                                        },
-                                        "v": {
-                                            "map": []
-                                        }
-                                    },
-                                    {
-                                        "k": {
-                                            "list": [
-                                                {
-                                                    "bytes": "0967460d"
-                                                }
-                                            ]
-                                        },
-                                        "v": {
-                                            "int": -2
-                                        }
-                                    },
-                                    {
-                                        "k": {
-                                            "constructor": 1,
-                                            "fields": []
-                                        },
-                                        "v": {
-                                            "map": [
-                                                {
-                                                    "k": {
-                                                        "bytes": "7942445f"
-                                                    },
-                                                    "v": {
-                                                        "list": []
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "inlineDatumRaw": "a5d87a80a124a500244154232244e1967b6f232044943fd97c0341a99fa441ca411243596e47440affbdd820200424d87a9f2420ff9f20200144f78f2049ffff42a143a09f440967460dff21d87a80a1447942445f80",
-                            "inlineDatumhash": "b07be078e30599cf366bd54072b855af5399c5a0b1be69e7edb232848e3bdb0c",
-                            "referenceScript": null,
-                            "value": {
-                                "41162b3c1a2d15e7c36a6fe67dbdc89d2c458930449b3053a21719d2": {
-                                    "469df3a4ef9018": 2078887372314866567
-                                },
-                                "lovelace": 1474020
-                            }
-                        },
-                        "0805040500080805010707060608020304000000080804080003030701070502#32": {
-                            "address": "addr_test1xrjypdmpv9c5crs2ez76eplua64azjvs2zkm3dnqmlfjzl9j9fry0turfkteccepc0m7yqc99gmr5h2v8cdtfcj6p5hqygrrpf",
+                        "0208060706070301060606070300080306000404040708010702080406040805#21": {
+                            "address": "addr_test1zpfvpfqsk0kctr50s6ap0ppl5dzcvmxjazfswegm0gp2vw20p4g07plxft59dap4779emazmcrzj8ju326yq6lq64d7s8yhldu",
                             "datum": null,
                             "inlineDatum": {
                                 "int": 0
@@ -4597,119 +5255,297 @@
                             "inlineDatumhash": "03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314",
                             "referenceScript": null,
                             "value": {
-                                "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
-                                    "30": 5148926948963788751
+                                "4d50a11e297e7783383bf06dd6e4e481230323bd96cd8b8d9ee3888d": {
+                                    "0bb0273d5cb1208d3f1d7d2b20877cd7": 5430877363925245425
+                                },
+                                "lovelace": 1262830
+                            }
+                        },
+                        "0305010308060506050306060302000406070300080603070204070408080006#15": {
+                            "address": "addr_test1vq33uhw42c5ug3evyqq8f6kf5nmsdqlvkzulzjy04lfs67suxkx8a",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0408040000080306020601050300080102080208000707060808060404050505#76": {
+                            "address": "addr_test1ypgyj0kqgw95jcy9xa0ctv02rvha8tzum6grtded8ga6xvgqlu3yt76g8wcjn0e5a696y44q0w9kcxvrkm4ssk5kjuese9f93u",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "2e12c5e499e0521b13837391beed1248a2e36117370662ee75918b56": {
+                                    "a897517eb254bc0d6630a08beb": 1
+                                },
+                                "lovelace": 1176630
+                            }
+                        },
+                        "0706050205030605020108060008070206070601080802030402000801050807#21": {
+                            "address": "addr_test1qrclygv752yymljf68garyfg8fgqjryl27wspeqfn366hw60jk4hp8kulv5crwmxenudjrjdtxcly9g9pxar49knhevqjy2mm4",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0802080006020404080305070400080500060007030102070307040508000504#25": {
+                            "address": "addr_test1zrkaqps3yhj4fzyk476vs490x9dnlfduupa45akwxn0j3xrv47a0m46s46xs3kdz9evg9yf5z07ulfcn5yktfwpeqw9smsdzqk",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "b46d48852535637ad2aac0f680a816183cc63f67de13ab7e9c563487": {
+                                    "e2b888c3b2e1cae1ad5c02022204752f2356cf5be44e55": 1
                                 },
                                 "lovelace": 7500000000000000
                             }
                         }
                     },
-                    "headId": "03050702030508000807040401040004",
-                    "status": "Inactive"
+                    "headId": "02040606070801040403070804000807",
+                    "status": "Active"
                 },
-                "0301040000010706020302010203080606070008010100070003080001030007": {
-                    "created": "1864-05-13T01:14:28.048808005678Z",
-                    "deadline": "1864-05-05T23:56:59.215083998264Z",
+                "0504050605010304030001070603030308070805080701000204060708080503": {
+                    "created": "1864-05-06T17:53:35.3748258013Z",
+                    "deadline": "1864-05-15T12:06:24.191377332179Z",
                     "deposited": {
-                        "0201080104000002050408040207010308050202000701010001020408010000#71": {
-                            "address": "addr_test1xzexpau3lwkhz3puudct83gr77wtvackvzk6jt9dxdlrsx5yrdedrdznzdh5rj8a9hd5z5859nnxefqgljluhlusapeq7y2c9q",
+                        "0004070507070602020101060401050500080504010101060007010606000008#10": {
+                            "address": "addr_test1yp5uclemedlae4v8mych5v4vdv6nzplygm5wstp33zg0h9hcyq33asmcpxczmzf85kxph8en6z3cx7q5ghsfvnwuqr4skpgsca",
                             "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
+                            "inlineDatum": {
+                                "list": [
+                                    {
+                                        "list": [
+                                            {
+                                                "int": 5
+                                            },
+                                            {
+                                                "map": [
+                                                    {
+                                                        "k": {
+                                                            "bytes": "2d9f50"
+                                                        },
+                                                        "v": {
+                                                            "bytes": "b365e7"
+                                                        }
+                                                    },
+                                                    {
+                                                        "k": {
+                                                            "int": -5
+                                                        },
+                                                        "v": {
+                                                            "int": -1
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "bytes": ""
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "map": [
+                                            {
+                                                "k": {
+                                                    "bytes": "c09f"
+                                                },
+                                                "v": {
+                                                    "list": []
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "list": []
+                                                },
+                                                "v": {
+                                                    "list": [
+                                                        {
+                                                            "bytes": "07"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "k": {
+                                                    "constructor": 3,
+                                                    "fields": [
+                                                        {
+                                                            "int": 4
+                                                        },
+                                                        {
+                                                            "int": -2
+                                                        }
+                                                    ]
+                                                },
+                                                "v": {
+                                                    "bytes": "c94b"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "int": -2
+                                    },
+                                    {
+                                        "int": 0
+                                    }
+                                ]
+                            },
+                            "inlineDatumRaw": "9f9f05a2432d9f5043b365e7242040ffa342c09f80809f4107ffd87c9f0421ff42c94b2100ff",
+                            "inlineDatumhash": "d00d9b98cead0f795442003595f04fc38a260ca7790e11be38239e3f412f7ea7",
                             "referenceScript": null,
                             "value": {
-                                "467f58932b54910584a0e8ea25a225e06a14530b2e96e938c53a3f22": {
-                                    "b9e68e29cfb8caa58c538f361f20716065248e91e712b06a1eb7": 1
+                                "48fe31df0deffd204c10fef6f7b47e12a291f3d637c5cb24b9bc3182": {
+                                    "b7200be14211d761acf28cf7bb6f98f0fdb8bb3f90d39569855863": 1
                                 },
-                                "lovelace": 7500000000000000
+                                "lovelace": 1443850
                             }
                         },
-                        "0205000804000107030500020002010808060700010203010503040600040306#5": {
-                            "address": "addr_test1zrxz7etkjd4dmy3ena6xgcg88j485z49869kpqhwl7khh5h434u9zlsgpdykpup49mey0kla4mw96wzdl4j60e9f05ks0dr5sl",
+                        "0005030307080307030402070801040708060302060101010102080808040207#81": {
+                            "address": "addr_test1qz6kycudzgeselffd54dupha3yu2gpgm2kwny5p9hplpgvgcf30gl95dwewet40cn7ckff03948ql3pvsmg0sz0kqlvqhnlt4s",
                             "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
+                            "inlineDatum": {
+                                "int": -2
+                            },
+                            "inlineDatumRaw": "21",
+                            "inlineDatumhash": "0268be9dbd0446eaa217e1dec8f399249305e551d7fc1437dd84521f74aa621c",
                             "referenceScript": null,
                             "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0207030601060002010004020708000607070708030100000804020307040600#56": {
-                            "address": "addr_test1yqrf6z2xmc6fsc2cqaveqkw72wfhcz8u0nra5qtag3t7p390eu2uvnk0m5uumuqm2la99ld3a60sf8f7l3nyx8w4899qq3j6pl",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0400010401020203030801000400050504010705010502020805010700050002#7": {
-                            "address": "addr_test1yp8wsp2pc0txntjvgjxa8ghcu92pelr3slszczsnj7844h8xcdy58xv30z69xnhaqej23rqg4znthlsrsnh3szajeyuqf5ehsa",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0402020300020400000700060405030408000006050404060405040508070003#78": {
-                            "address": "addr_test1zpaz25644gvqjmnhv62p5qklfuscsdv3fhrcwgfewlx74kzgstd9vd78j3zj0ahz0ks9t6qzlx8p754wz7wef8hm4ruq7nv47l",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "b0c53e2bf180858da4b64eb5598c5615bba7d723d2b604a83b7f9165": {
-                                    "2e472385457e9f3f308778a341d062441c27e3fad5d18ff281": 1613414359868400592
+                                "7fe8f811807e24398e01957b00056ddbe4162b11012834c38151a0b8": {
+                                    "80e7326ebf07625bd74c6707165e6259562dae89bb3a07a935345c505a": 1
                                 },
-                                "lovelace": 7500000000000000
+                                "lovelace": 1288690
                             }
                         },
-                        "0502040503030704020006000106040407030705080206000002050100020405#37": {
-                            "address": "addr_test1zra82tl3n8wtlyuz09n8gja8nuplccqlupnqtthtrn84nw0yf86aw34e0whns5s6ruuw0naxc2t7h75y2f78j9s6ja8qw94kkg",
+                        "0607030303050701020706060505000506010800020004050602010107010003#22": {
+                            "address": "addr_test1zrq90m3tntf59m6vt7qw0xnpt2rvh0atw5884tkharf3xfcd7mhmqyguwpxsz00twp0knyfa8fktxfzeyzvszg2rhr0qe0dl48",
                             "datum": null,
                             "datumhash": null,
                             "inlineDatum": null,
                             "inlineDatumRaw": null,
                             "referenceScript": null,
                             "value": {
-                                "882b75b34b879d544c8c2e62c076b1ce727b6c628955bf7a7e172254": {
-                                    "13c06a": 4343475172307676349
+                                "lovelace": 969750
+                            }
+                        },
+                        "0607050408070607080405040003020507080804050205020803050602050703#24": {
+                            "address": "addr_test1vq53qc5c8nghmmu0vt56h8fddmmyrdwewtastr5rwts05zctgjurm",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0801020402000206010005030102020801080200020107080508040104040208#23": {
+                            "address": "addr_test1qrhdcufnf7vl3pzcz833az2szn65wdjd74j69lvg5zknkhgj5hs8488tf7tkv8fmsz7y94meh7lwaeqxful3qm285zks7jumgs",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 969750
+                            }
+                        },
+                        "0802030407030105040802050701020104050604010006080700000204030000#69": {
+                            "address": "addr_test1xppratmyc4hll5l6amdl573rr6kexskncv3wpcxer0h2xtgpuzngwdu69z3u8d0c9rsxl263pagn900q82cwjhm9lmkqkgnvk4",
+                            "datum": null,
+                            "datumhash": "5692fec488dad777df3e260a3c1f7c2a69d760f0d515a27b4cd0f3c06ac015ea",
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "fcb818d6c1307b67d13731f63a76a4034c05384c0c5c5d1759a599d9": {
+                                    "35": 5640367823069515769
                                 },
                                 "lovelace": 7500000000000000
                             }
                         }
                     },
-                    "headId": "06040006020704000304030303080007",
+                    "headId": "06060506070508060605020501010001",
                     "status": "Inactive"
                 },
-                "0704020802050507010507070608060606010107060208010608030707040306": {
-                    "created": "1864-05-10T08:44:44.63675349186Z",
-                    "deadline": "1864-05-13T23:09:14.55753915917Z",
+                "0604040404010006030400030808020005060200030102010306060401080804": {
+                    "created": "1864-05-06T02:44:22.45891645925Z",
+                    "deadline": "1864-05-07T10:27:12.234154904232Z",
                     "deposited": {
-                        "0207030203070605010004080105040601020401030302070803070302080004#79": {
-                            "address": "addr_test1ypc2jd8xymqy7rftcaya20y7h9dc82mgr89td9lqpf0yhqn80qq7yz6ftz020szdumu6kcljxtjn8evy5gj0c22896kswa7lrd",
+                        "0105010508030108030208050104030300010303030101020802040108000504#69": {
+                            "address": "addr_test1zpzl43lau5j353exy8hxq5f9zdhcx4p3ew50uudyu5mwd64cr3s7kg7z4wva3gdkk38g0epranj3dfwf57gy05d3m55sd7ul9n",
                             "datum": null,
-                            "datumhash": "fe5fe983688aaa2a07950dfbde25b731d80ec5da9b89cfa15a90671c5f3a322f",
+                            "datumhash": null,
                             "inlineDatum": null,
                             "inlineDatumRaw": null,
                             "referenceScript": null,
                             "value": {
-                                "417286b414d09ed7a4dc33c9820661280d0a7fcf8c6d57b9418141ba": {
-                                    "e9c7ee13938ff3f1d8b10184b8464d9fc48e264c3771b2": 6745491070016637988
-                                },
-                                "lovelace": 1400750
+                                "lovelace": 7500000000000000
                             }
                         },
-                        "0300080801060603030704020706020700060202030500040200030002060703#72": {
-                            "address": "addr_test1vpxknaq4emwuv32797cj8fpzukqqc93m935ny4gnz82u6mgjuqxln",
+                        "0201030107030101030000080701020508060800030501080706040304060603#98": {
+                            "address": "addr_test1zpv2rtrgyq2p7n2k85dlmwnawsmws6h5wt0lrtc60ntqjuc7fy8mp5f6me3vnd9c809pwadqw5y5tdc9k6jdzjrmsesqav7xfj",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 969750
+                            }
+                        },
+                        "0405050406080504070500070702000103080602040503060203000007030806#44": {
+                            "address": "addr_test1yzulhqmw369pzggfd4qwnkcus6vumfkesl0kclhy6t3ffkmd9pmhkqah5necxxk36fpl7fma5dwen27xrpp85jx545jq4z5tay",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0602010806050507060101020503030100010000010503030701060707010704#38": {
+                            "address": "addr_test1wzn0mvmmxh9a8x5h8cshrendnqflwpnnsk9a0k6fwc2c4dspcvhcp",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "245d5a7a06fe18358242e81281cd5ba9e6abe4efc54e7b659f25abae": {
+                                    "989091dadec08e7154a018748412bcc71b1b2263e13a4c67cc0974a5": 2360073914783799128
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0707070601020805020807000508060201010108010006040207040206000102#96": {
+                            "address": "addr_test1qzhwm5nm6hq22l2qawsevjv6gmgxe7wcqtu2e9qkkq6yg4d39ul4ejq7zj0q4rmwdwkkcad34474yksg7vymeh84dy8ssahamw",
+                            "datum": null,
+                            "datumhash": null,
+                            "inlineDatum": null,
+                            "inlineDatumRaw": null,
+                            "referenceScript": null,
+                            "value": {
+                                "a0cfc07fee6e00bbe2625e2d105f39f53087dabfe967f0262d38e72b": {
+                                    "5832e77803a82f754c9806e3b9000b0241b7e09d871ac6c330c7c3bfff87": 1
+                                },
+                                "lovelace": 7500000000000000
+                            }
+                        },
+                        "0803060806080405060305030802020608010806050401050204080507010608#22": {
+                            "address": "addr_test1wr2cqnzfjsr0pp6ac3xxg25yg6nl70ggcezfaffp8pua25sr8sduf",
                             "datum": null,
                             "datumhash": null,
                             "inlineDatum": null,
@@ -4718,180 +5554,14 @@
                             "value": {
                                 "lovelace": 849070
                             }
-                        },
-                        "0601040508010207060203070301070308000001010708030104080403050704#26": {
-                            "address": "addr_test1xzmsst4zwpd8lq27hgxlqm4eny9hsldv7648fq7vud9ktn38dr7mtgq20mau9yfs3cst8kd2035yrqkgx4n5gpv7gmrqc0ey6s",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "7b6366a99835d3ab4278459fb27391e6a99d4c884d1000060dd04f3e": {
-                                    "1afa352c21178dde809cdd58": 837750872932150943
-                                },
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0603020305020200050207030108080007030403030702010700040602050400#87": {
-                            "address": "addr_test1zqucqal7qr8355uf9mfueef9pk9t6q7z8vud74dy5rwyg0ux8umjh2gg2rmlxsfxwekdqqcusf3gxsq5fazhhrq2kywql7wp7u",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0708010806040307000601040107020307080404030606060507060502030005#38": {
-                            "address": "addr_test1qqqlus6grs336gqphes2vvd6277ntqptyvnvvgcfwpx0akrmgpj8sh3rm2vsnj9fhe4aw88pc0tes0uepk6j8xxg7k8sxv7arm",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0802040004080706000805060404010301080308040205020105020502000607#46": {
-                            "address": "addr_test1xpvceh00sz62y58a0x42e406xhwesgvdytk06c28e7vd988qg7pjypmh4vxg2s4elgnjapg04z3sldym7hlrf9ulfpwqd8ep4w",
-                            "datum": null,
-                            "inlineDatum": {
-                                "constructor": 4,
-                                "fields": [
-                                    {
-                                        "map": [
-                                            {
-                                                "k": {
-                                                    "constructor": 4,
-                                                    "fields": [
-                                                        {
-                                                            "int": 4
-                                                        },
-                                                        {
-                                                            "int": 0
-                                                        }
-                                                    ]
-                                                },
-                                                "v": {
-                                                    "int": -5
-                                                }
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "int": -1
-                                    }
-                                ]
-                            },
-                            "inlineDatumRaw": "d87d9fa1d87d9f0400ff2420ff",
-                            "inlineDatumhash": "fd9f6508929e224dd32cba3dbe72928f9592f1fac05bee60a68ec72308012b7c",
-                            "referenceScript": null,
-                            "value": {
-                                "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
-                                    "327072dda3df331521a8347a489bb206a92054a453196dc493": 2708851172476693833
-                                },
-                                "lovelace": 7500000000000000
-                            }
                         }
                     },
-                    "headId": "07050000080806050308040100070500",
-                    "status": "Expired"
-                },
-                "0807020206010408040605050706080304070808020604040600030701000106": {
-                    "created": "1864-05-04T12:39:46.502975197479Z",
-                    "deadline": "1864-05-14T22:12:04.251750192182Z",
-                    "deposited": {
-                        "0408040507000808010007020705030001040301020704010505030800000408#23": {
-                            "address": "addr_test1qqs6dycwrx9fe0fyg683yejnmvspehvhd6qhwnmgu2wmhfp3tw62qmplagupys2kr2fzxrqchs96m45ltfmea3wvnypq2dvsl8",
-                            "datum": null,
-                            "datumhash": "a2aaa74d16f5f49cbfbc81e5675c858d9ecc56b75ed44f1abe74e69705e0407c",
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "5d077d702d711b5546c6eacded6697edfe9ff92a91c8cef211057218": {
-                                    "bca75c387589046c5fdc2e2dbf5d014902f74a61": 495995087620495055
-                                },
-                                "lovelace": 1387820
-                            }
-                        },
-                        "0505080702000403010003070701020801080507010004020804010401030600#30": {
-                            "address": "addr_test1yqulzvta3f9p2skk05yndsw8qn7czq9j2ydtcf4my97dnv6ss02kay6zekn67lz2rr5077yz84wnpctmwajy9e6gk7zq52aznk",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "2db8410d969b6ad6b6969703c77ebf6c44061aa51c5d6ceba46557e2": {
-                                    "1fb4b49493863d4f9c8ae6aeca3b8a6652d100c0f13b41f8e6adfcd833": 1
-                                },
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0602020803030201030005020500030200020008040404020608010402020605#22": {
-                            "address": "addr_test1vqmsjhj5364zre238eqw0993dt97dq0djsnj8tsfhn25flqvyy4k5",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "bbca3c2d759d07b1cadb98c74bf453cddc304d1d243c2946f4d8b739": {
-                                    "38": 7023306281238924143
-                                },
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0606000108080305070401020102080305000808080408020002070404020606#93": {
-                            "address": "addr_test1wzqk44rlnpqgz6hswq2d5smkmxdevg22x3kxrw0zeckj82cmegy3g",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0608010101050703010106050101070503070001010206040506060700050404#12": {
-                            "address": "addr_test1qzz7uxzruvheku56lx4j8946xg6yfg92pclqw8lw7m7fwrzh3h6v2x8jg0ju7q24r9q20d7f7kd9cyplnjn5zjh0u7msqzdjha",
-                            "datum": null,
-                            "datumhash": "2c4195466868b0e6b017646330be837365feeb26b804412cd404ed99952eeddc",
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "77e3d047bb69b2c4540c0dcff18ce79ee9afbe1a177dfb781afd8871": {
-                                    "0d399f86e1aca6d988f167988611fd9e6027b4b9e21c8f2d08281c2183b0c3fd": 1
-                                },
-                                "lovelace": 7500000000000000
-                            }
-                        },
-                        "0708070102020704060704060602020807050107030502050203060505050406#9": {
-                            "address": "addr_test1yruselfgq4w9lrt040hecz89fx06j3ul0hjzge068p8acwg849d9prjcewzfdkqtvggwl0m88jvkdg3kazerjnn262ksrv4vjt",
-                            "datum": null,
-                            "datumhash": null,
-                            "inlineDatum": null,
-                            "inlineDatumRaw": null,
-                            "referenceScript": null,
-                            "value": {
-                                "0a1dad5b6891145fb45bde330828e84069f5042b698469acbb5cb212": {
-                                    "17f91fd44d28d922a088": 1
-                                },
-                                "lovelace": 7500000000000000
-                            }
-                        }
-                    },
-                    "headId": "03030404030700060201070407050307",
+                    "headId": "03080504080500070807000408040004",
                     "status": "Inactive"
                 }
             },
             "tag": "NodeCatchingUp"
         }
     ],
-    "seed": 1572138587
+    "seed": 128673513
 }

--- a/hydra-node/golden/ServerOutput/HeadPartiallyFannedOut.json
+++ b/hydra-node/golden/ServerOutput/HeadPartiallyFannedOut.json
@@ -1,0 +1,38 @@
+{
+    "samples": [
+        {
+            "distributedUTxO": {
+                "0101010101010000000101000101010101000000000001000100000100000000#83": {
+                    "address": "addr_test1zz7lasal3hhuhhkrx70uutzqst7l6qhctlmphu28tqjse4293zj9hwlsmey2lj6q8j4haxljperqpnfmahmnn6rhwjjsewd22r",
+                    "datum": null,
+                    "datumhash": "51d0e841c2f555968dcf5f72699023b1f8d75a36d32b238f9119856e2fb02ecf",
+                    "inlineDatum": null,
+                    "inlineDatumRaw": null,
+                    "referenceScript": null,
+                    "value": {
+                        "49fc00ef1ddab272d80eddf887ba1033b65ec732bc1b149e7691cdc5": {
+                            "16ddd1185481891ea3474c57a147ad0c7669de18e893d6cf3d17": 4649008583924363101
+                        },
+                        "lovelace": 1417990
+                    }
+                }
+            },
+            "headId": "01010100010001010100000101000100",
+            "remainingUTxO": {
+                "0101010101000100000101010100010101010101000100000101000000010001#63": {
+                    "address": "addr_test1xpcs8g8rqn87a5ne53qjrw8xlkwulejjgxgcdc86ywj2aq0uczxg8sk52ymrc857dqzr5pep83sq66ldga678h39gcqqks2p83",
+                    "datum": null,
+                    "datumhash": null,
+                    "inlineDatum": null,
+                    "inlineDatumRaw": null,
+                    "referenceScript": null,
+                    "value": {
+                        "lovelace": 45000000000000000
+                    }
+                }
+            },
+            "tag": "HeadPartiallyFannedOut"
+        }
+    ],
+    "seed": -1436436631
+}

--- a/hydra-node/golden/ServerOutput/HeadPartiallyFannedOut.json
+++ b/hydra-node/golden/ServerOutput/HeadPartiallyFannedOut.json
@@ -2,25 +2,23 @@
     "samples": [
         {
             "distributedUTxO": {
-                "0101010101010000000101000101010101000000000001000100000100000000#83": {
-                    "address": "addr_test1zz7lasal3hhuhhkrx70uutzqst7l6qhctlmphu28tqjse4293zj9hwlsmey2lj6q8j4haxljperqpnfmahmnn6rhwjjsewd22r",
+                "0001010000010101000100000001000100000000000000010101010000010101#36": {
+                    "address": "addr_test1vr9qn32m8fh7dglk9tk8kchnkqxe9eem7dmrjnjyyl3cw8gdqpnly",
                     "datum": null,
-                    "datumhash": "51d0e841c2f555968dcf5f72699023b1f8d75a36d32b238f9119856e2fb02ecf",
+                    "datumhash": null,
                     "inlineDatum": null,
                     "inlineDatumRaw": null,
                     "referenceScript": null,
                     "value": {
-                        "49fc00ef1ddab272d80eddf887ba1033b65ec732bc1b149e7691cdc5": {
-                            "16ddd1185481891ea3474c57a147ad0c7669de18e893d6cf3d17": 4649008583924363101
-                        },
-                        "lovelace": 1417990
+                        "lovelace": 45000000000000000
                     }
                 }
             },
-            "headId": "01010100010001010100000101000100",
+            "fanoutMode": "AutoFanningOut",
+            "headId": "01000000000101000100000001010101",
             "remainingUTxO": {
-                "0101010101000100000101010100010101010101000100000101000000010001#63": {
-                    "address": "addr_test1xpcs8g8rqn87a5ne53qjrw8xlkwulejjgxgcdc86ywj2aq0uczxg8sk52ymrc857dqzr5pep83sq66ldga678h39gcqqks2p83",
+                "0000010100010100000001010100000000010001000000000000010001000000#78": {
+                    "address": "addr_test1vqk7a8suz4fc86nksmp2lthnmgetwz2vvx5xsc04lu24f4ckrw9gh",
                     "datum": null,
                     "datumhash": null,
                     "inlineDatum": null,
@@ -34,5 +32,5 @@
             "tag": "HeadPartiallyFannedOut"
         }
     ],
-    "seed": -1436436631
+    "seed": -2074689718
 }

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -118,6 +118,7 @@ channels:
           - $ref: "api.yaml#/components/messages/Close"
           - $ref: "api.yaml#/components/messages/Contest"
           - $ref: "api.yaml#/components/messages/Fanout"
+          - $ref: "api.yaml#/components/messages/PartialFanout"
           - $ref: "api.yaml#/components/messages/SideLoadSnapshot"
 
   /head:
@@ -549,6 +550,13 @@ components:
       payload:
         $ref: "api.yaml#/components/schemas/Fanout"
 
+    PartialFanout:
+      title: PartialFanout
+      description: |
+        Fan out a user-selected subset of the closed head's UTxO after the contestation period passed. Unlike 'Fanout' (which drains the whole set automatically), this distributes only the provided 'utxoToFanout' and then waits for the next 'PartialFanout' command. Once a partial fanout has started, 'Fanout' is no longer accepted; keep issuing 'PartialFanout' until the head is drained, at which point the node automatically produces the final fanout that burns the head tokens. Selecting the entire remaining UTxO drains the head in one user action (still chunked dynamically on chain).
+      payload:
+        $ref: "api.yaml#/components/schemas/PartialFanout"
+
     SideLoadSnapshot:
       title: SideLoadSnapshot
       description: |
@@ -875,6 +883,7 @@ components:
         - $ref: "api.yaml#/components/schemas/SafeClose"
         - $ref: "api.yaml#/components/schemas/Contest"
         - $ref: "api.yaml#/components/schemas/Fanout"
+        - $ref: "api.yaml#/components/schemas/PartialFanout"
         - $ref: "api.yaml#/components/schemas/SideLoadSnapshot"
 
     ServerOutput:
@@ -889,6 +898,7 @@ components:
         - $ref: "api.yaml#/components/schemas/HeadIsClosed"
         - $ref: "api.yaml#/components/schemas/HeadIsContested"
         - $ref: "api.yaml#/components/schemas/ReadyToFanout"
+        - $ref: "api.yaml#/components/schemas/HeadPartiallyFannedOut"
         - $ref: "api.yaml#/components/schemas/HeadIsFinalized"
         - $ref: "api.yaml#/components/schemas/TxValid"
         - $ref: "api.yaml#/components/schemas/TxInvalid"
@@ -1045,6 +1055,19 @@ components:
         tag:
           type: string
           enum: ["Fanout"]
+
+    PartialFanout:
+      title: PartialFanout
+      type: object
+      required:
+        - tag
+        - utxoToFanout
+      properties:
+        tag:
+          type: string
+          enum: ["PartialFanout"]
+        utxoToFanout:
+          $ref: "api.yaml#/components/schemas/UTxO"
 
     SideLoadSnapshot:
       title: SideLoadSnapshot
@@ -1258,6 +1281,30 @@ components:
         timestamp:
           $ref: "api.yaml#/components/schemas/UTCTime"
 
+    HeadPartiallyFannedOut:
+      type: object
+      required:
+        - tag
+        - headId
+        - distributedUTxO
+        - remainingUTxO
+        - seq
+        - timestamp
+      properties:
+        tag:
+          type: string
+          enum: ["HeadPartiallyFannedOut"]
+        headId:
+          $ref: "api.yaml#/components/schemas/HeadId"
+        distributedUTxO:
+          $ref: "api.yaml#/components/schemas/UTxO"
+        remainingUTxO:
+          $ref: "api.yaml#/components/schemas/UTxO"
+        seq:
+          $ref: "api.yaml#/components/schemas/SequenceNumber"
+        timestamp:
+          $ref: "api.yaml#/components/schemas/UTCTime"
+
     HeadIsFinalized:
       type: object
       required:
@@ -1401,6 +1448,7 @@ components:
             - $ref: "api.yaml#/components/messages/SafeClose/payload"
             - $ref: "api.yaml#/components/messages/Contest/payload"
             - $ref: "api.yaml#/components/messages/Fanout/payload"
+            - $ref: "api.yaml#/components/messages/PartialFanout/payload"
             - $ref: "api.yaml#/components/messages/SideLoadSnapshot/payload"
         state:
           $ref: "api.yaml#/components/schemas/HeadState"
@@ -1425,6 +1473,7 @@ components:
             - $ref: "api.yaml#/components/messages/SafeClose/payload"
             - $ref: "api.yaml#/components/messages/Contest/payload"
             - $ref: "api.yaml#/components/messages/Fanout/payload"
+            - $ref: "api.yaml#/components/messages/PartialFanout/payload"
             - $ref: "api.yaml#/components/messages/SideLoadSnapshot/payload"
         drift:
           $ref: "api.yaml#/components/schemas/NominalDiffTime"
@@ -1449,6 +1498,7 @@ components:
             - $ref: "api.yaml#/components/messages/SafeClose/payload"
             - $ref: "api.yaml#/components/messages/Contest/payload"
             - $ref: "api.yaml#/components/messages/Fanout/payload"
+            - $ref: "api.yaml#/components/messages/PartialFanout/payload"
             - $ref: "api.yaml#/components/messages/SideLoadSnapshot/payload"
         requirementFailure:
           $ref: "api.yaml#/components/schemas/SideLoadRequirementFailure"
@@ -2199,6 +2249,7 @@ components:
         - Open
         - Closed
         - FanoutPossible
+        - FanningOut
 
     MultiSignature:
       type: object
@@ -2558,18 +2609,18 @@ components:
           required:
             - tag
             - utxoToDistribute
-            - remainingUTxO
+            - utxoForProof
             - headSeed
             - contestationDeadline
           description: |
-            Distribute a subset of UTxOs from the closed Head on-chain as part of a partial fanout sequence.
+            Distribute a subset of UTxOs from the closed Head on-chain as part of a partial fanout sequence (non-final, does not burn head tokens).
           properties:
             tag:
               type: string
               enum: ["PartialFanoutTx"]
             utxoToDistribute:
               $ref: "api.yaml#/components/schemas/UTxO"
-            remainingUTxO:
+            utxoForProof:
               $ref: "api.yaml#/components/schemas/UTxO"
             headSeed:
               $ref: "api.yaml#/components/schemas/HeadSeed"
@@ -3510,6 +3561,17 @@ components:
               enum: ["Closed"]
             contents:
               $ref: "api.yaml#/components/schemas/ClosedState"
+        - title: "FanoutProgress"
+          additionalProperties: false
+          required:
+            - tag
+            - contents
+          properties:
+            tag:
+              type: string
+              enum: ["FanoutProgress"]
+            contents:
+              $ref: "api.yaml#/components/schemas/PartialFanoutState"
 
     IdleState:
       type: object
@@ -3553,7 +3615,6 @@ components:
         - headId
         - headSeed
         - version
-        - distributedFanoutOutputs
       properties:
         parameters:
           $ref: "api.yaml#/components/schemas/HeadParameters"
@@ -3571,12 +3632,72 @@ components:
           $ref: "api.yaml#/components/schemas/HeadSeed"
         version:
           $ref: "api.yaml#/components/schemas/SnapshotVersion"
-        remainingFanoutOutputs:
-          oneOf:
-            - type: "null"
-            - $ref: "api.yaml#/components/schemas/UTxO"
-        distributedFanoutOutputs:
+
+    PartialFanoutState:
+      type: object
+      additionalProperties: false
+      required:
+        - parameters
+        - confirmedSnapshot
+        - contestationDeadline
+        - chainState
+        - headId
+        - headSeed
+        - version
+        - remainingOutputs
+        - distributedOutputs
+        - mode
+      properties:
+        parameters:
+          $ref: "api.yaml#/components/schemas/HeadParameters"
+        confirmedSnapshot:
+          $ref: "api.yaml#/components/schemas/ConfirmedSnapshot"
+        contestationDeadline:
+          $ref: "api.yaml#/components/schemas/UTCTime"
+        chainState:
+          $ref: "api.yaml#/components/schemas/ChainState"
+        headId:
+          $ref: "api.yaml#/components/schemas/HeadId"
+        headSeed:
+          $ref: "api.yaml#/components/schemas/HeadSeed"
+        version:
+          $ref: "api.yaml#/components/schemas/SnapshotVersion"
+        remainingOutputs:
           $ref: "api.yaml#/components/schemas/UTxO"
+        distributedOutputs:
+          $ref: "api.yaml#/components/schemas/UTxO"
+        mode:
+          $ref: "api.yaml#/components/schemas/FanoutMode"
+
+    FanoutMode:
+      oneOf:
+        - title: "AutoDrain"
+          additionalProperties: false
+          required:
+            - tag
+          properties:
+            tag:
+              type: string
+              enum: ["AutoDrain"]
+        - title: "DistributingSelection"
+          additionalProperties: false
+          required:
+            - tag
+            - contents
+          properties:
+            tag:
+              type: string
+              enum: ["DistributingSelection"]
+            contents:
+              $ref: "api.yaml#/components/schemas/UTxO"
+        - title: "AwaitingSelection"
+          additionalProperties: false
+          required:
+            - tag
+          properties:
+            tag:
+              type: string
+              enum: ["AwaitingSelection"]
 
     CoordinatedHeadState:
       type: object

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -1288,6 +1288,7 @@ components:
         - headId
         - distributedUTxO
         - remainingUTxO
+        - fanoutMode
         - seq
         - timestamp
       properties:
@@ -1300,10 +1301,22 @@ components:
           $ref: "api.yaml#/components/schemas/UTxO"
         remainingUTxO:
           $ref: "api.yaml#/components/schemas/UTxO"
+        fanoutMode:
+          $ref: "api.yaml#/components/schemas/FanoutProgressMode"
         seq:
           $ref: "api.yaml#/components/schemas/SequenceNumber"
         timestamp:
           $ref: "api.yaml#/components/schemas/UTCTime"
+
+    FanoutProgressMode:
+      title: FanoutProgressMode
+      type: string
+      description: >-
+        Whether a fanning-out head keeps draining on its own or is waiting for
+        the client to choose the next PartialFanout selection.
+      enum:
+        - AutoFanningOut
+        - AwaitingFanoutSelection
 
     HeadIsFinalized:
       type: object

--- a/hydra-node/src/Hydra/API/ClientInput.hs
+++ b/hydra-node/src/Hydra/API/ClientInput.hs
@@ -13,6 +13,13 @@ data ClientInput tx
   | SafeClose
   | Contest
   | Fanout
+  | -- | Fan out a user-selected subset of the closed head's UTxO. Unlike
+    -- 'Fanout' (which drains the whole set automatically), this distributes only
+    -- 'utxoToFanout' and then waits for the next 'PartialFanout' command. Once a
+    -- partial fanout has started, 'Fanout' is no longer accepted; the user keeps
+    -- issuing 'PartialFanout' until the head is drained, at which point the node
+    -- automatically produces the final fanout that burns the head tokens.
+    PartialFanout {utxoToFanout :: UTxOType tx}
   | SideLoadSnapshot {snapshot :: ConfirmedSnapshot tx}
   deriving stock (Generic)
 

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -248,7 +248,11 @@ mkTimedServerOutputFromStateEvent mSeenSnapshot event =
     StateChanged.HeadContested{..} -> Just HeadIsContested{..}
     StateChanged.HeadIsReadyToFanout{..} -> Just ReadyToFanout{..}
     StateChanged.HeadFannedOut{headId, finalizedOutputs} -> Just HeadIsFinalized{headId, finalizedUTxO = finalizedOutputs}
-    StateChanged.HeadPartialFannedOut{} -> Nothing
+    StateChanged.HeadPartialFannedOut{headId, distributedOutputs, remainingOutputs} ->
+      Just HeadPartiallyFannedOut{headId, distributedUTxO = distributedOutputs, remainingUTxO = remainingOutputs}
+    StateChanged.HeadFanoutInitiated{} -> Nothing
+    StateChanged.HeadPartialFanoutSelected{} -> Nothing
+    StateChanged.HeadFanoutReverted{} -> Nothing
     StateChanged.TransactionAppliedToLocalUTxO{..} -> Just TxValid{headId, transactionId = txId tx}
     StateChanged.TxInvalid{..} -> Just $ TxInvalid{..}
     StateChanged.SnapshotConfirmed{headId, snapshot = mSnapshot, signatures} ->

--- a/hydra-node/src/Hydra/API/Server.hs
+++ b/hydra-node/src/Hydra/API/Server.hs
@@ -22,6 +22,7 @@ import Hydra.API.ServerOutput (
   NetworkInfo (..),
   ServerOutput (..),
   TimedServerOutput (..),
+  fanoutProgressMode,
  )
 import Hydra.API.ServerOutputFilter (
   ServerOutputFilter,
@@ -248,8 +249,8 @@ mkTimedServerOutputFromStateEvent mSeenSnapshot event =
     StateChanged.HeadContested{..} -> Just HeadIsContested{..}
     StateChanged.HeadIsReadyToFanout{..} -> Just ReadyToFanout{..}
     StateChanged.HeadFannedOut{headId, finalizedOutputs} -> Just HeadIsFinalized{headId, finalizedUTxO = finalizedOutputs}
-    StateChanged.HeadPartialFannedOut{headId, distributedOutputs, remainingOutputs} ->
-      Just HeadPartiallyFannedOut{headId, distributedUTxO = distributedOutputs, remainingUTxO = remainingOutputs}
+    StateChanged.HeadPartialFannedOut{headId, distributedOutputs, remainingOutputs, mode} ->
+      Just HeadPartiallyFannedOut{headId, distributedUTxO = distributedOutputs, remainingUTxO = remainingOutputs, fanoutMode = fanoutProgressMode mode}
     StateChanged.HeadFanoutInitiated{} -> Nothing
     StateChanged.HeadPartialFanoutSelected{} -> Nothing
     StateChanged.HeadFanoutReverted{} -> Nothing

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -13,7 +13,7 @@ import Hydra.API.ClientInput (ClientInput)
 import Hydra.Chain (PostChainTx, PostTxError)
 import Hydra.Chain.ChainState (ChainSlot, IsChainState)
 import Hydra.HeadLogic.Error (SideLoadRequirementFailure)
-import Hydra.HeadLogic.State (ClosedState (..), HeadState (..), OpenState (..), PartialFanoutState (..), SeenSnapshot (..))
+import Hydra.HeadLogic.State (ClosedState (..), FanoutMode (..), HeadState (..), OpenState (..), PartialFanoutState (..), SeenSnapshot (..))
 import Hydra.HeadLogic.State qualified as HeadState
 import Hydra.Ledger (ValidationError)
 import Hydra.Network (Host, ProtocolVersion)
@@ -160,7 +160,10 @@ data ServerOutput tx
   | -- | A selective partial fanout step has been observed on chain. Reports the
     -- UTxO distributed in this step and what remains to be fanned out, so the
     -- client can choose the next 'PartialFanout' selection (or fan out the rest).
-    HeadPartiallyFannedOut {headId :: HeadId, distributedUTxO :: UTxOType tx, remainingUTxO :: UTxOType tx}
+    -- 'fanoutMode' tells the client whether the node will keep draining on its
+    -- own or is waiting for the next selection, so it can render the right
+    -- affordance instead of inferring it.
+    HeadPartiallyFannedOut {headId :: HeadId, distributedUTxO :: UTxOType tx, remainingUTxO :: UTxOType tx, fanoutMode :: FanoutProgressMode}
   | HeadIsFinalized {headId :: HeadId, finalizedUTxO :: UTxOType tx}
   | -- | Given transaction has been seen as valid in the Head. It is expected to
     -- eventually be part of a 'SnapshotConfirmed'.
@@ -300,6 +303,29 @@ data HeadStatus
     FanningOut
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
+
+-- | Client-facing projection of the node's fanout 'FanoutMode': whether a
+-- fanning-out head will continue draining on its own or is waiting for the
+-- client to choose the next 'PartialFanout'. Surfacing this lets clients render
+-- the correct affordance without inferring it from local actions.
+data FanoutProgressMode
+  = -- | The node keeps draining automatically (a full 'Fanout', or working
+    -- through a user selection). The client should wait, not prompt for input.
+    AutoFanningOut
+  | -- | The node has drained the current selection and is waiting for the next
+    -- 'PartialFanout' from the client.
+    AwaitingFanoutSelection
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+-- | Project the internal 'FanoutMode' to its client-facing 'FanoutProgressMode'.
+-- Both auto-drain and mid-selection draining present as 'AutoFanningOut' (the
+-- node advances by itself); only an exhausted selection awaits client input.
+fanoutProgressMode :: FanoutMode tx -> FanoutProgressMode
+fanoutProgressMode = \case
+  AutoDrain -> AutoFanningOut
+  DistributingSelection{} -> AutoFanningOut
+  AwaitingSelection -> AwaitingFanoutSelection
 
 -- | All information needed to distinguish behavior of the commit endpoint.
 data CommitInfo

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -13,7 +13,7 @@ import Hydra.API.ClientInput (ClientInput)
 import Hydra.Chain (PostChainTx, PostTxError)
 import Hydra.Chain.ChainState (ChainSlot, IsChainState)
 import Hydra.HeadLogic.Error (SideLoadRequirementFailure)
-import Hydra.HeadLogic.State (ClosedState (..), HeadState (..), OpenState (..), SeenSnapshot (..))
+import Hydra.HeadLogic.State (ClosedState (..), HeadState (..), OpenState (..), PartialFanoutState (..), SeenSnapshot (..))
 import Hydra.HeadLogic.State qualified as HeadState
 import Hydra.Ledger (ValidationError)
 import Hydra.Network (Host, ProtocolVersion)
@@ -157,6 +157,10 @@ data ServerOutput tx
       }
   | HeadIsContested {headId :: HeadId, snapshotNumber :: SnapshotNumber, contestationDeadline :: UTCTime}
   | ReadyToFanout {headId :: HeadId}
+  | -- | A selective partial fanout step has been observed on chain. Reports the
+    -- UTxO distributed in this step and what remains to be fanned out, so the
+    -- client can choose the next 'PartialFanout' selection (or fan out the rest).
+    HeadPartiallyFannedOut {headId :: HeadId, distributedUTxO :: UTxOType tx, remainingUTxO :: UTxOType tx}
   | HeadIsFinalized {headId :: HeadId, finalizedUTxO :: UTxOType tx}
   | -- | Given transaction has been seen as valid in the Head. It is expected to
     -- eventually be part of a 'SnapshotConfirmed'.
@@ -246,6 +250,7 @@ prepareServerOutput config response =
     HeadIsClosed{} -> encodedResponse
     HeadIsContested{} -> encodedResponse
     ReadyToFanout{} -> encodedResponse
+    HeadPartiallyFannedOut{} -> encodedResponse
     HeadIsFinalized{} -> encodedResponse
     TxValid{} -> encodedResponse
     TxInvalid{} -> encodedResponse
@@ -290,6 +295,9 @@ data HeadStatus
   | Open
   | Closed
   | FanoutPossible
+  | -- | A closed head whose UTxO is being distributed across multiple selective
+    -- partial fanout transactions.
+    FanningOut
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
@@ -317,6 +325,9 @@ getSnapshotUtxo = \case
   HeadState.Closed ClosedState{confirmedSnapshot} ->
     let snapshot = getSnapshot confirmedSnapshot
      in Just $ Tx.utxo snapshot <> fromMaybe mempty (Tx.utxoToCommit snapshot)
+  HeadState.FanoutProgress PartialFanoutState{confirmedSnapshot} ->
+    let snapshot = getSnapshot confirmedSnapshot
+     in Just $ Tx.utxo snapshot <> fromMaybe mempty (Tx.utxoToCommit snapshot)
 
 -- | Get latest seen snapshot from 'HeadState'.
 getSeenSnapshot :: IsTx tx => HeadState tx -> HeadState.SeenSnapshot tx
@@ -328,6 +339,9 @@ getSeenSnapshot = \case
   HeadState.Closed ClosedState{confirmedSnapshot} ->
     let Snapshot{number} = getSnapshot confirmedSnapshot
      in LastSeenSnapshot number
+  HeadState.FanoutProgress PartialFanoutState{confirmedSnapshot} ->
+    let Snapshot{number} = getSnapshot confirmedSnapshot
+     in LastSeenSnapshot number
 
 -- | Get latest confirmed snapshot from 'HeadState'.
 getConfirmedSnapshot :: HeadState tx -> Maybe (HeadState.ConfirmedSnapshot tx)
@@ -337,4 +351,6 @@ getConfirmedSnapshot = \case
   HeadState.Open OpenState{coordinatedHeadState} ->
     Just coordinatedHeadState.confirmedSnapshot
   HeadState.Closed ClosedState{confirmedSnapshot} ->
+    Just confirmedSnapshot
+  HeadState.FanoutProgress PartialFanoutState{confirmedSnapshot} ->
     Just confirmedSnapshot

--- a/hydra-node/src/Hydra/API/WSServer.hs
+++ b/hydra-node/src/Hydra/API/WSServer.hs
@@ -40,7 +40,7 @@ import Hydra.API.ServerOutputFilter (
  )
 import Hydra.Chain (Chain (..))
 import Hydra.Chain.ChainState (IsChainState)
-import Hydra.HeadLogic (ClosedState (ClosedState, readyToFanoutSent), HeadState, OpenState (..), StateChanged)
+import Hydra.HeadLogic (ClosedState (ClosedState, readyToFanoutSent), HeadState, OpenState (..), PartialFanoutState (..), StateChanged)
 import Hydra.HeadLogic.State qualified as HeadState
 import Hydra.Logging (Tracer, traceWith)
 import Hydra.NetworkVersions qualified as NetworkVersions
@@ -215,9 +215,11 @@ wsApp env party tracer chain history callback nodeStateP networkInfoP responseCh
     HeadState.Closed ClosedState{readyToFanoutSent}
       | readyToFanoutSent -> FanoutPossible
       | otherwise -> Closed
+    HeadState.FanoutProgress{} -> FanningOut
 
   getHeadId :: HeadState tx -> Maybe HeadId
   getHeadId = \case
     HeadState.Idle{} -> Nothing
     HeadState.Open OpenState{headId} -> Just headId
     HeadState.Closed ClosedState{headId} -> Just headId
+    HeadState.FanoutProgress PartialFanoutState{headId} -> Just headId

--- a/hydra-node/src/Hydra/Chain.hs
+++ b/hydra-node/src/Hydra/Chain.hs
@@ -89,6 +89,17 @@ data PostChainTx tx
       , headSeed :: HeadSeed
       , contestationDeadline :: UTCTime
       }
+  | -- | Non-final partial fanout of a user-selected subset. Distributes
+    -- 'utxoToDistribute' (dynamically chunked to fit) and leaves the head in the
+    -- 'FanoutProgress' state without burning tokens. 'utxoForProof' is the full
+    -- accumulator UTxO matching the current on-chain datum (everything still in
+    -- the head plus any pre-settled elements).
+    PartialFanoutTx
+      { utxoToDistribute :: UTxOType tx
+      , utxoForProof :: UTxOType tx
+      , headSeed :: HeadSeed
+      , contestationDeadline :: UTCTime
+      }
   | FinalPartialFanoutTx
       { utxoToDistribute :: UTxOType tx
       , presettledUTxO :: UTxOType tx

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -197,7 +197,7 @@ mkChain tracer queryTimeHandle wallet ctx LocalChainState{getLatest} submitTx =
               ctx
               spendableUTxO
               seedTxIn
-              (fanout ctx spendableUTxO seedTxIn utxo utxoToCommit utxoToDecommit utxoForProof deadlineSlot)
+              (rightToMaybe (fanout ctx spendableUTxO seedTxIn utxo utxoToCommit utxoToDecommit utxoForProof deadlineSlot))
               utxoForProof
               fullUTxO
               (UTxO.size fullUTxO - 1)
@@ -211,7 +211,7 @@ mkChain tracer queryTimeHandle wallet ctx LocalChainState{getLatest} submitTx =
               ctx
               spendableUTxO
               seedTxIn
-              (finalPartialFanout ctx spendableUTxO seedTxIn utxoToDistribute presettledUTxO deadlineSlot)
+              (rightToMaybe (finalPartialFanout ctx spendableUTxO seedTxIn utxoToDistribute presettledUTxO deadlineSlot))
               (utxoToDistribute <> presettledUTxO)
               utxoToDistribute
               (UTxO.size utxoToDistribute - 1)
@@ -232,7 +232,7 @@ mkChain tracer queryTimeHandle wallet ctx LocalChainState{getLatest} submitTx =
               ctx
               spendableUTxO
               seedTxIn
-              (Left () :: Either () Tx)
+              Nothing
               utxoForProof
               utxoToDistribute
               (UTxO.size utxoToDistribute)
@@ -606,7 +606,7 @@ fitsTx tracer withinSizeLimits evalCosts evalUTxO tx = do
 --   * No chunk fits within budget → 'FailedToConstructPartialFanoutTx'
 --     (budget exhaustion; also not a race condition).
 findFittingFanoutTx ::
-  forall m e.
+  forall m.
   MonadThrow m =>
   Tracer m CardanoChainLog ->
   TinyWallet m ->
@@ -615,8 +615,8 @@ findFittingFanoutTx ::
   UTxO ->
   -- | Seed TxIn
   TxIn ->
-  -- | Preferred tx to try first (FanoutTx or FinalPartialFanoutTx); Left skips straight to the loop
-  Either e Tx ->
+  -- | Preferred tx to try first (FanoutTx or FinalPartialFanoutTx); 'Nothing' skips straight to the fallback loop
+  Maybe Tx ->
   -- | UTxO for the accumulator check in the partial-fanout fallback (matches the on-chain datum)
   UTxO ->
   -- | UTxOs to distribute in the partial-fanout fallback
@@ -637,7 +637,7 @@ findFittingFanoutTx tracer TinyWallet{evaluateScriptCosts, isTxWithinSizeLimits}
  where
   -- Try the preferred tx (full fanout or final partial fanout) first; only
   -- fall back to the binary search if it doesn't fit.
-  findBest = either (const findFallback) tryPreferred ePreferred
+  findBest = maybe findFallback tryPreferred ePreferred
    where
     tryPreferred tx = fits tx >>= bool findFallback (pure (Right tx))
 

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -200,6 +200,7 @@ mkChain tracer queryTimeHandle wallet ctx LocalChainState{getLatest} submitTx =
               (fanout ctx spendableUTxO seedTxIn utxo utxoToCommit utxoToDecommit utxoForProof deadlineSlot)
               utxoForProof
               fullUTxO
+              (UTxO.size fullUTxO - 1)
               deadlineSlot
               >>= finalizeTx wallet ctx spendableUTxO mempty
           FinalPartialFanoutTx{utxoToDistribute, presettledUTxO, headSeed, contestationDeadline} -> do
@@ -213,6 +214,28 @@ mkChain tracer queryTimeHandle wallet ctx LocalChainState{getLatest} submitTx =
               (finalPartialFanout ctx spendableUTxO seedTxIn utxoToDistribute presettledUTxO deadlineSlot)
               (utxoToDistribute <> presettledUTxO)
               utxoToDistribute
+              (UTxO.size utxoToDistribute - 1)
+              deadlineSlot
+              >>= finalizeTx wallet ctx spendableUTxO mempty
+          PartialFanoutTx{utxoToDistribute, utxoForProof, headSeed, contestationDeadline} -> do
+            (deadlineSlot, seedTxIn) <- resolveHeadInfo headSeed contestationDeadline
+            -- Non-final partial fanout: no preferred tx, always chunk from the
+            -- user-selected set. The whole selection may be distributed in one
+            -- tx (size, not size-1): the selection is always a strict subset of
+            -- the head's remaining UTxO (HeadLogic routes a full selection to
+            -- the final/auto path instead), so the unselected remainder stays in
+            -- the accumulator and 'mustNotBeLastBatch' is satisfied regardless of
+            -- chunk size.
+            findFittingFanoutTx
+              tracer
+              wallet
+              ctx
+              spendableUTxO
+              seedTxIn
+              (Left () :: Either () Tx)
+              utxoForProof
+              utxoToDistribute
+              (UTxO.size utxoToDistribute)
               deadlineSlot
               >>= finalizeTx wallet ctx spendableUTxO mempty
           InitTx{participants, headParameters} -> do
@@ -504,6 +527,7 @@ prepareTxToPost timeHandle ctx spendableUTxO tx =
     -- These are handled in mkChain.postTx before reaching this function.
     FanoutTx{} -> throwSTM (FailedToConstructFanoutTx :: PostTxError Tx)
     FinalPartialFanoutTx{} -> throwSTM (FailedToConstructPartialFanoutTx :: PostTxError Tx)
+    PartialFanoutTx{} -> throwSTM (FailedToConstructPartialFanoutTx :: PostTxError Tx)
  where
   -- XXX: Might want a dedicated exception type here
   throwLeft :: Either Text a -> STM m a
@@ -597,10 +621,18 @@ findFittingFanoutTx ::
   UTxO ->
   -- | UTxOs to distribute in the partial-fanout fallback
   UTxO ->
+  -- | Upper bound (inclusive) of chunk sizes to search in the fallback. For the
+  --   final/full fanout fallback this is @size - 1@ (the preferred tx handles
+  --   the full set; a partial fanout must leave at least one output). For an
+  --   explicit non-final partial fanout this is the full @size@: the selection
+  --   is always a strict subset of the head's remaining UTxO, so even
+  --   distributing all of it leaves the unselected remainder in the accumulator
+  --   and 'mustNotBeLastBatch' holds.
+  Int ->
   -- | Contestation deadline as SlotNo
   SlotNo ->
   m Tx
-findFittingFanoutTx tracer TinyWallet{evaluateScriptCosts, isTxWithinSizeLimits} ctx spendableUTxO seedTxIn ePreferred proofUTxO fullUTxO deadlineSlot =
+findFittingFanoutTx tracer TinyWallet{evaluateScriptCosts, isTxWithinSizeLimits} ctx spendableUTxO seedTxIn ePreferred proofUTxO fullUTxO maxChunkSize deadlineSlot =
   findBest >>= either (const $ throwIO (FailedToConstructPartialFanoutTx @Tx)) pure
  where
   -- Try the preferred tx (full fanout or final partial fanout) first; only
@@ -609,7 +641,7 @@ findFittingFanoutTx tracer TinyWallet{evaluateScriptCosts, isTxWithinSizeLimits}
    where
     tryPreferred tx = fits tx >>= bool findFallback (pure (Right tx))
 
-  findFallback = findLargestFitting tryChunk (UTxO.size fullUTxO - 1)
+  findFallback = findLargestFitting tryChunk maxChunkSize
    where
     tryChunk n = buildTx n >>= \tx -> bool Nothing (Just tx) <$> fits tx
 

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -63,9 +63,11 @@ import Hydra.HeadLogic.Outcome (
 import Hydra.HeadLogic.State (
   ClosedState (..),
   CoordinatedHeadState (..),
+  FanoutMode (..),
   HeadState (..),
   IdleState (IdleState, chainState),
   OpenState (..),
+  PartialFanoutState (..),
   SeenSnapshot (..),
   getChainState,
   isCollectingAcks,
@@ -1352,62 +1354,120 @@ onClosedChainContestTx closedState newChainState snapshotNumber contestationDead
  where
   ClosedState{parameters = headParameters, confirmedSnapshot, headId, version} = closedState
 
--- | Client request to fanout leads to a fanout transaction on chain using the
--- latest confirmed snapshot from 'ClosedState'.
+-- | Client request to fanout the whole closed head automatically. Emits a
+-- 'FanoutTx'; the chain layer either lands a single full fanout (→ 'IdleState')
+-- or falls back to dynamically-chunked partial fanouts. The first observed
+-- partial fanout transitions the head to 'PartialFanout' in 'AutoDrain' mode,
+-- which keeps draining the rest automatically until the final (burning) step.
 --
--- The node decides the fanout tx TYPE based solely on the fanout phase:
+-- This node becomes the fanout /driver/: it transitions into 'PartialFanout' in
+-- 'AutoDrain' mode so that, as the chain layer chunks the fanout, /this/ node
+-- auto-continues to completion. Other parties that merely observe the resulting
+-- partial fanout do not auto-drive (see 'onClosedChainPartialFanoutTx').
 --
---  * 'FreshFanout' (no prior partial fanout observed): emit 'FanoutTx'. The
---    chain layer evaluates it and falls back to 'PartialFanoutTx' if it
---    exceeds the execution budget.
---  * 'FanoutInProgress' (prior partial fanouts observed): emit
---    'FinalPartialFanoutTx'. The chain layer similarly falls back to
---    'PartialFanoutTx' if the remaining set is still too large.
---
--- The chunk-size decision is fully dynamic in the chain layer — no threshold
--- constant is needed here.
---
--- If a partial fanout was already in progress (remainingFanoutUTxO is Just),
--- we fan out from the remaining UTxOs instead of the full snapshot.
---
--- __Transition__: 'ClosedState' → 'ClosedState' (partial) or 'ClosedState' → 'IdleState' (full)
+-- __Transition__: 'ClosedState' → 'PartialFanoutState' (then → 'IdleState' once
+-- the final fanout is observed).
 onClosedClientFanout ::
   IsTx tx =>
   ClosedState tx ->
   Outcome tx
-onClosedClientFanout closedState@ClosedState{remainingFanoutOutputs} =
-  case remainingFanoutOutputs of
-    Just remaining -> emitNextFanoutStep FanoutInProgress remaining closedState
-    Nothing -> emitNextFanoutStep FreshFanout mempty closedState
+onClosedClientFanout closedState =
+  newState HeadFanoutInitiated{headId, remainingOutputs = computeFullFanoutUTxO closedState}
+    <> cause OnChainEffect{postChainTx = fanoutTx}
+ where
+  ClosedState{headId, confirmedSnapshot, version, headSeed, contestationDeadline} = closedState
+  Snapshot{utxo, utxoToCommit, utxoToDecommit, version = snapshotVersion} = getSnapshot confirmedSnapshot
+  fanoutTx =
+    FanoutTx
+      { utxo
+      , -- Include utxoToCommit only if the increment has been applied on chain
+        -- (version bumped). Otherwise it was never used and must not be distributed.
+        utxoToCommit =
+          if snapshotVersion == version then Nothing else utxoToCommit
+      , -- Include utxoToDecommit only if the decrement has NOT been applied on
+        -- chain yet. If it was applied the UTxO is gone and must not be re-distributed.
+        utxoToDecommit =
+          if snapshotVersion == version then utxoToDecommit else Nothing
+      , -- Always use the snapshot's original (unfiltered) full UTxO set to rebuild
+        -- the accumulator that matches the closed datum.
+        utxoForProof = snapshotUTxO (getSnapshot confirmedSnapshot)
+      , headSeed
+      , contestationDeadline
+      }
 
--- | Observe a fanout transaction by finalize the head state and notifying
--- clients about it.
+-- | Client request to fan out a user-selected subset of a freshly closed head.
+-- Validates the selection is a non-empty sub-multiset (by content) of the
+-- fan-out-able UTxO, transitions the head into 'PartialFanout' (in
+-- 'DistributingSelection' mode) and emits the first 'PartialFanoutTx'.
+--
+-- __Transition__: 'ClosedState' → 'PartialFanoutState'
+onClosedClientPartialFanout ::
+  IsTx tx =>
+  ClosedState tx ->
+  UTxOType tx ->
+  Outcome tx
+onClosedClientPartialFanout closedState selection
+  | nullOutputs selection || not (selection `isSubMultisetOf` fullUTxO) =
+      cause . ClientEffect $ ServerOutput.CommandFailed (PartialFanout selection) (Closed closedState)
+  -- Selecting the whole head is just a full fanout: delegate to the automatic
+  -- drain. This is both what the user means ("fan out everything") and avoids an
+  -- impossible non-final partial fanout — a non-final batch must leave ≥1 UTxO, so
+  -- a fresh head with a single UTxO could not be drained selectively otherwise.
+  | selection `sameOutputs` fullUTxO = onClosedClientFanout closedState
+  | otherwise =
+      newState HeadPartialFanoutSelected{headId, remainingOutputs = fullUTxO, selection}
+        -- Fresh head: on-chain datum is still @Closed@, so the first step is a
+        -- non-final 'PartialFanoutTx'.
+        <> emitPartialFanoutStep selection fullUTxO False confirmedSnapshot version headSeed contestationDeadline
+ where
+  fullUTxO = computeFullFanoutUTxO closedState
+  ClosedState{headId, confirmedSnapshot, version, headSeed, contestationDeadline} = closedState
+
+-- | Client request to continue a selective partial fanout. Validates the
+-- selection against the current 'remainingOutputs', records it as the active
+-- selection and emits the next step.
+--
+-- __Transition__: 'PartialFanoutState' → 'PartialFanoutState'
+onPartialFanoutClientPartialFanout ::
+  IsTx tx =>
+  PartialFanoutState tx ->
+  UTxOType tx ->
+  Outcome tx
+onPartialFanoutClientPartialFanout pfs selection
+  | nullOutputs selection || not (selection `isSubMultisetOf` remainingOutputs) =
+      cause . ClientEffect $ ServerOutput.CommandFailed (PartialFanout selection) (FanoutProgress pfs)
+  | otherwise =
+      newState HeadPartialFanoutSelected{headId, remainingOutputs, selection}
+        -- Already in 'FanoutProgress' on chain.
+        <> emitPartialFanoutStep selection remainingOutputs True confirmedSnapshot version headSeed contestationDeadline
+ where
+  PartialFanoutState{headId, confirmedSnapshot, version, headSeed, contestationDeadline, remainingOutputs} = pfs
+
+-- | Observe a (full or final) fanout transaction, finalizing the head.
 --
 -- __Transition__: 'ClosedState' → 'IdleState'
 onClosedChainFanoutTx ::
-  IsTx tx =>
   ClosedState tx ->
   -- | New chain state
   ChainStateType tx ->
   UTxOType tx ->
   Outcome tx
 onClosedChainFanoutTx closedState newChainState fanoutUTxO =
-  -- When partial fanouts preceded this final fanout, combine the output values
-  -- distributed by each partial fanout with the final batch so clients receive
-  -- the complete set.
-  let allOutputs = distributedFanoutOutputs <> fanoutUTxO
-   in newState HeadFannedOut{headId, finalizedOutputs = allOutputs, chainState = newChainState}
+  newState HeadFannedOut{headId, finalizedOutputs = fanoutUTxO, chainState = newChainState}
  where
-  ClosedState{headId, distributedFanoutOutputs} = closedState
+  ClosedState{headId} = closedState
 
--- | Observe a partial fanout transaction on chain. This stays in 'ClosedState'
--- with updated remaining UTxOs and automatically triggers the next fanout.
+-- | Observe a partial fanout while this node is still 'Closed' — i.e. a partial
+-- fanout this node did NOT initiate (another party did). The fanout driver moved
+-- to 'PartialFanout' when it issued its 'Fanout'/'PartialFanout' command, so this
+-- handler is only reached by passive observers.
 --
--- Automatically triggers the next fanout step: 'FinalPartialFanoutTx'. The
--- chain layer falls back to another 'PartialFanoutTx' if remaining UTxOs do
--- not fit in a single tx.
+-- The observer transitions into 'PartialFanout' in 'AwaitingSelection' mode and
+-- does __not__ auto-drive the rest: only the driver advances the fanout. This is
+-- what makes selective partial fanout work in a multi-party head — observers must
+-- not steamroll the remaining UTxO the driver deliberately left.
 --
--- __Off-chain model__: 'ClosedState' → 'ClosedState' (the on-chain state transitions to FanoutProgress)
+-- __Transition__: 'ClosedState' → 'PartialFanoutState'
 onClosedChainPartialFanoutTx ::
   IsTx tx =>
   ClosedState tx ->
@@ -1417,20 +1477,85 @@ onClosedChainPartialFanoutTx ::
   UTxOType tx ->
   Outcome tx
 onClosedChainPartialFanoutTx closedState newChainState observedDistributed =
-  let fullUTxO = resolveRemainingUTxO closedState
+  let fullUTxO = computeFullFanoutUTxO closedState
       remaining = removeDistributedOutputs (outputsOfUTxO observedDistributed) fullUTxO
       distributedUTxO = withoutUTxO fullUTxO remaining
-      stateChange =
+   in newState
+        HeadPartialFannedOut
+          { headId
+          , distributedOutputs = distributedUTxO
+          , remainingOutputs = remaining
+          , chainState = newChainState
+          , mode = AwaitingSelection
+          }
+ where
+  ClosedState{headId} = closedState
+
+-- | Observe a partial fanout while in 'PartialFanout'. Updates the remaining and
+-- distributed sets and, depending on the current 'FanoutMode', either continues
+-- draining automatically (or within the active selection) or waits for the next
+-- 'PartialFanout' command.
+--
+-- __Transition__: 'PartialFanoutState' → 'PartialFanoutState'
+onPartialFanoutChainPartialFanoutTx ::
+  IsTx tx =>
+  PartialFanoutState tx ->
+  -- | New chain state
+  ChainStateType tx ->
+  -- | UTxO distributed in this partial fanout
+  UTxOType tx ->
+  Outcome tx
+onPartialFanoutChainPartialFanoutTx pfs newChainState observedDistributed =
+  let observedOutputs = outputsOfUTxO observedDistributed
+      remaining = removeDistributedOutputs observedOutputs remainingOutputs
+      distributedUTxO = withoutUTxO remainingOutputs remaining
+      newMode = case mode of
+        AutoDrain -> AutoDrain
+        AwaitingSelection -> AwaitingSelection
+        DistributingSelection sel ->
+          let sel' = removeDistributedOutputs observedOutputs sel
+           in if nullOutputs sel' then AwaitingSelection else DistributingSelection sel'
+      record =
         newState
           HeadPartialFannedOut
             { headId
             , distributedOutputs = distributedUTxO
             , remainingOutputs = remaining
             , chainState = newChainState
+            , mode = newMode
             }
-   in stateChange <> emitNextFanoutStep FanoutInProgress remaining closedState
+      -- Already in 'FanoutProgress' on chain, so any continuation may finalize.
+      finalize = emitPartialFanoutStep remaining remaining True confirmedSnapshot version headSeed contestationDeadline
+      continue
+        -- The head's remaining set is now empty: emit the final (burning) step,
+        -- which also distributes any pre-settled UTxO. This must happen regardless
+        -- of mode — otherwise a selection that drains everything (e.g. when a
+        -- pre-settled decommit UTxO keeps the on-chain accumulator non-empty) would
+        -- stop at 'AwaitingSelection' and wedge the head, never burning the tokens.
+        | nullOutputs remaining = finalize
+        | otherwise = case newMode of
+            AutoDrain -> finalize
+            DistributingSelection sel' -> emitPartialFanoutStep sel' remaining True confirmedSnapshot version headSeed contestationDeadline
+            AwaitingSelection -> noop
+   in record <> continue
  where
-  ClosedState{headId} = closedState
+  PartialFanoutState{headId, confirmedSnapshot, version, headSeed, contestationDeadline, remainingOutputs, mode} = pfs
+
+-- | Observe the final fanout while in 'PartialFanout', finalizing the head with
+-- the accumulated distributed outputs plus this final batch.
+--
+-- __Transition__: 'PartialFanoutState' → 'IdleState'
+onPartialFanoutChainFanoutTx ::
+  IsTx tx =>
+  PartialFanoutState tx ->
+  -- | New chain state
+  ChainStateType tx ->
+  UTxOType tx ->
+  Outcome tx
+onPartialFanoutChainFanoutTx pfs newChainState fanoutUTxO =
+  newState HeadFannedOut{headId, finalizedOutputs = distributedOutputs <> fanoutUTxO, chainState = newChainState}
+ where
+  PartialFanoutState{headId, distributedOutputs} = pfs
 
 -- | Compute the full UTxO set to be fanned out, combining snapshot utxo
 -- with utxoToCommit/utxoToDecommit based on version.
@@ -1439,6 +1564,17 @@ computeFullFanoutUTxO ::
   ClosedState tx ->
   UTxOType tx
 computeFullFanoutUTxO ClosedState{confirmedSnapshot, version} =
+  fanoutUTxOFromSnapshot confirmedSnapshot version
+
+-- | The fan-out-able UTxO of a confirmed snapshot at the given on-chain version:
+-- the snapshot UTxO plus a pending commit (if the increment landed on chain) or a
+-- pending decommit (if the decrement has not landed yet).
+fanoutUTxOFromSnapshot ::
+  IsTx tx =>
+  ConfirmedSnapshot tx ->
+  SnapshotVersion ->
+  UTxOType tx
+fanoutUTxOFromSnapshot confirmedSnapshot version =
   utxo
     <> fromMaybe mempty effectiveCommit
     <> fromMaybe mempty effectiveDecommit
@@ -1453,70 +1589,110 @@ computeFullFanoutUTxO ClosedState{confirmedSnapshot, version} =
       then utxoToDecommit
       else Nothing
 
+-- | Build the 'PartialFanout' ('FanoutProgress') head state from a closed head,
+-- carrying over the snapshot/parameters and using the given chain state, remaining
+-- and distributed UTxO and fanout 'mode'. Shared by the three @Closed →
+-- FanoutProgress@ transitions in 'aggregateNodeState'.
+closedToFanoutProgress ::
+  ClosedState tx ->
+  ChainStateType tx ->
+  UTxOType tx ->
+  UTxOType tx ->
+  FanoutMode tx ->
+  HeadState tx
+closedToFanoutProgress closedState chainState remaining distributed mode =
+  FanoutProgress
+    PartialFanoutState
+      { parameters
+      , confirmedSnapshot
+      , contestationDeadline
+      , chainState
+      , headId
+      , headSeed
+      , version
+      , remainingOutputs = remaining
+      , distributedOutputs = distributed
+      , mode
+      }
+ where
+  ClosedState{parameters, confirmedSnapshot, contestationDeadline, headId, headSeed, version} = closedState
+
+-- | Rebuild the 'ClosedState' from a 'PartialFanoutState' when reverting an
+-- optimistic 'Closed' → 'PartialFanout' transition (see 'HeadFanoutReverted').
+-- 'readyToFanoutSent' is restored to 'True' because a fanout is only reachable
+-- after the head was announced 'ReadyToFanout'.
+fanoutProgressToClosed :: PartialFanoutState tx -> ClosedState tx
+fanoutProgressToClosed pfs =
+  ClosedState
+    { parameters
+    , confirmedSnapshot
+    , contestationDeadline
+    , readyToFanoutSent = True
+    , chainState
+    , headId
+    , headSeed
+    , version
+    }
+ where
+  PartialFanoutState{parameters, confirmedSnapshot, contestationDeadline, chainState, headId, headSeed, version} = pfs
+
+-- | Whether a 'PostChainTx' is one of the fanout-posting transactions (used to
+-- scope the optimistic-fanout revert to genuine fanout post failures).
+isFanoutPostChainTx :: PostChainTx tx -> Bool
+isFanoutPostChainTx = \case
+  FanoutTx{} -> True
+  PartialFanoutTx{} -> True
+  FinalPartialFanoutTx{} -> True
+  _ -> False
+
 removeDistributedOutputs :: IsTx tx => [TxOutType tx] -> UTxOType tx -> UTxOType tx
 removeDistributedOutputs = flip (foldl' (flip removeOneOutputFromUTxO))
 
--- | Resolve the UTxO set to fan out: the already-narrowed remaining UTxO if a
--- partial fanout is in progress, or the full snapshot UTxO otherwise.
-resolveRemainingUTxO ::
-  IsTx tx =>
-  ClosedState tx ->
-  UTxOType tx
-resolveRemainingUTxO closedState@ClosedState{remainingFanoutOutputs} =
-  case remainingFanoutOutputs of
-    Just remaining -> remaining
-    Nothing -> computeFullFanoutUTxO closedState
+-- | Whether a UTxO has no outputs.
+nullOutputs :: IsTx tx => UTxOType tx -> Bool
+nullOutputs = null . outputsOfUTxO
 
--- | Tracks whether a partial fanout has already been observed on-chain.
--- Used to decide the final step: 'FanoutInProgress' heads go to
--- 'FinalPartialFanoutTx'; 'FreshFanout' heads can still use the direct 'FanoutTx'.
-data PartialFanoutPhase = FreshFanout | FanoutInProgress
-  deriving stock (Show)
+-- | Whether the outputs of @sub@ are a sub-multiset (by content) of @sup@. This
+-- mirrors how partial fanout tracks distributed UTxO by content rather than by
+-- 'TxIn', so a user-provided selection is validated against what is actually
+-- still in the head.
+isSubMultisetOf :: IsTx tx => UTxOType tx -> UTxOType tx -> Bool
+isSubMultisetOf sub sup =
+  length (outputsOfUTxO (removeDistributedOutputs (outputsOfUTxO sub) sup))
+    == length (outputsOfUTxO sup)
+    - length (outputsOfUTxO sub)
 
--- | Emit the appropriate on-chain effect based solely on the fanout phase.
--- 'FreshFanout' → 'FanoutTx' (chain layer evaluates; may fall back to PartialFanoutTx).
--- 'FanoutInProgress' → 'FinalPartialFanoutTx' (head output already in FanoutProgress state).
-emitNextFanoutStep ::
+-- | Whether two UTxO sets have the same outputs (by content, as a multiset).
+sameOutputs :: IsTx tx => UTxOType tx -> UTxOType tx -> Bool
+sameOutputs a b =
+  length (outputsOfUTxO a) == length (outputsOfUTxO b) && a `isSubMultisetOf` b
+
+-- | Emit the next partial fanout on-chain effect.
+--
+--  * When the chunk source @target@ covers the entire remaining set and the head
+--    is already in @FanoutProgress@ on chain, emit the final 'FinalPartialFanoutTx'
+--    that distributes the rest and burns the head tokens.
+--  * Otherwise emit a non-final 'PartialFanoutTx' drawing from @target@. The
+--    chain layer sizes the actual on-chain chunk dynamically.
+emitPartialFanoutStep ::
   IsTx tx =>
-  PartialFanoutPhase ->
+  -- | Chunk source for the next step (the user selection remainder, or the whole
+  --   remaining set when auto-draining)
   UTxOType tx ->
-  ClosedState tx ->
+  -- | The head's full remaining set
+  UTxOType tx ->
+  -- | Whether the on-chain head datum is already @FanoutProgress@ (i.e. at least
+  --   one partial fanout has happened). 'False' only for the very first step from
+  --   a @Closed@ head, where 'FinalPartialFanout' is not yet possible.
+  Bool ->
+  ConfirmedSnapshot tx ->
+  SnapshotVersion ->
+  HeadSeed ->
+  UTCTime ->
   Outcome tx
-emitNextFanoutStep FreshFanout _ closedState =
-  let ClosedState{confirmedSnapshot, version, headSeed, contestationDeadline} = closedState
-      Snapshot{utxo, utxoToCommit, utxoToDecommit, version = snapshotVersion} = getSnapshot confirmedSnapshot
-   in cause
-        OnChainEffect
-          { postChainTx =
-              FanoutTx
-                { utxo
-                , -- Include utxoToCommit only if the increment has been
-                  -- applied on chain (version bumped). Otherwise it was
-                  -- never used and must not be distributed.
-                  utxoToCommit =
-                    if snapshotVersion == version
-                      then Nothing
-                      else utxoToCommit
-                , -- Include utxoToDecommit only if the decrement has NOT
-                  -- been applied on chain yet. If it was applied the
-                  -- UTxO is gone and must not be re-distributed.
-                  utxoToDecommit =
-                    if snapshotVersion == version
-                      then utxoToDecommit
-                      else Nothing
-                , -- Always use the snapshot's original (unfiltered) full UTxO set
-                  -- to rebuild the accumulator that matches the closed datum.
-                  utxoForProof = snapshotUTxO (getSnapshot confirmedSnapshot)
-                , headSeed
-                , contestationDeadline
-                }
-          }
-emitNextFanoutStep FanoutInProgress remaining closedState =
-  let ClosedState{confirmedSnapshot, headSeed, contestationDeadline} = closedState
-      -- Pre-settled elements: in the snapshot accumulator but never distributed
-      -- (e.g. a decommit UTxO already paid out before close). mempty in normal case.
-      presettled = withoutUTxO (snapshotUTxO (getSnapshot confirmedSnapshot)) (computeFullFanoutUTxO closedState)
-   in cause
+emitPartialFanoutStep target remaining onChainIsFanoutProgress confirmedSnapshot version headSeed contestationDeadline
+  | target `sameOutputs` remaining && onChainIsFanoutProgress =
+      cause
         OnChainEffect
           { postChainTx =
               FinalPartialFanoutTx
@@ -1526,6 +1702,29 @@ emitNextFanoutStep FanoutInProgress remaining closedState =
                 , contestationDeadline
                 }
           }
+  | otherwise =
+      cause
+        OnChainEffect
+          { postChainTx =
+              PartialFanoutTx
+                { utxoToDistribute = target
+                , utxoForProof
+                , headSeed
+                , contestationDeadline
+                }
+          }
+ where
+  fullUTxO = fanoutUTxOFromSnapshot confirmedSnapshot version
+  -- Pre-settled elements: in the snapshot accumulator but never distributed
+  -- (e.g. a decommit UTxO already paid out before close). mempty in normal case.
+  presettled = withoutUTxO (snapshotUTxO (getSnapshot confirmedSnapshot)) fullUTxO
+  utxoForProof
+    -- First step from a @Closed@ head: the datum's accumulator commits to the
+    -- full snapshot UTxO.
+    | not onChainIsFanoutProgress = snapshotUTxO (getSnapshot confirmedSnapshot)
+    -- Otherwise the head is in @FanoutProgress@, whose accumulator commits to the
+    -- not-yet-distributed set plus any pre-settled elements.
+    | otherwise = remaining <> presettled
 
 -- | Detect our view of the chain going out of sync and issue a 'NodeUnsynced'
 -- event when this is the case.
@@ -1764,6 +1963,16 @@ handleChainInput env _ledger now _chainPointTime pendingDeposits st ev syncStatu
         onClosedChainPartialFanoutTx closedState newChainState distributedOutputs
     | otherwise ->
         Error NotOurHead{ourHeadId, otherHeadId = headId}
+  (FanoutProgress partialFanoutState@PartialFanoutState{headId = ourHeadId}, ChainInput Observation{observedTx = OnPartialFanoutTx{headId, distributedOutputs}, newChainState})
+    | ourHeadId == headId ->
+        onPartialFanoutChainPartialFanoutTx partialFanoutState newChainState distributedOutputs
+    | otherwise ->
+        Error NotOurHead{ourHeadId, otherHeadId = headId}
+  (FanoutProgress partialFanoutState@PartialFanoutState{headId = ourHeadId}, ChainInput Observation{observedTx = OnFanoutTx{headId, fanoutUTxO}, newChainState})
+    | ourHeadId == headId ->
+        onPartialFanoutChainFanoutTx partialFanoutState newChainState fanoutUTxO
+    | otherwise ->
+        Error NotOurHead{ourHeadId, otherHeadId = headId}
   -- Node-level: deposit/recover observations scoped to our head
   (Open OpenState{headId = ourHeadId}, ChainInput Observation{observedTx = OnDepositTx{headId, depositTxId, deposited, created, deadline}, newChainState})
     | ourHeadId == headId ->
@@ -1818,6 +2027,17 @@ handleChainInput env _ledger now _chainPointTime pendingDeposits st ev syncStatu
     -- was faster). The chain observation loop already emitted the correct next
     -- step, so this is safe to ignore.
     noop
+  (FanoutProgress PartialFanoutState{headId, distributedOutputs}, ChainInput PostTxError{postChainTx, postTxError})
+    -- We optimistically moved 'Closed' → 'PartialFanout' when the fanout was
+    -- initiated. If posting the initiating fanout tx fails terminally before
+    -- anything has been distributed on chain (so the on-chain datum is still
+    -- 'Closed'), revert to 'Closed' rather than wedging the head — otherwise
+    -- 'Fanout' stays rejected and there is no clean way to recover. Once any
+    -- partial fanout has landed ('distributedOutputs' non-empty) the on-chain
+    -- datum is genuinely 'FanoutProgress', so we must not revert.
+    | isFanoutPostChainTx postChainTx && nullOutputs distributedOutputs ->
+        newState HeadFanoutReverted{headId}
+          <> cause (ClientEffect ServerOutput.PostTxOnChainFailed{postChainTx, postTxError})
   (_, ChainInput PostTxError{postChainTx, postTxError}) ->
     cause . ClientEffect $ ServerOutput.PostTxOnChainFailed{postChainTx, postTxError}
   _ ->
@@ -1897,6 +2117,13 @@ handleClientInput env ledger ChainPointTime{currentSlot} pendingDeposits st ev =
   -- Closed
   (Closed closedState, ClientInput Fanout) ->
     onClosedClientFanout closedState
+  (Closed closedState, ClientInput PartialFanout{utxoToFanout}) ->
+    onClosedClientPartialFanout closedState utxoToFanout
+  -- PartialFanout: once a partial fanout has started, only further
+  -- 'PartialFanout' commands are accepted (a plain 'Fanout' falls through to the
+  -- general 'CommandFailed' below).
+  (FanoutProgress partialFanoutState, ClientInput PartialFanout{utxoToFanout}) ->
+    onPartialFanoutClientPartialFanout partialFanoutState utxoToFanout
   -- Node-level
   (_, ClientInput Recover{recoverTxId}) -> do
     onClientRecover currentSlot pendingDeposits recoverTxId
@@ -2042,6 +2269,9 @@ eventHeadId = \case
   HeadFannedOut{headId} -> Just headId
   TxInvalid{headId} -> Just headId
   HeadPartialFannedOut{headId} -> Just headId
+  HeadFanoutInitiated{headId} -> Just headId
+  HeadPartialFanoutSelected{headId} -> Just headId
+  HeadFanoutReverted{headId} -> Just headId
   -- The headId in IgnoredHeadInitializing is the OTHER head's id (not ours),
   -- so it must not be used to filter against the current head state.
   IgnoredHeadInitializing{} -> Nothing
@@ -2069,6 +2299,7 @@ headIdOf = \case
   Idle _ -> Nothing
   Open OpenState{headId} -> Just headId
   Closed ClosedState{headId} -> Just headId
+  FanoutProgress PartialFanoutState{headId} -> Just headId
 
 applyEvent :: IsChainState tx => HeadState tx -> StateChanged tx -> HeadState tx
 applyEvent st = \case
@@ -2333,13 +2564,11 @@ applyEvent st = \case
               , headId
               , headSeed
               , version
-              , remainingFanoutOutputs = Nothing
-              , distributedFanoutOutputs = mempty
               }
       _otherState -> st
   HeadContested{chainState, contestationDeadline} ->
     case st of
-      Closed ClosedState{parameters, confirmedSnapshot, readyToFanoutSent, headId, headSeed, version, remainingFanoutOutputs, distributedFanoutOutputs} ->
+      Closed ClosedState{parameters, confirmedSnapshot, readyToFanoutSent, headId, headSeed, version} ->
         Closed
           ClosedState
             { parameters
@@ -2350,26 +2579,51 @@ applyEvent st = \case
             , headId
             , headSeed
             , version
-            , remainingFanoutOutputs
-            , distributedFanoutOutputs
             }
       _otherState -> st
   HeadFannedOut{chainState} ->
     case st of
       Closed _ ->
-        Idle $
-          IdleState
-            { chainState
-            }
+        Idle $ IdleState{chainState}
+      FanoutProgress _ ->
+        Idle $ IdleState{chainState}
       _otherState -> st
-  HeadPartialFannedOut{distributedOutputs, remainingOutputs, chainState} ->
+  HeadFanoutInitiated{remainingOutputs} ->
     case st of
+      -- This node initiated a full automatic fanout: become the driver in
+      -- 'AutoDrain' mode so its observations auto-continue to completion.
+      Closed cst@ClosedState{chainState} ->
+        closedToFanoutProgress cst chainState remainingOutputs mempty AutoDrain
+      _otherState -> st
+  HeadPartialFanoutSelected{remainingOutputs, selection} ->
+    case st of
+      -- First selective partial fanout from a freshly closed head: enter the
+      -- 'PartialFanout' state with nothing distributed yet.
+      Closed cst@ClosedState{chainState} ->
+        closedToFanoutProgress cst chainState remainingOutputs mempty (DistributingSelection selection)
+      -- Continuing: just record the new active selection.
+      FanoutProgress pfs -> FanoutProgress pfs{mode = DistributingSelection selection}
+      _otherState -> st
+  HeadFanoutReverted{} ->
+    case st of
+      -- Roll the optimistic transition back: the initiating fanout tx failed to
+      -- post and nothing landed on chain, so the head is really still 'Closed'.
+      FanoutProgress pfs -> Closed (fanoutProgressToClosed pfs)
+      _otherState -> st
+  HeadPartialFannedOut{distributedOutputs = newlyDistributed, remainingOutputs, chainState, mode} ->
+    case st of
+      -- First partial fanout observed by a passive observer: transition from
+      -- 'Closed' into 'PartialFanout' (using the observed chain state).
       Closed cst ->
-        Closed
-          cst
+        closedToFanoutProgress cst chainState remainingOutputs newlyDistributed mode
+      -- Subsequent steps: accumulate distributed outputs and update remaining/mode.
+      FanoutProgress pfs@PartialFanoutState{distributedOutputs = priorDistributed} ->
+        FanoutProgress
+          pfs
             { chainState
-            , remainingFanoutOutputs = Just remainingOutputs
-            , distributedFanoutOutputs = distributedFanoutOutputs cst <> distributedOutputs
+            , remainingOutputs
+            , distributedOutputs = priorDistributed <> newlyDistributed
+            , mode
             }
       _otherState -> st
   HeadIsReadyToFanout{} ->
@@ -2429,6 +2683,9 @@ aggregateChainStateHistory history = \case
   HeadIsReadyToFanout{} -> history
   HeadFannedOut{chainState} -> pushNewState chainState history
   HeadPartialFannedOut{chainState} -> pushNewState chainState history
+  HeadFanoutInitiated{} -> history
+  HeadPartialFanoutSelected{} -> history
+  HeadFanoutReverted{} -> history
   ChainRolledBack{chainState} -> rollbackHistory (chainStateSlot chainState) history
   TickObserved{chainPoint} -> setLastKnown chainPoint history
   CommitApproved{} -> history

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1373,27 +1373,40 @@ onClosedClientFanout ::
   Outcome tx
 onClosedClientFanout closedState =
   newState HeadFanoutInitiated{headId, remainingOutputs = computeFullFanoutUTxO closedState}
-    <> cause OnChainEffect{postChainTx = fanoutTx}
+    <> cause OnChainEffect{postChainTx = mkFullFanoutTx confirmedSnapshot version headSeed contestationDeadline}
  where
   ClosedState{headId, confirmedSnapshot, version, headSeed, contestationDeadline} = closedState
-  Snapshot{utxo, utxoToCommit, utxoToDecommit, version = snapshotVersion} = getSnapshot confirmedSnapshot
-  fanoutTx =
-    FanoutTx
-      { utxo
-      , -- Include utxoToCommit only if the increment has been applied on chain
-        -- (version bumped). Otherwise it was never used and must not be distributed.
-        utxoToCommit =
-          if snapshotVersion == version then Nothing else utxoToCommit
-      , -- Include utxoToDecommit only if the decrement has NOT been applied on
-        -- chain yet. If it was applied the UTxO is gone and must not be re-distributed.
-        utxoToDecommit =
-          if snapshotVersion == version then utxoToDecommit else Nothing
-      , -- Always use the snapshot's original (unfiltered) full UTxO set to rebuild
-        -- the accumulator that matches the closed datum.
-        utxoForProof = snapshotUTxO (getSnapshot confirmedSnapshot)
-      , headSeed
-      , contestationDeadline
-      }
+
+-- | Build the full automatic 'FanoutTx' from a confirmed snapshot at the given
+-- on-chain version. Shared by 'onClosedClientFanout' and the rollback re-post in
+-- 'FanoutProgress' ('repostFanoutStep').
+mkFullFanoutTx ::
+  IsTx tx =>
+  ConfirmedSnapshot tx ->
+  SnapshotVersion ->
+  HeadSeed ->
+  UTCTime ->
+  PostChainTx tx
+mkFullFanoutTx confirmedSnapshot version headSeed contestationDeadline =
+  FanoutTx
+    { utxo
+    , -- Include utxoToCommit only if the increment has been applied on chain
+      -- (version bumped). Otherwise it was never used and must not be distributed.
+      utxoToCommit =
+        if snapshotVersion == version then Nothing else utxoToCommit
+    , -- Include utxoToDecommit only if the decrement has NOT been applied on
+      -- chain yet. If it was applied the UTxO is gone and must not be re-distributed.
+      utxoToDecommit =
+        if snapshotVersion == version then utxoToDecommit else Nothing
+    , -- Always use the snapshot's original (unfiltered) full UTxO set to rebuild
+      -- the accumulator that matches the closed datum.
+      utxoForProof = snapshotUTxO snapshot
+    , headSeed
+    , contestationDeadline
+    }
+ where
+  snapshot = getSnapshot confirmedSnapshot
+  Snapshot{utxo, utxoToCommit, utxoToDecommit, version = snapshotVersion} = snapshot
 
 -- | Client request to fan out a user-selected subset of a freshly closed head.
 -- Validates the selection is a non-empty sub-multiset (by content) of the
@@ -1726,6 +1739,37 @@ emitPartialFanoutStep target remaining onChainIsFanoutProgress confirmedSnapshot
     -- not-yet-distributed set plus any pre-settled elements.
     | otherwise = remaining <> presettled
 
+-- | Re-post the next fanout step after a chain rollback while in
+-- 'FanoutProgress', so the fanout resumes instead of stalling with the
+-- rolled-back transaction gone and nothing re-posted. This mirrors the
+-- Increment/Decrement re-post on rollback ('maybeRepostIncrementTx' /
+-- 'maybeRepostDecrementTx'): it uses the current best-effort bookkeeping and,
+-- like those re-posts, assumes the rolled-back transactions re-appear — it does
+-- not attempt to reconstruct fanout progress across a divergent rollback (the
+-- same limitation the general rollback handling has).
+--
+-- @distributedOutputs@ being empty means no partial fanout has landed on chain
+-- yet (the head datum is still @Closed@); otherwise the datum is
+-- @FanoutProgress@ and a 'FinalPartialFanoutTx' is possible.
+repostFanoutStep :: IsTx tx => PartialFanoutState tx -> Outcome tx
+repostFanoutStep pfs =
+  case mode of
+    -- Manual mode paused on the user: nothing to re-post, wait for the next
+    -- 'PartialFanout' command.
+    AwaitingSelection -> noop
+    AutoDrain
+      -- Nothing distributed yet: re-post the full automatic fanout, exactly as
+      -- the original 'Fanout' command did.
+      | not onChainIsFanoutProgress ->
+          cause OnChainEffect{postChainTx = mkFullFanoutTx confirmedSnapshot version headSeed contestationDeadline}
+      | otherwise ->
+          emitPartialFanoutStep remainingOutputs remainingOutputs True confirmedSnapshot version headSeed contestationDeadline
+    DistributingSelection selection ->
+      emitPartialFanoutStep selection remainingOutputs onChainIsFanoutProgress confirmedSnapshot version headSeed contestationDeadline
+ where
+  onChainIsFanoutProgress = not (nullOutputs distributedOutputs)
+  PartialFanoutState{confirmedSnapshot, version, headSeed, contestationDeadline, remainingOutputs, distributedOutputs, mode} = pfs
+
 -- | Detect our view of the chain going out of sync and issue a 'NodeUnsynced'
 -- event when this is the case.
 handleOutOfSync ::
@@ -2014,6 +2058,13 @@ handleChainInput env _ledger now _chainPointTime pendingDeposits st ev syncStatu
         <> handleOutOfSync env now (chainStatePoint rolledBackChainState) chainTime syncStatus
         <> maybeRepostIncrementTx headSeed headId parameters (depositsForHead headId pendingDeposits) currentDepositTxId confirmedSnapshot
         <> maybeRepostDecrementTx headSeed headId parameters decommitTx confirmedSnapshot
+  -- FanoutProgress + Rollback: re-post the next fanout step so the fanout
+  -- resumes rather than stalling (the in-flight fanout tx may have been rolled
+  -- back). Mirrors the Open re-post above.
+  (FanoutProgress partialFanoutState, ChainInput Rollback{rolledBackChainState, chainTime}) ->
+    newState ChainRolledBack{chainState = rolledBackChainState}
+      <> handleOutOfSync env now (chainStatePoint rolledBackChainState) chainTime syncStatus
+      <> repostFanoutStep partialFanoutState
   -- General
   (_, ChainInput Rollback{rolledBackChainState, chainTime}) ->
     newState ChainRolledBack{chainState = rolledBackChainState}

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -1377,6 +1377,26 @@ onClosedClientFanout closedState =
  where
   ClosedState{headId, confirmedSnapshot, version, headSeed, contestationDeadline} = closedState
 
+-- | Given the on-chain @version@ and a snapshot's own version, decide which of a
+-- pending commit / decommit is still to be distributed on fanout. When the
+-- increment has landed on chain (versions match) the commit was already applied
+-- (drop it) while a pending decommit still applies; otherwise the commit still
+-- applies and the decommit was already paid out. Centralises the version check
+-- shared by 'mkFullFanoutTx' and 'fanoutUTxOFromSnapshot'.
+effectiveCommitDecommit ::
+  -- | On-chain version
+  SnapshotVersion ->
+  -- | Snapshot version
+  SnapshotVersion ->
+  -- | Pending commit
+  Maybe (UTxOType tx) ->
+  -- | Pending decommit
+  Maybe (UTxOType tx) ->
+  (Maybe (UTxOType tx), Maybe (UTxOType tx))
+effectiveCommitDecommit onChainVersion snapshotVersion utxoToCommit utxoToDecommit
+  | snapshotVersion == onChainVersion = (Nothing, utxoToDecommit)
+  | otherwise = (utxoToCommit, Nothing)
+
 -- | Build the full automatic 'FanoutTx' from a confirmed snapshot at the given
 -- on-chain version. Shared by 'onClosedClientFanout' and the rollback re-post in
 -- 'FanoutProgress' ('repostFanoutStep').
@@ -1390,14 +1410,8 @@ mkFullFanoutTx ::
 mkFullFanoutTx confirmedSnapshot version headSeed contestationDeadline =
   FanoutTx
     { utxo
-    , -- Include utxoToCommit only if the increment has been applied on chain
-      -- (version bumped). Otherwise it was never used and must not be distributed.
-      utxoToCommit =
-        if snapshotVersion == version then Nothing else utxoToCommit
-    , -- Include utxoToDecommit only if the decrement has NOT been applied on
-      -- chain yet. If it was applied the UTxO is gone and must not be re-distributed.
-      utxoToDecommit =
-        if snapshotVersion == version then utxoToDecommit else Nothing
+    , utxoToCommit = effectiveCommit
+    , utxoToDecommit = effectiveDecommit
     , -- Always use the snapshot's original (unfiltered) full UTxO set to rebuild
       -- the accumulator that matches the closed datum.
       utxoForProof = snapshotUTxO snapshot
@@ -1405,6 +1419,7 @@ mkFullFanoutTx confirmedSnapshot version headSeed contestationDeadline =
     , contestationDeadline
     }
  where
+  (effectiveCommit, effectiveDecommit) = effectiveCommitDecommit version snapshotVersion utxoToCommit utxoToDecommit
   snapshot = getSnapshot confirmedSnapshot
   Snapshot{utxo, utxoToCommit, utxoToDecommit, version = snapshotVersion} = snapshot
 
@@ -1431,7 +1446,7 @@ onClosedClientPartialFanout closedState selection
       newState HeadPartialFanoutSelected{headId, remainingOutputs = fullUTxO, selection}
         -- Fresh head: on-chain datum is still @Closed@, so the first step is a
         -- non-final 'PartialFanoutTx'.
-        <> emitPartialFanoutStep selection fullUTxO False confirmedSnapshot version headSeed contestationDeadline
+        <> emitPartialFanoutStep selection fullUTxO DatumClosed confirmedSnapshot version headSeed contestationDeadline
  where
   fullUTxO = computeFullFanoutUTxO closedState
   ClosedState{headId, confirmedSnapshot, version, headSeed, contestationDeadline} = closedState
@@ -1451,10 +1466,13 @@ onPartialFanoutClientPartialFanout pfs selection
       cause . ClientEffect $ ServerOutput.CommandFailed (PartialFanout selection) (FanoutProgress pfs)
   | otherwise =
       newState HeadPartialFanoutSelected{headId, remainingOutputs, selection}
-        -- Already in 'FanoutProgress' on chain.
-        <> emitPartialFanoutStep selection remainingOutputs True confirmedSnapshot version headSeed contestationDeadline
+        -- The on-chain datum is only @FanoutProgress@ once a partial fanout has
+        -- actually landed (some outputs distributed); until then it is still
+        -- @Closed@ and a 'FinalPartialFanoutTx' is not yet valid. Compute this
+        -- the same way as 'repostFanoutStep' rather than assuming 'True'.
+        <> emitPartialFanoutStep selection remainingOutputs (onChainFanoutDatum distributedOutputs) confirmedSnapshot version headSeed contestationDeadline
  where
-  PartialFanoutState{headId, confirmedSnapshot, version, headSeed, contestationDeadline, remainingOutputs} = pfs
+  PartialFanoutState{headId, confirmedSnapshot, version, headSeed, contestationDeadline, remainingOutputs, distributedOutputs} = pfs
 
 -- | Observe a (full or final) fanout transaction, finalizing the head.
 --
@@ -1538,7 +1556,7 @@ onPartialFanoutChainPartialFanoutTx pfs newChainState observedDistributed =
             , mode = newMode
             }
       -- Already in 'FanoutProgress' on chain, so any continuation may finalize.
-      finalize = emitPartialFanoutStep remaining remaining True confirmedSnapshot version headSeed contestationDeadline
+      finalize = emitPartialFanoutStep remaining remaining DatumFanoutProgress confirmedSnapshot version headSeed contestationDeadline
       continue
         -- The head's remaining set is now empty: emit the final (burning) step,
         -- which also distributes any pre-settled UTxO. This must happen regardless
@@ -1548,7 +1566,7 @@ onPartialFanoutChainPartialFanoutTx pfs newChainState observedDistributed =
         | nullOutputs remaining = finalize
         | otherwise = case newMode of
             AutoDrain -> finalize
-            DistributingSelection sel' -> emitPartialFanoutStep sel' remaining True confirmedSnapshot version headSeed contestationDeadline
+            DistributingSelection sel' -> emitPartialFanoutStep sel' remaining DatumFanoutProgress confirmedSnapshot version headSeed contestationDeadline
             AwaitingSelection -> noop
    in record <> continue
  where
@@ -1593,14 +1611,7 @@ fanoutUTxOFromSnapshot confirmedSnapshot version =
     <> fromMaybe mempty effectiveDecommit
  where
   Snapshot{utxo, utxoToCommit, utxoToDecommit, version = snapshotVersion} = getSnapshot confirmedSnapshot
-  effectiveCommit =
-    if snapshotVersion == version
-      then Nothing
-      else utxoToCommit
-  effectiveDecommit =
-    if snapshotVersion == version
-      then utxoToDecommit
-      else Nothing
+  (effectiveCommit, effectiveDecommit) = effectiveCommitDecommit version snapshotVersion utxoToCommit utxoToDecommit
 
 -- | Build the 'PartialFanout' ('FanoutProgress') head state from a closed head,
 -- carrying over the snapshot/parameters and using the given chain state, remaining
@@ -1676,9 +1687,27 @@ isSubMultisetOf sub sup =
     - length (outputsOfUTxO sub)
 
 -- | Whether two UTxO sets have the same outputs (by content, as a multiset).
+-- The @a == b@ short-circuit avoids the O(n²) multiset comparison in the common
+-- case where both arguments are the same tracked set (e.g. the auto-drain
+-- @sameOutputs remaining remaining@ check on every observed chunk), which is
+-- exactly the large-UTxO heads partial fanout targets.
 sameOutputs :: IsTx tx => UTxOType tx -> UTxOType tx -> Bool
 sameOutputs a b =
-  length (outputsOfUTxO a) == length (outputsOfUTxO b) && a `isSubMultisetOf` b
+  a == b || (length (outputsOfUTxO a) == length (outputsOfUTxO b) && a `isSubMultisetOf` b)
+
+-- | Which on-chain head datum the next fanout step will be posted against:
+-- still @Closed@ (no partial fanout has landed yet) or already @FanoutProgress@.
+-- A 'FinalPartialFanoutTx' (which burns the head tokens) is only valid once the
+-- datum is 'DatumFanoutProgress'.
+data OnChainFanoutDatum = DatumClosed | DatumFanoutProgress
+  deriving stock (Eq)
+
+-- | The on-chain datum implied by how much has been distributed so far: still
+-- @Closed@ while nothing has landed, @FanoutProgress@ once some has.
+onChainFanoutDatum :: IsTx tx => UTxOType tx -> OnChainFanoutDatum
+onChainFanoutDatum distributed
+  | nullOutputs distributed = DatumClosed
+  | otherwise = DatumFanoutProgress
 
 -- | Emit the next partial fanout on-chain effect.
 --
@@ -1694,17 +1723,17 @@ emitPartialFanoutStep ::
   UTxOType tx ->
   -- | The head's full remaining set
   UTxOType tx ->
-  -- | Whether the on-chain head datum is already @FanoutProgress@ (i.e. at least
-  --   one partial fanout has happened). 'False' only for the very first step from
-  --   a @Closed@ head, where 'FinalPartialFanout' is not yet possible.
-  Bool ->
+  -- | The on-chain datum the step is posted against. 'DatumClosed' only for the
+  --   very first step from a @Closed@ head, where 'FinalPartialFanoutTx' is not
+  --   yet possible.
+  OnChainFanoutDatum ->
   ConfirmedSnapshot tx ->
   SnapshotVersion ->
   HeadSeed ->
   UTCTime ->
   Outcome tx
-emitPartialFanoutStep target remaining onChainIsFanoutProgress confirmedSnapshot version headSeed contestationDeadline
-  | target `sameOutputs` remaining && onChainIsFanoutProgress =
+emitPartialFanoutStep target remaining onChainDatum confirmedSnapshot version headSeed contestationDeadline
+  | target `sameOutputs` remaining && onChainDatum == DatumFanoutProgress =
       cause
         OnChainEffect
           { postChainTx =
@@ -1734,7 +1763,7 @@ emitPartialFanoutStep target remaining onChainIsFanoutProgress confirmedSnapshot
   utxoForProof
     -- First step from a @Closed@ head: the datum's accumulator commits to the
     -- full snapshot UTxO.
-    | not onChainIsFanoutProgress = snapshotUTxO (getSnapshot confirmedSnapshot)
+    | onChainDatum == DatumClosed = snapshotUTxO (getSnapshot confirmedSnapshot)
     -- Otherwise the head is in @FanoutProgress@, whose accumulator commits to the
     -- not-yet-distributed set plus any pre-settled elements.
     | otherwise = remaining <> presettled
@@ -1760,14 +1789,14 @@ repostFanoutStep pfs =
     AutoDrain
       -- Nothing distributed yet: re-post the full automatic fanout, exactly as
       -- the original 'Fanout' command did.
-      | not onChainIsFanoutProgress ->
+      | onChainDatum == DatumClosed ->
           cause OnChainEffect{postChainTx = mkFullFanoutTx confirmedSnapshot version headSeed contestationDeadline}
       | otherwise ->
-          emitPartialFanoutStep remainingOutputs remainingOutputs True confirmedSnapshot version headSeed contestationDeadline
+          emitPartialFanoutStep remainingOutputs remainingOutputs DatumFanoutProgress confirmedSnapshot version headSeed contestationDeadline
     DistributingSelection selection ->
-      emitPartialFanoutStep selection remainingOutputs onChainIsFanoutProgress confirmedSnapshot version headSeed contestationDeadline
+      emitPartialFanoutStep selection remainingOutputs onChainDatum confirmedSnapshot version headSeed contestationDeadline
  where
-  onChainIsFanoutProgress = not (nullOutputs distributedOutputs)
+  onChainDatum = onChainFanoutDatum distributedOutputs
   PartialFanoutState{confirmedSnapshot, version, headSeed, contestationDeadline, remainingOutputs, distributedOutputs, mode} = pfs
 
 -- | Detect our view of the chain going out of sync and issue a 'NodeUnsynced'
@@ -2024,6 +2053,14 @@ handleChainInput env _ledger now _chainPointTime pendingDeposits st ev syncStatu
     | otherwise ->
         Continue [] []
   (Closed ClosedState{headId = ourHeadId}, ChainInput Observation{observedTx = OnDepositTx{headId, depositTxId, deposited, created, deadline}, newChainState})
+    | ourHeadId == headId ->
+        newState DepositRecorded{chainState = newChainState, headId, depositTxId, deposited, created, deadline}
+    | otherwise ->
+        Continue [] []
+  -- Mirror the 'Closed' case while mid-fanout: a deposit observed during a
+  -- (partial) fanout must still be recorded so it remains recoverable via
+  -- 'Recover'. Without this the input falls through to 'Error' and is dropped.
+  (FanoutProgress PartialFanoutState{headId = ourHeadId}, ChainInput Observation{observedTx = OnDepositTx{headId, depositTxId, deposited, created, deadline}, newChainState})
     | ourHeadId == headId ->
         newState DepositRecorded{chainState = newChainState, headId, depositTxId, deposited, created, deadline}
     | otherwise ->

--- a/hydra-node/src/Hydra/HeadLogic/Outcome.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Outcome.hs
@@ -5,11 +5,13 @@ module Hydra.HeadLogic.Outcome where
 
 import Hydra.Prelude
 
+import Data.Aeson (Value (..), defaultOptions, genericParseJSON)
+import Data.Aeson.KeyMap qualified as KeyMap
 import Hydra.API.ServerOutput (ClientMessage, DecommitInvalidReason)
 import Hydra.Chain (PostChainTx)
 import Hydra.Chain.ChainState (ChainPointType, ChainSlot, ChainStateType, IsChainState)
 import Hydra.HeadLogic.Error (LogicError)
-import Hydra.HeadLogic.State (FanoutMode)
+import Hydra.HeadLogic.State (FanoutMode (..))
 import Hydra.Ledger (ValidationError)
 import Hydra.Network (Host, ProtocolVersion)
 import Hydra.Network.Message (Message)
@@ -177,7 +179,21 @@ data StateChanged tx
 deriving stock instance (IsChainState tx, IsTx tx, Eq (NodeState tx), Eq (ChainStateType tx)) => Eq (StateChanged tx)
 deriving stock instance (IsChainState tx, IsTx tx, Show (NodeState tx), Show (ChainStateType tx)) => Show (StateChanged tx)
 deriving anyclass instance (IsChainState tx, IsTx tx, ToJSON (ChainStateType tx)) => ToJSON (StateChanged tx)
-deriving anyclass instance (IsChainState tx, IsTx tx, FromJSON (NodeState tx), FromJSON (ChainStateType tx)) => FromJSON (StateChanged tx)
+
+-- | Decoded generically, except that a 'HeadPartialFannedOut' persisted before
+-- the 'mode' field existed (event logs from an earlier node) is decoded with
+-- 'mode' defaulting to 'AwaitingSelection'. That is the safe default: the node
+-- waits for the next 'PartialFanout' rather than assuming an auto-drain, so a
+-- node mid-fanout can still restart. All other constructors decode as before.
+instance forall tx. (IsChainState tx, IsTx tx, FromJSON (NodeState tx), FromJSON (ChainStateType tx)) => FromJSON (StateChanged tx) where
+  parseJSON = genericParseJSON defaultOptions . withDefaultFanoutMode
+   where
+    withDefaultFanoutMode = \case
+      Object o
+        | Just (String "HeadPartialFannedOut") <- KeyMap.lookup "tag" o
+        , not (KeyMap.member "mode" o) ->
+            Object (KeyMap.insert "mode" (toJSON (AwaitingSelection :: FanoutMode tx)) o)
+      v -> v
 
 data Outcome tx
   = -- | Continue with the given state updates and side effects.

--- a/hydra-node/src/Hydra/HeadLogic/Outcome.hs
+++ b/hydra-node/src/Hydra/HeadLogic/Outcome.hs
@@ -9,6 +9,7 @@ import Hydra.API.ServerOutput (ClientMessage, DecommitInvalidReason)
 import Hydra.Chain (PostChainTx)
 import Hydra.Chain.ChainState (ChainPointType, ChainSlot, ChainStateType, IsChainState)
 import Hydra.HeadLogic.Error (LogicError)
+import Hydra.HeadLogic.State (FanoutMode)
 import Hydra.Ledger (ValidationError)
 import Hydra.Network (Host, ProtocolVersion)
 import Hydra.Network.Message (Message)
@@ -123,12 +124,40 @@ data StateChanged tx
   | HeadClosed {headId :: HeadId, snapshotNumber :: SnapshotNumber, chainState :: ChainStateType tx, contestationDeadline :: UTCTime}
   | HeadContested {headId :: HeadId, chainState :: ChainStateType tx, contestationDeadline :: UTCTime, snapshotNumber :: SnapshotNumber}
   | HeadIsReadyToFanout {headId :: HeadId}
+  | -- | This node initiated a full automatic fanout ('Fanout' command). It
+    -- transitions 'Closed' → 'PartialFanout' in 'AutoDrain' mode so that this
+    -- node (the driver) auto-continues draining as chunks are observed. Other
+    -- parties that merely observe the resulting partial fanout do NOT auto-drive
+    -- (they go to 'AwaitingSelection'). No chain state change (client command).
+    HeadFanoutInitiated
+      { headId :: HeadId
+      , remainingOutputs :: UTxOType tx
+      }
+  | -- | A user initiated or updated a selective partial fanout. From 'Closed'
+    -- this transitions into the 'PartialFanout' state (using 'remainingOutputs'
+    -- as the initial remaining set); from 'PartialFanout' it just updates the
+    -- active selection. No chain state change (driven by a client command).
+    HeadPartialFanoutSelected
+      { headId :: HeadId
+      , remainingOutputs :: UTxOType tx
+      , selection :: UTxOType tx
+      }
+  | -- | Revert an optimistic 'Closed' → 'PartialFanout' transition back to
+    -- 'Closed'. Emitted when posting the initiating fanout transaction fails
+    -- terminally /before/ any partial fanout has landed on chain (i.e. while the
+    -- off-chain state is 'PartialFanout' but the on-chain datum is still
+    -- 'Closed'). Without this the head would wedge in 'PartialFanout' with
+    -- 'Fanout' rejected. No chain state change.
+    HeadFanoutReverted {headId :: HeadId}
   | HeadFannedOut {headId :: HeadId, finalizedOutputs :: UTxOType tx, chainState :: ChainStateType tx}
   | HeadPartialFannedOut
       { headId :: HeadId
       , distributedOutputs :: UTxOType tx
       , remainingOutputs :: UTxOType tx
       , chainState :: ChainStateType tx
+      , mode :: FanoutMode tx
+      -- ^ The fanout mode to continue with after this step (drives whether the
+      --   node auto-resumes draining or waits for the next 'PartialFanout').
       }
   | ChainRolledBack {chainState :: ChainStateType tx}
   | TickObserved {chainPoint :: ChainPointType tx}

--- a/hydra-node/src/Hydra/HeadLogic/State.hs
+++ b/hydra-node/src/Hydra/HeadLogic/State.hs
@@ -41,6 +41,10 @@ data HeadState tx
   = Idle (IdleState tx)
   | Open (OpenState tx)
   | Closed (ClosedState tx)
+  | -- | A closed head whose UTxO is being fanned out across multiple
+    -- transactions (on-chain in the @FanoutProgress@ state). Reached from
+    -- 'Closed' once the first partial fanout is observed.
+    FanoutProgress (PartialFanoutState tx)
   deriving stock (Generic)
 
 deriving stock instance (IsTx tx, Eq (ChainStateType tx)) => Eq (HeadState tx)
@@ -54,6 +58,7 @@ setChainState chainState = \case
   Idle st -> Idle st{chainState}
   Open st -> Open st{chainState}
   Closed st -> Closed st{chainState}
+  FanoutProgress st -> FanoutProgress st{chainState}
 
 -- | Get the chain state in any 'HeadState'.
 getChainState :: HeadState tx -> ChainStateType tx
@@ -61,6 +66,7 @@ getChainState = \case
   Idle IdleState{chainState} -> chainState
   Open OpenState{chainState} -> chainState
   Closed ClosedState{chainState} -> chainState
+  FanoutProgress PartialFanoutState{chainState} -> chainState
 
 -- | Get the head parameters in any 'HeadState'.
 getHeadParameters :: HeadState tx -> Maybe HeadParameters
@@ -68,6 +74,7 @@ getHeadParameters = \case
   Idle _ -> Nothing
   Open OpenState{parameters} -> Just parameters
   Closed ClosedState{parameters} -> Just parameters
+  FanoutProgress PartialFanoutState{parameters} -> Just parameters
 
 -- | Get the head parameters in any 'HeadState'.
 getOpenStateConfirmedSnapshot :: HeadState tx -> Maybe (ConfirmedSnapshot tx)
@@ -75,6 +82,7 @@ getOpenStateConfirmedSnapshot = \case
   Idle _ -> Nothing
   Open OpenState{coordinatedHeadState = CoordinatedHeadState{confirmedSnapshot}} -> Just confirmedSnapshot
   Closed ClosedState{} -> Nothing
+  FanoutProgress PartialFanoutState{} -> Nothing
 
 -- ** Idle
 
@@ -249,12 +257,6 @@ data ClosedState tx = ClosedState
   , headId :: HeadId
   , headSeed :: HeadSeed
   , version :: SnapshotVersion
-  , remainingFanoutOutputs :: Maybe (UTxOType tx)
-  -- ^ Tracks remaining UTxO to fan out after partial fanouts.
-  --   Nothing means no partial fanout has occurred yet.
-  , distributedFanoutOutputs :: UTxOType tx
-  -- ^ Accumulates UTxO distributed by partial fanout transactions.
-  --   Used to reconstruct the full UTxO set in 'HeadFannedOut'.
   }
   deriving stock (Generic)
 
@@ -262,3 +264,50 @@ deriving stock instance (IsTx tx, Eq (ChainStateType tx)) => Eq (ClosedState tx)
 deriving stock instance (IsTx tx, Show (ChainStateType tx)) => Show (ClosedState tx)
 deriving anyclass instance (IsTx tx, ToJSON (ChainStateType tx)) => ToJSON (ClosedState tx)
 deriving anyclass instance (IsTx tx, FromJSON (ChainStateType tx)) => FromJSON (ClosedState tx)
+
+-- ** PartialFanout
+
+-- | How the node decides which UTxOs to distribute in the next fanout step
+-- while the head is in 'PartialFanout'.
+data FanoutMode tx
+  = -- | Entered only via the 'Fanout' client command: drain the whole remaining
+    -- set automatically, dynamically chunked, ending in the final fanout.
+    AutoDrain
+  | -- | Manual mode: keep distributing this (content-tracked) user selection,
+    -- dynamically chunked, until it is exhausted.
+    DistributingSelection (UTxOType tx)
+  | -- | Manual mode: the previous selection has been fully distributed. Wait for
+    -- the next 'PartialFanout' command; do not auto-drain.
+    AwaitingSelection
+  deriving stock (Generic)
+
+deriving stock instance IsTx tx => Eq (FanoutMode tx)
+deriving stock instance IsTx tx => Show (FanoutMode tx)
+deriving anyclass instance IsTx tx => ToJSON (FanoutMode tx)
+deriving anyclass instance IsTx tx => FromJSON (FanoutMode tx)
+
+-- | A closed head whose UTxO is being distributed across multiple fanout
+-- transactions (on-chain @FanoutProgress@). Holds the partial-fanout bookkeeping
+-- that used to live in 'ClosedState'.
+data PartialFanoutState tx = PartialFanoutState
+  { parameters :: HeadParameters
+  , confirmedSnapshot :: ConfirmedSnapshot tx
+  , contestationDeadline :: UTCTime
+  , chainState :: ChainStateType tx
+  , headId :: HeadId
+  , headSeed :: HeadSeed
+  , version :: SnapshotVersion
+  , remainingOutputs :: UTxOType tx
+  -- ^ UTxO still to be fanned out (tracked by content, via set difference).
+  , distributedOutputs :: UTxOType tx
+  -- ^ Accumulates UTxO distributed so far; used to reconstruct the full set in
+  --   'HeadFannedOut' once the head is finalized.
+  , mode :: FanoutMode tx
+  -- ^ Drives the chunk source for the next step (see 'FanoutMode').
+  }
+  deriving stock (Generic)
+
+deriving stock instance (IsTx tx, Eq (ChainStateType tx)) => Eq (PartialFanoutState tx)
+deriving stock instance (IsTx tx, Show (ChainStateType tx)) => Show (PartialFanoutState tx)
+deriving anyclass instance (IsTx tx, ToJSON (ChainStateType tx)) => ToJSON (PartialFanoutState tx)
+deriving anyclass instance (IsTx tx, FromJSON (ChainStateType tx)) => FromJSON (PartialFanoutState tx)

--- a/hydra-node/src/Hydra/HeadLogic/State.hs
+++ b/hydra-node/src/Hydra/HeadLogic/State.hs
@@ -267,8 +267,18 @@ deriving anyclass instance (IsTx tx, FromJSON (ChainStateType tx)) => FromJSON (
 
 -- ** PartialFanout
 
+-- Terminology note: the selective-fanout feature spans several near-synonymous
+-- names; they map as follows:
+--
+--   * PartialFanout          — the client input (a user-selected subset to fan out)
+--   * HeadPartiallyFannedOut — the server output reporting one observed step
+--   * FanningOut             — the client-visible HeadStatus
+--   * FanoutProgress         — this off-chain HeadState constructor (and the
+--                              matching on-chain head datum), holding a PartialFanoutState
+--   * FanoutMode             — how the next step is chosen while in FanoutProgress
+
 -- | How the node decides which UTxOs to distribute in the next fanout step
--- while the head is in 'PartialFanout'.
+-- while the head is in 'FanoutProgress'.
 data FanoutMode tx
   = -- | Entered only via the 'Fanout' client command: drain the whole remaining
     -- set automatically, dynamically chunked, ending in the final fanout.

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -295,7 +295,18 @@ runHydraNode ::
   ) =>
   HydraNode tx m ->
   m ()
-runHydraNode node =
+runHydraNode node@HydraNode{tracer, nodeStateHandler = NodeStateHandler{queryNodeState}} = do
+  -- On startup, resume an interrupted fanout: if the node is mid-fanout
+  -- ('FanoutProgress'), re-emit the next fanout step so an auto-drain whose
+  -- driver crashed after its last observed chunk continues instead of stalling
+  -- (mirrors the rollback re-post). A step already on chain fails harmlessly
+  -- ('StalePartialFanoutTx' is silently ignored) and catch-up observations
+  -- re-drive; a passive observer ('AwaitingSelection') posts nothing.
+  atomically queryNodeState >>= \ns -> case headState ns of
+    FanoutProgress pfs -> case HeadLogic.repostFanoutStep pfs of
+      Continue{effects} -> processEffects node tracer 0 effects
+      _ -> pure ()
+    _ -> pure ()
   -- NOTE(SN): here we could introduce concurrent head processing, e.g. with
   -- something like 'forM_ [0..1] $ async'
   forever $ do

--- a/hydra-node/test/Hydra/BehaviorSpec.hs
+++ b/hydra-node/test/Hydra/BehaviorSpec.hs
@@ -937,7 +937,7 @@ spec = parallel $ do
               send n2 Fanout
               waitUntil [n1, n2] $ HeadIsFinalized{headId = testHeadId, finalizedUTxO = mempty}
 
-    it "handles partial fanout observation and triggers next fanout" $
+    it "selective partial fanout keeps the head open; other parties do not steamroll the remainder" $
       shouldRunInSim $ do
         withSimulatedChainAndNetwork $ \chain ->
           withHydraNode aliceSk [bob] chain $ \n1 ->
@@ -953,11 +953,39 @@ spec = parallel $ do
               send n1 Close
               forM_ [n1, n2] $ waitForNext >=> assertHeadIsClosed
               waitUntil [n1, n2] $ ReadyToFanout testHeadId
-              -- Simulate a partial fanout observed on chain (e.g. from the real
-              -- Handlers layer splitting a large UTxO set)
-              simulatePartialFanout chain testHeadId (utxoRef 1)
-              -- The node should auto-trigger the next fanout with the remaining UTxO
-              -- and report all UTxOs (not just the last batch) in HeadIsFinalized
+              -- n1 selectively fans out only UTxO 1. The head must stay open with
+              -- UTxO 2 remaining; crucially n2 (which did not initiate) must NOT
+              -- auto-drain the remainder.
+              send n1 (PartialFanout (utxoRef 1))
+              waitUntilMatch [n1, n2] $ \case
+                HeadPartiallyFannedOut{remainingUTxO} -> guard $ remainingUTxO == utxoRefs [2]
+                _ -> Nothing
+              -- n1 then fans out the rest, which finalizes the head with all UTxO.
+              send n1 (PartialFanout (utxoRef 2))
+              waitUntil [n1, n2] $ HeadIsFinalized{headId = testHeadId, finalizedUTxO = utxoRefs [1, 2]}
+
+    it "selective partial fanout can be continued by a different party" $
+      shouldRunInSim $ do
+        withSimulatedChainAndNetwork $ \chain ->
+          withHydraNode aliceSk [bob] chain $ \n1 ->
+            withHydraNode bobSk [alice] chain $ \n2 -> do
+              openHead2 n1 n2
+              send n1 (NewTx (aValidTx 1))
+              send n1 (NewTx (aValidTx 2))
+              waitUntilMatch [n1, n2] $ \case
+                SnapshotConfirmed{snapshot = Snapshot{utxo}} -> guard $ utxo == utxoRefs [1, 2]
+                _ -> Nothing
+              send n1 Close
+              forM_ [n1, n2] $ waitForNext >=> assertHeadIsClosed
+              waitUntil [n1, n2] $ ReadyToFanout testHeadId
+              -- n1 starts the selective fanout (distributing UTxO 1)...
+              send n1 (PartialFanout (utxoRef 1))
+              waitUntilMatch [n1, n2] $ \case
+                HeadPartiallyFannedOut{remainingUTxO} -> guard $ remainingUTxO == utxoRefs [2]
+                _ -> Nothing
+              -- ...but n2 (a different party) drives the next step. Any party in
+              -- FanoutProgress may continue the fanout; observers only wait.
+              send n2 (PartialFanout (utxoRef 2))
               waitUntil [n1, n2] $ HeadIsFinalized{headId = testHeadId, finalizedUTxO = utxoRefs [1, 2]}
 
     it "contest automatically when detecting closing with old snapshot" $
@@ -1215,7 +1243,6 @@ data SimulatedChainNetwork tx m = SimulatedChainNetwork
   , tickThread :: Async m ()
   , rollbackAndForward :: Natural -> m ()
   , simulateDeposit :: HeadId -> UTxOType tx -> UTCTime -> m (TxIdType tx)
-  , simulatePartialFanout :: HeadId -> UTxOType tx -> m ()
   , closeWithInitialSnapshot :: Party -> m ()
   , getChainHistory :: m [ChainEvent tx]
   }
@@ -1227,7 +1254,6 @@ dummySimulatedChainNetwork =
     , tickThread = error "tickThread"
     , rollbackAndForward = error "rollbackAndForward"
     , simulateDeposit = error "simulateDeposit"
-    , simulatePartialFanout = error "simulatePartialFanout"
     , closeWithInitialSnapshot = error "closeWithInitialSnapshot"
     , getChainHistory = error "getChainHistory"
     }
@@ -1306,8 +1332,6 @@ simulatedChainAndNetworkUsing networkCallback chainDelay initialChainState = do
           createAndYieldEvent nodes history localChainState $
             OnDepositTx{headId, deposited = toDeposit, created, deadline, depositTxId}
           pure depositTxId
-      , simulatePartialFanout = \headId distributedOutputs ->
-          createAndYieldEvent nodes history localChainState $ OnPartialFanoutTx{headId, distributedOutputs}
       , closeWithInitialSnapshot = error "unexpected call to closeWithInitialSnapshot"
       , getChainHistory = reverse <$> readTVarIO history
       }
@@ -1448,6 +1472,8 @@ toOnChainTx now = \case
       }
   FanoutTx{utxo, utxoToCommit, utxoToDecommit} ->
     OnFanoutTx{headId = testHeadId, fanoutUTxO = utxo <> fromMaybe mempty utxoToCommit <> fromMaybe mempty utxoToDecommit}
+  PartialFanoutTx{utxoToDistribute} ->
+    OnPartialFanoutTx{headId = testHeadId, distributedOutputs = utxoToDistribute}
   FinalPartialFanoutTx{utxoToDistribute} ->
     OnFanoutTx{headId = testHeadId, fanoutUTxO = utxoToDistribute}
 

--- a/hydra-node/test/Hydra/Chain/Direct/HandlersSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/HandlersSpec.hs
@@ -535,7 +535,7 @@ spec = do
                     , update = \_ _ -> pure ()
                     }
             run $
-              findFittingFanoutTx nullTracer wallet cctx spendableUTxO seedTxIn (Left ()) mismatchedUTxO mismatchedUTxO deadlineSlot
+              findFittingFanoutTx nullTracer wallet cctx spendableUTxO seedTxIn (Left ()) mismatchedUTxO mismatchedUTxO (UTxO.size mismatchedUTxO - 1) deadlineSlot
                 `shouldThrow` \(e :: PostTxError Tx) -> e == StalePartialFanoutTx
 
     prop "throws FailedToConstructPartialFanoutTx on non-stale structural failure" $
@@ -557,7 +557,7 @@ spec = do
                 , update = \_ _ -> pure ()
                 }
         run $
-          findFittingFanoutTx nullTracer wallet ctx mempty seedTxIn (Left ()) fullUTxO fullUTxO 1
+          findFittingFanoutTx nullTracer wallet ctx mempty seedTxIn (Left ()) fullUTxO fullUTxO (UTxO.size fullUTxO - 1) 1
             `shouldThrow` \(e :: PostTxError Tx) -> e == FailedToConstructPartialFanoutTx
 
     prop "throws FailedToConstructPartialFanoutTx when no chunk fits within budget" $
@@ -579,7 +579,7 @@ spec = do
                     , update = \_ _ -> pure ()
                     }
             run $
-              findFittingFanoutTx nullTracer wallet cctx spendableUTxO seedTxIn (Left ()) u0 u0 deadlineSlot
+              findFittingFanoutTx nullTracer wallet cctx spendableUTxO seedTxIn (Left ()) u0 u0 (UTxO.size u0 - 1) deadlineSlot
                 `shouldThrow` \(e :: PostTxError Tx) -> e == FailedToConstructPartialFanoutTx
 
     prop "falls back to partial fanout when preferred tx doesn't fit" $
@@ -606,7 +606,7 @@ spec = do
                     , update = \_ _ -> pure ()
                     }
             -- Any exception thrown here will fail the test automatically.
-            _ <- run $ findFittingFanoutTx nullTracer wallet cctx spendableUTxO seedTxIn (Right dummyTx) u0 u0 deadlineSlot
+            _ <- run $ findFittingFanoutTx nullTracer wallet cctx spendableUTxO seedTxIn (Right dummyTx) u0 u0 (UTxO.size u0 - 1) deadlineSlot
             assert True
 
 -- | Generate a byte-count limit that straddles the real serialised size of

--- a/hydra-node/test/Hydra/Chain/Direct/HandlersSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/HandlersSpec.hs
@@ -535,7 +535,7 @@ spec = do
                     , update = \_ _ -> pure ()
                     }
             run $
-              findFittingFanoutTx nullTracer wallet cctx spendableUTxO seedTxIn (Left ()) mismatchedUTxO mismatchedUTxO (UTxO.size mismatchedUTxO - 1) deadlineSlot
+              findFittingFanoutTx nullTracer wallet cctx spendableUTxO seedTxIn Nothing mismatchedUTxO mismatchedUTxO (UTxO.size mismatchedUTxO - 1) deadlineSlot
                 `shouldThrow` \(e :: PostTxError Tx) -> e == StalePartialFanoutTx
 
     prop "throws FailedToConstructPartialFanoutTx on non-stale structural failure" $
@@ -557,7 +557,7 @@ spec = do
                 , update = \_ _ -> pure ()
                 }
         run $
-          findFittingFanoutTx nullTracer wallet ctx mempty seedTxIn (Left ()) fullUTxO fullUTxO (UTxO.size fullUTxO - 1) 1
+          findFittingFanoutTx nullTracer wallet ctx mempty seedTxIn Nothing fullUTxO fullUTxO (UTxO.size fullUTxO - 1) 1
             `shouldThrow` \(e :: PostTxError Tx) -> e == FailedToConstructPartialFanoutTx
 
     prop "throws FailedToConstructPartialFanoutTx when no chunk fits within budget" $
@@ -579,7 +579,7 @@ spec = do
                     , update = \_ _ -> pure ()
                     }
             run $
-              findFittingFanoutTx nullTracer wallet cctx spendableUTxO seedTxIn (Left ()) u0 u0 (UTxO.size u0 - 1) deadlineSlot
+              findFittingFanoutTx nullTracer wallet cctx spendableUTxO seedTxIn Nothing u0 u0 (UTxO.size u0 - 1) deadlineSlot
                 `shouldThrow` \(e :: PostTxError Tx) -> e == FailedToConstructPartialFanoutTx
 
     prop "falls back to partial fanout when preferred tx doesn't fit" $
@@ -606,7 +606,7 @@ spec = do
                     , update = \_ _ -> pure ()
                     }
             -- Any exception thrown here will fail the test automatically.
-            _ <- run $ findFittingFanoutTx nullTracer wallet cctx spendableUTxO seedTxIn (Right dummyTx) u0 u0 (UTxO.size u0 - 1) deadlineSlot
+            _ <- run $ findFittingFanoutTx nullTracer wallet cctx spendableUTxO seedTxIn (Just dummyTx) u0 u0 (UTxO.size u0 - 1) deadlineSlot
             assert True
 
 -- | Generate a byte-count limit that straddles the real serialised size of

--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -31,7 +31,7 @@ import Hydra.Cardano.Api (
  )
 import Hydra.Cardano.Api.Gen (genTxIn)
 import Hydra.Cardano.Api.Pretty (renderTx, renderTxWithUTxO)
-import Hydra.Chain (PostChainTx (..), maximumNumberOfParties)
+import Hydra.Chain (maximumNumberOfParties)
 import Hydra.Chain.Direct.State (
   ChainContext (..),
   ChainState (..),
@@ -347,21 +347,23 @@ spec = parallel $ do
                           , headId = stClosed.headId
                           , headSeed = txInToHeadSeed stClosed.seedTxIn
                           , version = 0
-                          , remainingFanoutOutputs = Nothing
-                          , distributedFanoutOutputs = mempty
                           }
                       outcome = HL.onClosedChainPartialFanoutTx hlClosedState initialChainState distributedOutputs
                       expectedRemaining = UTxO.fromList . drop chunkSize . UTxO.toList $ u0WithDups
-                      fanoutUTxOs =
-                        [ utxo
-                        | HL.OnChainEffect{postChainTx = FinalPartialFanoutTx{utxoToDistribute = utxo}} <-
+                      -- A node observing a partial fanout it didn't initiate is a
+                      -- passive observer: it records the remaining set (by content)
+                      -- but does not post the next fanout.
+                      remainingUTxOs =
+                        [ remainingOutputs
+                        | HL.HeadPartialFannedOut{remainingOutputs} <-
                             case outcome of
-                              HL.Continue{effects} -> effects
+                              HL.Continue{stateChanges} -> stateChanges
+                              HL.Wait{stateChanges} -> stateChanges
                               _ -> []
                         ]
                    in counterexample
-                        ("Expected FinalPartialFanoutTx{utxoToDistribute = " <> show expectedRemaining <> "}")
-                        (fanoutUTxOs === [expectedRemaining])
+                        ("Expected HeadPartialFannedOut{remainingOutputs = " <> show expectedRemaining <> "}")
+                        (remainingUTxOs === [expectedRemaining])
 
 genInitTxMutation :: TxIn -> Tx -> Gen (Mutation, String, NotAnInitReason)
 genInitTxMutation seedInput tx =

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -18,6 +18,8 @@ import Cardano.Ledger.Api (bodyTxL, inputsTxBodyL)
 import Cardano.Slotting.Time (SystemStart (SystemStart))
 import Control.Lens ((.~))
 import Control.Monad (foldM)
+import Data.Aeson (Result (Success), Value (..), fromJSON)
+import Data.Aeson.KeyMap qualified as KeyMap
 import Data.List qualified as List
 import Data.Map.Strict (notMember)
 import Data.Map.Strict qualified as Map
@@ -2254,6 +2256,44 @@ spec =
           OnChainEffect{postChainTx = FanoutTx{}} -> True
           OnChainEffect{postChainTx = FinalPartialFanoutTx{}} -> True
           OnChainEffect{postChainTx = PartialFanoutTx{}} -> True
+          _ -> False
+
+      it "decodes a legacy HeadPartialFannedOut without 'mode' as AwaitingSelection" $ do
+        -- Backwards compatibility: events persisted before the 'mode' field
+        -- existed must still decode, so a node mid-fanout can restart after
+        -- upgrading rather than failing to replay its event log.
+        let event =
+              HeadPartialFannedOut
+                { headId = testHeadId
+                , distributedOutputs = utxoRefs [1]
+                , remainingOutputs = utxoRefs [2]
+                , chainState = SimpleChainState 0
+                , mode = AutoDrain
+                } ::
+                StateChanged SimpleTx
+            legacy = case toJSON event of
+              Object o -> Object (KeyMap.delete "mode" o)
+              v -> v
+        case fromJSON legacy :: Result (StateChanged SimpleTx) of
+          Success HeadPartialFannedOut{mode} -> mode `shouldBe` AwaitingSelection
+          other -> failure $ "Expected HeadPartialFannedOut, got: " <> show other
+
+      it "records a deposit observed while fanning out (stays recoverable)" $ do
+        -- Regression: a deposit observed mid-fanout must be recorded (as when the
+        -- head was still Closed), otherwise it is dropped and cannot be recovered.
+        let st = inAutoDrainProgress threeParties (utxoRefs [1, 2])
+        now <- nowFromSlot st.chainPointTime.currentSlot
+        let deposit =
+              OnDepositTx
+                { headId = testHeadId
+                , depositTxId = 7
+                , deposited = utxoRef 9
+                , created = now
+                , deadline = now
+                }
+            outcome = update bobEnv ledger now st (observeTx deposit)
+        outcome `hasStateChangedSatisfying` \case
+          DepositRecorded{depositTxId} -> depositTxId == 7
           _ -> False
 
       it "client fanout without prior partial fanout uses full snapshot utxo" $ do

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -23,7 +23,7 @@ import Data.Map.Strict (notMember)
 import Data.Map.Strict qualified as Map
 import Data.Sequence qualified as Seq
 import Data.Set qualified as Set
-import Hydra.API.ClientInput (ClientInput (Fanout, Recover, SideLoadSnapshot))
+import Hydra.API.ClientInput (ClientInput (Fanout, PartialFanout, Recover, SideLoadSnapshot))
 import Hydra.API.ServerOutput (ClientMessage (..), DecommitInvalidReason (..))
 import Hydra.Cardano.Api (ChainPoint (..), SlotNo (..), fromLedgerTx, mkVkAddress, toLedgerTx, txOutValue, unSlotNo, pattern TxValidityUpperBound)
 import Hydra.Cardano.Api.Gen (genTxIn)
@@ -36,7 +36,7 @@ import Hydra.Chain (
 import Hydra.Chain.ChainState (ChainSlot (..), IsChainState)
 import Hydra.Chain.Direct.State (ChainStateAt (..))
 import Hydra.Chain.Direct.TimeHandle (TimeHandle, mkTimeHandle, safeZone, slotToUTCTime)
-import Hydra.HeadLogic (ClosedState (..), CoordinatedHeadState (..), Effect (..), HeadState (..), Input (..), LogicError (..), OpenState (..), Outcome (..), RequirementFailure (..), SideLoadRequirementFailure (..), StateChanged (..), TTL, WaitReason (..), aggregateState, cause, newState, noop, update)
+import Hydra.HeadLogic (ClosedState (..), CoordinatedHeadState (..), Effect (..), FanoutMode (..), HeadState (..), Input (..), LogicError (..), OpenState (..), Outcome (..), PartialFanoutState (..), RequirementFailure (..), SideLoadRequirementFailure (..), StateChanged (..), TTL, WaitReason (..), aggregateState, cause, newState, noop, update)
 import Hydra.HeadLogic.State (IdleState (..), SeenSnapshot (..), getHeadParameters, mkSeenSnapshot)
 import Hydra.Ledger (Ledger (..), ValidationError (..))
 import Hydra.Ledger.Cardano (cardanoLedger, mkRangedTx, mkSimpleTx)
@@ -1922,9 +1922,25 @@ spec =
       prop "fanout utxo includes accumulated UTxO from prior partial fanouts" $
         \fanoutUTxO priorDistributed ->
           forAllShrink genClosedState shrink $ \closedState -> monadicIO $ do
+            -- Prior partial fanouts mean the head is on-chain in FanoutProgress.
             let stWithPrior = case closedState.headState of
-                  Closed cst ->
-                    closedState{headState = Closed cst{distributedFanoutOutputs = priorDistributed}}
+                  Closed ClosedState{parameters, confirmedSnapshot, contestationDeadline, chainState, headId, headSeed, version} ->
+                    closedState
+                      { headState =
+                          FanoutProgress
+                            PartialFanoutState
+                              { parameters
+                              , confirmedSnapshot
+                              , contestationDeadline
+                              , chainState
+                              , headId
+                              , headSeed
+                              , version
+                              , remainingOutputs = mempty
+                              , distributedOutputs = priorDistributed
+                              , mode = AutoDrain
+                              }
+                      }
                   _ -> closedState
                 fanoutHead = observeTx $ OnFanoutTx{headId = testHeadId, fanoutUTxO}
             now <- run $ nowFromSlot closedState.chainPointTime.currentSlot
@@ -1942,29 +1958,44 @@ spec =
         update bobEnv ledger now st partialFanoutOtherHead
           `shouldBe` Error (NotOurHead{ourHeadId = testHeadId, otherHeadId})
 
-      prop "partial fanout emits HeadPartialFannedOut and triggers next fanout" $ \distributedUTxO ->
+      prop "observing another party's partial fanout records it but does NOT auto-drive" $ \distributedUTxO ->
         forAllShrink genClosedState shrink $ \closedState -> monadicIO $ do
+          -- A node still in 'Closed' observing a partial fanout it did not initiate
+          -- is a passive observer: it records the step (HeadPartialFannedOut, mode
+          -- AwaitingSelection) but must NOT post the next fanout — otherwise it
+          -- would steamroll a selective fanout another party deliberately paused.
           let partialFanoutHead = observeTx $ OnPartialFanoutTx{headId = testHeadId, distributedOutputs = distributedUTxO}
           now <- run $ nowFromSlot closedState.chainPointTime.currentSlot
           let outcome = update bobEnv ledger now closedState partialFanoutHead
           monitor $ counterexample ("Outcome: " <> show outcome)
-          -- Should emit HeadPartialFannedOut state change
           run $
             outcome `hasStateChangedSatisfying` \case
-              HeadPartialFannedOut{} -> True
+              HeadPartialFannedOut{mode = AwaitingSelection} -> True
               _ -> False
-          -- Should also trigger the next fanout automatically. After observing a
-          -- PartialFanout the phase is always FanoutInProgress, so HeadLogic
-          -- always emits FinalPartialFanoutTx (Handlers decides whether to
-          -- actually do a partial chunk or finalize based on tx evaluation).
+          run $
+            outcome `hasNoEffectSatisfying` \case
+              OnChainEffect{postChainTx = FinalPartialFanoutTx{}} -> True
+              OnChainEffect{postChainTx = PartialFanoutTx{}} -> True
+              _ -> False
+
+      prop "client Fanout makes this node the driver (FanoutProgress AutoDrain) and posts FanoutTx" $
+        forAllShrink genClosedState shrink $ \closedState -> monadicIO $ do
+          now <- run $ nowFromSlot closedState.chainPointTime.currentSlot
+          let outcome = update bobEnv ledger now closedState (ClientInput Fanout)
+          monitor $ counterexample ("Outcome: " <> show outcome)
           run $
             outcome `hasEffectSatisfying` \case
-              OnChainEffect{postChainTx = FinalPartialFanoutTx{}} -> True
+              OnChainEffect{postChainTx = FanoutTx{}} -> True
               _ -> False
+          -- And it enters FanoutProgress in AutoDrain mode so subsequent chunk
+          -- observations auto-continue on this (driving) node.
+          case headState (aggregateState closedState outcome) of
+            FanoutProgress PartialFanoutState{mode = AutoDrain} -> pure ()
+            other -> run $ failure $ "Expected FanoutProgress AutoDrain, got: " <> show other
 
       it "partial fanout with large remaining triggers FinalPartialFanoutTx" $ do
         let bigRemaining = Set.fromList [SimpleTxOut i | i <- [1 .. fromIntegral fanoutOutputThreshold + 1]]
-            st = inClosedStateWithRemaining threeParties (Just bigRemaining)
+            st = inAutoDrainProgress threeParties bigRemaining
         now <- nowFromSlot st.chainPointTime.currentSlot
         let outcome = update bobEnv ledger now st (observeTx OnPartialFanoutTx{headId = testHeadId, distributedOutputs = mempty})
         outcome `hasEffectSatisfying` \case
@@ -1976,7 +2007,7 @@ spec =
         let allItems = Set.fromList [SimpleTxOut i | i <- [1 .. fromIntegral fanoutOutputThreshold + fromIntegral fanoutChunkSize + 1]]
             (distributedList, _) = splitAt fanoutChunkSize (Set.toList allItems)
             distributed = Set.fromList distributedList
-            st = inClosedStateWithRemaining threeParties (Just allItems)
+            st = inAutoDrainProgress threeParties allItems
         now <- nowFromSlot st.chainPointTime.currentSlot
         let outcome = update bobEnv ledger now st (observeTx OnPartialFanoutTx{headId = testHeadId, distributedOutputs = distributed})
         outcome `hasStateChangedSatisfying` \case
@@ -1994,7 +2025,7 @@ spec =
             attackedDistributed =
               Set.fromList
                 [SimpleTxOut i | i <- [fromIntegral (total - fanoutChunkSize + 1) .. fromIntegral total]]
-            st = inClosedStateWithRemaining threeParties (Just allItems)
+            st = inAutoDrainProgress threeParties allItems
         now <- nowFromSlot st.chainPointTime.currentSlot
         let outcome =
               update
@@ -2010,21 +2041,192 @@ spec =
 
       it "partial fanout with small remaining triggers FinalPartialFanoutTx" $ do
         let smallRemaining = Set.fromList [SimpleTxOut 1, SimpleTxOut 2]
-            st = inClosedStateWithRemaining threeParties (Just smallRemaining)
+            st = inAutoDrainProgress threeParties smallRemaining
         now <- nowFromSlot st.chainPointTime.currentSlot
         let outcome = update bobEnv ledger now st (observeTx OnPartialFanoutTx{headId = testHeadId, distributedOutputs = mempty})
         outcome `hasEffectSatisfying` \case
           OnChainEffect{postChainTx = FinalPartialFanoutTx{utxoToDistribute}} -> utxoToDistribute == smallRemaining
           _ -> False
 
-      it "client fanout uses remaining UTxO after partial fanout (FinalPartialFanoutTx)" $ do
+      it "client partial fanout selecting all remaining UTxO drains via FinalPartialFanoutTx" $ do
         let remaining = Set.fromList [SimpleTxOut 3, SimpleTxOut 4]
-            st = inClosedStateWithRemaining threeParties (Just remaining)
+            st = inAutoDrainProgress threeParties remaining
         now <- nowFromSlot st.chainPointTime.currentSlot
-        let outcome = update bobEnv ledger now st (ClientInput Fanout)
+        let outcome = update bobEnv ledger now st (ClientInput (PartialFanout remaining))
         outcome `hasEffectSatisfying` \case
           OnChainEffect{postChainTx = FinalPartialFanoutTx{utxoToDistribute}} -> utxoToDistribute == remaining
           _ -> False
+
+      it "an awaiting (observer) node can drive the next step with its own PartialFanout" $ do
+        -- A node that only observed someone else's partial fanout sits in
+        -- 'AwaitingSelection'; issuing its own 'PartialFanout' makes it the driver
+        -- for that step (posts a non-final PartialFanoutTx for the subset). This is
+        -- the "continue the fanout from a different party" path.
+        let remaining = Set.fromList [SimpleTxOut 1, SimpleTxOut 2, SimpleTxOut 3]
+            selection = Set.fromList [SimpleTxOut 1]
+            st = inFanoutProgressWith threeParties remaining AwaitingSelection
+        now <- nowFromSlot st.chainPointTime.currentSlot
+        let outcome = update bobEnv ledger now st (ClientInput (PartialFanout selection))
+        outcome `hasEffectSatisfying` \case
+          OnChainEffect{postChainTx = PartialFanoutTx{utxoToDistribute}} -> utxoToDistribute == selection
+          _ -> False
+        case headState (aggregateState st outcome) of
+          FanoutProgress PartialFanoutState{mode = DistributingSelection sel} -> sel `shouldBe` selection
+          other -> failure $ "Expected FanoutProgress DistributingSelection, got: " <> show other
+
+      it "selective fanout that drains the whole remaining set finalizes instead of wedging" $ do
+        -- Regression: a 'DistributingSelection' step whose observed distribution
+        -- empties 'remaining' (e.g. a chunk drained everything because a pre-settled
+        -- UTxO kept the on-chain accumulator non-empty) must still emit the burning
+        -- FinalPartialFanoutTx — not stop at AwaitingSelection and wedge the head.
+        let remaining = Set.fromList [SimpleTxOut 1, SimpleTxOut 2]
+            st = inFanoutProgressWith threeParties remaining (DistributingSelection remaining)
+        now <- nowFromSlot st.chainPointTime.currentSlot
+        let outcome = update bobEnv ledger now st (observeTx OnPartialFanoutTx{headId = testHeadId, distributedOutputs = remaining})
+        outcome `hasEffectSatisfying` \case
+          OnChainEffect{postChainTx = FinalPartialFanoutTx{}} -> True
+          _ -> False
+
+      it "client PartialFanout from Closed selects a subset and enters FanoutProgress" $ do
+        let fullUTxO = Set.fromList [SimpleTxOut 1, SimpleTxOut 2, SimpleTxOut 3]
+            selection = Set.fromList [SimpleTxOut 1, SimpleTxOut 2]
+            snap = testSnapshot 1 0 [] fullUTxO
+            st = inClosedState' threeParties (ConfirmedSnapshot snap (Crypto.aggregate []))
+        now <- nowFromSlot st.chainPointTime.currentSlot
+        let outcome = update bobEnv ledger now st (ClientInput (PartialFanout selection))
+        -- Emits a non-final PartialFanoutTx drawing from the user selection.
+        outcome `hasEffectSatisfying` \case
+          OnChainEffect{postChainTx = PartialFanoutTx{utxoToDistribute}} -> utxoToDistribute == selection
+          _ -> False
+        -- And transitions the head into FanoutProgress with the full remaining set.
+        case headState (aggregateState st outcome) of
+          FanoutProgress PartialFanoutState{remainingOutputs} -> remainingOutputs `shouldBe` fullUTxO
+          other -> failure $ "Expected FanoutProgress state, got: " <> show other
+
+      it "client PartialFanout selecting ALL of a fresh head delegates to the full Fanout" $ do
+        -- Selecting everything is a full fanout: it must post a FanoutTx (auto
+        -- drain), not an impossible non-final PartialFanoutTx of the whole set.
+        let fullUTxO = Set.fromList [SimpleTxOut 1, SimpleTxOut 2, SimpleTxOut 3]
+            snap = testSnapshot 1 0 [] fullUTxO
+            st = inClosedState' threeParties (ConfirmedSnapshot snap (Crypto.aggregate []))
+        now <- nowFromSlot st.chainPointTime.currentSlot
+        let outcome = update bobEnv ledger now st (ClientInput (PartialFanout fullUTxO))
+        outcome `hasEffectSatisfying` \case
+          OnChainEffect{postChainTx = FanoutTx{}} -> True
+          _ -> False
+
+      it "Fanout is rejected once a partial fanout is in progress (sticky)" $ do
+        let st = inAutoDrainProgress threeParties (Set.fromList [SimpleTxOut 1, SimpleTxOut 2])
+        now <- nowFromSlot st.chainPointTime.currentSlot
+        let outcome = update bobEnv ledger now st (ClientInput Fanout)
+        outcome `hasEffectSatisfying` \case
+          ClientEffect{clientMessage = CommandFailed{}} -> True
+          _ -> False
+
+      it "PartialFanout with an empty selection fails" $ do
+        let st = inAutoDrainProgress threeParties (Set.fromList [SimpleTxOut 1])
+        now <- nowFromSlot st.chainPointTime.currentSlot
+        let outcome = update bobEnv ledger now st (ClientInput (PartialFanout mempty))
+        outcome `hasEffectSatisfying` \case
+          ClientEffect{clientMessage = CommandFailed{}} -> True
+          _ -> False
+
+      it "PartialFanout with a non-subset selection fails" $ do
+        let remaining = Set.fromList [SimpleTxOut 1, SimpleTxOut 2]
+            notInRemaining = Set.fromList [SimpleTxOut 9]
+            st = inAutoDrainProgress threeParties remaining
+        now <- nowFromSlot st.chainPointTime.currentSlot
+        let outcome = update bobEnv ledger now st (ClientInput (PartialFanout notInRemaining))
+        outcome `hasEffectSatisfying` \case
+          ClientEffect{clientMessage = CommandFailed{}} -> True
+          _ -> False
+
+      it "reverts to Closed when the initiating Fanout tx fails to post before anything landed" $ do
+        -- The optimistic Closed -> FanoutProgress transition (which makes this
+        -- node the fanout driver) must be rolled back if posting the initiating
+        -- tx fails terminally before any partial fanout has landed on chain;
+        -- otherwise the head wedges in FanoutProgress with Fanout rejected.
+        let fullUTxO = Set.fromList [SimpleTxOut 1, SimpleTxOut 2, SimpleTxOut 3]
+            snap = testSnapshot 1 0 [] fullUTxO
+            st = inClosedState' threeParties (ConfirmedSnapshot snap (Crypto.aggregate []))
+        now <- nowFromSlot st.chainPointTime.currentSlot
+        let initiated = update bobEnv ledger now st (ClientInput Fanout)
+            st1 = aggregateState st initiated
+        -- Sanity: optimistically in FanoutProgress with nothing distributed yet.
+        case headState st1 of
+          FanoutProgress PartialFanoutState{distributedOutputs} -> distributedOutputs `shouldBe` mempty
+          other -> failure $ "Expected FanoutProgress, got: " <> show other
+        postedTx <- case [postChainTx | OnChainEffect{postChainTx} <- effectsOf initiated] of
+          tx : _ -> pure tx
+          [] -> failure "Expected a posted fanout tx from the initiating Fanout"
+        let failed =
+              update bobEnv ledger now st1 . ChainInput $
+                PostTxError
+                  { postChainTx = postedTx
+                  , postTxError = FailedToConstructPartialFanoutTx
+                  , failingTx = Nothing
+                  }
+        -- Reverts the head back to Closed and still reports the failure.
+        failed `hasStateChangedSatisfying` \case
+          HeadFanoutReverted{} -> True
+          _ -> False
+        failed `hasEffectSatisfying` \case
+          ClientEffect{clientMessage = PostTxOnChainFailed{}} -> True
+          _ -> False
+        case headState (aggregateState st1 failed) of
+          Closed ClosedState{readyToFanoutSent} -> readyToFanoutSent `shouldBe` True
+          other -> failure $ "Expected Closed after revert, got: " <> show other
+
+      it "reverts to Closed when a selective PartialFanout tx fails to post before anything landed" $ do
+        let fullUTxO = Set.fromList [SimpleTxOut 1, SimpleTxOut 2, SimpleTxOut 3]
+            selection = Set.fromList [SimpleTxOut 1, SimpleTxOut 2]
+            snap = testSnapshot 1 0 [] fullUTxO
+            st = inClosedState' threeParties (ConfirmedSnapshot snap (Crypto.aggregate []))
+        now <- nowFromSlot st.chainPointTime.currentSlot
+        let initiated = update bobEnv ledger now st (ClientInput (PartialFanout selection))
+            st1 = aggregateState st initiated
+        postedTx <- case [postChainTx | OnChainEffect{postChainTx} <- effectsOf initiated] of
+          tx : _ -> pure tx
+          [] -> failure "Expected a posted partial fanout tx from the initiating PartialFanout"
+        let failed =
+              update bobEnv ledger now st1 . ChainInput $
+                PostTxError
+                  { postChainTx = postedTx
+                  , postTxError = FailedToConstructPartialFanoutTx
+                  , failingTx = Nothing
+                  }
+        failed `hasStateChangedSatisfying` \case
+          HeadFanoutReverted{} -> True
+          _ -> False
+        case headState (aggregateState st1 failed) of
+          Closed{} -> pure ()
+          other -> failure $ "Expected Closed after revert, got: " <> show other
+
+      it "does NOT revert once a partial fanout has landed on chain" $ do
+        -- With outputs already distributed the on-chain datum is genuinely
+        -- FanoutProgress, so a later post failure must NOT roll back to Closed.
+        let remaining = Set.fromList [SimpleTxOut 1, SimpleTxOut 2]
+            st = inAutoDrainProgress threeParties remaining
+        now <- nowFromSlot st.chainPointTime.currentSlot
+        let failed =
+              update bobEnv ledger now st . ChainInput $
+                PostTxError
+                  { postChainTx =
+                      PartialFanoutTx
+                        { utxoToDistribute = remaining
+                        , utxoForProof = remaining
+                        , headSeed = testHeadSeed
+                        , contestationDeadline = arbitrary `generateWith` 42
+                        }
+                  , postTxError = FailedToConstructPartialFanoutTx
+                  , failingTx = Nothing
+                  }
+        failed `hasNoStateChangedSatisfying` \case
+          HeadFanoutReverted{} -> True
+          _ -> False
+        case headState (aggregateState st failed) of
+          FanoutProgress{} -> pure ()
+          other -> failure $ "Expected to stay in FanoutProgress, got: " <> show other
 
       it "client fanout without prior partial fanout uses full snapshot utxo" $ do
         let st = inClosedState threeParties
@@ -2055,24 +2257,25 @@ spec =
         let (distributed1List, remaining1List) = splitAt fanoutChunkSize (Set.toList allUTxO)
             distributed1 = Set.fromList distributed1List
             remaining1 = Set.fromList remaining1List
-        -- Step 1 was confirmed on-chain (HeadPartialFannedOut observed).
-        -- The auto-emitted step 2 effect was never posted because the operator
-        -- ran out of funds. State stays Closed with remainingFanoutUTxO = Just remaining1.
+        -- Step 1 was confirmed on-chain (HeadPartialFannedOut observed). The
+        -- auto-emitted step 2 effect was never posted because the operator ran
+        -- out of funds. The head is now in FanoutProgress with remaining1 left.
         let step1 =
               HeadPartialFannedOut
                 { headId = testHeadId
                 , distributedOutputs = distributed1
                 , remainingOutputs = remaining1
                 , chainState = SimpleChainState{slot = 0}
+                , mode = AutoDrain
                 }
             stAfterStep1 = aggregateState initialSt (newState step1)
         case headState stAfterStep1 of
-          Closed ClosedState{remainingFanoutOutputs} ->
-            remainingFanoutOutputs `shouldBe` Just remaining1
-          other -> failure $ "Expected Closed state, got: " <> show other
-        -- Operator tops up funds and calls Fanout again.
+          FanoutProgress PartialFanoutState{remainingOutputs} ->
+            remainingOutputs `shouldBe` remaining1
+          other -> failure $ "Expected FanoutProgress state, got: " <> show other
+        -- Operator tops up funds and resumes by selecting the remaining UTxO.
         now <- nowFromSlot stAfterStep1.chainPointTime.currentSlot
-        let outcome = update bobEnv ledger now stAfterStep1 (ClientInput Fanout)
+        let outcome = update bobEnv ledger now stAfterStep1 (ClientInput (PartialFanout remaining1))
         -- Must continue from remaining1: the next chunk is disjoint from distributed1.
         -- If fanout restarted from scratch it would re-distribute distributed1,
         -- making Set.disjoint fail.
@@ -2095,7 +2298,7 @@ spec =
           ClientEffect{} -> True
           _ -> False
 
-      it "aggregate HeadPartialFannedOut keeps state Closed with remaining UTxO" $ do
+      it "aggregate HeadPartialFannedOut transitions to FanoutProgress with remaining UTxO" $ do
         let remaining = Set.fromList [SimpleTxOut 5, SimpleTxOut 6]
             distributed = Set.fromList [SimpleTxOut 1, SimpleTxOut 2]
             closedSt = inClosedState threeParties
@@ -2107,16 +2310,17 @@ spec =
                     , distributedOutputs = distributed
                     , remainingOutputs = remaining
                     , chainState = SimpleChainState{slot = 0}
+                    , mode = AutoDrain
                     }
                 result = aggregateState closedSt (newState stateChange)
              in case headState result of
-                  Closed ClosedState{remainingFanoutOutputs, distributedFanoutOutputs} -> do
-                    remainingFanoutOutputs `shouldBe` Just remaining
-                    distributedFanoutOutputs `shouldBe` distributed
-                  other -> failure $ "Expected Closed state, got: " <> show other
+                  FanoutProgress PartialFanoutState{remainingOutputs, distributedOutputs} -> do
+                    remainingOutputs `shouldBe` remaining
+                    distributedOutputs `shouldBe` distributed
+                  other -> failure $ "Expected FanoutProgress state, got: " <> show other
           other -> failure $ "Expected Closed state, got: " <> show other
 
-      it "aggregate HeadPartialFannedOut accumulates distributedFanoutUTxO across steps" $ do
+      it "aggregate HeadPartialFannedOut accumulates distributedOutputs across steps" $ do
         let firstDistributed = Set.fromList [SimpleTxOut 1, SimpleTxOut 2]
             secondDistributed = Set.fromList [SimpleTxOut 3, SimpleTxOut 4]
             remaining = Set.fromList [SimpleTxOut 5, SimpleTxOut 6]
@@ -2129,6 +2333,7 @@ spec =
                     , distributedOutputs = firstDistributed
                     , remainingOutputs = secondDistributed <> remaining
                     , chainState = SimpleChainState{slot = 0}
+                    , mode = AutoDrain
                     }
                 afterStep1 = aggregateState closedSt (newState step1)
                 step2 =
@@ -2137,12 +2342,13 @@ spec =
                     , distributedOutputs = secondDistributed
                     , remainingOutputs = remaining
                     , chainState = SimpleChainState{slot = 0}
+                    , mode = AutoDrain
                     }
                 afterStep2 = aggregateState afterStep1 (newState step2)
              in case headState afterStep2 of
-                  Closed ClosedState{distributedFanoutOutputs} ->
-                    distributedFanoutOutputs `shouldBe` firstDistributed <> secondDistributed
-                  other -> failure $ "Expected Closed state, got: " <> show other
+                  FanoutProgress PartialFanoutState{distributedOutputs} ->
+                    distributedOutputs `shouldBe` firstDistributed <> secondDistributed
+                  other -> failure $ "Expected FanoutProgress state, got: " <> show other
           other -> failure $ "Expected Closed state, got: " <> show other
 
       describe "SideLoad InitialSnapshot" $ do
@@ -2658,7 +2864,7 @@ prop_ignoresUnrelatedOnInitTx =
 genClosedState :: Gen (NodeState SimpleTx)
 genClosedState = do
   closedState <- arbitrary
-  pure $ inSync (Closed $ closedState{headId = testHeadId, remainingFanoutOutputs = Nothing, distributedFanoutOutputs = mempty})
+  pure $ inSync (Closed $ closedState{headId = testHeadId})
 
 -- * Utilities
 
@@ -2763,39 +2969,46 @@ inClosedState' parties confirmedSnapshot =
         , headId = testHeadId
         , headSeed = testHeadSeed
         , version = 0
-        , remainingFanoutOutputs = Nothing
-        , distributedFanoutOutputs = mempty
         }
  where
   parameters = HeadParameters defaultContestationPeriod parties
 
   contestationDeadline = arbitrary `generateWith` 42
 
-inClosedStateWithRemaining :: [Party] -> Maybe (Set SimpleTxOut) -> NodeState SimpleTx
-inClosedStateWithRemaining parties remaining =
+-- | A head mid partial-fanout (on-chain 'FanoutProgress') with the given
+-- still-to-distribute set and 'FanoutMode'. 'distributedOutputs' is a non-empty
+-- placeholder so the head datum is treated as @FanoutProgress@ (some outputs
+-- already distributed).
+inFanoutProgressWith :: [Party] -> Set SimpleTxOut -> FanoutMode SimpleTx -> NodeState SimpleTx
+inFanoutProgressWith parties remaining mode =
   inSync $
-    Closed
-      ClosedState
+    FanoutProgress
+      PartialFanoutState
         { parameters
-        , -- Use a snapshot whose utxo matches the remaining set so that
-          -- filterUTxOByOutputs can find entries when emitNextFanoutStep
-          -- converts Set (TxOutType tx) back to UTxOType tx.
+        , -- Use a snapshot whose utxo matches the remaining set so the
+          -- accumulator/proof computations line up.
           confirmedSnapshot =
             ConfirmedSnapshot
-              (testSnapshot 0 0 [] (fromMaybe mempty remaining))
+              (testSnapshot 0 0 [] remaining)
               (Crypto.aggregate [])
         , contestationDeadline
-        , readyToFanoutSent = False
         , chainState = 0
         , headId = testHeadId
         , headSeed = testHeadSeed
         , version = 0
-        , remainingFanoutOutputs = remaining
-        , distributedFanoutOutputs = mempty
+        , remainingOutputs = remaining
+        , distributedOutputs = Set.singleton (SimpleTxOut 0)
+        , mode
         }
  where
   parameters = HeadParameters defaultContestationPeriod parties
   contestationDeadline = arbitrary `generateWith` 42
+
+-- | Like 'inFanoutProgressWith' but in 'AutoDrain' mode, as if a plain 'Fanout'
+-- kicked off the (chunked) fanout.
+inAutoDrainProgress :: [Party] -> Set SimpleTxOut -> NodeState SimpleTx
+inAutoDrainProgress parties remaining =
+  inFanoutProgressWith parties remaining AutoDrain
 
 getConfirmedSnapshot :: IsTx tx => NodeState tx -> Maybe (Snapshot tx)
 getConfirmedSnapshot = \case
@@ -2844,6 +3057,12 @@ assertWait outcome waitReason =
   case outcome of
     Wait{reason} -> reason `shouldBe` waitReason
     _ -> failure $ "Expected a wait, but got: " <> show outcome
+
+-- | The effects produced by an outcome (empty for 'Wait'/'Error').
+effectsOf :: Outcome tx -> [Effect tx]
+effectsOf = \case
+  Continue{effects} -> effects
+  _ -> []
 
 hasEffectSatisfying :: (HasCallStack, IsChainState tx) => Outcome tx -> (Effect tx -> Bool) -> IO ()
 hasEffectSatisfying outcome predicate =

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -2228,6 +2228,34 @@ spec =
           FanoutProgress{} -> pure ()
           other -> failure $ "Expected to stay in FanoutProgress, got: " <> show other
 
+      it "resumes the fanout after a chain rollback instead of stalling" $ do
+        -- A rollback mid-fanout may erase the in-flight fanout tx observation. The
+        -- node must re-post the next fanout step so the fanout continues; otherwise
+        -- it wedges in FanoutProgress with nothing driving it forward. Mirrors the
+        -- Increment/Decrement re-post on rollback.
+        let fullUTxO = Set.fromList [SimpleTxOut i | i <- [1 .. 5]]
+            snap = testSnapshot 1 0 [] fullUTxO
+            st0 = inClosedState' threeParties (ConfirmedSnapshot snap (Crypto.aggregate []))
+        now <- nowFromSlot st0.chainPointTime.currentSlot
+        -- Become the driver and observe one partial fanout distributing {1,2}.
+        let st1 = aggregateState st0 (update bobEnv ledger now st0 (ClientInput Fanout))
+            distributed = Set.fromList [SimpleTxOut 1, SimpleTxOut 2]
+            observed = update bobEnv ledger now st1 (observeTxAtSlot 1 OnPartialFanoutTx{headId = testHeadId, distributedOutputs = distributed})
+            st2 = aggregateState st1 observed
+        -- Sanity: mid-fanout with a narrowed remaining set.
+        case headState st2 of
+          FanoutProgress PartialFanoutState{remainingOutputs} ->
+            remainingOutputs `shouldBe` Set.fromList [SimpleTxOut 3, SimpleTxOut 4, SimpleTxOut 5]
+          other -> failure $ "Expected FanoutProgress, got: " <> show other
+        -- Roll back the partial fanout observation; the node must re-post a fanout
+        -- step to resume rather than stall.
+        let rolledBack = update bobEnv ledger now st2 (ChainInput Rollback{rolledBackChainState = SimpleChainState 0, chainTime = now})
+        rolledBack `hasEffectSatisfying` \case
+          OnChainEffect{postChainTx = FanoutTx{}} -> True
+          OnChainEffect{postChainTx = FinalPartialFanoutTx{}} -> True
+          OnChainEffect{postChainTx = PartialFanoutTx{}} -> True
+          _ -> False
+
       it "client fanout without prior partial fanout uses full snapshot utxo" $ do
         let st = inClosedState threeParties
         now <- nowFromSlot st.chainPointTime.currentSlot

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -116,7 +116,6 @@ mockChainAndNetwork tr seedKeys = do
       , tickThread
       , rollbackAndForward = rollbackAndForward nodes chain
       , simulateDeposit = simulateDeposit nodes
-      , simulatePartialFanout = \_ _ -> error "simulatePartialFanout not implemented for MockChain"
       , closeWithInitialSnapshot = closeWithInitialSnapshot nodes
       , getChainHistory = pure []
       }
@@ -234,6 +233,7 @@ mockChainAndNetwork tr seedKeys = do
                   , closingSnapshot = InitialSnapshot{headId = openHeadId}
                   }
             Closed ClosedState{} -> error "Cannot post Close tx when in Closed state"
+            FanoutProgress{} -> error "Cannot post Close tx when in FanoutProgress state"
 
   matchingParty :: Party -> MockHydraNode m -> Bool
   matchingParty us MockHydraNode{node = HydraNode{env = Environment{party}}} =

--- a/hydra-node/testlib/Test/Hydra/API/ClientInput.hs
+++ b/hydra-node/testlib/Test/Hydra/API/ClientInput.hs
@@ -27,6 +27,7 @@ instance (Arbitrary tx, Arbitrary (TxIdType tx), Arbitrary (UTxOType tx), IsTx t
     SafeClose -> []
     Contest -> []
     Fanout -> []
+    PartialFanout utxo -> PartialFanout <$> shrink utxo
     SideLoadSnapshot sn -> SideLoadSnapshot <$> shrink sn
 
 instance (Arbitrary tx, Arbitrary (TxIdType tx), Arbitrary (UTxOType tx), IsTx tx) => ToADTArbitrary (ClientInput tx)

--- a/hydra-node/testlib/Test/Hydra/API/ServerOutput.hs
+++ b/hydra-node/testlib/Test/Hydra/API/ServerOutput.hs
@@ -4,7 +4,7 @@
 module Test.Hydra.API.ServerOutput where
 
 import Hydra.API.ClientInput (ClientInput)
-import Hydra.API.ServerOutput (ClientMessage, DecommitInvalidReason, Greetings, HeadStatus, NetworkInfo, ServerOutput (..), TimedServerOutput)
+import Hydra.API.ServerOutput (ClientMessage, DecommitInvalidReason, FanoutProgressMode, Greetings, HeadStatus, NetworkInfo, ServerOutput (..), TimedServerOutput)
 import Hydra.Chain (PostChainTx)
 import Hydra.Chain.ChainState (ChainStateType, IsChainState)
 import Hydra.HeadLogic.Error (SideLoadRequirementFailure)
@@ -44,6 +44,9 @@ instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (ServerO
 instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx), IsChainState tx) => ToADTArbitrary (ServerOutput tx)
 
 instance Arbitrary HeadStatus where
+  arbitrary = genericArbitrary
+
+instance Arbitrary FanoutProgressMode where
   arbitrary = genericArbitrary
 
 -- | All information needed to distinguish behavior of the commit endpoint.

--- a/hydra-node/testlib/Test/Hydra/Chain.hs
+++ b/hydra-node/testlib/Test/Hydra/Chain.hs
@@ -31,6 +31,8 @@ instance ArbitraryIsTx tx => Arbitrary (PostChainTx tx) where
       ContestTx <$> shrink headId <*> shrink headParameters <*> shrink openVersion <*> shrink contestingSnapshot
     FanoutTx{utxo, utxoToCommit, utxoToDecommit, utxoForProof, headSeed, contestationDeadline} ->
       FanoutTx <$> shrink utxo <*> shrink utxoToCommit <*> shrink utxoToDecommit <*> shrink utxoForProof <*> shrink headSeed <*> shrink contestationDeadline
+    PartialFanoutTx{utxoToDistribute, utxoForProof, headSeed, contestationDeadline} ->
+      PartialFanoutTx <$> shrink utxoToDistribute <*> shrink utxoForProof <*> shrink headSeed <*> shrink contestationDeadline
     FinalPartialFanoutTx{utxoToDistribute, presettledUTxO, headSeed, contestationDeadline} ->
       FinalPartialFanoutTx <$> shrink utxoToDistribute <*> shrink presettledUTxO <*> shrink headSeed <*> shrink contestationDeadline
 

--- a/hydra-node/testlib/Test/Hydra/HeadLogic/Outcome.hs
+++ b/hydra-node/testlib/Test/Hydra/HeadLogic/Outcome.hs
@@ -11,6 +11,7 @@ import Hydra.HeadLogic.Outcome (StateChanged (..))
 import Hydra.Node.Environment (Environment (..), mkHeadParameters)
 import Test.Hydra.API.ServerOutput ()
 import Test.Hydra.Chain ()
+import Test.Hydra.HeadLogic.State ()
 import Test.Hydra.Tx.Gen (ArbitraryIsTx)
 import Test.QuickCheck (oneof)
 
@@ -49,7 +50,10 @@ genStateChanged env =
     , HeadContested <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
     , HeadIsReadyToFanout <$> arbitrary
     , HeadFannedOut <$> arbitrary <*> arbitrary <*> arbitrary
-    , HeadPartialFannedOut <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+    , HeadPartialFannedOut <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+    , HeadFanoutInitiated <$> arbitrary <*> arbitrary
+    , HeadPartialFanoutSelected <$> arbitrary <*> arbitrary <*> arbitrary
+    , HeadFanoutReverted <$> arbitrary
     , LocalStateCleared <$> arbitrary <*> arbitrary
     , NodeUnsynced <$> arbitrary <*> arbitrary <*> arbitrary
     , NodeSynced <$> arbitrary <*> arbitrary <*> arbitrary

--- a/hydra-node/testlib/Test/Hydra/HeadLogic/State.hs
+++ b/hydra-node/testlib/Test/Hydra/HeadLogic/State.hs
@@ -10,9 +10,11 @@ import Hydra.Chain.ChainState (IsChainState (..))
 import Hydra.HeadLogic.State (
   ClosedState (..),
   CoordinatedHeadState (..),
+  FanoutMode (..),
   HeadState (..),
   IdleState (..),
   OpenState (..),
+  PartialFanoutState (..),
   SeenSnapshot (..),
   mkSeenSnapshot,
  )
@@ -57,5 +59,9 @@ instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (ClosedS
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
-      <*> arbitrary
-      <*> arbitrary
+
+instance ArbitraryIsTx tx => Arbitrary (FanoutMode tx) where
+  arbitrary = genericArbitrary
+
+instance (ArbitraryIsTx tx, Arbitrary (ChainStateType tx)) => Arbitrary (PartialFanoutState tx) where
+  arbitrary = genericArbitrary

--- a/hydra-tui/src/Hydra/TUI.hs
+++ b/hydra-tui/src/Hydra/TUI.hs
@@ -102,6 +102,7 @@ runWithVty buildVty options@Options{hydraNodeHost, cardanoNetworkId, cardanoConn
       , previousTab = MainTab
       , theme = cfg.theme
       , recoveryForm = Nothing
+      , fanoutSelectionForm = Nothing
       , eventHistoryFilter = ShowAll
       }
 

--- a/hydra-tui/src/Hydra/TUI/Drawing.hs
+++ b/hydra-tui/src/Hydra/TUI/Drawing.hs
@@ -6,6 +6,7 @@ module Hydra.TUI.Drawing where
 import Hydra.Prelude hiding (Down, State)
 
 import Brick
+import Brick.Forms (formState, renderForm)
 import Brick.Widgets.Border (borderWithLabel)
 import Brick.Widgets.Border.Style (unicodeRounded)
 import Data.Text qualified as T
@@ -68,6 +69,7 @@ drawTabBar active modalTabName fundsLabel =
 modalTabLabel :: RootState -> Text
 modalTabLabel s
   | isJust (s ^. recoveryFormL) = "Recover"
+  | isJust (s ^. fanoutSelectionFormL) = "Partial fanout"
   | otherwise = case s ^? connectedStateL . connectionL . headStateL . activeLinkL . activeHeadStateL . openStateL of
       Just LoadingUTxOForIncrement -> "Increment"
       Just NoUTxOToIncrement -> "Increment"
@@ -105,9 +107,19 @@ drawModalTab CardanoClient{networkId} Client{sk} s =
                 fromMaybe [] $
                   s ^? connectedStateL . connectionL . headStateL . activeLinkL . pendingIncrementsL
            in drawRecoverFormWithDetail ownAddress form pendingIncrements (s ^. nowL)
-        Nothing -> case s ^. connectedStateL of
-          Disconnected -> emptyWidget
-          Connected k -> drawFocusPanel networkId (getVerificationKey sk) (s ^. nowL) k
+        Nothing -> case s ^. fanoutSelectionFormL of
+          Just form ->
+            let entries = toList (formState form)
+                total = length entries
+                selected = length (filter snd entries)
+             in vBox
+                  [ withAttr sectionHeaderA $ txt "Select UTxOs to fan out (Space toggle, A all):"
+                  , withAttr neutral $ txt ("Selected " <> show selected <> " of " <> show total <> " UTxO")
+                  , renderForm form
+                  ]
+          Nothing -> case s ^. connectedStateL of
+            Disconnected -> emptyWidget
+            Connected k -> drawFocusPanel networkId (getVerificationKey sk) (s ^. nowL) k
 
 drawActionBar :: RootState -> Widget n
 drawActionBar s =
@@ -123,11 +135,13 @@ drawActionBar s =
       Idle -> [("I", "nit"), ("Q", "uit")]
       Active (ActiveLink{activeHeadState}) ->
         if isModal
-          then case s ^. recoveryFormL of
-            -- Recovery is a top-level modal flow (uses recoveryFormL, not openState),
-            -- so its action bar wins over any per-head openState actions.
-            Just _ -> [("↑↓/Space", " choose"), ("Enter", " recover"), ("Esc/C", " cancel")]
-            Nothing -> case activeHeadState of
+          then case (s ^. recoveryFormL, s ^. fanoutSelectionFormL) of
+            -- Recovery and partial-fanout selection are top-level modal flows
+            -- (use their own form fields, not openState), so their action bars
+            -- win over any per-head openState actions.
+            (Just _, _) -> [("↑↓/Space", " choose"), ("Enter", " recover"), ("Esc/C", " cancel")]
+            (_, Just _) -> [("↑↓", " move"), ("Space", " toggle"), ("A", " all"), ("Enter", " fan out"), ("Esc/C", " cancel")]
+            (Nothing, Nothing) -> case activeHeadState of
               Open{openState} -> case openState of
                 SelectingUTxOToIncrement _ -> [("↑↓/Space", " choose"), ("Enter", " select"), ("U", " refresh"), ("Esc/C", " cancel")]
                 NoUTxOToIncrement -> [("U", " refresh"), ("Esc/C", " cancel")]
@@ -148,13 +162,16 @@ drawActionBar s =
   fundsTabActions = \case
     Open{} -> [("I", "ncrement"), ("D", "ecommit")] <> recoverIf <> [("U", "pdate"), ("Q", "uit")]
     Closed{} -> recoverIf <> [("U", "pdate"), ("Q", "uit")]
-    FanoutPossible{} -> recoverIf <> [("F", "anout"), ("U", "pdate"), ("Q", "uit")]
+    FanoutPossible{} -> recoverIf <> [("F", "anout"), ("P", "artial fanout"), ("U", "pdate"), ("Q", "uit")]
+    -- Mid partial fanout: only further partial fanouts (no full 'Fanout').
+    FanningOut{} -> recoverIf <> [("P", "artial fanout"), ("U", "pdate"), ("Q", "uit")]
     Final{} -> recoverIf <> [("I", "nit"), ("U", "pdate"), ("Q", "uit")]
   -- Per-state actions on every other (non-Funds, non-EventHistory) tab.
   mainTabActions = \case
     Open{} -> [("N", "ew Tx"), ("D", "ecommit"), ("I", "ncrement")] <> recoverIf <> [("C", "lose"), ("Q", "uit")]
     Closed{} -> recoverIf <> [("Q", "uit")]
-    FanoutPossible{} -> recoverIf <> [("F", "anout"), ("Q", "uit")]
+    FanoutPossible{} -> recoverIf <> [("F", "anout"), ("P", "artial fanout"), ("Q", "uit")]
+    FanningOut{} -> recoverIf <> [("P", "artial fanout"), ("Q", "uit")]
     Final{} -> recoverIf <> [("I", "nit"), ("Q", "uit")]
   recoverIf = case s ^? connectedStateL . connectionL . headStateL . activeLinkL . pendingIncrementsL of
     Just (_ : _) -> [("R", "ecover")]

--- a/hydra-tui/src/Hydra/TUI/Drawing.hs
+++ b/hydra-tui/src/Hydra/TUI/Drawing.hs
@@ -10,6 +10,7 @@ import Brick.Forms (formState, renderForm)
 import Brick.Widgets.Border (borderWithLabel)
 import Brick.Widgets.Border.Style (unicodeRounded)
 import Data.Text qualified as T
+import Hydra.API.ServerOutput (FanoutProgressMode (..))
 import Hydra.Cardano.Api hiding (Active, getVerificationKey)
 import Hydra.Chain.CardanoClient (CardanoClient (..))
 import Hydra.Client (Client (..))
@@ -17,6 +18,7 @@ import Hydra.TUI.Config (Theme (..))
 import Hydra.TUI.Drawing.EventHistoryTab (drawEventHistoryTab)
 import Hydra.TUI.Drawing.FundsTab (drawFocusPanel, drawFundsTab, drawRecoverFormWithDetail)
 import Hydra.TUI.Drawing.MainTab (drawMainTab)
+import Hydra.TUI.Drawing.Utils (scrollableViewport)
 import Hydra.TUI.Logging.Types (EventHistoryFilter (..))
 import Hydra.TUI.Model
 import Hydra.TUI.Style
@@ -113,9 +115,9 @@ drawModalTab CardanoClient{networkId} Client{sk} s =
                 total = length entries
                 selected = length (filter snd entries)
              in vBox
-                  [ withAttr sectionHeaderA $ txt "Select UTxOs to fan out (Space toggle, A all):"
+                  [ withAttr sectionHeaderA $ txt "Select UTxOs to fan out (Space toggle, A all, PgUp/PgDn scroll):"
                   , withAttr neutral $ txt ("Selected " <> show selected <> " of " <> show total <> " UTxO")
-                  , renderForm form
+                  , scrollableViewport fanoutSelectionViewportName $ renderForm form
                   ]
           Nothing -> case s ^. connectedStateL of
             Disconnected -> emptyWidget
@@ -163,15 +165,18 @@ drawActionBar s =
     Open{} -> [("I", "ncrement"), ("D", "ecommit")] <> recoverIf <> [("U", "pdate"), ("Q", "uit")]
     Closed{} -> recoverIf <> [("U", "pdate"), ("Q", "uit")]
     FanoutPossible{} -> recoverIf <> [("F", "anout"), ("P", "artial fanout"), ("U", "pdate"), ("Q", "uit")]
-    -- Mid partial fanout: only further partial fanouts (no full 'Fanout').
-    FanningOut{} -> recoverIf <> [("P", "artial fanout"), ("U", "pdate"), ("Q", "uit")]
+    -- Mid fanout: offer [P] only when the node awaits a selection; while it
+    -- auto-drains there is nothing for the user to do. Full 'Fanout' is gone.
+    FanningOut{fanoutMode = AwaitingFanoutSelection} -> recoverIf <> [("P", "artial fanout"), ("U", "pdate"), ("Q", "uit")]
+    FanningOut{} -> recoverIf <> [("U", "pdate"), ("Q", "uit")]
     Final{} -> recoverIf <> [("I", "nit"), ("U", "pdate"), ("Q", "uit")]
   -- Per-state actions on every other (non-Funds, non-EventHistory) tab.
   mainTabActions = \case
     Open{} -> [("N", "ew Tx"), ("D", "ecommit"), ("I", "ncrement")] <> recoverIf <> [("C", "lose"), ("Q", "uit")]
     Closed{} -> recoverIf <> [("Q", "uit")]
     FanoutPossible{} -> recoverIf <> [("F", "anout"), ("P", "artial fanout"), ("Q", "uit")]
-    FanningOut{} -> recoverIf <> [("P", "artial fanout"), ("Q", "uit")]
+    FanningOut{fanoutMode = AwaitingFanoutSelection} -> recoverIf <> [("P", "artial fanout"), ("Q", "uit")]
+    FanningOut{} -> recoverIf <> [("Q", "uit")]
     Final{} -> recoverIf <> [("I", "nit"), ("Q", "uit")]
   recoverIf = case s ^? connectedStateL . connectionL . headStateL . activeLinkL . pendingIncrementsL of
     Just (_ : _) -> [("R", "ecover")]

--- a/hydra-tui/src/Hydra/TUI/Drawing/FundsTab.hs
+++ b/hydra-tui/src/Hydra/TUI/Drawing/FundsTab.hs
@@ -14,6 +14,7 @@ import Hydra.Chain.CardanoClient (CardanoClient (..))
 import Hydra.Chain.Direct.State ()
 import Hydra.Client (Client (..))
 import Hydra.TUI.Drawing.Utils (
+  drawFanningOutMessage,
   drawFanoutPossibleMessage,
   drawHeadFinalizedMessage,
   drawRemainingContestationPeriod,
@@ -93,6 +94,7 @@ drawFocusPanel networkId vk now (Connection{headState}) = case headState of
     Open x -> drawFocusPanelOpen networkId vk utxo pendingUTxOToDecommit pendingIncrements now x
     Closed x -> drawFocusPanelClosed networkId vk utxo pendingIncrements now x
     FanoutPossible -> drawFocusPanelFanout networkId vk utxo pendingIncrements now
+    FanningOut{fanoutRemaining} -> drawFocusPanelFanningOut networkId vk fanoutRemaining pendingIncrements now
     Final -> drawFocusPanelFinal networkId vk utxo pendingIncrements now
 
 -- | Focus panel for an 'Open' head: dispatches to home view or the active modal-form view.
@@ -142,6 +144,19 @@ drawFocusPanelFanout networkId vk utxo pendingIncrements now =
     [ drawFanoutPossibleMessage
     , withAttr neutral (txt "Active UTxO")
     , drawUTxO (highlightOwnAddress ownAddress) utxo
+    ]
+      <> drawPendingCommits ownAddress pendingIncrements now
+ where
+  ownAddress = mkVkAddress networkId vk
+
+-- | Focus panel while a selective partial fanout is in progress: shows what is
+-- still to be fanned out.
+drawFocusPanelFanningOut :: NetworkId -> VerificationKey PaymentKey -> UTxO -> [PendingIncrement] -> UTCTime -> Widget Name
+drawFocusPanelFanningOut networkId vk remaining pendingIncrements now =
+  vBox $
+    [ drawFanningOutMessage remaining
+    , withAttr neutral (txt "Remaining UTxO")
+    , drawUTxO (highlightOwnAddress ownAddress) remaining
     ]
       <> drawPendingCommits ownAddress pendingIncrements now
  where

--- a/hydra-tui/src/Hydra/TUI/Drawing/FundsTab.hs
+++ b/hydra-tui/src/Hydra/TUI/Drawing/FundsTab.hs
@@ -9,6 +9,7 @@ import Brick.Forms (Form, formState, renderForm)
 import Brick.Widgets.Border (borderWithLabel, hBorder, hBorderWithLabel, vBorder)
 import Cardano.Api.UTxO qualified as UTxO
 import Data.Map qualified as Map
+import Hydra.API.ServerOutput (FanoutProgressMode)
 import Hydra.Cardano.Api hiding (Active, getVerificationKey)
 import Hydra.Chain.CardanoClient (CardanoClient (..))
 import Hydra.Chain.Direct.State ()
@@ -94,7 +95,7 @@ drawFocusPanel networkId vk now (Connection{headState}) = case headState of
     Open x -> drawFocusPanelOpen networkId vk utxo pendingUTxOToDecommit pendingIncrements now x
     Closed x -> drawFocusPanelClosed networkId vk utxo pendingIncrements now x
     FanoutPossible -> drawFocusPanelFanout networkId vk utxo pendingIncrements now
-    FanningOut{fanoutRemaining} -> drawFocusPanelFanningOut networkId vk fanoutRemaining pendingIncrements now
+    FanningOut{fanoutRemaining, fanoutMode} -> drawFocusPanelFanningOut networkId vk fanoutMode fanoutRemaining pendingIncrements now
     Final -> drawFocusPanelFinal networkId vk utxo pendingIncrements now
 
 -- | Focus panel for an 'Open' head: dispatches to home view or the active modal-form view.
@@ -151,10 +152,10 @@ drawFocusPanelFanout networkId vk utxo pendingIncrements now =
 
 -- | Focus panel while a selective partial fanout is in progress: shows what is
 -- still to be fanned out.
-drawFocusPanelFanningOut :: NetworkId -> VerificationKey PaymentKey -> UTxO -> [PendingIncrement] -> UTCTime -> Widget Name
-drawFocusPanelFanningOut networkId vk remaining pendingIncrements now =
+drawFocusPanelFanningOut :: NetworkId -> VerificationKey PaymentKey -> FanoutProgressMode -> UTxO -> [PendingIncrement] -> UTCTime -> Widget Name
+drawFocusPanelFanningOut networkId vk fanoutMode remaining pendingIncrements now =
   vBox $
-    [ drawFanningOutMessage remaining
+    [ drawFanningOutMessage fanoutMode remaining
     , withAttr neutral (txt "Remaining UTxO")
     , drawUTxO (highlightOwnAddress ownAddress) remaining
     ]

--- a/hydra-tui/src/Hydra/TUI/Drawing/MainTab.hs
+++ b/hydra-tui/src/Hydra/TUI/Drawing/MainTab.hs
@@ -15,6 +15,7 @@ import Hydra.Client (Client (..))
 import Hydra.Network (Host)
 import Hydra.TUI.Drawing.EventHistoryTab (drawEventListItem)
 import Hydra.TUI.Drawing.Utils (
+  drawFanningOutMessage,
   drawFanoutPossibleMessage,
   drawHeadFinalizedMessage,
   drawHex,
@@ -84,6 +85,7 @@ drawMainTab CardanoClient{networkId} Client{sk} s =
               Open{} -> "Open"
               Closed{} -> "Closed"
               FanoutPossible -> "Ready to Fanout"
+              FanningOut{} -> "Fanning out"
               Final -> "Finalized"
             hid = prettyHeadId headId
          in withAttr neutral (txt " ")
@@ -131,6 +133,11 @@ drawMainTab CardanoClient{networkId} Client{sk} s =
             vBox
               [ drawFanoutPossibleMessage
               , utxoBlock utxo
+              ]
+          FanningOut{fanoutRemaining} ->
+            vBox
+              [ drawFanningOutMessage fanoutRemaining
+              , utxoBlock fanoutRemaining
               ]
           Final ->
             vBox

--- a/hydra-tui/src/Hydra/TUI/Drawing/MainTab.hs
+++ b/hydra-tui/src/Hydra/TUI/Drawing/MainTab.hs
@@ -134,9 +134,9 @@ drawMainTab CardanoClient{networkId} Client{sk} s =
               [ drawFanoutPossibleMessage
               , utxoBlock utxo
               ]
-          FanningOut{fanoutRemaining} ->
+          FanningOut{fanoutRemaining, fanoutMode} ->
             vBox
-              [ drawFanningOutMessage fanoutRemaining
+              [ drawFanningOutMessage fanoutMode fanoutRemaining
               , utxoBlock fanoutRemaining
               ]
           Final ->

--- a/hydra-tui/src/Hydra/TUI/Drawing/Utils.hs
+++ b/hydra-tui/src/Hydra/TUI/Drawing/Utils.hs
@@ -122,6 +122,14 @@ drawFanoutPossibleMessage :: Widget n
 drawFanoutPossibleMessage =
   withAttr sectionHeaderA $ txt "Contestation period passed — ready to fan out."
 
+-- | Status message shown while a selective partial fanout is in progress,
+-- reporting how many UTxO are still to be fanned out. Shared between the Main
+-- and Funds tabs so the wording and count match.
+drawFanningOutMessage :: UTxO -> Widget n
+drawFanningOutMessage remaining =
+  withAttr infoA $
+    txt ("Partial fanout in progress — " <> show (UTxO.size remaining) <> " UTxO remaining (press [P] to fan out more)")
+
 -- | Status message shown when the head has been finalized, including the
 -- total ADA value of the distributed UTxO. Shared between the Main and
 -- Funds tabs so the wording matches.

--- a/hydra-tui/src/Hydra/TUI/Drawing/Utils.hs
+++ b/hydra-tui/src/Hydra/TUI/Drawing/Utils.hs
@@ -11,6 +11,7 @@ import Data.Map qualified as Map
 import Data.Text qualified as T
 import Data.Time (defaultTimeLocale, formatTime, utctDayTime)
 import Data.Time.Format (FormatTime)
+import Hydra.API.ServerOutput (FanoutProgressMode (..))
 import Hydra.Cardano.Api hiding (Active)
 import Hydra.TUI.Style (infoA, own, sectionHeaderA)
 import Hydra.Tx (HeadId, IsTx (..))
@@ -122,13 +123,21 @@ drawFanoutPossibleMessage :: Widget n
 drawFanoutPossibleMessage =
   withAttr sectionHeaderA $ txt "Contestation period passed — ready to fan out."
 
--- | Status message shown while a selective partial fanout is in progress,
--- reporting how many UTxO are still to be fanned out. Shared between the Main
--- and Funds tabs so the wording and count match.
-drawFanningOutMessage :: UTxO -> Widget n
-drawFanningOutMessage remaining =
-  withAttr infoA $
-    txt ("Partial fanout in progress — " <> show (UTxO.size remaining) <> " UTxO remaining (press [P] to fan out more)")
+-- | Status message shown while a fanout is in progress, reporting how many UTxO
+-- are still to be fanned out. The wording follows the node-reported
+-- 'FanoutProgressMode': while auto-draining we just report progress; when the
+-- node awaits the next selection we prompt for [P]. Shared between the Main and
+-- Funds tabs so the wording and count match.
+drawFanningOutMessage :: FanoutProgressMode -> UTxO -> Widget n
+drawFanningOutMessage mode remaining =
+  withAttr infoA $ txt message
+ where
+  count = show (UTxO.size remaining)
+  message = case mode of
+    AutoFanningOut ->
+      "Fanning out — " <> count <> " UTxO remaining…"
+    AwaitingFanoutSelection ->
+      "Partial fanout paused — " <> count <> " UTxO remaining (press [P] to fan out more)"
 
 -- | Status message shown when the head has been finalized, including the
 -- total ADA value of the distributed UTxO. Shared between the Main and

--- a/hydra-tui/src/Hydra/TUI/Forms.hs
+++ b/hydra-tui/src/Hydra/TUI/Forms.hs
@@ -15,6 +15,7 @@ import Brick.Forms (
   FormField (..),
   FormFieldState (..),
   FormFieldVisibilityMode (..),
+  checkboxField,
   focusedFormInputAttr,
   newForm,
   radioField,
@@ -26,7 +27,7 @@ import Data.Map.Strict qualified as Map
 import Data.Text qualified as Text
 import Graphics.Vty (Event (..), Key (..))
 import Hydra.Chain.Direct.State ()
-import Lens.Micro (Lens', (^.))
+import Lens.Micro (Lens', lens, (^.))
 
 -- | Render a UTxO entry as "txin#ix ↦ ₳ X.XXXXXX" for form labels.
 -- The TxIn is shortened to the last 10 characters of the hash plus its
@@ -61,6 +62,50 @@ utxoRadioField u = case Map.toList u of
             ]
         ]
         x
+
+-- | Build a multi-select (checkbox) form over a UTxO set: each entry can be
+-- toggled with Space, and the form state records which are selected. Used for
+-- selective partial fanout, where the user picks one or more UTxOs to fan out
+-- in a single 'PartialFanout'. Returns 'Nothing' for an empty UTxO set.
+utxoCheckboxField ::
+  forall e n.
+  n ~ Text =>
+  Map TxIn (TxOut CtxUTxO) ->
+  Maybe (Form (Map TxIn (TxOut CtxUTxO, Bool)) e n)
+utxoCheckboxField = utxoCheckboxFieldWith Nothing
+
+-- | Like 'utxoCheckboxField' but carries over a previous selection: any TxIn
+-- still present keeps its ticked state, new entries default to unticked, and
+-- entries no longer in the set are dropped. Used to rebuild the open fanout
+-- modal when a 'HeadPartiallyFannedOut' step shrinks the remaining UTxO.
+utxoCheckboxFieldWith ::
+  forall e n.
+  n ~ Text =>
+  Maybe (Map TxIn (TxOut CtxUTxO, Bool)) ->
+  Map TxIn (TxOut CtxUTxO) ->
+  Maybe (Form (Map TxIn (TxOut CtxUTxO, Bool)) e n)
+utxoCheckboxFieldWith mPrev u
+  | Map.null u = Nothing
+  | otherwise =
+      Just $
+        newForm
+          [ checkboxField (selectedL txin) (renderTxIn txin) (renderUTxOAsAda (txin, txout))
+          | (txin, txout) <- Map.toList u
+          ]
+          initial
+ where
+  initial :: Map TxIn (TxOut CtxUTxO, Bool)
+  initial = Map.mapWithKey (\txin txout -> (txout, wasSelected txin)) u
+
+  wasSelected :: TxIn -> Bool
+  wasSelected txin = maybe False snd (mPrev >>= Map.lookup txin)
+
+  -- Lens focusing the selected flag of one entry within the whole map state.
+  selectedL :: TxIn -> Lens' (Map TxIn (TxOut CtxUTxO, Bool)) Bool
+  selectedL txin =
+    lens
+      (maybe False snd . Map.lookup txin)
+      (\m b -> Map.adjust (\(o, _) -> (o, b)) txin m)
 
 -- | Build a radio form for selecting one pending deposit (by 'TxId') to
 -- recover. The form yields just the 'TxId' — the full UTxO breakdown is

--- a/hydra-tui/src/Hydra/TUI/Handlers.hs
+++ b/hydra-tui/src/Hydra/TUI/Handlers.hs
@@ -430,7 +430,10 @@ handleHydraEventsActiveLink e = do
       -- next selection (or fan out the rest). Full 'Fanout' is no longer offered.
       utxoL .= remainingUTxO
       activeHeadStateL .= FanningOut{fanoutRemaining = remainingUTxO}
-    Update (ApiTimedServerOutput TimedServerOutput{time, output = API.HeadIsFinalized{}}) -> do
+    Update (ApiTimedServerOutput TimedServerOutput{time, output = API.HeadIsFinalized{finalizedUTxO}}) -> do
+      -- Show the full cumulative set that was fanned out across all (partial)
+      -- fanout steps, not just the last batch that happened to be left in 'utxoL'.
+      utxoL .= finalizedUTxO
       activeHeadStateL .= Final
     Update (ApiTimedServerOutput TimedServerOutput{time, output = API.DecommitRequested{utxoToDecommit}}) -> do
       ActiveLink{utxo} <- get
@@ -852,14 +855,25 @@ refreshFanoutForm = do
       mUTxO <- gets (^? connectedStateL . connectionL . headStateL . activeLinkL . utxoL)
       let u = maybe mempty UTxO.toMap mUTxO
           prevSelection = formState form
-      case utxoCheckboxFieldWith (Just prevSelection) u of
-        Just refreshed | stillFanningOut -> fanoutSelectionFormL .= Just refreshed
-        -- Head finalized or left a fanout-capable state, or nothing remains:
-        -- close the modal so the user cannot submit against a stale UTxO set.
-        _ -> do
+      if not stillFanningOut || Map.null u
+        then do
+          -- Head finalized or left a fanout-capable state, or nothing remains:
+          -- close the modal so the user cannot submit against a stale UTxO set.
           fanoutSelectionFormL .= Nothing
           tab <- use activeTabL
           when (tab == ModalTab) leaveModal
+        else
+          -- Only rebuild the form when the underlying UTxO set actually changed
+          -- (e.g. a 'HeadPartiallyFannedOut' step shrank it). 'newForm' resets the
+          -- focus to the first field, so rebuilding on every tick would make the
+          -- selection jump back to the top and the list unusable.
+          when (Map.keysSet u /= Map.keysSet prevSelection) $
+            case utxoCheckboxFieldWith (Just prevSelection) u of
+              Just refreshed -> fanoutSelectionFormL .= Just refreshed
+              Nothing -> do
+                fanoutSelectionFormL .= Nothing
+                tab <- use activeTabL
+                when (tab == ModalTab) leaveModal
 
 -- | Run an IO action in a background thread, reporting any exception through
 -- the TUI's event channel as a 'TxBuildError' (visible in the pending-action

--- a/hydra-tui/src/Hydra/TUI/Handlers.hs
+++ b/hydra-tui/src/Hydra/TUI/Handlers.hs
@@ -9,7 +9,7 @@ import Hydra.Prelude hiding (Down)
 
 import Brick
 import Brick.BChan (BChan, writeBChan)
-import Brick.Forms (Form (formState), editField, editShowableFieldWithValidate, handleFormEvent, newForm)
+import Brick.Forms (Form (formState), editField, editShowableFieldWithValidate, handleFormEvent, newForm, updateFormState)
 import Brick.Widgets.List qualified as BrickList
 import Cardano.Api.UTxO qualified as UTxO
 import Control.Concurrent (forkIO)
@@ -67,6 +67,7 @@ handleEvent cardanoClient client chan = \case
       pendingActionL .= Nothing
     syncEventHistoryList
     refreshRecoveryForm
+    refreshFanoutForm
     case e of
       ClientConnected ->
         triggerL1Query cardanoClient client chan
@@ -84,6 +85,7 @@ handleEvent cardanoClient client chan = \case
         triggerL1Query cardanoClient client chan
       ClientDisconnected -> do
         recoveryFormL .= Nothing
+        fanoutSelectionFormL .= Nothing
         pendingActionL .= Nothing
         l1UTxOL .= Nothing
         fuelUTxOL .= Nothing
@@ -114,7 +116,8 @@ handleEvent cardanoClient client chan = \case
         -- would be stranded showing a stale loading panel.
         tab <- use activeTabL
         hasRecoveryForm <- isJust <$> use recoveryFormL
-        when (tab == ModalTab && not hasRecoveryForm) leaveModal
+        hasFanoutForm <- isJust <$> use fanoutSelectionFormL
+        when (tab == ModalTab && not hasRecoveryForm && not hasFanoutForm) leaveModal
       _ -> pure () -- User navigated away (Esc, started a different flow) — drop silently.
   MouseDown name Vty.BScrollUp _ _ ->
     vScrollBy (viewportScroll name) (-3)
@@ -189,6 +192,24 @@ handleEvent cardanoClient client chan = \case
         setPendingAction e
         zoom (connectedStateL . connectionL . headStateL) $
           handleVtyEventsHeadState cardanoClient client chan e
+      EvKey (KChar 'p') [] | not modalOpen -> do
+        -- Selective partial fanout: pick one or more UTxOs to fan out, then send
+        -- 'PartialFanout'. Only available once fanout is possible. This is a
+        -- top-level modal flow (uses 'fanoutSelectionFormL'), like recovery.
+        mLink <- gets (^? connectedStateL . connectionL . headStateL . activeLinkL)
+        let canPartialFanout = \case
+              FanoutPossible -> True
+              FanningOut{} -> True
+              _ -> False
+        case mLink of
+          Just ActiveLink{utxo = UTxO m, activeHeadState}
+            | canPartialFanout activeHeadState ->
+                case utxoCheckboxField m of
+                  Just form -> do
+                    fanoutSelectionFormL .= Just form
+                    enterModal
+                  Nothing -> liftIO $ writeBChan chan (TxBuildError "No UTxO available to fan out.")
+          _ -> pure ()
       EvKey (KChar 'i') [] | not modalOpen -> do
         -- Increment reads the cached L1 UTxO ('l1UTxOL') for a snappy modal
         -- rather than querying the cardano-node. With an empty/unloaded cache
@@ -242,18 +263,47 @@ handleEvent cardanoClient client chan = \case
             let closeModal = do
                   leaveModal
                   recoveryFormL .= Nothing
+                  fanoutSelectionFormL .= Nothing
                   zoomOpenScreen $ put OpenHome
             currentRecoveryForm <- use recoveryFormL
-            case (currentRecoveryForm, e) of
-              (_, EvKey KEsc []) -> closeModal
-              (_, EvKey (KChar 'c') []) -> closeModal
-              (Just form, EvKey KEnter []) -> do
+            currentFanoutForm <- use fanoutSelectionFormL
+            case (currentRecoveryForm, currentFanoutForm, e) of
+              (_, _, EvKey KEsc []) -> closeModal
+              (_, _, EvKey (KChar 'c') []) -> closeModal
+              (Just form, _, EvKey KEnter []) -> do
                 let selectedTxId = formState form
                 pendingActionL .= Just "Sending recovery…"
                 liftIO $ recoverCommitAsync client chan selectedTxId
                 closeModal
-              (Just _, _) -> zoom (recoveryFormL . _Just) $ handleFormEvent (VtyEvent e)
-              (Nothing, _) -> do
+              (Just _, _, _) -> zoom (recoveryFormL . _Just) $ handleFormEvent (VtyEvent e)
+              (_, Just form, EvKey KEnter []) -> do
+                -- Fan out all the UTxOs the operator ticked. The node distributes
+                -- them (chunking as needed) and reports 'HeadPartiallyFannedOut'
+                -- with the remaining set; repeat to fan out more, or tick the rest
+                -- to finish (the final step burns the head tokens).
+                let selected = UTxO.fromList [(txin, txout) | (txin, (txout, True)) <- Map.toList (formState form)]
+                if UTxO.null selected
+                  then pendingActionL .= Just "Select at least one UTxO to fan out (Space to toggle)."
+                  else do
+                    pendingActionL .= Just "Sending partial fanout…"
+                    liftIO $ sendInput client (PartialFanout selected)
+                    closeModal
+              (_, Just form, EvKey (KChar 'a') []) ->
+                -- Select-all toggle: if every UTxO is already ticked, clear them
+                -- all; otherwise tick them all.
+                let allTicked = all (snd . snd) (Map.toList (formState form))
+                    setAll b = Map.map (\(o, _) -> (o, b)) (formState form)
+                 in fanoutSelectionFormL . _Just %= updateFormState (setAll (not allTicked))
+              (_, Just _, _) ->
+                -- The multi-select is several separate checkbox fields, so brick
+                -- moves focus with Tab/BackTab. Map ↑/↓ to those so the arrow
+                -- keys navigate the list as users expect (Space still toggles).
+                let e' = case e of
+                      EvKey KDown [] -> EvKey (KChar '\t') []
+                      EvKey KUp [] -> EvKey KBackTab []
+                      _ -> e
+                 in zoom (fanoutSelectionFormL . _Just) $ handleFormEvent (VtyEvent e')
+              (Nothing, Nothing, _) -> do
                 -- Show "Sending …" status for in-modal Enter actions
                 -- (decommit / increment / recover / close confirm). Done
                 -- before handleVtyEventsHeadState so the read of openState
@@ -374,6 +424,12 @@ handleHydraEventsActiveLink e = do
       activeHeadStateL .= Closed{closedState = ClosedState{contestationDeadline}}
     Update (ApiTimedServerOutput TimedServerOutput{time, output = API.ReadyToFanout{}}) ->
       activeHeadStateL .= FanoutPossible
+    Update (ApiTimedServerOutput TimedServerOutput{time, output = API.HeadPartiallyFannedOut{remainingUTxO}}) -> do
+      -- A selective partial fanout step landed: move into the in-progress
+      -- 'FanningOut' state and reflect what is left so the operator can pick the
+      -- next selection (or fan out the rest). Full 'Fanout' is no longer offered.
+      utxoL .= remainingUTxO
+      activeHeadStateL .= FanningOut{fanoutRemaining = remainingUTxO}
     Update (ApiTimedServerOutput TimedServerOutput{time, output = API.HeadIsFinalized{}}) -> do
       activeHeadStateL .= Final
     Update (ApiTimedServerOutput TimedServerOutput{time, output = API.DecommitRequested{utxoToDecommit}}) -> do
@@ -439,6 +495,9 @@ handleVtyEventsActiveHeadState cardanoClient hydraClient chan utxo pendingIncrem
   s <- use id
   case s of
     FanoutPossible -> handleVtyEventsFanoutPossible hydraClient e
+    -- Mid partial fanout: full 'Fanout' is no longer valid; only the 'P' partial
+    -- fanout flow (handled in the outer event loop) applies here.
+    FanningOut{} -> pure ()
     Final -> handleVtyEventsFinal hydraClient e
     _ -> pure ()
 
@@ -772,6 +831,35 @@ refreshRecoveryForm = do
           when (tab == ModalTab) $ do
             leaveModal
             pendingActionL .= Just "No pending deposits left to recover."
+
+-- | Keep an open partial-fanout selection modal in sync with the head's
+-- remaining UTxO. When a 'HeadPartiallyFannedOut' step lands, the displayed
+-- 'utxoL' shrinks; rebuild the form against it so the user cannot tick (and
+-- submit) UTxOs that were already fanned out. Still-valid ticks are preserved.
+-- If the head is no longer fanning out (finalized, or otherwise left a
+-- fanout-capable state), close the modal.
+refreshFanoutForm :: EventM Name RootState ()
+refreshFanoutForm = do
+  mForm <- use fanoutSelectionFormL
+  case mForm of
+    Nothing -> pure ()
+    Just form -> do
+      mActiveHeadState <- gets (^? connectedStateL . connectionL . headStateL . activeLinkL . activeHeadStateL)
+      let stillFanningOut = case mActiveHeadState of
+            Just FanoutPossible -> True
+            Just FanningOut{} -> True
+            _ -> False
+      mUTxO <- gets (^? connectedStateL . connectionL . headStateL . activeLinkL . utxoL)
+      let u = maybe mempty UTxO.toMap mUTxO
+          prevSelection = formState form
+      case utxoCheckboxFieldWith (Just prevSelection) u of
+        Just refreshed | stillFanningOut -> fanoutSelectionFormL .= Just refreshed
+        -- Head finalized or left a fanout-capable state, or nothing remains:
+        -- close the modal so the user cannot submit against a stale UTxO set.
+        _ -> do
+          fanoutSelectionFormL .= Nothing
+          tab <- use activeTabL
+          when (tab == ModalTab) leaveModal
 
 -- | Run an IO action in a background thread, reporting any exception through
 -- the TUI's event channel as a 'TxBuildError' (visible in the pending-action

--- a/hydra-tui/src/Hydra/TUI/Handlers.hs
+++ b/hydra-tui/src/Hydra/TUI/Handlers.hs
@@ -24,7 +24,7 @@ import Graphics.Vty (
  )
 import Graphics.Vty qualified as Vty
 import Hydra.API.ClientInput (ClientInput (..))
-import Hydra.API.ServerOutput (NetworkInfo (..), TimedServerOutput (..))
+import Hydra.API.ServerOutput (FanoutProgressMode (..), NetworkInfo (..), TimedServerOutput (..))
 import Hydra.API.ServerOutput qualified as API
 import Hydra.Cardano.Api hiding (Active, getVerificationKey)
 import Hydra.Cardano.Api.Prelude ()
@@ -197,9 +197,12 @@ handleEvent cardanoClient client chan = \case
         -- 'PartialFanout'. Only available once fanout is possible. This is a
         -- top-level modal flow (uses 'fanoutSelectionFormL'), like recovery.
         mLink <- gets (^? connectedStateL . connectionL . headStateL . activeLinkL)
+        -- Offer partial fanout only when the node is actually waiting for a
+        -- selection: from 'FanoutPossible', or mid-fanout when the node reports
+        -- it is awaiting the next selection (not while it auto-drains).
         let canPartialFanout = \case
               FanoutPossible -> True
-              FanningOut{} -> True
+              FanningOut{fanoutMode} -> fanoutMode == AwaitingFanoutSelection
               _ -> False
         case mLink of
           Just ActiveLink{utxo = UTxO m, activeHeadState}
@@ -294,6 +297,10 @@ handleEvent cardanoClient client chan = \case
                 let allTicked = all (snd . snd) (Map.toList (formState form))
                     setAll b = Map.map (\(o, _) -> (o, b)) (formState form)
                  in fanoutSelectionFormL . _Just %= updateFormState (setAll (not allTicked))
+              -- Scroll the (possibly long) UTxO list with PageUp/PageDown, matching
+              -- the main/funds UTxO viewports.
+              (_, Just _, EvKey KPageUp []) -> vScrollBy (viewportScroll fanoutSelectionViewportName) (-10)
+              (_, Just _, EvKey KPageDown []) -> vScrollBy (viewportScroll fanoutSelectionViewportName) 10
               (_, Just _, _) ->
                 -- The multi-select is several separate checkbox fields, so brick
                 -- moves focus with Tab/BackTab. Map ↑/↓ to those so the arrow
@@ -424,12 +431,13 @@ handleHydraEventsActiveLink e = do
       activeHeadStateL .= Closed{closedState = ClosedState{contestationDeadline}}
     Update (ApiTimedServerOutput TimedServerOutput{time, output = API.ReadyToFanout{}}) ->
       activeHeadStateL .= FanoutPossible
-    Update (ApiTimedServerOutput TimedServerOutput{time, output = API.HeadPartiallyFannedOut{remainingUTxO}}) -> do
-      -- A selective partial fanout step landed: move into the in-progress
-      -- 'FanningOut' state and reflect what is left so the operator can pick the
-      -- next selection (or fan out the rest). Full 'Fanout' is no longer offered.
+    Update (ApiTimedServerOutput TimedServerOutput{time, output = API.HeadPartiallyFannedOut{remainingUTxO, fanoutMode}}) -> do
+      -- A fanout step landed: move into the in-progress 'FanningOut' state and
+      -- reflect what is left. 'fanoutMode' (from the node) decides whether we
+      -- prompt for the next selection or just report auto-draining progress.
+      -- Full 'Fanout' is no longer offered either way.
       utxoL .= remainingUTxO
-      activeHeadStateL .= FanningOut{fanoutRemaining = remainingUTxO}
+      activeHeadStateL .= FanningOut{fanoutRemaining = remainingUTxO, fanoutMode}
     Update (ApiTimedServerOutput TimedServerOutput{time, output = API.HeadIsFinalized{finalizedUTxO}}) -> do
       -- Show the full cumulative set that was fanned out across all (partial)
       -- fanout steps, not just the last batch that happened to be left in 'utxoL'.

--- a/hydra-tui/src/Hydra/TUI/Model.hs
+++ b/hydra-tui/src/Hydra/TUI/Model.hs
@@ -15,6 +15,7 @@ import Brick.Forms (Form)
 import Brick.Widgets.List qualified as BrickList
 import Data.Map qualified as Map
 import Data.Vector qualified as Vec
+import Hydra.API.ServerOutput (FanoutProgressMode (..), fanoutProgressMode)
 import Hydra.Chain.Direct.State ()
 import Hydra.Client (HydraEvent (..))
 import Hydra.HeadLogic.State (CoordinatedHeadState (CoordinatedHeadState))
@@ -161,8 +162,10 @@ data ActiveHeadState
   | FanoutPossible
   | -- | A selective partial fanout is in progress (on-chain @FanoutProgress@):
     -- some UTxO has been distributed and 'fanoutRemaining' is still in the head.
-    -- Only further partial fanouts are accepted (no full 'Fanout').
-    FanningOut {fanoutRemaining :: UTxO}
+    -- Only further partial fanouts are accepted (no full 'Fanout'). 'fanoutMode'
+    -- (reported by the node) says whether it keeps draining on its own or awaits
+    -- the next selection, driving what the UI offers.
+    FanningOut {fanoutRemaining :: UTxO, fanoutMode :: FanoutProgressMode}
   | Final
 
 type Name = Text
@@ -252,6 +255,9 @@ fundsL1ViewportName = "funds-l1"
 fundsFuelViewportName :: Name
 fundsFuelViewportName = "funds-fuel"
 
+fanoutSelectionViewportName :: Name
+fanoutSelectionViewportName = "fanout-selection"
+
 emptyEventHistoryList :: BrickList.List Name LogMessage
 emptyEventHistoryList = BrickList.list eventHistoryListName Vec.empty 1
 
@@ -338,6 +344,7 @@ recoverHeadState now current nodeState =
         , headId
         , confirmedSnapshot
         , remainingOutputs
+        , mode
         } ->
         let Snapshot{utxoToDecommit} = Snapshot.getSnapshot confirmedSnapshot
          in Active
@@ -347,7 +354,7 @@ recoverHeadState now current nodeState =
                 , pendingIncrements
                 , parties = HeadParameters.parties parameters
                 , headId
-                , activeHeadState = FanningOut{fanoutRemaining = remainingOutputs}
+                , activeHeadState = FanningOut{fanoutRemaining = remainingOutputs, fanoutMode = fanoutProgressMode mode}
                 }
  where
   pendingIncrements =

--- a/hydra-tui/src/Hydra/TUI/Model.hs
+++ b/hydra-tui/src/Hydra/TUI/Model.hs
@@ -57,6 +57,10 @@ data RootState = RootState
   , previousTab :: ActiveTab
   , theme :: Theme
   , recoveryForm :: Maybe (TxIdRadioFieldForm (HydraEvent Tx) Name)
+  , fanoutSelectionForm :: Maybe (UTxOCheckboxForm (HydraEvent Tx) Name)
+  -- ^ When set, the operator is multi-selecting which UTxOs to fan out for a
+  -- selective 'PartialFanout' (a top-level modal flow, like 'recoveryForm').
+  -- Available regardless of head state once fanout is possible.
   , eventHistoryFilter :: EventHistoryFilter
   }
 
@@ -155,6 +159,10 @@ data ActiveHeadState
   = Open {openState :: OpenScreen}
   | Closed {closedState :: ClosedState}
   | FanoutPossible
+  | -- | A selective partial fanout is in progress (on-chain @FanoutProgress@):
+    -- some UTxO has been distributed and 'fanoutRemaining' is still in the head.
+    -- Only further partial fanouts are accepted (no full 'Fanout').
+    FanningOut {fanoutRemaining :: UTxO}
   | Final
 
 type Name = Text
@@ -196,6 +204,7 @@ makeLensesFor
   , ("previousTab", "previousTabL")
   , ("theme", "themeL")
   , ("recoveryForm", "recoveryFormL")
+  , ("fanoutSelectionForm", "fanoutSelectionFormL")
   , ("eventHistoryFilter", "eventHistoryFilterL")
   ]
   ''RootState
@@ -322,6 +331,23 @@ recoverHeadState now current nodeState =
                     if readyToFanoutSent
                       then FanoutPossible
                       else Closed{closedState = ClosedState{contestationDeadline}}
+                }
+    State.FanoutProgress
+      State.PartialFanoutState
+        { parameters
+        , headId
+        , confirmedSnapshot
+        , remainingOutputs
+        } ->
+        let Snapshot{utxoToDecommit} = Snapshot.getSnapshot confirmedSnapshot
+         in Active
+              ActiveLink
+                { utxo = remainingOutputs
+                , pendingUTxOToDecommit = fromMaybe mempty utxoToDecommit
+                , pendingIncrements
+                , parties = HeadParameters.parties parameters
+                , headId
+                , activeHeadState = FanningOut{fanoutRemaining = remainingOutputs}
                 }
  where
   pendingIncrements =

--- a/hydra-tui/src/Hydra/TUI/RenderMessage.hs
+++ b/hydra-tui/src/Hydra/TUI/RenderMessage.hs
@@ -12,6 +12,7 @@ import Cardano.Api.UTxO qualified as UTxO
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as TL
 import Data.Text.Lazy.Encoding qualified as TLE
+import Hydra.API.ClientInput (ClientInput (..))
 import Hydra.API.ServerOutput (
   ClientMessage (..),
   DecommitInvalidReason (..),
@@ -145,6 +146,16 @@ renderServerOutput time output raw = case output of
       "Ready to fan out"
       [ fld "Head ID" (prettyHeadId headId)
       , "Contestation period has passed. You can now submit a fanout transaction."
+      ]
+      raw
+  HeadPartiallyFannedOut{headId, distributedUTxO, remainingUTxO} ->
+    mk
+      Success
+      time
+      "Head partially fanned out"
+      [ fld "Head ID" (prettyHeadId headId)
+      , fld "Distributed outputs" (show (UTxO.size distributedUTxO))
+      , fld "Remaining outputs" (show (UTxO.size remainingUTxO))
       ]
       raw
   HeadIsFinalized{headId, finalizedUTxO} ->
@@ -347,7 +358,12 @@ renderClientMessage now msg raw = case msg of
       now
       ("Invalid command: " <> show clientInput)
       [ fld "Command" (show clientInput)
-      , "This command is not valid in the current head state."
+      , case clientInput of
+          Fanout ->
+            "A partial fanout is already in progress for this head — use Partial fanout [P] to continue draining it."
+          PartialFanout{} ->
+            "Invalid selection: the head is not ready to fan out, or the chosen UTxO is not part of what remains."
+          _ -> "This command is not valid in the current head state."
       ]
       raw
   PostTxOnChainFailed{postTxError} ->


### PR DESCRIPTION
Resollves #2333  

instead of Fanout draining the whole head at once, you can PartialFanout a chosen subset of the UTxO and keep going until the head is empty.

A few design decisions worth calling out:

- Partial fanout gets its own state. I pulled the remaining/distributed bookkeeping out of `ClosedState` (where it lived as Maybe fields) into a dedicated `FanoutProgress`/`PartialFanoutState`
- One `FanoutMode`, two ways to drive it. AutoDrain is the old behavior: a plain Fanout and the node drains the rest itself. Manual selection (`DistributingSelection`/`AwaitingSelection`) is the new path. Same state machine, the mode just decides who picks the next chunk
- Only the node that issued the command drives. Everyone else observes and waits. This is the key bit for multi-party heads: observers must not steamroll the UTxO the driver deliberately left behind. Any party can pick up the next step with its own `PartialFanout`

Selecting the whole remaining set just falls back to a full fanout, and UTxO is matched by content (sub-multiset), not by `TxIn`. No on-chain changes: this reuses the existing partial fanout tx builders and validator.

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
