### PR TITLE
Fix VACUUM race between rotation and API history streaming

### DIFF
--- a/hydra-node/src/Hydra/Chain/Blockfrost/Client.hs
+++ b/hydra-node/src/Hydra/Chain/Blockfrost/Client.hs
@@ -79,7 +79,6 @@ data BlockfrostException
   | AssetNameMissing
   | DeserialiseError Text
   deriving stock (Show)
-  deriving anyclass (Exception)
 
 data APIBlockfrostError
   = BlockfrostError Text

--- a/hydra-node/src/Hydra/Events/SQLiteBased.hs
+++ b/hydra-node/src/Hydra/Events/SQLiteBased.hs
@@ -48,6 +48,12 @@
 --   ('processStateChanges'), so no concurrent enqueues can occur between the
 --   flush and the rotation write. The archive is taken before the DELETE, so a
 --   backup failure aborts rotation and leaves the events intact.
+--
+-- * __Separate read connection__: 'sourceEvents' streams over a dedicated
+--   connection. It can run concurrently on API server threads (client
+--   history replay), and @VACUUM INTO@ fails with "SQL statements in
+--   progress" if a streaming statement is open on the same connection as the
+--   rotation. WAL mode makes readers on a separate connection safe.
 module Hydra.Events.SQLiteBased where
 
 import Hydra.Prelude
@@ -107,14 +113,14 @@ withSQLiteEventStore ::
   (EventStore e IO -> IO a) ->
   IO a
 withSQLiteEventStore tracer dbFile legacyStateFile callback = do
-  (conn, store, flush, reinitLastSeen, cancelWriter) <- mkSQLiteEventStore dbFile
+  (conn, store, flush, reinitLastSeen, cleanup) <- mkSQLiteEventStore dbFile
   migrateFromFileBased (Proxy @e) tracer legacyStateFile conn reinitLastSeen
   callback store
-    `finally` (flush >> cancelWriter >> close conn)
+    `finally` (flush >> cleanup >> close conn)
 
 -- | Create an 'EventStore' backed by a SQLite database at the given file path.
 -- The database and schema are created on first use if they do not exist.
--- Returns @(conn, store, flush, reinitLastSeen, cancelWriter)@. Internal —
+-- Returns @(conn, store, flush, reinitLastSeen, cleanup)@. Internal —
 -- prefer 'withSQLiteEventStore' which handles cleanup, migration, and flushing
 -- automatically.
 mkSQLiteEventStore ::
@@ -126,6 +132,11 @@ mkSQLiteEventStore dbFile = do
   createDirectoryIfMissing True (takeDirectory dbFile)
   conn <- open dbFile
   initSchema conn
+  -- Dedicated connection for 'sourceEvents' streams, so concurrent client
+  -- history replay cannot hold statements open on the connection rotation
+  -- runs VACUUM INTO on (see module header).
+  readConn <- open dbFile
+  configurePragmas readConn
   eventIdV <- newLabelledTVarIO "sqlite-event-store-event-id" Nothing
   -- Initialise last-seen event id from existing rows.
   rows <- selectLastEventId conn
@@ -157,7 +168,7 @@ mkSQLiteEventStore dbFile = do
       bracketP openStmt closeStatement yieldRows
      where
       openStmt :: IO Statement
-      openStmt = getEventsASC conn
+      openStmt = getEventsASC readConn
 
       yieldRows :: Statement -> ConduitT () e (ResourceT IO) ()
       yieldRows stmt = do
@@ -221,7 +232,7 @@ mkSQLiteEventStore dbFile = do
         }
     , flushWriteQueue writeQueue
     , reinitLastSeen
-    , cancel writerThread
+    , cancel writerThread >> close readConn
     )
 
 -- | Background writer that drains the queue and batch-inserts into SQLite.

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -544,10 +544,12 @@ withTUITest region action = do
           -- Poll the frame buffer until @expected@ appears or the budget runs
           -- out. The TUI updates asynchronously (vty render + WebSocket event
           -- stream), so a single point check after a fixed 'threadDelay' is
-          -- racy under CI load — especially after 'restartNode', where the
-          -- ~700 ms hydra-node KZG warm-up eats most of the post-restart
-          -- budget before the head state is even pushed to the TUI.
-          let budget = 5 :: NominalDiffTime
+          -- racy under CI load — especially after 'restartNode', where a full
+          -- node restart (etcd spawn, KZG warm-up, state hydration) plus the
+          -- TUI reconnect must fit in the budget. Generous on purpose: the
+          -- poll returns as soon as the bytes appear, so passing tests do not
+          -- pay for it, and 5s proved too eager on loaded CI runners.
+          let budget = 30 :: NominalDiffTime
           deadline <- addUTCTime budget <$> getCurrentTime
           let loop = do
                 bytes <- getPicture

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -11,7 +11,7 @@ import CardanoNode (NodeLog, withCardanoNodeDevnet)
 import Control.Concurrent.Class.MonadMVar (MonadMVar (..))
 import Control.Concurrent.Class.MonadSTM (tryReadTQueue, writeTQueue)
 import Control.Concurrent.STM (newTChanIO)
-import Control.Monad.Class.MonadAsync (cancel, waitCatch)
+import Control.Monad.Class.MonadAsync (cancel, link, waitCatch)
 import Data.ByteString qualified as BS
 import Graphics.Vty (
   DisplayContext (..),
@@ -376,6 +376,9 @@ withHydraNodeHandle tracer tmpDir nodeId options action = do
           putMVar clientVar client
           -- keep async alive as long as node is running
           forever (threadDelay 1_000_000)
+      -- Surface node crashes in the test instead of hanging on a dead node;
+      -- 'link' ignores the 'AsyncCancelled' thrown by 'stopNode'.
+      link a
       putMVar runningAsyncVar a
 
     stopNode = do


### PR DESCRIPTION
This fixes a occasionaly test failure which was related to a genuine bug with vacuum'ing blocking event querying.

The rotation backup runs VACUUM INTO on the same SQLite connection that sourceEvents streams client history over; a reconnecting client holding a streaming statement open makes VACUUM fail ("SQL statements in progress") and takes the node down. Pre-existing race, but the faster restart and hydration on this branch compressed the reconnect-to-rotation window enough to hit it reliably on CI (tui-rotated). sourceEvents now streams over a dedicated read connection, which WAL supports concurrently and which VACUUM does not inspect.

Also link the hydra-node async in TUISpec so a crashing node fails the test immediately with its exit error instead of hanging until a frame timeout; this is what surfaced the actual crash.