### PR TITLE
Use peak instead of per-snapshot as now there are less snapshots

### DIFF
--- a/docs/docs/faqs.md
+++ b/docs/docs/faqs.md
@@ -58,7 +58,7 @@ constantly evaluating its real-world performance in terms of throughput and
 finality. For more details, read <a
 href="https://iohk.io/en/blog/posts/2021/09/17/hydra-cardano-s-solution-for-ultimate-scalability">this</a> blog post, see the latest
 benchmarking data <a href="../benchmarks">here</a>, and look at the
-<a href="../benchmarks/scenarios">scenario benchmarks</a> for per-snapshot and
+<a href="../benchmarks/scenarios">scenario benchmarks</a> for peak sustained and
 end-to-end TPS across head sizes, UTxO shapes, and incremental commit/decommit
 modes.
 

--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -5,7 +5,7 @@ module Bench.EndToEnd where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import Bench.Summary (Summary (..), SystemStats, makeDoubleQuantiles, makeQuantiles)
+import Bench.Summary (Summary (..), SystemStats, makeQuantiles)
 import Cardano.Api.UTxO qualified as UTxO
 import CardanoNode (EndToEndLog (..), HydraNodeLog, findRunningCardanoNode', runBackend, withCardanoNodeDevnet)
 import Control.Concurrent.Class.MonadSTM (
@@ -30,7 +30,7 @@ import Data.Scientific (Scientific)
 import Data.Set ((\\))
 import Data.Set qualified as Set
 import Data.Time (UTCTime (UTCTime), utctDayTime)
-import Data.Vector (Vector)
+import Data.Vector qualified as V
 import Hydra.Cardano.Api (NetworkId, PaymentKey, SigningKey, SocketPath, Tx, TxId, UTxO, lovelaceToValue, txOutAddress, txOutValue)
 import Hydra.Chain.Backend (ChainBackend (..))
 import Hydra.Cluster.Faucet (FaucetLog (..), publishHydraScriptsAs, returnFundsToFaucet', seedFromFaucet)
@@ -278,7 +278,7 @@ scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, descript
       quantiles = makeQuantiles confTimes
       summaryTitle = fromMaybe "Baseline Scenario" title
       summaryDescription = fromMaybe defaultDescription description
-      (endToEndTps, runWallClockSeconds, snapshotTpsQuantiles, numberOfSnapshots) =
+      (endToEndTps, runWallClockSeconds, peakSustainedTps, numberOfSnapshots) =
         computeThroughput processedTransactions snapshotsSeen
 
   pure $
@@ -294,7 +294,7 @@ scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, descript
       , numberOfFanoutOutputs
       , endToEndTps
       , runWallClockSeconds
-      , snapshotTpsQuantiles
+      , peakSustainedTps
       , numberOfSnapshots
       , incrementalCommitTimes
       , incrementalDecommitTimes
@@ -780,15 +780,23 @@ analyze = \case
     Just (submittedAt, valid `diffUTCTime` submittedAt, conf `diffUTCTime` submittedAt)
   _ -> Nothing
 
--- | Measured wall-clock span, end-to-end TPS over the run, and quantiles of
--- per-snapshot TPS.
+-- | Width of the sliding window used for 'peak sustained TPS'. One second is
+-- long enough to average out per-message scheduling jitter yet short enough to
+-- capture a genuine throughput peak.
+peakWindowSeconds :: Double
+peakWindowSeconds = 1.0
+
+-- | Measured wall-clock span, end-to-end TPS over the run, peak sustained TPS,
+-- and the number of snapshots observed.
 --
 -- The wall-clock span is the elapsed time from the earliest tx submission to
 -- the latest confirmation; end-to-end TPS is the confirmed tx count divided by
--- that span. Per-snapshot TPS is derived for snapshots that confirmed at least
--- one tx by dividing the tx count by the gap to the previous observation (or
--- the earliest submission time for the first snapshot).
-computeThroughput :: Map.Map TxId Event -> Map.Map Scientific (UTCTime, Int) -> (Double, Double, Vector Double, Int)
+-- that span. Peak sustained TPS is the highest confirmation rate held over any
+-- 'peakWindowSeconds' window (see 'peakWindowedTps'); it replaces the earlier
+-- per-snapshot instantaneous rate, which divided a snapshot's tx count by the
+-- gap between two client-side observations and so blew up for closely-spaced
+-- notifications and was estimated over only a handful of snapshots per run.
+computeThroughput :: Map.Map TxId Event -> Map.Map Scientific (UTCTime, Int) -> (Double, Double, Double, Int)
 computeThroughput txs snapshots =
   let submitted = map submittedAtFor (Map.elems txs)
       confirmed = mapMaybe confirmedAt (Map.elems txs)
@@ -797,28 +805,39 @@ computeThroughput txs snapshots =
         (_ : _, _ : _) -> realToFrac (List.maximum confirmed `diffUTCTime` List.minimum submitted) :: Double
         _ -> 0
       e2eTps = if wallClockSeconds > 0 then fromIntegral numberOfTxs / wallClockSeconds else 0
-      sortedSnapshots = sortOn fst (Map.toList snapshots)
-      anchor = case submitted of
-        [] -> Nothing
-        _ -> Just (List.minimum submitted)
-      perSnapshotRates = perSnapshotTps anchor sortedSnapshots
-   in (e2eTps, wallClockSeconds, makeDoubleQuantiles perSnapshotRates, length sortedSnapshots)
+      peakTps = peakWindowedTps peakWindowSeconds confirmed
+   in (e2eTps, wallClockSeconds, peakTps, Map.size snapshots)
  where
   submittedAtFor Event{submittedAt} = submittedAt
-  perSnapshotTps :: Maybe UTCTime -> [(Scientific, (UTCTime, Int))] -> [Double]
-  perSnapshotTps = go
-   where
-    go :: Maybe UTCTime -> [(Scientific, (UTCTime, Int))] -> [Double]
-    go _ [] = []
-    go prev ((_, (t, c)) : rest)
-      | c <= 0 = go (Just t) rest
-      | otherwise =
-          case prev of
-            Just p ->
-              let dt = realToFrac (t `diffUTCTime` p) :: Double
-                  rate = if dt > 0 then fromIntegral c / dt else 0
-               in rate : go (Just t) rest
-            Nothing -> go (Just t) rest
+
+-- | Peak transaction-confirmation throughput: the largest number of
+-- confirmations falling within any window of the given width, divided by that
+-- width. Every confirmation feeds it (hundreds of samples per run), so it is
+-- stable across runs and is not distorted by how many transactions a single
+-- snapshot happened to batch or by how closely two snapshot notifications were
+-- observed on the client.
+peakWindowedTps :: Double -> [UTCTime] -> Double
+peakWindowedTps windowSeconds times
+  | windowSeconds <= 0 = 0
+  | n == 0 = 0
+  | otherwise = fromIntegral (loop 0 0 0) / windowSeconds
+ where
+  sorted = V.fromList (sort times)
+  n = V.length sorted
+  window = realToFrac windowSeconds :: NominalDiffTime
+  -- Two pointers over the sorted confirmation times. An optimal window can
+  -- always be slid left until its start coincides with a confirmation, so it
+  -- suffices to anchor the left edge 'i' at each point and extend the
+  -- exclusive right edge 'j' over everything within 'window'. 'j' never moves
+  -- backwards as 'i' advances, so this is O(n).
+  loop i j best
+    | i >= n = best
+    | otherwise =
+        let j' = advance i (max j (i + 1))
+         in loop (i + 1) j' (max best (j' - i))
+  advance i j
+    | j < n && (sorted V.! j) `diffUTCTime` (sorted V.! i) < window = advance i (j + 1)
+    | otherwise = j
 
 writeResultsCsv :: FilePath -> [(UTCTime, NominalDiffTime, NominalDiffTime, Int)] -> IO ()
 writeResultsCsv fp res = do

--- a/hydra-cluster/bench/Bench/Summary.hs
+++ b/hydra-cluster/bench/Bench/Summary.hs
@@ -34,7 +34,9 @@ data Summary = Summary
   , numberOfFanoutOutputs :: Int
   , endToEndTps :: Double
   , runWallClockSeconds :: Double
-  , snapshotTpsQuantiles :: Vector Double
+  , peakSustainedTps :: Double
+  -- ^ Highest transaction-confirmation rate sustained over any
+  -- 'peakWindowSeconds'-wide window (see 'Bench.EndToEnd.computeThroughput').
   , numberOfSnapshots :: Int
   , incrementalCommitTimes :: [NominalDiffTime]
   , incrementalDecommitTimes :: [NominalDiffTime]
@@ -56,7 +58,7 @@ errorSummary Dataset{title, clientDatasets} (HUnitFailure sourceLocation reason)
     , numberOfFanoutOutputs = 0
     , endToEndTps = 0
     , runWallClockSeconds = 0
-    , snapshotTpsQuantiles = mempty
+    , peakSustainedTps = 0
     , numberOfSnapshots = 0
     , incrementalCommitTimes = []
     , incrementalDecommitTimes = []
@@ -79,17 +81,12 @@ makeQuantiles :: [NominalDiffTime] -> Vector Double
 makeQuantiles times =
   Statistics.quantilesVec def (fromList [0 .. 99]) 100 (fromList $ map (fromRational . (* 1000) . toRational . nominalDiffTimeToSeconds) times)
 
-makeDoubleQuantiles :: [Double] -> Vector Double
-makeDoubleQuantiles [] = mempty
-makeDoubleQuantiles xs =
-  Statistics.quantilesVec def (fromList [0 .. 99]) 100 (fromList xs)
-
 -- | Render a time value with at most one decimal place.
 oneDec :: Real a => a -> Text
 oneDec x = pack $ printf "%.1f" (realToFrac x :: Double)
 
 textReport :: (Summary, SystemStats) -> [Text]
-textReport (Summary{totalTxs, numberOfTxs, averageConfirmationTime, quantiles, numberOfInvalidTxs, numberOfFanoutOutputs, endToEndTps, snapshotTpsQuantiles, numberOfSnapshots, incrementalCommitTimes, incrementalDecommitTimes}, systemStats) =
+textReport (Summary{totalTxs, numberOfTxs, averageConfirmationTime, quantiles, numberOfInvalidTxs, numberOfFanoutOutputs, endToEndTps, peakSustainedTps, numberOfSnapshots, incrementalCommitTimes, incrementalDecommitTimes}, systemStats) =
   let frac :: Double
       frac = 100 * fromIntegral numberOfTxs / fromIntegral totalTxs
    in [ pack $ printf "Confirmed txs/Total expected txs: %d/%d (%.2f %%)" numberOfTxs totalTxs frac
@@ -105,14 +102,7 @@ textReport (Summary{totalTxs, numberOfTxs, averageConfirmationTime, quantiles, n
            )
         ++ [pack $ printf "End-to-end TPS: %.2f tx/s" endToEndTps]
         ++ [pack $ printf "Snapshots observed: %d" numberOfSnapshots]
-        ++ ( if length snapshotTpsQuantiles == 100
-              then
-                [ pack $ printf "Per-snapshot TPS P50: %.2f tx/s" (snapshotTpsQuantiles ! 50)
-                , pack $ printf "Per-snapshot TPS P95: %.2f tx/s" (snapshotTpsQuantiles ! 95)
-                , pack $ printf "Per-snapshot TPS max: %.2f tx/s" (snapshotTpsQuantiles ! 99)
-                ]
-              else []
-           )
+        ++ [pack $ printf "Peak sustained TPS: %.2f tx/s" peakSustainedTps]
         ++ ["Invalid txs: " <> show numberOfInvalidTxs]
         ++ ["Fanout outputs: " <> show numberOfFanoutOutputs]
         ++ incrementalLines "Incremental commit" incrementalCommitTimes
@@ -162,7 +152,7 @@ markdownReport now summaries =
     ]
 
 formattedSummary :: (Summary, SystemStats) -> [Text]
-formattedSummary (Summary{clusterSize, numberOfTxs, averageConfirmationTime, quantiles, summaryTitle, summaryDescription, numberOfInvalidTxs, numberOfFanoutOutputs, endToEndTps, snapshotTpsQuantiles, numberOfSnapshots, incrementalCommitTimes, incrementalDecommitTimes}, systemStats)
+formattedSummary (Summary{clusterSize, numberOfTxs, averageConfirmationTime, quantiles, summaryTitle, summaryDescription, numberOfInvalidTxs, numberOfFanoutOutputs, endToEndTps, peakSustainedTps, numberOfSnapshots, incrementalCommitTimes, incrementalDecommitTimes}, systemStats)
   | numberOfTxs == 0 =
       -- Failed cell: no confirmations, so all the latency / TPS rows would be
       -- zeros or empty quantiles. Render a short failure block instead of the
@@ -198,15 +188,8 @@ formattedSummary (Summary{clusterSize, numberOfTxs, averageConfirmationTime, qua
            )
         ++ [ pack $ printf "| _End-to-end TPS_ | %.2f tx/s |" endToEndTps
            , "| _Snapshots observed_ | " <> show numberOfSnapshots <> " |"
+           , pack $ printf "| _Peak sustained TPS_ | %.2f tx/s |" peakSustainedTps
            ]
-        ++ ( if length snapshotTpsQuantiles == 100
-              then
-                [ pack $ printf "| _Per-snapshot TPS P50_ | %.2f tx/s |" (snapshotTpsQuantiles ! 50)
-                , pack $ printf "| _Per-snapshot TPS P95_ | %.2f tx/s |" (snapshotTpsQuantiles ! 95)
-                , pack $ printf "| _Per-snapshot TPS max_ | %.2f tx/s |" (snapshotTpsQuantiles ! 99)
-                ]
-              else []
-           )
         ++ [ "| _Number of Invalid txs_ | " <> show numberOfInvalidTxs <> " |"
            ]
         ++ [ "| _Fanout outputs_        | " <> show numberOfFanoutOutputs <> " |"
@@ -268,24 +251,21 @@ comparisonTable summaries =
     \measured elapsed time from the first tx submission to the last \
     \confirmation. Times are rounded to one decimal."
   , ""
-  , "| Scenario | Txs | Wall clock (s) | End-to-end TPS (tx/s) | Per-snapshot p50 TPS (tx/s) | Avg conf (ms) | P95 conf (ms) |"
+  , "| Scenario | Txs | Wall clock (s) | End-to-end TPS (tx/s) | Peak sustained TPS (tx/s) | Avg conf (ms) | P95 conf (ms) |"
   , "| -- | -- | -- | -- | -- | -- | -- |"
   ]
     <> map row summaries
     <> [""]
  where
   row :: (Summary, SystemStats) -> Text
-  row (Summary{numberOfTxs, summaryTitle, averageConfirmationTime, quantiles, endToEndTps, runWallClockSeconds, snapshotTpsQuantiles}, _)
+  row (Summary{numberOfTxs, summaryTitle, averageConfirmationTime, quantiles, endToEndTps, runWallClockSeconds, peakSustainedTps}, _)
     | numberOfTxs == 0 =
         "| "
           <> summaryTitle
           <> " | 0 | n/a | n/a | n/a | n/a | n/a |"
     | otherwise =
         let p95Conf = if length quantiles == 100 then oneDec (quantiles ! 95) else "n/a"
-            p50Tps =
-              if length snapshotTpsQuantiles == 100
-                then pack $ printf "%.2f" (snapshotTpsQuantiles ! 50)
-                else "n/a"
+            peakTps = pack $ printf "%.2f" peakSustainedTps
             wallClock =
               if runWallClockSeconds > 0
                 then oneDec runWallClockSeconds
@@ -299,7 +279,7 @@ comparisonTable summaries =
               <> " | "
               <> pack (printf "%.2f" endToEndTps)
               <> " | "
-              <> p50Tps
+              <> peakTps
               <> " | "
               <> oneDec (nominalDiffTimeToMilliseconds averageConfirmationTime)
               <> " | "

--- a/scripts/bench-e2e-diff.py
+++ b/scripts/bench-e2e-diff.py
@@ -108,7 +108,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("old_file", help="master end-to-end-benchmarks.md")
     parser.add_argument("new_file", help="PR end-to-end-benchmarks.md")
-    parser.add_argument("--threshold", type=float, default=5.0,
+    parser.add_argument("--threshold", type=float, default=10.0,
                         help="percent change below which a metric is treated as noise")
     args = parser.parse_args()
 

--- a/scripts/bench-e2e-diff.py
+++ b/scripts/bench-e2e-diff.py
@@ -15,9 +15,7 @@ import sys
 # better. Keys must match Summary.hs exactly.
 METRICS = [
     ("End-to-end TPS", "End-to-end TPS (tx/s)", +1),
-    ("Per-snapshot TPS P50", "Per-snapshot TPS P50 (tx/s)", +1),
-    ("Per-snapshot TPS P95", "Per-snapshot TPS P95 (tx/s)", +1),
-    ("Per-snapshot TPS max", "Per-snapshot TPS max (tx/s)", +1),
+    ("Peak sustained TPS", "Peak sustained TPS (tx/s)", +1),
     ("Avg. Confirmation Time (ms)", "Avg. Confirmation Time (ms)", -1),
     ("P50", "P50 confirmation (ms)", -1),
     ("P95", "P95 confirmation (ms)", -1),


### PR DESCRIPTION
Change the benchmarks to be a little more useful; this should be merged before #2752 .

The existing benchmarks are a bit unreliable; and even worse after the changes in 2752; so hopefully these are more stable.