### PR TITLE
Parallelize hydra-node test suite

### DIFF
--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -54,16 +54,7 @@ jobs:
       run: |
         cd ${{ matrix.package }} # To ensure the `./golden` files are available.
         mkdir -p test-reports
-        # hydra-node's NetworkSpec spins etcd subprocesses; under tasty's
-        # default parallelism it wedges on these small CI runners (etcd
-        # loses quorum after the manual lease revoke and the suite hangs).
-        # Force the suite single-threaded here; other packages keep tasty's
-        # default parallelism, which they handle fine.
-        threads_flag=""
-        if [ "${{ matrix.package }}" = "hydra-node" ]; then
-          threads_flag="--num-threads=1"
-        fi
-        nix develop .#${{ matrix.package }}-tests --command tests --xml=test-reports/junit.xml $threads_flag
+        nix develop .#${{ matrix.package }}-tests --command tests --xml=test-reports/junit.xml
 
     # This one is special, as it requires a tty.
     - name: ❓ Test (TUI)

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -348,7 +348,11 @@ benchmark logging
 
 test-suite tests
   import:         project-config
-  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
+
+  -- -A64m enlarges the GC nursery: the suite now runs in parallel (see
+  -- test/Main.hs), and the default nursery causes heavy parallel-GC
+  -- stop-the-world contention that balloons allocation-heavy io-sim tests.
+  ghc-options:    -threaded -rtsopts "-with-rtsopts=-N -A64m"
   hs-source-dirs: test
   other-modules:
     Hydra.API.ClientInputSpec
@@ -462,6 +466,7 @@ test-suite tests
     , sop-extras
     , sqlite-simple
     , stm
+    , tasty
     , temporary
     , text
     , time

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -44,11 +44,11 @@ spec = do
   -- TODO: add tests about advertise being honored
   --
   -- Each Etcd test spins up a 2- or 3-node etcd cluster on loopback ports.
-  -- Running these in parallel (tasty's default on developer machines) means
-  -- multiple subprocesses fight for ports and CPU at the same instant, which
-  -- can cause failures. Force sequential execution within this describe;
-  -- CI already pins '--num-threads=1' for the whole hydra-node
-  -- suite, so this only changes behaviour for local runs.
+  -- Running these in parallel, or alongside the rest of the suite, makes the
+  -- subprocesses fight for ports and CPU at the same instant, which can make
+  -- etcd lose RAFT quorum and the tests fail. The "Network" group is gated in
+  -- test/Main.hs to run last and single-threaded so these clusters get the box
+  -- to themselves; the 'sequential' below is belt-and-suspenders for local runs.
   --
   -- Per-test 'failAfter' budgets in this block are deliberately generous
   -- (60s). The previous 15–30s budgets fired too eagerly when an etcd

--- a/hydra-node/test/Main.hs
+++ b/hydra-node/test/Main.hs
@@ -44,6 +44,8 @@ import Hydra.PartySpec qualified
 import Hydra.PersistentQueueSpec qualified
 import Hydra.UtilsSpec qualified
 import Test.Hydra.TastyMain (defaultMainHydra, testSpec)
+import Test.Tasty (DependencyType (AllFinish), after, localOption)
+import Test.Tasty.Runners (NumThreads (..))
 
 main :: IO ()
 main =
@@ -80,7 +82,12 @@ main =
     , testSpec "Model.MockChain" Hydra.Model.MockChainSpec.spec
     , testSpec "Model" Hydra.ModelSpec.spec
     , testSpec "Network.Authenticate" Hydra.Network.AuthenticateSpec.spec
-    , testSpec "Network" Hydra.NetworkSpec.spec
+    , -- NetworkSpec spins up etcd clusters that lose RAFT quorum when CPU is
+      -- oversubscribed. Run it last (after all other tests finish) and
+      -- single-threaded so the etcd processes get the box to themselves, while
+      -- the rest of the suite runs in parallel.
+      localOption (NumThreads 1) . after AllFinish "$2 != \"Network\""
+        <$> testSpec "Network" Hydra.NetworkSpec.spec
     , testSpec "NetworkVersions" Hydra.NetworkVersionsSpec.spec
     , testSpec "Node.InputQueue" Hydra.Node.InputQueueSpec.spec
     , testSpec "Node.Run" Hydra.Node.RunSpec.spec


### PR DESCRIPTION
- Allow (most) of hydra-node to run in parallel
- Single-threaded for only etcd tests
- `-A64m` seems to do better