### PR TITLE
CBOR-2: Add opt-in binary CBOR encoding to the client API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ changes.
 
 ## [UNRELEASED]
 
+- Add an opt-in binary CBOR encoding to the client API (WebSocket
+  `?encoding=cbor` query param, HTTP `Accept`/`Content-Type: application/cbor`
+  headers), keeping JSON as the default.
+  [#2543](https://github.com/cardano-scaling/hydra/issues/2543)
+
 - Fix a node dying under sustained load with
   `ConnectionErrorIsSent EnhanceYourCalm 0 "too many settings"`, leaving the
   head short a party. etcd's gRPC server raises its receive window as inbound

--- a/docs/adr/2026-07-16_034-binary-cbor-api.md
+++ b/docs/adr/2026-07-16_034-binary-cbor-api.md
@@ -1,0 +1,48 @@
+---
+slug: 34
+title: |
+  34. Binary CBOR encoding for the client API
+authors: [v0d1ch]
+tags: [Accepted]
+---
+
+## Status
+
+Accepted
+
+## Context
+
+- Following [ADR-9](/adr/9), the client API (WebSocket and HTTP) of the `hydra-node` exchanges JSON messages exclusively.
+
+- During high-throughput operation (notably the Hydra Doom event, see [#1585](https://github.com/cardano-scaling/hydra/issues/1585)), the JSON encoding proved to be a significant overhead: transactions of ~480 bytes inflate to several kilobytes because they are hex-encoded inside a JSON text envelope. [#2543](https://github.com/cardano-scaling/hydra/issues/2543) suggested a binary protocol option over the WebSocket for the same reason.
+
+- Baseline measurements (criterion micro-benchmarks over the API hot-path messages) show a `SnapshotConfirmed` over a 1000-UTxO head weighs ~446 KB of JSON, costing ~20 ms to encode on the node and ~48 ms to decode in the client, per message and per connected client. The `?snapshot-utxo=no` filter even increases server-side cost because it rewrites already-encoded JSON bytes.
+
+- The network layer already serializes messages with CBOR via the `cardano-binary` `ToCBOR`/`FromCBOR` classes (see `Hydra.Network.Message`), establishing a codec convention: a leading text tag naming the constructor, followed by the constructor fields in declaration order. Node-to-node traffic is therefore already binary; the client API is the only JSON wire surface.
+
+- gRPC/protobuf was considered and rejected: the dominant payloads are Cardano ledger types whose canonical serialization is CBOR, so protobuf messages would either wrap opaque CBOR blobs (no payload-level schema benefit) or require modeling the entire ledger in proto. gRPC would furthermore replace the WebSocket API instead of extending it, breaking browser-based clients.
+
+## Decision
+
+- All client API message types (and the protocol types they embed) get **native, hand-written `ToCBOR`/`FromCBOR` instances** following the existing `Hydra.Network.Message` convention. Text tags are identical to the JSON `tag` values, so both encodings share one schema vocabulary.
+
+  - Types with derived fields (e.g. the `Snapshot` accumulator, `SeenSnapshot` signable bytes) mirror their JSON instances: derived data is not transmitted and gets reconstructed on decode.
+
+- The **client API encoding is negotiated per connection**, JSON remains the default and no node-wide flag exists:
+
+  - WebSocket clients opt in with the `encoding=cbor` query parameter; messages are then exchanged as binary frames containing one CBOR term (`Cardano.Binary.serialize'` / `decodeFull'`). The server resolves the negotiated encoding once per connection into a `WsCodec` and dispatches on that, never on the frame type.
+  - HTTP clients negotiate per request with `Content-Type: application/cbor` (request bodies) and `Accept: application/cbor` (responses).
+
+- For CBOR connections, the `?snapshot-utxo=no` filter is applied as a **typed transformation before encoding** instead of the byte-level rewriting used for JSON: the snapshot `utxo` is sent as an empty set rather than omitted.
+
+- A CI-enforced property suite (`Hydra.CBORSpec`) roundtrips every codec, keeping the hand-written encoder/decoder pairs in sync as types evolve.
+
+## Consequences
+
+- High-throughput deployments can shrink their wire footprint substantially: transaction payloads travel as raw CBOR bytes instead of hex text inside JSON, and JSON syntax overhead disappears (see `benchmarks` on [#2543](https://github.com/cardano-scaling/hydra/issues/2543) for before/after numbers).
+
+- Existing clients (JSON) are entirely unaffected; hydra-cluster tests, the bench (`--cbor`) and hydra-tui (`--cbor`) can exercise the binary path.
+
+- Every new constructor in an API type now needs a CBOR codec next to its JSON instance; the roundtrip property suite fails CI when one is missing or inconsistent.
+
+- Event persistence is unchanged (JSON in SQLite), and the log stream remains JSON; a binary log format can be revisited separately.

--- a/docs/docs/api-behavior.md
+++ b/docs/docs/api-behavior.md
@@ -20,6 +20,7 @@ There are some options for API clients to control the server outputs. Server out
 
 + `history=no` -> Prevents historical outputs display. All server outputs are recorded and when a client re-connects these outputs are replayed unless `history=no` query param is used.
 + `snapshot-utxo=no` -> In case of a `SnapshotConfirmed` message the `utxo` field in the inner `Snapshot` will be omitted.
++ `encoding=cbor` -> All messages on this connection are exchanged as binary WebSocket frames containing a compact CBOR encoding instead of JSON text frames. Each message starts with a text tag identical to the JSON `tag` value, followed by the constructor fields in declaration order. HTTP endpoints negotiate the same encoding per request via `Content-Type: application/cbor` (request bodies) and `Accept: application/cbor` (responses). Note that combined with `snapshot-utxo=no`, the snapshot `utxo` is sent as an empty set rather than omitted.
 + `address=$address` -> In the case of a `TxValid` or a `TxInvalid` message, it will be filtered if its `transaction` address does not contain a reference to the provided. In the case of a `SnapshotConfirmed` message, it will be filtered if its `confirmed` transactions do not contain an address that references the one provided.
 
 ## Replay of past server outputs

--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -52,10 +52,8 @@ import Hydra.Tx (HeadId, txId)
 import Hydra.Tx.Crypto (generateSigningKey, getVerificationKey, signTx)
 import Hydra.Tx.Secret (Secret)
 import HydraNode (
-  HydraClient,
-  apiHost,
+  HydraClient (..),
   getSnapshotUTxO,
-  hydraNodeId,
   input,
   output,
   requestCommitTx,
@@ -83,6 +81,9 @@ data BenchRunOptions = BenchRunOptions
   , waitForTxValid :: Bool
   -- ^ Wait for each tx to confirm before posting the next (one in-flight tx
   -- per client) instead of firing the whole queue as fast as it drains.
+  , cborClients :: Bool
+  -- ^ Connect the bench clients using the binary CBOR API encoding
+  -- (@encoding=cbor@) instead of JSON.
   }
   deriving stock (Eq, Show)
 
@@ -207,7 +208,47 @@ scenario ::
   [UTxO] ->
   BenchRunOptions ->
   IO Summary
-scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, description} nonEmptyClients pumbaCommand sideUTxOs runOptions = do
+scenario hydraTracer timing opts workDir dataset nonEmptyClients pumbaCommand sideUTxOs runOptions =
+  withCborClients hydraTracer cborClients nonEmptyClients $ \scenarioClients ->
+    runScenario hydraTracer timing opts workDir dataset scenarioClients pumbaCommand sideUTxOs runOptions
+ where
+  BenchRunOptions{cborClients} = runOptions
+
+-- | Reconnect all clients using the binary CBOR API encoding when enabled.
+-- The original (JSON) connections stay open but unused; opening dedicated
+-- connections keeps the encoding choice orthogonal to how the cluster was
+-- started.
+withCborClients ::
+  Tracer IO HydraNodeLog ->
+  Bool ->
+  NonEmpty HydraClient ->
+  (NonEmpty HydraClient -> IO a) ->
+  IO a
+withCborClients tracer enabled clients action
+  | not enabled = action clients
+  | otherwise = do
+      putTextLn "Using CBOR encoded client connections"
+      go (toList clients) []
+ where
+  go [] acc = case nonEmpty (reverse acc) of
+    Nothing -> error "withCborClients: empty list of clients"
+    Just reconnected -> action reconnected
+  go (HydraClient{hydraNodeId = nodeId, apiHost = host, monitoringPort = monPort} : rest) acc =
+    withConnectionToNodeHost tracer nodeId host monPort (Just "/?history=no&encoding=cbor") $ \c' ->
+      go rest (c' : acc)
+
+runScenario ::
+  Tracer IO HydraNodeLog ->
+  Timing ->
+  ChainBackendOptions ->
+  FilePath ->
+  Dataset ->
+  NonEmpty HydraClient ->
+  Maybe String ->
+  [UTxO] ->
+  BenchRunOptions ->
+  IO Summary
+runScenario hydraTracer timing opts workDir Dataset{clientDatasets, title, description} nonEmptyClients pumbaCommand sideUTxOs runOptions = do
   let BenchRunOptions{waitForTxValid} = runOptions
   let clusterSize = fromIntegral $ length clientDatasets
   let leader = head nonEmptyClients

--- a/hydra-cluster/bench/Bench/Options.hs
+++ b/hydra-cluster/bench/Bench/Options.hs
@@ -41,6 +41,7 @@ data Options
       , startingNodeId :: Int
       , incrementalOps :: Bool
       , waitForTxValid :: Bool
+      , cborClients :: Bool
       }
   | DatasetOptions
       { outputDirectory :: Maybe FilePath
@@ -51,6 +52,7 @@ data Options
       , startingNodeId :: Int
       , incrementalOps :: Bool
       , waitForTxValid :: Bool
+      , cborClients :: Bool
       }
   | DemoOptions
       { outputDirectory :: Maybe FilePath
@@ -60,6 +62,7 @@ data Options
       , nodeSocket :: SocketPath
       , hydraClients :: [Host]
       , pumbaCommand :: Maybe String
+      , cborClients :: Bool
       }
   | MatrixOptions
       { outputDirectory :: Maybe FilePath
@@ -70,6 +73,7 @@ data Options
       , utxoShapes :: [UTxOSize]
       , incrementalModes :: [Bool]
       , waitForTxValidModes :: [Bool]
+      , cborClients :: Bool
       }
   | GenerateOptions
       { datasetUTxO :: UTxOSize
@@ -119,6 +123,7 @@ standaloneOptionsParser =
     <*> startingNodeIdParser
     <*> incrementalOpsParser
     <*> waitForTxValidParser
+    <*> cborClientsParser
 
 outputDirectoryParser :: Parser FilePath
 outputDirectoryParser =
@@ -215,6 +220,7 @@ demoOptionsParser =
     <*> nodeSocketParser
     <*> many hydraClientsParser
     <*> optional pumbaCommandParser
+    <*> cborClientsParser
 
 pumbaCommandParser :: Parser String
 pumbaCommandParser =
@@ -260,6 +266,7 @@ datasetOptionsParser =
     <*> startingNodeIdParser
     <*> incrementalOpsParser
     <*> waitForTxValidParser
+    <*> cborClientsParser
 
 generateOptionsInfo :: ParserInfo Options
 generateOptionsInfo =
@@ -322,6 +329,18 @@ incrementalOpsParser =
           \ default."
     )
 
+cborClientsParser :: Parser Bool
+cborClientsParser =
+  flag
+    False
+    True
+    ( long "cbor"
+        <> help
+          "If set, the bench clients connect to the hydra-nodes using the \
+          \ binary CBOR API encoding (encoding=cbor) instead of JSON. Useful \
+          \ to compare the client API encodings. Off by default."
+    )
+
 waitForTxValidParser :: Parser Bool
 waitForTxValidParser =
   flag
@@ -364,6 +383,7 @@ matrixOptionsParser =
     <*> utxoShapesParser
     <*> incrementalModesParser
     <*> waitForTxValidModesParser
+    <*> cborClientsParser
 
 clusterSizesParser :: Parser [Word64]
 clusterSizesParser =

--- a/hydra-cluster/bench/Main.hs
+++ b/hydra-cluster/bench/Main.hs
@@ -29,28 +29,28 @@ main :: IO ()
 main = do
   hSetBuffering stdout LineBuffering
   execParser benchOptionsParser >>= \case
-    StandaloneOptions{outputDirectory, timeoutSeconds, startingNodeId, datasetFiles, incrementalOps, waitForTxValid} -> do
+    StandaloneOptions{outputDirectory, timeoutSeconds, startingNodeId, datasetFiles, incrementalOps, waitForTxValid, cborClients} -> do
       datasets <- forM datasetFiles loadDataset
       putTextLn $ "Running benchmark with datasets: " <> show datasetFiles
-      let action = bench startingNodeId timeoutSeconds BenchRunOptions{incrementalOps, waitForTxValid}
+      let action = bench startingNodeId timeoutSeconds BenchRunOptions{incrementalOps, waitForTxValid, cborClients}
       results <- forM datasets $ \dataset ->
         withTempDir "bench-dataset" $ \dir -> do
           threadDelay 10
           runSingle dataset dir action
       summarizeResults outputDirectory results
-    DemoOptions{outputDirectory, numberOfTxs, timeoutSeconds, networkId, nodeSocket, hydraClients, pumbaCommand} -> do
+    DemoOptions{outputDirectory, numberOfTxs, timeoutSeconds, networkId, nodeSocket, hydraClients, pumbaCommand, cborClients} -> do
       (_, faucetSk) <- keysFor Faucet
       dataset <- generateDemoUTxODataset networkId nodeSocket faucetSk (length hydraClients) numberOfTxs
       workDir <- maybe (createTempDir "bench-demo") checkEmpty outputDirectory
       results <-
         runSingle dataset workDir $
-          benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand BenchRunOptions{incrementalOps = False, waitForTxValid = False}
+          benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand BenchRunOptions{incrementalOps = False, waitForTxValid = False, cborClients}
       summarizeResults outputDirectory [results]
       removeDirectoryRecursive workDir
-    DatasetOptions{outputDirectory, timeoutSeconds, datasetUTxO, numberOfTxs, clusterSize, startingNodeId, incrementalOps, waitForTxValid} -> do
+    DatasetOptions{outputDirectory, timeoutSeconds, datasetUTxO, numberOfTxs, clusterSize, startingNodeId, incrementalOps, waitForTxValid, cborClients} -> do
       (_, faucetSk) <- keysFor Faucet
       workDir <- maybe (createTempDir "bench-e2e") checkEmpty outputDirectory
-      let action = bench startingNodeId timeoutSeconds BenchRunOptions{incrementalOps, waitForTxValid}
+      let action = bench startingNodeId timeoutSeconds BenchRunOptions{incrementalOps, waitForTxValid, cborClients}
       dataset <- generate $ datasetGen faucetSk datasetUTxO clusterSize numberOfTxs
       saveDataset (workDir </> "dataset.json") dataset
       putStrLn $ "Saved dataset in: " <> (workDir </> "dataset.json")
@@ -59,7 +59,7 @@ main = do
         threadDelay 10
         runSingle dataset workDir action
       summarizeResults outputDirectory [results]
-    MatrixOptions{outputDirectory, timeoutSeconds, numberOfTxs, startingNodeId, clusterSizes, utxoShapes, incrementalModes, waitForTxValidModes} -> do
+    MatrixOptions{outputDirectory, timeoutSeconds, numberOfTxs, startingNodeId, clusterSizes, utxoShapes, incrementalModes, waitForTxValidModes, cborClients} -> do
       (_, faucetSk) <- keysFor Faucet
       -- NOTE: Unlike a standalone matrix run, the docs pipeline points
       -- --output-directory at the shared benchmarks/ directory that already
@@ -83,7 +83,7 @@ main = do
         saveDataset (cellDir </> "dataset.json") labelled
         threadDelay 10
         let nodeIdOffset = startingNodeId + i * fromIntegral (List.maximum clusterSizes)
-        let action = bench nodeIdOffset timeoutSeconds BenchRunOptions{incrementalOps = im, waitForTxValid = wt}
+        let action = bench nodeIdOffset timeoutSeconds BenchRunOptions{incrementalOps = im, waitForTxValid = wt, cborClients}
         -- Run the cluster in a throwaway dir, not 'cellDir': node working state
         -- (etcd WAL, cardano-node db, logs) must not reach the published docs.
         -- Only 'dataset.json' and the aggregated 'scenarios.md' are kept.

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -90,6 +90,7 @@ library
     , base                   >=4.7 && <5
     , bytestring
     , cardano-api
+    , cardano-binary
     , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-core

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -8,6 +8,7 @@ module HydraNode (
 import Hydra.Cardano.Api hiding (getVerificationKey)
 import Hydra.Prelude hiding (STM, delete)
 
+import Cardano.Binary (serialize')
 import CardanoNode (HydraNodeLog (..), cliQueryProtocolParameters)
 import Control.Concurrent.Async (forConcurrently_)
 import Control.Concurrent.Class.MonadSTM (modifyTVar', readTVarIO)
@@ -23,7 +24,10 @@ import Data.ByteString (hGetContents)
 import Data.List qualified as List
 import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
+import Hydra.API.ClientInput (ClientInput)
 import Hydra.API.HTTPServer (DraftCommitTxRequest (..), DraftCommitTxResponse (..))
+import Hydra.API.ServerOutput (ApiEncoding (..), ApiMessage)
+import Hydra.API.WireFormat (decodeWire)
 import Hydra.Chain.Blockfrost.Client qualified as Blockfrost
 import Hydra.Cluster.Util (Timing (..), readConfigFile)
 import Hydra.Logging (Tracer, Verbosity (..), traceWith)
@@ -38,7 +42,7 @@ import Network.HTTP.Conduit (parseUrlThrow)
 import Network.HTTP.Req (GET (..), HttpException, JsonResponse, NoReqBody (..), POST (..), ReqBodyJson (..), defaultHttpConfig, responseBody, runReq, (/:))
 import Network.HTTP.Req qualified as Req
 import Network.HTTP.Simple (getResponseBody, httpJSON, httpLbs, setRequestBodyJSON)
-import Network.WebSockets (Connection, ConnectionException, HandshakeException, receiveData, runClient, sendClose, sendTextData)
+import Network.WebSockets (Connection, ConnectionException, HandshakeException, receiveData, runClient, sendBinaryData, sendClose, sendTextData)
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath ((<.>), (</>))
 import System.IO.Unsafe (unsafePerformIO)
@@ -69,6 +73,10 @@ data HydraClient = HydraClient
   -- ^ Port the hydra-node exposes Prometheus metrics on, if enabled.
   , connection :: Connection
   , tracer :: Tracer IO HydraNodeLog
+  , apiEncoding :: ApiEncoding
+  -- ^ Which wire encoding was negotiated for 'connection' (via the
+  -- @encoding=cbor@ query param). 'send' and 'waitNext' translate between
+  -- CBOR on the wire and the 'Aeson.Value's used by test assertions.
   }
 
 -- | Create an input as expected by 'send'.
@@ -76,12 +84,19 @@ input :: Text -> [Pair] -> Aeson.Value
 input tag pairs = object $ ("tag" .= tag) : pairs
 
 send :: HydraClient -> Aeson.Value -> IO ()
-send HydraClient{tracer, hydraNodeId, connection} v = do
-  sendTextData connection (Aeson.encode v)
+send HydraClient{tracer, hydraNodeId, connection, apiEncoding} v = do
+  case apiEncoding of
+    JsonEncoding -> sendTextData connection (Aeson.encode v)
+    CborEncoding ->
+      -- Convert the 'Aeson.Value' to a typed 'ClientInput' and send its CBOR.
+      case Aeson.fromJSON v of
+        Aeson.Error err -> failure $ "send: cannot convert to ClientInput for CBOR encoding: " <> err
+        Aeson.Success (clientInput :: ClientInput Tx) ->
+          sendBinaryData connection (serialize' clientInput)
   traceWith tracer $ SentMessage hydraNodeId v
 
 waitNext :: HasCallStack => HydraClient -> IO Aeson.Value
-waitNext HydraClient{connection} = do
+waitNext HydraClient{connection, apiEncoding} = do
   -- NOTE: We delay on connection errors to give other assertions the chance to
   -- provide more detail (e.g. checkProcessHasNotDied) before this fails.
   bytes <-
@@ -90,9 +105,17 @@ waitNext HydraClient{connection} = do
         threadDelay 1
         failure $ "waitNext: " <> show err
       Right msg -> pure msg
-  case Aeson.eitherDecode' bytes of
-    Left err -> failure $ "WaitNext failed to decode msg: " <> err
-    Right value -> pure value
+  case apiEncoding of
+    JsonEncoding ->
+      case Aeson.eitherDecode' bytes of
+        Left err -> failure $ "WaitNext failed to decode msg: " <> err
+        Right value -> pure value
+    CborEncoding ->
+      -- Decode the typed message and re-encode as a JSON 'Aeson.Value', so
+      -- that existing lens-based assertions keep working unchanged.
+      case decodeWire CborEncoding bytes of
+        Left err -> failure $ "WaitNext failed to decode CBOR msg: " <> err
+        Right (msg :: ApiMessage Tx) -> pure $ toJSON msg
 
 -- | Create an output as expected by 'waitFor' and 'waitForAll'.
 output :: Text -> [Pair] -> Aeson.Value
@@ -790,11 +813,17 @@ withConnectionToNodeHost tracer hydraNodeId apiHost@Host{hostname, port} monitor
 
   queryParams = fromMaybe "/" mQueryParams
 
+  -- NOTE: Derived from the query string, so callers opt into CBOR by adding
+  -- @encoding=cbor@ to their query params.
+  apiEncoding
+    | "encoding=cbor" `List.isInfixOf` queryParams = CborEncoding
+    | otherwise = JsonEncoding
+
   doConnect connectedOnce = runClient (T.unpack hostname) (fromInteger . toInteger $ port) queryParams $
     \connection -> do
       atomicWriteIORef connectedOnce True
       traceWith tracer (NodeStarted hydraNodeId)
-      res <- action $ HydraClient{hydraNodeId, apiHost, monitoringPort, connection, tracer}
+      res <- action $ HydraClient{hydraNodeId, apiHost, monitoringPort, connection, tracer, apiEncoding}
       sendClose connection ("Bye" :: Text)
       pure res
 

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -91,7 +91,7 @@ import Hydra.Logging (Tracer, showLogsOnFailure)
 import Hydra.Options
 import Hydra.Tx.IsTx (txId)
 import Hydra.Tx.Secret (mkSecret)
-import HydraNode (allocateHydraNodePortsFor, getMetrics, getSnapshotUTxO, input, output, prepareHydraNode, requestCommitTx, send, waitFor, waitForAllMatch, waitForNodesConnected, waitForNodesSynced, waitMatch, withHydraCluster, withHydraNode, withPreparedHydraNode, withSoloHydraNode, withUnsyncedSoloHydraNode)
+import HydraNode (HydraClient (..), allocateHydraNodePortsFor, getMetrics, getSnapshotUTxO, input, output, prepareHydraNode, requestCommitTx, send, waitFor, waitForAllMatch, waitForNodesConnected, waitForNodesSynced, waitMatch, withConnectionToNodeHost, withHydraCluster, withHydraNode, withPreparedHydraNode, withSoloHydraNode, withUnsyncedSoloHydraNode)
 import Network.HTTP.Conduit (parseUrlThrow)
 import Network.HTTP.Simple (getResponseBody, httpJSON)
 import System.Directory (removeDirectoryRecursive)
@@ -304,6 +304,10 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
         withClusterTempDir $ \tmpDir ->
           withHydraScriptsAndBackendRunning tracer tmpDir $
             nodeReObservesOnChainTxs tracer tmpDir
+      it "can open, transact and close a head over the CBOR API" $ \tracer ->
+        withClusterTempDir $ \tmpDir ->
+          withHydraScriptsAndBackendRunning tracer tmpDir $
+            cborApiLifeCycle tmpDir tracer
 
     describe "security scenarios" $ do
       it "cannot steal a pending deposit with no head input at all" $ \tracer ->
@@ -827,6 +831,70 @@ timedTx tmpDir tracer opts hydraScriptsTxId = do
       guard $ v ^? key "tag" == Just "SnapshotConfirmed"
       v ^? key "snapshot" . key "confirmed"
     confirmedTransactions ^.. values `shouldBe` [toJSON tx]
+
+-- | Drive a full single-party head life-cycle through a WebSocket connection
+-- which negotiated the CBOR wire encoding (via the @encoding=cbor@ query
+-- param). The standard 'send' / 'waitFor' / 'waitMatch' helpers work
+-- unchanged because 'HydraClient' transparently translates between CBOR
+-- frames on the wire and the JSON values used by the assertions.
+cborApiLifeCycle :: FilePath -> Tracer IO EndToEndLog -> ChainBackendOptions -> [TxId] -> IO ()
+cborApiLifeCycle tmpDir tracer opts hydraScriptsTxId = do
+  (aliceCardanoVk, _) <- keysFor Alice
+  blockTime <- runBackend opts getBlockTime
+  let timing = mkTestTiming blockTime
+  aliceChainConfig <- chainConfigFor Alice tmpDir opts hydraScriptsTxId [] timing
+  let hydraTracer = contramap FromHydraNode tracer
+  withSoloHydraNode hydraTracer blockTime aliceChainConfig tmpDir 1 aliceSk [] $ \node -> do
+    let HydraClient{hydraNodeId, apiHost, monitoringPort} = node
+    -- Open a second connection which negotiates the CBOR encoding and drive
+    -- the whole head life-cycle through it.
+    withConnectionToNodeHost hydraTracer hydraNodeId apiHost monitoringPort (Just "/?history=yes&encoding=cbor") $ \n1 -> do
+      -- Funds to be used as fuel by Hydra protocol transactions
+      seedFromFaucet_ opts aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
+
+      send n1 $ input "Init" []
+      headId <- waitForAllMatch 10 [n1] $ headIsOpenWith (Set.fromList [alice])
+
+      -- Deposit some UTxO into the head
+      (aliceExternalVk, aliceExternalSk) <- generate genKeyPair
+      utxoToCommit <- seedFromFaucet opts aliceExternalVk (lovelaceToValue aliceCommittedToHead) (contramap FromFaucet tracer)
+      txDeposit <- requestCommitTx n1 utxoToCommit <&> signTx aliceExternalSk
+      runBackend opts $ submitTransaction txDeposit
+      waitFor hydraTracer (depositTimeout timing) [n1] $
+        output "CommitFinalized" ["headId" .= headId, "depositTxId" .= txId txDeposit]
+
+      -- Submit a transaction moving the committed funds within the head
+      let Right tx =
+            mkSimpleTx
+              (Prelude.head $ UTxO.toList utxoToCommit)
+              (inHeadAddress aliceExternalVk, lovelaceToValue paymentFromAliceToBob)
+              (mkSecret aliceExternalSk)
+      send n1 $ input "NewTx" ["transaction" .= tx]
+      waitFor hydraTracer 10 [n1] $
+        output "TxValid" ["transactionId" .= txId tx, "headId" .= headId]
+
+      expectedUTxO <- waitMatch 10 n1 $ \v -> do
+        guard $ v ^? key "tag" == Just "SnapshotConfirmed"
+        guard $ v ^? key "headId" == Just (toJSON headId)
+        confirmed <- v ^? key "snapshot" . key "confirmed"
+        guard $ confirmed == toJSON [tx]
+        v ^? key "snapshot" . key "utxo" >>= parseMaybe parseJSON
+
+      -- Close the head and expect the snapshot UTxO to be fanned out on the
+      -- main chain
+      send n1 $ input "Close" []
+      deadline <- waitMatch 3 n1 $ \v -> do
+        guard $ v ^? key "tag" == Just "HeadIsClosed"
+        guard $ v ^? key "headId" == Just (toJSON headId)
+        v ^? key "contestationDeadline" . _JSON
+
+      remainingTime <- diffUTCTime deadline <$> getCurrentTime
+      waitFor hydraTracer (remainingTime + 3) [n1] $
+        output "ReadyToFanout" ["headId" .= headId]
+
+      send n1 $ input "Fanout" []
+      waitForAllMatch 10 [n1] $ headIsFinalizedWith headId expectedUTxO
+      failAfter 5 $ waitForUTxO opts expectedUTxO
 
 initAndClose :: FilePath -> Tracer IO EndToEndLog -> Int -> ChainBackendOptions -> [TxId] -> IO ()
 initAndClose tmpDir tracer clusterIx opts hydraScriptsTxId = do

--- a/hydra-node/bench/micro-bench/Main.hs
+++ b/hydra-node/bench/micro-bench/Main.hs
@@ -6,18 +6,45 @@ import Criterion (bench, bgroup, nf, whnf)
 import Criterion.Main (defaultMain)
 import Data.Aeson (Value (String), object, (.=))
 import Data.Aeson qualified as Aeson
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as LBS
 import Data.List qualified as List
+import Data.Time (UTCTime (..), fromGregorian)
 import Hydra.API.ClientInput (ClientInput (NewTx))
+import Hydra.API.ServerOutput (
+  ApiEncoding (..),
+  Greetings (..),
+  ServerOutput (..),
+  ServerOutputConfig (..),
+  TimedServerOutput (..),
+  WithAddressedTx (..),
+  WithUTxO (..),
+  handleUtxoInclusionTyped,
+  prepareServerOutput,
+ )
+import Hydra.API.WireFormat (decodeWire, encodeWire)
 import Hydra.Cardano.Api (
   UTxO,
   serialiseToCBOR,
  )
 import Hydra.Chain.ChainState (ChainSlot (ChainSlot))
+
+-- Provides the 'IsChainState Tx' instance required by API server output codecs.
+import Hydra.Chain.Direct.State ()
 import Hydra.Ledger (Ledger (applyTransactions), ValidationError)
 import Hydra.Ledger.Cardano (Tx, cardanoLedger)
+import Hydra.Tx.Accumulator qualified as Accumulator
+import Hydra.Tx.Crypto (aggregate, sign)
+import Hydra.Tx.IsTx (IsTx (txId))
+import Hydra.Tx.Snapshot (Snapshot (..))
+import Test.Hydra.API.ServerOutput ()
 import Test.Hydra.Ledger.Cardano (genFixedSizeSequenceOfSimplePaymentTransactions)
 import Test.Hydra.Node.Fixture (defaultGlobals, defaultLedgerEnv)
-import Test.QuickCheck (generate)
+import Test.Hydra.Tx.Fixture (aliceSk, bobSk, carolSk, testHeadId)
+import Test.Hydra.Tx.Gen (genUTxOSized)
+import Test.QuickCheck (arbitrary)
+import Test.QuickCheck.Gen (Gen, unGen)
+import Test.QuickCheck.Random (mkQCGen)
 
 main :: IO ()
 main = do
@@ -30,25 +57,133 @@ main = do
   -- command.)
   --
   nTxns <- fromMaybe 1 . (>>= readMaybe) <$> lookupEnv "N_TXNS"
-  (utxo, tx) <- prepareTx nTxns
+  let (utxo, tx) = prepareTx nTxns
   let jsonNewTx = (Aeson.encode . NewTx) tx
       toNewTx :: ByteString -> Value
       toNewTx bs = object ["tag" .= ("NewTx" :: Text), "transaction" .= String (decodeUtf8 bs)]
       cborNewTx = (Aeson.encode . toNewTx . serialiseToCBOR) tx
+
+  -- API server output messages as sent over the websocket. All values are
+  -- generated with a fixed seed so payload sizes are reproducible across runs
+  -- and comparable between wire formats.
+  let txValid = mkTimed $ TxValid testHeadId (txId tx)
+      snapshotsConfirmed = [(n, mkSnapshotConfirmed tx n) | n <- utxoSizes]
+      greetings = mkGreetings
+      greetingsJson = Aeson.encode greetings
+
+  let cborWire :: (ToJSON a, ToCBOR a) => a -> LBS.ByteString
+      cborWire = encodeWire CborEncoding
+
+  putStrLn "Wire sizes (bytes):"
+  putStrLn $ sizeRow "message" "JSON" "CBOR"
+  putStrLn $ sizeRow "NewTx" (show $ LBS.length jsonNewTx) (show . LBS.length $ cborWire (NewTx tx))
+  putStrLn $ sizeRow "NewTx transaction (raw ledger CBOR floor)" "-" (show . BS.length $ serialiseToCBOR tx)
+  putStrLn $ sizeRow "TxValid" (show . LBS.length $ Aeson.encode txValid) (show . LBS.length $ cborWire txValid)
+  forM_ snapshotsConfirmed $ \(n, timed) ->
+    putStrLn $ sizeRow ("SnapshotConfirmed utxo=" <> show n) (show . LBS.length $ Aeson.encode timed) (show . LBS.length $ cborWire timed)
+  putStrLn $ sizeRow "Greetings utxo=100" (show $ LBS.length greetingsJson) (show . LBS.length $ cborWire greetings)
+  putStrLn ""
+
   defaultMain
     [ bgroup
         "Cardano Ledger"
         [ bench "Apply Tx" $ whnf benchApplyTxs (utxo, tx)
         , bench "Serialize NewTx (JSON)" $ nf (Aeson.encode . NewTx) tx
         , bench "Serialize NewTx (CBOR)" $ nf serialiseToCBOR tx
+        , bench "Serialize NewTx (CBOR wire)" $ nf (encodeWire CborEncoding . NewTx) tx
         , bench "Deserialize NewTx (JSON)" $ whnf (Aeson.decode @(ClientInput Tx)) jsonNewTx
         , bench "Deserialize NewTx (CBOR-in-JSON)" $ whnf (Aeson.decode @(ClientInput Tx)) cborNewTx
+        , bench "Deserialize NewTx (CBOR wire)" $ whnf decodeInputCbor (encodeWire CborEncoding (NewTx tx))
         ]
+    , bgroup "API server output" $
+        [ bench "Encode TxValid (JSON)" $ nf Aeson.encode txValid
+        , bench "Encode TxValid (CBOR)" $ nf (encodeWire CborEncoding) txValid
+        , bench "Decode TxValid (JSON)" $ whnf decodeTimed (Aeson.encode txValid)
+        , bench "Decode TxValid (CBOR)" $ whnf decodeTimedCbor (encodeWire CborEncoding txValid)
+        ]
+          <> concatMap
+            ( \(n, timed) ->
+                let benchLabel = "SnapshotConfirmed utxo=" <> show n
+                 in [ bench ("Encode " <> benchLabel <> " (JSON)") $ nf Aeson.encode timed
+                    , bench ("Encode " <> benchLabel <> " (CBOR)") $ nf (encodeWire CborEncoding) timed
+                    , bench ("Send " <> benchLabel <> " WithUTxO (JSON)") $ nf (prepareServerOutput withUTxOConfig) timed
+                    , bench ("Send " <> benchLabel <> " WithoutUTxO (JSON)") $ nf (prepareServerOutput withoutUTxOConfig) timed
+                    , bench ("Send " <> benchLabel <> " WithoutUTxO (CBOR)") $ nf (encodeWire CborEncoding . handleUtxoInclusionTyped withoutUTxOConfig) timed
+                    , bench ("Decode " <> benchLabel <> " (JSON)") $ whnf decodeTimed (Aeson.encode timed)
+                    , bench ("Decode " <> benchLabel <> " (CBOR)") $ whnf decodeTimedCbor (encodeWire CborEncoding timed)
+                    ]
+            )
+            snapshotsConfirmed
+          <> [ bench "Encode Greetings utxo=100 (JSON)" $ nf Aeson.encode greetings
+             , bench "Encode Greetings utxo=100 (CBOR)" $ nf (encodeWire CborEncoding) greetings
+             , bench "Decode Greetings utxo=100 (JSON)" $ whnf (Aeson.eitherDecode' @(Greetings Tx)) greetingsJson
+             , bench "Decode Greetings utxo=100 (CBOR)" $ whnf decodeGreetingsCbor (encodeWire CborEncoding greetings)
+             ]
     ]
+ where
+  decodeTimed = Aeson.eitherDecode' @(TimedServerOutput Tx)
 
-prepareTx :: Int -> IO (UTxO, Tx)
+  decodeTimedCbor :: LBS.ByteString -> Either String (TimedServerOutput Tx)
+  decodeTimedCbor = decodeWire CborEncoding
+
+  decodeGreetingsCbor :: LBS.ByteString -> Either String (Greetings Tx)
+  decodeGreetingsCbor = decodeWire CborEncoding
+
+  decodeInputCbor :: LBS.ByteString -> Either String (ClientInput Tx)
+  decodeInputCbor = decodeWire CborEncoding
+
+  withUTxOConfig = ServerOutputConfig{utxoInSnapshot = WithUTxO, addressInTx = WithoutAddressedTx, encoding = JsonEncoding}
+
+  withoutUTxOConfig = ServerOutputConfig{utxoInSnapshot = WithoutUTxO, addressInTx = WithoutAddressedTx, encoding = JsonEncoding}
+
+utxoSizes :: [Int]
+utxoSizes = [1, 10, 100, 1000]
+
+-- | Generate a value with a fixed seed so generated payloads (and hence wire
+-- sizes) are reproducible across benchmark runs.
+generateWith :: Gen a -> Int -> a
+generateWith g seed = unGen g (mkQCGen seed) 30
+
+prepareTx :: Int -> (UTxO, Tx)
 prepareTx n =
-  second List.head <$> generate (genFixedSizeSequenceOfSimplePaymentTransactions n)
+  second List.head $ generateWith (genFixedSizeSequenceOfSimplePaymentTransactions n) 42
+
+mkTimed :: ServerOutput Tx -> TimedServerOutput Tx
+mkTimed output = TimedServerOutput{output, seq = 1, time = UTCTime (fromGregorian 2026 7 16) 0}
+
+-- | A 'SnapshotConfirmed' server output with a snapshot over a UTxO set of
+-- given size, signed by three parties.
+mkSnapshotConfirmed :: Tx -> Int -> TimedServerOutput Tx
+mkSnapshotConfirmed tx n =
+  mkTimed $ SnapshotConfirmed testHeadId snapshot signatures
+ where
+  signatures = aggregate [sign sk snapshot | sk <- [aliceSk, bobSk, carolSk]]
+
+  snapshot =
+    Snapshot
+      { headId = testHeadId
+      , version = 1
+      , number = 2
+      , confirmed = [tx]
+      , utxo = u
+      , utxoToCommit = Nothing
+      , utxoToDecommit = Nothing
+      , accumulator = Accumulator.buildFromUTxO @Tx u
+      }
+
+  u = generateWith (genUTxOSized n) 42
+
+mkGreetings :: Greetings Tx
+mkGreetings =
+  (generateWith (arbitrary @(Greetings Tx)) 42)
+    { snapshotUtxo = Just $ generateWith (genUTxOSized 100) 42
+    }
+
+sizeRow :: String -> String -> String -> String
+sizeRow name jsonSize cborSize =
+  "  " <> pad 44 name <> pad 10 jsonSize <> cborSize
+ where
+  pad n s = s <> replicate (max 1 (n - length s)) ' '
 
 benchApplyTxs :: (UTxO, Tx) -> Either (Tx, ValidationError) UTxO
 benchApplyTxs (utxo, tx) = applyTransactions defaultLedger (ChainSlot 1) utxo [tx]

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -55,6 +55,7 @@ library
     Hydra.API.Server
     Hydra.API.ServerOutput
     Hydra.API.ServerOutputFilter
+    Hydra.API.WireFormat
     Hydra.API.WSServer
     Hydra.CBOR.Orphans
     Hydra.Chain
@@ -323,13 +324,16 @@ benchmark micro
   build-depends:
     , aeson
     , base
+    , bytestring
     , criterion
     , hydra-cardano-api
     , hydra-node
     , hydra-node:testlib
     , hydra-prelude
     , hydra-tx
+    , hydra-tx:testlib
     , QuickCheck
+    , time
 
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N4
 

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -9,6 +9,8 @@ info:
     Therefore, once connected, clients receive a stream of outputs as they arrive. Clients get to decide (using query parameters) if they want to observe the history of outputs and the transaction format.
     For example if client provides a path that looks like this `/?history=no&snapshot-utxo=no` the server will not serve prior history of server outputs, and the utxo field in the json will be omitted.
 
+    Besides JSON, a binary CBOR encoding of all messages is available. WebSocket clients opt in per connection with the `encoding=cbor` query parameter; messages are then exchanged as binary frames. HTTP clients negotiate per request using `Content-Type: application/cbor` for request bodies and `Accept: application/cbor` for responses. The CBOR encoding of every message is a text tag identical to the JSON `tag` value, followed by the constructor fields in declaration order (using the same CBOR codecs as the Hydra network layer). One exception: instead of the flattened JSON representation, `TimedServerOutput` is encoded as tag `TimedServerOutput` followed by `seq`, `timestamp` and the inner `ServerOutput`.
+
     They can interact with their node by pushing events to it, some are local, and some will have consequences on the rest of the head.
 
     See [the documentation](https://hydra.family/head-protocol/docs/dev/architecture#api) for more details on the overall API behavior.
@@ -66,6 +68,11 @@ channels:
             description: Specify whether the client wants see the transaction server outputs filtered by given address.
             schema:
               type: string
+          encoding:
+            description: Wire encoding for all messages on this connection. With `cbor`, messages are exchanged as binary WebSocket frames containing the CBOR encoding described above. Default is JSON text frames.
+            schema:
+              type: string
+              enum: ["cbor"]
 
     subscribe:
       summary: Events emitted by the Hydra node.

--- a/hydra-node/src/Hydra/API/HTTPServer.hs
+++ b/hydra-node/src/Hydra/API/HTTPServer.hs
@@ -4,18 +4,24 @@ module Hydra.API.HTTPServer where
 
 import Hydra.Prelude
 
+import Cardano.Ledger.Binary (encCBOR, toPlainEncoding)
 import Cardano.Ledger.Core (PParams)
+import Codec.CBOR.Write qualified as CBOR
 import Control.Concurrent.STM (TChan, dupTChan, readTChan)
 import Data.Aeson (KeyValue ((.=)), object, withObject, (.:), (.:?))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Types (Parser, parseEither)
+import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
 import Data.ByteString.Short ()
+import Data.List qualified as List
 import Data.Text (pack)
 import Hydra.API.APIServerLog (APIServerLog (..), Method (..), PathInfo (..))
 import Hydra.API.ClientInput (ClientInput (..))
-import Hydra.API.ServerOutput (ClientMessage (..), CommitInfo (..), ServerOutput (..), TimedServerOutput (..), getConfirmedSnapshot, getSeenSnapshot, getSnapshotUtxo)
-import Hydra.Cardano.Api (AddressInEra, LedgerEra, SlotNo, Tx)
+import Hydra.API.ServerOutput (ApiEncoding (..), ClientMessage (..), CommitInfo (..), ServerOutput (..), TimedServerOutput (..), getConfirmedSnapshot, getSeenSnapshot, getSnapshotUtxo)
+import Hydra.API.WireFormat (decodeWire, encodeWire)
+import Hydra.CBOR.Orphans ()
+import Hydra.Cardano.Api (AddressInEra, LedgerEra, SlotNo, Tx, ledgerEraVersion)
 import Hydra.Chain (Chain (..), PostTxError (..))
 import Hydra.Chain.ChainState (IsChainState)
 import Hydra.Chain.Direct.State ()
@@ -26,8 +32,8 @@ import Hydra.Node.Environment (Environment (..))
 import Hydra.Node.State (NodeState (..))
 import Hydra.Tx (CommitBlueprintTx (..), ConfirmedSnapshot, IsTx (..), Snapshot (..), UTxOType)
 import Hydra.Tx.DepositPeriod (toNominalDiffTime)
-import Network.HTTP.Types (ResponseHeaders, hContentType, status200, status202, status400, status404, status500, status503)
-import Network.Wai (Application, Request (pathInfo, requestMethod), Response, consumeRequestBodyStrict, rawPathInfo, responseLBS)
+import Network.HTTP.Types (ResponseHeaders, Status, hAccept, hContentType, status200, status202, status400, status404, status500, status503)
+import Network.Wai (Application, Request (pathInfo, requestMethod), Response, consumeRequestBodyStrict, rawPathInfo, requestHeaders, responseLBS)
 
 newtype DraftCommitTxResponse tx = DraftCommitTxResponse
   { commitTx :: tx
@@ -41,6 +47,12 @@ instance IsTx tx => ToJSON (DraftCommitTxResponse tx) where
 
 instance IsTx tx => FromJSON (DraftCommitTxResponse tx) where
   parseJSON v = DraftCommitTxResponse <$> parseJSON v
+
+instance IsTx tx => ToCBOR (DraftCommitTxResponse tx) where
+  toCBOR (DraftCommitTxResponse tx) = toCBOR tx
+
+instance IsTx tx => FromCBOR (DraftCommitTxResponse tx) where
+  fromCBOR = DraftCommitTxResponse <$> fromCBOR
 
 data DraftCommitTxRequest tx
   = SimpleCommitRequest
@@ -85,11 +97,31 @@ instance (FromJSON tx, FromJSON (UTxOType tx)) => FromJSON (DraftCommitTxRequest
     simpleDirectVariant :: Aeson.Value -> Parser (DraftCommitTxRequest tx)
     simpleDirectVariant val = SimpleCommitRequest <$> parseJSON val
 
+instance IsTx tx => ToCBOR (DraftCommitTxRequest tx) where
+  toCBOR = \case
+    SimpleCommitRequest{utxoToCommit} ->
+      toCBOR ("SimpleCommitRequest" :: Text) <> toCBOR utxoToCommit
+    FullCommitRequest{blueprintTx, utxo, changeAddress} ->
+      toCBOR ("FullCommitRequest" :: Text)
+        <> toCBOR blueprintTx
+        <> toCBOR utxo
+        <> toCBOR changeAddress
+
+instance IsTx tx => FromCBOR (DraftCommitTxRequest tx) where
+  fromCBOR =
+    fromCBOR >>= \case
+      ("SimpleCommitRequest" :: Text) -> SimpleCommitRequest <$> fromCBOR
+      "FullCommitRequest" -> FullCommitRequest <$> fromCBOR <*> fromCBOR <*> fromCBOR
+      tag -> fail $ show tag <> " is not a proper CBOR-encoded DraftCommitTxRequest"
+
 newtype SubmitTxRequest tx = SubmitTxRequest
   { txToSubmit :: tx
   }
   deriving newtype (Eq, Show)
   deriving newtype (ToJSON, FromJSON)
+
+deriving newtype instance (Typeable tx, ToCBOR tx) => ToCBOR (SubmitTxRequest tx)
+deriving newtype instance (Typeable tx, FromCBOR tx) => FromCBOR (SubmitTxRequest tx)
 
 data TransactionSubmitted = TransactionSubmitted
   deriving stock (Eq, Show, Generic)
@@ -108,11 +140,23 @@ instance FromJSON TransactionSubmitted where
         pure TransactionSubmitted
       _ -> fail "Expected tag to be TransactionSubmitted"
 
+instance ToCBOR TransactionSubmitted where
+  toCBOR TransactionSubmitted = toCBOR ("TransactionSubmitted" :: Text)
+
+instance FromCBOR TransactionSubmitted where
+  fromCBOR =
+    fromCBOR >>= \case
+      ("TransactionSubmitted" :: Text) -> pure TransactionSubmitted
+      tag -> fail $ show tag <> " is not a proper CBOR-encoded TransactionSubmitted"
+
 newtype SideLoadSnapshotRequest tx = SideLoadSnapshotRequest
   { snapshot :: ConfirmedSnapshot tx
   }
   deriving newtype (Eq, Show, Generic)
   deriving newtype (ToJSON, FromJSON)
+
+deriving newtype instance IsTx tx => ToCBOR (SideLoadSnapshotRequest tx)
+deriving newtype instance IsTx tx => FromCBOR (SideLoadSnapshotRequest tx)
 
 -- | Request to submit a transaction to the head
 newtype SubmitL2TxRequest tx = SubmitL2TxRequest
@@ -120,6 +164,9 @@ newtype SubmitL2TxRequest tx = SubmitL2TxRequest
   }
   deriving newtype (Eq, Show)
   deriving newtype (ToJSON, FromJSON)
+
+deriving newtype instance (Typeable tx, ToCBOR tx) => ToCBOR (SubmitL2TxRequest tx)
+deriving newtype instance (Typeable tx, FromCBOR tx) => FromCBOR (SubmitL2TxRequest tx)
 
 -- | Response for transaction submission
 data SubmitL2TxResponse
@@ -162,6 +209,27 @@ instance FromJSON SubmitL2TxResponse where
       "SubmitTxSubmitted" -> pure SubmitTxSubmitted
       _ -> fail "Expected tag to be SubmitTxConfirmed, SubmitTxInvalid, SubmitTxRejected, or SubmitTxSubmitted"
 
+-- NOTE: Tags are kept consistent with the JSON encoding above.
+instance ToCBOR SubmitL2TxResponse where
+  toCBOR = \case
+    SubmitTxConfirmed snapshotNumber ->
+      toCBOR ("SubmitTxConfirmed" :: Text) <> toCBOR snapshotNumber
+    SubmitTxInvalidResponse validationError ->
+      toCBOR ("SubmitTxInvalid" :: Text) <> toCBOR validationError
+    SubmitTxRejectedResponse reason ->
+      toCBOR ("SubmitTxRejected" :: Text) <> toCBOR reason
+    SubmitTxSubmitted ->
+      toCBOR ("SubmitTxSubmitted" :: Text)
+
+instance FromCBOR SubmitL2TxResponse where
+  fromCBOR =
+    fromCBOR >>= \case
+      ("SubmitTxConfirmed" :: Text) -> SubmitTxConfirmed <$> fromCBOR
+      "SubmitTxInvalid" -> SubmitTxInvalidResponse <$> fromCBOR
+      "SubmitTxRejected" -> SubmitTxRejectedResponse <$> fromCBOR
+      "SubmitTxSubmitted" -> pure SubmitTxSubmitted
+      tag -> fail $ show tag <> " is not a proper CBOR-encoded SubmitL2TxResponse"
+
 data HeadInitializationDetails
   = HeadInitializationDetails
   { time :: UTCTime
@@ -171,6 +239,71 @@ data HeadInitializationDetails
 
 jsonContent :: ResponseHeaders
 jsonContent = [(hContentType, "application/json")]
+
+cborContent :: ResponseHeaders
+cborContent = [(hContentType, "application/cbor")]
+
+-- | Response body sent when an operation was accepted but did not finish
+-- within the API transaction timeout.
+data OperationTimedOut = OperationTimedOut
+  { tag :: Text
+  , timeoutMessage :: Text
+  }
+  deriving stock (Eq, Show, Generic)
+
+-- NOTE: Encoded with a "timeout" key for backwards compatibility (the field
+-- is named differently to avoid clashing with 'Hydra.Prelude.timeout').
+instance ToJSON OperationTimedOut where
+  toJSON OperationTimedOut{tag, timeoutMessage} =
+    object ["tag" .= tag, "timeout" .= timeoutMessage]
+
+instance FromJSON OperationTimedOut where
+  parseJSON = withObject "OperationTimedOut" $ \o ->
+    OperationTimedOut <$> o .: "tag" <*> o .: "timeout"
+
+instance ToCBOR OperationTimedOut where
+  toCBOR OperationTimedOut{tag, timeoutMessage} =
+    toCBOR ("OperationTimedOut" :: Text) <> toCBOR tag <> toCBOR timeoutMessage
+
+instance FromCBOR OperationTimedOut where
+  fromCBOR =
+    fromCBOR >>= \case
+      ("OperationTimedOut" :: Text) -> OperationTimedOut <$> fromCBOR <*> fromCBOR
+      other -> fail $ show other <> " is not a proper CBOR-encoded OperationTimedOut"
+
+operationTimedOut :: Text -> ApiTransactionTimeout -> OperationTimedOut
+operationTimedOut tag apiTransactionTimeout =
+  OperationTimedOut
+    { tag
+    , timeoutMessage = "Operation timed out after " <> pack (show apiTransactionTimeout) <> " seconds"
+    }
+
+-- | Which encoding the client wants for the response, negotiated via the
+-- @Accept@ header. Anything but @application/cbor@ (including no header)
+-- yields JSON.
+responseEncodingFor :: Request -> ApiEncoding
+responseEncodingFor request =
+  case List.lookup hAccept (requestHeaders request) of
+    Just accept | "application/cbor" `BS.isInfixOf` accept -> CborEncoding
+    _ -> JsonEncoding
+
+-- | Which encoding the request body uses, negotiated via the @Content-Type@
+-- header. Anything but @application/cbor@ (including no header) is treated
+-- as JSON.
+requestEncodingFor :: Request -> ApiEncoding
+requestEncodingFor request =
+  case List.lookup hContentType (requestHeaders request) of
+    Just contentType | "application/cbor" `BS.isInfixOf` contentType -> CborEncoding
+    _ -> JsonEncoding
+
+-- | Respond in the given encoding, with matching @Content-Type@.
+respondApi :: (ToJSON a, ToCBOR a) => ApiEncoding -> Status -> a -> Response
+respondApi apiEncoding status a =
+  responseLBS status contentType (encodeWire apiEncoding a)
+ where
+  contentType = case apiEncoding of
+    JsonEncoding -> jsonContent
+    CborEncoding -> cborContent
 
 -- | Hydra HTTP server
 httpApp ::
@@ -203,52 +336,65 @@ httpApp tracer configDoc directChain env pparams getNodeState getCommitInfo getP
       }
   case (requestMethod request, pathInfo request) of
     ("GET", ["config"]) ->
-      respond $ okJSON configDoc
+      respond $ respondApi respEnc status200 configDoc
     ("GET", ["head"]) ->
-      getNodeState >>= (respond . okJSON) . headState
+      getNodeState >>= (respond . respondApi respEnc status200) . headState
     ("GET", ["snapshot"]) -> do
       hs <- headState <$> getNodeState
       case getConfirmedSnapshot hs of
-        Just confirmedSnapshot -> respond $ okJSON confirmedSnapshot
-        Nothing -> respond notFound
+        Just confirmedSnapshot -> respond $ respondApi respEnc status200 confirmedSnapshot
+        Nothing -> respond $ notFound respEnc
     ("GET", ["snapshot", "utxo"]) -> do
       hs <- headState <$> getNodeState
       case getSnapshotUtxo hs of
-        Just utxo -> respond $ okJSON utxo
-        _ -> respond notFound
+        Just utxo -> respond $ respondApi respEnc status200 utxo
+        _ -> respond $ notFound respEnc
     ("GET", ["snapshot", "last-seen"]) -> do
       hs <- headState <$> getNodeState
-      respond . okJSON $ getSeenSnapshot hs
+      respond . respondApi respEnc status200 $ getSeenSnapshot hs
     ("POST", ["snapshot"]) ->
       consumeRequestBodyStrict request
-        >>= handleSideLoadSnapshot putClientInput apiTransactionTimeout responseChannel
+        >>= handleSideLoadSnapshot putClientInput apiTransactionTimeout responseChannel reqEnc respEnc
         >>= respond
     ("POST", ["commit"]) ->
       consumeRequestBodyStrict request
-        >>= handleDraftCommitUtxo tracer env pparams directChain getNodeState getCommitInfo
+        >>= handleDraftCommitUtxo tracer env pparams directChain getNodeState getCommitInfo reqEnc respEnc
         >>= respond
     ("DELETE", ["commits", _]) ->
       consumeRequestBodyStrict request
-        >>= handleRecoverCommitUtxo putClientInput apiTransactionTimeout responseChannel (last . fromList $ pathInfo request)
+        >>= handleRecoverCommitUtxo putClientInput apiTransactionTimeout responseChannel (last . fromList $ pathInfo request) respEnc
         >>= respond
     ("GET", ["commits"]) ->
-      getPendingDeposits >>= respond . responseLBS status200 jsonContent . Aeson.encode
+      getPendingDeposits >>= respond . respondApi respEnc status200
     ("POST", ["decommit"]) ->
       consumeRequestBodyStrict request
-        >>= handleDecommit putClientInput apiTransactionTimeout responseChannel
+        >>= handleDecommit putClientInput apiTransactionTimeout responseChannel reqEnc respEnc
         >>= respond
     ("GET", ["protocol-parameters"]) ->
-      respond . responseLBS status200 jsonContent . Aeson.encode $ pparams
+      respond $ respondPParams respEnc pparams
     ("POST", ["cardano-transaction"]) ->
       consumeRequestBodyStrict request
-        >>= handleSubmitUserTx directChain
+        >>= handleSubmitUserTx directChain reqEnc respEnc
         >>= respond
     ("POST", ["transaction"]) ->
       consumeRequestBodyStrict request
-        >>= handleSubmitL2Tx putClientInput apiTransactionTimeout responseChannel
+        >>= handleSubmitL2Tx putClientInput apiTransactionTimeout responseChannel reqEnc respEnc
         >>= respond
     _ ->
-      respond $ responseLBS status400 jsonContent . Aeson.encode $ Aeson.String "Resource not found"
+      respond $ respondApi respEnc status400 ("Resource not found" :: Text)
+ where
+  reqEnc = requestEncodingFor request
+  respEnc = responseEncodingFor request
+
+-- | Respond with protocol parameters; the ledger 'PParams' have no plain
+-- 'ToCBOR' instance, so the CBOR case goes through the ledger's 'EncCBOR'.
+respondPParams :: ApiEncoding -> PParams LedgerEra -> Response
+respondPParams apiEncoding pparams =
+  case apiEncoding of
+    JsonEncoding -> responseLBS status200 jsonContent (Aeson.encode pparams)
+    CborEncoding ->
+      responseLBS status200 cborContent $
+        CBOR.toLazyByteString (toPlainEncoding ledgerEraVersion $ encCBOR pparams)
 
 -- * Handlers
 
@@ -266,18 +412,22 @@ handleDraftCommitUtxo ::
   IO (NodeState tx) ->
   -- | A means to get commit info.
   IO CommitInfo ->
+  -- | Request body encoding.
+  ApiEncoding ->
+  -- | Response encoding.
+  ApiEncoding ->
   -- | Request body.
   LBS.ByteString ->
   IO Response
-handleDraftCommitUtxo tracer env pparams directChain getNodeState getCommitInfo body = do
-  case Aeson.eitherDecode' body :: Either String (DraftCommitTxRequest tx) of
+handleDraftCommitUtxo tracer env pparams directChain getNodeState getCommitInfo reqEnc respEnc body = do
+  case decodeWire reqEnc body :: Either String (DraftCommitTxRequest tx) of
     Left err -> do
       traceWith tracer $
         APIInvalidInput
           { reason = "Failed to parse request to DraftCommitTxRequest: " <> show err
           , inputReceived = show body
           }
-      pure $ responseLBS status400 jsonContent (Aeson.encode $ Aeson.String $ pack err)
+      pure $ respondApi respEnc status400 (pack err)
     Right someCommitRequest ->
       getCommitInfo >>= \case
         IncrementalCommit headId -> do
@@ -292,7 +442,7 @@ handleDraftCommitUtxo tracer env pparams directChain getNodeState getCommitInfo 
               { reason = "CannotCommit: Hydra node does not have an open Head."
               , inputReceived = show body
               }
-          pure $ responseLBS status400 jsonContent (Aeson.encode $ Aeson.String "Head is not open")
+          pure $ respondApi respEnc status400 ("Head is not open" :: Text)
  where
   deposit headId commitBlueprint changeAddress = do
     nodeState <- getNodeState
@@ -303,7 +453,7 @@ handleDraftCommitUtxo tracer env pparams directChain getNodeState getCommitInfo 
             { reason = "Cannot commit: Hydra node does not have an open Head."
             , inputReceived = show body
             }
-        pure $ responseLBS status400 jsonContent (Aeson.encode $ Aeson.String "Head is not open")
+        pure $ respondApi respEnc status400 ("Head is not open" :: Text)
       Just currentSnapshot -> do
         -- NOTE: The deadline splits into three independent windows: a deposit
         -- matures (becomes active) after 'depositActivation', stays active for one
@@ -316,17 +466,17 @@ handleDraftCommitUtxo tracer env pparams directChain getNodeState getCommitInfo 
         case result of
           Left e ->
             case e of
-              UnsupportedLegacyOutput _ -> pure $ badRequest e
-              DepositTooLow _ _ -> pure $ badRequest e
-              DepositTooLarge{} -> pure $ badRequest e
-              FailedToConstructDepositTx _ -> pure $ badRequest e
+              UnsupportedLegacyOutput _ -> pure $ badRequest respEnc e
+              DepositTooLow _ _ -> pure $ badRequest respEnc e
+              DepositTooLarge{} -> pure $ badRequest respEnc e
+              FailedToConstructDepositTx _ -> pure $ badRequest respEnc e
               _ -> do
                 traceWith tracer $
                   APIReturnedError
                     { reason = "Failed to draft deposit transaction: " <> show e
                     }
-                pure $ responseLBS status500 jsonContent (Aeson.encode $ toJSON e)
-          Right depositTx -> pure $ okJSON $ DraftCommitTxResponse depositTx
+                pure $ respondApi respEnc status500 e
+          Right depositTx -> pure $ respondApi respEnc status200 $ DraftCommitTxResponse depositTx
 
   Chain{draftDepositTx} = directChain
 
@@ -340,9 +490,10 @@ handleRecoverCommitUtxo ::
   ApiTransactionTimeout ->
   TChan (Either (TimedServerOutput tx) (ClientMessage tx)) ->
   Text ->
+  ApiEncoding ->
   LBS.ByteString ->
   IO Response
-handleRecoverCommitUtxo putClientInput apiTransactionTimeout responseChannel recoverPath _body = do
+handleRecoverCommitUtxo putClientInput apiTransactionTimeout responseChannel recoverPath respEnc _body = do
   case parseTxIdFromPath recoverPath of
     Left err -> pure err
     Right recoverTxId -> do
@@ -352,25 +503,16 @@ handleRecoverCommitUtxo putClientInput apiTransactionTimeout responseChannel rec
             event <- atomically $ readTChan dupChannel
             case event of
               Left TimedServerOutput{output = CommitRecovered{}} ->
-                pure $ responseLBS status200 jsonContent (Aeson.encode $ Aeson.String "OK")
+                pure $ respondApi respEnc status200 ("OK" :: Text)
               Right (CommandFailed{clientInput = Recover{}}) ->
-                pure $ responseLBS status400 jsonContent (Aeson.encode $ Aeson.String "Recover failed")
+                pure $ respondApi respEnc status400 ("Recover failed" :: Text)
               Right (RejectedInputBecauseUnsynced{clientInput = Recover{}, drift}) ->
-                pure $ responseLBS status503 jsonContent (Aeson.encode $ Aeson.String ("Recover failed because node is out of sync with chain, drift: " <> show drift))
+                pure $ respondApi respEnc status503 ("Recover failed because node is out of sync with chain, drift: " <> show drift :: Text)
               _ -> wait
       timeout (realToFrac (apiTransactionTimeoutNominalDiffTime apiTransactionTimeout)) wait >>= \case
         Just r -> pure r
         Nothing ->
-          pure $
-            responseLBS
-              status202
-              jsonContent
-              ( Aeson.encode $
-                  object
-                    [ "tag" .= Aeson.String "RecoverSubmitted"
-                    , "timeout" .= Aeson.String ("Operation timed out after " <> pack (show apiTransactionTimeout) <> " seconds")
-                    ]
-              )
+          pure $ respondApi respEnc status202 $ operationTimedOut "RecoverSubmitted" apiTransactionTimeout
  where
   parseTxIdFromPath :: Text -> Either Response (TxIdType tx)
   parseTxIdFromPath txIdStr =
@@ -380,40 +522,46 @@ handleRecoverCommitUtxo putClientInput apiTransactionTimeout responseChannel rec
       Right txid -> Right txid
       Left _ -> case parseEither parseJSON (Aeson.String txIdStr) of
         Right txid -> Right txid
-        Left e -> Left $ responseLBS status400 jsonContent (Aeson.encode $ Aeson.String $ "Cannot recover funds. Failed to parse TxId: " <> pack e)
+        Left e -> Left $ respondApi respEnc status400 ("Cannot recover funds. Failed to parse TxId: " <> pack e)
 
 -- | Handle request to submit a cardano transaction.
 handleSubmitUserTx ::
   forall tx.
-  FromJSON tx =>
+  (FromJSON tx, FromCBOR tx) =>
   Chain tx IO ->
+  -- | Request body encoding.
+  ApiEncoding ->
+  -- | Response encoding.
+  ApiEncoding ->
   -- | Request body.
   LBS.ByteString ->
   IO Response
-handleSubmitUserTx directChain body = do
-  case Aeson.eitherDecode' body of
+handleSubmitUserTx directChain reqEnc respEnc body = do
+  case decodeWire reqEnc body of
     Left err ->
-      pure $ responseLBS status400 jsonContent (Aeson.encode $ Aeson.String $ pack err)
+      pure $ respondApi respEnc status400 (pack err)
     Right txToSubmit -> do
       try (submitTx txToSubmit) <&> \case
-        Left (e :: PostTxError Tx) -> badRequest e
+        Left (e :: PostTxError Tx) -> badRequest respEnc e
         Right _ ->
-          responseLBS status200 jsonContent (Aeson.encode TransactionSubmitted)
+          respondApi respEnc status200 TransactionSubmitted
  where
   Chain{submitTx} = directChain
 
 handleDecommit ::
   forall tx.
-  FromJSON tx =>
+  (FromJSON tx, FromCBOR tx) =>
   (ClientInput tx -> IO ()) ->
   ApiTransactionTimeout ->
   TChan (Either (TimedServerOutput tx) (ClientMessage tx)) ->
+  ApiEncoding ->
+  ApiEncoding ->
   LBS.ByteString ->
   IO Response
-handleDecommit putClientInput apiTransactionTimeout responseChannel body =
-  case Aeson.eitherDecode' body :: Either String tx of
+handleDecommit putClientInput apiTransactionTimeout responseChannel reqEnc respEnc body =
+  case decodeWire reqEnc body :: Either String tx of
     Left err ->
-      pure $ responseLBS status400 jsonContent (Aeson.encode $ Aeson.String $ pack err)
+      pure $ respondApi respEnc status400 (pack err)
     Right decommitTx -> do
       dupChannel <- atomically $ dupTChan responseChannel
       putClientInput Decommit{decommitTx}
@@ -421,27 +569,18 @@ handleDecommit putClientInput apiTransactionTimeout responseChannel body =
             event <- atomically $ readTChan dupChannel
             case event of
               Left TimedServerOutput{output = DecommitFinalized{}} ->
-                pure $ responseLBS status200 jsonContent (Aeson.encode $ Aeson.String "OK")
+                pure $ respondApi respEnc status200 ("OK" :: Text)
               Left TimedServerOutput{output = DecommitInvalid{}} ->
-                pure $ responseLBS status400 jsonContent (Aeson.encode $ Aeson.String "Decommit invalid")
+                pure $ respondApi respEnc status400 ("Decommit invalid" :: Text)
               Right (CommandFailed{clientInput = Decommit{}}) ->
-                pure $ responseLBS status400 jsonContent (Aeson.encode $ Aeson.String "Decommit failed")
+                pure $ respondApi respEnc status400 ("Decommit failed" :: Text)
               Right (RejectedInputBecauseUnsynced{clientInput = Decommit{}, drift}) ->
-                pure $ responseLBS status503 jsonContent (Aeson.encode $ Aeson.String ("Decommit failed because because node is out of sync with chain, drift: " <> show drift))
+                pure $ respondApi respEnc status503 ("Decommit failed because because node is out of sync with chain, drift: " <> show drift :: Text)
               _ -> wait
       timeout (realToFrac (apiTransactionTimeoutNominalDiffTime apiTransactionTimeout)) wait >>= \case
         Just r -> pure r
         Nothing ->
-          pure $
-            responseLBS
-              status202
-              jsonContent
-              ( Aeson.encode $
-                  object
-                    [ "tag" .= Aeson.String "DecommitSubmitted"
-                    , "timeout" .= Aeson.String ("Operation timed out after " <> pack (show apiTransactionTimeout) <> " seconds")
-                    ]
-              )
+          pure $ respondApi respEnc status202 $ operationTimedOut "DecommitSubmitted" apiTransactionTimeout
 
 -- | Handle request to side load confirmed snapshot.
 handleSideLoadSnapshot ::
@@ -450,12 +589,14 @@ handleSideLoadSnapshot ::
   (ClientInput tx -> IO ()) ->
   ApiTransactionTimeout ->
   TChan (Either (TimedServerOutput tx) (ClientMessage tx)) ->
+  ApiEncoding ->
+  ApiEncoding ->
   LBS.ByteString ->
   IO Response
-handleSideLoadSnapshot putClientInput apiTransactionTimeout responseChannel body = do
-  case Aeson.eitherDecode' body :: Either String (SideLoadSnapshotRequest tx) of
+handleSideLoadSnapshot putClientInput apiTransactionTimeout responseChannel reqEnc respEnc body = do
+  case decodeWire reqEnc body :: Either String (SideLoadSnapshotRequest tx) of
     Left err ->
-      pure $ responseLBS status400 jsonContent (Aeson.encode $ Aeson.String $ pack err)
+      pure $ respondApi respEnc status400 (pack err)
     Right SideLoadSnapshotRequest{snapshot} -> do
       dupChannel <- atomically $ dupTChan responseChannel
       putClientInput $ SideLoadSnapshot snapshot
@@ -463,27 +604,18 @@ handleSideLoadSnapshot putClientInput apiTransactionTimeout responseChannel body
             event <- atomically $ readTChan dupChannel
             case event of
               Left TimedServerOutput{output = SnapshotSideLoaded{}} ->
-                pure $ responseLBS status200 jsonContent (Aeson.encode $ Aeson.String "OK")
+                pure $ respondApi respEnc status200 ("OK" :: Text)
               Right (SideLoadSnapshotRejected{clientInput = SideLoadSnapshot{}, requirementFailure}) ->
-                pure $ responseLBS status400 jsonContent (Aeson.encode requirementFailure)
+                pure $ respondApi respEnc status400 requirementFailure
               Right (CommandFailed{clientInput = SideLoadSnapshot{}}) ->
-                pure $ responseLBS status400 jsonContent (Aeson.encode $ Aeson.String "Side-load snapshot failed")
+                pure $ respondApi respEnc status400 ("Side-load snapshot failed" :: Text)
               Right (RejectedInputBecauseUnsynced{clientInput = SideLoadSnapshot{}, drift}) ->
-                pure $ responseLBS status503 jsonContent (Aeson.encode $ Aeson.String ("Side-load snapshot failed because node is out of sync with chain, drift: " <> show drift))
+                pure $ respondApi respEnc status503 ("Side-load snapshot failed because node is out of sync with chain, drift: " <> show drift :: Text)
               _ -> wait
       timeout (realToFrac (apiTransactionTimeoutNominalDiffTime apiTransactionTimeout)) wait >>= \case
         Just r -> pure r
         Nothing ->
-          pure $
-            responseLBS
-              status202
-              jsonContent
-              ( Aeson.encode $
-                  object
-                    [ "tag" .= Aeson.String "SideLoadSnapshotSubmitted"
-                    , "timeout" .= Aeson.String ("Operation timed out after " <> pack (show apiTransactionTimeout) <> " seconds")
-                    ]
-              )
+          pure $ respondApi respEnc status202 $ operationTimedOut "SideLoadSnapshotSubmitted" apiTransactionTimeout
 
 -- | Handle request to submit a transaction to the head.
 handleSubmitL2Tx ::
@@ -492,12 +624,14 @@ handleSubmitL2Tx ::
   (ClientInput tx -> IO ()) ->
   ApiTransactionTimeout ->
   TChan (Either (TimedServerOutput tx) (ClientMessage tx)) ->
+  ApiEncoding ->
+  ApiEncoding ->
   LBS.ByteString ->
   IO Response
-handleSubmitL2Tx putClientInput apiTransactionTimeout responseChannel body = do
-  case Aeson.eitherDecode' @(SubmitL2TxRequest tx) body of
+handleSubmitL2Tx putClientInput apiTransactionTimeout responseChannel reqEnc respEnc body = do
+  case decodeWire @(SubmitL2TxRequest tx) reqEnc body of
     Left err ->
-      pure $ responseLBS status400 jsonContent (Aeson.encode $ Aeson.String $ pack err)
+      pure $ respondApi respEnc status400 (pack err)
     Right SubmitL2TxRequest{submitL2Tx} -> do
       -- Duplicate the channel to avoid consuming messages from other consumers.
       dupChannel <- atomically $ dupTChan responseChannel
@@ -513,25 +647,21 @@ handleSubmitL2Tx putClientInput apiTransactionTimeout responseChannel body = do
 
       case result of
         Just (SubmitTxConfirmed snapshotNumber) ->
-          pure $ responseLBS status200 jsonContent (Aeson.encode $ SubmitTxConfirmed snapshotNumber)
+          pure $ respondApi respEnc status200 (SubmitTxConfirmed snapshotNumber)
         Just (SubmitTxInvalidResponse validationError) ->
-          pure $ responseLBS status400 jsonContent (Aeson.encode $ SubmitTxInvalidResponse validationError)
+          pure $ respondApi respEnc status400 (SubmitTxInvalidResponse validationError)
         Just (SubmitTxRejectedResponse reason) ->
-          pure $ responseLBS status503 jsonContent (Aeson.encode $ SubmitTxRejectedResponse reason)
+          pure $ respondApi respEnc status503 (SubmitTxRejectedResponse reason)
         Just SubmitTxSubmitted ->
-          pure $ responseLBS status202 jsonContent (Aeson.encode SubmitTxSubmitted)
+          pure $ respondApi respEnc status202 SubmitTxSubmitted
         Nothing ->
           -- Timeout occurred - return 202 Accepted with timeout info
           pure $
-            responseLBS
-              status202
-              jsonContent
-              ( Aeson.encode $
-                  object
-                    [ "tag" .= Aeson.String "SubmitTxSubmitted"
-                    , "timeout" .= Aeson.String ("Transaction submission timed out after " <> pack (show apiTransactionTimeout) <> " seconds")
-                    ]
-              )
+            respondApi respEnc status202 $
+              OperationTimedOut
+                { tag = "SubmitTxSubmitted"
+                , timeoutMessage = "Transaction submission timed out after " <> pack (show apiTransactionTimeout) <> " seconds"
+                }
  where
   --  Wait for transaction result by listening to events
   waitForTransactionResult :: TChan (Either (TimedServerOutput tx) (ClientMessage tx)) -> TxIdType tx -> IO SubmitL2TxResponse
@@ -557,11 +687,11 @@ handleSubmitL2Tx putClientInput apiTransactionTimeout responseChannel body = do
           _ -> go
         Right _ -> go
 
-badRequest :: IsChainState tx => PostTxError tx -> Response
-badRequest = responseLBS status400 jsonContent . Aeson.encode . toJSON
+badRequest :: IsChainState tx => ApiEncoding -> PostTxError tx -> Response
+badRequest apiEncoding = respondApi apiEncoding status400
 
-notFound :: Response
-notFound = responseLBS status404 jsonContent (Aeson.encode $ Aeson.String "")
+notFound :: ApiEncoding -> Response
+notFound apiEncoding = respondApi apiEncoding status404 ("" :: Text)
 
 okJSON :: ToJSON a => a -> Response
 okJSON = responseLBS status200 jsonContent . Aeson.encode

--- a/hydra-node/src/Hydra/API/ServerOutput.hs
+++ b/hydra-node/src/Hydra/API/ServerOutput.hs
@@ -2,7 +2,10 @@
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Hydra.API.ServerOutput where
+module Hydra.API.ServerOutput (
+  module Hydra.API.ServerOutput,
+  ApiEncoding (..),
+) where
 
 import Cardano.Binary (Decoder)
 import Control.Lens ((.~))
@@ -11,6 +14,7 @@ import Data.Aeson.KeyMap qualified as KeyMap
 import Data.Aeson.Lens (atKey, key)
 import Data.ByteString.Lazy qualified as LBS
 import Hydra.API.ClientInput (ClientInput)
+import Hydra.API.WireFormat (ApiEncoding (..))
 import Hydra.Chain (PostChainTx, PostTxError)
 import Hydra.Chain.ChainState (ChainSlot, IsChainState)
 import Hydra.HeadLogic.Error (SideLoadRequirementFailure)
@@ -54,6 +58,8 @@ instance IsChainState tx => FromJSON (TimedServerOutput tx) where
 
 -- NOTE: Unlike the JSON instance, which merges 'seq' and 'timestamp' into the
 -- inner 'ServerOutput' object, the CBOR encoding is a plain tagged envelope.
+-- The tag makes any server-sent message start with a unique text token, so
+-- clients can dispatch on it (see 'ApiMessage').
 instance IsChainState tx => ToCBOR (TimedServerOutput tx) where
   toCBOR = genericToCBOR
 
@@ -107,7 +113,17 @@ instance IsChainState tx => ToCBOR (ClientMessage tx) where
   toCBOR = genericToCBOR
 
 instance IsChainState tx => FromCBOR (ClientMessage tx) where
-  fromCBOR = genericFromCBOR
+  fromCBOR = fromCBOR >>= decodeClientMessageBody
+
+-- | Decode a 'ClientMessage' given its already-decoded constructor tag (used
+-- for tag-based dispatch in 'ApiMessage').
+decodeClientMessageBody :: IsChainState tx => Text -> Decoder s (ClientMessage tx)
+decodeClientMessageBody = \case
+  "CommandFailed" -> CommandFailed <$> fromCBOR <*> fromCBOR
+  "PostTxOnChainFailed" -> PostTxOnChainFailed <$> fromCBOR <*> fromCBOR
+  "RejectedInputBecauseUnsynced" -> RejectedInputBecauseUnsynced <$> fromCBOR <*> fromCBOR
+  "SideLoadSnapshotRejected" -> SideLoadSnapshotRejected <$> fromCBOR <*> fromCBOR
+  tag -> fail $ show tag <> " is not a proper CBOR-encoded ClientMessage"
 
 -- | A friendly welcome message which tells a client something about the
 -- node. Currently used for knowing what signing key the server uses (it
@@ -165,7 +181,7 @@ instance IsChainState tx => FromCBOR (Greetings tx) where
       tag -> fail $ show tag <> " is not a proper CBOR-encoded Greetings"
 
 -- | Decode a 'Greetings' after its @Greetings@ tag has already been consumed
--- (used for tag-based dispatch).
+-- (used for tag-based dispatch in 'ApiMessage').
 decodeGreetingsBody :: IsChainState tx => Decoder s (Greetings tx)
 decodeGreetingsBody = do
   me <- fromCBOR
@@ -199,12 +215,60 @@ instance FromCBOR InvalidInput where
       tag -> fail $ show tag <> " is not a proper CBOR-encoded InvalidInput"
 
 -- | Decode an 'InvalidInput' after its @InvalidInput@ tag has already been
--- consumed (used for tag-based dispatch).
+-- consumed (used for tag-based dispatch in 'ApiMessage').
 decodeInvalidInputBody :: Decoder s InvalidInput
 decodeInvalidInputBody = do
   reason <- toString <$> fromCBOR @Text
   input <- fromCBOR
   pure InvalidInput{reason, input}
+
+-- | Union of all messages the hydra-node sends to clients. Only used for
+-- decoding on the client side; the server encodes and sends the individual
+-- types directly (their encodings are the same as the union's).
+--
+-- In CBOR, every server-sent message starts with a text tag that is unique
+-- across the whole API surface, so a single tag read suffices to dispatch.
+data ApiMessage tx
+  = ApiTimedServerOutput (TimedServerOutput tx)
+  | ApiClientMessage (ClientMessage tx)
+  | ApiGreetings (Greetings tx)
+  | ApiInvalidInput InvalidInput
+  deriving stock (Generic)
+
+deriving stock instance IsChainState tx => Eq (ApiMessage tx)
+deriving stock instance IsChainState tx => Show (ApiMessage tx)
+
+instance IsChainState tx => ToJSON (ApiMessage tx) where
+  toJSON = \case
+    ApiTimedServerOutput o -> toJSON o
+    ApiClientMessage m -> toJSON m
+    ApiGreetings g -> toJSON g
+    ApiInvalidInput i -> toJSON i
+
+instance IsChainState tx => FromJSON (ApiMessage tx) where
+  parseJSON v =
+    (ApiTimedServerOutput <$> parseJSON v)
+      <|> (ApiClientMessage <$> parseJSON v)
+      <|> (ApiGreetings <$> parseJSON v)
+      <|> (ApiInvalidInput <$> parseJSON v)
+
+instance IsChainState tx => ToCBOR (ApiMessage tx) where
+  toCBOR = \case
+    ApiTimedServerOutput o -> toCBOR o
+    ApiClientMessage m -> toCBOR m
+    ApiGreetings g -> toCBOR g
+    ApiInvalidInput i -> toCBOR i
+
+instance IsChainState tx => FromCBOR (ApiMessage tx) where
+  fromCBOR =
+    fromCBOR >>= \case
+      ("TimedServerOutput" :: Text) ->
+        -- Tag already consumed; decode the fields in declaration order as
+        -- 'genericFromCBOR' would.
+        ApiTimedServerOutput <$> (TimedServerOutput <$> fromCBOR <*> fromCBOR <*> fromCBOR)
+      "Greetings" -> ApiGreetings <$> decodeGreetingsBody
+      "InvalidInput" -> ApiInvalidInput <$> decodeInvalidInputBody
+      tag -> ApiClientMessage <$> decodeClientMessageBody tag
 
 data ServerOutput tx
   = NetworkConnected
@@ -312,6 +376,7 @@ data WithAddressedTx = WithAddressedTx Text | WithoutAddressedTx
 data ServerOutputConfig = ServerOutputConfig
   { utxoInSnapshot :: WithUTxO
   , addressInTx :: WithAddressedTx
+  , encoding :: ApiEncoding
   }
   deriving stock (Eq, Show)
 
@@ -339,7 +404,15 @@ prepareServerOutput config response =
     TxValid{} -> encodedResponse
     TxInvalid{} -> encodedResponse
     SnapshotConfirmed{} ->
-      handleUtxoInclusion config removeSnapshotUTxO encodedResponse
+      case utxoInSnapshot config of
+        WithUTxO -> encodedResponse
+        WithoutUTxO ->
+          -- Filter before serializing: 'handleUtxoInclusionTyped' empties the
+          -- utxo so its (potentially huge) 'Value' tree is never built, and
+          -- 'removeSnapshotUTxO' drops the residual empty key on the 'Value'
+          -- to keep the wire format identical (utxo key absent). This avoids
+          -- the old encode -> re-parse -> re-encode byte surgery.
+          encode . removeSnapshotUTxO . toJSON $ handleUtxoInclusionTyped config response
     IgnoredHeadInitializing{} -> encodedResponse
     DecommitRequested{} -> encodedResponse
     DecommitApproved{} -> encodedResponse
@@ -364,14 +437,45 @@ prepareServerOutput config response =
  where
   encodedResponse = encode response
 
-removeSnapshotUTxO :: LBS.ByteString -> LBS.ByteString
+-- | Drop the snapshot @utxo@ key from an already-converted JSON 'Value'.
+-- Working on the 'Value' (rather than encoded bytes) avoids a full re-parse
+-- and re-encode of the message.
+removeSnapshotUTxO :: Value -> Value
 removeSnapshotUTxO = key "snapshot" . atKey "utxo" .~ Nothing
 
-handleUtxoInclusion :: ServerOutputConfig -> (a -> a) -> a -> a
-handleUtxoInclusion config f bs =
+-- | Typed snapshot-utxo filter: with 'WithoutUTxO', the snapshot's utxo is
+-- replaced by 'mempty' before encoding. Used directly on CBOR connections
+-- (which keep the empty utxo set on the wire) and on the JSON path combined
+-- with 'removeSnapshotUTxO' (which then drops the residual empty key).
+--
+-- NOTE: These are display-only filters and not meant to round-trip back into
+-- a valid 'Snapshot'.
+handleUtxoInclusionTyped :: IsTx tx => ServerOutputConfig -> TimedServerOutput tx -> TimedServerOutput tx
+handleUtxoInclusionTyped config timed =
   case utxoInSnapshot config of
-    WithUTxO -> bs
-    WithoutUTxO -> bs & f
+    WithUTxO -> timed
+    WithoutUTxO ->
+      case output timed of
+        SnapshotConfirmed{headId, snapshot = Snapshot{headId = snapHeadId, version, number, confirmed, utxoToCommit, utxoToDecommit, accumulator}, signatures} ->
+          timed
+            { output =
+                SnapshotConfirmed
+                  { headId
+                  , snapshot =
+                      Snapshot
+                        { headId = snapHeadId
+                        , version
+                        , number
+                        , confirmed
+                        , utxo = mempty
+                        , utxoToCommit
+                        , utxoToDecommit
+                        , accumulator
+                        }
+                  , signatures
+                  }
+            }
+        _ -> timed
 
 -- | All possible Hydra states displayed in the API server outputs.
 data HeadStatus
@@ -405,6 +509,12 @@ data FanoutProgressMode
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
+instance ToCBOR FanoutProgressMode where
+  toCBOR = genericToCBOR
+
+instance FromCBOR FanoutProgressMode where
+  fromCBOR = genericFromCBOR
+
 -- | Project the internal 'FanoutMode' to its client-facing 'FanoutProgressMode'.
 -- Both auto-drain and mid-selection draining present as 'AutoFanningOut' (the
 -- node advances by itself); only an exhausted selection awaits client input.
@@ -413,12 +523,6 @@ fanoutProgressMode = \case
   AutoDrain -> AutoFanningOut
   DistributingSelection{} -> AutoFanningOut
   AwaitingSelection -> AwaitingFanoutSelection
-
-instance ToCBOR FanoutProgressMode where
-  toCBOR = genericToCBOR
-
-instance FromCBOR FanoutProgressMode where
-  fromCBOR = genericFromCBOR
 
 -- | All information needed to distinguish behavior of the commit endpoint.
 data CommitInfo

--- a/hydra-node/src/Hydra/API/WSServer.hs
+++ b/hydra-node/src/Hydra/API/WSServer.hs
@@ -6,18 +6,19 @@ module Hydra.API.WSServer where
 
 import Hydra.Prelude hiding (TVar, filter, readTVar, seq)
 
+import Cardano.Binary (serialize')
 import Conduit (ConduitT, ResourceT, mapM_C, runConduitRes, (.|))
 import Control.Concurrent.STM (TChan, dupTChan, readTChan)
 import Control.Concurrent.STM qualified as STM
-import Control.Lens ((.~))
 import Data.Aeson qualified as Aeson
-import Data.Aeson.Lens (atKey)
+import Data.ByteString.Lazy qualified as LBS
 import Data.Conduit.Combinators (filter)
 import Data.Version (showVersion)
 import Hydra.API.APIServerLog (APIServerLog (..))
 import Hydra.API.ClientInput (ClientInput (SafeClose))
 import Hydra.API.Projection (Projection (..))
 import Hydra.API.ServerOutput (
+  ApiEncoding (..),
   ClientMessage,
   Greetings (..),
   HeadStatus (..),
@@ -28,16 +29,16 @@ import Hydra.API.ServerOutput (
   WithAddressedTx (..),
   WithUTxO (..),
   getSnapshotUtxo,
-  handleUtxoInclusion,
+  handleUtxoInclusionTyped,
   headStatus,
   me,
   prepareServerOutput,
-  removeSnapshotUTxO,
   snapshotUtxo,
  )
 import Hydra.API.ServerOutputFilter (
   ServerOutputFilter (..),
  )
+import Hydra.API.WireFormat (decodeWire, describeWire)
 import Hydra.Chain (Chain (..))
 import Hydra.Chain.ChainState (IsChainState)
 import Hydra.HeadLogic (ClosedState (ClosedState, readyToFanoutSent), HeadState, OpenState (..), PartialFanoutState (..), StateChanged)
@@ -48,15 +49,66 @@ import Hydra.Node.Environment (Environment (..))
 import Hydra.Node.State (ChainPointTime (..), NodeState (..), syncedStatus)
 import Hydra.Tx (HeadId, Party)
 import Network.WebSockets (
+  Connection,
   PendingConnection (pendingRequest),
   RequestHead (..),
   acceptRequest,
   receiveData,
+  sendBinaryData,
   sendTextData,
   withPingThread,
  )
 import Text.URI hiding (ParseException)
 import Text.URI.QQ (queryKey, queryValue)
+
+-- | Per-connection codec: resolves the negotiated wire encoding and the
+-- snapshot-utxo display policy once, so message handling needs no dispatch.
+data WsCodec tx = WsCodec
+  { sendOutput :: TimedServerOutput tx -> IO ()
+  , sendClientMessage :: ClientMessage tx -> IO ()
+  , sendGreetings :: Greetings tx -> IO ()
+  , sendInvalidInput :: InvalidInput -> IO ()
+  , decodeInput :: LBS.ByteString -> Either String (ClientInput tx)
+  , describeInput :: LBS.ByteString -> Text
+  }
+
+-- | Resolve the negotiated encoding into a 'WsCodec'. This is the only place
+-- deciding how messages go onto (and come off) the wire: JSON as text frames,
+-- CBOR as binary frames.
+--
+-- NOTE: Inputs are decoded per the negotiated encoding, never the frame type:
+-- some JSON clients (e.g. the TUI) send binary frames containing JSON.
+mkWsCodec :: IsChainState tx => ServerOutputConfig -> Connection -> WsCodec tx
+mkWsCodec config con =
+  case config.encoding of
+    JsonEncoding ->
+      WsCodec
+        { sendOutput = sendTextData con . prepareServerOutput config
+        , -- NOTE: 'ClientMessage' has no top-level snapshot, so the
+          -- snapshot-utxo filter does not apply to it.
+          sendClientMessage = sendPlainJson
+        , sendGreetings = sendPlainJson
+        , sendInvalidInput = sendPlainJson
+        , decodeInput = decodeWire JsonEncoding
+        , describeInput = describeWire JsonEncoding
+        }
+    CborEncoding ->
+      WsCodec
+        { sendOutput = sendBinaryData con . serialize' . handleUtxoInclusionTyped config
+        , -- NOTE: 'ClientMessage' has no top-level snapshot, so the
+          -- snapshot-utxo filter does not apply to it.
+          sendClientMessage = sendPlainCbor
+        , sendGreetings = sendPlainCbor
+        , sendInvalidInput = sendPlainCbor
+        , decodeInput = decodeWire CborEncoding
+        , describeInput = describeWire CborEncoding
+        }
+ where
+  sendPlainJson :: ToJSON a => a -> IO ()
+  sendPlainJson = sendTextData con . Aeson.encode
+
+  sendPlainCbor :: ToCBOR a => a -> IO ()
+  sendPlainCbor = sendBinaryData con . serialize'
 
 wsApp ::
   forall tx.
@@ -83,39 +135,42 @@ wsApp env party tracer chain history callback nodeStateP networkInfoP responseCh
   chan <- STM.atomically $ dupTChan responseChannel
 
   let outConfig = mkServerOutputConfig queryParams
+      codec = mkWsCodec outConfig con
 
   -- api client can decide if they want to see the past history of server outputs
   when (shouldServeHistory queryParams) $
-    forwardHistory con outConfig
+    forwardHistory codec outConfig
 
-  forwardGreetingOnly outConfig con
+  forwardGreetingOnly codec outConfig
 
   withPingThread con 30 (pure ()) $
     raceLabelled_
-      ("ws-con-receive-inputs", receiveInputs con)
-      ("ws-con-send-outputs", sendOutputs chan con outConfig)
+      ("ws-con-receive-inputs", receiveInputs codec con)
+      ("ws-con-send-outputs", sendOutputs codec chan outConfig)
  where
   -- NOTE: We will add a 'Greetings' message on each API server start. This is
   -- important to make sure the latest configured 'party' is reaching the
   -- client.
-  forwardGreetingOnly config con = do
+  forwardGreetingOnly codec config = do
     nodeState <- atomically getLatestNodeState
     let headState = nodeState.headState
     networkInfo <- atomically getLatestNetworkInfo
-    sendTextData con $
-      handleUtxoInclusion config (atKey "snapshotUtxo" .~ Nothing) $
-        Aeson.encode
+    let greetings =
           Greetings
             { me = party
             , headStatus = getHeadStatus headState
             , hydraHeadId = getHeadId headState
-            , snapshotUtxo = getSnapshotUtxo headState
+            , snapshotUtxo =
+                case config.utxoInSnapshot of
+                  WithUTxO -> getSnapshotUtxo headState
+                  WithoutUTxO -> Nothing
             , hydraNodeVersion = showVersion NetworkVersions.hydraNodeVersion
             , env
             , networkInfo
             , chainSyncedStatus = syncedStatus nodeState
             , currentSlot = nodeState.chainPointTime.currentSlot
             }
+    codec.sendGreetings greetings
 
   Projection{getLatest = getLatestNodeState} = nodeStateP
   Projection{getLatest = getLatestNetworkInfo} = networkInfoP
@@ -125,7 +180,13 @@ wsApp env party tracer chain history callback nodeStateP networkInfoP responseCh
     ServerOutputConfig
       { utxoInSnapshot = decideOnUTxODisplay qp
       , addressInTx = decideOnAddressDisplay qp
+      , encoding = decideOnEncoding qp
       }
+
+  decideOnEncoding :: [QueryParam] -> ApiEncoding
+  decideOnEncoding qp =
+    let queryP = QueryParam [queryKey|encoding|] [queryValue|cbor|]
+     in if queryP `elem` qp then CborEncoding else JsonEncoding
 
   decideOnUTxODisplay :: [QueryParam] -> WithUTxO
   decideOnUTxODisplay qp =
@@ -153,25 +214,25 @@ wsApp env party tracer chain history callback nodeStateP networkInfoP responseCh
         | key == [queryKey|history|] -> val == [queryValue|yes|]
       _other -> False
 
-  sendOutputs chan con outConfig@ServerOutputConfig{addressInTx} = forever $ do
+  sendOutputs codec chan ServerOutputConfig{addressInTx} = forever $ do
     response <- STM.atomically $ readTChan chan
     when (isAddressInTx addressInTx response) $
       sendResponse response
    where
     sendResponse = \case
       Left response -> do
-        let sentResponse = prepareServerOutput outConfig response
-        sendTextData con sentResponse
+        codec.sendOutput response
         traceWith tracer (APIOutputSent $ toJSON response)
       Right response -> do
-        sendTextData con (handleUtxoInclusion outConfig removeSnapshotUTxO $ Aeson.encode response)
+        codec.sendClientMessage response
         traceWith tracer (APIOutputSent $ toJSON response)
 
   Chain{checkNonADAAssets} = chain
 
-  receiveInputs con = forever $ do
+  receiveInputs codec con = forever $ do
     msg <- receiveData con
-    case Aeson.eitherDecode msg of
+    let receivedText = codec.describeInput msg
+    case codec.decodeInput msg of
       Right input -> do
         traceWith tracer (APIInputReceived $ toJSON input)
         case input of
@@ -182,21 +243,19 @@ wsApp env party tracer chain history callback nodeStateP networkInfoP responseCh
               Just confirmedSnapshot ->
                 case checkNonADAAssets confirmedSnapshot of
                   Left nonADAValue -> do
-                    let clientInput = decodeUtf8With lenientDecode $ toStrict msg
                     let errorStr = "Cannot SafeClose with non-ADA assets present: " <> show nonADAValue
-                    sendTextData con $ Aeson.encode $ InvalidInput errorStr clientInput
-                    traceWith tracer (APIInvalidInput errorStr clientInput)
+                    codec.sendInvalidInput $ InvalidInput errorStr receivedText
+                    traceWith tracer (APIInvalidInput errorStr receivedText)
                   Right _ -> callback input
           _ -> callback input
       Left e -> do
         -- XXX(AB): toStrict might be problematic as it implies consuming the full
         -- message to memory
-        let clientInput = decodeUtf8With lenientDecode $ toStrict msg
-        sendTextData con $ Aeson.encode $ InvalidInput e clientInput
-        traceWith tracer (APIInvalidInput e clientInput)
+        codec.sendInvalidInput $ InvalidInput e receivedText
+        traceWith tracer (APIInvalidInput e receivedText)
 
-  forwardHistory con config@ServerOutputConfig{addressInTx} = do
-    runConduitRes $ history .| filter (isAddressInTx addressInTx . Left) .| mapM_C (liftIO . sendTextData con . prepareServerOutput config)
+  forwardHistory codec ServerOutputConfig{addressInTx} =
+    runConduitRes $ history .| filter (isAddressInTx addressInTx . Left) .| mapM_C (liftIO . codec.sendOutput)
 
   isAddressInTx addressInTx = \case
     Left tx -> checkAddress tx

--- a/hydra-node/src/Hydra/API/WireFormat.hs
+++ b/hydra-node/src/Hydra/API/WireFormat.hs
@@ -1,0 +1,37 @@
+-- | Wire encodings of the client API: JSON (the default) or native CBOR.
+--
+-- This module is the single home for the encode/decode primitives shared by
+-- the WebSocket server, the HTTP server and the clients; call sites resolve
+-- the negotiated 'ApiEncoding' once and stay dispatch-free afterwards.
+module Hydra.API.WireFormat where
+
+import Hydra.Prelude
+
+import Cardano.Binary (decodeFull', serialize')
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy qualified as LBS
+
+-- | Which wire encoding a client negotiated: JSON (the default) or native
+-- CBOR. WebSocket clients opt in via the @?encoding=cbor@ query parameter,
+-- HTTP clients via @Accept@ / @Content-Type: application/cbor@ headers.
+data ApiEncoding = JsonEncoding | CborEncoding
+  deriving stock (Eq, Show)
+
+-- | Encode a value in the given wire encoding.
+encodeWire :: (ToJSON a, ToCBOR a) => ApiEncoding -> a -> LBS.ByteString
+encodeWire = \case
+  JsonEncoding -> Aeson.encode
+  CborEncoding -> fromStrict . serialize'
+
+-- | Decode a value in the given wire encoding.
+decodeWire :: (FromJSON a, FromCBOR a) => ApiEncoding -> LBS.ByteString -> Either String a
+decodeWire = \case
+  JsonEncoding -> Aeson.eitherDecode'
+  CborEncoding -> first show . decodeFull' . toStrict
+
+-- | Echo received bytes in a readable form: raw text for JSON, base16 for
+-- CBOR (which is not valid UTF-8).
+describeWire :: ApiEncoding -> LBS.ByteString -> Text
+describeWire = \case
+  JsonEncoding -> decodeUtf8With lenientDecode . toStrict
+  CborEncoding -> encodeBase16 . toStrict

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -358,6 +358,18 @@ onOpenNetworkReqSn env ledger pendingDeposits currentSlot st otherParty sv sn re
                     prevSnapshot = getSnapshot confirmedSnapshot
                     accumulator = Accumulator.applyUTxODelta prevSnapshot.accumulator (snapshotUTxO prevSnapshot) nextCombined
                  in requireValidAccumulatorSize accumulator $ do
+                      -- NOTE: Deep-force the snapshot UTxO (via the same
+                      -- 'hashUTxO' the close tx needs) before storing it in the
+                      -- snapshot: applying transactions leaves the map values
+                      -- as chains of unevaluated thunks, and the first thing to
+                      -- force them would otherwise be the close tx
+                      -- construction, inside the close tx validity window
+                      -- (bounded by the contestation period). At e.g. 1000 UTxO
+                      -- after 4000 txs that forcing costs over a second, enough
+                      -- to miss the validity window on short contestation
+                      -- periods. Forcing here pays the cost incrementally per
+                      -- snapshot, off the time-critical path.
+                      let !_forcedUTxO = hashUTxO nextUTxO
                       -- Spec: ŝ ← ̅S.s + 1
                       -- NOTE: confSn == seenSn == sn here
                       let nextSnapshot =

--- a/hydra-node/test/Hydra/API/HTTPServerSpec.hs
+++ b/hydra-node/test/Hydra/API/HTTPServerSpec.hs
@@ -4,6 +4,7 @@ import Hydra.Prelude hiding (delete, get)
 import Test.Hydra.Prelude
 
 import Cardano.Api.UTxO qualified as UTxO
+import Cardano.Binary (decodeFull', serialize')
 import Control.Concurrent.STM (newTChanIO, writeTChan)
 import Control.Lens ((^?))
 import Data.Aeson (Result (Error, Success), eitherDecode, encode, fromJSON, object, (.=))
@@ -19,7 +20,7 @@ import Hydra.API.HTTPServer (
   SubmitL2TxRequest (..),
   SubmitL2TxResponse (..),
   SubmitTxRequest (..),
-  TransactionSubmitted,
+  TransactionSubmitted (..),
   httpApp,
  )
 import Hydra.API.ServerOutput (ClientMessage (..), CommitInfo (..), DecommitInvalidReason (..), ServerOutput (..), TimedServerOutput (..), getConfirmedSnapshot, getSeenSnapshot, getSnapshotUtxo)
@@ -31,7 +32,7 @@ import Hydra.Cardano.Api (
   renderTxIn,
   serialiseToTextEnvelope,
  )
-import Hydra.Chain (PostTxError (..), draftDepositTx)
+import Hydra.Chain (Chain, PostTxError (..), draftDepositTx, submitTx)
 import Hydra.Chain.Direct.Handlers (rejectLowDeposits)
 import Hydra.HeadLogic.Error (SideLoadRequirementFailure (..))
 import Hydra.HeadLogic.State (ClosedState (..), HeadState (..), SeenSnapshot (..))
@@ -49,7 +50,8 @@ import Hydra.Tx.Snapshot (Snapshot (..))
 import System.FilePath ((</>))
 import System.IO.Unsafe (unsafePerformIO)
 import Test.Aeson.GenericSpecs (roundtripAndGoldenSpecs)
-import Test.Hspec.Wai (MatchBody (..), ResponseMatcher (matchBody), delete, get, post, shouldRespondWith, with)
+import Test.Hspec.Wai (MatchBody (..), ResponseMatcher (matchBody, matchHeaders), delete, get, post, shouldRespondWith, with, (<:>))
+import Test.Hspec.Wai qualified as Wai
 import Test.Hspec.Wai.Internal (withApplication)
 import Test.Hydra.API.HTTPServer ()
 import Test.Hydra.Chain.Direct.State ()
@@ -1017,12 +1019,125 @@ apiServerSpec = do
           $ do
             delete ("/commits/" <> txidText) `shouldRespondWith` 503
 
+    describe "CBOR negotiation" $ do
+      responseChannel <- runIO newTChanIO
+
+      prop "GET /snapshot/last-seen responds CBOR given Accept: application/cbor" $ \nodeState -> do
+        let seenSnapshot :: SeenSnapshot SimpleTx = getSeenSnapshot (headState nodeState)
+        withApplication
+          ( httpApp @SimpleTx
+              nullTracer
+              Aeson.Null
+              dummyChainHandle
+              testEnvironment
+              defaultPParams
+              (pure nodeState)
+              cantCommit
+              getPendingDeposits
+              putClientInput
+              300
+              responseChannel
+          )
+          $ do
+            Wai.request "GET" "/snapshot/last-seen" [("Accept", "application/cbor")] mempty
+              `shouldRespondWith` 200
+                { matchHeaders = ["Content-Type" <:> "application/cbor"]
+                , matchBody = matchCBOR seenSnapshot
+                }
+
+      it "POST /cardano-transaction accepts a CBOR-encoded transaction" $ do
+        let tx = SimpleTx 1 mempty mempty
+            submittingChainHandle :: Chain SimpleTx IO
+            submittingChainHandle = dummyChainHandle{submitTx = const (pure ())}
+        withApplication
+          ( httpApp @SimpleTx
+              nullTracer
+              Aeson.Null
+              submittingChainHandle
+              testEnvironment
+              defaultPParams
+              getNodeState
+              cantCommit
+              getPendingDeposits
+              putClientInput
+              300
+              responseChannel
+          )
+          $ do
+            Wai.request
+              "POST"
+              "/cardano-transaction"
+              [("Content-Type", "application/cbor"), ("Accept", "application/cbor")]
+              (LBS.fromStrict $ serialize' tx)
+              `shouldRespondWith` 200
+                { matchHeaders = ["Content-Type" <:> "application/cbor"]
+                , matchBody = matchCBOR TransactionSubmitted
+                }
+
+      it "responds 400 given a malformed CBOR body with Content-Type: application/cbor" $ do
+        withApplication
+          ( httpApp @SimpleTx
+              nullTracer
+              Aeson.Null
+              dummyChainHandle
+              testEnvironment
+              defaultPParams
+              getNodeState
+              cantCommit
+              getPendingDeposits
+              putClientInput
+              300
+              responseChannel
+          )
+          $ do
+            Wai.request
+              "POST"
+              "/cardano-transaction"
+              [("Content-Type", "application/cbor")]
+              "not a valid CBOR transaction"
+              `shouldRespondWith` 400
+
+      prop "GET /snapshot/last-seen still responds JSON without CBOR headers" $ \nodeState -> do
+        let seenSnapshot :: SeenSnapshot SimpleTx = getSeenSnapshot (headState nodeState)
+        withApplication
+          ( httpApp @SimpleTx
+              nullTracer
+              Aeson.Null
+              dummyChainHandle
+              testEnvironment
+              defaultPParams
+              (pure nodeState)
+              cantCommit
+              getPendingDeposits
+              putClientInput
+              300
+              responseChannel
+          )
+          $ do
+            get "/snapshot/last-seen"
+              `shouldRespondWith` 200
+                { matchHeaders = ["Content-Type" <:> "application/json"]
+                , matchBody = matchJSON seenSnapshot
+                }
+
 -- * Helpers
 
 -- | Create a 'ResponseMatcher' or 'MatchBody' from a JSON serializable value
 -- (using their 'IsString' instances).
 matchJSON :: (IsString s, ToJSON a) => a -> s
 matchJSON = fromString . decodeUtf8 . encode
+
+-- | Create a 'MatchBody' that CBOR-decodes the response body and compares it
+-- to an expected value.
+matchCBOR :: (Eq a, Show a, FromCBOR a) => a -> MatchBody
+matchCBOR expected =
+  MatchBody $ \_headers body ->
+    case decodeFull' (toStrict body) of
+      Left err -> Just $ "failed to decode CBOR body: " <> show err
+      Right actual
+        | actual == expected -> Nothing
+        | otherwise ->
+            Just $ "decoded CBOR body: " <> show actual <> "\ndoes not match expected: " <> show expected
 
 -- | Create a 'MatchBody' that validates the returned JSON response against a
 -- schema. NOTE: This raises impure exceptions, so only use it in this test

--- a/hydra-node/test/Hydra/API/ServerSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerSpec.hs
@@ -5,6 +5,7 @@ module Hydra.API.ServerSpec where
 import Hydra.Prelude hiding (decodeUtf8, seq)
 import Test.Hydra.Prelude
 
+import Cardano.Binary (decodeFull', serialize')
 import Conduit (yieldMany)
 import Control.Concurrent.Class.MonadSTM (
   check,
@@ -24,8 +25,9 @@ import Data.Text.Encoding (decodeUtf8)
 import Data.Text.IO (hPutStrLn)
 import Data.Version (showVersion)
 import Hydra.API.APIServerLog (APIServerLog)
+import Hydra.API.ClientInput (ClientInput (Init))
 import Hydra.API.Server (APIServerConfig (..), RunServerException (..), Server, mkTimedServerOutputFromStateEvent, withAPIServer)
-import Hydra.API.ServerOutput (InvalidInput (..), input)
+import Hydra.API.ServerOutput (ApiMessage (..), InvalidInput (..), input)
 import Hydra.API.ServerOutputFilter (ServerOutputFilter (..))
 import Hydra.Chain (
   Chain (Chain),
@@ -314,6 +316,65 @@ spec =
         withFreePort $
           \port -> sendsAnErrorWhenInputCannotBeDecoded port
 
+    describe "CBOR encoding" $ do
+      it "sends a CBOR-encoded greeting when connecting with encoding=cbor" $
+        failAfter 5 $
+          showLogsOnFailure "ServerSpec" $ \tracer ->
+            withFreePort $ \port ->
+              withTestAPIServer port alice (mockSource []) tracer $ \_ ->
+                withClient port "/?encoding=cbor&history=no" $ \conn -> do
+                  bytes :: ByteString <- receiveData conn
+                  case decodeFull' @(ApiMessage SimpleTx) bytes of
+                    Left err -> failure $ "Failed to decode CBOR greeting: " <> show err
+                    Right ApiGreetings{} -> pure ()
+                    Right other -> failure $ "Expected ApiGreetings, but got: " <> show other
+
+      it "sends server outputs CBOR-encoded to clients connected with encoding=cbor" $
+        failAfter 5 $
+          showLogsOnFailure "ServerSpec" $ \tracer ->
+            withFreePort $ \port ->
+              withTestAPIServer port alice (mockSource []) tracer $ \(EventSink{putEvent}, _) ->
+                withClient port "/?encoding=cbor&history=no" $ \conn -> do
+                  _greeting :: ByteString <- receiveData conn
+                  arbitraryEvent <- generate genStateEventForApi
+                  let expectedMessage =
+                        fromMaybe (error "failed to convert stateEvent") $
+                          mkTimedServerOutputFromStateEvent Nothing arbitraryEvent
+                  putEvent arbitraryEvent
+                  bytes :: ByteString <- receiveData conn
+                  case decodeFull' @(ApiMessage SimpleTx) bytes of
+                    Left err -> failure $ "Failed to decode CBOR server output: " <> show err
+                    Right (ApiTimedServerOutput timedOutput) -> timedOutput `shouldBe` expectedMessage
+                    Right other -> failure $ "Expected ApiTimedServerOutput, but got: " <> show other
+
+      it "accepts CBOR-encoded client inputs when connected with encoding=cbor" $
+        failAfter 5 $
+          showLogsOnFailure "ServerSpec" $ \tracer ->
+            withFreePort $ \port -> do
+              inputs <- newLabelledTQueueIO "cbor-inputs"
+              let recordInput = atomically . writeTQueue inputs
+              withTestAPIServerWithCallback port alice (mockSource []) tracer recordInput $ \_ ->
+                withClient port "/?encoding=cbor&history=no" $ \conn -> do
+                  _greeting :: ByteString <- receiveData conn
+                  sendBinaryData conn $ serialize' (Init :: ClientInput SimpleTx)
+                  failAfter 1 $ atomically (readTQueue inputs) `shouldReturn` Init
+
+      it "sends a CBOR-encoded InvalidInput when input is not valid CBOR" $
+        failAfter 5 $
+          showLogsOnFailure "ServerSpec" $ \tracer ->
+            withFreePort $ \port ->
+              withTestAPIServer port alice (mockSource []) tracer $ \_ ->
+                withClient port "/?encoding=cbor&history=no" $ \conn -> do
+                  _greeting :: ByteString <- receiveData conn
+                  let garbage = "not a valid CBOR message" :: ByteString
+                  sendBinaryData conn garbage
+                  bytes :: ByteString <- receiveData conn
+                  case decodeFull' @(ApiMessage SimpleTx) bytes of
+                    Left err -> failure $ "Failed to decode CBOR InvalidInput: " <> show err
+                    Right (ApiInvalidInput InvalidInput{input = echoed}) ->
+                      echoed `shouldBe` encodeBase16 garbage
+                    Right other -> failure $ "Expected ApiInvalidInput, but got: " <> show other
+
     describe "TLS support" $ do
       it "accepts TLS connections when configured" $ do
         showLogsOnFailure "ServerSpec" $ \tracer ->
@@ -397,7 +458,20 @@ withTestAPIServer ::
   ((EventSink (StateEvent SimpleTx) IO, Server SimpleTx IO) -> IO ()) ->
   IO ()
 withTestAPIServer port actor eventSource tracer =
-  withAPIServer @SimpleTx config defaultRunOptions testEnvironment actor eventSource tracer 0 dummyChainHandle defaultPParams allowEverythingServerOutputFilter noop
+  withTestAPIServerWithCallback port actor eventSource tracer noop
+
+-- | Like 'withTestAPIServer', but with an explicit callback invoked for every
+-- 'ClientInput' received by the server.
+withTestAPIServerWithCallback ::
+  PortNumber ->
+  Party ->
+  EventSource (StateEvent SimpleTx) IO ->
+  Tracer IO APIServerLog ->
+  (ClientInput SimpleTx -> IO ()) ->
+  ((EventSink (StateEvent SimpleTx) IO, Server SimpleTx IO) -> IO ()) ->
+  IO ()
+withTestAPIServerWithCallback port actor eventSource tracer =
+  withAPIServer @SimpleTx config defaultRunOptions testEnvironment actor eventSource tracer 0 dummyChainHandle defaultPParams allowEverythingServerOutputFilter
  where
   config = APIServerConfig{host = "127.0.0.1", port, tlsCertPath = Nothing, tlsKeyPath = Nothing, apiTransactionTimeout = 1000000}
 

--- a/hydra-node/test/Hydra/CBORSpec.hs
+++ b/hydra-node/test/Hydra/CBORSpec.hs
@@ -27,6 +27,15 @@ import Test.Hydra.Prelude
 import Cardano.Binary (decodeFull', serialize')
 import Codec.CBOR.Write (toStrictByteString)
 import Hydra.API.ClientInput (ClientInput)
+import Hydra.API.HTTPServer (
+  DraftCommitTxRequest,
+  OperationTimedOut (..),
+  SideLoadSnapshotRequest (..),
+  SubmitL2TxRequest,
+  SubmitL2TxResponse,
+  SubmitTxRequest,
+  TransactionSubmitted,
+ )
 import Hydra.API.ServerOutput (
   ClientMessage,
   DecommitInvalidReason,
@@ -63,6 +72,7 @@ import Hydra.Tx.Crypto (MultiSignature, Signature)
 import Hydra.Tx.DepositPeriod (DepositPeriod)
 import Hydra.Tx.OnChainId (OnChainId)
 import Test.Hydra.API.ClientInput ()
+import Test.Hydra.API.HTTPServer ()
 import Test.Hydra.API.ServerOutput ()
 import Test.Hydra.CBOR (genGoldenSample, genGoldenSamples, goldenCBOR, roundtripCBOR)
 import Test.Hydra.Chain.Direct.State ()
@@ -83,6 +93,9 @@ import Test.QuickCheck.Arbitrary.ADT (ADTArbitrary (..), ConstructorArbitraryPai
 
 instance Arbitrary InvalidInput where
   arbitrary = InvalidInput <$> arbitrary <*> arbitrary
+
+instance Arbitrary OperationTimedOut where
+  arbitrary = OperationTimedOut <$> arbitrary <*> arbitrary
 
 -- * ToADTArbitrary instances for per-constructor golden samples
 
@@ -178,6 +191,13 @@ spec = parallel $ do
     roundtripCBOR $ Proxy @InvalidInput
     roundtripCBOR $ Proxy @HeadStatus
     roundtripCBOR $ Proxy @NetworkInfo
+    roundtripCBOR $ Proxy @(DraftCommitTxRequest Tx)
+    roundtripCBOR $ Proxy @(SubmitTxRequest Tx)
+    roundtripCBOR $ Proxy @TransactionSubmitted
+    roundtripCBOR $ Proxy @(SideLoadSnapshotRequest Tx)
+    roundtripCBOR $ Proxy @(SubmitL2TxRequest Tx)
+    roundtripCBOR $ Proxy @SubmitL2TxResponse
+    roundtripCBOR $ Proxy @OperationTimedOut
 
   describe "protocol types" $ do
     roundtripCBOR $ Proxy @(Snapshot Tx)

--- a/hydra-tui/hydra-tui.cabal
+++ b/hydra-tui/hydra-tui.cabal
@@ -63,6 +63,7 @@ library
     , base
     , brick                 >=1.10
     , cardano-api
+    , cardano-binary
     , containers
     , directory
     , filepath

--- a/hydra-tui/src/Hydra/Client.hs
+++ b/hydra-tui/src/Hydra/Client.hs
@@ -4,13 +4,15 @@ module Hydra.Client where
 
 import Hydra.Prelude
 
+import Cardano.Binary (serialize')
 import Control.Concurrent.Async (link)
 import Control.Concurrent.Class.MonadSTM (readTBQueue, writeTBQueue)
 import Control.Exception (Handler (Handler), IOException, catches)
-import Data.Aeson (eitherDecodeStrict, encode)
+import Data.Aeson (encode)
 import Hydra.API.ClientInput (ClientInput)
 import Hydra.API.HTTPServer (DraftCommitTxRequest (..), DraftCommitTxResponse (..))
-import Hydra.API.ServerOutput (ClientMessage, Greetings, InvalidInput, TimedServerOutput)
+import Hydra.API.ServerOutput (ApiEncoding (..), ApiMessage (..))
+import Hydra.API.WireFormat (decodeWire)
 import Hydra.Cardano.Api (TxId, UTxO)
 import Hydra.Cardano.Api.Prelude (
   PaymentKey,
@@ -32,27 +34,12 @@ import Network.WebSockets (Connection, ConnectionException, receiveData, runClie
 data HydraEvent tx
   = ClientConnected
   | ClientDisconnected
-  | Update (AllPossibleAPIMessages tx)
+  | Update (ApiMessage tx)
   | Tick UTCTime
   deriving stock (Generic)
 
 deriving stock instance IsChainState tx => Eq (HydraEvent tx)
 deriving stock instance IsChainState tx => Show (HydraEvent tx)
-
--- | All possible messages that expect to receive from the hydra-node.
-data AllPossibleAPIMessages tx
-  = ApiTimedServerOutput (TimedServerOutput tx)
-  | ApiClientMessage (ClientMessage tx)
-  | ApiGreetings (Greetings tx)
-  | ApiInvalidInput InvalidInput
-  deriving stock (Eq, Show)
-
-instance IsChainState tx => FromJSON (AllPossibleAPIMessages tx) where
-  parseJSON v =
-    (ApiTimedServerOutput <$> parseJSON v)
-      <|> (ApiClientMessage <$> parseJSON v)
-      <|> (ApiGreetings <$> parseJSON v)
-      <|> (ApiInvalidInput <$> parseJSON v)
 
 -- | Handle to interact with Hydra node
 data Client tx m = Client
@@ -75,7 +62,7 @@ withClient ::
   IsChainState tx =>
   Options ->
   ClientComponent tx IO a
-withClient Options{hydraNodeHost = Host{hostname, port}, cardanoSigningKey, cardanoNetworkId, cardanoConnection} callback action = do
+withClient Options{hydraNodeHost = Host{hostname, port}, cardanoSigningKey, cardanoNetworkId, cardanoConnection, apiEncoding} callback action = do
   sk <- readExternalSk
   q <- newLabelledTBQueueIO "tui-client-queue" 10
   withAsyncLabelled ("client-reconnect", reconnect $ client q) $ \thread -> do
@@ -91,22 +78,29 @@ withClient Options{hydraNodeHost = Host{hostname, port}, cardanoSigningKey, card
         }
  where
   readExternalSk = mkSecret <$> readFileTextEnvelopeThrow cardanoSigningKey
+
+  queryString = case apiEncoding of
+    JsonEncoding -> "/?history=yes"
+    CborEncoding -> "/?history=yes&encoding=cbor"
+
   -- TODO(SN): ping thread?
-  client q = runClient (toString hostname) (fromIntegral port) "/?history=yes" $ \con -> do
+  client q = runClient (toString hostname) (fromIntegral port) queryString $ \con -> do
     -- REVIEW(SN): is sharing the 'con' fine?
     callback ClientConnected
     raceLabelled_ ("receive-outputs", receiveOutputs con) ("send-inputs", sendInputs q con)
 
   receiveOutputs con = forever $ do
     msg <- receiveData con
-    case eitherDecodeStrict msg :: Either String (AllPossibleAPIMessages tx) of
+    case decodeWire apiEncoding (fromStrict msg) :: Either String (ApiMessage tx) of
       Left err -> throwIO $ ClientJSONDecodeError err msg
       Right output -> callback $ Update output
 
   sendInputs :: TBQueue IO (ClientInput tx) -> Connection -> IO ()
   sendInputs q con = forever $ do
     input <- atomically $ readTBQueue q
-    sendBinaryData con $ encode input
+    case apiEncoding of
+      JsonEncoding -> sendBinaryData con $ encode input
+      CborEncoding -> sendBinaryData con $ serialize' input
 
   reconnect f =
     f

--- a/hydra-tui/src/Hydra/TUI/Handlers.hs
+++ b/hydra-tui/src/Hydra/TUI/Handlers.hs
@@ -24,13 +24,13 @@ import Graphics.Vty (
  )
 import Graphics.Vty qualified as Vty
 import Hydra.API.ClientInput (ClientInput (..))
-import Hydra.API.ServerOutput (FanoutProgressMode (..), NetworkInfo (..), TimedServerOutput (..))
+import Hydra.API.ServerOutput (ApiMessage (..), FanoutProgressMode (..), NetworkInfo (..), TimedServerOutput (..))
 import Hydra.API.ServerOutput qualified as API
 import Hydra.Cardano.Api hiding (Active, getVerificationKey)
 import Hydra.Cardano.Api.Prelude ()
 import Hydra.Chain.CardanoClient (CardanoClient (..))
 import Hydra.Chain.Direct.State ()
-import Hydra.Client (AllPossibleAPIMessages (..), Client (..), HydraEvent (..))
+import Hydra.Client (Client (..), HydraEvent (..))
 import Hydra.Ledger.Cardano (mkSimpleTx)
 import Hydra.Network (Host, readHost)
 import Hydra.Node.Environment (Environment (..))

--- a/hydra-tui/src/Hydra/TUI/Options.hs
+++ b/hydra-tui/src/Hydra/TUI/Options.hs
@@ -3,6 +3,7 @@ module Hydra.TUI.Options where
 import Hydra.Prelude
 
 import Data.Version (Version (Version), showVersion)
+import Hydra.API.ServerOutput (ApiEncoding (..))
 import Hydra.Cardano.Api (NetworkId, SocketPath)
 import Hydra.Network (Host (Host))
 import Hydra.Options (networkIdParser)
@@ -10,6 +11,7 @@ import Hydra.Version (embeddedRevision, gitRevision, unknownVersion)
 import Options.Applicative (
   Parser,
   auto,
+  flag,
   help,
   infoOption,
   long,
@@ -31,6 +33,8 @@ data Options = Options
   , fuelVerificationKey :: Maybe FilePath
   -- ^ Optional verification key of the hydra-node's internal wallet, used only
   -- to display the node's available fuel. Never used for committing.
+  , apiEncoding :: ApiEncoding
+  -- ^ Which wire encoding to use on the WebSocket connection to the node.
   }
   deriving stock (Eq, Show)
 
@@ -42,6 +46,7 @@ parseOptions =
       <*> networkIdParser
       <*> parseCardanoSigningKey
       <*> parseFuelVerificationKey
+      <*> parseApiEncoding
   )
     <**> versionInfo
  where
@@ -102,6 +107,15 @@ parseCardanoSigningKey =
         <> help "The path to the user signing key file used for selecting UTxO and signing a commit transaction. This file uses the same 'TextEnvelope' format as cardano-cli."
         <> value "me.sk"
         <> showDefault
+    )
+
+parseApiEncoding :: Parser ApiEncoding
+parseApiEncoding =
+  flag
+    JsonEncoding
+    CborEncoding
+    ( long "cbor"
+        <> help "Use the binary CBOR encoding on the WebSocket connection to the hydra-node instead of JSON."
     )
 
 parseFuelVerificationKey :: Parser (Maybe FilePath)

--- a/hydra-tui/src/Hydra/TUI/RenderMessage.hs
+++ b/hydra-tui/src/Hydra/TUI/RenderMessage.hs
@@ -14,6 +14,7 @@ import Data.Text.Lazy qualified as TL
 import Data.Text.Lazy.Encoding qualified as TLE
 import Hydra.API.ClientInput (ClientInput (..))
 import Hydra.API.ServerOutput (
+  ApiMessage (..),
   ClientMessage (..),
   DecommitInvalidReason (..),
   Greetings (..),
@@ -23,7 +24,7 @@ import Hydra.API.ServerOutput (
  )
 import Hydra.Cardano.Api hiding (Active, txId)
 import Hydra.Chain (PostTxError (..), failureReason, reason, redeemerPtr)
-import Hydra.Client (AllPossibleAPIMessages (..))
+import Hydra.Chain.Direct.State ()
 import Hydra.TUI.Drawing.Utils (prettyHeadId, prettyTxId)
 import Hydra.TUI.Logging.Types (LogMessage (..), Severity (..))
 import Hydra.Tx (HeadId, Snapshot (..), SnapshotNumber, txId)
@@ -52,7 +53,7 @@ toLogMessage RenderedMessage{rmSeverity, rmTime, rmSummary, rmDetail, rmRawJson}
     }
 
 -- | Render any API message into its three representations: summary, detail, raw JSON.
-renderMessage :: UTCTime -> AllPossibleAPIMessages Tx -> RenderedMessage
+renderMessage :: UTCTime -> ApiMessage Tx -> RenderedMessage
 renderMessage now = \case
   ApiTimedServerOutput tso@TimedServerOutput{time, output} ->
     renderServerOutput time output (encodeJson tso)

--- a/hydra-tui/test/Hydra/TUI/OptionsSpec.hs
+++ b/hydra-tui/test/Hydra/TUI/OptionsSpec.hs
@@ -3,6 +3,7 @@ module Hydra.TUI.OptionsSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
+import Hydra.API.ServerOutput (ApiEncoding (..))
 import Hydra.Cardano.Api (NetworkId (..), NetworkMagic (..))
 import Hydra.Network (Host (Host))
 import Hydra.TUI.Options (
@@ -49,6 +50,7 @@ defaultOptions =
     , cardanoConnection = Right "node.socket"
     , cardanoSigningKey = "me.sk"
     , fuelVerificationKey = Nothing
+    , apiEncoding = JsonEncoding
     }
 
 shouldParseWith :: (Show a, Eq a) => Parser a -> [String] -> a -> Expectation

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -30,6 +30,7 @@ import Graphics.Vty.Image (DisplayRegion)
 import Graphics.Vty.Input (Input (..))
 import Graphics.Vty.Platform.Unix.Output (buildOutput)
 import Graphics.Vty.Platform.Unix.Settings (UnixSettings (..))
+import Hydra.API.ServerOutput (ApiEncoding (..))
 import Hydra.Cardano.Api (Coin)
 import Hydra.Cluster.Faucet (
   FaucetLog,
@@ -501,6 +502,7 @@ withTUIRotatedTest tracer tmpDir nodeId blockTime backend externalKeyFilePath op
                     networkId
                 , cardanoSigningKey = externalKeyFilePath
                 , fuelVerificationKey = Nothing
+                , apiEncoding = JsonEncoding
                 }
         )
         ( "action-brick-test"
@@ -555,6 +557,7 @@ setupNodeAndTUI' hostname lovelace action =
                         networkId
                     , cardanoSigningKey = externalKeyFilePath
                     , fuelVerificationKey = Nothing
+                    , apiEncoding = JsonEncoding
                     }
               )
               ("action-brick-test", action brickTest)


### PR DESCRIPTION
  WebSocket clients connect with `?encoding=cbor` to exchange all API
  messages as binary frames; HTTP clients negotiate per request via
  `Content-Type` / `Accept: application/cbor`. JSON remains the default
  and is byte-for-byte unchanged. Transactions and UTxO travel as raw
  ledger CBOR instead of hex text inside a JSON envelope.

  The negotiated encoding is resolved once per connection into a WsCodec,
  and the hand-written ToCBOR/FromCBOR codecs follow the network layer
  convention (text tag + fields in declaration order), kept in sync by
  Hydra.CBORSpec roundtrip properties. hydra-tui and bench-e2e gain a
  `--cbor` flag to exercise the binary path end to end.

  Measured on the API hot path (micro-bench, full numbers on #2543):
  2.2-3.1x smaller wire size (SnapshotConfirmed over 1000 UTxOs:
  456 KB -> 150 KB) and 3-21x faster encode/decode (client decode of
  that message: 46.8 ms -> 3.2 ms).

  Also rework the `snapshot-utxo=no` filter to apply before serialization
  (typed transform plus Value-level key removal) instead of re-parsing
  and re-encoding the already serialized message: filtered sends drop
  from 26 ms to ~10 us at 1000 UTxOs, with an unchanged wire format.

  Closes #2543

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
