### PR TITLE
Revised metric approach

### DIFF
--- a/.github/workflows/bench-e2e-diff.yaml
+++ b/.github/workflows/bench-e2e-diff.yaml
@@ -10,9 +10,10 @@ permissions:
 
 
 jobs:
-  # Run the single e2e benchmark on this branch and on master, then post the
+  # Run the e2e benchmark scenarios on this branch and on master, then post the
   # per-metric difference (TPS, confirmation time, ...) as a PR comment. Both
-  # runs happen on the same runner so the timing comparison is fair.
+  # runs happen on the same runner and consume the same generated datasets so
+  # the timing comparison is fair.
   bench-e2e-diff:
     name: Compute e2e benchmark differences
     runs-on: ubuntu-latest
@@ -27,36 +28,83 @@ jobs:
       with:
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
 
-    - name: 📈 Benchmark (this branch)
+    - name: 📦 Generate benchmark datasets
       working-directory: hydra-cluster
+      # One workload consumed by both sides. Scenario sizes are chosen so rate
+      # metrics are measured under sustained load rather than being capped by
+      # the dataset (see hydra-cluster/README.md), while the slower side still
+      # fits the per-scenario timeout: per-round costs scale with the pending
+      # backlog, so drain time grows super-linearly with dataset size. Seeds
+      # are fixed so datasets are also comparable across workflow runs.
       run: |
         nix build .#hydra-cluster-bench
+        mkdir -p "$PWD/../bench-datasets"
+        nix develop .#hydra-cluster-bench --command bench-e2e generate \
+          --utxo-size Constant --cluster-size 3 --number-of-txs 5000 --seed 2752 \
+          --title "Sustained load (3 nodes, 3x5000 txs)" \
+          --out "$PWD/../bench-datasets/sustained-3nodes.json"
+        nix develop .#hydra-cluster-bench --command bench-e2e generate \
+          --utxo-size 'Plateau 1000' --cluster-size 1 --number-of-txs 4000 --seed 2753 \
+          --title "Plateau 1000 UTxO (1 node, 4000 txs)" \
+          --out "$PWD/../bench-datasets/plateau-1k.json"
+        nix develop .#hydra-cluster-bench --command bench-e2e generate \
+          --utxo-size Constant --cluster-size 3 --number-of-txs 250 --seed 2754 \
+          --title "Round-trip latency (3 nodes, closed-loop, 3x250 txs)" \
+          --out "$PWD/../bench-datasets/closed-loop-3nodes.json"
+
+    - name: 📈 Benchmark (this branch)
+      working-directory: hydra-cluster
+      # The closed-loop scenario needs its own invocation ('--wait-for-tx-valid'
+      # applies to the whole invocation); reports are concatenated afterwards,
+      # which the diff script handles since it keys on scenario titles.
+      run: |
         nix develop .#hydra-cluster-bench --command bench-e2e single \
-          datasets/1-node.json datasets/3-nodes.json \
-          --output-directory "$PWD/../bench-new" --timeout 1000s
+          "$PWD/../bench-datasets/sustained-3nodes.json" \
+          "$PWD/../bench-datasets/plateau-1k.json" \
+          --output-directory "$PWD/../bench-new-open" --timeout 1800s
+        nix develop .#hydra-cluster-bench --command bench-e2e single \
+          "$PWD/../bench-datasets/closed-loop-3nodes.json" \
+          --wait-for-tx-valid \
+          --output-directory "$PWD/../bench-new-closed" --timeout 1800s
+        cat "$PWD/../bench-new-open/end-to-end-benchmarks.md" \
+          "$PWD/../bench-new-closed/end-to-end-benchmarks.md" > "$PWD/../bench-new.md"
 
     - name: 📈 Benchmark (master)
       working-directory: hydra-cluster
-      # Same committed datasets, so the workload is identical; only master's
-      # bench code differs from this branch.
+      # Same generated datasets, so the workload is identical; only master's
+      # code (hydra-node and bench) differs from this branch.
       run: |
         nix develop "git+https://github.com/cardano-scaling/hydra?ref=master#hydra-cluster-bench" \
           --command bench-e2e single \
-          datasets/1-node.json datasets/3-nodes.json \
-          --output-directory "$PWD/../bench-old" --timeout 1000s
+          "$PWD/../bench-datasets/sustained-3nodes.json" \
+          "$PWD/../bench-datasets/plateau-1k.json" \
+          --output-directory "$PWD/../bench-old-open" --timeout 1800s
+        nix develop "git+https://github.com/cardano-scaling/hydra?ref=master#hydra-cluster-bench" \
+          --command bench-e2e single \
+          "$PWD/../bench-datasets/closed-loop-3nodes.json" \
+          --wait-for-tx-valid \
+          --output-directory "$PWD/../bench-old-closed" --timeout 1800s
+        cat "$PWD/../bench-old-open/end-to-end-benchmarks.md" \
+          "$PWD/../bench-old-closed/end-to-end-benchmarks.md" > "$PWD/../bench-old.md"
 
     - name: 🧮 Compute the difference markdown
       run: |
         python3 scripts/bench-e2e-diff.py \
-          bench-old/end-to-end-benchmarks.md \
-          bench-new/end-to-end-benchmarks.md > bench-e2e-diff.md
+          bench-old.md \
+          bench-new.md > bench-e2e-diff.md
 
-    - name: 💾 Upload e2e bench diff artifact
+    - name: 💾 Upload e2e bench artifacts
+      # Raw reports included so a failed or one-sided comparison (e.g. a PR
+      # that changes the report format itself) can still be judged.
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: bench-e2e-diff
-        path: bench-e2e-diff.md
-        if-no-files-found: error
+        path: |
+          bench-e2e-diff.md
+          bench-new.md
+          bench-old.md
+        if-no-files-found: warn
 
     - name: 🔎 Find Comment
       if: github.event.pull_request.head.repo.full_name == github.repository

--- a/hydra-cluster/README.md
+++ b/hydra-cluster/README.md
@@ -132,18 +132,24 @@ produces a `results.csv` file in a work directory. To plot the transaction
 confirmation times you can use the `bench/plot.sh` script, passing it the
 directory containing the benchmark's results.
 
-For the benchmarks, you can choose between generating either a constant-size
-UTxO set or a growing UTxO set.
+For the benchmarks, you can choose between several generated UTxO shapes via
+`--utxo-size`:
 
-Constant UTxO set:
-Each transaction spends one input and creates exactly one new output (1-in-1-out), so the total number of
-UTxOs in the set remains roughly the same over time.
+* `Constant`: each transaction spends one input and creates exactly one new
+  output (1-in-1-out), so the size of the UTxO set stays flat over the run.
+* `Growing`: each transaction spends one input and creates two outputs,
+  gradually increasing the UTxO set as more transactions are processed.
+* `Mixed`: grows for the first half of the run, then contracts via 2-in-1-out
+  merges for the second half.
+* `Plateau N` (quoted, e.g. `--utxo-size 'Plateau 1000'`): splits each
+  client's funds into N outputs, then holds that size with full-value
+  self-transfers so every snapshot carries a large UTxO set. This is the
+  reference workload for large-UTxO head performance, where snapshot signing
+  cost dominates.
 
-Growing UTxO set:
-Each transaction spends one input but creates two outputs gradually increasing the total number of UTxOs as more
-transactions are processed. For this we use the `--number-of-txs` argument.
-
-This distinction allows you to measure performance under different realistic UTxO-set growth scenarios on Cardano.
+The number of transactions per client is set with `--number-of-txs`. This
+distinction allows you to measure performance under different realistic
+UTxO-set scenarios on Cardano.
 
 
 To generate, run and then plot results of the benchmark:
@@ -193,11 +199,64 @@ Writing report to: out/end-to-end-benchmarks.md
 Created plot: out/results.png
 ```
 
-Note that if it's present in the environment, benchmark executable will gather basic system-level statistics about the RAM, CPU, and network bandwidth used. The `plot.sh` script then displays those alongside tx confirmation time in a single graph.
+Note that the summary reports the peak resident memory of the scenario's
+hydra-node processes (Linux only). The `system.csv` file referenced by
+`plot.sh` is not currently produced.
 
-The benchmark can be run in three modes:
+The benchmark can be run in several modes:
 
-* `single`: Generate a single _dataset_ and runs the benchmark with it.
-* `datasets`: Runs one or more pre-existing _datasets_ in sequence and collect their results in a single markdown formatted file. This is useful to track the evolution of hydra-node's performance over some well-known datasets over time and produce a human-readable summary.
+* `single`: Runs one or more pre-existing _dataset_ files in sequence and collects their results in a single markdown formatted file. This is useful to track the evolution of hydra-node's performance over well-known datasets and is what CI uses to compare a PR against master.
+* `datasets`: Generates a dataset from options (UTxO shape, cluster size, number of txs), saves it, and runs it.
+* `generate`: Generates and saves a dataset file without running it. `--seed` makes generation reproducible and `--title` names the scenario in reports (scenarios are paired by title when diffing two reports). Feed the resulting file to `single`.
+* `matrix`: Runs a scenario matrix over cluster sizes, UTxO shapes and incremental-ops modes, and writes a `scenarios.md` comparison page.
 * `demo`: Generates transactions against an already running network of cardano and hydra nodes. This can serve as a workload when testing network-resilience scenarios, such as packet loss or node failures. See [this CI workflow](https://github.com/cardano-scaling/hydra/blob/master/.github/workflows/network-test.yaml) for how it is used.
+
+## Load modes and reported metrics
+
+Transactions are submitted either open-loop (the default: each client fires
+its whole transaction sequence as fast as the queue drains, building a deep
+backlog that exercises the head's saturation throughput) or closed-loop
+(`--wait-for-tx-valid`: one in-flight transaction per client, so
+per-transaction times measure the true round-trip latency of a snapshot
+cycle).
+
+The benchmark starts its hydra-nodes with logging disabled (`--quiet`):
+tracing serialises large event envelopes on the node's critical path and its
+cost differs across compared versions, so leaving it on would distort the
+comparison.
+
+Interpret the metrics accordingly:
+
+* In open-loop runs, per-transaction confirmation times are dominated by time
+  spent queued behind the backlog; they scale with the dataset size and mostly
+  restate throughput. The rate metrics are the signal there.
+* In closed-loop runs, the confirmation percentiles are honest latency
+  figures.
+
+Reported metrics:
+
+* _End-to-end TPS_: confirmed transactions over the whole run, from first
+  submission to last confirmation.
+* _Sustained TPS_: confirmation rate over the middle ~80% of the run, trimmed
+  on snapshot boundaries so ramp-up and tail effects are excluded. Only
+  reported when at least 10 snapshots were observed.
+* _Backlog drain time (s)_: last confirmation minus last submission; how long
+  the head needed to work through the submitted backlog.
+* _Snapshots per second_ and _Avg txs per snapshot_: the decomposition of
+  throughput (TPS = snapshots/s x txs/snapshot). Both are neutral measures:
+  raising the node's `maxTxsPerSnapshot` moves them in opposite directions
+  while improving throughput.
+* _Tx validation time p50 (ms)_: median submission-to-TxValid time; a
+  responsiveness signal for the node's ingest path under load.
+* _Peak node RSS (MB)_: peak resident memory across the scenario's hydra-node
+  processes (Linux only); guards against memory regressions under load.
+* Confirmation time average and percentiles: see load modes above.
+
+The CI workflow `.github/workflows/bench-e2e-diff.yaml` generates three
+scenarios per PR (3-node sustained load, 1-node `Plateau 1000` large-UTxO
+load, 3-node closed-loop latency) and runs them on this branch and on master
+on the same runner, posting the per-metric differences as a PR comment via
+`scripts/bench-e2e-diff.py`. A new summary metric only shows a difference once
+it exists on master too, and must be registered in that script's `METRICS`
+table.
 

--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -5,7 +5,7 @@ module Bench.EndToEnd where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import Bench.Summary (Summary (..), SystemStats, makeQuantiles)
+import Bench.Summary (Summary (..), SystemStats, makeQuantiles, nominalDiffTimeToMilliseconds)
 import Cardano.Api.UTxO qualified as UTxO
 import CardanoNode (EndToEndLog (..), HydraNodeLog, findRunningCardanoNode', runBackend, withCardanoNodeDevnet)
 import Control.Concurrent.Class.MonadSTM (
@@ -21,16 +21,18 @@ import Control.Exception (SomeAsyncException)
 import Control.Lens (to, (^..), (^?))
 import Control.Monad.Class.MonadAsync (concurrently, mapConcurrently)
 import Data.Aeson (Result (Error, Success), Value, encode, fromJSON, (.=))
-import Data.Aeson.Lens (key, values, _JSON, _Number, _String)
+import Data.Aeson.Lens (key, members, values, _JSON, _Number, _String)
 import Data.Aeson.Types (parseMaybe)
+import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
+import Data.Char (isDigit)
 import Data.List qualified as List
 import Data.Map.Strict qualified as Map
 import Data.Scientific (Scientific)
 import Data.Set ((\\))
 import Data.Set qualified as Set
+import Data.Text qualified as T
 import Data.Time (UTCTime (UTCTime), utctDayTime)
-import Data.Vector qualified as V
 import Hydra.Cardano.Api (NetworkId, PaymentKey, SigningKey, SocketPath, Tx, TxId, UTxO, lovelaceToValue, txOutAddress, txOutValue)
 import Hydra.Chain.Backend (ChainBackend (..))
 import Hydra.Cluster.Faucet (FaucetLog (..), publishHydraScriptsAs, returnFundsToFaucet', seedFromFaucet)
@@ -40,11 +42,12 @@ import Hydra.Generator (ClientDataset (..), Dataset (..))
 import Hydra.Ledger.Cardano (mkSimpleTx)
 import Hydra.Logging (
   Tracer,
+  Verbosity (Quiet),
   traceWith,
   withTracerOutputTo,
  )
 import Hydra.Network (Host)
-import Hydra.Options (ChainBackendOptions (..), DirectOptions (..))
+import Hydra.Options (ChainBackendOptions (..), DirectOptions (..), RunOptions (verbosity))
 import Hydra.Tx (HeadId, txId)
 import Hydra.Tx.Crypto (generateSigningKey, getVerificationKey, signTx)
 import Hydra.Tx.Secret (Secret)
@@ -62,9 +65,10 @@ import HydraNode (
   waitForNodesConnected,
   waitMatch,
   withConnectionToNodeHost,
-  withHydraCluster,
+  withHydraClusterWith,
  )
-import System.FilePath ((</>))
+import System.Directory (listDirectory)
+import System.FilePath (takeFileName, (</>))
 import System.Process.Typed (shell, withProcessTerm)
 import System.Timeout qualified
 import Test.HUnit.Lang (formatFailureReason)
@@ -107,9 +111,27 @@ bench startingNodeId timeoutSeconds runOptions workDir dataset = do
           let hydraTracer = contramap FromHydraNode tracer
           let timing = Timing{blockTime, contestationPeriod, depositPeriod = truncate $ 50 * blockTime}
           putStrLn $ "Timing: " <> show timing
-          withHydraCluster hydraTracer timing workDir nodeSocket' startingNodeId cardanoKeys hydraKeys hydraScriptsTxId $ \clients -> do
-            waitForNodesConnected hydraTracer 20 clients
-            scenario hydraTracer timing opts workDir dataset clients Nothing sideUTxOs runOptions
+          -- Trim the full snapshot UTxO map from SnapshotConfirmed payloads:
+          -- the bench only reads txIds and the snapshot number, and parsing
+          -- multi-MB UTxO maps on the measurement path distorts client-side
+          -- timestamps at large head sizes. Nodes run with logging disabled
+          -- (--quiet): tracing serialises large event envelopes on the node
+          -- loop (#2685) and its cost differs across compared versions, which
+          -- would distort the A/B.
+          withHydraClusterWith
+            (Just "/?history=yes&snapshot-utxo=no")
+            (\o -> o{verbosity = Quiet})
+            hydraTracer
+            timing
+            workDir
+            nodeSocket'
+            startingNodeId
+            cardanoKeys
+            hydraKeys
+            hydraScriptsTxId
+            $ \clients -> do
+              waitForNodesConnected hydraTracer 20 clients
+              scenario hydraTracer timing opts workDir dataset clients Nothing sideUTxOs runOptions
         systemStats <- readTVarIO statsTvar
         pure (scenarioData, systemStats)
 
@@ -258,27 +280,39 @@ scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, descript
 
   putTextLn "Finalizing the Head"
   send leader $ input "Fanout" []
-  fanoutResult :: Either SomeException Int <- try $ waitMatch 100 leader $ \v -> do
+  -- Partial fanout distributes a large UTxO over a chain of transactions, so
+  -- scale the wait with the head's size on top of a fixed floor.
+  headSize <- UTxO.size <$> getSnapshotUTxO leader
+  let fanoutBudget = fromIntegral $ 100 + headSize `div` 2
+  fanoutResult :: Either SomeException Int <- try $ waitMatch fanoutBudget leader $ \v -> do
     guard (v ^? key "tag" == Just "HeadIsFinalized")
     guard $ v ^? key "headId" == Just (toJSON headId)
-    finalizedArr <- v ^? key "finalizedUTxO"
-    pure $ length (finalizedArr ^.. values)
+    -- 'finalizedUTxO' is a JSON object keyed by tx input, so count its
+    -- members ('values' would traverse an array and always yield 0).
+    finalizedObj <- v ^? key "finalizedUTxO"
+    pure $ length (finalizedObj ^.. members)
 
   numberOfFanoutOutputs <-
     case fanoutResult of
-      Left _ -> do
-        putStrLn "Fanout failed."
-        UTxO.size <$> getSnapshotUTxO leader
+      Left err -> do
+        putStrLn $ "Fanout did not finalize within " <> show fanoutBudget <> "s: " <> show err
+        pure 0
       Right n -> pure n
 
+  -- VmHWM is monotone, so sampling once at the end of the scenario (nodes
+  -- still running) captures the peak across the whole run.
+  peakNodeRssMb <- readPeakNodeRssMb workDir
+
   let confTimes = map (\(_, _, a) -> a) res
+      validationTimes = map (\(_, v, _) -> v) res
       numberOfTxs = length confTimes
       numberOfInvalidTxs = length $ Map.filter (isJust . invalidAt) processedTransactions
       averageConfirmationTime = sum confTimes / fromIntegral numberOfTxs
       quantiles = makeQuantiles confTimes
+      validationP50Ms = medianMilliseconds validationTimes
       summaryTitle = fromMaybe "Baseline Scenario" title
       summaryDescription = fromMaybe defaultDescription description
-      (endToEndTps, runWallClockSeconds, peakSustainedTps, numberOfSnapshots) =
+      Throughput{endToEndTps, runWallClockSeconds, sustainedTps, drainSeconds, avgTxsPerSnapshot, numberOfSnapshots} =
         computeThroughput processedTransactions snapshotsSeen
 
   pure $
@@ -288,13 +322,17 @@ scenario hydraTracer timing opts workDir Dataset{clientDatasets, title, descript
       , numberOfTxs
       , averageConfirmationTime
       , quantiles
+      , validationP50Ms
       , summaryTitle
       , summaryDescription
       , numberOfInvalidTxs
       , numberOfFanoutOutputs
       , endToEndTps
       , runWallClockSeconds
-      , peakSustainedTps
+      , sustainedTps
+      , drainSeconds
+      , avgTxsPerSnapshot
+      , peakNodeRssMb
       , numberOfSnapshots
       , incrementalCommitTimes
       , incrementalDecommitTimes
@@ -780,71 +818,120 @@ analyze = \case
     Just (submittedAt, valid `diffUTCTime` submittedAt, conf `diffUTCTime` submittedAt)
   _ -> Nothing
 
--- | Width of the sliding window used for 'peak sustained TPS'. One second is
--- long enough to average out per-message scheduling jitter yet short enough to
--- capture a genuine throughput peak.
-peakWindowSeconds :: Double
-peakWindowSeconds = 1.0
+-- | Throughput measures derived from the recorded per-transaction events and
+-- the observed snapshot series.
+data Throughput = Throughput
+  { endToEndTps :: Double
+  , runWallClockSeconds :: Double
+  , sustainedTps :: Maybe Double
+  , drainSeconds :: Double
+  , avgTxsPerSnapshot :: Double
+  , numberOfSnapshots :: Int
+  }
 
--- | Measured wall-clock span, end-to-end TPS over the run, peak sustained TPS,
--- and the number of snapshots observed.
---
--- The wall-clock span is the elapsed time from the earliest tx submission to
--- the latest confirmation; end-to-end TPS is the confirmed tx count divided by
--- that span. Peak sustained TPS is the highest confirmation rate held over any
--- 'peakWindowSeconds' window (see 'peakWindowedTps'); it replaces the earlier
--- per-snapshot instantaneous rate, which divided a snapshot's tx count by the
--- gap between two client-side observations and so blew up for closely-spaced
--- notifications and was estimated over only a handful of snapshots per run.
-computeThroughput :: Map.Map TxId Event -> Map.Map Scientific (UTCTime, Int) -> (Double, Double, Double, Int)
+-- | Wall clock spans the earliest submission to the latest confirmation;
+-- end-to-end TPS is the confirmed count over that span. The backlog drain time
+-- (latest confirmation minus latest submission) isolates how long the head
+-- needed to work through the submitted backlog; unlike snapshot-derived rates
+-- it is not affected by how many transactions each snapshot batches.
+computeThroughput :: Map.Map TxId Event -> Map.Map Scientific (UTCTime, Int) -> Throughput
 computeThroughput txs snapshots =
-  let submitted = map submittedAtFor (Map.elems txs)
-      confirmed = mapMaybe confirmedAt (Map.elems txs)
-      numberOfTxs = length confirmed
-      wallClockSeconds = case (submitted, confirmed) of
-        (_ : _, _ : _) -> realToFrac (List.maximum confirmed `diffUTCTime` List.minimum submitted) :: Double
-        _ -> 0
-      e2eTps = if wallClockSeconds > 0 then fromIntegral numberOfTxs / wallClockSeconds else 0
-      peakTps = peakWindowedTps peakWindowSeconds confirmed
-   in (e2eTps, wallClockSeconds, peakTps, Map.size snapshots)
+  Throughput
+    { endToEndTps = if wallClockSeconds > 0 then fromIntegral numberOfTxs / wallClockSeconds else 0
+    , runWallClockSeconds = wallClockSeconds
+    , sustainedTps = sustainedSnapshotTps (Map.elems snapshots)
+    , drainSeconds
+    , avgTxsPerSnapshot =
+        if numberOfSnapshots > 0
+          then fromIntegral numberOfTxs / fromIntegral numberOfSnapshots
+          else 0
+    , numberOfSnapshots
+    }
  where
+  submitted = map submittedAtFor (Map.elems txs)
+  confirmed = mapMaybe confirmedAt (Map.elems txs)
+  numberOfTxs = length confirmed
+  numberOfSnapshots = Map.size snapshots
+  wallClockSeconds = case (submitted, confirmed) of
+    (_ : _, _ : _) -> realToFrac (List.maximum confirmed `diffUTCTime` List.minimum submitted) :: Double
+    _ -> 0
+  drainSeconds = case (submitted, confirmed) of
+    (_ : _, _ : _) -> realToFrac (List.maximum confirmed `diffUTCTime` List.maximum submitted) :: Double
+    _ -> 0
   submittedAtFor Event{submittedAt} = submittedAt
 
--- | Peak transaction-confirmation throughput: the largest number of
--- confirmations falling within any window of the given width, divided by that
--- width. Every confirmation feeds it (hundreds of samples per run), so it is
--- stable across runs and is not distorted by how many transactions a single
--- snapshot happened to batch or by how closely two snapshot notifications were
--- observed on the client.
-peakWindowedTps :: Double -> [UTCTime] -> Double
-peakWindowedTps windowSeconds times
-  | windowSeconds <= 0 = 0
-  | n == 0 = 0
-  | otherwise = fromIntegral (loop 0 0 0) / windowSeconds
+-- | Sustained confirmation throughput over the middle of the run, computed on
+-- snapshot boundaries. Confirmations arrive in per-snapshot bursts sharing one
+-- client-side observation timestamp, so trimming per-transaction quantiles
+-- would be quantized by batch size (and thus by the node's maxTxsPerSnapshot).
+-- Instead, trim roughly 10% of confirmed transactions at each end aligned to
+-- whole snapshots: with snapshots ordered by observation time, pick the first
+-- snapshots i and j whose cumulative transaction count reaches 10% and 90% of
+-- the total, and divide the transactions confirmed in the interval (t_i, t_j]
+-- by that time span. Nothing when fewer than 10 snapshots were observed or the
+-- span is degenerate; the report omits the row rather than quietly reporting a
+-- differently-defined rate.
+sustainedSnapshotTps :: [(UTCTime, Int)] -> Maybe Double
+sustainedSnapshotTps snapshots = do
+  guard (length snapshots >= 10)
+  (tLow, cumLow) <- firstReaching (share 0.1)
+  (tHigh, cumHigh) <- firstReaching (share 0.9)
+  let spanSeconds = realToFrac (tHigh `diffUTCTime` tLow) :: Double
+  guard (spanSeconds > 0)
+  pure $ fromIntegral (cumHigh - cumLow) / spanSeconds
  where
-  sorted = V.fromList (sort times)
-  n = V.length sorted
-  window = realToFrac windowSeconds :: NominalDiffTime
-  -- Two pointers over the sorted confirmation times. An optimal window can
-  -- always be slid left until its start coincides with a confirmation, so it
-  -- suffices to anchor the left edge 'i' at each point and extend the
-  -- exclusive right edge 'j' over everything within 'window'. 'j' never moves
-  -- backwards as 'i' advances, so this is O(n).
-  loop i j best
-    | i >= n = best
-    | otherwise =
-        let j' = advance i (max j (i + 1))
-         in loop (i + 1) j' (max best (j' - i))
-  advance i j
-    | j < n && (sorted V.! j) `diffUTCTime` (sorted V.! i) < window = advance i (j + 1)
-    | otherwise = j
+  ordered = sortOn fst snapshots
+  total = sum (map snd ordered)
+  cumulative = zip (map fst ordered) (drop 1 $ scanl (+) 0 (map snd ordered))
+  firstReaching target = find (\(_, cum) -> cum >= target) cumulative
+  share p = ceiling (p * fromIntegral total :: Double) :: Int
+
+medianMilliseconds :: [NominalDiffTime] -> Maybe Double
+medianMilliseconds = \case
+  [] -> Nothing
+  xs -> Just . realToFrac . nominalDiffTimeToMilliseconds $ sort xs List.!! (length xs `div` 2)
+
+-- | Peak resident set size (VmHWM) in MB across this scenario's hydra-node
+-- processes, identified by executable name plus the scenario work directory in
+-- their command line (other hydra-nodes on the host are ignored). Linux-only;
+-- Nothing when nothing matches or /proc is unavailable.
+readPeakNodeRssMb :: FilePath -> IO (Maybe Double)
+readPeakNodeRssMb workDir = do
+  pids <- ignoringErrors [] $ filter (all isDigit) <$> listDirectory "/proc"
+  peaks <- forM pids $ \pid ->
+    ignoringErrors Nothing $ do
+      cmdline <- readFileBS ("/proc" </> pid </> "cmdline")
+      if isScenarioNode cmdline
+        then vmHwmKb <$> readFileBS ("/proc" </> pid </> "status")
+        else pure Nothing
+  pure $ case catMaybes peaks of
+    [] -> Nothing
+    kbs -> Just (List.maximum kbs / 1024)
+ where
+  ignoringErrors :: forall a. a -> IO a -> IO a
+  ignoringErrors def act = act `catch` \(_ :: SomeException) -> pure def
+
+  isScenarioNode cmdline = case BS.split 0 cmdline of
+    (exe : args) ->
+      takeFileName (decodeUtf8 exe :: String) == "hydra-node"
+        && any (encodeUtf8 workDir `BS.isInfixOf`) args
+    [] -> False
+
+  vmHwmKb :: ByteString -> Maybe Double
+  vmHwmKb status =
+    listToMaybe
+      [ kb
+      | line <- T.lines (decodeUtf8 status)
+      , Just rest <- [T.stripPrefix "VmHWM:" line]
+      , Just (kb :: Double) <- [readMaybe . toString . T.strip $ T.replace "kB" "" rest]
+      ]
 
 writeResultsCsv :: FilePath -> [(UTCTime, NominalDiffTime, NominalDiffTime, Int)] -> IO ()
 writeResultsCsv fp res = do
   putStrLn $ "Writing results to: " <> fp
   writeFileLBS fp $ headers <> "\n" <> foldMap toCsv res
  where
-  headers = "txId,confirmationTime"
+  headers = "time,averageValidationTime,averageConfirmationTime,count"
 
   toCsv :: (UTCTime, NominalDiffTime, NominalDiffTime, Int) -> LBS.ByteString
   toCsv (a, b, c, d) = show a <> "," <> encode b <> "," <> encode c <> "," <> encode d <> "\n"

--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -908,8 +908,10 @@ readPeakNodeRssMb workDir = do
     [] -> Nothing
     kbs -> Just (List.maximum kbs / 1024)
  where
+  -- Synchronous exceptions only: swallowing an async cancellation here would
+  -- defer the scenario's 'failAfter' timeout (see 'tryNonAsync').
   ignoringErrors :: forall a. a -> IO a -> IO a
-  ignoringErrors def act = act `catch` \(_ :: SomeException) -> pure def
+  ignoringErrors def act = fromRight def <$> tryNonAsync act
 
   isScenarioNode cmdline = case BS.split 0 cmdline of
     (exe : args) ->

--- a/hydra-cluster/bench/Bench/Options.hs
+++ b/hydra-cluster/bench/Bench/Options.hs
@@ -31,7 +31,7 @@ import Options.Applicative (
  )
 import Options.Applicative.Builder (argument)
 
-data UTxOSize = Constant | Growing | Mixed deriving stock (Eq, Show, Read)
+data UTxOSize = Constant | Growing | Mixed | Plateau Int deriving stock (Eq, Show, Read)
 
 data Options
   = StandaloneOptions
@@ -71,6 +71,14 @@ data Options
       , incrementalModes :: [Bool]
       , waitForTxValidModes :: [Bool]
       }
+  | GenerateOptions
+      { datasetUTxO :: UTxOSize
+      , numberOfTxs :: Int
+      , clusterSize :: Word64
+      , datasetTitle :: Maybe Text
+      , generationSeed :: Maybe Int
+      , outputFile :: FilePath
+      }
 
 benchOptionsParser :: ParserInfo Options
 benchOptionsParser =
@@ -78,6 +86,7 @@ benchOptionsParser =
     ( hsubparser
         ( command "single" standaloneOptionsInfo
             <> command "datasets" datasetOptionsInfo
+            <> command "generate" generateOptionsInfo
             <> command "demo" demoOptionsInfo
             <> command "matrix" matrixOptionsInfo
         )
@@ -179,7 +188,10 @@ utxoSizeParser =
           "Generated UTxO shape. 'Constant' keeps the head UTxO at a fixed size by \
           \ submitting self-transfers. 'Growing' adds one extra output per tx so the \
           \ head UTxO grows over the run. 'Mixed' grows for the first half of the run \
-          \ then contracts via 2-in 1-out merges for the second half."
+          \ then contracts via 2-in 1-out merges for the second half. 'Plateau N' \
+          \ (quoted, e.g. --utxo-size 'Plateau 1000') splits each client's funds \
+          \ into N outputs and then holds that size with full-value self-transfers, \
+          \ so every snapshot carries a large UTxO set."
     )
 
 demoOptionsInfo :: ParserInfo Options
@@ -248,6 +260,54 @@ datasetOptionsParser =
     <*> startingNodeIdParser
     <*> incrementalOpsParser
     <*> waitForTxValidParser
+
+generateOptionsInfo :: ParserInfo Options
+generateOptionsInfo =
+  info
+    generateOptionsParser
+    ( progDesc
+        "Generate a dataset file without running it. The bench-e2e-diff CI \
+        \ workflow uses this to produce one workload that both sides of an \
+        \ A/B comparison then run via 'single'."
+    )
+
+generateOptionsParser :: Parser Options
+generateOptionsParser =
+  GenerateOptions
+    <$> utxoSizeParser
+    <*> numberOfTxsParser
+    <*> clusterSizeParser
+    <*> optional datasetTitleParser
+    <*> optional generationSeedParser
+    <*> outputFileParser
+
+datasetTitleParser :: Parser Text
+datasetTitleParser =
+  strOption
+    ( long "title"
+        <> metavar "TEXT"
+        <> help
+          "Title embedded in the dataset. Reports and the CI diff comment \
+          \ identify scenarios by it, so keep it unique per scenario and put \
+          \ the workload parameters in it. Defaults to the generator's title."
+    )
+
+generationSeedParser :: Parser Int
+generationSeedParser =
+  option
+    auto
+    ( long "seed"
+        <> metavar "INT"
+        <> help "Fix the generation seed for reproducible datasets. Random when unset."
+    )
+
+outputFileParser :: Parser FilePath
+outputFileParser =
+  strOption
+    ( long "out"
+        <> metavar "FILE"
+        <> help "Where to write the generated dataset JSON."
+    )
 
 incrementalOpsParser :: Parser Bool
 incrementalOpsParser =

--- a/hydra-cluster/bench/Bench/Summary.hs
+++ b/hydra-cluster/bench/Bench/Summary.hs
@@ -34,9 +34,19 @@ data Summary = Summary
   , numberOfFanoutOutputs :: Int
   , endToEndTps :: Double
   , runWallClockSeconds :: Double
-  , peakSustainedTps :: Double
-  -- ^ Highest transaction-confirmation rate sustained over any
-  -- 'peakWindowSeconds'-wide window (see 'Bench.EndToEnd.computeThroughput').
+  , sustainedTps :: Maybe Double
+  -- ^ Confirmation rate over the middle ~80% of the run, trimmed on snapshot
+  -- boundaries (see 'Bench.EndToEnd.sustainedSnapshotTps'). Nothing when too
+  -- few snapshots were observed for the rate to be meaningful.
+  , drainSeconds :: Double
+  -- ^ Time from the last submission to the last confirmation: how long the
+  -- head needed to work through the submitted backlog.
+  , avgTxsPerSnapshot :: Double
+  , validationP50Ms :: Maybe Double
+  -- ^ Median time from submission to the TxValid server output.
+  , peakNodeRssMb :: Maybe Double
+  -- ^ Peak resident set size (VmHWM) across the scenario's hydra-node
+  -- processes.
   , numberOfSnapshots :: Int
   , incrementalCommitTimes :: [NominalDiffTime]
   , incrementalDecommitTimes :: [NominalDiffTime]
@@ -58,7 +68,11 @@ errorSummary Dataset{title, clientDatasets} (HUnitFailure sourceLocation reason)
     , numberOfFanoutOutputs = 0
     , endToEndTps = 0
     , runWallClockSeconds = 0
-    , peakSustainedTps = 0
+    , sustainedTps = Nothing
+    , drainSeconds = 0
+    , avgTxsPerSnapshot = 0
+    , validationP50Ms = Nothing
+    , peakNodeRssMb = Nothing
     , numberOfSnapshots = 0
     , incrementalCommitTimes = []
     , incrementalDecommitTimes = []
@@ -85,8 +99,16 @@ makeQuantiles times =
 oneDec :: Real a => a -> Text
 oneDec x = pack $ printf "%.1f" (realToFrac x :: Double)
 
+-- | Confirmed snapshots per second over the run's wall clock. This is the
+-- headline rate for snapshot-throughput comparisons: unlike TPS it does not
+-- conflate the number of transactions batched into each snapshot.
+snapshotsPerSecond :: Summary -> Double
+snapshotsPerSecond Summary{numberOfSnapshots, runWallClockSeconds}
+  | runWallClockSeconds > 0 = fromIntegral numberOfSnapshots / runWallClockSeconds
+  | otherwise = 0
+
 textReport :: (Summary, SystemStats) -> [Text]
-textReport (Summary{totalTxs, numberOfTxs, averageConfirmationTime, quantiles, numberOfInvalidTxs, numberOfFanoutOutputs, endToEndTps, peakSustainedTps, numberOfSnapshots, incrementalCommitTimes, incrementalDecommitTimes}, systemStats) =
+textReport (summary@Summary{totalTxs, numberOfTxs, averageConfirmationTime, quantiles, validationP50Ms, numberOfInvalidTxs, numberOfFanoutOutputs, endToEndTps, sustainedTps, drainSeconds, avgTxsPerSnapshot, peakNodeRssMb, numberOfSnapshots, incrementalCommitTimes, incrementalDecommitTimes}, systemStats) =
   let frac :: Double
       frac = 100 * fromIntegral numberOfTxs / fromIntegral totalTxs
    in [ pack $ printf "Confirmed txs/Total expected txs: %d/%d (%.2f %%)" numberOfTxs totalTxs frac
@@ -100,9 +122,14 @@ textReport (Summary{totalTxs, numberOfTxs, averageConfirmationTime, quantiles, n
                 ]
               else []
            )
+        ++ maybe [] (\v -> [pack $ printf "Tx validation time p50 (ms): %.1f" v]) validationP50Ms
         ++ [pack $ printf "End-to-end TPS: %.2f tx/s" endToEndTps]
+        ++ maybe [] (\tps -> [pack $ printf "Sustained TPS: %.2f tx/s" tps]) sustainedTps
+        ++ [pack $ printf "Backlog drain time (s): %.1f" drainSeconds]
         ++ [pack $ printf "Snapshots observed: %d" numberOfSnapshots]
-        ++ [pack $ printf "Peak sustained TPS: %.2f tx/s" peakSustainedTps]
+        ++ [pack $ printf "Snapshots per second: %.2f /s" (snapshotsPerSecond summary)]
+        ++ [pack $ printf "Avg txs per snapshot: %.1f" avgTxsPerSnapshot]
+        ++ maybe [] (\mb -> [pack $ printf "Peak node RSS (MB): %.1f" mb]) peakNodeRssMb
         ++ ["Invalid txs: " <> show numberOfInvalidTxs]
         ++ ["Fanout outputs: " <> show numberOfFanoutOutputs]
         ++ incrementalLines "Incremental commit" incrementalCommitTimes
@@ -152,7 +179,7 @@ markdownReport now summaries =
     ]
 
 formattedSummary :: (Summary, SystemStats) -> [Text]
-formattedSummary (Summary{clusterSize, numberOfTxs, averageConfirmationTime, quantiles, summaryTitle, summaryDescription, numberOfInvalidTxs, numberOfFanoutOutputs, endToEndTps, peakSustainedTps, numberOfSnapshots, incrementalCommitTimes, incrementalDecommitTimes}, systemStats)
+formattedSummary (summary@Summary{clusterSize, numberOfTxs, averageConfirmationTime, quantiles, validationP50Ms, summaryTitle, summaryDescription, numberOfInvalidTxs, numberOfFanoutOutputs, endToEndTps, sustainedTps, drainSeconds, avgTxsPerSnapshot, peakNodeRssMb, numberOfSnapshots, incrementalCommitTimes, incrementalDecommitTimes}, systemStats)
   | numberOfTxs == 0 =
       -- Failed cell: no confirmations, so all the latency / TPS rows would be
       -- zeros or empty quantiles. Render a short failure block instead of the
@@ -186,10 +213,15 @@ formattedSummary (Summary{clusterSize, numberOfTxs, averageConfirmationTime, qua
                 ]
               else []
            )
-        ++ [ pack $ printf "| _End-to-end TPS_ | %.2f tx/s |" endToEndTps
+        ++ maybe [] (\v -> [pack $ printf "| _Tx validation time p50 (ms)_ | %.1f |" v]) validationP50Ms
+        ++ [pack $ printf "| _End-to-end TPS_ | %.2f tx/s |" endToEndTps]
+        ++ maybe [] (\tps -> [pack $ printf "| _Sustained TPS_ | %.2f tx/s |" tps]) sustainedTps
+        ++ [ pack $ printf "| _Backlog drain time (s)_ | %.1f |" drainSeconds
            , "| _Snapshots observed_ | " <> show numberOfSnapshots <> " |"
-           , pack $ printf "| _Peak sustained TPS_ | %.2f tx/s |" peakSustainedTps
+           , pack $ printf "| _Snapshots per second_ | %.2f /s |" (snapshotsPerSecond summary)
+           , pack $ printf "| _Avg txs per snapshot_ | %.1f |" avgTxsPerSnapshot
            ]
+        ++ maybe [] (\mb -> [pack $ printf "| _Peak node RSS (MB)_ | %.1f |" mb]) peakNodeRssMb
         ++ [ "| _Number of Invalid txs_ | " <> show numberOfInvalidTxs <> " |"
            ]
         ++ [ "| _Fanout outputs_        | " <> show numberOfFanoutOutputs <> " |"
@@ -251,21 +283,21 @@ comparisonTable summaries =
     \measured elapsed time from the first tx submission to the last \
     \confirmation. Times are rounded to one decimal."
   , ""
-  , "| Scenario | Txs | Wall clock (s) | End-to-end TPS (tx/s) | Peak sustained TPS (tx/s) | Avg conf (ms) | P95 conf (ms) |"
+  , "| Scenario | Txs | Wall clock (s) | End-to-end TPS (tx/s) | Sustained TPS (tx/s) | Avg conf (ms) | P95 conf (ms) |"
   , "| -- | -- | -- | -- | -- | -- | -- |"
   ]
     <> map row summaries
     <> [""]
  where
   row :: (Summary, SystemStats) -> Text
-  row (Summary{numberOfTxs, summaryTitle, averageConfirmationTime, quantiles, endToEndTps, runWallClockSeconds, peakSustainedTps}, _)
+  row (Summary{numberOfTxs, summaryTitle, averageConfirmationTime, quantiles, endToEndTps, runWallClockSeconds, sustainedTps}, _)
     | numberOfTxs == 0 =
         "| "
           <> summaryTitle
           <> " | 0 | n/a | n/a | n/a | n/a | n/a |"
     | otherwise =
         let p95Conf = if length quantiles == 100 then oneDec (quantiles ! 95) else "n/a"
-            peakTps = pack $ printf "%.2f" peakSustainedTps
+            sustained = maybe "n/a" (pack . printf "%.2f") sustainedTps
             wallClock =
               if runWallClockSeconds > 0
                 then oneDec runWallClockSeconds
@@ -279,7 +311,7 @@ comparisonTable summaries =
               <> " | "
               <> pack (printf "%.2f" endToEndTps)
               <> " | "
-              <> peakTps
+              <> sustained
               <> " | "
               <> oneDec (nominalDiffTimeToMilliseconds averageConfirmationTime)
               <> " | "

--- a/hydra-cluster/bench/Main.hs
+++ b/hydra-cluster/bench/Main.hs
@@ -11,15 +11,19 @@ import Bench.Summary (Summary (..), SystemStats, errorSummary, markdownReport, m
 import Data.Aeson (eitherDecodeFileStrict', encodeFile)
 import Data.List qualified as List
 import Data.Text qualified as T
+import Hydra.Cardano.Api (PaymentKey, SigningKey)
 import Hydra.Cluster.Fixture (Actor (..))
 import Hydra.Cluster.Util (keysFor)
-import Hydra.Generator (Dataset (..), generateConstantUTxODataset, generateDemoUTxODataset, generateGrowingUTxODataset, generateMixedUTxODataset)
+import Hydra.Generator (Dataset (..), generateConstantUTxODataset, generateDemoUTxODataset, generateGrowingUTxODataset, generateLargeUTxODataset, generateMixedUTxODataset)
+import Hydra.Tx.Secret (Secret)
 import Options.Applicative (execParser)
 import System.Directory (createDirectoryIfMissing, listDirectory, removeDirectoryRecursive)
 import System.Environment (withArgs)
 import System.FilePath (takeDirectory, (</>))
 import Test.HUnit.Lang (formatFailureReason)
 import Test.QuickCheck (generate)
+import Test.QuickCheck.Gen (unGen)
+import Test.QuickCheck.Random (mkQCGen)
 
 main :: IO ()
 main = do
@@ -47,10 +51,7 @@ main = do
       (_, faucetSk) <- keysFor Faucet
       workDir <- maybe (createTempDir "bench-e2e") checkEmpty outputDirectory
       let action = bench startingNodeId timeoutSeconds BenchRunOptions{incrementalOps, waitForTxValid}
-      dataset <- generate $ case datasetUTxO of
-        Constant -> generateConstantUTxODataset faucetSk (fromIntegral clusterSize) numberOfTxs
-        Growing -> generateGrowingUTxODataset faucetSk (fromIntegral clusterSize) numberOfTxs
-        Mixed -> generateMixedUTxODataset faucetSk (fromIntegral clusterSize) numberOfTxs
+      dataset <- generate $ datasetGen faucetSk datasetUTxO clusterSize numberOfTxs
       saveDataset (workDir </> "dataset.json") dataset
       putStrLn $ "Saved dataset in: " <> (workDir </> "dataset.json")
       results <- do
@@ -77,10 +78,7 @@ main = do
       results <- forM (zip [0 :: Int ..] cells) $ \(i, (cs, sh, im, wt)) -> do
         let cellDir = workDir </> ("cell-" <> show i)
         createDirectoryIfMissing True cellDir
-        dataset <- generate $ case sh of
-          Constant -> generateConstantUTxODataset faucetSk (fromIntegral cs) numberOfTxs
-          Growing -> generateGrowingUTxODataset faucetSk (fromIntegral cs) numberOfTxs
-          Mixed -> generateMixedUTxODataset faucetSk (fromIntegral cs) numberOfTxs
+        dataset <- generate $ datasetGen faucetSk sh cs numberOfTxs
         let labelled = dataset{title = Just (matrixCellTitle cs sh im wt)}
         saveDataset (cellDir </> "dataset.json") labelled
         threadDelay 10
@@ -92,7 +90,24 @@ main = do
         withTempDir ("bench-matrix-cell-" <> show i) $ \runDir ->
           runSingle labelled runDir action
       summarizeMatrixResults outputDirectory results
+    GenerateOptions{datasetUTxO, numberOfTxs, clusterSize, datasetTitle, generationSeed, outputFile} -> do
+      (_, faucetSk) <- keysFor Faucet
+      let gen = datasetGen faucetSk datasetUTxO clusterSize numberOfTxs
+      dataset <- case generationSeed of
+        Nothing -> generate gen
+        -- Same generation size as QuickCheck's 'generate' so seeded and
+        -- unseeded datasets have the same shape.
+        Just seed -> pure $ unGen gen (mkQCGen seed) 30
+      saveDataset outputFile $ maybe dataset (\t -> dataset{title = Just t}) datasetTitle
  where
+  datasetGen :: Secret (SigningKey PaymentKey) -> UTxOSize -> Word64 -> Int -> Gen Dataset
+  datasetGen faucetSk shape clusterSize numberOfTxs =
+    case shape of
+      Constant -> generateConstantUTxODataset faucetSk (fromIntegral clusterSize) numberOfTxs
+      Growing -> generateGrowingUTxODataset faucetSk (fromIntegral clusterSize) numberOfTxs
+      Mixed -> generateMixedUTxODataset faucetSk (fromIntegral clusterSize) numberOfTxs
+      Plateau plateauSize -> generateLargeUTxODataset faucetSk (fromIntegral clusterSize) numberOfTxs plateauSize
+
   matrixCellTitle :: Word64 -> UTxOSize -> Bool -> Bool -> Text
   matrixCellTitle cs sh im wt =
     "Nodes="

--- a/hydra-cluster/src/Hydra/Generator.hs
+++ b/hydra-cluster/src/Hydra/Generator.hs
@@ -272,11 +272,149 @@ generateMixedUTxODataset faucetSk nClients nTxs = do
              in (remaining <> utxoFromTx tx, tx : txs)
       _ -> error "mixed/contract: need at least 2 utxos to merge"
 
-  largestVkUTxO :: VerificationKey PaymentKey -> UTxO.UTxO Era -> Maybe (TxIn, TxOut CtxUTxO)
-  largestVkUTxO vk =
-    let byLovelace :: (TxIn, TxOut CtxUTxO) -> Coin
-        byLovelace (_, o) = selectLovelace (txOutValue o)
-     in fmap (List.maximumBy (comparing byLovelace)) . nonEmpty . UTxO.toList . UTxO.filter (isVkTxOut vk)
+largestVkUTxO :: VerificationKey PaymentKey -> UTxO.UTxO Era -> Maybe (TxIn, TxOut CtxUTxO)
+largestVkUTxO vk =
+  let byLovelace :: (TxIn, TxOut CtxUTxO) -> Coin
+      byLovelace (_, o) = selectLovelace (txOutValue o)
+   in fmap (List.maximumBy (comparing byLovelace)) . nonEmpty . UTxO.toList . UTxO.filter (isVkTxOut vk)
+
+-- | Generate a 'Dataset' that grows each client's UTxO set to a target size
+-- ("plateau") with 1-in 10-out split transactions, then holds that size with
+-- full-value self-transfers (1-in 1-out, no change output). While the plateau
+-- holds, every snapshot carries the accumulator cost of the full UTxO set,
+-- making this the reference workload for large-UTxO head performance.
+--
+-- The head-level UTxO size is roughly clients * target and must stay below
+-- the 4095 accumulator element limit.
+generateLargeUTxODataset ::
+  -- | Faucet signing key
+  Secret (SigningKey PaymentKey) ->
+  -- | Number of clients
+  Int ->
+  -- | Number of transactions
+  Int ->
+  -- | Target UTxO entries per client (plateau)
+  Int ->
+  Gen Dataset
+generateLargeUTxODataset faucetSk nClients nTxs plateauTarget = do
+  hydraNodeKeys <- replicateM nClients genSigningKey
+  allPaymentKeys <- replicateM nClients genSigningKey
+  clientFunds <- genClientFunds allPaymentKeys availableInitialFunds
+  let fundingTransaction =
+        mkGenesisTx networkId faucetSk (Coin availableInitialFunds) clientFunds
+  clientDatasets <- forM allPaymentKeys (genClientDataset fundingTransaction)
+  pure
+    Dataset
+      { fundingTransaction
+      , hydraNodeKeys = mkSecret <$> hydraNodeKeys
+      , clientDatasets
+      , title = Just $ "Plateau " <> show plateauTarget <> " UTxO"
+      , description =
+          Just $
+            "Each client splits its funds into "
+              <> show plateauTarget
+              <> " outputs (1-in 10-out), then holds that plateau with \
+                 \full-value self-transfers so every snapshot carries the \
+                 \large UTxO set."
+      }
+ where
+  splitFanout = 10
+
+  chunk = Coin 2_000_000
+
+  -- Each split adds (splitFanout - 1) net outputs on top of the initial one.
+  splitSteps = max 0 ((plateauTarget - 1 + splitFanout - 2) `div` (splitFanout - 1))
+
+  genClientDataset :: Tx -> SigningKey PaymentKey -> Gen ClientDataset
+  genClientDataset fundingTransaction paymentKey = do
+    let initialUTxO = withInitialUTxO paymentKey fundingTransaction
+        vk = getVerificationKey paymentKey
+        nSplits = min nTxs splitSteps
+        (afterGrow, splitTxs) = foldl' (genSplitTx paymentKey vk) (initialUTxO, []) [1 .. nSplits]
+        (_, holdTxs) = foldl' (genHoldTx paymentKey vk) (afterGrow, []) [1 .. nTxs - nSplits]
+    pure
+      ClientDataset
+        { paymentKey = mkSecret paymentKey
+        , initialUTxO
+        , txSequence = reverse splitTxs <> reverse holdTxs
+        }
+
+  genSplitTx ::
+    SigningKey PaymentKey ->
+    VerificationKey PaymentKey ->
+    (UTxO.UTxO Era, [Tx]) ->
+    Int ->
+    (UTxO.UTxO Era, [Tx])
+  genSplitTx sk vk (utxo, txs) _ =
+    case largestVkUTxO vk utxo of
+      Nothing -> error "plateau/split: no utxo left to spend"
+      Just (txIn, txOut)
+        | selectLovelace (txOutValue txOut) <= minSplitValue ->
+            error $ "plateau/split: largest VK utxo (" <> show (txOutValue txOut) <> ") is too small to split"
+        | otherwise ->
+            case mkSplitTx networkId sk (splitFanout - 1) chunk (txIn, txOut) of
+              Left err -> error $ "plateau/split mkSplitTx failed: " <> show err
+              Right tx ->
+                let remaining = UTxO.difference utxo (UTxO.singleton txIn txOut)
+                 in (remaining <> utxoFromTx tx, tx : txs)
+   where
+    -- Chunks plus a change output that stays comfortably spendable
+    Coin chunkLovelace = chunk
+    minSplitValue = Coin (fromIntegral splitFanout * chunkLovelace)
+
+  genHoldTx ::
+    SigningKey PaymentKey ->
+    VerificationKey PaymentKey ->
+    (UTxO.UTxO Era, [Tx]) ->
+    Int ->
+    (UTxO.UTxO Era, [Tx])
+  genHoldTx sk vk (utxo, txs) _ =
+    case UTxO.find (isVkTxOut vk) utxo of
+      Nothing -> error "plateau/hold: no utxo left to spend"
+      Just (txIn, txOut) ->
+        -- Full-value self-transfer: 'mkSimpleTx' omits the change output when
+        -- the transferred value equals the input value, keeping the UTxO set
+        -- size constant.
+        case mkSimpleTx (txIn, txOut) (mkVkAddress networkId vk, txOutValue txOut) (mkSecret sk) of
+          Left err -> error $ "plateau/hold mkSimpleTx failed: " <> show err
+          Right tx ->
+            let remaining = UTxO.difference utxo (UTxO.singleton txIn txOut)
+             in (remaining <> utxoFromTx tx, tx : txs)
+
+-- | Build a zero-fee 1-in N-out transaction that splits off @nChunks@ outputs
+-- of @chunkValue@ each and returns the remainder as change. Used by the
+-- Plateau generator to grow a client's UTxO set inside the head.
+mkSplitTx ::
+  NetworkId ->
+  SigningKey PaymentKey ->
+  -- | Number of chunk outputs
+  Int ->
+  -- | Value of each chunk output
+  Coin ->
+  (TxIn, TxOut CtxUTxO) ->
+  Either TxBodyError Tx
+mkSplitTx network sk nChunks chunkValue (txIn, txOut) = do
+  body <- createAndValidateTransactionBody bodyContent
+  let witnesses = [makeShelleyKeyWitness body (WitnessPaymentKey sk)]
+  pure $ makeSignedTransaction witnesses body
+ where
+  vk = getVerificationKey sk
+  addr = mkVkAddress network vk
+  chunkOut = TxOut @CtxTx addr (lovelaceToValue chunkValue) TxOutDatumNone ReferenceScriptNone
+  Coin perChunk = chunkValue
+  chunksTotal = lovelaceToValue $ Coin (fromIntegral nChunks * perChunk)
+  changeOut =
+    TxOut @CtxTx
+      addr
+      (txOutValue txOut <> negateValue chunksTotal)
+      TxOutDatumNone
+      ReferenceScriptNone
+  bodyContent =
+    defaultTxBodyContent
+      { txIns = [(txIn, BuildTxWith $ KeyWitness KeyWitnessForSpending)]
+      , txOuts = replicate nChunks chunkOut <> [changeOut]
+      , txFee = TxFeeExplicit (Coin 0)
+      }
 
 -- | Build a zero-fee 2-in 1-out transaction that merges two of a sender's own
 -- outputs into one. Used by the Mixed generator to contract the UTxO set.

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -294,7 +294,27 @@ withHydraCluster ::
   [TxId] ->
   (NonEmpty HydraClient -> IO a) ->
   IO a
-withHydraCluster tracer timing workDir nodeSocket firstNodeId allKeys hydraKeys hydraScriptsTxId action = do
+withHydraCluster = withHydraClusterWith Nothing id
+
+-- | Like 'withHydraCluster' but connecting each node's API client with the
+-- given query string (e.g. "/?history=yes&snapshot-utxo=no") instead of the
+-- default "/?history=yes", and adjusting each node's 'RunOptions' (e.g. to
+-- disable logging) before it is started.
+withHydraClusterWith ::
+  HasCallStack =>
+  Maybe String ->
+  (RunOptions -> RunOptions) ->
+  Tracer IO HydraNodeLog ->
+  Timing ->
+  FilePath ->
+  SocketPath ->
+  Int ->
+  [(VerificationKey PaymentKey, Secret (SigningKey PaymentKey))] ->
+  [Secret (SigningKey HydraKey)] ->
+  [TxId] ->
+  (NonEmpty HydraClient -> IO a) ->
+  IO a
+withHydraClusterWith mQueryParams mapOptions tracer timing workDir nodeSocket firstNodeId allKeys hydraKeys hydraScriptsTxId action = do
   when (clusterSize == 0) $
     failure "Cannot run a cluster with 0 number of nodes"
   when (length allKeys /= length hydraKeys) $
@@ -334,7 +354,9 @@ withHydraCluster tracer timing workDir nodeSocket firstNodeId allKeys hydraKeys 
                         { nodeSocket = nodeSocket
                         }
                 }
-      withHydraNode
+      withHydraNodeWith
+        mQueryParams
+        mapOptions
         tracer
         blockTime
         chainConfig
@@ -552,7 +574,20 @@ withPreparedHydraNode ::
   RunOptions ->
   (HydraClient -> IO a) ->
   IO a
-withPreparedHydraNode tracer workDir hydraNodeId runOptions action =
+withPreparedHydraNode = withPreparedHydraNodeWithQuery Nothing
+
+-- | Like 'withPreparedHydraNode' but connecting the API client with the given
+-- query string instead of the default "/?history=yes".
+withPreparedHydraNodeWithQuery ::
+  HasCallStack =>
+  Maybe String ->
+  Tracer IO HydraNodeLog ->
+  FilePath ->
+  Int ->
+  RunOptions ->
+  (HydraClient -> IO a) ->
+  IO a
+withPreparedHydraNodeWithQuery mQueryParams tracer workDir hydraNodeId runOptions action =
   Prelude.withLogFile logFilePath $ \logFileHandle -> do
     let cmd =
           (proc "hydra-node" . toArgs $ runOptions)
@@ -566,7 +601,7 @@ withPreparedHydraNode tracer workDir hydraNodeId runOptions action =
       -- NOTE: exit code thread gets cancelled if 'action' terminates first
       raceLabelled
         ("collect-check-process-exit-code", collectAndCheckExitCode p)
-        ("with-connection-to-node", withConnectionToNode tracer hydraNodeId apiAddress monPort action)
+        ("with-connection-to-node", withConnectionToNodeHost tracer hydraNodeId apiAddress monPort (mQueryParams <|> Just "/?history=yes") action)
         <&> either absurd id
  where
   apiAddress =
@@ -659,9 +694,28 @@ withHydraNode ::
   Map Int HydraNodePorts ->
   (HydraClient -> IO a) ->
   IO a
-withHydraNode tracer blockTime chainConfig workDir hydraNodeId hydraSKey hydraVKeys nodePorts action = do
+withHydraNode = withHydraNodeWith Nothing id
+
+-- | Like 'withHydraNode' but connecting the API client with the given query
+-- string instead of the default "/?history=yes", and adjusting the node's
+-- 'RunOptions' before it is started.
+withHydraNodeWith ::
+  HasCallStack =>
+  Maybe String ->
+  (RunOptions -> RunOptions) ->
+  Tracer IO HydraNodeLog ->
+  NominalDiffTime ->
+  ChainConfig ->
+  FilePath ->
+  Int ->
+  Secret (SigningKey HydraKey) ->
+  [VerificationKey HydraKey] ->
+  Map Int HydraNodePorts ->
+  (HydraClient -> IO a) ->
+  IO a
+withHydraNodeWith mQueryParams mapOptions tracer blockTime chainConfig workDir hydraNodeId hydraSKey hydraVKeys nodePorts action = do
   opts <- prepareHydraNode chainConfig workDir hydraNodeId hydraSKey hydraVKeys nodePorts id
-  withPreparedHydraNode tracer workDir hydraNodeId opts action'
+  withPreparedHydraNodeWithQuery mQueryParams tracer workDir hydraNodeId (mapOptions opts) action'
  where
   waitTime = blockTime * 5
   action' client = do

--- a/hydra-node/src/Hydra/Logging.hs
+++ b/hydra-node/src/Hydra/Logging.hs
@@ -128,8 +128,11 @@ withTracerOutputTo bufferingMode hdl namespace action = do
   -- 'withAsync' cancels the writer in that case.
   drainLogs closed writer = liftIO $ do
     atomically $ writeTVar closed True
-    void $ timeout 5 (wait writer)
+    void $ timeout drainGraceSeconds (wait writer)
     hFlush hdl
+
+  drainGraceSeconds :: DiffTime
+  drainGraceSeconds = 5
 
   write bs = LBS.hPut hdl (bs <> "\n")
 

--- a/hydra-node/src/Hydra/Logging.hs
+++ b/hydra-node/src/Hydra/Logging.hs
@@ -30,10 +30,12 @@ import Cardano.BM.Tracing (ToObject (..), TracingVerbosity (..))
 import Control.Concurrent.Class.MonadSTM (
   flushTBQueue,
   modifyTVar,
-  readTBQueue,
   readTVarIO,
+  retry,
   writeTBQueue,
+  writeTVar,
  )
+import Control.Monad.Class.MonadAsync (wait)
 import Control.Monad.Class.MonadSay (MonadSay, say)
 import Control.Tracer (
   Tracer (..),
@@ -98,24 +100,35 @@ withTracerOutputTo ::
 withTracerOutputTo bufferingMode hdl namespace action = do
   hSetBuffering hdl bufferingMode
   msgQueue <- newLabelledTBQueueIO @_ @(Envelope msg) "logging-msg-queue" defaultQueueSize
-  withAsyncLabelled ("logging-writeLogs", writeLogs msgQueue) $ \_ ->
-    action (tracer msgQueue) `finally` flushLogs msgQueue
+  closed <- newLabelledTVarIO "logging-closed" False
+  withAsyncLabelled ("logging-writeLogs", writeLogs msgQueue closed) $ \writer ->
+    action (tracer msgQueue) `finally` drainLogs closed writer
  where
   tracer queue =
     Tracer $
       mkEnvelope namespace >=> liftIO . atomically . writeTBQueue queue
 
-  writeLogs queue =
-    forever $ do
-      entries <- atomically $ do
-        firstEntry <- readTBQueue queue
-        rest <- flushTBQueue queue
-        pure (firstEntry : rest)
+  writeLogs queue closed = do
+    entries <- atomically $ do
+      es <- flushTBQueue queue
+      -- Block until there is something to write, or exit the loop below by
+      -- returning the empty batch once the tracer scope has closed.
+      when (null es) $ do
+        isClosed <- readTVar closed
+        unless isClosed retry
+      pure es
+    unless (null entries) $ do
       forM_ entries (write . Aeson.encode)
+      writeLogs queue closed
 
-  flushLogs queue = liftIO $ do
-    entries <- atomically $ flushTBQueue queue
-    forM_ entries (write . Aeson.encode)
+  -- The writer thread claims queued entries before writing them, so shutdown
+  -- must hand over to the writer rather than inspect the queue itself:
+  -- signal it to stop, wait for it to finish draining, then flush. The wait
+  -- is bounded so a stuck handle cannot block shutdown; the surrounding
+  -- 'withAsync' cancels the writer in that case.
+  drainLogs closed writer = liftIO $ do
+    atomically $ writeTVar closed True
+    void $ timeout 5 (wait writer)
     hFlush hdl
 
   write bs = LBS.hPut hdl (bs <> "\n")

--- a/hydra-node/test/Hydra/LoggingSpec.hs
+++ b/hydra-node/test/Hydra/LoggingSpec.hs
@@ -14,7 +14,4 @@ spec = do
       withTracerOutputTo LineBuffering stdout "test" $ \tracer -> do
         traceWith tracer (object ["foo" .= (42 :: Int)])
 
-    -- This test is flakey in CI. Suspected race condition.
-    liftIO $ threadDelay 5
-
     captured `shouldContain` "{\"foo\":42}"

--- a/scripts/bench-e2e-diff.py
+++ b/scripts/bench-e2e-diff.py
@@ -153,8 +153,8 @@ def main():
     )
     out.append("")
 
-    # Match by scenario title; fall back to positional pairing when titles are
-    # absent on either side.
+    # Match scenarios by title (reports always carry one; untitled datasets
+    # get a default title from the bench).
     common = [t for t in branch_order if t in base]
     matched_any = False
     warn_keys = set()

--- a/scripts/bench-e2e-diff.py
+++ b/scripts/bench-e2e-diff.py
@@ -12,14 +12,22 @@ import sys
 # Metrics we diff, in display order. Each entry maps the markdown row key (the
 # text between underscores in `| _key_ | value |`) to a display label and the
 # direction that counts as an improvement: +1 = higher is better, -1 = lower is
-# better. Keys must match Summary.hs exactly.
+# better, 0 = neutral. Neutral rows are shown without a good/bad color: e.g.
+# snapshot counts move with the node's snapshot batching cap without being
+# better or worse by themselves (throughput = snapshots/s x txs/snapshot).
+# Keys must match Summary.hs exactly.
 METRICS = [
     ("End-to-end TPS", "End-to-end TPS (tx/s)", +1),
-    ("Peak sustained TPS", "Peak sustained TPS (tx/s)", +1),
+    ("Sustained TPS", "Sustained TPS (tx/s)", +1),
+    ("Backlog drain time (s)", "Backlog drain time (s)", -1),
+    ("Snapshots per second", "Snapshots per second (/s)", 0),
+    ("Avg txs per snapshot", "Avg txs per snapshot", 0),
     ("Avg. Confirmation Time (ms)", "Avg. Confirmation Time (ms)", -1),
     ("P50", "P50 confirmation (ms)", -1),
     ("P95", "P95 confirmation (ms)", -1),
     ("P99", "P99 confirmation (ms)", -1),
+    ("Tx validation time p50 (ms)", "Tx validation time p50 (ms)", -1),
+    ("Peak node RSS (MB)", "Peak node RSS (MB)", 0),
     ("Incremental commit avg (ms)", "Incremental commit avg (ms)", -1),
     ("Incremental decommit avg (ms)", "Incremental decommit avg (ms)", -1),
     ("Number of Invalid txs", "Invalid txs", -1),
@@ -79,10 +87,21 @@ def fmt_delta(delta, pct, good_dir, threshold):
     body = f"{sign}{delta:.2f} ({pct_sign}{pct:.1f}%)"
     if abs(pct) < threshold:
         return f"≈ {body}"
+    if good_dir == 0:
+        return body
     return colored(body, delta, good_dir)
 
 
-def scenario_rows(old, new, threshold, warn_keys):
+# Headline metrics that emit a GitHub ::warning:: annotation (still exit 0)
+# when they regress more than WARN_PCT. Coarse on purpose: shared-runner e2e
+# noise makes a hard gate impractical, but a large drop on a headline rate
+# should be visible without opening the report. Only directional metrics
+# belong here; neutral (0) ones have no regression direction.
+WARN_METRICS = {"End-to-end TPS", "Sustained TPS"}
+WARN_PCT = 15.0
+
+
+def scenario_rows(old, new, threshold, warn_keys, regressions, title):
     rows = []
     for key, label, good_dir in METRICS:
         if key not in old or key not in new:
@@ -91,12 +110,21 @@ def scenario_rows(old, new, threshold, warn_keys):
             continue
         o, n = old[key], new[key]
         delta = n - o
+        if key in WARN_METRICS and o != 0:
+            pct = 100.0 * delta * good_dir / o
+            if pct < -WARN_PCT:
+                regressions.append(f"{title}: {label} changed {100.0 * delta / o:+.1f}%")
         if o == 0:
             # No baseline to compute a percentage from. Any nonzero change is a
             # real one (the metric went from "none" to "some"), so color it.
             sign = "+" if delta >= 0 else ""
             body = f"{sign}{delta:.2f} (n/a%)"
-            cell = f"≈ {body}" if delta == 0 else colored(body, delta, good_dir)
+            if delta == 0:
+                cell = f"≈ {body}"
+            elif good_dir == 0:
+                cell = body
+            else:
+                cell = colored(body, delta, good_dir)
         else:
             pct = 100.0 * delta / o
             cell = fmt_delta(delta, pct, good_dir, threshold)
@@ -108,7 +136,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("old_file", help="master end-to-end-benchmarks.md")
     parser.add_argument("new_file", help="PR end-to-end-benchmarks.md")
-    parser.add_argument("--threshold", type=float, default=10.0,
+    parser.add_argument("--threshold", type=float, default=5.0,
                         help="percent change below which a metric is treated as noise")
     args = parser.parse_args()
 
@@ -120,7 +148,8 @@ def main():
         f"Comparing this PR (`new`) against `master` (`old`). Numbers come from "
         f"cloud VMs, so changes under {args.threshold:g}% are shown as `≈` and "
         f"are likely run-to-run noise rather than a real regression or "
-        f"improvement. 🟢 = improvement, 🔴 = regression."
+        f"improvement. 🟢 = improvement, 🔴 = regression; uncolored rows are "
+        f"neutral measures reported for context."
     )
     out.append("")
 
@@ -129,8 +158,9 @@ def main():
     common = [t for t in branch_order if t in base]
     matched_any = False
     warn_keys = set()
+    regressions = []
     for title in common:
-        rows = scenario_rows(base[title], branch[title], args.threshold, warn_keys)
+        rows = scenario_rows(base[title], branch[title], args.threshold, warn_keys, regressions, title)
         if not rows:
             continue
         matched_any = True
@@ -146,6 +176,10 @@ def main():
         # Surface format drift loudly so it's noticed in CI logs, but don't fail.
         print("WARNING: metric(s) found on only one side, skipped: "
               + ", ".join(sorted(warn_keys)), file=sys.stderr)
+
+    for regression in regressions:
+        # GitHub annotation; soft gate only (exit code stays 0).
+        print(f"::warning title=Benchmark regression::{regression}", file=sys.stderr)
 
     print("\n".join(out))
 


### PR DESCRIPTION
Another attempt to rationalise the metrics so that the diff is more meaningful on #2752 . Basically just removes an invalid metric, generates more UTxOs so that the statistics are more meaningflu, and does all the busywork to support that.

This PR also disables logging for the benchmark runs; which is maybe a little erroneous, but at least reports a kind of "raw" value, rather than something intermixed with IO.

We could perhaps add a logging-on metric later; but I don't want to waste yet more CI time at the moment.


### Claude's notes

*Workload*
- The PR-comment workflow no longer runs the committed 300-tx burst datasets (which drained in under a second and capped every rate metric at the dataset size); it now generates three scenarios per run with fixed seeds: sustained load (3 nodes, 3x5000 txs, open loop), Plateau 1000 UTxO (1 node, 4000 txs, open loop), and round-trip latency (3 nodes, 3x250 txs, closed loop via --wait-for-tx-valid).
- New bench-e2e generate subcommand: writes a dataset file without running it, with --seed (deterministic, verified byte-identical) and --title (scenario identity in reports and diffs).
- Ported the Plateau N UTxO shape generator from the 10x-perf branch (grow to N outputs, then hold with full-value self-transfers).

*Metrics (in Bench/Summary.hs, registered in scripts/bench-e2e-diff.py)*
- Removed "Peak sustained TPS" and its sliding-window machinery.
- Added "Sustained TPS": confirmation rate over the middle ~80% of the run, trimmed on snapshot boundaries (confirmations arrive in per-snapshot bursts, so per-tx quantile trimming would be quantized by maxTxsPerSnapshot); omitted below 10 snapshots instead of degrading silently.
- Added "Backlog drain time (s)": last confirmation minus last submission; batching-immune and monotone.
- Added "Snapshots per second" and "Avg txs per snapshot" as neutral-direction rows (TPS = product of the two); neutral because raising the snapshot cap moves them in opposite directions while improving throughput, so a signed direction would mark the perf PR red against itself.
- Added "Tx validation time p50 (ms)" (submission to TxValid; data was already collected, unused) and "Peak node RSS (MB)" (VmHWM of the scenario's nodes; guards the cap=1000 memory risk).
- Kept E2E TPS and confirmation percentiles; README documents that the percentiles are honest latency only in the closed-loop scenario and queue-time proxies under open loop.

*Measurement fairness*
- Bench nodes now start with --quiet: tracing serialises large envelopes on the node loop and its cost differs across compared versions.
- Bench clients connect with snapshot-utxo=no so multi-MB UTxO maps are not serialized/parsed on the measurement path.
- Both threaded via new withHydraClusterWith/withHydraNodeWith/withPreparedHydraNodeWithQuery wrappers in HydraNode.hs; existing entry points delegate with identity defaults, so all other tests are behaviorally unchanged.

*Diff script / workflow*
- bench-e2e-diff.py: new METRICS registry, neutral (dir=0) rendering without color, warn-gate restricted to E2E TPS and Sustained TPS, noise threshold 5% (ported from 10x-perf and adjusted).
- Workflow: dataset-generation step, separate closed-loop invocation per side (the flag is invocation-global), reports concatenated before diffing, artifact upload if: always() now including both raw reports (needed to judge format-changing PRs whose new keys are one-sided), timeouts at 1800s. S1 sized 3x5000 from measured calibration: master's drain grows super-linearly with backlog, and 3x8000 would blow the CI timeout on the old side.
- Ported from 10x-perf: the fanout finalizedUTxO counting fix (values on an object always yielded 0) with a size-scaled fanout wait.

*Fixes / docs*
- results.csv header now matches its four columns.
- hydra-cluster/README.md: corrected the swapped single/datasets mode descriptions, documented all modes (incl. generate), UTxO shapes, open- vs closed-loop semantics, and a metric glossary.