### PR TITLE
perf-2: Batch etcd broadcast into one Raft commit per revision (protocol v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,15 @@ compile-time coupling to a single version's scripts [#2740](https://github.com/c
   Extended keys produced by HD wallets (e.g., Daedalus, hardware wallets) are now
   natively supported, removing the need to manually convert them before use.
 
+- **BREAKING** Network protocol version bumped to 2: broadcast messages are
+  now batched into a single etcd value (one Raft commit per batch) and the
+  broadcast path reuses gRPC connections, substantially increasing in-head
+  throughput. Nodes on different protocol versions cannot exchange messages
+  (older nodes drop batched values); all members of a head must upgrade
+  together before reopening network connections. A version mismatch is
+  surfaced as a `NetworkVersionMismatch` server output but does not stop the
+  node. [#2778](https://github.com/cardano-scaling/hydra/pull/2778)
+
 - `maxTxsPerSnapshot` raised from 100 to 1000 (leader-side only, no
   coordinated upgrade required).
   [#2777](https://github.com/cardano-scaling/hydra/pull/2777)

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -519,3 +519,13 @@ You can override this by setting the relevant `etcd` [environment variables](htt
 ETCD_AUTO_COMPACTION_MODE=periodic
 ETCD_AUTO_COMPACTION_RETENTION=168h
 ```
+
+### Network protocol version and upgrades
+
+Nodes of the same head must run the same network protocol version to exchange
+messages. The wire format changed in protocol version 2 (messages are batched
+into single etcd values), so a node running an older version silently drops
+values written by a newer one. A mismatch is reported to API clients as a
+`NetworkVersionMismatch` server output, but the node keeps running, so watch
+for it after upgrades. Upgrade all members of a head together before resuming
+operation; there is no support for mixed-version heads.

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -127,6 +127,7 @@ library
     , cardano-ledger-shelley
     , cardano-slotting
     , cardano-strict-containers
+    , cborg
     , conduit
     , containers
     , contra-tracer

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -42,6 +42,8 @@ import Hydra.Prelude
 
 import Cardano.Binary (decodeFull', serialize')
 import Cardano.Crypto.Hash (SHA256, hashToStringAsHex, hashWithSerialiser)
+import Codec.CBOR.Encoding qualified as CBOR
+import Codec.CBOR.Write qualified as CBOR
 import Control.Concurrent.Class.MonadSTM (
   isFullTBQueue,
   modifyTVar',
@@ -49,6 +51,9 @@ import Control.Concurrent.Class.MonadSTM (
   readTBQueue,
   readTVarIO,
   swapTVar,
+  tryPeekTBQueue,
+  tryReadTBQueue,
+  unGetTBQueue,
   writeTBQueue,
   writeTVar,
  )
@@ -360,7 +365,6 @@ checkVersion tracer conn ourVersion NetworkCallback{onConnectivity} = do
 -- revisions and the watcher on each peer sees exactly one event per logical
 -- broadcast. Same key namespace as master ('msg-\<host\>'), no disk growth.
 broadcastMessages ::
-  ToCBOR msg =>
   Tracer IO EtcdLog ->
   NetworkConfiguration ->
   -- | Used to identify sender.
@@ -385,9 +389,20 @@ broadcastMessages tracer config ourHost queue = do
   -- failure branch just adopts the new baseline and pops.
   initialModRev <- retryInitQuery
   lastModRevVar <- newLabelledTVarIO "etcd-broadcast-last-mod-rev" initialModRev
+  inFlightVar <- newLabelledTVarIO "etcd-broadcast-in-flight" Nothing
   withGrpcContext "broadcastMessages" . forever $ do
-    msg <- peekPersistentQueue queue
-    (putMessage tracer config ourHost lastModRevVar msg >> popPersistentQueue tracer queue)
+    -- Block for work before opening a connection, then reuse that connection
+    -- for up to 'maxPutsPerConnection' queued messages. Per-message
+    -- connections pay a TCP + HTTP/2 handshake on the broadcast hot path and
+    -- exhaust ephemeral ports at high message rates, while an unbounded
+    -- connection lifetime runs into
+    -- https://github.com/cardano-scaling/hydra/issues/2167 (long-lived
+    -- connections observed to block after several thousand unary calls).
+    -- Bounded reuse amortizes the handshake while staying well below that
+    -- onset. Messages are only popped after a successful put, so a recycled
+    -- or failed connection never loses a message.
+    void $ peekPersistentQueue queue
+    sendPending lastModRevVar inFlightVar
       `catch` \case
         e@GrpcException{grpcError, grpcErrorMessage}
           | isTransientGrpcError grpcError -> do
@@ -395,6 +410,28 @@ broadcastMessages tracer config ourHost queue = do
               threadDelay 1
           | otherwise -> throwIO e
  where
+  sendPending lastModRevVar inFlightVar =
+    withConnection (connParams tracer (Just . Timeout Second $ TimeoutValue 3)) (grpcServer config) $ \conn ->
+      let go n
+            | n <= 0 = pure ()
+            | otherwise =
+                nextPendingBatch inFlightVar queue maxBatchCount maxBatchBytes >>= \case
+                  Nothing -> pure ()
+                  Just batch -> do
+                    putMessage tracer conn ourHost lastModRevVar (batchValue $ snd <$> batch)
+                    popBatchPersistentQueue tracer queue batch
+                    atomically $ writeTVar inFlightVar Nothing
+                    go (n - 1)
+       in go maxPutsPerConnection
+
+  -- Each batch is one unary call; bounded well below the several-thousand
+  -- calls where #2167 was observed.
+  maxPutsPerConnection = 1000 :: Int
+
+  maxBatchCount = 50
+
+  -- Keeps the value comfortably below etcd's default 1.5MiB request limit.
+  maxBatchBytes = 256 * 1024
   -- Same retry shape as the broadcast loop: keep trying through
   -- transient connection errors so we can survive an etcd cluster that
   -- is still electing or that we briefly cannot reach.
@@ -453,48 +490,46 @@ queryInitialModRev tracer config ourHost =
 -- down the node, and on restart 'queryInitialModRev' re-seeds
 -- 'lastModRev' from whatever state etcd actually has.
 putMessage ::
-  ToCBOR msg =>
   Tracer IO EtcdLog ->
-  NetworkConfiguration ->
+  -- | Connection provided (and recycled) by 'broadcastMessages'.
+  Connection ->
   -- | Used to identify sender.
   Host ->
   -- | The peer's last observed 'mod_revision' on its own broadcast key.
   TVar IO Int64 ->
-  msg ->
+  -- | Value to write, a batch of serialized messages (see 'batchValue').
+  ByteString ->
   IO ()
-putMessage tracer config ourHost lastModRevVar msg = do
+putMessage tracer conn ourHost lastModRevVar value = do
   lastModRev <- readTVarIO lastModRevVar
-  -- XXX: Here we open a new connection _for every message_! This is
-  -- effectively a work-around for https://github.com/cardano-scaling/hydra/issues/2167.
-  withConnection (connParams tracer (Just . Timeout Second $ TimeoutValue 3)) (grpcServer config) $ \conn -> do
-    res <- nonStreaming conn (rpc @(Protobuf KV "txn")) (txnReq lastModRev)
-    if res ^. #succeeded
-      then
-        -- Our compare matched and the put ran. The new mod_revision on
-        -- our key equals the cluster revision returned in the response
-        -- header.
-        atomically $ writeTVar lastModRevVar (res ^. #header . #revision)
-      else case res ^? #responses . traverse . #responseRange . #kvs . traverse . #modRevision of
-        Just observedModRev -> do
-          -- Compare failed. Since 'broadcastMessages' seeded 'lastModRev'
-          -- from etcd at startup and we are the only writer to our key,
-          -- the only way 'mod_revision' moved past 'lastModRev' is an
-          -- earlier attempt of ours committing server-side despite a
-          -- 'GrpcDeadlineExceeded' to the client. The message has been
-          -- delivered; adopt the new baseline and let the outer loop pop.
-          traceWith tracer BroadcastDeduped{previousModRev = lastModRev, observedModRev}
-          atomically $ writeTVar lastModRevVar observedModRev
-        Nothing ->
-          -- Compare failed AND range came back empty: etcd has no record
-          -- of our key. Unreachable in normal operation (only we write to
-          -- our key; nothing deletes it). If we ever do hit this, the
-          -- safe move is to crash loudly — the surrounding race kills the
-          -- node and a fresh start re-runs 'queryInitialModRev' against
-          -- whatever state etcd actually has.
-          fail $
-            "putMessage: compare against mod_revision "
-              <> show lastModRev
-              <> " failed but our broadcast key has no current value in etcd"
+  res <- nonStreaming conn (rpc @(Protobuf KV "txn")) (txnReq lastModRev)
+  if res ^. #succeeded
+    then
+      -- Our compare matched and the put ran. The new mod_revision on
+      -- our key equals the cluster revision returned in the response
+      -- header.
+      atomically $ writeTVar lastModRevVar (res ^. #header . #revision)
+    else case res ^? #responses . traverse . #responseRange . #kvs . traverse . #modRevision of
+      Just observedModRev -> do
+        -- Compare failed. Since 'broadcastMessages' seeded 'lastModRev'
+        -- from etcd at startup and we are the only writer to our key,
+        -- the only way 'mod_revision' moved past 'lastModRev' is an
+        -- earlier attempt of ours committing server-side despite a
+        -- 'GrpcDeadlineExceeded' to the client. The message has been
+        -- delivered; adopt the new baseline and let the outer loop pop.
+        traceWith tracer BroadcastDeduped{previousModRev = lastModRev, observedModRev}
+        atomically $ writeTVar lastModRevVar observedModRev
+      Nothing ->
+        -- Compare failed AND range came back empty: etcd has no record
+        -- of our key. Unreachable in normal operation (only we write to
+        -- our key; nothing deletes it). If we ever do hit this, the
+        -- safe move is to crash loudly — the surrounding race kills the
+        -- node and a fresh start re-runs 'queryInitialModRev' against
+        -- whatever state etcd actually has.
+        fail $
+          "putMessage: compare against mod_revision "
+            <> show lastModRev
+            <> " failed but our broadcast key has no current value in etcd"
  where
   key = encodeUtf8 @Text $ "msg-" <> show ourHost
 
@@ -511,7 +546,7 @@ putMessage tracer config ourHost lastModRevVar msg = do
       & #requestPut
         .~ ( defMessage
               & #key .~ key
-              & #value .~ serialize' msg
+              & #value .~ value
            )
 
   rangeReqOp =
@@ -523,8 +558,20 @@ putMessage tracer config ourHost lastModRevVar msg = do
       & #success .~ [putReqOp]
       & #failure .~ [rangeReqOp]
 
+-- | Assemble the etcd value for a batch of already-serialized messages: a
+-- CBOR list reusing each message's encoding verbatim. Uses the same
+-- indefinite-length list format as cardano-binary's list instances, so the
+-- value decodes as @[msg]@ on the receiving side.
+batchValue :: [ByteString] -> ByteString
+batchValue encodedItems =
+  CBOR.toStrictByteString $
+    CBOR.encodeListLenIndef
+      <> foldMap CBOR.encodePreEncoded encodedItems
+      <> CBOR.encodeBreak
+
 -- | Fetch and wait for messages from the etcd cluster.
 waitMessages ::
+  forall msg.
   FromCBOR msg =>
   Tracer IO EtcdLog ->
   Connection ->
@@ -570,16 +617,22 @@ waitMessages tracer conn directory NetworkCallback{deliver} =
 
   process event = do
     let value = event ^. #kv . #value
-    case decodeFull' value of
+    -- Broadcast values carry a batch of messages per revision (see
+    -- 'batchValue'). Watch catch-up can still replay single-message values
+    -- written before an upgrade, so fall back to decoding one message.
+    case decodeFull' @[msg] value of
+      Right msgs -> forM_ msgs deliver
       Left err ->
-        traceWith
-          tracer
-          FailedToDecodeValue
-            { key = decodeUtf8 $ event ^. #kv . #key
-            , value = encodeBase16 value
-            , reason = show err
-            }
-      Right msg -> deliver msg
+        case decodeFull' value of
+          Right msg -> deliver msg
+          Left _ ->
+            traceWith
+              tracer
+              FailedToDecodeValue
+                { key = decodeUtf8 $ event ^. #kv . #key
+                , value = encodeBase16 value
+                , reason = show err
+                }
 
 getLastKnownRevision :: MonadIO m => FilePath -> m Natural
 getLastKnownRevision directory = do
@@ -730,8 +783,11 @@ withProcessInterrupt config =
 
 -- * Persistent queue
 
+-- | Queue elements carry the item's CBOR serialization, produced once on
+-- write and reused for both the on-disk file and the etcd value, so
+-- broadcasting does not serialize twice.
 data PersistentQueue m a = PersistentQueue
-  { queue :: TBQueue m (Natural, a)
+  { queue :: TBQueue m (Natural, a, ByteString)
   , nextIx :: TVar m Natural
   , directory :: FilePath
   }
@@ -768,7 +824,7 @@ newPersistentQueue tracer path capacity = do
           Left err ->
             fail $ "Failed to decode item: " <> show err
           Right item ->
-            atomically $ writeTBQueue queue (idx, item)
+            atomically $ writeTBQueue queue (idx, item, bs)
       pure $ List.last idxs
 
 -- | Write a value to the queue, blocking if the queue is full.
@@ -778,25 +834,106 @@ writePersistentQueue tracer PersistentQueue{queue, nextIx, directory} item = do
     next <- readTVar nextIx
     modifyTVar' nextIx (+ 1)
     pure next
-  writeFileBS (directory </> show next) (serialize' item)
+  let !bytes = serialize' item
+  writeFileBS (directory </> show next) bytes
   full <- atomically $ isFullTBQueue queue
   when full $ liftIO $ traceWith tracer PersistentQueueFull
-  atomically $ writeTBQueue queue (next, item)
+  atomically $ writeTBQueue queue (next, item, bytes)
 
 -- | Get the next value from the queue without removing it, blocking if the
 -- queue is empty.
 peekPersistentQueue :: MonadSTM m => PersistentQueue m a -> m a
 peekPersistentQueue PersistentQueue{queue} = do
-  snd <$> atomically (peekTBQueue queue)
+  (\(_, item, _) -> item) <$> atomically (peekTBQueue queue)
+
+-- | Like 'peekPersistentQueue', but returns 'Nothing' instead of blocking
+-- when the queue is empty.
+tryPeekPersistentQueue :: MonadSTM m => PersistentQueue m a -> m (Maybe a)
+tryPeekPersistentQueue PersistentQueue{queue} = do
+  fmap (\(_, item, _) -> item) <$> atomically (tryPeekTBQueue queue)
+
+-- | Get all pending values and their serializations, up to the given count
+-- and total byte limits, blocking until at least one is available. Values
+-- are not removed; use 'popBatchPersistentQueue' after they were sent.
+peekBatchPersistentQueue :: MonadSTM m => PersistentQueue m a -> Int -> Int -> m [(a, ByteString)]
+peekBatchPersistentQueue PersistentQueue{queue} maxCount maxBytes = atomically $ do
+  first' <- readTBQueue queue
+  -- Collected in reverse consumption order
+  rest <- go (remainingAfter first') []
+  -- Restore everything we consumed: 'unGetTBQueue' pushes to the front, so
+  -- restoring newest-first re-establishes the original queue order.
+  forM_ (rest <> [first']) $ unGetTBQueue queue
+  pure $ (\(_, item, bytes) -> (item, bytes)) <$> (first' : reverse rest)
+ where
+  go budget acc
+    | length acc >= maxCount - 1 = pure acc
+    | otherwise =
+        tryReadTBQueue queue >>= \case
+          Nothing -> pure acc
+          Just next@(_, _, bytes)
+            | BS.length bytes > budget -> do
+                unGetTBQueue queue next
+                pure acc
+            | otherwise -> go (budget - BS.length bytes) (next : acc)
+
+  remainingAfter (_, _, bytes) = maxBytes - BS.length bytes
+
+-- | Get the batch to broadcast next: the batch already in flight if there is
+-- one, otherwise a fresh one peeked from the queue (and recorded as in
+-- flight). Returns 'Nothing' when nothing is pending. The caller must clear
+-- the in-flight var after popping a successfully sent batch.
+--
+-- Pinning the in-flight batch across transient retries matters for the
+-- compare-fail dedup in 'putMessage': a put can commit server-side while the
+-- client sees e.g. 'GrpcDeadlineExceeded'. The retry must send (and
+-- afterwards pop) exactly the content of the committed attempt. Re-peeking
+-- on retry could pick up messages enqueued in the meantime; the dedup branch
+-- would then declare the grown batch delivered and the never-sent tail would
+-- be popped and lost.
+nextPendingBatch ::
+  MonadSTM m =>
+  TVar m (Maybe [(a, ByteString)]) ->
+  PersistentQueue m a ->
+  Int ->
+  Int ->
+  m (Maybe [(a, ByteString)])
+nextPendingBatch inFlightVar queue maxCount maxBytes =
+  readTVarIO inFlightVar >>= \case
+    Just batch -> pure (Just batch)
+    Nothing ->
+      tryPeekPersistentQueue queue >>= \case
+        Nothing -> pure Nothing
+        Just _ -> do
+          -- All pending messages (bounded by the given limits) are sent as a
+          -- single etcd value, so a whole batch costs one Raft commit
+          -- instead of one per message.
+          batch <- peekBatchPersistentQueue queue maxCount maxBytes
+          atomically $ writeTVar inFlightVar (Just batch)
+          pure (Just batch)
+
+-- | Remove a batch previously returned by 'peekBatchPersistentQueue'. Pops
+-- unconditionally, one item per batch entry: this thread is the sole
+-- consumer, so the queue head still holds exactly the peeked items (an
+-- item-matching guard could only silently no-op and wedge the queue, see
+-- #2742).
+popBatchPersistentQueue :: (MonadSTM m, MonadIO m) => Tracer IO EtcdLog -> PersistentQueue m a -> [(a, ByteString)] -> m ()
+popBatchPersistentQueue tracer PersistentQueue{queue, directory} batch = do
+  indices <- atomically $ forM batch $ \_ -> (\(ix, _, _) -> ix) <$> readTBQueue queue
+  forM_ indices $ removeQueueFile tracer directory
 
 -- | Remove the head element from the queue. Must only be called after a
 -- successful 'peekPersistentQueue' by the same (single) consumer thread.
--- Failing to delete the backing file is traced but not fatal: the message was
--- already broadcast, so a leftover file only means it may be re-broadcast
--- after a restart (at-least-once delivery, same as the crash-recovery path).
 popPersistentQueue :: (MonadSTM m, MonadIO m) => Tracer IO EtcdLog -> PersistentQueue m a -> m ()
 popPersistentQueue tracer PersistentQueue{queue, directory} = do
-  (ix, _) <- atomically $ readTBQueue queue
+  (ix, _, _) <- atomically $ readTBQueue queue
+  removeQueueFile tracer directory ix
+
+-- | Delete the backing file of a popped queue item. Failing to delete is
+-- traced but not fatal: the message was already broadcast, so a leftover
+-- file only means it may be re-broadcast after a restart (at-least-once
+-- delivery, same as the crash-recovery path).
+removeQueueFile :: MonadIO m => Tracer IO EtcdLog -> FilePath -> Natural -> m ()
+removeQueueFile tracer directory ix =
   liftIO $
     removeFile (directory </> show ix) `catch` \e ->
       unless (isDoesNotExistError e) $

--- a/hydra-node/src/Hydra/Node/Network.hs
+++ b/hydra-node/src/Hydra/Node/Network.hs
@@ -74,8 +74,11 @@ withNetwork tracer conf callback action = do
 
 -- | The latest hydra network protocol version. Used to identify
 -- incompatibilities ahead of time.
+--
+-- Version 2: broadcast values carry a CBOR list of messages per etcd
+-- revision (batched broadcast) instead of a single message.
 currentNetworkProtocolVersion :: ProtocolVersion
-currentNetworkProtocolVersion = ProtocolVersion 1
+currentNetworkProtocolVersion = ProtocolVersion 2
 
 -- * Tracing
 

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -6,6 +6,7 @@ module Hydra.NetworkSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
+import Cardano.Binary (serialize')
 import Codec.CBOR.Read (deserialiseFromBytes)
 import Codec.CBOR.Write (toLazyByteString)
 import Control.Concurrent.Class.MonadSTM (
@@ -23,9 +24,10 @@ import Hydra.Network (
   ProtocolVersion (..),
   WhichEtcd (..),
  )
-import Hydra.Network.Etcd (EtcdLog (..), getClientPort, isTransientGrpcError, peerPortToClientPort, putMessage, withEtcdNetwork)
+import Hydra.Network.Etcd (EtcdLog (..), batchValue, connParams, getClientPort, grpcServer, isTransientGrpcError, peerPortToClientPort, putMessage, queryInitialModRev, withEtcdNetwork)
 import Hydra.Network.Message (Message (..))
 import Hydra.Node.Network (NetworkConfiguration (..))
+import Network.GRPC.Client (withConnection)
 import Network.GRPC.Common (GrpcError (..))
 import System.Directory (removeFile)
 import System.FilePath ((</>))
@@ -133,7 +135,8 @@ spec = do
                 -- Compare against 0 must fail (real modRev > 0); the
                 -- failure branch should adopt the observed revision
                 -- and trace BroadcastDeduped instead of writing.
-                putMessage @Int captureTracer config host staleVar 99
+                withConnection (connParams captureTracer Nothing) (grpcServer config) $ \conn ->
+                  putMessage captureTracer conn host staleVar (batchValue [serialize' (99 :: Int)])
                 captured <- map message <$> readTVarIO traces
                 captured
                   `shouldSatisfy` any
@@ -318,6 +321,64 @@ spec = do
                 withEtcdNetwork @Int tracer v1 carolConfig recordCarol $ \_ -> do
                   broadcast n1 1001
                   waitCarol `shouldReturn` 1001
+
+      -- Sequential broadcasts force one etcd put each (batching only kicks
+      -- in when the queue backs up), so 5000 sends cross the broadcast
+      -- connection recycle boundary several times. Guards against the
+      -- long-lived connection blocking (issue #2167) with the reused
+      -- connection. Takes a few minutes, hence local-only.
+      around_ onlyLocal $ it "sustains sequential broadcasts across connection recycles" $ \tracer ->
+        withTempDir "test-etcd" $ \tmp -> do
+          failAfter 600 $ do
+            PeerConfig2{aliceConfig, bobConfig} <- setup2Peers tmp
+            (recordBob, waitBob, _) <- newRecordingCallback
+            withEtcdNetwork @Int tracer v1 aliceConfig noopCallback $ \n1 ->
+              withEtcdNetwork @Int tracer v1 bobConfig recordBob $ \_ ->
+                forM_ [1 .. 5000 :: Int] $ \msg -> do
+                  broadcast n1 msg
+                  waitBob `shouldReturn` msg
+
+      it "batches queued messages and delivers them in order" $ \tracer -> do
+        withTempDir "test-etcd" $ \tmp -> do
+          failAfter 60 $ do
+            PeerConfig2{aliceConfig, bobConfig} <- setup2Peers tmp
+            (recordBob, waitBob, _) <- newRecordingCallback
+            withEtcdNetwork @Int tracer v1 aliceConfig noopCallback $ \n1 ->
+              withEtcdNetwork @Int tracer v1 bobConfig recordBob $ \_ -> do
+                -- Broadcast without waiting in between, so the sender's queue
+                -- accumulates and messages travel as multi-message batch
+                -- values. Delivery must still be in order, exactly once.
+                forM_ [1 .. 200] $ broadcast n1
+                forM_ [1 .. 200] $ \msg -> waitBob `shouldReturn` msg
+
+      it "delivers legacy single-message values" $ \tracer -> do
+        failAfter 30 $
+          withTempDir "test-etcd" $ \tmp -> do
+            withFreePortAndDerived peerPortToClientPort $ \port -> do
+              let host = Host lo port
+                  config =
+                    NetworkConfiguration
+                      { listen = host
+                      , advertise = host
+                      , signingKey = aliceSk
+                      , otherParties = []
+                      , peers = []
+                      , nodeId = "alice"
+                      , persistenceDir = tmp </> "alice"
+                      , whichEtcd = SystemEtcd
+                      }
+              (recordingCallback, waitNext, _) <- newRecordingCallback
+              withEtcdNetwork @Int tracer v1 config recordingCallback $ \n -> do
+                broadcast n 1
+                waitNext `shouldReturn` 1
+                -- Write a value in the pre-batching wire format (a single
+                -- CBOR message, not a list); the watch must deliver it
+                -- through the legacy fallback decoder.
+                rev <- queryInitialModRev tracer config host
+                revVar <- newLabelledTVarIO "legacy-value-mod-rev" rev
+                withConnection (connParams tracer Nothing) (grpcServer config) $ \conn ->
+                  putMessage tracer conn host revVar (serialize' (7 :: Int))
+                waitNext `shouldReturn` 7
 
       it "handles compaction and lost local state" $ \tracer -> do
         withTempDir "test-etcd" $ \tmp -> do

--- a/hydra-node/test/Hydra/PersistentQueueSpec.hs
+++ b/hydra-node/test/Hydra/PersistentQueueSpec.hs
@@ -4,10 +4,10 @@ module Hydra.PersistentQueueSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import Control.Concurrent.Class.MonadSTM (check, newTVarIO, readTVarIO)
+import Control.Concurrent.Class.MonadSTM (check, newTVarIO, readTVarIO, writeTVar)
 import Control.Monad.Class.MonadAsync (concurrently, wait, withAsync)
 import Hydra.Logging (Envelope (message), nullTracer, traceInTVar)
-import Hydra.Network.Etcd (EtcdLog (..), newPersistentQueue, peekPersistentQueue, popPersistentQueue, writePersistentQueue)
+import Hydra.Network.Etcd (EtcdLog (..), newPersistentQueue, nextPendingBatch, peekBatchPersistentQueue, peekPersistentQueue, popBatchPersistentQueue, popPersistentQueue, writePersistentQueue)
 import System.Directory (createDirectory, listDirectory, removeFile)
 import System.FilePath ((</>))
 import Test.QuickCheck (counterexample, generate, ioProperty)
@@ -115,6 +115,79 @@ spec = do
       -- The queue starts empty but stays functional
       writePersistentQueue tracer q 42
       peekPersistentQueue q `shouldReturn` 42
+
+  it "peekBatch returns the FIFO prefix and popBatch removes exactly it" $ do
+    withTempDir "persistent-queue" $ \dir -> do
+      q <- newPersistentQueue nullTracer dir 10
+      forM_ [1 .. 5 :: Int] $ writePersistentQueue nullTracer q
+      batch <- peekBatchPersistentQueue q 3 maxBound
+      (fst <$> batch) `shouldBe` [1, 2, 3]
+      -- Peeking does not consume
+      peekPersistentQueue q `shouldReturn` 1
+      popBatchPersistentQueue nullTracer q batch
+      peekPersistentQueue q `shouldReturn` 4
+      -- Popped items must not be reloaded on restart
+      q2 <- shouldNotBlock $ newPersistentQueue @_ @Int nullTracer dir 10
+      peekPersistentQueue q2 `shouldReturn` 4
+
+  it "popBatch unblocks a blocked writer when at capacity" $ do
+    withTempDir "persistent-queue" $ \dir -> do
+      traces <- newTVarIO []
+      let tracer = traceInTVar traces "PersistentQueueSpec"
+      q <- newPersistentQueue tracer dir 2
+      forM_ [1, 2 :: Int] $ writePersistentQueue tracer q
+      withAsync (writePersistentQueue tracer q 3) $ \writer -> do
+        shouldNotBlock_ . atomically $ do
+          entries <- readTVar traces
+          check $ PersistentQueueFull `elem` (message <$> entries)
+        batch <- peekBatchPersistentQueue q 2 maxBound
+        popBatchPersistentQueue tracer q batch
+        shouldNotBlock_ $ wait writer
+      peekPersistentQueue q `shouldReturn` 3
+
+  it "popBatch tolerates missing backing files and traces failing deletions" $ do
+    withTempDir "persistent-queue" $ \dir -> do
+      traces <- newTVarIO []
+      let tracer = traceInTVar traces "PersistentQueueSpec"
+      q <- newPersistentQueue tracer dir 10
+      forM_ [1, 2 :: Int] $ writePersistentQueue tracer q
+      files <- sort <$> listDirectory dir
+      case files of
+        [f1, f2] -> do
+          -- One file vanished (ENOENT, tolerated silently), the other
+          -- becomes a directory so deletion fails with EISDIR (traced)
+          removeFile (dir </> f1)
+          removeFile (dir </> f2)
+          createDirectory (dir </> f2)
+        _ -> failure $ "expected two backing files, got: " <> show files
+      batch <- peekBatchPersistentQueue q 2 maxBound
+      popBatchPersistentQueue tracer q batch
+      entries <- readTVarIO traces
+      (message <$> entries) `shouldSatisfy` any isDeleteFailed
+      -- The queue keeps operating
+      writePersistentQueue tracer q (3 :: Int)
+      peekPersistentQueue q `shouldReturn` 3
+
+  it "keeps the in-flight batch pinned across retries" $ do
+    withTempDir "persistent-queue" $ \dir -> do
+      q <- newPersistentQueue nullTracer dir 10
+      inFlightVar <- newTVarIO Nothing
+      forM_ [1, 2 :: Int] $ writePersistentQueue nullTracer q
+      Just batch <- nextPendingBatch inFlightVar q 50 maxBound
+      (fst <$> batch) `shouldBe` [1, 2]
+      -- Messages arriving while a send is in flight (e.g. during a transient
+      -- gRPC retry) must not grow the retried batch: the compare-fail dedup
+      -- in putMessage would declare a grown batch delivered and its
+      -- never-sent tail would be popped and lost.
+      writePersistentQueue nullTracer q 3
+      Just retried <- nextPendingBatch inFlightVar q 50 maxBound
+      (fst <$> retried) `shouldBe` [1, 2]
+      -- After a successful send the pin is cleared and the next batch picks
+      -- up the remaining messages.
+      popBatchPersistentQueue nullTracer q retried
+      atomically $ writeTVar inFlightVar Nothing
+      Just next <- nextPendingBatch inFlightVar q 50 maxBound
+      (fst <$> next) `shouldBe` [3]
 
 isDeleteFailed :: EtcdLog -> Bool
 isDeleteFailed = \case


### PR DESCRIPTION
- Broadcast sends all pending messages as a single CBOR-list etcd value over a reused gRPC connection (one Raft commit), instead of a new connection + commit per message.
- **BREAKING**: bumps the network protocol version to 2; mixed-version heads cannot exchange messages (older nodes drop batched values).

Stacked on `10x-perf-1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)