### PR TITLE
perf-4: Compute accumulator commitment via rust FFI and update incrementally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@ compile-time coupling to a single version's scripts [#2740](https://github.com/c
   surfaced as a `NetworkVersionMismatch` server output but does not stop the
   node. [#2778](https://github.com/cardano-scaling/hydra/pull/2778)
 
+- Snapshot creation is much faster on large UTxO sets: the accumulator
+  commitment is computed through the rust-accumulator FFI (bit-identical
+  output) and updated incrementally from the previous confirmed snapshot.
+  [#2780](https://github.com/cardano-scaling/hydra/pull/2780)
+
 - `maxTxsPerSnapshot` raised from 100 to 1000 (leader-side only, no
   coordinated upgrade required).
   [#2777](https://github.com/cardano-scaling/hydra/pull/2777)

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -529,3 +529,18 @@ values written by a newer one. A mismatch is reported to API clients as a
 `NetworkVersionMismatch` server output, but the node keeps running, so watch
 for it after upgrades. Upgrade all members of a head together before resuming
 operation; there is no support for mixed-version heads.
+
+### Snapshot signing thread pool
+
+Computing the snapshot accumulator commitment runs through a Rust library
+(`rust-accumulator`) which parallelizes with a [rayon](https://github.com/rayon-rs/rayon)
+thread pool sized to all visible cores by default. On hosts where hydra-node
+shares cores with other latency-sensitive processes (such as cardano-node), the
+pool size can be bounded via the environment:
+
+```
+RAYON_NUM_THREADS=2
+```
+
+This trades some per-snapshot signing latency on large UTxO sets for less
+scheduler interference; with small UTxO sets the effect is negligible.

--- a/hydra-node/src/Hydra/HeadLogic.hs
+++ b/hydra-node/src/Hydra/HeadLogic.hs
@@ -347,7 +347,14 @@ onOpenNetworkReqSn env ledger pendingDeposits currentSlot st otherParty sv sn re
               --       𝑈 ← 𝑈_active ◦ Treq
               requireApplyTxs activeUTxO requestedTxs $ \u ->
                 let nextUTxO = u `withoutUTxO` fromMaybe mempty mUtxoToCommit
-                    accumulator = Accumulator.buildFromSnapshotUTxOs nextUTxO mUtxoToCommit mUtxoToDecommit
+                    nextCombined = nextUTxO <> fromMaybe mempty mUtxoToCommit <> fromMaybe mempty mUtxoToDecommit
+                    -- The predecessor is confirmed at this point (see
+                    -- requireReqSn and waitNoSnapshotInFlight), so its
+                    -- accumulator covers exactly 'snapshotUTxO prevSnapshot'
+                    -- and can be updated by the UTxO delta instead of
+                    -- re-serializing and re-hashing every output.
+                    prevSnapshot = getSnapshot confirmedSnapshot
+                    accumulator = Accumulator.applyUTxODelta prevSnapshot.accumulator (snapshotUTxO prevSnapshot) nextCombined
                  in requireValidAccumulatorSize accumulator $ do
                       -- Spec: ŝ ← ̅S.s + 1
                       -- NOTE: confSn == seenSn == sn here

--- a/hydra-node/src/Hydra/HeadLogic/State.hs
+++ b/hydra-node/src/Hydra/HeadLogic/State.hs
@@ -161,9 +161,13 @@ data SeenSnapshot tx
       { snapshot :: Snapshot tx
       , signatories :: Map Party (Signature (Snapshot tx))
       -- ^ Collected signatures so far.
-      , signableBytes :: ByteString
+      , signableBytes :: ~ByteString
       -- ^ Pre-computed result of 'getSignableRepresentation snapshot', cached
-      -- to avoid recomputing the expensive UTxO hash on every AckSn verification.
+      -- to avoid recomputing the expensive UTxO hash on every AckSn
+      -- verification. Explicitly lazy under StrictData: state hydration folds
+      -- every historical 'NodeState' to WHNF, and a strict field here would
+      -- force one full accumulator commitment per replayed SnapshotRequested
+      -- event. At runtime it is forced once, on the first AckSn.
       }
   deriving stock (Generic)
 

--- a/hydra-node/src/Hydra/Node/Run.hs
+++ b/hydra-node/src/Hydra/Node/Run.hs
@@ -80,8 +80,9 @@ run opts = do
   -- access parses ~300KB of JSON and BLS-decompresses 4096 curve points.
   -- Doing it here means the API server only starts after the warm-up, so
   -- clients cannot connect and time out waiting for HeadIsOpen while the
-  -- node is still initialising the cryptographic setup.
-  void $ evaluate $ either (error . show) length KZG.g1BuiltinPoints
+  -- node is still initialising the cryptographic setup. The native Point1
+  -- CRS is what the rust FFI commitment path consumes.
+  void $ evaluate $ either (error . show) length KZG.g1Points
   either (throwIO . InvalidOptionException) pure $ validateRunOptions opts
   withTracer verbosity $ \tracer' -> do
     traceWith tracer' (NodeOptions opts)

--- a/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSnapshotSpec.hs
@@ -75,6 +75,18 @@ spec = do
     describe "Generic Snapshot property" $ do
       prop "there's always a leader for every snapshot number" prop_thereIsAlwaysALeader
 
+    describe "SeenSnapshot" $ do
+      it "forcing to WHNF does not compute the signable bytes" $ do
+        -- State hydration folds every historical NodeState to WHNF; a strict
+        -- signableBytes field would recompute one accumulator commitment per
+        -- replayed SnapshotRequested event. This throws if the field ever
+        -- loses its laziness annotation.
+        let poisoned =
+              (testSnapshot 1 0 [] mempty :: Snapshot SimpleTx)
+                { accumulator = error "signableBytes forced during WHNF"
+                }
+        mkSeenSnapshot poisoned mempty `seq` pure @IO ()
+
     describe "On ReqTx" $ do
       prop "always emit ReqSn given head has 1 member" prop_singleMemberHeadAlwaysSnapshotOnReqTx
 

--- a/hydra-tx/bench/accumulator/Main.hs
+++ b/hydra-tx/bench/accumulator/Main.hs
@@ -5,6 +5,19 @@
 -- This suite measures the performance of accumulator operations with realistic
 -- UTxO sets to understand the performance implications of using accumulators
 -- for snapshot signing and partial fanout.
+--
+-- Benchmarking rules:
+--
+--  * 'HydraAccumulator' memoizes its commitment and hash per value, so never
+--    measure a cache-reading function (like 'getAccumulatorHash' or
+--    'getAccumulatorCommitment') applied to an argument shared across
+--    iterations; either rebuild the accumulator inside the measured function
+--    or measure one that recomputes unconditionally (like
+--    'computeG1CommitmentBytes').
+--
+--  * Plutus builtin wrappers ('BuiltinBLS12_381_G1_Element' et al) are lazy:
+--    WHNF of a commitment point does none of the BLS math. Always force
+--    through compression to bytes.
 module Main where
 
 import Hydra.Prelude
@@ -15,6 +28,7 @@ import Criterion.Main (bench, bgroup, defaultMain, nf, whnf)
 import Hydra.Cardano.Api
 import Hydra.Tx.Accumulator (
   buildFromUTxO,
+  computeG1CommitmentBytes,
   createMembershipProof,
   createMembershipProofFromUTxO,
   crsG1Points,
@@ -30,92 +44,67 @@ import Test.QuickCheck (generate)
 -- comment thing
 main :: IO ()
 main = do
+  -- A single uncached commitment at 4000 UTxOs currently takes minutes, so the
+  -- largest sizes are opt-in:
+  --
+  -- > BENCH_MAX_UTXO=4000 cabal bench hydra-tx:accumulator-bench
+  maxN <- fromMaybe 1000 . (>>= readMaybe) <$> lookupEnv "BENCH_MAX_UTXO"
+  let sizes = filter (<= maxN) [10, 50, 100, 500, 1000, 2000, 4000]
+
   putTextLn "=== Accumulator Benchmark Suite ==="
-  putTextLn "Generating test data..."
+  putTextLn $ "Generating UTxO sets: " <> show sizes
 
-  -- NOTE: The accumulator now uses G1 points for commitment (4096 available from
-  -- EIP-4844), so the maximum is 4095 elements. We benchmark a wide range to show
-  -- how build/hash/proof costs scale.
+  fixtures <- forM sizes $ \n -> do
+    utxo <- generate $ genUTxOAdaOnlyOfSize n
+    let acc = buildFromUTxO @Tx utxo
+        crs = crsG1Points (n + 1)
+        subset = generateSubset utxo fanoutChunkSize
+    -- Deep-force the accumulator map (but not the memoized hash) and the CRS
+    -- spine (Point1 has no NFData) so benchmarks measure only their own work.
+    let !_ = unHydraAccumulator acc `deepseq` (length crs + UTxO.size subset)
+    pure (n, utxo, acc, crs, subset)
 
-  -- Generate UTxO sets across the full useful range
-  utxo10 <- generateUTxO 10
-  utxo50 <- generateUTxO 50
-  utxo100 <- generateUTxO 100
-  utxo500 <- generateUTxO 500
-  utxo1000 <- generateUTxO 1000
-  utxo2000 <- generateUTxO 2000
-  utxo4000 <- generateUTxO 4000
-
-  putTextLn "Generated UTxO sets: 10, 50, 100, 500, 1000, 2000, 4000"
-
-  -- Pre-build accumulators and force them
-  let !acc10 = buildFromUTxO @Tx utxo10
-      !acc50 = buildFromUTxO @Tx utxo50
-      !acc100 = buildFromUTxO @Tx utxo100
-      !acc500 = buildFromUTxO @Tx utxo500
-      !acc1000 = buildFromUTxO @Tx utxo1000
-      !acc2000 = buildFromUTxO @Tx utxo2000
-      !acc4000 = buildFromUTxO @Tx utxo4000
-
-  putTextLn "Pre-built accumulators"
-
-  -- Pre-generate G1 CRS of various sizes and force them
-  let !crs11 = crsG1Points 11
-      !crs51 = crsG1Points 51
-      !crs101 = crsG1Points 101
-      !crs501 = crsG1Points 501
-      !crs1001 = crsG1Points 1001
-      !crs2001 = crsG1Points 2001
-      !crs4001 = crsG1Points 4001
-
-  putTextLn "Pre-generated CRS"
-
-  -- Generate 7 subsets for membership proofs
-  let !subsetChunk_from50 = generateSubset utxo50 fanoutChunkSize
-  let !subsetChunk_from100 = generateSubset utxo100 fanoutChunkSize
-  let !subsetChunk_from500 = generateSubset utxo500 fanoutChunkSize
-  let !subsetChunk_from1000 = generateSubset utxo1000 fanoutChunkSize
-  let !subsetChunk_from2000 = generateSubset utxo2000 fanoutChunkSize
-  let !subsetChunk_from4000 = generateSubset utxo4000 fanoutChunkSize
-
-  putTextLn "Generated subsets for membership proofs"
-
-  -- Extract individual elements for low-level proof testing
-  let !elements10 = outputsOfUTxO @Tx utxo10
-      !elements100 = outputsOfUTxO @Tx utxo100
-      !serialized10 = utxoToElement @Tx <$> elements10
-      !serialized100 = utxoToElement @Tx <$> elements100
+  -- Fixed-size fixtures for element conversion and low-level proof benches
+  utxo10 <- generate $ genUTxOAdaOnlyOfSize 10
+  utxo100 <- generate $ genUTxOAdaOnlyOfSize 100
+  let elements10 = outputsOfUTxO @Tx utxo10
+      elements100 = outputsOfUTxO @Tx utxo100
+      serialized10 = utxoToElement @Tx <$> elements10
+      serialized100 = utxoToElement @Tx <$> elements100
+      acc10 = buildFromUTxO @Tx utxo10
+      acc100 = buildFromUTxO @Tx utxo100
+      crs11 = crsG1Points 11
+      crs101 = crsG1Points 101
+  let !_ =
+        (serialized10, serialized100)
+          `deepseq` unHydraAccumulator acc10
+          `deepseq` unHydraAccumulator acc100
+          `deepseq` (length crs11 + length crs101)
 
   putTextLn "Starting benchmarks..."
   putTextLn ""
 
   defaultMain
     [ bgroup
-        "1. Build Accumulator from UTxO"
-        [ bench "10 UTxOs" $ whnf (buildFromUTxO @Tx) utxo10
-        , bench "50 UTxOs" $ whnf (buildFromUTxO @Tx) utxo50
-        , bench "100 UTxOs" $ whnf (buildFromUTxO @Tx) utxo100
-        , bench "500 UTxOs" $ whnf (buildFromUTxO @Tx) utxo500
-        , bench "1000 UTxOs" $ whnf (buildFromUTxO @Tx) utxo1000
-        , bench "2000 UTxOs" $ whnf (buildFromUTxO @Tx) utxo2000
-        , bench "4000 UTxOs" $ whnf (buildFromUTxO @Tx) utxo4000
+        "1. Build Accumulator Map from UTxO"
+        -- Forces per-TxOut plutus-Data serialization + sha256 + blake2b224 and
+        -- the Map, but not the G1 commitment (see group 5 and 8 for that).
+        [ bench (show n <> " UTxOs") $ nf (unHydraAccumulator . buildFromUTxO @Tx) utxo
+        | (n, utxo, _, _, _) <- fixtures
         ]
     , bgroup
         "2. UTxO to Elements Conversion"
-        [ bench "Extract 10 TxOuts" $ whnf (outputsOfUTxO @Tx) utxo10
-        , bench "Extract 100 TxOuts" $ whnf (outputsOfUTxO @Tx) utxo100
-        , bench "Extract 1000 TxOuts" $ whnf (outputsOfUTxO @Tx) utxo1000
-        , bench "Serialize 10 TxOuts" $ whnf (fmap (utxoToElement @Tx)) elements10
-        , bench "Serialize 100 TxOuts" $ whnf (fmap (utxoToElement @Tx)) elements100
+        [ bench "Extract 10 TxOuts" $ whnf (length . outputsOfUTxO @Tx) utxo10
+        , bench "Extract 100 TxOuts" $ whnf (length . outputsOfUTxO @Tx) utxo100
+        , bench "Serialize 10 TxOuts" $ nf (map (utxoToElement @Tx)) elements10
+        , bench "Serialize 100 TxOuts" $ nf (map (utxoToElement @Tx)) elements100
         ]
     , bgroup
         "3. Create Membership Proofs (fanoutChunkSize batch)"
-        [ bench "fanoutChunkSize from 50" $ nf (\s -> unsafeProof $ createMembershipProofFromUTxO @Tx s acc50 crs51) subsetChunk_from50
-        , bench "fanoutChunkSize from 100" $ nf (\s -> unsafeProof $ createMembershipProofFromUTxO @Tx s acc100 crs101) subsetChunk_from100
-        , bench "fanoutChunkSize from 500" $ nf (\s -> unsafeProof $ createMembershipProofFromUTxO @Tx s acc500 crs501) subsetChunk_from500
-        , bench "fanoutChunkSize from 1000" $ nf (\s -> unsafeProof $ createMembershipProofFromUTxO @Tx s acc1000 crs1001) subsetChunk_from1000
-        , bench "fanoutChunkSize from 2000" $ nf (\s -> unsafeProof $ createMembershipProofFromUTxO @Tx s acc2000 crs2001) subsetChunk_from2000
-        , bench "fanoutChunkSize from 4000" $ nf (\s -> unsafeProof $ createMembershipProofFromUTxO @Tx s acc4000 crs4001) subsetChunk_from4000
+        [ bench ("fanoutChunkSize from " <> show n) $
+          nf (\s -> unsafeProof $ createMembershipProofFromUTxO @Tx s acc crs) subset
+        | (n, _, acc, crs, subset) <- fixtures
+        , n >= 50
         ]
     , bgroup
         "4. Create Membership Proofs (Low-level, variable batch size)"
@@ -125,45 +114,37 @@ main = do
         , bench "60 from 100" $ nf (\s -> unsafeProof $ createMembershipProof s acc100 crs101) (take 60 serialized100)
         ]
     , bgroup
-        "5. Accumulator Hashing (blake2b of compressed G1 commitment)"
-        [ bench "Hash 10 UTxOs" $ nf getAccumulatorHash acc10
-        , bench "Hash 100 UTxOs" $ nf getAccumulatorHash acc100
-        , bench "Hash 500 UTxOs" $ nf getAccumulatorHash acc500
-        , bench "Hash 1000 UTxOs" $ nf getAccumulatorHash acc1000
-        , bench "Hash 2000 UTxOs" $ nf getAccumulatorHash acc2000
-        , bench "Hash 4000 UTxOs" $ nf getAccumulatorHash acc4000
+        "5. Commitment (uncached: polynomial expansion + MSM)"
+        -- computeG1CommitmentBytes recomputes on every call (it does not read
+        -- the memoized hash) and returns strict bytes, so WHNF forces the
+        -- whole computation. This is the per-snapshot signing cost minus the
+        -- map build.
+        [ bench (show n <> " UTxOs") $
+          whnf (computeG1CommitmentBytes . unHydraAccumulator) acc
+        | (n, _, acc, _, _) <- fixtures
         ]
     , bgroup
         "6. Accumulator Serialization"
-        [ bench "Serialize accumulator (10)" $ nf (serialise . unHydraAccumulator) acc10
-        , bench "Serialize accumulator (100)" $ nf (serialise . unHydraAccumulator) acc100
-        , bench "Serialize accumulator (1000)" $ nf (serialise . unHydraAccumulator) acc1000
-        , bench "Serialize accumulator (4000)" $ nf (serialise . unHydraAccumulator) acc4000
+        [ bench ("Serialize accumulator (" <> show n <> ")") $ nf (serialise . unHydraAccumulator) acc
+        | (n, _, acc, _, _) <- fixtures
         ]
     , bgroup
         "7. CRS Loading (G1 powers of tau from EIP-4844 trusted setup)"
         -- Point1 lacks NFData, so we force the full spine via length
-        [ bench "CRS size 11" $ whnf (length . crsG1Points) 11
-        , bench "CRS size 101" $ whnf (length . crsG1Points) 101
-        , bench "CRS size 501" $ whnf (length . crsG1Points) 501
-        , bench "CRS size 1001" $ whnf (length . crsG1Points) 1001
-        , bench "CRS size 2001" $ whnf (length . crsG1Points) 2001
-        , bench "CRS size 4001" $ whnf (length . crsG1Points) 4001
+        [ bench ("CRS size " <> show (n + 1)) $ whnf (length . crsG1Points) (n + 1)
+        | (n, _, _, _, _) <- fixtures
         ]
     , bgroup
         "8. End-to-End Snapshot Simulation"
-        [ bench "Full cycle: 100 UTxOs" $ nf fullSnapshotCycle utxo100
-        , bench "Full cycle: 1000 UTxOs" $ nf fullSnapshotCycle utxo1000
-        , bench "Full cycle: 4000 UTxOs" $ nf fullSnapshotCycle utxo4000
-        , bench "Partial fanout: fanoutChunkSize from 50" $ nf (partialFanoutCycle utxo50) subsetChunk_from50
-        , bench "Partial fanout: fanoutChunkSize from 500" $ nf (partialFanoutCycle utxo500) subsetChunk_from500
-        , bench "Partial fanout: fanoutChunkSize from 4000" $ nf (partialFanoutCycle utxo4000) subsetChunk_from4000
-        ]
+        ( [ bench ("Full cycle: " <> show n <> " UTxOs") $ nf fullSnapshotCycle utxo
+          | (n, utxo, _, _, _) <- fixtures
+          ]
+            <> [ bench ("Partial fanout: fanoutChunkSize from " <> show n) $ nf (partialFanoutCycle utxo) subset
+               | (n, utxo, _, _, subset) <- fixtures
+               , n >= 50
+               ]
+        )
     ]
-
--- | Generate a UTxO set of specified size with realistic transaction outputs.
-generateUTxO :: Int -> IO UTxO
-generateUTxO n = generate $ genUTxOAdaOnlyOfSize n
 
 -- | Generate a subset of a given UTxO.
 -- This simulates selecting UTxOs for partial fanout.
@@ -180,6 +161,9 @@ generateSubset utxo n =
 -- 1. Build accumulator from UTxO
 -- 2. Hash the accumulator
 -- 3. Serialize for signing
+--
+-- The accumulator is rebuilt inside the measured function, so its memoized
+-- hash is computed fresh on every iteration.
 fullSnapshotCycle :: UTxO -> ByteString
 fullSnapshotCycle utxo =
   let accumulator = buildFromUTxO @Tx utxo

--- a/hydra-tx/hydra-tx.cabal
+++ b/hydra-tx/hydra-tx.cabal
@@ -101,7 +101,6 @@ library
     , lens
     , lens-aeson
     , mono-traversable
-    , plutus-accumulator
     , plutus-ledger-api
     , plutus-tx
     , prettyprinter
@@ -212,7 +211,9 @@ test-suite tests
     , cardano-ledger-api
     , cardano-ledger-babbage
     , cardano-ledger-core
+    , containers
     , deepseq
+    , haskell-accumulator
     , hedgehog-quickcheck
     , hspec
     , hspec-golden-aeson
@@ -226,6 +227,7 @@ test-suite tests
     , hydra-tx
     , hydra-tx:testlib
     , lens
+    , plutus-accumulator
     , plutus-ledger-api
     , plutus-tx
     , QuickCheck

--- a/hydra-tx/src/Hydra/Tx/Accumulator.hs
+++ b/hydra-tx/src/Hydra/Tx/Accumulator.hs
@@ -5,11 +5,13 @@ module Hydra.Tx.Accumulator (
   unHydraAccumulator,
   getAccumulatorHash,
   getAccumulatorCommitment,
+  computeG1CommitmentBytes,
   accumulatorSize,
   maxAccumulatorSize,
   build,
   buildFromUTxO,
   buildFromSnapshotUTxOs,
+  applyUTxODelta,
 
   -- * CRS (Common Reference String)
   crsG2Points,
@@ -23,7 +25,7 @@ module Hydra.Tx.Accumulator (
   createCRSG2Datum,
 ) where
 
-import Hydra.Prelude
+import Hydra.Prelude hiding (show)
 
 import Accumulator (Accumulator, Element)
 import Accumulator qualified
@@ -33,40 +35,46 @@ import Cardano.Crypto.EllipticCurve.BLS12_381.Internal (Point1, Point2, blsCompr
 import Cardano.Crypto.Hash (Blake2b_256)
 import Cardano.Crypto.Hash.Class (HashAlgorithm (digest))
 import Data.Map.Strict qualified as Map
-import GHC.ByteOrder (ByteOrder (BigEndian))
 import Hydra.Cardano.Api qualified as HApi
 import Hydra.Contract.KZGTrustedSetup qualified as KZG
 import Hydra.Tx.IsTx (IsTx (..))
-import Plutus.Crypto.BlsUtils (getFinalPoly, getG1Commitment, mkScalar)
 import PlutusTx.Builtins (
   BuiltinBLS12_381_G1_Element,
-  bls12_381_G1_compress,
+  bls12_381_G1_uncompress,
   bls12_381_G2_uncompress,
-  byteStringToInteger,
-  fromBuiltin,
   toBuiltin,
  )
+import Text.Show (Show (..))
 
 -- * HydraAccumulator
 
 data HydraAccumulator = HydraAccumulator
   { unHydraAccumulator :: Accumulator
+  , _cachedCommitment :: ByteString
+  -- ^ Lazy thunk: compressed G1 commitment. Forced at most once per value,
+  -- shared by the hash below and by 'getAccumulatorCommitment' (datum
+  -- construction at close/contest/fanout).
   , _cachedHash :: ByteString
-  -- ^ Lazy thunk: blake2b-256 of the compressed G1 commitment. Forced once on
-  -- first access; subsequent reads return the memoized value, avoiding repeated
+  -- ^ Lazy thunk: blake2b-256 of '_cachedCommitment'. Forced once on first
+  -- access; subsequent reads return the memoized value, avoiding repeated
   -- BLS12-381 multi-scalar multiplications for the same accumulator.
   }
-  deriving stock (Show)
+
+-- | Shows only the element map: the derived instance would force the cached
+-- commitment, so showing head state in logs or test output would compute a
+-- BLS commitment as a side effect.
+instance Show HydraAccumulator where
+  show HydraAccumulator{unHydraAccumulator = acc} =
+    "HydraAccumulator " <> show acc
 
 instance Eq HydraAccumulator where
   a == b = unHydraAccumulator a == unHydraAccumulator b
 
 mkHydraAccumulator :: Accumulator -> HydraAccumulator
-mkHydraAccumulator acc = HydraAccumulator acc cachedHash
+mkHydraAccumulator acc = HydraAccumulator acc cachedCommitment cachedHash
  where
-  cachedHash =
-    digest (Proxy @Blake2b_256) . fromBuiltin . bls12_381_G1_compress $
-      computeG1Commitment acc
+  cachedCommitment = computeG1CommitmentBytes acc
+  cachedHash = digest (Proxy @Blake2b_256) cachedCommitment
 
 build :: [ByteString] -> HydraAccumulator
 build = mkHydraAccumulator . Accumulator.buildAccumulator
@@ -131,6 +139,48 @@ buildFromSnapshotUTxOs utxo mUtxoToCommit mUtxoToDecommit =
       <> fromMaybe mempty mUtxoToCommit
       <> fromMaybe mempty mUtxoToDecommit
 
+-- | Update an accumulator from one snapshot's combined UTxO set to the next
+-- by adding and removing only the changed outputs, avoiding the per-output
+-- serialization and hashing of a full rebuild. Extensionally equal to
+-- 'buildFromUTxO' on the new set (see the property in
+-- "Hydra.Tx.AccumulatorSpec"): the underlying map tracks element multiplicity
+-- and the TxIn-keyed set difference removes exactly one occurrence per
+-- consumed input. Falls back to a full rebuild if a removed element is
+-- missing or has lower multiplicity than the removals require, which would
+-- indicate the given accumulator was not built from the given previous UTxO
+-- set.
+applyUTxODelta ::
+  forall tx.
+  IsTx tx =>
+  -- | Accumulator built from the previous combined UTxO set
+  HydraAccumulator ->
+  -- | The previous combined UTxO set
+  UTxOType tx ->
+  -- | The new combined UTxO set
+  UTxOType tx ->
+  HydraAccumulator
+applyUTxODelta prevAcc prevUTxO nextUTxO
+  | removalsCovered =
+      mkHydraAccumulator $
+        foldl' (flip Accumulator.removeElement) (foldl' Accumulator.addElement prev addedEls) removedEls
+  | otherwise = buildFromUTxO @tx nextUTxO
+ where
+  prev = unHydraAccumulator prevAcc
+
+  -- Multiset containment: every element must be present with at least the
+  -- multiplicity about to be removed. Membership alone would let a
+  -- mismatched (accumulator, previous UTxO) pair skip the fallback:
+  -- 'Accumulator.removeElement' silently no-ops once a count is exhausted,
+  -- yielding a commitment that does not bind 'nextUTxO'.
+  removalsCovered =
+    Map.isSubmapOfBy (\needed (_, held) -> needed <= held) removedCounts prev
+
+  removedCounts = Map.fromListWith (+) [(el, 1 :: Int) | el <- removedEls]
+
+  removedEls = utxoToElement @tx <$> outputsOfUTxO @tx (prevUTxO `withoutUTxO` nextUTxO)
+
+  addedEls = utxoToElement @tx <$> outputsOfUTxO @tx (nextUTxO `withoutUTxO` prevUTxO)
+
 -- | Get a blake2b-256 hash of the accumulator commitment (compressed G1 point).
 --
 -- This is a pure function that returns a 32-byte deterministic hash of the
@@ -162,21 +212,26 @@ maxAccumulatorSize = KZG.maxAccumulatorSize
 -- exercised by the test suite. A failure here would indicate binary tampering
 -- or a corrupted build artefact.
 fromKZGSetup :: Either KZG.KZGSetupError a -> a
-fromKZGSetup = either (\e -> error $ "KZG trusted setup invariant violated: " <> show e) id
+fromKZGSetup = either (\e -> error . toText $ "KZG trusted setup invariant violated: " <> show e) id
 
 getAccumulatorCommitment :: HydraAccumulator -> BuiltinBLS12_381_G1_Element
-getAccumulatorCommitment = computeG1Commitment . unHydraAccumulator
+getAccumulatorCommitment = bls12_381_G1_uncompress . toBuiltin . _cachedCommitment
 
-computeG1Commitment :: Accumulator -> BuiltinBLS12_381_G1_Element
-computeG1Commitment acc =
-  let expandedElems = concatMap (\(hash, count) -> replicate count hash) $ Map.elems acc
-      n = length expandedElems
-   in if n > KZG.maxAccumulatorSize
-        then error $ "getAccumulatorCommitment: accumulator has " <> show n <> " elements, exceeding the G1 CRS limit of " <> show KZG.maxAccumulatorSize
-        else
-          let crsG1 = take (n + 1) $ fromKZGSetup KZG.g1BuiltinPoints
-           in getG1Commitment crsG1 . getFinalPoly . map (mkScalar . byteStringToInteger BigEndian . toBuiltin) $
-                expandedElems
+-- | Compute the compressed G1 commitment for an accumulator through the
+-- rust-accumulator FFI (divide-and-conquer FFT polynomial expansion and a
+-- Pippenger multi-scalar multiplication), which is orders of magnitude
+-- faster than expanding the polynomial in Haskell. Bit-for-bit equal to the
+-- PlutusTx reference path; see the equivalence properties and golden values
+-- in "Hydra.Tx.AccumulatorSpec".
+computeG1CommitmentBytes :: Accumulator -> ByteString
+computeG1CommitmentBytes acc
+  | n > KZG.maxAccumulatorSize =
+      error . toText $ "getAccumulatorCommitment: accumulator has " <> show n <> " elements, exceeding the G1 CRS limit of " <> show KZG.maxAccumulatorSize
+  | otherwise =
+      either (\e -> error $ "computeG1CommitmentBytes: " <> toText e) blsCompress $
+        getPolyCommitOverG1 [] acc (crsG1Points (n + 1))
+ where
+  n = sum (snd <$> Map.elems acc)
 
 -- * CRS (Common Reference String)
 

--- a/hydra-tx/src/Hydra/Tx/Snapshot.hs
+++ b/hydra-tx/src/Hydra/Tx/Snapshot.hs
@@ -127,6 +127,10 @@ instance IsTx tx => FromJSON (Snapshot tx) where
     -- Reconstruct accumulator from all UTxOs (including commit/decommit).
     -- The "accumulator" JSON field stores only the hash (consistent with signing
     -- and on-chain datum), so we always rebuild the full accumulator from UTxOs.
+    -- SECURITY: never trust a hash from the JSON instead of rebuilding. This
+    -- instance is reachable from untrusted client input (SideLoadSnapshot),
+    -- and the accumulator hash is what multisignatures verify against, so it
+    -- must always be derived from the UTxO content.
     let accumulator = Accumulator.buildFromSnapshotUTxOs utxo utxoToCommit utxoToDecommit
     pure $ Snapshot{headId, version, number, confirmed, utxo, utxoToCommit, utxoToDecommit, accumulator}
 

--- a/hydra-tx/test/Hydra/Tx/AccumulatorSpec.hs
+++ b/hydra-tx/test/Hydra/Tx/AccumulatorSpec.hs
@@ -3,32 +3,118 @@ module Hydra.Tx.AccumulatorSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
+import Accumulator qualified
 import Cardano.Api.UTxO qualified as UTxO
 import Cardano.Crypto.EllipticCurve.BLS12_381.Internal (blsCompress)
-import Cardano.Crypto.Hash (Blake2b_224)
+import Cardano.Crypto.Hash (Blake2b_224, Blake2b_256)
 import Cardano.Crypto.Hash.Class (HashAlgorithm (digest))
+import Data.ByteString.Base16 qualified as Base16
+import Data.Map.Strict qualified as Map
 import GHC.ByteOrder (ByteOrder (BigEndian))
 import Hydra.Cardano.Api (Tx, UTxO)
 import Hydra.Contract.CRS (checkMembershipPairing)
 import Hydra.Contract.Head qualified as Head
-import Hydra.Contract.KZGTrustedSetup (g2BuiltinPoints)
+import Hydra.Contract.KZGTrustedSetup (g1BuiltinPoints, g2BuiltinPoints)
 import Hydra.Tx.Accumulator (
+  applyUTxODelta,
+  build,
   buildFromUTxO,
+  computeG1CommitmentBytes,
   createMembershipProofFromUTxO,
   crsG1Points,
   crsG2Points,
   defaultItems,
   getAccumulatorCommitment,
+  getAccumulatorHash,
   requiredCRSPointCount,
+  unHydraAccumulator,
  )
 import Hydra.Tx.IsTx (IsTx (outputsOfUTxO, utxoToElement))
-import PlutusTx.Builtins (bls12_381_G1_uncompress, bls12_381_G2_uncompress, byteStringToInteger, toBuiltin)
-import Test.Hydra.Tx.Gen (genUTxOWithSimplifiedAddresses)
-import Test.QuickCheck (counterexample, forAll, property, resize, sublistOf, suchThat, (===))
+import Plutus.Crypto.BlsUtils (getFinalPoly, getG1Commitment, mkScalar)
+import PlutusTx.Builtins (bls12_381_G1_compress, bls12_381_G1_uncompress, bls12_381_G2_uncompress, byteStringToInteger, fromBuiltin, toBuiltin)
+import Test.Hydra.Tx.Gen (genTxOutAdaOnly, genUTxOWithSimplifiedAddresses)
+import Test.QuickCheck (counterexample, forAll, property, resize, sublistOf, suchThat, (.&&.), (===), (==>))
 
 spec :: Spec
 spec = parallel $ do
   let g2BuiltinPts = either (error . show) id g2BuiltinPoints
+
+  -- The commitment is computed through the rust-accumulator FFI; these
+  -- properties pin it bit-for-bit against the PlutusTx path the codebase used
+  -- before, kept below as 'referenceCommitmentBytes'.
+  describe "G1 commitment" $ do
+    prop "rust FFI commitment equals the PlutusTx reference (UTxO sets)" $
+      forAll (resize 30 genUTxOWithSimplifiedAddresses) $ \utxo ->
+        let acc = unHydraAccumulator $ buildFromUTxO @Tx utxo
+         in computeG1CommitmentBytes acc === referenceCommitmentBytes acc
+
+    prop "rust FFI commitment equals the PlutusTx reference (raw elements incl. duplicates and empty)" $
+      forAll (resize 64 arbitrary) $ \(ints :: [Int]) ->
+        let els = show <$> ints
+            acc = unHydraAccumulator $ build (els <> take 3 els <> [""])
+         in computeG1CommitmentBytes acc === referenceCommitmentBytes acc
+
+    prop "applyUTxODelta equals a fresh build on the new set" $
+      forAll (resize 20 genUTxOWithSimplifiedAddresses) $ \base ->
+        forAll (sublistOf (UTxO.toList base)) $ \dropped ->
+          forAll (resize 10 genUTxOWithSimplifiedAddresses) $ \grown ->
+            let prevU = base
+                nextU = UTxO.difference base (UTxO.fromList dropped) <> grown
+                delta = applyUTxODelta @Tx (buildFromUTxO @Tx prevU) prevU nextU
+                fresh = buildFromUTxO @Tx nextU
+             in (unHydraAccumulator delta === unHydraAccumulator fresh)
+                  .&&. (getAccumulatorHash delta === getAccumulatorHash fresh)
+
+    prop "applyUTxODelta decrements duplicated outputs correctly" $
+      forAll arbitrary $ \(txIn1, txIn2) ->
+        txIn1 /= txIn2 ==>
+          forAll (genTxOutAdaOnly =<< arbitrary) $ \txOut ->
+            -- Two inputs carrying byte-identical outputs collapse to one
+            -- accumulator element with count 2; consuming one of them must
+            -- decrement, not delete.
+            let prevU = UTxO.fromList [(txIn1, txOut), (txIn2, txOut)]
+                nextU = UTxO.fromList [(txIn2, txOut)]
+                delta = applyUTxODelta @Tx (buildFromUTxO @Tx prevU) prevU nextU
+             in unHydraAccumulator delta === unHydraAccumulator (buildFromUTxO @Tx nextU)
+
+    prop "applyUTxODelta falls back to a fresh build on multiplicity mismatch" $
+      forAll arbitrary $ \(txIn1, txIn2, txIn3) ->
+        (txIn1 /= txIn2 && txIn2 /= txIn3 && txIn1 /= txIn3) ==>
+          forAll (genTxOutAdaOnly =<< arbitrary) $ \txOut ->
+            -- Mismatched precondition: the accumulator holds ONE copy of the
+            -- element while the claimed previous set carries it three times.
+            -- Removing two copies exceeds the held count; without the
+            -- multiplicity check 'Accumulator.removeElement' would silently
+            -- no-op past zero and drop the copy that 'nextU' still contains.
+            let accU = UTxO.fromList [(txIn1, txOut)]
+                prevU = UTxO.fromList [(txIn1, txOut), (txIn2, txOut), (txIn3, txOut)]
+                nextU = UTxO.fromList [(txIn3, txOut)]
+                delta = applyUTxODelta @Tx (buildFromUTxO @Tx accU) prevU nextU
+             in unHydraAccumulator delta === unHydraAccumulator (buildFromUTxO @Tx nextU)
+
+    prop "accumulator hash is the blake2b of the commitment in the datum" $
+      -- Off-chain mirror of the on-chain mustMatchAccumulatorCommitmentHash
+      -- check: the signed hash must bind to the G1 commitment stored in
+      -- close/contest datums, whatever caching sits between them.
+      forAll (resize 10 genUTxOWithSimplifiedAddresses) $ \utxo ->
+        let acc = buildFromUTxO @Tx utxo
+         in getAccumulatorHash acc
+              === digest (Proxy @Blake2b_256) (fromBuiltin (bls12_381_G1_compress (getAccumulatorCommitment acc)))
+
+    it "empty accumulator commits to the G1 generator" $
+      case crsG1Points 1 of
+        [g1] -> computeG1CommitmentBytes (unHydraAccumulator $ build []) `shouldBe` blsCompress g1
+        _ -> expectationFailure "expected exactly one CRS point"
+
+    it "oversized accumulator errors when the commitment is forced" $ do
+      let acc = unHydraAccumulator $ build (show <$> [1 .. (4096 :: Int)])
+      (pure $! computeG1CommitmentBytes acc) `shouldThrow` anyErrorCall
+
+    describe "golden commitments (recorded from the PlutusTx path before the FFI swap)" $
+      forM_ goldenCases $ \(caseName, els, expectedHex) ->
+        it ("matches golden for " <> caseName) $ do
+          let acc = unHydraAccumulator $ build els
+          Base16.encode (computeG1CommitmentBytes acc) `shouldBe` expectedHex
 
   -- checkMembershipPairing is the on-chain pairing check run by the partial
   -- fanout validator to confirm a batch of UTxOs belongs to the full snapshot.
@@ -75,6 +161,33 @@ spec = parallel $ do
       let publishedCRSDatum =
             bls12_381_G2_uncompress . toBuiltin . blsCompress <$> crsG2Points defaultItems
        in Head.canonicalCRSDatumHash `shouldBe` Head.hashCRSDatum publishedCRSDatum
+
+-- | The PlutusTx commitment implementation this codebase used before
+-- switching to the rust FFI, kept verbatim as an equivalence oracle.
+referenceCommitmentBytes :: Accumulator.Accumulator -> ByteString
+referenceCommitmentBytes acc =
+  let expandedElems = concatMap (\(h, count) -> replicate count h) $ Map.elems acc
+      n = length expandedElems
+      crsG1 = take (n + 1) $ either (error . show) id g1BuiltinPoints
+   in fromBuiltin . bls12_381_G1_compress $
+        getG1Commitment crsG1 . getFinalPoly . map (mkScalar . byteStringToInteger BigEndian . toBuiltin) $
+          expandedElems
+
+-- | Deterministic element sets with expected commitment (compressed G1, hex),
+-- recorded from the PlutusTx path before the FFI swap. These also guard
+-- future haskell-accumulator / rust-accumulator / plutus-accumulator bumps
+-- against silent behavior changes.
+goldenCases :: [(String, [ByteString], ByteString)]
+goldenCases =
+  [ ("0 elements", goldenElements 0, "97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb")
+  , ("1 element", goldenElements 1, "82d3e038e43f9ee73805cc8a6078365b8140a4012fa92643c2b3732d51cecf1fe0a1928d62fbf39878763549951bdb5a")
+  , ("3 elements with a duplicate", goldenElements 2 <> take 1 (goldenElements 1), "91211024a7d57d2648b42394f87d2740fe5ebea49ef943aae048acf5a1b59c8bbd783801d9418af9a37e4673f3f5f1fe")
+  , ("100 elements", goldenElements 100, "ac19336fad62fc5bfb9ec509bd13ecae9c8eabd4f1a5af163a0ecb71684f3f12933bac6180c52727dcf5bd44a1c2890f")
+  , ("1000 elements", goldenElements 1000, "a49e01e30e499a14b161e7fab22b80d8a49d787cd80d0298b6a445b69f506003d3ad764704de29fc9ea22a5f7de7afe9")
+  ]
+
+goldenElements :: Int -> [ByteString]
+goldenElements n = ["element-" <> show i | i <- [1 .. n]]
 
 utxoScalars :: UTxO -> [Integer]
 utxoScalars utxo = toInt <$> filter (/= mempty) (utxoToElement @Tx <$> outputsOfUTxO @Tx utxo)


### PR DESCRIPTION
- Snapshot commitment computed through the rust-accumulator FFI (bit-identical, pinned by equivalence + golden tests) instead of the O(n^2) off-chain PlutusTx path, and updated by the UTxO delta from the previous confirmed snapshot.
- `signableBytes` made explicitly lazy so state hydration no longer forces a commitment per replayed `SnapshotRequested` event.

Stacked on `10x-perf-3`. Tip of the stack; tree is identical to the original `10x-perf` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)