### PR TITLE
typst-agda-spec-3: Add the Agda formalisation of the specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,22 @@ changes.
     reader going away (`hydra-node | head`, a restarting log shipper) made the
     next write throw; the writer is not linked to the node, so it died unnoticed
     and every subsequent trace blocked once the queue filled.
+- The formal specification (`spec/`) was migrated from LaTeX to literate Agda +
+  Typst: the same sources are type-checked by Agda (definitions, validity
+  bundles and security proofs are machine-checked, including consistency,
+  soundness/completeness and the on-chain safety invariants) and rendered to
+  the PDF by Typst. A decidable core is extracted to Haskell via MAlonzo (the
+  new `hydra-agda` package) and differentially tested against the real Plutus
+  validator (`hydra-tx` `HeadValidatorAgreement`) and the real head logic
+  handlers (`hydra-node` `OffChainAgreementSpec`/`OffChainLeaderSpec`). CI
+  gates the spec build (`checks.spec`, including reference/diagram and
+  trust-ledger drift checks) and the extraction freshness
+  (`checks.hydra-agda-generated`). The spec models the current protocol,
+  including the commit/decommit output-set hashes bound into the snapshot
+  multisignature, the deposit-identity binding of the commit digest (a snapshot
+  authorizes one deposit by transaction id, not any look-alike recording the
+  same UTxO) and the canonical CRS datum binding of the fanout paths.
+
 - The head logic now enforces the specification's "no commit and decommit in
   flight at once" discipline on the message level: a `ReqDec` received while a
   deposit is pending waits for the deposit to resolve instead of starting a

--- a/docs/docs/dev/agda.md
+++ b/docs/docs/dev/agda.md
@@ -16,7 +16,9 @@ the prose, the math and the machine-checked definitions come from one set of
 sources ([`spec/src/Hydra/Protocol/`](https://github.com/cardano-scaling/hydra/tree/master/spec/src/Hydra/Protocol)):
 `agda Main.lagda.typ` type-checks the whole document and Typst renders the same
 files to the PDF. Two kinds of code fences exist: rendered ones (collected into
-the PDF's Agda appendix) and typecheck-only ones (imports, proof plumbing). See
+the PDF's Agda appendix) and bare ones, which are typechecked but never rendered - the latter
+carry the bulk of the model: imports and proof plumbing, but also the whole §5 datum/redeemer,
+transition-relation and validity-bundle layer and the §6 handler model. See
 [`spec/README.md`](https://github.com/cardano-scaling/hydra/tree/master/spec)
 for the authoring details.
 
@@ -26,7 +28,7 @@ Three groups of modules, one build:
 
 | Group | Modules | Role |
 | --- | --- | --- |
-| Rendered (the document) | `Introduction`, `Overview`, `Preliminaries`, `Setup`, `OnChain`, `OnChainCoverage`, `OffChain`, `Security`, `SecurityProofs` | Prose + the machine-checked definitions, validity bundles, invariants and §7 proofs |
+| Rendered (the document) | `Introduction`, `Overview`, `Preliminaries`, `Setup`, `OnChain`, `OnChainCoverage`, `OffChain`, `Security`, `SecurityProofs` | The prose. Their ```` ```agda ```` fences are collected into the PDF's Agda appendix, which is restricted to the machine-checked theorem statements (`OnChainCoverage`, `SecurityProofs`, `Security`, `OffChain`); the datum/redeemer types, transition relations and validity bundles in `Preliminaries`/`Setup`/`OnChain` are typechecked but deliberately not rendered |
 | Typecheck-only | `Prelude`, `ReferenceBridge`, `RefReflection` | The abstract trust base and the bridge proofs; verified on every build, never rendered |
 | Extractable | `Reference`, `OffChainReference` | Decidable checkers, self-contained over `Agda.Builtin` types so the extracted Haskell stays small |
 
@@ -47,7 +49,7 @@ Three tiers, from strongest to weakest guarantee:
    modelled), a small set of on-chain "search" postulates over the opaque
    value/key models, and the honest-behaviour premises of the security model.
    The PDF appendix section **"What the formalisation assumes"** inventories
-   all of it — the reading rule is: `postulate` means assumption, everything
+   all of it; the reading rule is that `postulate` means assumption, everything
    else is proved.
 
 3. **Differentially tested.** Where the abstract model meets the real code,
@@ -57,13 +59,13 @@ Three tiers, from strongest to weakest guarantee:
    postulates, enumerated in
    [`spec/check-trust-ledger.sh`](https://github.com/cardano-scaling/hydra/blob/master/spec/check-trust-ledger.sh).
    That script fails the spec build if a mock or postulate is added or removed
-   without updating the ledger — the trusted base cannot grow silently.
+   without updating the ledger, so the trusted base cannot grow silently.
 
 The bridge direction is *completeness*: `ReferenceBridge.agda` proves that a
 spec-valid transaction makes the extracted checker accept, so a
 reference-reject implies a spec-reject. Joined with the agreement tests'
 `reference === validator`, a spec-valid transaction is accepted by the real
-validator and vice versa — modulo the documented mocks, each of which the
+validator and vice versa, modulo the documented mocks, each of which the
 tests exercise with real crypto (Ed25519 signatures, BLS/KZG pairings) in both
 accept and reject directions.
 
@@ -74,7 +76,7 @@ backend into
 [`hydra-agda/generated/`](https://github.com/cardano-scaling/hydra/tree/master/hydra-agda),
 which is committed. Hand-written shims (`Hydra.Agda.Reference`,
 `Hydra.Agda.OffChainReference`) pin the mangled MAlonzo names to stable,
-documented Haskell names — a stale pin is a loud compile error. Regeneration
+documented Haskell names, so a stale pin is a loud compile error. Regeneration
 is manual (`hydra-agda/regenerate.sh`); freshness is CI-enforced: the
 `hydra-agda-generated` flake check re-extracts hermetically and fails on any
 diff against the committed tree.
@@ -83,11 +85,11 @@ diff against the committed tree.
 
 Two layers bind the extracted spec to the real implementation:
 
-- **On-chain** —
+- **On-chain**:
   [`Hydra.Tx.Contract.HeadValidatorAgreement`](https://github.com/cardano-scaling/hydra/blob/master/hydra-tx/test/Hydra/Tx/Contract/HeadValidatorAgreement.hs)
   (hydra-tx) runs the *real* `Head.headValidator` (and the compiled
   `deposit.ak` as UPLC) and the extracted reference on the same directly
-  constructed inputs — no transactions, no mutation corpus — and asserts
+  constructed inputs (no transactions, no mutation corpus) and asserts
   `reference === validator` across every transaction family, in both the
   accept and reject directions. The crypto the reference mocks is exercised
   for real: valid and invalid Ed25519 snapshot signatures (including the
@@ -95,7 +97,7 @@ Two layers bind the extracted spec to the real implementation:
   deposit transaction id bound into the commit digest), BLS/KZG
   membership proofs against the canonical CRS, and the canonical-CRS datum
   binding (`InvalidCRSDatum`).
-- **Off-chain** —
+- **Off-chain**:
   [`Hydra.OffChainAgreementSpec`](https://github.com/cardano-scaling/hydra/blob/master/hydra-node/test/Hydra/OffChainAgreementSpec.hs)
   and `Hydra.OffChainLeaderSpec` (hydra-node) bind the extracted §6 handler
   decisions (snapshot-signing eligibility, decommit recording, deposit status,
@@ -108,10 +110,10 @@ Two layers bind the extracted spec to the real implementation:
 | --- | --- |
 | Build the PDF | `nix build .#spec`, or `./build.sh` inside `nix develop` (output: `spec/_build/hydra-spec.pdf`) |
 | Type-check only | `agda src/Hydra/Protocol/Main.lagda.typ` in `spec/` |
-| Change a validator condition | Update the section + `*Valid` bundle in `OnChain.lagda.typ`, mirror in `Reference.agda`, prove in `ReferenceBridge.agda`, `regenerate.sh`, extend the shim + `HeadValidatorAgreement` — see the checklist in [`spec/README.md`](https://github.com/cardano-scaling/hydra/tree/master/spec) |
+| Change a validator condition | Update the section + `*Valid` bundle in `OnChain.lagda.typ`, mirror in `Reference.agda`, prove in `ReferenceBridge.agda`, `regenerate.sh`, extend the shim + `HeadValidatorAgreement`; see the checklist in [`spec/README.md`](https://github.com/cardano-scaling/hydra/tree/master/spec) |
 | Change a head-logic handler | Update the §6 arm (+ figure) in `OffChain.lagda.typ`, mirror in `OffChainReference.agda`, bind in the hydra-node agreement tests |
 | Change the datum shape | `HeadDatum` in `OnChain.lagda.typ` + `state-fields` in `diagrams.typ`; `check-refs.sh` catches constructor drift |
-| Add a mock/postulate to the bridge | The build fails until `check-trust-ledger.sh`'s ledger is updated — that is the point |
+| Add a mock/postulate to the bridge | The build fails until `check-trust-ledger.sh`'s ledger is updated, which is the point |
 
 CI gates: `checks.spec` (Agda typecheck, reference/diagram lints, trust-ledger
 drift check, PDF render) and `checks.hydra-agda-generated` (extraction
@@ -123,8 +125,8 @@ freshness). The agreement tests run in the ordinary package test suites.
   Haskell-to-Agda glossary) and *"What the formalisation assumes"* (the full
   trust-base inventory).
 - [`spec/README.md`](https://github.com/cardano-scaling/hydra/tree/master/spec)
-  — building, authoring, and the keep-in-sync checklist.
+  covers building, authoring, and the keep-in-sync checklist.
 - [`spec/check-trust-ledger.sh`](https://github.com/cardano-scaling/hydra/blob/master/spec/check-trust-ledger.sh)
-  — the enumerated bridge trust ledger.
+  is the enumerated bridge trust ledger.
 - The three agreement test modules named above, whose headers document the
   per-conjunct coverage.

--- a/docs/docs/dev/agda.md
+++ b/docs/docs/dev/agda.md
@@ -1,0 +1,130 @@
+# Formal specification in Agda
+
+The Hydra Head protocol specification is written in *literate Agda* rendered by
+[Typst](https://typst.app): every definition, validity condition and security
+proof shown in the [specification PDF](./specification.md) comes from source
+files that Agda type-checks on every build. On top of that, a decidable core of
+the spec is extracted to Haskell and *differentially tested* against the real
+Plutus validators and the real `hydra-node` head logic. This page is an
+orientation: what is proved, what is tested, what is assumed, and where the
+machinery lives.
+
+## Why literate Agda + Typst
+
+A specification that lives next to the code but is only prose will drift. Here
+the prose, the math and the machine-checked definitions come from one set of
+sources ([`spec/src/Hydra/Protocol/`](https://github.com/cardano-scaling/hydra/tree/master/spec/src/Hydra/Protocol)):
+`agda Main.lagda.typ` type-checks the whole document and Typst renders the same
+files to the PDF. Two kinds of code fences exist: rendered ones (collected into
+the PDF's Agda appendix) and typecheck-only ones (imports, proof plumbing). See
+[`spec/README.md`](https://github.com/cardano-scaling/hydra/tree/master/spec)
+for the authoring details.
+
+## Module map
+
+Three groups of modules, one build:
+
+| Group | Modules | Role |
+| --- | --- | --- |
+| Rendered (the document) | `Introduction`, `Overview`, `Preliminaries`, `Setup`, `OnChain`, `OnChainCoverage`, `OffChain`, `Security`, `SecurityProofs` | Prose + the machine-checked definitions, validity bundles, invariants and §7 proofs |
+| Typecheck-only | `Prelude`, `ReferenceBridge`, `RefReflection` | The abstract trust base and the bridge proofs; verified on every build, never rendered |
+| Extractable | `Reference`, `OffChainReference` | Decidable checkers, self-contained over `Agda.Builtin` types so the extracted Haskell stays small |
+
+## The trust story
+
+Three tiers, from strongest to weakest guarantee:
+
+1. **Proved.** The §7 security results (consistency, soundness, completeness,
+   the reachability invariant, no-settlement-without-unanimity) and the
+   on-chain coverage/safety theorems (non-stuckness, value conservation,
+   bounded contest window) are closed Agda proofs over the abstract model.
+   Multisignature unforgeability is *derived* from per-signature EUF-CMA plus
+   the aggregation scheme's decomposition, not assumed monolithically.
+
+2. **Assumed.** The model bottoms out in an enumerated trust base: ledger and
+   crypto primitives (hashing, the multisignature verifier, the `Value`
+   algebra), the accumulator laws (the KZG construction itself is not
+   modelled), a small set of on-chain "search" postulates over the opaque
+   value/key models, and the honest-behaviour premises of the security model.
+   The PDF appendix section **"What the formalisation assumes"** inventories
+   all of it — the reading rule is: `postulate` means assumption, everything
+   else is proved.
+
+3. **Differentially tested.** Where the abstract model meets the real code,
+   the bridge's trusted base is *fixed and machine-enforced*: exactly 6
+   injected const-true mocks (crypto/accumulator conjuncts the tests cover
+   against the real primitives instead) and 7 encoding/faithfulness
+   postulates, enumerated in
+   [`spec/check-trust-ledger.sh`](https://github.com/cardano-scaling/hydra/blob/master/spec/check-trust-ledger.sh).
+   That script fails the spec build if a mock or postulate is added or removed
+   without updating the ledger — the trusted base cannot grow silently.
+
+The bridge direction is *completeness*: `ReferenceBridge.agda` proves that a
+spec-valid transaction makes the extracted checker accept, so a
+reference-reject implies a spec-reject. Joined with the agreement tests'
+`reference === validator`, a spec-valid transaction is accepted by the real
+validator and vice versa — modulo the documented mocks, each of which the
+tests exercise with real crypto (Ed25519 signatures, BLS/KZG pairings) in both
+accept and reject directions.
+
+## The extraction pipeline
+
+`Reference.agda` and `OffChainReference.agda` are compiled by Agda's MAlonzo
+backend into
+[`hydra-agda/generated/`](https://github.com/cardano-scaling/hydra/tree/master/hydra-agda),
+which is committed. Hand-written shims (`Hydra.Agda.Reference`,
+`Hydra.Agda.OffChainReference`) pin the mangled MAlonzo names to stable,
+documented Haskell names — a stale pin is a loud compile error. Regeneration
+is manual (`hydra-agda/regenerate.sh`); freshness is CI-enforced: the
+`hydra-agda-generated` flake check re-extracts hermetically and fails on any
+diff against the committed tree.
+
+## The agreement tests
+
+Two layers bind the extracted spec to the real implementation:
+
+- **On-chain** —
+  [`Hydra.Tx.Contract.HeadValidatorAgreement`](https://github.com/cardano-scaling/hydra/blob/master/hydra-tx/test/Hydra/Tx/Contract/HeadValidatorAgreement.hs)
+  (hydra-tx) runs the *real* `Head.headValidator` (and the compiled
+  `deposit.ak` as UPLC) and the extracted reference on the same directly
+  constructed inputs — no transactions, no mutation corpus — and asserts
+  `reference === validator` across every transaction family, in both the
+  accept and reject directions. The crypto the reference mocks is exercised
+  for real: valid and invalid Ed25519 snapshot signatures (including the
+  commit/decommit output-set hashes bound into the signed message, and the
+  deposit transaction id bound into the commit digest), BLS/KZG
+  membership proofs against the canonical CRS, and the canonical-CRS datum
+  binding (`InvalidCRSDatum`).
+- **Off-chain** —
+  [`Hydra.OffChainAgreementSpec`](https://github.com/cardano-scaling/hydra/blob/master/hydra-node/test/Hydra/OffChainAgreementSpec.hs)
+  and `Hydra.OffChainLeaderSpec` (hydra-node) bind the extracted §6 handler
+  decisions (snapshot-signing eligibility, decommit recording, deposit status,
+  ack counting, contest eligibility, leader election) against the real
+  `HeadLogic.update` outcomes.
+
+## How do I ...
+
+| Task | What to do |
+| --- | --- |
+| Build the PDF | `nix build .#spec`, or `./build.sh` inside `nix develop` (output: `spec/_build/hydra-spec.pdf`) |
+| Type-check only | `agda src/Hydra/Protocol/Main.lagda.typ` in `spec/` |
+| Change a validator condition | Update the section + `*Valid` bundle in `OnChain.lagda.typ`, mirror in `Reference.agda`, prove in `ReferenceBridge.agda`, `regenerate.sh`, extend the shim + `HeadValidatorAgreement` — see the checklist in [`spec/README.md`](https://github.com/cardano-scaling/hydra/tree/master/spec) |
+| Change a head-logic handler | Update the §6 arm (+ figure) in `OffChain.lagda.typ`, mirror in `OffChainReference.agda`, bind in the hydra-node agreement tests |
+| Change the datum shape | `HeadDatum` in `OnChain.lagda.typ` + `state-fields` in `diagrams.typ`; `check-refs.sh` catches constructor drift |
+| Add a mock/postulate to the bridge | The build fails until `check-trust-ledger.sh`'s ledger is updated — that is the point |
+
+CI gates: `checks.spec` (Agda typecheck, reference/diagram lints, trust-ledger
+drift check, PDF render) and `checks.hydra-agda-generated` (extraction
+freshness). The agreement tests run in the ordinary package test suites.
+
+## Pointers
+
+- The PDF appendix: *"Reading the Agda (for Haskell programmers)"* (a
+  Haskell-to-Agda glossary) and *"What the formalisation assumes"* (the full
+  trust-base inventory).
+- [`spec/README.md`](https://github.com/cardano-scaling/hydra/tree/master/spec)
+  — building, authoring, and the keep-in-sync checklist.
+- [`spec/check-trust-ledger.sh`](https://github.com/cardano-scaling/hydra/blob/master/spec/check-trust-ledger.sh)
+  — the enumerated bridge trust ledger.
+- The three agreement test modules named above, whose headers document the
+  per-conjunct coverage.

--- a/docs/docs/dev/specification.md
+++ b/docs/docs/dev/specification.md
@@ -1,6 +1,6 @@
 # Specification
 
-The specification is written in Agda and Typst and lives in the [`spec/`](https://github.com/cardano-scaling/hydra/tree/master/spec) directory of this repository. You can view the rendered version below or download it for fullscreen viewing [here](/hydra-spec.pdf).
+The specification is written in literate Agda and Typst (the same sources are type-checked by Agda and rendered to PDF by Typst) and lives in the [`spec/`](https://github.com/cardano-scaling/hydra/tree/master/spec) directory of this repository. You can view the rendered version below or download it for fullscreen viewing [here](/hydra-spec.pdf). See [Agda formalisation](./agda.md) for how the specification is machine-checked and kept in sync with the implementation.
 
 import HydraSpecUrl from '@site/static/hydra-spec.pdf';
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -76,6 +76,11 @@ module.exports = {
       id: "dev/specification",
       label: "Specification",
     },
+    {
+      type: "doc",
+      id: "dev/agda",
+      label: "Agda formalisation",
+    },
     "dev/protocol",
     "dev/commit",
     "dev/rollbacks/index",

--- a/justfile
+++ b/justfile
@@ -176,9 +176,10 @@ bench-e2e DATASET:
     --command bench-e2e single "{{DATASET}}" --output-directory "$outdir"
   echo "Results in: $outdir"
 
-# Render spec/_build/hydra-spec.pdf in place; mirrors `nix build .#spec` but
-# reuses the working tree for fast iteration, and re-renders only when a source
-# is newer than the PDF (see spec/build.sh).
+# Typecheck the literate-Agda sources and render spec/_build/hydra-spec.pdf in
+# place; mirrors `nix build .#spec` but reuses the working tree for fast
+# iteration, and re-runs only when a source is newer than the PDF (see
+# spec/build.sh).
 #
 # The spec toolchain lives in its own dev shell (nix/hydra/spec.nix) so that it
 # is not in every developer's default shell, hence the explicit `nix develop`.

--- a/nix/hydra/shell.nix
+++ b/nix/hydra/shell.nix
@@ -12,9 +12,9 @@
       cleanPkgs = inputs'.nixpkgs.legacyPackages;
 
       buildInputs = [
-        # NB the spec toolchain (typst + PyMuPDF) is NOT here: it lives in its
-        # own `nix develop .#spec` shell, defined next to the spec build in
-        # nix/hydra/spec.nix and used by `just spec`.
+        # NB the spec toolchain (agda + typst + PyMuPDF) is NOT here: it lives
+        # in its own `nix develop .#spec` shell, defined next to the spec build
+        # in nix/hydra/spec.nix and used by `just spec`.
         # To compile hydra scripts
         pkgs.aiken
         pkgs.cabal-fmt

--- a/nix/hydra/spec.nix
+++ b/nix/hydra/spec.nix
@@ -1,6 +1,6 @@
-_: {
+{ self, inputs, ... }: {
 
-  perSystem = { config, pkgs, pkgs-2511, ... }:
+  perSystem = { config, pkgs, pkgs-2411, pkgs-2511, ... }:
     let
       inherit (pkgs) lib;
 
@@ -43,6 +43,20 @@ _: {
         # of its own to keep in lockstep.
         ++ [ p.oxifmt_0_2_1 ]);
 
+      # The specification's Agda libraries, pinned to the 24.11 Agda (the
+      # formal-ledger / abstract-set-theory set is built against it).
+      agdaPackages = pkgs-2411.callPackage "${self}/spec/pkgs/initial-packages.nix" {
+        inherit (pkgs-2411.haskellPackages) Agda;
+        nixpkgs = inputs.nixpkgs-2411;
+      };
+      agdaLibraries = with agdaPackages; [
+        abstract-set-theory
+        formal-ledger
+        standard-library
+        standard-library-classes
+        standard-library-meta
+      ];
+
       # PyMuPDF for annotate-notation.py. Deliberately from the default pin, not
       # 25.11: keeping typst the sole consumer of that input is what makes the
       # "drop when the main pin ships typst >= 0.14.1" note in flake.nix true.
@@ -62,7 +76,7 @@ _: {
         fileset = ../../spec;
       };
 
-      # The Typst render, WITHOUT the notation-tooltip postprocess
+      # The Agda typecheck + lints + Typst render, WITHOUT the notation-tooltip postprocess
       # (ANNOTATE_NOTATION=skip, see build.sh stage 3). Internal: consume
       # packages.spec, which adds the tooltips.
       #
@@ -78,12 +92,14 @@ _: {
         pname = "hydra-spec-unannotated.pdf";
         version = "0.0.1";
         nativeBuildInputs = [
+          config.packages.spec-agda
           config.packages.spec-typst
         ];
         meta = { };
         src = specSrc;
-        # build.sh renders the literate-Typst sources with Typst (no
-        # LaTeX/Inkscape toolchain needed). --ignore-system-fonts keeps Typst
+        # build.sh typechecks the literate-Typst sources with Agda and renders
+        # the PDF with Typst (no LaTeX/Inkscape toolchain needed).
+        # --ignore-system-fonts keeps Typst
         # reproducible: only the fonts bundled with Typst plus JuliaMono from
         # nixpkgs (code blocks, wired through JULIAMONO_FONT_DIR, see build.sh)
         # are used.
@@ -111,6 +127,10 @@ _: {
       # exposed so the dev shell can offer the same `typst` for working on the spec.
       packages.spec-typst = spec-typst;
 
+      # Agda with the specification's libraries, reused by the spec build and
+      # exposed so the dev shell can offer the same `agda` for working on the spec.
+      packages.spec-agda = agdaPackages.withPackages agdaLibraries;
+
       # The python environment annotate-notation.py needs, exposed for the same
       # reason: the shell and the build stamp tooltips with one interpreter.
       packages.spec-python = spec-python;
@@ -121,6 +141,7 @@ _: {
       devShells.spec = pkgs.mkShell {
         name = "hydra-spec-shell";
         buildInputs = [
+          config.packages.spec-agda
           config.packages.spec-typst
           config.packages.spec-python
         ];

--- a/spec/build.sh
+++ b/spec/build.sh
@@ -1,13 +1,11 @@
 #!/usr/bin/env bash
-# Build the Hydra specification PDF via Typst.
+# Build the Hydra specification PDF via Agda (typecheck) + Typst (render).
 #
-# `typst compile` renders the .lagda.typ tree in place (Typst reads the literate
-# files directly; code fences render as raw blocks, see template.typ for the
-# hidden/visible idiom) to _build/hydra-spec.pdf.
-#
-# NB the Agda typecheck of these same sources (and the Agda↔Typst/trust-ledger
-# lints) is added alongside the formalisation itself; until then the code fences
-# are prose-free placeholders and only the Typst render runs here.
+# Stage 1: `agda` typechecks the literate-Typst source tree (fails on type error,
+#          preserving the machine-checked property).
+# Stage 2: `typst compile` renders the same .lagda.typ tree in place (Typst reads
+#          the literate files directly; code fences render as raw blocks, see
+#          template.typ for the hidden/visible idiom) to _build/hydra-spec.pdf.
 set -euo pipefail
 cd "$(dirname "$0")"
 
@@ -15,18 +13,6 @@ SRC=src
 PDF=_build/hydra-spec.pdf
 ENTRY="$SRC/Hydra/Protocol/Main.lagda.typ"
 
-# Render in place. --root=src so the root-relative imports (/template.typ,
-# /macros.typ, /short.bib, /agda.sublime-syntax) resolve; the .lagda.typ files
-# include each other by name, so no staging/extension-stripping is needed.
-#
-# JuliaMono (the code font, see template.typ) is not vendored: nix provides it
-# (nixpkgs `julia-mono`) via JULIAMONO_FONT_DIR, exported by both `nix build .#spec`
-# and the dev shell. Hard-error when unset: typst only warns on a missing font
-# family and would silently render code blocks with a fallback font.
-#
-# The @preview diagram packages (cetz, fletcher, oxifmt) are supplied at pinned
-# versions by the wrapped typst's TYPST_PACKAGE_CACHE_PATH (see nix/hydra/spec.nix),
-# so no --package-cache-path / in-repo vendoring is needed.
 mkdir -p "$(dirname "$PDF")"
 
 # Skip the work when the PDF is already newer than every input: `typst compile`
@@ -36,15 +22,30 @@ mkdir -p "$(dirname "$PDF")"
 # well as the timestamps: a PDF left behind by an ANNOTATE_NOTATION=skip run is
 # NOT up to date for a run that wants tooltips, and vice versa.
 #
-# Never fires in the nix build, which starts from an empty _build.
+# Placed before the typecheck so an unchanged tree is a true no-op. Never
+# fires in the nix build, which starts from an empty _build.
 MODE_STAMP="$(dirname "$PDF")/.build-mode"
 MODE="annotate=${ANNOTATE_NOTATION:-full}"
 if [ -f "$PDF" ] &&
   [ "$(cat "$MODE_STAMP" 2>/dev/null || true)" = "$MODE" ] &&
-  [ -z "$(find "$SRC" build.sh annotate-notation.py -newer "$PDF" -print -quit 2>/dev/null)" ]; then
+  [ -z "$(find "$SRC" build.sh annotate-notation.py check-refs.sh check-trust-ledger.sh -newer "$PDF" -print -quit 2>/dev/null)" ]; then
   echo "Up to date: $PDF ($MODE); touch a source or rm the PDF to force a rebuild"
   exit 0
 fi
+# Stage 1: typecheck, then the Agda↔Typst reference consistency lint (W6) and the C3 trust-ledger drift check.
+agda "$ENTRY"
+bash check-refs.sh
+bash check-trust-ledger.sh
+
+# Stage 2: render in place. --root=src so the root-relative imports (/template.typ,
+# /macros.typ, /short.bib, /agda.sublime-syntax) resolve; the .lagda.typ files include
+# each other by name, so no staging/extension-stripping is needed.
+#
+# JuliaMono (the code font, see template.typ) is not vendored: nix provides it
+# (nixpkgs `julia-mono`) via JULIAMONO_FONT_DIR, exported by both `nix build .#spec`
+# and the dev shell. Hard-error when unset: typst only warns on a missing font
+# family and would silently render code blocks with a fallback font.
+
 # Build via a temp file and rename into place ATOMICALLY: typst
 # truncate-and-writes its output, and a PDF viewer auto-reloading on change
 # (okular etc.) can catch a torn mid-write file and sit on a broken parse.
@@ -60,14 +61,14 @@ typst compile --ignore-system-fonts --root "$SRC" \
   "$ENTRY" "$TMP"
 
 
-# Stage: stamp invisible hover-tooltips (definitions of the notation symbols)
+# Stage 3: stamp invisible hover-tooltips (definitions of the notation symbols)
 # over the prose math; see annotate-notation.py. The rendered pages are
 # pixel-identical; viewers with annotation popups (okular, pdf.js, Acrobat)
 # show the definition on hover.
 #
 # ANNOTATE_NOTATION=skip skips the stage: `nix build .#spec` runs it as a
 # SEPARATE seconds-long derivation (nix/hydra/spec.nix), so the minutes-long
-# Typst build does not share a build window with the python closure - a
+# Agda+Typst build does not share a build window with the python closure - a
 # busy builder's mid-build auto-GC (observed on the darwin CI builders) could
 # otherwise collect the late-used python environment out from under this step.
 if [ "${ANNOTATE_NOTATION:-}" = "skip" ]; then

--- a/spec/check-refs.sh
+++ b/spec/check-refs.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Agda↔Typst consistency lint.
+#
+# Full type-checking of the Typst against Agda needs an Agda→Typst backend we
+# don't have, so this guards the two single-source links that matter:
+#
+#  (1) every transition rule the prose cites as `<name>` rule is a real
+#      constructor of the Agda relation `_⟶⟨_⟩_`; and
+#  (2) the head state-machine DIAGRAM (data in diagrams.typ) has exactly the same
+#      (source, rule, target) transitions as that Agda relation — so the picture
+#      cannot drift from the formal state machine.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+ON=src/Hydra/Protocol/OnChain.lagda.typ
+DIAG=src/diagrams.typ
+fail=0
+
+# --- Agda transition relation: emit "source|rule|target" per constructor ----
+agda_transitions() {
+  awk '
+    /data _⟶⟨_⟩_ :/ { inrel=1; next }
+    inrel && /^```/  { inrel=0 }
+    !inrel           { next }
+    /^  [a-z]/       { if (name != "") emit(); name=$1; buf=$0; next }
+                     { buf = buf " " $0 }
+    END              { if (name != "") emit() }
+    function emit(   a, b, s, t) {
+      s = (match(buf, /→[ ]*([A-Za-z]+)/, a)   ? a[1] : "?")
+      t = (match(buf, /⟩[ ]*([A-Za-z]+)/, b)   ? b[1] : "?")
+      print s "|" name "|" t
+    }
+  ' "$ON" | sort -u
+}
+
+# --- Diagram data: emit "from|rule|to" per transition --------------------------
+diagram_transitions() {
+  grep -oE '\(from: "[A-Za-z]+", rule: "[A-Za-z]+", to: "[A-Za-z]+"' "$DIAG" \
+    | sed -E 's/.*from: "([A-Za-z]+)", rule: "([A-Za-z]+)", to: "([A-Za-z]+)".*/\1|\2|\3/' \
+    | sort -u
+}
+
+# --- Check (1): cited rule names exist ----------------------------------------
+rules=$(agda_transitions | cut -d'|' -f2 | sort -u)
+cited=$(grep -oE '`[A-Za-z]+` rule' "$ON" | sed -E 's/`([A-Za-z]+)` rule/\1/' | sort -u)
+for c in $cited; do
+  if ! grep -qx "$c" <<<"$rules"; then
+    echo "ERROR: prose cites transition rule '$c' that is not a constructor of _⟶⟨_⟩_"
+    fail=1
+  fi
+done
+
+# --- Check (2): diagram transitions == Agda transitions ------------------------
+only_agda=$(comm -23 <(agda_transitions) <(diagram_transitions))
+only_diag=$(comm -13 <(agda_transitions) <(diagram_transitions))
+if [ -n "$only_agda" ]; then
+  echo "ERROR: transitions in the Agda relation but MISSING from the diagram (diagrams.typ):"
+  echo "$only_agda" | sed 's/^/  /'
+  fail=1
+fi
+if [ -n "$only_diag" ]; then
+  echo "ERROR: transitions in the diagram but NOT in the Agda relation _⟶⟨_⟩_:"
+  echo "$only_diag" | sed 's/^/  /'
+  fail=1
+fi
+
+# --- Check (3): diagrams.typ `state-fields` keys == HeadDatum constructors -----
+datum_ctors=$(awk '
+  /data HeadDatum :/                  { ind=1; next }
+  ind && (/^```/ || /^$/ || /^data /) { ind=0 }
+  ind && /^  [A-Z]/                   { print $1 }
+' "$ON" | sort -u)
+state_keys=$(awk '
+  /#let state-fields = \(/ { ins=1; next }
+  ins && /^\)/             { ins=0 }
+  ins && /^  "[A-Za-z]+":/ { gsub(/[",:]/,"",$1); print $1 }
+' "$DIAG" | sort -u)
+if [ -z "$datum_ctors" ] || [ -z "$state_keys" ]; then
+  # A silent skip here would let real drift through: if either parse comes back empty the
+  # anchors (`data HeadDatum :` / `#let state-fields = (`) no longer match the sources.
+  echo "ERROR: check (3) parsed no HeadDatum constructors or no state-fields keys (anchor drift);"
+  echo "  update the awk anchors in check-refs.sh to match the current source layout."
+  fail=1
+elif [ "$datum_ctors" != "$state_keys" ]; then
+  echo "ERROR: diagrams.typ state-fields keys do not match HeadDatum constructors:"
+  echo "  HeadDatum: $(echo $datum_ctors)"
+  echo "  state-fields: $(echo $state_keys)"
+  fail=1
+fi
+
+# --- Check (4): every tx-rule diagram maps to a real transition rule -----------
+tx_rules=$(awk '
+  /#let tx-rule = \(/ { intr=1; next }
+  intr && /^\)/       { intr=0 }
+  intr && /: "[A-Za-z]+"/ { match($0, /"([A-Za-z]+)"/, a); print a[1] }
+' "$DIAG" | sort -u)
+for r in $tx_rules; do
+  if ! grep -qx "$r" <<<"$rules"; then
+    echo "ERROR: diagrams.typ tx-rule maps to '$r', not a constructor of _⟶⟨_⟩_"
+    fail=1
+  fi
+done
+
+# --- Check (5): every code fence opens as ``` (bare) or ```agda exactly --------
+# Agda's literate mode typechecks a fence only when its info string is empty or
+# exactly `agda`; a mistyped tag (```Agda, ```agda2, ```haskell) is silently NOT
+# typechecked AND renders as a literal raw block. Flag any non-`agda` tag.
+badfence=$(grep -nE '^```[^`]' src/Hydra/Protocol/*.lagda.typ | grep -vE ':```agda$' || true)
+if [ -n "$badfence" ]; then
+  echo "ERROR: code fence with a tag other than 'agda' (skips Agda typecheck AND misrenders):"
+  echo "$badfence" | sed 's/^/  /'
+  fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo "check-refs: OK — cited rules exist, the head-state diagram matches the Agda"
+  echo "relation, state-fields KEYS match the HeadDatum constructors (names only, not"
+  echo "the per-state field tuples), tx diagrams map to real rules, and"
+  echo "every code fence is bare or \`\`\`agda."
+fi
+exit "$fail"

--- a/spec/check-refs.sh
+++ b/spec/check-refs.sh
@@ -7,7 +7,7 @@
 #  (1) every transition rule the prose cites as `<name>` rule is a real
 #      constructor of the Agda relation `_⟶⟨_⟩_`; and
 #  (2) the head state-machine DIAGRAM (data in diagrams.typ) has exactly the same
-#      (source, rule, target) transitions as that Agda relation — so the picture
+#      (source, rule, target) transitions as that Agda relation, so the picture
 #      cannot drift from the formal state machine.
 set -euo pipefail
 cd "$(dirname "$0")"
@@ -113,7 +113,7 @@ if [ -n "$badfence" ]; then
 fi
 
 if [ "$fail" -eq 0 ]; then
-  echo "check-refs: OK — cited rules exist, the head-state diagram matches the Agda"
+  echo "check-refs: OK: cited rules exist, the head-state diagram matches the Agda"
   echo "relation, state-fields KEYS match the HeadDatum constructors (names only, not"
   echo "the per-state field tuples), tx diagrams map to real rules, and"
   echo "every code fence is bare or \`\`\`agda."

--- a/spec/check-trust-ledger.sh
+++ b/spec/check-trust-ledger.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Trust-ledger drift check (bridge layer).
+#
+# The machine-checked `spec ⇒ extracted-reference` bridge rests on a FIXED, enumerated trusted base:
+#   (a) injected `Ops` mocks — the const-`true` boundaries the reference delegates (crypto / accumulator /
+#       value-map conjuncts), and
+#   (b) extraction-faithfulness / encoding postulates (hash/out-ref encodings and the
+#       participant / no-mint faithfulness assumptions).
+#
+# This script extracts that set from the Agda sources and FAILS if it drifts from the ledger below.
+# So a NEW mock or postulate cannot enter the trusted base silently: adding one fails the build until
+# both the EXPECTED_* lists and this ledger table are updated.
+#
+# Bridge-layer trust ledger (what each trusted item assumes; the HeadValidatorAgreement test covers each
+# against the real validator/crypto where constructible). SCOPE: this gates ReferenceBridge/RefReflection
+# only; the abstract model's own axioms (Prelude value/crypto laws, accumulator laws, §7 assumptions) are
+# inventoried in the spec's "What the formalisation assumes" appendix section, not drift-checked here.
+#   Ops mocks (const-true boundaries the reference delegates). The snapshot signature is the 6-tuple
+#   message cid‖v‖s‖η#‖δ#‖κ# (accumulator + decommit-/commit-output-set hashes):
+#     closeCryptoOK    close snapshot signature + accumulator-commitment hash (real Ed25519 in the test,
+#                      incl. a tampered-δ#/κ# reject)
+#     incCryptoOK      increment/decrement snapshot signature incl. the recomputed commit-set hash
+#                      (increment, DepositDatumInvalid) / decommit-set hash (decrement) (real Ed25519)
+#     contestCryptoOK  contest snapshot signature, η binding, contest-once (real Ed25519)
+#     fanoutCryptoOK   fanout KZG membership + value conservation + the canonical-CRS datum binding
+#                      (crsBindOK; real BLS pairing, InvalidCRSDatum reject in the test)
+#     recoverHashOK    recover recovered-outputs serialisation hash (empty-deposit case)
+#     initPlacementOK  μHead seed-spent + token placement (real validateTokensMinting)
+#   Postulates (typecheck-only):
+#     cidToNat, refCodeOf                          head-id / out-ref → ℕ encodings (used with cong only)
+#     signerCodes, ptCodes, participantSigned→ref  signer / PT-name encodings + overlap faithfulness
+#     mintEntryCount, noMint→ref                   mint-entry count encoding + noMint faithfulness
+set -euo pipefail
+cd "$(dirname "$0")"
+
+BR=src/Hydra/Protocol/ReferenceBridge.agda
+RR=src/Hydra/Protocol/RefReflection.agda
+
+# (a) Ops mocks: every `<field> = λ … → true` const-true binding (ANY field in a record, first or
+# not, single- OR multi-line; NOT record-pattern matches like `step =`, which don't bind `λ … → true`).
+# Newlines are flattened first so a multi-line record literal cannot hide a mock from the line-based grep.
+actual_mocks=$(tr '\n' ' ' < "$BR" | grep -oE '[a-zA-Z][a-zA-Z0-9]* = λ[^;{}]*→ true' | sed -E 's/ = λ.*//' | sort -u)
+
+# (b) Postulated names, both single-line (`postulate name :`) and block (`postulate` then indented `name :`).
+actual_postulates=$(awk '
+  /^[ ]*--/ {next}
+  /^postulate$/ {inblock=1; next}
+  /^postulate[ ]+[^ ]/ {print $2; inblock=0; next}
+  inblock && /^[ ]+[^ ]+ +:/ {print $1; next}
+  inblock && /^[^ ]/ {inblock=0}
+' "$BR" "$RR" | sort -u)
+
+expected_mocks=$(printf '%s\n' \
+  closeCryptoOK contestCryptoOK fanoutCryptoOK incCryptoOK initPlacementOK recoverHashOK \
+  | sort -u)
+expected_postulates=$(printf '%s\n' \
+  cidToNat mintEntryCount 'noMint→ref' 'participantSigned→ref' ptCodes refCodeOf signerCodes \
+  | sort -u)
+
+fail=0
+if [ "$actual_mocks" != "$expected_mocks" ]; then
+  echo "check-trust-ledger: the injected Ops-mock set DRIFTED from the documented ledger (- expected, + actual):"
+  diff <(echo "$expected_mocks") <(echo "$actual_mocks") || true
+  fail=1
+fi
+if [ "$actual_postulates" != "$expected_postulates" ]; then
+  echo "check-trust-ledger: the postulate set DRIFTED from the documented ledger (- expected, + actual):"
+  diff <(echo "$expected_postulates") <(echo "$actual_postulates") || true
+  fail=1
+fi
+if [ "$fail" -ne 0 ]; then
+  echo "Update the trust-ledger table in this script's header comment and the EXPECTED_* lists."
+  exit 1
+fi
+echo "check-trust-ledger: OK — the bridge-layer trusted base is the 6 documented Ops mocks + 7 documented postulates."

--- a/spec/check-trust-ledger.sh
+++ b/spec/check-trust-ledger.sh
@@ -2,8 +2,8 @@
 # Trust-ledger drift check (bridge layer).
 #
 # The machine-checked `spec ⇒ extracted-reference` bridge rests on a FIXED, enumerated trusted base:
-#   (a) injected `Ops` mocks — the const-`true` boundaries the reference delegates (crypto / accumulator /
-#       value-map conjuncts), and
+#   (a) the injected `Ops` boundaries: the fields of the mock records the reference delegates to
+#       (crypto / accumulator / value-map conjuncts), whatever they are bound to, and
 #   (b) extraction-faithfulness / encoding postulates (hash/out-ref encodings and the
 #       participant / no-mint faithfulness assumptions).
 #
@@ -36,18 +36,45 @@ cd "$(dirname "$0")"
 BR=src/Hydra/Protocol/ReferenceBridge.agda
 RR=src/Hydra/Protocol/RefReflection.agda
 
-# (a) Ops mocks: every `<field> = λ … → true` const-true binding (ANY field in a record, first or
-# not, single- OR multi-line; NOT record-pattern matches like `step =`, which don't bind `λ … → true`).
-# Newlines are flattened first so a multi-line record literal cannot hide a mock from the line-based grep.
-actual_mocks=$(tr '\n' ' ' < "$BR" | grep -oE '[a-zA-Z][a-zA-Z0-9]* = λ[^;{}]*→ true' | sed -E 's/ = λ.*//' | sort -u)
+# (a) Injected Ops boundaries: every field of every record VALUE the bridge builds.
+#
+# Keyed on `= record {` (an assignment whose right-hand side is a record literal), which is what
+# distinguishes the injected mocks from the record PATTERNS the `*Valid → ref` clauses destructure
+# on their left-hand side. Newlines are flattened first so a multi-line record literal cannot hide a
+# field from a line-based scan, and each field name is read as the first token of a `;`-separated
+# component, so a field whose value itself contains `=` (say `λ x → x == y`) cannot be mistaken for
+# one. Deliberately NOT keyed on the const-true spelling `= λ … → true`: it is the injection that
+# widens the trusted base, and `= const true`, `= alwaysTrue` or any other spelling injects just as
+# much. (Today all six happen to be written as const-true lambdas.)
+actual_mocks=$(tr '\n' ' ' < "$BR" |
+  grep -oE '= record[[:space:]]+\{[^}]*\}' |
+  sed -E 's/^= record[[:space:]]+\{//; s/\}$//' |
+  tr ';' '\n' |
+  awk 'NF {print $1}' |
+  sort -u)
 
-# (b) Postulated names, both single-line (`postulate name :`) and block (`postulate` then indented `name :`).
+# (b) Postulated names, single-line (`postulate name : T`) and block (`postulate` then indented
+# declarations). Every name of a declaration is emitted, not just the first: `postulate` permits
+# `one two : T`, which the previous per-line `print $1`/`print $2` silently dropped (both names in
+# the block form, the second onwards in the single-line form) - a hole big enough to add an
+# assumption through. Names may themselves contain unicode arrows (`noMint→ref`), so a declaration
+# is recognised by its first token not being an operator/binder, which is what distinguishes it
+# from a wrapped continuation line of the previous type signature.
 actual_postulates=$(awk '
-  /^[ ]*--/ {next}
-  /^postulate$/ {inblock=1; next}
-  /^postulate[ ]+[^ ]/ {print $2; inblock=0; next}
-  inblock && /^[ ]+[^ ]+ +:/ {print $1; next}
-  inblock && /^[^ ]/ {inblock=0}
+  function emit(decl) {
+    sub(/:.*/, "", decl)
+    n = split(decl, names, /[ \t]+/)
+    if (n == 0) return
+    first = names[1] != "" ? names[1] : names[2]
+    if (first ~ /^([-=<>]|→|⇒|∀|\(|\{|\[)/) return   # continuation of the previous signature
+    for (i = 1; i <= n; i++) if (names[i] != "") print names[i]
+  }
+  { line = $0; sub(/--.*/, "", line) }
+  line ~ /^[ \t]*$/ { next }
+  line ~ /^postulate[ \t]*$/ { inblock = 1; next }
+  line ~ /^postulate[ \t]+/ { sub(/^postulate[ \t]+/, "", line); emit(line); inblock = 0; next }
+  inblock && line ~ /^[ \t]+[^ \t].*:/ { emit(line); next }
+  inblock && line ~ /^[^ \t]/ { inblock = 0 }
 ' "$BR" "$RR" | sort -u)
 
 expected_mocks=$(printf '%s\n' \
@@ -72,4 +99,4 @@ if [ "$fail" -ne 0 ]; then
   echo "Update the trust-ledger table in this script's header comment and the EXPECTED_* lists."
   exit 1
 fi
-echo "check-trust-ledger: OK — the bridge-layer trusted base is the 6 documented Ops mocks + 7 documented postulates."
+echo "check-trust-ledger: OK: the bridge-layer trusted base is the 6 documented Ops mocks + 7 documented postulates."

--- a/spec/src/Hydra/Protocol/Introduction.lagda.typ
+++ b/spec/src/Hydra/Protocol/Introduction.lagda.typ
@@ -1,3 +1,6 @@
+```
+module Hydra.Protocol.Introduction where
+```
 
 #import "/template.typ": *
 #import "/macros.typ": *

--- a/spec/src/Hydra/Protocol/Main.lagda.typ
+++ b/spec/src/Hydra/Protocol/Main.lagda.typ
@@ -15,6 +15,30 @@
   body,
 )
 
+```
+module Hydra.Protocol.Main where
+
+import Hydra.Protocol.Prelude
+import Hydra.Protocol.Introduction
+import Hydra.Protocol.Overview
+import Hydra.Protocol.Preliminaries
+import Hydra.Protocol.Setup
+import Hydra.Protocol.OnChain
+import Hydra.Protocol.OffChain
+import Hydra.Protocol.Security
+-- The machine-checked §7 proof terms (rendered: the statements appear under §7 "Machine-checked
+-- results", included below after Security; the proof bodies are typechecked but hidden).
+import Hydra.Protocol.SecurityProofs
+-- Extractable decidable reference checker + the bridge proving it reflects the on-chain
+-- validity bundles (Tier 2 differential-testing; not rendered in the document).
+import Hydra.Protocol.Reference
+import Hydra.Protocol.ReferenceBridge
+-- Extractable decidable reference for the OFF-CHAIN HeadLogic figure (Tier 2 differential, off-chain
+-- side; typecheck-only here, extracted via regenerate.sh, not rendered in the document).
+import Hydra.Protocol.OffChainReference
+-- On-chain coverage / non-stuckness + safety invariants (rendered: included below after OnChain).
+import Hydra.Protocol.OnChainCoverage
+```
 
 #include "Introduction.lagda.typ"
 #include "Overview.lagda.typ"
@@ -128,8 +152,10 @@ The trust base, in five families:
 - *On-chain search postulates* (@sec:on-chain): `burnedValue`, `burnedCount`,
   `mintedCount`, `μHead`, `signerKeyHash` - witnesses over the opaque value and
   key-set models - plus the context lookups the `Context` model does not expose:
-  `depositCommitsHashOf` (the increment's recomputed commit-set hash, from the
-  claimed deposit's datum) and `crsDatumHashAt`/`canonicalCRS#` (the CRS
+  `depositDatumCommitsHash` (the hash of the commit list decoded from the
+  claimed deposit's datum; the full commit digest `depositCommitsHashOf` is a
+  _definition_ over it, binding the deposit's transaction id) and
+  `crsDatumHashAt`/`canonicalCRS#` (the CRS
   reference-input datum hash and the canonical trusted-setup constant the
   fanout bundles bind it to).
 - *Security-model assumptions* (@sec:security): per-signature EUF-CMA

--- a/spec/src/Hydra/Protocol/Main.lagda.typ
+++ b/spec/src/Hydra/Protocol/Main.lagda.typ
@@ -143,7 +143,7 @@ The trust base, in five families:
 
 - *Ledger and crypto primitives* (the typecheck-only `Prelude`, postulates):
   `hash`, `bytes`/`concat`, the multisignature verifier `msVfy`, the `Value`
-  algebra (`_+ᵛ_`/`_≤ᵛ_`/`εᵛ` with commutative-monoid and order laws) and its
+  algebra (`_+ᵛ_`/`εᵛ` with the associativity and identity laws the proofs use) and its
   projections (`adaOf`, `nonAdaOf`, `quantityOf`, `stQty`, `headTokenCount`);
   the off-chain ledger `applyTxs` with its nil and compositionality laws (@sec:offchain).
 - *Accumulator laws* (@sec:on-chain): `accUTxO`/`accVerify`/`accVerifyExclude`

--- a/spec/src/Hydra/Protocol/OffChain.lagda.typ
+++ b/spec/src/Hydra/Protocol/OffChain.lagda.typ
@@ -190,16 +190,20 @@ record Snapshot : Set where        -- the confirmed snapshot object S̄
     version : ℕ                    -- S̄.v
     number  : ℕ                    -- S̄.s
     txs     : List Data            -- S̄.T
-    utxo    : UTxO                 -- S̄.U
-    utxoInc : UTxO                 -- S̄.U_α (pending increment)
-    depRef  : Maybe Data           -- S̄.txOutRef_α (deposit tx-id the pending increment comes from;
-                                   -- bound into κ# so the signature authorizes that one deposit and
-                                   -- no other recording the same UTxO - node `Snapshot.depositTxId`)
-    utxoDec : UTxO                 -- S̄.U_ω (pending decrement)
+    utxo    : UTxO                 -- S̄.U (descriptive, see the note after this record)
+    utxoInc : UTxO                 -- S̄.U_α (pending increment; a κ# argument, see `signHonest`)
+    depRef  : Maybe Data           -- S̄.txOutRef_α: the deposit the pending increment comes from
+                                   -- (node `Snapshot.depositTxId`). An argument of κ# via the
+                                   -- `signHonest` digest premise (@sec:security), which is what
+                                   -- makes the signature authorize that one deposit and no other
+                                   -- recording the same UTxO.
+    utxoDec : UTxO                 -- S̄.U_ω (pending decrement; the δ# argument, see `signHonest`)
     etaHash : ℍ                    -- S̄.(η')# (accumulator-commitment hash; always present, like the node's HydraAccumulator)
     decHash : ℍ                    -- S̄.δ# (decommit-output-set hash, node `decommitOutputsHash`; signed 5th component)
     comHash : ℍ                    -- S̄.κ# (commit-output-set hash, node `commitOutputsHash`; signed 6th component)
-    sig     : Maybe AggSig         -- S̄.σ (aggregate multisignature; ⊥ until confirmed — the sole signing-status marker)
+    sig     : Maybe AggSig         -- S̄.σ, mirroring the §6 snapshot object (descriptive: the proofs
+                                   -- read signing status from the system's `sigs`/`aggSigOf`, never
+                                   -- from here, so this field marks nothing on its own)
 
 record LocalState : Set where      -- a party's local state (besides setup params)
   field
@@ -343,7 +347,7 @@ $cal(D)$. \
 $t$, parties update the status of deposits in $cal(D)$ accordingly using
 the configured deposit period $Tdeposit$:
 - $sans("Expired")$ when deadline passed (or too soon): $t > t_("deadline") - Tdeposit$
-- $sans("Active")$ when deposit settled enough: $t > t_("created") + Tdeposit$
+- $sans("Active")$ when deposit settled enough: $t > t_("created") + Tactivate$
 When deposits become $sans("Active")$ and no other deposit / decommit is
 pending, and the party is the next snapshot leader, it may request a new
 snapshot including the deposit transaction $tx_(alpha)$. \
@@ -355,14 +359,18 @@ the off-chain twin of the extracted reference's
 
 ```
 -- ── Chain observations (§6.4 `from chain`): the deposit lifecycle ────────────────────────────────
--- The §6 `tick` deposit-status transition for one deposit, as a function of the deposit period
--- T_deposit and the current time t (the off-chain twin of `OffChainReference.depositStatusRef`):
---   t > deadline − T_deposit ⇒ Expired;  else t > created + T_deposit ⇒ Active;  else unchanged.
-depositStatusAt : ℕ → ℕ → DepositObj → DepositStatus
-depositStatusAt Tdep t D =
+-- The §6 `tick` deposit-status transition for one deposit, as a function of the expiry period
+-- T_deposit, the activation period T_activate and the current time t (the off-chain twin of
+-- `OffChainReference.depositStatusRef`):
+--   t > deadline − T_deposit ⇒ Expired;  else t > created + T_activate ⇒ Active;  else Inactive.
+-- The two periods are distinct: the node keys expiry off `depositPeriod` and activation off
+-- `depositActivation`, which are separately configurable, so collapsing them into one would put
+-- the model's activation boundary an arbitrary distance from the real node's.
+depositStatusAt : ℕ → ℕ → ℕ → DepositObj → DepositStatus
+depositStatusAt Tdep Tact t D =
   if ⌊ (DepositObj.deadline D ∸ Tdep) <? t ⌋ then Expired
-  else if ⌊ (DepositObj.created D + Tdep) <? t ⌋ then Active
-  else DepositObj.status D
+  else if ⌊ (DepositObj.created D + Tact) <? t ⌋ then Active
+  else Inactive
 ```
 #dparagraph[$hpRS$.]#h(1em) Upon receiving request
 $(hpRS,v,s,underline(tx)_(sans("req")), tx_alpha, tx_omega)$#footnote[Snapshot
@@ -554,7 +562,9 @@ data _observes_↝_ : LocalState → ChainEvent → LocalState → Set where
             { deposits =
                 map (λ kD → proj₁ kD ,
                        record (proj₂ kD)
-                         { status = depositStatusAt (HeadParameters.depositPeriod (LocalState.params st)) t (proj₂ kD) })
+                         { status = depositStatusAt (HeadParameters.depositPeriod (LocalState.params st))
+                                                        (HeadParameters.depositActivation (LocalState.params st))
+                                                        t (proj₂ kD) })
                     (LocalState.deposits st) }
 
   -- §6 chain observations that bump the open-state version (increment/decrement). Increment adds the

--- a/spec/src/Hydra/Protocol/OffChain.lagda.typ
+++ b/spec/src/Hydra/Protocol/OffChain.lagda.typ
@@ -471,6 +471,20 @@ data _handles_↝_ : LocalState → Message → LocalState → Set where
 
   -- on (reqDec, tx): the §6 `wait U_α = ∅ ∧ tx_ω = ⊥ ∧ L̂ ∘ tx ≠ ⊥` guard (no commit/decommit in flight,
   -- and tx applies), all three de-abstracted as premises; then `L̂ ← L̂ ∘ tx ∖ outputs(tx)` and tx_ω ← tx.
+  --
+  -- NB this rule reads `U_α = ∅` as "no deposit tx-id is recorded at all", which is the clean case and
+  -- a SUFFICIENT condition, not a characterisation. The implementation additionally proceeds when a
+  -- tx-id IS recorded but names nothing the head can still settle, because tx_α is cleared on neither
+  -- expiry nor recovery: an Expired deposit stays in 𝒟 so it can still be recovered, and a recovered
+  -- one only leaves 𝒟. Treating either as a commit in flight would block every later decommit on
+  -- something no increment can ever settle. `Hydra.Protocol.OffChainReference.reqDecEligibleRef` models
+  -- that refinement (its `PendingCommitᶜ` separates the four cases) and the off-chain differential
+  -- binds it to the node.
+  --
+  -- Consequence worth stating plainly: `NoBothInFlight` below is therefore STRONGER than what the
+  -- implementation guarantees, since a recorded-but-unsettleable tx_α can coexist with a pending tx_ω.
+  -- Restating it over settleable commits means weakening a §7 safety invariant and adding a freshness
+  -- premise to `deposit-add`, which is deliberately left as its own change rather than folded in here.
   reqDec-pending : ∀ {st tx L'}
     → LocalState.currentDepositTxId st ≡ nothing         -- U_α = ∅ (no commit in flight)
     → LocalState.pendingDecrement st ≡ nothing       -- tx_ω = ⊥ (no decommit in flight)

--- a/spec/src/Hydra/Protocol/OffChain.lagda.typ
+++ b/spec/src/Hydra/Protocol/OffChain.lagda.typ
@@ -1,3 +1,15 @@
+```
+module Hydra.Protocol.OffChain where
+
+open import Hydra.Protocol.Prelude
+open import Hydra.Protocol.Preliminaries
+open import Hydra.Protocol.Setup
+-- Extra list/nat helpers for the off-chain handler model (the deposit registry + tick).
+open import Data.List using (map; _++_)
+open import Data.List.Properties using (length-map)
+open import Data.Nat using (_<?_)
+open import Relation.Binary.PropositionalEquality using (sym; trans)
+```
 
 #import "/template.typ": *
 #import "/macros.typ": *
@@ -141,7 +153,9 @@ The Agda `Snapshot` record additionally carries the head id $cid$ (the first
 signed component of the message
 $cid || v || s || (eta')^(\#) || delta^(\#) || kappa^(\#)$), the decommit- and
 commit-output-set hashes $delta^(\#)$/$kappa^(\#)$ (the node's
-`decommitOutputsHash`/`commitOutputsHash`, bound into the signed message) and
+`decommitOutputsHash`/`commitOutputsHash`, bound into the signed message), the
+deposit reference $macron(mc(S)).txOutRef_alpha$ the pending increment comes
+from (bound into $kappa^(\#)$, node `depositTxId`) and
 the aggregate-signature slot $macron(mc(S)).sigma$ ($bot$ until confirmed),
 which the figure leaves implicit. \
 \
@@ -153,6 +167,63 @@ In Agda, a UTxO set is a finite map from output references to outputs, and a
 party's local state and the protocol messages are captured by dedicated record
 types.
 
+```
+UTxO : Set
+UTxO = OutputRef ⇀ Output
+
+-- §6 deposit objects (the 𝒟 registry). A deposit moves Inactive → Active → Expired over time as
+-- chain `tick`s arrive (see `depositStatusAt` and the `_observes_↝_` chain-event relation below).
+data DepositStatus : Set where
+  Inactive Active Expired : DepositStatus
+
+record DepositObj : Set where      -- §6 depositObj(U, t_created, t_deadline, status)
+  constructor depositObj
+  field
+    utxoD    : UTxO                 -- the deposited UTxO U
+    created  : ℕ                    -- t_created
+    deadline : ℕ                    -- t_deadline
+    status   : DepositStatus
+
+record Snapshot : Set where        -- the confirmed snapshot object S̄
+  field
+    cid     : ℍ                    -- S̄.cid (head currency id; the FIRST signed component, cid‖v‖s‖η#‖δ#‖κ#)
+    version : ℕ                    -- S̄.v
+    number  : ℕ                    -- S̄.s
+    txs     : List Data            -- S̄.T
+    utxo    : UTxO                 -- S̄.U
+    utxoInc : UTxO                 -- S̄.U_α (pending increment)
+    depRef  : Maybe Data           -- S̄.txOutRef_α (deposit tx-id the pending increment comes from;
+                                   -- bound into κ# so the signature authorizes that one deposit and
+                                   -- no other recording the same UTxO - node `Snapshot.depositTxId`)
+    utxoDec : UTxO                 -- S̄.U_ω (pending decrement)
+    etaHash : ℍ                    -- S̄.(η')# (accumulator-commitment hash; always present, like the node's HydraAccumulator)
+    decHash : ℍ                    -- S̄.δ# (decommit-output-set hash, node `decommitOutputsHash`; signed 5th component)
+    comHash : ℍ                    -- S̄.κ# (commit-output-set hash, node `commitOutputsHash`; signed 6th component)
+    sig     : Maybe AggSig         -- S̄.σ (aggregate multisignature; ⊥ until confirmed — the sole signing-status marker)
+
+record LocalState : Set where      -- a party's local state (besides setup params)
+  field
+    params             : HeadParameters
+    seenVersion        : ℕ          -- v̂
+    seenNumber         : ℕ          -- ŝ
+    seenSigs           : List (ℕ × PartySig) -- Σ̂ (individual signatures, indexed by party)
+    localLedger        : UTxO       -- L̂
+    pending            : List Data  -- T̂ (txs pending a snapshot)
+    confirmed          : Snapshot   -- S̄
+    currentDepositTxId : Maybe Data -- tx_α (pending deposit tx-id, the key into 𝒟; ⊥ if none — node's currentDepositTxId)
+    pendingDecrement   : Maybe Data -- tx_ω (pending decrement, ⊥ if none)
+    deposits           : List (Data × DepositObj)  -- 𝒟 (registry keyed by deposit tx-id tx_α)
+
+data Message : Set where           -- network messages of the coordinated head (§6)
+  reqTx  : (tx : Data)                          → Message  -- hpRT
+  reqDec : (tx : Data)                          → Message  -- hpRD
+  -- hpRS (full payload). NB the payload order here (deposit txα before decommit txω) follows
+  -- the §6 figure; the Haskell `ReqSn` record (Hydra.Network.Message) lists the same fields by
+  -- NAME as txReq↔transactionIds, txα↔depositTxId, txω↔decommitTx, with decommit before deposit
+  -- - match them by name, not position (the deposit and decommit slots are easy to confuse).
+  reqSn  : (v s : ℕ) (txReq txα txω : Data)     → Message
+  ackSn  : (s : ℕ) (σ : PartySig)               → Message  -- hpAS (σⱼ, an individual signature)
+```
 
 The local-ledger application $applytx$ and the UTxO-map operations the handlers
 use are kept abstract, as the off-chain trust base: `applyTxs` with its nil and
@@ -160,6 +231,34 @@ compositionality laws (the two ledger laws the @sec:security proofs consume), th
 joint-applicability predicate `Applicable`, and the map operations recording how
 $hatmL$ changes.
 
+```
+-- Ledger application: apply a transaction list to a UTxO set; `nothing` = ⊥ (conflict). Kept abstract.
+-- `applyTxs-nil` is the (trivial) ledger law that applying no transactions never conflicts.
+-- `applyTxs-compose` is ledger COMPOSITIONALITY: applying `txs₁` then `txs₂` equals applying their
+-- concatenation (the one ledger law, alongside nil, that lets the §7 honest-signer applicability guard
+-- be DERIVED against U₀). The off-chain handler arms below also use `applyTxs`/`Applicable`,
+-- which is why they live here; @sec:security re-exports them via its `open import` of this module.
+postulate
+  applyTxs         : UTxO → List Data → Maybe UTxO
+  applyTxs-nil     : ∀ U → applyTxs U [] ≡ just U
+  applyTxs-compose : ∀ {U U′} txs₁ txs₂ → applyTxs U txs₁ ≡ just U′
+                   → applyTxs U (txs₁ ++ txs₂) ≡ applyTxs U′ txs₂
+
+-- A transaction list is jointly applicable to U when applying it does not conflict (≠ ⊥).
+Applicable : UTxO → List Data → Set
+Applicable U txs = ¬ (applyTxs U txs ≡ nothing)
+
+-- UTxO-map operations used by the local-ledger (L̂) updates of the handlers below. Kept abstract (same
+-- trust family as `applyTxs`): the handler arms only need them to RECORD how L̂ changes (∅ at head open,
+-- ∪ on increment, ∖ outputs(tx) on decommit), faithfully to the §6 figure; the §7 invariants do not
+-- reason about ledger CONTENTS, so no laws are required here.
+infixl 6 _∪ᵘ_ _∖ᵘ_
+postulate
+  εᵘ      : UTxO                -- the empty UTxO map (L̂ ← ∅ when the head opens)
+  _∪ᵘ_    : UTxO → UTxO → UTxO  -- UTxO-map union (L̂ ∪ U when an increment is observed)
+  _∖ᵘ_    : UTxO → UTxO → UTxO  -- UTxO-map difference (… ∖ outputs(tx) when a decommit is requested)
+  outputs : Data → UTxO         -- the outputs a transaction produces, as a UTxO map
+```
 
 == Protocol flow
 
@@ -254,6 +353,17 @@ The `tick` deposit-status transition is the function `depositStatusAt`,
 the off-chain twin of the extracted reference's
 `depositStatusRef`.
 
+```
+-- ── Chain observations (§6.4 `from chain`): the deposit lifecycle ────────────────────────────────
+-- The §6 `tick` deposit-status transition for one deposit, as a function of the deposit period
+-- T_deposit and the current time t (the off-chain twin of `OffChainReference.depositStatusRef`):
+--   t > deadline − T_deposit ⇒ Expired;  else t > created + T_deposit ⇒ Active;  else unchanged.
+depositStatusAt : ℕ → ℕ → DepositObj → DepositStatus
+depositStatusAt Tdep t D =
+  if ⌊ (DepositObj.deadline D ∸ Tdep) <? t ⌋ then Expired
+  else if ⌊ (DepositObj.created D + Tdep) <? t ⌋ then Active
+  else DepositObj.status D
+```
 #dparagraph[$hpRS$.]#h(1em) Upon receiving request
 $(hpRS,v,s,underline(tx)_(sans("req")), tx_alpha, tx_omega)$#footnote[Snapshot
 requests with only transaction identifiers and output references are possible
@@ -332,6 +442,66 @@ handlers here and the deposit/tick/increment/decrement/initialTx chain
 observations below - while the close/contest/fanout observations and the
 leader-multicast effects are not modelled at this level.
 
+```
+-- Handling a network message updates a party's local state (spec §6.4); together with `_observes_↝_`
+-- (chain events) below it transcribes the §6.4 handlers, the figure (`Protocol flow`) being the rendered
+-- authority. Each arm carries its §6 `require`/`wait` guards as premises (normative):
+-- reqTx the applicability guard `wait L̂ ∘ tx ≠ ⊥` (de-abstracted over `applyTxs`) + ledger update;
+-- reqDec its no-in-flight + applicability guard (`U_α = ∅ ∧ tx_ω = ⊥ ∧ L̂ ∘ tx ≠ ⊥`) + ledger update;
+-- reqSn-sign the version/number guards (§7);
+-- ackSn-collect the no-double-sign guard (`(j,·) ∉ Σ̂`); ackSn-confirm the n-of-n all-signed guard. The
+-- ackSn-confirm multisignature VERIFY is the operational realisation of all-signed and is formalised at
+-- the §7 `confirm` step (`AggVerified`), not duplicated here; the leader-snapshot multicast EFFECTS are
+-- likewise deferred to the §7 system wiring.
+data _handles_↝_ : LocalState → Message → LocalState → Set where
+  -- on (reqTx, tx): `wait L̂ ∘ tx ≠ ⊥` (tx applies to the local ledger), then `L̂ ← L̂ ∘ tx` and
+  -- `T̂ ← T̂ ∪ {tx}`. The applicability guard is de-abstracted as the witness `applyTxs L̂ [tx] ≡ just L'`,
+  -- which also supplies the updated ledger L'. (The leader-snapshot multicast is a deferred effect.)
+  reqTx-pending : ∀ {st tx L'}
+    → applyTxs (LocalState.localLedger st) (tx ∷ []) ≡ just L'
+    → st handles (reqTx tx) ↝ record st { localLedger = L' ; pending = LocalState.pending st ++ (tx ∷ []) }
+
+  -- on (reqDec, tx): the §6 `wait U_α = ∅ ∧ tx_ω = ⊥ ∧ L̂ ∘ tx ≠ ⊥` guard (no commit/decommit in flight,
+  -- and tx applies), all three de-abstracted as premises; then `L̂ ← L̂ ∘ tx ∖ outputs(tx)` and tx_ω ← tx.
+  reqDec-pending : ∀ {st tx L'}
+    → LocalState.currentDepositTxId st ≡ nothing         -- U_α = ∅ (no commit in flight)
+    → LocalState.pendingDecrement st ≡ nothing       -- tx_ω = ⊥ (no decommit in flight)
+    → applyTxs (LocalState.localLedger st) (tx ∷ []) ≡ just L'   -- L̂ ∘ tx ≠ ⊥ (applicability, witnessed)
+    → st handles (reqDec tx) ↝ record st { localLedger = L' ∖ᵘ outputs tx ; pendingDecrement = just tx }
+
+  -- on (ackSn, s, σ) before the round completes: record sender j's signature in Σ̂; S̄ unchanged. The §6
+  -- `require (j,·) ∉ Σ̂` guard (sender j has not already signed this round) is de-abstracted as the
+  -- premise, so Σ̂ never double-counts a party.
+  ackSn-collect : ∀ {st s σ j}
+    → ¬ (j ∈ˡ map proj₁ (LocalState.seenSigs st))   -- (j,·) ∉ Σ̂ (sender has not signed yet)
+    → st handles (ackSn s σ) ↝ record st { seenSigs = (j , σ) ∷ LocalState.seenSigs st }
+
+  -- on (ackSn, s, σ) completing the round: every party has signed, so the seen snapshot becomes the new
+  -- confirmed S̄ (txs = T̂, number = ŝ). The §6 `if ∀ k ∈ [1..n] : (k,·) ∈ Σ̂` all-signed guard is
+  -- de-abstracted as the `allSigned` premise: the n-of-n condition (every party index < n is recorded
+  -- in Σ̂), the SEMANTIC content the §7 `Certified` predicate captures (no tx confirmed unless every
+  -- honest party signed it). The figure's operational `require msVfy(…, msComb Σ̂)` over the COMBINED
+  -- multisignature is the implementation of that n-of-n condition (via ms-unforgeability); it is
+  -- formalised precisely at the §7 `confirm` step (`AggVerified`/`msVfy`), so it is not duplicated here.
+  ackSn-confirm : ∀ {st s σ snap}
+    → (∀ {k} → k < HeadParameters.n (LocalState.params st) → k ∈ˡ map proj₁ (LocalState.seenSigs st))  -- ∀k:(k,·)∈Σ̂
+    → Snapshot.txs snap ≡ LocalState.pending st          -- S̄'.T = T̂
+    → Snapshot.number snap ≡ LocalState.seenNumber st    -- S̄'.s = ŝ
+    → (LocalState.seenVersion st ≡ Snapshot.version snap) ⊎ (LocalState.seenVersion st ≡ suc (Snapshot.version snap))  -- v̂ = S̄'.v or S̄'.v+1: a snapshot is confirmed at the current or one-prior version (supports `VersionDiscipline`; the v̂ = S̄'.v+1 case is a snapshot signed before its increment/decrement version bump was observed)
+    → st handles (ackSn s σ) ↝ record st { confirmed = snap }
+
+  -- on (reqSn, v, s, …): the honest snapshot-leader's request triggers a party to sign (§6.4
+  -- onOpenNetworkReqSn). The `require` guards captured here: v ≡ v̂ (version matches) and s ≡ s̄+1
+  -- (the requested number is one above the party's CONFIRMED snapshot - combined with the §7
+  -- `signHonest` no-in-flight precondition ŝ = s̄, this is the node's `requireReqSn` s = ŝ+1 /
+  -- `waitNoSnapshotInFlight`). Signing advances the last-seen number ŝ ← s, the local mutation that
+  -- makes one-signature-per-round (`sigDedup`) DERIVABLE. The requested-tx applicability and the
+  -- resulting snapshot's tx set are handled at the §7 signing step (they need U₀ / the ledger laws).
+  reqSn-sign : ∀ {st v s txReq txα txω}
+    → v ≡ LocalState.seenVersion st
+    → s ≡ suc (Snapshot.number (LocalState.confirmed st))
+    → st handles (reqSn v s txReq txα txω) ↝ record st { seenNumber = s }
+```
 #dparagraph[$mono("decrementTx")$.]#h(1em) Upon observing the $mtxDecrement$
 transaction, which removed outputs $U$ from the head, the corresponding pending
 decrement transaction is cleared and the observed version $v$ is used for future
@@ -353,7 +523,109 @@ handler of the figure - the deposit lifecycle above, the version-bumping
 increment/decrement observations, and the head-opening `initialTx` of the
 Initializing-the-head paragraph.
 
+```
+-- Chain events a party observes: the deposit lifecycle (deposit/recover/tick), the version-bumping
+-- increment/decrement observations, and the head-opening initialTx. Close/contest/fanout
+-- observations are not modelled (see the scope note above).
+data ChainEvent : Set where
+  depositTx : (txα : Data) (U : UTxO) (created deadline : ℕ) → ChainEvent  -- on (depositTx, …)
+  recoverTx : (txα : Data)                                   → ChainEvent  -- on (recoverTx, txα)
+  tick      : (t : ℕ)                                        → ChainEvent  -- on (tick, t)
+  incrementTx : (U : UTxO) (v : ℕ)                           → ChainEvent  -- on (incrementTx, U, v)
+  decrementTx : (U : UTxO) (v : ℕ)                           → ChainEvent  -- on (decrementTx, U, v)
+  initialTx   :                                                ChainEvent  -- on (initialTx, …): head opens
 
+-- Observing a chain event updates a party's deposit registry 𝒟 (and, for `tick`, every entry's
+-- status). `recover` removes a WITNESSED occurrence, so no decidable Data-equality is assumed.
+-- Mirrors the figure's deposit / recover / tick handlers; the leader re-trigger `multicast` effect is
+-- modelled when these events are lifted into the §7 system (as the existing network arms are).
+data _observes_↝_ : LocalState → ChainEvent → LocalState → Set where
+  deposit-add : ∀ {st txα U c d}
+    → st observes (depositTx txα U c d)
+        ↝ record st { deposits = (txα , depositObj U c d Inactive) ∷ LocalState.deposits st }
+
+  recover-del : ∀ {st txα D before after}
+    → LocalState.deposits st ≡ before ++ ((txα , D) ∷ after)
+    → st observes (recoverTx txα) ↝ record st { deposits = before ++ after }
+
+  tick-update : ∀ {st t}
+    → st observes (tick t)
+        ↝ record st
+            { deposits =
+                map (λ kD → proj₁ kD ,
+                       record (proj₂ kD)
+                         { status = depositStatusAt (HeadParameters.depositPeriod (LocalState.params st)) t (proj₂ kD) })
+                    (LocalState.deposits st) }
+
+  -- §6 chain observations that bump the open-state version (increment/decrement). Increment adds the
+  -- committed UTxO to the local ledger (`L̂ ← L̂ ∪ U`); decrement leaves L̂ (its outputs left earlier, at
+  -- the decommit request). Each bumps v̂ and clears the matching in-flight pending (tx_α / tx_ω).
+  -- NB the seen number ŝ is PRESERVED, not reset to S̄.s: an unconditional `ŝ ← S̄.s` would
+  -- drop ŝ below an in-flight signature's number and break `signNumBound` (§7). The §6 figure, this
+  -- model and the node agree: the seen snapshot is carried across the version bump (the node keeps an
+  -- in-flight `SeenSnapshot`, a no-op on ŝ given the invariant ŝ ∈ {s̄, s̄+1}).
+  increment-obs : ∀ {st U v}
+    → v ≡ suc (Snapshot.version (LocalState.confirmed st))   -- authorize-then-bump: v = S̄.v + 1 (the increment is signed at the confirmed snapshot's version); supports `VersionDiscipline`
+    → st observes (incrementTx U v)
+        ↝ record st { seenVersion = v ; currentDepositTxId = nothing ; localLedger = LocalState.localLedger st ∪ᵘ U }
+
+  decrement-obs : ∀ {st U v}
+    → v ≡ suc (Snapshot.version (LocalState.confirmed st))   -- as increment: v = S̄.v + 1 (authorize-then-bump)
+    → st observes (decrementTx U v)
+        ↝ record st { seenVersion = v ; pendingDecrement = nothing }
+
+  -- on (initialTx, …): the head opens with a genesis confirmed snapshot (number/version 0, no txs) and
+  -- an empty local ledger (`L̂ ← ∅`); the §6 setup `require`s stay abstracted (genesis is given here,
+  -- like ackSn-confirm). The deposit registry 𝒟 is NOT reset: the figure leaves it untouched and the
+  -- node carries `pendingDeposits` through head-open unchanged.
+  initialTx-obs : ∀ {st genesis}
+    → Snapshot.version genesis ≡ 0
+    → Snapshot.number  genesis ≡ 0
+    → Snapshot.txs     genesis ≡ []
+    → st observes initialTx
+        ↝ record st { seenVersion = 0 ; seenNumber = 0 ; pending = [] ; confirmed = genesis
+                    ; currentDepositTxId = nothing ; pendingDecrement = nothing ; localLedger = εᵘ }
+```
+
+```
+-- A tick only recomputes statuses: it never adds or drops a deposit (the registry length is preserved).
+tick-preserves-deposits-length : ∀ {st t st'}
+  → st observes (tick t) ↝ st'
+  → length (LocalState.deposits st') ≡ length (LocalState.deposits st)
+tick-preserves-deposits-length {st = st} tick-update = length-map _ (LocalState.deposits st)
+
+-- The de-abstracted reqDec guard is load-bearing: reqDec fires ONLY from a no-decommit-in-flight state
+-- (tx_ω = ⊥) and results in exactly the requested decommit (so it never silently overwrites an
+-- in-flight one). Deleting the `pendingDecrement ≡ nothing` premise on `reqDec-pending` makes the first
+-- conjunct underivable (an adversarial check that the guard carries weight).
+reqDec-starts-decommit : ∀ {st tx st'}
+  → st handles (reqDec tx) ↝ st'
+  → (LocalState.pendingDecrement st ≡ nothing) × (LocalState.pendingDecrement st' ≡ just tx)
+reqDec-starts-decommit (reqDec-pending _ q _) = q , refl
+
+-- The de-abstracted reqTx guard is load-bearing too: reqTx fires only for transactions that APPLY to
+-- the local ledger (the §6 `wait L̂ ∘ tx ≠ ⊥`). Deleting the `applyTxs … ≡ just L'` witness premise on
+-- `reqTx-pending` makes this underivable.
+reqTx-applicable : ∀ {st tx st'}
+  → st handles (reqTx tx) ↝ st'
+  → Applicable (LocalState.localLedger st) (tx ∷ [])
+reqTx-applicable (reqTx-pending eq) p with trans (sym eq) p
+... | ()
+
+-- The ackSn guards are load-bearing too. ackSn-collect records a signature only for a sender that is
+-- NOT already in Σ̂ (so Σ̂ never double-counts a party):
+ackSn-collect-fresh : ∀ {st s σ j}
+  → st handles (ackSn s σ) ↝ record st { seenSigs = (j , σ) ∷ LocalState.seenSigs st }
+  → ¬ (j ∈ˡ map proj₁ (LocalState.seenSigs st))
+ackSn-collect-fresh (ackSn-collect p) = p
+
+-- ackSn-confirm adopts a snapshot only once EVERY party (index < n) has signed (the n-of-n condition
+-- the §7 `Certified` predicate captures):
+ackSn-confirm-allSigned : ∀ {st s σ snap}
+  → st handles (ackSn s σ) ↝ record st { confirmed = snap }
+  → ∀ {k} → k < HeadParameters.n (LocalState.params st) → k ∈ˡ map proj₁ (LocalState.seenSigs st)
+ackSn-confirm-allSigned (ackSn-confirm allSigned _ _ _) = allSigned
+```
 
 === Closing the head
 
@@ -405,6 +677,16 @@ but proved to be maintained by every off-chain step. A step of the handler
 model is a network-message handling or a chain observation (`_⟶ᴴ_`), and
 `Reachableᴴ` closes it reflexively-transitively from a given start state.
 
+```
+-- One off-chain step: handle a network message OR observe a chain event.
+data _⟶ᴴ_ : LocalState → LocalState → Set where
+  hstep : ∀ {st m st'} → st handles m  ↝ st' → st ⟶ᴴ st'
+  ostep : ∀ {st e st'} → st observes e ↝ st' → st ⟶ᴴ st'
+
+data Reachableᴴ (init : LocalState) : LocalState → Set where
+  base : Reachableᴴ init init
+  step : ∀ {st st'} → Reachableᴴ init st → st ⟶ᴴ st' → Reachableᴴ init st'
+```
 
 #invariant(name: "Handler-model safety disciplines")[
   Along any off-chain run from a state satisfying them (such as the state
@@ -425,13 +707,40 @@ slot; every other step leaves both slots untouched. Deleting the
 `pendingDecrement ≡ nothing` premise on `reqDec-pending` makes the proof fail,
 which is the adversarial check that the guard carries weight.
 
+```agda
+NoBothInFlight : LocalState → Set
+NoBothInFlight st = (LocalState.currentDepositTxId st ≡ nothing) ⊎ (LocalState.pendingDecrement st ≡ nothing)
+```
 
+```
+noBothInFlight-step : ∀ {st st'} → st ⟶ᴴ st' → NoBothInFlight st → NoBothInFlight st'
+```
 
+```
+noBothInFlight-step (hstep (reqTx-pending _))     inv = inv
+noBothInFlight-step (hstep (reqDec-pending p _ _)) _  = inj₁ p
+noBothInFlight-step (hstep (ackSn-collect _))     inv = inv
+noBothInFlight-step (hstep (ackSn-confirm _ _ _ _)) inv = inv
+noBothInFlight-step (hstep (reqSn-sign _ _))      inv = inv
+noBothInFlight-step (ostep deposit-add)           inv = inv
+noBothInFlight-step (ostep (recover-del _))       inv = inv
+noBothInFlight-step (ostep tick-update)           inv = inv
+noBothInFlight-step (ostep (increment-obs _))      _  = inj₁ refl
+noBothInFlight-step (ostep (decrement-obs _))      _  = inj₂ refl
+noBothInFlight-step (ostep (initialTx-obs _ _ _))  _  = inj₁ refl
+```
 
 Hence the discipline holds throughout any off-chain run whose start state
 satisfies it.
 
+```agda
+noBothInFlight-reachable : ∀ {init st} → NoBothInFlight init → Reachableᴴ init st → NoBothInFlight st
+```
 
+```
+noBothInFlight-reachable inv base       = inv
+noBothInFlight-reachable inv (step r s) = noBothInFlight-step s (noBothInFlight-reachable inv r)
+```
 
 `VersionDiscipline` makes the close/contest version reuse well-formed: the node
 reuses the open-state version $hatv$ when posting a contest, which is meaningful
@@ -444,10 +753,39 @@ re-establishes the discipline from its own version premise. This turns an
 otherwise unchecked runtime assumption of the implementation into a theorem of
 the off-chain state machine.
 
+```agda
+VersionDiscipline : LocalState → Set
+VersionDiscipline st =
+    (LocalState.seenVersion st ≡ Snapshot.version (LocalState.confirmed st))
+  ⊎ (LocalState.seenVersion st ≡ suc (Snapshot.version (LocalState.confirmed st)))
+```
 
+```
+versionDiscipline-step : ∀ {st st'} → st ⟶ᴴ st' → VersionDiscipline st → VersionDiscipline st'
+```
 
+```
+versionDiscipline-step (hstep (reqTx-pending _))       inv = inv
+versionDiscipline-step (hstep (reqDec-pending _ _ _))  inv = inv
+versionDiscipline-step (hstep (ackSn-collect _))       inv = inv
+versionDiscipline-step (hstep (ackSn-confirm _ _ _ d)) _   = d
+versionDiscipline-step (hstep (reqSn-sign _ _))        inv = inv
+versionDiscipline-step (ostep deposit-add)             inv = inv
+versionDiscipline-step (ostep (recover-del _))         inv = inv
+versionDiscipline-step (ostep tick-update)             inv = inv
+versionDiscipline-step (ostep (increment-obs e))       _   = inj₂ e
+versionDiscipline-step (ostep (decrement-obs e))       _   = inj₂ e
+versionDiscipline-step (ostep (initialTx-obs eq _ _))  _   = inj₁ (sym eq)
+```
 
+```agda
+versionDiscipline-reachable : ∀ {init st} → VersionDiscipline init → Reachableᴴ init st → VersionDiscipline st
+```
 
+```
+versionDiscipline-reachable inv base       = inv
+versionDiscipline-reachable inv (step r s) = versionDiscipline-step s (versionDiscipline-reachable inv r)
+```
 
 == Rollbacks and protocol changes <sec:rollbacks>
 #todo[Explain why rollbacks are no problem to increment/decrement]

--- a/spec/src/Hydra/Protocol/OffChainReference.agda
+++ b/spec/src/Hydra/Protocol/OffChainReference.agda
@@ -36,14 +36,16 @@ if false then _ else y = y
 
 -- The §6 `tick` deposit-status decision for one deposit object, as a pure function of times (all
 -- POSIXTime; Nat truncated subtraction, matching the on-chain Reference's time arithmetic):
---   on (tick, t):  if  t > deadline − T_deposit   then Expired
---                  else if t > created + T_deposit then Active
---                  else Inactive (unchanged)
+--   on (tick, t):  if  t > deadline − T_deposit     then Expired
+--                  else if t > created + T_activate then Active
+--                  else Inactive
+-- T_deposit (expiry) and T_activate (activation) are the node's `depositPeriod` and
+-- `depositActivation`, which are configured independently, so they are separate arguments here.
 -- (`_<_`/`_-_`/`_+_` are the `Agda.Builtin.Nat` Bool-valued / arithmetic builtins; `t > x` is `x < t`.)
-depositStatusRef : Nat → Nat → Nat → Nat → DepositStatusᶜ
-depositStatusRef created deadline tDeposit t =
+depositStatusRef : Nat → Nat → Nat → Nat → Nat → DepositStatusᶜ
+depositStatusRef created deadline tDeposit tActivation t =
   if (deadline - tDeposit) < t then expiredᶜ
-  else if (created + tDeposit) < t then activeᶜ
+  else if (created + tActivation) < t then activeᶜ
   else inactiveᶜ
 
 infixr 6 _&&_
@@ -120,7 +122,13 @@ modSuc : Nat → Nat → Nat   -- modSuc a b = a mod (suc b), via the Agda.Built
 modSuc a b = mod-helper 0 b a b
 
 -- Round-robin leader, matching the node's `isLeader` (HeadLogic.hs): for `suc m` parties and snapshot
--- number sn, the party at 0-based index i is the leader iff (sn - 1) mod (suc m) == i. Only meaningful
--- for sn ≥ 1; the differential against the REAL `isLeader` exercises that domain.
+-- number sn, the party at 0-based index i is the leader iff (sn - 1) mod (suc m) == i.
+--
+-- Written `(sn + m) mod (suc m)` rather than `(sn - 1) mod (suc m)` so it agrees with the node at
+-- EVERY sn, including 0. The node computes `(fromIntegral sn - 1) mod length parties` over signed
+-- Int, so at sn = 0 it asks for `(-1) mod n`, which Haskell returns as n - 1 = m; Agda's `_-_` on ℕ
+-- truncates to 0 instead, which would name party 0 and make the oracle confidently disagree with
+-- the implementation on a reachable input (a ReqSn can carry sn = 0). Adding m is the same residue
+-- as subtracting 1 for every sn ≥ 1, and yields m at sn = 0.
 leaderRef : Nat → Nat → Nat → Bool   -- (m where #parties = suc m, sn, party index i)
-leaderRef m sn i = modSuc (sn - 1) m == i
+leaderRef m sn i = modSuc (sn + m) m == i

--- a/spec/src/Hydra/Protocol/OffChainReference.agda
+++ b/spec/src/Hydra/Protocol/OffChainReference.agda
@@ -7,7 +7,9 @@
 --
 -- Decisions covered (off-chain differential), one decidable function per handler guard: the
 -- deposit-status transition of the §6 `tick` handler (`depositStatusRef`), the reqSn
--- signing-eligibility and reqDec eligibility checks (`signEligibleRef`/`reqDecEligibleRef`), the
+-- signing-eligibility and reqDec eligibility checks (`signEligibleRef`/`reqDecEligibleRef`, the
+-- latter over the four-case `PendingCommitᶜ` rather than a Bool, so WHICH commits block a decommit
+-- is decided here and not by whoever projects the node state), the
 -- reqSn incremental-action guards (`reqSnNotBothRef`/`reqSnDecommitOutputsRef`/
 -- `reqSnDepositSettledRef`), the ackSn no-double-sign and all-signed guards
 -- (`notAlreadySignedRef`/`allSignedRef`), the close/contest eligibility gate
@@ -75,9 +77,37 @@ elemᵇ : Nat → List Nat → Bool
 elemᵇ _ []       = false
 elemᵇ x (y ∷ ys) = (x == y) || elemᵇ x ys
 
--- reqDec eligibility (the §6 `wait U_α = ∅ ∧ tx_ω = ⊥`): neither a commit nor a decommit in flight.
-reqDecEligibleRef : Bool → Bool → Bool   -- (commitInFlight, decommitInFlight)
-reqDecEligibleRef commit decommit = not commit && not decommit
+-- The state of the head's recorded pending commit: the node's `currentDepositTxId` together with
+-- the status of the deposit it names. Four cases rather than one Bool, because the difference
+-- between them is exactly what decides whether a commit holds a decommit back, and a Bool leaves
+-- that decision to whoever computes it.
+data PendingCommitᶜ : Set where
+  noCommitᶜ      : PendingCommitᶜ   -- no deposit id is recorded
+  commitPendingᶜ : PendingCommitᶜ   -- recorded, and the deposit is Inactive or Active
+  commitExpiredᶜ : PendingCommitᶜ   -- recorded, and the deposit has Expired
+  commitGoneᶜ    : PendingCommitᶜ   -- recorded, but no such deposit is registered (recovered)
+{-# FOREIGN GHC data HsPendingCommit = NoCommitP | CommitPendingP | CommitExpiredP | CommitGoneP
+                   deriving (Eq, Show) #-}
+{-# COMPILE GHC PendingCommitᶜ = data HsPendingCommit (NoCommitP | CommitPendingP | CommitExpiredP | CommitGoneP) #-}
+
+-- Whether a recorded pending commit is one the head can still settle, which is the `U_α ≠ ∅` a
+-- decommit has to wait behind. Only a registered, unexpired deposit is: an expired one is
+-- unclaimable and a recovered one is gone, and neither is reachable by any later increment.
+--
+-- This distinction is load-bearing rather than pedantic. The node clears `currentDepositTxId` on
+-- neither expiry nor recovery (`DepositExpired` keeps the deposit so it can still be recovered,
+-- `DepositRecovered` only drops the map entry), so a decision that read that field alone would
+-- block every later decommit on a commit that can never settle.
+commitBlocksᵇ : PendingCommitᶜ → Bool
+commitBlocksᵇ commitPendingᶜ = true
+commitBlocksᵇ noCommitᶜ      = false
+commitBlocksᵇ commitExpiredᶜ = false
+commitBlocksᵇ commitGoneᶜ    = false
+
+-- reqDec eligibility (the §6 `wait U_α = ∅ ∧ tx_ω = ⊥`): neither a settleable commit nor a decommit
+-- in flight.
+reqDecEligibleRef : PendingCommitᶜ → Bool → Bool   -- (pending commit, decommitInFlight)
+reqDecEligibleRef commit decommit = not (commitBlocksᵇ commit) && not decommit
 
 -- reqSn incremental-action exclusivity (the §6 `require tx_ω = ⊥ ∨ tx_α = ⊥`, node
 -- `ReqSnBothCommitAndDecommit`): a snapshot request may carry a commit (deposit) or a decommit,

--- a/spec/src/Hydra/Protocol/OffChainReference.agda
+++ b/spec/src/Hydra/Protocol/OffChainReference.agda
@@ -1,0 +1,126 @@
+-- Executable, decidable reference for the OFF-CHAIN HeadLogic decisions (the §6 figure).
+--
+-- Off-chain analog of `Reference.agda`: kept self-contained over `Agda.Builtin` types so MAlonzo
+-- extracts it to clean Haskell, which an off-chain differential test runs as a second oracle against
+-- `Hydra.HeadLogic`. (See `Reference.agda`'s header for why the imports stay minimal: Prelude/OffChain
+-- and stdlib do not extract / balloon the generated tree.)
+--
+-- Decisions covered (off-chain differential), one decidable function per handler guard: the
+-- deposit-status transition of the §6 `tick` handler (`depositStatusRef`), the reqSn
+-- signing-eligibility and reqDec eligibility checks (`signEligibleRef`/`reqDecEligibleRef`), the
+-- reqSn incremental-action guards (`reqSnNotBothRef`/`reqSnDecommitOutputsRef`/
+-- `reqSnDepositSettledRef`), the ackSn no-double-sign and all-signed guards
+-- (`notAlreadySignedRef`/`allSignedRef`), the close/contest eligibility gate
+-- (`contestEligibleRef`), and round-robin leader selection (`leaderRef`).
+module Hydra.Protocol.OffChainReference where
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Nat
+open import Agda.Builtin.List
+
+-- ── boundary types, bound to clean Haskell at extraction ──────────────────────────────────
+
+-- Deposit lifecycle status (§6 `depositObj.status` / the 𝒟 registry).
+data DepositStatusᶜ : Set where
+  inactiveᶜ activeᶜ expiredᶜ : DepositStatusᶜ
+{-# FOREIGN GHC data HsDepositStatus = InactiveS | ActiveS | ExpiredS deriving (Eq, Show) #-}
+{-# COMPILE GHC DepositStatusᶜ = data HsDepositStatus (InactiveS | ActiveS | ExpiredS) #-}
+
+-- ── small helper ──────────────────────────────────────────────────────────────────────────
+
+if_then_else_ : {A : Set} → Bool → A → A → A
+if true  then x else _ = x
+if false then _ else y = y
+
+-- ── the decidable decision ──────────────────────────────────────────────────────────────────
+
+-- The §6 `tick` deposit-status decision for one deposit object, as a pure function of times (all
+-- POSIXTime; Nat truncated subtraction, matching the on-chain Reference's time arithmetic):
+--   on (tick, t):  if  t > deadline − T_deposit   then Expired
+--                  else if t > created + T_deposit then Active
+--                  else Inactive (unchanged)
+-- (`_<_`/`_-_`/`_+_` are the `Agda.Builtin.Nat` Bool-valued / arithmetic builtins; `t > x` is `x < t`.)
+depositStatusRef : Nat → Nat → Nat → Nat → DepositStatusᶜ
+depositStatusRef created deadline tDeposit t =
+  if (deadline - tDeposit) < t then expiredᶜ
+  else if (created + tDeposit) < t then activeᶜ
+  else inactiveᶜ
+
+infixr 6 _&&_
+_&&_ : Bool → Bool → Bool
+true  && b = b
+false && _ = false
+
+-- The §6 reqSn signing-eligibility check (`require v = v̂ ∧ s = ŝ + 1 ∧ leader(s) = j`), as a pure
+-- decision over the version/number inputs with the leader test resolved to a Bool by the caller
+-- (the leader function needs the party set, supplied Haskell-side). Mirrors the node's
+-- `onOpenNetworkReqSn` `requireReqSn` (sv == version, sn == seenSn + 1, isLeader). `_==_` is the
+-- `Agda.Builtin.Nat` Bool equality.
+signEligibleRef : Nat → Nat → Nat → Nat → Bool → Bool
+signEligibleRef v vHat s sHat leaderOk = (v == vHat) && ((s == suc sHat) && leaderOk)
+
+infixr 5 _||_
+_||_ : Bool → Bool → Bool
+true  || _ = true
+false || b = b
+
+not : Bool → Bool
+not true  = false
+not false = true
+
+-- List membership for the signature-accumulator (Σ̂) checks.
+elemᵇ : Nat → List Nat → Bool
+elemᵇ _ []       = false
+elemᵇ x (y ∷ ys) = (x == y) || elemᵇ x ys
+
+-- reqDec eligibility (the §6 `wait U_α = ∅ ∧ tx_ω = ⊥`): neither a commit nor a decommit in flight.
+reqDecEligibleRef : Bool → Bool → Bool   -- (commitInFlight, decommitInFlight)
+reqDecEligibleRef commit decommit = not commit && not decommit
+
+-- reqSn incremental-action exclusivity (the §6 `require tx_ω = ⊥ ∨ tx_α = ⊥`, node
+-- `ReqSnBothCommitAndDecommit`): a snapshot request may carry a commit (deposit) or a decommit,
+-- never both - close and fanout express a single incremental action, so a snapshot settling both
+-- would be unclosable.
+reqSnNotBothRef : Bool → Bool → Bool   -- (hasDeposit, hasDecommit)
+reqSnNotBothRef hasDep hasDec = not (hasDep && hasDec)
+
+-- reqSn decommit-materializes-outputs (node `ReqSnDecommitNoOutputs`): a requested decommit must
+-- produce at least one output - the decrement validator materializes the decommit outputs and
+-- requires one, so a no-output decommit could never settle on-chain and would be re-proposed by
+-- every later snapshot. (`0 < n` is the Agda.Builtin Bool-valued `_<_`.)
+reqSnDecommitOutputsRef : Nat → Bool   -- number of outputs the requested decommit produces
+reqSnDecommitOutputsRef n = 0 < n
+
+-- reqSn same-version deposit settlement (node `waitForDeposit`, the `ReqSnCommitNotSettled`
+-- require): when the request is at the same version as the confirmed snapshot and that snapshot
+-- carries a pending commit, the requested deposit must be the same deposit, matched by identity
+-- (deposit tx-id, `confDepositTxId == Just depositTxId`) on top of content: two deposits can record
+-- the same UTxO, and only the one bound into the confirmed snapshot's κ# is the pending commit
+-- being settled. The tx-ids are supplied as deterministic Integer encodings (as the on-chain
+-- reference's `refCodeOf`); `contentOk` is the caller-resolved `confUTxOToCommit == Just deposited`.
+reqSnDepositSettledRef : Bool → Nat → Nat → Bool   -- (contentOk, confirmed dep tx-id, requested)
+reqSnDepositSettledRef contentOk confDep reqDep = contentOk && (confDep == reqDep)
+
+-- ackSn-collect (the §6 `require (j,·) ∉ Σ̂`): sender j has not already signed this round.
+notAlreadySignedRef : List Nat → Nat → Bool   -- (Σ̂ signer indices, j)
+notAlreadySignedRef signers j = not (elemᵇ j signers)
+
+-- ackSn-confirm (the §6 `if ∀ k ∈ [1..n] : (k,·) ∈ Σ̂`): every party index below n has signed (n-of-n).
+allBelowᵇ : Nat → List Nat → Bool
+allBelowᵇ zero    _       = true
+allBelowᵇ (suc k) signers = elemᵇ k signers && allBelowᵇ k signers
+allSignedRef : Nat → List Nat → Bool     -- (n, Σ̂ signer indices)
+allSignedRef n signers = allBelowᵇ n signers
+
+-- Contest re-post (the §6 `if S̄.s > s_c`): our confirmed snapshot is newer than the closed/contested one.
+contestEligibleRef : Nat → Nat → Bool    -- (S̄.s, s_c)
+contestEligibleRef sBar sc = sc < sBar
+
+modSuc : Nat → Nat → Nat   -- modSuc a b = a mod (suc b), via the Agda.Builtin `mod-helper` primitive
+modSuc a b = mod-helper 0 b a b
+
+-- Round-robin leader, matching the node's `isLeader` (HeadLogic.hs): for `suc m` parties and snapshot
+-- number sn, the party at 0-based index i is the leader iff (sn - 1) mod (suc m) == i. Only meaningful
+-- for sn ≥ 1; the differential against the REAL `isLeader` exercises that domain.
+leaderRef : Nat → Nat → Nat → Bool   -- (m where #parties = suc m, sn, party index i)
+leaderRef m sn i = modSuc (sn - 1) m == i

--- a/spec/src/Hydra/Protocol/OnChain.lagda.typ
+++ b/spec/src/Hydra/Protocol/OnChain.lagda.typ
@@ -160,7 +160,6 @@ postulate
   -- soundness: a verified membership witness attests a genuine subset (no proving non-members)
   accVerify-sound : ∀ {U S π} → accVerify (accUTxO U) S π ≡ true → S ⊆ U
   -- completeness: any genuine subset has a membership witness that verifies
-  accVerify-complete : ∀ {U S} → S ⊆ U → ∃[ π ] (accVerify (accUTxO U) S π ≡ true)
   -- a set is always provably a member of its own commitment (the S ≔ U case of completeness; stated
   -- directly to avoid the set-theory `⊆`-reflexivity plumbing). Used by the coverage obligations.
   accVerify-self : ∀ U → ∃[ π ] (accVerify (accUTxO U) U π ≡ true)
@@ -219,11 +218,13 @@ depositValueAt ctx ref = inputValueAt ref (Context.inputs ctx)
 
 -- DERIVED (increment, all deposits): the total value of EVERY spent deposit input -- the value at the
 -- νDeposit script (`Context.depHash`) summed over the resolved inputs. This mirrors Plutus
--- `totalNonHeadInputValue` in `checkIncrement` (the sum over every non-head script input, which the
--- non-head SPENT inputs of an increment are exactly the claimed deposits), and is what the value
--- conservation must account for -- forbidding the multi-deposit siphon (an extra deposit whose value
--- is routed away would leave `headValueIn +ᵛ depositsValue ≠ headValue`). For a single-deposit
--- increment it coincides with `depositValueAt ctx ref` (the single-deposit value above).
+-- the νDeposit-governed spent inputs. `checkIncrement`'s own `mustPreserveValue` is stated over the
+-- single CLAIMED deposit (`claimedDepositValue`); summing every νDeposit input instead is what makes
+-- the multi-deposit siphon visible to value conservation here (an extra deposit whose value is routed
+-- away leaves `headValueIn +ᵛ depositsValue ≠ headValue`), and it coincides with
+-- `depositValueAt ctx ref` exactly when the claimed deposit is the only one -- which is what
+-- `IncrementValid.onlyClaimedDeposit` below requires, mirroring the validator's
+-- `mustNotSpendOtherScripts`.
 depositsValue : Context → Value
 depositsValue ctx = valueAtIn (Context.depHash ctx) (Context.inputs ctx)
 
@@ -418,8 +419,10 @@ state-machine shape, the version discipline, contester growth and deduplication,
 the deadline equations, close-initialises-to-$emptyset$, the head value in/out
 (derived: `headValue`/`headValueIn` sum the value at `ownHash` over the produced
 outputs / resolved inputs), the increment deposit value (derived: `depositsValue`
-sums the value at the $nuDeposit$ script `depHash` over _all_ spent inputs, as
-Plutus `totalNonHeadInputValue`), the decrement decommit value (derived:
+sums the value at the $nuDeposit$ script `depHash` over _all_ spent inputs,
+where Plutus `mustPreserveValue` uses the claimed deposit alone and rules the
+others out separately with `mustNotSpendOtherScripts`), the decrement decommit
+value (derived:
 `decommitValue` sums the `m` outputs after the head output, as Plutus
 `take m (tail outputs)`), and the participant signature: close, increment and
 decrement carry the structural `signedByParticipant cid ctx` (an existence witness
@@ -427,7 +430,7 @@ decrement carry the structural `signedByParticipant cid ctx` (an existence witne
 value), while contest carries the sharper `contesterSigned`/`contesterIsParticipant`
 pair about the appended contester, from which `signedByParticipant` is derived
 (`contest-participantSigned`); fanout and partial fanout have no such field. What
-remains abstracted: the value arithmetic laws (`_+ᵛ_`/`_≤ᵛ_`/`εᵛ`) and the
+remains abstracted: the value arithmetic laws (`_+ᵛ_`/`εᵛ`) and the
 per-asset projection `quantityOf` on the opaque `Value`, crypto
 (`msVfy`/`snapshotSigOK`) and the accumulator operations
 (`accVerify`/`accVerifyExclude`/`accUTxO`), all via postulated laws, plus the
@@ -861,8 +864,17 @@ record IncrementValid (ctx : Context) (hk : VKey) (cid : ℍ) (v : ℕ)
     step               : d ⟶⟨ Increment ξ s ref δ# ⟩ d'
     mintEmpty          : noMint ctx
     sigOK              : snapshotSigOK hk cid v s (hash (ηOf d')) δ# (depositCommitsHashOf ctx ref) ξ
-    valueOK            : incrementValueOK (headValueIn ctx) (depositsValue ctx) (headValue ctx)  -- ALL deposits (§5.4, Plutus `totalNonHeadInputValue`)
+    valueOK            : incrementValueOK (headValueIn ctx) (depositsValue ctx) (headValue ctx)  -- ALL νDeposit inputs (§5.4)
     depositSpent       : depositSpentOK ctx ref            -- claimed deposit is spent (§5.4)
+    -- §5.4: the claimed deposit is the only νDeposit value the transaction spends (the validator's
+    -- `mustNotSpendOtherScripts`, error `MustNotSpendOtherScripts`). Without it `valueOK` alone
+    -- permits a second pending deposit to be spent alongside: `mustPreserveValue` is an equality, so
+    -- it stops that value entering the head, but not its being routed OUT to an address of the
+    -- transaction author's choosing - theft of a pending commit. Stated as a value equation because
+    -- it is the half the `Context` model can express: the validator's stronger claim (NO other
+    -- script input of any kind, νDeposit or not) needs a script/pub-key distinction on addresses
+    -- that `Output.address` does not carry, so that generalisation stays a hand-reviewed boundary.
+    onlyClaimedDeposit : depositsValue ctx ≡ depositValueAt ctx ref
     -- §5.4: the claimed deposit is output 0 of its transaction (Plutus `txOutRefIdx ref == 0`).
     -- κ# binds a deposit by its transaction id, so sibling outputs of the same transaction would
     -- otherwise be interchangeable under one signature.
@@ -1124,6 +1136,12 @@ closeAnyOK _                  _  = ⊤
 -- message (the implementation copies them from the redeemer; they are authenticated
 -- only through the signature). The Used case refers to the *previous* state version
 -- v-1 (a pending delta is applied in the snapshot); the others use the current v (spec §5.6).
+-- Modelling boundary at version 0: the Used cases verify at `v ∸ 1` on ℕ, which truncates to 0,
+-- while the validator builds its message with signed `version - 1` and so uses -1 there. The two
+-- agree for every v ≥ 1, and a Used close/contest at version 0 is not reachable (Used means a
+-- pending delta was applied, which bumps the version at least once), so no reachable transaction
+-- distinguishes them - but the model is strictly weaker at v = 0, and the signature conjunct is an
+-- injected `Ops` boundary, so neither the bridge nor the differential can observe the difference.
 closeSigOK : (hydraKey : VKey) (cid : ℍ) (v s : ℕ) → CloseType → Set
 closeSigOK _  _   _ _ closeInitial             = ⊤
 closeSigOK hk cid v s (closeAny ξ η# δ# κ#)    = snapshotSigOK hk cid v s η# δ# κ# ξ

--- a/spec/src/Hydra/Protocol/OnChain.lagda.typ
+++ b/spec/src/Hydra/Protocol/OnChain.lagda.typ
@@ -1,3 +1,12 @@
+```
+module Hydra.Protocol.OnChain where
+
+open import Hydra.Protocol.Prelude
+open import Hydra.Protocol.Preliminaries
+open import Data.Product using (∃-syntax)
+open import Data.Integer using (1ℤ)
+open import Data.List using (take; drop)
+```
 
 #import "/template.typ": *
 #import "/macros.typ": *
@@ -38,6 +47,41 @@ machine and its per-state fields (as enumerated in the transitions below) are
 captured by an Agda type, with the redeemer $redeemerHead$ selecting
 the $nuHead$ transition.
 
+```
+-- Redeemer "hints" for closing/contesting (the CloseType / ContestType unions).
+-- Besides the accumulator hash η#, the signed close/contest redeemers carry the
+-- decommit- and commit-output-set hashes δ# and κ# (implementation
+-- `decommitOutputsHash` / `commitOutputsHash`), which the snapshot
+-- multisignature binds (see `snapshotSigOK`).
+data CloseType : Set where
+  closeInitial                   : CloseType
+  closeAny closeUnused closeUsed : (ξ : AggSig) (ηhash δhash κhash : ℍ) → CloseType
+
+data ContestType : Set where
+  contestUnused contestUsed : (ξ : AggSig) (ηhash δhash κhash : ℍ) → ContestType
+
+data HeadDatum : Set where
+  Open : (cid : ℍ) (hydraKey : VKey) (n : ℕ) (contestationPeriod : ℕ)
+         (version : ℕ) (η : AccCommitment) (ada : Value) → HeadDatum
+  Closed : (cid : ℍ) (hydraKey : VKey) (n : ℕ) (contestationPeriod : ℕ)
+           (version : ℕ) (snapshotNumber : ℕ) (η : AccCommitment)
+           (contesters : List ℍ) (tfinal : ℕ) (ada : Value) → HeadDatum
+  FanoutProgress : (cid : ℍ) (hydraKey : VKey) (n : ℕ) (tfinal : ℕ)
+                   (η : AccCommitment) (ada : Value) → HeadDatum
+  Final : HeadDatum
+
+data HeadRedeemer : Set where
+  -- Increment carries the decommit-set hash δ# (its commit digest κ# is recomputed on-chain
+  -- from the claimed deposit's datum AND its transaction id); decrement carries the commit-set hash κ# (its
+  -- decommit-set hash is recomputed from the tx's decommit outputs). Cf. `snapshotSigOK`.
+  Increment          : (ξ : AggSig) (s : ℕ) (ref : OutputRef) (δ# : ℍ) → HeadRedeemer
+  Decrement          : (ξ : AggSig) (s : ℕ) (m : ℕ) (κ# : ℍ)           → HeadRedeemer
+  Close              : CloseType                                  → HeadRedeemer
+  Contest            : ContestType                                → HeadRedeemer
+  Fanout             : (m : ℕ) (π : AccWitness) (crs : OutputRef) → HeadRedeemer
+  PartialFanout      : (m : ℕ) (crs : OutputRef)                  → HeadRedeemer
+  FinalPartialFanout : (m : ℕ) (π : AccWitness) (crs : OutputRef) → HeadRedeemer
+```
 
 The admissible $nuHead$ state transitions are captured as a typed relation
 $d ⟶⟨ r ⟩ d'$ ("datum $d$ steps to $d'$ under redeemer $r$"). The relation
@@ -54,6 +98,37 @@ remaining per-transaction conditions (signatures, value conservation, deadlines)
 are separate predicates (e.g. `closeDeadlineOK`/`contestDeadlineOK`) applied
 alongside it.
 
+```
+data _⟶⟨_⟩_ : HeadDatum → HeadRedeemer → HeadDatum → Set where
+
+  increment : ∀ {cid hk n cp v η ada η' ξ s ref δ#}
+    → Open cid hk n cp v η ada ⟶⟨ Increment ξ s ref δ# ⟩ Open cid hk n cp (suc v) η' ada
+
+  decrement : ∀ {cid hk n cp v η ada η' ξ s m κ#}
+    → Open cid hk n cp v η ada ⟶⟨ Decrement ξ s m κ# ⟩ Open cid hk n cp (suc v) η' ada
+
+  close : ∀ {cid hk n cp v η ada s' η' tfin ct}
+    → Open cid hk n cp v η ada ⟶⟨ Close ct ⟩ Closed cid hk n cp v s' η' [] tfin ada
+
+  contest : ∀ {cid hk n cp v s η C tfin ada s' η' kh tfin' ct}
+    → ¬ (kh ∈ˡ C)                                 -- the contester has not already contested
+    → Closed cid hk n cp v s η C tfin ada
+        ⟶⟨ Contest ct ⟩ Closed cid hk n cp v s' η' (kh ∷ C) tfin' ada
+
+  fanout : ∀ {cid hk n cp v s η C tfin ada m π crs}
+    → Closed cid hk n cp v s η C tfin ada ⟶⟨ Fanout m π crs ⟩ Final
+
+  partialFanoutStart : ∀ {cid hk n cp v s η C tfin ada η' m crs}
+    → Closed cid hk n cp v s η C tfin ada
+        ⟶⟨ PartialFanout m crs ⟩ FanoutProgress cid hk n tfin η' ada
+
+  partialFanoutStep : ∀ {cid hk n tfin η ada η' m crs}
+    → FanoutProgress cid hk n tfin η ada
+        ⟶⟨ PartialFanout m crs ⟩ FanoutProgress cid hk n tfin η' ada
+
+  finalPartialFanout : ∀ {cid hk n tfin η ada m π crs}
+    → FanoutProgress cid hk n tfin η ada ⟶⟨ FinalPartialFanout m π crs ⟩ Final
+```
 
 Beyond the state-machine shape, individual $nuHead$ *checks* are stated as
 predicates over the validation $sans("Context")$ and the datums. For example,
@@ -67,10 +142,273 @@ value projections, the signature check - and the predicates common to several
 transactions are stated once here; each transaction's own conditions are then
 given in its section below.
 
+```
+-- spec §3.4/§5.8 accumulator operations (the §3.4 Accumulator scheme at the
+-- protocol's commitment/output/witness types), kept abstract, plus the G1
+-- generator representing the empty accumulator.
+postulate
+  accUTxO          : ℙ Output → AccCommitment   -- commitment to a UTxO set
+  accVerify        : AccCommitment → ℙ Output → AccWitness → Bool
+  accVerifyExclude : AccCommitment → ℙ Output → AccCommitment → Bool
+  G₁               : AccCommitment
 
+-- We do NOT model the KZG construction; we only assume the scheme functions correctly, via
+-- these specifying laws (used to connect the on-chain accumulator to the off-chain UTxO sets):
+postulate
+  -- the empty set commits to the generator (the "empty accumulator" G₁)
+  accUTxO-∅       : accUTxO ∅ˢ ≡ G₁
+  -- soundness: a verified membership witness attests a genuine subset (no proving non-members)
+  accVerify-sound : ∀ {U S π} → accVerify (accUTxO U) S π ≡ true → S ⊆ U
+  -- completeness: any genuine subset has a membership witness that verifies
+  accVerify-complete : ∀ {U S} → S ⊆ U → ∃[ π ] (accVerify (accUTxO U) S π ≡ true)
+  -- a set is always provably a member of its own commitment (the S ≔ U case of completeness; stated
+  -- directly to avoid the set-theory `⊆`-reflexivity plumbing). Used by the coverage obligations.
+  accVerify-self : ∀ U → ∃[ π ] (accVerify (accUTxO U) U π ≡ true)
 
+-- Set-level cardinality of a UTxO set: the number of outputs a fanout distributes. Postulated (with
+-- only the non-emptiness law the coverage proofs need) rather than via the set theory's `card`, which
+-- requires strong-finiteness witnesses - this is a SPECIFICATION of the abstract accumulator/fanout's
+-- set behaviour, not the KZG construction (cf. the `accVerify-*` laws). It lets the coverage obligations
+-- DERIVE `0 < m` for a non-empty remainder instead of assuming it.
+postulate
+  setSize     : ℙ Output → ℕ
+  setSize-pos : ∀ {U} → ¬ (U ≡ ∅ˢ) → 0 < setSize U
+```
 
+```
+-- Sum the value of all outputs / resolved inputs paying to a given script hash (cf. the Plutus
+-- `valueLockedBy`/`valueSpent` idiom of folding the tx outputs/inputs at `ownHash`). `ℍ` has
+-- decidable equality (`_≟ℍ_`, Prelude), so the per-output membership test is concrete.
+valueAtOut : ℍ → List Output → Value
+valueAtOut h []       = εᵛ
+valueAtOut h (o ∷ os) =
+  if ⌊ Output.address o ≟ℍ h ⌋ then Output.value o +ᵛ valueAtOut h os else valueAtOut h os
 
+valueAtIn : ℍ → List Input → Value
+valueAtIn h []       = εᵛ
+valueAtIn h (i ∷ is) =
+  if ⌊ Output.address (Input.resolved i) ≟ℍ h ⌋
+    then Output.value (Input.resolved i) +ᵛ valueAtIn h is
+    else valueAtIn h is
+
+-- Head value in/out, DERIVED from the context: the value at the νHead script (`Context.ownHash`)
+-- among the spent inputs / produced outputs (§5.x head-output identification).
+headValueIn : Context → Value
+headValueIn ctx = valueAtIn (Context.ownHash ctx) (Context.inputs ctx)
+
+headValue : Context → Value
+headValue ctx = valueAtOut (Context.ownHash ctx) (Context.outputs ctx)
+
+-- Decidable equality of output references (txId + index), from `_≟ℍ_` and `_≟_`.
+outputRef-eqᵇ : OutputRef → OutputRef → Bool
+outputRef-eqᵇ a b = ⌊ OutputRef.txId a ≟ℍ OutputRef.txId b ⌋ ∧ ⌊ OutputRef.index a ≟ OutputRef.index b ⌋
+
+-- Value of the resolved input spending a given output reference (there is exactly one such input).
+inputValueAt : OutputRef → List Input → Value
+inputValueAt ref []       = εᵛ
+inputValueAt ref (i ∷ is) =
+  if outputRef-eqᵇ (Input.outputRef i) ref
+    then Output.value (Input.resolved i) +ᵛ inputValueAt ref is
+    else inputValueAt ref is
+
+-- DERIVED (increment): the value of the spent deposit is the value of the resolved input at the
+-- claimed deposit reference `ref` (the same `ref` the increment redeemer carries / `depositSpentOK`
+-- requires spent).
+depositValueAt : Context → OutputRef → Value
+depositValueAt ctx ref = inputValueAt ref (Context.inputs ctx)
+
+-- DERIVED (increment, all deposits): the total value of EVERY spent deposit input -- the value at the
+-- νDeposit script (`Context.depHash`) summed over the resolved inputs. This mirrors Plutus
+-- `totalNonHeadInputValue` in `checkIncrement` (the sum over every non-head script input, which the
+-- non-head SPENT inputs of an increment are exactly the claimed deposits), and is what the value
+-- conservation must account for -- forbidding the multi-deposit siphon (an extra deposit whose value
+-- is routed away would leave `headValueIn +ᵛ depositsValue ≠ headValue`). For a single-deposit
+-- increment it coincides with `depositValueAt ctx ref` (the single-deposit value above).
+depositsValue : Context → Value
+depositsValue ctx = valueAtIn (Context.depHash ctx) (Context.inputs ctx)
+
+-- DERIVED (recover): the number of νDeposit-governed inputs (address = `Context.depHash`), the count
+-- companion to `depositsValue`. Recover requires exactly one (deposit.ak `single_deposit`, §5.3): the
+-- recovered outputs are the transaction's first m outputs, shared by every deposit input, so a second
+-- deposit whose C hashes alike would be satisfied by the same output set, leaving its value free for
+-- the transaction author to direct anywhere.
+depositInputCount : Context → ℕ
+depositInputCount ctx = go (Context.inputs ctx)
+  where
+  go : List Input → ℕ
+  go []       = 0
+  go (i ∷ is) = if ⌊ Output.address (Input.resolved i) ≟ℍ Context.depHash ctx ⌋ then suc (go is) else go is
+
+-- DERIVED (decrement): the decommitted value is the total value of the `m` outputs FOLLOWING the head
+-- output (output 0), mirroring Plutus `decommitOutputs = take numberOfDecommitOutputs (tail outputs)`
+-- in `checkDecrement`. `m` is the decrement redeemer's output count (the same `m` carried by
+-- `Decrement ξ s m`). (The head output is identified positionally as output 0,
+-- as on-chain; change/fee outputs sit beyond index `m` and are excluded by the `take`.)
+takeSumᵛ : ℕ → List Output → Value
+takeSumᵛ zero    _        = εᵛ
+takeSumᵛ (suc _) []       = εᵛ
+takeSumᵛ (suc k) (o ∷ os) = Output.value o +ᵛ takeSumᵛ k os
+
+decommitValue : Context → ℕ → Value
+decommitValue ctx m with Context.outputs ctx
+... | []     = εᵛ
+... | _ ∷ os = takeSumᵛ m os
+```
+
+```
+-- The postulated search obligations (trust base): witnesses that involve searching the context's
+-- value/keys/mint, which the opaque Value and key-set models do not expose.
+postulate
+  -- total value of the tokens burned by the transaction (the n+1 νHead PTs + ST at fan-out). The
+  -- mint multiset is not modelled, so the burned VALUE stays abstract (the burned COUNT is
+  -- `burnedCount` / `burnAllTokensOK`); only the OUTPUT-distribution half of conservation is concrete.
+  burnedValue   : Context → Value
+  -- `signerKeyHash ctx kh` = kh names one of the transaction's signers (∃ vk ∈ keys, hash vk ≡ kh).
+  -- The thin residue of the opaque key-set model; the PT-presence half of `signedByParticipant` is
+  -- structural via `quantityOf`.
+  signerKeyHash : Context → ℍ → Set
+  -- count of policy-cid tokens burnt (mint quantity -1); the (final) fan-out law is `≡ n+1` (§5.8)
+  burnedCount   : Context → ℍ → ℕ
+  -- §5.1 init (μHead minting policy): the seed-parameterised policy script and the mint count
+  μHead         : OutputRef → Script
+  mintedCount   : Context → ℍ → ℕ   -- count of policy-cid tokens minted (positive mint quantity)
+  -- §5.4 increment: the hash of the commit list C the validator decodes from the claimed deposit
+  -- input's own datum (Plutus `hashPreSerializedCommits claimedDepositCommits`). The deposit datum
+  -- decode `(cid, t_recover, C)` is below the model's granularity (`Data` is opaque); a datum that
+  -- fails to decode makes the validator error (`DepositDatumInvalid`), i.e. reject -- differentially
+  -- tested.
+  depositDatumCommitsHash : Context → OutputRef → ℍ
+  -- §5.8 fanout paths: the hash of the CRS carried by the reference input named by the redeemer's
+  -- `crs` out-ref (Plutus `hashCRSDatum` of the decoded G2-point list; reference inputs are not in
+  -- the Context model, so the lookup stays abstract), and the compile-time canonical trusted-setup
+  -- hash the validator is parameterised by (`canonicalCRSDatumHash`). An unresolvable or undecodable
+  -- reference input makes the validator error (`MissingCRSRefInput`/`MissingCRSDatum`), i.e. reject.
+  crsDatumHashAt : Context → OutputRef → ℍ
+  canonicalCRS#  : ℍ
+
+-- §5.4 increment: the commit digest κ# the validator RECOMPUTES from the claimed deposit itself,
+-- binding both the commit list C decoded from its datum (`depositDatumCommitsHash`) and the identity
+-- of the transaction that created the deposit (Plutus `sha2_256 (hashPreSerializedCommits commits <>
+-- getTxId (txOutRefId ref))`). Hashing C alone would not identify a deposit: a deposit datum is
+-- unauthenticated data anyone can copy into a look-alike deposit holding less value, which hashes
+-- identically and would accept the same signature.
+depositCommitsHashOf : Context → OutputRef → ℍ
+depositCommitsHashOf ctx ref = hash (depositDatumCommitsHash ctx ref ‖ OutputRef.txId ref)
+
+-- The binding is definitional and named so the appendix carries it as a machine-checked statement:
+-- the signed commit digest is a hash over the claimed deposit's transaction id, not over its datum
+-- alone. The converse direction - distinct tx ids give distinct κ# - is collision resistance of
+-- `hash`, deliberately not axiomatised (the model's `hash` is law-free); it is what the
+-- implementation relies on and what the differential test exercises against the real sha2_256.
+depositCommitsHashOf-binds-txId : ∀ ctx ref
+  → depositCommitsHashOf ctx ref ≡ hash (depositDatumCommitsHash ctx ref ‖ OutputRef.txId ref)
+depositCommitsHashOf-binds-txId ctx ref = refl
+
+-- §5.5 decrement: the decommit-set hash the validator RECOMPUTES from the transaction's own decommit
+-- outputs (Plutus `hashTxOuts decommitOutputs` over `take m (tail outputs)`). Anchored to the SAME
+-- positional output list `decommitValue` sums, so the signature constrains exactly the outputs the
+-- value check accounts for. `hash` here stands for the on-chain serialise-and-hash (`hashTxOuts`).
+decommitOutputsHashOf : Context → ℕ → ℍ
+decommitOutputsHashOf ctx m = hash (take m (drop 1 (Context.outputs ctx)))
+
+-- spec §5.4–5.7: the snapshot multisignature ξ verifies, under the aggregate hydra key, over the
+-- message cid ‖ v ‖ s ‖ η# ‖ δ# ‖ κ# (shared by increment, decrement, close and contest; §7's
+-- `snapMsg` is defined as this same concatenation). Besides the accumulator hash η#, the message
+-- binds the decommit-output-set hash δ# and the commit-output-set hash κ# -- in THIS order, matching
+-- the implementation's `verifyPartySignature` tuple `(headId, version, number, accumulatorHash,
+-- decommitOutputsHash, commitOutputsHash)` -- so a participant cannot redirect the committed or
+-- decommitted outputs while reusing a valid signature.
+snapshotSigOK : (hydraKey : VKey) (cid : ℍ) (v s : ℕ) (η# δ# κ# : ℍ) (ξ : AggSig) → Set
+snapshotSigOK hydraKey cid v s η# δ# κ# ξ = msVfy hydraKey (cid ‖ v ‖ s ‖ η# ‖ δ# ‖ κ#) ξ ≡ true
+```
+
+```
+-- A participant signed (§5.4–5.7): there is a key-hash `kh` that BOTH names one of the transaction's
+-- signers AND names a participation token present in the head value - i.e. the value carries the asset
+-- (cid , kh) with quantity 1. This is the spec prose `∃ {cid ↦ keyHashᵢ ↦ 1} ∈ valHead' ⇒ keyHashᵢ ∈
+-- txKeys`. The PT-presence half is structural via the per-asset
+-- projection `quantityOf` (same trust family as `adaOf`/`nonAdaOf`); the signer-naming half is the
+-- postulated `signerKeyHash` above. The head currency `cid` is supplied by the caller's datum.
+-- SCOPE NOTE: this reads the PT off `headValue` (the produced head OUTPUT). The real validator's
+-- `mustBeSignedByParticipant` loops over the spent INPUTS instead. The two coincide here: every bundle
+-- carrying this field also preserves/grows the head value with its PTs intact (close/contest/decrement
+-- preserve it exactly, increment adds a deposit), so the head input and output carry the same PTs under
+-- the single-head-script-UTxO assumption. They could differ only on a malformed multi-head tx.
+signedByParticipant : ℍ → Context → Set
+signedByParticipant cid ctx =
+  ∃[ kh ] (signerKeyHash ctx kh) × (quantityOf (headValue ctx) (cid , kh) ≡ 1ℤ)
+
+-- spec §5.6/§5.7: close and contest mint or burn nothing.
+noMint : Context → Set
+noMint ctx = Context.mint ctx ≡ εᵛ
+
+-- The outputs a fan-out step ACTUALLY distributes, as a set: the first `m` transaction outputs for a
+-- full/final fan-out (no continuing head output), and the `m` outputs FOLLOWING the continuing head
+-- output (output 0) for an intermediate partial fan-out - the same positional conventions as
+-- `fanoutValueOK` / `partialFanoutValueOK` (on-chain `take m txInfoOutputs` / `take m (tail outputs)`).
+-- The membership/exclusion conjuncts below are anchored to THESE sets (not a free `ℙ Output` bundle
+-- parameter), so the accumulator checks and the value accounting constrain the SAME transaction
+-- outputs - a fan-out cannot satisfy `membersOK` with one set while paying out another.
+distributedOuts : Context → ℕ → ℙ Output
+distributedOuts ctx m = fromList (take m (Context.outputs ctx))
+
+partialDistributedOuts : Context → ℕ → ℙ Output
+partialDistributedOuts ctx m = fromList (take m (drop 1 (Context.outputs ctx)))
+
+-- All distributed outputs are members of the unified accumulator η
+-- (fanout §5.8 and final partial fanout §5.8.2).
+fanoutMembersOK : (η : AccCommitment) (outs : ℙ Output) (π : AccWitness) → Set
+fanoutMembersOK η outs π = accVerify η outs π ≡ true
+
+-- η' is the correct accumulator after excluding the distributed batch S (§5.8.1).
+fanoutExcludeOK : (η : AccCommitment) (S : ℙ Output) (η' : AccCommitment) → Set
+fanoutExcludeOK η S η' = accVerifyExclude η S η' ≡ true
+
+-- An intermediate partial fan-out has not yet removed everything (η' ≠ G₁); the
+-- last batch must use finalPartialFanout instead (§5.8.1).
+partialFanoutNotDoneOK : (η' : AccCommitment) → Set
+partialFanoutNotDoneOK η' = ¬ (η' ≡ G₁)
+
+-- §5.8/§5.8.1/§5.8.2: the CRS reference input carries the CANONICAL trusted setup - its datum hash
+-- equals the validator's compile-time canonical hash (Plutus `withCRSLookup`: `hashCRSDatum crsData ==
+-- canonicalCRSDatumHash`, else `InvalidCRSDatum`). Without this binding an attacker could supply a
+-- substituted powers-of-tau setup with known τ and forge membership witnesses for arbitrary outputs;
+-- fanout is permissionless after the deadline, so that would be direct fund theft.
+crsBindOK : Context → OutputRef → Set
+crsBindOK ctx crs = crsDatumHashAt ctx crs ≡ canonicalCRS#
+
+-- The claimed deposit OutputRef is actually spent by the transaction (§5.4: txOutRef_increment =
+-- txOutRef_deposit). Unlike the postulated value/crypto extractors this is a STRUCTURAL check over
+-- the context's inputs, so it is defined concretely. (The νDeposit validator's own checks remain
+-- out of scope; see the deposit/recover note.)
+depositSpentOK : Context → OutputRef → Set
+depositSpentOK ctx ref = ∃[ i ] (i ∈ˡ Context.inputs ctx) × (Input.outputRef i ≡ ref)
+```
+
+```
+-- Field extractors used by the validity bundles below.
+snapNum : HeadDatum → ℕ
+snapNum (Closed _ _ _ _ _ s _ _ _ _) = s
+snapNum _ = 0
+
+ηOf : HeadDatum → AccCommitment
+ηOf (Open _ _ _ _ _ η _)             = η
+ηOf (Closed _ _ _ _ _ _ η _ _ _)     = η
+ηOf (FanoutProgress _ _ _ _ η _)     = η
+ηOf Final                            = G₁
+
+tfinalOf : HeadDatum → ℕ
+tfinalOf (Closed _ _ _ _ _ _ _ _ t _) = t
+tfinalOf (FanoutProgress _ _ _ t _ _) = t
+tfinalOf _ = 0
+
+-- The ada-overhead value stored in the datum (the head-UTxO lovelace not part of any L2 UTxO, §5.8).
+headAda : HeadDatum → Value
+headAda (Open _ _ _ _ _ _ ada)             = ada
+headAda (Closed _ _ _ _ _ _ _ _ _ ada)     = ada
+headAda (FanoutProgress _ _ _ _ _ ada)     = ada
+headAda Final                              = εᵛ
+```
 
 #dparagraph[Scope of the validity bundles.] The per-transaction conditions of the
 following sections are _validity bundles_: records conjoining the state-machine
@@ -93,8 +431,10 @@ remains abstracted: the value arithmetic laws (`_+ᵛ_`/`_≤ᵛ_`/`εᵛ`) and 
 per-asset projection `quantityOf` on the opaque `Value`, crypto
 (`msVfy`/`snapshotSigOK`) and the accumulator operations
 (`accVerify`/`accVerifyExclude`/`accUTxO`), all via postulated laws, plus the
-context lookups the `Context` model does not expose: the recomputed increment
-commit-set hash (`depositCommitsHashOf`, from the claimed deposit's datum) and the
+context lookups the `Context` model does not expose: the hash of the commit list
+decoded from the claimed deposit's datum (`depositDatumCommitsHash`; the full
+commit digest `depositCommitsHashOf` is a definition over it, binding the
+deposit's transaction id) and the
 CRS reference-input datum hash with its canonical constant
 (`crsDatumHashAt`/`canonicalCRS#`). So value conservation is stated over the real
 head, increment-deposit and decrement-decommit values (modulo the abstract value
@@ -210,6 +550,39 @@ counterpart (the `Open` datum carries no seed field).
 
 The conditions are conjoined in the `InitValid` bundle with its dispatching `initValid` predicate (typechecked, not rendered).
 
+```
+-- ── §5.1 init (μHead minting policy) ────────────────────────────────────────────────────────────
+-- A head is created by the seed-parameterised μHead policy. `cid` is the seed-derived policy id, the
+-- seed is spent (so the EUTxO ledger guarantees `cid` is unique), exactly n+1 tokens of `cid` are
+-- minted (1 ST + n PTs), and the produced head output is a well-formed initial Open (version 0,
+-- η = accUTxO ∅). Init has no predecessor datum, so it is a creation PREDICATE, not a `_⟶⟨_⟩_` step.
+-- Token PLACEMENT into the head output is modelled (`stPlaced`/`tokensPlaced`, via the `stQty`/
+-- `headTokenCount` value projections): the head output carries exactly the n+1 head-policy tokens, one
+-- being the ST. Together with the n+1 MINT count (`mintedCountOK`) this pins that every minted token is
+-- placed in the head output (form (a): the count + ST presence; naming the individual PTs would need the
+-- per-party key list, which the on-chain `Open` datum abstracts into `hk`/`n`).
+-- `mintedCountOK`/`stPlaced`/`tokensPlaced` are bridged + differentially tested (`initValid→ref`, the
+-- `HeadValidatorAgreement` init agreement). The thin `initValid` function dispatches on the produced `Open` head datum
+-- (binding its cid/n/v/η) and is ⊥ for any other produced shape.
+-- WHY count + ST presence pins placement: each head-policy token is minted with quantity 1 (the μHead
+-- policy), so the mint COUNT (n+1) equals the number of DISTINCT tokens; with the head output carrying
+-- n+1 DISTINCT head-policy tokens (`tokensPlaced`) and the ST among them (`stPlaced`), every minted token
+-- lands in the head output (pigeonhole) - no token can be minted-but-not-placed or duplicated.
+record InitValid (ctx : Context) (seed : OutputRef) (cid : ℍ) (n v : ℕ) (η : AccCommitment) : Set where
+  constructor mkInitValid
+  field
+    cidIsSeedHash : cid ≡ hash (μHead seed)         -- cid = hash(μHead(seed)) (§5.1)
+    seedSpent     : depositSpentOK ctx seed         -- the seed output is spent (uniqueness of cid)
+    mintedCountOK : mintedCount ctx cid ≡ suc n     -- mints exactly n+1 tokens of policy cid (1 ST + n PTs)
+    stPlaced      : stQty (headValue ctx) cid ≡ 1   -- the ST is placed in the head output
+    tokensPlaced  : headTokenCount (headValue ctx) cid ≡ suc n  -- all n+1 head-policy tokens placed there
+    versionZero   : v ≡ 0                           -- initial snapshot version
+    etaEmpty      : η ≡ accUTxO ∅ˢ                  -- accumulator commits to the empty initial UTxO set
+
+initValid : Context → OutputRef → HeadDatum → Set
+initValid ctx seed (Open cid hk n cp v η ada) = InitValid ctx seed cid n v η
+initValid _ _ _ = ⊥
+```
 
 The $sans("Burn")$ arm's single check is the `BurnValid` bundle: every
 head-policy entry of the mint field is a burn - no head-policy token is minted
@@ -219,6 +592,22 @@ bridged (`burnValid→ref`) and differentially tested (the
 `HeadValidatorAgreement` burn agreement, calling the real
 `validateTokensBurning`).
 
+```
+-- ── §5.1 burn (μHead minting policy, Burn redeemer) ──────────────────────────────────────────────
+-- The Burn arm forbids minting alongside a burn: every head-policy entry of the mint field is
+-- negative, i.e. no positive entry exists (`mintedCount ≡ 0`) and at least one token is burned
+-- (`1 ≤ burnedCount`; the real policy rejects a mint field without head-policy entries). WHICH
+-- burns are legitimate is νHead's concern (the fan-out family's `burnAllTokensOK` n+1 count);
+-- μHead only guarantees a burn-only mint field.
+record BurnValid (ctx : Context) (cid : ℍ) : Set where
+  constructor mkBurnValid
+  field
+    noneMinted      : mintedCount ctx cid ≡ 0
+    somethingBurned : 1 ≤ burnedCount ctx cid
+
+burnValid : Context → ℍ → Set
+burnValid = BurnValid
+```
 
 #figure(initTx-diagram, caption: [$mtxInit$ transaction spending a seed UTxO and producing the head output directly in state $stOpen$.]) <fig:initTx>
 
@@ -258,6 +647,21 @@ In Agda the deposit datum and the $nuDeposit$ redeemer are the `DepositDatum` /
 `DepositRedeemer` types; the deposit transaction itself has no
 on-chain verification, so there is no corresponding validity bundle.
 
+```
+-- ── §5.2–5.3 deposit / recover (νDeposit) ───────────────────────────────────────────────────────
+-- A deposit locks funds for later collection into the head via increment. The datum records the
+-- target head `cid`, a recover deadline, and the committed outputs C (refs + serialised outputs).
+record DepositDatum : Set where
+  constructor mkDepositDatum
+  field
+    depCid    : ℍ                      -- target head currency id
+    tRecover  : ℕ                      -- deadline after which the deposit can be recovered
+    committed : List (OutputRef × ℍ)   -- C: deposited output refs + their serialisations
+
+data DepositRedeemer : Set where
+  claim   : DepositRedeemer
+  recover : ℕ → DepositRedeemer        -- m = number of outputs to recover
+```
 
 Head protocol participants determine *off-chain* whether a
 deposit output $o_(sans("deposit"))$ is eligible for their head by checking
@@ -310,11 +714,59 @@ into the head (Claim) is authorised by the `incrementValid` predicate's `deposit
 
 The recover conditions form the `RecoverValid` bundle (typechecked, not rendered).
 
+```
+-- The deposit transaction itself has NO on-chain verification (§5.2: any payment to νDeposit is a
+-- deposit; eligibility is an off-chain check), so there is no `depositValid`. §5.3 recover: νDeposit,
+-- on `recover m`, checks the recovered outputs match the deposited ones (a serialisation-hash
+-- equality, abstracted) and that the transaction is posted strictly after the recover deadline.
+postulate
+  recoveredMatchesDeposited : Context → List (OutputRef × ℍ) → ℕ → Set  -- §5.3.1 hash(⊕oⱼ)=hash(C)
+
+-- The after-deadline conjunct is bridged + differentially tested (`recoverValid→ref` in
+-- `ReferenceBridge`, exercised by the `HeadValidatorAgreement` recover agreement, which runs the compiled
+-- `deposit.ak` as UPLC); the hash-equality conjunct stays abstracted (injected mock), as for the
+-- close/inc crypto conjuncts.
+record RecoverValid (ctx : Context) (dd : DepositDatum) (m : ℕ) : Set where
+  constructor mkRecoverValid
+  field
+    recoveredMatches     : recoveredMatchesDeposited ctx (DepositDatum.committed dd) m  -- recovered exactly as deposited
+    afterRecoverDeadline : DepositDatum.tRecover dd < ValidityInterval.lo (Context.validity ctx)  -- §5.3.2: txValidityMin > t_recover
+    -- §5.3.3: this deposit is the only νDeposit input (deposit.ak `single_deposit`). The recovered
+    -- outputs are positional (the tx's first m outputs) and shared by every deposit input, so two
+    -- deposits whose C hashes alike would both accept one output set, freeing the second's value.
+    singleDeposit        : depositInputCount ctx ≡ 1
+
+recoverValid : Context → DepositDatum → ℕ → Set
+recoverValid = RecoverValid
+```
 
 The Claim arm's own checks - the head binding and the before-deadline check, the
 two checks $nuDeposit$ performs that $nuHead$ does not - form the `ClaimValid`
 bundle, consumed by the joint claim obligation stated in @sec:increment-tx.
 
+```
+-- §5.2 Claim: a deposit is collected by an increment of its OWN head. The head-binding `cid = hcid`:
+depositClaimedBy : DepositDatum → HeadDatum → Set
+depositClaimedBy (mkDepositDatum cid _ _) (Open hcid _ _ _ _ _ _) = cid ≡ hcid
+depositClaimedBy _ _ = ⊥
+
+-- §5.2 Claim validity (νDeposit), mirroring `deposit.ak`'s Claim arm: a deposit output may be spent on
+-- `claim` only if (i) it is consumed by an increment of ITS OWN head -- the deposit datum's `cid`
+-- equals the head datum `hd` being spent in the same transaction (deposit.ak
+-- `expect_increment_redeemer(self, datum.head_id)`, modelled here as `depositClaimedBy`), and (ii) the
+-- transaction is posted strictly BEFORE the recover deadline (deposit.ak `before_deadline`:
+-- txValidityMax ≤ tRecover). These are the two checks νDeposit performs that νHead does NOT; the
+-- "spent with the Increment redeemer" half is enforced head-side by `incrementValid`/`depositSpentOK`.
+-- (claim carries no payload, so `claimValid` takes the head datum directly rather than via a redeemer.)
+record ClaimValid (ctx : Context) (dd : DepositDatum) (hd : HeadDatum) : Set where
+  constructor mkClaimValid
+  field
+    claimedByOwnHead      : depositClaimedBy dd hd             -- deposit's cid binds to the head's (deposit.ak `expect_increment_redeemer`)
+    beforeRecoverDeadline : ValidityInterval.hi (Context.validity ctx) ≤ DepositDatum.tRecover dd  -- deposit.ak `before_deadline`
+
+claimValid : Context → DepositDatum → HeadDatum → Set
+claimValid = ClaimValid
+```
 
 #figure(recoverTx-diagram, caption: [$mtxRecover$ transaction restoring UTxO of a deposit output.]) <fig:recoverTx>
 
@@ -391,12 +843,69 @@ checks:
 These conditions form the `IncrementValid` bundle, over the additive
 value-conservation predicate `incrementValueOK`.
 
+```
+-- Value conservation (additive, §5.4/§5.5). The head value grows by the deposit
+-- on increment and shrinks by the decommitted value on decrement.
+incrementValueOK : (valHead valDeposit valHead' : Value) → Set
+incrementValueOK vh vd vh' = vh +ᵛ vd ≡ vh'
+
+-- Increment: a confirmed deposit is collected into the head (version bumps to `suc v`, head value
+-- grows by ALL spent deposits). The thin `incrementValid` function destructures the source `Open`
+-- datum to feed the head key/id/version into the record, and is ⊥ for any other source shape.
+-- The signature binds the redeemer-carried decommit hash δ# and the RECOMPUTED commit hash
+-- `depositCommitsHashOf ctx ref` (from the claimed deposit's own datum, §5.4).
+record IncrementValid (ctx : Context) (hk : VKey) (cid : ℍ) (v : ℕ)
+                      (d d' : HeadDatum) (ξ : AggSig) (s : ℕ) (ref : OutputRef) (δ# : ℍ) : Set where
+  constructor mkIncrementValid
+  field
+    step               : d ⟶⟨ Increment ξ s ref δ# ⟩ d'
+    mintEmpty          : noMint ctx
+    sigOK              : snapshotSigOK hk cid v s (hash (ηOf d')) δ# (depositCommitsHashOf ctx ref) ξ
+    valueOK            : incrementValueOK (headValueIn ctx) (depositsValue ctx) (headValue ctx)  -- ALL deposits (§5.4, Plutus `totalNonHeadInputValue`)
+    depositSpent       : depositSpentOK ctx ref            -- claimed deposit is spent (§5.4)
+    -- §5.4: the claimed deposit is output 0 of its transaction (Plutus `txOutRefIdx ref == 0`).
+    -- κ# binds a deposit by its transaction id, so sibling outputs of the same transaction would
+    -- otherwise be interchangeable under one signature.
+    depositFirstOutput : OutputRef.index ref ≡ 0
+    participantSigned  : signedByParticipant cid ctx
+
+incrementValid : Context → HeadDatum → HeadDatum → AggSig → ℕ → OutputRef → ℍ → Set
+incrementValid ctx d@(Open cid hk _ _ v _ _) d' ξ s ref δ# = IncrementValid ctx hk cid v d d' ξ s ref δ#
+incrementValid _ _ _ _ _ _ _ = ⊥
+```
 
 A deposit claim must satisfy both validators run in the same transaction:
 $nuHead$'s `incrementValid` above and $nuDeposit$'s `claimValid`
 (@sec:recover-tx). The joint claim obligation is stated here as `ClaimTxValid`,
 since it conjoins `incrementValid` with the deposit-side bundle.
 
+```
+-- A deposit is collected by an INCREMENT transaction that spends both the head and the deposit. Such a
+-- transaction must satisfy BOTH validators run in it: νHead's `incrementValid` (version/value/signature)
+-- AND νDeposit's `claimValid` for the claimed deposit datum `dd` (its `cid` binds to the head, and the
+-- claim is before the recover deadline). Conjoining them here makes the deposit→head binding a
+-- type-enforced part of a valid claim transaction, mirroring
+-- that on-chain BOTH scripts must pass. (`dd` is supplied like `recoverValid`'s, not decoded here.)
+-- NB: this type-ENCODES the joint requirement (so `depositClaimedBy`/`claimValid` are both used).
+-- ALL the decidable conjuncts of the Claim arm are bridged from this joint bundle (`claimTxValid→ref`):
+-- the before-deadline `validityHi ≤ tRecover` and head-id binding `depositCid == headCid` from the
+-- deposit side, and the Increment-redeemer-index coupling (the other half of
+-- `expect_increment_redeemer`) from the HEAD side - the joint bundle's head input is spent with
+-- `Increment` BY TYPE, so its pinned constructor index is 0 definitionally. All three are
+-- differentially tested (the `HeadValidatorAgreement` claim agreement, running the compiled
+-- `deposit.ak` Claim arm as UPLC, including a wrong-redeemer rejection). (The Recover arm is likewise
+-- bridged + tested: `recoverValid→ref` + the `HeadValidatorAgreement` recover agreement cover
+-- deposit.ak's after-deadline check.)
+record ClaimTxValid (ctx : Context) (dd : DepositDatum) (headIn headOut : HeadDatum)
+                    (ξ : AggSig) (s : ℕ) (ref : OutputRef) (δ# : ℍ) : Set where
+  constructor mkClaimTxValid
+  field
+    headSideOK    : incrementValid ctx headIn headOut ξ s ref δ#  -- νHead: version / value / signature
+    depositSideOK : claimValid ctx dd headIn                      -- νDeposit: cid-binding + before-deadline
+
+claimTxValid : Context → DepositDatum → HeadDatum → HeadDatum → AggSig → ℕ → OutputRef → ℍ → Set
+claimTxValid = ClaimTxValid
+```
 
 #figure(incrementTx-diagram, caption: [$mtxIncrement$ transaction spending an open head output, producing a new head output which includes the new UTxO.]) <fig:incrementTx>
 
@@ -459,6 +968,35 @@ validator checks:
 
 These conditions form the `DecrementValid` bundle.
 
+```
+decrementValueOK : (valHead valHead' valDecommit : Value) → Set
+decrementValueOK vh vh' vdec = vh' +ᵛ vdec ≡ vh
+
+-- Decrement: a decommit removes the `m` outputs after the head output (version bumps, head value
+-- shrinks by the decommit). Same source-shape dispatch as increment.
+-- The signature binds the RECOMPUTED decommit hash `decommitOutputsHashOf ctx m` (over the same
+-- `take m (tail outputs)` list `decommitValue` sums, §5.5) and the redeemer-carried commit hash κ#.
+record DecrementValid (ctx : Context) (hk : VKey) (cid : ℍ) (v : ℕ)
+                      (d d' : HeadDatum) (ξ : AggSig) (s : ℕ) (m : ℕ) (κ# : ℍ) : Set where
+  constructor mkDecrementValid
+  field
+    step              : d ⟶⟨ Decrement ξ s m κ# ⟩ d'
+    mintEmpty         : noMint ctx
+    sigOK             : snapshotSigOK hk cid v s (hash (ηOf d')) (decommitOutputsHashOf ctx m) κ# ξ
+    valueOK           : decrementValueOK (headValueIn ctx) (headValue ctx) (decommitValue ctx m)
+    -- §5.5: at least one decommit output is materialized (checked on the outputs actually present,
+    -- not the redeemer's m - `take m (tail outputs)` truncates silently). Increment and decrement
+    -- verify the same signed message, so with no decommit outputs the recomputed δ# is the
+    -- empty-set digest - exactly what an increment snapshot produces - and that snapshot's
+    -- signature would authorize a decrement adopting an accumulator that counts deposited UTxOs
+    -- while no deposit is spent.
+    decommitNonEmpty  : 0 < length (take m (drop 1 (Context.outputs ctx)))
+    participantSigned : signedByParticipant cid ctx
+
+decrementValid : Context → HeadDatum → HeadDatum → AggSig → ℕ → ℕ → ℍ → Set
+decrementValid ctx d@(Open cid hk _ _ v _ _) d' ξ s m κ# = DecrementValid ctx hk cid v d d' ξ s m κ#
+decrementValid _ _ _ _ _ _ _ = ⊥
+```
 
 #figure(decrementTx-diagram, caption: [$mtxDecrement$ transaction spending an open head output, producing a new head output and multiple decommitted outputs.]) <fig:decrementTx>
 
@@ -548,6 +1086,79 @@ Initial-case constraint, the η-hash binding, the positive-snapshot Any case and
 the version-dependent signature obligation - and conjoined in the `CloseValid`
 bundle.
 
+```
+-- spec §5.6 (close): the recorded contestation deadline is the transaction's
+-- upper validity bound extended by the contestation period, tfinal = txValidityMax
+-- + T_contest, and close must produce a Closed datum. (Contest's deadline update
+-- in §5.7 is conditional - tfinal' = tfinal if all parties contested, else
+-- tfinal + T - and is left to a separate predicate.)
+closeDeadlineOK : Context → HeadDatum → Set
+closeDeadlineOK ctx (Closed cid hk n cp v s η C tfinal ada) =
+  tfinal ≡ ValidityInterval.hi (Context.validity ctx) + cp
+closeDeadlineOK ctx _ = ⊥
+
+-- spec §5.6, CloseType = Initial case: closing on the initial snapshot requires
+-- version 0, snapshot number 0, and η' = accUTxO(∅). The other close types impose
+-- no such constraint.
+closeInitialOK : CloseType → HeadDatum → Set
+closeInitialOK closeInitial (Closed _ _ _ _ v s η _ _ _) = (v ≡ 0) × (s ≡ 0) × (η ≡ accUTxO ∅ˢ)
+closeInitialOK _            _                            = ⊤
+
+-- The redeemer-supplied η# must equal the hash of the accumulator η' actually
+-- stored in the produced datum (spec §5.6/§5.7: (η')# = hash(η')) - otherwise the
+-- signature would attest to an accumulator unrelated to the on-chain state.
+closeηOK : CloseType → HeadDatum → Set
+closeηOK closeInitial           _  = ⊤
+closeηOK (closeAny _ η# _ _)    d' = η# ≡ hash (ηOf d')
+closeηOK (closeUnused _ η# _ _) d' = η# ≡ hash (ηOf d')
+closeηOK (closeUsed _ η# _ _)   d' = η# ≡ hash (ηOf d')
+
+-- spec §5.6, Any case: the closing snapshot number is positive (s' > 0).
+closeAnyOK : CloseType → HeadDatum → Set
+closeAnyOK (closeAny _ _ _ _) d' = 0 < snapNum d'
+closeAnyOK _                  _  = ⊤
+
+-- Signature obligation of a close redeemer: the Initial type carries no signature;
+-- the other types must verify a multisignature over cid ‖ v ‖ s ‖ η# ‖ δ# ‖ κ#, with
+-- the decommit/commit-set hashes δ#/κ# passed VERBATIM from the redeemer into the
+-- message (the implementation copies them from the redeemer; they are authenticated
+-- only through the signature). The Used case refers to the *previous* state version
+-- v-1 (a pending delta is applied in the snapshot); the others use the current v (spec §5.6).
+closeSigOK : (hydraKey : VKey) (cid : ℍ) (v s : ℕ) → CloseType → Set
+closeSigOK _  _   _ _ closeInitial             = ⊤
+closeSigOK hk cid v s (closeAny ξ η# δ# κ#)    = snapshotSigOK hk cid v s η# δ# κ# ξ
+closeSigOK hk cid v s (closeUnused ξ η# δ# κ#) = snapshotSigOK hk cid v s η# δ# κ# ξ
+closeSigOK hk cid v s (closeUsed ξ η# δ# κ#)   = snapshotSigOK hk cid (v ∸ 1) s η# δ# κ# ξ
+
+-- A close is *valid* when the state-machine step holds together with all the close
+-- checks: the contestation deadline (§5.6), no minting/burning, the Initial-case
+-- constraint, and the snapshot signature. The head key/id/version come from the
+-- source Open datum, the snapshot number from the produced Closed datum, and the
+-- signature/η# from the CloseType redeemer - so the predicate is only inhabited for
+-- genuinely valid close transactions. Value is preserved EXACTLY (§5.6: valHead' = valHead).
+-- The thin `closeValid` function destructures the source `Open` and produced `Closed` datums
+-- (binding the head key/id/version/contestation-period and the produced snapshot number) and is ⊥ for
+-- any other shapes; each close check is then a named field of `CloseValid`.
+record CloseValid (ctx : Context) (hk : VKey) (cid : ℍ) (v cp s' : ℕ)
+                  (d d' : HeadDatum) (ct : CloseType) : Set where
+  constructor mkCloseValid
+  field
+    step              : d ⟶⟨ Close ct ⟩ d'
+    deadlineOK        : closeDeadlineOK ctx d'             -- tfinal = validity.hi + cp (§5.6)
+    mintEmpty         : noMint ctx
+    initialOK         : closeInitialOK ct d'               -- closeInitial ⇒ v=0 ∧ s=0 ∧ η=accUTxO(∅)
+    sigOK             : closeSigOK hk cid v s' ct
+    etaOK             : closeηOK ct d'                     -- η# bound to stored η'
+    anyOK             : closeAnyOK ct d'                   -- closeAny ⇒ 0 < s
+    valuePreserved    : headValueIn ctx ≡ headValue ctx    -- value preserved EXACTLY (§5.6; matches Plutus `mustPreserveHeadValue`, `==`)
+    participantSigned : signedByParticipant cid ctx
+    -- validity range bounded so the deadline is at most 2·T ahead (§5.6)
+    validityBounded   : ValidityInterval.hi (Context.validity ctx) ∸ ValidityInterval.lo (Context.validity ctx) ≤ cp
+
+closeValid : Context → HeadDatum → HeadDatum → CloseType → Set
+closeValid ctx d@(Open cid hk _ cp v _ _) d'@(Closed _ _ _ _ _ s' _ _ _ _) ct = CloseValid ctx hk cid v cp s' d d' ct
+closeValid _ _ _ _ = ⊥
+```
 
 #figure(closeTx-diagram, caption: [$mtxClose$ transaction spending the $stOpen$ head output and producing a $stClosed$ head output with unified accumulator $eta'$.]) <fig:closeTx>
 
@@ -616,7 +1227,68 @@ appended contester is _a_ transaction signer; the implementation's stronger
 sole-signer cardinality (${keyHash} = txKeys$, exactly one signer) is not
 modelled.
 
+```
+-- spec §5.7: contest updates the deadline conditionally - it stays at the previous
+-- tfinal once all parties have contested (|contesters'| = n), otherwise it extends
+-- by the contestation period T (= cp). Fully computed: contesters is a List, so
+-- the cardinality is `length`, and n is carried in the datum.
+contestDeadlineOK : HeadDatum → HeadDatum → Set
+contestDeadlineOK (Closed _ _ _ _ _ _ _ _ tfinal _) (Closed _ _ n cp _ _ _ C' tfinal' _) =
+  tfinal' ≡ (if ⌊ length C' ≟ n ⌋ then tfinal else tfinal + cp)
+contestDeadlineOK _ _ = ⊥
 
+contestηOK : ContestType → HeadDatum → Set
+contestηOK (contestUnused _ η# _ _) d' = η# ≡ hash (ηOf d')
+contestηOK (contestUsed _ η# _ _)   d' = η# ≡ hash (ηOf d')
+
+-- Contest signature obligation (both ContestType cases must verify). The
+-- decommit/commit-set hashes δ#/κ# pass verbatim from the redeemer into the
+-- message, as for close. As for close, the Used case verifies against the
+-- previous version v-1 (§5.7).
+contestSigOK : (hydraKey : VKey) (cid : ℍ) (v s : ℕ) → ContestType → Set
+contestSigOK hk cid v s (contestUnused ξ η# δ# κ#) = snapshotSigOK hk cid v s η# δ# κ# ξ
+contestSigOK hk cid v s (contestUsed ξ η# δ# κ#)   = snapshotSigOK hk cid (v ∸ 1) s η# δ# κ# ξ
+
+-- A contest replaces the closed snapshot with a more recent one and appends the contester (a key
+-- hash, as on-chain: `contesters :: [PubKeyHash]`). The thin `contestValid` function destructures the
+-- source `Closed` datum (binding its key/id/version/snapshot/deadline) and is ⊥ for any other source
+-- shape.
+record ContestValid (ctx : Context) (hk : VKey) (cid : ℍ) (v s tfin : ℕ)
+                    (d d' : HeadDatum) (ct : ContestType) (kh : ℍ) : Set where
+  constructor mkContestValid
+  field
+    step              : d ⟶⟨ Contest ct ⟩ d'
+    deadlineOK        : contestDeadlineOK d d'
+    mintEmpty         : noMint ctx
+    sigOK             : contestSigOK hk cid v (snapNum d') ct
+    etaOK             : contestηOK ct d'                      -- η# bound to stored η' (§5.7)
+    snapIncreases     : s < snapNum d'                        -- snapshot strictly increases (§5.7)
+    beforeDeadline    : ValidityInterval.hi (Context.validity ctx) ≤ tfin  -- posted before the deadline
+    valuePreserved    : headValueIn ctx ≡ headValue ctx       -- value preserved EXACTLY (§5.7; matches Plutus `mustPreserveHeadValue`, `==`)
+    contesterSigned   : signerKeyHash ctx kh                  -- the appended contester `kh` is a tx signer (§5.7; Plutus derives `contester` from the SOLE signer - that exact-one cardinality is not modelled)
+    -- the appended contester holds this head's participation token (§5.7; Plutus
+    -- `mustBeSignedByParticipant` + contester ≔ the sole signer make these one check on-chain)
+    contesterIsParticipant : quantityOf (headValue ctx) (cid , kh) ≡ 1ℤ
+
+-- `kh` (the record's contester parameter) is bound to the head of the produced datum's contesters,
+-- so `contesterSigned`/`contesterIsParticipant` require that the newly-appended contester actually
+-- signed the transaction and is a participant of THIS head.
+contestValid : Context → HeadDatum → HeadDatum → ContestType → Set
+contestValid ctx d@(Closed cid hk _ _ v s _ _ tfin _) d'@(Closed _ _ _ _ _ _ _ (kh ∷ _) _ _) ct = ContestValid ctx hk cid v s tfin d d' ct kh
+contestValid _ _ _ _ = ⊥
+
+-- The §5.4-§5.7 shared "signed by a participant" obligation is DERIVED for contest (not a separate
+-- field): the appended contester is a signer and holds a participation token, which is exactly the
+-- `signedByParticipant` witness.
+contest-participantSigned : ∀ {ctx hk cid v s tfin d d' ct kh}
+  → ContestValid ctx hk cid v s tfin d d' ct kh
+  → signedByParticipant cid ctx
+```
+
+```
+contest-participantSigned {kh = kh} b =
+  kh , ContestValid.contesterSigned b , ContestValid.contesterIsParticipant b
+```
 
 #figure(contestTx-diagram, caption: [$mtxContest$ transaction spending the $stClosed$ head output and producing a different $stClosed$ head output.]) <fig:contestTx>
 
@@ -660,6 +1332,40 @@ The fan-out checks - the burn count, membership of the distributed outputs in th
 accumulator, the deadline, value conservation and the canonical-CRS binding - form
 the `FanoutValid` bundle.
 
+```
+burnAllTokensOK : Context → HeadDatum → Set
+burnAllTokensOK ctx (Closed cid _ n _ _ _ _ _ _ _)      = burnedCount ctx cid ≡ suc n
+burnAllTokensOK ctx (FanoutProgress cid _ n _ _ _)      = burnedCount ctx cid ≡ suc n
+burnAllTokensOK ctx _                                    = ⊥
+
+-- §5.8 value conservation for (final) fan-out (DERIVED output-sum): the head input value equals the
+-- sum of the `m` distributed (fanned-out) outputs PLUS the burned tokens PLUS the ada overhead --
+-- mirroring Plutus `mustConserveValue` (`headInValue == Σ fanoutOutputs <> mintValueBurned <> ada`).
+-- The distributed outputs are the first `m` (`takeSumᵛ m outputs`, as on-chain `take m txInfoOutputs`,
+-- since a full fan-out has no continuing head output); `burnedValue` is the only piece left abstract.
+fanoutValueOK : Context → Value → ℕ → Set
+fanoutValueOK ctx ada m =
+  headValueIn ctx ≡ (takeSumᵛ m (Context.outputs ctx) +ᵛ (burnedValue ctx +ᵛ ada))
+
+-- Fan-out is posted after the deadline (txValidityMin > tfinal), distributes m
+-- outputs that are members of η, conserves value, and burns all n+1 tokens (§5.8).
+-- NB m = 0 is permitted: it is the (only) way to finalise a genuinely EMPTY head - distribute
+-- nothing, burn the n+1 tokens. Value conservation (exact, via `valueOK`) prevents any theft at m = 0,
+-- so no `0 < m` guard is imposed on the FULL fanout (unlike the partial paths, where a 0-output batch
+-- makes no progress); this matches the real νHead `headIsFinalizedWith` (no `numberOfFanoutOutputs > 0`).
+record FanoutValid (ctx : Context) (d : HeadDatum) (m : ℕ) (π : AccWitness) (crs : OutputRef) : Set where
+  constructor mkFanoutValid
+  field
+    step            : d ⟶⟨ Fanout m π crs ⟩ Final
+    burnAllTokens   : burnAllTokensOK ctx d                    -- burns the n+1 tokens (§5.8)
+    membersOK       : fanoutMembersOK (ηOf d) (distributedOuts ctx m) π  -- the m distributed outputs ∈ η
+    afterDeadline   : tfinalOf d < ValidityInterval.lo (Context.validity ctx)
+    valueOK         : fanoutValueOK ctx (headAda d) m
+    crsBound        : crsBindOK ctx crs                        -- the CRS ref input is canonical (§5.8)
+
+fanoutValid : Context → HeadDatum → ℕ → AccWitness → OutputRef → Set
+fanoutValid = FanoutValid
+```
 
 #figure(fanoutTx-diagram, caption: [$mtxFanout$ transaction spending the $stClosed$ head output with unified accumulator $eta$ and distributing funds with outputs $o_1 dots.h o_m$.]) <fig:fanoutTx>
 
@@ -705,6 +1411,32 @@ The validator checks:
 
 An intermediate step's conditions form the `PartialFanoutValid` bundle.
 
+```
+-- §5.8.1 value conservation for an intermediate partial fan-out (DERIVED, no burn yet): the head input
+-- value equals the CONTINUING head output (the `FanoutProgress` output at the νHead script) plus the
+-- `m` distributed outputs after it -- exactly the decrement shape (`headValue +ᵛ decommit ≡ headValueIn`).
+partialFanoutValueOK : Context → ℕ → Set
+partialFanoutValueOK ctx m =
+  headValueIn ctx ≡ (headValue ctx +ᵛ decommitValue ctx m)
+
+-- A *partial* fan-out distributes m > 0 of the still-locked outputs and carries the head on to a
+-- `FanoutProgress`. Each conjunct is a named field; the `step` field forces d' to be a `FanoutProgress`
+-- (so `ηOf d'` is its accumulator η'), which is why no wrong-shape ⊥ case is needed.
+record PartialFanoutValid (ctx : Context) (d d' : HeadDatum) (m : ℕ) (crs : OutputRef) : Set where
+  constructor mkPartialFanoutValid
+  field
+    step            : d ⟶⟨ PartialFanout m crs ⟩ d'
+    excludeOK       : fanoutExcludeOK (ηOf d) (partialDistributedOuts ctx m) (ηOf d')  -- the m distributed outputs removed from η (→ η')
+    notDoneOK       : partialFanoutNotDoneOK (ηOf d')         -- η' still non-empty (more to fan out)
+    outputsPositive : 0 < m                                   -- §5.8 no zero-output batch
+    afterDeadline   : tfinalOf d < ValidityInterval.lo (Context.validity ctx)  -- posted after tfinal
+    mintEmpty       : noMint ctx
+    valueOK         : partialFanoutValueOK ctx m              -- value conserved (modulo abstract algebra)
+    crsBound        : crsBindOK ctx crs                       -- the CRS ref input is canonical (§5.8.1)
+
+partialFanoutValid : Context → HeadDatum → HeadDatum → ℕ → OutputRef → Set
+partialFanoutValid = PartialFanoutValid
+```
 
 #figure(partialFanoutTx-diagram, caption: [$mtxPartialFanout$ transaction spending the $stFanoutProgress$ head output, distributing outputs $o_1 dots.h o_m$, and producing a new $stFanoutProgress$ head output with updated accumulator $eta'$.]) <fig:partialFanoutTx>
 
@@ -736,6 +1468,22 @@ The validator checks:
 
 The final step's conditions form the `FinalPartialFanoutValid` bundle.
 
+```
+-- The last batch of a multi-step fan-out: like `FanoutValid` but from a `FanoutProgress` source.
+record FinalPartialFanoutValid (ctx : Context) (d : HeadDatum) (m : ℕ) (π : AccWitness) (crs : OutputRef) : Set where
+  constructor mkFinalPartialFanoutValid
+  field
+    step            : d ⟶⟨ FinalPartialFanout m π crs ⟩ Final
+    burnAllTokens   : burnAllTokensOK ctx d
+    membersOK       : fanoutMembersOK (ηOf d) (distributedOuts ctx m) π
+    outputsPositive : 0 < m
+    afterDeadline   : tfinalOf d < ValidityInterval.lo (Context.validity ctx)
+    valueOK         : fanoutValueOK ctx (headAda d) m
+    crsBound        : crsBindOK ctx crs                       -- the CRS ref input is canonical (§5.8.2)
+
+finalPartialFanoutValid : Context → HeadDatum → ℕ → AccWitness → OutputRef → Set
+finalPartialFanoutValid = FinalPartialFanoutValid
+```
 
 #figure(finalPartialFanoutTx-diagram, caption: [$mtxFinalPartialFanout$ transaction spending the $stFanoutProgress$ head output, distributing the final batch of UTxOs $o_1 dots.h o_m$, and burning all head tokens to reach $stFinal$.]) <fig:finalPartialFanoutTx>
 

--- a/spec/src/Hydra/Protocol/OnChainCoverage.lagda.typ
+++ b/spec/src/Hydra/Protocol/OnChainCoverage.lagda.typ
@@ -144,13 +144,15 @@ finalize-reachable-empty aft burn val crsOK =
   reach-empty-closed , fanout-empty-inhabited aft burn val crsOK
 ```
 
-#theorem(name: "Reachable heads can finalise")[
-  Any reachable `Closed` head committing to a known UTxO set $V$
+#theorem(name: "Closed heads can finalise")[
+  Any `Closed` head committing to a known UTxO set $V$
   ($eta = accUTxO(V)$) admits a valid full fan-out of $V$, provided the
   transaction actually distributes $V$; the membership witness is derived
   from the accumulator laws, so only the genuinely contextual antecedents
   (deadline, burn, value conservation, pays-out-$V$, the canonical CRS
-  reference resolved) remain. Likewise, a reachable `FanoutProgress` is
+  reference resolved) remain. Reachability is not among them: the witness
+  follows from the accumulator laws for any such datum, so `fanout-coverage`
+  does not take it as a hypothesis. Likewise, a reachable `FanoutProgress` is
   never stuck: its remaining accumulator is provably non-empty
   (`progress-nonEmpty`), which _derives_ the final batch's $0 < m$
   requirement rather than assuming it
@@ -158,8 +160,12 @@ finalize-reachable-empty aft burn val crsOK =
 ] <thm:coverage>
 
 ```agda
+-- No `Reachable` premise: the membership witness comes from `accVerify-self`, so the bundle is
+-- constructible from the contextual antecedents alone. Taking reachability and discarding it would
+-- state something weaker than what is proved while reading as though reachability were needed -
+-- contrast `progress-finalizable` below, which genuinely consumes its `Reachableᵛ` (via
+-- `progress-nonEmpty`) to derive the final batch's `0 < m`.
 fanout-coverage : ∀ {ctx cid hk n cp v s C tfin ada V crs}
-  → Reachable (Closed cid hk n cp v s (accUTxO V) C tfin ada)
   → distributedOuts ctx (setSize V) ≡ V
   → tfin < ValidityInterval.lo (Context.validity ctx)
   → burnAllTokensOK ctx (Closed cid hk n cp v s (accUTxO V) C tfin ada)
@@ -169,7 +175,7 @@ fanout-coverage : ∀ {ctx cid hk n cp v s C tfin ada V crs}
 ```
 
 ```
-fanout-coverage {V = V} _ outsEq aft burn val crsOK =
+fanout-coverage {V = V} outsEq aft burn val crsOK =
   let (π , mem) = accVerify-self V
    in π , mkFanoutValid fanout burn
             (subst (λ z → accVerify (accUTxO V) z π ≡ true) (sym outsEq) mem) aft val crsOK

--- a/spec/src/Hydra/Protocol/OnChainCoverage.lagda.typ
+++ b/spec/src/Hydra/Protocol/OnChainCoverage.lagda.typ
@@ -1,3 +1,22 @@
+```
+module Hydra.Protocol.OnChainCoverage where
+
+open import Hydra.Protocol.Prelude
+open import Hydra.Protocol.Preliminaries
+open import Hydra.Protocol.OnChain
+open import Data.Product using (_×_; _,_; ∃-syntax)
+open import Data.Unit using (⊤; tt)
+open import Data.Empty using (⊥-elim)
+open import Data.Nat using (_*_; z≤n; s≤s)
+open import Data.Integer using (1ℤ)
+open import Data.Nat.Properties using (≤-reflexive; ≤-trans; m≤m+n; +-monoˡ-≤; +-monoʳ-≤; *-monoˡ-≤; +-assoc; +-comm)
+open import Data.List.Relation.Unary.Any using (here; there)
+open import Relation.Nullary using (yes; no)
+open import Relation.Binary.PropositionalEquality using (trans; cong; subst; sym)
+-- For the rendered bridge flagship (the spec ⇒ extracted-reference statement below).
+import Hydra.Protocol.Reference as R
+import Hydra.Protocol.ReferenceBridge as RB
+```
 
 #import "/template.typ": *
 #import "/macros.typ": *
@@ -28,9 +47,55 @@ set of states a validating chain can occupy. The contest step of
 `Reachableᵛ` is stated on concrete datums so the bundle's contester is tied
 to the datum's newly-appended one.
 
+```
+data Reachable : HeadDatum → Set where
+  reach-init : ∀ {cid hk n cp ada}
+    → Reachable (Open cid hk n cp 0 (accUTxO ∅ˢ) ada)
+  reach-step : ∀ {d r d'}
+    → Reachable d → d ⟶⟨ r ⟩ d' → Reachable d'
 
+-- The empty Closed head: opened with no committed UTxO, closed on its initial snapshot.
+emptyClosed : ℍ → VKey → ℕ → ℕ → ℕ → Value → HeadDatum
+emptyClosed cid hk n cp tfin ada = Closed cid hk n cp 0 0 (accUTxO ∅ˢ) [] tfin ada
 
+reach-empty-closed : ∀ {cid hk n cp tfin ada}
+  → Reachable (emptyClosed cid hk n cp tfin ada)
+```
 
+```
+reach-empty-closed = reach-step reach-init (close {ct = closeInitial})
+```
+
+```
+data Reachableᵛ : HeadDatum → Set where
+  initᵛ : ∀ {cid hk n cp ada}
+    → Reachableᵛ (Open cid hk n cp 0 (accUTxO ∅ˢ) ada)
+  closeᵛ : ∀ {ctx hk cid v cp s' d d' ct}
+    → Reachableᵛ d → CloseValid ctx hk cid v cp s' d d' ct → Reachableᵛ d'
+  contestᵛ : ∀ {ctx hk cid n cp v s η C tfin ada s' η' kh tfin' ct}
+    → Reachableᵛ (Closed cid hk n cp v s η C tfin ada)
+    → ContestValid ctx hk cid v s tfin
+        (Closed cid hk n cp v s η C tfin ada)
+        (Closed cid hk n cp v s' η' (kh ∷ C) tfin' ada) ct kh
+    → Reachableᵛ (Closed cid hk n cp v s' η' (kh ∷ C) tfin' ada)
+  incrementᵛ : ∀ {ctx hk cid v d d' ξ s ref δ#}
+    → Reachableᵛ d → IncrementValid ctx hk cid v d d' ξ s ref δ# → Reachableᵛ d'
+  decrementᵛ : ∀ {ctx hk cid v d d' ξ s m κ#}
+    → Reachableᵛ d → DecrementValid ctx hk cid v d d' ξ s m κ# → Reachableᵛ d'
+  partialᵛ : ∀ {ctx d d' m crs}
+    → Reachableᵛ d → PartialFanoutValid ctx d d' m crs → Reachableᵛ d'
+```
+
+```
+-- Valid-gated reachability embeds into shape reachability: every `*Valid` bundle carries its `step`.
+reachableᵛ→reachable : ∀ {d} → Reachableᵛ d → Reachable d
+reachableᵛ→reachable initᵛ            = reach-init
+reachableᵛ→reachable (closeᵛ r cv)     = reach-step (reachableᵛ→reachable r) (CloseValid.step cv)
+reachableᵛ→reachable (contestᵛ r cv)   = reach-step (reachableᵛ→reachable r) (ContestValid.step cv)
+reachableᵛ→reachable (incrementᵛ r iv) = reach-step (reachableᵛ→reachable r) (IncrementValid.step iv)
+reachableᵛ→reachable (decrementᵛ r dv) = reach-step (reachableᵛ→reachable r) (DecrementValid.step dv)
+reachableᵛ→reachable (partialᵛ r pv)   = reach-step (reachableᵛ→reachable r) (PartialFanoutValid.step pv)
+```
 
 === Non-stuckness (coverage)
 
@@ -49,9 +114,35 @@ lemmas fail to compile (the empty head forces $m = 0$), so the build itself
 rejects introducing that over-strict guard, which is exactly the
 defect class this direction exists to catch.
 
+```agda
+fanout-empty-inhabited : ∀ {ctx cid hk n cp tfin ada} {crs}
+  → tfin < ValidityInterval.lo (Context.validity ctx)
+  → burnAllTokensOK ctx (emptyClosed cid hk n cp tfin ada)
+  → fanoutValueOK ctx ada 0
+  → crsBindOK ctx crs
+  → ∃[ π ] FanoutValid ctx (emptyClosed cid hk n cp tfin ada) 0 π crs
+```
 
+```
+fanout-empty-inhabited aft burn val crsOK =
+  let π , mem = accVerify-self ∅ˢ
+   in π , mkFanoutValid fanout burn mem aft val crsOK
+```
 
+```agda
+finalize-reachable-empty : ∀ {ctx cid hk n cp tfin ada} {crs}
+  → tfin < ValidityInterval.lo (Context.validity ctx)
+  → burnAllTokensOK ctx (emptyClosed cid hk n cp tfin ada)
+  → fanoutValueOK ctx ada 0
+  → crsBindOK ctx crs
+  → Reachable (emptyClosed cid hk n cp tfin ada)
+    × (∃[ π ] FanoutValid ctx (emptyClosed cid hk n cp tfin ada) 0 π crs)
+```
 
+```
+finalize-reachable-empty aft burn val crsOK =
+  reach-empty-closed , fanout-empty-inhabited aft burn val crsOK
+```
 
 #theorem(name: "Reachable heads can finalise")[
   Any reachable `Closed` head committing to a known UTxO set $V$
@@ -66,11 +157,59 @@ defect class this direction exists to catch.
   (@agda-appendix: `fanout-coverage`, `progress-finalizable`).
 ] <thm:coverage>
 
+```agda
+fanout-coverage : ∀ {ctx cid hk n cp v s C tfin ada V crs}
+  → Reachable (Closed cid hk n cp v s (accUTxO V) C tfin ada)
+  → distributedOuts ctx (setSize V) ≡ V
+  → tfin < ValidityInterval.lo (Context.validity ctx)
+  → burnAllTokensOK ctx (Closed cid hk n cp v s (accUTxO V) C tfin ada)
+  → fanoutValueOK ctx ada (setSize V)
+  → crsBindOK ctx crs
+  → ∃[ π ] FanoutValid ctx (Closed cid hk n cp v s (accUTxO V) C tfin ada) (setSize V) π crs
+```
 
+```
+fanout-coverage {V = V} _ outsEq aft burn val crsOK =
+  let (π , mem) = accVerify-self V
+   in π , mkFanoutValid fanout burn
+            (subst (λ z → accVerify (accUTxO V) z π ≡ true) (sym outsEq) mem) aft val crsOK
+```
 
+```agda
+progress-nonEmpty : ∀ {cid hk n tfin η ada}
+  → Reachableᵛ (FanoutProgress cid hk n tfin η ada) → ¬ (η ≡ G₁)
+```
 
+```
+progress-nonEmpty (partialᵛ _ pv)     = PartialFanoutValid.notDoneOK pv
+progress-nonEmpty (closeᵛ _ cv)       with CloseValid.step cv
+... | ()
+-- (contestᵛ produces a Closed datum by construction, so it cannot reach a FanoutProgress index.)
+progress-nonEmpty (incrementᵛ _ iv)   with IncrementValid.step iv
+... | ()
+progress-nonEmpty (decrementᵛ _ dv)   with DecrementValid.step dv
+... | ()
+```
 
+```agda
+progress-finalizable : ∀ {ctx cid hk n tfin ada V crs}
+  → Reachableᵛ (FanoutProgress cid hk n tfin (accUTxO V) ada)
+  → distributedOuts ctx (setSize V) ≡ V
+  → tfin < ValidityInterval.lo (Context.validity ctx)
+  → burnAllTokensOK ctx (FanoutProgress cid hk n tfin (accUTxO V) ada)
+  → fanoutValueOK ctx ada (setSize V)
+  → crsBindOK ctx crs
+  → ∃[ π ] FinalPartialFanoutValid ctx (FanoutProgress cid hk n tfin (accUTxO V) ada) (setSize V) π crs
+```
 
+```
+progress-finalizable {V = V} reach outsEq aft burn val crsOK =
+  let (π , mem) = accVerify-self V
+   in π , mkFinalPartialFanoutValid finalPartialFanout burn
+            (subst (λ z → accVerify (accUTxO V) z π ≡ true) (sym outsEq) mem)
+            (setSize-pos (λ V≡∅ → progress-nonEmpty reach (trans (cong accUTxO V≡∅) accUTxO-∅)))
+            aft val crsOK
+```
 
 === Safety invariants of reachable states
 
@@ -88,9 +227,38 @@ compile time.
   `reachable-contesters-distinct`, `final-is-terminal`).
 ] <inv:contest-final>
 
+```
+contestersOf : HeadDatum → List ℍ
+contestersOf (Closed _ _ _ _ _ _ _ C _ _) = C
+contestersOf _                            = []
 
+-- No-duplicate predicate: each element is absent from the tail.
+Distinct : List ℍ → Set
+Distinct []       = ⊤
+Distinct (x ∷ xs) = ¬ (x ∈ˡ xs) × Distinct xs
 
+reachable-contesters-distinct : ∀ {d} → Reachable d → Distinct (contestersOf d)
+```
 
+```
+reachable-contesters-distinct reach-init                              = tt
+reachable-contesters-distinct (reach-step r increment)               = tt
+reachable-contesters-distinct (reach-step r decrement)               = tt
+reachable-contesters-distinct (reach-step r close)                   = tt
+reachable-contesters-distinct (reach-step r (contest kh∉C))          = kh∉C , reachable-contesters-distinct r
+reachable-contesters-distinct (reach-step r fanout)                  = tt
+reachable-contesters-distinct (reach-step r partialFanoutStart)      = tt
+reachable-contesters-distinct (reach-step r partialFanoutStep)       = tt
+reachable-contesters-distinct (reach-step r finalPartialFanout)      = tt
+```
+
+```agda
+final-is-terminal : ∀ {r d'} → ¬ (Final ⟶⟨ r ⟩ d')
+```
+
+```
+final-is-terminal ()
+```
 
 === Value conservation (no theft)
 
@@ -107,15 +275,64 @@ compile time.
   `contest-preserves-value`, `partialFanout-conserves-ada`).
 ] <thm:value-conservation>
 
+```agda
+fanout-conserves-ada : ∀ {ctx d m π crs}
+  → (b : FanoutValid ctx d m π crs)
+  → adaOf (headValueIn ctx)
+    ≡ adaOf (takeSumᵛ m (Context.outputs ctx)) + (adaOf (burnedValue ctx) + adaOf (headAda d))
+```
 
+```
+fanout-conserves-ada {ctx} {d} {m = m} b =
+  trans (cong adaOf (FanoutValid.valueOK b))
+  (trans (adaOf-+ᵛ (takeSumᵛ m (Context.outputs ctx)) (burnedValue ctx +ᵛ headAda d))
+         (cong (adaOf (takeSumᵛ m (Context.outputs ctx)) +_) (adaOf-+ᵛ (burnedValue ctx) (headAda d))))
+```
 
+```agda
+finalPartialFanout-conserves-ada : ∀ {ctx d m π crs}
+  → (b : FinalPartialFanoutValid ctx d m π crs)
+  → adaOf (headValueIn ctx)
+    ≡ adaOf (takeSumᵛ m (Context.outputs ctx)) + (adaOf (burnedValue ctx) + adaOf (headAda d))
+```
 
+```
+finalPartialFanout-conserves-ada {ctx} {d} {m = m} b =
+  trans (cong adaOf (FinalPartialFanoutValid.valueOK b))
+  (trans (adaOf-+ᵛ (takeSumᵛ m (Context.outputs ctx)) (burnedValue ctx +ᵛ headAda d))
+         (cong (adaOf (takeSumᵛ m (Context.outputs ctx)) +_) (adaOf-+ᵛ (burnedValue ctx) (headAda d))))
+```
 
+```agda
+close-preserves-value : ∀ {ctx cid hk n cp v η ada s′ η′ C tfin ct}
+  → (b : closeValid ctx (Open cid hk n cp v η ada) (Closed cid hk n cp v s′ η′ C tfin ada) ct)
+  → (adaOf (headValueIn ctx) ≡ adaOf (headValue ctx)) × (nonAdaOf (headValueIn ctx) ≡ nonAdaOf (headValue ctx))
+```
 
+```
+close-preserves-value b = cong adaOf (CloseValid.valuePreserved b) , cong nonAdaOf (CloseValid.valuePreserved b)
+```
 
+```agda
+contest-preserves-value : ∀ {ctx cid hk n cp v s η C tfin ada s′ η′ kh tfin′ ct}
+  → (b : contestValid ctx (Closed cid hk n cp v s η C tfin ada) (Closed cid hk n cp v s′ η′ (kh ∷ C) tfin′ ada) ct)
+  → (adaOf (headValueIn ctx) ≡ adaOf (headValue ctx)) × (nonAdaOf (headValueIn ctx) ≡ nonAdaOf (headValue ctx))
+```
 
+```
+contest-preserves-value b = cong adaOf (ContestValid.valuePreserved b) , cong nonAdaOf (ContestValid.valuePreserved b)
+```
 
+```agda
+partialFanout-conserves-ada : ∀ {ctx d d′ m crs}
+  → (b : PartialFanoutValid ctx d d′ m crs)
+  → adaOf (headValueIn ctx) ≡ adaOf (headValue ctx) + adaOf (decommitValue ctx m)
+```
 
+```
+partialFanout-conserves-ada {ctx} {m = m} b =
+  trans (cong adaOf (PartialFanoutValid.valueOK b)) (adaOf-+ᵛ (headValue ctx) (decommitValue ctx m))
+```
 
 #theorem(name: "No output fabrication at fan-out")[
   The outputs a fan-out transaction actually pays (the anchored
@@ -127,15 +344,39 @@ compile time.
   `finalPartialFanout-distributes-committed`).
 ] <thm:no-fabrication>
 
+```agda
+fanout-distributes-committed : ∀ {ctx cid hk n cp v s V C tfin ada m π crs}
+  → FanoutValid ctx (Closed cid hk n cp v s (accUTxO V) C tfin ada) m π crs
+  → distributedOuts ctx m ⊆ V
+```
 
+```
+fanout-distributes-committed b = accVerify-sound (FanoutValid.membersOK b)
+```
 
+```agda
+finalPartialFanout-distributes-committed : ∀ {ctx cid hk n tfin V ada m π crs}
+  → FinalPartialFanoutValid ctx (FanoutProgress cid hk n tfin (accUTxO V) ada) m π crs
+  → distributedOuts ctx m ⊆ V
+```
 
+```
+finalPartialFanout-distributes-committed b = accVerify-sound (FinalPartialFanoutValid.membersOK b)
+```
 
 A validly-initialised head is moreover a reachable state, tying the
 $muHead$ init conditions (`versionZero`, `etaEmpty`) to the reachability
 all of the above is stated over (@agda-appendix: `init-reachable`).
 
+```agda
+init-reachable : ∀ {ctx seed cid hk n cp v η ada}
+  → initValid ctx seed (Open cid hk n cp v η ada)
+  → Reachable (Open cid hk n cp v η ada)
+```
 
+```
+init-reachable b rewrite InitValid.versionZero b | InitValid.etaEmpty b = reach-init
+```
 
 === The contest game is bounded
 
@@ -147,7 +388,78 @@ close-time deadline plus one contestation period per recorded contester:
 each contest extends the deadline by at most $T$, consuming the close and
 contest deadline equations across the whole run.
 
+```agda
+deadline-bounded : ∀ {cid hk n cp v s η C tfin ada}
+  → Reachableᵛ (Closed cid hk n cp v s η C tfin ada)
+  → ∃[ hi ] (tfin ≤ (hi + cp) + length C * cp)
+```
 
+```
+deadline-bounded (closeᵛ {ctx = ctx} r cv) with CloseValid.step cv
+... | close =
+  ValidityInterval.hi (Context.validity ctx) ,
+  ≤-trans (≤-reflexive (CloseValid.deadlineOK cv)) (m≤m+n _ 0)
+deadline-bounded {n = n} {cp = cp} (contestᵛ {C = C₀} {kh = kh} r cv)
+  with deadline-bounded r
+... | hi , ih = hi , bound
+  where
+    step≤ : ∀ {tfin₀ tfin} → tfin ≡ (if ⌊ length (kh ∷ C₀) ≟ n ⌋ then tfin₀ else (tfin₀ + cp))
+          → tfin ≤ tfin₀ + cp
+    step≤ {tfin₀} eq with length (kh ∷ C₀) ≟ n
+    ... | yes _ = ≤-trans (≤-reflexive eq) (m≤m+n tfin₀ cp)
+    ... | no  _ = ≤-reflexive eq
+
+    reassoc : ∀ a b c → (a + b) + c ≡ a + (c + b)
+    reassoc a b c = trans (+-assoc a b c) (cong (a +_) (+-comm b c))
+
+    bound : _ ≤ (hi + cp) + (cp + length C₀ * cp)
+    bound = ≤-trans (step≤ (ContestValid.deadlineOK cv))
+            (≤-trans (+-monoˡ-≤ cp ih)
+                     (≤-reflexive (reassoc (hi + cp) (length C₀ * cp) cp)))
+deadline-bounded (incrementᵛ r iv) with IncrementValid.step iv
+... | ()
+deadline-bounded (decrementᵛ r dv) with DecrementValid.step dv
+... | ()
+deadline-bounded (partialᵛ r pv) with PartialFanoutValid.step pv
+... | ()
+
+-- List pigeonhole plumbing for the cardinality bound: a duplicate-free list that injects into `ys`
+-- is no longer than `ys` (via first-occurrence removal, decidable by `_≟ℍ_`).
+private
+  ∉ˡ[] : ∀ {kh : ℍ} → ¬ (kh ∈ˡ [])
+  ∉ˡ[] ()
+
+  removeʰ : ℍ → List ℍ → List ℍ
+  removeʰ x []       = []
+  removeʰ x (y ∷ ys) with x ≟ℍ y
+  ... | yes _ = ys
+  ... | no  _ = y ∷ removeʰ x ys
+
+  length-removeʰ : ∀ {x} ys → x ∈ˡ ys → length ys ≡ suc (length (removeʰ x ys))
+  length-removeʰ {x} (y ∷ ys) (here px)   with x ≟ℍ y
+  ... | yes _  = refl
+  ... | no ¬p  = ⊥-elim (¬p px)
+  length-removeʰ {x} (y ∷ ys) (there mem) with x ≟ℍ y
+  ... | yes _  = refl
+  ... | no  _  = cong suc (length-removeʰ ys mem)
+
+  ∈-removeʰ : ∀ {a x} ys → a ∈ˡ ys → ¬ (a ≡ x) → a ∈ˡ removeʰ x ys
+  ∈-removeʰ {a} {x} (y ∷ ys) (here px)   a≢x with x ≟ℍ y
+  ... | yes x≡y = ⊥-elim (a≢x (trans px (sym x≡y)))
+  ... | no  _   = here px
+  ∈-removeʰ {a} {x} (y ∷ ys) (there mem) a≢x with x ≟ℍ y
+  ... | yes _ = mem
+  ... | no  _ = there (∈-removeʰ ys mem a≢x)
+
+  distinct-⊆-length : ∀ {xs ys} → Distinct xs → (∀ {a} → a ∈ˡ xs → a ∈ˡ ys) → length xs ≤ length ys
+  distinct-⊆-length {[]}     _           _   = z≤n
+  distinct-⊆-length {x ∷ xs} {ys} (x∉xs , dxs) sub =
+    ≤-trans (s≤s (distinct-⊆-length dxs sub'))
+            (≤-reflexive (sym (length-removeʰ ys (sub (here refl)))))
+    where
+      sub' : ∀ {a} → a ∈ˡ xs → a ∈ˡ removeʰ x ys
+      sub' {a} mem = ∈-removeʰ ys (sub (there mem)) (λ a≡x → x∉xs (subst (_∈ˡ xs) a≡x mem))
+```
 
 Second, the contesters are drawn from the head's $n$ participation-token
 names, so there are at most $n$ of them. The participant-set facts are
@@ -172,11 +484,55 @@ model or run where the values at the head are ledger-produced.
   safety half of the contest game; no fairness or liveness is assumed.
 ] <thm:contest-window>
 
+```agda
+module ContestBound
+  (ptKeysOf : ℍ → List ℍ)
+  (pt-mem   : ∀ {ctx cid kh} → quantityOf (headValue ctx) (cid , kh) ≡ 1ℤ → kh ∈ˡ ptKeysOf cid)
+  where
 
+  contesters-are-participants : ∀ {cid hk n cp v s η C tfin ada}
+    → Reachableᵛ (Closed cid hk n cp v s η C tfin ada)
+    → ∀ {kh} → kh ∈ˡ C → kh ∈ˡ ptKeysOf cid
+```
 
+```
+  contesters-are-participants (closeᵛ r cv) mem with CloseValid.step cv
+  ... | close = ⊥-elim (∉ˡ[] mem)
+  contesters-are-participants (contestᵛ {ctx = ctx} r cv) (here refl) =
+    pt-mem {ctx = ctx} (ContestValid.contesterIsParticipant cv)
+  contesters-are-participants (contestᵛ r cv) (there mem) = contesters-are-participants r mem
+  contesters-are-participants (incrementᵛ r iv) mem with IncrementValid.step iv
+  ... | ()
+  contesters-are-participants (decrementᵛ r dv) mem with DecrementValid.step dv
+  ... | ()
+  contesters-are-participants (partialᵛ r pv) mem with PartialFanoutValid.step pv
+  ... | ()
+```
 
+```agda
+  contesters-bounded : ∀ {cid hk n cp v s η C tfin ada}
+    → Reachableᵛ (Closed cid hk n cp v s η C tfin ada)
+    → length C ≤ length (ptKeysOf cid)
+```
 
+```
+  contesters-bounded reach =
+    distinct-⊆-length (reachable-contesters-distinct (reachableᵛ→reachable reach))
+                      (contesters-are-participants reach)
+```
 
+```agda
+  contest-window-bounded : ∀ {cid hk n cp v s η C tfin ada}
+    → length (ptKeysOf cid) ≡ n
+    → Reachableᵛ (Closed cid hk n cp v s η C tfin ada)
+    → ∃[ hi ] (tfin ≤ (hi + cp) + n * cp)
+```
+
+```
+  contest-window-bounded {cp = cp} {C = C} pn reach =
+    let (hi , le) = deadline-bounded reach
+    in hi , ≤-trans le (+-monoʳ-≤ (hi + cp) (*-monoˡ-≤ cp (subst (length C ≤_) pn (contesters-bounded reach))))
+```
 
 === The bridge to the extracted reference checker <sec:bridge-flagship>
 
@@ -192,4 +548,18 @@ identically; their statements live in `ReferenceBridge`, and the injected mocks
 and encoding postulates the bridge rests on are the drift-checked ledger of
 @sec:assumption-inventory.
 
+```agda
+close-spec⇒reference : ∀ ctx cid hk n cp v η ada s′ η′ C tfin
+  → closeValid ctx (Open cid hk n cp v η ada) (Closed cid hk n cp v s′ η′ C tfin ada) closeInitial
+  → (R.closeRefᵇ RB.mockOps (R.mkOpenᶜ v cp) (R.mkClosedᶜ v cp s′ (length C) tfin)
+        (RB.closeTagOf closeInitial)
+        (ValidityInterval.hi (Context.validity ctx)) (ValidityInterval.lo (Context.validity ctx)) ≡ true)
+    × (R.valuePreservedᵇ (adaOf (headValueIn ctx)) (adaOf (headValue ctx))
+                         (nonAdaOf (headValueIn ctx)) (nonAdaOf (headValue ctx)) ≡ true)
+    × (R.noMintRefᵇ (RB.mintEntryCount ctx) ≡ true)
+    × (R.participantSignedRefᵇ (R.mkSignerIOᶜ (RB.signerCodes ctx) (RB.ptCodes cid ctx)) ≡ true)
+```
 
+```
+close-spec⇒reference = RB.closeChainInitial→ref
+```

--- a/spec/src/Hydra/Protocol/Overview.lagda.typ
+++ b/spec/src/Hydra/Protocol/Overview.lagda.typ
@@ -1,3 +1,6 @@
+```
+module Hydra.Protocol.Overview where
+```
 
 #import "/template.typ": *
 #import "/macros.typ": *

--- a/spec/src/Hydra/Protocol/Preliminaries.lagda.typ
+++ b/spec/src/Hydra/Protocol/Preliminaries.lagda.typ
@@ -337,7 +337,7 @@ protocol's types (@sec:on-chain): `accUTxO`, `accVerify` and
 `accVerifyExclude` are abstract functions over UTxO-output sets, commitments
 and witnesses, and the security property above is captured by the specifying
 laws `accVerify-sound` (a verified membership witness attests a genuine
-subset) and `accVerify-complete` (any genuine subset has a verifying witness),
+subset) and `accVerify-self` (a set always verifies against its own commitment),
 which the fan-out safety and coverage theorems consume.
 
 The implementation uses KZG polynomial commitments~@KZG10 over the BLS12-381 elliptic curve.

--- a/spec/src/Hydra/Protocol/Preliminaries.lagda.typ
+++ b/spec/src/Hydra/Protocol/Preliminaries.lagda.typ
@@ -1,3 +1,8 @@
+```
+module Hydra.Protocol.Preliminaries where
+
+open import Hydra.Protocol.Prelude
+```
 
 #import "/template.typ": *
 #import "/macros.typ": *
@@ -62,6 +67,11 @@ and $concat$ (both law-free primitives; the definition fixes the encoding shape,
 constrain the operands). Readers new to Agda may want @sec:reading-agda, which maps the idioms
 used from here on to their Haskell counterparts.
 
+```
+infixl 6 _‖_
+_‖_ : ∀ {A B : Set} → A → B → ℍ
+a ‖ b = concat (bytes a ∷ bytes b ∷ [])
+```
 
 == Public key multi-signature scheme <sec:multisig>
 // TODO: move/merge with protocol setup and make concrete
@@ -246,6 +256,40 @@ As a first step of the machine-checked formalisation, these definitions are
 captured directly in Agda, with the value, script and key types
 kept abstract for now.
 
+```
+record Output : Set where
+  field
+    value   : Value
+    address : ℍ            -- the validator script hash ν#
+    datum   : Data
+
+record OutputRef : Set where
+  field
+    txId  : ℍ
+    index : ℕ
+
+record Input : Set where
+  field
+    outputRef : OutputRef
+    resolved  : Output      -- the spent output (value/address/datum), as in Plutus 'TxInInfo'
+    redeemer  : Data
+
+record ValidityInterval : Set where
+  field
+    lo hi : ℕ              -- lower/upper validity bounds
+    lo≤hi : lo ≤ hi        -- the spec's constraint, enforced by the type
+
+record Context : Set where
+  field
+    ownHash  : ℍ            -- hash of the validator script being run (e.g. νHead)
+    depHash  : ℍ            -- hash of the νDeposit script (so deposit inputs can be summed, cf. §5.4)
+    inputs   : List Input   -- the transaction's resolved inputs (a set at the ledger level;
+                            -- modelled as a list so per-script value can be summed, cf. Plutus)
+    outputs  : List Output  -- a list of outputs
+    mint     : Value
+    validity : ValidityInterval
+    keys     : ℙ VKey       -- verification keys that signed the transaction
+```
 
 Informally, scripts are evaluated by the ledger when it applies a transaction to
 its current state to yield a new ledger state (besides checking the transaction

--- a/spec/src/Hydra/Protocol/Prelude.agda
+++ b/spec/src/Hydra/Protocol/Prelude.agda
@@ -1,0 +1,120 @@
+-- Project-wide Agda foundation for the Hydra specification.
+--
+-- This module is pure plumbing: it is type-checked by Agda (imported by
+-- Hydra.Protocol.Main) but is NOT part of the rendered Typst document (build.sh
+-- only stages .lagda.typ files). It re-exports the libraries the spec builds on
+-- and fixes the opaque base types. Crypto primitives are postulated here as
+-- abstract interfaces.
+
+module Hydra.Protocol.Prelude where
+
+-- Finite sets (ℙ_), finite maps (_⇀_), singletons, ∅ˢ, mapˢ, … on a concrete
+-- list-based model. This backs the spec's sets of inputs/outputs and UTxO maps.
+open import abstract-set-theory.FiniteSetTheory public
+
+-- Standard-library essentials used throughout the spec's notation.
+open import Data.Nat using (ℕ; zero; suc; _≤_; _<_; _+_; _∸_; _≟_) public
+open import Data.Integer using (ℤ) public
+open import Data.Bool using (Bool; true; false; if_then_else_; _∧_) public
+open import Data.Empty using (⊥) public
+open import Data.Unit using (⊤) public
+open import Relation.Nullary using (¬_; Dec) public
+open import Relation.Nullary.Decidable using (⌊_⌋) public
+open import Relation.Binary.PropositionalEquality using (_≡_; refl) public
+open import Data.Maybe using (Maybe; just; nothing) public
+open import Data.List using (List; []; _∷_; length) public
+-- List membership, renamed to avoid clashing with the set-theory `_∈_`.
+open import Data.List.Membership.Propositional using () renaming (_∈_ to _∈ˡ_) public
+open import Data.Product using (_×_; _,_; proj₁; proj₂) public
+open import Data.Sum using (_⊎_; inj₁; inj₂) public
+
+-- Spec notation: 𝔹 = booleans, ℍ = byte strings (hashes, keys), Data = Plutus Data.
+𝔹 : Set
+𝔹 = Bool
+
+postulate
+  ℍ      : Set         -- byte strings (spec's tyBytes); hashes and keys live here
+  Data   : Set         -- Plutus Data (spec's tyData)
+  Script : Set         -- validator/minting scripts 𝒱; outputs store their hash
+  VKey   : Set         -- verification keys (elements of 𝒦)
+
+-- On-chain payload types carried in datums/redeemers. Kept abstract; the
+-- accumulator commitment η is deliberately distinct from its hash η# = hash η.
+postulate
+  AccCommitment : Set  -- accumulator commitment η (NOT its hash)
+  PartySig      : Set  -- individual party signature σⱼ (NOT the aggregate)
+  AggSig        : Set  -- aggregate multi-signature ξ (= msComb of the σⱼ)
+  AccWitness    : Set  -- accumulator membership/exclusion witness π
+
+-- Serialisation / hashing (spec §3.1). Kept abstract.
+postulate
+  concat : List ℍ → ℍ              -- ℍ* → ℍ
+  bytes  : ∀ {A : Set} → A → ℍ     -- invertible serialisation to bytes
+  hash   : ∀ {A : Set} → A → ℍ     -- collision-resistant hash; x# = hash x
+  _≟ℍ_   : (x y : ℍ) → Dec (x ≡ y) -- hashes are byte strings: decidable equality
+
+-- Aggregate multisignature verification (the §3.2 scheme's MS-Verify, instantiated
+-- at the protocol's key/message/signature types). Kept abstract (EdDSA-based).
+postulate
+  msVfy : VKey → ℍ → AggSig → Bool  -- aggregate key, message, aggregate signature
+
+-- Multi-asset values (spec's 𝖵𝖺𝗅): a finite map from (policy, token) to a
+-- signed quantity (negative quantities express burning when minting).
+CId Token : Set
+CId   = ℍ
+Token = ℍ
+
+Quantity : Set
+Quantity = ℤ
+
+Value : Set
+Value = (CId × Token) ⇀ Quantity
+
+-- Multi-asset value arithmetic. Kept abstract (the pointwise definitions over the
+-- map are not needed to state the validator's value conditions).
+postulate
+  εᵛ   : Value                  -- the empty/zero value
+  _+ᵛ_ : Value → Value → Value  -- value addition (multiset union of assets)
+  _≤ᵛ_ : Value → Value → Set    -- "contained in" (the head value is preserved/grows)
+  -- Lovelace (ada) projection: the ada quantity of a value. Additive, so it commutes with `_+ᵛ_`.
+  -- This is the homomorphism the differential test exploits to check value conservation on the
+  -- (extractable) lovelace component.
+  adaOf    : Value → ℕ
+  adaOf-+ᵛ : ∀ a b → adaOf (a +ᵛ b) ≡ adaOf a + adaOf b
+  -- Non-ada projection: the TOTAL quantity of all non-ada tokens in a value. Also an additive
+  -- homomorphism, so it commutes with `_+ᵛ_` exactly like `adaOf`. Checking conservation on BOTH
+  -- projections (`adaOf` and `nonAdaOf`) catches value movement in ada AND in native tokens, so a
+  -- non-ada token siphon is visible. (Per-token granularity
+  -- would need the full asset map; this total-quantity projection catches any siphon that changes the
+  -- non-ada total, which a real token theft does.)
+  nonAdaOf    : Value → ℕ
+  nonAdaOf-+ᵛ : ∀ a b → nonAdaOf (a +ᵛ b) ≡ nonAdaOf a + nonAdaOf b
+  -- Per-asset projection: the quantity of a single (policy, token) asset in a value. Used to express
+  -- token PRESENCE (e.g. a participation token of a given name) without unfolding the opaque value
+  -- map; kept abstract in the same trust family as `adaOf`/`nonAdaOf`.
+  quantityOf : Value → (CId × Token) → Quantity
+  -- Per-asset NON-NEGATIVE quantity (ℕ): the per-(policy,token) refinement of `nonAdaOf`. Same trust
+  -- family as `adaOf`/`nonAdaOf` (ℕ projections of the signed value map) and additive exactly like
+  -- them, so the differential can check value conservation PER ASSET (catching a selective single-token
+  -- siphon that leaves the ada + total-non-ada totals balanced), not just on the two scalar totals.
+  quantityOfᴺ    : Value → (CId × Token) → ℕ
+  quantityOfᴺ-+ᵛ : ∀ a b k → quantityOfᴺ (a +ᵛ b) k ≡ quantityOfᴺ a k + quantityOfᴺ b k
+  -- Token PLACEMENT projections (μHead init, §5.1), same trust family. `stQty v cid` is the quantity of
+  -- the policy's STATE token (fixed ST name) in `v`; `headTokenCount v cid` is the number of DISTINCT
+  -- tokens of policy `cid` in `v` (each minted with quantity 1, so the head output should carry n+1: one
+  -- ST + n PTs). Counting in the head OUTPUT (with the n+1 MINT count) pins that every minted token is
+  -- placed there. These are ℕ projections, so the reference reflects them by plain `==` (no additional axiom).
+  stQty          : Value → CId → ℕ
+  headTokenCount : Value → CId → ℕ
+  -- The algebra the value-conservation predicates reason over: (Value, _+ᵛ_, εᵛ) is a commutative
+  -- monoid and _≤ᵛ_ a partial order compatible with addition. All hold of the pointwise signed
+  -- multi-asset map. NB quantities are ℤ (negative = burning), so `a ≤ᵛ a +ᵛ b` does NOT hold in
+  -- general (only when `b` is non-negative); that monotone-growth fact is therefore NOT a law here.
+  +ᵛ-assoc     : ∀ a b c → ((a +ᵛ b) +ᵛ c) ≡ (a +ᵛ (b +ᵛ c))
+  +ᵛ-comm      : ∀ a b → (a +ᵛ b) ≡ (b +ᵛ a)
+  +ᵛ-identityˡ : ∀ a → (εᵛ +ᵛ a) ≡ a
+  +ᵛ-identityʳ : ∀ a → (a +ᵛ εᵛ) ≡ a
+  ≤ᵛ-refl      : ∀ {a} → a ≤ᵛ a
+  ≤ᵛ-trans     : ∀ {a b c} → a ≤ᵛ b → b ≤ᵛ c → a ≤ᵛ c
+  ≤ᵛ-antisym   : ∀ {a b} → a ≤ᵛ b → b ≤ᵛ a → a ≡ b
+  +ᵛ-monoˡ     : ∀ {a b} (c : Value) → a ≤ᵛ b → (a +ᵛ c) ≤ᵛ (b +ᵛ c)

--- a/spec/src/Hydra/Protocol/Prelude.agda
+++ b/spec/src/Hydra/Protocol/Prelude.agda
@@ -75,7 +75,6 @@ Value = (CId × Token) ⇀ Quantity
 postulate
   εᵛ   : Value                  -- the empty/zero value
   _+ᵛ_ : Value → Value → Value  -- value addition (multiset union of assets)
-  _≤ᵛ_ : Value → Value → Set    -- "contained in" (the head value is preserved/grows)
   -- Lovelace (ada) projection: the ada quantity of a value. Additive, so it commutes with `_+ᵛ_`.
   -- This is the homomorphism the differential test exploits to check value conservation on the
   -- (extractable) lovelace component.
@@ -106,15 +105,12 @@ postulate
   -- placed there. These are ℕ projections, so the reference reflects them by plain `==` (no additional axiom).
   stQty          : Value → CId → ℕ
   headTokenCount : Value → CId → ℕ
-  -- The algebra the value-conservation predicates reason over: (Value, _+ᵛ_, εᵛ) is a commutative
-  -- monoid and _≤ᵛ_ a partial order compatible with addition. All hold of the pointwise signed
-  -- multi-asset map. NB quantities are ℤ (negative = burning), so `a ≤ᵛ a +ᵛ b` does NOT hold in
-  -- general (only when `b` is non-negative); that monotone-growth fact is therefore NOT a law here.
+  -- The algebra the value-conservation predicates reason over. Only the laws the proofs actually
+  -- consume are assumed: every postulate here carries proof weight, so the assumption inventory
+  -- measures what is really trusted. (An earlier version also postulated a `_≤ᵛ_` partial order with
+  -- reflexivity, transitivity, antisymmetry and monotonicity, plus commutativity and a left
+  -- identity, none of which any proof used. Re-add a law when a proof needs it - all hold of the
+  -- pointwise signed multi-asset map. NB quantities are ℤ, negative meaning burning, so a
+  -- monotone-growth law `a ≤ᵛ a +ᵛ b` would NOT hold in general.)
   +ᵛ-assoc     : ∀ a b c → ((a +ᵛ b) +ᵛ c) ≡ (a +ᵛ (b +ᵛ c))
-  +ᵛ-comm      : ∀ a b → (a +ᵛ b) ≡ (b +ᵛ a)
-  +ᵛ-identityˡ : ∀ a → (εᵛ +ᵛ a) ≡ a
   +ᵛ-identityʳ : ∀ a → (a +ᵛ εᵛ) ≡ a
-  ≤ᵛ-refl      : ∀ {a} → a ≤ᵛ a
-  ≤ᵛ-trans     : ∀ {a b c} → a ≤ᵛ b → b ≤ᵛ c → a ≤ᵛ c
-  ≤ᵛ-antisym   : ∀ {a b} → a ≤ᵛ b → b ≤ᵛ a → a ≡ b
-  +ᵛ-monoˡ     : ∀ {a b} (c : Value) → a ≤ᵛ b → (a +ᵛ c) ≤ᵛ (b +ᵛ c)

--- a/spec/src/Hydra/Protocol/RefReflection.agda
+++ b/spec/src/Hydra/Protocol/RefReflection.agda
@@ -1,0 +1,63 @@
+-- Reflection of the `Reference` checker's decidable Bool operators into propositional truth: each
+-- lemma turns a propositional equality/inequality into the corresponding Bool check (`_==ᵇ_`/`_≤ᵇ_`/
+-- `_<ᵇ_`/`_&&_`, or the builtin `_==_`/`_<_`) returning `true`. This is the boilerplate the
+-- `ReferenceBridge` correspondence proofs reason with; it is factored out here so the bridge module
+-- reads as the `*Valid → ref` correspondence and nothing else. Typecheck-only (not extracted, not
+-- rendered).
+module Hydra.Protocol.RefReflection where
+
+open import Hydra.Protocol.Prelude
+open import Data.Nat using (z≤n; s≤s)
+open import Agda.Builtin.Nat using (_==_; suc) renaming (_<_ to _<ᴮ_)
+open import Data.Empty using (⊥-elim)
+open import Relation.Binary.PropositionalEquality using (cong)
+import Hydra.Protocol.Reference as R
+
+-- Soundness of the BUILTIN Nat equality `_==_` w.r.t. propositional equality. The lovelace / deadline
+-- conjuncts are checked with `_==_` (native Integer equality at extraction) rather than the structural
+-- `_==ᵇ_` (O(n) unary recursion, pathological on lovelace- / POSIXTime-scale values). The builtin only
+-- fails to reduce on NEUTRAL (variable-headed) terms; induction supplies constructor heads, so both
+-- lemmas are proved rather than postulated.
+==-refl : ∀ n → (n == n) ≡ true
+==-refl zero    = refl
+==-refl (suc n) = ==-refl n
+
+==-sound : ∀ {m n} → m ≡ n → (m == n) ≡ true
+==-sound {m} refl = ==-refl m
+
+-- Same, for the BUILTIN strict-less-than `_<ᴮ_` (used for the after-deadline conjunct).
+<ᴮ-sound : ∀ {m n} → m < n → (m <ᴮ n) ≡ true
+<ᴮ-sound {zero}  {suc n} (s≤s _) = refl
+<ᴮ-sound {suc m} {suc n} (s≤s p) = <ᴮ-sound p
+
+-- Soundness of the builtin-based `_≤ᴮ_` (= `a <ᴮ suc b`; the posted-before-deadline conjuncts). Unlike
+-- the two postulates above this is PROVED: `m ≤ n` gives `m < suc n` (= `suc m ≤ suc n`) by `s≤s`, and
+-- `m R.≤ᴮ n` unfolds definitionally to `m <ᴮ suc n`, so it is exactly `<ᴮ-sound (s≤s p)`.
+≤ᴮ-sound : ∀ {m n} → m ≤ n → (m R.≤ᴮ n) ≡ true
+≤ᴮ-sound p = <ᴮ-sound (s≤s p)
+
+-- The structural Bool checks reflect their propositional relations:
+==ᵇ-refl : ∀ n → (n R.==ᵇ n) ≡ true
+==ᵇ-refl zero    = refl
+==ᵇ-refl (suc n) = ==ᵇ-refl n
+
+≡→==ᵇ : ∀ {m n} → m ≡ n → (m R.==ᵇ n) ≡ true
+≡→==ᵇ {m} refl = ==ᵇ-refl m
+
+-- The negative direction: distinct numbers fail the structural equality. (Used by the contest bridge
+-- to reflect the conditional deadline-update's all-contested test `⌊ length C' ≟ n ⌋` into `_==ᵇ_`.)
+¬→==ᵇfalse : ∀ {m n} → ¬ (m ≡ n) → (m R.==ᵇ n) ≡ false
+¬→==ᵇfalse {zero}  {zero}  ¬e = ⊥-elim (¬e refl)
+¬→==ᵇfalse {zero}  {suc n} _  = refl
+¬→==ᵇfalse {suc m} {zero}  _  = refl
+¬→==ᵇfalse {suc m} {suc n} ¬e = ¬→==ᵇfalse {m} {n} (λ e → ¬e (cong suc e))
+
+≤→≤ᵇ : ∀ {m n} → m ≤ n → (m R.≤ᵇ n) ≡ true
+≤→≤ᵇ z≤n     = refl
+≤→≤ᵇ (s≤s p) = ≤→≤ᵇ p
+
+<→<ᵇ : ∀ {m n} → m < n → (m R.<ᵇ n) ≡ true
+<→<ᵇ p = ≤→≤ᵇ p
+
+&&-intro : ∀ {a b} → a ≡ true → b ≡ true → (a R.&& b) ≡ true
+&&-intro refl q = q

--- a/spec/src/Hydra/Protocol/Reference.agda
+++ b/spec/src/Hydra/Protocol/Reference.agda
@@ -102,7 +102,10 @@ if false then _ else b = b
 
 -- ── the decidable close checker ───────────────────────────────────────────────────────────
 -- Mirrors the decidable, unit-robust conjuncts of `closeValid` (OnChain.lagda.typ):
---   • version preserved (Open.v ≡ Closed.v) and contestation period preserved
+--   • version preserved (Open.v ≡ Closed.v), on the structural `_==ᵇ_` (versions are small), and
+--     the contestation period preserved, on the BUILTIN `_==_`: a ContestationPeriod is POSIXTime
+--     MILLISECONDS (60_000 at the one-minute default), and `_==ᵇ_` is unary `suc`/`zero` recursion,
+--     which MAlonzo compiles to that many Integer decrements per call
 --   • contesters initialised to [] (length 0)
 --   • closeInitial ⇒ Open.v ≡ 0 ∧ Closed.s ≡ 0   (the η ≡ accUTxO ∅ part is in `Ops`)
 --   • closeAny    ⇒ 0 < Closed.s
@@ -117,7 +120,7 @@ if false then _ else b = b
 closeRefᵇ : Ops → Openᶜ → Closedᶜ → CloseTagᶜ → Nat → Nat → Bool
 closeRefᵇ ops o c tag validityHi validityLo =
       (Openᶜ.versionO o ==ᵇ Closedᶜ.versionC c)
-   && (Openᶜ.cpO o ==ᵇ Closedᶜ.cpC c)
+   && (Openᶜ.cpO o == Closedᶜ.cpC c)
    && (Closedᶜ.contesterLenC c ==ᵇ zero)
    && initialOK tag
    && anyOK tag
@@ -397,8 +400,8 @@ participantSignedRefᵇ s = anySharedᵇ (SignerIOᶜ.signerCodesS s) (SignerIO�
 
 -- ══ per-asset value conservation (increment / decrement) ══════════════════════════════════════
 -- The finer companion to the `adaOf`/`nonAdaOf` TOTALS checked by `incRefᵇ`/`decRefᵇ`. Given each native
--- asset's (qIn, qDelta, qOut) — its quantity in the head input, the delta (deposit on increment /
--- decommit on decrement) and the head output — EVERY asset must conserve: qIn + qDelta == qOut. (For the
+-- asset's (qIn, qDelta, qOut), i.e. its quantity in the head input, the delta (deposit on increment
+-- / decommit on decrement) and the head output: every asset must conserve qIn + qDelta == qOut. (For the
 -- decrement direction the caller supplies (qOut, qDelta, qIn) so the same sum-check applies.) Catches a
 -- SELECTIVE single-token siphon that leaves the two scalar totals balanced. Each quantity is a
 -- (non-negative) per-asset amount (`quantityOfᴺ`); BUILTIN `_==_` per asset (amounts may be large).

--- a/spec/src/Hydra/Protocol/Reference.agda
+++ b/spec/src/Hydra/Protocol/Reference.agda
@@ -1,0 +1,499 @@
+-- Executable, decidable reference checker for the on-chain validator conditions.
+--
+-- This module is the EXTRACTABLE half of the Agda↔Haskell correspondence (Tier 2): it is
+-- self-contained over concrete `Agda.Builtin` types (Nat→Integer, Bool→Bool, List→[]) and
+-- carries `FOREIGN`/`COMPILE GHC` bindings so MAlonzo extracts it to clean Haskell, which the
+-- `hydra-tx` differential test runs as a second oracle alongside the real Plutus validator.
+--
+-- It mirrors only the DECIDABLE conjuncts of the validity bundles in `OnChain.lagda.typ`
+-- (state-machine shape, version discipline, deadline/bounds arithmetic, snapshot ordering,
+-- contester checks). The crypto/value/accumulator conjuncts are lumped into an injected `Ops`
+-- record, supplied (mocked) from Haskell. Correspondence to the abstract `closeValid` is proved
+-- (separately, typecheck-only) in `ReferenceBridge.lagda.typ`.
+--
+-- NB on imports: this module stays SELF-CONTAINED over `Agda.Builtin.{Bool,Nat,List}`. Two reasons:
+-- (1) Prelude/OnChain/abstract-set-theory do not extract at all; (2) even stdlib modules that DO
+-- extract balloon the committed `generated/MAlonzo` tree - importing `Data.Bool.Base` just for `not`
+-- pulls in `Level`/`Data.Empty`/`Data.Irrelevant`/`Data.Unit.Base` and grows the tree from 7 to 13
+-- generated files (measured). So the few small Bool/Nat helpers below are hand-rolled on purpose; the
+-- structural `_==ᵇ_`/`_≤ᵇ_`/`_<ᵇ_` additionally let their reflection lemmas be PROVED (not postulated)
+-- in `RefReflection`. The PROOF-side modules (RefReflection, ReferenceBridge) are typecheck-only and
+-- import stdlib freely - minimality only matters here, on the extracted side.
+module Hydra.Protocol.Reference where
+
+open import Agda.Builtin.Bool
+open import Agda.Builtin.Nat
+open import Agda.Builtin.List
+
+-- ── concrete boundary types, bound to clean Haskell types at extraction ───────────────────
+
+-- Close redeemer selector (the CloseType union, payload-free at this layer).
+data CloseTagᶜ : Set where
+  closeInitialᶜ closeAnyᶜ closeUnusedᶜ closeUsedᶜ : CloseTagᶜ
+{-# FOREIGN GHC data HsCloseTag = CloseInitialT | CloseAnyT | CloseUnusedT | CloseUsedT #-}
+{-# COMPILE GHC CloseTagᶜ = data HsCloseTag (CloseInitialT | CloseAnyT | CloseUnusedT | CloseUsedT) #-}
+
+-- The fields of the input (Open) datum the decidable close checks read.
+record Openᶜ : Set where
+  constructor mkOpenᶜ
+  field
+    versionO : Nat
+    cpO      : Nat
+{-# FOREIGN GHC data HsOpen = MkOpen Integer Integer #-}
+{-# COMPILE GHC Openᶜ = data HsOpen (MkOpen) #-}
+
+-- The fields of the produced (Closed) datum the decidable close checks read.
+record Closedᶜ : Set where
+  constructor mkClosedᶜ
+  field
+    versionC      : Nat
+    cpC           : Nat
+    snapshotC     : Nat
+    contesterLenC : Nat
+    tfinalC       : Nat   -- the recorded contestation deadline (POSIXTime ms)
+{-# FOREIGN GHC data HsClosed = MkClosed Integer Integer Integer Integer Integer #-}
+{-# COMPILE GHC Closedᶜ = data HsClosed (MkClosed) #-}
+
+-- Injected operations: the conjuncts the decidable layer does not model - crypto/value/
+-- accumulator. Supplied as a Haskell function (mocked = const True in the differential test).
+record Ops : Set where
+  field
+    closeCryptoOK : Openᶜ → Closedᶜ → CloseTagᶜ → Bool
+open Ops public
+
+-- ── small decidable helpers over Nat/Bool ─────────────────────────────────────────────────
+
+infixr 6 _&&_
+_&&_ : Bool → Bool → Bool
+true  && b = b
+false && _ = false
+
+infixr 5 _||_
+_||_ : Bool → Bool → Bool
+true  || _ = true
+false || b = b
+
+_==ᵇ_ : Nat → Nat → Bool
+zero    ==ᵇ zero    = true
+zero    ==ᵇ (suc _) = false
+(suc _) ==ᵇ zero    = false
+(suc m) ==ᵇ (suc n) = m ==ᵇ n
+
+_≤ᵇ_ : Nat → Nat → Bool
+zero    ≤ᵇ _       = true
+(suc _) ≤ᵇ zero    = false
+(suc m) ≤ᵇ (suc n) = m ≤ᵇ n
+
+_<ᵇ_ : Nat → Nat → Bool
+m <ᵇ n = (suc m) ≤ᵇ n
+
+-- builtin-based ≤ (native at extraction): `a ≤ b ⟺ a < b + 1`, on the BUILTIN strict `_<_` and `suc`
+-- (no extra import, no hand-rolled `not`). Used for the "posted before the deadline" conjuncts
+-- (`hi ≤ tfinal` / `hi ≤ tRecover`), whose POSIXTime-ms operands are far too large for the structural
+-- `_≤ᵇ_` (O(n) unary recursion). Its reflection lemma is PROVED (not postulated) from `<ᴮ-sound`.
+_≤ᴮ_ : Nat → Nat → Bool
+a ≤ᴮ b = a < suc b
+
+-- Boolean conditional (hand-rolled to keep the extractable module self-contained over Agda.Builtin;
+-- used for the contest conditional deadline-update rule). Extracts to a clean GHC `case`.
+if_then_else_ : {A : Set} → Bool → A → A → A
+if true  then a else _ = a
+if false then _ else b = b
+
+-- ── the decidable close checker ───────────────────────────────────────────────────────────
+-- Mirrors the decidable, unit-robust conjuncts of `closeValid` (OnChain.lagda.typ):
+--   • version preserved (Open.v ≡ Closed.v) and contestation period preserved
+--   • contesters initialised to [] (length 0)
+--   • closeInitial ⇒ Open.v ≡ 0 ∧ Closed.s ≡ 0   (the η ≡ accUTxO ∅ part is in `Ops`)
+--   • closeAny    ⇒ 0 < Closed.s
+--   • the recorded deadline is the tx upper validity bound + the contestation period: tfinal ≡
+--     validityHi + cp (`closeDeadlineOK`, Plutus `checkDeadline`/`makeContestationDeadline`). Uses the
+--     BUILTIN `_==_` (native Integer eq) and `_+_`: the values are POSIXTime ms, far too large for the
+--     structural `_==ᵇ_` (which is O(n) unary recursion). `validityHi` is the tx upper bound in ms.
+--   • the validity range is bounded so the deadline is at most one period ahead: `hi ∸ lo ≤ cp`
+--     (`validityBounded`, §5.6); uses the BUILTIN truncated `_-_` and `_≤ᴮ_` (POSIXTime ms). `validityLo`
+--     is the tx LOWER bound in ms.
+-- The remaining crypto/value conjuncts are injected (mock).
+closeRefᵇ : Ops → Openᶜ → Closedᶜ → CloseTagᶜ → Nat → Nat → Bool
+closeRefᵇ ops o c tag validityHi validityLo =
+      (Openᶜ.versionO o ==ᵇ Closedᶜ.versionC c)
+   && (Openᶜ.cpO o ==ᵇ Closedᶜ.cpC c)
+   && (Closedᶜ.contesterLenC c ==ᵇ zero)
+   && initialOK tag
+   && anyOK tag
+   && closeCryptoOK ops o c tag
+   && (Closedᶜ.tfinalC c == (validityHi + Openᶜ.cpO o))
+   && ((validityHi - validityLo) ≤ᴮ Openᶜ.cpO o)
+  where
+    initialOK : CloseTagᶜ → Bool
+    initialOK closeInitialᶜ = (Openᶜ.versionO o ==ᵇ zero) && (Closedᶜ.snapshotC c ==ᵇ zero)
+    initialOK _             = true
+    anyOK : CloseTagᶜ → Bool
+    anyOK closeAnyᶜ = zero <ᵇ Closedᶜ.snapshotC c
+    anyOK _         = true
+
+-- ══ increment / decrement ═════════════════════════════════════════════════════════════════
+-- The single decidable conjunct of `incrementValid`/`decrementValid` is the version
+-- discipline: the produced Open datum carries `suc v` (transition `Open … v … ⟶ Open … (suc v)`),
+-- which the validator enforces as `VersionNotIncremented`. Crypto/value are injected.
+
+-- The version fields of the input/produced Open datums, plus the lovelace (ada) amounts the
+-- value-conservation check needs: `adaIn`/`adaOut` are the head input/output lovelace, `adaDelta`
+-- the deposit (increment) lovelace. (The full multi-asset `Value` is not extractable; lovelace -
+-- a plain Integer - is the boundary-friendly component the differential test can supply for real.)
+record IncIOᶜ : Set where
+  constructor mkIncIOᶜ
+  field
+    versionIn  : Nat
+    versionOut : Nat
+    adaIn      : Nat
+    adaDelta   : Nat
+    adaOut     : Nat
+    nonAdaIn   : Nat   -- total NON-ada token quantity of the head input  (`nonAdaOf headValueIn`)
+    nonAdaDelta : Nat  -- total non-ada quantity of the deposit / decommit (`nonAdaOf depositsValue` / `decommitValue`)
+    nonAdaOut  : Nat   -- total non-ada token quantity of the head output (`nonAdaOf headValue`)
+    depositIdxI : Nat  -- increment only: output index of the claimed deposit out-ref (`txOutRefIdx`; must be 0)
+    numDecOutsI : Nat  -- decrement only: count of MATERIALIZED decommit outputs (`take m (tail outputs)`; must be ≥ 1)
+{-# FOREIGN GHC data HsIncIO = MkIncIO Integer Integer Integer Integer Integer Integer Integer Integer Integer Integer #-}
+{-# COMPILE GHC IncIOᶜ = data HsIncIO (MkIncIO) #-}
+
+record OpsInc : Set where
+  field incCryptoOK : IncIOᶜ → Bool
+open OpsInc public
+
+-- increment: version bumps (`VersionNotIncremented`) AND head value grows by the deposit
+-- (`mustPreserveValue`): on the lovelace component, adaIn + adaDelta ≡ adaOut. Crypto injected.
+-- The lovelace equality uses the BUILTIN `_==_` (extracts to native Integer equality): the
+-- structural `_==ᵇ_` is O(n) unary recursion, which is pathological on lovelace-scale values
+-- (millions), so it must NOT be used here. The version bump stays on `_==ᵇ_` (versions are small).
+-- The claimed-deposit first-output rule (`depositIdxI ==ᵇ 0`, §5.4): κ# binds a deposit by its
+-- transaction id, so sibling outputs of that same transaction would otherwise be interchangeable
+-- under one signature. Structural `_==ᵇ_` (the index is 0 or tiny).
+incRefᵇ : OpsInc → IncIOᶜ → Bool
+incRefᵇ ops i =
+     (IncIOᶜ.versionOut i ==ᵇ suc (IncIOᶜ.versionIn i))
+  && (IncIOᶜ.depositIdxI i ==ᵇ 0)
+  && ((IncIOᶜ.adaIn i + IncIOᶜ.adaDelta i) == IncIOᶜ.adaOut i)
+  && ((IncIOᶜ.nonAdaIn i + IncIOᶜ.nonAdaDelta i) == IncIOᶜ.nonAdaOut i)
+  && incCryptoOK ops i
+
+-- decrement: same transition shape (version bumps) AND head value SHRINKS by the decommit
+-- (`mustDecreaseValue`): on the lovelace component, adaOut + adaDelta ≡ adaIn (head output + the
+-- decommitted outputs ≡ head input). Note the equation differs from increment's (which grows): here
+-- the deposit field `adaDelta` carries the decommit lovelace and the head INPUT is the larger side.
+-- Uses the BUILTIN `_==_` (native Integer equality) on the lovelace, as in `incRefᵇ`. Crypto injected.
+-- The at-least-one-decommit-output rule (`0 <ᵇ numDecOutsI`, §5.5): counted on the outputs actually
+-- materialized (`take m (tail outputs)` truncates silently), not the redeemer's m. Increment and
+-- decrement verify the same signed message, so with no decommit outputs an increment snapshot's
+-- signature would authorize a decrement that adopts its accumulator while no deposit is spent.
+decRefᵇ : OpsInc → IncIOᶜ → Bool
+decRefᵇ ops i =
+     (IncIOᶜ.versionOut i ==ᵇ suc (IncIOᶜ.versionIn i))
+  && (0 <ᵇ IncIOᶜ.numDecOutsI i)
+  && ((IncIOᶜ.adaOut i + IncIOᶜ.adaDelta i) == IncIOᶜ.adaIn i)
+  && ((IncIOᶜ.nonAdaOut i + IncIOᶜ.nonAdaDelta i) == IncIOᶜ.nonAdaIn i)
+  && incCryptoOK ops i
+
+-- ══ contest ═══════════════════════════════════════════════════════════════════════════════
+-- Decidable conjuncts of `contestValid` (transition `Closed … v s … C … ⟶ Closed … v s' … (kh ∷ C)`):
+--   • version preserved (vIn ≡ vOut)
+--   • snapshot strictly increases (sIn < sOut), the validator's `TooOldSnapshot`
+--   • exactly one contester appended (contesterLenOut ≡ suc contesterLenIn)
+-- Crypto/value/deadline are injected.
+record ContestIOᶜ : Set where
+  constructor mkContestIOᶜ
+  field
+    versionInK      : Nat
+    versionOutK     : Nat
+    snapIn          : Nat
+    snapOut         : Nat
+    contesterLenIn  : Nat
+    contesterLenOut : Nat
+    tfinalK         : Nat   -- the (input) recorded contestation deadline (POSIXTime ms)
+    validityHiK     : Nat   -- the contest tx's upper validity bound (POSIXTime ms)
+    tfinalOutK      : Nat   -- the PRODUCED datum's recorded deadline tfinal' (POSIXTime ms)
+    numPartiesK     : Nat   -- n: the number of parties (from the head datum)
+    cpK             : Nat   -- the contestation period T (added when not all parties have contested)
+{-# FOREIGN GHC data HsContestIO = MkContestIO Integer Integer Integer Integer Integer Integer Integer Integer Integer Integer Integer #-}
+{-# COMPILE GHC ContestIOᶜ = data HsContestIO (MkContestIO) #-}
+
+record OpsContest : Set where
+  field contestCryptoOK : ContestIOᶜ → Bool
+open OpsContest public
+
+-- Decidable contest conjuncts: version preserved, snapshot strictly increases, one contester appended,
+-- posted before the deadline (`validityHi ≤ᴮ tfinal`), AND the conditional deadline-UPDATE rule (§5.7,
+-- Plutus `makeContestationDeadline`): tfinal' = tfinal if EVERY party has now contested
+-- (contesterLenOut ≡ n), else tfinal + cp. The count test uses the structural `_==ᵇ_` (small n); the
+-- deadline arithmetic/equality use the BUILTIN `_+_`/`_==_` (POSIXTime ms). Crypto/value injected.
+contestRefᵇ : OpsContest → ContestIOᶜ → Bool
+contestRefᵇ ops c =
+      (ContestIOᶜ.versionInK c ==ᵇ ContestIOᶜ.versionOutK c)
+   && (ContestIOᶜ.snapIn c <ᵇ ContestIOᶜ.snapOut c)
+   && (ContestIOᶜ.contesterLenOut c ==ᵇ suc (ContestIOᶜ.contesterLenIn c))
+   && (ContestIOᶜ.validityHiK c ≤ᴮ ContestIOᶜ.tfinalK c)
+   && (ContestIOᶜ.tfinalOutK c ==
+        (if (ContestIOᶜ.contesterLenOut c ==ᵇ ContestIOᶜ.numPartiesK c)
+         then ContestIOᶜ.tfinalK c
+         else (ContestIOᶜ.tfinalK c + ContestIOᶜ.cpK c)))
+   && contestCryptoOK ops c
+
+-- ══ fanout / finalPartialFanout ═══════════════════════════════════════════════════════════
+-- The decidable conjuncts of `fanoutValid`/`finalPartialFanoutValid`:
+--   • all `n+1` head tokens burned (`burnAllTokensOK`: `burnedCount == n+1`, the mirror of the init
+--     mint count) - BUILTIN `_==_` (a mutation could inject a large burn quantity);
+--   • posted strictly AFTER the deadline (`tfinal < lo`, the mirror of the recover after-deadline) -
+--     BUILTIN `_<_` (POSIXTime ms). Accumulator membership / value conservation are injected.
+-- NB no `0 < m` conjunct: the FULL fanout permits m = 0 (finalising an empty head), so the reference
+-- must not reject it (it would contradict the relaxed νHead `headIsFinalizedWith`). The `numOutputsF`
+-- field is supplied for the differential but not gated. (Partial fanout's `0 < m` is enforced
+-- by its own validator guard, not modelled at this shared checker.)
+record Fanoutᶜ : Set where
+  constructor mkFanoutᶜ
+  field
+    numOutputsF  : Nat   -- m: number of distributed outputs
+    burnedCountF : Nat   -- total head-policy tokens burned (negated mint quantity)
+    numPartiesF  : Nat   -- n (from the head datum)
+    tfinalF      : Nat   -- the recorded contestation deadline (POSIXTime ms)
+    validityLoF  : Nat   -- the fanout tx's lower validity bound (POSIXTime ms)
+{-# FOREIGN GHC data HsFanout = MkFanout Integer Integer Integer Integer Integer #-}
+{-# COMPILE GHC Fanoutᶜ = data HsFanout (MkFanout) #-}
+
+record OpsFanout : Set where
+  field fanoutCryptoOK : Fanoutᶜ → Bool
+open OpsFanout public
+
+fanoutRefᵇ : OpsFanout → Fanoutᶜ → Bool
+fanoutRefᵇ ops f =
+     (Fanoutᶜ.burnedCountF f == suc (Fanoutᶜ.numPartiesF f))
+  && (Fanoutᶜ.tfinalF f < Fanoutᶜ.validityLoF f)
+  && fanoutCryptoOK ops f
+
+-- ══ deposit recover (νDeposit, Recover redeemer) ══════════════════════════════════════════════
+-- The decidable conjunct of `recoverValid` (deposit.ak's Recover arm, §5.3.2): the recover tx is
+-- posted strictly AFTER the recover deadline - txValidityMin > tRecover, i.e. `tRecover < lo`. Uses
+-- the BUILTIN `_<_` (native Integer `<` at extraction): the deadline is a POSIXTime in milliseconds,
+-- far too large for the structural `_<ᵇ_` (O(n) unary recursion), exactly as on the close deadline.
+-- The recovered-outputs hash equality (deposit.ak `recover_outputs`, the serialisation-hash match) is
+-- crypto/serialisation and is injected (mock), as the close/inc crypto conjuncts are.
+record RecoverIOᶜ : Set where
+  constructor mkRecoverIOᶜ
+  field
+    tRecoverR     : Nat   -- the deposit datum's recover deadline (POSIXTime ms)
+    validityLoR   : Nat   -- the recover tx's lower validity bound (POSIXTime ms)
+    depositCountR : Nat   -- number of νDeposit-governed inputs (deposit.ak `single_deposit`; must be 1)
+{-# FOREIGN GHC data HsRecoverIO = MkRecoverIO Integer Integer Integer #-}
+{-# COMPILE GHC RecoverIOᶜ = data HsRecoverIO (MkRecoverIO) #-}
+
+record OpsRecover : Set where
+  field recoverHashOK : RecoverIOᶜ → Bool
+open OpsRecover public
+
+-- The single-deposit rule (`depositCountR ==ᵇ 1`, §5.3): the recovered outputs are the tx's first m
+-- outputs, shared by every deposit input, so two deposits whose C hashes alike would both accept one
+-- output set, freeing the second's value. Structural `_==ᵇ_` (the count is tiny).
+recoverRefᵇ : OpsRecover → RecoverIOᶜ → Bool
+recoverRefᵇ ops r =
+     (RecoverIOᶜ.tRecoverR r < RecoverIOᶜ.validityLoR r)
+  && (RecoverIOᶜ.depositCountR r ==ᵇ 1)
+  && recoverHashOK ops r
+
+-- ══ init (μHead minting policy: token COUNT + PLACEMENT) ══════════════════════════════════════
+-- The decidable conjuncts of `initValid` / the μHead policy (`HeadTokens.validateTokensMinting`):
+--   • the tx MINTS exactly `n + 1` tokens of the head policy (one ST + one PT per party,
+--     `checkNumberOfTokens`: `mintedTokenCount == nParties + 1`) - `mintedCountM`;
+--   • the n+1 tokens are PLACED in the head output: the ST is present (`stQtyM == 1`) AND the head
+--     output carries exactly n+1 head-policy tokens (`headTokenCountM == n+1`). Mint count + placed
+--     count together pin that every minted token lands in the head output (the value-map API the spec
+--     abstracts over). All BUILTIN `_==_` (counts are small but a mutation could inject a
+--     large quantity). The remaining μHead checks - seed-input spent and the datum `headId`/`seed`
+--     binding - stay injected (mock); a hand-reviewed / type-encoded boundary. (Naming the individual
+--     PTs is out of reach: the head datum abstracts the per-party keys into `hk`/`n`.)
+record MintIOᶜ : Set where
+  constructor mkMintIOᶜ
+  field
+    numPartiesM     : Nat   -- n: the number of parties (from the head datum)
+    mintedCountM    : Nat   -- the head policy's total minted token quantity
+    stQtyM          : Nat   -- quantity of the ST in the head output (should be 1)
+    headTokenCountM : Nat   -- number of head-policy tokens in the head output (should be n+1)
+{-# FOREIGN GHC data HsMintIO = MkMintIO Integer Integer Integer Integer #-}
+{-# COMPILE GHC MintIOᶜ = data HsMintIO (MkMintIO) #-}
+
+record OpsInit : Set where
+  field initPlacementOK : MintIOᶜ → Bool
+open OpsInit public
+
+initRefᵇ : OpsInit → MintIOᶜ → Bool
+initRefᵇ ops m =
+     (MintIOᶜ.mintedCountM m == suc (MintIOᶜ.numPartiesM m))
+  && (MintIOᶜ.stQtyM m == 1)
+  && (MintIOᶜ.headTokenCountM m == suc (MintIOᶜ.numPartiesM m))
+  && initPlacementOK ops m
+
+-- ══ deposit claim (νDeposit, Claim redeemer) ══════════════════════════════════════════════════
+-- The decidable conjuncts of the deposit.ak Claim arm (§5.2): the increment tx collecting the
+-- deposit is posted BEFORE the recover deadline - txValidityMax ≤ tRecover, i.e.
+-- `validityHi ≤ᴮ tRecover` (BUILTIN-based `_≤ᴮ_`, POSIXTime ms); the own-head binding
+-- (`depositClaimedBy`, half of deposit.ak `expect_increment_redeemer`): the deposit datum's head id
+-- equals the head being spent - head ids are hashes, represented as the Integers `depositCidC` /
+-- `headCidC` (a deterministic encoding supplied by the test) and compared with the BUILTIN `_==_`
+-- (native Integer eq; the encodings may be large); AND the Increment-redeemer coupling (the other
+-- half): the redeemer SPENDING the located head input has constructor index 0, the index pinned for
+-- `Increment` by HeadState.hs's `makeIsDataIndexed` (deposit.ak `is_head_increment`). The boundary
+-- carries that OBSERVED index (`headRedeemerIdxC`), read from the tx's redeemer map exactly as
+-- deposit.ak reads it. Nothing in the Claim arm stays injected: locating the head input by its ST is
+-- the projection's job (deposit.ak's `list.find`), mirrored on the Haskell side.
+record ClaimIOᶜ : Set where
+  constructor mkClaimIOᶜ
+  field
+    tRecoverC        : Nat   -- the deposit datum's recover deadline (POSIXTime ms)
+    validityHiC      : Nat   -- the claim (increment) tx's upper validity bound (POSIXTime ms)
+    depositCidC      : Nat   -- the deposit datum's head id, encoded as an Integer
+    headCidC         : Nat   -- the spent head's id, encoded as an Integer
+    headRedeemerIdxC : Nat   -- constructor index of the redeemer spending the head input
+    claimedRefCodeC  : Nat   -- out-ref the head's Increment redeemer claims, encoded as an Integer
+    ownRefCodeC      : Nat   -- out-ref of the deposit input being validated, encoded as an Integer
+{-# FOREIGN GHC data HsClaimIO = MkClaimIO Integer Integer Integer Integer Integer Integer Integer #-}
+{-# COMPILE GHC ClaimIOᶜ = data HsClaimIO (MkClaimIO) #-}
+
+-- The claims-this-deposit coupling (`claimedRefCodeC == ownRefCodeC`, §5.2, the second half of
+-- deposit.ak `expect_increment_redeemer`): the head input's Increment redeemer must claim the very
+-- deposit being spent, else a legitimate increment could carry additional deposit inputs whose
+-- value enters the head without any snapshot crediting it. Encodings may be large: BUILTIN `_==_`.
+claimRefᵇ : ClaimIOᶜ → Bool
+claimRefᵇ c =
+     (ClaimIOᶜ.validityHiC c ≤ᴮ ClaimIOᶜ.tRecoverC c)
+  && (ClaimIOᶜ.depositCidC c == ClaimIOᶜ.headCidC c)
+  && (ClaimIOᶜ.headRedeemerIdxC c == 0)
+  && (ClaimIOᶜ.claimedRefCodeC c == ClaimIOᶜ.ownRefCodeC c)
+
+-- ══ participant signature (shared: close / contest / increment / decrement) ════════════════════
+-- The §5.4–5.7 `mustBeSignedByParticipant` check, a fully-extractable conjunct of its own
+-- (no injected Ops): SOME transaction signer holds a participation token in
+-- the head value. Both sides are Integer-encoded key-hashes - `signerCodesS` the tx's signing key-hashes
+-- (txInfoSignatories), `ptCodesS` the names of the participation tokens carried by the head value (a PT's
+-- token name IS a participant's key-hash) - and the check is that the two lists OVERLAP. The differential
+-- supplies both lists from the real tx with the SAME hash→Integer encoding, so a non-participant signer
+-- (the validator's `SignerIsNotAParticipant`) makes the lists disjoint and the reference reject. Uses the
+-- BUILTIN `_==_` (key-hash encodings are large).
+elemᵇ : Nat → List Nat → Bool
+elemᵇ _ []       = false
+elemᵇ x (y ∷ ys) = (x == y) || elemᵇ x ys
+
+anySharedᵇ : List Nat → List Nat → Bool
+anySharedᵇ []       _  = false
+anySharedᵇ (x ∷ xs) ys = elemᵇ x ys || anySharedᵇ xs ys
+
+record SignerIOᶜ : Set where
+  constructor mkSignerIOᶜ
+  field
+    signerCodesS : List Nat   -- Integer-encoded key-hashes of the tx signers (txInfoSignatories)
+    ptCodesS     : List Nat   -- Integer-encoded names of the participation tokens in the head value
+{-# FOREIGN GHC data HsSignerIO = MkSignerIO [Integer] [Integer] #-}
+{-# COMPILE GHC SignerIOᶜ = data HsSignerIO (MkSignerIO) #-}
+
+participantSignedRefᵇ : SignerIOᶜ → Bool
+participantSignedRefᵇ s = anySharedᵇ (SignerIOᶜ.signerCodesS s) (SignerIOᶜ.ptCodesS s)
+
+-- ══ per-asset value conservation (increment / decrement) ══════════════════════════════════════
+-- The finer companion to the `adaOf`/`nonAdaOf` TOTALS checked by `incRefᵇ`/`decRefᵇ`. Given each native
+-- asset's (qIn, qDelta, qOut) — its quantity in the head input, the delta (deposit on increment /
+-- decommit on decrement) and the head output — EVERY asset must conserve: qIn + qDelta == qOut. (For the
+-- decrement direction the caller supplies (qOut, qDelta, qIn) so the same sum-check applies.) Catches a
+-- SELECTIVE single-token siphon that leaves the two scalar totals balanced. Each quantity is a
+-- (non-negative) per-asset amount (`quantityOfᴺ`); BUILTIN `_==_` per asset (amounts may be large).
+-- Defined last so MAlonzo appends fresh names without drifting the earlier mangled names in the shim.
+record AssetIOᶜ : Set where
+  constructor mkAssetIOᶜ
+  field
+    qInA    : Nat
+    qDeltaA : Nat
+    qOutA   : Nat
+{-# FOREIGN GHC data HsAssetIO = MkAssetIO Integer Integer Integer #-}
+{-# COMPILE GHC AssetIOᶜ = data HsAssetIO (MkAssetIO) #-}
+
+perAssetConservedᵇ : List AssetIOᶜ → Bool
+perAssetConservedᵇ []       = true
+perAssetConservedᵇ (a ∷ as) =
+  ((AssetIOᶜ.qInA a + AssetIOᶜ.qDeltaA a) == AssetIOᶜ.qOutA a) && perAssetConservedᵇ as
+
+-- ══ no mint / no burn (shared: close / contest / increment / decrement) ════════════════════════
+-- The `mustNotMintOrBurn` conjunct (Util.hs, a premise of checkClose/checkContest/checkIncrement/
+-- checkDecrement): the tx mints AND burns nothing (`isZero minted && isZero burned`). The differential
+-- supplies the number of NON-ZERO asset entries in `txInfoMint`; that value is empty exactly when the
+-- count is 0. Structural `_==ᵇ_` (an entry count is small). No injected Ops: a minting/burning mutation
+-- makes the count positive and the reference rejects. Appended last so MAlonzo does not drift earlier names.
+noMintRefᵇ : Nat → Bool
+noMintRefᵇ k = k ==ᵇ zero
+
+-- ══ referenced output is spent (increment claimed deposit / init seed) ══════════════════════════
+-- `claimedDepositIsSpent` (checkIncrement) / `seedInputIsConsumed` (μHead validateTokensMinting): a
+-- referenced out-ref is among the tx's spent inputs. The differential supplies the referenced out-ref and
+-- the list of the tx's input out-refs, both under ONE deterministic Integer encoding, and checks
+-- membership (reusing `elemᵇ`, whose `_==_` is the BUILTIN; the encodings may be large). No injected Ops:
+-- spending a different deposit / dropping the seed makes the ref absent and the reference rejects.
+refSpentᵇ : Nat → List Nat → Bool
+refSpentᵇ r rs = elemᵇ r rs
+
+-- ══ non-final partial fanout (FanoutProgress → FanoutProgress) ══════════════════════════════════
+-- The decidable conjuncts of `partialFanoutValid` (νHead `checkPartialFanout`, the intermediate batch):
+--   • at least one output is distributed (`mustHaveOutputs`: 0 < m, §5.8 no zero-output batch) -
+--     structural `_<ᵇ_` (m is small); UNLIKE the FULL fanout (which permits m = 0 to finalise an empty
+--     head), the partial path forbids m = 0, so this IS gated here;
+--   • posted strictly AFTER the deadline (`afterContestationDeadline`: tfinal < lo) - BUILTIN `_<_`
+--     (POSIXTime ms), the same after-deadline check as the recover / full fanout.
+-- The anti-theft `mustConserveValue` (value) and `checkCRSAndMembership` / `mustNotBeLastBatch`
+-- (accumulator) conjuncts are crypto/abstract and not modelled; the `mustNotMintOrBurn` conjunct is the
+-- shared `noMintRefᵇ` (the differential ANDs it). No injected Ops.
+partialFanoutRefᵇ : Nat → Nat → Nat → Bool
+partialFanoutRefᵇ m tfinal lo = (zero <ᵇ m) && (tfinal < lo)
+
+-- ══ value preservation (close / contest mustPreserveHeadValue) ══════════════════════════════════
+-- The decidable conjunct of closeValid/contestValid `valuePreserved` (headValueIn ≡ headValue, the
+-- validator's `mustPreserveHeadValue` EXACT `==`): the ada AND the non-ada totals are unchanged in→out.
+-- BUILTIN `_==_` (ada/token totals can be lovelace-scale, far too large for the structural `_==ᵇ_`).
+-- Bridged from the `valuePreserved` field via `cong adaOf`/`cong nonAdaOf` + `==-sound` (no injectivity,
+-- no new postulate). Appended last so MAlonzo extends with a fresh mangled name without drifting the others.
+valuePreservedᵇ : Nat → Nat → Nat → Nat → Bool
+valuePreservedᵇ adaIn adaOut nonAdaIn nonAdaOut = (adaIn == adaOut) && (nonAdaIn == nonAdaOut)
+
+-- ══ contest parameter preservation (contest mustNotChangeParameters: headId + contestationPeriod) ══
+-- The decidable scalar half of the contest `mustNotChangeParameters`: the produced datum keeps the same
+-- head id and contestation period (headId' == headId, cp' == cp). BUILTIN `_==_` (cp is a POSIXTime-scale
+-- period; the head id is a hash encoded as an Integer). Bridged from the contest transition, whose produced
+-- `Closed` reuses the same `cid`/`cp` binders, so the bridge is `refl`-based (`cong cidToNat` + `==-sound`,
+-- no injectivity, no new postulate beyond the existing `cidToNat` encoding). The `parties` half stays a
+-- documented boundary: the spec abstracts the party LIST into a count `n`, so a same-count party swap is
+-- below this model's granularity. Appended last to avoid MAlonzo name drift.
+contestParamsᵇ : Nat → Nat → Nat → Nat → Bool
+contestParamsᵇ cidIn cidOut cpIn cpOut = (cidIn == cidOut) && (cpIn == cpOut)
+
+-- ══ init datum head-id binding (μHead checkDatum: headId == currency) ══════════════════════════════
+-- The decidable half of the μHead `checkDatum`: the head output datum declares its own policy as its head
+-- id (datumHeadId == currency). BUILTIN `_==_` on the head-id Integer encodings. In the spec the produced
+-- `Open` datum's head id and the policy currency are the SAME `cid` (= hash(μHead seed)), so the bridge is
+-- `refl`-discharged via the existing `cidToNat` encoding (no injectivity, no new postulate). The other
+-- `checkDatum` half (`seed == seedInput`) is NOT modelled (the Agda `Open` has no `headSeed` field), and the
+-- `cid = hash(μHead seed)` binding stays the injected (hash) boundary. Appended last to avoid name drift.
+initHeadIdᵇ : Nat → Nat → Bool
+initHeadIdᵇ datumHeadId currency = datumHeadId == currency
+
+-- ══ μHead token burning (Burn redeemer, §5.1) ═══════════════════════════════════════════════════
+-- The μHead policy's Burn arm (`validateTokensBurning`): the mint field must carry head-policy
+-- entries and ALL of them must be negative (burn-only). Modelled as the counts of the positive and
+-- negative head-policy mint entries: accept iff no positive entry exists AND at least one negative
+-- one does (the real policy rejects a mint map without head-policy entries, mirrored by `0 < burned`;
+-- zero-quantity entries are not representable in canonical ledger values, a documented domain note).
+-- Fully extractable (no injected Ops). WHICH burns are legitimate is νHead's concern (the fan-out
+-- family's n+1 burn count); μHead only guarantees a burn-only mint field. BUILTIN `_==_`/`_<_`.
+-- Appended last to avoid MAlonzo name drift.
+record BurnIOᶜ : Set where
+  constructor mkBurnIOᶜ
+  field
+    mintedCountB : Nat   -- head-policy mint entries with positive quantity
+    burnedCountB : Nat   -- head-policy mint entries with negative quantity (counted positively)
+{-# FOREIGN GHC data HsBurnIO = MkBurnIO Integer Integer #-}
+{-# COMPILE GHC BurnIOᶜ = data HsBurnIO (MkBurnIO) #-}
+
+burnRefᵇ : BurnIOᶜ → Bool
+burnRefᵇ b = (BurnIOᶜ.mintedCountB b == 0) && (0 < BurnIOᶜ.burnedCountB b)

--- a/spec/src/Hydra/Protocol/ReferenceBridge.agda
+++ b/spec/src/Hydra/Protocol/ReferenceBridge.agda
@@ -63,7 +63,7 @@ closeValid→ref : ∀ ctx cid hk n cp v η ada s′ η′ C tfin ct
 closeValid→ref ctx cid hk n cp v η ada s′ η′ C tfin closeInitial
   record { step = close ; deadlineOK = dl ; initialOK = (v≡0 , s≡0 , _) ; validityBounded = vb } =
     &&-intro (==ᵇ-refl v)
-   (&&-intro (==ᵇ-refl cp)
+   (&&-intro (==-refl cp)
    (&&-intro refl
    (&&-intro (&&-intro (≡→==ᵇ v≡0) (≡→==ᵇ s≡0))
    (&&-intro refl
@@ -72,7 +72,7 @@ closeValid→ref ctx cid hk n cp v η ada s′ η′ C tfin closeInitial
 closeValid→ref ctx cid hk n cp v η ada s′ η′ C tfin (closeAny ξ η# δ# κ#)
   record { step = close ; deadlineOK = dl ; anyOK = anyOK ; validityBounded = vb } =
     &&-intro (==ᵇ-refl v)
-   (&&-intro (==ᵇ-refl cp)
+   (&&-intro (==-refl cp)
    (&&-intro refl
    (&&-intro refl
    (&&-intro (<→<ᵇ anyOK)
@@ -81,7 +81,7 @@ closeValid→ref ctx cid hk n cp v η ada s′ η′ C tfin (closeAny ξ η# δ#
 closeValid→ref ctx cid hk n cp v η ada s′ η′ C tfin (closeUnused ξ η# δ# κ#)
   record { step = close ; deadlineOK = dl ; validityBounded = vb } =
     &&-intro (==ᵇ-refl v)
-   (&&-intro (==ᵇ-refl cp)
+   (&&-intro (==-refl cp)
    (&&-intro refl
    (&&-intro refl
    (&&-intro refl
@@ -90,7 +90,7 @@ closeValid→ref ctx cid hk n cp v η ada s′ η′ C tfin (closeUnused ξ η# 
 closeValid→ref ctx cid hk n cp v η ada s′ η′ C tfin (closeUsed ξ η# δ# κ#)
   record { step = close ; deadlineOK = dl ; validityBounded = vb } =
     &&-intro (==ᵇ-refl v)
-   (&&-intro (==ᵇ-refl cp)
+   (&&-intro (==-refl cp)
    (&&-intro refl
    (&&-intro refl
    (&&-intro refl
@@ -500,7 +500,7 @@ initSeedSpent→ref ctx seed cid hk n cp v η ada b = refSpent→ref ctx seed (I
 -- participant-signature checker at once. The other validators compose identically
 -- (each `*Valid` discharges its core `*Refᵇ` plus the pulled-out conjuncts via the lemmas above). This is
 -- the `spec-bundle ⇒ extracted-reference` half; it is joined to the `extracted-reference === real-validator`
--- differential (Hydra.Tx.Contract.HeadValidatorAgreement) at the SHARED extracted Reference module — the
+-- differential (Hydra.Tx.Contract.HeadValidatorAgreement) at the SHARED extracted Reference module: the
 -- single ANDed end-to-end property there checks that join across every validator family.
 closeChainInitial→ref : ∀ ctx cid hk n cp v η ada s′ η′ C tfin
   → (b : closeValid ctx (Open cid hk n cp v η ada) (Closed cid hk n cp v s′ η′ C tfin ada) closeInitial)

--- a/spec/src/Hydra/Protocol/ReferenceBridge.agda
+++ b/spec/src/Hydra/Protocol/ReferenceBridge.agda
@@ -1,0 +1,525 @@
+-- Bridge: the extractable decidable checker `Reference.closeRefᵇ` faithfully reflects the
+-- (unit-robust) DECIDABLE conjuncts of the abstract `closeValid` (OnChain.lagda.typ). Typecheck-
+-- only - this module is NOT extracted (it imports OnChain / set-theory). Imported by Main so the
+-- spec build (`spec/build.sh`) verifies the correspondence.
+--
+-- Direction proved (completeness): `closeValid ⇒ closeRefᵇ ≡ true`. The reference therefore
+-- accepts every spec-valid close (a reference REJECT implies the spec rejects), making the reference
+-- a faithful proxy for the spec. The hydra-tx `HeadValidatorAgreement` test then checks
+-- `reference === validator` on the SAME inputs, so spec-valid ⇒ reference-accepts ⇒ validator-accepts.
+--
+-- The deadline (`tfinal = hi + cp`) and bounded-validity (`hi - lo <= cp`) conjuncts ARE part of
+-- `closeRefᵇ` and are discharged from the bundle's `deadlineOK`/`validityBounded` fields; the
+-- crypto/accumulator conjuncts stay in the injected (mock) `Ops`.
+--
+-- One conjunct is NOT a closed proof: `participantSigned→ref` rests on a POSTULATED extraction-
+-- faithfulness boundary (`signerCodes`/`ptCodes` encode the tx's signer key-hashes / head PT names, and
+-- a spec-valid tx is ASSUMED to make those lists overlap). It is honest about this in-line; it is the
+-- one bridge clause whose correspondence is assumed rather than derived (same trust family as the
+-- `cidToNat`/`refCodeOf` encoding postulates). Every other `*Valid → ref` clause is a genuine proof.
+module Hydra.Protocol.ReferenceBridge where
+
+open import Hydra.Protocol.Prelude
+open import Hydra.Protocol.Preliminaries
+open import Hydra.Protocol.OnChain
+import Hydra.Protocol.Reference as R
+-- The Bool-check ⇄ proposition reflection lemmas (==ᵇ-refl, ≡→==ᵇ, ≤→≤ᵇ, <→<ᵇ, &&-intro) and the
+-- builtin-soundness lemmas (==-sound, <ᴮ-sound, both PROVED by induction, not postulated) live in
+-- `RefReflection`; this module is just the `*Valid → ref` correspondence.
+open import Hydra.Protocol.RefReflection
+open import Relation.Binary.PropositionalEquality using (trans; sym; cong)
+open import Relation.Nullary using (yes; no)
+open import Data.List using (map; take; drop)
+open import Data.Product using (_,_; _×_; ∃-syntax)
+open import Data.List.Relation.Unary.Any using (here; there)
+open import Agda.Builtin.Bool using (true; false)
+open import Agda.Builtin.Nat using (_==_)
+
+-- abstraction map: abstract close-redeemer tag → concrete Reference tag.
+-- (The Haskell `HeadValidatorAgreement` test passes the matching `R.CloseTagᶜ` constructor directly.)
+closeTagOf : CloseType → R.CloseTagᶜ
+closeTagOf closeInitial     = R.closeInitialᶜ
+closeTagOf (closeAny _ _ _ _)    = R.closeAnyᶜ
+closeTagOf (closeUnused _ _ _ _) = R.closeUnusedᶜ
+closeTagOf (closeUsed _ _ _ _)   = R.closeUsedᶜ
+
+-- The injected boundary, mocked to `true` (the differential test supplies the same).
+mockOps : R.Ops
+mockOps = record { closeCryptoOK = λ _ _ _ → true }
+
+-- ── the bridge ──────────────────────────────────────────────────────────────────────────────
+-- For any spec-valid close (the produced Closed datum shares the preserved parameters, as the
+-- `close` rule guarantees), the reference checker accepts.
+-- `validityHi := ValidityInterval.hi (Context.validity ctx)` and the Closed datum's deadline `tfin`
+-- feed the reference's deadline conjunct `tfinalC ≡ validityHi + cp`, discharged from the bundle's
+-- `closeDeadlineOK` (the 2nd conjunct `dl`) via `==-sound`. The conjunct holds in all four close cases.
+closeValid→ref : ∀ ctx cid hk n cp v η ada s′ η′ C tfin ct
+  → closeValid ctx (Open cid hk n cp v η ada) (Closed cid hk n cp v s′ η′ C tfin ada) ct
+  → R.closeRefᵇ mockOps (R.mkOpenᶜ v cp) (R.mkClosedᶜ v cp s′ (length C) tfin) (closeTagOf ct)
+       (ValidityInterval.hi (Context.validity ctx)) (ValidityInterval.lo (Context.validity ctx)) ≡ true
+-- Record-pattern destructuring: `step = close` matches the close rule's constructor, which refines
+-- the produced contesters `C` to `[]` (the rule's output) - so the reference's `length C ==ᵇ zero`
+-- discharges by `refl`. The named fields (`deadlineOK`, `initialOK`, `anyOK`) give field access.
+closeValid→ref ctx cid hk n cp v η ada s′ η′ C tfin closeInitial
+  record { step = close ; deadlineOK = dl ; initialOK = (v≡0 , s≡0 , _) ; validityBounded = vb } =
+    &&-intro (==ᵇ-refl v)
+   (&&-intro (==ᵇ-refl cp)
+   (&&-intro refl
+   (&&-intro (&&-intro (≡→==ᵇ v≡0) (≡→==ᵇ s≡0))
+   (&&-intro refl
+   (&&-intro refl
+   (&&-intro (==-sound dl) (≤ᴮ-sound vb)))))))
+closeValid→ref ctx cid hk n cp v η ada s′ η′ C tfin (closeAny ξ η# δ# κ#)
+  record { step = close ; deadlineOK = dl ; anyOK = anyOK ; validityBounded = vb } =
+    &&-intro (==ᵇ-refl v)
+   (&&-intro (==ᵇ-refl cp)
+   (&&-intro refl
+   (&&-intro refl
+   (&&-intro (<→<ᵇ anyOK)
+   (&&-intro refl
+   (&&-intro (==-sound dl) (≤ᴮ-sound vb)))))))
+closeValid→ref ctx cid hk n cp v η ada s′ η′ C tfin (closeUnused ξ η# δ# κ#)
+  record { step = close ; deadlineOK = dl ; validityBounded = vb } =
+    &&-intro (==ᵇ-refl v)
+   (&&-intro (==ᵇ-refl cp)
+   (&&-intro refl
+   (&&-intro refl
+   (&&-intro refl
+   (&&-intro refl
+   (&&-intro (==-sound dl) (≤ᴮ-sound vb)))))))
+closeValid→ref ctx cid hk n cp v η ada s′ η′ C tfin (closeUsed ξ η# δ# κ#)
+  record { step = close ; deadlineOK = dl ; validityBounded = vb } =
+    &&-intro (==ᵇ-refl v)
+   (&&-intro (==ᵇ-refl cp)
+   (&&-intro refl
+   (&&-intro refl
+   (&&-intro refl
+   (&&-intro refl
+   (&&-intro (==-sound dl) (≤ᴮ-sound vb)))))))
+
+-- ── increment / decrement ───────────────────────────────────────────────────────────────────
+-- The produced Open datum carries `suc v`; the reference's `versionOut ==ᵇ suc versionIn` holds.
+mockOpsInc : R.OpsInc
+mockOpsInc = record { incCryptoOK = λ _ → true }
+
+-- Increment: version bumps AND the head value grows by ALL deposits. The reference's lovelace check
+-- `adaIn + adaDelta ≡ adaOut` follows from `incrementValueOK` (headValueIn +ᵛ depositsValue ≡ headValue)
+-- via the `adaOf` additivity law - so a reference value-reject implies the spec rejects. `adaDelta` is
+-- the lovelace of ALL spent deposits (`depositsValue`, Plutus `totalNonHeadInputValue`), which is what
+-- lets the differential catch the multi-deposit siphon.
+-- BOTH projections (`adaOf` and `nonAdaOf`) are checked: each is an additive homomorphism, so each
+-- conjunct follows from the SAME value equation `headValueIn +ᵛ depositsValue ≡ headValue` by the
+-- respective additivity law. Checking the non-ada total catches a native-token siphon the lovelace
+-- check alone misses.
+incrementValid→ref : ∀ ctx cid hk n cp v η ada η′ ξ s ref δ#
+  → incrementValid ctx (Open cid hk n cp v η ada) (Open cid hk n cp (suc v) η′ ada) ξ s ref δ#
+  → R.incRefᵇ mockOpsInc
+       (R.mkIncIOᶜ v (suc v) (adaOf (headValueIn ctx)) (adaOf (depositsValue ctx)) (adaOf (headValue ctx))
+          (nonAdaOf (headValueIn ctx)) (nonAdaOf (depositsValue ctx)) (nonAdaOf (headValue ctx))
+          (OutputRef.index ref) 0)
+     ≡ true
+incrementValid→ref ctx cid hk n cp v η ada η′ ξ s ref δ# b =
+  &&-intro (==ᵇ-refl (suc v))
+ (&&-intro (≡→==ᵇ (IncrementValid.depositFirstOutput b))
+ (&&-intro (==-sound (trans (sym (adaOf-+ᵛ (headValueIn ctx) (depositsValue ctx)))
+                            (cong adaOf (IncrementValid.valueOK b))))
+ (&&-intro (==-sound (trans (sym (nonAdaOf-+ᵛ (headValueIn ctx) (depositsValue ctx)))
+                            (cong nonAdaOf (IncrementValid.valueOK b))))
+           refl)))
+
+-- PER-ASSET refinement of the increment value check: for EVERY native asset `k` (the caller supplies the
+-- list), `quantityOfᴺ headValueIn k + quantityOfᴺ depositsValue k ≡ quantityOfᴺ headValue k`, each derived
+-- from the SAME `incrementValueOK` value equation by the per-asset additivity law `quantityOfᴺ-+ᵛ` (exactly
+-- as the ada/non-ada totals are, but per asset). So a reference per-asset reject ⇒ the spec rejects ⇒ the
+-- validator rejects. This catches a selective single-token siphon the two scalar totals miss. Inducts on
+-- the asset list; nil is `perAssetConservedᵇ [] = true`.
+incPerAsset→ref : ∀ ctx cid hk n cp v η ada η′ ξ s ref δ# (assets : List (CId × Token))
+  → incrementValid ctx (Open cid hk n cp v η ada) (Open cid hk n cp (suc v) η′ ada) ξ s ref δ#
+  → R.perAssetConservedᵇ
+       (map (λ k → R.mkAssetIOᶜ (quantityOfᴺ (headValueIn ctx) k)
+                                (quantityOfᴺ (depositsValue ctx) k)
+                                (quantityOfᴺ (headValue ctx) k)) assets)
+     ≡ true
+incPerAsset→ref ctx cid hk n cp v η ada η′ ξ s ref δ# []       b = refl
+incPerAsset→ref ctx cid hk n cp v η ada η′ ξ s ref δ# (k ∷ ks) b =
+  &&-intro (==-sound (trans (sym (quantityOfᴺ-+ᵛ (headValueIn ctx) (depositsValue ctx) k))
+                            (cong (λ w → quantityOfᴺ w k) (IncrementValid.valueOK b))))
+           (incPerAsset→ref ctx cid hk n cp v η ada η′ ξ s ref δ# ks b)
+
+-- Decrement: version bumps AND the head value shrinks by the decommit. The reference's lovelace check
+-- `adaOut + adaDelta ≡ adaIn` follows from `decrementValueOK` (headValue +ᵛ decommitValue ≡ headValueIn)
+-- via the `adaOf` additivity law -- so a reference value-reject implies the spec rejects. The ada
+-- fields carry: adaIn = head input, adaDelta = decommit value, adaOut = head output (the larger side
+-- is the head INPUT, unlike increment).
+decrementValid→ref : ∀ ctx cid hk n cp v η ada η′ ξ s m κ#
+  → decrementValid ctx (Open cid hk n cp v η ada) (Open cid hk n cp (suc v) η′ ada) ξ s m κ#
+  → R.decRefᵇ mockOpsInc
+       (R.mkIncIOᶜ v (suc v) (adaOf (headValueIn ctx)) (adaOf (decommitValue ctx m)) (adaOf (headValue ctx))
+          (nonAdaOf (headValueIn ctx)) (nonAdaOf (decommitValue ctx m)) (nonAdaOf (headValue ctx))
+          0 (length (take m (drop 1 (Context.outputs ctx)))))
+     ≡ true
+decrementValid→ref ctx cid hk n cp v η ada η′ ξ s m κ# b =
+  &&-intro (==ᵇ-refl (suc v))
+ (&&-intro (<→<ᵇ (DecrementValid.decommitNonEmpty b))
+ (&&-intro (==-sound (trans (sym (adaOf-+ᵛ (headValue ctx) (decommitValue ctx m)))
+                            (cong adaOf (DecrementValid.valueOK b))))
+ (&&-intro (==-sound (trans (sym (nonAdaOf-+ᵛ (headValue ctx) (decommitValue ctx m)))
+                            (cong nonAdaOf (DecrementValid.valueOK b))))
+           refl)))
+
+-- PER-ASSET refinement of the DECREMENT value check (mirror of `incPerAsset→ref`): for EVERY native asset
+-- `k`, `quantityOfᴺ headValue k + quantityOfᴺ decommitValue k ≡ quantityOfᴺ headValueIn k`, each derived from
+-- the SAME `decrementValueOK` equation (`headValue +ᵛ decommitValue ≡ headValueIn`) by the per-asset
+-- additivity law `quantityOfᴺ-+ᵛ`. The caller supplies each AssetIOᶜ as (qIn := headValue, qDelta :=
+-- decommitValue, qOut := headValueIn), so the shared `perAssetConservedᵇ` sum-check `qIn + qDelta == qOut`
+-- IS this equation. Catches a selective single-token over-decommit the two scalar totals miss.
+decPerAsset→ref : ∀ ctx cid hk n cp v η ada η′ ξ s m κ# (assets : List (CId × Token))
+  → decrementValid ctx (Open cid hk n cp v η ada) (Open cid hk n cp (suc v) η′ ada) ξ s m κ#
+  → R.perAssetConservedᵇ
+       (map (λ k → R.mkAssetIOᶜ (quantityOfᴺ (headValue ctx) k)
+                                (quantityOfᴺ (decommitValue ctx m) k)
+                                (quantityOfᴺ (headValueIn ctx) k)) assets)
+     ≡ true
+decPerAsset→ref ctx cid hk n cp v η ada η′ ξ s m κ# []       b = refl
+decPerAsset→ref ctx cid hk n cp v η ada η′ ξ s m κ# (k ∷ ks) b =
+  &&-intro (==-sound (trans (sym (quantityOfᴺ-+ᵛ (headValue ctx) (decommitValue ctx m) k))
+                            (cong (λ w → quantityOfᴺ w k) (DecrementValid.valueOK b))))
+           (decPerAsset→ref ctx cid hk n cp v η ada η′ ξ s m κ# ks b)
+
+-- ── contest ─────────────────────────────────────────────────────────────────────────────────
+-- Version preserved (both v), snapshot strictly increases (s < s′ from the bundle), one contester
+-- appended (output contesters ≡ kh ∷ C, so length ≡ suc (length C)), and posted before the
+-- contestation deadline (`validityHi ≤ tfin` from `beforeDeadline`, via `≤ᴮ-sound`). The conditional
+-- deadline-UPDATE rule stays in the injected (mock) `contestCryptoOK`.
+mockOpsContest : R.OpsContest
+mockOpsContest = record { contestCryptoOK = λ _ → true }
+
+-- The deadline-UPDATE conjunct `tfinalOut == if (lenOut ==ᵇ n) then tfin else tfin+cp` is discharged
+-- from `contestDeadlineOK` (the bundle's `deadlineOK`, stated with the stdlib `if ⌊ len ≟ n ⌋`): case on
+-- the decidable `length (kh ∷ C) ≟ n` and reflect its `⌊_⌋` into the structural `_==ᵇ_` via `≡→==ᵇ`
+-- (yes) / `¬→==ᵇfalse` (no), so the two conditionals pick the same branch.
+contestValid→ref : ∀ ctx cid hk n cp v s η C tfin ada s′ η′ kh tfin′ ct
+  → contestValid ctx (Closed cid hk n cp v s η C tfin ada)
+                     (Closed cid hk n cp v s′ η′ (kh ∷ C) tfin′ ada) ct
+  → R.contestRefᵇ mockOpsContest
+       (R.mkContestIOᶜ v v s s′ (length C) (length (kh ∷ C))
+          tfin (ValidityInterval.hi (Context.validity ctx)) tfin′ n cp) ≡ true
+contestValid→ref ctx cid hk n cp v s η C tfin ada s′ η′ kh tfin′ ct b =
+    &&-intro (==ᵇ-refl v)
+   (&&-intro (<→<ᵇ (ContestValid.snapIncreases b))
+   (&&-intro (==ᵇ-refl (suc (length C)))
+   (&&-intro (≤ᴮ-sound (ContestValid.beforeDeadline b))
+   (&&-intro (==-sound deadlineEq) refl))))
+  where
+    deadlineEq : tfin′ ≡ (R.if (length (kh ∷ C) R.==ᵇ n) then tfin else (tfin + cp))
+    deadlineEq with length (kh ∷ C) ≟ n | ContestValid.deadlineOK b
+    ... | yes p  | dl = trans dl (sym (cong (λ z → R.if z then tfin else (tfin + cp)) (≡→==ᵇ p)))
+    ... | no  ¬p | dl = trans dl (sym (cong (λ z → R.if z then tfin else (tfin + cp)) (¬→==ᵇfalse ¬p)))
+
+-- ── value preservation (close / contest mustPreserveHeadValue) ──────────────────────────────────
+-- The `valuePreserved` field (headValueIn ctx ≡ headValue ctx, the validator's EXACT
+-- `mustPreserveHeadValue`) reflects to `valuePreservedᵇ ≡ true` on BOTH the ada total and the non-ada
+-- total: each half is `cong adaOf`/`cong nonAdaOf` applied to the single value equality, then `==-sound`.
+-- No additivity law, no injectivity, no new postulate. ct-independent: `closeValid`/`contestValid` reduce
+-- to their records on the datum shapes alone. Moves close/contest `mustPreserveHeadValue` out of the
+-- injected (mock) `Ops` into the bridged + (differentially) tested layer.
+closeValuePreserved→ref : ∀ ctx cid hk n cp v η ada s′ η′ C tfin ct
+  → closeValid ctx (Open cid hk n cp v η ada) (Closed cid hk n cp v s′ η′ C tfin ada) ct
+  → R.valuePreservedᵇ (adaOf (headValueIn ctx)) (adaOf (headValue ctx))
+                       (nonAdaOf (headValueIn ctx)) (nonAdaOf (headValue ctx)) ≡ true
+closeValuePreserved→ref ctx cid hk n cp v η ada s′ η′ C tfin ct b =
+  &&-intro (==-sound (cong adaOf (CloseValid.valuePreserved b)))
+           (==-sound (cong nonAdaOf (CloseValid.valuePreserved b)))
+
+contestValuePreserved→ref : ∀ ctx cid hk n cp v s η C tfin ada s′ η′ kh tfin′ ct
+  → contestValid ctx (Closed cid hk n cp v s η C tfin ada)
+                     (Closed cid hk n cp v s′ η′ (kh ∷ C) tfin′ ada) ct
+  → R.valuePreservedᵇ (adaOf (headValueIn ctx)) (adaOf (headValue ctx))
+                       (nonAdaOf (headValueIn ctx)) (nonAdaOf (headValue ctx)) ≡ true
+contestValuePreserved→ref ctx cid hk n cp v s η C tfin ada s′ η′ kh tfin′ ct b =
+  &&-intro (==-sound (cong adaOf (ContestValid.valuePreserved b)))
+           (==-sound (cong nonAdaOf (ContestValid.valuePreserved b)))
+
+-- ── fanout / finalPartialFanout ───────────────────────────────────────────────────────────────
+-- `burnedCount == n+1` from `burnAllTokensOK` (via `==-sound`); `tfinal < lo` (posted after the
+-- deadline) from `afterDeadline` (via `<ᴮ-sound`). The accumulator-membership and value-conservation
+-- conjuncts stay in the injected (mock) `fanoutCryptoOK`. No `0 < m` conjunct: the FULL fanout permits
+-- m = 0 (empty-head finalisation), so `fanoutRefᵇ` does not gate it (`FanoutValid` carries no
+-- `outputsPositive`); `FinalPartialFanoutValid.outputsPositive` is in the spec record but not bridged.
+mockOpsFanout : R.OpsFanout
+mockOpsFanout = record { fanoutCryptoOK = λ _ → true }
+
+fanoutValid→ref : ∀ ctx cid hk n cp v s η C tfin ada m π crs
+  → fanoutValid ctx (Closed cid hk n cp v s η C tfin ada) m π crs
+  → R.fanoutRefᵇ mockOpsFanout
+       (R.mkFanoutᶜ m (burnedCount ctx cid) n tfin (ValidityInterval.lo (Context.validity ctx))) ≡ true
+fanoutValid→ref ctx cid hk n cp v s η C tfin ada m π crs b =
+    &&-intro (==-sound (FanoutValid.burnAllTokens b))
+   (&&-intro (<ᴮ-sound (FanoutValid.afterDeadline b)) refl)
+
+finalPartialFanoutValid→ref : ∀ ctx cid hk n tfin η ada m π crs
+  → finalPartialFanoutValid ctx (FanoutProgress cid hk n tfin η ada) m π crs
+  → R.fanoutRefᵇ mockOpsFanout
+       (R.mkFanoutᶜ m (burnedCount ctx cid) n tfin (ValidityInterval.lo (Context.validity ctx))) ≡ true
+finalPartialFanoutValid→ref ctx cid hk n tfin η ada m π crs b =
+    &&-intro (==-sound (FinalPartialFanoutValid.burnAllTokens b))
+   (&&-intro (<ᴮ-sound (FinalPartialFanoutValid.afterDeadline b)) refl)
+
+-- ── non-final partial fanout (FanoutProgress → FanoutProgress) ─────────────────────────────────
+-- The reference's `0 <ᵇ m` holds from `outputsPositive` (the §5.8 no-zero-output-batch guard, via the
+-- structural `<→<ᵇ`); `tfinal < lo` (posted after the deadline) from `afterDeadline` (via `<ᴮ-sound`).
+-- UNLIKE the full/final fanout, the partial path forbids m = 0, so `0 < m` IS bridged here. The
+-- accumulator-exclusion/non-empty-progress (`excludeOK`/`notDoneOK`) and value-conservation conjuncts stay
+-- abstract; `mintEmpty` is the shared `noMintRefᵇ`. So a reference reject ⇒ the spec rejects ⇒ the
+-- validator rejects (`PartialFanoutZeroOutputs` / `LowerBoundBeforeContestationDeadline`).
+partialFanoutValid→ref : ∀ ctx d d′ m crs
+  → partialFanoutValid ctx d d′ m crs
+  → R.partialFanoutRefᵇ m (tfinalOf d) (ValidityInterval.lo (Context.validity ctx)) ≡ true
+partialFanoutValid→ref ctx d d′ m crs b =
+    &&-intro (<→<ᵇ (PartialFanoutValid.outputsPositive b))
+             (<ᴮ-sound (PartialFanoutValid.afterDeadline b))
+
+-- ── deposit recover (νDeposit) ────────────────────────────────────────────────────────────────
+-- The reference's after-deadline check `tRecover <ᴮ validityLo` holds from the bundle's
+-- `tRec < ValidityInterval.lo (validity ctx)` (§5.3.2 `txValidityMin > t_recover`), discharged via
+-- `<ᴮ-sound`. The recovered-outputs hash equality (`recoveredMatchesDeposited`) is the injected (mock)
+-- `recoverHashOK`, matching the differential. So a reference deadline-reject ⇒ the spec rejects ⇒ (by
+-- the deposit.ak Recover arm) the validator rejects (`DepositPeriodNotReached`).
+mockOpsRecover : R.OpsRecover
+mockOpsRecover = record { recoverHashOK = λ _ → true }
+
+recoverValid→ref : ∀ ctx cid tRec C m
+  → recoverValid ctx (mkDepositDatum cid tRec C) m
+  → R.recoverRefᵇ mockOpsRecover
+       (R.mkRecoverIOᶜ tRec (ValidityInterval.lo (Context.validity ctx)) (depositInputCount ctx)) ≡ true
+recoverValid→ref ctx cid tRec C m b =
+  &&-intro (<ᴮ-sound (RecoverValid.afterRecoverDeadline b))
+ (&&-intro (≡→==ᵇ (RecoverValid.singleDeposit b)) refl)
+
+-- ── init (μHead minting policy: token count + placement) ─────────────────────────────────────────
+-- The reference's count check `mintedCount == suc n` holds from `mintedCountOK` (the μHead
+-- `checkNumberOfTokens`), and the PLACEMENT checks `stQty == 1` / `headTokenCount == suc n` hold from
+-- `stPlaced` / `tokensPlaced` - all `≡`-of-ℕ-projection conjuncts, discharged directly via `==-sound`
+-- (no new axiom; the reference IO fields ARE those projections, as for `mintedCount`). The remaining
+-- μHead conjuncts (seed-spent, datum binding) are the injected (mock) `initPlacementOK`. So a reference
+-- reject ⇒ the spec rejects ⇒ the μHead policy rejects (`WrongNumberOfTokensMinted` / a misplaced-token
+-- failure).
+mockOpsInit : R.OpsInit
+mockOpsInit = record { initPlacementOK = λ _ → true }
+
+initValid→ref : ∀ ctx seed cid hk n cp v η ada
+  → initValid ctx seed (Open cid hk n cp v η ada)
+  → R.initRefᵇ mockOpsInit
+       (R.mkMintIOᶜ n (mintedCount ctx cid) (stQty (headValue ctx) cid) (headTokenCount (headValue ctx) cid))
+     ≡ true
+initValid→ref ctx seed cid hk n cp v η ada b =
+  &&-intro (==-sound (InitValid.mintedCountOK b))
+ (&&-intro (==-sound (InitValid.stPlaced b))
+ (&&-intro (==-sound (InitValid.tokensPlaced b)) refl))
+
+-- ── deposit claim (νDeposit, Claim redeemer) ──────────────────────────────────────────────────
+-- The reference's before-deadline check `validityHi ≤ᴮ tRecover` holds from the bundle's
+-- `ValidityInterval.hi (validity ctx) ≤ DepositDatum.tRecover dd` (§5.2 deposit.ak `before_deadline`:
+-- txValidityMax ≤ t_recover), discharged via `≤ᴮ-sound`. The own-head binding (`claimedByOwnHead`,
+-- deposit.ak `expect_increment_redeemer`) is also checked: the deposit datum's head id `cid` equals
+-- the spent head's id `hcid`. Head ids are hashes, which the hash-free reference layer cannot hold, so
+-- the boundary represents each as the Integer `cidToNat ·` and the reference compares those. The bridge
+-- only needs `cid ≡ hcid ⇒ cidToNat cid ≡ cidToNat hcid` - plain `cong` on the encoding, NO injectivity
+-- assumption (that would only be needed for the converse, which the bridge direction `bundle ⇒ reference`
+-- does not require). `cidToNat` is a typecheck-only encoding postulate (it is not part of the extracted
+-- reference; the `HeadValidatorAgreement` test supplies a concrete deterministic encoding, `cidToInteger`,
+-- injective on the distinct head ids it compares, on the Haskell side).
+-- The Increment-redeemer coupling comes from the JOINT bundle below. So a reference reject ⇒ the
+-- spec rejects ⇒ (by the deposit.ak Claim arm) the validator rejects (`DepositPeriodSurpassed` /
+-- `expect_increment_redeemer`).
+postulate cidToNat : ℍ → ℕ
+
+-- The deterministic out-ref → ℕ encoding the differential mirrors (same trust family as `cidToNat`;
+-- no injectivity needed). Declared here so the claim bridge below can name it; the referenced-output
+-- membership lemma (`refSpent→ref`, further down) is its other consumer.
+postulate refCodeOf : OutputRef → ℕ
+
+-- The abstract redeemer's pinned on-chain constructor index (the `makeIsDataIndexed ''Input` list in
+-- HeadState.hs, which deposit.ak's `is_head_increment` reads raw; the alignment fact is that the Agda
+-- and Plutus constructor orders coincide). A definition, not a postulate: the coupling bridge below
+-- discharges `redeemerIndex (Increment …) == 0` by computation.
+redeemerIndex : HeadRedeemer → ℕ
+redeemerIndex (Increment _ _ _ _)        = 0
+redeemerIndex (Decrement _ _ _ _)        = 1
+redeemerIndex (Close _)                  = 2
+redeemerIndex (Contest _)                = 3
+redeemerIndex (Fanout _ _ _)             = 4
+redeemerIndex (PartialFanout _ _)        = 5
+redeemerIndex (FinalPartialFanout _ _ _) = 6
+
+-- Joint claim bundle ⇒ the extracted claim checker. The before-deadline and own-head conjuncts come
+-- from the νDeposit side (`ClaimTxValid.depositSideOK`); the Increment-redeemer coupling comes from
+-- the νHEAD side - the joint bundle's head input is spent with `Increment ξ s ref δ#` BY TYPE
+-- (`ClaimTxValid.headSideOK`'s step), so its pinned index is 0 definitionally and the reference's
+-- `headRedeemerIdxC == 0` conjunct is discharged by `refl`. The claims-this-deposit coupling
+-- (deposit.ak's ref equality, `claimedRefCodeC == ownRefCodeC`) is likewise definitional here: the
+-- joint bundle carries one `ref` shared by both sides, so both codes are `refCodeOf ref` and the
+-- conjunct is `==-sound refl`. No mock and no new postulate: the only assumed pieces remain the
+-- `cidToNat`/`refCodeOf` encodings (used with `cong`/`refl`, no injectivity).
+claimTxValid→ref : ∀ ctx cid tRec C hcid hk n cp v η ada headOut ξ s ref δ#
+  → claimTxValid ctx (mkDepositDatum cid tRec C) (Open hcid hk n cp v η ada) headOut ξ s ref δ#
+  → R.claimRefᵇ
+      (R.mkClaimIOᶜ tRec (ValidityInterval.hi (Context.validity ctx)) (cidToNat cid) (cidToNat hcid)
+         (redeemerIndex (Increment ξ s ref δ#)) (refCodeOf ref) (refCodeOf ref)) ≡ true
+claimTxValid→ref ctx cid tRec C hcid hk n cp v η ada headOut ξ s ref δ# b =
+  &&-intro (≤ᴮ-sound (ClaimValid.beforeRecoverDeadline (ClaimTxValid.depositSideOK b)))
+ (&&-intro (==-sound (cong cidToNat (ClaimValid.claimedByOwnHead (ClaimTxValid.depositSideOK b))))
+ -- the redeemer-index conjunct computes away (`redeemerIndex (Increment …) == 0` is `true`), leaving
+ -- exactly the ref-coupling conjunct: both codes are `refCodeOf ref`.
+ (==-refl (refCodeOf ref)))
+
+-- ── contest parameter preservation (scalar half of mustNotChangeParameters: headId + cp) ─────────
+-- The contest transition's produced `Closed` reuses the SAME `cid`/`cp` binders, so head-id and
+-- contestation-period preservation are definitional: `contestParamsᵇ (cidToNat cid) (cidToNat cid) cp cp`
+-- is `refl`-discharged through `==-sound` (no injectivity, only the existing `cidToNat` encoding). The
+-- validity premise is unused (the datum shape alone gives preservation). The `parties`-list half stays a
+-- documented boundary (the spec abstracts the party list into a count `n`). Placed after `cidToNat`.
+contestParams→ref : ∀ ctx cid hk n cp v s η C tfin ada s′ η′ kh tfin′ ct
+  → contestValid ctx (Closed cid hk n cp v s η C tfin ada)
+                     (Closed cid hk n cp v s′ η′ (kh ∷ C) tfin′ ada) ct
+  → R.contestParamsᵇ (cidToNat cid) (cidToNat cid) cp cp ≡ true
+contestParams→ref ctx cid hk n cp v s η C tfin ada s′ η′ kh tfin′ ct _ =
+  &&-intro (==-sound {cidToNat cid} {cidToNat cid} refl) (==-sound {cp} {cp} refl)
+
+-- ── init datum head-id binding (decidable half of μHead checkDatum: headId == currency) ───────────
+-- In the spec the produced `Open` datum's head id and the policy currency are the SAME `cid`
+-- (= hash(μHead seed)), so `initHeadIdᵇ (cidToNat cid) (cidToNat cid)` is `refl`-discharged via `==-sound`
+-- and the existing `cidToNat` encoding (no injectivity, no new postulate). The `seed == seedInput` half is
+-- unmodelled (the Agda `Open` has no `headSeed`) and `cid = hash(seed)` stays the injected hash boundary.
+initHeadId→ref : ∀ ctx seed cid hk n cp v η ada
+  → initValid ctx seed (Open cid hk n cp v η ada)
+  → R.initHeadIdᵇ (cidToNat cid) (cidToNat cid) ≡ true
+initHeadId→ref ctx seed cid hk n cp v η ada _ = ==-sound {cidToNat cid} {cidToNat cid} refl
+
+-- ── participant signature (shared: close / contest / increment / decrement) ──────────────────────
+-- The reference's overlap check `anySharedᵇ signerCodes ptCodes` reflects `signedByParticipant`
+-- (the §5.4–5.7 `mustBeSignedByParticipant`). The abstract predicate is an existential over the opaque
+-- signer set (`signerKeyHash`) and the opaque value (`quantityOf`); NEITHER has a computational link to
+-- the extracted Integer code lists, so - unlike the `cong cidToNat` bridge - the correspondence is a
+-- POSTULATED extraction-faithfulness boundary (typecheck-only, same trust family as `cidToNat`/
+-- `refCodeOf`): `signerCodes`/`ptCodes` are the deterministic hash→Integer encodings the differential
+-- supplies for real (the tx signers' key-hashes and the head value's PT names), and a spec-valid tx is
+-- asserted to make those two lists overlap. So a reference overlap-reject ⇒ the spec rejects ⇒ the
+-- validator rejects (`SignerIsNotAParticipant`). The encoding aligns by construction: a PT's token name
+-- IS the participant's key-hash, so the same byte string is encoded on both sides.
+postulate
+  signerCodes : Context → List ℕ
+  ptCodes     : ℍ → Context → List ℕ
+  participantSigned→ref : ∀ cid ctx → signedByParticipant cid ctx
+    → R.participantSignedRefᵇ (R.mkSignerIOᶜ (signerCodes ctx) (ptCodes cid ctx)) ≡ true
+
+-- Per-family wiring: each of the four bundles discharges the shared checker through its own
+-- participant evidence - close/increment/decrement project their `participantSigned` field, and
+-- contest derives the witness from its sharper contester fields (`contest-participantSigned`).
+closeParticipant→ref : ∀ ctx cid hk n cp v η ada s′ η′ C tfin ct
+  → closeValid ctx (Open cid hk n cp v η ada) (Closed cid hk n cp v s′ η′ C tfin ada) ct
+  → R.participantSignedRefᵇ (R.mkSignerIOᶜ (signerCodes ctx) (ptCodes cid ctx)) ≡ true
+closeParticipant→ref ctx cid hk n cp v η ada s′ η′ C tfin ct b =
+  participantSigned→ref cid ctx (CloseValid.participantSigned b)
+
+incrementParticipant→ref : ∀ ctx cid hk n cp v η ada η′ ξ s ref δ#
+  → incrementValid ctx (Open cid hk n cp v η ada) (Open cid hk n cp (suc v) η′ ada) ξ s ref δ#
+  → R.participantSignedRefᵇ (R.mkSignerIOᶜ (signerCodes ctx) (ptCodes cid ctx)) ≡ true
+incrementParticipant→ref ctx cid hk n cp v η ada η′ ξ s ref δ# b =
+  participantSigned→ref cid ctx (IncrementValid.participantSigned b)
+
+decrementParticipant→ref : ∀ ctx cid hk n cp v η ada η′ ξ s m κ#
+  → decrementValid ctx (Open cid hk n cp v η ada) (Open cid hk n cp (suc v) η′ ada) ξ s m κ#
+  → R.participantSignedRefᵇ (R.mkSignerIOᶜ (signerCodes ctx) (ptCodes cid ctx)) ≡ true
+decrementParticipant→ref ctx cid hk n cp v η ada η′ ξ s m κ# b =
+  participantSigned→ref cid ctx (DecrementValid.participantSigned b)
+
+contestParticipant→ref : ∀ ctx cid hk n cp v s η C tfin ada s′ η′ kh tfin′ ct
+  → contestValid ctx (Closed cid hk n cp v s η C tfin ada)
+                     (Closed cid hk n cp v s′ η′ (kh ∷ C) tfin′ ada) ct
+  → R.participantSignedRefᵇ (R.mkSignerIOᶜ (signerCodes ctx) (ptCodes cid ctx)) ≡ true
+contestParticipant→ref ctx cid hk n cp v s η C tfin ada s′ η′ kh tfin′ ct b =
+  participantSigned→ref cid ctx (contest-participantSigned b)
+
+-- ── no mint / no burn (shared: close / contest / increment / decrement) ────────────────────────
+-- The reference's `noMintRefᵇ (mintEntryCount ctx)` reflects `noMint ctx` (the §5.4–5.7 `mustNotMintOrBurn`).
+-- `noMint ctx = Context.mint ctx ≡ εᵛ` is over the opaque `Value`; its NON-ZERO entry count has no
+-- computational link to the abstract `≡ εᵛ`, so - exactly as `participantSigned→ref` - the correspondence
+-- is a POSTULATED extraction-faithfulness boundary: `mintEntryCount` is the count the differential supplies
+-- for real (the length of the flattened tx mint value), and a tx with empty mint is asserted to make it 0.
+-- So a reference reject (count ≠ 0) ⇒ the spec rejects ⇒ the validator rejects (`MintingOrBurningIsForbidden`).
+postulate
+  mintEntryCount : Context → ℕ
+  noMint→ref : ∀ ctx → noMint ctx → R.noMintRefᵇ (mintEntryCount ctx) ≡ true
+
+-- ── referenced output is spent (increment claimed deposit / init seed) ─────────────────────────
+-- The reference's `refSpentᵇ (refCodeOf ref) (inputRefCodes ctx)` reflects `depositSpentOK ctx ref` (the
+-- increment `claimedDepositIsSpent` / the μHead `seedInputIsConsumed`). Unlike `participantSigned→ref`,
+-- this is a REAL proof (no faithfulness postulate): `inputRefCodes` is CONCRETE (the out-ref of each spent
+-- input, encoded), and the membership is DERIVED from the `depositSpentOK` ∃-witness by induction. Only
+-- `refCodeOf` stays a postulate - the deterministic out-ref→ℕ encoding the differential mirrors (same trust
+-- family as `cidToNat`; no injectivity needed). So a reference reject ⇒ the spec rejects ⇒ the validator
+-- rejects (`DepositNotSpent` / `SeedNotSpent`). One lemma serves increment (ref = the claimed deposit) and
+-- init (ref = the seed). (`refCodeOf` itself is declared next to `cidToNat` above.)
+
+-- CONCRETE: the encoded out-ref of every spent input (the differential supplies the same map).
+inputRefCodes : Context → List ℕ
+inputRefCodes ctx = map (λ i → refCodeOf (Input.outputRef i)) (Context.inputs ctx)
+
+-- `b || true ≡ true` for the extracted `_||_` (used in the `there`/short-circuit step of `elemᵇ-mapped`).
+||ᵇ-trueʳ : ∀ b → (b R.|| true) ≡ true
+||ᵇ-trueʳ true  = refl
+||ᵇ-trueʳ false = refl
+
+-- membership ⇒ the extracted overlap check fires: if `c` encodes some `i ∈ xs` (c ≡ g i), then
+-- `elemᵇ c (map g xs) ≡ true`. Induction over the `Any (_≡_)` witness; the head case discharges via
+-- `==-sound` (c ≡ g y so `c == g y ≡ true`), the tail case via the IH and `||ᵇ-trueʳ`.
+elemᵇ-mapped : ∀ {A : Set} (g : A → ℕ) (c : ℕ) {i : A} (xs : List A)
+  → i ∈ˡ xs → c ≡ g i → R.elemᵇ c (map g xs) ≡ true
+elemᵇ-mapped g c (y ∷ ys) (here  i≡y) c≡gi =
+  cong (R._|| R.elemᵇ c (map g ys)) (==-sound (trans c≡gi (cong g i≡y)))
+elemᵇ-mapped g c (y ∷ ys) (there p)   c≡gi =
+  trans (cong ((c == g y) R.||_) (elemᵇ-mapped g c ys p c≡gi)) (||ᵇ-trueʳ (c == g y))
+
+refSpent→ref : ∀ ctx ref → depositSpentOK ctx ref
+  → R.refSpentᵇ (refCodeOf ref) (inputRefCodes ctx) ≡ true
+refSpent→ref ctx ref (i , i∈inputs , outRef≡ref) =
+  elemᵇ-mapped (λ j → refCodeOf (Input.outputRef j)) (refCodeOf ref) (Context.inputs ctx)
+    i∈inputs (sym (cong refCodeOf outRef≡ref))
+
+-- init's `seedSpent` (the μHead `seedInputIsConsumed`) reuses the real `refSpent→ref` for the seed
+-- out-ref, consuming `InitValid.seedSpent`.
+initSeedSpent→ref : ∀ ctx seed cid hk n cp v η ada
+  → initValid ctx seed (Open cid hk n cp v η ada)
+  → R.refSpentᵇ (refCodeOf seed) (inputRefCodes ctx) ≡ true
+initSeedSpent→ref ctx seed cid hk n cp v η ada b = refSpent→ref ctx seed (InitValid.seedSpent b)
+
+-- ── composition: the per-conjunct bridges JOIN into one spec ⇒ extracted-reference verdict ──
+-- Demonstrated for the close flagship (closeInitial): a SINGLE `closeValid` discharges the core close
+-- reference checker, the value-preservation checker, the no-mint checker AND the shared
+-- participant-signature checker at once. The other validators compose identically
+-- (each `*Valid` discharges its core `*Refᵇ` plus the pulled-out conjuncts via the lemmas above). This is
+-- the `spec-bundle ⇒ extracted-reference` half; it is joined to the `extracted-reference === real-validator`
+-- differential (Hydra.Tx.Contract.HeadValidatorAgreement) at the SHARED extracted Reference module — the
+-- single ANDed end-to-end property there checks that join across every validator family.
+closeChainInitial→ref : ∀ ctx cid hk n cp v η ada s′ η′ C tfin
+  → (b : closeValid ctx (Open cid hk n cp v η ada) (Closed cid hk n cp v s′ η′ C tfin ada) closeInitial)
+  → (R.closeRefᵇ mockOps (R.mkOpenᶜ v cp) (R.mkClosedᶜ v cp s′ (length C) tfin) (closeTagOf closeInitial)
+        (ValidityInterval.hi (Context.validity ctx)) (ValidityInterval.lo (Context.validity ctx)) ≡ true)
+    × (R.valuePreservedᵇ (adaOf (headValueIn ctx)) (adaOf (headValue ctx))
+                         (nonAdaOf (headValueIn ctx)) (nonAdaOf (headValue ctx)) ≡ true)
+    × (R.noMintRefᵇ (mintEntryCount ctx) ≡ true)
+    × (R.participantSignedRefᵇ (R.mkSignerIOᶜ (signerCodes ctx) (ptCodes cid ctx)) ≡ true)
+closeChainInitial→ref ctx cid hk n cp v η ada s′ η′ C tfin b =
+    closeValid→ref ctx cid hk n cp v η ada s′ η′ C tfin closeInitial b
+  , closeValuePreserved→ref ctx cid hk n cp v η ada s′ η′ C tfin closeInitial b
+  , noMint→ref ctx (CloseValid.mintEmpty b)
+  , participantSigned→ref cid ctx (CloseValid.participantSigned b)
+
+-- ── §5.1 burn (μHead Burn arm): the bundle implies the extracted burn checker ─────────────────
+-- Both conjuncts are genuine proofs: `==-sound` reflects `mintedCount ≡ 0` into the builtin `_==_`,
+-- and `<ᴮ-sound` reflects `1 ≤ burnedCount` (= `0 < burnedCount`) into the builtin `_<_`.
+burnValid→ref : ∀ ctx cid → burnValid ctx cid
+  → R.burnRefᵇ (R.mkBurnIOᶜ (mintedCount ctx cid) (burnedCount ctx cid)) ≡ true
+burnValid→ref ctx cid b =
+  &&-intro (==-sound (BurnValid.noneMinted b)) (<ᴮ-sound (BurnValid.somethingBurned b))

--- a/spec/src/Hydra/Protocol/Security.lagda.typ
+++ b/spec/src/Hydra/Protocol/Security.lagda.typ
@@ -448,6 +448,15 @@ data _⟶ˢ_ : System → System → Set where
     → (∀ {U′} → applyTxs (U₀ sys) (confirmedTxs (lookup (localOf sys) i)) ≡ just U′
               → Applicable U′ Δ)                                                      -- Δ applies on top of confirmed (requireApplyTxs)
     → Δ ⊆ˡ lookup (seen sys) i                                                        -- Δ already observed (only-seen)
+    -- The digests an honest signer DERIVES from the snapshot it is about to sign, rather than
+    -- accepting from the request. κ# is the one with security content: binding the deposit
+    -- reference S̄.txOutRef_α alongside the recorded commit set is what stops a look-alike deposit
+    -- - same recorded UTxO, less value - being claimed under this signature (@sec:increment-tx; the
+    -- node's `commitOutputsHash`). Hashing the structured values directly takes the same liberty as
+    -- the on-chain `decommitOutputsHashOf`; what these premises pin is WHICH fields each digest is
+    -- a function of.
+    → Snapshot.comHash snap ≡ hash (hash (Snapshot.utxoInc snap) ‖ Snapshot.depRef snap)
+    → Snapshot.decHash snap ≡ hash (Snapshot.utxoDec snap)
     → sys ⟶ˢ record sys
         { localOf = localOf sys [ i ]≔ record (lookup (localOf sys) i) { seenNumber = Snapshot.number snap }
         ; sigs    = (i , snap) ∷ sigs sys }

--- a/spec/src/Hydra/Protocol/Security.lagda.typ
+++ b/spec/src/Hydra/Protocol/Security.lagda.typ
@@ -1,3 +1,27 @@
+```
+module Hydra.Protocol.Security where
+
+open import Hydra.Protocol.Prelude
+open import Hydra.Protocol.OffChain
+open import Hydra.Protocol.Preliminaries using (Output; _‖_)
+open import Data.Fin using (Fin)
+open import Data.Nat using (z≤n; s≤s)
+open import Data.Nat.Properties using (≤-total; ≤-antisym; +-identityʳ; +-suc; suc-injective; m+[n∸m]≡n; m+n≡0⇒m≡0)
+open import Data.Sum using (map₁; map₂)
+open import Data.List using (_++_)
+open import Data.List.Relation.Unary.Any using (here; there)
+open import Data.List.Membership.Propositional.Properties using (∈-++⁺ʳ)
+open import Data.List.Relation.Binary.Subset.Propositional.Properties using () renaming (⊆-refl to ⊆ˡ-refl; ⊆-trans to ⊆ˡ-trans)
+open import Data.Vec using (Vec; lookup; _[_]≔_)
+open import Data.Vec.Properties using (lookup∘update; lookup∘update′)
+import Data.Fin.Properties as FinP
+open import Data.Product using (Σ-syntax)
+open import Data.List.Relation.Binary.Subset.Propositional using () renaming (_⊆_ to _⊆ˡ_)
+open import Relation.Nullary using (yes; no)
+open import Relation.Binary.PropositionalEquality using (trans; sym; cong; subst)
+open import Data.Empty using (⊥-elim)
+import Hydra.Protocol.OnChain as OC
+```
 
 #import "/template.typ": *
 #import "/macros.typ": *
@@ -259,8 +283,72 @@ global `System` records each party's local state, honesty flag, recorded
 signatures and seen sets; and `Certified` is the n-of-n signing predicate the
 proofs reason with.
 
+```
+-- The ledger primitives (`applyTxs`, its `applyTxs-nil`/`applyTxs-compose` laws, and `Applicable`) are
+-- defined in the off-chain handler model `Hydra.Protocol.OffChain` (whose handler arms also use them)
+-- and are in scope here via this section's `open import` of that module.
 
 
+-- T̄ᵢ / ŝᵢ: a party's confirmed transactions and confirmed snapshot number.
+confirmedTxs : LocalState → List Data
+confirmedTxs st = Snapshot.txs (LocalState.confirmed st)
+
+confirmedNo : LocalState → ℕ
+confirmedNo st = Snapshot.number (LocalState.confirmed st)
+```
+
+```
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- The signature model: DERIVING the agreement/applicability of confirmed snapshots.
+-- We record individual party
+-- signatures, declare a snapshot CONFIRMABLE (`Certified`) only once EVERY party signed it (the
+-- coordinated head's full multisignature), and constrain HONEST signing to applicable snapshots,
+-- at most one per number, each extending its own confirmed snapshot. From these we DERIVE below:
+-- every honest party's confirmed snapshot is applicable to U₀ (L3); two certified snapshots of the
+-- same number are equal (L1); and confirmed snapshots NEST by number (L2, `confirmed-nest`).
+-- `confirm` checks the §3.2 aggregate multisignature (`msVfy`); the only irreducible
+-- assumptions are the ledger `applyTxs` / nil law and the scheme's unforgeability (per-signature
+-- `sigUnforge` + `aggSound`, from which the aggregate `ms-unforgeable` is derived).
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+
+-- Global system state. Party-indexed data are vectors for clean updates. `sigs` records the
+-- individual signatures produced so far as (party, snapshot) pairs; there is NO pre-ordained chain.
+record System : Set where
+  field
+    parties  : ℕ
+    localOf  : Vec LocalState parties
+    onChain  : OC.HeadDatum
+    honest   : Vec Bool parties
+    U₀       : UTxO
+    sigs     : List (Fin parties × Snapshot)
+    seen     : Vec (List Data) parties   -- T̂ᵢ: the txs each party has observed (hpSeen), monotone
+open System
+
+-- Party i has signed snapshot snap (its (i , snap) pair is recorded).
+Signed : (sys : System) → Fin (parties sys) → Snapshot → Set
+Signed sys i snap = (i , snap) ∈ˡ sigs sys
+
+-- A snapshot is CERTIFIED when EVERY party signed it: the SEMANTIC content of the coordinated head's
+-- n-of-n multisignature, which the safety proofs reason with directly.
+Certified : (sys : System) → Snapshot → Set
+Certified sys snap = ∀ (i : Fin (parties sys)) → Signed sys i snap
+```
+
+```
+-- Operationally a node does not test `Certified` (all n individual signatures); it checks ONE
+-- AGGREGATE multisignature with the §3.2 scheme's verifier `msVfy`, under the head's aggregate key
+-- (§4) over the snapshot's message cid‖v‖s‖η#‖δ#‖κ# (§6). `aggKey` is that aggregate key.
+--
+-- `aggSigOf sys snap` is the AGGREGATE signature verified for `snap` -- the combination of the
+-- individual signatures the SYSTEM has recorded on `snap` (in `sigs sys`). It is therefore a function
+-- of BOTH the system and the snapshot, NOT of the snapshot alone, which keeps the model non-vacuous.
+-- Tying the verified
+-- aggregate to `sigs sys` makes `AggVerified sys snap` correctly FALSE for a system missing signatures
+-- yet SATISFIABLE for one where every party signed -- so an execution can genuinely confirm.
+postulate
+  aggKey      : VKey
+  aggSigOf    : System → Snapshot → AggSig
+```
 
 === The signing message and unforgeability
 
@@ -269,9 +357,61 @@ the on-chain signature conjuncts verify; aggregate unforgeability is derived
 from per-signature EUF-CMA plus the aggregation scheme's decomposition
 (@agda-appendix).
 
+```
+-- `snapMsg` is the §6 message SERIALISATION -- DEFINED (not postulated) as the same §3.1 concatenation
+-- the on-chain signature conjuncts verify (`OC.snapshotSigOK`'s `cid ‖ v ‖ s ‖ η# ‖ δ# ‖ κ#`), so the
+-- off-chain certificate and the on-chain `sigOK` fields meet DEFINITIONALLY at the message (consumed by
+-- `sig-certifies` and the per-transaction `*-certified` corollaries in `SecurityProofs`). It is a
+-- function of the snapshot's OWN identifying fields, so the verified message `msgOf snap` manifestly
+-- depends only on those fields (two snapshots agreeing on them have the same message, by definition);
+-- no injectivity is assumed (`_‖_` bottoms out in the law-free `concat`/`bytes`).
+snapMsg : ℍ → ℕ → ℕ → ℍ → ℍ → ℍ → ℍ
+snapMsg cid v s η# δ# κ# = cid ‖ v ‖ s ‖ η# ‖ δ# ‖ κ#
 
+-- The message a snapshot's aggregate signature is verified against: its own (cid, version, number,
+-- η#, δ#, κ#), the §6 signing message cid‖v‖s‖η#‖δ#‖κ#. cid is constant within a head, so it does
+-- not affect the proofs (which use `msgOf` abstractly), but carrying it keeps the message faithful
+-- to the implementation. The decommit/commit-set hashes δ#/κ# are snapshot fields like η#: honest
+-- signing leaves them unconstrained in the model (they are authenticated only through the signature),
+-- exactly the status η# has.
+msgOf : Snapshot → ℍ
+msgOf snap = snapMsg (Snapshot.cid snap) (Snapshot.version snap) (Snapshot.number snap)
+                     (Snapshot.etaHash snap) (Snapshot.decHash snap) (Snapshot.comHash snap)
 
+-- The operational check `confirm` performs: the aggregate built from THIS system's recorded signatures
+-- on `snap` verifies under the head key over `snap`'s message. System-relative (see above).
+AggVerified : System → Snapshot → Set
+AggVerified sys snap = msVfy aggKey (msgOf snap) (aggSigOf sys snap) ≡ true
+```
 
+```
+-- Aggregate unforgeability is FACTORED through the per-signature level (A2): rather than postulate
+-- "verifying aggregate ⇒ every party signed" monolithically, we postulate the two more-elementary facts
+-- it rests on and DERIVE it. `PartyVerified sys i snap` is party i's individual component of the
+-- aggregate verifying under i's own key (the σⱼ the system recorded on snap).
+postulate
+  PartyVerified : (sys : System) → Fin (parties sys) → Snapshot → Set
+  -- §3.2 scheme STRUCTURE: a verifying n-of-n aggregate decomposes -- if `msVfy` accepts the aggregate
+  -- (`AggVerified`), then every party's individual component verifies. (A property of the aggregation
+  -- scheme, e.g. BLS, where the aggregate verifies iff each constituent does.)
+  aggSound  : ∀ sys snap → AggVerified sys snap → (i : Fin (parties sys)) → PartyVerified sys i snap
+  -- per-signature UNFORGEABILITY (EUF-CMA, the irreducible cryptographic hardness assumption): a
+  -- verifying individual signature on `snap` means that party actually signed it (recorded in `sigs`).
+  sigUnforge : ∀ sys snap (i : Fin (parties sys)) → PartyVerified sys i snap → Signed sys i snap
+```
+
+```agda
+-- MS-scheme unforgeability is a DERIVED THEOREM: a verifying aggregate ⇒
+-- every party signed. It FACTORS through the scheme's decomposition (`aggSound`) and per-signature
+-- unforgeability (`sigUnforge`) -- so the trusted base is the standard per-signature EUF-CMA assumption
+-- plus the aggregation scheme's structure, not a monolithic aggregate-level axiom. Downstream uses
+-- (`confirm`, `soundness`, `reflects`, `confCert-all`) consume it through this unchanged type.
+ms-unforgeable : ∀ sys snap → AggVerified sys snap → Certified sys snap
+```
+
+```
+ms-unforgeable sys snap aggOK i = sigUnforge sys snap i (aggSound sys snap aggOK i)
+```
 
 === The step relation
 
@@ -279,6 +419,82 @@ The single-step relation captures honest signing (firing the `reqSn-sign`
 handler), corrupt signing, confirmation against a verifying aggregate,
 corruption, finalization, observation, and lifted local off-chain steps.
 
+```
+-- The single-step relation _⟶ˢ_:
+--   signHonest  : an honest party signs a snapshot by FIRING the off-chain `reqSn-sign` handler
+--                 (OffChain `_handles_↝_`): it requires no snapshot in flight (ŝ = s̄), the requested
+--                 txs Δ extend its OWN confirmed snapshot and apply on top of it, and Δ is already
+--                 observed. The handler advances ŝ ← s. The four honest-signing safety guards L1/L3
+--                 rest on (applicability, one-per-round, chain-extension, only-seen) are DERIVED from
+--                 these operational inputs + the invariant (see
+--                 `invStep`'s signHonest arm and `signNumBound`/`sigSeen` in `Inv`).
+--   signCorrupt : a corrupt party may sign ANY snapshot (the adversary forges nothing honest).
+--   confirm     : a party adopts a snapshot whose AGGREGATE multisignature verifies (`AggVerified`,
+--                 i.e. `msVfy` passes); unforgeability then makes it certified (all parties signed).
+--   corrupt     : the active adversary corrupts a party (honest parties only ever shrink).
+-- `sigs` only grows; `U₀` and `onChain` are never changed by a step. `signHonest` additionally bumps
+-- the signer's `seenNumber` (ŝ); `confirm` updates a party's `confirmed`; `see` grows `seen`.
+data _⟶ˢ_ : System → System → Set where
+  signHonest : ∀ {sys i snap Δ txReq txα txω}
+    → lookup (honest sys) i ≡ true                                                   -- honest signer
+    → LocalState.seenNumber (lookup (localOf sys) i) ≡ confirmedNo (lookup (localOf sys) i)  -- no snapshot in flight (ŝ = s̄)
+    -- FIRE the reqSn-sign handler: witnesses the §6.4 `require` guards (s = s̄+1, v = v̂) and advances
+    -- ŝ ← s. This is the "every step ≈ a handler execution" link. (The requested txs the snapshot
+    -- includes are the list Δ below; the message's `txReq` payload is the abstract §6 encoding.)
+    → (lookup (localOf sys) i) handles
+          (reqSn (Snapshot.version snap) (Snapshot.number snap) txReq txα txω)
+        ↝ record (lookup (localOf sys) i) { seenNumber = Snapshot.number snap }
+    → Snapshot.txs snap ≡ confirmedTxs (lookup (localOf sys) i) ++ Δ                  -- snapshot = confirmed ++ requested
+    → (∀ {U′} → applyTxs (U₀ sys) (confirmedTxs (lookup (localOf sys) i)) ≡ just U′
+              → Applicable U′ Δ)                                                      -- Δ applies on top of confirmed (requireApplyTxs)
+    → Δ ⊆ˡ lookup (seen sys) i                                                        -- Δ already observed (only-seen)
+    → sys ⟶ˢ record sys
+        { localOf = localOf sys [ i ]≔ record (lookup (localOf sys) i) { seenNumber = Snapshot.number snap }
+        ; sigs    = (i , snap) ∷ sigs sys }
+
+  signCorrupt : ∀ {sys i snap}
+    → lookup (honest sys) i ≡ false
+    → sys ⟶ˢ record sys { sigs = (i , snap) ∷ sigs sys }
+
+  confirm : ∀ {sys i snap}
+    → AggVerified sys snap
+    → (LocalState.seenVersion (lookup (localOf sys) i) ≡ Snapshot.version snap)
+      ⊎ (LocalState.seenVersion (lookup (localOf sys) i) ≡ suc (Snapshot.version snap))   -- version discipline: a snapshot is confirmed at the current or one-prior open version
+    → sys ⟶ˢ record sys
+        { localOf = localOf sys [ i ]≔ record (lookup (localOf sys) i) { confirmed = snap } }
+
+  corrupt : ∀ {sys} (i : Fin (parties sys))
+    → sys ⟶ˢ record sys { honest = honest sys [ i ]≔ false }
+
+  -- finalize: the head posts an on-chain datum `d'` (a close/fanout) for a snapshot whose AGGREGATE
+  -- multisignature verifies, carrying that snapshot's number. This is what CONNECTS the otherwise
+  -- frozen `onChain` field to the dynamics, so `Reflects` (below) is CONSTRUCTED from a step.
+  -- It changes only `onChain`; `U₀`/`sigs`/`localOf`/`honest` are untouched, so it preserves
+  -- every `Inv` component (none of which mentions `onChain`).
+  finalize : ∀ {sys snap d'}
+    → AggVerified sys snap
+    → OC.snapNum d' ≡ Snapshot.number snap
+    → sys ⟶ˢ record sys { onChain = d' }
+
+  -- see: an honest (or any) party OBSERVES some transactions, growing its seen set `T̂` (models the
+  -- §6.4 hpSeen output / processing a reqTx). `seen` only grows; everything else is untouched, so it
+  -- preserves every `Inv` component (none of which mentions `seen`).
+  see : ∀ {sys i txs}
+    → sys ⟶ˢ record sys { seen = seen sys [ i ]≔ (txs ++ lookup (seen sys) i) }
+
+  -- offChain: party i takes a LOCAL off-chain step (`_⟶ᴴ_`: a chain observation deposit/recover/tick/
+  -- increment/decrement, or a reqDec) that PRESERVES its confirmed snapshot and seen number (the two
+  -- equality premises) and never touches `sigs`/`seen`/`U₀`. Hence it preserves every `Inv` component,
+  -- so the §7 theorems hold in the presence of the deposit/decommit flow. The preservation premises are
+  -- exactly what excludes the signing/confirming/head-open steps (`reqSn-sign` bumps ŝ, `ackSn-confirm`
+  -- sets S̄, `initialTx-obs` resets both); those are the dedicated `signHonest`/`confirm` steps / the
+  -- initial system, not lifted here.
+  offChain : ∀ {sys i st'}
+    → (lookup (localOf sys) i) ⟶ᴴ st'
+    → LocalState.confirmed  st' ≡ LocalState.confirmed  (lookup (localOf sys) i)
+    → LocalState.seenNumber st' ≡ LocalState.seenNumber (lookup (localOf sys) i)
+    → sys ⟶ˢ record sys { localOf = localOf sys [ i ]≔ st' }
+```
 
 === Initial systems, reachability and the invariant
 
@@ -287,19 +503,168 @@ closes the step relation from an initial system; and `Inv` is the eight-field
 invariant carried through every reachable system, proved by the `invariant`
 induction of @sec:security-theorems (@agda-appendix).
 
+```
+-- An initial system: no signatures yet, every party's confirmed snapshot is the genesis (number 0,
+-- empty tx list, applicable by the nil law), and no commit/decommit is in flight (a freshly-opened
+-- head has neither; the genesis state `initialTx-obs` produces it, seeding the `NoBothInFlight` safety
+-- invariant carried through every reachable system below).
+Initial : System → Set
+Initial sys =
+    (sigs sys ≡ [])
+  × (∀ i → confirmedNo (lookup (localOf sys) i) ≡ 0)
+  × (∀ i → confirmedTxs (lookup (localOf sys) i) ≡ [])
+  × (∀ i → NoBothInFlight (lookup (localOf sys) i))
+  × (∀ i → VersionDiscipline (lookup (localOf sys) i))
 
+-- Reachable = reflexive-transitive closure of _⟶ˢ_ from an initial system.
+data Reachable : System → Set where
+  base : ∀ {s}    → Initial s → Reachable s
+  step : ∀ {s s'} → Reachable s → s ⟶ˢ s' → Reachable s'
+```
 
+```
+-- Every honest signature on `snap` carries a predecessor snapshot `pre` it extends: `snap` is one
+-- number higher, contains `pre`'s txs, and `pre` is the genesis or is itself certified. (This is the
+-- §7 snapshot-extension discipline that yields L2 `confirmed-nest`.)
+-- Parameterised by the `certified` predicate (`Certified sys`), NOT by `sys` itself: this keeps the
+-- witness STABLE across steps that leave `sigs` (hence `Certified`) unchanged (confirm/corrupt only
+-- touch localOf/honest), so it can be carried through those steps without coercion.
+record PredecessorWitness (certified : Snapshot → Set) (snap : Snapshot) : Set where
+  constructor mkPredecessor
+  field
+    pre              : Snapshot
+    numberSuc        : Snapshot.number snap ≡ suc (Snapshot.number pre)
+    txsExtend        : Snapshot.txs pre ⊆ˡ Snapshot.txs snap
+    preGenesisOrCert : (Snapshot.number pre ≡ 0) ⊎ certified pre
+```
+
+```agda
+-- The DERIVED invariants carried through every reachable system, one per field. Each honest-signature
+-- fact is DERIVED at the `signHonest` step from the `reqSn-sign` handler + the no-in-flight
+-- precondition + the invariants (`signNumBound`/`sigSeen`):
+--   sigApp   : every honest signature is on a snapshot applicable to U₀ (via `applyTxs-compose`);
+--   sigDedup : an honest party signs at most one snapshot per number (via `signNumBound`);
+--   confApp  : every honest party's confirmed snapshot is applicable to U₀ (L3), DERIVED rather than
+--              assumed for the whole chain.
+--   sigPos   : an honest signature is on a snapshot of number > 0 (the handler's s = s̄+1);
+--   confCert : an honest party's confirmed snapshot is the genesis or is certified;
+--   sigChain : every honest signature has an extending certified-or-genesis `PredecessorWitness`.
+--              The last three give L2 (`confirmed-nest`).
+record Inv (sys : System) : Set where
+  field
+    sigApp   : ∀ {k snap} → lookup (honest sys) k ≡ true → Signed sys k snap
+             → Applicable (U₀ sys) (Snapshot.txs snap)
+    sigDedup : ∀ {k s1 s2} → lookup (honest sys) k ≡ true → Signed sys k s1 → Signed sys k s2
+             → Snapshot.number s1 ≡ Snapshot.number s2 → s1 ≡ s2
+    confApp  : ∀ {i} → lookup (honest sys) i ≡ true
+             → Applicable (U₀ sys) (confirmedTxs (lookup (localOf sys) i))
+    sigPos   : ∀ {k snap} → lookup (honest sys) k ≡ true → Signed sys k snap → 0 < Snapshot.number snap
+    confCert : ∀ {i} → lookup (honest sys) i ≡ true
+             → (confirmedNo (lookup (localOf sys) i) ≡ 0 × confirmedTxs (lookup (localOf sys) i) ≡ [])
+               ⊎ Certified sys (LocalState.confirmed (lookup (localOf sys) i))
+    sigChain : ∀ {k snap} → lookup (honest sys) k ≡ true → Signed sys k snap → PredecessorWitness (Certified sys) snap
+    -- signNumBound: every honest signature's number is ≤ that party's last-signed number ŝ. With the
+    --   `signHonest` no-in-flight precondition (ŝ = s̄) and the handler signing s = s̄+1 and bumping ŝ,
+    --   this DERIVES the one-signature-per-round guard (`sigDedup`): a fresh sign is strictly above ŝ.
+    signNumBound : ∀ {k snap} → lookup (honest sys) k ≡ true → Signed sys k snap
+                 → Snapshot.number snap ≤ LocalState.seenNumber (lookup (localOf sys) k)
+    -- sigSeen: every honest signature is on txs the party has SEEN. DERIVES the only-seen guard; from
+    --   the handler's Δ ⊆ seen + (confirmedTxs ⊆ seen, itself from confCert+sigSeen). Feeds the
+    --   second conjunct of `soundness`.
+    sigSeen      : ∀ {k snap} → lookup (honest sys) k ≡ true → Signed sys k snap
+                 → Snapshot.txs snap ⊆ˡ lookup (seen sys) k
+```
 
 === The property statements
 
 The properties above are stated as types; their proofs are the machine-checked
 results of @sec:security-theorems (@agda-appendix).
 
+```agda
+-- The §7 Consistency property: no two honest parties confirm conflicting transactions. We DERIVE
+-- that each honest party's confirmed set is applicable to U₀ (`conf-applicable`) and that the two
+-- sets nest (`confirmed-nest`); so their union is the larger set, which is applicable. "Conflicting"
+-- means the union fails to apply, which nesting + individual applicability rules out. The union form
+-- itself (a set T ⊇ both honest confirmed sets that is applicable to U₀) is machine-checked as
+-- `consistency-union` (SecurityProofs), so the paper's `U₀ ∘ (T̄ᵢ ∪ T̄ⱼ) ≠ ⊥` is not left as prose.
+HoldsAt : System → Set
+HoldsAt sys =
+  ∀ (i j : Fin (parties sys))
+  → lookup (honest sys) i ≡ true → lookup (honest sys) j ≡ true
+  → (confirmedTxs (lookup (localOf sys) i) ⊆ˡ confirmedTxs (lookup (localOf sys) j)
+       ⊎ confirmedTxs (lookup (localOf sys) j) ⊆ˡ confirmedTxs (lookup (localOf sys) i))
+  × Applicable (U₀ sys) (confirmedTxs (lookup (localOf sys) i))
+  × Applicable (U₀ sys) (confirmedTxs (lookup (localOf sys) j))
+
+Consistency : Set
+Consistency = ∀ (sys : System) → Reachable sys → HoldsAt sys
+```
+
+```agda
+-- ── Soundness and Completeness (Chain) ─────────────────────────────────────────────────────
+-- The finalized on-chain UTxO is the closed/fanned-out snapshot applied to U₀. That snapshot is
+-- certified (the head closes only against a fully-signed snapshot), so by `cert-applicable` it is
+-- conflict-free.
+Ufinal : System → Snapshot → Maybe UTxO
+Ufinal sys snap = applyTxs (U₀ sys) (Snapshot.txs snap)
 
 
+-- Soundness (Chain), §7: the final UTxO U₀ ∘ T̃ for a finalized snapshot T̃ whose aggregate
+-- multisignature verifies (`AggVerified`) is conflict-free AND its transactions were seen by EVERY
+-- honest party (`T̃ ⊆ ⋂_{j∈H} seen_j`). DERIVED: `ms-unforgeable` makes the verified snapshot certified
+-- (every party signed it); each honest signer signed only applicable txs (`cert-applicable`, giving
+-- conflict-freedom) it had seen (`sigSeen-inv`, giving the ⋂-seen subset).
+Soundness : Set
+Soundness = ∀ sys → Reachable sys → ∀ {h snap} → lookup (honest sys) h ≡ true → AggVerified sys snap
+          → Σ[ U ∈ UTxO ] (Ufinal sys snap ≡ just U)
+                        × (∀ {j} → lookup (honest sys) j ≡ true → Snapshot.txs snap ⊆ˡ lookup (seen sys) j)
+```
 
+```agda
+-- Completeness (Chain), §7: every transaction an honest party confirmed (T̄ᵢ) is included in the
+-- FINALIZED snapshot T̃ (the closed/fanned-out snapshot, whose aggregate multisignature verifies),
+-- for every honest party whose confirmed number is ≤ T̃'s. DERIVED: T̃ is certified
+-- (`ms-unforgeable`), the honest party's confirmed snapshot is certified-or-genesis (`confCert-of`),
+-- and two certified snapshots nest by number (`cert-nest`, L2). The `confirmedNo i ≤ number snap`
+-- premise is the §7 "the finalized snapshot is at least as advanced as every honest confirmed one"
+-- fact: in the real protocol the close/contest process always accepts the latest multi-signed
+-- snapshot (so Ufinal.s ≥ maxᵢ s̄ᵢ); our `finalize` admits ANY certified snapshot, so it is a
+-- per-party premise rather than derived. (The sibling honest-to-honest nesting is `confirmed-nest`.)
+Completeness : Set
+Completeness = ∀ sys → Reachable sys → ∀ {snap} → AggVerified sys snap
+  → ∀ i → lookup (honest sys) i ≡ true
+  → confirmedNo (lookup (localOf sys) i) ≤ Snapshot.number snap
+  → confirmedTxs (lookup (localOf sys) i) ⊆ˡ Snapshot.txs snap
+```
 
+```
+-- ── Linking the two Agda halves: off-chain confirmed snapshot ↔ on-chain close/fanout ──────────
+-- They meet at finalization: when the head closes/fans out, the on-chain Closed datum's accumulator
+-- commits to exactly the off-chain final UTxO U₀ ∘ (txs of the certified finalized snapshot).
 
+-- Glue: the set of outputs held in a UTxO map (its range). Basic, assumed (not modelled in detail).
+postulate
+  outsOf : UTxO → ℙ Output
+```
+
+```agda
+-- Bridge predicate: the on-chain head datum REFLECTS a finalized snapshot `snap` -- its snapshot
+-- number matches and its stored accumulator commits (`OC.accUTxO`) to U₀ ∘ (txs snap).
+record Reflects (sys : System) (snap : Snapshot) : Set where
+  constructor mkReflects
+  field
+    finalUtxo     : UTxO
+    conflictFree  : Ufinal sys snap ≡ just finalUtxo                  -- the final UTxO is conflict-free
+    numberMatches : OC.snapNum (onChain sys) ≡ Snapshot.number snap   -- on-chain snapshot number matches
+    accCommits    : OC.ηOf (onChain sys) ≡ OC.accUTxO (outsOf finalUtxo)  -- on-chain accumulator commits to it
+```
+
+```
+-- Liveness (head) is deliberately not yet STATED: the temporal/fairness layer it needs is
+-- deferred, so its type is left abstract (nothing about it is assumed to hold).
+postulate
+  Liveness : Set
+```
 
 #dparagraph[Consistency.]
 

--- a/spec/src/Hydra/Protocol/SecurityProofs.lagda.typ
+++ b/spec/src/Hydra/Protocol/SecurityProofs.lagda.typ
@@ -126,7 +126,7 @@ invariant sys (step {s} r tr) = invStep tr (invariant s r)
     -- Δ-seen premise (Δseen₀) + `sigSeen`/`confCert`. The signer's `seenNumber` is bumped, so the
     -- localOf-reading fields carry `lookup∘update` bookkeeping (the `.confirmed` they read is
     -- unchanged; only `seenNumber` moves).
-    invStep {a} (signHonest {i = i} {snap = snap₀} {Δ = Δ} hi₀ nf₀ (reqSn-sign vEq sEq) txsEq₀ appl₀ Δseen₀)
+    invStep {a} (signHonest {i = i} {snap = snap₀} {Δ = Δ} hi₀ nf₀ (reqSn-sign vEq sEq) txsEq₀ appl₀ Δseen₀ _ _)
             record { sigApp = sigApp ; sigDedup = sigDedup ; confApp = confApp
                    ; sigPos = sigPos ; confCert = confCert ; sigChain = sigChain
                    ; signNumBound = signNumBound ; sigSeen = sigSeen } = record
@@ -636,7 +636,7 @@ confCert-all sys (step {s} r tr) = cc tr (confCert-all s r)
                 ⊎ Certified a (LocalState.confirmed (lookup (localOf a) i)))
        → (∀ i → (confirmedNo (lookup (localOf b) i) ≡ 0 × confirmedTxs (lookup (localOf b) i) ≡ [])
                 ⊎ Certified b (LocalState.confirmed (lookup (localOf b) i)))
-    cc {a} (signHonest {i = signer} {snap = snap₀} _ _ _ _ _ _) ih i with signer FinP.≟ i
+    cc {a} (signHonest {i = signer} {snap = snap₀} _ _ _ _ _ _ _ _) ih i with signer FinP.≟ i
     ... | yes refl = subst (λ w → (confirmedNo w ≡ 0 × confirmedTxs w ≡ [])
                                    ⊎ Certified (record a { localOf = localOf a [ signer ]≔ st'ₕ ; sigs = (signer , snap₀) ∷ sigs a }) (LocalState.confirmed w))
                            (sym (lookup∘update signer (localOf a) st'ₕ)) (mono (ih signer))
@@ -1065,7 +1065,7 @@ noBothInFlightˢ sys (step {s} r tr) = nbStep tr (noBothInFlightˢ s r)
     nbStep : ∀ {a b} → a ⟶ˢ b
            → (∀ i → NoBothInFlight (lookup (localOf a) i))
            → ∀ i → NoBothInFlight (lookup (localOf b) i)
-    nbStep {a} (signHonest {i = j} _ _ _ _ _ _) ih i with j FinP.≟ i
+    nbStep {a} (signHonest {i = j} _ _ _ _ _ _ _ _) ih i with j FinP.≟ i
     ... | yes refl = subst NoBothInFlight (sym (lookup∘update j (localOf a) _)) (ih j)
     ... | no  j≢i  = subst NoBothInFlight (sym (lookup∘update′ (λ e → j≢i (sym e)) (localOf a) _)) (ih i)
     nbStep (signCorrupt _) ih i = ih i
@@ -1091,7 +1091,7 @@ versionDisciplineˢ sys (step {s} r tr) = vdStep tr (versionDisciplineˢ s r)
     vdStep : ∀ {a b} → a ⟶ˢ b
            → (∀ i → VersionDiscipline (lookup (localOf a) i))
            → ∀ i → VersionDiscipline (lookup (localOf b) i)
-    vdStep {a} (signHonest {i = j} _ _ _ _ _ _) ih i with j FinP.≟ i
+    vdStep {a} (signHonest {i = j} _ _ _ _ _ _ _ _) ih i with j FinP.≟ i
     ... | yes refl = subst VersionDiscipline (sym (lookup∘update j (localOf a) _)) (ih j)
     ... | no  j≢i  = subst VersionDiscipline (sym (lookup∘update′ (λ e → j≢i (sym e)) (localOf a) _)) (ih i)
     vdStep (signCorrupt _) ih i = ih i

--- a/spec/src/Hydra/Protocol/SecurityProofs.lagda.typ
+++ b/spec/src/Hydra/Protocol/SecurityProofs.lagda.typ
@@ -1,3 +1,36 @@
+```
+-- The machine-checked PROOFS of the §7 security properties. Factored out of `Security.lagda.typ` so
+-- that the rendered §7 shows the model + the property STATEMENTS first, and this literate module
+-- renders the machine-checked RESULTS (the statements below appear in the document and in the
+-- appendix; the proof terms are typechecked as part of the build but not rendered): the invariant
+-- and its corollaries (L1/L2/L3), `consistency`/`soundness`/`completeness`, the
+-- once-honest-then-corrupt extension, the seen-set invariant, and the off-chain⇒on-chain `reflects`
+-- bridge. Every name here is imported by the spec build, so the properties remain machine-checked.
+module Hydra.Protocol.SecurityProofs where
+
+open import Hydra.Protocol.Prelude
+open import Hydra.Protocol.OffChain
+open import Hydra.Protocol.Preliminaries using (Output; ValidityInterval; Context)
+open import Data.Fin using (Fin)
+open import Data.Nat using (z≤n; s≤s)
+open import Data.Nat.Properties using (≤-total; ≤-antisym; ≤-refl; ≤-trans; m≤n⇒m≤1+n; 1+n≰n; +-identityʳ; +-suc; suc-injective; m+[n∸m]≡n; m+n≡0⇒m≡0)
+open import Data.Sum using (map₁; map₂; [_,_]′)
+open import Data.List using (_++_)
+open import Data.List.Relation.Unary.Any using (here; there)
+open import Data.List.Membership.Propositional.Properties using (∈-++⁺ʳ; ∈-++⁺ˡ; ∈-++⁻)
+open import Data.List.Relation.Binary.Subset.Propositional.Properties using () renaming (⊆-refl to ⊆ˡ-refl; ⊆-trans to ⊆ˡ-trans)
+open import Data.Vec using (Vec; lookup; _[_]≔_)
+open import Data.Vec.Properties using (lookup∘update; lookup∘update′)
+import Data.Fin.Properties as FinP
+open import Data.Product using (Σ-syntax)
+open import Data.List.Relation.Binary.Subset.Propositional using () renaming (_⊆_ to _⊆ˡ_)
+open import Relation.Nullary using (yes; no)
+open import Relation.Binary.PropositionalEquality using (trans; sym; cong; subst)
+open import Data.Empty using (⊥-elim)
+import Hydra.Protocol.OnChain as OC
+open import Hydra.Protocol.Security
+open System  -- bring the System field projections (parties/honest/localOf/U₀/seen/onChain) into scope
+```
 
 #import "/template.typ": *
 #import "/macros.typ": *
@@ -19,6 +52,42 @@ the honest-behaviour premises of `signHonest`, and, where a result consumes an
 on-chain validity bundle, the per-instance signature-trust hypotheses noted
 with that result.
 
+```
+-- The empty tx list is always applicable (from the nil law).
+[]-applicable : ∀ U → Applicable U []
+[]-applicable U eq = bot (trans (sym (applyTxs-nil U)) eq)
+  where bot : just U ≡ nothing → ⊥
+        bot ()
+
+-- No element is a member of the empty list.
+∉[] : ∀ {A : Set} {x : A} → ¬ (x ∈ˡ [])
+∉[] ()
+
+-- `true` and `false` are distinct (one shared absurdity lemma, used wherever an honest flag clashes
+-- with a `false`).
+trueNotFalse : true ≡ false → ⊥
+trueNotFalse ()
+
+-- Vec/Fin helper: corruption only ever removes honest parties, so an honest party in the
+-- post-state was honest in the pre-state.
+honest-mono : ∀ {n} (v : Vec Bool n) (i k : Fin n)
+  → lookup (v [ i ]≔ false) k ≡ true → lookup v k ≡ true
+honest-mono v i k h with i FinP.≟ k
+... | no  i≢k  = trans (sym (lookup∘update′ (λ e → i≢k (sym e)) v false)) h
+... | yes refl = ⊥-elim (trueNotFalse (trans (sym h) (lookup∘update i v false)))
+
+-- A certified snapshot stays certified when a signature is added (`sigs` only grows): used to carry
+-- "predecessor is certified" facts forward as the signature set grows.
+Certified-mono : ∀ (sys : System) {snap : Snapshot} {x : Fin (parties sys) × Snapshot}
+  → Certified sys snap → Certified (record sys { sigs = x ∷ sigs sys }) snap
+Certified-mono _ cert i = there (cert i)
+
+-- A non-⊥ Maybe is some `just`. (Used by `invStep`'s signHonest applicability derivation and by
+-- `soundness`; defined here so it is in scope for both.)
+≢nothing→just : ∀ {A : Set} (m : Maybe A) → ¬ (m ≡ nothing) → Σ[ x ∈ A ] (m ≡ just x)
+≢nothing→just (just x) _  = x , refl
+≢nothing→just nothing  ¬n = ⊥-elim (¬n refl)
+```
 
 The workhorse is a single induction: every reachable system satisfies the
 eight-field invariant `Inv` of @sec:security (@agda-appendix: `invariant`).
@@ -33,24 +102,414 @@ only grows, so certification facts are carried forward across steps. All of
 the L1/L2/L3 consequences used by the theorems of this section are projections
 of this one invariant.
 
+```agda
+invariant : ∀ sys → Reachable sys → Inv sys
+```
 
+```
+invariant sys (base (noSigs , allConfNumZero , allConfTxsEmpty , _ , _)) = record
+  { sigApp   = λ {k} {snap} _ mem → ⊥-elim (∉[] (subst (λ z → (k , snap) ∈ˡ z) noSigs mem))
+  ; sigDedup = λ {k} {s1} _ m1 _ _ → ⊥-elim (∉[] (subst (λ z → (k , s1) ∈ˡ z) noSigs m1))
+  ; confApp  = λ {i} _ → subst (Applicable (U₀ sys)) (sym (allConfTxsEmpty i)) ([]-applicable (U₀ sys))
+  ; sigPos   = λ {k} {snap} _ mem → ⊥-elim (∉[] (subst (λ z → (k , snap) ∈ˡ z) noSigs mem))
+  ; confCert = λ {i} _ → inj₁ (allConfNumZero i , allConfTxsEmpty i)
+  ; sigChain = λ {k} {snap} _ mem → ⊥-elim (∉[] (subst (λ z → (k , snap) ∈ˡ z) noSigs mem))
+  ; signNumBound = λ {k} {snap} _ mem → ⊥-elim (∉[] (subst (λ z → (k , snap) ∈ˡ z) noSigs mem))
+  ; sigSeen      = λ {k} {snap} _ mem → ⊥-elim (∉[] (subst (λ z → (k , snap) ∈ˡ z) noSigs mem))
+  }
+invariant sys (step {s} r tr) = invStep tr (invariant s r)
+  where
+    invStep : ∀ {a b} → a ⟶ˢ b → Inv a → Inv b
+    -- signHonest fires the reqSn-sign handler (pattern `reqSn-sign vEq sEq`): the four guards are
+    -- derived here from the handler's `s ≡ s̄+1` (sEq), the snapshot/Δ shape (txsEq₀), the
+    -- U₀-applicability premise (appl₀), the no-in-flight precondition (nf₀) + `signNumBound`, and the
+    -- Δ-seen premise (Δseen₀) + `sigSeen`/`confCert`. The signer's `seenNumber` is bumped, so the
+    -- localOf-reading fields carry `lookup∘update` bookkeeping (the `.confirmed` they read is
+    -- unchanged; only `seenNumber` moves).
+    invStep {a} (signHonest {i = i} {snap = snap₀} {Δ = Δ} hi₀ nf₀ (reqSn-sign vEq sEq) txsEq₀ appl₀ Δseen₀)
+            record { sigApp = sigApp ; sigDedup = sigDedup ; confApp = confApp
+                   ; sigPos = sigPos ; confCert = confCert ; sigChain = sigChain
+                   ; signNumBound = signNumBound ; sigSeen = sigSeen } = record
+      { sigApp = newApp ; sigDedup = newDed ; confApp = newConfApp
+      ; sigPos = newPos ; confCert = newCert ; sigChain = newChain
+      ; signNumBound = newSNB ; sigSeen = newSigSeen }
+      where
+        stᵢ : LocalState
+        stᵢ = lookup (localOf a) i
+        st' : LocalState
+        st' = record stᵢ { seenNumber = Snapshot.number snap₀ }
+        -- G3a: the handler's `s ≡ s̄+1` guard (confirmedNo stᵢ = Snapshot.number (confirmed stᵢ)).
+        numEq₀ : Snapshot.number snap₀ ≡ suc (confirmedNo stᵢ)
+        numEq₀ = sEq
+        -- G3b: from snap.txs = confirmedTxs ++ Δ.
+        ext⊆₀ : confirmedTxs stᵢ ⊆ˡ Snapshot.txs snap₀
+        ext⊆₀ {x} x∈ = subst (x ∈ˡ_) (sym txsEq₀) (∈-++⁺ˡ x∈)
+        -- G1: confApp ⇒ applyTxs U₀ confirmedTxs ≡ just U′; Δ applies to U′ (appl₀); compose lifts to U₀.
+        g1 : Applicable (U₀ a) (Snapshot.txs snap₀)
+        g1 = subst (Applicable (U₀ a)) (sym txsEq₀) applU₀
+          where
+            U′just : Σ[ U′ ∈ UTxO ] applyTxs (U₀ a) (confirmedTxs stᵢ) ≡ just U′
+            U′just = ≢nothing→just (applyTxs (U₀ a) (confirmedTxs stᵢ)) (confApp hi₀)
+            applU₀ : Applicable (U₀ a) (confirmedTxs stᵢ ++ Δ)
+            applU₀ e≡n = appl₀ (proj₂ U′just)
+                              (trans (sym (applyTxs-compose (confirmedTxs stᵢ) Δ (proj₂ U′just))) e≡n)
+        -- the signer's own confirmed txs are seen (confCert: genesis [] or certified ⇒ it signed them).
+        confSeen-i : confirmedTxs stᵢ ⊆ˡ lookup (seen a) i
+        confSeen-i with confCert hi₀
+        ... | inj₁ (_ , ct≡[]) = subst (_⊆ˡ lookup (seen a) i) (sym ct≡[]) (λ ())
+        ... | inj₂ cert        = sigSeen hi₀ (cert i)
+        -- G4: snap.txs = confirmedTxs ++ Δ, both ⊆ seen (confSeen-i and the Δseen₀ premise).
+        here-seen : Snapshot.txs snap₀ ⊆ˡ lookup (seen a) i
+        here-seen {x} x∈ = [ (λ e → confSeen-i e) , (λ e → Δseen₀ e) ]′
+                             (∈-++⁻ (confirmedTxs stᵢ) (subst (x ∈ˡ_) txsEq₀ x∈))
+        -- map a pre-state certified-or-genesis fact to the post-state (sigs grew).
+        certMono : ∀ {k}
+                 → (confirmedNo (lookup (localOf a) k) ≡ 0 × confirmedTxs (lookup (localOf a) k) ≡ [])
+                     ⊎ Certified a (LocalState.confirmed (lookup (localOf a) k))
+                 → (confirmedNo (lookup (localOf a) k) ≡ 0 × confirmedTxs (lookup (localOf a) k) ≡ [])
+                     ⊎ Certified (record a { localOf = localOf a [ i ]≔ st' ; sigs = (i , snap₀) ∷ sigs a })
+                                 (LocalState.confirmed (lookup (localOf a) k))
+        certMono (inj₁ p) = inj₁ p
+        certMono (inj₂ c) = inj₂ (Certified-mono a {x = (i , snap₀)} c)
+        newApp : ∀ {k snap} → lookup (honest a) k ≡ true
+               → (k , snap) ∈ˡ ((i , snap₀) ∷ sigs a) → Applicable (U₀ a) (Snapshot.txs snap)
+        newApp _  (here e)  = subst (λ z → Applicable (U₀ a) (Snapshot.txs z)) (sym (cong proj₂ e)) g1
+        newApp hk (there m) = sigApp hk m
+        newDed : ∀ {k s1 s2} → lookup (honest a) k ≡ true
+               → (k , s1) ∈ˡ ((i , snap₀) ∷ sigs a) → (k , s2) ∈ˡ ((i , snap₀) ∷ sigs a)
+               → Snapshot.number s1 ≡ Snapshot.number s2 → s1 ≡ s2
+        newDed _  (here e1)  (here e2)  _  = trans (cong proj₂ e1) (sym (cong proj₂ e2))
+        newDed {s2 = s2} _ (here e1) (there m2) n≡ =
+          ⊥-elim (1+n≰n (subst (_≤ confirmedNo stᵢ)
+                               (trans (sym n≡) (trans (cong Snapshot.number (cong proj₂ e1)) numEq₀))
+                               (subst (Snapshot.number s2 ≤_) nf₀
+                                      (signNumBound hi₀ (subst (λ p → (p , s2) ∈ˡ sigs a) (cong proj₁ e1) m2)))))
+        newDed {s1 = s1} _ (there m1) (here e2) n≡ =
+          ⊥-elim (1+n≰n (subst (_≤ confirmedNo stᵢ)
+                               (trans n≡ (trans (cong Snapshot.number (cong proj₂ e2)) numEq₀))
+                               (subst (Snapshot.number s1 ≤_) nf₀
+                                      (signNumBound hi₀ (subst (λ p → (p , s1) ∈ˡ sigs a) (cong proj₁ e2) m1)))))
+        newDed hk (there m1) (there m2) n≡ = sigDedup hk m1 m2 n≡
+        newPos : ∀ {k snap} → lookup (honest a) k ≡ true
+               → (k , snap) ∈ˡ ((i , snap₀) ∷ sigs a) → 0 < Snapshot.number snap
+        newPos _  (here e)  = subst (0 <_) (sym (trans (cong Snapshot.number (cong proj₂ e)) numEq₀)) (s≤s z≤n)
+        newPos hk (there m) = sigPos hk m
+        newConfApp : ∀ {i'} → lookup (honest a) i' ≡ true
+                   → Applicable (U₀ a) (confirmedTxs (lookup (localOf a [ i ]≔ st') i'))
+        newConfApp {i'} hi' with i FinP.≟ i'
+        ... | no  i≢i' = subst (λ w → Applicable (U₀ a) (confirmedTxs w))
+                               (sym (lookup∘update′ (λ e → i≢i' (sym e)) (localOf a) st')) (confApp hi')
+        ... | yes refl = subst (λ w → Applicable (U₀ a) (confirmedTxs w))
+                               (sym (lookup∘update i (localOf a) st')) (confApp hi')
+        newCert : ∀ {k} → lookup (honest a) k ≡ true
+                → (confirmedNo (lookup (localOf a [ i ]≔ st') k) ≡ 0 × confirmedTxs (lookup (localOf a [ i ]≔ st') k) ≡ [])
+                  ⊎ Certified (record a { localOf = localOf a [ i ]≔ st' ; sigs = (i , snap₀) ∷ sigs a })
+                              (LocalState.confirmed (lookup (localOf a [ i ]≔ st') k))
+        newCert {k} hk with i FinP.≟ k
+        ... | no  i≢k  = subst (λ w → (confirmedNo w ≡ 0 × confirmedTxs w ≡ [])
+                                       ⊎ Certified (record a { localOf = localOf a [ i ]≔ st' ; sigs = (i , snap₀) ∷ sigs a })
+                                                   (LocalState.confirmed w))
+                               (sym (lookup∘update′ (λ e → i≢k (sym e)) (localOf a) st')) (certMono (confCert hk))
+        ... | yes refl = subst (λ w → (confirmedNo w ≡ 0 × confirmedTxs w ≡ [])
+                                       ⊎ Certified (record a { localOf = localOf a [ i ]≔ st' ; sigs = (i , snap₀) ∷ sigs a })
+                                                   (LocalState.confirmed w))
+                               (sym (lookup∘update i (localOf a) st')) (certMono (confCert hk))
+        newChain : ∀ {k snap} → lookup (honest a) k ≡ true
+                 → (k , snap) ∈ˡ ((i , snap₀) ∷ sigs a)
+                 → PredecessorWitness (Certified (record a { localOf = localOf a [ i ]≔ st' ; sigs = (i , snap₀) ∷ sigs a })) snap
+        newChain _ (here e) = mkPredecessor (LocalState.confirmed stᵢ)
+            (trans (cong Snapshot.number (cong proj₂ e)) numEq₀)
+            (subst (λ z → Snapshot.txs (LocalState.confirmed stᵢ) ⊆ˡ Snapshot.txs z) (sym (cong proj₂ e)) ext⊆₀)
+            preGenesisOrCert
+          where
+            preGenesisOrCert : (Snapshot.number (LocalState.confirmed stᵢ) ≡ 0)
+               ⊎ Certified (record a { localOf = localOf a [ i ]≔ st' ; sigs = (i , snap₀) ∷ sigs a }) (LocalState.confirmed stᵢ)
+            preGenesisOrCert with confCert hi₀
+            ... | inj₁ (n , _) = inj₁ n
+            ... | inj₂ c       = inj₂ (Certified-mono a {x = (i , snap₀)} c)
+        newChain hk (there m) with sigChain hk m
+        ... | mkPredecessor pre numberSuc txsExtend (inj₁ z) = mkPredecessor pre numberSuc txsExtend (inj₁ z)
+        ... | mkPredecessor pre numberSuc txsExtend (inj₂ c) =
+              mkPredecessor pre numberSuc txsExtend (inj₂ (Certified-mono a {x = (i , snap₀)} c))
+        newSNB : ∀ {k snap} → lookup (honest a) k ≡ true
+               → (k , snap) ∈ˡ ((i , snap₀) ∷ sigs a)
+               → Snapshot.number snap ≤ LocalState.seenNumber (lookup (localOf a [ i ]≔ st') k)
+        newSNB _ (here e) =
+          subst (λ p → Snapshot.number (proj₂ p) ≤ LocalState.seenNumber (lookup (localOf a [ i ]≔ st') (proj₁ p)))
+                (sym e)
+                (subst (Snapshot.number snap₀ ≤_)
+                       (sym (cong LocalState.seenNumber (lookup∘update i (localOf a) st'))) ≤-refl)
+        newSNB {k} {snap} hk (there m) with i FinP.≟ k
+        ... | no  i≢k  = subst (λ w → Snapshot.number snap ≤ LocalState.seenNumber w)
+                               (sym (lookup∘update′ (λ e → i≢k (sym e)) (localOf a) st')) (signNumBound hk m)
+        ... | yes refl = subst (λ w → Snapshot.number snap ≤ LocalState.seenNumber w)
+                               (sym (lookup∘update i (localOf a) st'))
+                               (subst (Snapshot.number snap ≤_) (sym numEq₀)
+                                      (m≤n⇒m≤1+n (subst (Snapshot.number snap ≤_) nf₀ (signNumBound hk m))))
+        newSigSeen : ∀ {k snap} → lookup (honest a) k ≡ true
+                   → (k , snap) ∈ˡ ((i , snap₀) ∷ sigs a) → Snapshot.txs snap ⊆ˡ lookup (seen a) k
+        newSigSeen _ (here e) =
+          subst (λ p → Snapshot.txs (proj₂ p) ⊆ˡ lookup (seen a) (proj₁ p)) (sym e) here-seen
+        newSigSeen hk (there m) = sigSeen hk m
+    invStep {a} (signCorrupt {i = i} {snap = snap₀} ci)
+            record { sigApp = sigApp ; sigDedup = sigDedup ; confApp = confApp
+                   ; sigPos = sigPos ; confCert = confCert ; sigChain = sigChain
+                   ; signNumBound = signNumBound ; sigSeen = sigSeen } = record
+      { sigApp = newApp ; sigDedup = newDed ; confApp = confApp
+      ; sigPos = newPos ; confCert = newCert ; sigChain = newChain
+      ; signNumBound = newSNB ; sigSeen = newSigSeen }
+      where
+        clash : ∀ {k snap} → lookup (honest a) k ≡ true → (k , snap) ≡ (i , snap₀) → ⊥
+        clash hk e = trueNotFalse (trans (sym (subst (λ p → lookup (honest a) p ≡ true) (cong proj₁ e) hk)) ci)
+        newApp : ∀ {k snap} → lookup (honest a) k ≡ true
+               → (k , snap) ∈ˡ ((i , snap₀) ∷ sigs a) → Applicable (U₀ a) (Snapshot.txs snap)
+        newApp hk (here e)  = ⊥-elim (clash hk e)
+        newApp hk (there m) = sigApp hk m
+        newDed : ∀ {k s1 s2} → lookup (honest a) k ≡ true
+               → (k , s1) ∈ˡ ((i , snap₀) ∷ sigs a) → (k , s2) ∈ˡ ((i , snap₀) ∷ sigs a)
+               → Snapshot.number s1 ≡ Snapshot.number s2 → s1 ≡ s2
+        newDed hk (here e1)  _          _  = ⊥-elim (clash hk e1)
+        newDed hk (there m1) (here e2)  _  = ⊥-elim (clash hk e2)
+        newDed hk (there m1) (there m2) n≡ = sigDedup hk m1 m2 n≡
+        newPos : ∀ {k snap} → lookup (honest a) k ≡ true
+               → (k , snap) ∈ˡ ((i , snap₀) ∷ sigs a) → 0 < Snapshot.number snap
+        newPos hk (here e)  = ⊥-elim (clash hk e)
+        newPos hk (there m) = sigPos hk m
+        newCert : ∀ {k} → lookup (honest a) k ≡ true
+                → (confirmedNo (lookup (localOf a) k) ≡ 0 × confirmedTxs (lookup (localOf a) k) ≡ [])
+                  ⊎ Certified (record a { sigs = (i , snap₀) ∷ sigs a }) (LocalState.confirmed (lookup (localOf a) k))
+        newCert hk with confCert hk
+        ... | inj₁ p = inj₁ p
+        ... | inj₂ c = inj₂ (Certified-mono a {x = (i , snap₀)} c)
+        newChain : ∀ {k snap} → lookup (honest a) k ≡ true
+                 → (k , snap) ∈ˡ ((i , snap₀) ∷ sigs a)
+                 → PredecessorWitness (Certified (record a { sigs = (i , snap₀) ∷ sigs a })) snap
+        newChain hk (here e)  = ⊥-elim (clash hk e)
+        newChain hk (there m) with sigChain hk m
+        ... | mkPredecessor pre numberSuc txsExtend (inj₁ z) = mkPredecessor pre numberSuc txsExtend (inj₁ z)
+        ... | mkPredecessor pre numberSuc txsExtend (inj₂ c) =
+              mkPredecessor pre numberSuc txsExtend (inj₂ (Certified-mono a {x = (i , snap₀)} c))
+        -- corrupt sign: localOf / seen unchanged, so the two new invariants pass through (the new sig
+        -- is the corrupt party's, on which the honest-only invariants impose nothing - `clash`).
+        newSNB : ∀ {k snap} → lookup (honest a) k ≡ true
+               → (k , snap) ∈ˡ ((i , snap₀) ∷ sigs a)
+               → Snapshot.number snap ≤ LocalState.seenNumber (lookup (localOf a) k)
+        newSNB hk (here e)  = ⊥-elim (clash hk e)
+        newSNB hk (there m) = signNumBound hk m
+        newSigSeen : ∀ {k snap} → lookup (honest a) k ≡ true
+                   → (k , snap) ∈ˡ ((i , snap₀) ∷ sigs a) → Snapshot.txs snap ⊆ˡ lookup (seen a) k
+        newSigSeen hk (here e)  = ⊥-elim (clash hk e)
+        newSigSeen hk (there m) = sigSeen hk m
+    invStep {a} (confirm {i = c} {snap = snap₀} aggOK _)
+            record { sigApp = sigApp ; sigDedup = sigDedup ; confApp = confApp
+                   ; sigPos = sigPos ; confCert = confCert ; sigChain = sigChain
+                   ; signNumBound = signNumBound ; sigSeen = sigSeen } = record
+      { sigApp = sigApp ; sigDedup = sigDedup ; confApp = newConfApp
+      ; sigPos = sigPos ; confCert = newCert ; sigChain = sigChain
+      ; signNumBound = newSNB ; sigSeen = sigSeen }
+      where
+        st' : LocalState
+        st' = record (lookup (localOf a) c) { confirmed = snap₀ }
+        cert : Certified a snap₀                     -- unforgeability: the verified agg sig ⇒ all signed
+        cert = ms-unforgeable a snap₀ aggOK
+        newConfApp : ∀ {i} → lookup (honest a) i ≡ true
+                   → Applicable (U₀ a) (confirmedTxs (lookup (localOf a [ c ]≔ st') i))
+        newConfApp {i} hi with c FinP.≟ i
+        ... | no  c≢i  = subst (λ w → Applicable (U₀ a) (confirmedTxs w))
+                               (sym (lookup∘update′ (λ e → c≢i (sym e)) (localOf a) st')) (confApp hi)
+        ... | yes refl = subst (λ w → Applicable (U₀ a) (confirmedTxs w))
+                               (sym (lookup∘update c (localOf a) st')) (sigApp hi (cert c))
+        newCert : ∀ {k} → lookup (honest a) k ≡ true
+                → (confirmedNo (lookup (localOf a [ c ]≔ st') k) ≡ 0 × confirmedTxs (lookup (localOf a [ c ]≔ st') k) ≡ [])
+                  ⊎ Certified a (LocalState.confirmed (lookup (localOf a [ c ]≔ st') k))
+        newCert {k} hk with c FinP.≟ k
+        ... | no  c≢k  = subst (λ w → (confirmedNo w ≡ 0 × confirmedTxs w ≡ []) ⊎ Certified a (LocalState.confirmed w))
+                               (sym (lookup∘update′ (λ e → c≢k (sym e)) (localOf a) st')) (confCert hk)
+        ... | yes refl = subst (λ w → (confirmedNo w ≡ 0 × confirmedTxs w ≡ []) ⊎ Certified a (LocalState.confirmed w))
+                               (sym (lookup∘update c (localOf a) st')) (inj₂ cert)
+        -- confirm changes only `.confirmed`; `seenNumber`/`sigs` are untouched, so signNumBound just
+        -- needs the lookup∘update bookkeeping (seenNumber of the updated entry is unchanged).
+        newSNB : ∀ {k snap} → lookup (honest a) k ≡ true → (k , snap) ∈ˡ sigs a
+               → Snapshot.number snap ≤ LocalState.seenNumber (lookup (localOf a [ c ]≔ st') k)
+        newSNB {k} {snap} hk m with c FinP.≟ k
+        ... | no  c≢k  = subst (λ w → Snapshot.number snap ≤ LocalState.seenNumber w)
+                               (sym (lookup∘update′ (λ e → c≢k (sym e)) (localOf a) st')) (signNumBound hk m)
+        ... | yes refl = subst (λ w → Snapshot.number snap ≤ LocalState.seenNumber w)
+                               (sym (lookup∘update c (localOf a) st')) (signNumBound hk m)
+    invStep {a} (corrupt i₀)
+            record { sigApp = sigApp ; sigDedup = sigDedup ; confApp = confApp
+                   ; sigPos = sigPos ; confCert = confCert ; sigChain = sigChain
+                   ; signNumBound = signNumBound ; sigSeen = sigSeen } = record
+      { sigApp   = λ {k} {snap} hk mem → sigApp (honest-mono (honest a) i₀ k hk) mem
+      ; sigDedup = λ {k} {s1} {s2} hk m1 m2 n≡ → sigDedup (honest-mono (honest a) i₀ k hk) m1 m2 n≡
+      ; confApp  = λ {i} hi → confApp (honest-mono (honest a) i₀ i hi)
+      ; sigPos   = λ {k} {snap} hk mem → sigPos (honest-mono (honest a) i₀ k hk) mem
+      ; confCert = λ {i} hi → confCert (honest-mono (honest a) i₀ i hi)
+      ; sigChain = λ {k} {snap} hk mem → sigChain (honest-mono (honest a) i₀ k hk) mem
+      ; signNumBound = λ {k} {snap} hk m → signNumBound (honest-mono (honest a) i₀ k hk) m
+      ; sigSeen      = λ {k} {snap} hk m → sigSeen (honest-mono (honest a) i₀ k hk) m }
+    -- `finalize` changes only `onChain`; no `Inv` field mentions it, so re-pack the same proofs (the
+    -- record is nominal in `sys`, so we cannot return `inv` directly even though the fields coincide).
+    invStep {a} (finalize _ _) inv = record
+      { sigApp = Inv.sigApp inv ; sigDedup = Inv.sigDedup inv ; confApp = Inv.confApp inv
+      ; sigPos = Inv.sigPos inv ; confCert = Inv.confCert inv ; sigChain = Inv.sigChain inv
+      ; signNumBound = Inv.signNumBound inv ; sigSeen = Inv.sigSeen inv }
+    -- `see` grows party i₀'s seen set; only `sigSeen` mentions `seen`, so it is the only field that
+    -- needs work (membership is preserved by the `++`); the rest re-pack unchanged.
+    invStep {a} (see {i = i₀} {txs = txs}) inv = record
+      { sigApp = Inv.sigApp inv ; sigDedup = Inv.sigDedup inv ; confApp = Inv.confApp inv
+      ; sigPos = Inv.sigPos inv ; confCert = Inv.confCert inv ; sigChain = Inv.sigChain inv
+      ; signNumBound = Inv.signNumBound inv ; sigSeen = newSigSeen }
+      where
+        newSigSeen : ∀ {k snap} → lookup (honest a) k ≡ true → (k , snap) ∈ˡ sigs a
+                   → Snapshot.txs snap ⊆ˡ lookup (seen a [ i₀ ]≔ (txs ++ lookup (seen a) i₀)) k
+        newSigSeen {k} {snap} hk m with i₀ FinP.≟ k
+        ... | no  i≢k  = subst (λ w → Snapshot.txs snap ⊆ˡ w)
+                               (sym (lookup∘update′ (λ e → i≢k (sym e)) (seen a) (txs ++ lookup (seen a) i₀)))
+                               (Inv.sigSeen inv hk m)
+        ... | yes refl = subst (λ w → Snapshot.txs snap ⊆ˡ w)
+                               (sym (lookup∘update i₀ (seen a) (txs ++ lookup (seen a) i₀)))
+                               (λ x∈ → ∈-++⁺ʳ txs (Inv.sigSeen inv hk m x∈))
+    -- offChain (deposit/recover/tick/increment/decrement or reqDec): `sigs`/`seen`/`U₀` unchanged, and
+    -- the updated party's confirmed snapshot + seen number are preserved (confPres/snPres). So the 5
+    -- signature-only fields re-pack verbatim; only the 3 localOf-reading fields need `lookup∘update`
+    -- bookkeeping plus the two preservation equalities.
+    invStep {a} (offChain {i = i} {st' = st'} _ confPres snPres)
+            record { sigApp = sigApp ; sigDedup = sigDedup ; confApp = confApp
+                   ; sigPos = sigPos ; confCert = confCert ; sigChain = sigChain
+                   ; signNumBound = signNumBound ; sigSeen = sigSeen } = record
+      { sigApp = sigApp ; sigDedup = sigDedup ; confApp = newConfApp
+      ; sigPos = sigPos ; confCert = newConfCert ; sigChain = sigChain
+      ; signNumBound = newSNB ; sigSeen = sigSeen }
+      where
+        newConfApp : ∀ {i'} → lookup (honest a) i' ≡ true
+                   → Applicable (U₀ a) (confirmedTxs (lookup (localOf a [ i ]≔ st') i'))
+        newConfApp {i'} hi' with i FinP.≟ i'
+        ... | no  i≢i' = subst (λ w → Applicable (U₀ a) (confirmedTxs w))
+                               (sym (lookup∘update′ (λ e → i≢i' (sym e)) (localOf a) st')) (confApp hi')
+        ... | yes refl = subst (λ w → Applicable (U₀ a) (confirmedTxs w))
+                               (sym (lookup∘update i (localOf a) st'))
+                               (subst (λ c → Applicable (U₀ a) (Snapshot.txs c)) (sym confPres) (confApp hi'))
+        newConfCert : ∀ {k} → lookup (honest a) k ≡ true
+                    → (confirmedNo (lookup (localOf a [ i ]≔ st') k) ≡ 0 × confirmedTxs (lookup (localOf a [ i ]≔ st') k) ≡ [])
+                      ⊎ Certified a (LocalState.confirmed (lookup (localOf a [ i ]≔ st') k))
+        newConfCert {k} hk with i FinP.≟ k
+        ... | no  i≢k  = subst (λ w → (confirmedNo w ≡ 0 × confirmedTxs w ≡ []) ⊎ Certified a (LocalState.confirmed w))
+                               (sym (lookup∘update′ (λ e → i≢k (sym e)) (localOf a) st')) (confCert hk)
+        ... | yes refl = subst (λ w → (confirmedNo w ≡ 0 × confirmedTxs w ≡ []) ⊎ Certified a (LocalState.confirmed w))
+                               (sym (lookup∘update i (localOf a) st'))
+                               (subst (λ c → (Snapshot.number c ≡ 0 × Snapshot.txs c ≡ []) ⊎ Certified a c)
+                                      (sym confPres) (confCert hk))
+        newSNB : ∀ {k snap} → lookup (honest a) k ≡ true → (k , snap) ∈ˡ sigs a
+               → Snapshot.number snap ≤ LocalState.seenNumber (lookup (localOf a [ i ]≔ st') k)
+        newSNB {k} {snap} hk m with i FinP.≟ k
+        ... | no  i≢k  = subst (λ w → Snapshot.number snap ≤ LocalState.seenNumber w)
+                               (sym (lookup∘update′ (λ e → i≢k (sym e)) (localOf a) st')) (signNumBound hk m)
+        ... | yes refl = subst (λ w → Snapshot.number snap ≤ LocalState.seenNumber w)
+                               (sym (lookup∘update i (localOf a) st'))
+                               (subst (Snapshot.number snap ≤_) (sym snPres) (signNumBound hk m))
+```
 
+```
+-- ── Derived corollaries of the invariant ───────────────────────────────────────────────────────
+-- L3 (applicability), exposed: every honest party's confirmed snapshot is applicable to U₀.
+conf-applicable : ∀ sys → Reachable sys → ∀ {i} → lookup (honest sys) i ≡ true
+  → Applicable (U₀ sys) (confirmedTxs (lookup (localOf sys) i))
+```
 
+```
+conf-applicable sys reach = Inv.confApp (invariant sys reach)
+```
 
+```
+-- L3 for certified snapshots: a CERTIFIED snapshot is applicable to U₀, witnessed by any honest
+-- party (who, by `Certified`, signed it, and whose signatures are only on applicable snapshots).
+cert-applicable : ∀ sys → Reachable sys → ∀ {h snap} → lookup (honest sys) h ≡ true
+  → Certified sys snap → Applicable (U₀ sys) (Snapshot.txs snap)
+```
 
+```
+cert-applicable sys reach {h} hh cert = Inv.sigApp (invariant sys reach) hh (cert h)
+```
 
 Agreement (L1) is the projection of the invariant's one-signature-per-number
 field: two certified snapshots of the same number are equal, witnessed by any
 honest party, who by `Certified` signed both (@agda-appendix: `agree`).
 
+```agda
+agree : ∀ sys → Reachable sys → ∀ {h s1 s2} → lookup (honest sys) h ≡ true
+  → Certified sys s1 → Certified sys s2 → Snapshot.number s1 ≡ Snapshot.number s2 → s1 ≡ s2
+```
 
+```
+agree sys reach {h} hh c1 c2 = Inv.sigDedup (invariant sys reach) hh (c1 h) (c2 h)
+```
 
+```
+-- A certified snapshot has number > 0 (an honest party signed it, and honest signing is for the
+-- snapshot one above its confirmed number, hence ≥ 1).
+cert-pos : ∀ sys → Reachable sys → ∀ {h snap} → lookup (honest sys) h ≡ true
+  → Certified sys snap → 0 < Snapshot.number snap
+```
 
+```
+cert-pos sys reach {h} hh cert = Inv.sigPos (invariant sys reach) hh (cert h)
+```
 
+```
+-- An honest party's confirmed snapshot is the genesis (number 0, txs []) or is certified.
+confCert-of : ∀ sys → Reachable sys → ∀ {i} → lookup (honest sys) i ≡ true
+  → (confirmedNo (lookup (localOf sys) i) ≡ 0 × confirmedTxs (lookup (localOf sys) i) ≡ [])
+    ⊎ Certified sys (LocalState.confirmed (lookup (localOf sys) i))
+```
 
+```
+confCert-of sys reach = Inv.confCert (invariant sys reach)
+```
 
+```
+-- Every honest signature on `snap` has an extending certified-or-genesis predecessor `pre`.
+sigChain-of : ∀ sys → Reachable sys → ∀ {k snap} → lookup (honest sys) k ≡ true → Signed sys k snap
+  → PredecessorWitness (Certified sys) snap
+```
 
+```
+sigChain-of sys reach = Inv.sigChain (invariant sys reach)
+```
 
+```
+-- ── L2: certified snapshots nest ────────────────────────────────────────────────────────────────
+-- Certified snapshots nest by number. Proof by induction on the gap d = number s2 ∸ number s1: at
+-- d=0 the numbers are equal, so by agreement (L1) the snapshots are equal; at d=suc, the higher
+-- snapshot s2 has (by `sigChain-of`) an extending certified-or-genesis predecessor `pre` one number
+-- below it, so we recurse on the smaller gap to `pre` and compose with `txs pre ⊆ txs s2`. The
+-- genesis case is impossible: `cert-pos` makes a certified snapshot's number positive, but `pre`
+-- would sit at number 0.
+cert-nest-aux : ∀ sys → Reachable sys → ∀ d {h s1 s2}
+  → lookup (honest sys) h ≡ true → Certified sys s1 → Certified sys s2
+  → Snapshot.number s1 + d ≡ Snapshot.number s2
+  → Snapshot.txs s1 ⊆ˡ Snapshot.txs s2
+cert-nest-aux sys reach zero {h} {s1} {s2} hh c1 c2 eq =
+  subst (λ z → Snapshot.txs s1 ⊆ˡ Snapshot.txs z)
+        (agree sys reach hh c1 c2 (trans (sym (+-identityʳ (Snapshot.number s1))) eq))
+        ⊆ˡ-refl
+cert-nest-aux sys reach (suc d') {h} {s1} {s2} hh c1 c2 eq
+  with sigChain-of sys reach hh (c2 h)
+... | mkPredecessor pre numberSuc txsExtend (inj₂ certPre) =
+      ⊆ˡ-trans (cert-nest-aux sys reach d' hh c1 certPre eq') txsExtend
+  where
+    eq' : Snapshot.number s1 + d' ≡ Snapshot.number pre
+    eq' = suc-injective (trans (sym (+-suc (Snapshot.number s1) d')) (trans eq numberSuc))
+... | mkPredecessor pre numberSuc txsExtend (inj₁ preNumZero) =
+      ⊥-elim (1≤0 (subst (1 ≤_) ns1≡0 (cert-pos sys reach hh c1)))
+  where
+    eq' : Snapshot.number s1 + d' ≡ Snapshot.number pre
+    eq' = suc-injective (trans (sym (+-suc (Snapshot.number s1) d')) (trans eq numberSuc))
+    ns1≡0 : Snapshot.number s1 ≡ 0
+    ns1≡0 = m+n≡0⇒m≡0 (Snapshot.number s1) (trans eq' preNumZero)
+    1≤0 : 1 ≤ 0 → ⊥
+    1≤0 ()
+```
 
 Certified snapshots nest by number (L2). The proof is an induction on the gap
 between the two numbers: at gap zero the snapshots are equal by `agree`;
@@ -60,14 +519,43 @@ recurses to the predecessor and composes with the extension, the genesis case
 being impossible for a certified (hence positive-numbered) snapshot
 (@agda-appendix: `cert-nest`).
 
+```agda
+cert-nest : ∀ sys → Reachable sys → ∀ {h s1 s2}
+  → lookup (honest sys) h ≡ true → Certified sys s1 → Certified sys s2
+  → Snapshot.number s1 ≤ Snapshot.number s2 → Snapshot.txs s1 ⊆ˡ Snapshot.txs s2
+```
 
+```
+cert-nest sys reach {h} {s1} {s2} hh c1 c2 le =
+  cert-nest-aux sys reach (Snapshot.number s2 ∸ Snapshot.number s1) hh c1 c2 (m+[n∸m]≡n le)
+```
 
 The @sec:security nesting obligation follows: two honest parties' confirmed snapshots
 nest by number, since an honest party's confirmed snapshot is the genesis
 (whose transaction list is empty, hence trivially contained) or is certified,
 in which case `cert-nest` applies (@agda-appendix: `confirmed-nest`).
 
+```agda
+confirmed-nest : ∀ sys → Reachable sys → ∀ i j
+  → lookup (honest sys) i ≡ true → lookup (honest sys) j ≡ true
+  → confirmedNo (lookup (localOf sys) i) ≤ confirmedNo (lookup (localOf sys) j)
+  → confirmedTxs (lookup (localOf sys) i) ⊆ˡ confirmedTxs (lookup (localOf sys) j)
+```
 
+```
+confirmed-nest sys reach i j hi hj le with confCert-of sys reach hi
+... | inj₁ (_ , ti≡[]) = subst (_⊆ˡ confirmedTxs (lookup (localOf sys) j)) (sym ti≡[]) []⊆
+  where []⊆ : [] ⊆ˡ confirmedTxs (lookup (localOf sys) j)
+        []⊆ ()
+... | inj₂ ci with confCert-of sys reach hj
+... | inj₁ (nj≡0 , _) =
+      ⊥-elim (1≤0 (subst (1 ≤_)
+        (≤-antisym (subst (confirmedNo (lookup (localOf sys) i) ≤_) nj≡0 le) z≤n)
+        (cert-pos sys reach hi ci)))
+  where 1≤0 : 1 ≤ 0 → ⊥
+        1≤0 ()
+... | inj₂ cj = cert-nest sys reach hi ci cj le
+```
 
 === Consistency
 
@@ -87,13 +575,41 @@ in which case `cert-nest` applies (@agda-appendix: `confirmed-nest`).
   (@agda-appendix).
 ] <thm:consistency>
 
+```agda
+consistency : Consistency
+```
 
+```
+consistency sys reach i j hi hj =
+  nested , conf-applicable sys reach hi , conf-applicable sys reach hj
+  where
+    nested : (confirmedTxs (lookup (localOf sys) i) ⊆ˡ confirmedTxs (lookup (localOf sys) j))
+           ⊎ (confirmedTxs (lookup (localOf sys) j) ⊆ˡ confirmedTxs (lookup (localOf sys) i))
+    nested with ≤-total (confirmedNo (lookup (localOf sys) i)) (confirmedNo (lookup (localOf sys) j))
+    ... | inj₁ le = inj₁ (confirmed-nest sys reach i j hi hj le)
+    ... | inj₂ ge = inj₂ (confirmed-nest sys reach j i hj hi ge)
+```
 
 The union form: there is a single transaction set `T` containing both honest
 confirmed sets (their union, i.e. the inclusion-larger of the two, since they
 nest) that is applicable to $Uinit$.
 
+```
+consistency-union : ∀ sys → Reachable sys → ∀ i j
+  → lookup (honest sys) i ≡ true → lookup (honest sys) j ≡ true
+  → Σ[ T ∈ List Data ] (confirmedTxs (lookup (localOf sys) i) ⊆ˡ T
+                      × confirmedTxs (lookup (localOf sys) j) ⊆ˡ T
+                      × Applicable (U₀ sys) T)
+```
 
+```
+consistency-union sys reach i j hi hj
+  with ≤-total (confirmedNo (lookup (localOf sys) i)) (confirmedNo (lookup (localOf sys) j))
+... | inj₁ le = confirmedTxs (lookup (localOf sys) j)
+              , confirmed-nest sys reach i j hi hj le , ⊆ˡ-refl , conf-applicable sys reach hj
+... | inj₂ ge = confirmedTxs (lookup (localOf sys) i)
+              , ⊆ˡ-refl , confirmed-nest sys reach j i hj hi ge , conf-applicable sys reach hi
+```
 
 The @sec:security random variables $Tbar_i$ scope a party's confirmed set to a party
 _while uncorrupted_, and an on-chain close could be built against the
@@ -105,12 +621,122 @@ confirmer's honesty flag. This is in fact stronger than the literal @sec:securit
 scoping, since it also covers any snapshot a corrupt party adopts after
 corruption.
 
+```
+confCert-all : ∀ sys → Reachable sys → ∀ i
+  → (confirmedNo (lookup (localOf sys) i) ≡ 0 × confirmedTxs (lookup (localOf sys) i) ≡ [])
+    ⊎ Certified sys (LocalState.confirmed (lookup (localOf sys) i))
+```
 
+```
+confCert-all sys (base (_ , cn≡0 , ct≡[] , _ , _)) i = inj₁ (cn≡0 i , ct≡[] i)
+confCert-all sys (step {s} r tr) = cc tr (confCert-all s r)
+  where
+    cc : ∀ {a b} → a ⟶ˢ b
+       → (∀ i → (confirmedNo (lookup (localOf a) i) ≡ 0 × confirmedTxs (lookup (localOf a) i) ≡ [])
+                ⊎ Certified a (LocalState.confirmed (lookup (localOf a) i)))
+       → (∀ i → (confirmedNo (lookup (localOf b) i) ≡ 0 × confirmedTxs (lookup (localOf b) i) ≡ [])
+                ⊎ Certified b (LocalState.confirmed (lookup (localOf b) i)))
+    cc {a} (signHonest {i = signer} {snap = snap₀} _ _ _ _ _ _) ih i with signer FinP.≟ i
+    ... | yes refl = subst (λ w → (confirmedNo w ≡ 0 × confirmedTxs w ≡ [])
+                                   ⊎ Certified (record a { localOf = localOf a [ signer ]≔ st'ₕ ; sigs = (signer , snap₀) ∷ sigs a }) (LocalState.confirmed w))
+                           (sym (lookup∘update signer (localOf a) st'ₕ)) (mono (ih signer))
+      where
+        st'ₕ = record (lookup (localOf a) signer) { seenNumber = Snapshot.number snap₀ }
+        mono : (confirmedNo (lookup (localOf a) signer) ≡ 0 × confirmedTxs (lookup (localOf a) signer) ≡ []) ⊎ Certified a (LocalState.confirmed (lookup (localOf a) signer))
+             → (confirmedNo (lookup (localOf a) signer) ≡ 0 × confirmedTxs (lookup (localOf a) signer) ≡ []) ⊎ Certified (record a { localOf = localOf a [ signer ]≔ st'ₕ ; sigs = (signer , snap₀) ∷ sigs a }) (LocalState.confirmed (lookup (localOf a) signer))
+        mono (inj₁ p) = inj₁ p
+        mono (inj₂ c) = inj₂ (Certified-mono a {x = signer , snap₀} c)
+    ... | no  s≢i  = subst (λ w → (confirmedNo w ≡ 0 × confirmedTxs w ≡ [])
+                                   ⊎ Certified (record a { localOf = localOf a [ signer ]≔ st'ₕ ; sigs = (signer , snap₀) ∷ sigs a }) (LocalState.confirmed w))
+                           (sym (lookup∘update′ (λ e → s≢i (sym e)) (localOf a) st'ₕ)) (mono (ih i))
+      where
+        st'ₕ = record (lookup (localOf a) signer) { seenNumber = Snapshot.number snap₀ }
+        mono : (confirmedNo (lookup (localOf a) i) ≡ 0 × confirmedTxs (lookup (localOf a) i) ≡ []) ⊎ Certified a (LocalState.confirmed (lookup (localOf a) i))
+             → (confirmedNo (lookup (localOf a) i) ≡ 0 × confirmedTxs (lookup (localOf a) i) ≡ []) ⊎ Certified (record a { localOf = localOf a [ signer ]≔ st'ₕ ; sigs = (signer , snap₀) ∷ sigs a }) (LocalState.confirmed (lookup (localOf a) i))
+        mono (inj₁ p) = inj₁ p
+        mono (inj₂ c) = inj₂ (Certified-mono a {x = signer , snap₀} c)
+    cc {a} (signCorrupt {i = signer} {snap = snap₀} _) ih i with ih i
+    ... | inj₁ p = inj₁ p
+    ... | inj₂ c = inj₂ (Certified-mono a {x = signer , snap₀} c)
+    cc {a} (confirm {i = c} {snap = snap₀} aggOK _) ih i with c FinP.≟ i
+    ... | yes refl = subst (λ w → (confirmedNo w ≡ 0 × confirmedTxs w ≡ []) ⊎ Certified a (LocalState.confirmed w))
+                           (sym (lookup∘update c (localOf a) (record (lookup (localOf a) c) { confirmed = snap₀ })))
+                           (inj₂ (ms-unforgeable a snap₀ aggOK))
+    ... | no  c≢i  = subst (λ w → (confirmedNo w ≡ 0 × confirmedTxs w ≡ []) ⊎ Certified a (LocalState.confirmed w))
+                           (sym (lookup∘update′ (λ e → c≢i (sym e)) (localOf a) (record (lookup (localOf a) c) { confirmed = snap₀ })))
+                           (ih i)
+    cc {a} (corrupt _)    ih i = ih i
+    cc {a} (finalize _ _) ih i = ih i
+    cc {a} (see)          ih i = ih i
+    -- offChain leaves `sigs` (hence `Certified`) untouched and preserves the updated party's confirmed
+    -- snapshot (confPres), so the genesis-or-certified status carries over (lookup∘update bookkeeping).
+    cc {a} (offChain {i = j} {st' = st'} _ confPres _) ih i with j FinP.≟ i
+    ... | yes refl = subst (λ w → (confirmedNo w ≡ 0 × confirmedTxs w ≡ []) ⊎ Certified a (LocalState.confirmed w))
+                           (sym (lookup∘update j (localOf a) st'))
+                           (subst (λ c → (Snapshot.number c ≡ 0 × Snapshot.txs c ≡ []) ⊎ Certified a c)
+                                  (sym confPres) (ih i))
+    ... | no  j≢i  = subst (λ w → (confirmedNo w ≡ 0 × confirmedTxs w ≡ []) ⊎ Certified a (LocalState.confirmed w))
+                           (sym (lookup∘update′ (λ e → j≢i (sym e)) (localOf a) st')) (ih i)
+```
 
+```
+-- Nesting for ANY two parties (via the honest witness `h`), from `confCert-all` + `cert-nest`.
+nestU : ∀ sys → Reachable sys → ∀ {h} → lookup (honest sys) h ≡ true → ∀ i j
+  → confirmedNo (lookup (localOf sys) i) ≤ confirmedNo (lookup (localOf sys) j)
+  → confirmedTxs (lookup (localOf sys) i) ⊆ˡ confirmedTxs (lookup (localOf sys) j)
+nestU sys reach hh i j le with confCert-all sys reach i
+... | inj₁ (_ , ti≡[]) = subst (_⊆ˡ confirmedTxs (lookup (localOf sys) j)) (sym ti≡[]) []⊆
+  where []⊆ : [] ⊆ˡ confirmedTxs (lookup (localOf sys) j)
+        []⊆ ()
+... | inj₂ ci with confCert-all sys reach j
+... | inj₁ (nj≡0 , _) =
+      ⊥-elim (1≤0 (subst (1 ≤_)
+        (≤-antisym (subst (confirmedNo (lookup (localOf sys) i) ≤_) nj≡0 le) z≤n)
+        (cert-pos sys reach hh ci)))
+  where 1≤0 : 1 ≤ 0 → ⊥
+        1≤0 ()
+... | inj₂ cj = cert-nest sys reach hh ci cj le
 
+-- Applicability for ANY party's confirmed snapshot (via the honest witness), from `confCert-all`.
+appU : ∀ sys → Reachable sys → ∀ {h} → lookup (honest sys) h ≡ true → ∀ i
+  → Applicable (U₀ sys) (confirmedTxs (lookup (localOf sys) i))
+appU sys reach hh i with confCert-all sys reach i
+... | inj₁ (_ , ti≡[]) = subst (Applicable (U₀ sys)) (sym ti≡[]) ([]-applicable (U₀ sys))
+... | inj₂ ci = cert-applicable sys reach hh ci
+```
 
+```agda
+consistency-uncorrupted : ∀ sys → Reachable sys → ∀ {h} → lookup (honest sys) h ≡ true → ∀ i j
+  → (confirmedTxs (lookup (localOf sys) i) ⊆ˡ confirmedTxs (lookup (localOf sys) j)
+       ⊎ confirmedTxs (lookup (localOf sys) j) ⊆ˡ confirmedTxs (lookup (localOf sys) i))
+   × Applicable (U₀ sys) (confirmedTxs (lookup (localOf sys) i))
+   × Applicable (U₀ sys) (confirmedTxs (lookup (localOf sys) j))
+```
 
+```
+consistency-uncorrupted sys reach hh i j =
+  nested , appU sys reach hh i , appU sys reach hh j
+  where
+    nested : (confirmedTxs (lookup (localOf sys) i) ⊆ˡ confirmedTxs (lookup (localOf sys) j))
+           ⊎ (confirmedTxs (lookup (localOf sys) j) ⊆ˡ confirmedTxs (lookup (localOf sys) i))
+    nested with ≤-total (confirmedNo (lookup (localOf sys) i)) (confirmedNo (lookup (localOf sys) j))
+    ... | inj₁ le = inj₁ (nestU sys reach hh i j le)
+    ... | inj₂ ge = inj₂ (nestU sys reach hh j i ge)
+```
 
+```
+-- ── Seen-set invariant: every honest signature is on txs that party has SEEN ───────────────────
+-- `Snapshot.txs snap ⊆ lookup seen k` for any honest `k` that signed `snap`. This is the `sigSeen`
+-- component of the main invariant (derived at `signHonest` from the handler's Δ ⊆ seen premise + the
+-- confirmed-txs-seen fact); exposed here as a thin corollary for `soundness`'s call site.
+sigSeen-inv : ∀ sys → Reachable sys → ∀ {k snap}
+  → lookup (honest sys) k ≡ true → Signed sys k snap
+  → Snapshot.txs snap ⊆ˡ lookup (seen sys) k
+```
+
+```
+sigSeen-inv sys reach = Inv.sigSeen (invariant sys reach)
+```
 
 === Soundness and completeness
 
@@ -129,7 +755,16 @@ certified, an honest signer signs only applicable snapshots
 seen (the `sigSeen` component of the invariant, giving the intersection-seen
 subset).
 
+```agda
+soundness : Soundness
+```
 
+```
+soundness sys reach {snap = snap} hh aggOK =
+  let cert      = ms-unforgeable sys snap aggOK
+      finalJust = ≢nothing→just (Ufinal sys snap) (cert-applicable sys reach hh cert)
+  in proj₁ finalJust , proj₂ finalJust , (λ {j} hj → sigSeen-inv sys reach hj (cert j))
+```
 
 #theorem(name: "Completeness")[
   Every honest party's confirmed transactions are contained in the finalized
@@ -147,7 +782,17 @@ close/contest process always settles on the latest multi-signed snapshot,
 whereas the model's `finalize` admits _any_ certified snapshot, so the fact
 enters as a per-party premise rather than being derived.
 
+```agda
+completeness : Completeness
+```
 
+```
+completeness sys reach {snap} aggOK i hi le with confCert-of sys reach hi
+... | inj₁ (_ , ti≡[]) = subst (_⊆ˡ Snapshot.txs snap) (sym ti≡[]) []⊆snap
+  where []⊆snap : [] ⊆ˡ Snapshot.txs snap
+        []⊆snap ()
+... | inj₂ ci = cert-nest sys reach hi ci (ms-unforgeable sys snap aggOK) le
+```
 
 === The on-chain reflection bridge
 
@@ -170,9 +815,31 @@ since `finalize` admits any datum with a matching snapshot number, a global
 axiom would have no model, and the finalizer discharges `ηEq` from the $eta$
 it actually committed.
 
+```agda
+reflects : ∀ sys → Reachable sys → ∀ {h snap}
+  → lookup (honest sys) h ≡ true
+  → AggVerified sys snap
+  → OC.snapNum (onChain sys) ≡ Snapshot.number snap
+  → (∀ U → Ufinal sys snap ≡ just U → OC.ηOf (onChain sys) ≡ OC.accUTxO (outsOf U))
+  → Reflects sys snap
+```
 
+```
+reflects sys reach {snap = snap} hh aggOK numEq ηEq =
+  let s        = soundness sys reach hh aggOK
+      finalEq  = proj₁ (proj₂ s)
+  in mkReflects (proj₁ s) finalEq numEq (ηEq (proj₁ s) finalEq)
+```
 
+```agda
+reflect-sound : ∀ sys → Reachable sys → ∀ {snap} → Reflects sys snap
+  → Σ[ U ∈ UTxO ] (Ufinal sys snap ≡ just U)
+                × (OC.ηOf (onChain sys) ≡ OC.accUTxO (outsOf U))
+```
 
+```
+reflect-sound sys reach (mkReflects U conflictFree _ accCommits) = U , conflictFree , accCommits
+```
 
 The fan-out half consumes the bundle's membership conjunct through the
 accumulator soundness law: the outputs the transaction pays (the anchored
@@ -180,7 +847,18 @@ accumulator soundness law: the outputs the transaction pays (the anchored
 tying the transaction's own outputs, not a free set parameter, to the
 Soundness UTxO.
 
+```agda
+reflect-fanout-⊆ : ∀ sys → ∀ {ctx U m π crs}
+  → OC.ηOf (onChain sys) ≡ OC.accUTxO (outsOf U)
+  → OC.FanoutValid ctx (onChain sys) m π crs
+  → OC.distributedOuts ctx m ⊆ outsOf U
+```
 
+```
+reflect-fanout-⊆ sys {ctx} {U} {m} {π} η≡ b =
+  OC.accVerify-sound
+    (subst (λ z → OC.accVerify z (OC.distributedOuts ctx m) π ≡ true) η≡ (OC.FanoutValid.membersOK b))
+```
 
 === No settlement without unanimity
 
@@ -208,7 +886,23 @@ signature conjuncts, not only at datum accessors. The field-matching
 equalities are dischargeable by `refl` for the snapshot actually signed;
 `ξEq` is per-instance for the same reason `ηEq` is.
 
+```agda
+sig-certifies : ∀ sys (snap : Snapshot) {hk cid v s η# δ# κ# ξ}
+  → OC.snapshotSigOK hk cid v s η# δ# κ# ξ
+  → hk ≡ aggKey
+  → Snapshot.cid snap ≡ cid
+  → Snapshot.version snap ≡ v
+  → Snapshot.number snap ≡ s
+  → Snapshot.etaHash snap ≡ η#
+  → Snapshot.decHash snap ≡ δ#
+  → Snapshot.comHash snap ≡ κ#
+  → ξ ≡ aggSigOf sys snap
+  → Certified sys snap
+```
 
+```
+sig-certifies sys snap sig refl refl refl refl refl refl refl refl = ms-unforgeable sys snap sig
+```
 
 The per-transaction corollaries (`increment-certified`, `decrement-certified`,
 `close-certified`, `contest-certified`) each consume their bundle's `sigOK`
@@ -217,13 +911,77 @@ rendered); the `closeUsed`/`contestUsed`/`closeAny` redeemer variants follow
 identically (their `sigOK` reduces to `snapshotSigOK` at version $v - 1$ or
 $v$).
 
+```
+increment-certified : ∀ sys {ctx cid v d d' ξ s ref δ#} (snap : Snapshot)
+  → OC.IncrementValid ctx aggKey cid v d d' ξ s ref δ#
+  → Snapshot.cid snap ≡ cid
+  → Snapshot.version snap ≡ v
+  → Snapshot.number snap ≡ s
+  → Snapshot.etaHash snap ≡ hash (OC.ηOf d')
+  → Snapshot.decHash snap ≡ δ#
+  → Snapshot.comHash snap ≡ OC.depositCommitsHashOf ctx ref
+  → ξ ≡ aggSigOf sys snap
+  → Certified sys snap
+```
 
+```
+increment-certified sys snap b cidEq vEq sEq ηEq δEq κEq ξEq =
+  sig-certifies sys snap (OC.IncrementValid.sigOK b) refl cidEq vEq sEq ηEq δEq κEq ξEq
+```
 
+```
+decrement-certified : ∀ sys {ctx cid v d d' ξ s m κ#} (snap : Snapshot)
+  → OC.DecrementValid ctx aggKey cid v d d' ξ s m κ#
+  → Snapshot.cid snap ≡ cid
+  → Snapshot.version snap ≡ v
+  → Snapshot.number snap ≡ s
+  → Snapshot.etaHash snap ≡ hash (OC.ηOf d')
+  → Snapshot.decHash snap ≡ OC.decommitOutputsHashOf ctx m
+  → Snapshot.comHash snap ≡ κ#
+  → ξ ≡ aggSigOf sys snap
+  → Certified sys snap
+```
 
+```
+decrement-certified sys snap b cidEq vEq sEq ηEq δEq κEq ξEq =
+  sig-certifies sys snap (OC.DecrementValid.sigOK b) refl cidEq vEq sEq ηEq δEq κEq ξEq
+```
 
+```
+close-certified : ∀ sys {ctx cid v cp s' d d' ξ η# δ# κ#} (snap : Snapshot)
+  → OC.CloseValid ctx aggKey cid v cp s' d d' (OC.closeUnused ξ η# δ# κ#)
+  → Snapshot.cid snap ≡ cid
+  → Snapshot.version snap ≡ v
+  → Snapshot.number snap ≡ s'
+  → Snapshot.etaHash snap ≡ η#
+  → Snapshot.decHash snap ≡ δ#
+  → Snapshot.comHash snap ≡ κ#
+  → ξ ≡ aggSigOf sys snap
+  → Certified sys snap
+```
 
+```
+close-certified sys snap b cidEq vEq sEq ηEq δEq κEq ξEq =
+  sig-certifies sys snap (OC.CloseValid.sigOK b) refl cidEq vEq sEq ηEq δEq κEq ξEq
+```
 
+```
+contest-certified : ∀ sys {ctx cid v s tfin d d' ξ η# δ# κ# kh} (snap : Snapshot)
+  → OC.ContestValid ctx aggKey cid v s tfin d d' (OC.contestUnused ξ η# δ# κ#) kh
+  → Snapshot.cid snap ≡ cid
+  → Snapshot.version snap ≡ v
+  → Snapshot.number snap ≡ OC.snapNum d'
+  → Snapshot.etaHash snap ≡ η#
+  → Snapshot.decHash snap ≡ δ#
+  → Snapshot.comHash snap ≡ κ#
+  → ξ ≡ aggSigOf sys snap
+  → Certified sys snap
+```
 
+```
+contest-certified sys snap b cidEq vEq sEq ηEq δEq κEq ξEq =
+  sig-certifies sys snap (OC.ContestValid.sigOK b) refl cidEq vEq sEq ηEq δEq κEq ξEq
+```
 
 On top of the certificate, close and contest cannot verify a signature over
 one accumulator while storing another: the `etaOK` conjunct binds the
@@ -231,16 +989,52 @@ redeemer's $eta^(\#)$ to the hash of the accumulator stored in the produced
 datum (the two-line corollaries `close-η-reflected` / `contest-η-reflected`,
 typechecked but not rendered).
 
+```
+close-η-reflected : ∀ {ctx cid v cp s' d d' ξ η# δ# κ#} (snap : Snapshot)
+  → OC.CloseValid ctx aggKey cid v cp s' d d' (OC.closeUnused ξ η# δ# κ#)
+  → Snapshot.etaHash snap ≡ η#
+  → Snapshot.etaHash snap ≡ hash (OC.ηOf d')
+```
 
+```
+close-η-reflected snap b ηEq = trans ηEq (OC.CloseValid.etaOK b)
+```
 
+```
+contest-η-reflected : ∀ {ctx cid v s tfin d d' ξ η# δ# κ# kh} (snap : Snapshot)
+  → OC.ContestValid ctx aggKey cid v s tfin d d' (OC.contestUnused ξ η# δ# κ#) kh
+  → Snapshot.etaHash snap ≡ η#
+  → Snapshot.etaHash snap ≡ hash (OC.ηOf d')
+```
 
+```
+contest-η-reflected snap b ηEq = trans ηEq (OC.ContestValid.etaOK b)
+```
 
 A valid deposit claim (the joint `ClaimTxValid` encoding, $nuHead$ increment
 and $nuDeposit$ claim both passing) is unanimously certified _and_ posted
 before the deposit's recover deadline: a deposit can be absorbed into the head
 neither without every party's signature nor after it has become recoverable.
 
+```agda
+claimTx-certified : ∀ sys {ctx dd cid n cp v η ada headOut ξ s ref δ#} (snap : Snapshot)
+  → OC.ClaimTxValid ctx dd (OC.Open cid aggKey n cp v η ada) headOut ξ s ref δ#
+  → Snapshot.cid snap ≡ cid
+  → Snapshot.version snap ≡ v
+  → Snapshot.number snap ≡ s
+  → Snapshot.etaHash snap ≡ hash (OC.ηOf headOut)
+  → Snapshot.decHash snap ≡ δ#
+  → Snapshot.comHash snap ≡ OC.depositCommitsHashOf ctx ref
+  → ξ ≡ aggSigOf sys snap
+  → Certified sys snap
+    × (ValidityInterval.hi (Context.validity ctx) ≤ OC.DepositDatum.tRecover dd)
+```
 
+```
+claimTx-certified sys snap b cidEq vEq sEq ηEq δEq κEq ξEq =
+    increment-certified sys snap (OC.ClaimTxValid.headSideOK b) cidEq vEq sEq ηEq δEq κEq ξEq
+  , OC.ClaimValid.beforeRecoverDeadline (OC.ClaimTxValid.depositSideOK b)
+```
 
 === Handler invariants across adversarial executions
 
@@ -260,6 +1054,54 @@ model to the multi-party adversarial system: the deposit/decommit exclusivity
 and the version discipline are properties of every reachable execution, not
 runtime assertions an honest node merely hopes to maintain.
 
+```agda
+noBothInFlightˢ : ∀ sys → Reachable sys → ∀ i → NoBothInFlight (lookup (localOf sys) i)
+```
 
+```
+noBothInFlightˢ sys (base (_ , _ , _ , nbf , _)) i = nbf i
+noBothInFlightˢ sys (step {s} r tr) = nbStep tr (noBothInFlightˢ s r)
+  where
+    nbStep : ∀ {a b} → a ⟶ˢ b
+           → (∀ i → NoBothInFlight (lookup (localOf a) i))
+           → ∀ i → NoBothInFlight (lookup (localOf b) i)
+    nbStep {a} (signHonest {i = j} _ _ _ _ _ _) ih i with j FinP.≟ i
+    ... | yes refl = subst NoBothInFlight (sym (lookup∘update j (localOf a) _)) (ih j)
+    ... | no  j≢i  = subst NoBothInFlight (sym (lookup∘update′ (λ e → j≢i (sym e)) (localOf a) _)) (ih i)
+    nbStep (signCorrupt _) ih i = ih i
+    nbStep {a} (confirm {i = c} _ _) ih i with c FinP.≟ i
+    ... | yes refl = subst NoBothInFlight (sym (lookup∘update c (localOf a) _)) (ih c)
+    ... | no  c≢i  = subst NoBothInFlight (sym (lookup∘update′ (λ e → c≢i (sym e)) (localOf a) _)) (ih i)
+    nbStep (corrupt _)    ih i = ih i
+    nbStep (finalize _ _) ih i = ih i
+    nbStep see            ih i = ih i
+    nbStep {a} (offChain {i = j} {st' = st'} w _ _) ih i with j FinP.≟ i
+    ... | yes refl = subst NoBothInFlight (sym (lookup∘update j (localOf a) st')) (noBothInFlight-step w (ih j))
+    ... | no  j≢i  = subst NoBothInFlight (sym (lookup∘update′ (λ e → j≢i (sym e)) (localOf a) st')) (ih i)
+```
 
+```agda
+versionDisciplineˢ : ∀ sys → Reachable sys → ∀ i → VersionDiscipline (lookup (localOf sys) i)
+```
 
+```
+versionDisciplineˢ sys (base (_ , _ , _ , _ , vd)) i = vd i
+versionDisciplineˢ sys (step {s} r tr) = vdStep tr (versionDisciplineˢ s r)
+  where
+    vdStep : ∀ {a b} → a ⟶ˢ b
+           → (∀ i → VersionDiscipline (lookup (localOf a) i))
+           → ∀ i → VersionDiscipline (lookup (localOf b) i)
+    vdStep {a} (signHonest {i = j} _ _ _ _ _ _) ih i with j FinP.≟ i
+    ... | yes refl = subst VersionDiscipline (sym (lookup∘update j (localOf a) _)) (ih j)
+    ... | no  j≢i  = subst VersionDiscipline (sym (lookup∘update′ (λ e → j≢i (sym e)) (localOf a) _)) (ih i)
+    vdStep (signCorrupt _) ih i = ih i
+    vdStep {a} (confirm {i = c} {snap = snap₀} _ vd) ih i with c FinP.≟ i
+    ... | yes refl = subst VersionDiscipline (sym (lookup∘update c (localOf a) (record (lookup (localOf a) c) { confirmed = snap₀ }))) vd
+    ... | no  c≢i  = subst VersionDiscipline (sym (lookup∘update′ (λ e → c≢i (sym e)) (localOf a) _)) (ih i)
+    vdStep (corrupt _)    ih i = ih i
+    vdStep (finalize _ _) ih i = ih i
+    vdStep see            ih i = ih i
+    vdStep {a} (offChain {i = j} {st' = st'} w _ _) ih i with j FinP.≟ i
+    ... | yes refl = subst VersionDiscipline (sym (lookup∘update j (localOf a) st')) (versionDiscipline-step w (ih j))
+    ... | no  j≢i  = subst VersionDiscipline (sym (lookup∘update′ (λ e → j≢i (sym e)) (localOf a) st')) (ih i)
+```

--- a/spec/src/Hydra/Protocol/Setup.lagda.typ
+++ b/spec/src/Hydra/Protocol/Setup.lagda.typ
@@ -55,5 +55,9 @@ record HeadParameters : Set where
     hydraVKeys         : List VKey  -- per-party Hydra verification keys k_H
     aggregateKey       : VKey       -- aggregate Hydra key k̃_H
     contestationPeriod : ℕ          -- T_contest
-    depositPeriod      : ℕ          -- T_deposit (the §6 deposit settling / expiry period)
+    depositPeriod      : ℕ          -- T_deposit (the §6 deposit expiry period)
+    depositActivation  : ℕ          -- T_activate: the settling period a deposit must age before it
+                                    -- becomes Active. Independent of T_deposit, which only bounds
+                                    -- expiry, and separately configurable in the node
+                                    -- (--deposit-activation vs --deposit-period).
 ```

--- a/spec/src/Hydra/Protocol/Setup.lagda.typ
+++ b/spec/src/Hydra/Protocol/Setup.lagda.typ
@@ -1,3 +1,8 @@
+```
+module Hydra.Protocol.Setup where
+
+open import Hydra.Protocol.Prelude
+```
 
 #import "/template.typ": *
 #import "/macros.typ": *
@@ -42,3 +47,13 @@ The parameters each party stores after a successful setup are captured by an
 Agda record (verification keys and the contestation period are kept
 abstract, the latter as a duration in time units).
 
+```
+record HeadParameters : Set where
+  field
+    n                  : ℕ          -- number of participants (n)
+    cardanoVKeys       : List VKey  -- per-party Cardano verification keys k_C
+    hydraVKeys         : List VKey  -- per-party Hydra verification keys k_H
+    aggregateKey       : VKey       -- aggregate Hydra key k̃_H
+    contestationPeriod : ℕ          -- T_contest
+    depositPeriod      : ℕ          -- T_deposit (the §6 deposit settling / expiry period)
+```

--- a/spec/src/macros.typ
+++ b/spec/src/macros.typ
@@ -98,6 +98,7 @@
 #let Tcontest = $T_sans("contest")$
 #let tfinal = $t_sans("final")$
 #let Tdeposit = $T_sans("deposit")$
+#let Tactivate = $T_sans("activate")$
 
 #let txIpend = $i_sans("pend")$
 #let txIpendSet = $I_sans("pend")$


### PR DESCRIPTION
### 🧱 Stack (split of #2736)
   1. #2784 — protocol fix
   2. #2785 — Typst prose migration
👉 3. #2786 — Agda formalisation + developer docs + changelog
   4. #2787 — hydra-agda package + CI
   5. #2788 — agreement tests
   6. #2842 — solvency invariant + error-code ledger

Merge in order (1→6) into the `typst-agda-stacked` integration branch, then merge that branch into `master` as the final step.

---


**Stacked PR 3/5** — splits #2736.
Base: `typst-agda-spec-2` · Next: `typst-agda-spec-4`.

Also includes the developer docs page for the Agda formalisation (`docs/dev/agda.md`), the specification docs + sidebar updates, and the spec-migration changelog entry (absorbed from the former docs PR #2789).

Populate the literate sources with their Agda content and machine-check them as
part of the spec build. This PR is the **formalisation** half of the migration:
it re-inserts exactly the Agda code blocks that PR 2 held back, so the two PRs
together reproduce the full literate tree.

- Re-add the Agda code blocks to the `.lagda.typ` tree (datum/redeemer types,
  transition relations, validity bundles, coverage/safety and security theorems
  and proofs); they now render in the formalisation appendix.
- Add the standalone reference modules (`Prelude`, `Reference`,
  `ReferenceBridge`, `OffChainReference`, `RefReflection`).
- `build.sh` now typechecks the tree with Agda before rendering and runs the
  Agda↔Typst reference lint (`check-refs.sh`) and the trust-ledger drift check
  (`check-trust-ledger.sh`); the Agda toolchain is wired into the build and dev
  shell.

Verified: `nix build .#spec` runs the full Agda typecheck + lints and renders the
61-page PDF; treefmt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



