### PR TITLE
typst-agda-spec-6: Document the Agda formalisation and record the changelog entry

### DIFF
--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -87,6 +87,28 @@ jobs:
         path: /tmp/nix-shell.*/hydra-cluster-e2e-*/logs/*
         if-no-files-found: ignore
 
+  spec:
+    name: "Formal specification"
+    runs-on: ubuntu-latest
+    steps:
+    - name: 📥 Checkout repository
+      uses: actions/checkout@v4
+
+    - name: ❄ Setup Nix/Cachix
+      uses: ./.github/actions/nix-cachix-setup
+      with:
+        authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
+
+    # Same derivations as the `spec` / `hydra-agda-generated` flake checks
+    # (checks are not resolved by bare `nix build .#name`, hence the full path):
+    # Agda-typechecks the literate spec and renders the PDF, then verifies the
+    # committed MAlonzo extraction under hydra-agda/generated is not stale.
+    - name: 📖 Build specification & check Agda extraction
+      run: |
+        nix build --no-link \
+          .#checks.x86_64-linux.spec \
+          .#checks.x86_64-linux.hydra-agda-generated
+
   benchmarks:
     name: "Benchmarks"
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,20 @@ compile-time coupling to a single version's scripts [#2740](https://github.com/c
   the funds to the prefilled own address, and an invalid amount sent the full
   UTxO value).
 
+- The formal specification (`spec/`) was migrated from LaTeX to literate Agda +
+  Typst: the same sources are type-checked by Agda (definitions, validity
+  bundles and security proofs are machine-checked, including consistency,
+  soundness/completeness and the on-chain safety invariants) and rendered to
+  the PDF by Typst. A decidable core is extracted to Haskell via MAlonzo (the
+  new `hydra-agda` package) and differentially tested against the real Plutus
+  validator (`hydra-tx` `HeadValidatorAgreement`) and the real head logic
+  handlers (`hydra-node` `OffChainAgreementSpec`/`OffChainLeaderSpec`). CI
+  gates the spec build (`checks.spec`, including reference/diagram and
+  trust-ledger drift checks) and the extraction freshness
+  (`checks.hydra-agda-generated`). The spec models the current protocol,
+  including the commit/decommit output-set hashes bound into the snapshot
+  multisignature and the canonical CRS datum binding of the fanout paths.
+
 - The head logic now enforces the specification's "no commit and decommit in
   flight at once" discipline on the message level: a `ReqSn` carrying both a
   deposit and a decommit is rejected (`ReqSnDepositAndDecommit`), and a

--- a/docs/docs/dev/agda.md
+++ b/docs/docs/dev/agda.md
@@ -1,0 +1,129 @@
+# Formal specification in Agda
+
+The Hydra Head protocol specification is written in *literate Agda* rendered by
+[Typst](https://typst.app): every definition, validity condition and security
+proof shown in the [specification PDF](./specification.md) comes from source
+files that Agda type-checks on every build. On top of that, a decidable core of
+the spec is extracted to Haskell and *differentially tested* against the real
+Plutus validators and the real `hydra-node` head logic. This page is an
+orientation: what is proved, what is tested, what is assumed, and where the
+machinery lives.
+
+## Why literate Agda + Typst
+
+A specification that lives next to the code but is only prose will drift. Here
+the prose, the math and the machine-checked definitions come from one set of
+sources ([`spec/src/Hydra/Protocol/`](https://github.com/cardano-scaling/hydra/tree/master/spec/src/Hydra/Protocol)):
+`agda Main.lagda.typ` type-checks the whole document and Typst renders the same
+files to the PDF. Two kinds of code fences exist: rendered ones (collected into
+the PDF's Agda appendix) and typecheck-only ones (imports, proof plumbing). See
+[`spec/README.md`](https://github.com/cardano-scaling/hydra/tree/master/spec)
+for the authoring details.
+
+## Module map
+
+Three groups of modules, one build:
+
+| Group | Modules | Role |
+| --- | --- | --- |
+| Rendered (the document) | `Introduction`, `Overview`, `Preliminaries`, `Setup`, `OnChain`, `OnChainCoverage`, `OffChain`, `Security`, `SecurityProofs` | Prose + the machine-checked definitions, validity bundles, invariants and §7 proofs |
+| Typecheck-only | `Prelude`, `ReferenceBridge`, `RefReflection` | The abstract trust base and the bridge proofs; verified on every build, never rendered |
+| Extractable | `Reference`, `OffChainReference` | Decidable checkers, self-contained over `Agda.Builtin` types so the extracted Haskell stays small |
+
+## The trust story
+
+Three tiers, from strongest to weakest guarantee:
+
+1. **Proved.** The §7 security results (consistency, soundness, completeness,
+   the reachability invariant, no-settlement-without-unanimity) and the
+   on-chain coverage/safety theorems (non-stuckness, value conservation,
+   bounded contest window) are closed Agda proofs over the abstract model.
+   Multisignature unforgeability is *derived* from per-signature EUF-CMA plus
+   the aggregation scheme's decomposition, not assumed monolithically.
+
+2. **Assumed.** The model bottoms out in an enumerated trust base: ledger and
+   crypto primitives (hashing, the multisignature verifier, the `Value`
+   algebra), the accumulator laws (the KZG construction itself is not
+   modelled), a small set of on-chain "search" postulates over the opaque
+   value/key models, and the honest-behaviour premises of the security model.
+   The PDF appendix section **"What the formalisation assumes"** inventories
+   all of it — the reading rule is: `postulate` means assumption, everything
+   else is proved.
+
+3. **Differentially tested.** Where the abstract model meets the real code,
+   the bridge's trusted base is *fixed and machine-enforced*: exactly 6
+   injected const-true mocks (crypto/accumulator conjuncts the tests cover
+   against the real primitives instead) and 7 encoding/faithfulness
+   postulates, enumerated in
+   [`spec/check-trust-ledger.sh`](https://github.com/cardano-scaling/hydra/blob/master/spec/check-trust-ledger.sh).
+   That script fails the spec build if a mock or postulate is added or removed
+   without updating the ledger — the trusted base cannot grow silently.
+
+The bridge direction is *completeness*: `ReferenceBridge.agda` proves that a
+spec-valid transaction makes the extracted checker accept, so a
+reference-reject implies a spec-reject. Joined with the agreement tests'
+`reference === validator`, a spec-valid transaction is accepted by the real
+validator and vice versa — modulo the documented mocks, each of which the
+tests exercise with real crypto (Ed25519 signatures, BLS/KZG pairings) in both
+accept and reject directions.
+
+## The extraction pipeline
+
+`Reference.agda` and `OffChainReference.agda` are compiled by Agda's MAlonzo
+backend into
+[`hydra-agda/generated/`](https://github.com/cardano-scaling/hydra/tree/master/hydra-agda),
+which is committed. Hand-written shims (`Hydra.Agda.Reference`,
+`Hydra.Agda.OffChainReference`) pin the mangled MAlonzo names to stable,
+documented Haskell names — a stale pin is a loud compile error. Regeneration
+is manual (`hydra-agda/regenerate.sh`); freshness is CI-enforced: the
+`hydra-agda-generated` flake check re-extracts hermetically and fails on any
+diff against the committed tree.
+
+## The agreement tests
+
+Two layers bind the extracted spec to the real implementation:
+
+- **On-chain** —
+  [`Hydra.Tx.Contract.HeadValidatorAgreement`](https://github.com/cardano-scaling/hydra/blob/master/hydra-tx/test/Hydra/Tx/Contract/HeadValidatorAgreement.hs)
+  (hydra-tx) runs the *real* `Head.headValidator` (and the compiled
+  `deposit.ak` as UPLC) and the extracted reference on the same directly
+  constructed inputs — no transactions, no mutation corpus — and asserts
+  `reference === validator` across every transaction family, in both the
+  accept and reject directions. The crypto the reference mocks is exercised
+  for real: valid and invalid Ed25519 snapshot signatures (including the
+  commit/decommit output-set hashes bound into the signed message), BLS/KZG
+  membership proofs against the canonical CRS, and the canonical-CRS datum
+  binding (`InvalidCRSDatum`).
+- **Off-chain** —
+  [`Hydra.OffChainAgreementSpec`](https://github.com/cardano-scaling/hydra/blob/master/hydra-node/test/Hydra/OffChainAgreementSpec.hs)
+  and `Hydra.OffChainLeaderSpec` (hydra-node) bind the extracted §6 handler
+  decisions (snapshot-signing eligibility, decommit recording, deposit status,
+  ack counting, contest eligibility, leader election) against the real
+  `HeadLogic.update` outcomes.
+
+## How do I ...
+
+| Task | What to do |
+| --- | --- |
+| Build the PDF | `nix build .#spec`, or `./build.sh` inside `nix develop` (output: `spec/_build/hydra-spec.pdf`) |
+| Type-check only | `agda src/Hydra/Protocol/Main.lagda.typ` in `spec/` |
+| Change a validator condition | Update the section + `*Valid` bundle in `OnChain.lagda.typ`, mirror in `Reference.agda`, prove in `ReferenceBridge.agda`, `regenerate.sh`, extend the shim + `HeadValidatorAgreement` — see the checklist in [`spec/README.md`](https://github.com/cardano-scaling/hydra/tree/master/spec) |
+| Change a head-logic handler | Update the §6 arm (+ figure) in `OffChain.lagda.typ`, mirror in `OffChainReference.agda`, bind in the hydra-node agreement tests |
+| Change the datum shape | `HeadDatum` in `OnChain.lagda.typ` + `state-fields` in `diagrams.typ`; `check-refs.sh` catches constructor drift |
+| Add a mock/postulate to the bridge | The build fails until `check-trust-ledger.sh`'s ledger is updated — that is the point |
+
+CI gates: `checks.spec` (Agda typecheck, reference/diagram lints, trust-ledger
+drift check, PDF render) and `checks.hydra-agda-generated` (extraction
+freshness). The agreement tests run in the ordinary package test suites.
+
+## Pointers
+
+- The PDF appendix: *"Reading the Agda (for Haskell programmers)"* (a
+  Haskell-to-Agda glossary) and *"What the formalisation assumes"* (the full
+  trust-base inventory).
+- [`spec/README.md`](https://github.com/cardano-scaling/hydra/tree/master/spec)
+  — building, authoring, and the keep-in-sync checklist.
+- [`spec/check-trust-ledger.sh`](https://github.com/cardano-scaling/hydra/blob/master/spec/check-trust-ledger.sh)
+  — the enumerated bridge trust ledger.
+- The three agreement test modules named above, whose headers document the
+  per-conjunct coverage.

--- a/docs/docs/dev/specification.md
+++ b/docs/docs/dev/specification.md
@@ -1,6 +1,6 @@
 # Specification
 
-The specification is written in Agda and LaTeX and lives in the [`spec/`](https://github.com/cardano-scaling/hydra/tree/master/spec) directory of this repository. You can view the rendered version below or download it for fullscreen viewing [here](/hydra-spec.pdf).
+The specification is written in literate Agda and Typst (the same sources are type-checked by Agda and rendered to PDF by Typst) and lives in the [`spec/`](https://github.com/cardano-scaling/hydra/tree/master/spec) directory of this repository. You can view the rendered version below or download it for fullscreen viewing [here](/hydra-spec.pdf). See [Agda formalisation](./agda.md) for how the specification is machine-checked and kept in sync with the implementation.
 
 import HydraSpecUrl from '@site/static/hydra-spec.pdf';
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -76,6 +76,11 @@ module.exports = {
       id: "dev/specification",
       label: "Specification",
     },
+    {
+      type: "doc",
+      id: "dev/agda",
+      label: "Agda formalisation",
+    },
     "dev/protocol",
     "dev/commit",
     "dev/rollbacks/index",

--- a/hydra-agda/LICENSE
+++ b/hydra-agda/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2021-2022] [IOG]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/hydra-agda/NOTICE
+++ b/hydra-agda/NOTICE
@@ -1,0 +1,14 @@
+Copyright 2024 Input Output Global Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/hydra-agda/generated/MAlonzo/Code/Agda/Builtin/Bool.hs
+++ b/hydra-agda/generated/MAlonzo/Code/Agda/Builtin/Bool.hs
@@ -1,0 +1,26 @@
+{-# OPTIONS_GHC -w #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -Wno-overlapping-patterns #-}
+
+module MAlonzo.Code.Agda.Builtin.Bool where
+
+import MAlonzo.RTE (coe, erased, AgdaAny, addInt, subInt, mulInt,
+                    quotInt, remInt, geqInt, ltInt, eqInt, add64, sub64, mul64, quot64,
+                    rem64, lt64, eq64, word64FromNat, word64ToNat)
+import qualified MAlonzo.RTE
+import qualified Data.Text
+
+-- Agda.Builtin.Bool.Bool
+type T_Bool_6 = Bool
+d_Bool_6 = ()
+pattern C_false_8 = False
+pattern C_true_10 = True

--- a/hydra-agda/generated/MAlonzo/Code/Agda/Builtin/List.hs
+++ b/hydra-agda/generated/MAlonzo/Code/Agda/Builtin/List.hs
@@ -1,0 +1,26 @@
+{-# OPTIONS_GHC -w #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -Wno-overlapping-patterns #-}
+
+module MAlonzo.Code.Agda.Builtin.List where
+
+import MAlonzo.RTE (coe, erased, AgdaAny, addInt, subInt, mulInt,
+                    quotInt, remInt, geqInt, ltInt, eqInt, add64, sub64, mul64, quot64,
+                    rem64, lt64, eq64, word64FromNat, word64ToNat)
+import qualified MAlonzo.RTE
+import qualified Data.Text
+
+-- Agda.Builtin.List.List
+type T_List_10 a0 = []
+d_List_10 a0 a1 = ()
+pattern C_'91''93'_16 = []
+pattern C__'8759'__22 a0 a1 = (:) a0 a1

--- a/hydra-agda/generated/MAlonzo/Code/Agda/Builtin/Nat.hs
+++ b/hydra-agda/generated/MAlonzo/Code/Agda/Builtin/Nat.hs
@@ -1,0 +1,41 @@
+{-# OPTIONS_GHC -w #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -Wno-overlapping-patterns #-}
+
+module MAlonzo.Code.Agda.Builtin.Nat where
+
+import MAlonzo.RTE (coe, erased, AgdaAny, addInt, subInt, mulInt,
+                    quotInt, remInt, geqInt, ltInt, eqInt, add64, sub64, mul64, quot64,
+                    rem64, lt64, eq64, word64FromNat, word64ToNat)
+import qualified MAlonzo.RTE
+import qualified Data.Text
+
+-- Agda.Builtin.Nat.Nat
+d_Nat_6 = ()
+data T_Nat_6 = C_zero_8 | C_suc_12 Integer
+-- Agda.Builtin.Nat._+_
+d__'43'__14 = ((+) :: Integer -> Integer -> Integer)
+-- Agda.Builtin.Nat._-_
+d__'45'__22
+  = ((\ x y -> max 0 (x - y)) :: Integer -> Integer -> Integer)
+-- Agda.Builtin.Nat._*_
+d__'42'__32 = ((*) :: Integer -> Integer -> Integer)
+-- Agda.Builtin.Nat._==_
+d__'61''61'__40 = ((==) :: Integer -> Integer -> Bool)
+-- Agda.Builtin.Nat._<_
+d__'60'__46 = ((<) :: Integer -> Integer -> Bool)
+-- Agda.Builtin.Nat.div-helper
+d_div'45'helper_60
+  = ((\ k m n j -> k + div (max 0 $ n + m - j) (m + 1)) :: Integer -> Integer -> Integer -> Integer -> Integer)
+-- Agda.Builtin.Nat.mod-helper
+d_mod'45'helper_90
+  = ((\ k m n j -> if n > j then mod (n - j - 1) (m + 1) else (k + n)) :: Integer -> Integer -> Integer -> Integer -> Integer)

--- a/hydra-agda/generated/MAlonzo/Code/Agda/Primitive.hs
+++ b/hydra-agda/generated/MAlonzo/Code/Agda/Primitive.hs
@@ -1,0 +1,32 @@
+{-# OPTIONS_GHC -w #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -Wno-overlapping-patterns #-}
+
+module MAlonzo.Code.Agda.Primitive where
+
+import MAlonzo.RTE (coe, erased, AgdaAny, addInt, subInt, mulInt,
+                    quotInt, remInt, geqInt, ltInt, eqInt, add64, sub64, mul64, quot64,
+                    rem64, lt64, eq64, word64FromNat, word64ToNat)
+import qualified MAlonzo.RTE
+import qualified Data.Text
+
+-- Agda.Primitive.Level
+type T_Level_18 = ()
+d_Level_18
+  = error
+      "MAlonzo Runtime Error: postulate evaluated: Agda.Primitive.Level"
+-- Agda.Primitive.lzero
+d_lzero_20 = ()
+-- Agda.Primitive.lsuc
+d_lsuc_24 = (\ _ -> ())
+-- Agda.Primitive._⊔_
+d__'8852'__30 = (\ _ _ -> ())

--- a/hydra-agda/generated/MAlonzo/Code/Hydra/Protocol/OffChainReference.hs
+++ b/hydra-agda/generated/MAlonzo/Code/Hydra/Protocol/OffChainReference.hs
@@ -1,0 +1,132 @@
+{-# OPTIONS_GHC -w #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -Wno-overlapping-patterns #-}
+
+module MAlonzo.Code.Hydra.Protocol.OffChainReference where
+
+import MAlonzo.RTE (coe, erased, AgdaAny, addInt, subInt, mulInt,
+                    quotInt, remInt, geqInt, ltInt, eqInt, add64, sub64, mul64, quot64,
+                    rem64, lt64, eq64, word64FromNat, word64ToNat)
+import qualified MAlonzo.RTE
+import qualified Data.Text
+import qualified MAlonzo.Code.Agda.Builtin.Bool
+import qualified MAlonzo.Code.Agda.Builtin.Nat
+
+data HsDepositStatus = InactiveS | ActiveS | ExpiredS deriving (Eq, Show)
+-- Hydra.Protocol.OffChainReference.DepositStatusᶜ
+d_DepositStatus'7580'_6 = ()
+type T_DepositStatus'7580'_6 = HsDepositStatus
+pattern C_inactive'7580'_8 = InactiveS
+pattern C_active'7580'_10 = ActiveS
+pattern C_expired'7580'_12 = ExpiredS
+check_inactive'7580'_8 :: T_DepositStatus'7580'_6
+check_inactive'7580'_8 = InactiveS
+check_active'7580'_10 :: T_DepositStatus'7580'_6
+check_active'7580'_10 = ActiveS
+check_expired'7580'_12 :: T_DepositStatus'7580'_6
+check_expired'7580'_12 = ExpiredS
+cover_DepositStatus'7580'_6 :: HsDepositStatus -> ()
+cover_DepositStatus'7580'_6 x
+  = case x of
+      InactiveS -> ()
+      ActiveS -> ()
+      ExpiredS -> ()
+-- Hydra.Protocol.OffChainReference.if_then_else_
+d_if_then_else__16 :: () -> Bool -> AgdaAny -> AgdaAny -> AgdaAny
+d_if_then_else__16 ~v0 v1 v2 v3 = du_if_then_else__16 v1 v2 v3
+du_if_then_else__16 :: Bool -> AgdaAny -> AgdaAny -> AgdaAny
+du_if_then_else__16 v0 v1 v2 = if coe v0 then coe v1 else coe v2
+-- Hydra.Protocol.OffChainReference.depositStatusRef
+d_depositStatusRef_22 ::
+  Integer -> Integer -> Integer -> Integer -> T_DepositStatus'7580'_6
+d_depositStatusRef_22 v0 v1 v2 v3
+  = coe
+      du_if_then_else__16
+      (coe
+         ltInt (coe MAlonzo.Code.Agda.Builtin.Nat.d__'45'__22 v1 v2)
+         (coe v3))
+      (coe C_expired'7580'_12)
+      (coe
+         du_if_then_else__16
+         (coe ltInt (coe addInt (coe v0) (coe v2)) (coe v3))
+         (coe C_active'7580'_10) (coe C_inactive'7580'_8))
+-- Hydra.Protocol.OffChainReference._&&_
+d__'38''38'__32 :: Bool -> Bool -> Bool
+d__'38''38'__32 v0 v1 = if coe v0 then coe v1 else coe v0
+-- Hydra.Protocol.OffChainReference.signEligibleRef
+d_signEligibleRef_36 ::
+  Integer -> Integer -> Integer -> Integer -> Bool -> Bool
+d_signEligibleRef_36 v0 v1 v2 v3 v4
+  = coe
+      d__'38''38'__32 (coe eqInt (coe v0) (coe v1))
+      (coe
+         d__'38''38'__32
+         (coe eqInt (coe v2) (coe addInt (coe (1 :: Integer)) (coe v3)))
+         (coe v4))
+-- Hydra.Protocol.OffChainReference._||_
+d__'124''124'__48 :: Bool -> Bool -> Bool
+d__'124''124'__48 v0 v1 = if coe v0 then coe v0 else coe v1
+-- Hydra.Protocol.OffChainReference.not
+d_not_52 :: Bool -> Bool
+d_not_52 v0
+  = if coe v0
+      then coe MAlonzo.Code.Agda.Builtin.Bool.C_false_8
+      else coe MAlonzo.Code.Agda.Builtin.Bool.C_true_10
+-- Hydra.Protocol.OffChainReference.elemᵇ
+d_elem'7495'_54 :: Integer -> [Integer] -> Bool
+d_elem'7495'_54 v0 v1
+  = case coe v1 of
+      [] -> coe MAlonzo.Code.Agda.Builtin.Bool.C_false_8
+      (:) v2 v3
+        -> coe
+             d__'124''124'__48 (coe eqInt (coe v0) (coe v2))
+             (coe d_elem'7495'_54 (coe v0) (coe v3))
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.OffChainReference.reqDecEligibleRef
+d_reqDecEligibleRef_62 :: Bool -> Bool -> Bool
+d_reqDecEligibleRef_62 v0 v1
+  = coe
+      d__'38''38'__32 (coe d_not_52 (coe v0)) (coe d_not_52 (coe v1))
+-- Hydra.Protocol.OffChainReference.notAlreadySignedRef
+d_notAlreadySignedRef_68 :: [Integer] -> Integer -> Bool
+d_notAlreadySignedRef_68 v0 v1
+  = coe d_not_52 (coe d_elem'7495'_54 (coe v1) (coe v0))
+-- Hydra.Protocol.OffChainReference.allBelowᵇ
+d_allBelow'7495'_74 :: Integer -> [Integer] -> Bool
+d_allBelow'7495'_74 v0 v1
+  = case coe v0 of
+      0 -> coe MAlonzo.Code.Agda.Builtin.Bool.C_true_10
+      _ -> let v2 = subInt (coe v0) (coe (1 :: Integer)) in
+           coe
+             (coe
+                d__'38''38'__32 (coe d_elem'7495'_54 (coe v2) (coe v1))
+                (coe d_allBelow'7495'_74 (coe v2) (coe v1)))
+-- Hydra.Protocol.OffChainReference.allSignedRef
+d_allSignedRef_80 :: Integer -> [Integer] -> Bool
+d_allSignedRef_80 v0 v1 = coe d_allBelow'7495'_74 (coe v0) (coe v1)
+-- Hydra.Protocol.OffChainReference.contestEligibleRef
+d_contestEligibleRef_86 :: Integer -> Integer -> Bool
+d_contestEligibleRef_86 v0 v1 = coe ltInt (coe v1) (coe v0)
+-- Hydra.Protocol.OffChainReference.modSuc
+d_modSuc_92 :: Integer -> Integer -> Integer
+d_modSuc_92 v0 v1
+  = coe remInt (coe v0) (coe addInt (coe (1 :: Integer)) (coe v1))
+-- Hydra.Protocol.OffChainReference.leaderRef
+d_leaderRef_98 :: Integer -> Integer -> Integer -> Bool
+d_leaderRef_98 v0 v1 v2
+  = coe
+      eqInt
+      (coe
+         d_modSuc_92
+         (coe MAlonzo.Code.Agda.Builtin.Nat.d__'45'__22 v1 (1 :: Integer))
+         (coe v0))
+      (coe v2)

--- a/hydra-agda/generated/MAlonzo/Code/Hydra/Protocol/Reference.hs
+++ b/hydra-agda/generated/MAlonzo/Code/Hydra/Protocol/Reference.hs
@@ -1,0 +1,913 @@
+{-# OPTIONS_GHC -w #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -Wno-overlapping-patterns #-}
+
+module MAlonzo.Code.Hydra.Protocol.Reference where
+
+import MAlonzo.RTE (coe, erased, AgdaAny, addInt, subInt, mulInt,
+                    quotInt, remInt, geqInt, ltInt, eqInt, add64, sub64, mul64, quot64,
+                    rem64, lt64, eq64, word64FromNat, word64ToNat)
+import qualified MAlonzo.RTE
+import qualified Data.Text
+import qualified MAlonzo.Code.Agda.Builtin.Bool
+import qualified MAlonzo.Code.Agda.Builtin.List
+import qualified MAlonzo.Code.Agda.Builtin.Nat
+
+data HsCloseTag = CloseInitialT | CloseAnyT | CloseUnusedT | CloseUsedT
+data HsOpen = MkOpen Integer Integer
+data HsClosed = MkClosed Integer Integer Integer Integer Integer
+data HsIncIO = MkIncIO Integer Integer Integer Integer Integer Integer Integer Integer
+data HsContestIO = MkContestIO Integer Integer Integer Integer Integer Integer Integer Integer Integer Integer Integer
+data HsFanout = MkFanout Integer Integer Integer Integer Integer
+data HsRecoverIO = MkRecoverIO Integer Integer
+data HsMintIO = MkMintIO Integer Integer Integer Integer
+data HsClaimIO = MkClaimIO Integer Integer Integer Integer Integer
+data HsSignerIO = MkSignerIO [Integer] [Integer]
+data HsAssetIO = MkAssetIO Integer Integer Integer
+data HsBurnIO = MkBurnIO Integer Integer
+-- Hydra.Protocol.Reference.CloseTagᶜ
+d_CloseTag'7580'_6 = ()
+type T_CloseTag'7580'_6 = HsCloseTag
+pattern C_closeInitial'7580'_8 = CloseInitialT
+pattern C_closeAny'7580'_10 = CloseAnyT
+pattern C_closeUnused'7580'_12 = CloseUnusedT
+pattern C_closeUsed'7580'_14 = CloseUsedT
+check_closeInitial'7580'_8 :: T_CloseTag'7580'_6
+check_closeInitial'7580'_8 = CloseInitialT
+check_closeAny'7580'_10 :: T_CloseTag'7580'_6
+check_closeAny'7580'_10 = CloseAnyT
+check_closeUnused'7580'_12 :: T_CloseTag'7580'_6
+check_closeUnused'7580'_12 = CloseUnusedT
+check_closeUsed'7580'_14 :: T_CloseTag'7580'_6
+check_closeUsed'7580'_14 = CloseUsedT
+cover_CloseTag'7580'_6 :: HsCloseTag -> ()
+cover_CloseTag'7580'_6 x
+  = case x of
+      CloseInitialT -> ()
+      CloseAnyT -> ()
+      CloseUnusedT -> ()
+      CloseUsedT -> ()
+-- Hydra.Protocol.Reference.Openᶜ
+d_Open'7580'_16 = ()
+type T_Open'7580'_16 = HsOpen
+pattern C_mkOpen'7580'_26 a0 a1 = MkOpen a0 a1
+check_mkOpen'7580'_26 :: Integer -> Integer -> T_Open'7580'_16
+check_mkOpen'7580'_26 = MkOpen
+cover_Open'7580'_16 :: HsOpen -> ()
+cover_Open'7580'_16 x
+  = case x of
+      MkOpen _ _ -> ()
+-- Hydra.Protocol.Reference.Openᶜ.versionO
+d_versionO_22 :: T_Open'7580'_16 -> Integer
+d_versionO_22 v0
+  = case coe v0 of
+      C_mkOpen'7580'_26 v1 v2 -> coe v1
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.Openᶜ.cpO
+d_cpO_24 :: T_Open'7580'_16 -> Integer
+d_cpO_24 v0
+  = case coe v0 of
+      C_mkOpen'7580'_26 v1 v2 -> coe v2
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.Closedᶜ
+d_Closed'7580'_28 = ()
+type T_Closed'7580'_28 = HsClosed
+pattern C_mkClosed'7580'_50 a0 a1 a2 a3 a4 = MkClosed a0 a1 a2 a3 a4
+check_mkClosed'7580'_50 ::
+  Integer ->
+  Integer -> Integer -> Integer -> Integer -> T_Closed'7580'_28
+check_mkClosed'7580'_50 = MkClosed
+cover_Closed'7580'_28 :: HsClosed -> ()
+cover_Closed'7580'_28 x
+  = case x of
+      MkClosed _ _ _ _ _ -> ()
+-- Hydra.Protocol.Reference.Closedᶜ.versionC
+d_versionC_40 :: T_Closed'7580'_28 -> Integer
+d_versionC_40 v0
+  = case coe v0 of
+      C_mkClosed'7580'_50 v1 v2 v3 v4 v5 -> coe v1
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.Closedᶜ.cpC
+d_cpC_42 :: T_Closed'7580'_28 -> Integer
+d_cpC_42 v0
+  = case coe v0 of
+      C_mkClosed'7580'_50 v1 v2 v3 v4 v5 -> coe v2
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.Closedᶜ.snapshotC
+d_snapshotC_44 :: T_Closed'7580'_28 -> Integer
+d_snapshotC_44 v0
+  = case coe v0 of
+      C_mkClosed'7580'_50 v1 v2 v3 v4 v5 -> coe v3
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.Closedᶜ.contesterLenC
+d_contesterLenC_46 :: T_Closed'7580'_28 -> Integer
+d_contesterLenC_46 v0
+  = case coe v0 of
+      C_mkClosed'7580'_50 v1 v2 v3 v4 v5 -> coe v4
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.Closedᶜ.tfinalC
+d_tfinalC_48 :: T_Closed'7580'_28 -> Integer
+d_tfinalC_48 v0
+  = case coe v0 of
+      C_mkClosed'7580'_50 v1 v2 v3 v4 v5 -> coe v5
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.Ops
+d_Ops_52 = ()
+newtype T_Ops_52
+  = C_Ops'46'constructor_125 (T_Open'7580'_16 ->
+                              T_Closed'7580'_28 -> T_CloseTag'7580'_6 -> Bool)
+-- Hydra.Protocol.Reference.Ops.closeCryptoOK
+d_closeCryptoOK_56 ::
+  T_Ops_52 ->
+  T_Open'7580'_16 -> T_Closed'7580'_28 -> T_CloseTag'7580'_6 -> Bool
+d_closeCryptoOK_56 v0
+  = case coe v0 of
+      C_Ops'46'constructor_125 v1 -> coe v1
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference._&&_
+d__'38''38'__58 :: Bool -> Bool -> Bool
+d__'38''38'__58 v0 v1 = if coe v0 then coe v1 else coe v0
+-- Hydra.Protocol.Reference._||_
+d__'124''124'__62 :: Bool -> Bool -> Bool
+d__'124''124'__62 v0 v1 = if coe v0 then coe v0 else coe v1
+-- Hydra.Protocol.Reference._==ᵇ_
+d__'61''61''7495'__66 :: Integer -> Integer -> Bool
+d__'61''61''7495'__66 v0 v1
+  = case coe v0 of
+      0 -> case coe v1 of
+             0 -> coe MAlonzo.Code.Agda.Builtin.Bool.C_true_10
+             _ -> coe MAlonzo.Code.Agda.Builtin.Bool.C_false_8
+      _ -> let v2 = subInt (coe v0) (coe (1 :: Integer)) in
+           coe
+             (case coe v1 of
+                0 -> coe MAlonzo.Code.Agda.Builtin.Bool.C_false_8
+                _ -> let v3 = subInt (coe v1) (coe (1 :: Integer)) in
+                     coe (coe d__'61''61''7495'__66 (coe v2) (coe v3)))
+-- Hydra.Protocol.Reference._≤ᵇ_
+d__'8804''7495'__72 :: Integer -> Integer -> Bool
+d__'8804''7495'__72 v0 v1
+  = case coe v0 of
+      0 -> coe MAlonzo.Code.Agda.Builtin.Bool.C_true_10
+      _ -> let v2 = subInt (coe v0) (coe (1 :: Integer)) in
+           coe
+             (case coe v1 of
+                0 -> coe MAlonzo.Code.Agda.Builtin.Bool.C_false_8
+                _ -> let v3 = subInt (coe v1) (coe (1 :: Integer)) in
+                     coe (coe d__'8804''7495'__72 (coe v2) (coe v3)))
+-- Hydra.Protocol.Reference._<ᵇ_
+d__'60''7495'__78 :: Integer -> Integer -> Bool
+d__'60''7495'__78 v0 v1
+  = coe
+      d__'8804''7495'__72 (coe addInt (coe (1 :: Integer)) (coe v0))
+      (coe v1)
+-- Hydra.Protocol.Reference._≤ᴮ_
+d__'8804''7470'__84 :: Integer -> Integer -> Bool
+d__'8804''7470'__84 v0 v1
+  = coe ltInt (coe v0) (coe addInt (coe (1 :: Integer)) (coe v1))
+-- Hydra.Protocol.Reference.if_then_else_
+d_if_then_else__92 :: () -> Bool -> AgdaAny -> AgdaAny -> AgdaAny
+d_if_then_else__92 ~v0 v1 v2 v3 = du_if_then_else__92 v1 v2 v3
+du_if_then_else__92 :: Bool -> AgdaAny -> AgdaAny -> AgdaAny
+du_if_then_else__92 v0 v1 v2 = if coe v0 then coe v1 else coe v2
+-- Hydra.Protocol.Reference.closeRefᵇ
+d_closeRef'7495'_98 ::
+  T_Ops_52 ->
+  T_Open'7580'_16 ->
+  T_Closed'7580'_28 ->
+  T_CloseTag'7580'_6 -> Integer -> Integer -> Bool
+d_closeRef'7495'_98 v0 v1 v2 v3 v4 v5
+  = coe
+      d__'38''38'__58
+      (coe
+         d__'61''61''7495'__66 (coe d_versionO_22 (coe v1))
+         (coe d_versionC_40 (coe v2)))
+      (coe
+         d__'38''38'__58
+         (coe
+            d__'61''61''7495'__66 (coe d_cpO_24 (coe v1))
+            (coe d_cpC_42 (coe v2)))
+         (coe
+            d__'38''38'__58
+            (coe
+               d__'61''61''7495'__66 (coe d_contesterLenC_46 (coe v2))
+               (coe (0 :: Integer)))
+            (coe
+               d__'38''38'__58 (coe du_initialOK_116 (coe v1) (coe v2) (coe v3))
+               (coe
+                  d__'38''38'__58 (coe du_anyOK_118 (coe v2) (coe v3))
+                  (coe
+                     d__'38''38'__58 (coe d_closeCryptoOK_56 v0 v1 v2 v3)
+                     (coe
+                        d__'38''38'__58
+                        (coe
+                           eqInt (coe d_tfinalC_48 (coe v2))
+                           (coe addInt (coe d_cpO_24 (coe v1)) (coe v4)))
+                        (coe
+                           d__'8804''7470'__84
+                           (coe MAlonzo.Code.Agda.Builtin.Nat.d__'45'__22 v4 v5)
+                           (coe d_cpO_24 (coe v1)))))))))
+-- Hydra.Protocol.Reference._.initialOK
+d_initialOK_116 ::
+  T_Ops_52 ->
+  T_Open'7580'_16 ->
+  T_Closed'7580'_28 ->
+  T_CloseTag'7580'_6 ->
+  Integer -> Integer -> T_CloseTag'7580'_6 -> Bool
+d_initialOK_116 ~v0 v1 v2 ~v3 ~v4 ~v5 v6
+  = du_initialOK_116 v1 v2 v6
+du_initialOK_116 ::
+  T_Open'7580'_16 -> T_Closed'7580'_28 -> T_CloseTag'7580'_6 -> Bool
+du_initialOK_116 v0 v1 v2
+  = let v3 = coe MAlonzo.Code.Agda.Builtin.Bool.C_true_10 in
+    coe
+      (case coe v2 of
+         C_closeInitial'7580'_8
+           -> coe
+                d__'38''38'__58
+                (coe
+                   d__'61''61''7495'__66 (coe d_versionO_22 (coe v0))
+                   (coe (0 :: Integer)))
+                (coe
+                   d__'61''61''7495'__66 (coe d_snapshotC_44 (coe v1))
+                   (coe (0 :: Integer)))
+         _ -> coe v3)
+-- Hydra.Protocol.Reference._.anyOK
+d_anyOK_118 ::
+  T_Ops_52 ->
+  T_Open'7580'_16 ->
+  T_Closed'7580'_28 ->
+  T_CloseTag'7580'_6 ->
+  Integer -> Integer -> T_CloseTag'7580'_6 -> Bool
+d_anyOK_118 ~v0 ~v1 v2 ~v3 ~v4 ~v5 v6 = du_anyOK_118 v2 v6
+du_anyOK_118 :: T_Closed'7580'_28 -> T_CloseTag'7580'_6 -> Bool
+du_anyOK_118 v0 v1
+  = let v2 = coe MAlonzo.Code.Agda.Builtin.Bool.C_true_10 in
+    coe
+      (case coe v1 of
+         C_closeAny'7580'_10
+           -> coe
+                d__'60''7495'__78 (coe (0 :: Integer))
+                (coe d_snapshotC_44 (coe v0))
+         _ -> coe v2)
+-- Hydra.Protocol.Reference.IncIOᶜ
+d_IncIO'7580'_120 = ()
+type T_IncIO'7580'_120 = HsIncIO
+pattern C_mkIncIO'7580'_154 a0 a1 a2 a3 a4 a5 a6 a7 = MkIncIO a0 a1 a2 a3 a4 a5 a6 a7
+check_mkIncIO'7580'_154 ::
+  Integer ->
+  Integer ->
+  Integer ->
+  Integer ->
+  Integer -> Integer -> Integer -> Integer -> T_IncIO'7580'_120
+check_mkIncIO'7580'_154 = MkIncIO
+cover_IncIO'7580'_120 :: HsIncIO -> ()
+cover_IncIO'7580'_120 x
+  = case x of
+      MkIncIO _ _ _ _ _ _ _ _ -> ()
+-- Hydra.Protocol.Reference.IncIOᶜ.versionIn
+d_versionIn_138 :: T_IncIO'7580'_120 -> Integer
+d_versionIn_138 v0
+  = case coe v0 of
+      C_mkIncIO'7580'_154 v1 v2 v3 v4 v5 v6 v7 v8 -> coe v1
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.IncIOᶜ.versionOut
+d_versionOut_140 :: T_IncIO'7580'_120 -> Integer
+d_versionOut_140 v0
+  = case coe v0 of
+      C_mkIncIO'7580'_154 v1 v2 v3 v4 v5 v6 v7 v8 -> coe v2
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.IncIOᶜ.adaIn
+d_adaIn_142 :: T_IncIO'7580'_120 -> Integer
+d_adaIn_142 v0
+  = case coe v0 of
+      C_mkIncIO'7580'_154 v1 v2 v3 v4 v5 v6 v7 v8 -> coe v3
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.IncIOᶜ.adaDelta
+d_adaDelta_144 :: T_IncIO'7580'_120 -> Integer
+d_adaDelta_144 v0
+  = case coe v0 of
+      C_mkIncIO'7580'_154 v1 v2 v3 v4 v5 v6 v7 v8 -> coe v4
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.IncIOᶜ.adaOut
+d_adaOut_146 :: T_IncIO'7580'_120 -> Integer
+d_adaOut_146 v0
+  = case coe v0 of
+      C_mkIncIO'7580'_154 v1 v2 v3 v4 v5 v6 v7 v8 -> coe v5
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.IncIOᶜ.nonAdaIn
+d_nonAdaIn_148 :: T_IncIO'7580'_120 -> Integer
+d_nonAdaIn_148 v0
+  = case coe v0 of
+      C_mkIncIO'7580'_154 v1 v2 v3 v4 v5 v6 v7 v8 -> coe v6
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.IncIOᶜ.nonAdaDelta
+d_nonAdaDelta_150 :: T_IncIO'7580'_120 -> Integer
+d_nonAdaDelta_150 v0
+  = case coe v0 of
+      C_mkIncIO'7580'_154 v1 v2 v3 v4 v5 v6 v7 v8 -> coe v7
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.IncIOᶜ.nonAdaOut
+d_nonAdaOut_152 :: T_IncIO'7580'_120 -> Integer
+d_nonAdaOut_152 v0
+  = case coe v0 of
+      C_mkIncIO'7580'_154 v1 v2 v3 v4 v5 v6 v7 v8 -> coe v8
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.OpsInc
+d_OpsInc_156 = ()
+newtype T_OpsInc_156
+  = C_OpsInc'46'constructor_2927 (T_IncIO'7580'_120 -> Bool)
+-- Hydra.Protocol.Reference.OpsInc.incCryptoOK
+d_incCryptoOK_160 :: T_OpsInc_156 -> T_IncIO'7580'_120 -> Bool
+d_incCryptoOK_160 v0
+  = case coe v0 of
+      C_OpsInc'46'constructor_2927 v1 -> coe v1
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.incRefᵇ
+d_incRef'7495'_162 :: T_OpsInc_156 -> T_IncIO'7580'_120 -> Bool
+d_incRef'7495'_162 v0 v1
+  = coe
+      d__'38''38'__58
+      (coe
+         d__'61''61''7495'__66 (coe d_versionOut_140 (coe v1))
+         (coe addInt (coe (1 :: Integer)) (coe d_versionIn_138 (coe v1))))
+      (coe
+         d__'38''38'__58
+         (coe
+            eqInt
+            (coe
+               addInt (coe d_adaDelta_144 (coe v1)) (coe d_adaIn_142 (coe v1)))
+            (coe d_adaOut_146 (coe v1)))
+         (coe
+            d__'38''38'__58
+            (coe
+               eqInt
+               (coe
+                  addInt (coe d_nonAdaDelta_150 (coe v1))
+                  (coe d_nonAdaIn_148 (coe v1)))
+               (coe d_nonAdaOut_152 (coe v1)))
+            (coe d_incCryptoOK_160 v0 v1)))
+-- Hydra.Protocol.Reference.decRefᵇ
+d_decRef'7495'_168 :: T_OpsInc_156 -> T_IncIO'7580'_120 -> Bool
+d_decRef'7495'_168 v0 v1
+  = coe
+      d__'38''38'__58
+      (coe
+         d__'61''61''7495'__66 (coe d_versionOut_140 (coe v1))
+         (coe addInt (coe (1 :: Integer)) (coe d_versionIn_138 (coe v1))))
+      (coe
+         d__'38''38'__58
+         (coe
+            eqInt
+            (coe
+               addInt (coe d_adaOut_146 (coe v1)) (coe d_adaDelta_144 (coe v1)))
+            (coe d_adaIn_142 (coe v1)))
+         (coe
+            d__'38''38'__58
+            (coe
+               eqInt
+               (coe
+                  addInt (coe d_nonAdaOut_152 (coe v1))
+                  (coe d_nonAdaDelta_150 (coe v1)))
+               (coe d_nonAdaIn_148 (coe v1)))
+            (coe d_incCryptoOK_160 v0 v1)))
+-- Hydra.Protocol.Reference.ContestIOᶜ
+d_ContestIO'7580'_174 = ()
+type T_ContestIO'7580'_174 = HsContestIO
+pattern C_mkContestIO'7580'_220 a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 = MkContestIO a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10
+check_mkContestIO'7580'_220 ::
+  Integer ->
+  Integer ->
+  Integer ->
+  Integer ->
+  Integer ->
+  Integer ->
+  Integer ->
+  Integer -> Integer -> Integer -> Integer -> T_ContestIO'7580'_174
+check_mkContestIO'7580'_220 = MkContestIO
+cover_ContestIO'7580'_174 :: HsContestIO -> ()
+cover_ContestIO'7580'_174 x
+  = case x of
+      MkContestIO _ _ _ _ _ _ _ _ _ _ _ -> ()
+-- Hydra.Protocol.Reference.ContestIOᶜ.versionInK
+d_versionInK_198 :: T_ContestIO'7580'_174 -> Integer
+d_versionInK_198 v0
+  = case coe v0 of
+      C_mkContestIO'7580'_220 v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11
+        -> coe v1
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.ContestIOᶜ.versionOutK
+d_versionOutK_200 :: T_ContestIO'7580'_174 -> Integer
+d_versionOutK_200 v0
+  = case coe v0 of
+      C_mkContestIO'7580'_220 v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11
+        -> coe v2
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.ContestIOᶜ.snapIn
+d_snapIn_202 :: T_ContestIO'7580'_174 -> Integer
+d_snapIn_202 v0
+  = case coe v0 of
+      C_mkContestIO'7580'_220 v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11
+        -> coe v3
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.ContestIOᶜ.snapOut
+d_snapOut_204 :: T_ContestIO'7580'_174 -> Integer
+d_snapOut_204 v0
+  = case coe v0 of
+      C_mkContestIO'7580'_220 v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11
+        -> coe v4
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.ContestIOᶜ.contesterLenIn
+d_contesterLenIn_206 :: T_ContestIO'7580'_174 -> Integer
+d_contesterLenIn_206 v0
+  = case coe v0 of
+      C_mkContestIO'7580'_220 v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11
+        -> coe v5
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.ContestIOᶜ.contesterLenOut
+d_contesterLenOut_208 :: T_ContestIO'7580'_174 -> Integer
+d_contesterLenOut_208 v0
+  = case coe v0 of
+      C_mkContestIO'7580'_220 v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11
+        -> coe v6
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.ContestIOᶜ.tfinalK
+d_tfinalK_210 :: T_ContestIO'7580'_174 -> Integer
+d_tfinalK_210 v0
+  = case coe v0 of
+      C_mkContestIO'7580'_220 v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11
+        -> coe v7
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.ContestIOᶜ.validityHiK
+d_validityHiK_212 :: T_ContestIO'7580'_174 -> Integer
+d_validityHiK_212 v0
+  = case coe v0 of
+      C_mkContestIO'7580'_220 v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11
+        -> coe v8
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.ContestIOᶜ.tfinalOutK
+d_tfinalOutK_214 :: T_ContestIO'7580'_174 -> Integer
+d_tfinalOutK_214 v0
+  = case coe v0 of
+      C_mkContestIO'7580'_220 v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11
+        -> coe v9
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.ContestIOᶜ.numPartiesK
+d_numPartiesK_216 :: T_ContestIO'7580'_174 -> Integer
+d_numPartiesK_216 v0
+  = case coe v0 of
+      C_mkContestIO'7580'_220 v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11
+        -> coe v10
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.ContestIOᶜ.cpK
+d_cpK_218 :: T_ContestIO'7580'_174 -> Integer
+d_cpK_218 v0
+  = case coe v0 of
+      C_mkContestIO'7580'_220 v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11
+        -> coe v11
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.OpsContest
+d_OpsContest_222 = ()
+newtype T_OpsContest_222
+  = C_OpsContest'46'constructor_3599 (T_ContestIO'7580'_174 -> Bool)
+-- Hydra.Protocol.Reference.OpsContest.contestCryptoOK
+d_contestCryptoOK_226 ::
+  T_OpsContest_222 -> T_ContestIO'7580'_174 -> Bool
+d_contestCryptoOK_226 v0
+  = case coe v0 of
+      C_OpsContest'46'constructor_3599 v1 -> coe v1
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.contestRefᵇ
+d_contestRef'7495'_228 ::
+  T_OpsContest_222 -> T_ContestIO'7580'_174 -> Bool
+d_contestRef'7495'_228 v0 v1
+  = coe
+      d__'38''38'__58
+      (coe
+         d__'61''61''7495'__66 (coe d_versionInK_198 (coe v1))
+         (coe d_versionOutK_200 (coe v1)))
+      (coe
+         d__'38''38'__58
+         (coe
+            d__'60''7495'__78 (coe d_snapIn_202 (coe v1))
+            (coe d_snapOut_204 (coe v1)))
+         (coe
+            d__'38''38'__58
+            (coe
+               d__'61''61''7495'__66 (coe d_contesterLenOut_208 (coe v1))
+               (coe
+                  addInt (coe (1 :: Integer)) (coe d_contesterLenIn_206 (coe v1))))
+            (coe
+               d__'38''38'__58
+               (coe
+                  d__'8804''7470'__84 (coe d_validityHiK_212 (coe v1))
+                  (coe d_tfinalK_210 (coe v1)))
+               (coe
+                  d__'38''38'__58
+                  (coe
+                     eqInt (coe d_tfinalOutK_214 (coe v1))
+                     (coe
+                        du_if_then_else__92
+                        (coe
+                           d__'61''61''7495'__66 (coe d_contesterLenOut_208 (coe v1))
+                           (coe d_numPartiesK_216 (coe v1)))
+                        (coe d_tfinalK_210 (coe v1))
+                        (coe
+                           addInt (coe d_cpK_218 (coe v1)) (coe d_tfinalK_210 (coe v1)))))
+                  (coe d_contestCryptoOK_226 v0 v1)))))
+-- Hydra.Protocol.Reference.Fanoutᶜ
+d_Fanout'7580'_234 = ()
+type T_Fanout'7580'_234 = HsFanout
+pattern C_mkFanout'7580'_256 a0 a1 a2 a3 a4 = MkFanout a0 a1 a2 a3 a4
+check_mkFanout'7580'_256 ::
+  Integer ->
+  Integer -> Integer -> Integer -> Integer -> T_Fanout'7580'_234
+check_mkFanout'7580'_256 = MkFanout
+cover_Fanout'7580'_234 :: HsFanout -> ()
+cover_Fanout'7580'_234 x
+  = case x of
+      MkFanout _ _ _ _ _ -> ()
+-- Hydra.Protocol.Reference.Fanoutᶜ.numOutputsF
+d_numOutputsF_246 :: T_Fanout'7580'_234 -> Integer
+d_numOutputsF_246 v0
+  = case coe v0 of
+      C_mkFanout'7580'_256 v1 v2 v3 v4 v5 -> coe v1
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.Fanoutᶜ.burnedCountF
+d_burnedCountF_248 :: T_Fanout'7580'_234 -> Integer
+d_burnedCountF_248 v0
+  = case coe v0 of
+      C_mkFanout'7580'_256 v1 v2 v3 v4 v5 -> coe v2
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.Fanoutᶜ.numPartiesF
+d_numPartiesF_250 :: T_Fanout'7580'_234 -> Integer
+d_numPartiesF_250 v0
+  = case coe v0 of
+      C_mkFanout'7580'_256 v1 v2 v3 v4 v5 -> coe v3
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.Fanoutᶜ.tfinalF
+d_tfinalF_252 :: T_Fanout'7580'_234 -> Integer
+d_tfinalF_252 v0
+  = case coe v0 of
+      C_mkFanout'7580'_256 v1 v2 v3 v4 v5 -> coe v4
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.Fanoutᶜ.validityLoF
+d_validityLoF_254 :: T_Fanout'7580'_234 -> Integer
+d_validityLoF_254 v0
+  = case coe v0 of
+      C_mkFanout'7580'_256 v1 v2 v3 v4 v5 -> coe v5
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.OpsFanout
+d_OpsFanout_258 = ()
+newtype T_OpsFanout_258
+  = C_OpsFanout'46'constructor_3853 (T_Fanout'7580'_234 -> Bool)
+-- Hydra.Protocol.Reference.OpsFanout.fanoutCryptoOK
+d_fanoutCryptoOK_262 ::
+  T_OpsFanout_258 -> T_Fanout'7580'_234 -> Bool
+d_fanoutCryptoOK_262 v0
+  = case coe v0 of
+      C_OpsFanout'46'constructor_3853 v1 -> coe v1
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.fanoutRefᵇ
+d_fanoutRef'7495'_264 ::
+  T_OpsFanout_258 -> T_Fanout'7580'_234 -> Bool
+d_fanoutRef'7495'_264 v0 v1
+  = coe
+      d__'38''38'__58
+      (coe
+         eqInt (coe d_burnedCountF_248 (coe v1))
+         (coe addInt (coe (1 :: Integer)) (coe d_numPartiesF_250 (coe v1))))
+      (coe
+         d__'38''38'__58
+         (coe
+            ltInt (coe d_tfinalF_252 (coe v1))
+            (coe d_validityLoF_254 (coe v1)))
+         (coe d_fanoutCryptoOK_262 v0 v1))
+-- Hydra.Protocol.Reference.RecoverIOᶜ
+d_RecoverIO'7580'_270 = ()
+type T_RecoverIO'7580'_270 = HsRecoverIO
+pattern C_mkRecoverIO'7580'_280 a0 a1 = MkRecoverIO a0 a1
+check_mkRecoverIO'7580'_280 ::
+  Integer -> Integer -> T_RecoverIO'7580'_270
+check_mkRecoverIO'7580'_280 = MkRecoverIO
+cover_RecoverIO'7580'_270 :: HsRecoverIO -> ()
+cover_RecoverIO'7580'_270 x
+  = case x of
+      MkRecoverIO _ _ -> ()
+-- Hydra.Protocol.Reference.RecoverIOᶜ.tRecoverR
+d_tRecoverR_276 :: T_RecoverIO'7580'_270 -> Integer
+d_tRecoverR_276 v0
+  = case coe v0 of
+      C_mkRecoverIO'7580'_280 v1 v2 -> coe v1
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.RecoverIOᶜ.validityLoR
+d_validityLoR_278 :: T_RecoverIO'7580'_270 -> Integer
+d_validityLoR_278 v0
+  = case coe v0 of
+      C_mkRecoverIO'7580'_280 v1 v2 -> coe v2
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.OpsRecover
+d_OpsRecover_282 = ()
+newtype T_OpsRecover_282
+  = C_OpsRecover'46'constructor_3947 (T_RecoverIO'7580'_270 -> Bool)
+-- Hydra.Protocol.Reference.OpsRecover.recoverHashOK
+d_recoverHashOK_286 ::
+  T_OpsRecover_282 -> T_RecoverIO'7580'_270 -> Bool
+d_recoverHashOK_286 v0
+  = case coe v0 of
+      C_OpsRecover'46'constructor_3947 v1 -> coe v1
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.recoverRefᵇ
+d_recoverRef'7495'_288 ::
+  T_OpsRecover_282 -> T_RecoverIO'7580'_270 -> Bool
+d_recoverRef'7495'_288 v0 v1
+  = coe
+      d__'38''38'__58
+      (coe
+         ltInt (coe d_tRecoverR_276 (coe v1))
+         (coe d_validityLoR_278 (coe v1)))
+      (coe d_recoverHashOK_286 v0 v1)
+-- Hydra.Protocol.Reference.MintIOᶜ
+d_MintIO'7580'_294 = ()
+type T_MintIO'7580'_294 = HsMintIO
+pattern C_mkMintIO'7580'_312 a0 a1 a2 a3 = MkMintIO a0 a1 a2 a3
+check_mkMintIO'7580'_312 ::
+  Integer -> Integer -> Integer -> Integer -> T_MintIO'7580'_294
+check_mkMintIO'7580'_312 = MkMintIO
+cover_MintIO'7580'_294 :: HsMintIO -> ()
+cover_MintIO'7580'_294 x
+  = case x of
+      MkMintIO _ _ _ _ -> ()
+-- Hydra.Protocol.Reference.MintIOᶜ.numPartiesM
+d_numPartiesM_304 :: T_MintIO'7580'_294 -> Integer
+d_numPartiesM_304 v0
+  = case coe v0 of
+      C_mkMintIO'7580'_312 v1 v2 v3 v4 -> coe v1
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.MintIOᶜ.mintedCountM
+d_mintedCountM_306 :: T_MintIO'7580'_294 -> Integer
+d_mintedCountM_306 v0
+  = case coe v0 of
+      C_mkMintIO'7580'_312 v1 v2 v3 v4 -> coe v2
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.MintIOᶜ.stQtyM
+d_stQtyM_308 :: T_MintIO'7580'_294 -> Integer
+d_stQtyM_308 v0
+  = case coe v0 of
+      C_mkMintIO'7580'_312 v1 v2 v3 v4 -> coe v3
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.MintIOᶜ.headTokenCountM
+d_headTokenCountM_310 :: T_MintIO'7580'_294 -> Integer
+d_headTokenCountM_310 v0
+  = case coe v0 of
+      C_mkMintIO'7580'_312 v1 v2 v3 v4 -> coe v4
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.OpsInit
+d_OpsInit_314 = ()
+newtype T_OpsInit_314
+  = C_OpsInit'46'constructor_4075 (T_MintIO'7580'_294 -> Bool)
+-- Hydra.Protocol.Reference.OpsInit.initPlacementOK
+d_initPlacementOK_318 ::
+  T_OpsInit_314 -> T_MintIO'7580'_294 -> Bool
+d_initPlacementOK_318 v0
+  = case coe v0 of
+      C_OpsInit'46'constructor_4075 v1 -> coe v1
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.initRefᵇ
+d_initRef'7495'_320 :: T_OpsInit_314 -> T_MintIO'7580'_294 -> Bool
+d_initRef'7495'_320 v0 v1
+  = coe
+      d__'38''38'__58
+      (coe
+         eqInt (coe d_mintedCountM_306 (coe v1))
+         (coe addInt (coe (1 :: Integer)) (coe d_numPartiesM_304 (coe v1))))
+      (coe
+         d__'38''38'__58
+         (coe eqInt (coe d_stQtyM_308 (coe v1)) (coe (1 :: Integer)))
+         (coe
+            d__'38''38'__58
+            (coe
+               eqInt (coe d_headTokenCountM_310 (coe v1))
+               (coe addInt (coe (1 :: Integer)) (coe d_numPartiesM_304 (coe v1))))
+            (coe d_initPlacementOK_318 v0 v1)))
+-- Hydra.Protocol.Reference.ClaimIOᶜ
+d_ClaimIO'7580'_326 = ()
+type T_ClaimIO'7580'_326 = HsClaimIO
+pattern C_mkClaimIO'7580'_348 a0 a1 a2 a3 a4 = MkClaimIO a0 a1 a2 a3 a4
+check_mkClaimIO'7580'_348 ::
+  Integer ->
+  Integer -> Integer -> Integer -> Integer -> T_ClaimIO'7580'_326
+check_mkClaimIO'7580'_348 = MkClaimIO
+cover_ClaimIO'7580'_326 :: HsClaimIO -> ()
+cover_ClaimIO'7580'_326 x
+  = case x of
+      MkClaimIO _ _ _ _ _ -> ()
+-- Hydra.Protocol.Reference.ClaimIOᶜ.tRecoverC
+d_tRecoverC_338 :: T_ClaimIO'7580'_326 -> Integer
+d_tRecoverC_338 v0
+  = case coe v0 of
+      C_mkClaimIO'7580'_348 v1 v2 v3 v4 v5 -> coe v1
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.ClaimIOᶜ.validityHiC
+d_validityHiC_340 :: T_ClaimIO'7580'_326 -> Integer
+d_validityHiC_340 v0
+  = case coe v0 of
+      C_mkClaimIO'7580'_348 v1 v2 v3 v4 v5 -> coe v2
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.ClaimIOᶜ.depositCidC
+d_depositCidC_342 :: T_ClaimIO'7580'_326 -> Integer
+d_depositCidC_342 v0
+  = case coe v0 of
+      C_mkClaimIO'7580'_348 v1 v2 v3 v4 v5 -> coe v3
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.ClaimIOᶜ.headCidC
+d_headCidC_344 :: T_ClaimIO'7580'_326 -> Integer
+d_headCidC_344 v0
+  = case coe v0 of
+      C_mkClaimIO'7580'_348 v1 v2 v3 v4 v5 -> coe v4
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.ClaimIOᶜ.headRedeemerIdxC
+d_headRedeemerIdxC_346 :: T_ClaimIO'7580'_326 -> Integer
+d_headRedeemerIdxC_346 v0
+  = case coe v0 of
+      C_mkClaimIO'7580'_348 v1 v2 v3 v4 v5 -> coe v5
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.claimRefᵇ
+d_claimRef'7495'_350 :: T_ClaimIO'7580'_326 -> Bool
+d_claimRef'7495'_350 v0
+  = coe
+      d__'38''38'__58
+      (coe
+         d__'8804''7470'__84 (coe d_validityHiC_340 (coe v0))
+         (coe d_tRecoverC_338 (coe v0)))
+      (coe
+         d__'38''38'__58
+         (coe
+            eqInt (coe d_depositCidC_342 (coe v0))
+            (coe d_headCidC_344 (coe v0)))
+         (coe
+            eqInt (coe d_headRedeemerIdxC_346 (coe v0)) (coe (0 :: Integer))))
+-- Hydra.Protocol.Reference.elemᵇ
+d_elem'7495'_354 :: Integer -> [Integer] -> Bool
+d_elem'7495'_354 v0 v1
+  = case coe v1 of
+      [] -> coe MAlonzo.Code.Agda.Builtin.Bool.C_false_8
+      (:) v2 v3
+        -> coe
+             d__'124''124'__62 (coe eqInt (coe v0) (coe v2))
+             (coe d_elem'7495'_354 (coe v0) (coe v3))
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.anySharedᵇ
+d_anyShared'7495'_362 :: [Integer] -> [Integer] -> Bool
+d_anyShared'7495'_362 v0 v1
+  = case coe v0 of
+      [] -> coe MAlonzo.Code.Agda.Builtin.Bool.C_false_8
+      (:) v2 v3
+        -> coe
+             d__'124''124'__62 (coe d_elem'7495'_354 (coe v2) (coe v1))
+             (coe d_anyShared'7495'_362 (coe v3) (coe v1))
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.SignerIOᶜ
+d_SignerIO'7580'_370 = ()
+type T_SignerIO'7580'_370 = HsSignerIO
+pattern C_mkSignerIO'7580'_380 a0 a1 = MkSignerIO a0 a1
+check_mkSignerIO'7580'_380 ::
+  MAlonzo.Code.Agda.Builtin.List.T_List_10 () Integer ->
+  MAlonzo.Code.Agda.Builtin.List.T_List_10 () Integer ->
+  T_SignerIO'7580'_370
+check_mkSignerIO'7580'_380 = MkSignerIO
+cover_SignerIO'7580'_370 :: HsSignerIO -> ()
+cover_SignerIO'7580'_370 x
+  = case x of
+      MkSignerIO _ _ -> ()
+-- Hydra.Protocol.Reference.SignerIOᶜ.signerCodesS
+d_signerCodesS_376 :: T_SignerIO'7580'_370 -> [Integer]
+d_signerCodesS_376 v0
+  = case coe v0 of
+      C_mkSignerIO'7580'_380 v1 v2 -> coe v1
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.SignerIOᶜ.ptCodesS
+d_ptCodesS_378 :: T_SignerIO'7580'_370 -> [Integer]
+d_ptCodesS_378 v0
+  = case coe v0 of
+      C_mkSignerIO'7580'_380 v1 v2 -> coe v2
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.participantSignedRefᵇ
+d_participantSignedRef'7495'_382 :: T_SignerIO'7580'_370 -> Bool
+d_participantSignedRef'7495'_382 v0
+  = coe
+      d_anyShared'7495'_362 (coe d_signerCodesS_376 (coe v0))
+      (coe d_ptCodesS_378 (coe v0))
+-- Hydra.Protocol.Reference.AssetIOᶜ
+d_AssetIO'7580'_386 = ()
+type T_AssetIO'7580'_386 = HsAssetIO
+pattern C_mkAssetIO'7580'_400 a0 a1 a2 = MkAssetIO a0 a1 a2
+check_mkAssetIO'7580'_400 ::
+  Integer -> Integer -> Integer -> T_AssetIO'7580'_386
+check_mkAssetIO'7580'_400 = MkAssetIO
+cover_AssetIO'7580'_386 :: HsAssetIO -> ()
+cover_AssetIO'7580'_386 x
+  = case x of
+      MkAssetIO _ _ _ -> ()
+-- Hydra.Protocol.Reference.AssetIOᶜ.qInA
+d_qInA_394 :: T_AssetIO'7580'_386 -> Integer
+d_qInA_394 v0
+  = case coe v0 of
+      C_mkAssetIO'7580'_400 v1 v2 v3 -> coe v1
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.AssetIOᶜ.qDeltaA
+d_qDeltaA_396 :: T_AssetIO'7580'_386 -> Integer
+d_qDeltaA_396 v0
+  = case coe v0 of
+      C_mkAssetIO'7580'_400 v1 v2 v3 -> coe v2
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.AssetIOᶜ.qOutA
+d_qOutA_398 :: T_AssetIO'7580'_386 -> Integer
+d_qOutA_398 v0
+  = case coe v0 of
+      C_mkAssetIO'7580'_400 v1 v2 v3 -> coe v3
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.perAssetConservedᵇ
+d_perAssetConserved'7495'_402 :: [T_AssetIO'7580'_386] -> Bool
+d_perAssetConserved'7495'_402 v0
+  = case coe v0 of
+      [] -> coe MAlonzo.Code.Agda.Builtin.Bool.C_true_10
+      (:) v1 v2
+        -> coe
+             d__'38''38'__58
+             (coe
+                eqInt
+                (coe addInt (coe d_qDeltaA_396 (coe v1)) (coe d_qInA_394 (coe v1)))
+                (coe d_qOutA_398 (coe v1)))
+             (coe d_perAssetConserved'7495'_402 (coe v2))
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.noMintRefᵇ
+d_noMintRef'7495'_408 :: Integer -> Bool
+d_noMintRef'7495'_408 v0
+  = coe d__'61''61''7495'__66 (coe v0) (coe (0 :: Integer))
+-- Hydra.Protocol.Reference.refSpentᵇ
+d_refSpent'7495'_412 :: Integer -> [Integer] -> Bool
+d_refSpent'7495'_412 v0 v1 = coe d_elem'7495'_354 (coe v0) (coe v1)
+-- Hydra.Protocol.Reference.partialFanoutRefᵇ
+d_partialFanoutRef'7495'_418 ::
+  Integer -> Integer -> Integer -> Bool
+d_partialFanoutRef'7495'_418 v0 v1 v2
+  = coe
+      d__'38''38'__58
+      (coe d__'60''7495'__78 (coe (0 :: Integer)) (coe v0))
+      (coe ltInt (coe v1) (coe v2))
+-- Hydra.Protocol.Reference.valuePreservedᵇ
+d_valuePreserved'7495'_426 ::
+  Integer -> Integer -> Integer -> Integer -> Bool
+d_valuePreserved'7495'_426 v0 v1 v2 v3
+  = coe
+      d__'38''38'__58 (coe eqInt (coe v0) (coe v1))
+      (coe eqInt (coe v2) (coe v3))
+-- Hydra.Protocol.Reference.contestParamsᵇ
+d_contestParams'7495'_436 ::
+  Integer -> Integer -> Integer -> Integer -> Bool
+d_contestParams'7495'_436 v0 v1 v2 v3
+  = coe
+      d__'38''38'__58 (coe eqInt (coe v0) (coe v1))
+      (coe eqInt (coe v2) (coe v3))
+-- Hydra.Protocol.Reference.initHeadIdᵇ
+d_initHeadId'7495'_446 :: Integer -> Integer -> Bool
+d_initHeadId'7495'_446 v0 v1 = coe eqInt (coe v0) (coe v1)
+-- Hydra.Protocol.Reference.BurnIOᶜ
+d_BurnIO'7580'_452 = ()
+type T_BurnIO'7580'_452 = HsBurnIO
+pattern C_mkBurnIO'7580'_462 a0 a1 = MkBurnIO a0 a1
+check_mkBurnIO'7580'_462 ::
+  Integer -> Integer -> T_BurnIO'7580'_452
+check_mkBurnIO'7580'_462 = MkBurnIO
+cover_BurnIO'7580'_452 :: HsBurnIO -> ()
+cover_BurnIO'7580'_452 x
+  = case x of
+      MkBurnIO _ _ -> ()
+-- Hydra.Protocol.Reference.BurnIOᶜ.mintedCountB
+d_mintedCountB_458 :: T_BurnIO'7580'_452 -> Integer
+d_mintedCountB_458 v0
+  = case coe v0 of
+      C_mkBurnIO'7580'_462 v1 v2 -> coe v1
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.BurnIOᶜ.burnedCountB
+d_burnedCountB_460 :: T_BurnIO'7580'_452 -> Integer
+d_burnedCountB_460 v0
+  = case coe v0 of
+      C_mkBurnIO'7580'_462 v1 v2 -> coe v2
+      _ -> MAlonzo.RTE.mazUnreachableError
+-- Hydra.Protocol.Reference.burnRefᵇ
+d_burnRef'7495'_464 :: T_BurnIO'7580'_452 -> Bool
+d_burnRef'7495'_464 v0
+  = coe
+      d__'38''38'__58
+      (coe eqInt (coe d_mintedCountB_458 (coe v0)) (coe (0 :: Integer)))
+      (coe ltInt (coe (0 :: Integer)) (coe d_burnedCountB_460 (coe v0)))

--- a/hydra-agda/generated/MAlonzo/RTE.hs
+++ b/hydra-agda/generated/MAlonzo/RTE.hs
@@ -1,0 +1,122 @@
+{-# OPTIONS_GHC -w #-}
+{-# LANGUAGE PolyKinds #-}
+
+module MAlonzo.RTE where
+
+import Prelude
+  ( Bool, Char, Double, Integer, String
+  , Enum(..), Eq(..), Ord(..), Integral(..), Num(..)
+  , ($), error, otherwise
+  , (++), fromIntegral
+  )
+
+import Data.Char ( GeneralCategory(Surrogate), generalCategory )
+import Data.Kind ( Type)
+import qualified Data.Word
+import qualified GHC.Exts as GHC ( Any )
+import Unsafe.Coerce ( unsafeCoerce )
+
+type AgdaAny = GHC.Any
+
+-- Special version of coerce that plays well with rules.
+{-# INLINE [1] coe #-}
+coe :: a -> b
+coe = unsafeCoerce
+{-# RULES "coerce-id" forall (x :: a) . coe x = x #-}
+
+-- Builtin QNames.
+data QName = QName { nameId, moduleId :: Integer, qnameString :: String, qnameFixity :: Fixity }
+
+data Assoc      = NonAssoc | LeftAssoc | RightAssoc
+data Precedence = Unrelated | Related PrecedenceLevel
+data Fixity     = Fixity Assoc Precedence
+type PrecedenceLevel = Double
+
+instance Eq QName where
+  QName a b _ _ == QName c d _ _ = (a, b) == (c, d)
+
+instance Ord QName where
+  compare (QName a b _ _) (QName c d _ _) = compare (a, b) (c, d)
+
+erased :: a
+erased = coe (\ _ -> erased)
+
+mazUnreachableError :: a
+mazUnreachableError = error ("Agda: unreachable code reached.")
+
+mazHole :: String -> a
+mazHole s = error ("Agda: reached hole: " ++ s)
+
+addInt :: Integer -> Integer -> Integer
+addInt = (+)
+
+subInt :: Integer -> Integer -> Integer
+subInt = (-)
+
+mulInt :: Integer -> Integer -> Integer
+mulInt = (*)
+
+geqInt :: Integer -> Integer -> Bool
+geqInt = (>=)
+
+ltInt :: Integer -> Integer -> Bool
+ltInt = (<)
+
+eqInt :: Integer -> Integer -> Bool
+eqInt = (==)
+
+quotInt :: Integer -> Integer -> Integer
+quotInt = quot
+
+remInt :: Integer -> Integer -> Integer
+remInt = rem
+
+-- #4999: Data.Text maps surrogate code points (\xD800 - \xDFFF) to the replacement character
+-- \xFFFD, so to keep strings isomorphic to list of characters we do the same for characters.
+natToChar :: Integer -> Char
+natToChar n | generalCategory c == Surrogate = '\xFFFD'
+            | otherwise                      = c
+  where c = toEnum $ fromIntegral $ mod n 0x110000
+
+-- Words --
+
+type Word64 = Data.Word.Word64
+
+word64ToNat :: Word64 -> Integer
+word64ToNat = fromIntegral
+
+word64FromNat :: Integer -> Word64
+word64FromNat = fromIntegral
+
+{-# INLINE add64 #-}
+add64 :: Word64 -> Word64 -> Word64
+add64 = (+)
+
+{-# INLINE sub64 #-}
+sub64 :: Word64 -> Word64 -> Word64
+sub64 = (-)
+
+{-# INLINE mul64 #-}
+mul64 :: Word64 -> Word64 -> Word64
+mul64 = (*)
+
+{-# INLINE quot64 #-}
+quot64 :: Word64 -> Word64 -> Word64
+quot64 = quot
+
+{-# INLINE rem64 #-}
+rem64 :: Word64 -> Word64 -> Word64
+rem64 = rem
+
+{-# INLINE eq64 #-}
+eq64 :: Word64 -> Word64 -> Bool
+eq64 = (==)
+
+{-# INLINE lt64 #-}
+lt64 :: Word64 -> Word64 -> Bool
+lt64 = (<)
+
+-- Support for musical coinduction.
+
+data Inf                      a = Sharp { flat :: a }
+type Infinity (level :: Type) a = Inf a

--- a/hydra-agda/generated/MAlonzo/RTE/Float.hs
+++ b/hydra-agda/generated/MAlonzo/RTE/Float.hs
@@ -1,0 +1,286 @@
+{-# OPTIONS_GHC -w #-}
+{-# LANGUAGE CPP #-}
+
+module MAlonzo.RTE.Float where
+
+import Prelude
+  ( Bool, Double, Int, Integer, Maybe(..), Ordering(..)
+  , Eq(..), Ord(..), Functor(..)
+  , Floating(..), Fractional(..), Integral(..), Num(..), Real(..), RealFloat(..), RealFrac(..)
+  , ($), (.), otherwise, uncurry, undefined
+  , (&&), fst, snd
+  , (^), even, fromIntegral
+  )
+
+import Data.Bifunctor   ( bimap, second )
+import Data.Function    ( on )
+import Data.Maybe       ( fromMaybe )
+import Data.Ratio       ( (%), numerator, denominator )
+import Data.Word        ( Word64 )
+
+#if __GLASGOW_HASKELL__ >= 804
+import GHC.Float (castDoubleToWord64, castWord64ToDouble)
+#else
+import System.IO.Unsafe (unsafePerformIO)
+import qualified Foreign          as F
+import qualified Foreign.Storable as F
+#endif
+
+#if __GLASGOW_HASKELL__ < 804
+castDoubleToWord64 :: Double -> Word64
+castDoubleToWord64 float = unsafePerformIO $ F.alloca $ \buf -> do
+  F.poke (F.castPtr buf) float
+  F.peek buf
+
+castWord64ToDouble :: Word64 -> Double
+castWord64ToDouble word = unsafePerformIO $ F.alloca $ \buf -> do
+  F.poke (F.castPtr buf) word
+  F.peek buf
+#endif
+
+{-# INLINE doubleEq #-}
+doubleEq :: Double -> Double -> Bool
+doubleEq = (==)
+
+{-# INLINE doubleLe #-}
+doubleLe :: Double -> Double -> Bool
+doubleLe = (<=)
+
+{-# INLINE doubleLt #-}
+doubleLt :: Double -> Double -> Bool
+doubleLt = (<)
+
+truncateDouble :: Double -> Double
+truncateDouble = castWord64ToDouble . castDoubleToWord64
+
+{-# INLINE intToDouble #-}
+intToDouble :: Integral a => a -> Double
+intToDouble = truncateDouble . fromIntegral
+
+{-# INLINE doublePlus #-}
+doublePlus :: Double -> Double -> Double
+doublePlus x y = truncateDouble (x + y)
+
+{-# INLINE doubleMinus #-}
+doubleMinus :: Double -> Double -> Double
+doubleMinus x y = truncateDouble (x - y)
+
+{-# INLINE doubleTimes #-}
+doubleTimes :: Double -> Double -> Double
+doubleTimes x y = truncateDouble (x * y)
+
+{-# INLINE doubleNegate #-}
+doubleNegate :: Double -> Double
+doubleNegate = negate -- NOTE: doesn't cause underflow/overflow
+
+{-# INLINE doubleDiv #-}
+doubleDiv :: Double -> Double -> Double
+doubleDiv = (/) -- NOTE: doesn't cause underflow/overflow
+
+{-# INLINE doublePow #-}
+doublePow :: Double -> Double -> Double
+doublePow x y = truncateDouble (x ** y)
+
+{-# INLINE doubleSqrt #-}
+doubleSqrt :: Double -> Double
+doubleSqrt = sqrt -- NOTE: doesn't cause underflow/overflow
+
+{-# INLINE doubleExp #-}
+doubleExp :: Double -> Double
+doubleExp x = truncateDouble (exp x)
+
+{-# INLINE doubleLog #-}
+doubleLog :: Double -> Double
+doubleLog = log -- NOTE: doesn't cause underflow/overflow
+
+{-# INLINE doubleSin #-}
+doubleSin :: Double -> Double
+doubleSin = sin -- NOTE: doesn't cause underflow/overflow
+
+{-# INLINE doubleCos #-}
+doubleCos :: Double -> Double
+doubleCos = cos -- NOTE: doesn't cause underflow/overflow
+
+{-# INLINE doubleTan #-}
+doubleTan :: Double -> Double
+doubleTan = tan -- NOTE: doesn't cause underflow/overflow
+
+{-# INLINE doubleASin #-}
+doubleASin :: Double -> Double
+doubleASin = asin -- NOTE: doesn't cause underflow/overflow
+
+{-# INLINE doubleACos #-}
+doubleACos :: Double -> Double
+doubleACos = acos -- NOTE: doesn't cause underflow/overflow
+
+{-# INLINE doubleATan #-}
+doubleATan :: Double -> Double
+doubleATan = atan -- NOTE: doesn't cause underflow/overflow
+
+{-# INLINE doubleATan2 #-}
+doubleATan2 :: Double -> Double -> Double
+doubleATan2 = atan2 -- NOTE: doesn't cause underflow/overflow
+
+{-# INLINE doubleSinh #-}
+doubleSinh :: Double -> Double
+doubleSinh = sinh -- NOTE: doesn't cause underflow/overflow
+
+{-# INLINE doubleCosh #-}
+doubleCosh :: Double -> Double
+doubleCosh = cosh -- NOTE: doesn't cause underflow/overflow
+
+{-# INLINE doubleTanh #-}
+doubleTanh :: Double -> Double
+doubleTanh = tanh -- NOTE: doesn't cause underflow/overflow
+
+{-# INLINE doubleASinh #-}
+doubleASinh :: Double -> Double
+doubleASinh = asinh -- NOTE: doesn't cause underflow/overflow
+
+{-# INLINE doubleACosh #-}
+doubleACosh :: Double -> Double
+doubleACosh = acosh -- NOTE: doesn't cause underflow/overflow
+
+{-# INLINE doubleATanh #-}
+doubleATanh :: Double -> Double
+doubleATanh = atanh -- NOTE: doesn't cause underflow/overflow
+
+{-# INLINE negativeZero #-}
+negativeZero :: Double
+negativeZero = -0.0
+
+positiveInfinity :: Double
+positiveInfinity = 1.0 / 0.0
+
+negativeInfinity :: Double
+negativeInfinity = -positiveInfinity
+
+nan :: Double
+nan = 0.0 / 0.0
+
+isPosInf :: Double -> Bool
+isPosInf x = x > 0.0 && isInfinite x
+
+isNegInf :: Double -> Bool
+isNegInf x = x < 0.0 && isInfinite x
+
+isPosZero :: Double -> Bool
+isPosZero x = doubleDenotEq x 0.0
+
+isNegZero :: Double -> Bool
+isNegZero x = doubleDenotEq x (-0.0)
+
+doubleRound :: Double -> Maybe Integer
+doubleRound = fmap round . asFinite
+
+doubleFloor :: Double -> Maybe Integer
+doubleFloor = fmap floor . asFinite
+
+doubleCeiling :: Double -> Maybe Integer
+doubleCeiling = fmap ceiling . asFinite
+
+normaliseNaN :: Double -> Double
+normaliseNaN x
+  | isNaN x   = nan
+  | otherwise = x
+
+doubleToWord64 :: Double -> Maybe Word64
+doubleToWord64 x
+  | isNaN x   = Nothing
+  | otherwise = Just (castDoubleToWord64 x)
+
+-- |Denotational equality for floating point numbers, checks bitwise equality.
+--
+--  NOTE: Denotational equality distinguishes NaNs, so its results may vary
+--        depending on the architecture and compilation flags. Unfortunately,
+--        this is a problem with floating-point numbers in general.
+--
+doubleDenotEq :: Double -> Double -> Bool
+doubleDenotEq = (==) `on` doubleToWord64
+
+-- |I guess "denotational orderings" are now a thing? The point is that we need
+--  an Ord instance which provides a total ordering, and is consistent with the
+--  denotational equality.
+--
+--  NOTE: The ordering induced via `doubleToWord64` is total, and is consistent
+--        with `doubleDenotEq`. However, it is *deeply* unintuitive. For one, it
+--        considers all negative numbers to be larger than positive numbers.
+--
+doubleDenotOrd :: Double -> Double -> Ordering
+doubleDenotOrd = compare `on` doubleToWord64
+
+-- |Return Just x if it's a finite number, otherwise return Nothing.
+asFinite :: Double -> Maybe Double
+asFinite x
+  | isNaN      x = Nothing
+  | isInfinite x = Nothing
+  | otherwise    = Just x
+
+-- |Decode a Double to an integer ratio.
+doubleToRatio :: Double -> (Integer, Integer)
+doubleToRatio x
+  | isNaN      x = (0, 0)
+  | isInfinite x = (signum (floor x), 0)
+  | otherwise    = let r = toRational x in (numerator r, denominator r)
+
+-- |Encode an integer ratio as a double.
+ratioToDouble :: Integer -> Integer -> Double
+ratioToDouble n d
+  | d == 0 = case compare n 0 of
+      LT -> negativeInfinity
+      EQ -> nan
+      GT -> positiveInfinity
+  | otherwise = fromRational (n % d)
+
+-- |Decode a Double to its mantissa and its exponent, normalised such that the
+--  mantissa is the smallest possible number without loss of accuracy.
+doubleDecode :: Double -> Maybe (Integer, Integer)
+doubleDecode x
+  | isNaN      x = Nothing
+  | isInfinite x = Nothing
+  | otherwise    = Just (uncurry normalise (second toInteger (decodeFloat x)))
+  where
+    normalise :: Integer -> Integer -> (Integer, Integer)
+    normalise mantissa exponent
+      | even mantissa = normalise (mantissa `div` 2) (exponent + 1)
+      | otherwise = (mantissa, exponent)
+
+-- |Checks whether or not the Double is within a safe range of operation.
+isSafeInteger :: Double -> Bool
+isSafeInteger x = case properFraction x of
+  (n, f) -> f == 0.0 && minMantissa <= n && n <= maxMantissa
+
+doubleRadix :: Integer
+doubleRadix = floatRadix (undefined :: Double)
+
+doubleDigits :: Int
+doubleDigits = floatDigits (undefined :: Double)
+
+doubleRange :: (Int, Int)
+doubleRange = floatRange (undefined :: Double)
+
+-- |The smallest representable mantissa. Simultaneously, the smallest integer which can be
+--  represented as a Double without loss of precision.
+minMantissa :: Integer
+minMantissa = - maxMantissa
+
+-- |The largest representable mantissa. Simultaneously, the largest integer which can be
+--  represented as a Double without loss of precision.
+maxMantissa :: Integer
+maxMantissa = (doubleRadix ^ toInteger doubleDigits) - 1
+
+-- |The largest representable exponent.
+minExponent :: Integer
+minExponent = toInteger $ (fst doubleRange - doubleDigits) - 1
+
+-- |The smallest representable exponent.
+maxExponent :: Integer
+maxExponent = toInteger $ snd doubleRange - doubleDigits
+
+-- |Encode a mantissa and an exponent as a Double.
+doubleEncode :: Integer -> Integer -> Maybe Double
+doubleEncode mantissa exponent
+  = if minMantissa <= mantissa && mantissa <= maxMantissa &&
+       minExponent <= exponent && exponent <= maxExponent
+    then Just (encodeFloat mantissa (fromInteger exponent))
+    else Nothing

--- a/hydra-agda/hydra-agda.cabal
+++ b/hydra-agda/hydra-agda.cabal
@@ -1,0 +1,51 @@
+cabal-version: 3.0
+name:          hydra-agda
+version:       2.3.0
+synopsis:
+  Agda-extracted decidable reference checkers for the Hydra on-chain validator and off-chain head logic.
+
+description:
+  The on-chain validity conditions and the off-chain handler decisions are
+  specified in Agda (spec/). The decidable cores
+  (`spec/src/Hydra/Protocol/Reference.agda` and
+  `spec/src/Hydra/Protocol/OffChainReference.agda`) are extracted to Haskell
+  via MAlonzo and exposed here through thin shims ('Hydra.Agda.Reference' and
+  'Hydra.Agda.OffChainReference'). They are used as second oracles in the
+  hydra-tx and hydra-node agreement tests, so the real Plutus validator and
+  the real HeadLogic handlers are checked to agree with the spec. The
+  'generated/' tree is MAlonzo output — do not edit it by hand; run
+  'regenerate.sh' (which re-extracts from the Agda) to refresh it.
+
+author:        IOG
+copyright:     2026 IOG
+license:       Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+build-type:    Simple
+
+library
+  default-language: GHC2021
+  hs-source-dirs:   src generated
+  ghc-options:      -Wall
+  exposed-modules:
+    Hydra.Agda.OffChainReference
+    Hydra.Agda.Reference
+
+  -- The generated MAlonzo modules are self-silencing: regenerate.sh stamps
+  -- every generated file with {-# OPTIONS_GHC -w #-}, so -Wall above lints
+  -- only the hand-written shims in src/.
+  other-modules:
+    MAlonzo.Code.Agda.Builtin.Bool
+    MAlonzo.Code.Agda.Builtin.List
+    MAlonzo.Code.Agda.Builtin.Nat
+    MAlonzo.Code.Agda.Primitive
+    MAlonzo.Code.Hydra.Protocol.OffChainReference
+    MAlonzo.Code.Hydra.Protocol.Reference
+    MAlonzo.RTE
+    MAlonzo.RTE.Float
+
+  build-depends:
+    , base
+    , text

--- a/hydra-agda/regenerate.sh
+++ b/hydra-agda/regenerate.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Regenerate the MAlonzo-extracted Haskell under generated/ from the Agda reference checkers.
+# Run inside the default dev shell (`nix develop`), which provides `agda` (with the spec
+# libraries) and GHC. After running, review the diff and update src/Hydra/Agda/Reference.hs and
+# src/Hydra/Agda/OffChainReference.hs if any mangled MAlonzo names (T_Ops_*,
+# C_Ops'46'constructor_*, d_closeRef'7495'_*, d_depositStatusRef_*) changed.
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo="$(cd "$here/.." && pwd)"
+rm -rf "$here/generated/MAlonzo"
+cd "$repo/spec"
+# On-chain validator reference (Reference.agda) and off-chain HeadLogic reference
+# (OffChainReference.agda). Both extract into the same generated/ tree (shared MAlonzo runtime).
+agda --compile --no-main --ghc-dont-call-ghc --compile-dir="$here/generated" \
+  src/Hydra/Protocol/Reference.agda
+agda --compile --no-main --ghc-dont-call-ghc --compile-dir="$here/generated" \
+  src/Hydra/Protocol/OffChainReference.agda
+
+# Stamp `-w` on every generated module: `just lint` builds with command-line
+# `-Werror -Wall`, which would otherwise escalate the extractor's harmless warnings
+# (name shadowing, unused imports, …) to errors. A file-level OPTIONS_GHC pragma is
+# appended after the command-line flags, so `-w` wins. The whole generated/ tree is
+# also excluded from treefmt (see nix/coding-standards.nix).
+find "$here/generated" -name '*.hs' -print0 | while IFS= read -r -d '' f; do
+  chmod u+w "$f"   # stdlib runtime files are copied read-only from the nix store
+  if ! head -1 "$f" | grep -q -- '-w'; then
+    printf '{-# OPTIONS_GHC -w #-}\n%s' "$(cat "$f")" > "$f"
+  fi
+done
+echo "Regenerated $here/generated/MAlonzo"

--- a/hydra-agda/src/Hydra/Agda/OffChainReference.hs
+++ b/hydra-agda/src/Hydra/Agda/OffChainReference.hs
@@ -1,0 +1,68 @@
+-- | Clean Haskell surface over the MAlonzo-extracted OFF-CHAIN HeadLogic reference decisions
+-- (@spec\/src\/Hydra\/Protocol\/OffChainReference.agda@). This is the off-chain analog of
+-- "Hydra.Agda.Reference": the extractable half of the figure↔Agda↔Haskell correspondence for the §6
+-- off-chain protocol, run as a second oracle against "Hydra.HeadLogic" in an off-chain differential
+-- test. The mangled MAlonzo names below are pinned to the committed @generated/@ tree; if they change,
+-- @regenerate.sh@ updates both this shim and @generated/@ together and a stale name is a compile error.
+module Hydra.Agda.OffChainReference (
+  -- * deposit lifecycle (the @tick@ handler)
+  HsDepositStatus (..),
+  depositStatusRef,
+
+  -- * reqSn signing eligibility
+  signEligibleRef,
+
+  -- * reqDec / ackSn / contest guards
+  reqDecEligibleRef,
+  notAlreadySignedRef,
+  allSignedRef,
+  contestEligibleRef,
+
+  -- * round-robin leader (bound to the real 'Hydra.HeadLogic.isLeader')
+  leaderRef,
+) where
+
+import MAlonzo.Code.Hydra.Protocol.OffChainReference (HsDepositStatus (..))
+import MAlonzo.Code.Hydra.Protocol.OffChainReference qualified as M
+
+-- | Extracted decidable deposit-status decision of the §6 @tick@ handler: given a deposit's
+-- @created@ and @deadline@ times, the deposit period @T_deposit@, and the current time @t@ (all
+-- POSIXTime), it returns the deposit's lifecycle status. Mirrors the figure's
+-- @on (tick, t)@ status transition (@t > deadline − T_deposit@ ⇒ Expired; else
+-- @t > created + T_deposit@ ⇒ Active; else Inactive).
+depositStatusRef :: Integer -> Integer -> Integer -> Integer -> HsDepositStatus
+depositStatusRef = M.d_depositStatusRef_22
+
+-- | Extracted decidable reqSn signing-eligibility check (the §6 @require v = v̂ ∧ s = ŝ + 1 ∧
+-- leader(s) = j@): given the requested version @v@, the party's seen version @v̂@, the requested
+-- snapshot number @s@, the party's seen number @ŝ@, and whether the requested leader is the sender
+-- (resolved Haskell-side from the party set), decides whether the party should sign. Mirrors the node's
+-- @onOpenNetworkReqSn@ @requireReqSn@.
+signEligibleRef :: Integer -> Integer -> Integer -> Integer -> Bool -> Bool
+signEligibleRef = M.d_signEligibleRef_36
+
+-- | Extracted reqDec eligibility (§6 @wait U_α = ∅ ∧ tx_ω = ⊥@): given whether a commit and a decommit
+-- are in flight, decides whether a new decommit may start.
+reqDecEligibleRef :: Bool -> Bool -> Bool
+reqDecEligibleRef = M.d_reqDecEligibleRef_62
+
+-- | Extracted ackSn-collect guard (§6 @require (j,·) ∉ Σ̂@): given the signer indices already in Σ̂ and a
+-- sender @j@, decides whether @j@ is a fresh signer.
+notAlreadySignedRef :: [Integer] -> Integer -> Bool
+notAlreadySignedRef = M.d_notAlreadySignedRef_68
+
+-- | Extracted ackSn-confirm guard (§6 @if ∀ k ∈ [1..n] : (k,·) ∈ Σ̂@): given the party count @n@ and the
+-- signer indices in Σ̂, decides whether every party (index @< n@) has signed (n-of-n).
+allSignedRef :: Integer -> [Integer] -> Bool
+allSignedRef = M.d_allSignedRef_80
+
+-- | Extracted contest re-post guard (§6 @if S̄.s > s_c@): our confirmed snapshot number vs the
+-- closed/contested one.
+contestEligibleRef :: Integer -> Integer -> Bool
+contestEligibleRef = M.d_contestEligibleRef_86
+
+-- | Extracted round-robin leader (the §6 @leader(s)@). Arguments: @m@ where the head has @suc m@ parties,
+-- the snapshot number, and a 0-based party index. Bound against the real 'Hydra.HeadLogic.isLeader' in
+-- the hydra-node off-chain differential.
+leaderRef :: Integer -> Integer -> Integer -> Bool
+leaderRef = M.d_leaderRef_98

--- a/hydra-agda/src/Hydra/Agda/Reference.hs
+++ b/hydra-agda/src/Hydra/Agda/Reference.hs
@@ -1,0 +1,289 @@
+-- | Clean Haskell surface over the MAlonzo-extracted decidable reference checkers
+-- (@spec\/src\/Hydra\/Protocol\/Reference.agda@). The mangled MAlonzo names below are
+-- pinned to the committed @generated/@ tree; if they change, regeneration updates both this
+-- shim and @generated/@ together (see @regenerate.sh@) and a stale name is a loud compile error.
+module Hydra.Agda.Reference (
+  -- * close
+  HsCloseTag (..),
+  HsOpen (..),
+  HsClosed (..),
+  Ops,
+  mkOps,
+  checkClose,
+
+  -- * increment / decrement
+  HsIncIO (..),
+  OpsInc,
+  mkOpsInc,
+  checkInc,
+  checkDec,
+  HsAssetIO (..),
+  checkPerAsset,
+
+  -- * contest
+  HsContestIO (..),
+  OpsContest,
+  mkOpsContest,
+  checkContest,
+
+  -- * fanout / finalPartialFanout
+  HsFanout (..),
+  OpsFanout,
+  mkOpsFanout,
+  checkFanout,
+
+  -- * deposit recover (νDeposit)
+  HsRecoverIO (..),
+  OpsRecover,
+  mkOpsRecover,
+  checkRecover,
+
+  -- * init (μHead minting policy: token count)
+  HsMintIO (..),
+  OpsInit,
+  mkOpsInit,
+  checkInit,
+
+  -- * deposit claim (νDeposit)
+  HsClaimIO (..),
+  checkClaim,
+
+  -- * participant signature (shared: close / contest / increment / decrement)
+  HsSignerIO (..),
+  checkParticipantSigned,
+
+  -- * no mint / no burn (shared: close / contest / increment / decrement)
+  checkNoMint,
+
+  -- * referenced output is spent (increment claimed deposit / init seed)
+  checkRefSpent,
+
+  -- * non-final partial fanout (FanoutProgress → FanoutProgress)
+  checkPartialFanout,
+
+  -- * value preservation (shared: close / contest mustPreserveHeadValue)
+  checkValuePreserved,
+
+  -- * contest parameter preservation (contest mustNotChangeParameters: headId + contestationPeriod)
+  checkContestParams,
+
+  -- * init datum head-id binding (μHead checkDatum: headId == currency)
+  checkInitHeadId,
+
+  -- * μHead token burning (Burn redeemer)
+  HsBurnIO (..),
+  checkBurn,
+) where
+
+import MAlonzo.Code.Hydra.Protocol.Reference (
+  HsAssetIO (..),
+  HsBurnIO (..),
+  HsClaimIO (..),
+  HsCloseTag (..),
+  HsClosed (..),
+  HsContestIO (..),
+  HsFanout (..),
+  HsIncIO (..),
+  HsMintIO (..),
+  HsOpen (..),
+  HsRecoverIO (..),
+  HsSignerIO (..),
+ )
+import MAlonzo.Code.Hydra.Protocol.Reference qualified as M
+
+-- | The injected (mock) crypto\/value boundary — the Agda @Ops@ record. The function decides
+-- the conjuncts the decidable layer does not model; the differential tests supply @const True@.
+type Ops = M.T_Ops_52
+
+mkOps :: (HsOpen -> HsClosed -> HsCloseTag -> Bool) -> Ops
+mkOps = M.C_Ops'46'constructor_125
+
+-- | Extracted decidable close-validity checker. Mirrors the decidable conjuncts of @closeValid@
+-- (version\/cp preserved, contesters empty, initial\/any snapshot rules, and the recorded
+-- contestation deadline @tfinal == validityHi + cp@, and the bounded validity range @hi - lo \<= cp@);
+-- proved to reflect them in @spec\/src\/Hydra\/Protocol\/ReferenceBridge.agda@. The two trailing
+-- 'Integer' arguments are the tx upper and lower validity bounds (POSIXTime ms). The crypto\/value\/
+-- accumulator conjuncts remain delegated to the injected (mock) @Ops@.
+checkClose :: Ops -> HsOpen -> HsClosed -> HsCloseTag -> Integer -> Integer -> Bool
+checkClose = M.d_closeRef'7495'_98
+
+-- | Injected boundary for increment\/decrement.
+type OpsInc = M.T_OpsInc_156
+
+mkOpsInc :: (HsIncIO -> Bool) -> OpsInc
+mkOpsInc = M.C_OpsInc'46'constructor_2927
+
+-- | Decidable increment checker: the produced version is @suc@ the input version
+-- (@VersionNotIncremented@) AND the head value grows by the deposit on BOTH the lovelace component
+-- (@adaIn + adaDelta == adaOut@) and the total non-ada token quantity
+-- (@nonAdaIn + nonAdaDelta == nonAdaOut@) — the validator's @mustPreserveValue@, which also catches a
+-- native-token siphon that an ada-only check would miss. Crypto delegated to @OpsInc@.
+checkInc :: OpsInc -> HsIncIO -> Bool
+checkInc = M.d_incRef'7495'_162
+
+-- | Decidable decrement checker: the produced version is @suc@ the input version AND the head value
+-- SHRINKS by the decommit on BOTH the lovelace component (@adaOut + adaDelta == adaIn@) and the total
+-- non-ada token quantity (@nonAdaOut + nonAdaDelta == nonAdaIn@): head output + decommitted outputs ==
+-- head input, the validator's @mustDecreaseValue@. Crypto delegated to @OpsInc@.
+checkDec :: OpsInc -> HsIncIO -> Bool
+checkDec = M.d_decRef'7495'_168
+
+-- | Per-asset value-conservation checker (the finer companion to 'checkInc'\/'checkDec', which check
+-- only the @adaOf@\/@nonAdaOf@ totals). Each 'HsAssetIO' is one native asset's @(qIn, qDelta, qOut)@;
+-- every asset must satisfy @qIn + qDelta == qOut@ (for decrement, pass @(qOut, qDelta, qIn)@). Proved to
+-- reflect @incrementValueOK@ per asset via @quantityOfᴺ-+ᵛ@ (@incPerAsset→ref@). Catches a selective
+-- single-token siphon that leaves the two scalar totals balanced.
+checkPerAsset :: [HsAssetIO] -> Bool
+checkPerAsset = M.d_perAssetConserved'7495'_402
+
+-- | Injected boundary for contest.
+type OpsContest = M.T_OpsContest_222
+
+mkOpsContest :: (HsContestIO -> Bool) -> OpsContest
+mkOpsContest = M.C_OpsContest'46'constructor_3599
+
+-- | Decidable contest checker: version preserved, snapshot strictly increases
+-- (@TooOldSnapshot@), exactly one contester appended, AND posted before the contestation deadline
+-- (@validityHi \<= tfinal@, the validator's @mustBeWithinContestationPeriod@); proved to reflect
+-- @contestValid@ in @spec\/src\/Hydra\/Protocol\/ReferenceBridge.agda@. The trailing two 'Integer'
+-- fields of 'HsContestIO' are the input contestation deadline and the contest tx's upper validity
+-- bound (POSIXTime ms), and the conditional deadline-UPDATE rule (@tfinal' == if all-contested then
+-- tfinal else tfinal+cp@, the last three 'HsContestIO' fields: tfinal', n, cp). Crypto\/value delegated.
+checkContest :: OpsContest -> HsContestIO -> Bool
+checkContest = M.d_contestRef'7495'_228
+
+-- | Injected boundary for fanout\/finalPartialFanout.
+type OpsFanout = M.T_OpsFanout_258
+
+mkOpsFanout :: (HsFanout -> Bool) -> OpsFanout
+mkOpsFanout = M.C_OpsFanout'46'constructor_3853
+
+-- | Decidable fanout checker: all @n+1@ head tokens burned (@burnedCount == n+1@) AND posted after the
+-- contestation deadline (@tfinal \< lo@). No @0 \< m@ guard — the full fanout permits @m == 0@ to finalise
+-- an empty head. Accumulator\/value conservation delegated to @OpsFanout@.
+checkFanout :: OpsFanout -> HsFanout -> Bool
+checkFanout = M.d_fanoutRef'7495'_264
+
+-- | Injected boundary for deposit recover (the recovered-outputs serialisation-hash equality).
+type OpsRecover = M.T_OpsRecover_282
+
+mkOpsRecover :: (HsRecoverIO -> Bool) -> OpsRecover
+mkOpsRecover = M.C_OpsRecover'46'constructor_3947
+
+-- | Decidable deposit-recover checker (@deposit.ak@ Recover arm): the recover tx is posted strictly
+-- after the recover deadline (@tRecover \< validityLo@, i.e. txValidityMin > t_recover, the
+-- validator's @DepositPeriodNotReached@); proved to reflect @recoverValid@ in
+-- @spec\/src\/Hydra\/Protocol\/ReferenceBridge.agda@. The recovered-outputs hash equality is
+-- delegated to the injected (mock) @OpsRecover@.
+checkRecover :: OpsRecover -> HsRecoverIO -> Bool
+checkRecover = M.d_recoverRef'7495'_288
+
+-- | Injected boundary for init: the seed-spent and datum-binding μHead checks (token PLACEMENT is
+-- checked by 'checkInit' itself, not delegated here).
+type OpsInit = M.T_OpsInit_314
+
+mkOpsInit :: (HsMintIO -> Bool) -> OpsInit
+mkOpsInit = M.C_OpsInit'46'constructor_4075
+
+-- | Decidable init token COUNT + PLACEMENT checker (μHead @validateTokensMinting@): the transaction
+-- MINTS exactly @n + 1@ tokens of the head policy (@checkNumberOfTokens@) AND those tokens are PLACED in
+-- the head output — the ST is present (@stQty == 1@) and the head output carries exactly @n + 1@
+-- head-policy tokens (@headTokenCount == n + 1@). The four 'HsMintIO' fields are @n@, the minted count,
+-- the head-output ST quantity, and the head-output head-policy token count. Proved to reflect @initValid@
+-- in @spec\/src\/Hydra\/Protocol\/ReferenceBridge.agda@. Seed-spent and datum binding stay delegated to
+-- @OpsInit@.
+checkInit :: OpsInit -> HsMintIO -> Bool
+checkInit = M.d_initRef'7495'_320
+
+-- | Decidable deposit-claim checker (@deposit.ak@ Claim arm): the increment tx collecting the deposit
+-- is posted BEFORE the recover deadline (@validityHi \<= tRecover@, i.e. txValidityMax <= t_recover,
+-- the validator's @before_deadline@ / @DepositPeriodSurpassed@), the deposit datum's head id equals
+-- the spent head's id (@depositCid == headCid@, the head-id half of @expect_increment_redeemer@; the
+-- ids are passed as 'HsClaimIO' integer encodings), AND the redeemer spending the head input has the
+-- @Increment@ constructor index 0 (the other half of @expect_increment_redeemer@, deposit.ak's
+-- @is_head_increment@; the observed index is the last 'HsClaimIO' field). No injected boundary;
+-- proved to reflect the joint @claimTxValid@ in @spec\/src\/Hydra\/Protocol\/ReferenceBridge.agda@.
+checkClaim :: HsClaimIO -> Bool
+checkClaim = M.d_claimRef'7495'_350
+
+-- | Decidable, fully-extractable participant-signature checker (the §5.4–5.7
+-- @mustBeSignedByParticipant@, shared by close\/contest\/increment\/decrement): SOME transaction
+-- signer holds a participation token in the head value. 'HsSignerIO' carries two @[Integer]@ lists —
+-- the tx signers' key-hashes (txInfoSignatories) and the head value's PT token-names (a PT's name IS a
+-- key-hash) — both with the same hash→Integer encoding; the check is that they OVERLAP. No injected
+-- boundary: a non-participant signer (the validator's @SignerIsNotAParticipant@) makes the lists
+-- disjoint and the reference reject. Proved to reflect @signedByParticipant@ in
+-- @spec\/src\/Hydra\/Protocol\/ReferenceBridge.agda@ (a postulated extraction-faithfulness boundary).
+checkParticipantSigned :: HsSignerIO -> Bool
+checkParticipantSigned = M.d_participantSignedRef'7495'_382
+
+-- | Decidable, fully-extractable no-mint\/no-burn checker (the §5.4–5.7 @mustNotMintOrBurn@, shared by
+-- close\/contest\/increment\/decrement): the tx mints and burns nothing. The differential supplies the
+-- number of non-zero asset entries in @txInfoMint@; the mint is empty exactly when that count is 0. No
+-- injected boundary: a minting\/burning mutation (the validator's @MintingOrBurningIsForbidden@) makes the
+-- count positive and the reference rejects. Proved to reflect @noMint@ in
+-- @spec\/src\/Hydra\/Protocol\/ReferenceBridge.agda@ (a postulated extraction-faithfulness boundary).
+checkNoMint :: Integer -> Bool
+checkNoMint = M.d_noMintRef'7495'_408
+
+-- | Decidable, fully-extractable "referenced output is spent" checker (the increment
+-- @claimedDepositIsSpent@ and the μHead @seedInputIsConsumed@): a referenced out-ref is among the tx's
+-- spent inputs. The differential supplies the referenced out-ref and the list of the tx's input out-refs,
+-- both under one deterministic Integer encoding, and checks membership. No injected boundary: spending a
+-- different deposit \/ dropping the seed (the validator's @DepositNotSpent@ \/ @SeedNotSpent@) makes the ref
+-- absent and the reference rejects. Proved to reflect @depositSpentOK@ in
+-- @spec\/src\/Hydra\/Protocol\/ReferenceBridge.agda@ (a postulated extraction-faithfulness boundary).
+checkRefSpent :: Integer -> [Integer] -> Bool
+checkRefSpent = M.d_refSpent'7495'_412
+
+-- | Decidable non-final partial-fanout checker (νHead @checkPartialFanout@, the intermediate
+-- FanoutProgress→FanoutProgress batch): at least one output is distributed (@0 \< m@, the
+-- @PartialFanoutZeroOutputs@ guard the FULL fanout omits) AND the tx is posted after the contestation
+-- deadline (@tfinal \< lo@). The three 'Integer' arguments are @m@, the recorded deadline and the tx lower
+-- validity bound (POSIXTime ms). Accumulator\/value conjuncts stay abstract; @mustNotMintOrBurn@ is the
+-- shared 'checkNoMint'. Proved to reflect @partialFanoutValid@ in
+-- @spec\/src\/Hydra\/Protocol\/ReferenceBridge.agda@.
+checkPartialFanout :: Integer -> Integer -> Integer -> Bool
+checkPartialFanout = M.d_partialFanoutRef'7495'_418
+
+-- | Decidable, fully-extractable value-preservation checker (the close \/ contest
+-- @mustPreserveHeadValue@, the exact @==@ on the head value): the ada total AND the non-ada total are
+-- unchanged from the head input to the head output. The four 'Integer' arguments are
+-- @(adaIn, adaOut, nonAdaIn, nonAdaOut)@; the check is @adaIn == adaOut && nonAdaIn == nonAdaOut@. No
+-- injected boundary: a value siphon (the validator's @HeadValueIsNotPreserved@) makes a total differ and
+-- the reference rejects. Proved to reflect the @valuePreserved@ conjunct of @closeValid@\/@contestValid@ in
+-- @spec\/src\/Hydra\/Protocol\/ReferenceBridge.agda@ via @cong adaOf@\/@cong nonAdaOf@ + @==-sound@ (no new
+-- postulate).
+checkValuePreserved :: Integer -> Integer -> Integer -> Integer -> Bool
+checkValuePreserved = M.d_valuePreserved'7495'_426
+
+-- | Decidable, fully-extractable contest parameter-preservation checker (the scalar half of contest
+-- @mustNotChangeParameters@): the produced datum keeps the same head id and contestation period. The four
+-- 'Integer' arguments are @(headIdIn, headIdOut, cpIn, cpOut)@ (head ids as their deterministic Integer
+-- encoding); the check is @headIdIn == headIdOut && cpIn == cpOut@. No injected boundary: re-pointing the
+-- head id or changing the period (the validator's @ChangedParameters@) makes a pair differ and the
+-- reference rejects. Proved to reflect the contest transition's parameter preservation in
+-- @spec\/src\/Hydra\/Protocol\/ReferenceBridge.agda@ via @cong cidToNat@ + @==-sound@ (no new postulate;
+-- the @parties@-list half stays a documented boundary, as the spec abstracts parties into a count).
+checkContestParams :: Integer -> Integer -> Integer -> Integer -> Bool
+checkContestParams = M.d_contestParams'7495'_436
+
+-- | Decidable, fully-extractable init datum head-id binding (the decidable half of the μHead
+-- @checkDatum@): the head output datum declares its own minting policy as its head id
+-- (@datumHeadId == currency@). The two 'Integer' arguments are the head-id and currency Integer
+-- encodings. No injected boundary: a datum naming a different head id (the validator's @WrongDatum@) makes
+-- the pair differ and the reference rejects. Proved to reflect the init datum binding in
+-- @spec\/src\/Hydra\/Protocol\/ReferenceBridge.agda@ via the existing @cidToNat@ encoding (no new
+-- postulate). The @seed == seedInput@ half and the @cid = hash(seed)@ binding stay documented boundaries.
+checkInitHeadId :: Integer -> Integer -> Bool
+checkInitHeadId = M.d_initHeadId'7495'_446
+
+-- | Decidable, fully-extractable μHead Burn-arm checker (@validateTokensBurning@): every head-policy
+-- entry of the mint field is negative — no positive entry exists and at least one negative one does
+-- (the real policy rejects a mint field without head-policy entries). The two 'HsBurnIO' fields are
+-- the counts of the positive and negative head-policy mint entries. No injected boundary. Proved to
+-- reflect @burnValid@ in @spec\/src\/Hydra\/Protocol\/ReferenceBridge.agda@. Zero-quantity mint
+-- entries are outside the domain (not representable in canonical ledger values). WHICH burns are
+-- legitimate is νHead's concern (the fan-out family's burn count); μHead only guarantees burn-only.
+checkBurn :: HsBurnIO -> Bool
+checkBurn = M.d_burnRef'7495'_464

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -396,6 +396,8 @@ test-suite tests
     Hydra.Node.RunSpec
     Hydra.Node.UtilSpec
     Hydra.NodeSpec
+    Hydra.OffChainAgreementSpec
+    Hydra.OffChainLeaderSpec
     Hydra.OptionsSpec
     Hydra.PartySpec
     Hydra.PersistentQueueSpec
@@ -437,6 +439,7 @@ test-suite tests
     , hspec-golden-aeson
     , hspec-wai
     , HUnit
+    , hydra-agda
     , hydra-cardano-api
     , hydra-cardano-api:testlib
     , hydra-node

--- a/hydra-node/test/Hydra/OffChainAgreementSpec.hs
+++ b/hydra-node/test/Hydra/OffChainAgreementSpec.hs
@@ -1,0 +1,445 @@
+-- | Off-chain differential (real-node bindings): the Agda-extracted §6 handler decisions
+-- ("Hydra.Agda.OffChainReference") checked against the REAL 'Hydra.HeadLogic.update' outcomes, not
+-- against transcriptions of the figure. This extends 'Hydra.OffChainLeaderSpec' (which binds
+-- @leaderRef@ to the real @isLeader@) to three more decisions, closing the figure↔Agda↔Haskell loop:
+--
+--   * @signEligibleRef@ vs @onOpenNetworkReqSn@: we drive 'update' with a @ReqSn@ over an open state
+--     with version v̂ and a settled snapshot ŝ (confirmed = seen, nothing in flight) and binarise the
+--     outcome: ACCEPT iff the node reaches the signing continuation ('SnapshotRequested' + an @AckSn@
+--     effect). The node splits the figure's single @require@ into an Error (number:
+--     'ReqSnNumberInvalid', leader: 'ReqSnNotLeader') and a Wait (version: 'WaitOnSnapshotVersion',
+--     so a follower behind on the version bump does not drop the message); Error and Wait both map to
+--     non-accept. The reference's leader input is resolved by the EXTRACTED @leaderRef@ (itself bound
+--     to the real @isLeader@ in 'Hydra.OffChainLeaderSpec'), so the composed decision is fully Agda-derived.
+--
+--   * @reqDecEligibleRef@ vs @onOpenNetworkReqDec@: ACCEPT iff the node records the decommit
+--     ('DecommitRecorded'). A pending deposit (commit in flight, @currentDepositTxId@ set) makes the
+--     node WAIT ('WaitOnUnresolvedCommit') at ttl > 0; an in-flight decommit makes it WAIT at ttl > 0
+--     ('WaitOnNotApplicableDecommitTx' with 'DecommitAlreadyInFlight'); both are non-accept, matching
+--     the reference's single Bool.
+--
+--   * @depositStatusRef@ vs the deposit-status transition the node applies on a chain 'Tick'
+--     ('onOpenChainTick' via @determineNextDepositStatus@): starting from a fresh Inactive deposit,
+--     one tick at time t yields 'DepositExpired' / 'DepositActivated' / no status event, mapping to
+--     ExpiredS / ActiveS / InactiveS.
+--
+--   * @notAlreadySignedRef@ vs @onOpenNetworkAckSn@'s @requireNotSignedYet@: over a directly
+--     constructed in-flight 'SeenSnapshot' whose signatories map holds REAL signatures, an @AckSn@
+--     from a sender already in the map is the node's 'SnapshotAlreadySigned'; a fresh sender is not.
+--
+--   * @allSignedRef@ vs the round completion of @onOpenNetworkAckSn@: a fresh sender's ack CONFIRMS
+--     (the node aggregates the real signatures in order and verifies the real multisignature before
+--     emitting 'SnapshotConfirmed') exactly when it completes the n-of-n signer set; the composed
+--     decision is @notAlreadySignedRef ∧ allSignedRef (sender ∷ Σ̂)@.
+--
+--   * @contestEligibleRef@ vs @onOpenChainCloseTx@: observing a close of snapshot s_c while our
+--     confirmed snapshot is S̄.s posts a 'ContestTx' exactly when S̄.s > s_c.
+--
+-- Domain note (deposit status): the extracted decision uses Nat truncated subtraction for
+-- @deadline − T_deposit@ whereas the node subtracts over 'UTCTime'; the two agree whenever
+-- @deadline ≥ T_deposit@, which the protocol guarantees (an observed deposit deadline sits a full
+-- deposit period after creation). The property therefore quantifies over that domain, with all times
+-- as whole POSIX seconds (exact in both representations).
+--
+-- Scope note (ackSn): the extracted guards model the COUNTING decisions (who signed, n-of-n); the
+-- collected signatures themselves are held healthy, exactly as the on-chain reference holds crypto
+-- conjuncts healthy. The real node additionally verifies the aggregate multisignature at
+-- confirmation; a corrupt collected signature makes it reject ('InvalidMultisignature') where the
+-- counting reference alone would accept, demonstrated as a validator-only rejection below.
+module Hydra.OffChainAgreementSpec (spec) where
+
+import Hydra.Prelude
+import Test.Hydra.Prelude
+
+import Data.Map.Strict qualified as Map
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import Hydra.API.ServerOutput (DecommitInvalidReason (..))
+import Hydra.Agda.OffChainReference (
+  HsDepositStatus (..),
+  allSignedRef,
+  contestEligibleRef,
+  depositStatusRef,
+  leaderRef,
+  notAlreadySignedRef,
+  reqDecEligibleRef,
+  signEligibleRef,
+ )
+import Hydra.Chain (ChainEvent (..), OnChainTx (..), PostChainTx (..))
+import Hydra.HeadLogic (
+  CoordinatedHeadState (..),
+  Effect (..),
+  Input (..),
+  LogicError (..),
+  Outcome (..),
+  RequirementFailure (..),
+  SeenSnapshot (..),
+  StateChanged (..),
+  WaitReason (..),
+  mkSeenSnapshot,
+  update,
+ )
+import Hydra.HeadLogicSpec (assertWait, inOpenState, inOpenState', observeTx, receiveMessageFrom, testSnapshot)
+import Hydra.Ledger.Simple (SimpleTx (..), simpleLedger, utxoRef)
+import Hydra.Network.Message (Message (..))
+import Hydra.Node.Environment (Environment (..))
+import Hydra.Node.State (Deposit (..), DepositStatus (..), NodeState (..))
+import Hydra.Options (defaultContestationPeriod, defaultDepositPeriod, defaultUnsyncedPeriod)
+import Hydra.Prelude qualified as Prelude
+import Hydra.Tx.Crypto (HydraKey, Signature, SigningKey, aggregate, sign)
+import Hydra.Tx.Party (Party)
+import Hydra.Tx.Secret (Secret)
+import Hydra.Tx.Snapshot (ConfirmedSnapshot (..), Snapshot)
+import Test.Hydra.Tx.Fixture (alice, aliceSk, bob, bobSk, carol, carolSk, deriveOnChainId, testHeadId)
+import Test.QuickCheck (choose, elements, forAll, sublistOf, (===))
+
+threeParties :: [Party]
+threeParties = [alice, bob, carol]
+
+-- The node under test is alice; the handlers' guards concern the SENDER, so one env suffices.
+aliceEnv :: Environment
+aliceEnv =
+  Environment
+    { party = alice
+    , signingKey = aliceSk
+    , otherParties = [bob, carol]
+    , contestationPeriod = defaultContestationPeriod
+    , depositPeriod = defaultDepositPeriod
+    , unsyncedPeriod = defaultUnsyncedPeriod
+    , participants = deriveOnChainId <$> threeParties
+    , configuredPeers = ""
+    }
+
+-- 'update' ignores the wall clock on the NetworkInput path; any fixed time works.
+time0 :: UTCTime
+time0 = posixSecondsToUTCTime 0
+
+posixTime :: Integer -> UTCTime
+posixTime = posixSecondsToUTCTime . fromInteger
+
+-- ── reqSn signing eligibility ────────────────────────────────────────────────────────────────────────
+
+-- Open state with version v̂ and a settled snapshot ŝ: confirmed = seen (nothing in flight), so the
+-- handler's wait-guards outside the modeled decision (ŝ = S̄.s) hold by construction.
+reqSnState :: Integer -> Integer -> NodeState SimpleTx
+reqSnState vHat sHat =
+  inOpenState' threeParties $
+    CoordinatedHeadState
+      { localUTxO = mempty
+      , allTxs = mempty
+      , localTxs = mempty
+      , confirmedSnapshot =
+          if sHat == 0
+            then InitialSnapshot testHeadId
+            else ConfirmedSnapshot (testSnapshot (fromInteger sHat) (fromInteger vHat) [] mempty) (aggregate [])
+      , seenSnapshot = if sHat == 0 then NoSeenSnapshot else LastSeenSnapshot (fromInteger sHat)
+      , currentDepositTxId = Nothing
+      , decommitTx = Nothing
+      , version = fromInteger vHat
+      }
+
+-- Run the REAL handler on a (v, s) request from the given sender.
+reqSnOutcome :: Integer -> Integer -> Integer -> Integer -> Party -> Outcome SimpleTx
+reqSnOutcome vHat sHat v s sender =
+  update aliceEnv simpleLedger time0 (reqSnState vHat sHat) $
+    receiveMessageFrom sender (ReqSn (fromInteger v) (fromInteger s) [] Nothing Nothing)
+
+-- ACCEPT iff the node reaches the signing continuation; Error and Wait are both non-accept.
+reqSnAccepts :: Outcome SimpleTx -> Bool
+reqSnAccepts = \case
+  Continue{stateChanges} -> any isRequested stateChanges
+  _ -> False
+ where
+  isRequested :: StateChanged SimpleTx -> Bool
+  isRequested = \case
+    SnapshotRequested{} -> True
+    _ -> False
+
+-- ── reqDec eligibility ───────────────────────────────────────────────────────────────────────────────
+
+-- The requested decommit (no inputs, so it applies to any local UTxO) and a distinct in-flight one.
+requestedDecommit :: SimpleTx
+requestedDecommit = SimpleTx 1 mempty (utxoRef 1)
+
+inFlightDecommit :: SimpleTx
+inFlightDecommit = SimpleTx 2 mempty (utxoRef 2)
+
+-- Open state on the reqDec decision's domain: a pending deposit (U_α ≠ ∅) and/or an in-flight
+-- decommit (tx_ω ≠ ⊥).
+reqDecState :: Bool -> Bool -> NodeState SimpleTx
+reqDecState commitInFlight decommitInFlight =
+  inOpenState' threeParties $
+    CoordinatedHeadState
+      { localUTxO = mempty
+      , allTxs = mempty
+      , localTxs = mempty
+      , confirmedSnapshot = InitialSnapshot testHeadId
+      , seenSnapshot = NoSeenSnapshot
+      , currentDepositTxId = if commitInFlight then Just 7 else Nothing
+      , decommitTx = if decommitInFlight then Just inFlightDecommit else Nothing
+      , version = 0
+      }
+
+reqDecOutcome :: Bool -> Bool -> Outcome SimpleTx
+reqDecOutcome commitInFlight decommitInFlight =
+  update aliceEnv simpleLedger time0 (reqDecState commitInFlight decommitInFlight) $
+    receiveMessageFrom bob ReqDec{transaction = requestedDecommit}
+
+reqDecAccepts :: Outcome SimpleTx -> Bool
+reqDecAccepts = \case
+  Continue{stateChanges} -> any isRecorded stateChanges
+  _ -> False
+ where
+  isRecorded :: StateChanged SimpleTx -> Bool
+  isRecorded = \case
+    DecommitRecorded{} -> True
+    _ -> False
+
+-- ── deposit status on tick ───────────────────────────────────────────────────────────────────────────
+
+-- An env whose deposit period is the modeled T_deposit (whole seconds).
+tickEnv :: Integer -> Environment
+tickEnv tDep = aliceEnv{depositPeriod = fromInteger tDep}
+
+-- Open state holding one FRESH (Inactive) pending deposit with the given creation time and deadline.
+depositState :: Integer -> Integer -> NodeState SimpleTx
+depositState created deadline =
+  (inOpenState threeParties)
+    { pendingDeposits =
+        Map.fromList
+          [
+            ( 1
+            , Deposit
+                { headId = testHeadId
+                , deposited = utxoRef 1
+                , created = posixTime created
+                , deadline = posixTime deadline
+                , status = Inactive
+                }
+            )
+          ]
+    }
+
+-- One REAL tick at time t (now = chainTime, so the node stays in sync) over the fresh deposit; the
+-- resulting status is read off the emitted transition event (none = still Inactive).
+realTickStatus :: Integer -> Integer -> Integer -> Integer -> HsDepositStatus
+realTickStatus created deadline tDep t =
+  case update (tickEnv tDep) simpleLedger (posixTime t) (depositState created deadline) tick of
+    Continue{stateChanges}
+      | any isExpired stateChanges -> ExpiredS
+      | any isActivated stateChanges -> ActiveS
+      | otherwise -> InactiveS
+    outcome -> Prelude.error $ "tick produced a non-Continue outcome: " <> show outcome
+ where
+  tick = ChainInput Tick{chainTime = posixTime t, chainPoint = 1}
+
+  isExpired :: StateChanged SimpleTx -> Bool
+  isExpired = \case
+    DepositExpired{} -> True
+    _ -> False
+
+  isActivated :: StateChanged SimpleTx -> Bool
+  isActivated = \case
+    DepositActivated{} -> True
+    _ -> False
+
+-- ── ackSn collect/confirm ────────────────────────────────────────────────────────────────────────────
+
+-- Index ↔ party ↔ signing key, positional in 'threeParties' (as everywhere in this module).
+partySks :: [(Party, Secret (SigningKey HydraKey))]
+partySks = [(alice, aliceSk), (bob, bobSk), (carol, carolSk)]
+
+partySkAt :: Integer -> (Party, Secret (SigningKey HydraKey))
+partySkAt i = case drop (fromInteger i) partySks of
+  x : _ -> x
+  [] -> Prelude.error "partySkAt: index out of range"
+
+-- The in-flight round's snapshot (ŝ = 1 on v̂ = 0) and its real per-party signatures.
+ackSnapshot :: Snapshot SimpleTx
+ackSnapshot = testSnapshot 1 0 [] mempty
+
+ackSigFor :: Integer -> (Party, Signature (Snapshot SimpleTx))
+ackSigFor i = let (p, sk) = partySkAt i in (p, sign sk ackSnapshot)
+
+-- Open state mid-round: the seen snapshot is in flight with the given parties' REAL signatures
+-- already collected ('mkSeenSnapshot' caches the signable bytes the verification runs over).
+ackState :: [(Party, Signature (Snapshot SimpleTx))] -> NodeState SimpleTx
+ackState collected =
+  inOpenState' threeParties $
+    CoordinatedHeadState
+      { localUTxO = mempty
+      , allTxs = mempty
+      , localTxs = mempty
+      , confirmedSnapshot = InitialSnapshot testHeadId
+      , seenSnapshot = mkSeenSnapshot ackSnapshot (Map.fromList collected)
+      , currentDepositTxId = Nothing
+      , decommitTx = Nothing
+      , version = 0
+      }
+
+-- Run the REAL handler on sender's (real-signature) AckSn over the given collected subset.
+ackOutcome :: [Integer] -> Integer -> Outcome SimpleTx
+ackOutcome signedIdxs senderIdx =
+  update aliceEnv simpleLedger time0 (ackState (ackSigFor <$> signedIdxs)) $
+    receiveMessageFrom sender (AckSn senderSig 1)
+ where
+  (sender, _) = partySkAt senderIdx
+  (_, senderSig) = ackSigFor senderIdx
+
+-- The already-signed reject direction: the node's SnapshotAlreadySigned require failure.
+ackAlreadySigned :: Outcome SimpleTx -> Bool
+ackAlreadySigned = \case
+  Error (RequireFailed SnapshotAlreadySigned{}) -> True
+  _ -> False
+
+-- The round completes: SnapshotConfirmed is emitted (behind the real multisignature verification).
+ackConfirms :: Outcome SimpleTx -> Bool
+ackConfirms = \case
+  Continue{stateChanges} -> any isConfirmed stateChanges
+  _ -> False
+ where
+  isConfirmed :: StateChanged SimpleTx -> Bool
+  isConfirmed = \case
+    SnapshotConfirmed{} -> True
+    _ -> False
+
+-- Validator-only rejection (the crypto boundary): alice's COLLECTED signature is over garbage, and
+-- carol's final ack completes the signer set, so the counting guards pass but the real aggregate
+-- verification fails.
+ackOutcomeCorrupt :: Outcome SimpleTx
+ackOutcomeCorrupt =
+  update aliceEnv simpleLedger time0 (ackState [corrupt, ackSigFor 1]) $
+    receiveMessageFrom sender (AckSn senderSig 1)
+ where
+  corrupt = (alice, coerce (sign aliceSk ("garbage" :: ByteString)))
+  (sender, _) = partySkAt 2
+  (_, senderSig) = ackSigFor 2
+
+ackInvalidMultisig :: Outcome SimpleTx -> Bool
+ackInvalidMultisig = \case
+  Error (RequireFailed InvalidMultisignature{}) -> True
+  _ -> False
+
+-- ── contest eligibility on a close observation ───────────────────────────────────────────────────────
+
+-- Observe a close of snapshot s_c while our confirmed snapshot is S̄.s ('reqSnState' already builds
+-- exactly the open state with a confirmed snapshot at a given number; version 0 here).
+contestOutcome :: Integer -> Integer -> Outcome SimpleTx
+contestOutcome sBar sc =
+  update aliceEnv simpleLedger time0 (reqSnState 0 sBar) $
+    observeTx
+      OnCloseTx
+        { headId = testHeadId
+        , snapshotNumber = fromInteger sc
+        , contestationDeadline = posixTime 1_000
+        }
+
+contestPosts :: Outcome SimpleTx -> Bool
+contestPosts = \case
+  Continue{effects} -> any isContest effects
+  _ -> False
+ where
+  isContest :: Effect SimpleTx -> Bool
+  isContest = \case
+    OnChainEffect{postChainTx = ContestTx{}} -> True
+    _ -> False
+
+spec :: Spec
+spec = parallel $ do
+  describe "reqSn signing eligibility: extracted signEligibleRef vs the real onOpenNetworkReqSn" $ do
+    it "anchor: an eligible ReqSn (v = v̂, s = ŝ + 1, sender leads s) is signed by the real node" $ do
+      signEligibleRef 0 0 1 0 (leaderRef 2 1 0) `shouldBe` True
+      reqSnAccepts (reqSnOutcome 0 0 0 1 alice) `shouldBe` True
+    it "a wrong snapshot number is the node's ReqSnNumberInvalid" $
+      reqSnOutcome 0 0 0 2 alice `shouldBe` Error (RequireFailed $ ReqSnNumberInvalid 2 0)
+    it "a non-leader sender is the node's ReqSnNotLeader" $
+      reqSnOutcome 0 0 0 1 bob `shouldBe` Error (RequireFailed $ ReqSnNotLeader 1 bob)
+    it "a version mismatch WAITS (WaitOnSnapshotVersion), which is non-accept" $
+      reqSnOutcome 0 0 1 1 alice `assertWait` WaitOnSnapshotVersion 1
+    prop "signEligibleRef === real ReqSn accept/reject across (v, v̂, s, ŝ, sender)" $
+      forAll (choose (0, 1)) $ \vHat ->
+        forAll (choose (0, 2)) $ \v ->
+          forAll (choose (0, 2)) $ \sHat ->
+            forAll (choose (0, 4)) $ \s ->
+              forAll (elements (zip [0 ..] threeParties)) $ \(i, sender) ->
+                signEligibleRef v vHat s sHat (leaderRef 2 s i)
+                  === reqSnAccepts (reqSnOutcome vHat sHat v s sender)
+
+  describe "reqDec eligibility: extracted reqDecEligibleRef vs the real onOpenNetworkReqDec" $ do
+    it "anchor: with nothing in flight the real node records the decommit" $ do
+      reqDecEligibleRef False False `shouldBe` True
+      reqDecAccepts (reqDecOutcome False False) `shouldBe` True
+    it "a pending deposit (commit in flight) makes the real node WAIT (WaitOnUnresolvedCommit)" $
+      reqDecOutcome True False `assertWait` WaitOnUnresolvedCommit{commitUTxO = mempty}
+    it "an in-flight decommit makes the real node WAIT (DecommitAlreadyInFlight)" $
+      reqDecOutcome False True
+        `assertWait` WaitOnNotApplicableDecommitTx
+          { notApplicableReason = DecommitAlreadyInFlight{otherDecommitTxId = 2}
+          }
+    prop "reqDecEligibleRef === real ReqDec accept/non-accept across (commit?, decommit?)" $
+      \commitInFlight decommitInFlight ->
+        reqDecEligibleRef commitInFlight decommitInFlight
+          === reqDecAccepts (reqDecOutcome commitInFlight decommitInFlight)
+
+  describe "deposit status on tick: extracted depositStatusRef vs the real deposit transition" $ do
+    -- The same boundary points the extracted checker pins, now against the real node.
+    it "Inactive before created + T_deposit (both)" $ do
+      depositStatusRef 0 100 10 5 `shouldBe` InactiveS
+      realTickStatus 0 100 10 5 `shouldBe` InactiveS
+    it "still Inactive AT created + T_deposit (strictly-greater boundary, both)" $ do
+      depositStatusRef 0 100 10 10 `shouldBe` InactiveS
+      realTickStatus 0 100 10 10 `shouldBe` InactiveS
+    it "Active once t > created + T_deposit (both)" $ do
+      depositStatusRef 0 100 10 15 `shouldBe` ActiveS
+      realTickStatus 0 100 10 15 `shouldBe` ActiveS
+    it "still Active AT deadline − T_deposit (not yet expired, both)" $ do
+      depositStatusRef 0 100 10 90 `shouldBe` ActiveS
+      realTickStatus 0 100 10 90 `shouldBe` ActiveS
+    it "Expired once t > deadline − T_deposit (both)" $ do
+      depositStatusRef 0 100 10 95 `shouldBe` ExpiredS
+      realTickStatus 0 100 10 95 `shouldBe` ExpiredS
+    prop "depositStatusRef === real tick status transition (time grid incl. boundaries)" $
+      forAll (choose (0, 3)) $ \created ->
+        forAll (choose (1, 3)) $ \tDep ->
+          forAll (choose (0, 4)) $ \slack ->
+            let deadline = created + 2 * tDep + slack
+             in forAll (choose (0, deadline + tDep + 1)) $ \t ->
+                  depositStatusRef created deadline tDep t
+                    === realTickStatus created deadline tDep t
+
+  describe "ackSn collect/confirm: extracted notAlreadySignedRef/allSignedRef vs the real onOpenNetworkAckSn" $ do
+    it "anchor: a fresh, non-final ack is collected (neither already-signed nor confirmed)" $ do
+      notAlreadySignedRef [0] 1 `shouldBe` True
+      allSignedRef 3 [1, 0] `shouldBe` False
+      ackAlreadySigned (ackOutcome [0] 1) `shouldBe` False
+      ackConfirms (ackOutcome [0] 1) `shouldBe` False
+    it "anchor: the final ack CONFIRMS (real signatures aggregated in order and verified)" $ do
+      allSignedRef 3 [2, 0, 1] `shouldBe` True
+      ackConfirms (ackOutcome [0, 1] 2) `shouldBe` True
+    it "a duplicate ack is the node's SnapshotAlreadySigned" $ do
+      notAlreadySignedRef [0, 1] 1 `shouldBe` False
+      ackAlreadySigned (ackOutcome [0, 1] 1) `shouldBe` True
+    prop "notAlreadySignedRef === real not-already-signed across (signed subset, sender)" $
+      forAll (sublistOf [0, 1, 2]) $ \signedIdxs ->
+        forAll (elements [0, 1, 2]) $ \senderIdx ->
+          notAlreadySignedRef signedIdxs senderIdx
+            === not (ackAlreadySigned (ackOutcome signedIdxs senderIdx))
+    prop "composed: the ack CONFIRMS iff the sender is fresh AND completes the n-of-n signer set" $
+      forAll (sublistOf [0, 1, 2]) $ \signedIdxs ->
+        forAll (elements [0, 1, 2]) $ \senderIdx ->
+          (notAlreadySignedRef signedIdxs senderIdx && allSignedRef 3 (senderIdx : signedIdxs))
+            === ackConfirms (ackOutcome signedIdxs senderIdx)
+    it "scope: a corrupt collected signature fails the real multisignature verification (the counting reference alone would accept)" $ do
+      allSignedRef 3 [2, 0, 1] `shouldBe` True
+      ackInvalidMultisig ackOutcomeCorrupt `shouldBe` True
+
+  describe "contest eligibility: extracted contestEligibleRef vs the real onOpenChainCloseTx" $ do
+    it "anchor: a newer confirmed snapshot posts a ContestTx" $ do
+      contestEligibleRef 1 0 `shouldBe` True
+      contestPosts (contestOutcome 1 0) `shouldBe` True
+    it "an equal snapshot number does NOT contest (strictly-greater boundary)" $ do
+      contestEligibleRef 1 1 `shouldBe` False
+      contestPosts (contestOutcome 1 1) `shouldBe` False
+    prop "contestEligibleRef === real contest re-post across (S̄.s, s_c)" $
+      forAll (choose (0, 2)) $ \sBar ->
+        forAll (choose (0, 3)) $ \sc ->
+          contestEligibleRef sBar sc === contestPosts (contestOutcome sBar sc)

--- a/hydra-node/test/Hydra/OffChainLeaderSpec.hs
+++ b/hydra-node/test/Hydra/OffChainLeaderSpec.hs
@@ -1,0 +1,41 @@
+-- | Off-chain differential (real-node binding): the Agda-extracted round-robin leader
+-- 'Hydra.Agda.OffChainReference.leaderRef' (the §6 figure's @leader(s)@) checked against the REAL
+-- 'Hydra.HeadLogic.isLeader'. This is the off-chain counterpart of the on-chain validator differentials:
+-- the extracted decision is pinned not just to a Haskell transcription of the figure but to the function
+-- the node actually runs, closing the figure↔Agda↔Haskell loop for leader selection.
+--
+-- Domain note: snapshot numbers in the protocol start at 1, and the extracted @leaderRef@ uses Nat
+-- truncated subtraction whereas @isLeader@ subtracts over 'Int'; the two agree for every @sn ≥ 1@ and
+-- diverge only at @sn = 0@ (Nat @0 ∸ 1 = 0@ vs Int @-1 `mod` n = n-1@), which is outside the protocol's
+-- domain. The property therefore quantifies over @sn ≥ 1@.
+module Hydra.OffChainLeaderSpec (spec) where
+
+import Hydra.Prelude
+import Test.Hydra.Prelude
+
+import Hydra.Agda.OffChainReference (leaderRef)
+import Hydra.HeadLogic (isLeader)
+import Hydra.Tx.HeadParameters (HeadParameters (..))
+import Hydra.Tx.Snapshot (SnapshotNumber)
+import Test.Hydra.Tx.Fixture (alice, bob, carol)
+import Test.QuickCheck (Positive (..), elements, forAll, (===))
+
+spec :: Spec
+spec =
+  describe "Off-chain round-robin leader: extracted leaderRef vs real Hydra.HeadLogic.isLeader" $ do
+    -- A 3-party head; @leaderRef@ takes @m@ where #parties = @suc m@, so @m = 2@ here.
+    let parties = [alice, bob, carol]
+        params = HeadParameters{contestationPeriod = 60, parties}
+    it "sn 1 elects party 0 (alice)" $
+      leaderRef 2 1 0 `shouldBe` True
+    it "sn 2 elects party 1 (bob)" $
+      leaderRef 2 2 1 `shouldBe` True
+    it "sn 3 elects party 2 (carol)" $
+      leaderRef 2 3 2 `shouldBe` True
+    it "sn 4 wraps back to party 0 (alice)" $
+      leaderRef 2 4 0 `shouldBe` True
+    it "a non-leader index is rejected" $
+      leaderRef 2 1 1 `shouldBe` False
+    prop "leaderRef agrees with the real isLeader for every party index, sn ≥ 1" $
+      \(Positive sn) -> forAll (elements (zip [0 :: Integer ..] parties)) $ \(i, party) ->
+        leaderRef 2 sn i === isLeader params party (fromInteger sn :: SnapshotNumber)

--- a/hydra-node/test/Main.hs
+++ b/hydra-node/test/Main.hs
@@ -40,6 +40,8 @@ import Hydra.Node.InputQueueSpec qualified
 import Hydra.Node.RunSpec qualified
 import Hydra.Node.UtilSpec qualified
 import Hydra.NodeSpec qualified
+import Hydra.OffChainAgreementSpec qualified
+import Hydra.OffChainLeaderSpec qualified
 import Hydra.OptionsSpec qualified
 import Hydra.PartySpec qualified
 import Hydra.PersistentQueueSpec qualified
@@ -95,6 +97,8 @@ main =
     , testSpec "Node.Run" Hydra.Node.RunSpec.spec
     , testSpec "Node.Util" Hydra.Node.UtilSpec.spec
     , testSpec "Node" Hydra.NodeSpec.spec
+    , testSpec "OffChainAgreement" Hydra.OffChainAgreementSpec.spec
+    , testSpec "OffChainLeader" Hydra.OffChainLeaderSpec.spec
     , testSpec "Options" Hydra.OptionsSpec.spec
     , testSpec "Party" Hydra.PartySpec.spec
     , testSpec "PersistentQueue" Hydra.PersistentQueueSpec.spec

--- a/hydra-tx/hydra-tx.cabal
+++ b/hydra-tx/hydra-tx.cabal
@@ -188,6 +188,7 @@ test-suite tests
     Hydra.Tx.Contract.Deposit
     Hydra.Tx.Contract.FanOut
     Hydra.Tx.Contract.FinalPartialFanout
+    Hydra.Tx.Contract.HeadValidatorAgreement
     Hydra.Tx.Contract.Increment
     Hydra.Tx.Contract.Init
     Hydra.Tx.Contract.PartialFanout
@@ -216,6 +217,7 @@ test-suite tests
     , hedgehog-quickcheck
     , hspec
     , hspec-golden-aeson
+    , hydra-agda
     , hydra-cardano-api
     , hydra-cardano-api:testlib
     , hydra-plutus
@@ -226,6 +228,7 @@ test-suite tests
     , hydra-tx
     , hydra-tx:testlib
     , lens
+    , mtl
     , plutus-ledger-api
     , plutus-tx
     , QuickCheck

--- a/hydra-tx/test/Hydra/Tx/Contract/HeadValidatorAgreement.hs
+++ b/hydra-tx/test/Hydra/Tx/Contract/HeadValidatorAgreement.hs
@@ -1,0 +1,2619 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Function-level agreement between the Agda-extracted reference checker and the REAL Plutus
+-- validator, with NO transactions, NO ledger evaluation, and NO mutation generators.
+--
+-- The validator is a plain Haskell function (@Head.headValidator :: BuiltinByteString -> State -> Input ->
+-- ScriptContext -> Bool@; the leading argument is the canonical CRS datum hash). So we construct its
+-- inputs directly, run BOTH the validator and the Agda
+-- reference (@Ref.checkClose@) on the SAME inputs, and assert @reference === validator@. The fields the
+-- reference models are generated independently (so e.g. the produced version is sometimes equal to the
+-- input version, sometimes not), which exercises BOTH the accept and the reject directions in one
+-- property — unlike reusing the hydra mutation generators (a corpus that is
+-- validator-rejecting by construction, making @reference-reject ⇒ validator-reject@ vacuous).
+--
+-- Crypto is satisfied by construction: this spike covers @CloseInitial@, the one close case with no
+-- signature (it requires only the empty-accumulator BLS G1 generator), so no signing is needed.
+--
+-- This is the close/CloseInitial spike that validates the whole approach; the other families/redeemers
+-- follow the same pattern.
+module Hydra.Tx.Contract.HeadValidatorAgreement (spec) where
+
+import Hydra.Prelude
+
+import Cardano.Crypto.DSIGN (
+  Ed25519DSIGN,
+  SignKeyDSIGN,
+  deriveVerKeyDSIGN,
+  genKeyDSIGN,
+  rawSerialiseSigDSIGN,
+  rawSerialiseVerKeyDSIGN,
+  signDSIGN,
+ )
+import Cardano.Crypto.Hash (SHA256, digest)
+import Cardano.Crypto.Seed (mkSeedFromBytes)
+import Cardano.Ledger.Plutus.CostModels (getCostModelParams)
+import Control.Exception qualified as E
+import Control.Monad.Writer (runWriterT)
+import Data.ByteString qualified as BS
+import Hydra.Agda.Reference qualified as Ref
+import Hydra.Cardano.Api (pattern PlutusScriptSerialised)
+import Hydra.Contract.Deposit qualified as Deposit
+import Hydra.Contract.Head qualified as Head
+import Hydra.Contract.HeadState qualified as HS
+import Hydra.Contract.HeadTokens qualified as Tokens
+import Hydra.Contract.KZGTrustedSetup qualified as KZG
+import Hydra.Contract.Util (hashPreSerializedCommits, hashTxOuts, hydraHeadV2)
+import Hydra.Data.ContestationPeriod (ContestationPeriod (..))
+import Hydra.Data.Party (Party, partyFromVerificationKeyBytes)
+import Hydra.Plutus (depositValidatorScript)
+import Hydra.Tx.Accumulator qualified as Accumulator
+import PlutusLedgerApi.V1.Time (fromMilliSeconds)
+import PlutusLedgerApi.V1.Value (adaSymbol, adaToken, getValue, singleton)
+import PlutusLedgerApi.V3 (
+  Address (..),
+  Credential (..),
+  CurrencySymbol (..),
+  Datum (..),
+  EvaluationContext,
+  Extended (..),
+  Interval (..),
+  LowerBound (..),
+  MajorProtocolVersion (..),
+  OutputDatum (..),
+  POSIXTime (..),
+  PubKeyHash (..),
+  Redeemer (..),
+  ScriptContext (..),
+  ScriptForEvaluation,
+  ScriptHash (..),
+  ScriptInfo (..),
+  ScriptPurpose (..),
+  SerialisedScript,
+  TokenName (..),
+  TxId (..),
+  TxInInfo (..),
+  TxInfo (..),
+  TxOut (..),
+  TxOutRef (..),
+  UpperBound (..),
+  Value,
+  VerboseMode (..),
+  deserialiseScript,
+  emptyMintValue,
+  evaluateScriptCounting,
+  mkEvaluationContext,
+  toData,
+ )
+import PlutusLedgerApi.V3.MintValue (MintValue (..))
+import PlutusTx qualified
+import PlutusTx.AssocMap qualified as AMap
+import PlutusTx.Builtins qualified as Builtins
+import System.IO.Unsafe (unsafePerformIO)
+import Test.Hydra.Ledger.Cardano.Fixtures (plutusV3CostModel)
+import Test.Hydra.Prelude
+import Test.QuickCheck (choose, elements, forAll, (.&&.), (===))
+
+-- ── fixed, well-formed scaffolding (held healthy; only the modeled fields below are varied) ──────────
+
+headPolicy :: CurrencySymbol
+headPolicy = CurrencySymbol "00000000000000000000000000000000000000000000000000000000"
+
+headScriptHash :: ScriptHash
+headScriptHash = ScriptHash "11111111111111111111111111111111111111111111111111111111"
+
+headAddr :: Address
+headAddr = Address (ScriptCredential headScriptHash) Nothing
+
+ownRef :: TxOutRef
+ownRef = TxOutRef (TxId "22222222222222222222222222222222222222222222222222222222222222222222") 0
+
+-- A single signer whose key-hash IS a participation-token name in the head value (so
+-- mustBeSignedByParticipant holds).
+signerKH :: PubKeyHash
+signerKH = PubKeyHash "33333333333333333333333333333333333333333333333333333333"
+
+ptName :: TokenName
+ptName = TokenName (getPubKeyHash signerKH)
+
+-- Head value carries the participation token; identical on input and output (mustPreserveHeadValue).
+headVal :: Value
+headVal = singleton adaSymbol adaToken 2_000_000 <> singleton headPolicy ptName 1
+
+-- The empty-accumulator KZG commitment is the BLS G1 generator (isG1Generator).
+g1Generator :: Builtins.BuiltinBLS12_381_G1_Element
+g1Generator = Builtins.bls12_381_G1_uncompress Builtins.bls12_381_G1_compressed_generator
+
+-- Healthy open input version (CloseInitial requires version == 0) and OPEN contestation period (ms);
+-- the lower validity bound is fixed. The CloseInitial grid also varies the INPUT version/period (via
+-- `openDatumAt`; no signature pins them), so a validator reading a constant instead of the datum is
+-- caught; the signed close families keep this healthy base.
+openVersionN :: Integer
+openVersionN = 0
+
+openCpMs :: Integer
+openCpMs = 100
+
+validityLoN :: Integer
+validityLoN = 1_000
+
+openDatum :: HS.OpenDatum
+openDatum =
+  HS.OpenDatum
+    { HS.headSeed = ownRef
+    , HS.headId = headPolicy
+    , HS.parties = []
+    , HS.contestationPeriod = UnsafeContestationPeriod (fromInteger openCpMs)
+    , HS.version = openVersionN
+    , HS.accumulatorHash = Builtins.toBuiltin ("" :: ByteString)
+    , HS.headAdaOverhead = 0
+    }
+
+-- openDatum with the input version and contestation period (ms) as parameters (headSeed pins the
+-- record-update type).
+openDatumAt :: Integer -> Integer -> HS.OpenDatum
+openDatumAt inV inCp =
+  openDatum{HS.headSeed = ownRef, HS.version = inV, HS.contestationPeriod = UnsafeContestationPeriod (fromInteger inCp)}
+
+-- ── projections: reference arguments READ from the constructed State/Input/ScriptContext ──────────────
+-- Each family asserts `reference === validator` on one (state, input, ctx) triple. The reference
+-- checker's arguments are PROJECTED from that triple: datum fields from the State, redeemer fields
+-- from the Input, tx-level facts (validity bounds, mint, values, signers, spent refs) from the
+-- ScriptContext. Never hand-transcribed from the fixture constants, so the two oracles cannot
+-- silently diverge. Only the injected Ops mocks stay explicit: they stand for the crypto/value/
+-- accumulator conjuncts the reference does not model, so they have no ScriptContext counterpart.
+
+cpMs :: ContestationPeriod -> Integer
+cpMs = getPOSIXTime . fromMilliSeconds . milliseconds
+
+txValidityLo :: ScriptContext -> Integer
+txValidityLo ctx = case ivFrom (txInfoValidRange (scriptContextTxInfo ctx)) of
+  LowerBound (Finite (POSIXTime t)) _ -> t
+  _ -> error "projection: no finite lower validity bound"
+
+txValidityHi :: ScriptContext -> Integer
+txValidityHi ctx = case ivTo (txInfoValidRange (scriptContextTxInfo ctx)) of
+  UpperBound (Finite (POSIXTime t)) _ -> t
+  _ -> error "projection: no finite upper validity bound"
+
+-- the resolved head input: the SpendingScript's own out-ref among the tx inputs (findOwnInput).
+ownHeadInput :: ScriptContext -> TxOut
+ownHeadInput ctx = case scriptContextScriptInfo ctx of
+  SpendingScript ref _ ->
+    maybe (error "projection: own input not found") txInInfoResolved $
+      find (\i -> txInInfoOutRef i == ref) (txInfoInputs (scriptContextTxInfo ctx))
+  _ -> error "projection: not a spending script"
+
+outputState :: TxOut -> Maybe HS.State
+outputState o = case txOutDatum o of
+  OutputDatum (Datum d) -> PlutusTx.fromBuiltinData d
+  _ -> Nothing
+
+-- the produced head state: the FIRST tx output's datum (the validators' decodeHeadOutput*Datum).
+producedState :: ScriptContext -> HS.State
+producedState ctx = case txInfoOutputs (scriptContextTxInfo ctx) of
+  o : _ -> fromMaybe (error "projection: first output is not a head state") (outputState o)
+  [] -> error "projection: no outputs"
+
+assetList :: Value -> [((CurrencySymbol, TokenName), Integer)]
+assetList v = [((cs, tn), q) | (cs, m) <- AMap.toList (getValue v), (tn, q) <- AMap.toList m]
+
+adaOf :: Value -> Integer
+adaOf v = sum [q | ((cs, tn), q) <- assetList v, cs == adaSymbol && tn == adaToken]
+
+nonAdaOf :: Value -> Integer
+nonAdaOf v = sum [q | ((cs, _), q) <- assetList v, cs /= adaSymbol]
+
+-- non-zero asset entries in txInfoMint (checkNoMint's count) and the burned quantity of one policy.
+mintEntries :: ScriptContext -> [(CurrencySymbol, TokenName, Integer)]
+mintEntries ctx = case txInfoMint (scriptContextTxInfo ctx) of
+  UnsafeMintValue m -> [(cs, tn, q) | (cs, tns) <- AMap.toList m, (tn, q) <- AMap.toList tns, q /= 0]
+
+burnedCountOf :: CurrencySymbol -> ScriptContext -> Integer
+burnedCountOf cid ctx = negate (sum [q | (cs, _, q) <- mintEntries ctx, cs == cid])
+
+-- sum of every script input that is not the own head input (the increment's deposit value).
+scriptNonHeadInputsValue :: ScriptContext -> Value
+scriptNonHeadInputsValue ctx =
+  mconcat
+    [ txOutValue (txInInfoResolved i)
+    | i <- txInfoInputs (scriptContextTxInfo ctx)
+    , txInInfoOutRef i /= ownR
+    , isScript (txInInfoResolved i)
+    ]
+ where
+  ownR = case scriptContextScriptInfo ctx of
+    SpendingScript r _ -> r
+    _ -> error "projection: not a spending script"
+  isScript o = case addressCredential (txOutAddress o) of
+    ScriptCredential _ -> True
+    PubKeyCredential _ -> False
+
+headIdOfState :: HS.State -> CurrencySymbol
+headIdOfState (HS.Open HS.OpenDatum{HS.headId = cid}) = cid
+headIdOfState (HS.Closed HS.ClosedDatum{HS.headId = cid}) = cid
+headIdOfState (HS.FanoutProgress HS.FanoutProgressDatum{HS.headId = cid}) = cid
+headIdOfState HS.Final = error "projection: Final carries no head id"
+
+-- close: open fields from the input State, produced Closed fields from the first output's datum, the
+-- tag from the redeemer, the bounds from the validity range.
+projectClose :: HS.State -> HS.Input -> ScriptContext -> Bool
+projectClose st input ctx =
+  case (st, input, producedState ctx) of
+    ( HS.Open HS.OpenDatum{HS.version = v, HS.contestationPeriod = cp}
+      , HS.Close redeemer
+      , HS.Closed
+          HS.ClosedDatum
+            { HS.version = v'
+            , HS.contestationPeriod = cp'
+            , HS.snapshotNumber = s'
+            , HS.contesters = contesters'
+            , HS.contestationDeadline = POSIXTime tfinal'
+            }
+      ) ->
+        Ref.checkClose
+          (Ref.mkOps (\_ _ _ -> True))
+          (Ref.MkOpen v (cpMs cp))
+          (Ref.MkClosed v' (cpMs cp') s' (toInteger (length contesters')) tfinal')
+          (closeTag redeemer)
+          (txValidityHi ctx)
+          (txValidityLo ctx)
+    _ -> error "projectClose: not a close triple"
+ where
+  closeTag HS.CloseInitial = Ref.CloseInitialT
+  closeTag HS.CloseAny{} = Ref.CloseAnyT
+  closeTag HS.CloseUnused{} = Ref.CloseUnusedT
+  closeTag HS.CloseUsed{} = Ref.CloseUsedT
+
+-- increment/decrement share the IncIO shape: versions from the input/produced Open datums, ada and
+-- non-ada totals from the head input, the delta value and the head output.
+projectIncIO :: Integer -> Value -> ScriptContext -> Ref.HsIncIO
+projectIncIO vIn delta ctx =
+  Ref.MkIncIO vIn vOut (adaOf hIn) (adaOf delta) (adaOf hOut) (nonAdaOf hIn) (nonAdaOf delta) (nonAdaOf hOut)
+ where
+  vOut = case producedState ctx of
+    HS.Open HS.OpenDatum{HS.version = v} -> v
+    _ -> error "projectIncIO: produced state is not Open"
+  hIn = txOutValue (ownHeadInput ctx)
+  hOut = case txInfoOutputs (scriptContextTxInfo ctx) of
+    o : _ -> txOutValue o
+    [] -> error "projection: no outputs"
+
+-- increment: the delta is the spent deposit (every non-head script input).
+projectInc :: HS.State -> HS.Input -> ScriptContext -> Bool
+projectInc (HS.Open HS.OpenDatum{HS.version = vIn}) (HS.Increment _) ctx =
+  Ref.checkInc (Ref.mkOpsInc (const True)) (projectIncIO vIn (scriptNonHeadInputsValue ctx) ctx)
+projectInc _ _ _ = error "projectInc: not an increment triple"
+
+-- decrement: the delta is the decommitted outputs at indices [1..m] (m from the redeemer).
+projectDec :: HS.State -> HS.Input -> ScriptContext -> Bool
+projectDec (HS.Open HS.OpenDatum{HS.version = vIn}) (HS.Decrement HS.DecrementRedeemer{HS.numberOfDecommitOutputs = m}) ctx =
+  Ref.checkDec (Ref.mkOpsInc (const True)) (projectIncIO vIn decommitted ctx)
+ where
+  decommitted = mconcat (map txOutValue (take (fromInteger m) (drop 1 (txInfoOutputs (scriptContextTxInfo ctx)))))
+projectDec _ _ _ = error "projectDec: not a decrement triple"
+
+-- per-asset conservation, over the union of the non-ada assets of head input, delta and head output.
+projectPerAssetInc :: ScriptContext -> Bool
+projectPerAssetInc ctx = Ref.checkPerAsset [Ref.MkAssetIO (q hIn k) (q delta k) (q hOut k) | k <- assetKeys]
+ where
+  hIn = txOutValue (ownHeadInput ctx)
+  delta = scriptNonHeadInputsValue ctx
+  hOut = case txInfoOutputs (scriptContextTxInfo ctx) of
+    o : _ -> txOutValue o
+    [] -> error "projection: no outputs"
+  assetKeys = ordNub [k | v <- [hIn, delta, hOut], (k@(cs, _), _) <- assetList v, cs /= adaSymbol]
+  q v k = sum [n | (k', n) <- assetList v, k' == k]
+
+-- contest: input Closed fields from the State, produced Closed fields from the first output's datum,
+-- the upper validity bound from the ScriptContext. numParties is read from the produced datum, as the
+-- validator's mustPushDeadline compares contesters' against parties'.
+projectContest :: HS.State -> HS.Input -> ScriptContext -> Bool
+projectContest st input ctx =
+  case (st, input, producedState ctx) of
+    ( HS.Closed
+        HS.ClosedDatum
+          { HS.version = vIn
+          , HS.snapshotNumber = sIn
+          , HS.contesters = contestersIn
+          , HS.contestationDeadline = POSIXTime tfinal
+          , HS.contestationPeriod = cp
+          }
+      , HS.Contest _
+      , HS.Closed
+          HS.ClosedDatum
+            { HS.version = vOut
+            , HS.snapshotNumber = sOut
+            , HS.contesters = contestersOut
+            , HS.contestationDeadline = POSIXTime tfinal'
+            , HS.parties = parties'
+            }
+      ) ->
+        Ref.checkContest
+          (Ref.mkOpsContest (const True))
+          ( Ref.MkContestIO
+              vIn
+              vOut
+              sIn
+              sOut
+              (toInteger (length contestersIn))
+              (toInteger (length contestersOut))
+              tfinal
+              (txValidityHi ctx)
+              tfinal'
+              (toInteger (length parties'))
+              (cpMs cp)
+          )
+    _ -> error "projectContest: not a contest triple"
+
+-- contest parameter preservation: head id + period of the input vs the produced Closed datum.
+projectContestParams :: HS.State -> ScriptContext -> Bool
+projectContestParams st ctx =
+  case (st, producedState ctx) of
+    ( HS.Closed HS.ClosedDatum{HS.headId = cidIn, HS.contestationPeriod = cpIn}
+      , HS.Closed HS.ClosedDatum{HS.headId = cidOut, HS.contestationPeriod = cpOut}
+      ) ->
+        Ref.checkContestParams (cidToInteger cidIn) (cidToInteger cidOut) (cpMs cpIn) (cpMs cpOut)
+    _ -> error "projectContestParams: not a contest pair"
+
+-- value preservation (close/contest mustPreserveHeadValue): own head input vs first output.
+projectValuePreserved :: ScriptContext -> Bool
+projectValuePreserved ctx = Ref.checkValuePreserved (adaOf hIn) (adaOf hOut) (nonAdaOf hIn) (nonAdaOf hOut)
+ where
+  hIn = txOutValue (ownHeadInput ctx)
+  hOut = case txInfoOutputs (scriptContextTxInfo ctx) of
+    o : _ -> txOutValue o
+    [] -> error "projection: no outputs"
+
+-- participant signature: tx signers vs the head-policy token names of the head input.
+projectParticipant :: HS.State -> ScriptContext -> Bool
+projectParticipant st ctx = Ref.checkParticipantSigned (Ref.MkSignerIO signers pts)
+ where
+  cid = headIdOfState st
+  signers = bytesToInteger . getPubKeyHash <$> txInfoSignatories (scriptContextTxInfo ctx)
+  pts = [bytesToInteger (unTokenName tn) | ((cs, tn), q) <- assetList (txOutValue (ownHeadInput ctx)), cs == cid, q > 0]
+
+projectNoMint :: ScriptContext -> Bool
+projectNoMint ctx = Ref.checkNoMint (toInteger (length (mintEntries ctx)))
+
+-- referenced-output-is-spent: the increment redeemer's claimed deposit vs the tx's spent out-refs.
+projectRefSpent :: HS.Input -> ScriptContext -> Bool
+projectRefSpent (HS.Increment HS.IncrementRedeemer{HS.increment = claimed}) ctx =
+  Ref.checkRefSpent (encodeTxOutRef claimed) (encodeTxOutRef . txInInfoOutRef <$> txInfoInputs (scriptContextTxInfo ctx))
+projectRefSpent _ _ = error "projectRefSpent: not an increment redeemer"
+
+-- init (μHead minting policy, no State/Input): n from the head output datum's parties, the minted
+-- count from txInfoMint, ST quantity and head-policy token count COUNTED from the head output value.
+projectInitIO :: ScriptContext -> Ref.HsMintIO
+projectInitIO ctx = case scriptContextScriptInfo ctx of
+  MintingScript cid ->
+    case [(od, txOutValue o) | o <- txInfoOutputs (scriptContextTxInfo ctx), Just (HS.Open od) <- [outputState o]] of
+      [(HS.OpenDatum{HS.parties = ps}, headOutVal)] ->
+        Ref.MkMintIO
+          (toInteger (length ps))
+          (sum [q | (cs, _, q) <- mintEntries ctx, cs == cid])
+          (sum [q | ((cs, tn), q) <- assetList headOutVal, cs == cid, tn == stName])
+          (sum [q | ((cs, _), q) <- assetList headOutVal, cs == cid])
+      _ -> error "projection: expected exactly one head output"
+  _ -> error "projection: not a minting script"
+
+projectInit :: ScriptContext -> Bool
+projectInit = Ref.checkInit (Ref.mkOpsInit (const True)) . projectInitIO
+
+-- init datum head-id binding: the head output datum's headId vs the minting currency.
+projectInitHeadId :: ScriptContext -> Bool
+projectInitHeadId ctx = case scriptContextScriptInfo ctx of
+  MintingScript cid ->
+    case [od | o <- txInfoOutputs (scriptContextTxInfo ctx), Just (HS.Open od) <- [outputState o]] of
+      [HS.OpenDatum{HS.headId = did}] -> Ref.checkInitHeadId (cidToInteger did) (cidToInteger cid)
+      _ -> error "projection: expected exactly one head output"
+  _ -> error "projection: not a minting script"
+
+-- burn: counts of the positive / negative head-policy mint entries.
+projectBurn :: ScriptContext -> Bool
+projectBurn ctx = case scriptContextScriptInfo ctx of
+  MintingScript cid ->
+    let qs = [q | (cs, _, q) <- mintEntries ctx, cs == cid]
+     in Ref.checkBurn (Ref.MkBurnIO (count (> 0) qs) (count (< 0) qs))
+  _ -> error "projection: not a minting script"
+ where
+  count :: (Integer -> Bool) -> [Integer] -> Integer
+  count p = toInteger . length . filter p
+
+-- νDeposit: the deposit datum from the SpendingScript.
+projectDepositDatum :: ScriptContext -> Deposit.DepositDatum
+projectDepositDatum ctx = case scriptContextScriptInfo ctx of
+  SpendingScript _ (Just (Datum d)) -> fromMaybe (error "projection: not a deposit datum") (PlutusTx.fromBuiltinData d)
+  _ -> error "projection: no spending datum"
+
+projectRecover :: ScriptContext -> Bool
+projectRecover ctx = Ref.checkRecover (Ref.mkOpsRecover (const True)) (Ref.MkRecoverIO deadline (txValidityLo ctx))
+ where
+  (_, POSIXTime deadline, _) = projectDepositDatum ctx
+
+-- claim: deadline + head id from the deposit datum; the spent head's id and out-ref come from the
+-- ST-carrying tx input (deposit.ak's list.find), and the head redeemer's RAW constructor index is
+-- read off the redeemer map exactly as deposit.ak's is_head_increment does (un_constr_data).
+projectClaim :: ScriptContext -> Bool
+projectClaim ctx =
+  Ref.checkClaim
+    (Ref.MkClaimIO deadline (txValidityHi ctx) (cidToInteger depCid) (cidToInteger headCid) headRedeemerIdx)
+ where
+  (depCid, POSIXTime deadline, _) = projectDepositDatum ctx
+  ownR = case scriptContextScriptInfo ctx of
+    SpendingScript r _ -> r
+    _ -> error "projection: not a spending script"
+  (headCid, headRef) = case stCarriers of
+    [x] -> x
+    _ -> error "projection: expected exactly one head input"
+  stCarriers =
+    [ (cs, txInInfoOutRef i)
+    | i <- txInfoInputs (scriptContextTxInfo ctx)
+    , txInInfoOutRef i /= ownR
+    , ((cs, tn), q) <- assetList (txOutValue (txInInfoResolved i))
+    , tn == stName
+    , q > 0
+    ]
+  headRedeemerIdx =
+    case [d | (Spending ref, Redeemer d) <- AMap.toList (txInfoRedeemers (scriptContextTxInfo ctx)), ref == headRef] of
+      [d] -> case Builtins.builtinDataToData d of
+        PlutusTx.Constr i _ -> i
+        _ -> error "projection: head redeemer is not a Constr"
+      _ -> error "projection: no spend redeemer for the head input"
+
+-- fanout (full AND final partial: the bridge maps finalPartialFanoutValid onto the same extracted
+-- fanoutRef): m from the redeemer, the burned count from txInfoMint, n/tfinal from the input datum,
+-- the lower bound from the validity range. The Ops mock is per family: the mocked conjuncts differ
+-- (see fpfOps at the final-partial fixture).
+projectFanout :: Ref.OpsFanout -> HS.State -> HS.Input -> ScriptContext -> Bool
+projectFanout ops st input ctx =
+  case (st, input) of
+    (HS.Closed HS.ClosedDatum{HS.parties = ps, HS.contestationDeadline = POSIXTime tfinal}, HS.Fanout{HS.numberOfFanoutOutputs = m}) ->
+      go ps tfinal m
+    (HS.FanoutProgress HS.FanoutProgressDatum{HS.parties = ps, HS.contestationDeadline = POSIXTime tfinal}, HS.FinalPartialFanout{HS.numberOfPartialOutputs = m}) ->
+      go ps tfinal m
+    _ -> error "projectFanout: not a fanout triple"
+ where
+  go ps tfinal m =
+    Ref.checkFanout ops (Ref.MkFanout m (burnedCountOf (headIdOfState st) ctx) (toInteger (length ps)) tfinal (txValidityLo ctx))
+
+-- non-final partial fanout: (m, tfinal, validityLo) in checkPartialFanout's order, read from the
+-- redeemer/input datum/ScriptContext. This is the ONLY call site, so the historical partialRef/
+-- partialVal argument-order swap cannot recur.
+projectPartial :: HS.State -> HS.Input -> ScriptContext -> Bool
+projectPartial st (HS.PartialFanout{HS.numberOfPartialOutputs = m}) ctx =
+  case st of
+    HS.Closed HS.ClosedDatum{HS.contestationDeadline = POSIXTime tfinal} -> Ref.checkPartialFanout m tfinal (txValidityLo ctx)
+    HS.FanoutProgress HS.FanoutProgressDatum{HS.contestationDeadline = POSIXTime tfinal} -> Ref.checkPartialFanout m tfinal (txValidityLo ctx)
+    _ -> error "projectPartial: not a partial-fanout input state"
+projectPartial _ _ _ = error "projectPartial: not a partial-fanout redeemer"
+
+-- ── the constructed inputs, parameterized over the fields the reference models ────────────────────────
+
+closedDatum :: Integer -> Integer -> Integer -> Integer -> Integer -> HS.ClosedDatum
+closedDatum closedVersion closedCpMs closedSnap contestersLen deadline =
+  HS.ClosedDatum
+    { HS.headId = headPolicy
+    , HS.parties = []
+    , HS.contestationPeriod = UnsafeContestationPeriod (fromInteger closedCpMs)
+    , HS.version = closedVersion
+    , HS.snapshotNumber = closedSnap
+    , HS.contesters = replicate (fromInteger contestersLen) signerKH
+    , HS.contestationDeadline = POSIXTime deadline
+    , HS.accumulatorCommitment = g1Generator
+    , HS.headAdaOverhead = 0
+    }
+
+mkContext :: HS.OpenDatum -> Integer -> Integer -> Integer -> Integer -> Integer -> Integer -> ScriptContext
+mkContext od closedVersion closedCpMs closedSnap contestersLen deadline tMax =
+  ScriptContext
+    { scriptContextTxInfo =
+        TxInfo
+          { txInfoInputs = [TxInInfo ownRef headInputOut]
+          , txInfoReferenceInputs = []
+          , txInfoOutputs = [headOutputOut]
+          , txInfoFee = 0
+          , txInfoMint = emptyMintValue
+          , txInfoTxCerts = []
+          , txInfoWdrl = AMap.empty
+          , txInfoValidRange =
+              Interval (LowerBound (Finite (POSIXTime validityLoN)) True) (UpperBound (Finite (POSIXTime tMax)) True)
+          , txInfoSignatories = [signerKH]
+          , txInfoRedeemers = AMap.empty
+          , txInfoData = AMap.empty
+          , txInfoId = TxId "44444444444444444444444444444444444444444444444444444444444444444444"
+          , txInfoVotes = AMap.empty
+          , txInfoProposalProcedures = []
+          , txInfoCurrentTreasuryAmount = Nothing
+          , txInfoTreasuryDonation = Nothing
+          }
+    , scriptContextRedeemer = Redeemer (PlutusTx.toBuiltinData (HS.Close HS.CloseInitial))
+    , scriptContextScriptInfo = SpendingScript ownRef (Just (Datum (PlutusTx.toBuiltinData (HS.Open od))))
+    }
+ where
+  headInputOut = TxOut headAddr headVal (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Open od)))) Nothing
+  headOutputOut =
+    TxOut
+      headAddr
+      headVal
+      (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Closed (closedDatum closedVersion closedCpMs closedSnap contestersLen deadline)))))
+      Nothing
+
+-- ── the two oracles on the SAME inputs ───────────────────────────────────────────────────────────────
+
+-- The real Plutus validator (a plain Haskell function). The leading ScriptHash (the CRS) is unused for
+-- close.
+validatorVerdict :: HS.OpenDatum -> ScriptContext -> Bool
+validatorVerdict od = Head.headValidator Head.canonicalCRSDatumHash (HS.Open od) (HS.Close HS.CloseInitial)
+
+-- The Agda-extracted reference, projected from the SAME open datum and context.
+referenceVerdict :: HS.OpenDatum -> ScriptContext -> Bool
+referenceVerdict od = projectClose (HS.Open od) (HS.Close HS.CloseInitial)
+
+-- ── close value preservation demo (C3.4): mustPreserveHeadValue is the EXACT `==` on the head value ──
+-- A CloseInitial healthy in every other conjunct, with the head OUTPUT value's ada parameterized: equal to
+-- the input (2_000_000) is accepted; siphoned (< input) is rejected by mustPreserveHeadValue. Exercises the
+-- extracted checkValuePreserved (bridged from closeValid.valuePreserved) against the real validator.
+mkCloseValueContext :: Integer -> ScriptContext
+mkCloseValueContext headOutAda =
+  ScriptContext
+    { scriptContextTxInfo =
+        TxInfo
+          { txInfoInputs = [TxInInfo ownRef headInputOut]
+          , txInfoReferenceInputs = []
+          , txInfoOutputs = [headOutputOut]
+          , txInfoFee = 0
+          , txInfoMint = emptyMintValue
+          , txInfoTxCerts = []
+          , txInfoWdrl = AMap.empty
+          , txInfoValidRange = Interval (LowerBound (Finite (POSIXTime validityLoN)) True) (UpperBound (Finite (POSIXTime tMax)) True)
+          , txInfoSignatories = [signerKH]
+          , txInfoRedeemers = AMap.empty
+          , txInfoData = AMap.empty
+          , txInfoId = TxId "44444444444444444444444444444444444444444444444444444444444444444444"
+          , txInfoVotes = AMap.empty
+          , txInfoProposalProcedures = []
+          , txInfoCurrentTreasuryAmount = Nothing
+          , txInfoTreasuryDonation = Nothing
+          }
+    , scriptContextRedeemer = Redeemer (PlutusTx.toBuiltinData (HS.Close HS.CloseInitial))
+    , scriptContextScriptInfo = SpendingScript ownRef (Just (Datum (PlutusTx.toBuiltinData (HS.Open openDatum))))
+    }
+ where
+  tMax = 1_100
+  deadline = tMax + openCpMs
+  headInputOut = TxOut headAddr headVal (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Open openDatum)))) Nothing
+  headOutputOut =
+    TxOut
+      headAddr
+      (singleton adaSymbol adaToken headOutAda <> singleton headPolicy ptName 1)
+      (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Closed (closedDatum 0 100 0 0 deadline)))))
+      Nothing
+
+closeValueVal :: Integer -> Bool
+closeValueVal headOutAda = validatorVerdict openDatum (mkCloseValueContext headOutAda)
+
+closeValueRef :: Integer -> Bool
+closeValueRef headOutAda = projectValuePreserved (mkCloseValueContext headOutAda)
+
+-- ── signed CloseUnused: a REAL Ed25519 signature over the exact validator message ──────────────────────
+-- CloseInitial needs no signature. CloseUnused does: the validator runs `verifySnapshotSignature` for real
+-- (it is NOT mocked on the validator side, only on the reference side). We hold the test key, so we produce
+-- a genuine signature the real validator accepts — and a deliberately wrong one it must reject.
+
+-- Our own snapshot signing key (deterministic; the "mocked" crypto is just key material we control).
+snapshotSK :: SignKeyDSIGN Ed25519DSIGN
+snapshotSK = genKeyDSIGN (mkSeedFromBytes (digest (Proxy :: Proxy SHA256) ("hva-snapshot-seed" :: ByteString)))
+
+snapshotParty :: Party
+snapshotParty = partyFromVerificationKeyBytes (rawSerialiseVerKeyDSIGN (deriveVerKeyDSIGN snapshotSK))
+
+-- Empty-set accumulator hash, matching mustMatchAccumulatorCommitmentHash (blake2b_256 ∘ compress).
+emptyAccHash :: Builtins.BuiltinByteString
+emptyAccHash = Builtins.blake2b_256 (Builtins.bls12_381_G1_compress g1Generator)
+
+-- Empty commit/decommit output-set hashes bound into every snapshot signature (the signature binds
+-- the exact commit/decommit output sets). Close and Contest copy these straight from the redeemer into the signed
+-- message, so any fixed value works as long as the signature covers it. Increment recomputes the commit
+-- side from the claimed deposit's commits (here empty, so == emptyCommitOutputsHash) and Decrement
+-- recomputes the decommit side from the tx outputs (see incMsg/decMsg).
+emptyDecommitOutputsHash :: HS.Hash
+emptyDecommitOutputsHash = hashTxOuts []
+
+emptyCommitOutputsHash :: HS.Hash
+emptyCommitOutputsHash = hashPreSerializedCommits []
+
+-- A decommit/commit-outputs hash DIFFERENT from the empty ones the fixtures sign: redirecting a signed
+-- redeemer's hash to this must break signature verification (the tampered-hash reject props).
+wrongOutputsHash :: HS.Hash
+wrongOutputsHash = hashTxOuts [pfDistributedOut]
+
+-- The exact bytes the validator reconstructs for CloseUnused: serialiseData of (headId, OPEN version,
+-- snapshotNumber', accumulatorHash). Signing this with snapshotSK makes verifySnapshotSignature accept.
+closeMsg :: Integer -> ByteString
+closeMsg snap =
+  Builtins.fromBuiltin $
+    Builtins.serialiseData (PlutusTx.toBuiltinData headPolicy)
+      <> Builtins.serialiseData (PlutusTx.toBuiltinData openVersionN)
+      <> Builtins.serialiseData (PlutusTx.toBuiltinData snap)
+      <> Builtins.serialiseData (PlutusTx.toBuiltinData emptyAccHash)
+      <> Builtins.serialiseData (PlutusTx.toBuiltinData emptyDecommitOutputsHash)
+      <> Builtins.serialiseData (PlutusTx.toBuiltinData emptyCommitOutputsHash)
+
+closeSigFor :: Integer -> HS.Signature
+closeSigFor snap = Builtins.toBuiltin (rawSerialiseSigDSIGN (signDSIGN () (closeMsg snap) snapshotSK))
+
+-- CloseUnused datums carry the snapshot signer as the head party (so verifySnapshotSignature + the
+-- mustNotChangeParameters parties-preservation both hold). Built explicitly (not by record update) because
+-- `parties` is a duplicate field across the datum records, so a single-field update is ambiguous.
+openDatumU :: HS.OpenDatum
+openDatumU =
+  HS.OpenDatum
+    { HS.headSeed = ownRef
+    , HS.headId = headPolicy
+    , HS.parties = [snapshotParty]
+    , HS.contestationPeriod = UnsafeContestationPeriod (fromInteger openCpMs)
+    , HS.version = openVersionN
+    , HS.accumulatorHash = Builtins.toBuiltin ("" :: ByteString)
+    , HS.headAdaOverhead = 0
+    }
+
+closedDatumU :: Integer -> Integer -> Integer -> Integer -> Integer -> HS.ClosedDatum
+closedDatumU cv ccp cs cl dl =
+  HS.ClosedDatum
+    { HS.headId = headPolicy
+    , HS.parties = [snapshotParty]
+    , HS.contestationPeriod = UnsafeContestationPeriod (fromInteger ccp)
+    , HS.version = cv
+    , HS.snapshotNumber = cs
+    , HS.contesters = replicate (fromInteger cl) signerKH
+    , HS.contestationDeadline = POSIXTime dl
+    , HS.accumulatorCommitment = g1Generator
+    , HS.headAdaOverhead = 0
+    }
+
+-- Build the CloseUnused context for a given redeemer (so we can supply a valid OR a bad signature).
+mkContextU :: HS.CloseRedeemer -> Integer -> Integer -> Integer -> Integer -> Integer -> Integer -> ScriptContext
+mkContextU redeemer cv ccp cs cl dl tMax =
+  ScriptContext
+    { scriptContextTxInfo =
+        TxInfo
+          { txInfoInputs = [TxInInfo ownRef headInU]
+          , txInfoReferenceInputs = []
+          , txInfoOutputs = [headOutU]
+          , txInfoFee = 0
+          , txInfoMint = emptyMintValue
+          , txInfoTxCerts = []
+          , txInfoWdrl = AMap.empty
+          , txInfoValidRange =
+              Interval (LowerBound (Finite (POSIXTime validityLoN)) True) (UpperBound (Finite (POSIXTime tMax)) True)
+          , txInfoSignatories = [signerKH]
+          , txInfoRedeemers = AMap.empty
+          , txInfoData = AMap.empty
+          , txInfoId = TxId "44444444444444444444444444444444444444444444444444444444444444444444"
+          , txInfoVotes = AMap.empty
+          , txInfoProposalProcedures = []
+          , txInfoCurrentTreasuryAmount = Nothing
+          , txInfoTreasuryDonation = Nothing
+          }
+    , scriptContextRedeemer = Redeemer (PlutusTx.toBuiltinData (HS.Close redeemer))
+    , scriptContextScriptInfo = SpendingScript ownRef (Just (Datum (PlutusTx.toBuiltinData (HS.Open openDatumU))))
+    }
+ where
+  headInU = TxOut headAddr headVal (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Open openDatumU)))) Nothing
+  headOutU = TxOut headAddr headVal (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Closed (closedDatumU cv ccp cs cl dl))))) Nothing
+
+-- The CloseUnused redeemer with a VALID signature over the given snapshot number.
+unusedRedeemer :: Integer -> HS.CloseRedeemer
+unusedRedeemer cs = HS.CloseUnused{HS.signature = [closeSigFor cs], HS.accumulatorHash = emptyAccHash, HS.decommitOutputsHash = emptyDecommitOutputsHash, HS.commitOutputsHash = emptyCommitOutputsHash}
+
+-- both oracles on a valid-signature CloseUnused (decidable-conjunct agreement: crypto valid on both sides).
+unusedRef :: Integer -> Integer -> Integer -> Integer -> Integer -> Integer -> Bool
+unusedRef cv ccp cs cl dl tMax =
+  projectClose (HS.Open openDatumU) (HS.Close (unusedRedeemer cs)) (mkContextU (unusedRedeemer cs) cv ccp cs cl dl tMax)
+
+unusedVal :: HS.CloseRedeemer -> Integer -> Integer -> Integer -> Integer -> Integer -> Integer -> Bool
+unusedVal redeemer cv ccp cs cl dl tMax =
+  Head.headValidator Head.canonicalCRSDatumHash (HS.Open openDatumU) (HS.Close redeemer) (mkContextU redeemer cv ccp cs cl dl tMax)
+
+-- ── signed CloseAny: like CloseUnused (signature over the CURRENT version) PLUS snapshot number > 0 ─────
+-- The validator's CloseAny arm additionally requires snapshotNumber' > 0; the reference models the same
+-- via the anyOK conjunct on the CloseAnyT tag. The signature message is identical to CloseUnused's (open
+-- version 0), so the scaffolding (openDatumU, mkContextU, closeSigFor) is shared; only the redeemer and
+-- the reference tag differ.
+anyRedeemer :: Integer -> HS.CloseRedeemer
+anyRedeemer cs = HS.CloseAny{HS.signature = [closeSigFor cs], HS.accumulatorHash = emptyAccHash, HS.decommitOutputsHash = emptyDecommitOutputsHash, HS.commitOutputsHash = emptyCommitOutputsHash}
+
+anyRef :: Integer -> Integer -> Integer -> Integer -> Integer -> Integer -> Bool
+anyRef cv ccp cs cl dl tMax =
+  projectClose (HS.Open openDatumU) (HS.Close (anyRedeemer cs)) (mkContextU (anyRedeemer cs) cv ccp cs cl dl tMax)
+
+anyVal :: HS.CloseRedeemer -> Integer -> Integer -> Integer -> Integer -> Integer -> Integer -> Bool
+anyVal = unusedVal
+
+-- ── signed CloseUsed: the signature is over version - 1 (a pending inc/dec was already applied) ─────────
+-- The validator's CloseUsed arm verifies the snapshot signature at the PREVIOUS open version. We open at
+-- version 1, so version - 1 = 0 and the message is exactly `closeMsg` again (Plutus Integer subtraction
+-- and the Agda v ∸ 1 agree away from 0; the v = 0 corner lives inside the mocked crypto boundary). The
+-- reference sees the same fields under the CloseUsedT tag; version preservation now demands cv = 1.
+usedOpenVersionN :: Integer
+usedOpenVersionN = 1
+
+-- openDatumU at version 1; headSeed (unique to OpenDatum) pins the record-update type.
+openDatumUsed :: HS.OpenDatum
+openDatumUsed = openDatumU{HS.headSeed = ownRef, HS.version = usedOpenVersionN}
+
+usedRedeemer :: Integer -> HS.CloseRedeemer
+usedRedeemer cs = HS.CloseUsed{HS.signature = [closeSigFor cs], HS.accumulatorHash = emptyAccHash, HS.decommitOutputsHash = emptyDecommitOutputsHash, HS.commitOutputsHash = emptyCommitOutputsHash}
+
+-- mkContextU with the version-1 open datum (each family keeps its own builder).
+mkContextUsed :: HS.CloseRedeemer -> Integer -> Integer -> Integer -> Integer -> Integer -> Integer -> ScriptContext
+mkContextUsed redeemer cv ccp cs cl dl tMax =
+  ScriptContext
+    { scriptContextTxInfo =
+        TxInfo
+          { txInfoInputs = [TxInInfo ownRef headInU]
+          , txInfoReferenceInputs = []
+          , txInfoOutputs = [headOutU]
+          , txInfoFee = 0
+          , txInfoMint = emptyMintValue
+          , txInfoTxCerts = []
+          , txInfoWdrl = AMap.empty
+          , txInfoValidRange =
+              Interval (LowerBound (Finite (POSIXTime validityLoN)) True) (UpperBound (Finite (POSIXTime tMax)) True)
+          , txInfoSignatories = [signerKH]
+          , txInfoRedeemers = AMap.empty
+          , txInfoData = AMap.empty
+          , txInfoId = TxId "44444444444444444444444444444444444444444444444444444444444444444444"
+          , txInfoVotes = AMap.empty
+          , txInfoProposalProcedures = []
+          , txInfoCurrentTreasuryAmount = Nothing
+          , txInfoTreasuryDonation = Nothing
+          }
+    , scriptContextRedeemer = Redeemer (PlutusTx.toBuiltinData (HS.Close redeemer))
+    , scriptContextScriptInfo = SpendingScript ownRef (Just (Datum (PlutusTx.toBuiltinData (HS.Open openDatumUsed))))
+    }
+ where
+  headInU = TxOut headAddr headVal (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Open openDatumUsed)))) Nothing
+  headOutU = TxOut headAddr headVal (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Closed (closedDatumU cv ccp cs cl dl))))) Nothing
+
+usedRef :: Integer -> Integer -> Integer -> Integer -> Integer -> Integer -> Bool
+usedRef cv ccp cs cl dl tMax =
+  projectClose (HS.Open openDatumUsed) (HS.Close (usedRedeemer cs)) (mkContextUsed (usedRedeemer cs) cv ccp cs cl dl tMax)
+
+usedVal :: HS.CloseRedeemer -> Integer -> Integer -> Integer -> Integer -> Integer -> Integer -> Bool
+usedVal redeemer cv ccp cs cl dl tMax =
+  Head.headValidator Head.canonicalCRSDatumHash (HS.Open openDatumUsed) (HS.Close redeemer) (mkContextUsed redeemer cv ccp cs cl dl tMax)
+
+-- CloseUsed hash-vs-datum coupling (mustBindAccumulatorCommitment): the redeemer's accumulatorHash must
+-- be the blake2b of the PRODUCED datum's commitment. Here the redeemer carries the hash of a DIFFERENT
+-- G1 point (2·G) and the signature is over that same wrong hash, so verifySnapshotSignature ACCEPTS and
+-- only the datum binding fails (a validator-only conjunct; the reference mocks the accumulator).
+usedWrongAccHash :: Builtins.BuiltinByteString
+usedWrongAccHash = Builtins.blake2b_256 (Builtins.bls12_381_G1_compress (Builtins.bls12_381_G1_add g1Generator g1Generator))
+
+usedRedeemerWrongHash :: Integer -> HS.CloseRedeemer
+usedRedeemerWrongHash cs =
+  HS.CloseUsed{HS.signature = [Builtins.toBuiltin (rawSerialiseSigDSIGN (signDSIGN () msg snapshotSK))], HS.accumulatorHash = usedWrongAccHash, HS.decommitOutputsHash = emptyDecommitOutputsHash, HS.commitOutputsHash = emptyCommitOutputsHash}
+ where
+  -- the CloseUsed message at open version 1 signs the version slot v - 1 = 0 (= openVersionN).
+  msg :: ByteString
+  msg =
+    Builtins.fromBuiltin $
+      Builtins.serialiseData (PlutusTx.toBuiltinData headPolicy)
+        <> Builtins.serialiseData (PlutusTx.toBuiltinData openVersionN)
+        <> Builtins.serialiseData (PlutusTx.toBuiltinData cs)
+        <> Builtins.serialiseData (PlutusTx.toBuiltinData usedWrongAccHash)
+        <> Builtins.serialiseData (PlutusTx.toBuiltinData emptyDecommitOutputsHash)
+        <> Builtins.serialiseData (PlutusTx.toBuiltinData emptyCommitOutputsHash)
+
+-- ── increment (Open→Open: version bump + value flow + a deposit script input + signature) ───────────────
+-- checkIncrement finds the head input by its STATE token (hasST), requires headIn ◇ Σdeposits == headOut,
+-- bumps the version, and verifies a signature over (headId, prevVersion, snapshotNumber, nextAccumulatorHash).
+-- We hold everything healthy except the two MODELED conjuncts (version bump, value) and assert
+-- reference (Ref.checkInc) === validator; plus a crypto non-vacuity (bad sig → validator rejects).
+
+stName :: TokenName
+stName = TokenName hydraHeadV2
+
+-- the head value carries the ST (so hasST finds the head input) AND a PT (mustBeSignedByParticipant).
+incHeadVal :: Value
+incHeadVal = singleton adaSymbol adaToken 2_000_000 <> singleton headPolicy stName 1 <> singleton headPolicy ptName 1
+
+depRef :: TxOutRef
+depRef = TxOutRef (TxId "55555555555555555555555555555555555555555555555555555555555555555555") 0
+
+depAddr :: Address
+depAddr = Address (ScriptCredential (ScriptHash "66666666666666666666666666666666666666666666666666666666")) Nothing
+
+depVal :: Value
+depVal = singleton adaSymbol adaToken 500_000
+
+incNextAccHash :: Builtins.BuiltinByteString
+incNextAccHash = Builtins.toBuiltin ("inc-acc" :: ByteString)
+
+-- identical to openDatumU (open datum with the snapshot signer as sole party).
+incOpenPrev :: HS.OpenDatum
+incOpenPrev = openDatumU
+
+incOpenNext :: Integer -> HS.OpenDatum
+incOpenNext nextV = incOpenPrev{HS.version = nextV, HS.accumulatorHash = incNextAccHash}
+
+-- message the validator reconstructs: (headId, OPEN version, snapshotNumber, nextAccumulatorHash).
+incMsg :: Integer -> ByteString
+incMsg snap =
+  Builtins.fromBuiltin $
+    Builtins.serialiseData (PlutusTx.toBuiltinData headPolicy)
+      <> Builtins.serialiseData (PlutusTx.toBuiltinData openVersionN)
+      <> Builtins.serialiseData (PlutusTx.toBuiltinData snap)
+      <> Builtins.serialiseData (PlutusTx.toBuiltinData incNextAccHash)
+      <> Builtins.serialiseData (PlutusTx.toBuiltinData emptyDecommitOutputsHash)
+      <> Builtins.serialiseData (PlutusTx.toBuiltinData emptyCommitOutputsHash)
+
+incSigFor :: Integer -> HS.Signature
+incSigFor snap = Builtins.toBuiltin (rawSerialiseSigDSIGN (signDSIGN () (incMsg snap) snapshotSK))
+
+incRedeemer :: Integer -> HS.IncrementRedeemer
+incRedeemer snap = HS.IncrementRedeemer{HS.signature = [incSigFor snap], HS.snapshotNumber = snap, HS.increment = depRef, HS.decommitOutputsHash = emptyDecommitOutputsHash}
+
+-- build the increment context. `nextV` is the produced version; `vPerturb` adds extra ada to the head
+-- output (breaking value conservation when ≠ 0). Everything else is healthy.
+mkIncContext :: HS.IncrementRedeemer -> Integer -> Integer -> ScriptContext
+mkIncContext = mkIncContextDep (depositDatum headPolicy 0)
+
+-- The same healthy increment context with the deposit input's DATUM as a knob (the
+-- DepositDatumInvalid reject swaps in an undecodable datum; everything else stays healthy).
+mkIncContextDep :: Datum -> HS.IncrementRedeemer -> Integer -> Integer -> ScriptContext
+mkIncContextDep depDatum redeemer nextV vPerturb =
+  ScriptContext
+    { scriptContextTxInfo =
+        TxInfo
+          { txInfoInputs = [TxInInfo ownRef headIn, TxInInfo depRef depIn]
+          , txInfoReferenceInputs = []
+          , txInfoOutputs = [headOut]
+          , txInfoFee = 0
+          , txInfoMint = emptyMintValue
+          , txInfoTxCerts = []
+          , txInfoWdrl = AMap.empty
+          , txInfoValidRange = Interval (LowerBound (Finite (POSIXTime validityLoN)) True) (UpperBound (Finite (POSIXTime 2_000)) True)
+          , txInfoSignatories = [signerKH]
+          , txInfoRedeemers = AMap.empty
+          , txInfoData = AMap.empty
+          , txInfoId = TxId "44444444444444444444444444444444444444444444444444444444444444444444"
+          , txInfoVotes = AMap.empty
+          , txInfoProposalProcedures = []
+          , txInfoCurrentTreasuryAmount = Nothing
+          , txInfoTreasuryDonation = Nothing
+          }
+    , scriptContextRedeemer = Redeemer (PlutusTx.toBuiltinData (HS.Increment redeemer))
+    , scriptContextScriptInfo = SpendingScript ownRef (Just (Datum (PlutusTx.toBuiltinData (HS.Open incOpenPrev))))
+    }
+ where
+  headIn = TxOut headAddr incHeadVal (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Open incOpenPrev)))) Nothing
+  depIn = TxOut depAddr depVal (OutputDatum depDatum) Nothing
+  headOut =
+    TxOut
+      headAddr
+      (incHeadVal <> depVal <> singleton adaSymbol adaToken vPerturb)
+      (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Open (incOpenNext nextV)))))
+      Nothing
+
+-- reference: version bump + value conservation (ada + non-ada totals), projected from the same
+-- constructed context (the redeemer's snapshot number only feeds the mocked crypto conjunct).
+incRef :: Integer -> Integer -> Bool
+incRef nextV vPerturb =
+  projectInc (HS.Open incOpenPrev) (HS.Increment (incRedeemer 3)) (mkIncContext (incRedeemer 3) nextV vPerturb)
+
+incVal :: HS.IncrementRedeemer -> Integer -> Integer -> Bool
+incVal redeemer nextV vPerturb =
+  Head.headValidator Head.canonicalCRSDatumHash (HS.Open incOpenPrev) (HS.Increment redeemer) (mkIncContext redeemer nextV vPerturb)
+
+-- ── increment conjunct demos: extracted conjunct checkers the family `checkInc` agreement does NOT exercise ──
+-- The family test above holds no-mint / participant / per-asset HEALTHY and varies only version + value
+-- totals. These targeted demos construct a single-conjunct attack and assert BOTH the extracted conjunct
+-- checker AND the real validator reject it (and accept the healthy form), keeping the coverage the deleted
+-- mutation-based `Differential.hs` had for these conjuncts. The healthy increment is `incRedeemer 3`,
+-- nextV = 1, deposit 500_000; the snapshot signature is valid throughout, so each attack isolates one check.
+
+-- a flexible increment context for the demos: knobs are the mint, the tx signatories, and the head input /
+-- output values; everything else is the healthy increment (valid sig, deposit, version bump).
+mkIncDemoContext :: MintValue -> [PubKeyHash] -> Value -> Value -> ScriptContext
+mkIncDemoContext mint signers hInVal hOutVal =
+  ScriptContext
+    { scriptContextTxInfo =
+        TxInfo
+          { txInfoInputs = [TxInInfo ownRef headIn, TxInInfo depRef depIn]
+          , txInfoReferenceInputs = []
+          , txInfoOutputs = [headOut]
+          , txInfoFee = 0
+          , txInfoMint = mint
+          , txInfoTxCerts = []
+          , txInfoWdrl = AMap.empty
+          , txInfoValidRange = Interval (LowerBound (Finite (POSIXTime validityLoN)) True) (UpperBound (Finite (POSIXTime 2_000)) True)
+          , txInfoSignatories = signers
+          , txInfoRedeemers = AMap.empty
+          , txInfoData = AMap.empty
+          , txInfoId = TxId "44444444444444444444444444444444444444444444444444444444444444444444"
+          , txInfoVotes = AMap.empty
+          , txInfoProposalProcedures = []
+          , txInfoCurrentTreasuryAmount = Nothing
+          , txInfoTreasuryDonation = Nothing
+          }
+    , scriptContextRedeemer = Redeemer (PlutusTx.toBuiltinData (HS.Increment (incRedeemer 3)))
+    , scriptContextScriptInfo = SpendingScript ownRef (Just (Datum (PlutusTx.toBuiltinData (HS.Open incOpenPrev))))
+    }
+ where
+  headIn = TxOut headAddr hInVal (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Open incOpenPrev)))) Nothing
+  depIn = TxOut depAddr depVal (OutputDatum (depositDatum headPolicy 0)) Nothing
+  headOut = TxOut headAddr hOutVal (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Open (incOpenNext 1))))) Nothing
+
+incDemoVal :: ScriptContext -> Bool
+incDemoVal = Head.headValidator Head.canonicalCRSDatumHash (HS.Open incOpenPrev) (HS.Increment (incRedeemer 3))
+
+-- big-endian integer encoding of a builtin byte string (equal iff the bytes are equal): the encoding the
+-- extracted participant/cid checkers compare on the Haskell side.
+bytesToInteger :: Builtins.BuiltinByteString -> Integer
+bytesToInteger = BS.foldl' (\acc w -> acc * 256 + toInteger w) 0 . Builtins.fromBuiltin
+
+-- no-mint attack: an increment that mints a head-policy token (any non-zero mint breaks mustNotMintOrBurn).
+incAttackMint :: MintValue
+incAttackMint = UnsafeMintValue (AMap.unsafeFromList [(headPolicy, AMap.unsafeFromList [(TokenName (Builtins.toBuiltin ("\11" :: ByteString)), 1)])])
+
+incHealthyHeadOut :: Value
+incHealthyHeadOut = incHeadVal <> depVal
+
+-- participant attack: a signer whose key-hash is NOT a participation-token name in the head value.
+nonParticipantKH :: PubKeyHash
+nonParticipantKH = PubKeyHash "99999999999999999999999999999999999999999999999999999999"
+
+-- Swap the tx signatories on a built context: the participant demos vary ONLY the signer set,
+-- keeping every other conjunct of the family's healthy fixture intact.
+withSignatories :: [PubKeyHash] -> ScriptContext -> ScriptContext
+withSignatories ks ctx = ctx{scriptContextTxInfo = (scriptContextTxInfo ctx){txInfoSignatories = ks}}
+
+-- On-chain, a script 'error' ('traceError') is a validation FAILURE, indistinguishable from returning
+-- False. The uncompiled validator instead throws, so normalise a verdict by reading a thrown error as
+-- rejection (False), matching on-chain semantics and the reference's Bool model. Used where the
+-- validator hard-errors instead of returning False (e.g. an increment claiming a deposit that is not a
+-- tx input aborts with DepositInputNotFound while computing the commit-outputs hash).
+rejectingErrors :: Bool -> Bool
+rejectingErrors b = unsafePerformIO $ fromRight False <$> (E.try (E.evaluate b) :: IO (Either E.SomeException Bool))
+{-# NOINLINE rejectingErrors #-}
+
+-- per-asset attack: a balanced A→B token swap (the non-ada TOTAL is preserved, but one asset is not).
+tokenA :: TokenName
+tokenA = TokenName (Builtins.toBuiltin ("token-A" :: ByteString))
+
+tokenB :: TokenName
+tokenB = TokenName (Builtins.toBuiltin ("token-B" :: ByteString))
+
+incPerAssetHeadIn :: Value
+incPerAssetHeadIn = incHeadVal <> singleton headPolicy tokenA 1
+
+incPerAssetHeadOutHealthy :: Value
+incPerAssetHeadOutHealthy = incHeadVal <> depVal <> singleton headPolicy tokenA 1
+
+incPerAssetHeadOutSwap :: Value
+incPerAssetHeadOutSwap = incHeadVal <> depVal <> singleton headPolicy tokenB 1
+
+-- ref-spent attack (the increment claimedDepositIsSpent): the redeemer claims a deposit out-ref that is
+-- NOT among the tx inputs. Only that conjunct breaks (the signature message does not cover the claimed
+-- ref, and the deposit input still feeds mustPreserveValue), so both the extracted checkRefSpent and the
+-- real validator must reject; the healthy claim (= depRef) passes both.
+unspentDepRef :: TxOutRef
+unspentDepRef = TxOutRef (TxId "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee") 0
+
+-- deterministic injective encoding of an out-ref (txid bytes big-endian, then the index): equal iff the
+-- out-refs are equal for index < 256 (all fixtures use index 0). The one encoding both checkRefSpent
+-- arguments share.
+encodeTxOutRef :: TxOutRef -> Integer
+encodeTxOutRef (TxOutRef (TxId tid) ix) = bytesToInteger tid * 256 + ix
+
+incRedeemerUnspent :: Integer -> HS.IncrementRedeemer
+incRedeemerUnspent snap = HS.IncrementRedeemer{HS.signature = [incSigFor snap], HS.snapshotNumber = snap, HS.increment = unspentDepRef, HS.decommitOutputsHash = emptyDecommitOutputsHash}
+
+-- ── decrement (Open→Open: version bump + value SHRINKS by decommit OUTPUTS + signature) ─────────────────
+-- checkDecrement finds the head input via findOwnInput and requires headIn == headOut ◇ Σdecommit-outputs
+-- (the decommitted value leaves via tx outputs [1..m]). Same signature format as increment.
+
+decHeadInVal :: Value
+decHeadInVal = singleton adaSymbol adaToken 2_500_000 <> singleton headPolicy stName 1 <> singleton headPolicy ptName 1
+
+-- the single decommit output leaving the head (index 1 in the tx). The validator recomputes the
+-- decommit-outputs hash from exactly these outputs, so the signed message must hash the same list.
+decDecommitOut :: TxOut
+decDecommitOut = TxOut (Address (PubKeyCredential signerKH) Nothing) (singleton adaSymbol adaToken 500_000) NoOutputDatum Nothing
+
+-- decrement signs the RECOMPUTED decommit-outputs hash (hashTxOuts of the tx's decommit outputs) plus the
+-- redeemer's (empty) commit-outputs hash. prevVersion = openVersionN, nextAccumulatorHash = incNextAccHash.
+decMsg :: Integer -> ByteString
+decMsg snap =
+  Builtins.fromBuiltin $
+    Builtins.serialiseData (PlutusTx.toBuiltinData headPolicy)
+      <> Builtins.serialiseData (PlutusTx.toBuiltinData openVersionN)
+      <> Builtins.serialiseData (PlutusTx.toBuiltinData snap)
+      <> Builtins.serialiseData (PlutusTx.toBuiltinData incNextAccHash)
+      <> Builtins.serialiseData (PlutusTx.toBuiltinData (hashTxOuts [decDecommitOut]))
+      <> Builtins.serialiseData (PlutusTx.toBuiltinData emptyCommitOutputsHash)
+
+decSigFor :: Integer -> HS.Signature
+decSigFor snap = Builtins.toBuiltin (rawSerialiseSigDSIGN (signDSIGN () (decMsg snap) snapshotSK))
+
+decRedeemer :: Integer -> HS.DecrementRedeemer
+decRedeemer snap = HS.DecrementRedeemer{HS.signature = [decSigFor snap], HS.snapshotNumber = snap, HS.numberOfDecommitOutputs = 1, HS.commitOutputsHash = emptyCommitOutputsHash}
+
+-- `vPerturb` adds extra ada to the head output (breaking value decrease when ≠ 0). Decommit = 500_000 ada.
+mkDecContext :: HS.DecrementRedeemer -> Integer -> Integer -> ScriptContext
+mkDecContext redeemer nextV vPerturb =
+  ScriptContext
+    { scriptContextTxInfo =
+        TxInfo
+          { txInfoInputs = [TxInInfo ownRef headIn]
+          , txInfoReferenceInputs = []
+          , txInfoOutputs = [headOut, decDecommitOut]
+          , txInfoFee = 0
+          , txInfoMint = emptyMintValue
+          , txInfoTxCerts = []
+          , txInfoWdrl = AMap.empty
+          , txInfoValidRange = Interval (LowerBound (Finite (POSIXTime validityLoN)) True) (UpperBound (Finite (POSIXTime 2_000)) True)
+          , txInfoSignatories = [signerKH]
+          , txInfoRedeemers = AMap.empty
+          , txInfoData = AMap.empty
+          , txInfoId = TxId "44444444444444444444444444444444444444444444444444444444444444444444"
+          , txInfoVotes = AMap.empty
+          , txInfoProposalProcedures = []
+          , txInfoCurrentTreasuryAmount = Nothing
+          , txInfoTreasuryDonation = Nothing
+          }
+    , scriptContextRedeemer = Redeemer (PlutusTx.toBuiltinData (HS.Decrement redeemer))
+    , scriptContextScriptInfo = SpendingScript ownRef (Just (Datum (PlutusTx.toBuiltinData (HS.Open incOpenPrev))))
+    }
+ where
+  headIn = TxOut headAddr decHeadInVal (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Open incOpenPrev)))) Nothing
+  headOut =
+    TxOut
+      headAddr
+      (singleton adaSymbol adaToken (2_000_000 + vPerturb) <> singleton headPolicy stName 1 <> singleton headPolicy ptName 1)
+      (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Open (incOpenNext nextV)))))
+      Nothing
+
+decRef :: Integer -> Integer -> Bool
+decRef nextV vPerturb =
+  projectDec (HS.Open incOpenPrev) (HS.Decrement (decRedeemer 3)) (mkDecContext (decRedeemer 3) nextV vPerturb)
+
+decVal :: HS.DecrementRedeemer -> Integer -> Integer -> Bool
+decVal redeemer nextV vPerturb =
+  Head.headValidator Head.canonicalCRSDatumHash (HS.Open incOpenPrev) (HS.Decrement redeemer) (mkDecContext redeemer nextV vPerturb)
+
+-- ── contest (Closed→Closed: version preserved + snapshot increases + one contester + deadline + sig) ────
+-- One party (= one contester), so mustPushDeadline keeps the deadline (contesters'==parties'). The contester
+-- is the lone signatory (signerKH); the snapshot signature is over (headId, version, snapshotNumber', accHash).
+contestPrev :: HS.ClosedDatum
+contestPrev =
+  HS.ClosedDatum
+    { HS.headId = headPolicy
+    , HS.parties = [snapshotParty]
+    , HS.contestationPeriod = UnsafeContestationPeriod (fromInteger openCpMs)
+    , HS.version = 0
+    , HS.snapshotNumber = 0
+    , HS.contesters = []
+    , HS.contestationDeadline = POSIXTime 2_000
+    , HS.accumulatorCommitment = g1Generator
+    , HS.headAdaOverhead = 0
+    }
+
+contestNext :: Integer -> Integer -> HS.ClosedDatum
+contestNext sPrime tfinPerturb =
+  contestPrev{HS.snapshotNumber = sPrime, HS.contesters = [signerKH], HS.contestationDeadline = POSIXTime (2_000 + tfinPerturb)}
+
+contestMsg :: Integer -> ByteString
+contestMsg sPrime =
+  Builtins.fromBuiltin $
+    Builtins.serialiseData (PlutusTx.toBuiltinData headPolicy)
+      <> Builtins.serialiseData (PlutusTx.toBuiltinData (0 :: Integer))
+      <> Builtins.serialiseData (PlutusTx.toBuiltinData sPrime)
+      <> Builtins.serialiseData (PlutusTx.toBuiltinData emptyAccHash)
+      <> Builtins.serialiseData (PlutusTx.toBuiltinData emptyDecommitOutputsHash)
+      <> Builtins.serialiseData (PlutusTx.toBuiltinData emptyCommitOutputsHash)
+
+contestSigFor :: Integer -> HS.Signature
+contestSigFor sPrime = Builtins.toBuiltin (rawSerialiseSigDSIGN (signDSIGN () (contestMsg sPrime) snapshotSK))
+
+contestRedeemer :: Integer -> HS.ContestRedeemer
+contestRedeemer sPrime = HS.ContestUnused{HS.signature = [contestSigFor sPrime], HS.accumulatorHash = emptyAccHash, HS.decommitOutputsHash = emptyDecommitOutputsHash, HS.commitOutputsHash = emptyCommitOutputsHash}
+
+mkContestContext :: HS.ContestRedeemer -> Integer -> Integer -> Integer -> ScriptContext
+mkContestContext redeemer sPrime tfinPerturb tMax =
+  ScriptContext
+    { scriptContextTxInfo =
+        TxInfo
+          { txInfoInputs = [TxInInfo ownRef headIn]
+          , txInfoReferenceInputs = []
+          , txInfoOutputs = [headOut]
+          , txInfoFee = 0
+          , txInfoMint = emptyMintValue
+          , txInfoTxCerts = []
+          , txInfoWdrl = AMap.empty
+          , txInfoValidRange = Interval (LowerBound (Finite (POSIXTime validityLoN)) True) (UpperBound (Finite (POSIXTime tMax)) True)
+          , txInfoSignatories = [signerKH]
+          , txInfoRedeemers = AMap.empty
+          , txInfoData = AMap.empty
+          , txInfoId = TxId "44444444444444444444444444444444444444444444444444444444444444444444"
+          , txInfoVotes = AMap.empty
+          , txInfoProposalProcedures = []
+          , txInfoCurrentTreasuryAmount = Nothing
+          , txInfoTreasuryDonation = Nothing
+          }
+    , scriptContextRedeemer = Redeemer (PlutusTx.toBuiltinData (HS.Contest redeemer))
+    , scriptContextScriptInfo = SpendingScript ownRef (Just (Datum (PlutusTx.toBuiltinData (HS.Closed contestPrev))))
+    }
+ where
+  headIn = TxOut headAddr headVal (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Closed contestPrev)))) Nothing
+  headOut = TxOut headAddr headVal (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Closed (contestNext sPrime tfinPerturb))))) Nothing
+
+contestRef :: Integer -> Integer -> Integer -> Bool
+contestRef sPrime tfinPerturb tMax =
+  projectContest
+    (HS.Closed contestPrev)
+    (HS.Contest (contestRedeemer sPrime))
+    (mkContestContext (contestRedeemer sPrime) sPrime tfinPerturb tMax)
+
+contestVal :: HS.ContestRedeemer -> Integer -> Integer -> Integer -> Bool
+contestVal redeemer sPrime tfinPerturb tMax =
+  Head.headValidator Head.canonicalCRSDatumHash (HS.Closed contestPrev) (HS.Contest redeemer) (mkContestContext redeemer sPrime tfinPerturb tMax)
+
+-- ── contest mustNotChangeParameters demo (C3.3): headId preservation (bridged from the contest transition) ──
+-- A healthy ContestUnused (s'=1) whose PRODUCED datum changes the head id. The snapshot signature is over the
+-- INPUT head id, so it still verifies; only mustNotChangeParameters fails. Built explicitly (headId is a
+-- duplicate field, so a record update would be ambiguous).
+contestNextBadHeadId :: HS.ClosedDatum
+contestNextBadHeadId =
+  HS.ClosedDatum
+    { HS.headId = otherHeadCid
+    , HS.parties = [snapshotParty]
+    , HS.contestationPeriod = UnsafeContestationPeriod (fromInteger openCpMs)
+    , HS.version = 0
+    , HS.snapshotNumber = 1
+    , HS.contesters = [signerKH]
+    , HS.contestationDeadline = POSIXTime 2_000
+    , HS.accumulatorCommitment = g1Generator
+    , HS.headAdaOverhead = 0
+    }
+
+-- a contest context with an explicitly-supplied produced datum (otherwise the healthy s'=1 contest).
+mkContestParamsContext :: HS.ClosedDatum -> ScriptContext
+mkContestParamsContext producedDatum =
+  ScriptContext
+    { scriptContextTxInfo =
+        TxInfo
+          { txInfoInputs = [TxInInfo ownRef headIn]
+          , txInfoReferenceInputs = []
+          , txInfoOutputs = [headOut]
+          , txInfoFee = 0
+          , txInfoMint = emptyMintValue
+          , txInfoTxCerts = []
+          , txInfoWdrl = AMap.empty
+          , txInfoValidRange = Interval (LowerBound (Finite (POSIXTime validityLoN)) True) (UpperBound (Finite (POSIXTime 1_500)) True)
+          , txInfoSignatories = [signerKH]
+          , txInfoRedeemers = AMap.empty
+          , txInfoData = AMap.empty
+          , txInfoId = TxId "44444444444444444444444444444444444444444444444444444444444444444444"
+          , txInfoVotes = AMap.empty
+          , txInfoProposalProcedures = []
+          , txInfoCurrentTreasuryAmount = Nothing
+          , txInfoTreasuryDonation = Nothing
+          }
+    , scriptContextRedeemer = Redeemer (PlutusTx.toBuiltinData (HS.Contest (contestRedeemer 1)))
+    , scriptContextScriptInfo = SpendingScript ownRef (Just (Datum (PlutusTx.toBuiltinData (HS.Closed contestPrev))))
+    }
+ where
+  headIn = TxOut headAddr headVal (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Closed contestPrev)))) Nothing
+  headOut = TxOut headAddr headVal (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Closed producedDatum)))) Nothing
+
+contestParamsVal :: HS.ClosedDatum -> Bool
+contestParamsVal producedDatum =
+  Head.headValidator Head.canonicalCRSDatumHash (HS.Closed contestPrev) (HS.Contest (contestRedeemer 1)) (mkContestParamsContext producedDatum)
+
+-- ── signed ContestUsed: the contest signature is over version - 1 (pending inc/dec already applied) ─────
+-- The validator's ContestUsed arm verifies the snapshot signature at the PREVIOUS version. The closed
+-- input carries version 1, so version - 1 = 0 and the message is exactly `contestMsg` again (as with
+-- CloseUsed, the v = 0 monus corner lives inside the mocked crypto boundary). The reference has no
+-- contest tag: the redeemer choice only moves the signature message, which is the injected conjunct.
+contestUsedPrev :: HS.ClosedDatum
+contestUsedPrev =
+  HS.ClosedDatum
+    { HS.headId = headPolicy
+    , HS.parties = [snapshotParty]
+    , HS.contestationPeriod = UnsafeContestationPeriod (fromInteger openCpMs)
+    , HS.version = 1
+    , HS.snapshotNumber = 0
+    , HS.contesters = []
+    , HS.contestationDeadline = POSIXTime 2_000
+    , HS.accumulatorCommitment = g1Generator
+    , HS.headAdaOverhead = 0
+    }
+
+contestUsedNext :: Integer -> Integer -> HS.ClosedDatum
+contestUsedNext sPrime tfinPerturb =
+  contestUsedPrev{HS.snapshotNumber = sPrime, HS.contesters = [signerKH], HS.contestationDeadline = POSIXTime (2_000 + tfinPerturb)}
+
+contestUsedRedeemer :: Integer -> HS.ContestRedeemer
+contestUsedRedeemer sPrime = HS.ContestUsed{HS.signature = [contestSigFor sPrime], HS.accumulatorHash = emptyAccHash, HS.decommitOutputsHash = emptyDecommitOutputsHash, HS.commitOutputsHash = emptyCommitOutputsHash}
+
+mkContestUsedContext :: HS.ContestRedeemer -> Integer -> Integer -> Integer -> ScriptContext
+mkContestUsedContext redeemer sPrime tfinPerturb tMax =
+  ScriptContext
+    { scriptContextTxInfo =
+        TxInfo
+          { txInfoInputs = [TxInInfo ownRef headIn]
+          , txInfoReferenceInputs = []
+          , txInfoOutputs = [headOut]
+          , txInfoFee = 0
+          , txInfoMint = emptyMintValue
+          , txInfoTxCerts = []
+          , txInfoWdrl = AMap.empty
+          , txInfoValidRange = Interval (LowerBound (Finite (POSIXTime validityLoN)) True) (UpperBound (Finite (POSIXTime tMax)) True)
+          , txInfoSignatories = [signerKH]
+          , txInfoRedeemers = AMap.empty
+          , txInfoData = AMap.empty
+          , txInfoId = TxId "44444444444444444444444444444444444444444444444444444444444444444444"
+          , txInfoVotes = AMap.empty
+          , txInfoProposalProcedures = []
+          , txInfoCurrentTreasuryAmount = Nothing
+          , txInfoTreasuryDonation = Nothing
+          }
+    , scriptContextRedeemer = Redeemer (PlutusTx.toBuiltinData (HS.Contest redeemer))
+    , scriptContextScriptInfo = SpendingScript ownRef (Just (Datum (PlutusTx.toBuiltinData (HS.Closed contestUsedPrev))))
+    }
+ where
+  headIn = TxOut headAddr headVal (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Closed contestUsedPrev)))) Nothing
+  headOut = TxOut headAddr headVal (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Closed (contestUsedNext sPrime tfinPerturb))))) Nothing
+
+contestUsedRef :: Integer -> Integer -> Integer -> Bool
+contestUsedRef sPrime tfinPerturb tMax =
+  projectContest
+    (HS.Closed contestUsedPrev)
+    (HS.Contest (contestUsedRedeemer sPrime))
+    (mkContestUsedContext (contestUsedRedeemer sPrime) sPrime tfinPerturb tMax)
+
+contestUsedVal :: HS.ContestRedeemer -> Integer -> Integer -> Integer -> Bool
+contestUsedVal redeemer sPrime tfinPerturb tMax =
+  Head.headValidator Head.canonicalCRSDatumHash (HS.Closed contestUsedPrev) (HS.Contest redeemer) (mkContestUsedContext redeemer sPrime tfinPerturb tMax)
+
+-- ── contest deadline-push (n = 2): the contest does NOT complete the round, so tfinal' = tfinal + cp ───
+-- With one party the deadline-push accept branch is unreachable (one contester is all of them), so the
+-- n = 1 family above only exercises the tfinal' = tfinal side of mustPushDeadline. Here TWO parties hold
+-- the head and ONE contests: contesters' (1) /= parties' (2), so the produced datum must record
+-- tfinal + cp. The snapshot multisignature needs BOTH parties' keys (verifySnapshotSignature zips
+-- parties with signatures), so a second deterministic Ed25519 key joins the head.
+snapshotSK2 :: SignKeyDSIGN Ed25519DSIGN
+snapshotSK2 = genKeyDSIGN (mkSeedFromBytes (digest (Proxy :: Proxy SHA256) ("hva-snapshot-seed-2" :: ByteString)))
+
+snapshotParty2 :: Party
+snapshotParty2 = partyFromVerificationKeyBytes (rawSerialiseVerKeyDSIGN (deriveVerKeyDSIGN snapshotSK2))
+
+-- Task-3 axis: the INPUT datum's contestation period (ms) is a parameter (the contest signature
+-- message does not cover it), so a validator reading a constant instead of the datum's period in the
+-- deadline push is caught.
+contest2Prev :: Integer -> HS.ClosedDatum
+contest2Prev cp =
+  HS.ClosedDatum
+    { HS.headId = headPolicy
+    , HS.parties = [snapshotParty, snapshotParty2]
+    , HS.contestationPeriod = UnsafeContestationPeriod (fromInteger cp)
+    , HS.version = 0
+    , HS.snapshotNumber = 0
+    , HS.contesters = []
+    , HS.contestationDeadline = POSIXTime 2_000
+    , HS.accumulatorCommitment = g1Generator
+    , HS.headAdaOverhead = 0
+    }
+
+contest2Next :: Integer -> Integer -> Integer -> HS.ClosedDatum
+contest2Next cp sPrime tfinPerturb =
+  (contest2Prev cp){HS.snapshotNumber = sPrime, HS.contesters = [signerKH], HS.contestationDeadline = POSIXTime (2_000 + tfinPerturb)}
+
+-- both parties sign the same ContestUnused message (version 0), in parties order.
+contest2SigsFor :: Integer -> [HS.Signature]
+contest2SigsFor sPrime =
+  [ contestSigFor sPrime
+  , Builtins.toBuiltin (rawSerialiseSigDSIGN (signDSIGN () (contestMsg sPrime) snapshotSK2))
+  ]
+
+contest2Redeemer :: Integer -> HS.ContestRedeemer
+contest2Redeemer sPrime = HS.ContestUnused{HS.signature = contest2SigsFor sPrime, HS.accumulatorHash = emptyAccHash, HS.decommitOutputsHash = emptyDecommitOutputsHash, HS.commitOutputsHash = emptyCommitOutputsHash}
+
+mkContest2Context :: HS.ContestRedeemer -> Integer -> Integer -> Integer -> Integer -> ScriptContext
+mkContest2Context redeemer cp sPrime tfinPerturb tMax =
+  ScriptContext
+    { scriptContextTxInfo =
+        TxInfo
+          { txInfoInputs = [TxInInfo ownRef headIn]
+          , txInfoReferenceInputs = []
+          , txInfoOutputs = [headOut]
+          , txInfoFee = 0
+          , txInfoMint = emptyMintValue
+          , txInfoTxCerts = []
+          , txInfoWdrl = AMap.empty
+          , txInfoValidRange = Interval (LowerBound (Finite (POSIXTime validityLoN)) True) (UpperBound (Finite (POSIXTime tMax)) True)
+          , txInfoSignatories = [signerKH]
+          , txInfoRedeemers = AMap.empty
+          , txInfoData = AMap.empty
+          , txInfoId = TxId "44444444444444444444444444444444444444444444444444444444444444444444"
+          , txInfoVotes = AMap.empty
+          , txInfoProposalProcedures = []
+          , txInfoCurrentTreasuryAmount = Nothing
+          , txInfoTreasuryDonation = Nothing
+          }
+    , scriptContextRedeemer = Redeemer (PlutusTx.toBuiltinData (HS.Contest redeemer))
+    , scriptContextScriptInfo = SpendingScript ownRef (Just (Datum (PlutusTx.toBuiltinData (HS.Closed (contest2Prev cp)))))
+    }
+ where
+  headIn = TxOut headAddr headVal (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Closed (contest2Prev cp))))) Nothing
+  headOut = TxOut headAddr headVal (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Closed (contest2Next cp sPrime tfinPerturb))))) Nothing
+
+-- reference with numParties = 2: the deadline-update rule now demands tfinal' = tfinal + cp.
+contest2Ref :: Integer -> Integer -> Integer -> Integer -> Bool
+contest2Ref cp sPrime tfinPerturb tMax =
+  projectContest
+    (HS.Closed (contest2Prev cp))
+    (HS.Contest (contest2Redeemer sPrime))
+    (mkContest2Context (contest2Redeemer sPrime) cp sPrime tfinPerturb tMax)
+
+contest2Val :: HS.ContestRedeemer -> Integer -> Integer -> Integer -> Integer -> Bool
+contest2Val redeemer cp sPrime tfinPerturb tMax =
+  Head.headValidator Head.canonicalCRSDatumHash (HS.Closed (contest2Prev cp)) (HS.Contest redeemer) (mkContest2Context redeemer cp sPrime tfinPerturb tMax)
+
+-- ── init (μHead minting policy: token COUNT + PLACEMENT) ────────────────────────────────────────────────
+-- validateTokensMinting checks: the head policy MINTS exactly n+1 tokens (checkNumberOfTokens), the head
+-- output carries the single ST (singleSTIsPaidToTheHead) and exactly n unique PTs
+-- (enoughUniquePTsPaidToHead), plus the seed input is consumed and the datum binds headId/seed. We hold the
+-- seed + datum healthy and vary the three modeled quantities (minted count, ST quantity, PT count) to
+-- exercise the accept AND reject directions, asserting Ref.checkInit === validateTokensMinting. n = 1 party.
+
+initSeedRef :: TxOutRef
+initSeedRef = TxOutRef (TxId "77777777777777777777777777777777777777777777777777777777777777777777") 0
+
+-- one party (snapshotParty); headId = the minting currency; headSeed = the consumed seed (datum binding).
+initOpenDatum :: HS.OpenDatum
+initOpenDatum = openDatum{HS.headSeed = initSeedRef, HS.parties = [snapshotParty]}
+
+-- distinct 1-byte PT names, none equal to the 11-byte ST name (hydraHeadV2).
+initPtNames :: [TokenName]
+initPtNames =
+  [ TokenName (Builtins.toBuiltin ("\1" :: ByteString))
+  , TokenName (Builtins.toBuiltin ("\2" :: ByteString))
+  , TokenName (Builtins.toBuiltin ("\3" :: ByteString))
+  ]
+
+-- head output value: ada + ST(stQty) + numPT PTs (each qty 1). headTokenCount (sum) = stQty + numPT.
+initHeadVal :: Integer -> Integer -> Value
+initHeadVal stQty numPT =
+  singleton adaSymbol adaToken 2_000_000
+    <> (if stQty == 0 then mempty else singleton headPolicy stName stQty)
+    <> mconcat [singleton headPolicy nm 1 | nm <- take (fromInteger numPT) initPtNames]
+
+initMint :: Integer -> MintValue
+initMint mintedCount = UnsafeMintValue (AMap.unsafeFromList [(headPolicy, AMap.unsafeFromList [(stName, mintedCount)])])
+
+-- `inputSeedRef` is the out-ref of the (only) tx input; the validator's seedInput arg is fixed to
+-- initSeedRef, so passing a different inputSeedRef breaks seedInputIsConsumed (a validator-only conjunct).
+mkInitContext :: TxOutRef -> HS.OpenDatum -> Integer -> Integer -> Integer -> ScriptContext
+mkInitContext inputSeedRef headDatum mintedCount stQty numPT =
+  ScriptContext
+    { scriptContextTxInfo =
+        TxInfo
+          { txInfoInputs = [TxInInfo inputSeedRef seedIn]
+          , txInfoReferenceInputs = []
+          , txInfoOutputs = [headOut]
+          , txInfoFee = 0
+          , txInfoMint = initMint mintedCount
+          , txInfoTxCerts = []
+          , txInfoWdrl = AMap.empty
+          , txInfoValidRange = Interval (LowerBound (Finite (POSIXTime validityLoN)) True) (UpperBound (Finite (POSIXTime 2_000)) True)
+          , txInfoSignatories = [signerKH]
+          , txInfoRedeemers = AMap.empty
+          , txInfoData = AMap.empty
+          , txInfoId = TxId "44444444444444444444444444444444444444444444444444444444444444444444"
+          , txInfoVotes = AMap.empty
+          , txInfoProposalProcedures = []
+          , txInfoCurrentTreasuryAmount = Nothing
+          , txInfoTreasuryDonation = Nothing
+          }
+    , scriptContextRedeemer = Redeemer (PlutusTx.toBuiltinData ())
+    , scriptContextScriptInfo = MintingScript headPolicy
+    }
+ where
+  seedIn = TxOut (Address (PubKeyCredential signerKH) Nothing) (singleton adaSymbol adaToken 10_000_000) NoOutputDatum Nothing
+  headOut = TxOut headAddr (initHeadVal stQty numPT) (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Open headDatum)))) Nothing
+
+initRef :: Integer -> Integer -> Integer -> Bool
+initRef mintedCount stQty numPT = projectInit (mkInitContext initSeedRef initOpenDatum mintedCount stQty numPT)
+
+initVal :: Integer -> Integer -> Integer -> Bool
+initVal mintedCount stQty numPT =
+  Tokens.validateTokensMinting headScriptHash initSeedRef (mkInitContext initSeedRef initOpenDatum mintedCount stQty numPT)
+
+-- ── init datum head-id binding demo (C3.2): μHead checkDatum requires datum.headId == currency ──
+-- The head output datum names a different head id than the minting policy → checkDatum (WrongDatum) rejects.
+-- headSeed (unique to OpenDatum) pins the record-update type so the headId update is unambiguous.
+initOpenDatumBadHeadId :: HS.OpenDatum
+initOpenDatumBadHeadId = initOpenDatum{HS.headId = otherHeadCid, HS.headSeed = initSeedRef}
+
+initHeadIdVal :: HS.OpenDatum -> Bool
+initHeadIdVal od = Tokens.validateTokensMinting headScriptHash initSeedRef (mkInitContext initSeedRef od 2 1 1)
+
+-- ── μHead Burn arm (validateTokensBurning): burn-only mint field ────────────────────────────────
+-- The Burn arm requires head-policy entries to EXIST in the mint field and ALL to be negative
+-- (MintingNotAllowed otherwise); WHICH burns are legitimate is vHead's concern (the fanout family's
+-- burn count). We vary the head-policy entry quantities, asserting Ref.checkBurn ===
+-- validateTokensBurning. An empty list leaves the head policy out of the mint field entirely (the
+-- validator's lookup-Nothing branch); zero quantities are excluded (not representable in canonical
+-- ledger mint values).
+
+burnMint :: [Integer] -> MintValue
+burnMint qtys
+  | null qtys = UnsafeMintValue (AMap.unsafeFromList [])
+  | otherwise =
+      UnsafeMintValue
+        (AMap.unsafeFromList [(headPolicy, AMap.unsafeFromList (zip (stName : initPtNames) qtys))])
+
+mkBurnContext :: [Integer] -> ScriptContext
+mkBurnContext qtys =
+  ScriptContext
+    { scriptContextTxInfo =
+        TxInfo
+          { txInfoInputs = []
+          , txInfoReferenceInputs = []
+          , txInfoOutputs = []
+          , txInfoFee = 0
+          , txInfoMint = burnMint qtys
+          , txInfoTxCerts = []
+          , txInfoWdrl = AMap.empty
+          , txInfoValidRange = Interval (LowerBound (Finite (POSIXTime validityLoN)) True) (UpperBound (Finite (POSIXTime 2_000)) True)
+          , txInfoSignatories = [signerKH]
+          , txInfoRedeemers = AMap.empty
+          , txInfoData = AMap.empty
+          , txInfoId = TxId "44444444444444444444444444444444444444444444444444444444444444444444"
+          , txInfoVotes = AMap.empty
+          , txInfoProposalProcedures = []
+          , txInfoCurrentTreasuryAmount = Nothing
+          , txInfoTreasuryDonation = Nothing
+          }
+    , scriptContextRedeemer = Redeemer (PlutusTx.toBuiltinData ())
+    , scriptContextScriptInfo = MintingScript headPolicy
+    }
+
+burnRef :: [Integer] -> Bool
+burnRef = projectBurn . mkBurnContext
+
+burnVal :: [Integer] -> Bool
+burnVal = Tokens.validateTokensBurning . mkBurnContext
+
+-- ── νDeposit (recover/claim): the REAL Aiken validator, run as compiled UPLC on a hand-built context ────
+-- The deposit validator is Aiken (deposit.ak), not a Haskell function, so we cannot call it directly. We
+-- deserialise the compiled validator from plutus.json, build a V3 EvaluationContext from the test cost
+-- model, construct a ScriptContext directly, serialise it, and run the CEK machine on it (no transaction,
+-- no fixtures, no mutations). A successful evaluation = accept; any script error = reject. We then assert
+-- Ref.checkRecover / Ref.checkClaim === depositAccepts over independently-generated deadlines and head ids.
+
+-- The V3 evaluation context built from the test PlutusV3 cost model (the same model the ledger fixtures use).
+depositEvalContext :: EvaluationContext
+depositEvalContext =
+  case runWriterT (mkEvaluationContext (getCostModelParams plutusV3CostModel)) of
+    Left err -> error ("deposit cost model: " <> show err)
+    Right (ec, _warns) -> ec
+
+-- The compiled deposit validator, deserialised ready for evaluation (major protocol version 11, the value
+-- the test pparams pin).
+depositScriptForEval :: ScriptForEvaluation
+depositScriptForEval =
+  case deserialiseScript (MajorProtocolVersion 11) serialised of
+    Left err -> error ("deposit deserialise: " <> show err)
+    Right s -> s
+ where
+  serialised :: SerialisedScript
+  serialised = case depositValidatorScript of PlutusScriptSerialised sbs -> sbs
+
+-- Run the actual compiled deposit validator on a directly-constructed V3 ScriptContext.
+depositAccepts :: ScriptContext -> Bool
+depositAccepts ctx =
+  case snd (evaluateScriptCounting (MajorProtocolVersion 11) Quiet depositEvalContext depositScriptForEval (toData ctx)) of
+    Right _ -> True
+    Left _ -> False
+
+-- A deposit script address (the deposit input being spent) and the deposit out-ref.
+depositScriptAddr :: Address
+depositScriptAddr = Address (ScriptCredential (ScriptHash "99999999999999999999999999999999999999999999999999999999")) Nothing
+
+depositOwnRef :: TxOutRef
+depositOwnRef = TxOutRef (TxId "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") 0
+
+-- Deposit datum: head id, deadline, EMPTY commit list. The empty list makes recover_outputs trivially
+-- satisfied (take 0 outputs == [] and sort [] == [], so both sha2_256 hashes are over the empty string),
+-- isolating the modeled deadline conjunct (the recovered-outputs hash equality is the mocked Ops boundary).
+depositDatum :: CurrencySymbol -> Integer -> Datum
+depositDatum headCid deadline = Deposit.datum ((headCid, POSIXTime deadline, []) :: Deposit.DepositDatum)
+
+-- ── Recover (posted strictly AFTER the recover deadline: validityLo > deadline) ──
+mkRecoverContext :: Integer -> Integer -> ScriptContext
+mkRecoverContext deadline validityLo =
+  ScriptContext
+    { scriptContextTxInfo =
+        TxInfo
+          { txInfoInputs = [TxInInfo depositOwnRef depIn]
+          , txInfoReferenceInputs = []
+          , txInfoOutputs = []
+          , txInfoFee = 0
+          , txInfoMint = emptyMintValue
+          , txInfoTxCerts = []
+          , txInfoWdrl = AMap.empty
+          , txInfoValidRange = Interval (LowerBound (Finite (POSIXTime validityLo)) True) (UpperBound PosInf True)
+          , txInfoSignatories = [signerKH]
+          , txInfoRedeemers = AMap.empty
+          , txInfoData = AMap.empty
+          , txInfoId = TxId "44444444444444444444444444444444444444444444444444444444444444444444"
+          , txInfoVotes = AMap.empty
+          , txInfoProposalProcedures = []
+          , txInfoCurrentTreasuryAmount = Nothing
+          , txInfoTreasuryDonation = Nothing
+          }
+    , scriptContextRedeemer = Deposit.redeemer (Deposit.Recover 0)
+    , scriptContextScriptInfo = SpendingScript depositOwnRef (Just (depositDatum headPolicy deadline))
+    }
+ where
+  depIn = TxOut depositScriptAddr (singleton adaSymbol adaToken 3_000_000) (OutputDatum (depositDatum headPolicy deadline)) Nothing
+
+recoverRef :: Integer -> Integer -> Bool
+recoverRef deadline validityLo = projectRecover (mkRecoverContext deadline validityLo)
+
+recoverVal :: Integer -> Integer -> Bool
+recoverVal deadline validityLo = depositAccepts (mkRecoverContext deadline validityLo)
+
+-- ── Claim (posted BEFORE the deadline: validityHi <= deadline, AND the head input carries the deposit's
+-- head id ST and is spent by an Increment) ──
+claimHeadInRef :: TxOutRef
+claimHeadInRef = TxOutRef (TxId "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb") 0
+
+-- the head-input redeemer under test: the healthy claim spends the head with an Increment (constr
+-- index 0, satisfying is_head_increment); any other constructor index is the coupling's reject
+-- direction (HeadRedeemerNotIncrement).
+claimIncrementInput :: HS.Input
+claimIncrementInput = HS.Increment (incRedeemer 0)
+
+claimDecrementInput :: HS.Input
+claimDecrementInput = HS.Decrement (decRedeemer 3)
+
+-- `depHeadCid` is the deposit datum's head id; the head input always carries headPolicy's ST. When they
+-- differ, expect_increment_redeemer finds no matching head input and the validator rejects (own-head bind).
+mkClaimContext :: HS.Input -> Integer -> Integer -> CurrencySymbol -> ScriptContext
+mkClaimContext headRedeemer deadline validityHi depHeadCid =
+  ScriptContext
+    { scriptContextTxInfo =
+        TxInfo
+          { txInfoInputs = [TxInInfo depositOwnRef depIn, TxInInfo claimHeadInRef headIn]
+          , txInfoReferenceInputs = []
+          , txInfoOutputs = []
+          , txInfoFee = 0
+          , txInfoMint = emptyMintValue
+          , txInfoTxCerts = []
+          , txInfoWdrl = AMap.empty
+          , txInfoValidRange = Interval (LowerBound NegInf True) (UpperBound (Finite (POSIXTime validityHi)) True)
+          , txInfoSignatories = [signerKH]
+          , txInfoRedeemers = AMap.unsafeFromList [(Spending claimHeadInRef, Redeemer (PlutusTx.toBuiltinData headRedeemer))]
+          , txInfoData = AMap.empty
+          , txInfoId = TxId "44444444444444444444444444444444444444444444444444444444444444444444"
+          , txInfoVotes = AMap.empty
+          , txInfoProposalProcedures = []
+          , txInfoCurrentTreasuryAmount = Nothing
+          , txInfoTreasuryDonation = Nothing
+          }
+    , scriptContextRedeemer = Deposit.redeemer Deposit.Claim
+    , scriptContextScriptInfo = SpendingScript depositOwnRef (Just (depositDatum depHeadCid deadline))
+    }
+ where
+  depIn = TxOut depositScriptAddr (singleton adaSymbol adaToken 3_000_000) (OutputDatum (depositDatum depHeadCid deadline)) Nothing
+  headIn = TxOut headAddr (singleton adaSymbol adaToken 5_000_000 <> singleton headPolicy stName 1) (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Open incOpenPrev)))) Nothing
+
+-- Deterministic encoding of a head-id currency symbol as the big-endian integer of its bytes: equal iff the
+-- symbols are equal (the cid-binding check needs nothing more — see the cidToNat note in ReferenceBridge).
+cidToInteger :: CurrencySymbol -> Integer
+cidToInteger = bytesToInteger . unCurrencySymbol
+
+claimRef :: HS.Input -> Integer -> Integer -> CurrencySymbol -> Bool
+claimRef headRedeemer deadline validityHi depHeadCid = projectClaim (mkClaimContext headRedeemer deadline validityHi depHeadCid)
+
+claimVal :: HS.Input -> Integer -> Integer -> CurrencySymbol -> Bool
+claimVal headRedeemer deadline validityHi depHeadCid = depositAccepts (mkClaimContext headRedeemer deadline validityHi depHeadCid)
+
+-- a head id distinct from headPolicy, for exercising the own-head-binding reject direction.
+otherHeadCid :: CurrencySymbol
+otherHeadCid = CurrencySymbol "abababababababababababababababababababababababababababab"
+
+-- ── full fanout (Closed → finalised, empty head: m = 0, the only path that burns the head tokens) ───────
+-- headIsFinalizedWith checks: all n+1 head tokens burned (mustBurnAllHeadTokens), posted after the
+-- contestation deadline (validityLo > tfinal), the distributed outputs are accumulator members
+-- (checkCRSAndMembership), and value is conserved (mustConserveValue). For the empty head m = 0, so the
+-- subset is empty and checkMembershipPairing reduces to commitment == proof: with the empty-accumulator
+-- G1 generator as both the commitment and the proof, and a CRS reference input carrying the canonical
+-- trusted-setup G2 points, the REAL BLS pairing check runs and passes. We vary the burned-token count and
+-- the lower validity bound to exercise both directions and assert Ref.checkFanout === headIsFinalizedWith.
+-- n = 1.
+
+-- The address of the CRS reference input. The validator binds the CRS by datum content
+-- (hashCRSDatum crsData == canonicalCRSDatumHash), not by script hash, so this hash only fixes where the
+-- reference UTxO sits, not what makes it canonical.
+crsScriptHash :: ScriptHash
+crsScriptHash = ScriptHash "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+
+crsRefOut :: TxOutRef
+crsRefOut = TxOutRef (TxId "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd") 0
+
+crsRefInput :: TxInInfo
+crsRefInput =
+  TxInInfo
+    crsRefOut
+    ( TxOut
+        (Address (ScriptCredential crsScriptHash) Nothing)
+        (singleton adaSymbol adaToken 2_000_000)
+        (OutputDatum (Datum (PlutusTx.toBuiltinData KZG.canonicalG2Points)))
+        (Just crsScriptHash)
+    )
+
+-- A NON-CANONICAL CRS datum: the canonical points padded with a duplicate of the first one. Same-τ
+-- prefix (any pairing over the prefix still verifies) and still decodes as a non-empty [G2], but the
+-- datum BYTES differ, so hashCRSDatum no longer matches the validator's canonicalCRSDatumHash and
+-- withCRSLookup must reject with InvalidCRSDatum before any pairing runs.
+paddedCrsData :: [Builtins.BuiltinBLS12_381_G2_Element]
+paddedCrsData = KZG.canonicalG2Points <> take 1 KZG.canonicalG2Points
+
+paddedCrsRefInput :: TxInInfo
+paddedCrsRefInput =
+  TxInInfo
+    crsRefOut
+    ( TxOut
+        (Address (ScriptCredential crsScriptHash) Nothing)
+        (singleton adaSymbol adaToken 2_000_000)
+        (OutputDatum (Datum (PlutusTx.toBuiltinData paddedCrsData)))
+        (Just crsScriptHash)
+    )
+
+fanoutOverhead :: Integer
+fanoutOverhead = 2_000_000
+
+-- the head input value: the n+1 = 2 head tokens (ST + PT) plus the locked ada overhead.
+fanoutHeadInVal :: Value
+fanoutHeadInVal = singleton headPolicy stName 1 <> singleton headPolicy ptName 1 <> singleton adaSymbol adaToken fanoutOverhead
+
+-- Closed datum before the empty-head fanout: empty-accumulator commitment (g1Generator), one party.
+fanoutClosedDatum :: Integer -> HS.ClosedDatum
+fanoutClosedDatum tfinal =
+  HS.ClosedDatum
+    { HS.headId = headPolicy
+    , HS.parties = [snapshotParty]
+    , HS.contestationPeriod = UnsafeContestationPeriod (fromInteger openCpMs)
+    , HS.version = 0
+    , HS.snapshotNumber = 0
+    , HS.contesters = []
+    , HS.contestationDeadline = POSIXTime tfinal
+    , HS.accumulatorCommitment = g1Generator
+    , HS.headAdaOverhead = fanoutOverhead
+    }
+
+-- token names available to burn; the healthy burn is ST + PT (n+1 = 2). Burning a different count breaks
+-- both mustBurnAllHeadTokens and mustConserveValue (the head input fixes the conserved value at ST+PT+ada).
+fanoutBurnNames :: [TokenName]
+fanoutBurnNames = [stName, ptName, TokenName (Builtins.toBuiltin ("\7" :: ByteString))]
+
+fanoutMint :: Integer -> MintValue
+fanoutMint burnedCount =
+  UnsafeMintValue (AMap.unsafeFromList [(headPolicy, AMap.unsafeFromList [(nm, -1) | nm <- take (fromInteger burnedCount) fanoutBurnNames])])
+
+fanoutRedeemer :: HS.Input
+fanoutRedeemer = HS.Fanout{HS.numberOfFanoutOutputs = 0, HS.proof = g1Generator, HS.crsRef = crsRefOut}
+
+mkFanoutContext :: Integer -> Integer -> Integer -> ScriptContext
+mkFanoutContext = mkFanoutContextWith crsRefInput
+
+-- The same healthy full-fanout context with the CRS reference input as a knob (the padded-CRS
+-- reject swaps in 'paddedCrsRefInput'; everything else stays the healthy fixture).
+mkFanoutContextWith :: TxInInfo -> Integer -> Integer -> Integer -> ScriptContext
+mkFanoutContextWith crsIn burnedCount validityLo tfinal =
+  ScriptContext
+    { scriptContextTxInfo =
+        TxInfo
+          { txInfoInputs = [TxInInfo ownRef headIn]
+          , txInfoReferenceInputs = [crsIn]
+          , txInfoOutputs = []
+          , txInfoFee = 0
+          , txInfoMint = fanoutMint burnedCount
+          , txInfoTxCerts = []
+          , txInfoWdrl = AMap.empty
+          , txInfoValidRange = Interval (LowerBound (Finite (POSIXTime validityLo)) True) (UpperBound PosInf True)
+          , txInfoSignatories = [signerKH]
+          , txInfoRedeemers = AMap.empty
+          , txInfoData = AMap.empty
+          , txInfoId = TxId "44444444444444444444444444444444444444444444444444444444444444444444"
+          , txInfoVotes = AMap.empty
+          , txInfoProposalProcedures = []
+          , txInfoCurrentTreasuryAmount = Nothing
+          , txInfoTreasuryDonation = Nothing
+          }
+    , scriptContextRedeemer = Redeemer (PlutusTx.toBuiltinData fanoutRedeemer)
+    , scriptContextScriptInfo = SpendingScript ownRef (Just (Datum (PlutusTx.toBuiltinData (HS.Closed (fanoutClosedDatum tfinal)))))
+    }
+ where
+  headIn = TxOut headAddr fanoutHeadInVal (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.Closed (fanoutClosedDatum tfinal))))) Nothing
+
+fanoutRef :: Integer -> Integer -> Integer -> Bool
+fanoutRef burnedCount validityLo tfinal =
+  projectFanout
+    (Ref.mkOpsFanout (const True))
+    (HS.Closed (fanoutClosedDatum tfinal))
+    fanoutRedeemer
+    (mkFanoutContext burnedCount validityLo tfinal)
+
+fanoutVal :: Integer -> Integer -> Integer -> Bool
+fanoutVal burnedCount validityLo tfinal =
+  Head.headValidator Head.canonicalCRSDatumHash (HS.Closed (fanoutClosedDatum tfinal)) fanoutRedeemer (mkFanoutContext burnedCount validityLo tfinal)
+
+-- A WRONG BLS membership proof: a G1 point ≠ the empty-accumulator commitment (g1Generator). For the
+-- empty head (m = 0) checkMembershipPairing reduces to `commitment == proof`, so feeding a mismatched
+-- proof makes the REAL bls12_381 pairing check FAIL — exercising the BLS crypto in the reject direction
+-- (the reference mocks this conjunct, so only the real validator sees it). 2·G ≠ G.
+fanoutBadProof :: Builtins.BuiltinBLS12_381_G1_Element
+fanoutBadProof = Builtins.bls12_381_G1_add g1Generator g1Generator
+
+fanoutValBadProof :: Integer -> Integer -> Integer -> Bool
+fanoutValBadProof burnedCount validityLo tfinal =
+  Head.headValidator
+    Head.canonicalCRSDatumHash
+    (HS.Closed (fanoutClosedDatum tfinal))
+    (HS.Fanout{HS.numberOfFanoutOutputs = 0, HS.proof = fanoutBadProof, HS.crsRef = crsRefOut})
+    (mkFanoutContext burnedCount validityLo tfinal)
+
+-- The healthy fanout with a NON-CANONICAL CRS reference-input datum (see 'paddedCrsData'): the
+-- validator must reject with InvalidCRSDatum inside withCRSLookup, before any pairing. traceError
+-- THROWS in the uncompiled validator, so callers assert via 'rejectingErrors'.
+fanoutValPaddedCrs :: Integer -> Integer -> Integer -> Bool
+fanoutValPaddedCrs burnedCount validityLo tfinal =
+  Head.headValidator
+    Head.canonicalCRSDatumHash
+    (HS.Closed (fanoutClosedDatum tfinal))
+    fanoutRedeemer
+    (mkFanoutContextWith paddedCrsRefInput burnedCount validityLo tfinal)
+
+-- ── partial fanout (Closed → FanoutProgress: distribute a subset, continue with the remaining acc) ──────
+-- checkPartialFanout requires m > 0 distributed outputs (mustHaveOutputs), no mint, after the deadline, the
+-- continuing FanoutProgress datum preserves the head parameters, value is conserved, and the membership
+-- pairing e(oldAcc, G2) == e(newAcc, P_S(τ)·G2) holds. We build a REAL 2-element accumulator and distribute
+-- one element: the accumulator is built directly over the on-chain element pre-image (hashTxOuts of the
+-- distributed Plutus TxOut) — blake2b_224 is applied identically by the off-chain addElement and the
+-- on-chain txOutsToSubsetScalars — so the proof (= the remaining accumulator's commitment) verifies against
+-- the real CRS G2 powers of tau. We vary m (0 vs 1) and the lower validity bound and assert
+-- Ref.checkPartialFanout === checkPartialFanout. n = 1.
+
+-- the single distributed output and its on-chain element pre-image (sha2_256 of the serialised TxOut).
+pfDistributedOut :: TxOut
+pfDistributedOut = TxOut (Address (PubKeyCredential signerKH) Nothing) (singleton adaSymbol adaToken 1_500_000) NoOutputDatum Nothing
+
+pfDistributedElem :: ByteString
+pfDistributedElem = Builtins.fromBuiltin (hashTxOuts [pfDistributedOut])
+
+-- a second accumulator element that stays in the head (not fanned out this batch); any distinct bytes.
+pfRemainingElem :: ByteString
+pfRemainingElem = "partial-fanout-remaining-element-marker"
+
+pfFullAcc :: Accumulator.HydraAccumulator
+pfFullAcc = Accumulator.build [pfDistributedElem, pfRemainingElem]
+
+pfRemainingAcc :: Accumulator.HydraAccumulator
+pfRemainingAcc = Accumulator.build [pfRemainingElem]
+
+-- input accumulator commitment (over both elements) and the proof = remaining commitment (over one).
+pfInputAccCommitment :: Builtins.BuiltinBLS12_381_G1_Element
+pfInputAccCommitment = Accumulator.getAccumulatorCommitment pfFullAcc
+
+pfNewAccCommitment :: Builtins.BuiltinBLS12_381_G1_Element
+pfNewAccCommitment = Accumulator.getAccumulatorCommitment pfRemainingAcc
+
+-- the on-chain CRS: the canonical trusted-setup G2 powers of tau. The validator binds the CRS by
+-- datum content (hashCRSDatum crsData == canonicalCRSDatumHash), so the reference input must carry
+-- exactly 'KZG.canonicalG2Points'. This is a prefix of the same setup the off-chain accumulator
+-- commitments were built against (Accumulator.crsG2Points = take n KZG.g2Points), so the membership
+-- pairing still verifies against it.
+pfCrsData :: [Builtins.BuiltinBLS12_381_G2_Element]
+pfCrsData = KZG.canonicalG2Points
+
+pfCrsRefInput :: TxInInfo
+pfCrsRefInput =
+  TxInInfo
+    crsRefOut
+    ( TxOut
+        (Address (ScriptCredential crsScriptHash) Nothing)
+        (singleton adaSymbol adaToken 2_000_000)
+        (OutputDatum (Datum (PlutusTx.toBuiltinData pfCrsData)))
+        (Just crsScriptHash)
+    )
+
+-- closed input carrying the full-accumulator commitment (built explicitly; accumulatorCommitment is a
+-- duplicate field, so a record update would be ambiguous).
+pfClosedDatum :: Integer -> HS.ClosedDatum
+pfClosedDatum tfinal =
+  HS.ClosedDatum
+    { HS.headId = headPolicy
+    , HS.parties = [snapshotParty]
+    , HS.contestationPeriod = UnsafeContestationPeriod (fromInteger openCpMs)
+    , HS.version = 0
+    , HS.snapshotNumber = 0
+    , HS.contesters = []
+    , HS.contestationDeadline = POSIXTime tfinal
+    , HS.accumulatorCommitment = pfInputAccCommitment
+    , HS.headAdaOverhead = fanoutOverhead
+    }
+
+-- the continuing FanoutProgress output datum: same head parameters, the remaining-accumulator commitment.
+pfProgressOut :: Integer -> HS.FanoutProgressDatum
+pfProgressOut tfinal =
+  HS.FanoutProgressDatum
+    { HS.headId = headPolicy
+    , HS.parties = [snapshotParty]
+    , HS.contestationDeadline = POSIXTime tfinal
+    , HS.accumulatorCommitment = pfNewAccCommitment
+    , HS.headAdaOverhead = fanoutOverhead
+    }
+
+-- head input = continuing head output + distributed output (value conservation, no token burn).
+pfHeadOutVal :: Value
+pfHeadOutVal = singleton headPolicy stName 1 <> singleton headPolicy ptName 1 <> singleton adaSymbol adaToken 2_000_000
+
+pfHeadInVal :: Value
+pfHeadInVal = pfHeadOutVal <> singleton adaSymbol adaToken 1_500_000
+
+pfRedeemer :: Integer -> HS.Input
+pfRedeemer m = HS.PartialFanout{HS.numberOfPartialOutputs = m, HS.crsRef = crsRefOut}
+
+-- the spent head input's state: Closed (first batch) or FanoutProgress (mid-chain batch); the
+-- validator routes BOTH through the same checkPartialFanout.
+mkPartialContext :: HS.State -> Integer -> Integer -> Integer -> ScriptContext
+mkPartialContext inputState m validityLo tfinal =
+  ScriptContext
+    { scriptContextTxInfo =
+        TxInfo
+          { txInfoInputs = [TxInInfo ownRef headIn]
+          , txInfoReferenceInputs = [pfCrsRefInput]
+          , txInfoOutputs = [continuingOut, pfDistributedOut]
+          , txInfoFee = 0
+          , txInfoMint = emptyMintValue
+          , txInfoTxCerts = []
+          , txInfoWdrl = AMap.empty
+          , txInfoValidRange = Interval (LowerBound (Finite (POSIXTime validityLo)) True) (UpperBound PosInf True)
+          , txInfoSignatories = [signerKH]
+          , txInfoRedeemers = AMap.empty
+          , txInfoData = AMap.empty
+          , txInfoId = TxId "44444444444444444444444444444444444444444444444444444444444444444444"
+          , txInfoVotes = AMap.empty
+          , txInfoProposalProcedures = []
+          , txInfoCurrentTreasuryAmount = Nothing
+          , txInfoTreasuryDonation = Nothing
+          }
+    , scriptContextRedeemer = Redeemer (PlutusTx.toBuiltinData (pfRedeemer m))
+    , scriptContextScriptInfo = SpendingScript ownRef (Just (Datum (PlutusTx.toBuiltinData inputState)))
+    }
+ where
+  headIn = TxOut headAddr pfHeadInVal (OutputDatum (Datum (PlutusTx.toBuiltinData inputState))) Nothing
+  continuingOut = TxOut headAddr pfHeadOutVal (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.FanoutProgress (pfProgressOut tfinal))))) Nothing
+
+-- both oracles take (m, validityLo, tfinal); the reference's (m, tfinal, lo) order lives only inside
+-- projectPartial, which reads the fields by name.
+partialRef :: Integer -> Integer -> Integer -> Bool
+partialRef m validityLo tfinal =
+  projectPartial
+    (HS.Closed (pfClosedDatum tfinal))
+    (pfRedeemer m)
+    (mkPartialContext (HS.Closed (pfClosedDatum tfinal)) m validityLo tfinal)
+
+partialVal :: Integer -> Integer -> Integer -> Bool
+partialVal m validityLo tfinal =
+  Head.headValidator
+    Head.canonicalCRSDatumHash
+    (HS.Closed (pfClosedDatum tfinal))
+    (pfRedeemer m)
+    (mkPartialContext (HS.Closed (pfClosedDatum tfinal)) m validityLo tfinal)
+
+-- ── mid-chain partial fanout (FanoutProgress → FanoutProgress): the SAME checkPartialFanout arm, but
+-- driven from a FanoutProgress INPUT datum (the batch after the first). Fixtures are shared with the
+-- Closed → FanoutProgress family; only the spent input's state differs.
+pfProgressIn :: Integer -> HS.FanoutProgressDatum
+pfProgressIn tfinal = HS.progressFromClosed (pfClosedDatum tfinal)
+
+partialMidRef :: Integer -> Integer -> Integer -> Bool
+partialMidRef m validityLo tfinal =
+  projectPartial
+    (HS.FanoutProgress (pfProgressIn tfinal))
+    (pfRedeemer m)
+    (mkPartialContext (HS.FanoutProgress (pfProgressIn tfinal)) m validityLo tfinal)
+
+partialMidVal :: Integer -> Integer -> Integer -> Bool
+partialMidVal m validityLo tfinal =
+  Head.headValidator
+    Head.canonicalCRSDatumHash
+    (HS.FanoutProgress (pfProgressIn tfinal))
+    (pfRedeemer m)
+    (mkPartialContext (HS.FanoutProgress (pfProgressIn tfinal)) m validityLo tfinal)
+
+-- A WRONG KZG membership: the continuing FanoutProgress output claims the head did NOT shrink (its
+-- commitment = the OLD full-accumulator commitment), so e(oldAcc, G2) == e(newAcc, P_S(τ)·G2) fails
+-- against the real CRS — exercising the KZG pairing in the reject direction. Value is unchanged, so
+-- the ONLY failing check is the membership pairing. (Built explicitly: accumulatorCommitment is a
+-- duplicate field, so a record update would be ambiguous.)
+pfProgressOutBad :: Integer -> HS.FanoutProgressDatum
+pfProgressOutBad tfinal =
+  HS.FanoutProgressDatum
+    { HS.headId = headPolicy
+    , HS.parties = [snapshotParty]
+    , HS.contestationDeadline = POSIXTime tfinal
+    , HS.accumulatorCommitment = pfInputAccCommitment
+    , HS.headAdaOverhead = fanoutOverhead
+    }
+
+mkPartialContextBadProof :: Integer -> Integer -> Integer -> ScriptContext
+mkPartialContextBadProof m validityLo tfinal =
+  base{scriptContextTxInfo = (scriptContextTxInfo base){txInfoOutputs = [continuingOutBad, pfDistributedOut]}}
+ where
+  base = mkPartialContext (HS.Closed (pfClosedDatum tfinal)) m validityLo tfinal
+  continuingOutBad = TxOut headAddr pfHeadOutVal (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.FanoutProgress (pfProgressOutBad tfinal))))) Nothing
+
+partialValBadProof :: Integer -> Integer -> Integer -> Bool
+partialValBadProof m validityLo tfinal =
+  Head.headValidator Head.canonicalCRSDatumHash (HS.Closed (pfClosedDatum tfinal)) (pfRedeemer m) (mkPartialContextBadProof m validityLo tfinal)
+
+-- ── final partial fanout (FanoutProgress → finalised: burn n+1, distribute the LAST batch) ─────────────
+-- checkFinalPartialFanout requires m > 0 outputs, all n+1 tokens burned, posted after the deadline,
+-- value conservation (outputs + burned tokens + overhead == head input) and the KZG membership of the
+-- last batch. The input FanoutProgress accumulator commits to the remaining TWO outputs and the final
+-- batch distributes exactly those, so the remainder is empty and the membership proof is the
+-- empty-set commitment = the G1 generator (as in the empty-head full fanout); the pairing runs against
+-- the real CRS. The bridged reference is the shared checkFanout (finalPartialFanoutValid→ref). n = 1.
+
+fpfOutA :: TxOut
+fpfOutA = TxOut (Address (PubKeyCredential signerKH) Nothing) (singleton adaSymbol adaToken 1_200_000) NoOutputDatum Nothing
+
+fpfOutB :: TxOut
+fpfOutB = TxOut (Address (PubKeyCredential signerKH) Nothing) (singleton adaSymbol adaToken 1_800_000) NoOutputDatum Nothing
+
+-- the input accumulator commits to exactly the two remaining outputs (same element pre-image as the
+-- on-chain txOutsToSubsetScalars: hashTxOuts per output).
+fpfAcc :: Accumulator.HydraAccumulator
+fpfAcc = Accumulator.build (Builtins.fromBuiltin . hashTxOuts . (: []) <$> [fpfOutA, fpfOutB])
+
+fpfProgressDatum :: Integer -> HS.FanoutProgressDatum
+fpfProgressDatum tfinal =
+  HS.FanoutProgressDatum
+    { HS.headId = headPolicy
+    , HS.parties = [snapshotParty]
+    , HS.contestationDeadline = POSIXTime tfinal
+    , HS.accumulatorCommitment = Accumulator.getAccumulatorCommitment fpfAcc
+    , HS.headAdaOverhead = fanoutOverhead
+    }
+
+-- head input = both distributed outputs + the n+1 head tokens (to burn) + the locked overhead.
+fpfHeadInVal :: Value
+fpfHeadInVal =
+  singleton headPolicy stName 1
+    <> singleton headPolicy ptName 1
+    <> singleton adaSymbol adaToken (1_200_000 + 1_800_000 + fanoutOverhead)
+
+fpfRedeemer :: Integer -> Builtins.BuiltinBLS12_381_G1_Element -> HS.Input
+fpfRedeemer m proof = HS.FinalPartialFanout{HS.numberOfPartialOutputs = m, HS.proof = proof, HS.crsRef = crsRefOut}
+
+mkFinalPartialContext :: HS.Input -> Integer -> Integer -> Integer -> ScriptContext
+mkFinalPartialContext redeemer burnedCount validityLo tfinal =
+  ScriptContext
+    { scriptContextTxInfo =
+        TxInfo
+          { txInfoInputs = [TxInInfo ownRef headIn]
+          , txInfoReferenceInputs = [pfCrsRefInput]
+          , txInfoOutputs = [fpfOutA, fpfOutB]
+          , txInfoFee = 0
+          , txInfoMint = fanoutMint burnedCount
+          , txInfoTxCerts = []
+          , txInfoWdrl = AMap.empty
+          , txInfoValidRange = Interval (LowerBound (Finite (POSIXTime validityLo)) True) (UpperBound PosInf True)
+          , txInfoSignatories = [signerKH]
+          , txInfoRedeemers = AMap.empty
+          , txInfoData = AMap.empty
+          , txInfoId = TxId "44444444444444444444444444444444444444444444444444444444444444444444"
+          , txInfoVotes = AMap.empty
+          , txInfoProposalProcedures = []
+          , txInfoCurrentTreasuryAmount = Nothing
+          , txInfoTreasuryDonation = Nothing
+          }
+    , scriptContextRedeemer = Redeemer (PlutusTx.toBuiltinData redeemer)
+    , scriptContextScriptInfo = SpendingScript ownRef (Just (Datum (PlutusTx.toBuiltinData (HS.FanoutProgress (fpfProgressDatum tfinal)))))
+    }
+ where
+  headIn = TxOut headAddr fpfHeadInVal (OutputDatum (Datum (PlutusTx.toBuiltinData (HS.FanoutProgress (fpfProgressDatum tfinal))))) Nothing
+
+-- The reference's mocked conjuncts here are outputsPositive (in the spec's FinalPartialFanoutValid
+-- record but NOT bridged into fanoutRef, see ReferenceBridge), the KZG membership and value
+-- conservation. In THIS fixture all three hold exactly when the full 2-output batch is distributed,
+-- so the mock computes that fixture truth and the grid can cross the output-count axis under ===.
+fpfOps :: Ref.OpsFanout
+fpfOps = Ref.mkOpsFanout (\(Ref.MkFanout m _ _ _ _) -> m == 2)
+
+finalPartialRef :: Integer -> Integer -> Integer -> Integer -> Bool
+finalPartialRef m burnedCount validityLo tfinal =
+  projectFanout
+    fpfOps
+    (HS.FanoutProgress (fpfProgressDatum tfinal))
+    (fpfRedeemer m g1Generator)
+    (mkFinalPartialContext (fpfRedeemer m g1Generator) burnedCount validityLo tfinal)
+
+finalPartialVal :: Integer -> Integer -> Integer -> Integer -> Bool
+finalPartialVal m burnedCount validityLo tfinal =
+  Head.headValidator
+    Head.canonicalCRSDatumHash
+    (HS.FanoutProgress (fpfProgressDatum tfinal))
+    (fpfRedeemer m g1Generator)
+    (mkFinalPartialContext (fpfRedeemer m g1Generator) burnedCount validityLo tfinal)
+
+-- a wrong membership proof (2·G ≠ G, the empty-remainder commitment): only the pairing fails, so the
+-- reject is the REAL BLS crypto (mocked on the reference side).
+finalPartialValBadProof :: Integer -> Integer -> Integer -> Integer -> Bool
+finalPartialValBadProof m burnedCount validityLo tfinal =
+  Head.headValidator
+    Head.canonicalCRSDatumHash
+    (HS.FanoutProgress (fpfProgressDatum tfinal))
+    (fpfRedeemer m fanoutBadProof)
+    (mkFinalPartialContext (fpfRedeemer m fanoutBadProof) burnedCount validityLo tfinal)
+
+-- ── the agreement property ───────────────────────────────────────────────────────────────────────────
+
+spec :: Spec
+spec = parallel $ do
+  -- Non-vacuity anchors: the agreement is not "both always reject". The validator genuinely ACCEPTS a
+  -- well-formed CloseInitial and genuinely REJECTS one with a changed version, and the reference matches
+  -- both. (Healthy: version'=0, cp'=100, snap'=0, contesters=0, deadline = tMax + cp.)
+  prop "anchor: healthy CloseInitial — BOTH oracles accept" $
+    let tMax = 1_100
+        deadline = tMax + openCpMs
+        ctx = mkContext openDatum 0 100 0 0 deadline tMax
+     in validatorVerdict openDatum ctx === True
+          .&&. referenceVerdict openDatum ctx === True
+
+  prop "anchor: changed version — BOTH oracles reject" $
+    let tMax = 1_100
+        deadline = tMax + openCpMs
+        ctx = mkContext openDatum 1 100 0 0 deadline tMax
+     in validatorVerdict openDatum ctx === False
+          .&&. referenceVerdict openDatum ctx === False
+
+  -- ── close mustPreserveHeadValue (C3.4: bridged from closeValid.valuePreserved + tested here) ──
+  prop "close/value: a siphoned head output is REJECTED by both checkValuePreserved and the real validator" $
+    closeValueRef 1_500_000 === False
+      .&&. closeValueVal 1_500_000 === False
+  prop "close/value: the value-preserving close is accepted by both" $
+    closeValueRef 2_000_000 === True
+      .&&. closeValueVal 2_000_000 === True
+
+  -- ── close participant signature (bridged from closeValid.participantSigned + tested here) ──
+  prop "close/participant: a non-participant signer is REJECTED by both checkParticipantSigned and the real validator" $
+    let ctx = withSignatories [nonParticipantKH] (mkContext openDatum 0 100 0 0 1_200 1_100)
+     in projectParticipant (HS.Open openDatum) ctx === False .&&. validatorVerdict openDatum ctx === False
+  prop "close/participant: a participant signer is accepted by both" $
+    let ctx = mkContext openDatum 0 100 0 0 1_200 1_100
+     in projectParticipant (HS.Open openDatum) ctx === True .&&. validatorVerdict openDatum ctx === True
+
+  -- The INPUT open datum's version and contestation period are varied too (CloseInitial carries no
+  -- signature, so nothing pins them).
+  prop "close/CloseInitial: extracted Agda reference === real validator (function-level, no tx, no mutation)" $
+    forAll (elements [0, 1]) $ \inV ->
+      forAll (elements [100, 86_400_000]) $ \inCp ->
+        forAll (choose (0, 2)) $ \closedVersion ->
+          forAll (elements [50, inCp, 200]) $ \closedCpMs ->
+            forAll (choose (0, 1)) $ \closedSnap ->
+              forAll (choose (0, 1)) $ \contestersLen ->
+                forAll (elements [1_050, 1_100, 2_000]) $ \tMax ->
+                  forAll (elements [0, 1]) $ \deadlineExtra ->
+                    let od = openDatumAt inV inCp
+                        deadline = tMax + inCp + deadlineExtra
+                        ctx = mkContext od closedVersion closedCpMs closedSnap contestersLen deadline tMax
+                     in referenceVerdict od ctx === validatorVerdict od ctx
+
+  -- ── CloseUnused: the validator runs verifySnapshotSignature FOR REAL (signed with our test key) ──
+  -- Anchor: a healthy CloseUnused (version preserved = 0, valid signature over the snapshot) is accepted by
+  -- BOTH the real validator (signature verifies) and the reference.
+  prop "anchor: healthy CloseUnused — BOTH oracles accept (real signature verified)" $
+    let cs = 3; tMax = 1_100; dl = tMax + openCpMs
+     in unusedVal (unusedRedeemer cs) 0 100 cs 0 dl tMax === True
+          .&&. unusedRef 0 100 cs 0 dl tMax === True
+
+  -- Agreement on the decidable conjuncts WITH a valid signature: reference === validator across the
+  -- generated fields (the signature is valid, so crypto is not the deciding factor).
+  prop "close/CloseUnused: reference === real validator (valid sig; decidable conjuncts)" $
+    forAll (choose (0, 1)) $ \cv ->
+      forAll (elements [50, 100]) $ \ccp ->
+        forAll (choose (1, 3)) $ \cs ->
+          forAll (choose (0, 1)) $ \cl ->
+            forAll (elements [1_050, 2_000]) $ \tMax ->
+              forAll (elements [0, 1]) $ \dExtra ->
+                let dl = tMax + openCpMs + dExtra
+                 in unusedRef cv ccp cs cl dl tMax === unusedVal (unusedRedeemer cs) cv ccp cs cl dl tMax
+
+  -- Crypto non-vacuity (what the Agda CANNOT prove): the REAL validator rejects a CloseUnused whose
+  -- signature is over the WRONG snapshot number, even though everything else is healthy. This genuinely
+  -- exercises verifySnapshotSignature against the real validator (the reference mocks it, so this is a
+  -- validator-only assertion).
+  prop "close/CloseUnused: real validator REJECTS a bad-snapshot signature" $
+    let cs = 3
+        tMax = 1_100
+        dl = tMax + openCpMs
+        badRedeemer = HS.CloseUnused{HS.signature = [closeSigFor (cs + 1)], HS.accumulatorHash = emptyAccHash, HS.decommitOutputsHash = emptyDecommitOutputsHash, HS.commitOutputsHash = emptyCommitOutputsHash}
+     in unusedVal badRedeemer 0 100 cs 0 dl tMax === False
+
+  prop "close/CloseUnused: the healthy (correctly-signed) version of that tx IS accepted" $
+    let cs = 3; tMax = 1_100; dl = tMax + openCpMs
+     in unusedVal (unusedRedeemer cs) 0 100 cs 0 dl tMax === True
+
+  -- The exact attack the commit/decommit-output-set binding closes: the signature is VALID (over the
+  -- original, empty hashes) but the redeemer redirects decommitOutputsHash (resp. commitOutputsHash).
+  -- The validator rebuilds the signed message from the redeemer's hashes, so it no longer matches what
+  -- the parties signed and verifySnapshotSignature rejects. Distinct from the bad-signature props above
+  -- (there the signature is wrong for the carried message; here the message is redirected under a
+  -- genuinely valid signature).
+  prop "close/CloseUnused: real validator REJECTS a tampered decommit/commit-outputs hash under a VALID signature" $
+    let cs = 3
+        tMax = 1_100
+        dl = tMax + openCpMs
+        tamperDec = HS.CloseUnused{HS.signature = [closeSigFor cs], HS.accumulatorHash = emptyAccHash, HS.decommitOutputsHash = wrongOutputsHash, HS.commitOutputsHash = emptyCommitOutputsHash}
+        tamperCom = HS.CloseUnused{HS.signature = [closeSigFor cs], HS.accumulatorHash = emptyAccHash, HS.decommitOutputsHash = emptyDecommitOutputsHash, HS.commitOutputsHash = wrongOutputsHash}
+     in unusedVal tamperDec 0 100 cs 0 dl tMax === False
+          .&&. unusedVal tamperCom 0 100 cs 0 dl tMax === False
+          .&&. unusedVal (unusedRedeemer cs) 0 100 cs 0 dl tMax === True
+
+  -- ── CloseAny: signature over the CURRENT version PLUS snapshot number > 0 (the anyOK conjunct) ──
+  prop "anchor: healthy CloseAny, BOTH oracles accept (real signature verified, snapshot > 0)" $
+    let cs = 3; tMax = 1_100; dl = tMax + openCpMs
+     in anyVal (anyRedeemer cs) 0 100 cs 0 dl tMax === True
+          .&&. anyRef 0 100 cs 0 dl tMax === True
+
+  -- Agreement across a grid that INCLUDES snapshot number 0: there the signature still verifies (it is
+  -- over the same snapshot-0 message) but the validator's `snapshotNumber' > 0` and the reference's
+  -- anyOK both reject, so the tag-specific conjunct is exercised in both directions.
+  prop "close/CloseAny: reference === real validator (valid sig; includes snapshot 0)" $
+    forAll (choose (0, 1)) $ \cv ->
+      forAll (elements [50, 100]) $ \ccp ->
+        forAll (choose (0, 3)) $ \cs ->
+          forAll (choose (0, 1)) $ \cl ->
+            forAll (elements [1_050, 2_000]) $ \tMax ->
+              forAll (elements [0, 1]) $ \dExtra ->
+                let dl = tMax + openCpMs + dExtra
+                 in anyRef cv ccp cs cl dl tMax === anyVal (anyRedeemer cs) cv ccp cs cl dl tMax
+
+  prop "close/CloseAny: snapshot number 0, BOTH oracles reject" $
+    let tMax = 1_100; dl = tMax + openCpMs
+     in anyVal (anyRedeemer 0) 0 100 0 0 dl tMax === False
+          .&&. anyRef 0 100 0 0 dl tMax === False
+
+  prop "close/CloseAny: real validator REJECTS a bad-snapshot signature" $
+    let cs = 3
+        tMax = 1_100
+        dl = tMax + openCpMs
+        badRedeemer = HS.CloseAny{HS.signature = [closeSigFor (cs + 1)], HS.accumulatorHash = emptyAccHash, HS.decommitOutputsHash = emptyDecommitOutputsHash, HS.commitOutputsHash = emptyCommitOutputsHash}
+     in anyVal badRedeemer 0 100 cs 0 dl tMax === False
+
+  prop "close/CloseAny: the healthy (correctly-signed) version of that tx IS accepted" $
+    let cs = 3; tMax = 1_100; dl = tMax + openCpMs
+     in anyVal (anyRedeemer cs) 0 100 cs 0 dl tMax === True
+
+  -- ── CloseUsed: signature over version - 1 (open version 1 here, so the message is at version 0) ──
+  prop "anchor: healthy CloseUsed, BOTH oracles accept (real signature at version - 1 verified)" $
+    let cs = 3; tMax = 1_100; dl = tMax + openCpMs
+     in usedVal (usedRedeemer cs) usedOpenVersionN 100 cs 0 dl tMax === True
+          .&&. usedRef usedOpenVersionN 100 cs 0 dl tMax === True
+
+  -- Agreement on the decidable conjuncts WITH a valid signature: cv spans 0/1/2, so the
+  -- version-preservation boundary (accept only at cv = 1) is crossed in both directions.
+  prop "close/CloseUsed: reference === real validator (valid sig; decidable conjuncts)" $
+    forAll (choose (0, 2)) $ \cv ->
+      forAll (elements [50, 100]) $ \ccp ->
+        forAll (choose (1, 3)) $ \cs ->
+          forAll (choose (0, 1)) $ \cl ->
+            forAll (elements [1_050, 2_000]) $ \tMax ->
+              forAll (elements [0, 1]) $ \dExtra ->
+                let dl = tMax + openCpMs + dExtra
+                 in usedRef cv ccp cs cl dl tMax === usedVal (usedRedeemer cs) cv ccp cs cl dl tMax
+
+  prop "close/CloseUsed: real validator REJECTS a bad-snapshot signature" $
+    let cs = 3
+        tMax = 1_100
+        dl = tMax + openCpMs
+        badRedeemer = HS.CloseUsed{HS.signature = [closeSigFor (cs + 1)], HS.accumulatorHash = emptyAccHash, HS.decommitOutputsHash = emptyDecommitOutputsHash, HS.commitOutputsHash = emptyCommitOutputsHash}
+     in usedVal badRedeemer usedOpenVersionN 100 cs 0 dl tMax === False
+
+  -- The hash-vs-datum coupling in isolation: the signature over the WRONG hash verifies, so the reject
+  -- comes from mustBindAccumulatorCommitment alone (the reference mocks the accumulator conjunct).
+  prop "close/CloseUsed: real validator REJECTS a redeemer hash that does not match the datum commitment" $
+    let cs = 3; tMax = 1_100; dl = tMax + openCpMs
+     in usedVal (usedRedeemerWrongHash cs) usedOpenVersionN 100 cs 0 dl tMax === False
+
+  prop "close/CloseUsed: the healthy (correctly-signed) version of that tx IS accepted" $
+    let cs = 3; tMax = 1_100; dl = tMax + openCpMs
+     in usedVal (usedRedeemer cs) usedOpenVersionN 100 cs 0 dl tMax === True
+
+  -- ── increment: version bump + value conservation + a deposit script input + real signature ──
+  prop "anchor: healthy increment — BOTH oracles accept (real signature verified)" $
+    let cs = 3
+     in incVal (incRedeemer cs) 1 0 === True .&&. incRef 1 0 === True
+
+  prop "increment: reference === real validator (valid sig; version bump + value conservation)" $
+    forAll (choose (0, 2)) $ \nextV ->
+      forAll (elements [0, 1_000]) $ \vPerturb ->
+        let cs = 3
+         in incRef nextV vPerturb === incVal (incRedeemer cs) nextV vPerturb
+
+  prop "increment: real validator REJECTS a bad snapshot signature" $
+    let cs = 3
+        badRedeemer = HS.IncrementRedeemer{HS.signature = [incSigFor (cs + 1)], HS.snapshotNumber = cs, HS.increment = depRef, HS.decommitOutputsHash = emptyDecommitOutputsHash}
+     in incVal badRedeemer 1 0 === False
+
+  prop "increment: the healthy (correctly-signed) version of that tx IS accepted" $
+    let cs = 3 in incVal (incRedeemer cs) 1 0 === True
+
+  -- ── increment conjunct demos (extracted checker + real validator both catch a single-conjunct attack) ──
+  prop "increment/no-mint: a minting increment is REJECTED by both checkNoMint and the real validator" $
+    let ctx = mkIncDemoContext incAttackMint [signerKH] incHeadVal incHealthyHeadOut
+     in projectNoMint ctx === False .&&. incDemoVal ctx === False
+  prop "increment/no-mint: the healthy (no-mint) increment is accepted by both" $
+    let ctx = mkIncDemoContext emptyMintValue [signerKH] incHeadVal incHealthyHeadOut
+     in projectNoMint ctx === True .&&. incDemoVal ctx === True
+
+  prop "increment/participant: a non-participant signer is REJECTED by both checkParticipantSigned and the real validator" $
+    let ctx = mkIncDemoContext emptyMintValue [nonParticipantKH] incHeadVal incHealthyHeadOut
+     in projectParticipant (HS.Open incOpenPrev) ctx === False .&&. incDemoVal ctx === False
+  prop "increment/participant: a participant signer is accepted by both" $
+    let ctx = mkIncDemoContext emptyMintValue [signerKH] incHeadVal incHealthyHeadOut
+     in projectParticipant (HS.Open incOpenPrev) ctx === True .&&. incDemoVal ctx === True
+
+  -- a balanced A→B swap keeps the non-ada TOTAL (3 in, 3 out), so the scalar-total checkInc accepts it,
+  -- but per-asset conservation (and the validator's Value ==) does not.
+  prop "increment/per-asset: a balanced token swap passes the non-ada TOTAL but is REJECTED by checkPerAsset and the real validator" $
+    let ctx = mkIncDemoContext emptyMintValue [signerKH] incPerAssetHeadIn incPerAssetHeadOutSwap
+     in projectInc (HS.Open incOpenPrev) (HS.Increment (incRedeemer 3)) ctx === True
+          .&&. projectPerAssetInc ctx === False
+          .&&. incDemoVal ctx === False
+  prop "increment/per-asset: the healthy (no swap) increment is accepted by both checkPerAsset and the real validator" $
+    let ctx = mkIncDemoContext emptyMintValue [signerKH] incPerAssetHeadIn incPerAssetHeadOutHealthy
+     in projectPerAssetInc ctx === True .&&. incDemoVal ctx === True
+
+  prop "increment/ref-spent: a claimed deposit that is NOT a tx input is REJECTED by both checkRefSpent and the real validator" $
+    let ctx = mkIncContext (incRedeemerUnspent 3) 1 0
+     in projectRefSpent (HS.Increment (incRedeemerUnspent 3)) ctx === False
+          .&&. rejectingErrors (incVal (incRedeemerUnspent 3) 1 0) === False
+  prop "increment/ref-spent: the healthy (spent-deposit) claim is accepted by both" $
+    let ctx = mkIncContext (incRedeemer 3) 1 0
+     in projectRefSpent (HS.Increment (incRedeemer 3)) ctx === True
+          .&&. incVal (incRedeemer 3) 1 0 === True
+
+  -- The commit-outputs hash is RECOMPUTED from the claimed deposit's own datum, so a deposit input
+  -- whose datum does not decode as (CurrencySymbol, POSIXTime, [Commit]) hard-fails the validator
+  -- with DepositDatumInvalid (a traceError, hence 'rejectingErrors'). This is the decode path the
+  -- deposit-datum binding introduced; on-chain a script error is a rejection.
+  prop "increment: real validator REJECTS a deposit input whose datum does not decode — DepositDatumInvalid" $
+    rejectingErrors
+      ( Head.headValidator
+          Head.canonicalCRSDatumHash
+          (HS.Open incOpenPrev)
+          (HS.Increment (incRedeemer 3))
+          (mkIncContextDep (Datum (PlutusTx.toBuiltinData (42 :: Integer))) (incRedeemer 3) 1 0)
+      )
+      === False
+      .&&. incVal (incRedeemer 3) 1 0 === True
+
+  -- ── decrement: version bump + value shrinks by decommit outputs + real signature ──
+  prop "anchor: healthy decrement — BOTH oracles accept (real signature verified)" $
+    let cs = 3 in decVal (decRedeemer cs) 1 0 === True .&&. decRef 1 0 === True
+
+  prop "decrement: reference === real validator (valid sig; version bump + value decrease)" $
+    forAll (choose (0, 2)) $ \nextV ->
+      forAll (elements [0, 1_000]) $ \vPerturb ->
+        let cs = 3
+         in decRef nextV vPerturb === decVal (decRedeemer cs) nextV vPerturb
+
+  prop "decrement: real validator REJECTS a bad snapshot signature" $
+    let cs = 3
+        badRedeemer = HS.DecrementRedeemer{HS.signature = [decSigFor (cs + 1)], HS.snapshotNumber = cs, HS.numberOfDecommitOutputs = 1, HS.commitOutputsHash = emptyCommitOutputsHash}
+     in decVal badRedeemer 1 0 === False
+
+  prop "decrement/participant: a non-participant signer is REJECTED by both checkParticipantSigned and the real validator" $
+    let ctx = withSignatories [nonParticipantKH] (mkDecContext (decRedeemer 3) 1 0)
+     in projectParticipant (HS.Open incOpenPrev) ctx === False
+          .&&. Head.headValidator Head.canonicalCRSDatumHash (HS.Open incOpenPrev) (HS.Decrement (decRedeemer 3)) ctx === False
+  prop "decrement/participant: a participant signer is accepted by both" $
+    let ctx = mkDecContext (decRedeemer 3) 1 0
+     in projectParticipant (HS.Open incOpenPrev) ctx === True
+          .&&. Head.headValidator Head.canonicalCRSDatumHash (HS.Open incOpenPrev) (HS.Decrement (decRedeemer 3)) ctx === True
+
+  prop "decrement: the healthy (correctly-signed) version of that tx IS accepted" $
+    let cs = 3 in decVal (decRedeemer cs) 1 0 === True
+
+  -- ── contest: version preserved + snapshot increases + one contester + deadline + real signature ──
+  prop "anchor: healthy contest — BOTH oracles accept (real signature verified)" $
+    let s' = 1; tMax = 1_500
+     in contestVal (contestRedeemer s') s' 0 tMax === True .&&. contestRef s' 0 tMax === True
+
+  prop "contest: reference === real validator (valid sig; snapshot increase + deadline + within-period)" $
+    forAll (choose (0, 2)) $ \s' ->
+      forAll (elements [0, 100]) $ \tfinPerturb ->
+        forAll (elements [1_500, 2_500]) $ \tMax ->
+          contestRef s' tfinPerturb tMax === contestVal (contestRedeemer s') s' tfinPerturb tMax
+
+  prop "contest: real validator REJECTS a bad snapshot signature" $
+    let s' = 1
+        tMax = 1_500
+        badRedeemer = HS.ContestUnused{HS.signature = [contestSigFor (s' + 1)], HS.accumulatorHash = emptyAccHash, HS.decommitOutputsHash = emptyDecommitOutputsHash, HS.commitOutputsHash = emptyCommitOutputsHash}
+     in contestVal badRedeemer s' 0 tMax === False
+
+  prop "contest: the healthy (correctly-signed) version of that tx IS accepted" $
+    let s' = 1; tMax = 1_500 in contestVal (contestRedeemer s') s' 0 tMax === True
+
+  -- ── contest mustNotChangeParameters (C3.3: bridged from the contest transition + tested here) ──
+  prop "contest/params: a changed head id is REJECTED by both checkContestParams and the real validator" $
+    projectContestParams (HS.Closed contestPrev) (mkContestParamsContext contestNextBadHeadId) === False
+      .&&. contestParamsVal contestNextBadHeadId === False
+  prop "contest/params: the parameter-preserving contest is accepted by both" $
+    projectContestParams (HS.Closed contestPrev) (mkContestParamsContext (contestNext 1 0)) === True
+      .&&. contestParamsVal (contestNext 1 0) === True
+
+  -- ── contest participant signature (derived spec-side via contest-participantSigned + tested here;
+  -- the swapped signer also breaks the validator's contester derivation, which only strengthens the reject) ──
+  prop "contest/participant: a non-participant signer is REJECTED by both checkParticipantSigned and the real validator" $
+    let ctx = withSignatories [nonParticipantKH] (mkContestContext (contestRedeemer 1) 1 0 1_500)
+     in projectParticipant (HS.Closed contestPrev) ctx === False
+          .&&. Head.headValidator Head.canonicalCRSDatumHash (HS.Closed contestPrev) (HS.Contest (contestRedeemer 1)) ctx === False
+  prop "contest/participant: a participant signer is accepted by both" $
+    let ctx = mkContestContext (contestRedeemer 1) 1 0 1_500
+     in projectParticipant (HS.Closed contestPrev) ctx === True
+          .&&. Head.headValidator Head.canonicalCRSDatumHash (HS.Closed contestPrev) (HS.Contest (contestRedeemer 1)) ctx === True
+
+  -- ── ContestUsed: the contest signature is over version - 1 (closed version 1 here) ──
+  prop "anchor: healthy ContestUsed, BOTH oracles accept (real signature at version - 1 verified)" $
+    let s' = 1; tMax = 1_500
+     in contestUsedVal (contestUsedRedeemer s') s' 0 tMax === True .&&. contestUsedRef s' 0 tMax === True
+
+  prop "contest/ContestUsed: reference === real validator (valid sig; snapshot increase + deadline + within-period)" $
+    forAll (choose (0, 2)) $ \s' ->
+      forAll (elements [0, 100]) $ \tfinPerturb ->
+        forAll (elements [1_500, 2_500]) $ \tMax ->
+          contestUsedRef s' tfinPerturb tMax === contestUsedVal (contestUsedRedeemer s') s' tfinPerturb tMax
+
+  prop "contest/ContestUsed: real validator REJECTS a bad snapshot signature" $
+    let s' = 1
+        tMax = 1_500
+        badRedeemer = HS.ContestUsed{HS.signature = [contestSigFor (s' + 1)], HS.accumulatorHash = emptyAccHash, HS.decommitOutputsHash = emptyDecommitOutputsHash, HS.commitOutputsHash = emptyCommitOutputsHash}
+     in contestUsedVal badRedeemer s' 0 tMax === False
+
+  prop "contest/ContestUsed: the healthy (correctly-signed) version of that tx IS accepted" $
+    let s' = 1; tMax = 1_500 in contestUsedVal (contestUsedRedeemer s') s' 0 tMax === True
+
+  -- ── contest deadline-push (n = 2, 1 contester): the produced deadline MUST be tfinal + cp ──
+  prop "anchor: n = 2 contest with a pushed deadline, BOTH oracles accept (2-of-2 signature verified)" $
+    let s' = 1; tMax = 1_500
+     in contest2Val (contest2Redeemer s') openCpMs s' openCpMs tMax === True
+          .&&. contest2Ref openCpMs s' openCpMs tMax === True
+
+  prop "contest/deadline-push (n=2): a NON-pushed deadline is rejected by both (mustPushDeadline)" $
+    let s' = 1; tMax = 1_500
+     in contest2Val (contest2Redeemer s') openCpMs s' 0 tMax === False
+          .&&. contest2Ref openCpMs s' 0 tMax === False
+
+  -- the INPUT datum's contestation period is varied too (Task-3 axis; the deadline perturbation is in
+  -- units of cp, so the push boundary is crossed at every period).
+  prop "contest/deadline-push (n=2): reference === real validator (deadline-update rule both directions)" $
+    forAll (elements [100, 86_400_000]) $ \cp ->
+      forAll (choose (0, 2)) $ \s' ->
+        forAll (elements [0, cp, 2 * cp]) $ \tfinPerturb ->
+          forAll (elements [1_500, 2_500]) $ \tMax ->
+            contest2Ref cp s' tfinPerturb tMax === contest2Val (contest2Redeemer s') cp s' tfinPerturb tMax
+
+  -- ── init (μHead): minted-token count + ST/PT placement in the head output ──
+  prop "anchor: healthy init — BOTH oracles accept (mint 2, ST 1, 1 PT)" $
+    initVal 2 1 1 === True .&&. initRef 2 1 1 === True
+
+  prop "init: reference === real validator (minted count + ST quantity + unique-PT count)" $
+    forAll (choose (1, 3)) $ \mintedCount ->
+      forAll (choose (0, 2)) $ \stQty ->
+        forAll (choose (0, 2)) $ \numPT ->
+          initRef mintedCount stQty numPT === initVal mintedCount stQty numPT
+
+  -- Non-vacuity for the conjuncts the reference MOCKS (OpsInit = const True): the REAL validator still
+  -- enforces them. seedInputIsConsumed fails when the consumed input is not the seed.
+  prop "init: real validator REJECTS when the seed input is not consumed" $
+    let wrongRef = TxOutRef (TxId "88888888888888888888888888888888888888888888888888888888888888888888") 0
+     in Tokens.validateTokensMinting headScriptHash initSeedRef (mkInitContext wrongRef initOpenDatum 2 1 1) === False
+
+  prop "init: the healthy (seed-consumed) version of that tx IS accepted" $
+    Tokens.validateTokensMinting headScriptHash initSeedRef (mkInitContext initSeedRef initOpenDatum 2 1 1) === True
+
+  -- ── init datum head-id binding (C3.2: bridged from the spec's cid identity + tested here) ──
+  prop "init/datum: a head output datum naming a different head id is REJECTED by both checkInitHeadId and the real policy" $
+    projectInitHeadId (mkInitContext initSeedRef initOpenDatumBadHeadId 2 1 1) === False
+      .&&. initHeadIdVal initOpenDatumBadHeadId === False
+  prop "init/datum: the head-id-binding datum is accepted by both" $
+    projectInitHeadId (mkInitContext initSeedRef initOpenDatum 2 1 1) === True
+      .&&. initHeadIdVal initOpenDatum === True
+
+  -- ── μHead Burn arm: burn-only mint field ──
+  prop "anchor: healthy burn: BOTH oracles accept (all head-policy entries negative)" $
+    burnVal [-1, -1] === True .&&. burnRef [-1, -1] === True
+
+  prop "burn: reference === real validator (burn-only mint field, incl. the no-head-entries case)" $
+    forAll (elements [[], [-1], [1], [-1, -1], [-1, 1], [1, -1], [-2, -1], [2, 1], [-1, 2]]) $ \qtys ->
+      burnRef qtys === burnVal qtys
+
+  prop "burn: real validator REJECTS a mint alongside a burn (healthy burn-only accepts)" $
+    burnVal [1, -1] === False .&&. burnVal [-1, -1] === True
+
+  -- ── νDeposit Recover: the real Aiken validator (compiled UPLC) vs Ref.checkRecover ──
+  prop "anchor: healthy recover — BOTH oracles accept (posted after the deadline)" $
+    recoverVal 1_000 1_050 === True .&&. recoverRef 1_000 1_050 === True
+
+  prop "recover: reference === real Aiken validator (after-deadline conjunct)" $
+    forAll (elements [950, 1_000, 1_050]) $ \validityLo ->
+      let deadline = 1_000
+       in recoverRef deadline validityLo === recoverVal deadline validityLo
+
+  -- ── νDeposit Claim: the real Aiken validator (compiled UPLC) vs Ref.checkClaim ──
+  prop "anchor: healthy claim — BOTH oracles accept (before deadline + own-head increment)" $
+    claimVal claimIncrementInput 1_000 950 headPolicy === True
+      .&&. claimRef claimIncrementInput 1_000 950 headPolicy === True
+
+  prop "claim: reference === real Aiken validator (before-deadline + own-head binding + Increment coupling)" $
+    forAll (elements [950, 1_000, 1_050]) $ \validityHi ->
+      forAll (elements [headPolicy, otherHeadCid]) $ \depHeadCid ->
+        forAll (elements [claimIncrementInput, claimDecrementInput]) $ \headRedeemer ->
+          let deadline = 1_000
+           in claimRef headRedeemer deadline validityHi depHeadCid
+                === claimVal headRedeemer deadline validityHi depHeadCid
+
+  prop "claim: real Aiken validator REJECTS a non-Increment head redeemer (healthy Increment accepts)" $
+    claimVal claimDecrementInput 1_000 950 headPolicy === False
+      .&&. claimVal claimIncrementInput 1_000 950 headPolicy === True
+
+  -- ── full fanout (empty head): real BLS membership (empty subset) + burn count + deadline + value ──
+  prop "anchor: healthy empty-head fanout — BOTH oracles accept (real BLS pairing verified)" $
+    fanoutVal 2 1_050 1_000 === True .&&. fanoutRef 2 1_050 1_000 === True
+
+  prop "fanout: reference === real validator (burned-token count + after-deadline)" $
+    forAll (choose (1, 3)) $ \burnedCount ->
+      forAll (elements [950, 1_000, 1_050]) $ \validityLo ->
+        let tfinal = 1_000
+         in fanoutRef burnedCount validityLo tfinal === fanoutVal burnedCount validityLo tfinal
+
+  prop "fanout: real validator REJECTS a wrong BLS membership proof (healthy accepts, bad proof rejects)" $
+    fanoutVal 2 1_050 1_000 === True .&&. fanoutValBadProof 2 1_050 1_000 === False
+
+  -- The canonical-CRS datum binding: a CRS reference input carrying a padded (same-τ prefix but
+  -- byte-different) setup must be rejected with InvalidCRSDatum inside withCRSLookup, BEFORE any
+  -- pairing runs (a traceError, hence 'rejectingErrors'). Without this binding a substituted
+  -- powers-of-tau setup would let an attacker forge membership proofs (permissionless fund theft).
+  prop "fanout: real validator REJECTS a padded (non-canonical) CRS ref-input datum — InvalidCRSDatum" $
+    rejectingErrors (fanoutValPaddedCrs 2 1_050 1_000) === False
+      .&&. fanoutVal 2 1_050 1_000 === True
+
+  -- ── partial fanout (real 2-element accumulator, distribute 1): membership + 0<m + after-deadline ──
+  prop "anchor: healthy partial fanout — BOTH oracles accept (real KZG membership verified)" $
+    partialVal 1 1_050 1_000 === True .&&. partialRef 1 1_050 1_000 === True
+
+  prop "partial fanout: reference === real validator (mustHaveOutputs 0<m + after-deadline)" $
+    forAll (elements [0, 1]) $ \m ->
+      forAll (elements [950, 1_050]) $ \validityLo ->
+        let tfinal = 1_000
+         in partialRef m validityLo tfinal === partialVal m validityLo tfinal
+
+  prop "partial fanout: real validator REJECTS a wrong KZG membership proof (healthy accepts, bad proof rejects)" $
+    partialVal 1 1_050 1_000 === True .&&. partialValBadProof 1 1_050 1_000 === False
+
+  -- ── mid-chain partial fanout ((FanoutProgress, PartialFanout): the same checkPartialFanout arm,
+  -- driven from a FanoutProgress input datum) ──
+  prop "anchor: healthy mid-chain partial fanout: BOTH oracles accept (real KZG membership verified)" $
+    partialMidVal 1 1_050 1_000 === True .&&. partialMidRef 1 1_050 1_000 === True
+
+  prop "mid-chain partial fanout: reference === real validator (mustHaveOutputs 0<m + after-deadline)" $
+    forAll (elements [0, 1]) $ \m ->
+      forAll (elements [950, 1_050]) $ \validityLo ->
+        let tfinal = 1_000
+         in partialMidRef m validityLo tfinal === partialMidVal m validityLo tfinal
+
+  prop "mid-chain partial fanout: a before-deadline batch is REJECTED by both" $
+    partialMidRef 1 950 1_000 === False .&&. partialMidVal 1 950 1_000 === False
+
+  -- ── final partial fanout ((FanoutProgress, FinalPartialFanout): burn n+1, last batch, real KZG) ──
+  prop "anchor: healthy final partial fanout: BOTH oracles accept (last-batch KZG verified, n+1 burned)" $
+    finalPartialVal 2 2 1_050 1_000 === True .&&. finalPartialRef 2 2 1_050 1_000 === True
+
+  prop "final partial fanout: reference === real validator (output count + burned count + after-deadline)" $
+    forAll (choose (0, 2)) $ \m ->
+      forAll (choose (1, 3)) $ \burnedCount ->
+        forAll (elements [950, 1_050]) $ \validityLo ->
+          let tfinal = 1_000
+           in finalPartialRef m burnedCount validityLo tfinal === finalPartialVal m burnedCount validityLo tfinal
+
+  prop "final partial fanout: real validator REJECTS a wrong KZG membership proof (healthy accepts, bad proof rejects)" $
+    finalPartialVal 2 2 1_050 1_000 === True .&&. finalPartialValBadProof 2 2 1_050 1_000 === False
+
+  prop "final partial fanout: real validator REJECTS a before-deadline final batch" $
+    finalPartialVal 2 2 950 1_000 === False
+
+  -- ── C3.5: the JOIN as one checked artifact ──
+  -- The bridge proves spec-bundle ⇒ extracted-reference (Agda). This single property checks the other half,
+  -- extracted-reference === real-validator, on the SAME inputs across EVERY validator family (one accept +
+  -- one reject each), so the end-to-end spec ⇒ validator chain (modulo the documented postulates) is a
+  -- single named, checked artifact rather than per-family scattered tests.
+  prop "end-to-end (join): the bridged reference === the real validator across every family (accept + reject)" $
+    let dl = 1_200
+        tMax = 1_100
+        closeCtxAccept = mkContext openDatum 0 100 0 0 dl tMax
+        closeCtxReject = mkContext openDatum 1 100 0 0 dl tMax
+     in -- close (CloseInitial): healthy accept + changed-version reject
+        (referenceVerdict openDatum closeCtxAccept === validatorVerdict openDatum closeCtxAccept)
+          .&&. (referenceVerdict openDatum closeCtxReject === validatorVerdict openDatum closeCtxReject)
+          -- increment: version-bump accept + no-bump reject
+          .&&. (incRef 1 0 === incVal (incRedeemer 3) 1 0)
+          .&&. (incRef 0 0 === incVal (incRedeemer 3) 0 0)
+          -- decrement: accept + value-perturbation reject
+          .&&. (decRef 1 0 === decVal (decRedeemer 3) 1 0)
+          .&&. (decRef 1 1_000 === decVal (decRedeemer 3) 1 1_000)
+          -- contest: accept + too-old-snapshot reject
+          .&&. (contestRef 1 0 1_500 === contestVal (contestRedeemer 1) 1 0 1_500)
+          .&&. (contestRef 0 0 1_500 === contestVal (contestRedeemer 0) 0 0 1_500)
+          -- close (CloseAny): snapshot > 0 accept + snapshot-0 reject
+          .&&. (anyRef 0 100 3 0 dl tMax === anyVal (anyRedeemer 3) 0 100 3 0 dl tMax)
+          .&&. (anyRef 0 100 0 0 dl tMax === anyVal (anyRedeemer 0) 0 100 0 0 dl tMax)
+          -- close (CloseUsed, signature at version - 1): version-preserved accept + changed-version reject
+          .&&. (usedRef usedOpenVersionN 100 3 0 dl tMax === usedVal (usedRedeemer 3) usedOpenVersionN 100 3 0 dl tMax)
+          .&&. (usedRef 0 100 3 0 dl tMax === usedVal (usedRedeemer 3) 0 100 3 0 dl tMax)
+          -- contest (ContestUsed, signature at version - 1): accept + too-old-snapshot reject
+          .&&. (contestUsedRef 1 0 1_500 === contestUsedVal (contestUsedRedeemer 1) 1 0 1_500)
+          .&&. (contestUsedRef 0 0 1_500 === contestUsedVal (contestUsedRedeemer 0) 0 0 1_500)
+          -- contest deadline-push (n = 2): pushed-deadline accept + non-pushed reject
+          .&&. (contest2Ref openCpMs 1 openCpMs 1_500 === contest2Val (contest2Redeemer 1) openCpMs 1 openCpMs 1_500)
+          .&&. (contest2Ref openCpMs 1 0 1_500 === contest2Val (contest2Redeemer 1) openCpMs 1 0 1_500)
+          -- init (μHead): healthy accept + wrong-mint-count reject
+          .&&. (initRef 2 1 1 === initVal 2 1 1)
+          .&&. (initRef 3 1 1 === initVal 3 1 1)
+          -- burn (μHead Burn arm): burn-only accept + mint-alongside-burn reject
+          .&&. (burnRef [-1, -1] === burnVal [-1, -1])
+          .&&. (burnRef [1, -1] === burnVal [1, -1])
+          -- recover (νDeposit, real Aiken UPLC): after-deadline accept + not-after reject
+          .&&. (recoverRef 1_000 1_050 === recoverVal 1_000 1_050)
+          .&&. (recoverRef 1_000 950 === recoverVal 1_000 950)
+          -- claim (νDeposit, real Aiken UPLC): before-deadline accept + own-head-mismatch reject
+          .&&. (claimRef claimIncrementInput 1_000 950 headPolicy === claimVal claimIncrementInput 1_000 950 headPolicy)
+          .&&. (claimRef claimDecrementInput 1_000 950 headPolicy === claimVal claimDecrementInput 1_000 950 headPolicy)
+          .&&. (claimRef claimIncrementInput 1_000 950 otherHeadCid === claimVal claimIncrementInput 1_000 950 otherHeadCid)
+          -- full fanout (real BLS): burn-count accept + wrong-count reject
+          .&&. (fanoutRef 2 1_050 1_000 === fanoutVal 2 1_050 1_000)
+          .&&. (fanoutRef 3 1_050 1_000 === fanoutVal 3 1_050 1_000)
+          -- partial fanout (real KZG): 0<m accept + m=0 reject
+          .&&. (partialRef 1 1_050 1_000 === partialVal 1 1_050 1_000)
+          .&&. (partialRef 0 1_050 1_000 === partialVal 0 1_050 1_000)
+          -- mid-chain partial fanout (FanoutProgress input): 0<m accept + m=0 reject
+          .&&. (partialMidRef 1 1_050 1_000 === partialMidVal 1 1_050 1_000)
+          .&&. (partialMidRef 0 1_050 1_000 === partialMidVal 0 1_050 1_000)
+          -- final partial fanout (real KZG last batch): accept + wrong-burn-count reject
+          .&&. (finalPartialRef 2 2 1_050 1_000 === finalPartialVal 2 2 1_050 1_000)
+          .&&. (finalPartialRef 2 3 1_050 1_000 === finalPartialVal 2 3 1_050 1_000)
+          -- the C3 pulled-out conjuncts (value preservation, contest params, init head-id)
+          .&&. (closeValueVal 2_000_000 === True)
+          .&&. (closeValueVal 1_500_000 === False)
+          .&&. (contestParamsVal (contestNext 1 0) === True)
+          .&&. (contestParamsVal contestNextBadHeadId === False)
+          .&&. (initHeadIdVal initOpenDatum === True)
+          .&&. (initHeadIdVal initOpenDatumBadHeadId === False)
+          -- the ref-spent conjunct (increment claimedDepositIsSpent): spent accept + unspent reject
+          .&&. (projectRefSpent (HS.Increment (incRedeemer 3)) (mkIncContext (incRedeemer 3) 1 0) === True)
+          .&&. (incVal (incRedeemer 3) 1 0 === True)
+          .&&. (projectRefSpent (HS.Increment (incRedeemerUnspent 3)) (mkIncContext (incRedeemerUnspent 3) 1 0) === False)
+          .&&. (rejectingErrors (incVal (incRedeemerUnspent 3) 1 0) === False)

--- a/hydra-tx/test/Main.hs
+++ b/hydra-tx/test/Main.hs
@@ -5,6 +5,7 @@ import Hydra.Prelude
 import Hydra.Tx.AccumulatorSpec qualified
 import Hydra.Tx.ContestationPeriodSpec qualified
 import Hydra.Tx.Contract.ContractSpec qualified
+import Hydra.Tx.Contract.HeadValidatorAgreement qualified
 import Hydra.Tx.HeadIdSpec qualified
 import Hydra.Tx.IsTxSpec qualified
 import Hydra.Tx.KZGTrustedSetupSpec qualified
@@ -19,6 +20,7 @@ main =
     [ testSpec "Accumulator" Hydra.Tx.AccumulatorSpec.spec
     , testSpec "ContestationPeriod" Hydra.Tx.ContestationPeriodSpec.spec
     , testSpec "Contract" Hydra.Tx.Contract.ContractSpec.spec
+    , testSpec "HeadValidatorAgreement" Hydra.Tx.Contract.HeadValidatorAgreement.spec
     , testSpec "HeadId" Hydra.Tx.HeadIdSpec.spec
     , testSpec "IsTx" Hydra.Tx.IsTxSpec.spec
     , testSpec "KZGTrustedSetup" Hydra.Tx.KZGTrustedSetupSpec.spec

--- a/nix/coding-standards.nix
+++ b/nix/coding-standards.nix
@@ -20,5 +20,10 @@ _: {
         haskellType = "haskell.nix";
       };
 
+      # The MAlonzo-extracted Haskell under hydra-agda/generated is machine-generated
+      # (regenerate.sh) and must not be reformatted/linted; treefmt would fight the
+      # extractor. Exclude it globally (covers fourmolu, hlint, typos).
+      treefmt.settings.global.excludes = [ "hydra-agda/generated/**" ];
+
     };
 }

--- a/nix/hydra/spec.nix
+++ b/nix/hydra/spec.nix
@@ -99,5 +99,36 @@
       # .#checks) and selfci all build the flake checks. Reuses the derivation
       # above, so this adds no duplicate compilation.
       checks.spec = config.packages.spec;
+
+      # The MAlonzo extraction under hydra-agda/generated is committed and only
+      # regenerated manually (hydra-agda/regenerate.sh), so a semantic edit to
+      # Reference.agda / OffChainReference.agda would otherwise silently leave the
+      # committed oracle stale. Regenerate hermetically, replicating regenerate.sh
+      # (same agda invocation and OPTIONS_GHC stamping), and fail on any drift.
+      checks.hydra-agda-generated = pkgs.stdenv.mkDerivation {
+        name = "hydra-agda-generated";
+        nativeBuildInputs = [ config.packages.spec-agda ];
+        src = "${self}/spec";
+        buildPhase = ''
+          export HOME=$TMPDIR
+          agda --compile --no-main --ghc-dont-call-ghc --compile-dir="$TMPDIR/generated" \
+            src/Hydra/Protocol/Reference.agda
+          agda --compile --no-main --ghc-dont-call-ghc --compile-dir="$TMPDIR/generated" \
+            src/Hydra/Protocol/OffChainReference.agda
+          # Same `-w` stamping as regenerate.sh (see the rationale there).
+          find "$TMPDIR/generated" -name '*.hs' -print0 | while IFS= read -r -d "" f; do
+            chmod u+w "$f"
+            if ! head -1 "$f" | grep -q -- '-w'; then
+              printf '{-# OPTIONS_GHC -w #-}\n%s' "$(cat "$f")" > "$f"
+            fi
+          done
+          diff -ru ${self}/hydra-agda/generated/MAlonzo "$TMPDIR/generated/MAlonzo" || {
+            echo "hydra-agda/generated is out of date with spec/src/Hydra/Protocol/*.agda:"
+            echo "run hydra-agda/regenerate.sh and commit the result."
+            exit 1
+          }
+        '';
+        installPhase = "touch $out";
+      };
     };
 }


### PR DESCRIPTION
### 🧱 Stack (split of #2736)
   1. #2784 — protocol fix
   2. #2785 — Typst prose migration
   3. #2786 — Agda formalisation
   4. #2787 — hydra-agda package + CI
   5. #2788 — agreement tests
👉 6. #2789 — docs + changelog

Merge in order (1→6); each PR targets the previous branch.

---

**Stacked PR 6/6** — splits #2736.
Base: `typst-agda-spec-5`.

- Add the developer docs page for the Agda formalisation and update the
  specification docs page and sidebar.
- Changelog entry for the spec migration and agreement layer.

Once this stack is reviewed/merged it supersedes #2736 (which can then be
closed). The tip of this stack equals #2736's branch except that the vendored
`spec/typst-packages` (~15k lines) is replaced by the `typst.withPackages`
approach (PR 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
