### PR TITLE
Make prop_specIsComplete actually enforce API doc completeness

### DIFF
--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -103,6 +103,9 @@ channels:
           - $ref: "api.yaml#/components/messages/CommitRecovered"
           - $ref: "api.yaml#/components/messages/SnapshotSideLoaded"
           - $ref: "api.yaml#/components/messages/EventLogRotated"
+          - $ref: "api.yaml#/components/messages/DepositActivated"
+          - $ref: "api.yaml#/components/messages/DepositExpired"
+          - $ref: "api.yaml#/components/messages/HeadPartiallyFannedOut"
           - $ref: "api.yaml#/components/messages/NodeUnsynced"
           - $ref: "api.yaml#/components/messages/NodeSynced"
     publish:
@@ -115,6 +118,7 @@ channels:
           - $ref: "api.yaml#/components/messages/Recover"
           - $ref: "api.yaml#/components/messages/Decommit"
           - $ref: "api.yaml#/components/messages/Close"
+          - $ref: "api.yaml#/components/messages/SafeClose"
           - $ref: "api.yaml#/components/messages/Contest"
           - $ref: "api.yaml#/components/messages/Fanout"
           - $ref: "api.yaml#/components/messages/PartialFanout"
@@ -805,6 +809,27 @@ components:
         The node event log file has been rotated. The current aggregated head state is used as the checkpoint event to resume from.
       payload:
         $ref: "api.yaml#/components/schemas/EventLogRotated"
+
+    DepositActivated:
+      title: DepositActivated
+      description: |
+        A recorded deposit has reached its activation time and is now eligible to be included in an incremental commit.
+      payload:
+        $ref: "api.yaml#/components/schemas/DepositActivated"
+
+    DepositExpired:
+      title: DepositExpired
+      description: |
+        A recorded deposit has passed its deadline without being finalized and is no longer eligible for an incremental commit.
+      payload:
+        $ref: "api.yaml#/components/schemas/DepositExpired"
+
+    HeadPartiallyFannedOut:
+      title: HeadPartiallyFannedOut
+      description: |
+        A partial fanout was observed on-chain: a subset of the closed head's UTxO was distributed. Emitted for each step until the head is fully drained.
+      payload:
+        $ref: "api.yaml#/components/schemas/HeadPartiallyFannedOut"
 
     NodeUnsynced:
       title: NodeUnsynced

--- a/hydra-node/test/Hydra/API/ClientInputSpec.hs
+++ b/hydra-node/test/Hydra/API/ClientInputSpec.hs
@@ -26,7 +26,6 @@ spec = parallel $ do
     prop_validateJSONSchema @(ClientInput Tx) "api.json" $
       key "components" . key "schemas" . key "ClientInput"
 
-  -- XXX: This seems no to be working? Adding a new message does not lead to a failure here
   prop "schema covers all defined client inputs" $
     withMaxSuccess 1 $
       prop_specIsComplete @(ClientInput Tx) "api.json" $

--- a/hydra-node/test/Hydra/API/ServerOutputSpec.hs
+++ b/hydra-node/test/Hydra/API/ServerOutputSpec.hs
@@ -47,11 +47,10 @@ spec = parallel $ do
             key "components" . key "schemas" . key "ClientMessage"
         ]
 
-  -- XXX: This seems no to be working? Adding a new message does not lead to a failure here
   prop "schema covers all defined server outputs" $
     withMaxSuccess 1 $
       conjoin
-        [ prop_specIsComplete @(TimedServerOutput Tx) "api.json" $
+        [ prop_specIsComplete @(ServerOutput Tx) "api.json" $
             key "channels" . key "/" . key "subscribe" . key "message"
         , prop_specIsComplete @(Greetings Tx) "api.json" $
             key "channels" . key "/" . key "subscribe" . key "message"

--- a/hydra-node/testlib/Hydra/JSONSchema.hs
+++ b/hydra-node/testlib/Hydra/JSONSchema.hs
@@ -13,8 +13,7 @@ import Data.Aeson (Value, (.=))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Lens (key, _Array, _String)
 import Data.List qualified as List
-import Data.Map.Strict qualified as Map
-import Data.Text (pack)
+import Data.Text (pack, takeWhileEnd)
 import Data.Versions (SemVer (SemVer), prettySemVer, semver)
 import Data.Yaml qualified as Yaml
 import Paths_hydra_node qualified as Pkg
@@ -167,34 +166,40 @@ prop_specIsComplete specFileName selector =
       withJsonSpecifications $ \tmpDir -> do
         let specFile = tmpDir </> specFileName
         specs <- run $ Aeson.decodeFileStrict specFile
-        let knownKeys = classify specFile specs a
-        let unknownConstructors = Map.keys $ Map.filter (== 0) knownKeys
+        let documented = documentedConstructors specFile specs
+        let generated = List.nub (poormansGetConstr <$> a)
+        -- Constructors the type can produce that the specification does not
+        -- document. Catches a new message added in code but forgotten in the
+        -- schema.
+        let undocumented = filter (`notElem` documented) generated
 
-        when (null knownKeys) $ do
+        when (null documented) $ do
           monitor $ counterexample "No keys found in given specification fragment"
           assert False
 
-        unless (null unknownConstructors) $ do
-          let commaSeparated = intercalate ", " (toString <$> unknownConstructors)
-          monitor $ counterexample $ "Unimplemented constructors present in specification: " <> commaSeparated
-          monitor $ counterexample $ show a
+        unless (null undocumented) $ do
+          let commaSeparated = intercalate ", " (toString <$> undocumented)
+          monitor $ counterexample $ "Constructors produced by the type but missing from the specification: " <> commaSeparated
           assert False
  where
   -- Like Generics, if you squint hard-enough.
   poormansGetConstr :: a -> Text
   poormansGetConstr = toText . Prelude.head . List.words . show
 
-  classify :: FilePath -> Maybe Aeson.Value -> [a] -> Map Text Integer
-  classify _ (Just specs) =
-    let ks = specs ^.. selector . key "oneOf" . _Array . traverse . key "title" . _String
-
-        knownKeys = Map.fromList $ zip ks (repeat @Integer 0)
-
-        countMatch (poormansGetConstr -> tag) =
-          Map.alter (Just . maybe 1 (+ 1)) tag
-     in foldr countMatch knownKeys
-  classify specFile _ =
+  -- Names of the constructors documented in the selected 'oneOf' fragment.
+  -- Entries are usually '$ref's to the individual message/schema (e.g.
+  -- "…/messages/HeadIsOpen"), from which we take the last path segment; inline
+  -- 'title's are also supported.
+  documentedConstructors :: FilePath -> Maybe Aeson.Value -> [Text]
+  documentedConstructors _ (Just specs) =
+    (refName <$> specs ^.. selector . key "oneOf" . _Array . traverse . key "$ref" . _String)
+      <> specs
+      ^.. selector . key "oneOf" . _Array . traverse . key "title" . _String
+  documentedConstructors specFile _ =
     error $ "Invalid specification file. Does not decode to an object: " <> show specFile
+
+  refName :: Text -> Text
+  refName = takeWhileEnd (/= '/')
 
 -- | An alias for a traversal selecting some part of a 'Value'
 -- This alleviates the need for users of this module to import explicitly the types


### PR DESCRIPTION
`prop_specIsComplete` was a silent no-op. It read constructor names from `oneOf[].title`, but those entries are bare `$refs` with no title, so it extracted zero keys and always passed, and it was instantiated at `TimedServerOutput` whose show never reveals the inner constructor. This PR reworks it to read names from the `$ref` `basename` and fail when the type produces a constructor missing from the spec, and switches the call site to `ServerOutput`. 
Enabling it surfaced four messages that existed in code but were missing from the api.yaml channel `oneOfs`: `DepositActivated`, `DepositExpired`, `HeadPartiallyFannedOut` (server outputs) and `SafeClose` (client input). 

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
