### PR TITLE
Make mac release binaries runnable without nix

### DIFF
--- a/nix/packaging.nix
+++ b/nix/packaging.nix
@@ -28,10 +28,11 @@
             text = ''
               for nixlib in $(otool -L "$1" |awk '/nix\/store/{ print $1 }'); do
                   case "$nixlib" in
-                  *libiconv.dylib) install_name_tool -change "$nixlib" /usr/lib/libiconv.dylib "$1" ;;
-                  *libffi.*.dylib) install_name_tool -change "$nixlib" /usr/lib/libffi.dylib   "$1" ;;
-                  *libc++.*.dylib) install_name_tool -change "$nixlib" /usr/lib/libc++.dylib   "$1" ;;
-                  *libz.dylib)     install_name_tool -change "$nixlib" /usr/lib/libz.dylib     "$1" ;;
+                  # Match versioned names too, e.g. libiconv.2.dylib.
+                  *libiconv*.dylib) install_name_tool -change "$nixlib" /usr/lib/libiconv.dylib "$1" ;;
+                  *libffi.*.dylib)  install_name_tool -change "$nixlib" /usr/lib/libffi.dylib   "$1" ;;
+                  *libc++.*.dylib)  install_name_tool -change "$nixlib" /usr/lib/libc++.dylib   "$1" ;;
+                  *libz.dylib)      install_name_tool -change "$nixlib" /usr/lib/libz.dylib     "$1" ;;
                   *) ;;
                   esac
               done
@@ -40,7 +41,8 @@
         in
         pkgs.stdenv.mkDerivation {
           name = "${name'}.zip";
-          buildInputs = with pkgs; [ patchelf zip fixup-nix-deps ];
+          buildInputs = with pkgs; [ patchelf zip fixup-nix-deps ]
+            ++ pkgs.lib.optionals targetPlatform.isDarwin [ pkgs.macdylibbundler ];
 
           phases = [ "buildPhase" "installPhase" ];
 
@@ -63,6 +65,19 @@
               fixup-nix-deps $bin
               chmod $mode $bin
             done
+
+            # Whatever still points at /nix/store are libraries macOS does not
+            # ship (libsodium-vrf, secp256k1, gmp, ncursesw). Bundle them next
+            # to the binaries and rewrite the load commands to @executable_path
+            # so the zip runs on a machine without nix.
+            chmod +w bin/*
+            # --no-codesign: install_name_tool already re-signs ad-hoc on each
+            # edit, and codesign is not on PATH in the build sandbox.
+            dylibbundler \
+              --overwrite-dir --create-dir --bundle-deps --no-codesign \
+              --install-path @executable_path/lib/ \
+              --dest-dir bin/lib \
+              $(for bin in bin/*; do echo "--fix-file $bin"; done)
           '';
 
           # compress and put into hydra products


### PR DESCRIPTION
The pre-built mac binaries hard-linked their libraries from `/nix/store`, so they only launched on a machine that had nix installed. On a plain mac `dyld` could not find those paths and the binaries would not start at all.

This fixes the packaging step. The libiconv rewrite now matches the versioned name so `hydra-node` points at the macOS system copy, and the libraries that macOS does not ship (`libsodium-vrf`, `secp256k1`, `gmp`, `ncursesw`) get bundled next to the binaries with dylibbundler and referenced via `@executable_path`. Verified on a fresh `nix build .#release` that both binaries have no /nix/store paths left, stay validly signed and launch fine.


Fixes #2461 
Fixes #2790 

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
