### PR TITLE
Vary the number of parties in the fanout benchmark

### DIFF
--- a/hydra-node/bench/tx-cost/Main.hs
+++ b/hydra-node/bench/tx-cost/Main.hs
@@ -321,6 +321,7 @@ costOfFanOut = markdownFanOutCost . genFromSeed computeFanOutCost
     unlines $
       [ "## `FanOut` transaction costs"
       , "Involves spending head output and burning head tokens. Uses ada-only UTXO for better comparability."
+      , "Rows first grow the UTxO set at a fixed 10 parties, then show the largest set that still fits per number of parties (burning more participation tokens leaves less room for outputs)."
       , ""
       , "| Parties | UTxO  | UTxO (bytes) | Tx size | % max Mem | % max CPU | Min fee ₳ |"
       , "| :------ | :---- | :----------- | ------: | --------: | --------: | --------: |"

--- a/hydra-node/bench/tx-cost/TxCost.hs
+++ b/hydra-node/bench/tx-cost/TxCost.hs
@@ -160,17 +160,25 @@ computeContestCost = do
 
 computeFanOutCost :: Gen [(NumParties, NumUTxO, Natural, TxSize, MemUnit, CpuUnit, Coin)]
 computeFanOutCost = do
-  interesting <- catMaybes <$> mapM (uncurry compute) [(p, u) | p <- [numberOfParties], u <- [0, 1, 5, 10, 20, 30, 50, 100, 200, 500, 1000]]
-  limit <-
-    maybeToList
-      . getFirst
-      <$> foldMapM
-        (\(p, u) -> First <$> compute p u)
-        -- Sparse descending search: find the largest UTxO count that still fits in a tx.
-        [(p, u) | p <- [numberOfParties], u <- [2000, 1500, 1000, 500, 200, 100, 60, 50, 40, 30, 20, 15, 10]]
-  pure $ interesting <> limit
+  -- Detailed cost of growing the fanned-out UTxO set, at a representative
+  -- number of parties.
+  interesting <- catMaybes <$> mapM (compute representativeParties) [0, 1, 5, 10, 20, 30, 50, 100, 200, 500, 1000]
+  -- Largest UTxO set that still fits in a single fanout tx, per number of
+  -- parties. Fanout burns one participation token per party, so more parties
+  -- leaves less room for outputs; this shows how fanout capacity shrinks as the
+  -- number of parties grows.
+  limits <-
+    fmap concat . forM partiesRange $ \parties ->
+      maybeToList
+        . getFirst
+        <$> foldMapM
+          (fmap First . compute parties)
+          -- Sparse descending search: find the largest UTxO count that still fits in a tx.
+          [2000, 1500, 1000, 500, 200, 100, 60, 50, 40, 30, 20, 15, 10]
+  pure $ interesting <> limits
  where
-  numberOfParties = 10
+  representativeParties = 10
+  partiesRange = [1, 5, 10, 20, 50]
 
   compute parties numElems = do
     (utxo, tx, knownUTxO) <- genFanoutTx parties numElems


### PR DESCRIPTION
The fanout tx-cost table was pinned to 10 parties, so you could not see how the number of parties changes fanout cost. Now it sweeps a few party counts and shows the largest UTxO set that still fits for each, since burning more participation tokens leaves less room for outputs.
Part of #2439 

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
