### PR TITLE
Fail on startup when etcd peer configuration changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ changes.
   the funds to the prefilled own address, and an invalid amount sent the full
   UTxO value).
 
+- Fail fast on startup when the etcd peer configuration changed since the node
+  last ran against the same persistence directory. Previously, changing `--peer`
+  or `--advertise` would silently start a fresh, empty etcd cluster and orphan
+  all persisted message history, because the etcd data directory is keyed by a
+  hash of the peers. The node now records the peer set and refuses to start with
+  a clear error if it changed, so you consciously either wipe the etcd directory
+  or restore the previous configuration. [#2804](https://github.com/cardano-scaling/hydra/pull/2804)
+
 - **BREAKING** (WebSocket API) Removed the `SyncedStatusReport` server output.
   The node used to push it on every block, flooding clients; it is now gone from
   the message stream. Chain-sync status remains available on the WebSocket via

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -409,6 +409,7 @@ test-suite tests
     Hydra.Model.Payment
     Hydra.ModelSpec
     Hydra.Network.AuthenticateSpec
+    Hydra.Network.EtcdSpec
     Hydra.NetworkSpec
     Hydra.NetworkVersionsSpec
     Hydra.Node.InputQueueSpec

--- a/hydra-node/src/Hydra/Network/Etcd.hs
+++ b/hydra-node/src/Hydra/Network/Etcd.hs
@@ -104,7 +104,7 @@ import Network.GRPC.Etcd (
   Watch,
  )
 import Network.Socket (PortNumber)
-import System.Directory (createDirectoryIfMissing, listDirectory, removeFile)
+import System.Directory (createDirectoryIfMissing, doesFileExist, listDirectory, removeFile)
 import System.Environment.Blank (getEnvironment)
 import System.FilePath ((</>))
 import System.IO.Error (isDoesNotExistError, isEOFError)
@@ -124,6 +124,54 @@ import System.Process.Typed (
   waitExitCode,
  )
 
+-- | Exception thrown on startup when the etcd cluster configuration changed
+-- since this persistence directory was last used. See 'checkClusterPeers'.
+data NetworkConfigurationMismatch = NetworkConfigurationMismatch
+  { persistedPeers :: Text
+  , configuredPeers :: Text
+  }
+  deriving stock (Eq, Show)
+
+instance Exception NetworkConfigurationMismatch where
+  displayException NetworkConfigurationMismatch{persistedPeers, configuredPeers} =
+    toString $
+      T.unlines
+        [ "Network configuration changed since this node last ran against this persistence directory."
+        , "  persisted peers:  " <> persistedPeers
+        , "  configured peers: " <> configuredPeers
+        , "Refusing to start to avoid silently bootstrapping a fresh, empty etcd cluster and"
+        , "orphaning previously persisted message history."
+        , "To intentionally reconfigure, delete the 'etcd' sub-directory of your persistence"
+        , "directory (this discards etcd history) or restore the previous --peer/--advertise settings."
+        ]
+
+-- | Guard against silently forking a new cluster after a peer configuration
+-- change. The etcd '--data-dir' is namespaced by a hash of the cluster peers,
+-- so a changed '--peer'/'--advertise' set would otherwise bootstrap a fresh,
+-- empty cluster and orphan all previously persisted message history with no
+-- signal to the operator. We persist the last-used cluster peers next to the
+-- (hashed) etcd data directories and 'throwIO' 'NetworkConfigurationMismatch'
+-- if they differ on a later run. This mirrors the parameter-mismatch bail-out
+-- done when loading persisted head state.
+checkClusterPeers :: FilePath -> String -> IO ()
+checkClusterPeers persistenceDir clusterPeers = do
+  createDirectoryIfMissing True dir
+  whenM (doesFileExist configFile) $
+    decodeFileStrict' configFile >>= \case
+      Just persisted
+        | persisted /= clusterPeers ->
+            throwIO
+              NetworkConfigurationMismatch
+                { persistedPeers = toText persisted
+                , configuredPeers = toText clusterPeers
+                }
+      -- Matches, or the file is unreadable: fall through and (re)write it below.
+      _ -> pure ()
+  encodeFile configFile clusterPeers
+ where
+  dir = persistenceDir </> "etcd"
+  configFile = dir </> "network-config.json"
+
 -- | Concrete network component that broadcasts messages to an etcd cluster and
 -- listens for incoming messages.
 withEtcdNetwork ::
@@ -135,9 +183,7 @@ withEtcdNetwork ::
   NetworkComponent IO msg msg ()
 withEtcdNetwork tracer protocolVersion config callback action = do
   etcdBinPath <- getEtcdBinary persistenceDir whichEtcd
-  -- TODO: fail if cluster config / members do not match --peer
-  -- configuration? That would be similar to the 'acks' persistence
-  -- bailing out on loading.
+  checkClusterPeers persistenceDir clusterPeers
   envVars <- Map.fromList <$> getEnvironment
   withProcessInterrupt (etcdCmd etcdBinPath envVars) $ \p -> do
     raceLabelled_

--- a/hydra-node/test/Hydra/Network/EtcdSpec.hs
+++ b/hydra-node/test/Hydra/Network/EtcdSpec.hs
@@ -1,0 +1,25 @@
+-- | Tests of the etcd-backed network component.
+module Hydra.Network.EtcdSpec where
+
+import Hydra.Prelude
+import Test.Hydra.Prelude
+
+import Hydra.Network.Etcd (NetworkConfigurationMismatch (..), checkClusterPeers)
+
+spec :: Spec
+spec = do
+  describe "checkClusterPeers" $ do
+    it "succeeds on first run" $
+      withTempDir "etcd-cluster-peers" $ \dir ->
+        checkClusterPeers dir "alice=http://a,bob=http://b"
+
+    it "succeeds when re-run with the same peers" $
+      withTempDir "etcd-cluster-peers" $ \dir -> do
+        checkClusterPeers dir "alice=http://a,bob=http://b"
+        checkClusterPeers dir "alice=http://a,bob=http://b"
+
+    it "fails when re-run with a changed peer configuration" $
+      withTempDir "etcd-cluster-peers" $ \dir -> do
+        checkClusterPeers dir "alice=http://a,bob=http://b"
+        checkClusterPeers dir "alice=http://a,carol=http://c"
+          `shouldThrow` \NetworkConfigurationMismatch{} -> True

--- a/hydra-node/test/Main.hs
+++ b/hydra-node/test/Main.hs
@@ -34,6 +34,7 @@ import Hydra.LoggingSpec qualified
 import Hydra.Model.MockChainSpec qualified
 import Hydra.ModelSpec qualified
 import Hydra.Network.AuthenticateSpec qualified
+import Hydra.Network.EtcdSpec qualified
 import Hydra.NetworkSpec qualified
 import Hydra.NetworkVersionsSpec qualified
 import Hydra.Node.InputQueueSpec qualified
@@ -84,6 +85,7 @@ main =
     , testSpec "Model.MockChain" Hydra.Model.MockChainSpec.spec
     , testSpec "Model" Hydra.ModelSpec.spec
     , testSpec "Network.Authenticate" Hydra.Network.AuthenticateSpec.spec
+    , testSpec "Network.Etcd" Hydra.Network.EtcdSpec.spec
     , -- NetworkSpec spins up etcd clusters that lose RAFT quorum when CPU is
       -- oversubscribed. Run it last (after all other tests finish) and
       -- single-threaded so the etcd processes get the box to themselves, while


### PR DESCRIPTION

Follow up #1965 

Changing `--peer` or `--advertise` used to silently start a fresh empty etcd cluster and orphan all persisted message history, because the data dir is keyed by a hash of the peers. Now we persist the peer set and refuse to start with a clear error if it changed, so the operator has to consciously wipe the etcd dir or restore the old config.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
