### PR TITLE
Make rejectLowDeposits a single pass instead of O(n^2)

### DIFF
--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -20,7 +20,6 @@ import Control.Lens ((^.))
 import Control.Monad.Class.MonadSTM (throwSTM)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
-import Data.List qualified as List
 import Data.Map.Strict qualified as Map
 import Hydra.Cardano.Api (
   Address,
@@ -297,21 +296,14 @@ mkChain tracer queryTimeHandle wallet ctx LocalChainState{getLatest} submitTx =
 -- Check each UTxO entry against the minADAUTxO value.
 -- Throws 'DepositTooLow' exception.
 rejectLowDeposits :: PParams LedgerEra -> UTxO -> Either (PostTxError Tx) ()
-rejectLowDeposits pparams utxo = do
-  let insAndOuts = UTxO.toList utxo
-  let providedValues = (\(i, o) -> (i, UTxO.totalLovelace $ UTxO.singleton i o)) <$> insAndOuts
-  let minimumValues = (\(i, o) -> (i, calculateMinimumUTxO shelleyBasedEra pparams $ fromCtxUTxOTxOut o)) <$> insAndOuts
-  let results =
-        ( \(i, minVal) ->
-            case List.find (\(ix, providedVal) -> i == ix && providedVal < minVal) providedValues of
-              Nothing -> Right ()
-              Just (_, tooLowValue) ->
-                Left (DepositTooLow{providedValue = tooLowValue, minimumValue = minVal} :: PostTxError Tx)
-        )
-          <$> minimumValues
-  case lefts results of
-    [] -> pure ()
-    (e : _) -> Left e
+rejectLowDeposits pparams utxo =
+  -- The provided and minimum values both derive from the same output, so we can
+  -- compare them in a single pass over the UTxO.
+  forM_ (UTxO.toList utxo) $ \(i, o) -> do
+    let providedValue = UTxO.totalLovelace $ UTxO.singleton i o
+        minimumValue = calculateMinimumUTxO shelleyBasedEra pparams $ fromCtxUTxOTxOut o
+    when (providedValue < minimumValue) $
+      Left (DepositTooLow{providedValue, minimumValue} :: PostTxError Tx)
 
 -- | Reject any UTxO containing a Byron address, which cannot be represented
 -- in the Hydra head protocol.

--- a/hydra-node/test/Hydra/API/HTTPServerSpec.hs
+++ b/hydra-node/test/Hydra/API/HTTPServerSpec.hs
@@ -57,12 +57,14 @@ import Test.Hydra.Node.Fixture (testEnvironment)
 import Test.Hydra.Tx.Fixture (defaultPParams, pparams)
 import Test.Hydra.Tx.Gen (genTxOut, genUTxOAdaOnlyOfSize)
 import Test.QuickCheck (
+  choose,
   counterexample,
   cover,
   forAll,
   generate,
   property,
   withMaxSuccess,
+  (===),
  )
 
 spec :: Spec
@@ -698,6 +700,18 @@ apiServerSpec = do
                 minimumValue >= providedValue
                   & counterexample ("Minimum value: " <> show minimumValue <> " Provided value: " <> show providedValue)
             _ -> property True
+
+      -- A deposit is fine exactly when each of its outputs is fine on its own.
+      -- Check the whole-UTxO verdict against checking every output individually:
+      -- if the walk ever compared one output's ada to another output's minimum,
+      -- the two would disagree. Uses several outputs so such a mix-up can show.
+      prop "rejects a multi-output deposit exactly when some output alone is rejected" $
+        forAll (choose (1, 20) >>= genUTxOAdaOnlyOfSize) $ \(utxo :: UTxO) ->
+          let outputs = UTxO.toList utxo
+              eachOutputOk =
+                all (\(i, o) -> isRight (rejectLowDeposits pparams (UTxO.singleton i o))) outputs
+           in isRight (rejectLowDeposits pparams utxo) === eachOutputOk
+                & counterexample ("UTxO size: " <> show (length outputs))
 
     describe "POST /transaction" $ do
       let mkReq :: SimpleTx -> LBS.ByteString


### PR DESCRIPTION
Resolves #2670 
`rejectLowDeposits` paired each output with its minimum using a nested `List.find`, which is quadratic in the number of deposit inputs. Both lists come from the same UTxO in the same order, so a single walk does the same work. Also adds a property test over multi-output UTxOs, since the old one only ever checked a single output

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
