### PR TITLE
Bump Mithril to 2630.0 and switch to the v2 database backend

### DIFF
--- a/docs/docs/tutorial/index.md
+++ b/docs/docs/tutorial/index.md
@@ -153,7 +153,7 @@ The Hydra Head protocol requires a connection to Cardano layer 1 to verify and p
 Download the latest blockchain snapshot using `mithril-client` configured for the `preprod` network:
 
 ```shell
-mithril-client --origin-tag HYDRA cardano-db download latest --include-ancillary
+mithril-client --origin-tag HYDRA cardano-db download latest --backend v2 --include-ancillary
 ```
 
 <details>

--- a/flake.lock
+++ b/flake.lock
@@ -365,11 +365,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1776635034,
-        "narHash": "sha256-OEOJrT3ZfwbChzODfIH4GzlNTtOFuZFWPtW7jIeR8xU=",
+        "lastModified": 1783203018,
+        "narHash": "sha256-G6R9IT/xwFuu+CYBWDUAok6AdC4ERC4ZfPPFtEpxnZE=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "dc7496d8ea6e526b1254b55d09b966e94673750f",
+        "rev": "80db5bdc391be8a1794f6d8a2d56e3a84ebcede2",
         "type": "github"
       },
       "original": {
@@ -653,11 +653,11 @@
         "nixpkgs-lib": "nixpkgs-lib_4"
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -1859,16 +1859,16 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1776926918,
-        "narHash": "sha256-muV2LpheC4OZsU1ipL9j6TmjGufMpGrXzvon+eWahgg=",
+        "lastModified": 1785407305,
+        "narHash": "sha256-8Ay4GLKQGeJwGQPLliUNvgfkKCHFVUeASWFu/e0SxqM=",
         "owner": "input-output-hk",
         "repo": "mithril",
-        "rev": "2478748ea9771baed8181ef0938c78f79ed60760",
+        "rev": "23e124d99320adea6eb3eca361132c6c43d59cfa",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "2617.0",
+        "ref": "2630.0",
         "repo": "mithril",
         "type": "github"
       }
@@ -2242,11 +2242,11 @@
     },
     "nixpkgs-lib_4": {
       "locked": {
-        "lastModified": 1774748309,
-        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {
@@ -2573,11 +2573,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1776329215,
-        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "lastModified": 1783279667,
+        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
         "type": "github"
       },
       "original": {
@@ -2801,11 +2801,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776654897,
-        "narHash": "sha256-Vqi4AiJVCcBGn/RmBtRCgyH5rCxqm/w0xV9diJWF1Ic=",
+        "lastModified": 1783320166,
+        "narHash": "sha256-l7C/OsjcnWDOk2K3ssj+SBduwL67LashjBqis9+t468=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "25d75be8139815a53560745fa060909777495105",
+        "rev": "20ee15370c9256669d66968b89ee20a4b0a4e673",
         "type": "github"
       },
       "original": {
@@ -3081,11 +3081,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
     hydra-coding-standards.url = "github:cardano-scaling/hydra-coding-standards/0.8.0";
     import-tree.url = "github:vic/import-tree";
     iohk-nix.url = "github:input-output-hk/iohk-nix";
-    mithril.url = "github:input-output-hk/mithril/2617.0";
+    mithril.url = "github:input-output-hk/mithril/2630.0";
     nixpkgs.follows = "haskellNix/nixpkgs";
     nixpkgs-2411.url = "github:NixOS/nixpkgs/nixos-24.11";
     nix-npm-buildpackage.url = "github:serokell/nix-npm-buildpackage";

--- a/hydra-cluster/src/Hydra/Cluster/Mithril.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Mithril.hs
@@ -37,6 +37,10 @@ downloadLatestSnapshotTo tracer network directory = do
                   [ ["--origin-tag", "HYDRA"]
                   , ["--aggregator-endpoint", aggregatorEndpoint']
                   , ["cardano-db", "download", "latest"]
+                  , -- Use the v2 (CardanoDatabase) backend. Since the 2630.0
+                    -- distribution the aggregator no longer certifies the v1
+                    -- backend, so a plain 'cardano-db download' (v1) fails.
+                    ["--backend", "v2"]
                   , ["--include-ancillary"]
                   , ["--genesis-verification-key", decodeUtf8 genesisKey]
                   , ["--ancillary-verification-key", decodeUtf8 ancillaryKey]

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -39,7 +39,7 @@
             weeder = pkgs.haskell-nix.tool compiler "weeder" "2.9.0";
             inherit (inputs.cardano-node.packages.${system}) cardano-cli;
             inherit (inputs.cardano-node.packages.${system}) cardano-node;
-            mithril-client-cli = inputs.mithril.packages.${system}.mithril-client-cli or inputs.mithril.packages.${system}.mithril; # Todo: revert when https://github.com/input-output-hk/mithril/pull/3224 is released
+            inherit (inputs.mithril.packages.${system}) mithril-client-cli;
             pumba = inputs.pumba.packages.${system}.default;
           })
         ];


### PR DESCRIPTION
The 2630.0 Mithril distribution drops aggregator certification of the Cardano database v1 backend, so our cardano-db download calls (which defaulted to v1) stopped working against the aggregator. This bumps the pinned mithril input to 2630.0 and passes `--backend v2` in both the `hydra-cluster` download code and the tutorial, matching the backend the aggregator now certifies.

It also removes the darwin mithril-client-cli fallback in pkgs.nix. That workaround (from #2598 ) existed only because older mithril did not expose the client package on Mac. 2630.0 finally ships it for all our targets including aarch64-darwin, which is exactly what the tracked PR #3224 was waiting on, so the fallback is gone.

Release notes: https://github.com/IntersectMBO/mithril/releases/tag/2630.0

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
