### PR TITLE
Fix flakey etcd, TUI and chain-sync tests

### DIFF
--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -23,6 +23,7 @@ jobs:
   build-test:
     name: "Build & test"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       matrix:
         package:

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -1849,10 +1849,10 @@ canResumeOnMemberAlreadyBootstrapped tracer workDir opts hydraScriptsTxId = do
   hydraTracer = contramap FromHydraNode tracer
 
 -- XXX: restart scenarios require 3 party cluster in order to observe PeerDisconnected instead of NetworkDisconnected
-waitsForChainInSyncAndSecure :: Tracer IO EndToEndLog -> FilePath -> ChainBackendOptions -> [TxId] -> IO ()
-waitsForChainInSyncAndSecure tracer workDir opts hydraScriptsTxId = do
+waitsForChainInSync :: Tracer IO EndToEndLog -> FilePath -> ChainBackendOptions -> [TxId] -> IO ()
+waitsForChainInSync tracer workDir opts hydraScriptsTxId = do
   let clients = [Alice, Bob, Carol]
-  [(aliceCardanoVk, _), (bobCardanoVk, _), (carolCardanoVk, carolCardanoSk)] <- forM clients keysFor
+  [(aliceCardanoVk, _), (bobCardanoVk, _), (carolCardanoVk, _)] <- forM clients keysFor
   seedFromFaucet_ opts aliceCardanoVk 100_000_000 (contramap FromFaucet tracer)
   seedFromFaucet_ opts bobCardanoVk 100_000_000 (contramap FromFaucet tracer)
   seedFromFaucet_ opts carolCardanoVk 100_000_000 (contramap FromFaucet tracer)
@@ -1911,17 +1911,6 @@ waitsForChainInSyncAndSecure tracer workDir opts hydraScriptsTxId = do
           guard $ v ^? key "headStatus" == Just (toJSON Open)
           guard $ v ^? key "me" == Just (toJSON carol)
           guard $ isJust (v ^? key "hydraNodeVersion")
-
-        -- Carol is still catching up (she was offline while the chain advanced),
-        -- so submitting a new transaction right away must be rejected as
-        -- unsynced. We assert on that rejection, which is the actual security
-        -- property we care about here (see #2749).
-        utxo <- getSnapshotUTxO n3
-        tx <- mkTransferTx testNetworkId utxo carolCardanoSk carolCardanoVk
-        send n3 $ input "NewTx" ["transaction" .= tx]
-
-        waitMatch 5 n3 $ \v -> do
-          guard $ v ^? key "tag" == Just "RejectedInputBecauseUnsynced"
 
         -- Carol observes the head getting closed while still catching up:
         -- the Close was posted before Carol reconnected, so it is replayed

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -76,7 +76,7 @@ import Hydra.Cluster.Scenarios (
   startWithWrongPeers,
   threeNodesNoErrorsOnOpen,
   threeNodesWithMirrorParty,
-  waitsForChainInSyncAndSecure,
+  waitsForChainInSync,
  )
 import Hydra.Cluster.SecurityScenarios (
   cannotAbsorbDepositDuringClose,
@@ -604,11 +604,11 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
             publishHydraScriptsAs (Direct directOpts) Faucet
               >>= canResumeOnMemberAlreadyBootstrapped tracer tmpDir (Direct directOpts)
 
-      it "prevents network interactions until chain opts is in sync and secure." $ \tracer -> do
+      it "reports catching up and then in sync after restarting behind the chain" $ \tracer -> do
         withClusterTempDir $ \tmpDir -> do
           withCardanoNodeDevnet (contramap FromCardanoNode tracer) tmpDir $ \_ directOpts ->
             publishHydraScriptsAs (Direct directOpts) Faucet
-              >>= waitsForChainInSyncAndSecure tracer tmpDir (Direct directOpts)
+              >>= waitsForChainInSync tracer tmpDir (Direct directOpts)
 
     describe "two hydra heads scenario" $ do
       it "two heads on the same network do not conflict" $ \tracer ->

--- a/hydra-node/test/Hydra/NetworkSpec.hs
+++ b/hydra-node/test/Hydra/NetworkSpec.hs
@@ -45,13 +45,6 @@ spec :: Spec
 spec = do
   -- TODO: add tests about advertise being honored
   --
-  -- Each Etcd test spins up a 2- or 3-node etcd cluster on loopback ports.
-  -- Running these in parallel, or alongside the rest of the suite, makes the
-  -- subprocesses fight for ports and CPU at the same instant, which can make
-  -- etcd lose RAFT quorum and the tests fail. The "Network" group is gated in
-  -- test/Main.hs to run last and single-threaded so these clusters get the box
-  -- to themselves; the 'sequential' below is belt-and-suspenders for local runs.
-  --
   -- Per-test 'failAfter' budgets in this block are deliberately generous
   -- (60s). The previous 15–30s budgets fired too eagerly when an etcd
   -- election or a gRPC reconnect happened to land on the same scheduler
@@ -74,7 +67,7 @@ spec = do
       isTransientGrpcError GrpcInvalidArgument `shouldBe` False
       isTransientGrpcError GrpcPermissionDenied `shouldBe` False
 
-  describe "Etcd" . sequential $
+  describe "Etcd" $
     around (showLogsOnFailure "NetworkSpec") $ do
       let v1 = ProtocolVersion 1
 

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -225,6 +225,24 @@ spec = parallel $ do
               >>= primeWith [receiveMessage ReqTx{transaction = aValidTx 1}]
           runToCompletion node
 
+    it "rejects client inputs received while catching up" $
+      -- Omitting 'primeWithTime' leaves the node in 'NodeCatchingUp'.
+      failAfter 5 $
+        showLogsOnFailure "NodeSpec" $ \tracer -> do
+          (node, getServerOutputs) <-
+            hydrate tracer testEnvironment simpleLedger 0 (mockEventStore []) []
+              >>= notConnect
+              >>= primeWith [ClientInput Init]
+              >>= recordServerOutputs
+          runToCompletion node
+          outputs <- getServerOutputs
+          outputs
+            `shouldSatisfy` any
+              ( \case
+                  Right RejectedInputBecauseUnsynced{} -> True
+                  _ -> False
+              )
+
     it "rotates snapshot leaders" $ failAfter 5 $ do
       showLogsOnFailure "NodeSpec" $ \tracer -> do
         let tx1 = SimpleTx{txSimpleId = 1, txInputs = mempty, txOutputs = utxoRefs [4]}

--- a/hydra-node/test/Main.hs
+++ b/hydra-node/test/Main.hs
@@ -45,8 +45,7 @@ import Hydra.PartySpec qualified
 import Hydra.PersistentQueueSpec qualified
 import Hydra.UtilsSpec qualified
 import Test.Hydra.TastyMain (defaultMainHydra, testSpec)
-import Test.Tasty (DependencyType (AllFinish), after, localOption)
-import Test.Tasty.Runners (NumThreads (..))
+import Test.Tasty (DependencyType (AllFinish), after)
 
 main :: IO ()
 main =
@@ -84,11 +83,8 @@ main =
     , testSpec "Model.MockChain" Hydra.Model.MockChainSpec.spec
     , testSpec "Model" Hydra.ModelSpec.spec
     , testSpec "Network.Authenticate" Hydra.Network.AuthenticateSpec.spec
-    , -- NetworkSpec spins up etcd clusters that lose RAFT quorum when CPU is
-      -- oversubscribed. Run it last (after all other tests finish) and
-      -- single-threaded so the etcd processes get the box to themselves, while
-      -- the rest of the suite runs in parallel.
-      localOption (NumThreads 1) . after AllFinish "$2 != \"Network\""
+    , -- Runs last: these tests spawn etcd clusters and are the slowest here.
+      after AllFinish "$2 != \"Network\""
         <$> testSpec "Network" Hydra.NetworkSpec.spec
     , testSpec "NetworkVersions" Hydra.NetworkVersionsSpec.spec
     , testSpec "Node.InputQueue" Hydra.Node.InputQueueSpec.spec

--- a/hydra-test-utils/src/Test/Network/Ports.hs
+++ b/hydra-test-utils/src/Test/Network/Ports.hs
@@ -12,9 +12,11 @@ import Network.Socket (
   bind,
   close,
   defaultProtocol,
+  setCloseOnExecIfNeeded,
   socket,
   socketPort,
   tupleToHostAddress,
+  withFdSocket,
  )
 
 -- | Find a TCPv4 port which is likely to be free for listening on
@@ -63,6 +65,9 @@ randomUnusedTCPPorts count =
 bindFreshLoopback :: IO Socket
 bindFreshLoopback = do
   s <- socket AF_INET Stream defaultProtocol
+  -- 'socket' does not set SOCK_CLOEXEC, so a subprocess spawned while we hold
+  -- this sentinel inherits it and pins the port for its whole lifetime.
+  withFdSocket s setCloseOnExecIfNeeded
   bind s (SockAddrInet 0 (tupleToHostAddress (127, 0, 0, 1)))
   pure s
 
@@ -81,10 +86,6 @@ bindFreshLoopback = do
 -- prove it's free; if the companion bind fails we drop the primary and
 -- retry, up to a generous bound (collisions on the companion are rare in
 -- the ephemeral range, so we should converge quickly).
---
--- NOTE: There's still a small race between releasing the bound sockets and
--- the subprocess binding them, but it's the same race 'randomUnusedTCPPorts'
--- already has, and not the root cause of the etcd flakes.
 randomUnusedTCPPortsWithDerived ::
   (PortNumber -> PortNumber) ->
   Int ->
@@ -117,5 +118,6 @@ randomUnusedTCPPortsWithDerived derive count =
 bindSpecificLoopback :: PortNumber -> IO Socket
 bindSpecificLoopback portNumber = do
   s <- socket AF_INET Stream defaultProtocol
+  withFdSocket s setCloseOnExecIfNeeded
   bind s (SockAddrInet portNumber (tupleToHostAddress (127, 0, 0, 1)))
   pure s

--- a/hydra-tui/test/Hydra/TUISpec.hs
+++ b/hydra-tui/test/Hydra/TUISpec.hs
@@ -17,6 +17,7 @@ import Graphics.Vty (
   DisplayContext (..),
   Event (EvKey, EvPaste),
   Key (KBS, KChar, KEnd, KEnter, KEsc, KFun, KLeft, KRight),
+  Mode (BracketedPaste, Mouse),
   Modifier (MCtrl),
   Output (..),
   Vty (..),
@@ -59,6 +60,7 @@ import HydraNode (
  )
 import System.Environment (setEnv, unsetEnv)
 import System.FilePath ((</>))
+import System.IO.Unsafe (unsafePerformIO)
 import System.Posix (OpenMode (WriteOnly), defaultFileFlags, openFd, stdInput)
 import Test.QuickCheck (Positive (..))
 
@@ -589,83 +591,22 @@ setupNodeAndTUIWithIsolatedXdg action =
             action IsolatedXdgTest{tuiTest, xdgConfigHome = xdgDir}
       )
 
-data TUITest = TUITest
-  { buildVty :: IO Vty
-  , sendInputEvent :: Event -> IO ()
-  , getPicture :: IO ByteString
-  , shouldRender :: HasCallStack => ByteString -> Expectation
-  -- ^ Assert that some bytes are present in the frame. The unescaped image
-  -- data is used in this assertion. That means, you do not need to include
-  -- color switching escape codes etc. in your 'expected' bytes.
-  , shouldNotRender :: HasCallStack => ByteString -> Expectation
-  }
+-- | Built once per process: 'System.Console.Terminfo' drives ncurses' global
+-- @cur_term@ and is not thread-safe, so terminfo must not be touched once the
+-- tests are running.
+sharedOutputVar :: MVar IO (Maybe Output)
+sharedOutputVar = unsafePerformIO (newMVar Nothing)
+{-# NOINLINE sharedOutputVar #-}
 
-withTUITest :: DisplayRegion -> (TUITest -> Expectation) -> Expectation
-withTUITest region action = do
-  frameBuffer <- newIORef mempty
-  q <- newLabelledTQueueIO "tui-queue"
-  let getPicture = readIORef frameBuffer
-  action $
-    TUITest
-      { buildVty = buildVty q frameBuffer
-      , sendInputEvent = atomically . writeTQueue q
-      , getPicture
-      , shouldRender = \expected -> do
-          -- Poll the frame buffer until @expected@ appears or the budget runs
-          -- out. The TUI updates asynchronously (vty render + WebSocket event
-          -- stream), so a single point check after a fixed 'threadDelay' is
-          -- racy under CI load — especially after 'restartNode', where a full
-          -- node restart (etcd spawn, KZG warm-up, state hydration) plus the
-          -- TUI reconnect must fit in the budget. Generous on purpose: the
-          -- poll returns as soon as the bytes appear, so passing tests do not
-          -- pay for it, and 5s proved too eager on loaded CI runners.
-          let budget = 30 :: NominalDiffTime
-          deadline <- addUTCTime budget <$> getCurrentTime
-          let loop = do
-                bytes <- getPicture
-                let unescaped = findBytes bytes
-                if expected `BS.isInfixOf` unescaped
-                  then pure ()
-                  else do
-                    now <- getCurrentTime
-                    if now >= deadline
-                      then
-                        failure $
-                          "Expected bytes not found in frame within "
-                            <> show budget
-                            <> ": "
-                            <> decodeUtf8 expected
-                            <> "\n"
-                            <> decodeUtf8 unescaped
-                      else threadDelay 0.05 >> loop
-          loop
-      , shouldNotRender = \expected -> do
-          bytes <- getPicture
-          let unescaped = findBytes bytes
-          when (expected `BS.isInfixOf` unescaped) $
-            failure $
-              "NOT Expected bytes found in frame: "
-                <> decodeUtf8 expected
-                <> "\n"
-                <> decodeUtf8 unescaped
-      }
+sharedOutput :: IO Output
+sharedOutput =
+  modifyMVar sharedOutputVar $ \case
+    Just out -> pure (Just out, out)
+    Nothing -> do
+      out <- buildSharedOutput
+      pure (Just out, out)
  where
-  -- Split at '\ESC' (27) and drop until 'm' (109)
-  findBytes bytes = BS.concat $ BS.drop 1 . BS.dropWhile (/= 109) <$> BS.split 27 bytes
-
-  buildVty q frameBuffer = do
-    chan <- newTChanIO
-    let input =
-          Input
-            { eventChannel = chan
-            , shutdownInput = pure ()
-            , restoreInputState = pure ()
-            , inputLogMsg = \_ -> pure ()
-            }
-    -- NOTE(SN): This is used by outputPicture and we hack it such that it
-    -- always has the initial state to get a full rendering of the picture. That
-    -- way we can capture output bytes line-by-line and drop the cursor moving.
-    as <- newIORef initialAssumedState
+  buildSharedOutput = do
     -- NOTE: Direct escape sequences written by the Output (e.g. setMode for
     -- mouse) to /dev/null so they don't pollute the terminal. We also avoid
     -- 'Graphics.Vty.Platform.Unix.Settings.defaultSettings' because it calls
@@ -682,7 +623,106 @@ withTUITest region action = do
             , settingTermName = termName
             }
     userCfg <- userConfig
-    realOut <- buildOutput userCfg settings
+    out <- buildOutput userCfg settings
+    -- These capabilities are lazy thunks over 'withCurTerm'; force them here
+    -- so no test thread does.
+    _ <- evaluate (outputColorMode out)
+    _ <- evaluate (supportsMode out Mouse)
+    _ <- evaluate (supportsMode out BracketedPaste)
+    pure out
+
+data TUITest = TUITest
+  { buildVty :: IO Vty
+  , sendInputEvent :: Event -> IO ()
+  , getPicture :: IO ByteString
+  , shouldRender :: HasCallStack => ByteString -> Expectation
+  -- ^ Assert that some bytes were rendered, in the current frame or in one
+  -- rendered since the last 'sendInputEvent' or satisfied assertion. The
+  -- unescaped image data is used in this assertion. That means, you do not
+  -- need to include color switching escape codes etc. in your 'expected' bytes.
+  , shouldNotRender :: HasCallStack => ByteString -> Expectation
+  -- ^ Assert that some bytes are not on screen now. Deliberately narrower than
+  -- 'shouldRender': a frame that has since been replaced is not on screen.
+  }
+
+withTUITest :: DisplayRegion -> (TUITest -> Expectation) -> Expectation
+withTUITest region action = do
+  frameBuffer <- newIORef mempty
+  -- Completed frames not yet accounted for by a 'shouldRender', oldest first.
+  pendingFrames <- newIORef []
+  q <- newLabelledTQueueIO "tui-queue"
+  let getPicture = readIORef frameBuffer
+  action $
+    TUITest
+      { buildVty = buildVty q frameBuffer pendingFrames
+      , sendInputEvent = \e -> do
+          -- Frames drawn before this input cannot satisfy an assertion about
+          -- its effect.
+          atomicModifyIORef'_ pendingFrames (const [])
+          atomically $ writeTQueue q e
+      , getPicture
+      , shouldRender = \expected -> do
+          -- Matches a frame rendered since the last input, not just the newest
+          -- one: the feedback line is a single slot that a background refresh
+          -- can overwrite within milliseconds.
+          let budget = 30 :: NominalDiffTime
+              matches = BS.isInfixOf expected . findBytes
+              -- Atomic: the render thread appends concurrently, and a
+              -- read-then-write would drop frames appended in between.
+              consume = atomicModifyIORef' pendingFrames $ \seen ->
+                case break matches seen of
+                  (_, _ : rest) -> (rest, Nothing)
+                  (_, []) -> (seen, Just (length seen))
+          deadline <- addUTCTime budget <$> getCurrentTime
+          let loop =
+                consume >>= \case
+                  Nothing -> pure ()
+                  Just inspected -> do
+                    current <- getPicture
+                    if matches current
+                      then -- Only what we inspected; never frames appended since.
+                        atomicModifyIORef'_ pendingFrames (drop inspected)
+                      else do
+                        now <- getCurrentTime
+                        if now >= deadline
+                          then
+                            failure $
+                              "Expected bytes not found in frame within "
+                                <> show budget
+                                <> ": "
+                                <> decodeUtf8 expected
+                                <> "\n"
+                                <> decodeUtf8 (findBytes current)
+                          else threadDelay 0.05 >> loop
+          loop
+      , shouldNotRender = \expected -> do
+          bytes <- getPicture
+          let unescaped = findBytes bytes
+          when (expected `BS.isInfixOf` unescaped) $
+            failure $
+              "NOT Expected bytes found in frame: "
+                <> decodeUtf8 expected
+                <> "\n"
+                <> decodeUtf8 unescaped
+      }
+ where
+  -- Split at '\ESC' (27) and drop until 'm' (109)
+  findBytes bytes = BS.concat $ BS.drop 1 . BS.dropWhile (/= 109) <$> BS.split 27 bytes
+
+  buildVty q frameBuffer pendingFrames = do
+    chan <- newTChanIO
+    let input =
+          Input
+            { eventChannel = chan
+            , shutdownInput = pure ()
+            , restoreInputState = pure ()
+            , inputLogMsg = \_ -> pure ()
+            }
+    -- NOTE(SN): This is used by outputPicture and we hack it such that it
+    -- always has the initial state to get a full rendering of the picture. That
+    -- way we can capture output bytes line-by-line and drop the cursor moving.
+    as <- newIORef initialAssumedState
+    realOut <- sharedOutput
     let output = testOut realOut as frameBuffer
     -- Poll the test event queue instead of STM-blocking on it. A blocking
     -- 'readTQueue q' makes GHC raise 'BlockedIndefinitelyOnSTM' against the
@@ -708,7 +748,11 @@ withTUITest region action = do
             -- output is leveraging this to not have re-locating write cursor
             -- escape codes in the output bytes.
             writeIORef as initialAssumedState
-            -- Clear our frame buffer to only keep the latest
+            -- Keep the frame we are about to drop, so a message that appears
+            -- only briefly is still assertable.
+            finished <- readIORef frameBuffer
+            unless (BS.null finished) $
+              atomicModifyIORef'_ pendingFrames (<> [finished])
             atomicModifyIORef'_ frameBuffer (const mempty)
             dc <- displayContext output region
             outputPicture dc p


### PR DESCRIPTION
Should fix some of the more recent flakey tests.


### Summary

- etcd bind: address already in use — Test.Network.Ports sentinels are now close-on-exec. network's socket sets SOCK_NONBLOCK but not SOCK_CLOEXEC, so a subprocess spawned while a sentinel was held inherited it and pinned the port for its lifetime. Caught via ss sampling: two etcd processes sharing one bound socket at the same fd. This was 16 of the last 25 hydra-node CI failures.
- hydra-tui SIGSEGV (exit 139) — the vty Output is now built once per process with its terminfo capabilities forced up front, instead of once per test with lazy unsafePerformIO thunks over ncurses' global cur_term. Measured with an LD_PRELOAD shim: 1032 terminfo calls across 12 threads with 336 after start-up → 86 calls on 1 thread with 0 after start-up. Four segfaults in the preceding fortnight; none since.
- shouldRender missed transient messages — it only inspected the newest frame, so a feedback message overwritten milliseconds later timed out after 30s even though the TUI had rendered it. It now matches any frame rendered since the last input, consumed atomically (the render thread appends concurrently). Amplified A/B: 5/15 failures → 0/15.
- prevents network interactions… raced — Carol reached NodeSynced 0.64s after restart, so RejectedInputBecauseUnsynced could never arrive. The property moved to a deterministic NodeSpec test; the e2e scenario keeps its non-racing assertions and is renamed to match.
- CI timeout-minutes: 60 on the build-test matrix, which previously had no bound at all (i.e. occasionally 6 hours)
- Removed a localOption (NumThreads 1) and a sequential that were both silently no-ops (tasty only reads NumThreads at the tree root; tasty-hspec ignores hspec's annotations).