### PR TITLE
Bench variance pairing 1

### DIFF
--- a/.github/workflows/bench-e2e-diff.yaml
+++ b/.github/workflows/bench-e2e-diff.yaml
@@ -3,12 +3,12 @@ name: "Compute e2e benchmark differences"
 # Paired benchmark comparison: every benchmark job measures BOTH sides (PR
 # and merge-base) back to back on ITS OWN runner, and the diff aggregates the
 # same-machine pair deltas. GitHub's hosted fleet mixes CPU models with a
-# large single-thread spread, so one sample per side on separate runners
-# (the previous design) mostly measured which VMs the jobs landed on.
-# Non-PR triggers run an A/A null experiment (both sides the same SHA): any
-# colored row there is a false positive; the nightly run accumulates that
-# null distribution for threshold calibration (see scripts/bench-e2e-diff.py
-# and hydra-cluster/README.md).
+# large single-thread spread, so unpaired samples on separate runners mostly
+# measure which VMs the jobs landed on; machine identity cancels inside a
+# pair. A workflow_dispatch without base_ref is an A/A null experiment (both
+# sides the same SHA): any colored row there is a false positive, and
+# accumulated A/A results calibrate the noise thresholds (see
+# scripts/bench-e2e-diff.py and hydra-cluster/README.md).
 
 on:
   pull_request:
@@ -24,8 +24,8 @@ on:
         description: "Baseline ref or SHA (default: head_ref, i.e. an A/A null run)"
         required: false
 
-# Superseded runs measure dead code; non-PR runs key on run_id so nothing
-# cancels the nightly.
+# Superseded runs measure dead code; non-PR runs key on run_id so they never
+# cancel each other.
 concurrency:
   group: bench-e2e-diff-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
@@ -81,10 +81,6 @@ jobs:
           workflow_dispatch)
             HEAD_SHA=$(gh api "repos/${{ github.repository }}/commits/${{ inputs.head_ref || github.ref_name }}" --jq .sha)
             BASE_SHA=$(gh api "repos/${{ github.repository }}/commits/${{ inputs.base_ref || inputs.head_ref || github.ref_name }}" --jq .sha)
-            ;;
-          schedule)
-            HEAD_SHA=$(gh api "repos/${{ github.repository }}/commits/master" --jq .sha)
-            BASE_SHA="$HEAD_SHA"
             ;;
         esac
         echo "Comparing head $HEAD_SHA against base $BASE_SHA"
@@ -232,17 +228,16 @@ jobs:
         path: results
         if-no-files-found: warn
 
-  # Aggregate all machines' pairs and post/update the PR comment. Named to
-  # match the original single job so required-check configuration resolves.
+  # Aggregate all machines' pairs and post/update the PR comment.
   comment:
     name: Compute e2e benchmark differences
     needs: [generate-datasets, benchmark]
     # !cancelled(): still post when a benchmark leg fails (partial pairs are
-    # fine), but never from a superseded run; always() would survive the
-    # concurrency cancellation and clobber the previous comment with "no
-    # results" (observed on #2828). It also ignores the needs-skip, so the
-    # draft/label condition must be mirrored here. Non-PR (A/A) runs write
-    # the diff to the step summary and artifact only.
+    # fine), but never from a superseded run; always() survives concurrency
+    # cancellation and would clobber the comment with "no results". It also
+    # ignores the needs-skip, so the draft/label condition must be mirrored
+    # here. Non-PR (A/A) runs write the diff to the step summary and artifact
+    # only.
     if: ${{ !cancelled() && (github.event_name != 'pull_request' || !github.event.pull_request.draft || contains(github.event.pull_request.labels.*.name, 'bench')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/bench-e2e-diff.yaml
+++ b/.github/workflows/bench-e2e-diff.yaml
@@ -15,8 +15,6 @@ on:
     # Default types plus ready_for_review: draft PRs are skipped below, so the
     # transition out of draft must trigger a run.
     types: [opened, synchronize, reopened, ready_for_review]
-  schedule:
-    - cron: "23 2 * * *"
   workflow_dispatch:
     inputs:
       head_ref:
@@ -38,7 +36,7 @@ permissions:
 
 
 jobs:
-  # Generate the workload ONCE, with the head binary, for all bench jobs:
+  # Generate the workload once, with the head binary, for all bench jobs:
   # per-side generation would silently compare different workloads whenever a
   # PR touches the generator. Fixed seeds keep datasets comparable across
   # workflow runs. Also resolves the compared SHAs.

--- a/.github/workflows/bench-e2e-diff.yaml
+++ b/.github/workflows/bench-e2e-diff.yaml
@@ -1,7 +1,36 @@
 name: "Compute e2e benchmark differences"
 
+# Paired benchmark comparison: every benchmark job measures BOTH sides (PR
+# and merge-base) back to back on ITS OWN runner, and the diff aggregates the
+# same-machine pair deltas. GitHub's hosted fleet mixes CPU models with a
+# large single-thread spread, so one sample per side on separate runners
+# (the previous design) mostly measured which VMs the jobs landed on.
+# Non-PR triggers run an A/A null experiment (both sides the same SHA): any
+# colored row there is a false positive; the nightly run accumulates that
+# null distribution for threshold calibration (see scripts/bench-e2e-diff.py
+# and hydra-cluster/README.md).
+
 on:
   pull_request:
+    # Default types plus ready_for_review: draft PRs are skipped below, so the
+    # transition out of draft must trigger a run.
+    types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    - cron: "23 2 * * *"
+  workflow_dispatch:
+    inputs:
+      head_ref:
+        description: "Ref or SHA to benchmark (default: the ref this runs on)"
+        required: false
+      base_ref:
+        description: "Baseline ref or SHA (default: head_ref, i.e. an A/A null run)"
+        required: false
+
+# Superseded runs measure dead code; non-PR runs key on run_id so nothing
+# cancels the nightly.
+concurrency:
+  group: bench-e2e-diff-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 # Default (inherited) token: read-only. Only the comment job is granted write.
 permissions:
@@ -9,18 +38,57 @@ permissions:
 
 
 jobs:
-  # Generate the workload ONCE, with the PR (branch) binary, and publish it as an
-  # artifact both bench jobs consume. Generating per-side would let the branch and
-  # master generators diverge (any PR touching the generator or Dataset format),
-  # silently comparing different workloads; a single shared dataset avoids that.
-  # Seeds are fixed so datasets are also comparable across workflow runs.
+  # Generate the workload ONCE, with the head binary, for all bench jobs:
+  # per-side generation would silently compare different workloads whenever a
+  # PR touches the generator. Fixed seeds keep datasets comparable across
+  # workflow runs. Also resolves the compared SHAs.
   generate-datasets:
     name: Generate benchmark datasets
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    # Benchmarking every draft push is wasted runner time; the benchmark jobs
+    # inherit this skip through needs.
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    timeout-minutes: 45
+    outputs:
+      head_sha: ${{ steps.resolve.outputs.head_sha }}
+      base_sha: ${{ steps.resolve.outputs.base_sha }}
     steps:
-    - name: "Checkout the PR as the 'new' source"
+    - name: "Checkout the head as the 'new' source"
       uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.head_ref || github.ref }}
+
+    - name: 🔎 Resolve compared SHAs
+      id: resolve
+      env:
+        GH_TOKEN: ${{ github.token }}
+      # The compare API yields the merge-base without a full clone and works
+      # for fork PRs. base.ref rather than base.sha: the latter is a snapshot
+      # from PR creation time and goes stale.
+      run: |
+        case "${{ github.event_name }}" in
+          pull_request)
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+            BASE_SHA=$(gh api \
+              "repos/${{ github.repository }}/compare/${{ github.event.pull_request.base.ref }}...$HEAD_SHA" \
+              --jq .merge_base_commit.sha) || BASE_SHA=""
+            if [ -z "$BASE_SHA" ]; then
+              echo "::warning title=bench-e2e-diff::merge-base resolution failed; falling back to master HEAD"
+              BASE_SHA=$(gh api "repos/${{ github.repository }}/commits/master" --jq .sha)
+            fi
+            ;;
+          workflow_dispatch)
+            HEAD_SHA=$(gh api "repos/${{ github.repository }}/commits/${{ inputs.head_ref || github.ref_name }}" --jq .sha)
+            BASE_SHA=$(gh api "repos/${{ github.repository }}/commits/${{ inputs.base_ref || inputs.head_ref || github.ref_name }}" --jq .sha)
+            ;;
+          schedule)
+            HEAD_SHA=$(gh api "repos/${{ github.repository }}/commits/master" --jq .sha)
+            BASE_SHA="$HEAD_SHA"
+            ;;
+        esac
+        echo "Comparing head $HEAD_SHA against base $BASE_SHA"
+        echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+        echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
 
     - name: ❄ Setup Nix/Cachix
       uses: ./.github/actions/nix-cachix-setup
@@ -30,10 +98,8 @@ jobs:
     - name: 📦 Generate benchmark datasets
       working-directory: hydra-cluster
       # Scenario sizes are chosen so rate metrics are measured under sustained
-      # load rather than being capped by the dataset (see hydra-cluster/README.md),
-      # while the slower side still fits the per-scenario timeout: per-round costs
-      # scale with the pending backlog, so drain time grows super-linearly with
-      # dataset size.
+      # load rather than being capped by the dataset (see
+      # hydra-cluster/README.md) while fitting the per-scenario timeout.
       run: |
         nix build .#hydra-cluster-bench
         mkdir -p "$PWD/../bench-datasets"
@@ -57,37 +123,66 @@ jobs:
         path: bench-datasets
         if-no-files-found: error
 
-  # Benchmark each side on its OWN fresh runner, in parallel. This is the fix for
-  # the ordering bias: previously both sides ran back-to-back on one runner, so
-  # the second side (always master) was measured on a machine already degraded by
-  # ~30 min of load, inflating the branch's apparent gain regardless of code.
-  # Isolated runners remove that confound; both sides still consume the identical
-  # shared dataset artifact. NOTE: the branch is (re)built here, on a different
-  # runner from generate-datasets, so its closure is downloaded from cachix or
-  # rebuilt once more; accept that, or push the branch closure to cachix.
+  # Four jobs, each measuring one same-machine pair; slot order alternates so
+  # slot-position effects (cold caches in slot 1) cancel across the fleet.
+  # More pairs per machine is a one-line change to `order`.
   benchmark:
-    name: Benchmark (${{ matrix.side }})
+    name: Benchmark (${{ matrix.machine }})
     needs: generate-datasets
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
-      # Don't let one side's timeout cancel the other; the diff job handles a
-      # one-sided result.
+      # A wedged machine only costs its own pair.
       fail-fast: false
       matrix:
         include:
-          - side: branch
-            flake: ".#hydra-cluster-bench"
-          - side: master
-            flake: "git+https://github.com/cardano-scaling/hydra?ref=master#hydra-cluster-bench"
+          - machine: m1
+            order: "branch master"
+          - machine: m2
+            order: "master branch"
+          - machine: m3
+            order: "branch master"
+          - machine: m4
+            order: "master branch"
+    env:
+      BRANCH_FLAKE: ".#hydra-cluster-bench"
+      MASTER_FLAKE: "github:cardano-scaling/hydra/${{ needs.generate-datasets.outputs.base_sha }}#hydra-cluster-bench"
     steps:
-    # Needed for the composite nix action and, on the branch side, the '.' flake.
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.head_ref || github.ref }}
 
     - name: ❄ Setup Nix/Cachix
       uses: ./.github/actions/nix-cachix-setup
       with:
         authToken: '${{ secrets.CACHIX_CARDANO_SCALING_AUTH_TOKEN }}'
+
+    - name: 🧬 Record machine fingerprint
+      # Shown in the comment footer: the reader should see which silicon each
+      # pair ran on.
+      run: |
+        mkdir -p results
+        python3 - "$RUNNER_NAME" > results/fingerprint.json <<'PY'
+        import json, os, sys
+        cpu = ""
+        for line in open("/proc/cpuinfo"):
+            if line.startswith("model name"):
+                cpu = line.split(":", 1)[1].strip()
+                break
+        mem_kb = 0
+        for line in open("/proc/meminfo"):
+            if line.startswith("MemTotal"):
+                mem_kb = int(line.split()[1])
+                break
+        print(json.dumps({
+            "cpu_model": cpu,
+            "nproc": os.cpu_count(),
+            "mem_gb": round(mem_kb / 1048576),
+            "runner": sys.argv[1] if len(sys.argv) > 1 else "",
+        }))
+        PY
+        cat results/fingerprint.json
 
     - name: ⬇ Download benchmark datasets
       uses: actions/download-artifact@v4
@@ -95,41 +190,58 @@ jobs:
         name: bench-datasets
         path: bench-datasets
 
-    - name: 📈 Benchmark
-      working-directory: hydra-cluster
-      # The closed-loop scenario needs its own invocation ('--wait-for-tx-valid'
-      # applies to the whole invocation); reports are concatenated afterwards,
-      # which the diff script handles since it keys on scenario titles.
+    - name: ❄ Prefetch both closures
+      # Realize and warm both sides before the first measured slot so no
+      # build or download lands inside a measurement.
       run: |
-        nix develop "${{ matrix.flake }}" --command bench-e2e single \
-          "$PWD/../bench-datasets/sustained-3nodes.json" \
-          "$PWD/../bench-datasets/plateau-1k.json" \
-          --output-directory "$PWD/../bench-open" --timeout 1800s
-        nix develop "${{ matrix.flake }}" --command bench-e2e single \
-          "$PWD/../bench-datasets/closed-loop-3nodes.json" \
-          --wait-for-tx-valid \
-          --output-directory "$PWD/../bench-closed" --timeout 1800s
-        cat "$PWD/../bench-open/end-to-end-benchmarks.md" \
-            "$PWD/../bench-closed/end-to-end-benchmarks.md" > "$PWD/../bench-${{ matrix.side }}.md"
+        time nix develop "$BRANCH_FLAKE" --command hydra-node --version
+        time nix develop "$MASTER_FLAKE" --command hydra-node --version
 
-    - name: 💾 Upload ${{ matrix.side }} report
-      # if: always() so a partial report from a failed/timed-out side is still
-      # uploaded and the diff can be judged.
+    - name: 📈 Benchmark (${{ matrix.order }})
+      working-directory: hydra-cluster
+      # The closed-loop scenario needs its own invocation (--wait-for-tx-valid
+      # applies to the whole invocation). '|| true': a failed invocation must
+      # not skip the remaining slots; its report carries an explicit FAILED
+      # outcome and the diff drops only the affected pairs.
+      run: |
+        slot=0
+        for side in ${{ matrix.order }}; do
+          slot=$((slot+1))
+          case "$side" in
+            branch) flake="$BRANCH_FLAKE" ;;
+            master) flake="$MASTER_FLAKE" ;;
+          esac
+          out="$PWD/../results/rep-$slot-$side"
+          nix develop "$flake" --command bench-e2e single \
+            "$PWD/../bench-datasets/sustained-3nodes.json" \
+            "$PWD/../bench-datasets/plateau-1k.json" \
+            --output-directory "$out/open" --timeout 1800s || true
+          nix develop "$flake" --command bench-e2e single \
+            "$PWD/../bench-datasets/closed-loop-3nodes.json" \
+            --wait-for-tx-valid \
+            --output-directory "$out/closed" --timeout 1800s || true
+        done
+
+    - name: 💾 Upload results
+      # if: always() so partial results still contribute surviving pairs.
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: bench-report-${{ matrix.side }}
-        path: bench-${{ matrix.side }}.md
+        name: bench-results-${{ matrix.machine }}
+        path: results
         if-no-files-found: warn
 
-  # Diff the two reports and post/update the PR comment. Named to match the
-  # original single job so any required-check configuration still resolves.
+  # Aggregate all machines' pairs and post/update the PR comment. Named to
+  # match the original single job so required-check configuration resolves.
   comment:
     name: Compute e2e benchmark differences
-    needs: benchmark
-    # if: always() so a one-sided result (a bench leg failed) still surfaces.
-    if: always() && github.event_name == 'pull_request'
+    needs: [generate-datasets, benchmark]
+    # if: always() so partial results still surface; non-PR (A/A) runs write
+    # the diff to the step summary and artifact only. always() ignores the
+    # needs-skip, so drafts must be excluded here too.
+    if: always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       checks: write
@@ -137,44 +249,43 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.head_ref || github.ref }}
 
-    - name: ⬇ Download branch report
+    - name: ⬇ Download benchmark results
       uses: actions/download-artifact@v4
-      # A failed bench leg leaves no artifact; don't fail the diff over it.
+      # A wedged machine leaves no artifact; don't fail the diff over it.
       continue-on-error: true
       with:
-        name: bench-report-branch
+        pattern: bench-results-*
+        path: results
 
-    - name: ⬇ Download master report
-      uses: actions/download-artifact@v4
-      continue-on-error: true
-      with:
-        name: bench-report-master
+    - name: 🧪 Self-test the diff script
+      run: python3 scripts/test_bench_e2e_diff.py
 
     - name: 🧮 Compute the difference markdown
-      # touch so a one-sided run still renders: the diff script reports "No
-      # comparable scenarios" instead of crashing on a missing file.
       run: |
-        touch bench-master.md bench-branch.md
+        mkdir -p results
         python3 scripts/bench-e2e-diff.py \
-          bench-master.md \
-          bench-branch.md > bench-e2e-diff.md
+          --results-dir results \
+          --base-sha "${{ needs.generate-datasets.outputs.base_sha }}" \
+          --head-sha "${{ needs.generate-datasets.outputs.head_sha }}" \
+          > bench-e2e-diff.md
+        printf '\n[Workflow run](%s)\n' \
+          "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+          >> bench-e2e-diff.md
+        cat bench-e2e-diff.md >> "$GITHUB_STEP_SUMMARY"
 
-    - name: 💾 Upload e2e bench artifacts
-      # Raw reports included so a failed or one-sided comparison (e.g. a PR that
-      # changes the report format itself) can still be judged.
+    - name: 💾 Upload e2e bench diff
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: bench-e2e-diff
-        path: |
-          bench-e2e-diff.md
-          bench-branch.md
-          bench-master.md
+        path: bench-e2e-diff.md
         if-no-files-found: warn
 
     - name: 🔎 Find Comment
-      if: github.event.pull_request.head.repo.full_name == github.repository
+      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
       uses: peter-evans/find-comment@v3
       id: find-comment
       with:
@@ -183,7 +294,7 @@ jobs:
         body-includes: End-to-end benchmark differences
 
     - name: ✏ Create or update comment
-      if: github.event.pull_request.head.repo.full_name == github.repository
+      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
       uses: peter-evans/create-or-update-comment@v4
       with:
         comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/.github/workflows/bench-e2e-diff.yaml
+++ b/.github/workflows/bench-e2e-diff.yaml
@@ -45,9 +45,12 @@ jobs:
   generate-datasets:
     name: Generate benchmark datasets
     runs-on: ubuntu-latest
-    # Benchmarking every draft push is wasted runner time; the benchmark jobs
-    # inherit this skip through needs.
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    # Draft pushes skip benchmarking (runner cost) unless the PR carries the
+    # 'bench' label; there is deliberately no 'labeled' trigger (any label
+    # addition would cancel an in-flight run via the concurrency group), so
+    # the label takes effect from the next push or dispatch. The benchmark
+    # jobs inherit this skip through needs.
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft || contains(github.event.pull_request.labels.*.name, 'bench')
     timeout-minutes: 45
     outputs:
       head_sha: ${{ steps.resolve.outputs.head_sha }}
@@ -239,10 +242,10 @@ jobs:
     # !cancelled(): still post when a benchmark leg fails (partial pairs are
     # fine), but never from a superseded run; always() would survive the
     # concurrency cancellation and clobber the previous comment with "no
-    # results" (observed on #2828). It also ignores the needs-skip, so drafts
-    # must be excluded here too. Non-PR (A/A) runs write the diff to the step
-    # summary and artifact only.
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
+    # results" (observed on #2828). It also ignores the needs-skip, so the
+    # draft/label condition must be mirrored here. Non-PR (A/A) runs write
+    # the diff to the step summary and artifact only.
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || !github.event.pull_request.draft || contains(github.event.pull_request.labels.*.name, 'bench')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/bench-e2e-diff.yaml
+++ b/.github/workflows/bench-e2e-diff.yaml
@@ -236,10 +236,13 @@ jobs:
   comment:
     name: Compute e2e benchmark differences
     needs: [generate-datasets, benchmark]
-    # if: always() so partial results still surface; non-PR (A/A) runs write
-    # the diff to the step summary and artifact only. always() ignores the
-    # needs-skip, so drafts must be excluded here too.
-    if: always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft)
+    # !cancelled(): still post when a benchmark leg fails (partial pairs are
+    # fine), but never from a superseded run; always() would survive the
+    # concurrency cancellation and clobber the previous comment with "no
+    # results" (observed on #2828). It also ignores the needs-skip, so drafts
+    # must be excluded here too. Non-PR (A/A) runs write the diff to the step
+    # summary and artifact only.
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -174,14 +174,25 @@ jobs:
     - name: ⚙ Prepare comment body
       id: comment-body
       run: |
-        # Drop first 5 header lines and demote headlines one level. Concatenate
-        # tx costs, the existing single end-to-end run, and the matrix
-        # scenarios so reviewers see every benchmark output in one PR comment.
-        cat \
-          <(cat artifact/transaction-cost.md | sed '1,5d;s/^#/##/') \
-          <(cat artifact/end-to-end-benchmarks.md | sed '1,5d;s/^#/##/') \
-          <(cat artifact/scenarios.md | sed '1,5d;s/^#/##/') \
-          | grep -v '^:::' > comment-body.md
+        # Drop first 5 header lines and demote headlines one level. Every
+        # benchmark output lands in one PR comment, each report inside its own
+        # collapsed <details> section so the comment stays short to scroll.
+        # The blank line after <summary> is required for the markdown inside
+        # to render.
+        section() {
+          echo "<details>"
+          echo "<summary><b>$1</b></summary>"
+          echo ""
+          sed '1,5d;s/^#/##/' "$2" | grep -v '^:::'
+          echo ""
+          echo "</details>"
+          echo ""
+        }
+        {
+          section "Transaction costs" artifact/transaction-cost.md
+          section "End-to-end benchmark results" artifact/end-to-end-benchmarks.md
+          section "Scenario benchmark results" artifact/scenarios.md
+        } > comment-body.md
 
     - name: 🔎 Find Comment
       uses: peter-evans/find-comment@v3

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -123,7 +123,9 @@ jobs:
             # Skip the incremental-ops dimension in CI: per-cycle ~90s adds up
             # across cells and the cost is known/bounded. Local runs can still
             # opt in via `--incremental-modes False,True`.
-            options: 'matrix --output-directory $(pwd)/../benchmarks --number-of-txs 30 --timeout 3600s --incremental-modes False'
+            # Fixed seed (cell i uses seed+i) so the matrix benchmarks the
+            # same workloads on every run and pages are comparable over time.
+            options: 'matrix --output-directory $(pwd)/../benchmarks --number-of-txs 30 --timeout 3600s --incremental-modes False --seed 2755'
     steps:
     - name: 📥 Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -85,13 +85,16 @@ jobs:
           hydra-cluster/datasets/1-node-1kutxo.json \
           --timeout 1800s \
           --output-directory $out/benchmarks
+        # Same fixed seed as the ci-nix matrix job so both pipelines measure
+        # identical workloads (cell i uses seed+i).
         nix develop .#hydra-cluster-bench --command -- \
           bench-e2e \
           matrix \
           --output-directory $out/benchmarks \
           --number-of-txs 30 \
           --timeout 3600s \
-          --incremental-modes False
+          --incremental-modes False \
+          --seed 2755
 
     - name: 👉 Create redirects
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ CLAUDE.local.md
 
 # Benchmarking
 bench-baselines/
+
+# Python bytecode from scripts/test_bench_e2e_diff.py
+__pycache__/

--- a/docs/benchmarks/index.md
+++ b/docs/benchmarks/index.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 This section provides up-to-date data regarding the known limitations of the Hydra Head on-chain protocol. Cardano transactions and blocks are subject to constraints on transaction size, execution cost, and the number of inputs and outputs. These constraints are determined by network parameters and significantly influence the capabilities of the Hydra Head protocol, such as the maximum number of parties that can participate, the amount of UTXOs that can be committed, and the extent to which these UTXOs can be fanned out. As on-chain scripts and transactions are further optimized, and as the underlying Cardano blockchain evolves with expanded parameters and enhanced script execution efficiency, these limitations are expected to evolve.
 
-The data in this section is _generated_ through Hydra's [continuous integration (CI)](https://github.com/cardano-scaling/hydra/actions/workflows/ci-nix.yaml) process, ensuring that it accurately reflects the current state of the code.
+The data in this section is _generated_ through Hydra's [continuous integration (CI)](https://github.com/cardano-scaling/hydra/actions/workflows/ci-nix.yaml) process, ensuring that it accurately reflects the current state of the code. For how per-PR performance comparisons are measured, see the [metrics reference](./metrics.md) and "PR comparison methodology" in `hydra-cluster/README.md`.
 
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -21,7 +21,15 @@ when comparing them:
 
 The absolute numbers produced by the cloud CI runners are noisy. Treat them as
 relative signals (how a value moves as the code changes), not as absolute
-hardware figures.
+hardware figures. Even relative signals need care: GitHub's runner fleet mixes
+CPU models with a large performance spread, so the PR comparison workflow
+measures the PR and its merge-base interleaved on each runner and aggregates
+same-machine pair deltas (see "PR comparison methodology" in
+`hydra-cluster/README.md`). The diff comment omits the open-loop
+confirmation-latency rows (they restate throughput) and P99 everywhere
+(confirmations arrive in per-snapshot bursts, so the top percentile is a
+handful of atoms); a failed run carries an explicit `Outcome` row instead of
+silently missing numbers.
 
 ## End-to-end benchmark results
 

--- a/hydra-cluster/README.md
+++ b/hydra-cluster/README.md
@@ -274,7 +274,9 @@ other people's merges cannot appear as PR deltas):
   in which any colored row is a false positive. Use its accumulated runs to
   judge the pipeline and recalibrate the thresholds in the script.
   `workflow_dispatch` takes `head_ref`/`base_ref` to compare arbitrary refs;
-  an empty `base_ref` makes it an A/A run of `head_ref`.
+  an empty `base_ref` makes it an A/A run of `head_ref`. Draft PRs are
+  skipped unless the PR carries the `bench` label (applies from the next
+  push).
 
 A new summary metric only shows a difference once both sides emit it, and
 must be registered in the script's `METRICS` table.

--- a/hydra-cluster/README.md
+++ b/hydra-cluster/README.md
@@ -261,20 +261,19 @@ other people's merges cannot appear as PR deltas):
   fixed seeds, consumed by every benchmark job.
 * Four benchmark jobs run in parallel; each measures BOTH sides back to back
   on its own runner (orders alternated), after prefetching both nix closures.
-  GitHub's hosted fleet mixes CPU models with a large single-thread spread,
-  so the earlier one-sample-per-side-on-separate-runners design measured
-  which VMs the jobs landed on (16-19% CV on open-loop TPS across
-  identical-code runs); machine identity cancels inside a same-machine pair.
+  GitHub's hosted fleet mixes CPU models with a large single-thread spread:
+  unpaired cross-machine comparisons see double-digit CV on open-loop TPS
+  even for identical code, while machine identity cancels inside a
+  same-machine pair.
 * `scripts/bench-e2e-diff.py` reports the median of the per-pair percent
   deltas and colors a row only beyond that metric's noise threshold with
   directional agreement across pairs. This is a calibrated heuristic, not a
   significance test, and nothing fails CI on it; strong regressions on the
   headline rates emit a `::warning` annotation.
-* A scheduled nightly run benchmarks master against itself: a null experiment
-  in which any colored row is a false positive. Use its accumulated runs to
-  judge the pipeline and recalibrate the thresholds in the script.
-  `workflow_dispatch` takes `head_ref`/`base_ref` to compare arbitrary refs;
-  an empty `base_ref` makes it an A/A run of `head_ref`. Draft PRs are
+* `workflow_dispatch` takes `head_ref`/`base_ref` to compare arbitrary refs;
+  an empty `base_ref` makes it an A/A null run of `head_ref`, in which any
+  colored row is a false positive. Use accumulated A/A runs to judge the
+  pipeline and recalibrate the thresholds in the script. Draft PRs are
   skipped unless the PR carries the `bench` label (applies from the next
   push).
 

--- a/hydra-cluster/README.md
+++ b/hydra-cluster/README.md
@@ -204,9 +204,9 @@ hydra-node processes (Linux only).
 The benchmark can be run in several modes:
 
 * `single`: Runs one or more pre-existing _dataset_ files in sequence and collects their results in a single markdown formatted file. This is useful to track the evolution of hydra-node's performance over well-known datasets and is what CI uses to compare a PR against master.
-* `datasets`: Generates a dataset from options (UTxO shape, cluster size, number of txs), saves it, and runs it.
+* `datasets`: Generates a dataset from options (UTxO shape, cluster size, number of txs), saves it, and runs it. `--seed` makes generation reproducible.
 * `generate`: Generates and saves a dataset file without running it. `--seed` makes generation reproducible and `--title` names the scenario in reports (scenarios are paired by title when diffing two reports). Feed the resulting file to `single`.
-* `matrix`: Runs a scenario matrix over cluster sizes, UTxO shapes and incremental-ops modes, and writes a `scenarios.md` comparison page.
+* `matrix`: Runs a scenario matrix over cluster sizes, UTxO shapes and incremental-ops modes, and writes a `scenarios.md` comparison page. With `--seed N`, cell i generates from seed N+i, so the matrix is reproducible across runs (CI pins this).
 * `demo`: Generates transactions against an already running network of cardano and hydra nodes. This can serve as a workload when testing network-resilience scenarios, such as packet loss or node failures. See [this CI workflow](https://github.com/cardano-scaling/hydra/blob/master/.github/workflows/network-test.yaml) for how it is used.
 
 ## Load modes and reported metrics

--- a/hydra-cluster/README.md
+++ b/hydra-cluster/README.md
@@ -250,14 +250,32 @@ Reported metrics:
   processes (Linux only); guards against memory regressions under load.
 * Confirmation time average and percentiles: see load modes above.
 
-The CI workflow `.github/workflows/bench-e2e-diff.yaml` generates three
-scenarios per PR (3-node sustained load, 1-node `Plateau 1000` large-UTxO
-load, 3-node closed-loop latency) once, then benchmarks this branch and master
-on separate, isolated runners in parallel, posting the per-metric differences
-as a PR comment via `scripts/bench-e2e-diff.py`. Both sides consume the same
-generated dataset artifact so the workload is identical; the isolation stops
-one side's ~30-minute run from degrading the runner the other is measured on
-(which otherwise biased every comparison toward the side measured first). A new
-summary metric only shows a difference once it exists on master too, and must
-be registered in that script's `METRICS` table.
+## PR comparison methodology
+
+The CI workflow `.github/workflows/bench-e2e-diff.yaml` compares each PR
+against its merge-base (not master HEAD, so re-runs keep their baseline and
+other people's merges cannot appear as PR deltas):
+
+* One job generates the three scenarios (3-node sustained load, 1-node
+  `Plateau 1000` large-UTxO load, 3-node closed-loop latency) once, with
+  fixed seeds, consumed by every benchmark job.
+* Four benchmark jobs run in parallel; each measures BOTH sides back to back
+  on its own runner (orders alternated), after prefetching both nix closures.
+  GitHub's hosted fleet mixes CPU models with a large single-thread spread,
+  so the earlier one-sample-per-side-on-separate-runners design measured
+  which VMs the jobs landed on (16-19% CV on open-loop TPS across
+  identical-code runs); machine identity cancels inside a same-machine pair.
+* `scripts/bench-e2e-diff.py` reports the median of the per-pair percent
+  deltas and colors a row only beyond that metric's noise threshold with
+  directional agreement across pairs. This is a calibrated heuristic, not a
+  significance test, and nothing fails CI on it; strong regressions on the
+  headline rates emit a `::warning` annotation.
+* A scheduled nightly run benchmarks master against itself: a null experiment
+  in which any colored row is a false positive. Use its accumulated runs to
+  judge the pipeline and recalibrate the thresholds in the script.
+  `workflow_dispatch` takes `head_ref`/`base_ref` to compare arbitrary refs;
+  an empty `base_ref` makes it an A/A run of `head_ref`.
+
+A new summary metric only shows a difference once both sides emit it, and
+must be registered in the script's `METRICS` table.
 

--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -352,7 +352,8 @@ runScenario hydraTracer timing opts workDir Dataset{clientDatasets, title, descr
       validationTimes = map (\(_, v, _) -> v) res
       numberOfTxs = length confTimes
       numberOfInvalidTxs = length $ Map.filter (isJust . invalidAt) processedTransactions
-      averageConfirmationTime = sum confTimes / fromIntegral numberOfTxs
+      -- 0/0 is NaN, which serializes as garbage; report 0 when nothing confirmed.
+      averageConfirmationTime = if numberOfTxs == 0 then 0 else sum confTimes / fromIntegral numberOfTxs
       quantiles = makeQuantiles confTimes
       validationP50Ms = medianMilliseconds validationTimes
       summaryTitle = fromMaybe "Baseline Scenario" title
@@ -666,8 +667,10 @@ processTransactions clients clientDatasets incrementalCtx waitForTxValidEnabled 
                 -- nodes may not yet have cleared their in-flight decommit state
                 -- after gossip propagation. Hold the lock for a short tail
                 -- before releasing so the next client's WS Decommit input is
-                -- not rejected with DecommitAlreadyInFlight.
-                threadDelay 2_000_000
+                -- not rejected with DecommitAlreadyInFlight. NOTE: threadDelay
+                -- is seconds here; 2_000_000 used to hit the 90s timeout above
+                -- instead, inflating every incremental cycle to that ceiling.
+                threadDelay 2
                 pure (Just commitTime, Just decommitTime)
 
 -- | Like 'try' but rethrows async exceptions instead of swallowing them. Using

--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -668,9 +668,7 @@ processTransactions clients clientDatasets incrementalCtx waitForTxValidEnabled 
                 -- nodes may not yet have cleared their in-flight decommit state
                 -- after gossip propagation. Hold the lock for a short tail
                 -- before releasing so the next client's WS Decommit input is
-                -- not rejected with DecommitAlreadyInFlight. NOTE: threadDelay
-                -- is seconds here; 2_000_000 used to hit the 90s timeout above
-                -- instead, inflating every incremental cycle to that ceiling.
+                -- not rejected with DecommitAlreadyInFlight.
                 threadDelay 2
                 pure (Just commitTime, Just decommitTime)
 

--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -382,6 +382,7 @@ runScenario hydraTracer timing opts workDir Dataset{clientDatasets, title, descr
       , numberOfSnapshots
       , incrementalCommitTimes
       , incrementalDecommitTimes
+      , runOutcome = Nothing
       }
  where
   Timing{blockTime} = timing

--- a/hydra-cluster/bench/Bench/Options.hs
+++ b/hydra-cluster/bench/Bench/Options.hs
@@ -53,6 +53,7 @@ data Options
       , incrementalOps :: Bool
       , waitForTxValid :: Bool
       , cborClients :: Bool
+      , generationSeed :: Maybe Int
       }
   | DemoOptions
       { outputDirectory :: Maybe FilePath
@@ -74,6 +75,8 @@ data Options
       , incrementalModes :: [Bool]
       , waitForTxValidModes :: [Bool]
       , cborClients :: Bool
+      , generationSeed :: Maybe Int
+      -- ^ Cell i derives its dataset from seed + i: distinct but reproducible.
       }
   | GenerateOptions
       { datasetUTxO :: UTxOSize
@@ -267,6 +270,7 @@ datasetOptionsParser =
     <*> incrementalOpsParser
     <*> waitForTxValidParser
     <*> cborClientsParser
+    <*> optional generationSeedParser
 
 generateOptionsInfo :: ParserInfo Options
 generateOptionsInfo =
@@ -384,6 +388,7 @@ matrixOptionsParser =
     <*> incrementalModesParser
     <*> waitForTxValidModesParser
     <*> cborClientsParser
+    <*> optional generationSeedParser
 
 clusterSizesParser :: Parser [Word64]
 clusterSizesParser =

--- a/hydra-cluster/bench/Bench/Summary.hs
+++ b/hydra-cluster/bench/Bench/Summary.hs
@@ -48,6 +48,8 @@ data Summary = Summary
   , numberOfSnapshots :: Int
   , incrementalCommitTimes :: [NominalDiffTime]
   , incrementalDecommitTimes :: [NominalDiffTime]
+  , runOutcome :: Maybe Text
+  -- ^ Nothing when the run completed; a short failure reason otherwise.
   }
   deriving stock (Generic, Eq, Show)
 
@@ -74,6 +76,7 @@ errorSummary Dataset{title, clientDatasets} (HUnitFailure sourceLocation reason)
     , numberOfSnapshots = 0
     , incrementalCommitTimes = []
     , incrementalDecommitTimes = []
+    , runOutcome = Just $ shortReason reason
     }
  where
   formatLocation = maybe "" (\loc -> "at " <> prettySrcLoc loc)
@@ -108,12 +111,13 @@ snapshotsPerSecond Summary{numberOfSnapshots, runWallClockSeconds}
   | otherwise = 0
 
 textReport :: (Summary, SystemStats) -> [Text]
-textReport (summary@Summary{totalTxs, numberOfTxs, averageConfirmationTime, quantiles, validationP50Ms, numberOfInvalidTxs, numberOfFanoutOutputs, endToEndTps, sustainedTps, drainSeconds, avgTxsPerSnapshot, peakNodeRssMb, numberOfSnapshots, incrementalCommitTimes, incrementalDecommitTimes}, systemStats) =
+textReport (summary@Summary{totalTxs, numberOfTxs, averageConfirmationTime, quantiles, validationP50Ms, numberOfInvalidTxs, numberOfFanoutOutputs, endToEndTps, sustainedTps, drainSeconds, avgTxsPerSnapshot, peakNodeRssMb, numberOfSnapshots, incrementalCommitTimes, incrementalDecommitTimes, runOutcome}, systemStats) =
   let frac :: Double
       frac = 100 * fromIntegral numberOfTxs / fromIntegral totalTxs
    in [ pack $ printf "Confirmed txs/Total expected txs: %d/%d (%.2f %%)" numberOfTxs totalTxs frac
       , "Average confirmation time (ms): " <> oneDec (nominalDiffTimeToMilliseconds averageConfirmationTime)
       ]
+        ++ maybe [] (\reason -> ["Outcome: FAILED: " <> reason]) runOutcome
         ++ ( if length quantiles == 100
               then
                 [ "P99: " <> oneDec (quantiles ! 99) <> "ms"
@@ -179,7 +183,7 @@ markdownReport now summaries =
     ]
 
 formattedSummary :: (Summary, SystemStats) -> [Text]
-formattedSummary (summary@Summary{clusterSize, numberOfTxs, averageConfirmationTime, quantiles, validationP50Ms, summaryTitle, summaryDescription, numberOfInvalidTxs, numberOfFanoutOutputs, endToEndTps, sustainedTps, drainSeconds, avgTxsPerSnapshot, peakNodeRssMb, numberOfSnapshots, incrementalCommitTimes, incrementalDecommitTimes}, systemStats)
+formattedSummary (summary@Summary{clusterSize, numberOfTxs, averageConfirmationTime, quantiles, validationP50Ms, summaryTitle, summaryDescription, numberOfInvalidTxs, numberOfFanoutOutputs, endToEndTps, sustainedTps, drainSeconds, avgTxsPerSnapshot, peakNodeRssMb, numberOfSnapshots, incrementalCommitTimes, incrementalDecommitTimes, runOutcome}, systemStats)
   | numberOfTxs == 0 =
       -- Failed cell: no confirmations, so all the latency / TPS rows would be
       -- zeros or empty quantiles. Render a short failure block instead of the
@@ -203,8 +207,10 @@ formattedSummary (summary@Summary{clusterSize, numberOfTxs, averageConfirmationT
       , "| Number of nodes |  " <> show clusterSize <> " | "
       , "| -- | -- |"
       , "| _Number of txs_ | " <> show numberOfTxs <> " |"
-      , "| _Avg. Confirmation Time (ms)_ | " <> oneDec (nominalDiffTimeToMilliseconds averageConfirmationTime) <> " |"
       ]
+        ++ maybe [] (\reason -> ["| _Outcome_ | FAILED: " <> reason <> " |"]) runOutcome
+        ++ [ "| _Avg. Confirmation Time (ms)_ | " <> oneDec (nominalDiffTimeToMilliseconds averageConfirmationTime) <> " |"
+           ]
         ++ ( if length quantiles == 100
               then
                 [ "| _P99_ | " <> oneDec (quantiles ! 99) <> "ms |"

--- a/hydra-cluster/bench/Bench/Summary.hs
+++ b/hydra-cluster/bench/Bench/Summary.hs
@@ -89,7 +89,9 @@ errorSummary Dataset{title, clientDatasets} (HUnitFailure sourceLocation reason)
           (l : rest) -> l <> if null rest then "" else " (full output omitted)"
 
 makeQuantiles :: [NominalDiffTime] -> Vector Double
--- makeQuantiles [] = mempty -- No confirmations, no quantiles.
+-- quantilesVec throws on empty input and report writers force this; renderers
+-- already guard on the vector's length.
+makeQuantiles [] = mempty
 makeQuantiles times =
   Statistics.quantilesVec def (fromList [0 .. 99]) 100 (fromList $ map (fromRational . (* 1000) . toRational . nominalDiffTimeToSeconds) times)
 

--- a/hydra-cluster/bench/Main.hs
+++ b/hydra-cluster/bench/Main.hs
@@ -47,11 +47,11 @@ main = do
           benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand BenchRunOptions{incrementalOps = False, waitForTxValid = False, cborClients}
       summarizeResults outputDirectory [results]
       removeDirectoryRecursive workDir
-    DatasetOptions{outputDirectory, timeoutSeconds, datasetUTxO, numberOfTxs, clusterSize, startingNodeId, incrementalOps, waitForTxValid, cborClients} -> do
+    DatasetOptions{outputDirectory, timeoutSeconds, datasetUTxO, numberOfTxs, clusterSize, startingNodeId, incrementalOps, waitForTxValid, cborClients, generationSeed} -> do
       (_, faucetSk) <- keysFor Faucet
       workDir <- maybe (createTempDir "bench-e2e") checkEmpty outputDirectory
       let action = bench startingNodeId timeoutSeconds BenchRunOptions{incrementalOps, waitForTxValid, cborClients}
-      dataset <- generate $ datasetGen faucetSk datasetUTxO clusterSize numberOfTxs
+      dataset <- runGen generationSeed $ datasetGen faucetSk datasetUTxO clusterSize numberOfTxs
       saveDataset (workDir </> "dataset.json") dataset
       putStrLn $ "Saved dataset in: " <> (workDir </> "dataset.json")
       results <- do
@@ -59,7 +59,7 @@ main = do
         threadDelay 10
         runSingle dataset workDir action
       summarizeResults outputDirectory [results]
-    MatrixOptions{outputDirectory, timeoutSeconds, numberOfTxs, startingNodeId, clusterSizes, utxoShapes, incrementalModes, waitForTxValidModes, cborClients} -> do
+    MatrixOptions{outputDirectory, timeoutSeconds, numberOfTxs, startingNodeId, clusterSizes, utxoShapes, incrementalModes, waitForTxValidModes, cborClients, generationSeed} -> do
       (_, faucetSk) <- keysFor Faucet
       -- NOTE: Unlike a standalone matrix run, the docs pipeline points
       -- --output-directory at the shared benchmarks/ directory that already
@@ -78,7 +78,7 @@ main = do
       results <- forM (zip [0 :: Int ..] cells) $ \(i, (cs, sh, im, wt)) -> do
         let cellDir = workDir </> ("cell-" <> show i)
         createDirectoryIfMissing True cellDir
-        dataset <- generate $ datasetGen faucetSk sh cs numberOfTxs
+        dataset <- runGen ((+ i) <$> generationSeed) $ datasetGen faucetSk sh cs numberOfTxs
         let labelled = dataset{title = Just (matrixCellTitle cs sh im wt)}
         saveDataset (cellDir </> "dataset.json") labelled
         threadDelay 10
@@ -92,14 +92,16 @@ main = do
       summarizeMatrixResults outputDirectory results
     GenerateOptions{datasetUTxO, numberOfTxs, clusterSize, datasetTitle, generationSeed, outputFile} -> do
       (_, faucetSk) <- keysFor Faucet
-      let gen = datasetGen faucetSk datasetUTxO clusterSize numberOfTxs
-      dataset <- case generationSeed of
-        Nothing -> generate gen
-        -- Same generation size as QuickCheck's 'generate' so seeded and
-        -- unseeded datasets have the same shape.
-        Just seed -> pure $ unGen gen (mkQCGen seed) 30
+      dataset <- runGen generationSeed $ datasetGen faucetSk datasetUTxO clusterSize numberOfTxs
       saveDataset outputFile $ maybe dataset (\t -> dataset{title = Just t}) datasetTitle
  where
+  -- Same generation size as QuickCheck's 'generate' so seeded and unseeded
+  -- datasets have the same shape.
+  runGen :: Maybe Int -> Gen a -> IO a
+  runGen = \case
+    Nothing -> generate
+    Just seed -> \gen -> pure $ unGen gen (mkQCGen seed) 30
+
   datasetGen :: Secret (SigningKey PaymentKey) -> UTxOSize -> Word64 -> Int -> Gen Dataset
   datasetGen faucetSk shape clusterSize numberOfTxs =
     case shape of

--- a/hydra-cluster/bench/Main.hs
+++ b/hydra-cluster/bench/Main.hs
@@ -144,14 +144,16 @@ main = do
 
   summarizeResults :: Maybe FilePath -> [Either (Dataset, FilePath, Summary, BenchmarkFailed) (Summary, SystemStats)] -> IO ()
   summarizeResults outputDirectory results = do
-    let (failures, summaries) = partitionEithers results
-    case failures of
-      [] -> writeBenchmarkReport outputDirectory summaries
-      errs -> do
-        forM_ errs $ \(_, dir, summary, exc) -> do
-          writeBenchmarkReport outputDirectory [(summary, [])]
-          benchmarkFailedWith dir exc
-        exitFailure
+    -- One report covering every dataset in order: a failing dataset must not
+    -- clobber or hide sibling results.
+    let summaries =
+          flip map results $ \case
+            Left (_, _, summary, exc) -> (summary{runOutcome = Just (failureLabel exc)}, [])
+            Right s -> s
+    writeBenchmarkReport outputDirectory summaries
+    let failures = lefts results
+    forM_ failures $ \(_, dir, _, exc) -> benchmarkFailedWith dir exc
+    unless (null failures) exitFailure
 
   summarizeMatrixResults :: Maybe FilePath -> [Either (Dataset, FilePath, Summary, BenchmarkFailed) (Summary, SystemStats)] -> IO ()
   summarizeMatrixResults outputDirectory results = do
@@ -185,6 +187,17 @@ data BenchmarkFailed
   = TestFailed HUnitFailure
   | InvalidTransactions Int
   | NotEnoughTransactions Int Int
+
+-- | One-line reason for the report's Outcome row; details go to stdout via
+-- 'benchmarkFailedWith'.
+failureLabel :: BenchmarkFailed -> Text
+failureLabel = \case
+  TestFailed (HUnitFailure _ reason) ->
+    case T.lines (T.pack (formatFailureReason reason)) of
+      [] -> "test failure"
+      (l : _) -> l
+  NotEnoughTransactions actual expected -> "confirmed " <> show actual <> " of " <> show expected <> " txs"
+  InvalidTransactions n -> show n <> " invalid txs"
 
 benchmarkFailedWith :: FilePath -> BenchmarkFailed -> IO ()
 benchmarkFailedWith benchDir = \case

--- a/justfile
+++ b/justfile
@@ -129,6 +129,7 @@ lint PKG="all":
   set -euo pipefail
   rc=0
   nix fmt || rc=1
+  python3 scripts/test_bench_e2e_diff.py || rc=1
   cabal build {{PKG}} \
     --builddir=dist-newstyle-lint \
     --ghc-options="-Werror \

--- a/scripts/bench-e2e-diff.py
+++ b/scripts/bench-e2e-diff.py
@@ -1,199 +1,359 @@
 #! /usr/bin/env python3
 
-# Diff two end-to-end benchmark reports (master vs PR) and render a colored
-# markdown comment. Parses the per-scenario tables emitted by
-# hydra-cluster/bench/Bench/Summary.hs (formattedSummary); see that function
-# for the source-of-truth row format. Pure stdlib so CI needs no extra deps.
+# Diff end-to-end benchmark reports (master vs PR) into a colored markdown
+# comment. Pure stdlib. Two modes:
+#
+#   bench-e2e-diff.py old.md new.md         one report per side (local use)
+#   bench-e2e-diff.py --results-dir DIR     paired CI mode
+#
+# Paired mode layout, produced by .github/workflows/bench-e2e-diff.yaml:
+#   DIR/<machine>/fingerprint.json                                (optional)
+#   DIR/<machine>/rep-<slot>-<side>/**/end-to-end-benchmarks.md
+# Every benchmark job measures BOTH sides on its own runner, so adjacent slots
+# form a same-machine pair and machine identity cancels in the pair delta
+# (GitHub's fleet mixes CPU models with a large performance spread; unpaired
+# cross-machine numbers mostly measure which VMs the jobs landed on).
+#
+# Aggregation: per metric, the median of the pairs' percent deltas. A row is
+# colored only when |median| exceeds the metric's noise threshold AND at
+# least 3/4 of pairs agree in direction. This is a calibrated heuristic, not
+# a significance test.
 
 import argparse
+import json
+import math
 import re
 import sys
+from pathlib import Path
+from statistics import median
 
-# Metrics we diff, in display order. Each entry is (row key, display label,
-# improvement direction, display scale):
-#   - row key: the text between underscores in `| _key_ | value |`, matched
-#     against Summary.hs's output exactly (same key in both the master and PR
-#     reports).
-#   - improvement direction: +1 = higher is better, -1 = lower is better,
-#     0 = neutral. Neutral rows are shown without a good/bad color: e.g.
-#     snapshot counts move with the node's snapshot batching cap without being
-#     better or worse by themselves (throughput = snapshots/s x txs/snapshot).
-#   - display scale: multiplies the raw value before rendering. Summary.hs emits
-#     the confirmation/validation rows in milliseconds, but under load they run
-#     to tens of thousands of ms; they read more naturally in seconds, so they
-#     are scaled by MS_TO_S and relabelled "(s)". Both reports are scaled the
-#     same way, so the delta and percentage are unchanged.
-# Keys must match Summary.hs exactly.
 MS_TO_S = 1e-3
+
+# (row key as emitted by Bench.Summary, display label, direction, display
+# scale, closed_loop_only, kind). direction: +1 higher is better, -1 lower,
+# 0 neutral context. Open-loop scenarios omit the confirmation-latency rows
+# (they restate throughput, see hydra-cluster/README.md) and P99 is omitted
+# everywhere (confirmations arrive in per-snapshot bursts, so the top
+# percentile is a handful of atoms). kind "count" diffs by absolute delta.
 METRICS = [
-    ("End-to-end TPS", "End-to-end TPS (tx/s)", +1, 1.0),
-    ("Sustained TPS", "Sustained TPS (tx/s)", +1, 1.0),
-    ("Backlog drain time (s)", "Backlog drain time (s)", -1, 1.0),
-    ("Snapshots per second", "Snapshots per second (/s)", 0, 1.0),
-    ("Avg txs per snapshot", "Avg txs per snapshot", 0, 1.0),
-    ("Avg. Confirmation Time (ms)", "Avg. Confirmation Time (s)", -1, MS_TO_S),
-    ("P50", "P50 confirmation (s)", -1, MS_TO_S),
-    ("P95", "P95 confirmation (s)", -1, MS_TO_S),
-    ("P99", "P99 confirmation (s)", -1, MS_TO_S),
-    ("Tx validation time p50 (ms)", "Tx validation time p50 (s)", -1, MS_TO_S),
-    ("Peak node RSS (MB)", "Peak node RSS (MB)", 0, 1.0),
-    ("Incremental commit avg (ms)", "Incremental commit avg (s)", -1, MS_TO_S),
-    ("Incremental decommit avg (ms)", "Incremental decommit avg (s)", -1, MS_TO_S),
-    ("Number of Invalid txs", "Invalid txs", -1, 1.0),
+    ("End-to-end TPS", "End-to-end TPS (tx/s)", +1, 1.0, False, "pct"),
+    ("Sustained TPS", "Sustained TPS (tx/s)", +1, 1.0, False, "pct"),
+    ("Backlog drain time (s)", "Backlog drain time (s)", -1, 1.0, False, "pct"),
+    ("Snapshots per second", "Snapshots per second (/s)", 0, 1.0, False, "pct"),
+    ("Avg txs per snapshot", "Avg txs per snapshot", 0, 1.0, False, "pct"),
+    ("Avg. Confirmation Time (ms)", "Avg. Confirmation Time (s)", -1, MS_TO_S, True, "pct"),
+    ("P50", "P50 confirmation (s)", -1, MS_TO_S, True, "pct"),
+    ("P95", "P95 confirmation (s)", -1, MS_TO_S, True, "pct"),
+    ("Tx validation time p50 (ms)", "Tx validation time p50 (s)", -1, MS_TO_S, False, "pct"),
+    ("Peak node RSS (MB)", "Peak node RSS (MB)", -1, 1.0, False, "pct"),
+    ("Number of Invalid txs", "Invalid txs", -1, 1.0, False, "count"),
+    ("Incremental commit avg (ms)", "Incremental commit avg (s)", -1, MS_TO_S, False, "pct"),
+    ("Incremental decommit avg (ms)", "Incremental decommit avg (s)", -1, MS_TO_S, False, "pct"),
 ]
 
-# `| _key_ | value |`, tolerant of surrounding whitespace.
+# Percent thresholds below which a median delta renders as noise. Initial
+# values; recalibrate from nightly A/A (null) runs when enough accumulate.
+THRESHOLDS = {
+    "default": 10.0,
+    "Avg. Confirmation Time (ms)": 5.0,
+    "P50": 5.0,
+    "P95": 5.0,
+}
+
+# Colored regressions beyond this on the headline rates additionally emit a
+# ::warning annotation (soft gate, exit code stays 0).
+WARN_METRICS = {"End-to-end TPS", "Sustained TPS"}
+WARN_PCT = 15.0
+
+REQUIRED_AGREEMENT = 0.75
+
 ROW_RE = re.compile(r"^\|\s*_(?P<key>.+?)_\s*\|\s*(?P<val>.*?)\s*\|")
-NUM_RE = re.compile(r"-?\d+(?:\.\d+)?")
+NUM_RE = re.compile(r"-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?")
+REP_DIR_RE = re.compile(r"^rep-(?P<slot>\d+)-(?P<side>branch|master)$")
 
 
 def parse_value(raw):
-    # Strip units (ms, tx/s, ₳, %, commas) and read the first number.
     m = NUM_RE.search(raw.replace(",", ""))
     return float(m.group()) if m else None
 
 
 def parse_report(path):
-    """{scenario_title: {metric_key: float}} in file order."""
-    scenarios = {}
-    order = []
-    title = None
+    """{scenario_title: record} plus title order, from `| _key_ | value |`
+    rows under `## title` headings. A missing 'Number of txs' row or an
+    Outcome row marks the scenario as failed."""
+    records, order, rec = {}, [], None
     with open(path, encoding="utf-8") as f:
         for line in f:
             if line.startswith("## "):
                 title = line[3:].strip()
-                if title not in scenarios:
-                    scenarios[title] = {}
+                rec = records.setdefault(title, {"title": title, "outcome": None, "metrics": {}})
+                if title not in order:
                     order.append(title)
                 continue
-            if title is None:
+            if rec is None:
                 continue
             m = ROW_RE.match(line)
             if not m:
                 continue
-            val = parse_value(m.group("val"))
+            key, raw = m.group("key").strip(), m.group("val").strip()
+            if key == "Outcome":
+                rec["outcome"] = raw
+                continue
+            val = parse_value(raw)
             if val is not None:
-                scenarios[title][m.group("key").strip()] = val
-    return scenarios, order
+                rec["metrics"][key] = val
+    for rec in records.values():
+        rec["failed"] = rec["outcome"] is not None or "Number of txs" not in rec["metrics"]
+    return records, order
+
+
+def collect_results(results_dir):
+    """Walk DIR/<machine>/rep-<slot>-<side>/ and merge every report found
+    under a rep (open and closed invocations write separately)."""
+    machines, scenario_order = {}, []
+    root = Path(results_dir)
+    for machine_dir in sorted(p for p in root.iterdir() if p.is_dir()):
+        machine = {"name": machine_dir.name, "fingerprint": None, "reps": []}
+        for fp in sorted(machine_dir.glob("**/fingerprint.json")):
+            try:
+                machine["fingerprint"] = json.loads(fp.read_text(encoding="utf-8"))
+                break
+            except (OSError, ValueError):
+                pass
+        for rep_dir in sorted(p for p in machine_dir.iterdir() if p.is_dir()):
+            m = REP_DIR_RE.match(rep_dir.name)
+            if not m:
+                continue
+            scenarios = {}
+            for report in sorted(rep_dir.glob("**/end-to-end-benchmarks.md")):
+                recs, order = parse_report(report)
+                for title in order:
+                    scenarios.setdefault(title, recs[title])
+                    if title not in scenario_order:
+                        scenario_order.append(title)
+            machine["reps"].append(
+                {"slot": int(m.group("slot")), "side": m.group("side"), "scenarios": scenarios}
+            )
+        machine["reps"].sort(key=lambda r: r["slot"])
+        if machine["reps"]:
+            machines[machine_dir.name] = machine
+    return machines, scenario_order
+
+
+def build_pairs(machines):
+    pairs = []
+    for machine in machines.values():
+        reps = machine["reps"]
+        for i in range(0, len(reps) - 1, 2):
+            a, b = reps[i], reps[i + 1]
+            if {a["side"], b["side"]} != {"branch", "master"}:
+                print(f"WARNING: slots {a['slot']},{b['slot']} on {machine['name']} are not a branch/master pair; skipped", file=sys.stderr)
+                continue
+            old, new = (a, b) if a["side"] == "master" else (b, a)
+            pairs.append({"machine": machine["name"], "old": old, "new": new})
+    return pairs
 
 
 def fmt_num(x, decimals=2):
     return f"{x:,.{decimals}f}"
 
 
-def colored(body, delta, good_dir):
-    # We deliberately avoid GitHub's $$\color{...}$$ math trick: a literal '%'
-    # in math mode is a comment and GitHub's markdown pipeline mangles even an
-    # escaped '\%', truncating the cell. A colored emoji + plain text is robust
-    # everywhere (including mobile) and conveys the same green/red signal.
-    improved = (delta > 0 and good_dir > 0) or (delta < 0 and good_dir < 0)
-    return f"{'🟢' if improved else '🔴'} {body}"
+def sign(x):
+    return (x > 0) - (x < 0)
 
 
-def fmt_delta(delta, pct, good_dir, threshold, decimals=2):
-    sign = "+" if delta >= 0 else ""
-    pct_sign = "+" if pct >= 0 else ""
-    body = f"{sign}{delta:,.{decimals}f} ({pct_sign}{pct:.1f}%)"
-    if abs(pct) < threshold:
-        return f"≈ {body}"
-    if good_dir == 0:
-        return body
-    return colored(body, delta, good_dir)
+def decide_cell(deltas, direction, threshold, kind):
+    """(cell text, warn_worthy_regression). deltas are percent for kind
+    'pct', absolute for 'count'."""
+    n = len(deltas)
+    med = median(deltas)
+    agreeing = sum(1 for d in deltas if sign(d) == sign(med))
+    unit = "%" if kind == "pct" else ""
+    body = f"{med:+.1f}{unit}"
+    if kind == "count":
+        significant = med != 0
+    else:
+        significant = abs(med) >= threshold and agreeing >= math.ceil(REQUIRED_AGREEMENT * n)
+    if not significant or direction == 0:
+        return (f"≈ {body}" if not significant else body), False
+    improved = (med > 0) == (direction > 0)
+    regressed_hard = not improved and kind == "pct" and abs(med) >= WARN_PCT and agreeing == n
+    return f"{'🟢' if improved else '🔴'} {body}", regressed_hard
 
 
-# Headline metrics that emit a GitHub ::warning:: annotation (still exit 0)
-# when they regress more than WARN_PCT. Coarse on purpose: shared-runner e2e
-# noise makes a hard gate impractical, but a large drop on a headline rate
-# should be visible without opening the report. Only directional metrics
-# belong here; neutral (0) ones have no regression direction.
-WARN_METRICS = {"End-to-end TPS", "Sustained TPS"}
-WARN_PCT = 15.0
-
-
-def scenario_rows(old, new, threshold, warn_keys, regressions, title):
+def scenario_rows(title, pairs, regressions):
+    valid = []
+    for p in pairs:
+        old = p["old"]["scenarios"].get(title)
+        new = p["new"]["scenarios"].get(title)
+        if old and new and not old["failed"] and not new["failed"]:
+            valid.append((old, new))
+    if not valid:
+        return [], 0
+    closed_loop = "closed-loop" in title
     rows = []
-    for key, label, good_dir, scale in METRICS:
-        if key not in old or key not in new:
-            if key in old or key in new:
-                warn_keys.add(key)  # present one side only: possible format drift
+    for key, label, direction, scale, closed_only, kind in METRICS:
+        if closed_only and not closed_loop:
             continue
-        o, n = old[key] * scale, new[key] * scale
-        # The ms->s scaled rows keep millisecond resolution (3 decimals) so the
-        # sub-second closed-loop latencies stay meaningful; the throughput and
-        # RSS rows read fine at 2.
+        deltas, olds, news = [], [], []
+        for old, new in valid:
+            if key not in old["metrics"] or key not in new["metrics"]:
+                continue
+            o, n = old["metrics"][key] * scale, new["metrics"][key] * scale
+            olds.append(o)
+            news.append(n)
+            if kind == "count":
+                deltas.append(n - o)
+            elif o != 0:
+                deltas.append(100.0 * (n - o) / o)
+        if not deltas:
+            continue
         decimals = 3 if scale != 1.0 else 2
-        delta = n - o
-        if key in WARN_METRICS and o != 0:
-            pct = 100.0 * delta * good_dir / o
-            if pct < -WARN_PCT:
-                regressions.append(f"{title}: {label} changed {100.0 * delta / o:+.1f}%")
-        if o == 0:
-            # No baseline to compute a percentage from. Any nonzero change is a
-            # real one (the metric went from "none" to "some"), so color it.
-            sign = "+" if delta >= 0 else ""
-            body = f"{sign}{delta:,.{decimals}f} (n/a%)"
-            if delta == 0:
-                cell = f"≈ {body}"
-            elif good_dir == 0:
-                cell = body
-            else:
-                cell = colored(body, delta, good_dir)
-        else:
-            pct = 100.0 * delta / o
-            cell = fmt_delta(delta, pct, good_dir, threshold, decimals)
-        rows.append(f"| {label} | {fmt_num(o, decimals)} | {fmt_num(n, decimals)} | {cell} |")
-    return rows
+        cell, warn = decide_cell(deltas, direction, THRESHOLDS.get(key, THRESHOLDS["default"]), kind)
+        if len(deltas) < len(valid):
+            cell += f" ({len(deltas)}/{len(valid)} pairs)"
+        if warn and key in WARN_METRICS:
+            regressions.append(f"{title}: {label} changed {median(deltas):+.1f}%")
+        rows.append(f"| {label} | {fmt_num(median(olds), decimals)} | {fmt_num(median(news), decimals)} | {cell} |")
+    return rows, len(valid)
+
+
+def failed_scenario_lines(title, pairs):
+    lines = []
+    for side, label in (("new", "PR"), ("old", "master")):
+        total, failed, reason = 0, 0, None
+        for p in pairs:
+            rec = p[side]["scenarios"].get(title)
+            if rec is None:
+                continue
+            total += 1
+            if rec["failed"]:
+                failed += 1
+                reason = reason or rec["outcome"] or "no measurements"
+        if total and failed:
+            lines.append(f"**FAILED on {label} ({failed}/{total} runs)**: {reason}")
+    return lines or ["No results on either side; see the workflow run."]
+
+
+def same_code_spread(machines, title, key="End-to-end TPS"):
+    """Cross-machine spread on identical code per side: the noise an unpaired
+    comparison would be exposed to."""
+    out = {}
+    for side in ("master", "branch"):
+        vals = [
+            rec["metrics"][key]
+            for machine in machines.values()
+            for rep in machine["reps"]
+            if rep["side"] == side
+            for rec in [rep["scenarios"].get(title)]
+            if rec and not rec["failed"] and key in rec["metrics"]
+        ]
+        if len(vals) >= 2 and min(vals) > 0:
+            out[side] = 100.0 * (max(vals) - min(vals)) / min(vals)
+    return out
+
+
+def render_details(machines, scenario_order):
+    lines = ["", "<details>", "<summary>Per-run raw values</summary>", "",
+             "| Machine | Slot | Side | Scenario | E2E TPS | Outcome |", "| -- | -- | -- | -- | -- | -- |"]
+    for machine in machines.values():
+        for rep in machine["reps"]:
+            for title in scenario_order:
+                rec = rep["scenarios"].get(title)
+                if rec is None:
+                    continue
+                tps = rec["metrics"].get("End-to-end TPS")
+                lines.append(
+                    f"| {machine['name']} | {rep['slot']} | {rep['side']} | {title} | "
+                    f"{fmt_num(tps) if tps is not None else 'n/a'} | {rec['outcome'] or 'ok'} |"
+                )
+    return lines + ["", "</details>"]
+
+
+def render(machines, scenario_order, base_sha=None, head_sha=None, with_footer=True):
+    pairs = build_pairs(machines)
+    out = ["# End-to-end benchmark differences", ""]
+    shas = f"Comparing `{(head_sha or 'PR')[:7]}` (PR) against merge-base `{(base_sha or 'master')[:7]}`. " if (base_sha or head_sha) else ""
+    out.append(
+        shas
+        + "Each runner measures both sides; every delta is the median over the "
+        + "same-machine pairs. Colored rows exceed the per-metric noise threshold "
+        + "with directional agreement (a calibrated heuristic, not a significance "
+        + "test); `≈` is within noise; uncolored rows are context. "
+        + "🟢 = improvement, 🔴 = regression."
+    )
+    out.append("")
+    if not pairs:
+        out.append("No valid same-machine pairs found; benchmark runs likely failed. See the workflow run for logs.")
+        return out, []
+    regressions = []
+    matched_any = False
+    for title in scenario_order:
+        rows, n_valid = scenario_rows(title, pairs, regressions)
+        if n_valid == 0:
+            out += ["", f"## {title}", ""] + failed_scenario_lines(title, pairs)
+            matched_any = True
+            continue
+        header = f"## {title}" + (f" ({n_valid}/{len(pairs)} pairs)" if n_valid < len(pairs) else "")
+        out += ["", header, "", "| Metric | master | PR | Δ |", "| -- | -- | -- | -- |"] + rows
+        matched_any = True
+    if not matched_any:
+        out.append("No comparable scenarios found between this PR and `master`.")
+    if with_footer:
+        out += ["", "---", ""]
+        for name, machine in machines.items():
+            fp = machine["fingerprint"] or {}
+            extra = ", ".join(str(x) for x in (f"{fp.get('nproc')} vCPU" if fp.get("nproc") else None, f"{fp.get('mem_gb')} GB" if fp.get("mem_gb") else None) if x)
+            out.append(f"- `{name}`: {fp.get('cpu_model', 'unknown CPU')}{f' ({extra})' if extra else ''}")
+        spreads = [
+            f"  - {title}: " + ", ".join(f"{side} {pct:.1f}%" for side, pct in sorted(spread.items()))
+            for title in scenario_order
+            for spread in [same_code_spread(machines, title)]
+            if spread
+        ]
+        if spreads:
+            out.append("- Same-code spread across runners (End-to-end TPS), the noise an unpaired comparison would see:")
+            out += spreads
+        out += render_details(machines, scenario_order)
+    return out, regressions
+
+
+def legacy_machines(old_file, new_file):
+    old_recs, _ = parse_report(Path(old_file))
+    new_recs, new_order = parse_report(Path(new_file))
+    machine = {
+        "name": "local",
+        "fingerprint": None,
+        "reps": [
+            {"slot": 1, "side": "master", "scenarios": old_recs},
+            {"slot": 2, "side": "branch", "scenarios": new_recs},
+        ],
+    }
+    order = [t for t in new_order if t in old_recs]
+    return {"local": machine}, order
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("old_file", help="master end-to-end-benchmarks.md")
-    parser.add_argument("new_file", help="PR end-to-end-benchmarks.md")
-    parser.add_argument("--threshold", type=float, default=5.0,
-                        help="percent change below which a metric is treated as noise")
+    parser.add_argument("old_file", nargs="?", help="legacy mode: master end-to-end-benchmarks.md")
+    parser.add_argument("new_file", nargs="?", help="legacy mode: PR end-to-end-benchmarks.md")
+    parser.add_argument("--results-dir", help="paired mode: directory of per-machine results")
+    parser.add_argument("--base-sha", default=None)
+    parser.add_argument("--head-sha", default=None)
     args = parser.parse_args()
 
-    base, _ = parse_report(args.old_file)
-    branch, branch_order = parse_report(args.new_file)
-
-    out = ["# End-to-end benchmark differences", ""]
-    out.append(
-        f"Comparing this PR (`new`) against `master` (`old`). Numbers come from "
-        f"cloud VMs, so changes under {args.threshold:g}% are shown as `≈` and "
-        f"are likely run-to-run noise rather than a real regression or "
-        f"improvement. 🟢 = improvement, 🔴 = regression; uncolored rows are "
-        f"neutral measures reported for context."
-    )
-    out.append("")
-
-    # Match scenarios by title (reports always carry one; untitled datasets
-    # get a default title from the bench).
-    common = [t for t in branch_order if t in base]
-    matched_any = False
-    warn_keys = set()
-    regressions = []
-    for title in common:
-        rows = scenario_rows(base[title], branch[title], args.threshold, warn_keys, regressions, title)
-        if not rows:
-            continue
-        matched_any = True
-        out += ["", f"## {title}", "",
-                "| Metric | master | PR | Δ |",
-                "| -- | -- | -- | -- |"]
-        out += rows
-
-    if not matched_any:
-        out.append("No comparable scenarios found between this PR and `master`.")
-
-    if warn_keys:
-        # Surface format drift loudly so it's noticed in CI logs, but don't fail.
-        print("WARNING: metric(s) found on only one side, skipped: "
-              + ", ".join(sorted(warn_keys)), file=sys.stderr)
+    if args.results_dir:
+        machines, order = collect_results(args.results_dir)
+        out, regressions = render(machines, order, args.base_sha, args.head_sha)
+    elif args.old_file and args.new_file:
+        machines, order = legacy_machines(args.old_file, args.new_file)
+        out, regressions = render(machines, order, with_footer=False)
+    else:
+        parser.error("either --results-dir or two report files are required")
+        return
 
     for regression in regressions:
-        # GitHub annotation; soft gate only (exit code stays 0).
         print(f"::warning title=Benchmark regression::{regression}", file=sys.stderr)
-
     print("\n".join(out))
 
 

--- a/scripts/bench-e2e-diff.py
+++ b/scripts/bench-e2e-diff.py
@@ -51,8 +51,8 @@ METRICS = [
     ("Incremental decommit avg (ms)", "Incremental decommit avg (s)", -1, MS_TO_S, False, "pct"),
 ]
 
-# Percent thresholds below which a median delta renders as noise. Initial
-# values; recalibrate from nightly A/A (null) runs when enough accumulate.
+# Percent thresholds below which a median delta renders as noise. Recalibrate
+# from accumulated A/A (null) runs.
 THRESHOLDS = {
     "default": 10.0,
     "Avg. Confirmation Time (ms)": 5.0,

--- a/scripts/test_bench_e2e_diff.py
+++ b/scripts/test_bench_e2e_diff.py
@@ -1,0 +1,196 @@
+#! /usr/bin/env python3
+
+# Self-test for bench-e2e-diff.py, run by the comment job before the real
+# diff: python3 scripts/test_bench_e2e_diff.py
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+spec = importlib.util.spec_from_file_location("bench_e2e_diff", HERE / "bench-e2e-diff.py")
+diff = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(diff)
+
+
+def report_md(title="Sustained load", tps=500.0, p50=25000.0, outcome=None):
+    lines = [f"## {title}", "", "| Number of nodes |  3 | ", "| -- | -- |"]
+    if outcome is not None:
+        return "\n".join(lines + [f"| _Outcome_ | {outcome} |"])
+    return "\n".join(
+        lines
+        + [
+            "| _Number of txs_ | 15000 |",
+            "| _Avg. Confirmation Time (ms)_ | 24409.0 |",
+            f"| _P50_ | {p50}ms |",
+            "| _P95_ | 29557.8ms |",
+            f"| _End-to-end TPS_ | {tps} tx/s |",
+            "| _Sustained TPS_ | 921.37 tx/s |",
+            "| _Backlog drain time (s)_ | 29.5 |",
+            "| _Snapshots observed_ | 17 |",
+            "| _Number of Invalid txs_ | 0 |",
+        ]
+    )
+
+
+def write_rep(root, machine, slot, side, md):
+    d = root / machine / f"rep-{slot}-{side}" / "open"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "end-to-end-benchmarks.md").write_text(md, encoding="utf-8")
+
+
+def render_dir(root):
+    machines, order = diff.collect_results(root)
+    return diff.render(machines, order, base_sha="a" * 40, head_sha="b" * 40)
+
+
+class DecideCell(unittest.TestCase):
+    def cell(self, deltas, direction=+1, threshold=10.0, kind="pct"):
+        return diff.decide_cell(deltas, direction, threshold, kind)
+
+    def test_within_noise(self):
+        text, warn = self.cell([2.0, -1.0, 3.0, 1.0])
+        self.assertTrue(text.startswith("≈"))
+        self.assertFalse(warn)
+
+    def test_disagreeing_pairs_are_noise(self):
+        text, _ = self.cell([15.0, -12.0, 14.0, -11.0])
+        self.assertTrue(text.startswith("≈"))
+
+    def test_three_of_four_agreement_colors(self):
+        text, _ = self.cell([15.0, 12.0, 14.0, -1.0])
+        self.assertTrue(text.startswith("🟢"))
+
+    def test_regression_warns_beyond_warn_pct(self):
+        text, warn = self.cell([-25.0, -22.0, -24.0, -21.0])
+        self.assertTrue(text.startswith("🔴"))
+        self.assertTrue(warn)
+
+    def test_mild_regression_does_not_warn(self):
+        text, warn = self.cell([-12.0, -11.0, -13.0, -11.0])
+        self.assertTrue(text.startswith("🔴"))
+        self.assertFalse(warn)
+
+    def test_lower_is_better(self):
+        text, _ = self.cell([-15.0, -12.0, -14.0, -11.0], direction=-1)
+        self.assertTrue(text.startswith("🟢"))
+
+    def test_neutral_never_colored(self):
+        text, _ = self.cell([15.0, 12.0, 14.0, 11.0], direction=0)
+        self.assertNotIn("🟢", text)
+        self.assertNotIn("🔴", text)
+
+    def test_count_kind_uses_absolute_delta(self):
+        text, _ = self.cell([1.0, 1.0, 2.0, 1.0], direction=-1, kind="count")
+        self.assertTrue(text.startswith("🔴"))
+        text, _ = self.cell([0.0, 0.0, 0.0, 0.0], direction=-1, kind="count")
+        self.assertTrue(text.startswith("≈"))
+
+    def test_all_zero_deltas_are_noise(self):
+        text, _ = self.cell([0.0, 0.0, 0.0, 0.0])
+        self.assertTrue(text.startswith("≈"))
+
+
+class Parsing(unittest.TestCase):
+    def test_rows_parsed_and_failure_detected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "r.md"
+            p.write_text(report_md() + "\n" + report_md(title="Broken", outcome="did not complete, no measurements"), encoding="utf-8")
+            recs, order = diff.parse_report(p)
+            self.assertEqual(order, ["Sustained load", "Broken"])
+            self.assertFalse(recs["Sustained load"]["failed"])
+            self.assertEqual(recs["Sustained load"]["metrics"]["End-to-end TPS"], 500.0)
+            self.assertTrue(recs["Broken"]["failed"])
+            self.assertIn("did not complete", recs["Broken"]["outcome"])
+
+
+class PairingAndRendering(unittest.TestCase):
+    def test_aa_run_is_all_noise(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for machine, order in (("m1", ["branch", "master"]), ("m2", ["master", "branch"])):
+                for slot, side in enumerate(order, start=1):
+                    write_rep(root, machine, slot, side, report_md(tps=500.0 + slot))
+            out, regressions = render_dir(root)
+            rows = [line for line in out if line.startswith("| ")]
+            self.assertFalse(any("🔴" in r or "🟢" in r for r in rows), rows)
+            self.assertEqual(regressions, [])
+
+    def test_regression_detected_and_warned(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for machine, order in (("m1", ["branch", "master"]), ("m2", ["master", "branch"])):
+                for slot, side in enumerate(order, start=1):
+                    write_rep(root, machine, slot, side, report_md(tps=350.0 if side == "branch" else 500.0))
+            out, regressions = render_dir(root)
+            self.assertIn("🔴", "\n".join(out))
+            self.assertTrue(any("End-to-end TPS" in r for r in regressions))
+
+    def test_odd_rep_drops_only_its_pair(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for slot, side in ((1, "branch"), (2, "master"), (3, "master")):
+                write_rep(root, "m1", slot, side, report_md())
+            machines, _ = diff.collect_results(root)
+            self.assertEqual(len(diff.build_pairs(machines)), 1)
+
+    def test_failed_side_rendered_prominently(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_rep(root, "m1", 1, "branch", report_md(outcome="FAILED: confirmed 10 of 15000 txs"))
+            write_rep(root, "m1", 2, "master", report_md())
+            out, _ = render_dir(root)
+            text = "\n".join(out)
+            self.assertIn("FAILED on PR", text)
+            self.assertIn("confirmed 10 of 15000 txs", text)
+
+    def test_open_loop_hides_latency_rows(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_rep(root, "m1", 1, "branch", report_md())
+            write_rep(root, "m1", 2, "master", report_md())
+            out, _ = render_dir(root)
+            text = "\n".join(out)
+            self.assertNotIn("P50 confirmation", text)
+            self.assertIn("End-to-end TPS", text)
+
+    def test_closed_loop_shows_latency_but_not_p99(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            md = report_md(title="Round-trip latency (closed-loop)")
+            write_rep(root, "m1", 1, "branch", md)
+            write_rep(root, "m1", 2, "master", md)
+            out, _ = render_dir(root)
+            text = "\n".join(out)
+            self.assertIn("P50 confirmation", text)
+            self.assertNotIn("P99", text)
+
+    def test_same_code_spread_in_footer(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for machine, tps in (("m1", 400.0), ("m2", 600.0)):
+                write_rep(root, machine, 1, "branch", report_md(tps=tps))
+                write_rep(root, machine, 2, "master", report_md(tps=tps))
+            (root / "m1" / "fingerprint.json").write_text(json.dumps({"cpu_model": "EPYC 7763", "nproc": 4}), encoding="utf-8")
+            out, _ = render_dir(root)
+            text = "\n".join(out)
+            self.assertIn("Same-code spread", text)
+            self.assertIn("EPYC 7763", text)
+
+    def test_legacy_mode_smoke(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            old = Path(tmp) / "old.md"
+            new = Path(tmp) / "new.md"
+            old.write_text(report_md(), encoding="utf-8")
+            new.write_text(report_md(tps=700.0), encoding="utf-8")
+            machines, order = diff.legacy_machines(old, new)
+            out, _ = diff.render(machines, order, with_footer=False)
+            text = "\n".join(out)
+            self.assertIn("End-to-end TPS", text)
+            self.assertIn("🟢", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Fix bench bugs: `threadDelay` unit mix-up, empty-quantiles crash, NaN average
- Add `--seed` to dataset/matrix generation and pin CI seeds, so workloads are comparable across runs
- Failed datasets still produce a report, with an explicit `Outcome: FAILED: <reason>` row
- Rework the PR benchmark comparison: each of 4 runners measures PR and merge-base back to back (slot order alternated), and the diff aggregates same-machine pair deltas, cancelling GitHub's cross-runner CPU spread
- Baseline is the merge-base and the measured binary is the PR head SHA (not master HEAD or the merge ref), so re-runs are stable and other people's merges can't appear as PR deltas
- `scripts/bench-e2e-diff.py` renders median pair deltas with per-metric noise thresholds and a 3/4 directional-agreement rule for coloring and `::warning` regressions; warns when a metric appears on only one side (format drift); self-tested (21 cases) in CI
- Comment hygiene: superseded and no-pair runs never clobber the previous comment; Transaction-costs comment sections collapsed
- Draft PRs skip benchmarks unless labelled `bench`; `workflow_dispatch` supports arbitrary refs and A/A null runs for threshold calibration
- Machine fingerprints, both-sides nix prefetch, and same-code spread in the comment footer; docs in `hydra-cluster/README.md` and `docs/benchmarks/metrics.md`