### PR TITLE
Bench variance pairing 2

### DIFF
--- a/.github/workflows/bench-e2e-diff.yaml
+++ b/.github/workflows/bench-e2e-diff.yaml
@@ -194,13 +194,36 @@ jobs:
         time nix develop "$BRANCH_FLAKE" --command hydra-node --version
         time nix develop "$MASTER_FLAKE" --command hydra-node --version
 
+    - name: 🎛 Probe node RTS knob support
+      # -N2 trims node oversubscription (3 nodes x 4 HECs on 4 vCPUs
+      # otherwise) and -T enables the RTS work counters. Enable only when
+      # BOTH sides' bench understands HYDRA_NODE_RTS_FLAGS, else one side's
+      # nodes would run different RTS settings than the other's, which is the
+      # asymmetry this workflow exists to prevent (a PR whose merge-base
+      # predates the hook would otherwise be silently skewed). The probe
+      # always passes once merge-bases include the hook.
+      run: |
+        if nix develop "$MASTER_FLAKE" --command bench-e2e --help 2>&1 | grep -q HYDRA_NODE_RTS_FLAGS \
+          && nix develop "$BRANCH_FLAKE" --command bench-e2e --help 2>&1 | grep -q HYDRA_NODE_RTS_FLAGS; then
+          echo "HYDRA_NODE_RTS_FLAGS=-N2 -T" >> "$GITHUB_ENV"
+          echo "Both sides support HYDRA_NODE_RTS_FLAGS; spawning nodes with -N2 -T"
+        else
+          echo "Base side predates HYDRA_NODE_RTS_FLAGS; leaving node RTS defaults on both sides"
+        fi
+
     - name: 📈 Benchmark (${{ matrix.order }})
       working-directory: hydra-cluster
+      env:
+        # Node state, etcd WAL and the devnet live in tmpfs: the runners'
+        # network-backed disks have unpredictable fsync latency that would
+        # otherwise land in the measurements.
+        TMPDIR: /dev/shm/bench
       # The closed-loop scenario needs its own invocation (--wait-for-tx-valid
       # applies to the whole invocation). '|| true': a failed invocation must
       # not skip the remaining slots; its report carries an explicit FAILED
       # outcome and the diff drops only the affected pairs.
       run: |
+        mkdir -p "$TMPDIR"
         slot=0
         for side in ${{ matrix.order }}; do
           slot=$((slot+1))
@@ -209,6 +232,7 @@ jobs:
             master) flake="$MASTER_FLAKE" ;;
           esac
           out="$PWD/../results/rep-$slot-$side"
+          rm -rf "${TMPDIR:?}"/*
           nix develop "$flake" --command bench-e2e single \
             "$PWD/../bench-datasets/sustained-3nodes.json" \
             "$PWD/../bench-datasets/plateau-1k.json" \
@@ -218,6 +242,8 @@ jobs:
             --wait-for-tx-valid \
             --output-directory "$out/closed" --timeout 1800s || true
         done
+        du -sh "$TMPDIR" || true
+        df -h /dev/shm || true
 
     - name: 💾 Upload results
       # if: always() so partial results still contribute surviving pairs.

--- a/docs/benchmarks/metrics.md
+++ b/docs/benchmarks/metrics.md
@@ -59,6 +59,17 @@ PR-versus-master comparison table is produced by `scripts/bench-e2e-diff.py`.
 | Number of Invalid txs | Transactions the node rejected as invalid | count of transactions that reached an `invalidAt` (`numberOfInvalidTxs`) |
 | Fanout outputs | UTxO entries fanned out when the head closed | member count of the final `finalizedUTxO`; reported as 0 if fanout did not finalize within the time budget (`numberOfFanoutOutputs`) |
 | Incremental commit / decommit: count, avg (ms), max (ms) | On-chain incremental (de)commit finalisation latency | per event, `finalisedAt - startedAt`; the run's count, mean, and maximum |
+| Alloc MB per confirmed tx / per snapshot | GHC heap allocation summed over nodes, per unit of work | delta of `hydra_rts_allocated_bytes` across the tx-processing window (`rtsAggregates`); only when nodes run with `+RTS -T` |
+| Mutator CPU s per 1k txs | Node CPU time outside GC, summed over nodes | delta of `hydra_rts_mutator_cpu_seconds`, per 1000 confirmed txs |
+| Max live MB (max node) | Peak live heap of the largest node | `hydra_rts_max_live_bytes` (peak since node start, not windowed) |
+
+The work counters exist because wall-clock numbers from shared runners never
+fully settle: bytes allocated per unit of work is nearly machine-independent
+and directly catches the extra-copying/serialization class of regression.
+Reports also carry an `end-to-end-benchmarks.json` twin with raw series;
+`scripts/bench-e2e-diff.py` derives percentiles and _Sustained TPS (slope)_
+(least-squares over the middle 80% by cumulative count) from it with one
+implementation for both compared sides.
 
 A note on the latency statistics: the percentiles are computed over every
 confirmed transaction in the run, not per snapshot. Because confirmations arrive
@@ -110,3 +121,9 @@ metrics above, these are live counters suitable for production dashboards.
 | `hydra_head_peers_connected` | gauge | number of currently connected peers |
 | `hydra_chain_drift_seconds` | gauge | how far behind the chain the node is, updated on each observed block |
 | `hydra_chain_last_block_timestamp_seconds` | gauge | wall-clock time the node last observed a block; alert on `time() - hydra_chain_last_block_timestamp_seconds` to catch a stalled backend, which freezes the drift gauge rather than growing it |
+
+When the node runs with `+RTS -T`, the endpoint additionally serves GHC RTS
+work counters, refreshed at scrape time (absent otherwise, so the output is
+unchanged without `-T`): `hydra_rts_allocated_bytes`,
+`hydra_rts_mutator_cpu_seconds`, `hydra_rts_gc_cpu_seconds`,
+`hydra_rts_max_live_bytes` and `hydra_rts_major_gcs`.

--- a/hydra-cluster/README.md
+++ b/hydra-cluster/README.md
@@ -270,12 +270,18 @@ other people's merges cannot appear as PR deltas):
   directional agreement across pairs. This is a calibrated heuristic, not a
   significance test, and nothing fails CI on it; strong regressions on the
   headline rates emit a `::warning` annotation.
+* Nodes are spawned with `+RTS -N2 -T` (via `HYDRA_NODE_RTS_FLAGS`, guarded
+  by a probe so both sides always get identical settings) and the cluster
+  runs on tmpfs, keeping scheduler oversubscription and network-disk fsync
+  latency out of the measurements. The `-T` counters feed the alloc/CPU
+  rows, the machine-insensitive signal to trust when wall clock wobbles.
 * `workflow_dispatch` takes `head_ref`/`base_ref` to compare arbitrary refs;
   an empty `base_ref` makes it an A/A null run of `head_ref`, in which any
-  colored row is a false positive. Use accumulated A/A runs to judge the
-  pipeline and recalibrate the thresholds in the script. Draft PRs are
-  skipped unless the PR carries the `bench` label (applies from the next
-  push).
+  colored row is a false positive. To recalibrate thresholds, download the
+  `bench-results-*` artifacts of accumulated A/A runs into one directory per
+  run; `scripts/bench-e2e-diff.py --calibrate <dir>` prints suggested
+  per-metric values to land in the script. Draft PRs are skipped unless the
+  PR carries the `bench` label (applies from the next push).
 
 A new summary metric only shows a difference once both sides emit it, and
 must be registered in the script's `METRICS` table.

--- a/hydra-cluster/bench/BASELINES.md
+++ b/hydra-cluster/bench/BASELINES.md
@@ -3,9 +3,9 @@
 Reference numbers every optimization PR in the 10x snapshot-throughput project
 is compared against. Captured before any optimization landed.
 
-Note: bench runs now also write an `end-to-end-benchmarks.json` next to the
+Note: bench runs also write an `end-to-end-benchmarks.json` next to the
 markdown report (raw series plus RTS counters); prefer capturing it alongside
-future baselines.
+baselines.
 
 ## Environment
 

--- a/hydra-cluster/bench/BASELINES.md
+++ b/hydra-cluster/bench/BASELINES.md
@@ -3,6 +3,10 @@
 Reference numbers every optimization PR in the 10x snapshot-throughput project
 is compared against. Captured before any optimization landed.
 
+Note: bench runs now also write an `end-to-end-benchmarks.json` next to the
+markdown report (raw series plus RTS counters); prefer capturing it alongside
+future baselines.
+
 ## Environment
 
 - CPU: Intel Core Ultra 7 258V (8 cores), 30 GiB RAM

--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -360,6 +360,12 @@ runScenario hydraTracer timing opts workDir Dataset{clientDatasets, title, descr
       summaryDescription = fromMaybe defaultDescription description
       Throughput{endToEndTps, runWallClockSeconds, sustainedTps, drainSeconds, avgTxsPerSnapshot, numberOfSnapshots} =
         computeThroughput processedTransactions snapshotsSeen
+      confirmationTimesMs = sort $ map (\(_, _, c) -> 1000 * realToFrac c) res
+      snapshotSeries = case map (\Event{submittedAt} -> submittedAt) (Map.elems processedTransactions) of
+        [] -> []
+        submissions ->
+          let t0 = List.minimum submissions
+           in [(realToFrac (t `diffUTCTime` t0), n) | (t, n) <- sortOn fst (Map.elems snapshotsSeen)]
 
   pure $
     Summary
@@ -383,6 +389,9 @@ runScenario hydraTracer timing opts workDir Dataset{clientDatasets, title, descr
       , incrementalCommitTimes
       , incrementalDecommitTimes
       , runOutcome = Nothing
+      , loadMode = if waitForTxValid then "closed-loop" else "open-loop"
+      , snapshotSeries
+      , confirmationTimesMs
       }
  where
   Timing{blockTime} = timing

--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -5,7 +5,7 @@ module Bench.EndToEnd where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
-import Bench.Summary (Summary (..), SystemStats, makeQuantiles, nominalDiffTimeToMilliseconds)
+import Bench.Summary (NodeRtsStats (..), Summary (..), SystemStats, makeQuantiles, nominalDiffTimeToMilliseconds)
 import Cardano.Api.UTxO qualified as UTxO
 import CardanoNode (EndToEndLog (..), HydraNodeLog, findRunningCardanoNode', runBackend, withCardanoNodeDevnet)
 import Control.Concurrent.Class.MonadSTM (
@@ -54,6 +54,7 @@ import Hydra.Tx.Crypto (generateSigningKey, getVerificationKey, signTx)
 import Hydra.Tx.Secret (Secret)
 import HydraNode (
   HydraClient (..),
+  getMetrics,
   getSnapshotUTxO,
   input,
   output,
@@ -282,6 +283,10 @@ runScenario hydraTracer timing opts workDir Dataset{clientDatasets, title, descr
 
   putTextLn "HeadIsOpen with deposits finalized"
 
+  -- Bracket the tx-processing window with RTS counter scrapes, outside the
+  -- measured phase so the HTTP requests cannot disturb it.
+  rtsBefore <- scrapeRtsStats clients
+
   -- Note: We only run Pumba during normal transaction processing; this is
   -- acceptable because otherwise we do not retry the particular actions that
   -- may or may not be dropped.
@@ -301,6 +306,8 @@ runScenario hydraTracer timing opts workDir Dataset{clientDatasets, title, descr
               }
   (processedTransactions, snapshotsSeen, incrementalCommitTimes, incrementalDecommitTimes) <-
     withPumba pumbaCommand $ processTransactions clients clientDatasets incrementalCtx waitForTxValid
+
+  rtsAfter <- scrapeRtsStats clients
 
   putTextLn "Closing the Head"
   send leader $ input "Close" []
@@ -392,6 +399,7 @@ runScenario hydraTracer timing opts workDir Dataset{clientDatasets, title, descr
       , loadMode = if waitForTxValid then "closed-loop" else "open-loop"
       , snapshotSeries
       , confirmationTimesMs
+      , nodeRtsStats = nodeRtsDeltas rtsBefore rtsAfter
       }
  where
   Timing{blockTime} = timing
@@ -987,6 +995,50 @@ readPeakNodeRssMb workDir = do
       , Just rest <- [T.stripPrefix "VmHWM:" line]
       , Just (kb :: Double) <- [readMaybe . toString . T.strip $ T.replace "kB" "" rest]
       ]
+
+-- | Scrape per-node GHC RTS gauges from the monitoring endpoints. Nothing for
+-- a node whose endpoint is unreachable or lacks the gauges (nodes not started
+-- with '+RTS -T' do not serve them).
+scrapeRtsStats :: [HydraClient] -> IO [Maybe NodeRtsStats]
+scrapeRtsStats = mapM $ \client ->
+  fromRight Nothing <$> tryNonAsync (parseRtsStats . decodeUtf8 <$> getMetrics client)
+
+parseRtsStats :: Text -> Maybe NodeRtsStats
+parseRtsStats body = do
+  allocatedBytes <- val "hydra_rts_allocated_bytes"
+  mutatorCpuSeconds <- val "hydra_rts_mutator_cpu_seconds"
+  gcCpuSeconds <- val "hydra_rts_gc_cpu_seconds"
+  maxLiveBytes <- val "hydra_rts_max_live_bytes"
+  majorGcs <- val "hydra_rts_major_gcs"
+  pure NodeRtsStats{allocatedBytes, mutatorCpuSeconds, gcCpuSeconds, maxLiveBytes, majorGcs}
+ where
+  val name =
+    listToMaybe
+      [ v
+      | line <- T.lines body
+      , [n, raw] <- [T.words line]
+      , n == name
+      , Just v <- [readMaybe (toString raw)]
+      ]
+
+-- | Pair up before/after scrapes into per-node deltas. All-or-nothing: a
+-- missing scrape on either side yields no stats at all, so aggregates never
+-- silently cover a subset of nodes.
+nodeRtsDeltas :: [Maybe NodeRtsStats] -> [Maybe NodeRtsStats] -> [NodeRtsStats]
+nodeRtsDeltas begins ends = fromMaybe [] $ do
+  bs <- sequence begins
+  as <- sequence ends
+  guard (length bs == length as)
+  pure $ zipWith delta bs as
+ where
+  delta b a =
+    NodeRtsStats
+      { allocatedBytes = allocatedBytes a - allocatedBytes b
+      , mutatorCpuSeconds = mutatorCpuSeconds a - mutatorCpuSeconds b
+      , gcCpuSeconds = gcCpuSeconds a - gcCpuSeconds b
+      , maxLiveBytes = maxLiveBytes a
+      , majorGcs = majorGcs a - majorGcs b
+      }
 
 writeResultsCsv :: FilePath -> [(UTCTime, NominalDiffTime, NominalDiffTime, Int)] -> IO ()
 writeResultsCsv fp res = do

--- a/hydra-cluster/bench/Bench/Options.hs
+++ b/hydra-cluster/bench/Bench/Options.hs
@@ -107,7 +107,10 @@ benchOptionsParser =
           \fast as possible.\n \
           \Arguments control various parameters of the run, like number of nodes, \
           \number of transactions generated, or the 'scenarios' to run. See individual \
-          \help for each command for more usage info."
+          \help for each command for more usage info.\n \
+          \Environment: HYDRA_NODE_RTS_FLAGS appends '+RTS <flags> -RTS' to every \
+          \spawned hydra-node (e.g. \"-N2 -T\"); CI probes this help text for the \
+          \variable name before enabling it, so keep this mention intact."
         <> header "bench - load tester for Hydra node cluster"
     )
 

--- a/hydra-cluster/bench/Bench/Summary.hs
+++ b/hydra-cluster/bench/Bench/Summary.hs
@@ -20,6 +20,19 @@ import Text.Printf (printf)
 -- | System stats like memory consumption.
 type SystemStats = [Text]
 
+-- | Per hydra-node GHC RTS deltas over the tx-processing window, scraped from
+-- the monitoring endpoint. Only available when nodes run with '+RTS -T'.
+data NodeRtsStats = NodeRtsStats
+  { allocatedBytes :: Double
+  , mutatorCpuSeconds :: Double
+  , gcCpuSeconds :: Double
+  , maxLiveBytes :: Double
+  -- ^ Peak live heap since process start, not a windowed delta.
+  , majorGcs :: Double
+  }
+  deriving stock (Generic, Eq, Show)
+  deriving anyclass (ToJSON)
+
 data Summary = Summary
   { clusterSize :: Word64
   , totalTxs :: Int
@@ -59,6 +72,8 @@ data Summary = Summary
   -- computed outside the compared binaries (see scripts/bench-e2e-diff.py).
   , confirmationTimesMs :: [Double]
   -- ^ Sorted per-transaction confirmation times in milliseconds.
+  , nodeRtsStats :: [NodeRtsStats]
+  -- ^ One entry per node; empty unless nodes ran with '+RTS -T'.
   }
   deriving stock (Generic, Eq, Show)
   deriving anyclass (ToJSON)
@@ -90,6 +105,7 @@ errorSummary Dataset{title, clientDatasets} (HUnitFailure sourceLocation reason)
     , loadMode = "unknown"
     , snapshotSeries = []
     , confirmationTimesMs = []
+    , nodeRtsStats = []
     }
  where
   formatLocation = maybe "" (\loc -> "at " <> prettySrcLoc loc)
@@ -123,6 +139,23 @@ snapshotsPerSecond Summary{numberOfSnapshots, runWallClockSeconds}
   | runWallClockSeconds > 0 = fromIntegral numberOfSnapshots / runWallClockSeconds
   | otherwise = 0
 
+-- | Aggregated RTS work counters across nodes, normalized by confirmed txs
+-- and snapshots: (alloc MB per tx, alloc MB per snapshot, mutator CPU s per
+-- 1k txs, max live MB of the largest node). Mirrored by rts_metrics in
+-- scripts/bench-e2e-diff.py; keep the two in sync.
+rtsAggregates :: Summary -> Maybe (Double, Double, Double, Double)
+rtsAggregates Summary{nodeRtsStats, numberOfTxs, numberOfSnapshots} = do
+  guard (not (null nodeRtsStats) && numberOfTxs > 0 && numberOfSnapshots > 0)
+  let mb = 1024 * 1024
+      totalAllocMb = sum (map allocatedBytes nodeRtsStats) / mb
+      totalMutCpu = sum (map mutatorCpuSeconds nodeRtsStats)
+  pure
+    ( totalAllocMb / fromIntegral numberOfTxs
+    , totalAllocMb / fromIntegral numberOfSnapshots
+    , totalMutCpu / (fromIntegral numberOfTxs / 1000)
+    , List.maximum (map maxLiveBytes nodeRtsStats) / mb
+    )
+
 textReport :: (Summary, SystemStats) -> [Text]
 textReport (summary@Summary{totalTxs, numberOfTxs, averageConfirmationTime, quantiles, validationP50Ms, numberOfInvalidTxs, numberOfFanoutOutputs, endToEndTps, sustainedTps, drainSeconds, avgTxsPerSnapshot, peakNodeRssMb, numberOfSnapshots, incrementalCommitTimes, incrementalDecommitTimes, runOutcome}, systemStats) =
   let frac :: Double
@@ -147,6 +180,16 @@ textReport (summary@Summary{totalTxs, numberOfTxs, averageConfirmationTime, quan
         ++ [pack $ printf "Snapshots per second: %.2f /s" (snapshotsPerSecond summary)]
         ++ [pack $ printf "Avg txs per snapshot: %.1f" avgTxsPerSnapshot]
         ++ maybe [] (\mb -> [pack $ printf "Peak node RSS (MB): %.1f" mb]) peakNodeRssMb
+        ++ maybe
+          []
+          ( \(allocTx, allocSnap, cpu1k, live) ->
+              [ pack $ printf "Alloc MB per confirmed tx: %.3f" allocTx
+              , pack $ printf "Alloc MB per snapshot: %.1f" allocSnap
+              , pack $ printf "Mutator CPU s per 1k txs: %.3f" cpu1k
+              , pack $ printf "Max live MB (max node): %.1f" live
+              ]
+          )
+          (rtsAggregates summary)
         ++ ["Invalid txs: " <> show numberOfInvalidTxs]
         ++ ["Fanout outputs: " <> show numberOfFanoutOutputs]
         ++ incrementalLines "Incremental commit" incrementalCommitTimes
@@ -242,6 +285,16 @@ formattedSummary (summary@Summary{clusterSize, numberOfTxs, averageConfirmationT
            , pack $ printf "| _Avg txs per snapshot_ | %.1f |" avgTxsPerSnapshot
            ]
         ++ maybe [] (\mb -> [pack $ printf "| _Peak node RSS (MB)_ | %.1f |" mb]) peakNodeRssMb
+        ++ maybe
+          []
+          ( \(allocTx, allocSnap, cpu1k, live) ->
+              [ pack $ printf "| _Alloc MB per confirmed tx_ | %.3f |" allocTx
+              , pack $ printf "| _Alloc MB per snapshot_ | %.1f |" allocSnap
+              , pack $ printf "| _Mutator CPU s per 1k txs_ | %.3f |" cpu1k
+              , pack $ printf "| _Max live MB (max node)_ | %.1f |" live
+              ]
+          )
+          (rtsAggregates summary)
         ++ [ "| _Number of Invalid txs_ | " <> show numberOfInvalidTxs <> " |"
            ]
         ++ [ "| _Fanout outputs_        | " <> show numberOfFanoutOutputs <> " |"

--- a/hydra-cluster/bench/Bench/Summary.hs
+++ b/hydra-cluster/bench/Bench/Summary.hs
@@ -50,8 +50,18 @@ data Summary = Summary
   , incrementalDecommitTimes :: [NominalDiffTime]
   , runOutcome :: Maybe Text
   -- ^ Nothing when the run completed; a short failure reason otherwise.
+  , loadMode :: Text
+  -- ^ "open-loop" (fire and forget) or "closed-loop" (one in-flight tx per
+  -- client).
+  , snapshotSeries :: [(Double, Int)]
+  -- ^ Per confirmed snapshot: (seconds since first submission, txs in the
+  -- snapshot), in observation order. Raw series so derived estimators can be
+  -- computed outside the compared binaries (see scripts/bench-e2e-diff.py).
+  , confirmationTimesMs :: [Double]
+  -- ^ Sorted per-transaction confirmation times in milliseconds.
   }
   deriving stock (Generic, Eq, Show)
+  deriving anyclass (ToJSON)
 
 errorSummary :: Dataset -> HUnitFailure -> Summary
 errorSummary Dataset{title, clientDatasets} (HUnitFailure sourceLocation reason) =
@@ -77,6 +87,9 @@ errorSummary Dataset{title, clientDatasets} (HUnitFailure sourceLocation reason)
     , incrementalCommitTimes = []
     , incrementalDecommitTimes = []
     , runOutcome = Just $ shortReason reason
+    , loadMode = "unknown"
+    , snapshotSeries = []
+    , confirmationTimesMs = []
     }
  where
   formatLocation = maybe "" (\loc -> "at " <> prettySrcLoc loc)
@@ -183,7 +196,7 @@ markdownReport now summaries =
     ]
 
 formattedSummary :: (Summary, SystemStats) -> [Text]
-formattedSummary (summary@Summary{clusterSize, numberOfTxs, averageConfirmationTime, quantiles, validationP50Ms, summaryTitle, summaryDescription, numberOfInvalidTxs, numberOfFanoutOutputs, endToEndTps, sustainedTps, drainSeconds, avgTxsPerSnapshot, peakNodeRssMb, numberOfSnapshots, incrementalCommitTimes, incrementalDecommitTimes, runOutcome}, systemStats)
+formattedSummary (summary@Summary{clusterSize, numberOfTxs, averageConfirmationTime, quantiles, validationP50Ms, summaryTitle, summaryDescription, numberOfInvalidTxs, numberOfFanoutOutputs, endToEndTps, sustainedTps, drainSeconds, avgTxsPerSnapshot, peakNodeRssMb, numberOfSnapshots, incrementalCommitTimes, incrementalDecommitTimes, runOutcome, loadMode}, systemStats)
   | numberOfTxs == 0 =
       -- Failed cell: no confirmations, so all the latency / TPS rows would be
       -- zeros or empty quantiles. Render a short failure block instead of the
@@ -207,6 +220,7 @@ formattedSummary (summary@Summary{clusterSize, numberOfTxs, averageConfirmationT
       , "| Number of nodes |  " <> show clusterSize <> " | "
       , "| -- | -- |"
       , "| _Number of txs_ | " <> show numberOfTxs <> " |"
+      , "| _Load mode_ | " <> loadMode <> " |"
       ]
         ++ maybe [] (\reason -> ["| _Outcome_ | FAILED: " <> reason <> " |"]) runOutcome
         ++ [ "| _Avg. Confirmation Time (ms)_ | " <> oneDec (nominalDiffTimeToMilliseconds averageConfirmationTime) <> " |"

--- a/hydra-cluster/bench/Main.hs
+++ b/hydra-cluster/bench/Main.hs
@@ -8,7 +8,7 @@ import Test.Hydra.Prelude
 import Bench.EndToEnd (BenchRunOptions (..), bench, benchDemo)
 import Bench.Options (Options (..), UTxOSize (..), benchOptionsParser)
 import Bench.Summary (Summary (..), SystemStats, errorSummary, markdownReport, matrixMarkdownReport, textReport)
-import Data.Aeson (eitherDecodeFileStrict', encodeFile)
+import Data.Aeson (eitherDecodeFileStrict', encodeFile, object, (.=))
 import Data.List qualified as List
 import Data.Text qualified as T
 import Hydra.Cardano.Api (PaymentKey, SigningKey)
@@ -231,6 +231,12 @@ writeBenchmarkReport outputDirectory summaries = do
     let report = markdownReport now summaries
     createDirectoryIfMissing True outputDir
     writeFileBS reportPath . encodeUtf8 $ unlines report
+    -- Machine-readable twin: scripts/bench-e2e-diff.py prefers it and derives
+    -- estimators from the raw series with one implementation for both sides.
+    let jsonPath = outputDir </> "end-to-end-benchmarks.json"
+    putStrLn $ "Writing report to: " <> jsonPath
+    encodeFile jsonPath $
+      object ["version" .= (1 :: Int), "generatedAt" .= now, "summaries" .= map fst summaries]
 
 writeMatrixReport :: Maybe FilePath -> [(Summary, SystemStats)] -> IO ()
 writeMatrixReport outputDirectory summaries = do

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -239,4 +239,8 @@ benchmark bench-e2e
     , vector
 
   build-tool-depends: hydra-node:hydra-node
-  ghc-options:        -threaded -rtsopts
+
+  -- -N2: the client is the measurement instrument; with the default single
+  -- capability its own scheduling latency lands in every confirmation
+  -- timestamp once thousands of WS messages queue up.
+  ghc-options:        -threaded -rtsopts -with-rtsopts=-N2

--- a/hydra-cluster/src/HydraNode.hs
+++ b/hydra-cluster/src/HydraNode.hs
@@ -686,8 +686,14 @@ withPreparedHydraNodeWithQuery mQueryParams extraEnv tracer workDir hydraNodeId 
         else do
           baseEnv <- getEnvironment
           pure $ setEnv (extraEnv <> filter ((`notElem` map fst extraEnv) . fst) baseEnv)
+    -- Benchmark-only hook: HYDRA_NODE_RTS_FLAGS appends '+RTS <flags> -RTS' to
+    -- the spawned node (e.g. "-N2 -T"). Deliberately not GHCRTS, which every
+    -- GHC binary in the environment would inherit. Unset means byte-identical
+    -- spawns.
+    rtsFlags <- maybe [] (map toString . words . toText) <$> lookupEnv "HYDRA_NODE_RTS_FLAGS"
+    let extraArgs = if null rtsFlags then [] else ["+RTS"] <> rtsFlags <> ["-RTS"]
     let cmd =
-          (proc "hydra-node" . toArgs $ runOptions)
+          proc "hydra-node" (toArgs runOptions <> extraArgs)
             & setStdout (useHandleOpen logFileHandle)
             & setStderr createPipe
             & setCloseFds True

--- a/hydra-node/src/Hydra/Logging/Monitoring.hs
+++ b/hydra-node/src/Hydra/Logging/Monitoring.hs
@@ -22,6 +22,7 @@ import Control.Concurrent.Class.MonadSTM (modifyTVar', readTVarIO, writeTVar)
 import Control.Tracer (Tracer (Tracer))
 import Data.Map.Strict as Map
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
+import GHC.Stats (RTSStats (..), getRTSStats, getRTSStatsEnabled)
 import Hydra.HeadLogic (
   Input (NetworkInput),
  )
@@ -75,13 +76,39 @@ withMonitoring ::
 withMonitoring Nothing tracer action = action tracer
 withMonitoring (Just monitoringPort) (Tracer tracer) action = do
   (traceMetric, registry) <- prepareRegistry
+  refreshRts <- liftIO $ registerRtsMetrics registry
   withAsyncLabelled
-    ("monitoring-serveMetrics", serveMetrics (fromIntegral monitoringPort) ["metrics"] (sample registry))
+    ("monitoring-serveMetrics", serveMetrics (fromIntegral monitoringPort) ["metrics"] (refreshRts >> sample registry))
     $ \_ ->
       let wrappedTracer = Tracer $ \msg -> do
             traceMetric msg
             tracer msg
        in action wrappedTracer
+
+-- | Register GHC RTS work counters when the runtime collects them (process
+-- started with '+RTS -T'); returns a refresh action run before each scrape.
+-- Without -T nothing is registered, so the endpoint output is identical to
+-- before these metrics existed.
+registerRtsMetrics :: Registry -> IO (IO ())
+registerRtsMetrics registry = do
+  enabled <- getRTSStatsEnabled
+  if not enabled
+    then pure (pure ())
+    else do
+      allocated <- rtsGauge "hydra_rts_allocated_bytes"
+      mutatorCpu <- rtsGauge "hydra_rts_mutator_cpu_seconds"
+      gcCpu <- rtsGauge "hydra_rts_gc_cpu_seconds"
+      maxLive <- rtsGauge "hydra_rts_max_live_bytes"
+      majorGcs <- rtsGauge "hydra_rts_major_gcs"
+      pure $ do
+        stats <- getRTSStats
+        Gauge.set (fromIntegral (allocated_bytes stats)) allocated
+        Gauge.set (fromIntegral (mutator_cpu_ns stats) / 1.0e9) mutatorCpu
+        Gauge.set (fromIntegral (gc_cpu_ns stats) / 1.0e9) gcCpu
+        Gauge.set (fromIntegral (max_live_bytes stats)) maxLive
+        Gauge.set (fromIntegral (major_gcs stats)) majorGcs
+ where
+  rtsGauge name = registerGauge (Name name) mempty registry
 
 -- | Register all relevant metrics.
 -- Returns the `Registry` which is needed to `serveMetrics` or any other form of publication

--- a/scripts/bench-e2e-diff.py
+++ b/scripts/bench-e2e-diff.py
@@ -28,7 +28,7 @@
 #
 #   bench-e2e-diff.py --calibrate DIR       suggest thresholds from A/A runs
 #
-# where DIR holds one downloaded results tree per nightly A/A run; suggested
+# where DIR holds one downloaded results tree per A/A run; suggested
 # thresholds are the p95 of the null |median pair delta| per metric.
 
 import argparse

--- a/scripts/bench-e2e-diff.py
+++ b/scripts/bench-e2e-diff.py
@@ -58,6 +58,10 @@ METRICS = [
     ("P50", "P50 confirmation (s)", -1, MS_TO_S, True, "pct"),
     ("P95", "P95 confirmation (s)", -1, MS_TO_S, True, "pct"),
     ("Tx validation time p50 (ms)", "Tx validation time p50 (s)", -1, MS_TO_S, False, "pct"),
+    ("Alloc MB per confirmed tx", "Alloc MB per confirmed tx", -1, 1.0, False, "pct"),
+    ("Alloc MB per snapshot", "Alloc MB per snapshot", 0, 1.0, False, "pct"),
+    ("Mutator CPU s per 1k txs", "Mutator CPU s per 1k txs", -1, 1.0, False, "pct"),
+    ("Max live MB (max node)", "Max live MB (max node)", -1, 1.0, False, "pct"),
     ("Peak node RSS (MB)", "Peak node RSS (MB)", -1, 1.0, False, "pct"),
     ("Number of Invalid txs", "Invalid txs", -1, 1.0, False, "count"),
     ("Incremental commit avg (ms)", "Incremental commit avg (s)", -1, MS_TO_S, False, "pct"),
@@ -71,6 +75,9 @@ THRESHOLDS = {
     "Avg. Confirmation Time (ms)": 5.0,
     "P50": 5.0,
     "P95": 5.0,
+    # Work counters are nearly machine-independent, so hold them tighter.
+    "Alloc MB per confirmed tx": 5.0,
+    "Mutator CPU s per 1k txs": 8.0,
 }
 
 # Colored regressions beyond this on the headline rates additionally emit a
@@ -120,6 +127,20 @@ def sustained_tps_slope(snapshot_series):
         return None
 
 
+def rts_metrics(node_stats, n_txs, n_snapshots):
+    # Mirrors Bench.Summary.rtsAggregates; keep the two in sync.
+    if not node_stats or n_txs <= 0 or n_snapshots <= 0:
+        return {}
+    mb = 1024.0 * 1024.0
+    total_alloc_mb = sum(s["allocatedBytes"] for s in node_stats) / mb
+    return {
+        "Alloc MB per confirmed tx": total_alloc_mb / n_txs,
+        "Alloc MB per snapshot": total_alloc_mb / n_snapshots,
+        "Mutator CPU s per 1k txs": sum(s["mutatorCpuSeconds"] for s in node_stats) / (n_txs / 1000.0),
+        "Max live MB (max node)": max(s["maxLiveBytes"] for s in node_stats) / mb,
+    }
+
+
 def summary_to_record(s):
     """One JSON summary -> the same record shape parse_report yields, with
     estimators recomputed from the raw series."""
@@ -148,6 +169,7 @@ def summary_to_record(s):
     if s.get("peakNodeRssMb") is not None:
         metrics["Peak node RSS (MB)"] = s["peakNodeRssMb"]
     metrics["Number of Invalid txs"] = float(s.get("numberOfInvalidTxs") or 0)
+    metrics.update(rts_metrics(s.get("nodeRtsStats") or [], n_txs, n_snapshots))
     for field, key in [
         ("incrementalCommitTimes", "Incremental commit avg (ms)"),
         ("incrementalDecommitTimes", "Incremental decommit avg (ms)"),

--- a/scripts/bench-e2e-diff.py
+++ b/scripts/bench-e2e-diff.py
@@ -18,6 +18,18 @@
 # colored only when |median| exceeds the metric's noise threshold AND at
 # least 3/4 of pairs agree in direction. This is a calibrated heuristic, not
 # a significance test.
+#
+# Reports carry an end-to-end-benchmarks.json twin with raw series; when BOTH
+# sides of a pair have it, derived estimators (percentiles, sustained-TPS
+# slope) are computed here with one implementation for both sides (each side
+# runs its own bench binary, so estimators computed in Haskell could silently
+# change definition across a comparison). A pair with only one json side
+# falls back to comparing the markdown rows, never mixing definitions.
+#
+#   bench-e2e-diff.py --calibrate DIR       suggest thresholds from A/A runs
+#
+# where DIR holds one downloaded results tree per nightly A/A run; suggested
+# thresholds are the p95 of the null |median pair delta| per metric.
 
 import argparse
 import json
@@ -25,7 +37,7 @@ import math
 import re
 import sys
 from pathlib import Path
-from statistics import median
+from statistics import StatisticsError, linear_regression, median, quantiles
 
 MS_TO_S = 1e-3
 
@@ -38,6 +50,7 @@ MS_TO_S = 1e-3
 METRICS = [
     ("End-to-end TPS", "End-to-end TPS (tx/s)", +1, 1.0, False, "pct"),
     ("Sustained TPS", "Sustained TPS (tx/s)", +1, 1.0, False, "pct"),
+    ("Sustained TPS (slope)", "Sustained TPS, slope (tx/s)", +1, 1.0, False, "pct"),
     ("Backlog drain time (s)", "Backlog drain time (s)", -1, 1.0, False, "pct"),
     ("Snapshots per second", "Snapshots per second (/s)", 0, 1.0, False, "pct"),
     ("Avg txs per snapshot", "Avg txs per snapshot", 0, 1.0, False, "pct"),
@@ -75,6 +88,93 @@ REP_DIR_RE = re.compile(r"^rep-(?P<slot>\d+)-(?P<side>branch|master)$")
 def parse_value(raw):
     m = NUM_RE.search(raw.replace(",", ""))
     return float(m.group()) if m else None
+
+
+def percentile(sorted_vals, p):
+    # quantiles' n=100 cut points put the p-th percentile at index p-1,
+    # linearly interpolated ('inclusive': the data is the whole population).
+    if not sorted_vals:
+        return None
+    if len(sorted_vals) == 1:
+        return sorted_vals[0]
+    return quantiles(sorted_vals, n=100, method="inclusive")[p - 1]
+
+
+def sustained_tps_slope(snapshot_series):
+    """Least-squares slope of cumulative confirmed txs over time, restricted
+    to snapshot points whose cumulative count lies in the middle 80%. Unlike
+    endpoint-based trimming it does not move in whole-snapshot steps and works
+    from 4 in-window points."""
+    pts, cum = [], 0
+    for t, n in sorted((float(t), int(n)) for t, n in snapshot_series):
+        cum += n
+        pts.append((t, cum))
+    if cum <= 0:
+        return None
+    window = [(t, c) for t, c in pts if 0.10 * cum <= c <= 0.90 * cum]
+    if len(window) < 4:
+        return None
+    try:
+        return linear_regression(*zip(*window)).slope
+    except StatisticsError:  # all window points at one timestamp
+        return None
+
+
+def summary_to_record(s):
+    """One JSON summary -> the same record shape parse_report yields, with
+    estimators recomputed from the raw series."""
+    metrics = {}
+    n_txs = s.get("numberOfTxs") or 0
+    wall = s.get("runWallClockSeconds") or 0.0
+    if n_txs:
+        metrics["Number of txs"] = float(n_txs)
+    conf_ms = s.get("confirmationTimesMs") or []
+    if conf_ms:
+        metrics["Avg. Confirmation Time (ms)"] = sum(conf_ms) / len(conf_ms)
+        metrics["P50"] = percentile(conf_ms, 50)
+        metrics["P95"] = percentile(conf_ms, 95)
+    if s.get("validationP50Ms") is not None:
+        metrics["Tx validation time p50 (ms)"] = s["validationP50Ms"]
+    if s.get("endToEndTps") is not None:
+        metrics["End-to-end TPS"] = s["endToEndTps"]
+    slope = sustained_tps_slope(s.get("snapshotSeries") or [])
+    if slope is not None:
+        metrics["Sustained TPS (slope)"] = slope
+    metrics["Backlog drain time (s)"] = s.get("drainSeconds") or 0.0
+    n_snapshots = s.get("numberOfSnapshots") or 0
+    if wall > 0:
+        metrics["Snapshots per second"] = n_snapshots / wall
+    metrics["Avg txs per snapshot"] = s.get("avgTxsPerSnapshot") or 0.0
+    if s.get("peakNodeRssMb") is not None:
+        metrics["Peak node RSS (MB)"] = s["peakNodeRssMb"]
+    metrics["Number of Invalid txs"] = float(s.get("numberOfInvalidTxs") or 0)
+    for field, key in [
+        ("incrementalCommitTimes", "Incremental commit avg (ms)"),
+        ("incrementalDecommitTimes", "Incremental decommit avg (ms)"),
+    ]:
+        times = s.get(field) or []
+        if times:
+            metrics[key] = 1000.0 * sum(times) / len(times)
+    outcome = s.get("runOutcome")
+    return {
+        "title": s.get("summaryTitle") or "Baseline Scenario",
+        "outcome": outcome,
+        "failed": outcome is not None or n_txs == 0,
+        "metrics": metrics,
+    }
+
+
+def parse_json_report(path):
+    try:
+        doc = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as e:
+        print(f"WARNING: unreadable JSON report {path}: {e}", file=sys.stderr)
+        return {}
+    records = {}
+    for s in doc.get("summaries", []):
+        rec = summary_to_record(s)
+        records.setdefault(rec["title"], rec)
+    return records
 
 
 def parse_report(path):
@@ -124,15 +224,24 @@ def collect_results(results_dir):
             m = REP_DIR_RE.match(rep_dir.name)
             if not m:
                 continue
-            scenarios = {}
+            scenarios, scenarios_json = {}, {}
             for report in sorted(rep_dir.glob("**/end-to-end-benchmarks.md")):
                 recs, order = parse_report(report)
                 for title in order:
                     scenarios.setdefault(title, recs[title])
                     if title not in scenario_order:
                         scenario_order.append(title)
+                twin = report.with_suffix(".json")
+                if twin.exists():
+                    for title, rec in parse_json_report(twin).items():
+                        scenarios_json.setdefault(title, rec)
             machine["reps"].append(
-                {"slot": int(m.group("slot")), "side": m.group("side"), "scenarios": scenarios}
+                {
+                    "slot": int(m.group("slot")),
+                    "side": m.group("side"),
+                    "scenarios": scenarios,
+                    "scenarios_json": scenarios_json,
+                }
             )
         machine["reps"].sort(key=lambda r: r["slot"])
         if machine["reps"]:
@@ -181,11 +290,20 @@ def decide_cell(deltas, direction, threshold, kind):
     return f"{'🟢' if improved else '🔴'} {body}", regressed_hard
 
 
+def pair_records(p, title):
+    """Prefer the json-derived records (shared estimator definitions) when
+    both sides have them; otherwise both sides' markdown rows. Never mix."""
+    oj = p["old"].get("scenarios_json", {}).get(title)
+    nj = p["new"].get("scenarios_json", {}).get(title)
+    if oj and nj:
+        return oj, nj
+    return p["old"]["scenarios"].get(title), p["new"]["scenarios"].get(title)
+
+
 def scenario_rows(title, pairs, regressions):
     valid = []
     for p in pairs:
-        old = p["old"]["scenarios"].get(title)
-        new = p["new"]["scenarios"].get(title)
+        old, new = pair_records(p, title)
         if old and new and not old["failed"] and not new["failed"]:
             valid.append((old, new))
     if not valid:
@@ -325,12 +443,40 @@ def legacy_machines(old_file, new_file):
         "name": "local",
         "fingerprint": None,
         "reps": [
-            {"slot": 1, "side": "master", "scenarios": old_recs},
-            {"slot": 2, "side": "branch", "scenarios": new_recs},
+            {"slot": 1, "side": "master", "scenarios": old_recs, "scenarios_json": {}},
+            {"slot": 2, "side": "branch", "scenarios": new_recs, "scenarios_json": {}},
         ],
     }
     order = [t for t in new_order if t in old_recs]
     return {"local": machine}, order
+
+
+def calibrate(runs_dir):
+    """runs_dir holds one downloaded A/A results tree per subdirectory."""
+    per_metric = {}
+    runs = sorted(p for p in Path(runs_dir).iterdir() if p.is_dir())
+    for run in runs:
+        machines, scenario_order = collect_results(run)
+        pairs = build_pairs(machines)
+        for title in scenario_order:
+            for key, _, _, scale, _, kind in METRICS:
+                if kind != "pct":
+                    continue
+                deltas = []
+                for p in pairs:
+                    old, new = pair_records(p, title)
+                    if not old or not new or old["failed"] or new["failed"]:
+                        continue
+                    if key in old["metrics"] and key in new["metrics"] and old["metrics"][key] != 0:
+                        deltas.append(100.0 * (new["metrics"][key] - old["metrics"][key]) / old["metrics"][key])
+                if deltas:
+                    per_metric.setdefault(key, []).append(abs(median(deltas)))
+    suggested = {}
+    for key, meds in sorted(per_metric.items()):
+        meds.sort()
+        idx = max(0, min(len(meds) - 1, math.ceil(0.95 * len(meds)) - 1))
+        suggested[key] = round(max(meds[idx], 1.0), 1)
+    print(json.dumps({"suggested_thresholds": suggested, "runs": len(runs)}, indent=2))
 
 
 def main():
@@ -340,7 +486,13 @@ def main():
     parser.add_argument("--results-dir", help="paired mode: directory of per-machine results")
     parser.add_argument("--base-sha", default=None)
     parser.add_argument("--head-sha", default=None)
+    parser.add_argument("--calibrate", metavar="DIR",
+                        help="suggest thresholds from a directory of A/A results trees")
     args = parser.parse_args()
+
+    if args.calibrate:
+        calibrate(args.calibrate)
+        return
 
     if args.results_dir:
         machines, order = collect_results(args.results_dir)

--- a/scripts/test_bench_e2e_diff.py
+++ b/scripts/test_bench_e2e_diff.py
@@ -166,6 +166,19 @@ class JsonPath(unittest.TestCase):
             self.assertIn("Sustained TPS (tx/s)", text)
             self.assertNotIn("slope", text)
 
+    def test_rts_metrics_mirror_haskell_formula(self):
+        mb = 1024.0 * 1024.0
+        stats = [
+            {"allocatedBytes": 1000 * mb, "mutatorCpuSeconds": 10.0, "maxLiveBytes": 300 * mb},
+            {"allocatedBytes": 500 * mb, "mutatorCpuSeconds": 6.0, "maxLiveBytes": 200 * mb},
+        ]
+        m = diff.rts_metrics(stats, n_txs=1000, n_snapshots=10)
+        self.assertAlmostEqual(m["Alloc MB per confirmed tx"], 1.5)
+        self.assertAlmostEqual(m["Alloc MB per snapshot"], 150.0)
+        self.assertAlmostEqual(m["Mutator CPU s per 1k txs"], 16.0)
+        self.assertAlmostEqual(m["Max live MB (max node)"], 300.0)
+        self.assertEqual(diff.rts_metrics([], 1000, 10), {})
+
     def test_calibrate_smoke(self):
         import contextlib
         import io

--- a/scripts/test_bench_e2e_diff.py
+++ b/scripts/test_bench_e2e_diff.py
@@ -39,6 +39,36 @@ def write_rep(root, machine, slot, side, md):
     d = root / machine / f"rep-{slot}-{side}" / "open"
     d.mkdir(parents=True, exist_ok=True)
     (d / "end-to-end-benchmarks.md").write_text(md, encoding="utf-8")
+    return d
+
+
+def summary_json(title="Sustained load", tps=500.0, n_txs=15000, snapshots=None):
+    snapshots = snapshots if snapshots is not None else [[0.5 * i, 1000] for i in range(1, 16)]
+    return {
+        "summaryTitle": title,
+        "loadMode": "open-loop",
+        "numberOfTxs": n_txs,
+        "numberOfInvalidTxs": 0,
+        "numberOfSnapshots": len(snapshots),
+        "avgTxsPerSnapshot": n_txs / len(snapshots),
+        "endToEndTps": tps,
+        "runWallClockSeconds": n_txs / tps,
+        "drainSeconds": 5.0,
+        "snapshotSeries": snapshots,
+        "confirmationTimesMs": [float(i) for i in range(1, 101)],
+        "validationP50Ms": 5.0,
+        "peakNodeRssMb": 400.0,
+        "incrementalCommitTimes": [],
+        "incrementalDecommitTimes": [],
+        "runOutcome": None,
+    }
+
+
+def write_rep_with_json(root, machine, slot, side, md, summaries):
+    d = write_rep(root, machine, slot, side, md)
+    (d / "end-to-end-benchmarks.json").write_text(
+        json.dumps({"version": 1, "summaries": summaries}), encoding="utf-8"
+    )
 
 
 def render_dir(root):
@@ -91,6 +121,66 @@ class DecideCell(unittest.TestCase):
     def test_all_zero_deltas_are_noise(self):
         text, _ = self.cell([0.0, 0.0, 0.0, 0.0])
         self.assertTrue(text.startswith("≈"))
+
+
+class Estimators(unittest.TestCase):
+    def test_slope_recovers_linear_rate(self):
+        series = [(0.5 * i, 200) for i in range(1, 21)]
+        self.assertAlmostEqual(diff.sustained_tps_slope(series), 400.0, places=6)
+
+    def test_slope_trims_ramp(self):
+        # Slow first 10% of txs, then steady 1000 tx/s: the window excludes
+        # the ramp point.
+        series = [(10.0, 100)] + [(10.0 + 0.1 * i, 100) for i in range(1, 10)]
+        self.assertAlmostEqual(diff.sustained_tps_slope(series), 1000.0, delta=1.0)
+
+    def test_slope_needs_four_window_points(self):
+        self.assertIsNone(diff.sustained_tps_slope([(1.0, 100), (2.0, 100), (3.0, 100)]))
+        self.assertIsNone(diff.sustained_tps_slope([]))
+
+    def test_percentile_interpolates(self):
+        self.assertEqual(diff.percentile([1.0, 2.0, 3.0, 4.0], 50), 2.5)
+        self.assertIsNone(diff.percentile([], 50))
+
+
+class JsonPath(unittest.TestCase):
+    def test_json_pair_uses_slope_and_python_percentiles(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for slot, side in ((1, "branch"), (2, "master")):
+                write_rep_with_json(root, "m1", slot, side, report_md(), [summary_json()])
+            out, _ = render_dir(root)
+            text = "\n".join(out)
+            self.assertIn("Sustained TPS, slope", text)
+            rows = [line for line in out if line.startswith("| ")]
+            self.assertFalse(any("🔴" in r or "🟢" in r for r in rows), rows)
+
+    def test_mixed_format_pair_falls_back_to_md(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_rep_with_json(root, "m1", 1, "branch", report_md(), [summary_json()])
+            write_rep(root, "m1", 2, "master", report_md())
+            out, _ = render_dir(root)
+            text = "\n".join(out)
+            self.assertIn("End-to-end TPS", text)
+            self.assertIn("Sustained TPS (tx/s)", text)
+            self.assertNotIn("slope", text)
+
+    def test_calibrate_smoke(self):
+        import contextlib
+        import io
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for run in ("run-1", "run-2"):
+                for slot, side in ((1, "branch"), (2, "master")):
+                    write_rep(root / run, "m1", slot, side, report_md(tps=500.0 + slot))
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                diff.calibrate(root)
+            doc = json.loads(buf.getvalue())
+            self.assertEqual(doc["runs"], 2)
+            self.assertIn("End-to-end TPS", doc["suggested_thresholds"])
 
 
 class Parsing(unittest.TestCase):


### PR DESCRIPTION
- Bench reports gain an `end-to-end-benchmarks.json` twin with raw series (snapshot series, confirmation times, per-node RTS stats)
- When both sides of a pair have JSON, the diff computes estimators (percentiles, sustained-TPS slope) with one implementation for both sides; otherwise it falls back to markdown rows, never mixing definitions
- `--calibrate` derives suggested noise thresholds from accumulated A/A result trees
- hydra-node serves `hydra_rts_*` gauges (alloc, mutator/GC CPU, max live, major GCs) when run with `+RTS -T`; endpoint output is unchanged otherwise
- Diff comment gains scrape-bracketed alloc/CPU/max-live rows with tighter thresholds (nearly machine-independent signals)
- Diff workflow spawns nodes with `+RTS -N2 -T` via `HYDRA_NODE_RTS_FLAGS`, probe-guarded so both sides always get identical settings, and passes `+RTS -N2 -RTS` to both sides' bench clients on the command line (no cabal change, published series unaffected)
- Cluster state lives on tmpfs during diff runs, keeping runner disk fsync latency out of measurements