### PR TITLE
typst-agda-spec-6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,7 +219,12 @@ changes.
   including the commit/decommit output-set hashes bound into the snapshot
   multisignature, the deposit-identity binding of the commit digest (a snapshot
   authorizes one deposit by transaction id, not any look-alike recording the
-  same UTxO) and the canonical CRS datum binding of the fanout paths.
+  same UTxO) and the canonical CRS datum binding of the fanout paths. A global
+  solvency invariant is machine-checked on top: the head output's value covers
+  the accumulator-committed UTxO set's L1-originating value across
+  init/increment/decrement/close/contest, and fanout can only distribute
+  committed outputs — the proof's increment case consumes the deposit-identity
+  binding, so weakening it fails the spec build.
 
 - The head logic now enforces the specification's "no commit and decommit in
   flight at once" discipline on the message level: a `ReqDec` received while a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,7 +223,7 @@ changes.
   solvency invariant is machine-checked on top: the head output's value covers
   the accumulator-committed UTxO set's L1-originating value across
   init/increment/decrement/close/contest, and fanout can only distribute
-  committed outputs — the proof's increment case consumes the deposit-identity
+  committed outputs; the proof's increment case consumes the deposit-identity
   binding, so weakening it fails the spec build.
 
 - CI now gates validator reject-path coverage: `checks.error-codes` verifies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,12 @@ changes.
   committed outputs — the proof's increment case consumes the deposit-identity
   binding, so weakening it fails the spec build.
 
+- CI now gates validator reject-path coverage: `checks.error-codes` verifies
+  that every error code the head and deposit validators can raise is either
+  referenced by a test or carries a reviewed exclusion in the ledger of
+  `spec/check-error-codes.sh`, that no code is dead, and that the Aiken and
+  Haskell deposit-error tables agree.
+
 - The head logic now enforces the specification's "no commit and decommit in
   flight at once" discipline on the message level: a `ReqDec` received while a
   deposit is pending waits for the deposit to resolve instead of starting a

--- a/docs/docs/dev/agda.md
+++ b/docs/docs/dev/agda.md
@@ -109,6 +109,12 @@ Two layers bind the extracted spec to the real implementation:
   deposit transaction id bound into the commit digest), BLS/KZG
   membership proofs against the canonical CRS, and the canonical-CRS datum
   binding (`InvalidCRSDatum`).
+  The differential and mutation layers only see the input families somebody
+  constructed, so `spec/check-error-codes.sh` (CI: `checks.error-codes`) keeps
+  the reject-path coverage honest: every error code a validator can raise must
+  be asserted by a test (via `toErrorCode`) or carry a reviewed exclusion in
+  its ledger, and
+  dead codes fail the build.
 - **Off-chain**:
   [`Hydra.OffChainAgreementSpec`](https://github.com/cardano-scaling/hydra/blob/master/hydra-node/test/Hydra/OffChainAgreementSpec.hs)
   and `Hydra.OffChainLeaderSpec` (hydra-node) bind the extracted §6 handler

--- a/docs/docs/dev/agda.md
+++ b/docs/docs/dev/agda.md
@@ -113,8 +113,7 @@ Two layers bind the extracted spec to the real implementation:
   constructed, so `spec/check-error-codes.sh` (CI: `checks.error-codes`) keeps
   the reject-path coverage honest: every error code a validator can raise must
   be asserted by a test (via `toErrorCode`) or carry a reviewed exclusion in
-  its ledger, and
-  dead codes fail the build.
+  its ledger, and dead codes fail the build.
 - **Off-chain**:
   [`Hydra.OffChainAgreementSpec`](https://github.com/cardano-scaling/hydra/blob/master/hydra-node/test/Hydra/OffChainAgreementSpec.hs)
   and `Hydra.OffChainLeaderSpec` (hydra-node) bind the extracted §6 handler

--- a/docs/docs/dev/agda.md
+++ b/docs/docs/dev/agda.md
@@ -53,13 +53,31 @@ Three tiers, from strongest to weakest guarantee:
    else is proved.
 
 3. **Differentially tested.** Where the abstract model meets the real code,
-   the bridge's trusted base is *fixed and machine-enforced*: exactly 6
-   injected const-true mocks (crypto/accumulator conjuncts the tests cover
-   against the real primitives instead) and 7 encoding/faithfulness
-   postulates, enumerated in
-   [`spec/check-trust-ledger.sh`](https://github.com/cardano-scaling/hydra/blob/master/spec/check-trust-ledger.sh).
-   That script fails the spec build if a mock or postulate is added or removed
-   without updating the ledger, so the trusted base cannot grow silently.
+   the trusted base is *fixed and machine-enforced* by
+   [`spec/check-trust-ledger.sh`](https://github.com/cardano-scaling/hydra/blob/master/spec/check-trust-ledger.sh),
+   which fails the spec build on any drift. It gates three things:
+
+   - the **bridge** layer: exactly 6 injected const-true mocks (crypto and
+     accumulator conjuncts the tests cover against the real primitives instead)
+     and 7 encoding/faithfulness postulates;
+   - the **model** layer: every postulate of the model modules as a name set, so
+     a new axiom cannot enter quietly either, plus the 4 `Assumptions` fields the
+     solvency theorem is parameterised over by *full signature*. Signatures for
+     those four because they are where a strengthening rather than an addition
+     does the damage: relax `κ#-pair-inj` to drop its hypothesis and `hash`
+     becomes injective on nothing, every hash equal, and the theorem vacuous,
+     all while still type-checking;
+   - the **escape hatches** that are not postulates at all: `TERMINATING` and
+     friends, `primTrustMe`, `REWRITE`, and the `OPTIONS` flags that switch off
+     termination, positivity or coverage checking. Agda's own `--safe` would be
+     the obvious tool and is unavailable, because `--safe` *bans postulates* and
+     this specification rests on 63 of them by design (and `--safe` is contagious
+     through imports, so nothing downstream of `Prelude` could carry it). The
+     enumerated list buys the same protection.
+
+   It also gates which on-chain transitions the solvency argument reaches: every
+   `*Valid` bundle must be consumed by a step or listed with the reason it is
+   out of reach, so a new transition cannot narrow the theorem silently.
 
 The bridge direction is *completeness*: `ReferenceBridge.agda` proves that a
 spec-valid transaction makes the extracted checker accept, so a
@@ -113,7 +131,10 @@ Two layers bind the extracted spec to the real implementation:
   constructed, so `spec/check-error-codes.sh` (CI: `checks.error-codes`) keeps
   the reject-path coverage honest: every error code a validator can raise must
   be asserted by a test (via `toErrorCode`) or carry a reviewed exclusion in
-  its ledger, and dead codes fail the build.
+  its ledger, and dead codes fail the build. Deleting a dead constructor leaves a
+  hole in the numbering, and the ledger's `RETIRED` list keeps that hole: the code
+  *string* is what the mutation corpus and anything outside the repo match on, so
+  a later constructor dropping into a retired number would inherit its meaning.
 - **Off-chain**:
   [`Hydra.OffChainAgreementSpec`](https://github.com/cardano-scaling/hydra/blob/master/hydra-node/test/Hydra/OffChainAgreementSpec.hs)
   and `Hydra.OffChainLeaderSpec` (hydra-node) bind the extracted §6 handler
@@ -131,6 +152,9 @@ Two layers bind the extracted spec to the real implementation:
 | Change a head-logic handler | Update the §6 arm (+ figure) in `OffChain.lagda.typ`, mirror in `OffChainReference.agda`, bind in the hydra-node agreement tests |
 | Change the datum shape | `HeadDatum` in `OnChain.lagda.typ` + `state-fields` in `diagrams.typ`; `check-refs.sh` catches constructor drift |
 | Add a mock/postulate to the bridge | The build fails until `check-trust-ledger.sh`'s ledger is updated, which is the point |
+| Add a postulate to the model | Same script, model layer: add the name to its list (and if it is an `Assumptions` field, its full signature) |
+| Reach for `TERMINATING`/`primTrustMe` | Don't; the same script rejects them by name. If a definition genuinely needs one, that is a design discussion, not a pragma |
+| Add a validator error code | Pick an unused number (`RETIRED` ones are burned), assert it from a test via `toErrorCode`, or record a reviewed exclusion in `check-error-codes.sh` |
 
 CI gates: `checks.spec` (Agda typecheck, reference/diagram lints, trust-ledger
 drift check, PDF render) and `checks.hydra-agda-generated` (extraction

--- a/docs/docs/dev/agda.md
+++ b/docs/docs/dev/agda.md
@@ -28,8 +28,8 @@ Three groups of modules, one build:
 
 | Group | Modules | Role |
 | --- | --- | --- |
-| Rendered (the document) | `Introduction`, `Overview`, `Preliminaries`, `Setup`, `OnChain`, `OnChainCoverage`, `OffChain`, `Security`, `SecurityProofs` | The prose. Their ```` ```agda ```` fences are collected into the PDF's Agda appendix, which is restricted to the machine-checked theorem statements (`OnChainCoverage`, `SecurityProofs`, `Security`, `OffChain`); the datum/redeemer types, transition relations and validity bundles in `Preliminaries`/`Setup`/`OnChain` are typechecked but deliberately not rendered |
-| Typecheck-only | `Prelude`, `ReferenceBridge`, `RefReflection` | The abstract trust base and the bridge proofs; verified on every build, never rendered |
+| Rendered (the document) | `Introduction`, `Overview`, `Preliminaries`, `Setup`, `OnChain`, `OnChainCoverage`, `OffChain`, `Security`, `SecurityProofs`, `Solvency` | The prose. Their ```` ```agda ```` fences are collected into the PDF's Agda appendix, which is restricted to the machine-checked theorem statements (`OnChainCoverage`, `SecurityProofs`, `Security`, `OffChain`, `Solvency` - including the global solvency invariant, whose increment case consumes the deposit-identity binding); the datum/redeemer types, transition relations and validity bundles in `Preliminaries`/`Setup`/`OnChain` are typechecked but deliberately not rendered |
+| Typecheck-only | `Prelude`, `ReferenceBridge`, `RefReflection`, `SolvencyCounterModel` | The abstract trust base, the bridge proofs, and the pre-fix deposit-aliasing counter-model; verified on every build, never rendered |
 | Extractable | `Reference`, `OffChainReference` | Decidable checkers, self-contained over `Agda.Builtin` types so the extracted Haskell stays small |
 
 ## The trust story

--- a/justfile
+++ b/justfile
@@ -130,6 +130,7 @@ lint PKG="all":
   rc=0
   nix fmt || rc=1
   python3 scripts/test_bench_e2e_diff.py || rc=1
+  bash spec/check-error-codes.sh || rc=1
   cabal build {{PKG}} \
     --builddir=dist-newstyle-lint \
     --ghc-options="-Werror \

--- a/nix/hydra/spec.nix
+++ b/nix/hydra/spec.nix
@@ -200,6 +200,17 @@
       # above, so this adds no duplicate compilation.
       checks.spec = config.packages.spec;
 
+      # Validator error-code coverage ledger: every Hxx/Dxx code a validator can
+      # raise must be referenced by some test or carry a reviewed exclusion (see
+      # spec/check-error-codes.sh). Runs as its own check because it greps the
+      # validator and test trees, which the spec derivation's src (spec/ only)
+      # does not contain.
+      checks.error-codes = pkgs.runCommand "error-codes" { } ''
+        cd ${self}
+        bash spec/check-error-codes.sh
+        touch $out
+      '';
+
       # The MAlonzo extraction under hydra-agda/generated is committed and only regenerated manually
       # (hydra-agda/regenerate.sh), so a semantic edit to Reference.agda / OffChainReference.agda
       # would otherwise silently leave the committed oracle stale. Re-extract hermetically and fail

--- a/nix/hydra/spec.nix
+++ b/nix/hydra/spec.nix
@@ -84,6 +84,22 @@
         fileset = lib.fileset.unions [ ../../spec ../../hydra-agda ];
       };
 
+      # Just what check-error-codes.sh reads: the validators that raise the codes, the test trees it
+      # searches for `toErrorCode` assertions, and the script itself. Scoped for the same reason
+      # again; the check is only seconds long, but with `${self}` those seconds were spent on every
+      # commit to the repository rather than on the commits that could change the answer.
+      errorCodesSrc = lib.fileset.toSource {
+        root = ../..;
+        fileset = lib.fileset.unions [
+          ../../spec/check-error-codes.sh
+          ../../hydra-plutus/src
+          ../../hydra-plutus/validators
+          ../../hydra-plutus/test
+          ../../hydra-tx/test
+          ../../hydra-node/test
+        ];
+      };
+
       # The Agda typecheck + lints + Typst render, WITHOUT the notation-tooltip postprocess
       # (ANNOTATE_NOTATION=skip, see build.sh stage 3). Internal: consume
       # packages.spec, which adds the tooltips.
@@ -206,7 +222,7 @@
       # validator and test trees, which the spec derivation's src (spec/ only)
       # does not contain.
       checks.error-codes = pkgs.runCommand "error-codes" { } ''
-        cd ${self}
+        cd ${errorCodesSrc}
         bash spec/check-error-codes.sh
         touch $out
       '';

--- a/spec/check-error-codes.sh
+++ b/spec/check-error-codes.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Validator error-code coverage ledger (implementation layer).
+#
+# Companion to check-trust-ledger.sh, one level down: that script gates the trusted
+# base of the model<->reference bridge; this one gates the reject-path coverage of the
+# on-chain validators themselves. The differential and mutation tests only see the
+# input families somebody constructed, so a new validator check can ship silently
+# uncovered - and a check nobody can trip is exactly where the next deposit-binding
+# class of bug hides.
+#
+# For every error code a validator can raise (Hydra.Contract.HeadError's "Hxx" codes
+# and deposit.ak's "Dxx" codes) this script verifies:
+#   1. the constructor is actually raised somewhere - a dead code fails the build:
+#      delete it instead (see the H15-H20/H40/H54 cleanup for precedent);
+#   2. the Aiken codes and their Haskell mirror (Hydra.Contract.DepositError) agree;
+#   3. the code appears in the ledger below with an accurate status:
+#        tested          - some test source references the constructor (mutation
+#                          corpus, contract test or agreement layer); verified by grep
+#        untested:<tag>  - a documented exclusion, printed as visible debt; if a test
+#                          starts referencing the constructor this FAILS so the row is
+#                          promoted to tested and the debt list stays accurate.
+# A new error code therefore cannot ship without either a test referencing it or an
+# explicit, reviewed exclusion here.
+#
+# Exclusion tags:
+#   catch-all         - a dispatcher/fallback arm, unreachable by a single mutation
+#   datum-plumbing    - malformed datum shapes the mutation corpus does not construct
+#   context-plumbing  - malformed script-context shapes (missing head input, missing
+#                       redeemer entry, ...)
+#   validity-plumbing - missing validity-bound arms (the finite/infinite bound cases
+#                       ARE tested where they guard protocol logic)
+#   crs-plumbing      - missing CRS reference-input/datum arms (the content binding is
+#                       tested: InvalidCRSDatum)
+#   variant-gap       - a genuine coverage gap worth a test; candidates for follow-up
+#
+# NB grep-based "tested" is a necessary condition, not proof the test is meaningful -
+# the ledger keeps the coverage question visible and reviewed, it does not answer it.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+HEAD_ERRORS=hydra-plutus/src/Hydra/Contract/HeadError.hs
+DEPOSIT_AK=hydra-plutus/validators/deposit.ak
+DEPOSIT_MIRROR=hydra-plutus/src/Hydra/Contract/DepositError.hs
+RAISE_DIRS=(hydra-plutus/src)
+TEST_DIRS=(hydra-tx/test hydra-plutus/test hydra-node/test)
+
+ledger=$(cat <<'LEDGER'
+D01 DepositPeriodSurpassed tested
+D02 DepositNoUpperBoundDefined untested:validity-plumbing
+D03 DepositNoLowerBoundDefined tested
+D04 DepositPeriodNotReached tested
+D05 IncorrectDepositHash tested
+D06 DepositHeadInputNotFound tested
+D07 HeadInputRedeemerNotFound untested:context-plumbing
+D08 HeadRedeemerNotIncrement tested
+D09 DepositNotClaimedByHead tested
+D10 MultipleDepositsRecovered tested
+H1 InvalidHeadStateTransition untested:catch-all
+H2 ChangedParameters tested
+H3 WrongStateInOutputDatum untested:datum-plumbing
+H4 HeadValueIsNotPreserved tested
+H5 SignerIsNotAParticipant tested
+H6 NoSigners tested
+H7 TooManySigners tested
+H8 ScriptNotSpendingAHeadInput untested:context-plumbing
+H9 NoOutputDatumError untested:datum-plumbing
+H10 UnexpectedNonInlineDatum untested:datum-plumbing
+H11 NotPayingToHead tested
+H12 SignatureVerificationFailed tested
+H13 MustNotChangeVersion tested
+H14 BurntTokenNumberMismatch tested
+H21 VersionNotIncremented tested
+H22 HasBoundedValidityCheckFailed tested
+H23 IncorrectClosedContestationDeadline tested
+H24 InfiniteUpperBound tested
+H25 InfiniteLowerBound tested
+H26 ContestersNonEmpty tested
+H27 CloseNoUpperBoundDefined untested:validity-plumbing
+H28 FailedCloseInitial tested
+H29 TooOldSnapshot tested
+H30 UpperBoundBeyondContestationDeadline tested
+H31 ContestNoUpperBoundDefined untested:validity-plumbing
+H32 MustNotPushDeadline tested
+H33 MustPushDeadline tested
+H34 ContesterNotIncluded tested
+H35 WrongNumberOfSigners untested:variant-gap
+H36 SignerAlreadyContested tested
+H37 FailedContestUnused tested
+H38 FailedContestUsed untested:variant-gap
+H39 FanoutUTxOHashMismatch tested
+H41 LowerBoundBeforeContestationDeadline tested
+H42 FanoutNoLowerBoundDefined untested:validity-plumbing
+H43 DepositNotSpent tested
+H44 DepositInputNotFound tested
+H45 HeadInputNotFound untested:context-plumbing
+H46 FailedCloseAny tested
+H47 FailedCloseUnused tested
+H48 FailedCloseUsed tested
+H55 MissingCRSDatum untested:crs-plumbing
+H56 MissingCRSRefInput untested:crs-plumbing
+H57 PartialFanoutMembershipFailed tested
+H58 PartialFanoutChangedParameters tested
+H59 AccumulatorCommitmentHashMismatch tested
+H60 FinalPartialFanoutMembershipFailed tested
+H62 FinalPartialFanoutZeroOutputs tested
+H63 PartialFanoutZeroOutputs tested
+H64 PartialFanoutCannotBeLastBatch tested
+H65 ChangedHeadAdaOverhead tested
+H67 DepositDatumInvalid tested
+H68 InvalidCRSDatum tested
+H69 DepositNotFirstOutput tested
+H70 DecrementZeroOutputs tested
+H71 MustNotSpendOtherScripts tested
+LEDGER
+)
+
+fail=0
+
+# extracted (code, constructor) pairs, one "CODE NAME" per line
+head_actual=$(sed -nE 's/^[[:space:]]*([A-Za-z]+) -> "(H[0-9]+)".*/\2 \1/p' "$HEAD_ERRORS" | sort)
+dep_actual=$(sed -nE 's/^[[:space:]]*([A-Za-z]+) -> @"(D[0-9]+)".*/\2 \1/p' "$DEPOSIT_AK" | sort)
+mirror_actual=$(sed -nE 's/^[[:space:]]*([A-Za-z]+) -> "(D[0-9]+)".*/\2 \1/p' "$DEPOSIT_MIRROR" | sort)
+
+# 1. Aiken <-> Haskell mirror agreement.
+if [ "$dep_actual" != "$mirror_actual" ]; then
+  echo "check-error-codes: deposit.ak and Hydra.Contract.DepositError DISAGREE (- aiken, + mirror):"
+  diff <(echo "$dep_actual") <(echo "$mirror_actual") || true
+  fail=1
+fi
+
+# 2. No duplicate codes within a namespace.
+dupes=$( (echo "$head_actual"; echo "$dep_actual") | cut -d' ' -f1 | sort | uniq -d)
+if [ -n "$dupes" ]; then
+  echo "check-error-codes: duplicate error codes: $dupes"
+  fail=1
+fi
+
+# 3. Ledger drift: the extracted set must equal the ledger's (code, constructor) set.
+actual=$( (echo "$head_actual"; echo "$dep_actual") | sort)
+expected=$(echo "$ledger" | awk '{print $1, $2}' | sort)
+if [ "$actual" != "$expected" ]; then
+  echo "check-error-codes: the error-code set DRIFTED from the ledger (- ledger, + sources):"
+  diff <(echo "$expected") <(echo "$actual") || true
+  echo "Update the ledger in this script: a new code needs a test referencing its"
+  echo "constructor (status: tested) or a reviewed exclusion (status: untested:<tag>)."
+  fail=1
+fi
+
+# 4. Every code is raised somewhere; 5. ledger statuses are accurate.
+untested_report=""
+while read -r code name status; do
+  case "$code" in
+    H*)
+      if ! grep -rqw "errorCode $name" "${RAISE_DIRS[@]}"; then
+        echo "check-error-codes: $code $name is never raised (no 'errorCode $name' under ${RAISE_DIRS[*]}): delete it."
+        fail=1
+      fi
+      ;;
+    D*)
+      if ! grep -q "toErrorCode($name)" "$DEPOSIT_AK"; then
+        echo "check-error-codes: $code $name is never raised (no 'toErrorCode($name)' in $DEPOSIT_AK): delete it."
+        fail=1
+      fi
+      ;;
+  esac
+  if grep -rqw --include='*.hs' "$name" "${TEST_DIRS[@]}"; then
+    if [ "$status" != tested ]; then
+      echo "check-error-codes: $code $name is referenced by tests but the ledger says '$status': promote it to 'tested'."
+      fail=1
+    fi
+  else
+    if [ "$status" = tested ]; then
+      echo "check-error-codes: $code $name claims 'tested' but no test source references it: add a test or record an exclusion."
+      fail=1
+    fi
+    untested_report+="  $code $name (${status#untested:})"$'\n'
+  fi
+done <<< "$ledger"
+
+if [ "$fail" -ne 0 ]; then
+  exit 1
+fi
+
+total=$(echo "$ledger" | wc -l)
+untested=$(printf '%s' "$untested_report" | grep -c . || true)
+echo "check-error-codes: OK — $total codes, $((total - untested)) referenced by tests, $untested documented exclusions:"
+printf '%s' "$untested_report"

--- a/spec/check-error-codes.sh
+++ b/spec/check-error-codes.sh
@@ -14,27 +14,39 @@
 #      delete it instead (see the H15-H20/H40/H54 cleanup for precedent);
 #   2. the Aiken codes and their Haskell mirror (Hydra.Contract.DepositError) agree;
 #   3. the code appears in the ledger below with an accurate status:
-#        tested          - some test source references the constructor (mutation
-#                          corpus, contract test or agreement layer); verified by grep
+#        tested          - a test ASSERTS this code, i.e. some test source applies
+#                          `toErrorCode` to the constructor. That is the mutation
+#                          framework's expected-error form, and the only one in use
+#                          (229 occurrences; no test names a code any other way).
 #        untested:<tag>  - a documented exclusion, printed as visible debt; if a test
-#                          starts referencing the constructor this FAILS so the row is
-#                          promoted to tested and the debt list stays accurate.
-# A new error code therefore cannot ship without either a test referencing it or an
+#                          starts asserting the code this FAILS so the row is promoted
+#                          to tested and the debt list stays accurate.
+# A new error code therefore cannot ship without either a test asserting it or an
 # explicit, reviewed exclusion here.
 #
-# Exclusion tags:
-#   catch-all         - a dispatcher/fallback arm, unreachable by a single mutation
-#   datum-plumbing    - malformed datum shapes the mutation corpus does not construct
-#   context-plumbing  - malformed script-context shapes (missing head input, missing
-#                       redeemer entry, ...)
-#   validity-plumbing - missing validity-bound arms (the finite/infinite bound cases
-#                       ARE tested where they guard protocol logic)
-#   crs-plumbing      - missing CRS reference-input/datum arms (the content binding is
-#                       tested: InvalidCRSDatum)
-#   variant-gap       - a genuine coverage gap worth a test; candidates for follow-up
+# The evidence has to be `toErrorCode <Name>` and not the bare constructor name,
+# because a bare-name grep counts prose. Both directions were wrong: H43 claimed
+# "tested" on the strength of a comment saying its check is *subsumed* by an earlier
+# one (i.e. the opposite of coverage), and a TODO or a prop description mentioning an
+# EXCLUDED code failed the check, demanding a promotion no test had earned.
 #
-# NB grep-based "tested" is a necessary condition, not proof the test is meaningful -
-# the ledger keeps the coverage question visible and reviewed, it does not answer it.
+# Exclusion tags:
+#   catch-all          - a dispatcher/fallback arm, unreachable by a single mutation
+#   datum-plumbing     - malformed datum shapes the mutation corpus does not construct
+#   context-plumbing   - malformed script-context shapes (missing head input, missing
+#                        redeemer entry, ...)
+#   validity-plumbing  - missing validity-bound arms (the finite/infinite bound cases
+#                        ARE tested where they guard protocol logic)
+#   crs-plumbing       - missing CRS reference-input/datum arms (the content binding is
+#                        tested: InvalidCRSDatum)
+#   variant-gap        - a genuine coverage gap worth a test; candidates for follow-up
+#   code-not-asserted  - a test does exercise the reject path, but nothing pins WHICH
+#                        code it raised, so the coverage cannot be attributed here
+#   unreachable        - an earlier conjunct subsumes this one, so no input can reach
+#                        it; a deletion candidate, kept visible rather than claimed
+#
+# NB even a strict "tested" is a necessary condition, not proof the test is meaningful.
+# The ledger keeps the coverage question visible and reviewed; it does not answer it.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -90,7 +102,7 @@ H38 FailedContestUsed untested:variant-gap
 H39 FanoutUTxOHashMismatch tested
 H41 LowerBoundBeforeContestationDeadline tested
 H42 FanoutNoLowerBoundDefined untested:validity-plumbing
-H43 DepositNotSpent tested
+H43 DepositNotSpent untested:unreachable
 H44 DepositInputNotFound tested
 H45 HeadInputNotFound untested:context-plumbing
 H46 FailedCloseAny tested
@@ -106,7 +118,7 @@ H62 FinalPartialFanoutZeroOutputs tested
 H63 PartialFanoutZeroOutputs tested
 H64 PartialFanoutCannotBeLastBatch tested
 H65 ChangedHeadAdaOverhead tested
-H67 DepositDatumInvalid tested
+H67 DepositDatumInvalid untested:code-not-asserted
 H68 InvalidCRSDatum tested
 H69 DepositNotFirstOutput tested
 H70 DecrementZeroOutputs tested
@@ -146,7 +158,27 @@ if [ "$actual" != "$expected" ]; then
   fail=1
 fi
 
-# 4. Every code is raised somewhere; 5. ledger statuses are accurate.
+# 4. Exclusion tags come from the documented vocabulary above: a typo'd tag would
+# otherwise pass as a reviewed exclusion and drop the row out of the debt report.
+KNOWN_TAGS="catch-all datum-plumbing context-plumbing validity-plumbing crs-plumbing variant-gap code-not-asserted unreachable"
+while read -r code name status; do
+  case "$status" in
+    tested) ;;
+    untested:*)
+      tag=${status#untested:}
+      if ! printf '%s\n' $KNOWN_TAGS | grep -qxF -- "$tag"; then
+        echo "check-error-codes: $code $name has unknown exclusion tag '$tag' (known: $KNOWN_TAGS)."
+        fail=1
+      fi
+      ;;
+    *)
+      echo "check-error-codes: $code $name has unrecognised status '$status' (want 'tested' or 'untested:<tag>')."
+      fail=1
+      ;;
+  esac
+done <<< "$ledger"
+
+# 5. Every code is raised somewhere; 6. ledger statuses are accurate.
 untested_report=""
 while read -r code name status; do
   case "$code" in
@@ -163,14 +195,14 @@ while read -r code name status; do
       fi
       ;;
   esac
-  if grep -rqw --include='*.hs' "$name" "${TEST_DIRS[@]}"; then
+  if grep -rqE --include='*.hs' "toErrorCode[[:space:]]*\(?[[:space:]]*$name\b" "${TEST_DIRS[@]}"; then
     if [ "$status" != tested ]; then
-      echo "check-error-codes: $code $name is referenced by tests but the ledger says '$status': promote it to 'tested'."
+      echo "check-error-codes: $code $name is asserted by a test but the ledger says '$status': promote it to 'tested'."
       fail=1
     fi
   else
     if [ "$status" = tested ]; then
-      echo "check-error-codes: $code $name claims 'tested' but no test source references it: add a test or record an exclusion."
+      echo "check-error-codes: $code $name claims 'tested' but no test asserts it (no 'toErrorCode $name'): add a test or record an exclusion."
       fail=1
     fi
     untested_report+="  $code $name (${status#untested:})"$'\n'
@@ -183,5 +215,5 @@ fi
 
 total=$(echo "$ledger" | wc -l)
 untested=$(printf '%s' "$untested_report" | grep -c . || true)
-echo "check-error-codes: OK — $total codes, $((total - untested)) referenced by tests, $untested documented exclusions:"
+echo "check-error-codes: OK: $total codes, $((total - untested)) asserted by tests, $untested documented exclusions:"
 printf '%s' "$untested_report"

--- a/spec/check-error-codes.sh
+++ b/spec/check-error-codes.sh
@@ -13,6 +13,10 @@
 #   1. the constructor is actually raised somewhere - a dead code fails the build:
 #      delete it instead (see the H15-H20/H40/H54 cleanup for precedent);
 #   2. the Aiken codes and their Haskell mirror (Hydra.Contract.DepositError) agree;
+#   2b. no RETIRED code is claimed again. Deleting a dead constructor leaves a hole in the numbering,
+#      and a later constructor dropping into that hole would silently inherit the old code's meaning
+#      everywhere the STRING is what gets matched: this ledger, the mutation corpus's expected-error
+#      assertions, and anything outside the repo that recorded it. Holes are cheap; reuse is not.
 #   3. the code appears in the ledger below with an accurate status:
 #        tested          - a test ASSERTS this code, i.e. some test source applies
 #                          `toErrorCode` to the constructor. That is the mutation
@@ -126,12 +130,24 @@ H71 MustNotSpendOtherScripts tested
 LEDGER
 )
 
+# Codes whose constructors have been deleted. Their numbers are burned: never reuse one.
+RETIRED="H15 H16 H17 H18 H19 H20 H40 H49 H50 H51 H52 H53 H54 H61 H66"
+
 fail=0
 
 # extracted (code, constructor) pairs, one "CODE NAME" per line
 head_actual=$(sed -nE 's/^[[:space:]]*([A-Za-z]+) -> "(H[0-9]+)".*/\2 \1/p' "$HEAD_ERRORS" | sort)
 dep_actual=$(sed -nE 's/^[[:space:]]*([A-Za-z]+) -> @"(D[0-9]+)".*/\2 \1/p' "$DEPOSIT_AK" | sort)
 mirror_actual=$(sed -nE 's/^[[:space:]]*([A-Za-z]+) -> "(D[0-9]+)".*/\2 \1/p' "$DEPOSIT_MIRROR" | sort)
+
+# 0. No retired code has been claimed again.
+for retired in $RETIRED; do
+  claimed=$( (echo "$head_actual"; echo "$dep_actual") | awk -v c="$retired" '$1 == c {print $2}')
+  if [ -n "$claimed" ]; then
+    echo "check-error-codes: $retired is RETIRED but claimed again by $claimed: pick an unused number."
+    fail=1
+  fi
+done
 
 # 1. Aiken <-> Haskell mirror agreement.
 if [ "$dep_actual" != "$mirror_actual" ]; then

--- a/spec/check-trust-ledger.sh
+++ b/spec/check-trust-ledger.sh
@@ -11,10 +11,23 @@
 # So a NEW mock or postulate cannot enter the trusted base silently: adding one fails the build until
 # both the EXPECTED_* lists and this ledger table are updated.
 #
+# It gates two layers:
+#   BRIDGE  the `spec => extracted-reference` trusted base (ReferenceBridge/RefReflection), itemised in
+#           the table below.
+#   MODEL   the abstract model's own axioms: every postulate of Prelude/Setup/OnChain/OffChain/Security/
+#           Solvency, as a name set, plus the FULL SIGNATURES of the `Assumptions` fields the solvency
+#           theorem is parameterised over. The signatures are gated and not just the names because those
+#           four are where a strengthening rather than an addition does the damage: relax
+#           `κ#-pair-inj` to drop its hypothesis and `hash` becomes injective on nothing, every ℍ
+#           equal, and the solvency theorem vacuous, all while still typechecking.
+#
+# Residual limit, stated rather than papered over: the model layer gates the postulate name SET, so it
+# catches a new axiom but not a strengthened type on an existing one. Their semantics live in the
+# spec's "What the formalisation assumes" appendix; the four that carry the solvency argument are the
+# ones gated by signature here.
+#
 # Bridge-layer trust ledger (what each trusted item assumes; the HeadValidatorAgreement test covers each
-# against the real validator/crypto where constructible). SCOPE: this gates ReferenceBridge/RefReflection
-# only; the abstract model's own axioms (Prelude value/crypto laws, accumulator laws, §7 assumptions) are
-# inventoried in the spec's "What the formalisation assumes" appendix section, not drift-checked here.
+# against the real validator/crypto where constructible).
 #   Ops mocks (const-true boundaries the reference delegates). The snapshot signature is the 6-tuple
 #   message cid‖v‖s‖η#‖δ#‖κ# (accumulator + decommit-/commit-output-set hashes):
 #     closeCryptoOK    close snapshot signature + accumulator-commitment hash (real Ed25519 in the test,
@@ -35,6 +48,40 @@ cd "$(dirname "$0")"
 
 BR=src/Hydra/Protocol/ReferenceBridge.agda
 RR=src/Hydra/Protocol/RefReflection.agda
+SOLVENCY=src/Hydra/Protocol/Solvency.lagda.typ
+MODEL_FILES=(
+  src/Hydra/Protocol/Prelude.agda
+  src/Hydra/Protocol/Setup.lagda.typ
+  src/Hydra/Protocol/OnChain.lagda.typ
+  src/Hydra/Protocol/OffChain.lagda.typ
+  src/Hydra/Protocol/Security.lagda.typ
+  "$SOLVENCY"
+)
+
+# The postulate scanner, shared by both layers. Emits every declared name of every `postulate`, in the
+# single-line (`postulate name : T`) and block forms, including the second and later names of a
+# multi-name declaration (`one two : T`) which a per-line `print $1` silently dropped. Names may
+# contain unicode arrows (`noMint→ref`), so a declaration is recognised by its first token NOT being an
+# operator/binder, which is what distinguishes it from a wrapped continuation of the previous
+# signature. Leading indentation is tolerated so the literate `.lagda.typ` code blocks scan too.
+postulate_names() {
+  awk '
+    function emit(decl) {
+      sub(/:.*/, "", decl)
+      n = split(decl, names, /[ \t]+/)
+      if (n == 0) return
+      first = names[1] != "" ? names[1] : names[2]
+      if (first ~ /^([-=<>]|→|⇒|∀|\(|\{|\[)/) return   # continuation of the previous signature
+      for (i = 1; i <= n; i++) if (names[i] != "") print names[i]
+    }
+    { line = $0; sub(/--.*/, "", line) }
+    line ~ /^[ \t]*$/ { next }
+    line ~ /^[ \t]*postulate[ \t]*$/ { inblock = 1; next }
+    line ~ /^[ \t]*postulate[ \t]+/ { sub(/^[ \t]*postulate[ \t]+/, "", line); emit(line); inblock = 0; next }
+    inblock && line ~ /^[ \t]+[^ \t].*:/ { emit(line); next }
+    inblock && line ~ /^[^ \t]/ { inblock = 0 }
+  ' "$@" | sort -u
+}
 
 # (a) Injected Ops boundaries: every field of every record VALUE the bridge builds.
 #
@@ -60,22 +107,7 @@ actual_mocks=$(tr '\n' ' ' < "$BR" |
 # assumption through. Names may themselves contain unicode arrows (`noMint→ref`), so a declaration
 # is recognised by its first token not being an operator/binder, which is what distinguishes it
 # from a wrapped continuation line of the previous type signature.
-actual_postulates=$(awk '
-  function emit(decl) {
-    sub(/:.*/, "", decl)
-    n = split(decl, names, /[ \t]+/)
-    if (n == 0) return
-    first = names[1] != "" ? names[1] : names[2]
-    if (first ~ /^([-=<>]|→|⇒|∀|\(|\{|\[)/) return   # continuation of the previous signature
-    for (i = 1; i <= n; i++) if (names[i] != "") print names[i]
-  }
-  { line = $0; sub(/--.*/, "", line) }
-  line ~ /^[ \t]*$/ { next }
-  line ~ /^postulate[ \t]*$/ { inblock = 1; next }
-  line ~ /^postulate[ \t]+/ { sub(/^postulate[ \t]+/, "", line); emit(line); inblock = 0; next }
-  inblock && line ~ /^[ \t]+[^ \t].*:/ { emit(line); next }
-  inblock && line ~ /^[^ \t]/ { inblock = 0 }
-' "$BR" "$RR" | sort -u)
+actual_postulates=$(postulate_names "$BR" "$RR")
 
 expected_mocks=$(printf '%s\n' \
   closeCryptoOK contestCryptoOK fanoutCryptoOK incCryptoOK initPlacementOK recoverHashOK \
@@ -83,6 +115,66 @@ expected_mocks=$(printf '%s\n' \
 expected_postulates=$(printf '%s\n' \
   cidToNat mintEntryCount 'noMint→ref' 'participantSigned→ref' ptCodes refCodeOf signerCodes \
   | sort -u)
+
+# ── MODEL layer ──────────────────────────────────────────────────────────────────────────────────
+# Every postulate of the model modules, as a name set: a new axiom cannot enter the abstract model
+# silently either.
+actual_model=$(postulate_names "${MODEL_FILES[@]}")
+expected_model=$(printf '%s\n' \
+  AccCommitment accUTxO accUTxO-∅ accVerify accVerifyExclude accVerify-self accVerify-sound \
+  AccWitness adaOf adaOf-+ᵛ aggKey AggSig aggSigOf aggSound applyTxs applyTxs-compose \
+  applyTxs-nil burnedCount burnedValue bytes canonicalCRS# concat crsDatumHashAt Data \
+  depositDatumCommitsHash G₁ _≟ℍ_ ℍ hash headTokenCount Liveness mintedCount msVfy noCommitHash \
+  nonAdaOf nonAdaOf-+ᵛ noTxId outputs outsOf PartySig PartyVerified quantityOf quantityOfᴺ \
+  quantityOfᴺ-+ᵛ recoveredMatchesDeposited Script setSize setSize-pos signerKeyHash sigUnforge \
+  stQty sumValue sumValue-∅ _∖ᵘ_ _∪ᵘ_ _+ᵛ_ +ᵛ-assoc +ᵛ-cancelʳ +ᵛ-identityʳ VKey εᵘ εᵛ μHead \
+  | sort -u)
+
+# The solvency theorem's trust parameters, gated by FULL SIGNATURE (see the header): these are the
+# four where weakening a hypothesis, rather than adding a field, is what would quietly make the
+# theorem say nothing. Comments are stripped and whitespace normalised, so reformatting is free and
+# any change to a binder, a hypothesis or a conclusion is not.
+actual_assumptions=$(awk '
+  /^record Assumptions/ { inrec = 1; next }
+  inrec && /^```/       { inrec = 0 }
+  inrec {
+    line = $0
+    sub(/--.*/, "", line)
+    gsub(/^[ \t]+|[ \t]+$/, "", line)
+    if (line == "" || line == "field") next
+    gsub(/[ \t]+/, " ", line)
+    print line
+  }
+' "$SOLVENCY")
+expected_assumptions=$(cat <<'ASSUMPTIONS'
+κ#-pair-inj : ∀ {x y r s : ℍ} → hash (x ‖ r) ≡ hash (y ‖ s) → r ≡ s
+η#-inj : ∀ {a b : AccCommitment} → hash a ≡ hash b → a ≡ b
+outs#-inj : ∀ {xs ys : List Output} → hash xs ≡ hash ys → xs ≡ ys
+honest-certified : ∀ {snap : Snapshot} → Certified sys snap → HonestFacts snap
+ASSUMPTIONS
+)
+
+# The solvency argument's reach over the on-chain transitions. `SolventReach` enumerates the steps it
+# covers, and nothing about adding a transition to OnChain forces a step to be added here: the theorem
+# would just silently say less. So the correspondence is enumerated instead of assumed. A bundle is
+# either consumed by a step, or listed with the reason it is out of reach.
+#
+#   consumed:  InitValid CloseValid ContestValid DecrementValid FanoutValid IncrementValid
+#   out of reach:
+#     PartialFanoutValid       the batched fan-out path: value leaves the head across several
+#     FinalPartialFanoutValid  transactions, so the single-step "head value = r₀ + committed" shape
+#                              does not apply and a multi-batch generalisation is future work
+#     ClaimValid ClaimTxValid  νDeposit arms; they govern the deposit UTxO, not the head output whose
+#     RecoverValid             value this invariant tracks (the increment step consumes their effect
+#                              through IncrementValid instead)
+#     BurnValid                the μHead burn arm, reached only via the fan-out family above
+ONCHAIN=src/Hydra/Protocol/OnChain.lagda.typ
+actual_reach=$(grep -oE "OC\.[A-Za-z]+Valid" "$SOLVENCY" | sed 's/^OC\.//' | sort -u)
+expected_reach=$(printf '%s\n' \
+  CloseValid ContestValid DecrementValid FanoutValid IncrementValid InitValid | sort -u)
+out_of_reach=$(printf '%s\n' \
+  BurnValid ClaimTxValid ClaimValid FinalPartialFanoutValid PartialFanoutValid RecoverValid | sort -u)
+all_bundles=$(grep -oE "^record [A-Za-z]+Valid" "$ONCHAIN" | awk '{print $2}' | sort -u)
 
 fail=0
 if [ "$actual_mocks" != "$expected_mocks" ]; then
@@ -95,8 +187,31 @@ if [ "$actual_postulates" != "$expected_postulates" ]; then
   diff <(echo "$expected_postulates") <(echo "$actual_postulates") || true
   fail=1
 fi
+if [ "$actual_model" != "$expected_model" ]; then
+  echo "check-trust-ledger: the MODEL-layer postulate set DRIFTED from the documented ledger (- expected, + actual):"
+  diff <(echo "$expected_model") <(echo "$actual_model") || true
+  fail=1
+fi
+if [ "$actual_reach" != "$expected_reach" ]; then
+  echo "check-trust-ledger: the set of validity bundles the solvency steps consume DRIFTED (- expected, + actual):"
+  diff <(echo "$expected_reach") <(echo "$actual_reach") || true
+  fail=1
+fi
+if [ "$(printf '%s\n' "$expected_reach" "$out_of_reach" | sort -u)" != "$all_bundles" ]; then
+  echo "check-trust-ledger: an OnChain validity bundle is neither consumed by a solvency step nor listed"
+  echo "as out of reach (- accounted for, + declared in OnChain):"
+  diff <(printf '%s\n' "$expected_reach" "$out_of_reach" | sort -u) <(echo "$all_bundles") || true
+  fail=1
+fi
+if [ "$actual_assumptions" != "$expected_assumptions" ]; then
+  echo "check-trust-ledger: the solvency theorem's Assumptions signatures DRIFTED (- expected, + actual):"
+  diff <(echo "$expected_assumptions") <(echo "$actual_assumptions") || true
+  fail=1
+fi
 if [ "$fail" -ne 0 ]; then
-  echo "Update the trust-ledger table in this script's header comment and the EXPECTED_* lists."
+  echo "Update the trust-ledger table in this script's header comment and the expected_* lists."
   exit 1
 fi
-echo "check-trust-ledger: OK: the bridge-layer trusted base is the 6 documented Ops mocks + 7 documented postulates."
+echo "check-trust-ledger: OK: bridge layer = $(echo "$expected_mocks" | wc -l) Ops mocks + $(echo "$expected_postulates" | wc -l) postulates;" \
+     "model layer = $(echo "$expected_model" | wc -l) postulates + $(echo "$expected_assumptions" | wc -l) gated Assumptions signatures;" \
+     "solvency reaches $(echo "$expected_reach" | wc -l) of $(echo "$all_bundles" | wc -l) validity bundles."

--- a/spec/check-trust-ledger.sh
+++ b/spec/check-trust-ledger.sh
@@ -21,6 +21,14 @@
 #           `κ#-pair-inj` to drop its hypothesis and `hash` becomes injective on nothing, every ℍ
 #           equal, and the solvency theorem vacuous, all while still typechecking.
 #
+# It also forbids the escape hatches that are not postulates at all. Agda's own `--safe` would be the
+# obvious tool and is not available: `--safe` BANS postulates, and this specification is built on 63
+# of them by design (verified: adding the pragma to Prelude fails with "Cannot postulate +ᵛ-assoc
+# with safe flag"), and `--safe` is contagious through imports, so no module downstream of Prelude
+# could carry it either. The enumerated list below is what `--safe` would have bought us here: the
+# ledger says which assumptions are intended, this says that unintended ones cannot be smuggled in
+# as a termination pragma, a trust-me, or a relaxed OPTIONS line.
+#
 # Residual limit, stated rather than papered over: the model layer gates the postulate name SET, so it
 # catches a new axiom but not a strengthened type on an existing one. Their semantics live in the
 # spec's "What the formalisation assumes" appendix; the four that carry the solvency argument are the
@@ -177,6 +185,37 @@ out_of_reach=$(printf '%s\n' \
 all_bundles=$(grep -oE "^record [A-Za-z]+Valid" "$ONCHAIN" | awk '{print $2}' | sort -u)
 
 fail=0
+# ── unsafe escape hatches ────────────────────────────────────────────────────────────────────────
+# Everything here defeats the proofs without adding a postulate the ledger would notice: a
+# TERMINATING pragma asserts a loop terminates, primTrustMe manufactures any equality, REWRITE turns
+# an equation into a reduction rule, and the OPTIONS flags switch off termination, positivity or
+# coverage checking (or let unsolved metas through). The tree has none; keep it that way.
+UNSAFE_PATTERNS='
+TERMINATING
+NON_TERMINATING
+NON_COVERING
+INJECTIVE_FOR_INFERENCE
+primTrustMe
+primEraseEquality
+--rewriting
+--allow-unsolved-metas
+--allow-incomplete-matches
+--no-termination-check
+--no-positivity-check
+--type-in-type
+--omega-in-omega
+--injective-type-constructors
+'
+for pattern in $UNSAFE_PATTERNS; do
+  hits=$(grep -rn --include='*.agda' --include='*.lagda.typ' -Fe "$pattern" src |
+    grep -vE '^[^:]+:[0-9]+:[[:space:]]*--' || true)
+  if [ -n "$hits" ]; then
+    echo "check-trust-ledger: unsafe Agda escape hatch '$pattern' entered the specification:"
+    printf '%s\n' "$hits"
+    fail=1
+  fi
+done
+
 if [ "$actual_mocks" != "$expected_mocks" ]; then
   echo "check-trust-ledger: the injected Ops-mock set DRIFTED from the documented ledger (- expected, + actual):"
   diff <(echo "$expected_mocks") <(echo "$actual_mocks") || true
@@ -214,4 +253,5 @@ if [ "$fail" -ne 0 ]; then
 fi
 echo "check-trust-ledger: OK: bridge layer = $(echo "$expected_mocks" | wc -l) Ops mocks + $(echo "$expected_postulates" | wc -l) postulates;" \
      "model layer = $(echo "$expected_model" | wc -l) postulates + $(echo "$expected_assumptions" | wc -l) gated Assumptions signatures;" \
-     "solvency reaches $(echo "$expected_reach" | wc -l) of $(echo "$all_bundles" | wc -l) validity bundles."
+     "solvency reaches $(echo "$expected_reach" | wc -l) of $(echo "$all_bundles" | wc -l) validity bundles;" \
+     "no unsafe escape hatches."

--- a/spec/src/Hydra/Protocol/Main.lagda.typ
+++ b/spec/src/Hydra/Protocol/Main.lagda.typ
@@ -29,6 +29,15 @@ import Hydra.Protocol.Security
 -- The machine-checked §7 proof terms (rendered: the statements appear under §7 "Machine-checked
 -- results", included below after Security; the proof bodies are typechecked but hidden).
 import Hydra.Protocol.SecurityProofs
+-- The global solvency invariant (rendered: included below after SecurityProofs): the head
+-- output's value covers the accumulator-committed UTxO set, proved over the head's on-chain
+-- transitions with the fanout payoff. Its increment case consumes the deposit-binding
+-- hardening, so weakening that binding fails this build.
+import Hydra.Protocol.Solvency
+-- Counter-model of the pre-fix commit digest (typecheck-only, not rendered): the
+-- deposit-aliasing attack is derivable against the datum-only digest and blocked by the
+-- id-binding one, kept checkable as regression documentation.
+import Hydra.Protocol.SolvencyCounterModel
 -- Extractable decidable reference checker + the bridge proving it reflects the on-chain
 -- validity bundles (Tier 2 differential-testing; not rendered in the document).
 import Hydra.Protocol.Reference
@@ -49,6 +58,7 @@ import Hydra.Protocol.OnChainCoverage
 #include "OffChain.lagda.typ"
 #include "Security.lagda.typ"
 #include "SecurityProofs.lagda.typ"
+#include "Solvency.lagda.typ"
 
 #pagebreak()
 
@@ -60,11 +70,12 @@ readable, the rendered Agda is collected here rather than shown inline; each blo
 section it supports, in document order, and the body links here in place. The appendix is
 deliberately restricted to the _machine-checked theorem statements_ (the coverage, safety,
 value-conservation and security results of @sec:onchain-theorems, @sec:offchain-theorems and
-@sec:security-theorems) together with the property types they inhabit. Everything else — the
+@sec:security-theorems, and the solvency invariant of @sec:solvency) together with the property
+types they inhabit. Everything else — the
 datum/redeemer types, the transition relations, the validity bundles, the helper definitions, every
 `postulate`, and all proof bodies — is typechecked as part of the build but not rendered, as are the
-typecheck-only modules `Prelude`, `Reference`, `ReferenceBridge`, `RefReflection` and
-`OffChainReference`. @sec:assumption-inventory lists what the formalisation takes on trust.
+typecheck-only modules `Prelude`, `Reference`, `ReferenceBridge`, `RefReflection`,
+`OffChainReference` and `SolvencyCounterModel`. @sec:assumption-inventory lists what the formalisation takes on trust.
 
 == Reading the Agda (for Haskell programmers) <sec:reading-agda>
 
@@ -166,6 +177,20 @@ The trust base, in five families:
   accumulator-commitment hypothesis of `reflects`, the `ξ ≡ aggSigOf` hypothesis
   of the `*-certified` family). The `ContestBound` module hypotheses of
   @sec:onchain-theorems are of the same kind.
+- *Solvency layer* (@sec:solvency): the L1-originating set-value fold
+  `sumValue` with its empty-set law and the two no-deposit digest constants
+  (postulates, the latter an encoding of the same family as the bridge's
+  `refCodeOf`); the `Assumptions` record - digest injectivity at the signed
+  shapes (`κ#`/`η#`/`δ#`), an information-theoretic idealization of
+  second-preimage resistance whose computational reading is the standard
+  reduction, plus `honest-certified`, the ≥1-honest-signer argument as a
+  named, consumed assumption; and the per-step hypotheses of `SolventReach`
+  (L1 continuity and observed-deposit resolution owned by the ledger,
+  settled-delta value coherence owned by the L2 ledger rules over
+  L1-originating assets, assuming burn-free traffic between settlements -
+  L2-minted tokens sit outside the accounting and cannot cross the L1
+  boundary). The `+ᵛ-cancelʳ` cancellation law joins the Prelude Value
+  algebra family above.
 - *Bridge layer* (typecheck-only `ReferenceBridge`/`RefReflection`): 6 injected
   const-true mocks (crypto/accumulator/hash conjuncts the differential covers
   against the real validator) and 7 encoding/faithfulness postulates, enumerated

--- a/spec/src/Hydra/Protocol/Prelude.agda
+++ b/spec/src/Hydra/Protocol/Prelude.agda
@@ -113,4 +113,8 @@ postulate
   -- pointwise signed multi-asset map. NB quantities are ℤ, negative meaning burning, so a
   -- monotone-growth law `a ≤ᵛ a +ᵛ b` would NOT hold in general.)
   +ᵛ-assoc     : ∀ a b c → ((a +ᵛ b) +ᵛ c) ≡ (a +ᵛ (b +ᵛ c))
+  -- Cancellation: pointwise addition of ℤ quantities is cancellative. Needed to reason
+  -- "backwards" through value-conservation equations (the solvency induction's decrement
+  -- case); same trust family as the monoid laws above.
+  +ᵛ-cancelʳ   : ∀ {a b} c → (a +ᵛ c) ≡ (b +ᵛ c) → a ≡ b
   +ᵛ-identityʳ : ∀ a → (a +ᵛ εᵛ) ≡ a

--- a/spec/src/Hydra/Protocol/Solvency.lagda.typ
+++ b/spec/src/Hydra/Protocol/Solvency.lagda.typ
@@ -208,6 +208,17 @@ Certification enters through the derived `*-certified` step forms inside
 `Invariant` below, which consume a `Certified` certificate through the named
 `honest-certified` assumption instead of taking the honest facts on faith.
 
+Which transitions the relation reaches is a real limit on what the theorem
+says, and nothing about adding a transition to @sec:on-chain forces a step to
+be added here - the theorem would simply say less. So the correspondence is
+enumerated and gated rather than left to inspection: `check-trust-ledger.sh`
+fails unless every `*Valid` bundle declared in @sec:on-chain is either
+consumed by a step below or listed there with the reason it is out of reach.
+Six of the twelve are consumed; the batched fan-out arms are out because value
+leaves the head across several transactions, which the single-step shape does
+not express, and the νDeposit arms because they govern the deposit UTxO rather
+than the head output whose value this invariant tracks.
+
 ```agda
 data SolventReach (r₀ : Value) : OC.HeadDatum → ℙ Output → Value → Set where
   s-init : ∀ {ctx seed cid n cp v η ada}
@@ -223,8 +234,6 @@ data SolventReach (r₀ : Value) : OC.HeadDatum → ℙ Output → Value → Set
     → Snapshot.etaHash snap ≡ hash η'                          -- unforgeability: η# is the signed one
     → Snapshot.comHash snap ≡ OC.depositCommitsHashOf ctx ref  -- unforgeability: κ# is the signed one
     → OC.headValueIn ctx ≡ w                                   -- L1 continuity (ledger)
-    → OC.depositsValue ctx ≡ OC.depositValueAt ctx ref         -- single claimed deposit (validator's
-                                                               -- mustNotSpendOtherScripts / deposit.ak D09)
     → OutputRef.txId ref ≢ noTxId                              -- a spent out-ref's tx id is real (ledger)
     → ObservedDeposit ctx (HonestFacts.shape hf)
     → IncCoherent U (HonestFacts.committed hf) (HonestFacts.shape hf)
@@ -309,10 +318,16 @@ decommitValue-take ctx m       | _ ∷ os = takeSumᵛ-take m os
 The invariant. The increment case is where the deposit-binding fix is
 consumed: the digest equality inverts (`κ#-pair-inj`) _only because_
 `depositCommitsHashOf` binds the transaction id, the first-output rule pins
-the claimed out-ref to the observed deposit output, and the
-single-claimed-deposit hypothesis equates the absorbed value with that one
+the claimed out-ref to the observed deposit output, and
+`IncrementValid.onlyClaimedDeposit` equates the absorbed value with that one
 deposit's. Under the pre-fix digest the chain from "the signature verifies"
-to "the head absorbed the recorded value" breaks at the first link. The
+to "the head absorbed the recorded value" breaks at the first link.
+
+All three of those are _fields of the validity bundle_ the step already
+takes, not hypotheses this relation grants itself. That is what makes the
+dependency load-bearing rather than asserted: drop the anti-siphon conjunct
+from `IncrementValid`, or weaken `depositCommitsHashOf` back to hashing the
+datum alone, and this proof stops typechecking. The
 decrement case consumes `decommitNonEmpty` and the pending-shape sum: an
 increment-shaped snapshot presented to a decrement forces the materialized
 output list to hash like the empty list, contradicting the at-least-one rule.
@@ -339,7 +354,7 @@ module Invariant {sys : System} (H : Assumptions sys) where
     OC.InitValid.etaEmpty iv ,
     sym (trans (cong (r₀ +ᵛ_) sumValue-∅) (+ᵛ-identityʳ r₀))
 
-  solvency {r₀ = r₀} (s-inc {ctx = ctx} {ref = ref} {U = U} {w = w} r b hf ηEq κEq chain single realId obs valCo)
+  solvency {r₀ = r₀} (s-inc {ctx = ctx} {ref = ref} {U = U} {w = w} r b hf ηEq κEq chain realId obs valCo)
     with HonestFacts.shape hf | solvency r
   ... | pendingCommit cHash depId incVal comCo _ _ | (_ , ih) =
     η#-inj (trans (sym ηEq) (HonestFacts.ηCoheres hf)) ,
@@ -351,7 +366,8 @@ module Invariant {sys : System} (H : Assumptions sys) where
     refIs : OutputRef.txId ref ≡ depId
     refIs = sym (κ#-pair-inj (trans (sym comCo) κEq))
     absorbed : OC.depositsValue ctx ≡ incVal
-    absorbed = trans single (obs ref refIs (OC.IncrementValid.depositFirstOutput b))
+    absorbed = trans (OC.IncrementValid.onlyClaimedDeposit b)
+                     (obs ref refIs (OC.IncrementValid.depositFirstOutput b))
     stepVal : OC.headValue ctx ≡ w +ᵛ incVal
     stepVal = trans (sym (OC.IncrementValid.valueOK b)) (cong₂ _+ᵛ_ chain absorbed)
   ... | pendingDecommit _ _ comCo | _ =
@@ -420,7 +436,6 @@ relation through a certificate, never through free-floating honest facts.
     → Snapshot.etaHash snap ≡ hash η'
     → Snapshot.comHash snap ≡ OC.depositCommitsHashOf ctx ref
     → OC.headValueIn ctx ≡ w
-    → OC.depositsValue ctx ≡ OC.depositValueAt ctx ref
     → OutputRef.txId ref ≢ noTxId
     → ObservedDeposit ctx (HonestFacts.shape (honest-certified cert))
     → IncCoherent U (HonestFacts.committed (honest-certified cert))
@@ -443,8 +458,8 @@ relation through a certificate, never through free-floating honest facts.
 ```
 
 ```
-  s-inc-certified r b cert ηEq κEq chain single realId obs valCo =
-    s-inc r b (honest-certified cert) ηEq κEq chain single realId obs valCo
+  s-inc-certified r b cert ηEq κEq chain realId obs valCo =
+    s-inc r b (honest-certified cert) ηEq κEq chain realId obs valCo
 
   s-dec-certified r b cert ηEq δEq chain valCo =
     s-dec r b (honest-certified cert) ηEq δEq chain valCo

--- a/spec/src/Hydra/Protocol/Solvency.lagda.typ
+++ b/spec/src/Hydra/Protocol/Solvency.lagda.typ
@@ -1,0 +1,513 @@
+```
+-- Solvency: the head output's L1 value covers exactly the L2 UTxO set the accumulator
+-- commits to. This is the global invariant whose absence let the deposit-binding bug
+-- pass every per-transition check (see the changelog entry for "Bind deposits to the
+-- snapshots that authorize them"): a look-alike deposit satisfied signature, value
+-- conservation and spentness locally, while the accumulator credited more value than
+-- the head absorbed. The induction below cannot close its increment case without the
+-- transaction-id binding in `depositCommitsHashOf`, the first-output rule, and the
+-- single-claimed-deposit discipline; its decrement case cannot close without the
+-- materialized-outputs rule and the no-both-in-flight snapshot shape. Each of those
+-- is a component of the fix - reverting any one reopens a hole here, at typecheck
+-- time, which is the point of this module.
+module Hydra.Protocol.Solvency where
+
+open import Hydra.Protocol.Prelude
+open import Hydra.Protocol.OffChain
+open import Hydra.Protocol.Preliminaries using (Output; OutputRef; Context; _‖_)
+open import Hydra.Protocol.Security
+import Hydra.Protocol.OnChain as OC
+open import Data.Empty using (⊥-elim)
+open import Data.Unit using (⊤; tt)
+open import Data.Product using (_×_; _,_; proj₁; proj₂)
+open import Data.List using (take; drop)
+open import Relation.Binary.PropositionalEquality using (trans; sym; cong; cong₂; subst; _≢_)
+```
+
+#import "/template.typ": *
+#import "/macros.typ": *
+
+== Solvency <sec:solvency>
+
+The per-transaction validity bundles of @sec:on-chain each conserve value
+locally, and the security results of @sec:security-theorems establish that
+every settled snapshot is unanimously certified. Neither layer states the
+property that actually protects funds: that the head output's value _covers_
+the UTxO set the accumulator commits to, so that fanout can distribute what L2
+accounting says participants own. The deposit-binding vulnerability violated
+exactly this while satisfying every local check. This section states the
+invariant, proves it inductively over the head's on-chain transitions, and
+derives the payoff at fanout: every distributed output is one the committed
+L2 set actually contains, funded by the head value the invariant accounts
+for.
+
+The L2 UTxO set is not recoverable from the on-chain state (the datum carries
+only the commitment $eta$), so the induction carries it as _ghost state_: a
+set $U$ alongside the datum, with the two-part invariant
+
+$ eta = accUTxO(U) quad "and" quad valHead = r_0 plus.o Sigma_(o in U) val(o), $
+
+where $r_0$ is the value the head output carried at init (the $adaO$ overhead
+plus the state and participation tokens, preserved by every transition) and
+$Sigma$ is the value of a UTxO set. The value function and its empty-set law
+are the only new postulates besides two digest constants; every other
+ingredient is a named hypothesis with a clear owner, gathered in the
+`Assumptions` record or supplied per step in the reachability relation below.
+
+```
+-- The value of a UTxO set in L1-originating assets - the fanoutable component.
+-- Abstract, in the same trust family as `setSize`: the set model is opaque, so the
+-- fold is postulated with its empty-set law rather than derived. The L1 restriction
+-- is the intended reading, not a checked side condition: L2 transactions may mint,
+-- but a minted token can never cross the L1 boundary (the increment, decrement and
+-- fanout value equations compare against a head output that never absorbed it), so
+-- the solvency accounting is over L1-originating value throughout.
+postulate
+  sumValue   : ℙ Output → Value
+  sumValue-∅ : sumValue ∅ˢ ≡ εᵛ
+
+-- The digest components an honest node uses when no deposit is pending: the node's
+-- `commitOutputsHash` over an empty commit set and an absent deposit id. Opaque
+-- constants; what matters is that a real spent out-ref's transaction id differs from
+-- `noTxId` (a per-step hypothesis, owner: the ledger - L1 transaction ids are hashes,
+-- never the absent-marker). Encoding fidelity note: in the implementation the
+-- no-deposit digest hashes a shorter preimage (no tx-id bytes appended) rather than a
+-- pair with a marker; the pair encoding models the same distinguishability and its
+-- faithfulness is an encoding assumption of the same family as the bridge's
+-- `refCodeOf`/`cidToNat`.
+postulate
+  noCommitHash : ℍ
+  noTxId       : ℍ
+
+-- The value of a list of outputs (the decrement side works over the positional
+-- decommit-output list). Definitional, no postulate.
+listValue : List Output → Value
+listValue []       = εᵛ
+listValue (o ∷ os) = Output.value o +ᵛ listValue os
+```
+
+What honest signing guarantees about a certified snapshot, in the on-chain
+vocabulary the induction consumes. A certificate is n-of-n (@thm:unanimity),
+so at least one honest party enforced the §6 handler `require`s before
+signing; these fields are that party's obligations. The pending shape is a
+_sum_: a snapshot carries a pending commit, a pending decommit, or neither -
+never both. That is the machine-checked `NoBothInFlight` state invariant of
+@sec:offchain-theorems lifted to the snapshot level, and it is load-bearing
+below: without it a decrement could settle an increment-shaped snapshot,
+adopting an accumulator that counts deposited UTxOs no transaction absorbed.
+
+```agda
+data PendingShape (snap : Snapshot) : Set where
+  -- a commit is pending: κ# binds the recorded commit set's hash and the deposit's
+  -- transaction id (node `commitOutputsHash`); `incVal` is the recorded set's value
+  -- (`observeDepositTx` refuses deposits whose value differs); no decommit digest.
+  pendingCommit :
+    (cHash depId : ℍ) (incVal : Value)
+    → Snapshot.comHash snap ≡ hash (cHash ‖ depId)
+    → depId ≢ noTxId
+    → Snapshot.decHash snap ≡ hash {A = List Output} []
+    → PendingShape snap
+  -- a decommit is pending: δ# binds the decommitted output list; no commit digest.
+  pendingDecommit :
+    (decOuts : List Output)
+    → Snapshot.decHash snap ≡ hash decOuts
+    → Snapshot.comHash snap ≡ hash (noCommitHash ‖ noTxId)
+    → PendingShape snap
+  -- neither is pending.
+  pendingNone :
+    Snapshot.comHash snap ≡ hash (noCommitHash ‖ noTxId)
+    → Snapshot.decHash snap ≡ hash {A = List Output} []
+    → PendingShape snap
+
+record HonestFacts (snap : Snapshot) : Set where
+  field
+    -- the L2 UTxO set the snapshot's accumulator commits to (the honest node computes
+    -- η from the snapshot UTxO it signs).
+    committed : ℙ Output
+    ηCoheres  : Snapshot.etaHash snap ≡ hash (OC.accUTxO committed)
+    shape     : PendingShape snap
+```
+
+The assumption bundle, relative to a system of parties. The three digest
+hypotheses are information-theoretic _idealizations_ of second-preimage
+resistance on the digest shapes the induction inverts - stated as injectivity
+on those shapes, which is stronger than the computational property, exactly as
+the model's multisignature unforgeability postulates are. The computational
+reading is the standard reduction: a violation of solvency under the other
+hypotheses yields a concrete digest collision. They are not global injectivity
+of `hash` (which would be inconsistent with compression); they apply only at
+the pair, commitment and output-list shapes actually signed. Owner: crypto.
+`honest-certified` is the ≥1-honest-signer argument as a _named, consumed_
+assumption rather than prose: an n-of-n certificate (@thm:unanimity) contains
+at least one honest party, whose §6 handler `require`s enforced exactly the
+`HonestFacts` fields before signing. Owner: the honest-majority premise of
+@sec:security.
+
+```agda
+record Assumptions (sys : System) : Set₁ where
+  field
+    -- the commit digest κ# = hash(commit-list hash ‖ deposit tx id) determines the
+    -- deposit's transaction id. This hypothesis is only applicable because
+    -- `depositCommitsHashOf` binds the tx id by definition: under the pre-fix
+    -- digest hash(C) it says nothing, and the increment case below cannot close.
+    κ#-pair-inj : ∀ {x y r s : ℍ} → hash (x ‖ r) ≡ hash (y ‖ s) → r ≡ s
+    -- the accumulator hash η# determines the commitment.
+    η#-inj      : ∀ {a b : AccCommitment} → hash a ≡ hash b → a ≡ b
+    -- the decommit digest δ# determines the output list.
+    outs#-inj   : ∀ {xs ys : List Output} → hash xs ≡ hash ys → xs ≡ ys
+    -- a certificate implies the honest-signing facts above.
+    honest-certified : ∀ {snap : Snapshot} → Certified sys snap → HonestFacts snap
+```
+
+Per-step hypotheses, dispatched on the pending shape (trivial for the shapes a
+step contradicts). `ObservedDeposit` is ledger resolution faithfulness at the
+observed deposit: any input of _this_ transaction whose out-ref names output 0
+of the deposit transaction the parties observed resolves to that deposit
+output, whose value is the recorded `incVal` (owners: the ledger for
+resolution, the honest `observeDepositTx` for the value). `IncCoherent` /
+`DecCoherent` relate consecutive committed sets by the settled delta; they
+package L2 value coherence between settlements and are stated per step.
+Their reading is over L1-originating value (see `sumValue`): L2-minted
+assets are outside the accounting and cannot cross the L1 boundary anyway,
+while an L2 _burn_ of an L1-originating asset would leave the head strictly
+richer than the committed set - safe for coverage, but breaking the equality
+form, so the hypotheses additionally assume the L2 traffic between
+settlements burns no L1-originating value. Deriving them from the off-chain
+ledger laws is future work alongside the closed-head cases.
+
+```agda
+-- Guard for reviewers: this hypothesis is stated against the _observed_ deposit id
+-- (`depId`, what the parties signed for), never against the claimed ref. That
+-- placement is the load-bearing modeling choice of the whole invariant - restated
+-- at the claimed ref it would make solvency vacuously provable for the pre-fix
+-- protocol, which the counter-model (`SolvencyCounterModel`) shows is unsound.
+-- The proof must earn the crossing from claimed ref to observed deposit, and can
+-- only do so through the transaction-id binding in the signed digest.
+ObservedDeposit : Context → ∀ {snap} → PendingShape snap → Set
+ObservedDeposit ctx (pendingCommit _ depId incVal _ _ _) =
+  ∀ (r : OutputRef) → OutputRef.txId r ≡ depId → OutputRef.index r ≡ 0
+    → OC.depositValueAt ctx r ≡ incVal
+ObservedDeposit _ _ = ⊤
+
+IncCoherent : ℙ Output → ℙ Output → ∀ {snap} → PendingShape snap → Set
+IncCoherent U U' (pendingCommit _ _ incVal _ _ _) = sumValue U' ≡ sumValue U +ᵛ incVal
+IncCoherent _ _ _ = ⊤
+
+DecCoherent : ℙ Output → ℙ Output → ∀ {snap} → PendingShape snap → Set
+DecCoherent U U' (pendingDecommit decOuts _ _) = sumValue U ≡ sumValue U' +ᵛ listValue decOuts
+DecCoherent _ _ _ = ⊤
+```
+
+The ghost-state reachability relation. Each step takes the on-chain validity
+bundle, the snapshot's honest facts, the unforgeability-derived digest
+equalities (the per-instance idiom of the `*-certified` corollaries of
+@sec:security-theorems), and the per-step ledger hypotheses; the
+`headValueIn ctx ≡ w` premise is L1 UTxO continuity - the head output this
+step spends is the one the previous step produced (owner: the ledger).
+Certification enters through the derived `*-certified` step forms inside
+`Invariant` below, which consume a `Certified` certificate through the named
+`honest-certified` assumption instead of taking the honest facts on faith.
+
+```agda
+data SolventReach (r₀ : Value) : OC.HeadDatum → ℙ Output → Value → Set where
+  s-init : ∀ {ctx seed cid n cp v η ada}
+    → OC.InitValid ctx seed cid n v η
+    → OC.headValue ctx ≡ r₀
+    → SolventReach r₀ (OC.Open cid aggKey n cp v η ada) ∅ˢ r₀
+
+  s-inc : ∀ {ctx cid n cp v η η' ada ξ s ref δ# U w} {snap : Snapshot}
+    → SolventReach r₀ (OC.Open cid aggKey n cp v η ada) U w
+    → (b : OC.IncrementValid ctx aggKey cid v (OC.Open cid aggKey n cp v η ada)
+                             (OC.Open cid aggKey n cp (suc v) η' ada) ξ s ref δ#)
+    → (hf : HonestFacts snap)
+    → Snapshot.etaHash snap ≡ hash η'                          -- unforgeability: η# is the signed one
+    → Snapshot.comHash snap ≡ OC.depositCommitsHashOf ctx ref  -- unforgeability: κ# is the signed one
+    → OC.headValueIn ctx ≡ w                                   -- L1 continuity (ledger)
+    → OC.depositsValue ctx ≡ OC.depositValueAt ctx ref         -- single claimed deposit (validator's
+                                                               -- mustNotSpendOtherScripts / deposit.ak D09)
+    → OutputRef.txId ref ≢ noTxId                              -- a spent out-ref's tx id is real (ledger)
+    → ObservedDeposit ctx (HonestFacts.shape hf)
+    → IncCoherent U (HonestFacts.committed hf) (HonestFacts.shape hf)
+    → SolventReach r₀ (OC.Open cid aggKey n cp (suc v) η' ada)
+                   (HonestFacts.committed hf) (OC.headValue ctx)
+
+  s-dec : ∀ {ctx cid n cp v η η' ada ξ s m κ# U w} {snap : Snapshot}
+    → SolventReach r₀ (OC.Open cid aggKey n cp v η ada) U w
+    → (b : OC.DecrementValid ctx aggKey cid v (OC.Open cid aggKey n cp v η ada)
+                             (OC.Open cid aggKey n cp (suc v) η' ada) ξ s m κ#)
+    → (hf : HonestFacts snap)
+    → Snapshot.etaHash snap ≡ hash η'                          -- unforgeability: η# is the signed one
+    → Snapshot.decHash snap ≡ OC.decommitOutputsHashOf ctx m   -- unforgeability: δ# is the signed one
+    → OC.headValueIn ctx ≡ w                                   -- L1 continuity (ledger)
+    → DecCoherent U (HonestFacts.committed hf) (HonestFacts.shape hf)
+    → SolventReach r₀ (OC.Open cid aggKey n cp (suc v) η' ada)
+                   (HonestFacts.committed hf) (OC.headValue ctx)
+
+  -- closing on the initial (empty) snapshot: the stored accumulator is the empty
+  -- commitment and the head value is preserved exactly.
+  s-closeInitial : ∀ {ctx cid n cp v η ada s' η' C tfin U w}
+    → SolventReach r₀ (OC.Open cid aggKey n cp v η ada) U w
+    → OC.CloseValid ctx aggKey cid v cp s' (OC.Open cid aggKey n cp v η ada)
+                    (OC.Closed cid aggKey n cp v s' η' C tfin ada) OC.closeInitial
+    → OC.headValueIn ctx ≡ w                                   -- L1 continuity (ledger)
+    → SolventReach r₀ (OC.Closed cid aggKey n cp v s' η' C tfin ada) ∅ˢ (OC.headValue ctx)
+
+  -- closing on a certified snapshot at the current version (the closeUnused
+  -- redeemer; closeAny differs only in its snapshot-number conjunct and follows
+  -- identically). The stored accumulator jumps to the closing snapshot's; the
+  -- head value is preserved exactly, so the per-step hypothesis is that the
+  -- closing snapshot's committed value equals the settled one - L2 transactions
+  -- between settlements preserve value (owner: the L2 ledger rules).
+  s-close : ∀ {ctx cid n cp v η ada ξ η# δ# κ# s' η' C tfin U w} {snap : Snapshot}
+    → SolventReach r₀ (OC.Open cid aggKey n cp v η ada) U w
+    → OC.CloseValid ctx aggKey cid v cp s' (OC.Open cid aggKey n cp v η ada)
+                    (OC.Closed cid aggKey n cp v s' η' C tfin ada) (OC.closeUnused ξ η# δ# κ#)
+    → (hf : HonestFacts snap)
+    → Snapshot.etaHash snap ≡ η#                               -- unforgeability: η# is the signed one
+    → OC.headValueIn ctx ≡ w                                   -- L1 continuity (ledger)
+    → sumValue (HonestFacts.committed hf) ≡ sumValue U         -- L2 value preservation
+    → SolventReach r₀ (OC.Closed cid aggKey n cp v s' η' C tfin ada)
+                   (HonestFacts.committed hf) (OC.headValue ctx)
+
+  -- contesting with a newer certified snapshot (the contestUnused redeemer;
+  -- contestUsed combines a pending delta into the stored accumulator and is
+  -- future work, as is closeUsed). Same jump-and-preserve pattern as close.
+  s-contest : ∀ {ctx cid n cp v s η C tfin ada ξ η# δ# κ# s' η' kh tfin' U w} {snap : Snapshot}
+    → SolventReach r₀ (OC.Closed cid aggKey n cp v s η C tfin ada) U w
+    → OC.ContestValid ctx aggKey cid v s tfin (OC.Closed cid aggKey n cp v s η C tfin ada)
+                      (OC.Closed cid aggKey n cp v s' η' (kh ∷ C) tfin' ada)
+                      (OC.contestUnused ξ η# δ# κ#) kh
+    → (hf : HonestFacts snap)
+    → Snapshot.etaHash snap ≡ η#                               -- unforgeability: η# is the signed one
+    → OC.headValueIn ctx ≡ w                                   -- L1 continuity (ledger)
+    → sumValue (HonestFacts.committed hf) ≡ sumValue U         -- L2 value preservation
+    → SolventReach r₀ (OC.Closed cid aggKey n cp v s' η' (kh ∷ C) tfin' ada)
+                   (HonestFacts.committed hf) (OC.headValue ctx)
+```
+
+```
+-- Helper lemmas tying the positional decommit machinery together (definitional
+-- inductions, no assumptions).
+takeSumᵛ-take : ∀ m os → OC.takeSumᵛ m os ≡ listValue (take m os)
+takeSumᵛ-take zero    _        = refl
+takeSumᵛ-take (suc _) []       = refl
+takeSumᵛ-take (suc k) (o ∷ os) = cong (Output.value o +ᵛ_) (takeSumᵛ-take k os)
+
+decommitValue-take : ∀ ctx m
+  → OC.decommitValue ctx m ≡ listValue (take m (drop 1 (Context.outputs ctx)))
+decommitValue-take ctx m with Context.outputs ctx
+decommitValue-take ctx zero    | []     = refl
+decommitValue-take ctx (suc _) | []     = refl
+decommitValue-take ctx m       | _ ∷ os = takeSumᵛ-take m os
+
+-- A materialized-output list that hashes like the empty list contradicts the
+-- decrement bundle's at-least-one rule.
+0<length[]-elim : ∀ {xs : List Output} → xs ≡ [] → 0 < length xs → ⊥
+0<length[]-elim refl ()
+```
+
+The invariant. The increment case is where the deposit-binding fix is
+consumed: the digest equality inverts (`κ#-pair-inj`) _only because_
+`depositCommitsHashOf` binds the transaction id, the first-output rule pins
+the claimed out-ref to the observed deposit output, and the
+single-claimed-deposit hypothesis equates the absorbed value with that one
+deposit's. Under the pre-fix digest the chain from "the signature verifies"
+to "the head absorbed the recorded value" breaks at the first link. The
+decrement case consumes `decommitNonEmpty` and the pending-shape sum: an
+increment-shaped snapshot presented to a decrement forces the materialized
+output list to hash like the empty list, contradicting the at-least-one rule.
+
+```
+-- A version-0 open head has never settled an increment or decrement (both bump the
+-- version), so its ghost set is still empty. Consumed by the closeInitial case.
+open-v0-empty : ∀ {r₀ cid hk n cp η ada U w}
+  → SolventReach r₀ (OC.Open cid hk n cp 0 η ada) U w → U ≡ ∅ˢ
+open-v0-empty (s-init _ _) = refl
+```
+
+```agda
+module Invariant {sys : System} (H : Assumptions sys) where
+  open Assumptions H
+
+  solvency : ∀ {r₀ d U w}
+    → SolventReach r₀ d U w
+    → (OC.ηOf d ≡ OC.accUTxO U) × (w ≡ r₀ +ᵛ sumValue U)
+```
+
+```
+  solvency {r₀ = r₀} (s-init iv hvEq) =
+    OC.InitValid.etaEmpty iv ,
+    sym (trans (cong (r₀ +ᵛ_) sumValue-∅) (+ᵛ-identityʳ r₀))
+
+  solvency {r₀ = r₀} (s-inc {ctx = ctx} {ref = ref} {U = U} {w = w} r b hf ηEq κEq chain single realId obs valCo)
+    with HonestFacts.shape hf | solvency r
+  ... | pendingCommit cHash depId incVal comCo _ _ | (_ , ih) =
+    η#-inj (trans (sym ηEq) (HonestFacts.ηCoheres hf)) ,
+    trans stepVal
+      (trans (cong (_+ᵛ incVal) ih)
+        (trans (+ᵛ-assoc r₀ (sumValue U) incVal)
+          (cong (r₀ +ᵛ_) (sym valCo))))
+   where
+    refIs : OutputRef.txId ref ≡ depId
+    refIs = sym (κ#-pair-inj (trans (sym comCo) κEq))
+    absorbed : OC.depositsValue ctx ≡ incVal
+    absorbed = trans single (obs ref refIs (OC.IncrementValid.depositFirstOutput b))
+    stepVal : OC.headValue ctx ≡ w +ᵛ incVal
+    stepVal = trans (sym (OC.IncrementValid.valueOK b)) (cong₂ _+ᵛ_ chain absorbed)
+  ... | pendingDecommit _ _ comCo | _ =
+    ⊥-elim (realId (κ#-pair-inj (trans (sym κEq) comCo)))
+  ... | pendingNone comCo _ | _ =
+    ⊥-elim (realId (κ#-pair-inj (trans (sym κEq) comCo)))
+
+  solvency {r₀ = r₀} (s-dec {ctx = ctx} {m = m} {U = U} {w = w} r b hf ηEq δEq chain valCo)
+    with HonestFacts.shape hf | solvency r
+  ... | pendingDecommit decOuts decCo _ | (_ , ih) =
+    η#-inj (trans (sym ηEq) (HonestFacts.ηCoheres hf)) ,
+    +ᵛ-cancelʳ (listValue decOuts) (trans lhs rhs)
+   where
+    decVal : OC.decommitValue ctx m ≡ listValue decOuts
+    decVal = trans (decommitValue-take ctx m)
+                   (cong listValue (outs#-inj (trans (sym δEq) decCo)))
+    -- headValue + listValue decOuts = headValueIn = w = r₀ + sumValue U
+    --   = r₀ + (sumValue U' + listValue decOuts) = (r₀ + sumValue U') + listValue decOuts
+    rhs : w ≡ (r₀ +ᵛ sumValue (HonestFacts.committed hf)) +ᵛ listValue decOuts
+    rhs = trans ih (trans (cong (r₀ +ᵛ_) valCo)
+                          (sym (+ᵛ-assoc r₀ (sumValue (HonestFacts.committed hf)) (listValue decOuts))))
+    lhs : OC.headValue ctx +ᵛ listValue decOuts ≡ w
+    lhs = trans (cong (OC.headValue ctx +ᵛ_) (sym decVal))
+                (trans (OC.DecrementValid.valueOK b) chain)
+  ... | pendingCommit _ _ _ _ _ decEmpty | _ =
+    ⊥-elim (0<length[]-elim (outs#-inj (trans (sym δEq) decEmpty))
+                            (OC.DecrementValid.decommitNonEmpty b))
+  ... | pendingNone _ decEmpty | _ =
+    ⊥-elim (0<length[]-elim (outs#-inj (trans (sym δEq) decEmpty))
+                            (OC.DecrementValid.decommitNonEmpty b))
+
+  solvency {r₀ = r₀} (s-closeInitial {ctx = ctx} {v = v} {U = U} {w = w} r b chain) =
+    ηE ,
+    trans (trans (sym (OC.CloseValid.valuePreserved b)) (trans chain ih))
+          (cong (λ u → r₀ +ᵛ sumValue u) (open-v0-empty r0))
+   where
+    ini = OC.CloseValid.initialOK b
+    v≡0 = proj₁ ini
+    ηE  = proj₂ (proj₂ ini)
+    ih  = proj₂ (solvency r)
+    r0 : SolventReach r₀ (OC.Open _ aggKey _ _ 0 _ _) U w
+    r0 = subst (λ vv → SolventReach r₀ (OC.Open _ aggKey _ _ vv _ _) U w) v≡0 r
+
+  solvency {r₀ = r₀} (s-close {U = U} r b hf ηEq chain sumEq) =
+    η#-inj (trans (sym (trans ηEq (OC.CloseValid.etaOK b))) (HonestFacts.ηCoheres hf)) ,
+    trans (sym (OC.CloseValid.valuePreserved b))
+      (trans chain (trans (proj₂ (solvency r)) (cong (r₀ +ᵛ_) (sym sumEq))))
+
+  solvency {r₀ = r₀} (s-contest {U = U} r b hf ηEq chain sumEq) =
+    η#-inj (trans (sym (trans ηEq (OC.ContestValid.etaOK b))) (HonestFacts.ηCoheres hf)) ,
+    trans (sym (OC.ContestValid.valuePreserved b))
+      (trans chain (trans (proj₂ (solvency r)) (cong (r₀ +ᵛ_) (sym sumEq))))
+```
+
+The certified step forms: the same steps, taking a `Certified` certificate
+and deriving the honest facts through the named `honest-certified` assumption.
+These are the intended entry points - a real chain history enters the
+relation through a certificate, never through free-floating honest facts.
+
+```agda
+  s-inc-certified : ∀ {r₀ ctx cid n cp v η η' ada ξ s ref δ# U w} {snap : Snapshot}
+    → SolventReach r₀ (OC.Open cid aggKey n cp v η ada) U w
+    → (b : OC.IncrementValid ctx aggKey cid v (OC.Open cid aggKey n cp v η ada)
+                             (OC.Open cid aggKey n cp (suc v) η' ada) ξ s ref δ#)
+    → (cert : Certified sys snap)
+    → Snapshot.etaHash snap ≡ hash η'
+    → Snapshot.comHash snap ≡ OC.depositCommitsHashOf ctx ref
+    → OC.headValueIn ctx ≡ w
+    → OC.depositsValue ctx ≡ OC.depositValueAt ctx ref
+    → OutputRef.txId ref ≢ noTxId
+    → ObservedDeposit ctx (HonestFacts.shape (honest-certified cert))
+    → IncCoherent U (HonestFacts.committed (honest-certified cert))
+                    (HonestFacts.shape (honest-certified cert))
+    → SolventReach r₀ (OC.Open cid aggKey n cp (suc v) η' ada)
+                   (HonestFacts.committed (honest-certified cert)) (OC.headValue ctx)
+
+  s-dec-certified : ∀ {r₀ ctx cid n cp v η η' ada ξ s m κ# U w} {snap : Snapshot}
+    → SolventReach r₀ (OC.Open cid aggKey n cp v η ada) U w
+    → (b : OC.DecrementValid ctx aggKey cid v (OC.Open cid aggKey n cp v η ada)
+                             (OC.Open cid aggKey n cp (suc v) η' ada) ξ s m κ#)
+    → (cert : Certified sys snap)
+    → Snapshot.etaHash snap ≡ hash η'
+    → Snapshot.decHash snap ≡ OC.decommitOutputsHashOf ctx m
+    → OC.headValueIn ctx ≡ w
+    → DecCoherent U (HonestFacts.committed (honest-certified cert))
+                    (HonestFacts.shape (honest-certified cert))
+    → SolventReach r₀ (OC.Open cid aggKey n cp (suc v) η' ada)
+                   (HonestFacts.committed (honest-certified cert)) (OC.headValue ctx)
+```
+
+```
+  s-inc-certified r b cert ηEq κEq chain single realId obs valCo =
+    s-inc r b (honest-certified cert) ηEq κEq chain single realId obs valCo
+
+  s-dec-certified r b cert ηEq δEq chain valCo =
+    s-dec r b (honest-certified cert) ηEq δEq chain valCo
+
+  -- the close/contest forms follow the same one-line pattern.
+  s-close-certified : ∀ {r₀ ctx cid n cp v η ada ξ η# δ# κ# s' η' C tfin U w} {snap : Snapshot}
+    → SolventReach r₀ (OC.Open cid aggKey n cp v η ada) U w
+    → OC.CloseValid ctx aggKey cid v cp s' (OC.Open cid aggKey n cp v η ada)
+                    (OC.Closed cid aggKey n cp v s' η' C tfin ada) (OC.closeUnused ξ η# δ# κ#)
+    → (cert : Certified sys snap)
+    → Snapshot.etaHash snap ≡ η#
+    → OC.headValueIn ctx ≡ w
+    → sumValue (HonestFacts.committed (honest-certified cert)) ≡ sumValue U
+    → SolventReach r₀ (OC.Closed cid aggKey n cp v s' η' C tfin ada)
+                   (HonestFacts.committed (honest-certified cert)) (OC.headValue ctx)
+  s-close-certified r b cert ηEq chain sumEq =
+    s-close r b (honest-certified cert) ηEq chain sumEq
+
+  s-contest-certified : ∀ {r₀ ctx cid n cp v s η C tfin ada ξ η# δ# κ# s' η' kh tfin' U w} {snap : Snapshot}
+    → SolventReach r₀ (OC.Closed cid aggKey n cp v s η C tfin ada) U w
+    → OC.ContestValid ctx aggKey cid v s tfin (OC.Closed cid aggKey n cp v s η C tfin ada)
+                      (OC.Closed cid aggKey n cp v s' η' (kh ∷ C) tfin' ada)
+                      (OC.contestUnused ξ η# δ# κ#) kh
+    → (cert : Certified sys snap)
+    → Snapshot.etaHash snap ≡ η#
+    → OC.headValueIn ctx ≡ w
+    → sumValue (HonestFacts.committed (honest-certified cert)) ≡ sumValue U
+    → SolventReach r₀ (OC.Closed cid aggKey n cp v s' η' (kh ∷ C) tfin' ada)
+                   (HonestFacts.committed (honest-certified cert)) (OC.headValue ctx)
+  s-contest-certified r b cert ηEq chain sumEq =
+    s-contest r b (honest-certified cert) ηEq chain sumEq
+```
+
+The payoff. `membersOK` alone says the distributed outputs are members of
+_whatever_ the stored accumulator commits to; only together with the
+invariant does that become "members of the L2 set the parties actually
+built". Combined with the fanout value equation, a solvent head can neither
+fan out phantom outputs nor come up short funding the real ones.
+
+```agda
+  fanout-covered : ∀ {r₀ d U w ctx m π crs}
+    → SolventReach r₀ d U w
+    → (fb : OC.FanoutValid ctx d m π crs)
+    → OC.headValueIn ctx ≡ w                                   -- L1 continuity (ledger)
+    → (OC.distributedOuts ctx m ⊆ U)
+      × (w ≡ (OC.takeSumᵛ m (Context.outputs ctx) +ᵛ (OC.burnedValue ctx +ᵛ OC.headAda d)))
+```
+
+```
+  fanout-covered {d = d} {ctx = ctx} {m = m} {π = π} r fb chain =
+    OC.accVerify-sound
+      (subst (λ e → OC.accVerify e (OC.distributedOuts ctx m) π ≡ true)
+             (proj₁ (solvency r)) (OC.FanoutValid.membersOK fb)) ,
+    trans (sym chain) (OC.FanoutValid.valueOK fb)
+```
+
+Two companions round the section off. `SolvencyCounterModel` (typecheck-only,
+not rendered) keeps the pre-fix attack derivable in miniature: against a
+digest covering datum content alone, a copied-datum deposit holding less
+value is accepted under the real deposit's signature and leaves the head
+insolvent, while the id-binding digest rejects the same claim by identity -
+regression documentation the checker rebuilds on every build. Not yet
+covered here: the `closeUsed`/`contestUsed` redeemers (their stored
+accumulator combines a pending delta, needing a generalized commitment
+invariant), partial fanout, and deriving the per-step L2 value-preservation
+hypotheses from the off-chain ledger laws.

--- a/spec/src/Hydra/Protocol/SolvencyCounterModel.agda
+++ b/spec/src/Hydra/Protocol/SolvencyCounterModel.agda
@@ -1,0 +1,80 @@
+-- Machine-checked counter-model of the pre-fix commit digest (typecheck-only; imported
+-- by Main so it stays checked, not rendered and not extracted).
+--
+-- The solvency induction (Solvency.lagda.typ) shows the post-fix digest is sufficient;
+-- this module shows the pre-fix digest was insufficient, as a positive artifact rather
+-- than a failed proof attempt. It distills the increment acceptance to the two conjuncts
+-- the deposit-binding attack exploited - "the claimed deposit's digest matches the signed
+-- one" and "the head grows by the claimed deposit's value" - over a concrete miniature
+-- (deposits are records of numbers, the digest projections are honest functions), and
+-- checks:
+--
+--   * `attack`: under the pre-fix digest (datum content only), a look-alike deposit
+--     carrying the same datum but less value is accepted under the signature the
+--     parties gave for the real deposit, and
+--   * `insolvent`: the resulting head value falls short of what the parties credited, and
+--   * `fixed`: under the post-fix digest (datum content plus the deposit's transaction
+--     id), the same claim is not even well-digested - the digests differ by identity.
+--
+-- The miniature is deliberately small: it is a counter-model of the digest SCHEME, not
+-- of the full validity-bundle set (whose abstract postulates would each need concrete
+-- instantiation to say more). Its value is regression documentation - the attack shape
+-- stays written down as something the checker can rebuild - and a template for
+-- counter-modeling future scheme changes before they ship.
+module Hydra.Protocol.SolvencyCounterModel where
+
+open import Agda.Builtin.Nat using (Nat; _+_)
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Agda.Builtin.Sigma using (Σ; _,_)
+open import Data.Empty using (⊥)
+
+record Deposit : Set where
+  field
+    txId      : Nat   -- the transaction that created the deposit (its identity)
+    datumHash : Nat   -- hash of the datum's recorded commit set (its content)
+    value     : Nat   -- what the deposit output actually holds
+
+-- Pre-fix: the signed commit digest covers the datum content only.
+digestOld : Deposit → Nat
+digestOld d = Deposit.datumHash d
+
+-- Post-fix: the digest also binds the deposit's transaction id.
+digestNew : Deposit → Σ Nat (λ _ → Nat)
+digestNew d = Deposit.datumHash d , Deposit.txId d
+
+-- The real deposit the parties observed and signed for, and a look-alike carrying a
+-- copied datum (deposit datums are unauthenticated) but a fraction of the value.
+real : Deposit
+real = record { txId = 1 ; datumHash = 7 ; value = 100 }
+
+fake : Deposit
+fake = record { txId = 2 ; datumHash = 7 ; value = 1 }
+
+-- What the parties signed and credited on L2: the real deposit's digest and value.
+signedDigest : Nat
+signedDigest = digestOld real
+
+credited : Nat
+credited = Deposit.value real
+
+-- The pre-fix acceptance shape: the claimed deposit's digest matches the signed one,
+-- and the head grows by the claimed deposit's value (both hold of the real increment
+-- checks; everything else the validator looks at is satisfied by an otherwise honest
+-- transaction).
+record AcceptsOld (claimed : Deposit) (headIn headOut : Nat) : Set where
+  field
+    digestOK : digestOld claimed ≡ signedDigest
+    valueOK  : headOut ≡ headIn + Deposit.value claimed
+
+-- The attack, accepted: claiming the look-alike under the real deposit's signature.
+attack : AcceptsOld fake 0 1
+attack = record { digestOK = refl ; valueOK = refl }
+
+-- The head is insolvent against what the parties credited: it absorbed 1, not 100.
+insolvent : 1 ≡ 0 + credited → ⊥
+insolvent ()
+
+-- Post-fix, the look-alike's digest differs from the real deposit's by identity, so
+-- the same claim cannot match the signed digest at all.
+fixed : digestNew fake ≡ digestNew real → ⊥
+fixed ()


### PR DESCRIPTION
### 🧱 Stack (split of #2736)
   1. #2784 — protocol fix
   2. #2785 — Typst prose migration
   3. #2786 — Agda formalisation + developer docs + changelog
   4. #2787 — hydra-agda package + CI
   5. #2788 — agreement tests
👉 6. #2842 — solvency invariant + error-code ledger

Merge in order (1→6) into the `typst-agda-stacked` integration branch, then merge that branch into `master` as the final step.

---

Attemp to add a bit more structure that would've caught a recent problem around deposits.

- Add a global invariant on the head's on-chain transactions
- Detect paths where error codes could be missed
  - surfaces as a nix flake check
