### PR TITLE
Trace the KZG trusted-setup warm-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,14 +183,19 @@ changes.
   before the tracer existed, so on a host slow at decompressing BLS12-381 points
   the node emitted nothing at all until it finished and was indistinguishable
   from one that hung before starting. It still completes before any socket is
-  opened. A trusted setup that fails to load now raises a
-  `ConfigurationException` rather than calling `error`.
+  opened, and now forces the G2 half as well, so a corrupt embedded setup raises
+  a `ConfigurationException` at startup instead of `error`-ing out of pure code
+  mid-session.
 
 - Fix `hydra-node` withholding log entries from whoever reads its stdout until
   64KB had accumulated. Output is block-buffered and was only flushed when the
   tracer shut down, so `docker logs` and process supervisors saw nothing from a
   node that was running but not logging heavily. The writer now flushes each
   batch it drains.
+  * A write failing no longer kills the log writer. GHC ignores `SIGPIPE`, so a
+    reader going away (`hydra-node | head`, a restarting log shipper) made the
+    next write throw; the writer is not linked to the node, so it died unnoticed
+    and every subsequent trace blocked once the queue filled.
 
 ## [2.3.0] - 2026.07.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,20 @@ changes.
   hydra-node versions refuse to open the database — there is no downgrade
   path.
 
+- `hydra-node` now traces the KZG trusted-setup warm-up it does at startup, as
+  `LoadingTrustedSetup` followed by `TrustedSetupLoaded`. The warm-up used to run
+  before the tracer existed, so on a host slow at decompressing BLS12-381 points
+  the node emitted nothing at all until it finished and was indistinguishable
+  from one that hung before starting. It still completes before any socket is
+  opened. A trusted setup that fails to load now raises a
+  `ConfigurationException` rather than calling `error`.
+
+- Fix `hydra-node` withholding log entries from whoever reads its stdout until
+  64KB had accumulated. Output is block-buffered and was only flushed when the
+  tracer shut down, so `docker logs` and process supervisors saw nothing from a
+  node that was running but not logging heavily. The writer now flushes each
+  batch it drains.
+
 ## [2.3.0] - 2026.07.15
 
 - Add **selective partial fanout**: distribute a chosen subset of a closed

--- a/hydra-cluster/bench/Bench/EndToEnd.hs
+++ b/hydra-cluster/bench/Bench/EndToEnd.hs
@@ -44,6 +44,7 @@ import Hydra.Ledger.Cardano (mkSimpleTx)
 import Hydra.Logging (
   Tracer,
   Verbosity (Quiet),
+  defaultLogBuffering,
   traceWith,
   withTracerOutputTo,
  )
@@ -95,7 +96,7 @@ bench startingNodeId timeoutSeconds runOptions workDir dataset = do
   let BenchRunOptions{incrementalOps} = runOptions
   putStrLn $ "Test logs available in: " <> (workDir </> "test.log")
   withFile (workDir </> "test.log") ReadWriteMode $ \hdl ->
-    withTracerOutputTo (BlockBuffering (Just 64000)) hdl "Test" $ \tracer ->
+    withTracerOutputTo defaultLogBuffering hdl "Test" $ \tracer ->
       failAfter timeoutSeconds $ do
         putTextLn "Starting benchmark"
         let cardanoKeys =
@@ -154,7 +155,7 @@ benchDemo networkId nodeSocket timeoutSeconds hydraClients pumbaCommand runOptio
   let BenchRunOptions{incrementalOps} = runOptions
   putStrLn $ "Test logs available in: " <> (workDir </> "test.log")
   withFile (workDir </> "test.log") ReadWriteMode $ \hdl ->
-    withTracerOutputTo (BlockBuffering (Just 64000)) hdl "Test" $ \tracer ->
+    withTracerOutputTo defaultLogBuffering hdl "Test" $ \tracer ->
       failAfter timeoutSeconds $ do
         putTextLn "Starting benchmark demo"
         let cardanoTracer = contramap FromCardanoNode tracer

--- a/hydra-node/hydra-node.cabal
+++ b/hydra-node/hydra-node.cabal
@@ -473,6 +473,7 @@ test-suite tests
     , ouroboros-consensus:cardano
     , plutus-ledger-api               >=1.1.1.0
     , plutus-tx
+    , process
     , QuickCheck
     , quickcheck-arbitrary-adt
     , quickcheck-dynamic              >=3.4     && <3.5

--- a/hydra-node/src/Hydra/Logging.hs
+++ b/hydra-node/src/Hydra/Logging.hs
@@ -119,6 +119,12 @@ withTracerOutputTo bufferingMode hdl namespace action = do
       pure es
     unless (null entries) $ do
       forM_ entries (write . Aeson.encode)
+      -- Flush once per drained batch. Batching is what amortises the syscalls
+      -- here; leaving the block buffer to decide when to write as well would
+      -- hold the first entries back until 64KB had accumulated, so a node
+      -- that is slow to start looks to 'docker logs' or to a supervisor like
+      -- one that never started at all.
+      hFlush hdl
       writeLogs queue closed
 
   -- The writer thread claims queued entries before writing them, so shutdown

--- a/hydra-node/src/Hydra/Logging.hs
+++ b/hydra-node/src/Hydra/Logging.hs
@@ -15,6 +15,7 @@ module Hydra.Logging (
   -- * Using it
   Verbosity (..),
   Envelope (..),
+  defaultLogBuffering,
   withTracer,
   withTracerOutputTo,
   showLogsOnFailure,
@@ -35,7 +36,8 @@ import Control.Concurrent.Class.MonadSTM (
   writeTBQueue,
   writeTVar,
  )
-import Control.Monad.Class.MonadAsync (wait)
+import Control.Exception (IOException)
+import Control.Monad.Class.MonadAsync (waitCatch)
 import Control.Monad.Class.MonadSay (MonadSay, say)
 import Control.Tracer (
   Tracer (..),
@@ -74,6 +76,11 @@ instance ToJSON a => ToJSON (Envelope a) where
 defaultQueueSize :: Natural
 defaultQueueSize = 500
 
+-- | Buffering used for log output. The writer batches whatever the queue holds
+-- and flushes each batch, so this bounds the syscalls rather than the latency.
+defaultLogBuffering :: BufferMode
+defaultLogBuffering = BlockBuffering (Just 64000)
+
 -- | Start logging thread and acquire a 'Tracer'. This tracer will dump all
 -- messages on @stdout@, one message per line, formatted as JSON. This tracer
 -- is wrapping 'msg' into an 'Envelope' with metadata.
@@ -84,7 +91,7 @@ withTracer ::
   (Tracer m msg -> IO a) ->
   IO a
 withTracer Quiet = ($ nullTracer)
-withTracer (Verbose namespace) = withTracerOutputTo (BlockBuffering (Just 64000)) stdout namespace
+withTracer (Verbose namespace) = withTracerOutputTo defaultLogBuffering stdout namespace
 
 -- | Start logging thread acquiring a 'Tracer', outputting JSON formatted
 -- messages to some 'Handle'. This tracer is wrapping 'msg' into an 'Envelope'
@@ -118,24 +125,33 @@ withTracerOutputTo bufferingMode hdl namespace action = do
         unless isClosed retry
       pure es
     unless (null entries) $ do
-      forM_ entries (write . Aeson.encode)
-      -- Flush once per drained batch. Batching is what amortises the syscalls
-      -- here; leaving the block buffer to decide when to write as well would
-      -- hold the first entries back until 64KB had accumulated, so a node
-      -- that is slow to start looks to 'docker logs' or to a supervisor like
-      -- one that never started at all.
-      hFlush hdl
+      -- Flush once per drained batch, so the block buffer does not hold the
+      -- first entries back until 64KB has accumulated.
+      --
+      -- Losing the batch must not take the node with it: GHC ignores SIGPIPE,
+      -- so a reader that goes away turns the next write into an IOException,
+      -- and this thread is not linked to its parent. Dying here would go
+      -- unnoticed until the queue filled, at which point every 'traceWith' in
+      -- the node blocks forever on a queue nobody drains.
+      liftIO $
+        (forM_ entries (write . Aeson.encode) >> hFlush hdl)
+          `catch` \(_ :: IOException) -> pure ()
       writeLogs queue closed
 
   -- The writer thread claims queued entries before writing them, so shutdown
-  -- must hand over to the writer rather than inspect the queue itself:
-  -- signal it to stop, wait for it to finish draining, then flush. The wait
-  -- is bounded so a stuck handle cannot block shutdown; the surrounding
-  -- 'withAsync' cancels the writer in that case.
+  -- must hand over to the writer rather than inspect the queue itself: signal
+  -- it to stop, wait for it to finish draining, then flush. The wait is
+  -- bounded, and the surrounding 'withAsync' cancels a writer that overran it,
+  -- but the final flush below is not bounded: a handle whose reader has
+  -- stalled can still hold up shutdown until an external signal arrives.
+  --
+  -- 'waitCatch' rather than 'wait': a writer that died would otherwise rethrow
+  -- here, inside a 'finally', and replace whatever actually terminated the
+  -- node.
   drainLogs closed writer = liftIO $ do
     atomically $ writeTVar closed True
-    void $ timeout drainGraceSeconds (wait writer)
-    hFlush hdl
+    void $ timeout drainGraceSeconds (waitCatch writer)
+    hFlush hdl `catch` \(_ :: IOException) -> pure ()
 
   drainGraceSeconds :: DiffTime
   drainGraceSeconds = 5

--- a/hydra-node/src/Hydra/Logging/Messages.hs
+++ b/hydra-node/src/Hydra/Logging/Messages.hs
@@ -28,9 +28,8 @@ data HydraLog tx
   | NodeHydrated
   | ChainBackendStarted
   | NetworkStarted
-  | -- | Emitted before forcing the embedded KZG trusted setup, which is the
-    -- first compute-bound step of a node start and can take minutes on hosts
-    -- that decompress BLS points slowly.
+  | -- | Emitted either side of forcing the embedded KZG trusted setup, the one
+    -- startup step with no bound on how long it takes.
     LoadingTrustedSetup
   | TrustedSetupLoaded {numG1Points :: Int}
   deriving stock (Generic)

--- a/hydra-node/src/Hydra/Logging/Messages.hs
+++ b/hydra-node/src/Hydra/Logging/Messages.hs
@@ -28,6 +28,11 @@ data HydraLog tx
   | NodeHydrated
   | ChainBackendStarted
   | NetworkStarted
+  | -- | Emitted before forcing the embedded KZG trusted setup, which is the
+    -- first compute-bound step of a node start and can take minutes on hosts
+    -- that decompress BLS points slowly.
+    LoadingTrustedSetup
+  | TrustedSetupLoaded {numG1Points :: Int}
   deriving stock (Generic)
 
 deriving stock instance Eq (HydraNodeLog tx) => Eq (HydraLog tx)

--- a/hydra-node/src/Hydra/Node/Run.hs
+++ b/hydra-node/src/Hydra/Node/Run.hs
@@ -62,6 +62,7 @@ data ConfigurationException
   = -- XXX: this is not used
     ConfigurationException ProtocolParametersConversionError
   | InvalidOptionException InvalidOptions
+  | TrustedSetupException KZG.KZGSetupError
   deriving stock (Show)
 
 instance Exception ConfigurationException where
@@ -72,20 +73,31 @@ instance Exception ConfigurationException where
       "Number of loaded cardano and hydra keys needs to match"
     ConfigurationException err ->
       "Incorrect protocol parameters configuration provided: " <> show err
+    TrustedSetupException err ->
+      "Embedded KZG trusted setup could not be loaded: " <> show err
 
 run :: RunOptions -> IO ()
 run opts = do
-  -- Force all KZG G1 points into memory before opening any sockets.
-  -- initTx (and snapshot signing) call getAccumulatorHash, which on first
-  -- access parses ~300KB of JSON and BLS-decompresses 4096 curve points.
-  -- Doing it here means the API server only starts after the warm-up, so
-  -- clients cannot connect and time out waiting for HeadIsOpen while the
-  -- node is still initialising the cryptographic setup. The native Point1
-  -- CRS is what the rust FFI commitment path consumes.
-  void $ evaluate $ either (error . show) length KZG.g1Points
   either (throwIO . InvalidOptionException) pure $ validateRunOptions opts
   withTracer verbosity $ \tracer' -> do
     traceWith tracer' (NodeOptions opts)
+    -- Force all KZG G1 points into memory before opening any sockets.
+    -- initTx (and snapshot signing) call getAccumulatorHash, which on first
+    -- access parses ~300KB of JSON and BLS-decompresses 4096 curve points.
+    -- Doing it here means the API server only starts after the warm-up, so
+    -- clients cannot connect and time out waiting for HeadIsOpen while the
+    -- node is still initialising the cryptographic setup. The native Point1
+    -- CRS is what the rust FFI commitment path consumes.
+    --
+    -- This runs under the tracer rather than before it, as it is the first
+    -- compute-bound thing the node does and the only startup step with no
+    -- upper bound on how long it takes: a host that decompresses BLS points
+    -- slowly, an emulated aarch64 one for instance, sits here for minutes.
+    -- Without these two lines that is indistinguishable from a node that
+    -- hung before it started, because nothing has been logged yet.
+    traceWith tracer' LoadingTrustedSetup
+    numG1Points <- either (throwIO . TrustedSetupException) (evaluate . length) KZG.g1Points
+    traceWith tracer' TrustedSetupLoaded{numG1Points}
     withMonitoring monitoringPort tracer' $ \tracer -> do
       env@Environment{party, otherParties, signingKey} <- initEnvironment opts
       -- Ledger

--- a/hydra-node/src/Hydra/Node/Run.hs
+++ b/hydra-node/src/Hydra/Node/Run.hs
@@ -81,22 +81,12 @@ run opts = do
   either (throwIO . InvalidOptionException) pure $ validateRunOptions opts
   withTracer verbosity $ \tracer' -> do
     traceWith tracer' (NodeOptions opts)
-    -- Force all KZG G1 points into memory before opening any sockets.
-    -- initTx (and snapshot signing) call getAccumulatorHash, which on first
-    -- access parses ~300KB of JSON and BLS-decompresses 4096 curve points.
-    -- Doing it here means the API server only starts after the warm-up, so
-    -- clients cannot connect and time out waiting for HeadIsOpen while the
-    -- node is still initialising the cryptographic setup. The native Point1
-    -- CRS is what the rust FFI commitment path consumes.
-    --
-    -- This runs under the tracer rather than before it, as it is the first
-    -- compute-bound thing the node does and the only startup step with no
-    -- upper bound on how long it takes: a host that decompresses BLS points
-    -- slowly, an emulated aarch64 one for instance, sits here for minutes.
-    -- Without these two lines that is indistinguishable from a node that
-    -- hung before it started, because nothing has been logged yet.
+    -- Force the KZG trusted setup before opening any socket, so that the API
+    -- server only starts once it is in memory and clients cannot connect and
+    -- time out waiting for HeadIsOpen mid warm-up (see 'KZG.warmup'). Traced
+    -- because it is the one startup step with no bound on how long it takes.
     traceWith tracer' LoadingTrustedSetup
-    numG1Points <- either (throwIO . TrustedSetupException) (evaluate . length) KZG.g1Points
+    numG1Points <- either (throwIO . TrustedSetupException) pure KZG.warmup
     traceWith tracer' TrustedSetupLoaded{numG1Points}
     withMonitoring monitoringPort tracer' $ \tracer -> do
       env@Environment{party, otherParties, signingKey} <- initEnvironment opts

--- a/hydra-node/test/Hydra/LoggingSpec.hs
+++ b/hydra-node/test/Hydra/LoggingSpec.hs
@@ -3,10 +3,12 @@ module Hydra.LoggingSpec where
 import Hydra.Prelude
 import Test.Hydra.Prelude
 
+import Control.Exception (IOException)
 import Data.Aeson (object, (.=))
 import Data.Text.IO qualified as Text.IO
-import Hydra.Logging (traceWith, withTracerOutputTo)
+import Hydra.Logging (defaultLogBuffering, defaultQueueSize, traceWith, withTracerOutputTo)
 import System.FilePath ((</>))
+import System.IO (hClose)
 import System.Process (createPipe)
 
 spec :: Spec
@@ -23,18 +25,29 @@ spec = do
       captured <- readFileBS logFile
       toString (decodeUtf8 @Text captured) `shouldContain` "{\"foo\":42}"
 
-  -- The node logs through a block-buffered handle, so an entry only reaches
-  -- whoever is reading the other end once the writer flushes. Without an
-  -- explicit flush the first entries sit in the buffer until 64KB has
-  -- accumulated, which makes a node that is slow to start indistinguishable,
-  -- to 'docker logs' or to a supervisor, from one that never started at all.
-  -- A pipe is what such a reader actually gets, and unlike a file it cannot be
-  -- satisfied after the fact by the unconditional flush on tracer shutdown.
-  it "flushes entries without waiting for the buffer to fill" $ do
-    (readEnd, writeEnd) <- createPipe
-    withTracerOutputTo (BlockBuffering (Just 64000)) writeEnd "test" $ \tracer -> do
-      traceWith tracer (object ["foo" .= (42 :: Int)])
-      -- The writer thread is asynchronous, so this blocks until it has both
-      -- written and flushed the entry.
-      line <- failAfter 5 $ Text.IO.hGetLine readEnd
-      toString line `shouldContain` "{\"foo\":42}"
+  -- A pipe is what a log reader actually gets, and unlike a file it cannot be
+  -- satisfied after the fact by the flush on tracer shutdown.
+  it "flushes entries without waiting for the buffer to fill" $
+    withPipe $ \(readEnd, writeEnd) ->
+      withTracerOutputTo defaultLogBuffering writeEnd "test" $ \tracer -> do
+        traceWith tracer (object ["foo" .= (42 :: Int)])
+        -- The writer thread is asynchronous, so this blocks until it has both
+        -- written and flushed the entry.
+        line <- failAfter 5 $ Text.IO.hGetLine readEnd
+        toString line `shouldContain` "{\"foo\":42}"
+
+  it "keeps logging after the reader of its output has gone away" $
+    withPipe $ \(readEnd, writeEnd) ->
+      withTracerOutputTo defaultLogBuffering writeEnd "test" $ \tracer -> do
+        hClose readEnd
+        -- Writing to a pipe nobody reads raises an IOException, as GHC ignores
+        -- SIGPIPE. The writer has to survive that: were it to die, the queue
+        -- would fill and every subsequent 'traceWith' would block forever.
+        failAfter 5 $
+          forM_ [1 .. 2 * fromIntegral defaultQueueSize :: Int] $ \i ->
+            traceWith tracer (object ["foo" .= i])
+ where
+  withPipe :: ((Handle, Handle) -> IO a) -> IO a
+  withPipe = bracket createPipe $ \(readEnd, writeEnd) ->
+    forM_ [readEnd, writeEnd] $ \h ->
+      hClose h `catch` \(_ :: IOException) -> pure ()

--- a/hydra-node/test/Hydra/LoggingSpec.hs
+++ b/hydra-node/test/Hydra/LoggingSpec.hs
@@ -4,8 +4,10 @@ import Hydra.Prelude
 import Test.Hydra.Prelude
 
 import Data.Aeson (object, (.=))
+import Data.Text.IO qualified as Text.IO
 import Hydra.Logging (traceWith, withTracerOutputTo)
 import System.FilePath ((</>))
+import System.Process (createPipe)
 
 spec :: Spec
 spec = do
@@ -20,3 +22,19 @@ spec = do
           traceWith tracer (object ["foo" .= (42 :: Int)])
       captured <- readFileBS logFile
       toString (decodeUtf8 @Text captured) `shouldContain` "{\"foo\":42}"
+
+  -- The node logs through a block-buffered handle, so an entry only reaches
+  -- whoever is reading the other end once the writer flushes. Without an
+  -- explicit flush the first entries sit in the buffer until 64KB has
+  -- accumulated, which makes a node that is slow to start indistinguishable,
+  -- to 'docker logs' or to a supervisor, from one that never started at all.
+  -- A pipe is what such a reader actually gets, and unlike a file it cannot be
+  -- satisfied after the fact by the unconditional flush on tracer shutdown.
+  it "flushes entries without waiting for the buffer to fill" $ do
+    (readEnd, writeEnd) <- createPipe
+    withTracerOutputTo (BlockBuffering (Just 64000)) writeEnd "test" $ \tracer -> do
+      traceWith tracer (object ["foo" .= (42 :: Int)])
+      -- The writer thread is asynchronous, so this blocks until it has both
+      -- written and flushed the entry.
+      line <- failAfter 5 $ Text.IO.hGetLine readEnd
+      toString line `shouldContain` "{\"foo\":42}"

--- a/hydra-plutus/src/Hydra/Contract/KZGTrustedSetup.hs
+++ b/hydra-plutus/src/Hydra/Contract/KZGTrustedSetup.hs
@@ -47,6 +47,7 @@
 -- so the 65 G2 points do not constrain the accumulator size.
 module Hydra.Contract.KZGTrustedSetup (
   KZGSetupError (..),
+  warmup,
   g1Points,
   g2Points,
   g1BuiltinPoints,
@@ -134,6 +135,31 @@ embeddedSetup = do
 
 decodeHexPoint :: Text -> Either String ByteString
 decodeHexPoint t = Base16.decode $ encodeUtf8 $ fromMaybe t (T.stripPrefix "0x" t)
+
+-- | Force the whole embedded trusted setup into memory, yielding the number of
+-- G1 points loaded.
+--
+-- Both halves are forced: the G1 CRS the off-chain commitment path consumes,
+-- and the G2 CRS behind 'canonicalG2Points', which the head validator binds.
+-- A caller gets a corrupt setup as a 'Left' here rather than as the 'error'
+-- those two would otherwise raise from pure code, mid-session.
+--
+-- The forcing lives in this module on purpose. 'g1Points' currently
+-- decompresses every point just to decide between 'Left' and 'Right', so any
+-- 'WHNF' happens to do the work — but that is a property of the
+-- representation, not a promise. Should either list become a lazy structure,
+-- this is the one place obliged to keep forcing, rather than a caller's
+-- 'length' silently degenerating into a spine walk.
+warmup :: Either KZGSetupError Int
+warmup = do
+  g1 <- g1Points
+  g2 <- g2Points
+  let !numG1 = countForced g1
+      !numG2 = countForced g2
+  numG2 `seq` Right numG1
+ where
+  countForced :: [a] -> Int
+  countForced = foldl' (\n x -> x `seq` n + 1) 0
 
 -- | G1 powers of tau [G1, τ·G1, ..., τ^4095·G1] from the EIP-4844 ceremony (monomial form).
 -- 4096 points; used off-chain to build accumulator commitments and membership proofs.


### PR DESCRIPTION
Follow-up to #2814: the KZG trusted-setup warm-up in `Hydra.Node.Run` was running before `withTracer`. It forces 4096 BLS12-381 point decompressions and has no bound on how long it takes, so a node can spend a long time starting up while writing nothing at all

Fixes in this PR:

1. Trace the warm-up as `LoadingTrustedSetup` / `TrustedSetupLoaded`. It still completes before any socket opens (`withTracer` only sets stdout buffering and forks the writer thread, so `withMonitoring` and the API server still come after), and a setup that fails to load now throws `ConfigurationException` instead of calling `error`. Option validation moves ahead of the warm-up, so bad options fail without doing the crypto work.
2. Flush log entries per batch. stdout is block-buffered at 64KB and the writer only flushed at shutdown, so a node that logs lightly was silent to `docker logs` regardless of the warm-up.

Verified on an offline head: `LoadingTrustedSetup` → `TrustedSetupLoaded (numG1Points=4096)` in ~290ms, head reaches `HeadOpened`. The new test traces through a pipe and fails with a 5s timeout if the flush is removed.

<!-- Describe your change here -->

---

<!-- Consider each and tick it off one way or the other -->
* [ ] CHANGELOG updated or not needed
* [ ] Documentation updated or not needed
* [ ] Haddocks updated or not needed
* [ ] No new TODOs introduced or explained herafter
