### PR TITLE
Fix the flaky snapshot-UTxO thunk test and harden the deposit ingress

### DIFF
--- a/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
+++ b/hydra-node/test/Hydra/Chain/Direct/StateSpec.hs
@@ -132,6 +132,7 @@ import Test.QuickCheck (
   forAllBlind,
   forAllShow,
   forAllShrink,
+  ioProperty,
   label,
   oneof,
   tabulate,
@@ -140,6 +141,7 @@ import Test.QuickCheck (
   (==>),
  )
 import Test.QuickCheck.Monadic (assert, assertWith, monadicIO, monitor)
+import Test.Util (utxoNoThunks)
 import Prelude qualified
 
 spec :: Spec
@@ -207,6 +209,23 @@ spec = parallel $ do
       forAllDeposit $ \utxo tx ->
         case observeDepositTx testNetworkId tx of
           Just DepositObservation{} -> property True
+          Nothing ->
+            False & counterexample ("observeDepositTx ignored transaction: " <> renderTxWithUTxO utxo tx)
+
+    -- The observed deposit UTxO is a 'UTxO' ingress point (decoded from the plutus
+    -- datum, not through the forcing JSON/CBOR instances) and flows into 'localUTxO'
+    -- and snapshots, where 'forceNewEntries' trusts carried-over entries - so it must
+    -- come out of observation fully evaluated. Guards the explicit 'forceUTxO' at the
+    -- observation (without it the property holds only incidentally, through the
+    -- round-trip guard's re-serialization).
+    prop "observed deposit UTxO is fully evaluated" $
+      forAllDeposit $ \utxo tx ->
+        case observeDepositTx testNetworkId tx of
+          Just DepositObservation{deposited} ->
+            ioProperty $
+              utxoNoThunks deposited >>= \case
+                Nothing -> pure $ property True
+                Just ti -> pure $ False & counterexample ("Thunk in observed deposit UTxO: " <> show ti)
           Nothing ->
             False & counterexample ("observeDepositTx ignored transaction: " <> renderTxWithUTxO utxo tx)
 

--- a/hydra-node/test/Hydra/HeadLogicSpec.hs
+++ b/hydra-node/test/Hydra/HeadLogicSpec.hs
@@ -27,7 +27,7 @@ import Data.Sequence qualified as Seq
 import Data.Set qualified as Set
 import Hydra.API.ClientInput (ClientInput (Fanout, PartialFanout, Recover, SideLoadSnapshot))
 import Hydra.API.ServerOutput (ClientMessage (..), DecommitInvalidReason (..))
-import Hydra.Cardano.Api (ChainPoint (..), SlotNo (..), fromLedgerTx, mkVkAddress, toLedgerTx, txOutValue, unSlotNo, pattern TxValidityUpperBound)
+import Hydra.Cardano.Api (ChainPoint (..), SlotNo (..), forceUTxO, fromLedgerTx, mkVkAddress, toLedgerTx, txOutValue, unSlotNo, pattern TxValidityUpperBound)
 import Hydra.Cardano.Api.Gen (genTxIn)
 import Hydra.Chain (
   ChainEvent (..),
@@ -2814,14 +2814,16 @@ spec =
 
       it "stores a fully evaluated snapshot UTxO when processing ReqSn" $ do
         -- Two outputs; the tx spends only the first. The second is carried over
-        -- unchanged: the accumulator delta never touches it, so only strict
-        -- construction in applyTransactions guarantees it is forced.
+        -- unchanged: 'forceNewEntries' deliberately trusts carried-over entries,
+        -- so the design invariant is that every UTxO ingress forces - the seed
+        -- models one (hence 'forceUTxO', as at the real ingress points) and the
+        -- application must force the transaction's own outputs.
         (vk, sk) <- generate genKeyPair
         txOut1 <- generate (genOutputFor vk)
         txOut2 <- generate (genOutputFor vk)
         txIn1 <- generate genTxIn
         txIn2 <- generate genTxIn
-        let u0 = UTxO.fromList [(txIn1, txOut1), (txIn2, txOut2)]
+        let u0 = forceUTxO $ UTxO.fromList [(txIn1, txOut1), (txIn2, txOut2)]
         tx <- case mkSimpleTx (txIn1, txOut1) (mkVkAddress Fixture.testNetworkId vk, txOutValue txOut1) (mkSecret sk) of
           Left err -> failure $ "cannot create tx: " <> show err
           Right tx' -> pure tx'

--- a/hydra-tx/src/Hydra/Tx/Deposit.hs
+++ b/hydra-tx/src/Hydra/Tx/Deposit.hs
@@ -166,7 +166,14 @@ observeDepositTxOut network depositOut = do
   (headCurrencySymbol, deadline, onChainDeposits) <- fromScriptData dat
   headId <- currencySymbolToHeadId headCurrencySymbol
   deposit <- do
-    depositedUTxO <- UTxO.fromList <$> traverse deserializeRoundTripping onChainDeposits
+    -- Force the decoded UTxO: this decode (plutus 'Data' via 'deserializeCommit') is an
+    -- ingress point for 'UTxO' that the forcing 'FromJSON'/'FromCBOR' instances do not
+    -- cover, and the observed set flows into 'localUTxO' and snapshots where
+    -- 'forceNewEntries' deliberately trusts carried-over entries. Today the round-trip
+    -- guard in 'deserializeRoundTripping' happens to force the entries deeply as a side
+    -- effect of re-serializing them; forcing explicitly here makes the ingress invariant
+    -- survive a refactor of that guard (and the observation test asserts it).
+    depositedUTxO <- forceUTxO . UTxO.fromList <$> traverse deserializeRoundTripping onChainDeposits
     -- TODO: This silently ignores deposits that deposit less ADA than what the
     -- min ADA for the deposit output would be. For example: a 1 ADA utxo can be
     -- deposited, but the deposit tx's output will require ~1.5 ADA because of


### PR DESCRIPTION
This caused one of my PRs to fail - https://github.com/cardano-scaling/hydra/actions/runs/32858023598/job/97834726763?pr=2842

*Claude's thoughts:*

The "stores a fully evaluated snapshot UTxO when processing ReqSn" test seeded its head state with an unforced, generated UTxO. forceNewEntries deliberately trusts carried-over entries (the strictness design is that every UTxO ingress forces), so whenever the generator produced a thunked inline datum on the output the transaction never touches, the NoThunks assertion tripped - a seed-dependent flake, observed in CI on several runners and reproduced locally. The seed now goes through forceUTxO, as at the real ingress points, and the comment states the invariant the test actually checks.

Auditing the real ingresses while diagnosing this: the deposit observation decodes its UTxO from the plutus datum, outside the forcing JSON/CBOR instances. It comes out fully evaluated today, but only incidentally - deserializeRoundTripping's guard re-serializes each commit, deep-forcing the stored entries as a side effect. Forcing explicitly at the observation makes the ingress invariant survive a refactor of that guard, and a new StateSpec property asserts the observed deposit UTxO carries no thunks (it is what would catch the guard's forcing disappearing).

Verified: the thunk test passes 60/60 stress iterations (previously failed within a few); the new property passes and the observation-level forcing is what it pins, not the incidental path.

cc @v0d1ch 