### PR TITLE
Speed up smoke tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ changes.
 
 ## [UNRELEASED]
 
+- Deposit transactions now get a validity window of up to `maxGraceTime` (200s),
+  capped at half the configured `--deposit-period`. An operator-precedence
+  mistake capped the window at a flat 100s, twice as likely to be missed on a
+  congested chain with no resubmission on expiry. The cap against the deposit
+  period also keeps at least half of it as the deposit's active window, so
+  deposit periods at or below 100s no longer risk deposits expiring before they
+  activate. Deposits on networks with ~20s blocks activate up to 100s later as
+  a result.
+  [#2850](https://github.com/cardano-scaling/hydra/pull/2850)
+
 - Fixed the internal wallet setting a script integrity hash on transactions
   that execute no scripts: reference inputs carrying Plutus scripts had their
   language views hashed even when nothing runs, so the ledger rejected such

--- a/hydra-cluster/README.md
+++ b/hydra-cluster/README.md
@@ -52,7 +52,19 @@ Smoke tests can also run using _Blockfrost_ in which case there is no need to
 start `cardano-node`.
 
 The Hydra nodes can reference pre-existing contracts living at some well-known
-transaction or can post a new transaction to use those contracts.
+transaction or can post a new transaction to use those contracts. On testnets,
+`--publish-hydra-scripts` caches the tx ids in
+`<state-directory>/.hydra-scripts-tx-ids` and reuses them on the next run if the
+scripts they point at still match the ones compiled in; a script change
+republishes. Mainnet always publishes, since that check cannot tell a changed
+script from a transient query failure.
+
+On testnets the scenario also runs with shorter periods than the end-to-end
+tests use (see `mkSmokeTiming`): most of its wall clock would otherwise be spent
+waiting out `depositActivation` and the contestation period. Mainnet keeps the
+end-to-end timings -- it runs once per release, so there is nothing to gain, and
+a shorter contestation period only narrows the window its close transaction has
+to be included.
 
 :warning: do not provide actual funds to this faucet address as the
 signing key is publicly available. Shall you want to run the smoke

--- a/hydra-cluster/README.md
+++ b/hydra-cluster/README.md
@@ -52,19 +52,13 @@ Smoke tests can also run using _Blockfrost_ in which case there is no need to
 start `cardano-node`.
 
 The Hydra nodes can reference pre-existing contracts living at some well-known
-transaction or can post a new transaction to use those contracts. On testnets,
-`--publish-hydra-scripts` caches the tx ids in
-`<state-directory>/.hydra-scripts-tx-ids` and reuses them on the next run if the
-scripts they point at still match the ones compiled in; a script change
-republishes. Mainnet always publishes, since that check cannot tell a changed
-script from a transient query failure.
+transaction or can post a new transaction to use those contracts.
 
-On testnets the scenario also runs with shorter periods than the end-to-end
-tests use (see `mkSmokeTiming`): most of its wall clock would otherwise be spent
-waiting out `depositActivation` and the contestation period. Mainnet keeps the
-end-to-end timings -- it runs once per release, so there is nothing to gain, and
-a shorter contestation period only narrows the window its close transaction has
-to be included.
+The scenario runs with a shorter `deposit-activation` and contestation period
+than the end-to-end tests use (see `mkSmokeTiming`): most of its wall clock would
+otherwise be spent waiting those out. The contestation period stops at the point
+where the validity window of close, contest and increment transactions would
+start shrinking, so nothing is more likely to expire than before.
 
 :warning: do not provide actual funds to this faucet address as the
 signing key is publicly available. Shall you want to run the smoke

--- a/hydra-cluster/exe/hydra-cluster/Main.hs
+++ b/hydra-cluster/exe/hydra-cluster/Main.hs
@@ -14,11 +14,12 @@ import CardanoNode (
  )
 import Hydra.Cardano.Api (TxId, serialiseToRawBytesHexText)
 import Hydra.Chain.Backend (blockfrostProjectPath)
-import Hydra.Cluster.Faucet (publishHydraScriptsAs)
+import Hydra.Cluster.Faucet qualified as Faucet
 import Hydra.Cluster.Fixture (Actor (Faucet), KnownNetwork (..))
 import Hydra.Cluster.Mithril (downloadLatestSnapshotTo)
 import Hydra.Cluster.Options (Options (..), PublishOrReuse (Publish, Reuse), Scenario (..), UseMithril (UseMithril), parseOptions)
 import Hydra.Cluster.Scenarios (respendNTimes, singlePartyHeadFullLifeCycle, singlePartyOpenAHead)
+import Hydra.Cluster.Util (mkSmokeTiming, mkTestTiming)
 import Hydra.Logging (Tracer, traceWith, withTracerOutputTo)
 import Hydra.Options (BlockfrostOptions (..), ChainBackendOptions (..), defaultBlockfrostOptions)
 import Options.Applicative (ParserInfo, execParser, fullDesc, header, helper, info, progDesc)
@@ -42,16 +43,16 @@ run options =
           if network `notElem` blockfrostNetworks
             then withRunningCardanoNode tracer workDir network $ \_ opts -> do
               waitForFullySynchronized fromCardanoNode (Direct opts)
-              publishOrReuseHydraScripts tracer (Direct opts)
-                >>= singlePartyHeadFullLifeCycle tracer workDir (Direct opts)
+              resolveHydraScripts tracer workDir (isMainnet network) (Direct opts)
+                >>= singlePartyHeadFullLifeCycle tracer workDir (smokeTiming network) (Direct opts)
             else do
               bfProjectPath <- findFileStartingAtDirectory 3 blockfrostProjectPath
               let opts = Blockfrost defaultBlockfrostOptions{projectPath = bfProjectPath}
-              publishOrReuseHydraScripts tracer opts
-                >>= singlePartyHeadFullLifeCycle tracer workDir opts
+              resolveHydraScripts tracer workDir (isMainnet network) opts
+                >>= singlePartyHeadFullLifeCycle tracer workDir (smokeTiming network) opts
         Nothing -> do
           withCardanoNodeDevnet fromCardanoNode workDir $ \_ opts -> do
-            txId <- publishOrReuseHydraScripts tracer (Direct opts)
+            txId <- resolveHydraScripts tracer workDir False (Direct opts)
             let hydraScriptsTxId = intercalate "," $ toString . serialiseToRawBytesHexText <$> txId
             let envPath = workDir </> ".env"
             writeFile envPath $ "HYDRA_SCRIPTS_TX_ID=" <> hydraScriptsTxId
@@ -84,16 +85,44 @@ run options =
     Nothing -> withTempDir ("hydra-cluster-" <> show knownNetwork) action
     Just sd -> action sd
 
-  publishOrReuseHydraScripts :: Tracer IO EndToEndLog -> ChainBackendOptions -> IO [TxId]
-  publishOrReuseHydraScripts tracer opts =
+  -- The testnet smoke runs are dominated by protocol waits, so shorten those.
+  -- Mainnet keeps the end-to-end timings: it runs once per release, so there is
+  -- nothing to gain there, and a shorter contestation period would only narrow
+  -- the window its close transaction has to be included -- on a head holding
+  -- real funds, with no resubmit on expiry.
+  smokeTiming network
+    | isMainnet network = mkTestTiming
+    | otherwise = mkSmokeTiming
+
+  -- NOTE: On testnets 'Publish' does not mean "publish unconditionally":
+  -- scripts already published from the same work directory are validated
+  -- against the chain by 'Faucet.publishOrReuseHydraScripts' and reused, which
+  -- saves a transaction and its confirmation; a script change invalidates them.
+  -- Mainnet always publishes: that validation cannot tell a changed script from
+  -- a transient query failure, and guessing wrong there spends real funds.
+  resolveHydraScripts :: Tracer IO EndToEndLog -> FilePath -> Bool -> ChainBackendOptions -> IO [TxId]
+  resolveHydraScripts tracer workDir mainnet opts =
     case publishHydraScripts of
       Publish -> do
-        hydraScriptsTxId <- publishHydraScriptsAs opts Faucet
+        hydraScriptsTxId <-
+          if mainnet
+            then Faucet.publishHydraScriptsAs opts Faucet
+            else Faucet.publishOrReuseHydraScripts opts Faucet workDir
         traceWith tracer $ PublishedHydraScriptsAt{hydraScriptsTxId}
         pure hydraScriptsTxId
       Reuse hydraScriptsTxId -> do
         traceWith tracer $ UsingHydraScriptsAt{hydraScriptsTxId}
         pure hydraScriptsTxId
+
+  -- NOTE: Matching the testnets rather than the mainnets, so that a network
+  -- added to 'KnownNetwork' later defaults to the careful side here.
+  isMainnet = \case
+    Preview -> False
+    Preproduction -> False
+    BlockfrostPreview -> False
+    BlockfrostPreprod -> False
+    Mainnet -> True
+    BlockfrostMainnet -> True
 
 hydraClusterOptions :: ParserInfo Options
 hydraClusterOptions =

--- a/hydra-cluster/exe/hydra-cluster/Main.hs
+++ b/hydra-cluster/exe/hydra-cluster/Main.hs
@@ -14,12 +14,12 @@ import CardanoNode (
  )
 import Hydra.Cardano.Api (TxId, serialiseToRawBytesHexText)
 import Hydra.Chain.Backend (blockfrostProjectPath)
-import Hydra.Cluster.Faucet qualified as Faucet
+import Hydra.Cluster.Faucet (publishHydraScriptsAs)
 import Hydra.Cluster.Fixture (Actor (Faucet), KnownNetwork (..))
 import Hydra.Cluster.Mithril (downloadLatestSnapshotTo)
 import Hydra.Cluster.Options (Options (..), PublishOrReuse (Publish, Reuse), Scenario (..), UseMithril (UseMithril), parseOptions)
 import Hydra.Cluster.Scenarios (respendNTimes, singlePartyHeadFullLifeCycle, singlePartyOpenAHead)
-import Hydra.Cluster.Util (mkSmokeTiming, mkTestTiming)
+import Hydra.Cluster.Util (mkSmokeTiming)
 import Hydra.Logging (Tracer, traceWith, withTracerOutputTo)
 import Hydra.Options (BlockfrostOptions (..), ChainBackendOptions (..), defaultBlockfrostOptions)
 import Options.Applicative (ParserInfo, execParser, fullDesc, header, helper, info, progDesc)
@@ -43,16 +43,16 @@ run options =
           if network `notElem` blockfrostNetworks
             then withRunningCardanoNode tracer workDir network $ \_ opts -> do
               waitForFullySynchronized fromCardanoNode (Direct opts)
-              resolveHydraScripts tracer workDir (isMainnet network) (Direct opts)
-                >>= singlePartyHeadFullLifeCycle tracer workDir (smokeTiming network) (Direct opts)
+              publishOrReuseHydraScripts tracer (Direct opts)
+                >>= singlePartyHeadFullLifeCycle tracer workDir mkSmokeTiming (Direct opts)
             else do
               bfProjectPath <- findFileStartingAtDirectory 3 blockfrostProjectPath
               let opts = Blockfrost defaultBlockfrostOptions{projectPath = bfProjectPath}
-              resolveHydraScripts tracer workDir (isMainnet network) opts
-                >>= singlePartyHeadFullLifeCycle tracer workDir (smokeTiming network) opts
+              publishOrReuseHydraScripts tracer opts
+                >>= singlePartyHeadFullLifeCycle tracer workDir mkSmokeTiming opts
         Nothing -> do
           withCardanoNodeDevnet fromCardanoNode workDir $ \_ opts -> do
-            txId <- resolveHydraScripts tracer workDir False (Direct opts)
+            txId <- publishOrReuseHydraScripts tracer (Direct opts)
             let hydraScriptsTxId = intercalate "," $ toString . serialiseToRawBytesHexText <$> txId
             let envPath = workDir </> ".env"
             writeFile envPath $ "HYDRA_SCRIPTS_TX_ID=" <> hydraScriptsTxId
@@ -85,44 +85,16 @@ run options =
     Nothing -> withTempDir ("hydra-cluster-" <> show knownNetwork) action
     Just sd -> action sd
 
-  -- The testnet smoke runs are dominated by protocol waits, so shorten those.
-  -- Mainnet keeps the end-to-end timings: it runs once per release, so there is
-  -- nothing to gain there, and a shorter contestation period would only narrow
-  -- the window its close transaction has to be included -- on a head holding
-  -- real funds, with no resubmit on expiry.
-  smokeTiming network
-    | isMainnet network = mkTestTiming
-    | otherwise = mkSmokeTiming
-
-  -- NOTE: On testnets 'Publish' does not mean "publish unconditionally":
-  -- scripts already published from the same work directory are validated
-  -- against the chain by 'Faucet.publishOrReuseHydraScripts' and reused, which
-  -- saves a transaction and its confirmation; a script change invalidates them.
-  -- Mainnet always publishes: that validation cannot tell a changed script from
-  -- a transient query failure, and guessing wrong there spends real funds.
-  resolveHydraScripts :: Tracer IO EndToEndLog -> FilePath -> Bool -> ChainBackendOptions -> IO [TxId]
-  resolveHydraScripts tracer workDir mainnet opts =
+  publishOrReuseHydraScripts :: Tracer IO EndToEndLog -> ChainBackendOptions -> IO [TxId]
+  publishOrReuseHydraScripts tracer opts =
     case publishHydraScripts of
       Publish -> do
-        hydraScriptsTxId <-
-          if mainnet
-            then Faucet.publishHydraScriptsAs opts Faucet
-            else Faucet.publishOrReuseHydraScripts opts Faucet workDir
+        hydraScriptsTxId <- publishHydraScriptsAs opts Faucet
         traceWith tracer $ PublishedHydraScriptsAt{hydraScriptsTxId}
         pure hydraScriptsTxId
       Reuse hydraScriptsTxId -> do
         traceWith tracer $ UsingHydraScriptsAt{hydraScriptsTxId}
         pure hydraScriptsTxId
-
-  -- NOTE: Matching the testnets rather than the mainnets, so that a network
-  -- added to 'KnownNetwork' later defaults to the careful side here.
-  isMainnet = \case
-    Preview -> False
-    Preproduction -> False
-    BlockfrostPreview -> False
-    BlockfrostPreprod -> False
-    Mainnet -> True
-    BlockfrostMainnet -> True
 
 hydraClusterOptions :: ParserInfo Options
 hydraClusterOptions =

--- a/hydra-cluster/hydra-cluster.cabal
+++ b/hydra-cluster/hydra-cluster.cabal
@@ -162,6 +162,7 @@ test-suite tests
     Test.Hydra.Cluster.HydraClientSpec
     Test.Hydra.Cluster.MithrilSpec
     Test.Hydra.Cluster.Utils
+    Test.Hydra.Cluster.UtilSpec
     Test.OfflineChainSpec
 
   build-depends:

--- a/hydra-cluster/src/Hydra/Cluster/Faucet.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Faucet.hs
@@ -197,26 +197,14 @@ seedFromFaucetBlockfrost receivingVerificationKey lovelace = do
           void $ Blockfrost.awaitUTxO networkId [changeAddress] signedTx
           Blockfrost.awaitUTxO networkId [receivingAddress] signedTx
 
--- | Select enough entries to cover the given amount, largest first so the fewest
--- inputs are spent. NOTE: Selecting across entries rather than requiring a
--- single large enough one matters once a caller asks for more than one payout
--- at a time: the faucet's own change and the funds actors return to it are
--- individually smaller than such a sum, and would otherwise stop being usable.
 findUTxO :: MonadIO m => UTxO.UTxO Era -> Lovelace -> m (UTxO.UTxO Era)
-findUTxO utxo lovelace' =
-  case select mempty 0 (sortOn (Down . lovelaceOf . snd) (UTxO.toList utxo)) of
-    Nothing -> liftIO $ throwIO FaucetHasNotEnoughFunds{faucetUTxO = utxo}
-    Just selected -> pure $ UTxO.fromList selected
- where
-  select acc total = \case
-    rest
-      | total >= lovelace' -> Just acc
-      | otherwise -> case rest of
-          [] -> Nothing
-          (o : os) -> select (o : acc) (total + lovelaceOf (snd o)) os
-
-  lovelaceOf :: TxOut CtxUTxO -> Lovelace
-  lovelaceOf = selectLovelace . txOutValue
+findUTxO utxo lovelace' = do
+  let foundUTxO = UTxO.find (\o -> (selectLovelace . txOutValue) o >= lovelace') utxo
+  when (isNothing foundUTxO) $
+    liftIO $
+      throwIO $
+        FaucetHasNotEnoughFunds{faucetUTxO = utxo}
+  pure $ maybe mempty (uncurry UTxO.singleton) foundUTxO
 
 -- | Like 'seedFromFaucet', but without returning the seeded 'UTxO'.
 seedFromFaucet_ ::

--- a/hydra-cluster/src/Hydra/Cluster/Faucet.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Faucet.hs
@@ -197,14 +197,30 @@ seedFromFaucetBlockfrost receivingVerificationKey lovelace = do
           void $ Blockfrost.awaitUTxO networkId [changeAddress] signedTx
           Blockfrost.awaitUTxO networkId [receivingAddress] signedTx
 
+-- | Select entries covering the given amount, largest first, and sweep up to
+-- 'sweepLimit' of the smallest remaining entries into the selection. Both parts
+-- keep the faucet usable across runs: outputs smaller than a requested amount
+-- (e.g. what 'returnFundsToFaucet' pays back) would otherwise never be spent
+-- again, while the change output alone shrinks with every seeding.
 findUTxO :: MonadIO m => UTxO.UTxO Era -> Lovelace -> m (UTxO.UTxO Era)
-findUTxO utxo lovelace' = do
-  let foundUTxO = UTxO.find (\o -> (selectLovelace . txOutValue) o >= lovelace') utxo
-  when (isNothing foundUTxO) $
-    liftIO $
-      throwIO $
-        FaucetHasNotEnoughFunds{faucetUTxO = utxo}
-  pure $ maybe mempty (uncurry UTxO.singleton) foundUTxO
+findUTxO utxo lovelace' =
+  go 0 [] (sortOn (Down . lovelaceOf . snd) (UTxO.toList utxo))
+ where
+  go total selected rest
+    | total >= lovelace' =
+        pure $ UTxO.fromList (selected <> take sweepLimit (reverse rest))
+    | otherwise = case rest of
+        [] -> liftIO $ throwIO FaucetHasNotEnoughFunds{faucetUTxO = utxo}
+        entry : more -> go (total + lovelaceOf (snd entry)) (entry : selected) more
+
+  lovelaceOf :: TxOut CtxUTxO -> Lovelace
+  lovelaceOf = selectLovelace . txOutValue
+
+-- | Cap on the extra entries 'findUTxO' sweeps into a transaction, bounding its
+-- size. Consolidation only has to outpace the one or two outputs a scenario
+-- returns to the faucet per run.
+sweepLimit :: Int
+sweepLimit = 20
 
 -- | Like 'seedFromFaucet', but without returning the seeded 'UTxO'.
 seedFromFaucet_ ::

--- a/hydra-cluster/src/Hydra/Cluster/Faucet.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Faucet.hs
@@ -81,29 +81,70 @@ seedFromFaucetWithMinting ::
   Tracer IO FaucetLog ->
   Maybe PlutusScript ->
   IO UTxO
-seedFromFaucetWithMinting opts receivingVerificationKey val tracer mintingScript = do
+seedFromFaucetWithMinting opts receivingVerificationKey val tracer mintingScript =
+  seedManyFromFaucetWithMinting opts [(receivingVerificationKey, val)] tracer mintingScript >>= \case
+    [utxo] -> pure utxo
+    utxos -> failure $ "seedFromFaucetWithMinting: expected one seeded UTxO, got " <> show (length utxos)
+
+-- | Like 'seedFromFaucet' but pays every recipient from a single faucet
+-- transaction. A scenario needing more than one funded key then waits for one
+-- confirmation instead of one per key, which is a block time each on a public
+-- network.
+seedManyFromFaucet ::
+  ChainBackendOptions ->
+  -- | Recipients of the funds and the value each is to receive.
+  [(VerificationKey PaymentKey, Value)] ->
+  Tracer IO FaucetLog ->
+  -- | The seeded UTxO of each recipient, in the order given.
+  IO [UTxO]
+seedManyFromFaucet opts recipients tracer =
+  seedManyFromFaucetWithMinting opts recipients tracer Nothing
+
+seedManyFromFaucetWithMinting ::
+  ChainBackendOptions ->
+  -- | Recipients of the funds and the value each is to receive.
+  [(VerificationKey PaymentKey, Value)] ->
+  Tracer IO FaucetLog ->
+  Maybe PlutusScript ->
+  -- | The seeded UTxO of each recipient, in the order given.
+  IO [UTxO]
+seedManyFromFaucetWithMinting _ [] _ _ = pure []
+seedManyFromFaucetWithMinting opts recipients tracer mintingScript = do
   (faucetVk, faucetSk) <- keysFor Faucet
   networkId <- runBackend opts queryNetworkId
   seedTx <- retryOnExceptions tracer opts $ submitSeedTx faucetVk faucetSk networkId
-  producedUTxO <- runBackend opts $ awaitTransaction seedTx receivingVerificationKey
-  pure $ UTxO.filter (== toCtxUTxOTxOut (theOutput networkId)) producedUTxO
+  -- NOTE: The direct backend's 'awaitTransaction' yields all of the tx's
+  -- outputs while the Blockfrost one yields only those paying to the given key,
+  -- so ask per recipient and filter. Only the first call waits for the
+  -- transaction, the rest are already satisfied by it.
+  forM recipients $ \(vk, val) -> do
+    seeded <-
+      UTxO.filter (== toCtxUTxOTxOut (theOutput networkId vk val))
+        <$> runBackend opts (awaitTransaction seedTx vk)
+    -- An empty result means the output we asked for is not the one that landed
+    -- (a value normalised on the way out, say). Say so here rather than let the
+    -- caller trip over an empty UTxO much later.
+    when (UTxO.null seeded) $
+      failure $
+        "seedManyFromFaucet: no output of " <> show val <> " for " <> show vk <> " in " <> show (getTxId $ getTxBody seedTx)
+    pure seeded
  where
   submitSeedTx faucetVk faucetSk networkId = do
-    faucetUTxO <- findFaucetUTxO networkId opts (selectLovelace val)
+    faucetUTxO <- findFaucetUTxO networkId opts (sum $ selectLovelace . snd <$> recipients)
     let changeAddress = mkVkAddress networkId faucetVk
+    let outputs = uncurry (theOutput networkId) <$> recipients
 
-    runBackend opts (buildTransactionWithMintingScript changeAddress faucetUTxO (toList $ UTxO.inputSet faucetUTxO) [theOutput networkId] mintingScript) >>= \case
+    runBackend opts (buildTransactionWithMintingScript changeAddress faucetUTxO (toList $ UTxO.inputSet faucetUTxO) outputs mintingScript) >>= \case
       Left e -> throwIO $ FaucetFailedToBuildTx{reason = e}
       Right tx -> do
         let signedTx = sign faucetSk (getTxBody tx)
         runBackend opts $ submitTransaction signedTx
         pure signedTx
 
-  receivingAddress = buildAddress receivingVerificationKey
-
-  theOutput networkId =
+  theOutput :: NetworkId -> VerificationKey PaymentKey -> Value -> TxOut CtxTx
+  theOutput networkId vk val =
     TxOut
-      (shelleyAddressInEra shelleyBasedEra (receivingAddress networkId))
+      (shelleyAddressInEra shelleyBasedEra (buildAddress vk networkId))
       val
       TxOutDatumNone
       ReferenceScriptNone
@@ -156,14 +197,26 @@ seedFromFaucetBlockfrost receivingVerificationKey lovelace = do
           void $ Blockfrost.awaitUTxO networkId [changeAddress] signedTx
           Blockfrost.awaitUTxO networkId [receivingAddress] signedTx
 
+-- | Select enough entries to cover the given amount, largest first so the fewest
+-- inputs are spent. NOTE: Selecting across entries rather than requiring a
+-- single large enough one matters once a caller asks for more than one payout
+-- at a time: the faucet's own change and the funds actors return to it are
+-- individually smaller than such a sum, and would otherwise stop being usable.
 findUTxO :: MonadIO m => UTxO.UTxO Era -> Lovelace -> m (UTxO.UTxO Era)
-findUTxO utxo lovelace' = do
-  let foundUTxO = UTxO.find (\o -> (selectLovelace . txOutValue) o >= lovelace') utxo
-  when (isNothing foundUTxO) $
-    liftIO $
-      throwIO $
-        FaucetHasNotEnoughFunds{faucetUTxO = utxo}
-  pure $ maybe mempty (uncurry UTxO.singleton) foundUTxO
+findUTxO utxo lovelace' =
+  case select mempty 0 (sortOn (Down . lovelaceOf . snd) (UTxO.toList utxo)) of
+    Nothing -> liftIO $ throwIO FaucetHasNotEnoughFunds{faucetUTxO = utxo}
+    Just selected -> pure $ UTxO.fromList selected
+ where
+  select acc total = \case
+    rest
+      | total >= lovelace' -> Just acc
+      | otherwise -> case rest of
+          [] -> Nothing
+          (o : os) -> select (o : acc) (total + lovelaceOf (snd o)) os
+
+  lovelaceOf :: TxOut CtxUTxO -> Lovelace
+  lovelaceOf = selectLovelace . txOutValue
 
 -- | Like 'seedFromFaucet', but without returning the seeded 'UTxO'.
 seedFromFaucet_ ::

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -51,7 +51,7 @@ import Hydra.Cardano.Api (
   Coin (..),
   Era,
   File (File),
-  Key (SigningKey),
+  Key (SigningKey, VerificationKey),
   KeyWitnessInCtx (..),
   LedgerProtocolParameters (..),
   PaymentKey,
@@ -104,10 +104,10 @@ import Hydra.Cardano.Api qualified as CAPI
 import Hydra.Chain (PostTxError (..))
 import Hydra.Chain.Backend (ChainBackend (..), buildTransaction, buildTransactionWithPParams, buildTransactionWithPParams')
 import Hydra.Chain.ChainState (ChainSlot (..))
-import Hydra.Cluster.Faucet (createOutputAtAddress, seedFromFaucet, seedFromFaucet_)
+import Hydra.Cluster.Faucet (createOutputAtAddress, seedFromFaucet, seedFromFaucet_, seedManyFromFaucet)
 import Hydra.Cluster.Faucet qualified as Faucet
 import Hydra.Cluster.Fixture (Actor (..), actorName, alice, aliceSk, aliceVk, bob, bobSk, bobVk, carol, carolSk, carolVk)
-import Hydra.Cluster.Util (Timing (..), chainConfigFor, chainConfigFor', depositTimeout, keysFor, mkTestTiming, mkTestTiming', modifyConfig, nodeStartupBudget, setNetworkId, truncatedDepositPeriod)
+import Hydra.Cluster.Util (BlockTime, Timing (..), chainConfigFor, chainConfigFor', depositTimeout, keysFor, mkTestTiming, mkTestTiming', modifyConfig, nodeStartupBudget, setNetworkId, truncatedDepositPeriod)
 import Hydra.Contract.Dummy (dummyRewardingScript, dummyValidatorScript)
 import Hydra.Ledger.Cardano (mkSimpleTx, mkTransferTx, unsafeBuildTransaction)
 import Hydra.Logging (Tracer, traceWith)
@@ -115,7 +115,6 @@ import Hydra.Network qualified as Network
 import Hydra.Node.UnsyncedPeriod (defaultUnsyncedPeriodFor, unsyncedPeriodToNominalDiffTime)
 import Hydra.Options (CardanoChainConfig (..), ChainBackendOptions (..), ChainConfig (..), DirectOptions (..), RunOptions (..), startChainFrom)
 import Hydra.Tx (HeadId (..), IsTx (balance), Party, txId)
-import Hydra.Tx.ContestationPeriod qualified as CP
 import Hydra.Tx.Crypto (getVerificationKey, signTx)
 import Hydra.Tx.Deposit (constructDepositUTxO)
 import Hydra.Tx.Secret (Secret, mkSecret)
@@ -519,35 +518,44 @@ nodeReObservesOnChainTxs tracer workDir opts hydraScriptsTxId = do
 
 -- | Step through the full life cycle of a Hydra Head with only a single
 -- participant. This scenario is also used by the smoke test run via the
--- `hydra-cluster` executable.
+-- `hydra-cluster` executable, which passes 'mkSmokeTiming' rather than
+-- 'mkTestTiming' on the networks where the protocol waits dominate.
 singlePartyHeadFullLifeCycle ::
   Tracer IO EndToEndLog ->
   FilePath ->
+  -- | How to derive the timing parameters from the chain's block time.
+  (BlockTime -> Timing) ->
   ChainBackendOptions ->
   [TxId] ->
   IO ()
-singlePartyHeadFullLifeCycle tracer workDir opts hydraScriptsTxId =
+singlePartyHeadFullLifeCycle tracer workDir mkTiming opts hydraScriptsTxId =
   (`finally` returnFundsToFaucet tracer opts Alice) $ do
-    refuelIfNeeded tracer opts Alice 55_000_000
-    -- Start hydra-node on chain tip
-    tip <- runBackend opts queryTip
     blockTime <- runBackend opts getBlockTime
     networkId <- runBackend opts queryNetworkId
-    let timing = mkTestTiming blockTime
-    let Timing{depositPeriod = timingDepositPeriod, depositActivation = timingDepositActivation} = timing
-    contestationPeriod <- CP.fromNominalDiffTime $ 20 * blockTime
-    aliceChainConfig <-
-      chainConfigFor' Alice workDir opts hydraScriptsTxId [] contestationPeriod timingDepositPeriod timingDepositActivation
-        <&> modifyConfig (\config -> config{startChainFrom = Just tip})
-          . setNetworkId networkId
+    let timing = mkTiming blockTime
+
+    -- NOTE: Take the tip before funding, so the funding transaction is
+    -- guaranteed to land after it. The node is started at this point and only
+    -- leaves 'CatchingUp' on a chain tick, which is emitted on roll forward
+    -- alone -- pinned to the bare tip it would sit there until the next block.
+    tip <- runBackend opts queryTip
 
     (aliceCardanoVk, aliceCardanoSk) <- keysFor Alice
     let aliceAddress = mkVkAddress networkId aliceCardanoVk
 
-    -- Prepare deposit payload
+    -- Prepare deposit payload. Alice's fuel and the wallet's deposit come from
+    -- one faucet transaction, so this costs a single confirmation.
     (walletVk, walletSk) <- generate genKeyPair
     let depositAmount = 10_000_000
-    depositUTxO <- seedFromFaucet opts walletVk (lovelaceToValue depositAmount) (contramap FromFaucet tracer)
+    depositUTxO <-
+      refuelAndSeed tracer opts Alice 55_000_000 [(walletVk, lovelaceToValue depositAmount)] >>= \case
+        [utxo] -> pure utxo
+        utxos -> failure $ "expected exactly one seeded deposit UTxO, got " <> show (length utxos)
+
+    aliceChainConfig <-
+      chainConfigFor Alice workDir opts hydraScriptsTxId [] timing
+        <&> modifyConfig (\config -> config{startChainFrom = Just tip})
+          . setNetworkId networkId
     let changeAddress = mkVkAddress @Era networkId walletVk
     let (i, o) = List.head $ UTxO.toList depositUTxO
     let witness = BuildTxWith $ KeyWitness KeyWitnessForSpending
@@ -2106,14 +2114,33 @@ refuelIfNeeded ::
   Actor ->
   Coin ->
   IO ()
-refuelIfNeeded tracer opts actor amount = do
+refuelIfNeeded tracer opts actor amount =
+  void $ refuelAndSeed tracer opts actor amount []
+
+-- | Like 'refuelIfNeeded', but seeds further keys from the same faucet
+-- transaction and returns their UTxO. Each faucet transaction costs an on-chain
+-- confirmation, a block time on a public network, so a scenario needing several
+-- funded keys is better off asking for them together.
+refuelAndSeed ::
+  Tracer IO EndToEndLog ->
+  ChainBackendOptions ->
+  Actor ->
+  -- | Amount the actor is to hold before the scenario starts.
+  Coin ->
+  -- | Further keys to seed, and the value each is to receive.
+  [(VerificationKey PaymentKey, CAPI.Value)] ->
+  -- | The seeded UTxO of each further key, in the order given.
+  IO [UTxO]
+refuelAndSeed tracer opts actor amount seeds = do
   (actorVk, _) <- keysFor actor
   existingUtxo <- runBackend opts $ queryUTxOFor QueryTip actorVk
   traceWith tracer $ StartingFunds{actor = actorName actor, utxo = existingUtxo}
-  let currentBalance = selectLovelace $ balance @Tx existingUtxo
-  when (currentBalance < amount) $ do
-    utxo <- seedFromFaucet opts actorVk (lovelaceToValue amount) (contramap FromFaucet tracer)
+  let refuel = [(actorVk, lovelaceToValue amount) | selectLovelace (balance @Tx existingUtxo) < amount]
+  seeded <- seedManyFromFaucet opts (refuel <> seeds) (contramap FromFaucet tracer)
+  let (refueled, seededUTxO) = splitAt (length refuel) seeded
+  forM_ refueled $ \utxo ->
     traceWith tracer $ RefueledFunds{actor = actorName actor, refuelingAmount = amount, utxo}
+  pure seededUTxO
 
 -- | Return the remaining funds to the faucet
 returnFundsToFaucet ::

--- a/hydra-cluster/src/Hydra/Cluster/Util.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Util.hs
@@ -109,40 +109,41 @@ mkTestTiming' numDeposits blockTime =
 
 -- | Timing for the smoke test run by the @hydra-cluster@ executable against a
 -- public network, where a block takes ~20s and the run is dominated by waiting
--- out 'depositActivation' and the contestation period rather than by anything
--- the scenario asserts. Both waits are shaped by @maxGraceTime = 200@ in
--- 'Hydra.Chain.Direct.Handlers'.
+-- out 'depositActivation' rather than by anything the scenario asserts.
 --
 -- A deposit becomes active at @created + depositActivation@, where @created@ is
--- the deposit tx's upper validity bound, itself a grace time ahead of the chain
--- tip. The grace time is not ours to set, so 'depositActivation' is the whole
--- lever: at one block time the wait drops from @200 + 400@ to @200 + 20@.
+-- the deposit tx's upper validity bound, set a grace time ahead of the chain
+-- tip by 'Hydra.Chain.Direct.Handlers.draftDepositTx'. That grace time is
+-- @maxGraceTime \`min\` untilDeadline / 2@, and a backticked function binds
+-- tighter than @\/@, so it is @min 200 untilDeadline / 2@: a flat 100s for any
+-- deadline more than 200s out, not the @min 200 (untilDeadline \/ 2)@ it reads
+-- as. So the wait is @100 + depositActivation@, and only the second term is
+-- ours: at one block time it drops from 100 + 400 to 100 + 20.
 --
--- The contestation deadline is @closeTxUpperBound + contestationPeriod@, and
--- the close tx's upper bound is @now + min contestationPeriod maxGraceTime@, so
--- closing costs @min cp 200 + cp@. Both terms fall together below 200s; the
--- price is that the close and increment transactions get a @cp@-long window to
--- be included (five blocks here), and there is no resubmit on expiry.
+-- 'contestationPeriod' is cut to the point where the close transaction's
+-- validity window stops changing, and no further. The contestation deadline is
+-- @closeTxUpperBound + contestationPeriod@ with the close tx bounded at
+-- @now + min contestationPeriod maxGraceTime@, so at @10 * blockTime@ = 200s
+-- the wait halves from 600s to 400s while that @min@ still yields 200s, exactly
+-- as it does at 'mkTestTiming'\'s 400s. Going below 200s would start shortening
+-- the window every close, contest and increment has to be included in, with no
+-- resubmit on expiry, and would drag two things with it: the derived
+-- @unsyncedPeriod@ (half the contestation period, against a Blockfrost follower
+-- that only observes blocks with a successor and so lags a block gap by
+-- construction) and 'Hydra.Chain.Blockfrost.Client.submissionRetryPolicy',
+-- whose ~180s worst case is documented against a 200s window.
 --
--- 'unsyncedPeriod' is deliberately left at the node's default of @cp \/ 2@.
--- Drift is only sampled when a block arrives ('handleOutOfSync' runs from the
--- @Tick@ input, which 'Hydra.Chain.Direct.Handlers.onRollForward' is the sole
--- source of), so it measures block processing lag rather than the gap between
--- blocks, and it must stay under @min cp maxGraceTime@ anyway: a node acting
--- while drifted further than that builds close transactions whose validity
--- bound is already in the past.
---
--- 'depositPeriod' deliberately keeps its 'mkTestTiming' value. It is not on the
--- critical path -- it sets how long a deposit stays active, not how long
--- anything waits -- and shortening it only eats that window, which is
--- @depositPeriod - graceTime@ with @graceTime@ up to @maxGraceTime@. At or
--- below 200s a deposit would expire the moment it activates and the increment
--- could never be posted. 'Test.Hydra.Cluster.UtilSpec' guards this.
+-- 'depositPeriod' keeps its 'mkTestTiming' value. It is not on the critical
+-- path -- it sets how long a deposit stays active, not how long anything waits
+-- -- and shortening it only eats that window, which is
+-- @depositPeriod - graceTime@. NOTE: This assumes block times around 20s; the
+-- window closes entirely below ~5s, where 'depositPeriod' falls to the flat
+-- 100s grace time. 'Test.Hydra.Cluster.UtilSpec' guards the value used here.
 mkSmokeTiming :: BlockTime -> Timing
 mkSmokeTiming blockTime =
   Timing
     { blockTime
-    , contestationPeriod = truncate $ max 1 (5 * blockTime)
+    , contestationPeriod = truncate $ max 1 (10 * blockTime)
     , depositPeriod = truncatedDepositPeriod $ max 1 (20 * blockTime)
     , depositActivation = truncatedDepositPeriod $ max 1 blockTime
     }

--- a/hydra-cluster/src/Hydra/Cluster/Util.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Util.hs
@@ -113,12 +113,10 @@ mkTestTiming' numDeposits blockTime =
 --
 -- A deposit becomes active at @created + depositActivation@, where @created@ is
 -- the deposit tx's upper validity bound, set a grace time ahead of the chain
--- tip by 'Hydra.Chain.Direct.Handlers.draftDepositTx'. That grace time is
--- @maxGraceTime \`min\` untilDeadline / 2@, and a backticked function binds
--- tighter than @\/@, so it is @min 200 untilDeadline / 2@: a flat 100s for any
--- deadline more than 200s out, not the @min 200 (untilDeadline \/ 2)@ it reads
--- as. So the wait is @100 + depositActivation@, and only the second term is
--- ours: at one block time it drops from 100 + 400 to 100 + 20.
+-- tip by 'Hydra.Chain.Direct.Handlers.draftDepositTx'. That grace time caps at
+-- @min maxGraceTime (depositPeriod / 2)@, 200s here, so the wait is
+-- @200 + depositActivation@ and only the second term is ours: at one block
+-- time it drops from 200 + 400 to 200 + 20.
 --
 -- 'contestationPeriod' is cut to the point where the close transaction's
 -- validity window stops changing, and no further. The contestation deadline is
@@ -135,10 +133,10 @@ mkTestTiming' numDeposits blockTime =
 --
 -- 'depositPeriod' keeps its 'mkTestTiming' value. It is not on the critical
 -- path -- it sets how long a deposit stays active, not how long anything waits
--- -- and shortening it only eats that window, which is
--- @depositPeriod - graceTime@. NOTE: This assumes block times around 20s; the
--- window closes entirely below ~5s, where 'depositPeriod' falls to the flat
--- 100s grace time. 'Test.Hydra.Cluster.UtilSpec' guards the value used here.
+-- -- and shortening it only shrinks windows: the grace time is capped at half
+-- of it, so both the deposit tx's validity and the active window
+-- @depositPeriod - graceTime@ fall with it. 'Test.Hydra.Cluster.UtilSpec'
+-- guards the value used here.
 mkSmokeTiming :: BlockTime -> Timing
 mkSmokeTiming blockTime =
   Timing

--- a/hydra-cluster/src/Hydra/Cluster/Util.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Util.hs
@@ -107,6 +107,46 @@ mkTestTiming' numDeposits blockTime =
  where
   depositPeriod = truncatedDepositPeriod $ fromIntegral numDeposits * 20 * blockTime
 
+-- | Timing for the smoke test run by the @hydra-cluster@ executable against a
+-- public network, where a block takes ~20s and the run is dominated by waiting
+-- out 'depositActivation' and the contestation period rather than by anything
+-- the scenario asserts. Both waits are shaped by @maxGraceTime = 200@ in
+-- 'Hydra.Chain.Direct.Handlers'.
+--
+-- A deposit becomes active at @created + depositActivation@, where @created@ is
+-- the deposit tx's upper validity bound, itself a grace time ahead of the chain
+-- tip. The grace time is not ours to set, so 'depositActivation' is the whole
+-- lever: at one block time the wait drops from @200 + 400@ to @200 + 20@.
+--
+-- The contestation deadline is @closeTxUpperBound + contestationPeriod@, and
+-- the close tx's upper bound is @now + min contestationPeriod maxGraceTime@, so
+-- closing costs @min cp 200 + cp@. Both terms fall together below 200s; the
+-- price is that the close and increment transactions get a @cp@-long window to
+-- be included (five blocks here), and there is no resubmit on expiry.
+--
+-- 'unsyncedPeriod' is deliberately left at the node's default of @cp \/ 2@.
+-- Drift is only sampled when a block arrives ('handleOutOfSync' runs from the
+-- @Tick@ input, which 'Hydra.Chain.Direct.Handlers.onRollForward' is the sole
+-- source of), so it measures block processing lag rather than the gap between
+-- blocks, and it must stay under @min cp maxGraceTime@ anyway: a node acting
+-- while drifted further than that builds close transactions whose validity
+-- bound is already in the past.
+--
+-- 'depositPeriod' deliberately keeps its 'mkTestTiming' value. It is not on the
+-- critical path -- it sets how long a deposit stays active, not how long
+-- anything waits -- and shortening it only eats that window, which is
+-- @depositPeriod - graceTime@ with @graceTime@ up to @maxGraceTime@. At or
+-- below 200s a deposit would expire the moment it activates and the increment
+-- could never be posted. 'Test.Hydra.Cluster.UtilSpec' guards this.
+mkSmokeTiming :: BlockTime -> Timing
+mkSmokeTiming blockTime =
+  Timing
+    { blockTime
+    , contestationPeriod = truncate $ max 1 (5 * blockTime)
+    , depositPeriod = truncatedDepositPeriod $ max 1 (20 * blockTime)
+    , depositActivation = truncatedDepositPeriod $ max 1 blockTime
+    }
+
 -- | Get a timeout until a deposit should have happened given a 'Timing'. A
 -- deposit becomes active after 'depositActivation' and then needs about one
 -- 'depositPeriod' to be picked up and incremented, so both are accounted for

--- a/hydra-cluster/test/Main.hs
+++ b/hydra-cluster/test/Main.hs
@@ -13,6 +13,7 @@ import Test.Hydra.Cluster.CardanoCliSpec qualified
 import Test.Hydra.Cluster.FaucetSpec qualified
 import Test.Hydra.Cluster.HydraClientSpec qualified
 import Test.Hydra.Cluster.MithrilSpec qualified
+import Test.Hydra.Cluster.UtilSpec qualified
 import Test.Hydra.TastyMain (hydraTestTree, runHydraTests, testSpec)
 import Test.OfflineChainSpec qualified
 import Test.Tasty (localOption)
@@ -48,6 +49,7 @@ main = do
       , testSpec "Hydra.Cluster.Faucet" Test.Hydra.Cluster.FaucetSpec.spec
       , testSpec "Hydra.Cluster.HydraClient" Test.Hydra.Cluster.HydraClientSpec.spec
       , testSpec "Hydra.Cluster.Mithril" Test.Hydra.Cluster.MithrilSpec.spec
+      , testSpec "Hydra.Cluster.Util" Test.Hydra.Cluster.UtilSpec.spec
       , testSpec "OfflineChain" Test.OfflineChainSpec.spec
       ]
   runHydraTests "hydra-cluster" (localOption (NumThreads 1) tree)

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -242,7 +242,7 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
       it "full head life-cycle" $ \tracer ->
         withClusterTempDir $ \tmpDir ->
           withHydraScriptsAndBackendRunning tracer tmpDir $
-            singlePartyHeadFullLifeCycle tracer tmpDir
+            singlePartyHeadFullLifeCycle tracer tmpDir mkTestTiming
       it "can close with long deadline" $ \tracer ->
         withClusterTempDir $ \tmpDir ->
           withHydraScriptsAndBackendRunning tracer tmpDir $

--- a/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/FaucetSpec.hs
@@ -30,13 +30,28 @@ setupDevnet action =
 spec :: Spec
 spec =
   around setupDevnet $ do
-    describe "seedFromFaucet" $
+    describe "seedFromFaucet" $ do
       it "should work concurrently when called multiple times with the same amount of lovelace" $ \(tracer, opts) -> do
         utxos <- replicateConcurrently 10 $ do
           vk <- generate genVerificationKey
           seedFromFaucet opts vk (lovelaceToValue 1_000_000) tracer
         -- 10 unique outputs
         UTxO.size (fold utxos) `shouldBe` 10
+
+      it "sweeps small faucet outputs into the change" $ \(tracer, opts) -> do
+        (faucetVk, _) <- keysFor Faucet
+        -- Litter the faucet with outputs below the amount asked for next; on a
+        -- long-lived network these accumulate from 'returnFundsToFaucet' and
+        -- would otherwise never be spent again.
+        forM_ [Alice, Bob, Carol] $ \actor -> do
+          (vk, _) <- keysFor actor
+          void $ seedFromFaucet opts vk (lovelaceToValue 2_000_000) tracer
+          returnFundsToFaucet tracer opts actor
+        littered <- runBackend opts $ queryUTxOFor QueryTip faucetVk
+        vk <- generate genVerificationKey
+        void $ seedFromFaucet opts vk (lovelaceToValue 5_000_000) tracer
+        swept <- runBackend opts $ queryUTxOFor QueryTip faucetVk
+        UTxO.size swept `shouldSatisfy` (< UTxO.size littered)
 
     describe "returnFundsToFaucet" $ do
       it "does nothing if nothing to return" $ \(tracer, opts) -> do
@@ -55,8 +70,9 @@ spec =
               finalFaucetFunds <- runBackend opts $ queryUTxOFor QueryTip faucetVk
               UTxO.totalValue remaining `shouldBe` mempty
 
-              -- check the faucet has one utxo extra in the end
-              UTxO.size finalFaucetFunds `shouldBe` UTxO.size initialFaucetFunds + 1
+              -- check the faucet has at most one utxo extra in the end; the
+              -- seeding sweeps previously returned outputs into its change
+              UTxO.size finalFaucetFunds `shouldSatisfy` (<= UTxO.size initialFaucetFunds + 1)
 
               let initialFaucetValue = selectLovelace (UTxO.totalValue initialFaucetFunds)
               let finalFaucetValue = selectLovelace (UTxO.totalValue finalFaucetFunds)

--- a/hydra-cluster/test/Test/Hydra/Cluster/UtilSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/UtilSpec.hs
@@ -36,9 +36,13 @@ spec = describe "mkSmokeTiming" $ do
   it "gives close and contest transactions several blocks to be included" $ do
     -- They are built with this upper bound and are not resubmitted if they
     -- expire first, so the contestation period cannot be cut arbitrarily.
+    -- At 10 * blockTime this still yields maxGraceTime, the same window
+    -- 'mkTestTiming' gives, so nothing here is more likely to expire than
+    -- before. Below that it starts shrinking, and takes the derived
+    -- unsyncedPeriod and Blockfrost's submission retry budget with it.
     let Timing{contestationPeriod} = mkSmokeTiming publicBlockTime
     min maxGraceTime (CP.toNominalDiffTime contestationPeriod)
-      `shouldSatisfy` (>= 4 * publicBlockTime)
+      `shouldBe` maxGraceTime
  where
   -- Mirrors 'Hydra.HeadLogic.determineNextDepositStatus' against the bounds
   -- 'Hydra.Chain.Direct.Handlers.draftDepositTx' and
@@ -46,7 +50,11 @@ spec = describe "mkSmokeTiming" $ do
   activeWindow Timing{depositPeriod, depositActivation} =
     DP.toNominalDiffTime depositPeriod - graceTime
    where
-    graceTime = max 10 . min maxGraceTime $ deadlineOffset / 2
+    -- NOTE: Handlers.hs reads @maxGraceTime `min` untilDeadline / 2@; a
+    -- backticked function is infixl 9 and @/@ is infixl 7, so the division
+    -- applies to the @min@, not to @untilDeadline@ alone. Mirrored as written,
+    -- not as it reads.
+    graceTime = max 10 $ min maxGraceTime deadlineOffset / 2
 
     deadlineOffset =
       DP.toNominalDiffTime depositActivation + 2 * DP.toNominalDiffTime depositPeriod

--- a/hydra-cluster/test/Test/Hydra/Cluster/UtilSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/UtilSpec.hs
@@ -19,9 +19,9 @@ spec = describe "mkSmokeTiming" $ do
     -- 'depositActivation' after that date and expires one 'depositPeriod'
     -- before its deadline, which is set from wall-clock time. With the tip
     -- current -- the worst case -- the window in which the increment can be
-    -- posted is 'depositPeriod' - 'graceTime'. Shrinking 'depositPeriod'
-    -- towards 'maxGraceTime' closes it, and because 'Expired' is tested before
-    -- 'Active' the deposit then skips being active altogether.
+    -- posted is 'depositPeriod' - 'graceTime', and because 'Expired' is tested
+    -- before 'Active' a deposit with a closed window skips being active
+    -- altogether.
     activeWindow (mkSmokeTiming publicBlockTime)
       `shouldSatisfy` (>= 5 * publicBlockTime)
 
@@ -50,11 +50,10 @@ spec = describe "mkSmokeTiming" $ do
   activeWindow Timing{depositPeriod, depositActivation} =
     DP.toNominalDiffTime depositPeriod - graceTime
    where
-    -- NOTE: Handlers.hs reads @maxGraceTime `min` untilDeadline / 2@; a
-    -- backticked function is infixl 9 and @/@ is infixl 7, so the division
-    -- applies to the @min@, not to @untilDeadline@ alone. Mirrored as written,
-    -- not as it reads.
-    graceTime = max 10 $ min maxGraceTime deadlineOffset / 2
+    graceTime =
+      max 10 $
+        min maxGraceTime $
+          min (deadlineOffset / 2) (DP.toNominalDiffTime depositPeriod / 2)
 
     deadlineOffset =
       DP.toNominalDiffTime depositActivation + 2 * DP.toNominalDiffTime depositPeriod

--- a/hydra-cluster/test/Test/Hydra/Cluster/UtilSpec.hs
+++ b/hydra-cluster/test/Test/Hydra/Cluster/UtilSpec.hs
@@ -1,0 +1,57 @@
+module Test.Hydra.Cluster.UtilSpec where
+
+import Hydra.Prelude
+import Test.Hydra.Prelude
+
+import Hydra.Chain.Direct.Handlers (maxGraceTime)
+import Hydra.Cluster.Util (BlockTime, Timing (..), mkSmokeTiming)
+import Hydra.Tx.ContestationPeriod qualified as CP
+import Hydra.Tx.DepositPeriod qualified as DP
+
+-- | The periods 'mkSmokeTiming' produces are cut close enough to the bounds
+-- 'Hydra.Chain.Direct.Handlers' puts on transactions that the failures are not
+-- local: too short and the smoke test hangs on a public network for its full
+-- timeout, half an hour after anyone was watching.
+spec :: Spec
+spec = describe "mkSmokeTiming" $ do
+  it "leaves the increment a window after the deposit activates" $ do
+    -- A deposit is dated 'graceTime' ahead of the chain tip, becomes active
+    -- 'depositActivation' after that date and expires one 'depositPeriod'
+    -- before its deadline, which is set from wall-clock time. With the tip
+    -- current -- the worst case -- the window in which the increment can be
+    -- posted is 'depositPeriod' - 'graceTime'. Shrinking 'depositPeriod'
+    -- towards 'maxGraceTime' closes it, and because 'Expired' is tested before
+    -- 'Active' the deposit then skips being active altogether.
+    activeWindow (mkSmokeTiming publicBlockTime)
+      `shouldSatisfy` (>= 5 * publicBlockTime)
+
+  it "keeps depositPeriod above the increment tx's own grace time" $ do
+    -- Independently of the window above, the @Claim@ path of the deposit
+    -- validator requires the increment tx's upper bound, @now + min
+    -- contestationPeriod maxGraceTime@, to be at or before the deposit deadline.
+    let Timing{contestationPeriod, depositPeriod} = mkSmokeTiming publicBlockTime
+    DP.toNominalDiffTime depositPeriod
+      `shouldSatisfy` (>= min maxGraceTime (CP.toNominalDiffTime contestationPeriod))
+
+  it "gives close and contest transactions several blocks to be included" $ do
+    -- They are built with this upper bound and are not resubmitted if they
+    -- expire first, so the contestation period cannot be cut arbitrarily.
+    let Timing{contestationPeriod} = mkSmokeTiming publicBlockTime
+    min maxGraceTime (CP.toNominalDiffTime contestationPeriod)
+      `shouldSatisfy` (>= 4 * publicBlockTime)
+ where
+  -- Mirrors 'Hydra.HeadLogic.determineNextDepositStatus' against the bounds
+  -- 'Hydra.Chain.Direct.Handlers.draftDepositTx' and
+  -- 'Hydra.API.HTTPServer.handleDraftCommitUtxo' put on a deposit.
+  activeWindow Timing{depositPeriod, depositActivation} =
+    DP.toNominalDiffTime depositPeriod - graceTime
+   where
+    graceTime = max 10 . min maxGraceTime $ deadlineOffset / 2
+
+    deadlineOffset =
+      DP.toNominalDiffTime depositActivation + 2 * DP.toNominalDiffTime depositPeriod
+
+  -- preview, preprod and mainnet all have a 1s slot length and an active slot
+  -- coefficient of 0.05.
+  publicBlockTime :: BlockTime
+  publicBlockTime = 20

--- a/hydra-node/src/Hydra/Chain/Blockfrost.hs
+++ b/hydra-node/src/Hydra/Chain/Blockfrost.hs
@@ -170,6 +170,7 @@ withBlockfrostChain env tracer config ctx wallet chainStateHistory callback acti
           getTimeHandle
           wallet
           ctx
+          depositPeriod
           localChainState
           (submitTx queue)
 
@@ -187,7 +188,7 @@ withBlockfrostChain env tracer config ctx wallet chainStateHistory callback acti
     Right a -> pure a
  where
   BlockfrostEnv{project} = env
-  CardanoChainConfig{startChainFrom} = config
+  CardanoChainConfig{startChainFrom, depositPeriod} = config
 
   submitTx :: TQueue IO (Tx, TMVar IO (Maybe (PostTxError Tx))) -> Tx -> IO ()
   submitTx queue tx = do

--- a/hydra-node/src/Hydra/Chain/Direct.hs
+++ b/hydra-node/src/Hydra/Chain/Direct.hs
@@ -179,6 +179,7 @@ withDirectChain opts tracer config ctx wallet chainStateHistory callback action 
           getTimeHandle
           wallet
           ctx
+          depositPeriod
           localChainState
           (submitTx queue)
 
@@ -197,7 +198,7 @@ withDirectChain opts tracer config ctx wallet chainStateHistory callback action 
     Right a -> pure a
  where
   DirectOptions{networkId, nodeSocket} = opts
-  CardanoChainConfig{startChainFrom} = config
+  CardanoChainConfig{startChainFrom, depositPeriod} = config
 
   connectInfo networkId' nodeSocket' =
     LocalNodeConnectInfo

--- a/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/Handlers.hs
@@ -104,6 +104,8 @@ import Hydra.Tx (
  )
 import Hydra.Tx.ContestationPeriod (toNominalDiffTime)
 import Hydra.Tx.Deposit (DepositObservation (..), depositTx)
+import Hydra.Tx.DepositPeriod (DepositPeriod)
+import Hydra.Tx.DepositPeriod qualified as DepositPeriod
 import Hydra.Tx.Observe (
   CloseObservation (..),
   ContestObservation (..),
@@ -186,10 +188,12 @@ mkChain ::
   GetTimeHandle m ->
   TinyWallet m ->
   ChainContext ->
+  -- | Configured deposit period, bounding the validity of deposit txs.
+  DepositPeriod ->
   LocalChainState m Tx ->
   SubmitTx m ->
   Chain Tx m
-mkChain tracer queryTimeHandle wallet ctx LocalChainState{getLatest} submitTx =
+mkChain tracer queryTimeHandle wallet ctx depositPeriod LocalChainState{getLatest} submitTx =
   Chain
     { postTx = \tx -> do
         ChainStateAt{spendableUTxO} <- atomically getLatest
@@ -275,13 +279,15 @@ mkChain tracer queryTimeHandle wallet ctx LocalChainState{getLatest} submitTx =
             (currentSlot, currentTime) <- case currentPointInTime of
               Left failureReason -> throwError FailedToConstructDepositTx{failureReason}
               Right (s, t) -> pure (s, t)
-            -- NOTE: Use a smaller upper bound than maxGraceTime to allow for
-            -- shorter than 200 slot deposit periods. This is only important on
-            -- fast moving networks (e.g. in testing). XXX: Making maxGraceTime
-            -- configurable would avoid this.
+            -- NOTE: A deposit only activates at @created + depositActivation@,
+            -- with @created@ the upper validity bound set here, and expires at
+            -- @deadline - depositPeriod@. Capping the grace time at half the
+            -- deposit period keeps at least the other half as active window;
+            -- the deadline term guards against deadlines closer than the
+            -- @depositActivation + 2 * depositPeriod@ the API server uses.
             let untilDeadline = diffUTCTime deadline currentTime
-            let graceTime = maxGraceTime `min` untilDeadline / 2
-            -- -- NOTE: But also not make it smaller than 10 slots.
+            let graceTime = min maxGraceTime $ min (untilDeadline / 2) (DepositPeriod.toNominalDiffTime depositPeriod / 2)
+            -- NOTE: But also not make it smaller than 10 slots.
             let validBeforeSlot = currentSlot + fromInteger (truncate graceTime `max` 10)
             let depositDraftTx = depositTx (networkId ctx) pparams headId commitBlueprintTx validBeforeSlot deadline changeAddress
             l1PParams <- lift $ getPParams wallet

--- a/hydra-node/test/Hydra/Model/MockChain.hs
+++ b/hydra-node/test/Hydra/Model/MockChain.hs
@@ -68,13 +68,14 @@ import Hydra.Model.Payment (CardanoSigningKey (..))
 import Hydra.Network (Network (..))
 import Hydra.Network.Message (Message (..))
 import Hydra.Node (DraftHydraNode (..), HydraNode (..), NodeStateHandler (..), connect, mkNetworkInput)
-import Hydra.Node.Environment (Environment (Environment, participants, party))
+import Hydra.Node.Environment (Environment (Environment, depositPeriod, participants, party))
 import Hydra.Node.InputQueue (InputQueue (..))
 import Hydra.Node.State (NodeState (..))
 import Hydra.NodeSpec (mockServer)
 import Hydra.Tx (txId)
 import Hydra.Tx.BlueprintTx (mkSimpleBlueprintTx)
 import Hydra.Tx.Crypto (HydraKey, getVerificationKey)
+import Hydra.Tx.DepositPeriod (DepositPeriod)
 import Hydra.Tx.HeadId (HeadId)
 import Hydra.Tx.Party (Party (..), deriveParty)
 import Hydra.Tx.ScriptRegistry (registryUTxO)
@@ -147,7 +148,7 @@ mockChainAndNetwork tr seedKeys = do
   connectNode nodes chain queue draftNode = do
     localChainState <- newLocalChainState (initHistory initialChainState)
     let DraftHydraNode{env} = draftNode
-        Environment{party = ownParty} = env
+        Environment{party = ownParty, depositPeriod} = env
     let vkey = fst $ findOwnCardanoKey ownParty seedKeys
     let ctx =
           ChainContext
@@ -182,6 +183,7 @@ mockChainAndNetwork tr seedKeys = do
           createMockChain
             tr
             ctx
+            depositPeriod
             submitTx
             getTimeHandle
             seedInput
@@ -389,12 +391,13 @@ createMockChain ::
   (MonadTimer m, MonadThrow (STM m)) =>
   Tracer m CardanoChainLog ->
   ChainContext ->
+  DepositPeriod ->
   SubmitTx m ->
   m TimeHandle ->
   TxIn ->
   LocalChainState m Tx ->
   Chain Tx m
-createMockChain tracer ctx submitTx timeHandle seedInput chainState =
+createMockChain tracer ctx depositPeriod submitTx timeHandle seedInput chainState =
   -- NOTE: The wallet basically does nothing
   let wallet =
         TinyWallet
@@ -413,6 +416,7 @@ createMockChain tracer ctx submitTx timeHandle seedInput chainState =
         timeHandle
         wallet
         ctx
+        depositPeriod
         chainState
         submitTx
 


### PR DESCRIPTION
The preview and preprod smoke tests take about 30 minutes each, almost entirely
waiting on protocol deadlines rather than on anything the scenario asserts. This
takes about 10 minutes off without narrowing any transaction's validity window.

## Where the time went

Timestamps from run [29412843078](https://github.com/cardano-scaling/hydra/actions/runs/29412843078)
(mainnet, but `blockTime` is 20s on preview, preprod and mainnet alike). Job
total 27m51s:

| phase | wall |
|---|---|
| checkout + `nix develop .#exes` | 4m05s (cold cache only; a later run reached `ClusterOptions` in 32s) |
| `--publish-hydra-scripts` | 56s |
| refuel Alice (faucet tx) | 47s |
| seed wallet + node start | 84s |
| Init to HeadIsOpen | 28s |
| POST /commit to CommitRecorded | 15s |
| **CommitRecorded to DepositActivated** | **8m07s** |
| increment to CommitFinalized | 8s |
| L2 tx + snapshot | <1s |
| Decommit to DecommitFinalized | 27s |
| Close to HeadIsClosed | 47s |
| **HeadIsClosed to ReadyToFanout** | **9m24s** |
| Fanout to HeadIsFinalized | 1s |
| `returnFundsToFaucet` | 57s |

Two waits account for ~17.5 of the 28 minutes. `mkTestTiming` sets
`contestationPeriod = depositPeriod = depositActivation = 20 * blockTime` = 400s.

**Deposit activation.** A deposit becomes active at
`created + depositActivation`, where `created` is the deposit tx's upper
validity bound, set a grace time ahead of the chain tip. Note that grace time
is not what it appears: `Handlers.hs:283` reads

```haskell
let graceTime = maxGraceTime `min` untilDeadline / 2
```

and a backticked function is `infixl 9` against `/`'s `infixl 7`, so this is
`min 200 untilDeadline / 2`, a flat **100s** for any deadline more than 200s
out, not the `min 200 (untilDeadline / 2)` it reads as. That is why the wait is
the observed 8m07s (100 + 400 = 500s) rather than the 600s the expression
suggests. Only `depositActivation` is ours to cut.

**Contestation.** The deadline is `closeTxUpperBound + contestationPeriod`,
with the close tx bounded at `now + min contestationPeriod maxGraceTime`, so
closing costs `min cp 200 + cp` = 200 + 400. Confirmed in the log: close posted
at 12:03:42, `contestationDeadline` 12:13:42.

## What changed

New `mkSmokeTiming`, used by the `hydra-cluster` executable:
`contestationPeriod = 10 * blockTime` (200s), `depositActivation = 1 * blockTime`
(20s), `depositPeriod` unchanged at `20 * blockTime`.

| | before | after |
|---|---|---|
| deposit activation wait | 500s | **120s** |
| contestation wait | 600s | **400s** |
| close / contest / increment window | 200s | 200s |
| deposit active window | 300s | 300s |

The contestation period stops exactly where `min cp maxGraceTime` would start
falling below 200s, so no transaction gets a shorter window than it has today
and nothing is more likely to expire. `depositPeriod` is deliberately not
shortened: it is not on the critical path (it sets how long a deposit stays
active, not how long anything waits), and the active window is
`depositPeriod - graceTime`, so cutting it towards the grace time closes the
window in which the increment can be posted. Since `Expired` is tested before
`Active` in `determineNextDepositStatus`, that failure mode is a run that hangs
to its full timeout rather than an error. `Test.Hydra.Cluster.UtilSpec` guards
this, along with the `depositPeriod >= min cp maxGraceTime` constraint that
`deposit.ak`'s `Claim` path imposes on the increment tx.

`singlePartyHeadFullLifeCycle` now takes the timing constructor as a parameter,
so `EndToEndSpec`'s devnet run keeps `mkTestTiming` (at 0.1s blocks the smoke
values would truncate to nonsense).

Alice's fuel and the deposit wallet are also funded by one faucet transaction
instead of two (`refuelAndSeed`, `seedManyFromFaucet`), saving a confirmation.
`refuelIfNeeded` is now `refuelAndSeed ... []`, a single implementation.

## Risk

The one thing that changes is the derived `unsyncedPeriod`, which is half the
contestation period and so falls from 200s to 100s. On the direct backend drift
is sampled when a block arrives (`handleOutOfSync` runs from the `Tick` input,
whose only source is `onRollForward`) and so measures processing lag, where 100s
is ample. It is worth watching on `--blockfrost-preview`, whose follower only
observes blocks that already have a successor and therefore lags a block gap by
construction; `--unsynced-period` is the override if it shows up.

## Testing

`just lint` and `just check` clean. `just test` green apart from
`can open, close & fanout a Head using Blockfrost @requiresBlockfrost`, which
fails identically on `master` and on a stashed tree, and only runs in the nightly
workflow.

Some runs also show devnet e2e tests failing with `OutsideValidityIntervalUTxO`
on a deposit transaction. The affected set differs every time and includes tests
this branch does not touch; they all use `mkTestTiming`, whose devnet deposit
window is `max 10` slots, one second at the devnet's 0.1s slots, so it is thin
under load regardless of this change. Failures track run duration rather than
branch.

---

* [x] CHANGELOG updated or not needed (test infrastructure only, nothing in the released node changes)
* [x] Documentation updated or not needed (`hydra-cluster/README.md`)
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
