### PR TITLE
Mint inside a Head tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ changes.
 
 ## UNRELEASED
 
+- Fixed the hydra-node crashing on `Fanout` when the head contains tokens
+  minted on layer 2: constructing a partial fanout step subtracted the
+  distributed value from the head output, and tokens which never entered the
+  head output on layer 1 produced a negative quantity that tripped an assertion
+  in cardano-ledger, bringing the node down. The node now rejects such a step
+  while constructing it and reports `FailedToConstructPartialFanoutTx` to
+  clients; the head remains closed and such tokens still cannot be fanned out
+  (see [#2334](https://github.com/cardano-scaling/hydra/issues/2334)).
+  As a safety net, an assertion firing anywhere while constructing or posting a
+  transaction no longer crashes the node either, but is reported to clients as
+  a new `UnexpectedPostTxError` API type.
+
 - Speed up posting a partial fanout step: the chunk size search was bounded by
   the size of the set being distributed, so a 4000-output head built twelve
   candidate transactions per step, the first of them carrying over a thousand

--- a/hydra-cardano-api/src/Hydra/Cardano/Api/TxOut.hs
+++ b/hydra-cardano-api/src/Hydra/Cardano/Api/TxOut.hs
@@ -33,6 +33,11 @@ txOuts' (getTxBodyContent . getTxBody -> txBody) =
 -- | Automatically balance a given output with the minimum required amount.
 -- Number of assets, presence of datum and/or reference scripts may affect this
 -- minimum value.
+--
+-- NOTE: The output value is /replaced/ by the computed minimum ada value, so
+-- any non-ada assets in the given 'Value' are silently discarded; they only
+-- contribute to the minimum ada calculation. Construct the 'TxOut' directly if
+-- the output is to hold tokens.
 mkTxOutAutoBalance ::
   Ledger.PParams LedgerEra ->
   AddressInEra Era ->

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -106,11 +106,11 @@ import Hydra.Cardano.Api qualified as CAPI
 import Hydra.Chain (PostTxError (..))
 import Hydra.Chain.Backend (ChainBackend (..), buildTransaction, buildTransactionWithPParams, buildTransactionWithPParams')
 import Hydra.Chain.ChainState (ChainSlot (..))
-import Hydra.Cluster.Faucet (createOutputAtAddress, seedFromFaucet, seedFromFaucet_, seedManyFromFaucet)
+import Hydra.Cluster.Faucet (createOutputAtAddress, seedFromFaucet, seedFromFaucetWithMinting, seedFromFaucet_, seedManyFromFaucet)
 import Hydra.Cluster.Faucet qualified as Faucet
 import Hydra.Cluster.Fixture (Actor (..), actorName, alice, aliceSk, aliceVk, bob, bobSk, bobVk, carol, carolSk, carolVk)
 import Hydra.Cluster.Util (BlockTime, Timing (..), chainConfigFor, chainConfigFor', depositTimeout, keysFor, mkTestTiming, mkTestTiming', modifyConfig, nodeStartupBudget, setNetworkId, truncatedDepositPeriod)
-import Hydra.Contract.Dummy (dummyRewardingScript, dummyValidatorScript)
+import Hydra.Contract.Dummy (dummyMintingScript, dummyRewardingScript, dummyValidatorScript)
 import Hydra.Ledger.Cardano (mkSimpleTx, mkTransferTx, unsafeBuildTransaction)
 import Hydra.Network qualified as Network
 import Hydra.Node.UnsyncedPeriod (defaultUnsyncedPeriodFor, unsyncedPeriodToNominalDiffTime)
@@ -847,6 +847,170 @@ singlePartyUsesScriptOnL2 tracer workDir opts hydraScriptsTxId =
             -- Assert final wallet balance
             (balance <$> runBackend opts (queryUTxOFor QueryTip walletVk))
               `shouldReturn` lovelaceToValue commitAmount
+
+-- | Open a head, mint tokens on L2 using a dummy minting policy and observe
+-- what happens on fanout: the minted tokens exist on L2 but never entered the
+-- head output on L1, so no fanout transaction can distribute them (see
+-- https://github.com/cardano-scaling/hydra/issues/2334).
+--
+-- XXX: The hydra-node currently *crashes* on 'Fanout': 'partialFanoutTx'
+-- computes the continuing head output as head value minus distributed value,
+-- which yields a negative token quantity and trips an 'error' in
+-- cardano-ledger ("Illegal Value in TxOut"). This test documents that
+-- behavior; once the node handles L2-minted tokens gracefully it should be
+-- updated.
+singlePartyMintsTokensOnL2 ::
+  Tracer IO EndToEndLog ->
+  FilePath ->
+  ChainBackendOptions ->
+  [TxId] ->
+  IO ()
+singlePartyMintsTokensOnL2 tracer workDir opts hydraScriptsTxId =
+  ( `finally`
+      do
+        returnFundsToFaucet tracer opts Alice
+        returnFundsToFaucet tracer opts AliceFunds
+  )
+    $ do
+      refuelIfNeeded tracer opts Alice 250_000_000
+      blockTime <- runBackend opts getBlockTime
+      let timing = mkTestTiming blockTime
+      aliceChainConfig <- chainConfigFor Alice workDir opts hydraScriptsTxId [] timing
+      let hydraNodeId = 1
+      let hydraTracer = contramap FromHydraNode tracer
+      res <- try $
+        withSoloHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] $ \n1 -> do
+          send n1 $ input "Init" []
+          headId <- waitMatch (10 * blockTime) n1 $ headIsOpenWith (Set.fromList [alice])
+
+          (walletVk, walletSk) <- keysFor AliceFunds
+
+          -- Deposit some ada to pay for the minting transaction on L2
+          utxoToDeposit <- seedFromFaucet opts walletVk (lovelaceToValue 10_000_000) (contramap FromFaucet tracer)
+          depositTx <- requestCommitTx n1 utxoToDeposit <&> signTx walletSk
+          runBackend opts $ submitTransaction depositTx
+          waitFor hydraTracer (depositTimeout timing) [n1] $
+            output "CommitFinalized" ["headId" .= headId, "depositTxId" .= txId depositTx]
+
+          -- Mint a token on L2 using the dummy minting policy
+          pparams <- getProtocolParameters n1
+          networkId <- runBackend opts queryNetworkId
+          systemStart <- runBackend opts $ querySystemStart QueryTip
+          eraHistory <- runBackend opts $ queryEraHistory QueryTip
+          stakePools <- runBackend opts $ queryStakePools QueryTip
+
+          let walletAddress = mkVkAddress networkId walletVk
+          let mintedValue :: CAPI.Value
+              mintedValue =
+                fromList
+                  [
+                    ( CAPI.AssetId (CAPI.scriptPolicyId (CAPI.PlutusScript dummyMintingScript)) (CAPI.UnsafeAssetName "L2Token")
+                    , CAPI.Quantity 1
+                    )
+                  ]
+          -- NOTE: Deliberately not using 'mkTxOutAutoBalance' as it would
+          -- replace the value (and thereby the token) with the minimum ada
+          -- value.
+          let tokenOutput =
+                TxOut
+                  walletAddress
+                  (lovelaceToValue 5_000_000 <> mintedValue)
+                  TxOutDatumNone
+                  ReferenceScriptNone
+
+          signedMintTx <-
+            case buildTransactionWithPParams' pparams systemStart eraHistory stakePools walletAddress utxoToDeposit (toList $ UTxO.inputSet utxoToDeposit) [tokenOutput] (Just dummyMintingScript) of
+              Left e -> failure $ show e
+              Right tx -> pure $ signTx walletSk tx
+          send n1 $ input "NewTx" ["transaction" .= signedMintTx]
+          waitMatch (10 * blockTime) n1 $ \v -> do
+            guard $ v ^? key "tag" == Just "SnapshotConfirmed"
+            guard $
+              toJSON signedMintTx
+                `elem` (v ^.. key "snapshot" . key "confirmed" . values)
+
+          -- Close the head and try to fan out
+          send n1 $ input "Close" []
+          deadline <- waitMatch (10 * blockTime) n1 $ \v -> do
+            guard $ v ^? key "tag" == Just "HeadIsClosed"
+            v ^? key "contestationDeadline" . _JSON
+          remainingTime <- diffUTCTime deadline <$> getCurrentTime
+          waitFor hydraTracer (remainingTime + 10 * blockTime) [n1] $
+            output "ReadyToFanout" ["headId" .= headId]
+          send n1 $ input "Fanout" []
+
+          -- If the fanout worked we would observe 'HeadIsFinalized' here;
+          -- instead the node process dies while constructing the fanout
+          -- transaction, which aborts this wait.
+          void $ waitMatch (30 * blockTime) n1 $ \v ->
+            guard $ v ^? key "tag" == Just "HeadIsFinalized"
+      case res of
+        Right () ->
+          failure "Expected fanout to fail for tokens minted on L2, but the head was finalized"
+        Left (HUnitFailure _ reason) ->
+          show reason `shouldContain` "Illegal Value in TxOut"
+
+-- | Mint tokens on L1 using a dummy minting policy, deposit them into an open
+-- head and fan out. Tokens which entered the head output on L1 are
+-- distributed by the fanout transaction like any other value.
+singlePartyFansOutTokensMintedOnL1 ::
+  Tracer IO EndToEndLog ->
+  FilePath ->
+  ChainBackendOptions ->
+  [TxId] ->
+  IO ()
+singlePartyFansOutTokensMintedOnL1 tracer workDir opts hydraScriptsTxId =
+  ( `finally`
+      do
+        returnFundsToFaucet tracer opts Alice
+        returnFundsToFaucet tracer opts AliceFunds
+  )
+    $ do
+      refuelIfNeeded tracer opts Alice 250_000_000
+      blockTime <- runBackend opts getBlockTime
+      let timing = mkTestTiming blockTime
+      aliceChainConfig <- chainConfigFor Alice workDir opts hydraScriptsTxId [] timing
+      let hydraNodeId = 1
+      let hydraTracer = contramap FromHydraNode tracer
+      withSoloHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] $ \n1 -> do
+        send n1 $ input "Init" []
+        headId <- waitMatch (10 * blockTime) n1 $ headIsOpenWith (Set.fromList [alice])
+
+        (walletVk, walletSk) <- keysFor AliceFunds
+
+        -- Mint a token on L1 into the wallet
+        let walletValue =
+              lovelaceToValue 10_000_000
+                <> fromList
+                  [
+                    ( CAPI.AssetId (CAPI.scriptPolicyId (CAPI.PlutusScript dummyMintingScript)) (CAPI.UnsafeAssetName "L1Token")
+                    , CAPI.Quantity 1
+                    )
+                  ]
+        utxoToDeposit <- seedFromFaucetWithMinting opts walletVk walletValue (contramap FromFaucet tracer) (Just dummyMintingScript)
+
+        -- Deposit the tokens into the head
+        depositTx <- requestCommitTx n1 utxoToDeposit <&> signTx walletSk
+        runBackend opts $ submitTransaction depositTx
+        waitFor hydraTracer (depositTimeout timing) [n1] $
+          output "CommitFinalized" ["headId" .= headId, "depositTxId" .= txId depositTx]
+        waitForSnapshotUTxO (depositTimeout timing) n1 utxoToDeposit
+
+        -- Close the head and fan out
+        send n1 $ input "Close" []
+        deadline <- waitMatch (10 * blockTime) n1 $ \v -> do
+          guard $ v ^? key "tag" == Just "HeadIsClosed"
+          v ^? key "contestationDeadline" . _JSON
+        remainingTime <- diffUTCTime deadline <$> getCurrentTime
+        waitFor hydraTracer (remainingTime + 10 * blockTime) [n1] $
+          output "ReadyToFanout" ["headId" .= headId]
+        send n1 $ input "Fanout" []
+        waitMatch (10 * blockTime) n1 $ \v ->
+          guard $ v ^? key "tag" == Just "HeadIsFinalized"
+
+        -- The tokens are back on L1 in the wallet
+        (balance <$> runBackend opts (queryUTxOFor QueryTip walletVk))
+          `shouldReturn` walletValue
 
 -- | Open a head and run a script using 'Rewarding' script purpose and a zero
 -- lovelace withdrawal.

--- a/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
+++ b/hydra-cluster/src/Hydra/Cluster/Scenarios.hs
@@ -140,6 +140,7 @@ import HydraNode (
   waitForNodesSynced,
   waitForSnapshotUTxO,
   waitMatch,
+  waitNoMatch,
   withConnectionToNode,
   withHydraCluster,
   withHydraNode,
@@ -850,15 +851,10 @@ singlePartyUsesScriptOnL2 tracer workDir opts hydraScriptsTxId =
 
 -- | Open a head, mint tokens on L2 using a dummy minting policy and observe
 -- what happens on fanout: the minted tokens exist on L2 but never entered the
--- head output on L1, so no fanout transaction can distribute them (see
--- https://github.com/cardano-scaling/hydra/issues/2334).
---
--- XXX: The hydra-node currently *crashes* on 'Fanout': 'partialFanoutTx'
--- computes the continuing head output as head value minus distributed value,
--- which yields a negative token quantity and trips an 'error' in
--- cardano-ledger ("Illegal Value in TxOut"). This test documents that
--- behavior; once the node handles L2-minted tokens gracefully it should be
--- updated.
+-- head output on L1, so no fanout transaction can distribute them and the head
+-- cannot be finalized (see
+-- https://github.com/cardano-scaling/hydra/issues/2334). The node reports this
+-- as a 'PostTxOnChainFailed' and keeps running.
 singlePartyMintsTokensOnL2 ::
   Tracer IO EndToEndLog ->
   FilePath ->
@@ -878,77 +874,79 @@ singlePartyMintsTokensOnL2 tracer workDir opts hydraScriptsTxId =
       aliceChainConfig <- chainConfigFor Alice workDir opts hydraScriptsTxId [] timing
       let hydraNodeId = 1
       let hydraTracer = contramap FromHydraNode tracer
-      res <- try $
-        withSoloHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] $ \n1 -> do
-          send n1 $ input "Init" []
-          headId <- waitMatch (10 * blockTime) n1 $ headIsOpenWith (Set.fromList [alice])
+      withSoloHydraNode hydraTracer blockTime aliceChainConfig workDir hydraNodeId aliceSk [] $ \n1 -> do
+        send n1 $ input "Init" []
+        headId <- waitMatch (10 * blockTime) n1 $ headIsOpenWith (Set.fromList [alice])
 
-          (walletVk, walletSk) <- keysFor AliceFunds
+        (walletVk, walletSk) <- keysFor AliceFunds
 
-          -- Deposit some ada to pay for the minting transaction on L2
-          utxoToDeposit <- seedFromFaucet opts walletVk (lovelaceToValue 10_000_000) (contramap FromFaucet tracer)
-          depositTx <- requestCommitTx n1 utxoToDeposit <&> signTx walletSk
-          runBackend opts $ submitTransaction depositTx
-          waitFor hydraTracer (depositTimeout timing) [n1] $
-            output "CommitFinalized" ["headId" .= headId, "depositTxId" .= txId depositTx]
+        -- Deposit some ada to pay for the minting transaction on L2
+        utxoToDeposit <- seedFromFaucet opts walletVk (lovelaceToValue 10_000_000) (contramap FromFaucet tracer)
+        depositTx <- requestCommitTx n1 utxoToDeposit <&> signTx walletSk
+        runBackend opts $ submitTransaction depositTx
+        waitFor hydraTracer (depositTimeout timing) [n1] $
+          output "CommitFinalized" ["headId" .= headId, "depositTxId" .= txId depositTx]
 
-          -- Mint a token on L2 using the dummy minting policy
-          pparams <- getProtocolParameters n1
-          networkId <- runBackend opts queryNetworkId
-          systemStart <- runBackend opts $ querySystemStart QueryTip
-          eraHistory <- runBackend opts $ queryEraHistory QueryTip
-          stakePools <- runBackend opts $ queryStakePools QueryTip
+        -- Mint a token on L2 using the dummy minting policy
+        pparams <- getProtocolParameters n1
+        networkId <- runBackend opts queryNetworkId
+        systemStart <- runBackend opts $ querySystemStart QueryTip
+        eraHistory <- runBackend opts $ queryEraHistory QueryTip
+        stakePools <- runBackend opts $ queryStakePools QueryTip
 
-          let walletAddress = mkVkAddress networkId walletVk
-          let mintedValue :: CAPI.Value
-              mintedValue =
-                fromList
-                  [
-                    ( CAPI.AssetId (CAPI.scriptPolicyId (CAPI.PlutusScript dummyMintingScript)) (CAPI.UnsafeAssetName "L2Token")
-                    , CAPI.Quantity 1
-                    )
-                  ]
-          -- NOTE: Deliberately not using 'mkTxOutAutoBalance' as it would
-          -- replace the value (and thereby the token) with the minimum ada
-          -- value.
-          let tokenOutput =
-                TxOut
-                  walletAddress
-                  (lovelaceToValue 5_000_000 <> mintedValue)
-                  TxOutDatumNone
-                  ReferenceScriptNone
+        let walletAddress = mkVkAddress networkId walletVk
+        let mintedValue :: CAPI.Value
+            mintedValue =
+              fromList
+                [
+                  ( CAPI.AssetId (CAPI.scriptPolicyId (CAPI.PlutusScript dummyMintingScript)) (CAPI.UnsafeAssetName "L2Token")
+                  , CAPI.Quantity 1
+                  )
+                ]
+        -- NOTE: Deliberately not using 'mkTxOutAutoBalance' as it would
+        -- replace the value (and thereby the token) with the minimum ada
+        -- value.
+        let tokenOutput =
+              TxOut
+                walletAddress
+                (lovelaceToValue 5_000_000 <> mintedValue)
+                TxOutDatumNone
+                ReferenceScriptNone
 
-          signedMintTx <-
-            case buildTransactionWithPParams' pparams systemStart eraHistory stakePools walletAddress utxoToDeposit (toList $ UTxO.inputSet utxoToDeposit) [tokenOutput] (Just dummyMintingScript) of
-              Left e -> failure $ show e
-              Right tx -> pure $ signTx walletSk tx
-          send n1 $ input "NewTx" ["transaction" .= signedMintTx]
-          waitMatch (10 * blockTime) n1 $ \v -> do
-            guard $ v ^? key "tag" == Just "SnapshotConfirmed"
-            guard $
-              toJSON signedMintTx
-                `elem` (v ^.. key "snapshot" . key "confirmed" . values)
+        signedMintTx <-
+          case buildTransactionWithPParams' pparams systemStart eraHistory stakePools walletAddress utxoToDeposit (toList $ UTxO.inputSet utxoToDeposit) [tokenOutput] (Just dummyMintingScript) of
+            Left e -> failure $ show e
+            Right tx -> pure $ signTx walletSk tx
+        send n1 $ input "NewTx" ["transaction" .= signedMintTx]
+        waitMatch (10 * blockTime) n1 $ \v -> do
+          guard $ v ^? key "tag" == Just "SnapshotConfirmed"
+          guard $
+            toJSON signedMintTx
+              `elem` (v ^.. key "snapshot" . key "confirmed" . values)
 
-          -- Close the head and try to fan out
-          send n1 $ input "Close" []
-          deadline <- waitMatch (10 * blockTime) n1 $ \v -> do
-            guard $ v ^? key "tag" == Just "HeadIsClosed"
-            v ^? key "contestationDeadline" . _JSON
-          remainingTime <- diffUTCTime deadline <$> getCurrentTime
-          waitFor hydraTracer (remainingTime + 10 * blockTime) [n1] $
-            output "ReadyToFanout" ["headId" .= headId]
-          send n1 $ input "Fanout" []
+        -- Close the head and try to fan out
+        send n1 $ input "Close" []
+        deadline <- waitMatch (10 * blockTime) n1 $ \v -> do
+          guard $ v ^? key "tag" == Just "HeadIsClosed"
+          v ^? key "contestationDeadline" . _JSON
+        remainingTime <- diffUTCTime deadline <$> getCurrentTime
+        waitFor hydraTracer (remainingTime + 10 * blockTime) [n1] $
+          output "ReadyToFanout" ["headId" .= headId]
+        send n1 $ input "Fanout" []
 
-          -- If the fanout worked we would observe 'HeadIsFinalized' here;
-          -- instead the node process dies while constructing the fanout
-          -- transaction, which aborts this wait.
-          void $ waitMatch (30 * blockTime) n1 $ \v ->
-            guard $ v ^? key "tag" == Just "HeadIsFinalized"
-      case res of
-        Right () ->
-          failure "Expected fanout to fail for tokens minted on L2, but the head was finalized"
-        Left (HUnitFailure _ reason) ->
-          show reason `shouldContain` "Illegal Value in TxOut"
+        -- No fanout transaction can produce the minted tokens which the head
+        -- output does not hold, so constructing one fails.
+        postTxErrorTag <- waitMatch (10 * blockTime) n1 $ \v -> do
+          guard $ v ^? key "tag" == Just "PostTxOnChainFailed"
+          v ^? key "postTxError" . key "tag" . _String
+        postTxErrorTag `shouldBe` "FailedToConstructPartialFanoutTx"
+
+        -- The head is not finalized and the node is still up, still serving
+        -- the L2 UTxO with the minted token.
+        waitNoMatch (10 * blockTime) n1 $ \v ->
+          guard $ v ^? key "tag" == Just "HeadIsFinalized"
+        l2UTxO <- getSnapshotUTxO n1
+        UTxO.totalValue l2UTxO `shouldBe` lovelaceToValue 10_000_000 <> mintedValue
 
 -- | Mint tokens on L1 using a dummy minting policy, deposit them into an open
 -- head and fan out. Tokens which entered the head output on L1 are

--- a/hydra-cluster/test/Test/EndToEndSpec.hs
+++ b/hydra-cluster/test/Test/EndToEndSpec.hs
@@ -72,7 +72,9 @@ import Hydra.Cluster.Scenarios (
   restartedNodeCanClose,
   restartedNodeCanObserveCommitTx,
   resumeFromLatestKnownPoint,
+  singlePartyFansOutTokensMintedOnL1,
   singlePartyHeadFullLifeCycle,
+  singlePartyMintsTokensOnL2,
   singlePartyUsesScriptOnL2,
   singlePartyUsesWithdrawZeroTrick,
   startWithWrongPeers,
@@ -291,6 +293,14 @@ spec = around (showLogsOnFailure "EndToEndSpec") $ do
         withClusterTempDir $ \tmpDir ->
           withHydraScriptsAndBackendRunning tracer tmpDir $
             singlePartyUsesWithdrawZeroTrick tracer tmpDir
+      it "cannot fanout tokens minted on L2" $ \tracer ->
+        withClusterTempDir $ \tmpDir ->
+          withHydraScriptsAndBackendRunning tracer tmpDir $
+            singlePartyMintsTokensOnL2 tracer tmpDir
+      it "can fanout tokens minted on L1 and deposited into the head" $ \tracer ->
+        withClusterTempDir $ \tmpDir ->
+          withHydraScriptsAndBackendRunning tracer tmpDir $
+            singlePartyFansOutTokensMintedOnL1 tracer tmpDir
       it "can submit a signed user transaction" $ \tracer ->
         withClusterTempDir $ \tmpDir ->
           withHydraScriptsAndBackendRunning tracer tmpDir $

--- a/hydra-node/json-schemas/api.yaml
+++ b/hydra-node/json-schemas/api.yaml
@@ -3131,6 +3131,22 @@ components:
                     type: integer
                     description: |
                       A quantity of the asset.
+        - title: UnexpectedPostTxError
+          description: |
+            An unexpected assertion (e.g. from the underlying ledger libraries)
+            fired while constructing or posting a transaction. Reported instead
+            of crashing the node.
+          type: object
+          additionalProperties: false
+          required:
+          - tag
+          - failureReason
+          properties:
+            tag:
+              type: string
+              enum: ["UnexpectedPostTxError"]
+            failureReason:
+              type: string
 
     Signature:
       type: string

--- a/hydra-node/src/Hydra/Chain.hs
+++ b/hydra-node/src/Hydra/Chain.hs
@@ -222,6 +222,10 @@ data PostTxError tx
     StalePartialFanoutTx
   | ContestationDeadlineOutsideTimeHorizon {failureReason :: Text}
   | InvalidTokenRequest [(PolicyId, PolicyAssets)]
+  | -- | An unexpected assertion (a call to 'error', e.g. from the underlying
+    -- ledger libraries) fired while constructing or posting a transaction.
+    -- Reported instead of crashing the node.
+    UnexpectedPostTxError {failureReason :: Text}
   deriving stock (Generic)
 
 deriving stock instance IsChainState tx => Eq (PostTxError tx)

--- a/hydra-node/src/Hydra/Chain/Direct/State.hs
+++ b/hydra-node/src/Hydra/Chain/Direct/State.hs
@@ -630,6 +630,12 @@ data PartialFanoutError
   | -- | Membership proof generation failed (e.g. subset element not in accumulator
     -- or CRS too short). Indicates a programming error in the caller.
     CannotCreateProof Text
+  | -- | The head output does not hold all of the value to distribute, so the
+    -- continuing head output would carry a negative quantity. This happens for
+    -- tokens minted on layer 2, which never entered the head output on layer 1
+    -- and hence can never be fanned out; see
+    -- https://github.com/cardano-scaling/hydra/issues/2334.
+    FanoutValueNegative
   deriving stock (Eq, Show)
 
 -- | Everything a partial fanout needs that does not depend on the chunk size.
@@ -704,6 +710,12 @@ partialFanoutFromPlan ::
 partialFanoutFromPlan ctx plan chunkSize deadlineSlotNo = do
   let utxoToDistribute = UTxO.fromList (take chunkSize orderedRemaining)
   when (UTxO.null utxoToDistribute) $ Left (CannotCreateProof "utxoToDistribute must not be empty")
+  -- The continuing head output is the head output minus the distributed value;
+  -- building a transaction with a negative quantity in it would trip an
+  -- 'error' in cardano-ledger.
+  let balance = txOutValue (snd headUTxO) <> negateValue (UTxO.totalValue utxoToDistribute)
+  when (any ((< 0) . snd) (IsList.toList balance)) $
+    Left FanoutValueNegative
   let remainingAccumulator = Accumulator.removeOutputs @Tx fullAccumulator utxoToDistribute
   pure $ partialFanoutTx scriptRegistry utxoToDistribute headUTxO deadlineSlotNo progressDatum remainingAccumulator
  where

--- a/hydra-node/src/Hydra/Node.hs
+++ b/hydra-node/src/Hydra/Node.hs
@@ -15,6 +15,7 @@ import Control.Concurrent.Class.MonadSTM (
   stateTVar,
   writeTVar,
  )
+import Control.Exception (ErrorCall (..))
 import Control.Monad.Trans.Writer (execWriter, tell)
 import Control.Tracer.JSON (Tracer, traceWith)
 import Data.EventSource (EventId, EventSink (..), EventSource (..), getEventId, putEventsToSinks)
@@ -26,7 +27,7 @@ import Hydra.API.Server (Server, sendMessage)
 import Hydra.Cardano.Api (
   getCardanoPaymentVerificationKey,
  )
-import Hydra.Chain (Chain (..), ChainEvent (..), ChainStateHistory (lastKnown), PostTxError, initHistory)
+import Hydra.Chain (Chain (..), ChainEvent (..), ChainStateHistory (lastKnown), PostTxError (..), initHistory)
 import Hydra.Chain.ChainState (IsChainState (..))
 import Hydra.HeadLogic (
   Effect (..),
@@ -431,8 +432,20 @@ processEffects node tracer inputId effects = do
       NetworkEffect msg -> broadcast hn msg
       OnChainEffect{postChainTx} ->
         postTx postChainTx
-          `catch` \(postTxError :: PostTxError tx) ->
-            enqueue . ChainInput $ PostTxError{postChainTx, postTxError, failingTx = Nothing}
+          `catch` ( \(postTxError :: PostTxError tx) ->
+                      enqueue . ChainInput $ PostTxError{postChainTx, postTxError, failingTx = Nothing}
+                  )
+          -- Assertions in the transaction construction code (calls to 'error',
+          -- e.g. from the underlying ledger libraries) must not bring down the
+          -- node; report them like any other failure to post the transaction.
+          `catch` ( \(ErrorCallWithLocation reason location) ->
+                      enqueue . ChainInput $
+                        PostTxError
+                          { postChainTx
+                          , postTxError = UnexpectedPostTxError{failureReason = toText $ reason <> "\n" <> location}
+                          , failingTx = Nothing
+                          }
+                  )
     traceWith tracer $ EndEffect party inputId effectId
 
   HydraNode

--- a/hydra-node/test/Hydra/NodeSpec.hs
+++ b/hydra-node/test/Hydra/NodeSpec.hs
@@ -3,6 +3,7 @@
 module Hydra.NodeSpec where
 
 import Data.Secret (Secret)
+import Data.Text qualified as Text
 import Hydra.Prelude hiding (label)
 import Test.Hydra.Prelude
 
@@ -299,6 +300,25 @@ spec = parallel $ do
               _ -> False
 
         any isPostTxOnChainFailed outputs `shouldBe` True
+
+    it "notifies client when postTx hits an unexpected assertion" $
+      showLogsOnFailure "NodeSpec" $ \tracer -> do
+        let inputs :: [Input SimpleTx] = [ClientInput Init]
+        (node, getServerOutputs) <-
+          testHydraNode tracer aliceSk [bob, carol] cperiod inputs
+            >>= errorOnPostTx
+            >>= recordServerOutputs
+
+        runToCompletion node
+
+        outputs <- getServerOutputs
+        let isUnexpectedPostTxError :: Either (ServerOutput SimpleTx) (ClientMessage SimpleTx) -> Bool
+            isUnexpectedPostTxError = \case
+              Right PostTxOnChainFailed{postTxError = UnexpectedPostTxError{failureReason}} ->
+                "unexpected assertion" `Text.isInfixOf` failureReason
+              _ -> False
+
+        any isUnexpectedPostTxError outputs `shouldBe` True
 
     it "signs snapshot even if it has seen conflicting transactions" $
       failAfter 10 $
@@ -598,6 +618,23 @@ throwExceptionOnPostTx exception node =
       { oc =
           Chain
             { postTx = \_ -> throwIO exception
+            , draftDepositTx = \_ -> error "draftDepositTx not implemented"
+            , submitTx = \_ -> error "submitTx not implemented"
+            , checkNonADAAssets = \_ -> error "checkNonADAAssets not implemented"
+            }
+      }
+
+-- | Modify a 'HydraNode' to trip an assertion (a call to 'error') on any
+-- 'postTx', like the underlying ledger libraries do on illegal values.
+errorOnPostTx ::
+  HydraNode tx IO ->
+  IO (HydraNode tx IO)
+errorOnPostTx node =
+  pure
+    node
+      { oc =
+          Chain
+            { postTx = \_ -> error "unexpected assertion"
             , draftDepositTx = \_ -> error "draftDepositTx not implemented"
             , submitTx = \_ -> error "submitTx not implemented"
             , checkNonADAAssets = \_ -> error "checkNonADAAssets not implemented"


### PR DESCRIPTION
- Two tests that exercise minting with known and unknown minting policy on L2. 
- Make sure some error call from tx construction (ledger) doesn't bring the node down

---

<!-- Consider each and tick it off one way or the other -->
* [x] CHANGELOG updated or not needed
* [x] Documentation updated or not needed
* [x] Haddocks updated or not needed
* [x] No new TODOs introduced or explained herafter
